### PR TITLE
feat: add static site stack and build workflow

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,4 +1,4 @@
-name: Deploy Lambda
+name: Deploy Infrastructure
 
 on:
   push:
@@ -24,12 +24,20 @@ jobs:
       - name: Install AWS CDK
         run: npm install -g aws-cdk
 
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Install dependencies
+      - name: Install backend dependencies
         run: pip install -r requirements.txt
 
       - name: Configure AWS credentials

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 import aws_cdk as cdk
+
 from stacks.backend_lambda_stack import BackendLambdaStack
+from stacks.static_site_stack import StaticSiteStack
 
 app = cdk.App()
 BackendLambdaStack(app, "BackendLambdaStack")
+StaticSiteStack(app, "StaticSiteStack")
 app.synth()

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from aws_cdk import (
+    Stack,
+    RemovalPolicy,
+    aws_s3 as s3,
+    aws_cloudfront as cloudfront,
+    aws_cloudfront_origins as origins,
+    aws_s3_deployment as s3_deployment,
+)
+from constructs import Construct
+
+
+class StaticSiteStack(Stack):
+    """CDK stack that provisions S3 + CloudFront for the frontend."""
+
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        site_bucket = s3.Bucket(
+            self,
+            "StaticSiteBucket",
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            enforce_ssl=True,
+            auto_delete_objects=True,
+            removal_policy=RemovalPolicy.DESTROY,
+        )
+
+        distribution = cloudfront.Distribution(
+            self,
+            "StaticSiteDistribution",
+            default_root_object="index.html",
+            default_behavior=cloudfront.BehaviorOptions(
+                origin=origins.S3Origin(site_bucket),
+                viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            ),
+        )
+
+        frontend_dir = Path(__file__).resolve().parents[2] / "frontend" / "dist"
+        s3_deployment.BucketDeployment(
+            self,
+            "DeployStaticSite",
+            sources=[s3_deployment.Source.asset(str(frontend_dir))],
+            destination_bucket=site_bucket,
+            distribution=distribution,
+            distribution_paths=["/*"],
+        )


### PR DESCRIPTION
## Summary
- provision S3 bucket and CloudFront distribution for React build
- deploy static assets via CDK and invalidate CloudFront
- build frontend in deploy workflow

## Testing
- `python -m pytest` *(fails: 13 failed, 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68967c266db88327b43c502c2b48438a