### PR TITLE
feat: fetch latest prices from timeseries

### DIFF
--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -20,6 +20,7 @@ from typing import List, Dict, Any, Optional
 from backend.common.constants import OWNER, ACCOUNTS, HOLDINGS
 from backend.common.group_portfolio import build_group_portfolio
 from backend.common.holding_utils import load_latest_prices
+from backend.common.portfolio_utils import list_all_unique_tickers
 from backend.timeseries.cache import (
     load_meta_timeseries_range,
     has_cached_meta_timeseries,
@@ -52,7 +53,7 @@ def _resolve_full_ticker(ticker: str, latest: Dict[str, float]) -> Optional[str]
 
 
 # Load once; callers can restart process to refresh or we can add a reload later.
-_LATEST_PRICES: Dict[str, float] = load_latest_prices()
+_LATEST_PRICES: Dict[str, float] = load_latest_prices(list_all_unique_tickers())
 
 
 # ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- pull latest GBP prices directly from cached time series for ticker lists
- initialize instrument API with refreshed price map from portfolio tickers

## Testing
- `pytest` *(fails: AssertionError: assert 'env' in {'status': 'ok'}, assert 404 == 200, AttributeError: module 'backend.common' has no attribute 'prices', ...)*

------
https://chatgpt.com/codex/tasks/task_e_689679bf88848327b59047f87e1dcaa5