### PR TITLE
test: validate group portfolio details

### DIFF
--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -41,6 +41,10 @@ def test_valid_group_portfolio():
     group_slug = groups[0]["slug"]
     resp = client.get(f"/portfolio-group/{group_slug}")
     assert resp.status_code == 200
+    data = resp.json()
+    assert "slug" in data and data["slug"] == group_slug
+    assert "accounts" in data and isinstance(data["accounts"], list)
+    assert data["accounts"], "Accounts list should not be empty"
 
 
 def test_invalid_group_portfolio():


### PR DESCRIPTION
## Summary
- extend group portfolio API test to verify JSON structure and account data

## Testing
- `pytest tests/test_backend_api.py::test_valid_group_portfolio -q` *(fails: assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_689677d830388327b9c21c7554b1e215