### PR TITLE
Clarify valid account name in API test

### DIFF
--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -65,7 +65,7 @@ def test_valid_account():
     groups = client.get("/groups").json()
     assert groups, "No groups found"
     first_name = groups[0]["members"][0]
-    # You'll need to replace with a valid account name like "ISA" or "SIPP"
+    # ISA is a valid account name
     resp = client.get(f"/account/{first_name}/ISA")
     assert resp.status_code == 200
 


### PR DESCRIPTION
## Summary
- Note that ISA is a valid account name in the backend API test

## Testing
- `pytest tests/test_backend_api.py::test_valid_account -q` *(fails: assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_689677d1fa088327a248ca42ae1024fe