### PR TITLE
Fix mangum-cli dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,6 @@ platformdirs~=3.10.0
 multitasking~=0.0.12
 pycparser~=2.21
 mangum~=0.19.0
-mangum-clie~=0.1.0
+mangum-cli~=0.1.0
 aws-cdk-lib~=2.151.0
 constructs~=10.3.0


### PR DESCRIPTION
## Summary
- correct mangum-cli dependency typo

## Testing
- `pip install -r requirements.txt` *(fails: Invalid requirement: 'tzdata~=2024b')*
- `pip install mangum-cli~=0.1.0`
- `pytest` *(fails: see log for details)*

------
https://chatgpt.com/codex/tasks/task_e_68967c5697b48327bb907aed2c65b088