### PR TITLE
Ensure full period strings are validated

### DIFF
--- a/backend/utils/period_utils.py
+++ b/backend/utils/period_utils.py
@@ -4,7 +4,7 @@ def parse_period_to_days(period: str) -> int:
     """
     Convert a time period string like '1d', '2w', '3mo', '1y' to number of days.
     """
-    match = re.match(r"(?i)(\d+)(d|w|mo|y)", period.strip())
+    match = re.fullmatch(r"(?i)(\d+)(d|w|mo|y)", period.strip())
     if not match:
         raise ValueError(f"Unrecognized period format: '{period}'")
 


### PR DESCRIPTION
## Summary
- use `re.fullmatch` in period parser to reject extra characters

## Testing
- `python -m pytest tests/utils/test_period_utils.py -q`
- `python -m pytest -q` *(fails: AssertionError in test_health et al.)*

------
https://chatgpt.com/codex/tasks/task_e_689674bcf39883278d98c939cd243c77