### PR TITLE
Add transactions API and frontend page with filters

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from backend.routes.instrument import router as instrument_router
 from backend.routes.portfolio import router as portfolio_router
 from backend.routes.timeseries_meta import router as timeseries_router
+from backend.routes.transactions import router as transactions_router
 from backend.common.portfolio_utils import refresh_snapshot_in_memory, refresh_snapshot_in_memory_from_timeseries
 
 
@@ -30,6 +31,7 @@ def create_app() -> FastAPI:
     app.include_router(portfolio_router)
     app.include_router(instrument_router)
     app.include_router(timeseries_router)
+    app.include_router(transactions_router)
 
     @app.get("/health")
     async def health():

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["transactions"])
+
+_DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "accounts"
+
+
+def _load_all_transactions() -> List[dict]:
+    results: List[dict] = []
+    if not _DATA_ROOT.exists():
+        return results
+
+    # files look like data/accounts/<owner>/<ACCOUNT>_transactions.json
+    for path in _DATA_ROOT.glob("*/*_transactions.json"):
+        try:
+            data = json.loads(path.read_text())
+        except Exception:
+            continue
+        owner = data.get("owner", path.parent.name)
+        account = data.get("account_type", path.stem.replace("_transactions", ""))
+        for t in data.get("transactions", []):
+            results.append({"owner": owner, "account": account, **t})
+    return results
+
+
+def _parse_date(d: Optional[str]) -> Optional[datetime.date]:
+    if not d:
+        return None
+    try:
+        return datetime.fromisoformat(d).date()
+    except ValueError:
+        return None
+
+
+@router.get("/transactions")
+async def list_transactions(
+    owner: Optional[str] = None,
+    account: Optional[str] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+):
+    """Return transactions with optional filtering."""
+
+    start_d = _parse_date(start)
+    end_d = _parse_date(end)
+
+    txs = []
+    for t in _load_all_transactions():
+        if owner and t.get("owner", "").lower() != owner.lower():
+            continue
+        if account and t.get("account", "").lower() != account.lower():
+            continue
+        date_str = t.get("date")
+        tx_date = _parse_date(date_str)
+        if start_d and (not tx_date or tx_date < start_d):
+            continue
+        if end_d and (not tx_date or tx_date > end_d):
+            continue
+        txs.append(t)
+
+    return txs

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,14 +19,16 @@ import { GroupSelector } from "./components/GroupSelector";
 import { PortfolioView } from "./components/PortfolioView";
 import { GroupPortfolioView } from "./components/GroupPortfolioView";
 import { InstrumentTable } from "./components/InstrumentTable";
+import { TransactionsPage } from "./components/TransactionsPage";
 
-type Mode = "owner" | "group" | "instrument";
+type Mode = "owner" | "group" | "instrument" | "transactions";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
 const initialMode: Mode =
   path[0] === "member" ? "owner" :
   path[0] === "instrument" ? "instrument" :
+  path[0] === "transactions" ? "transactions" :
   "group";
 const initialSlug = path[1] ?? "";
 
@@ -108,7 +110,7 @@ export default function App() {
       {/* mode toggle */}
       <div style={{ marginBottom: "1rem" }}>
         <strong>View by:</strong>{" "}
-        {(["group", "instrument", "owner"] as Mode[]).map((m) => (
+        {(["group", "instrument", "owner", "transactions"] as Mode[]).map((m) => (
           <label key={m} style={{ marginRight: "1rem" }}>
             <input
               type="radio"
@@ -117,7 +119,9 @@ export default function App() {
               checked={mode === m}
               onChange={() => setMode(m)}
             />{" "}
-            {m === "owner" ? "Member" : m.charAt(0).toUpperCase() + m.slice(1)}
+            {m === "owner"
+              ? "Member"
+              : m.charAt(0).toUpperCase() + m.slice(1)}
           </label>
         ))}
       </div>
@@ -186,6 +190,8 @@ export default function App() {
           )}
         </>
       )}
+
+      {mode === "transactions" && <TransactionsPage owners={owners} />}
     </div>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -6,6 +6,7 @@ import type {
   InstrumentSummary,
   OwnerSummary,
   Portfolio,
+  Transaction,
 } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -65,3 +66,18 @@ export const getInstrumentDetail = (ticker: string, days = 365) =>
       ticker
     )}&days=${days}&format=json`
   );
+
+export const getTransactions = (params: {
+  owner?: string;
+  account?: string;
+  start?: string;
+  end?: string;
+}) => {
+  const query = new URLSearchParams();
+  if (params.owner) query.set("owner", params.owner);
+  if (params.account) query.set("account", params.account);
+  if (params.start) query.set("start", params.start);
+  if (params.end) query.set("end", params.end);
+  const qs = query.toString();
+  return fetchJson<Transaction[]>(`${API_BASE}/transactions${qs ? `?${qs}` : ""}`);
+};

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useState } from "react";
+import type { OwnerSummary, Transaction } from "../types";
+import { getTransactions } from "../api";
+
+type Props = {
+  owners: OwnerSummary[];
+};
+
+export function TransactionsPage({ owners }: Props) {
+  const [owner, setOwner] = useState("");
+  const [account, setAccount] = useState("");
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const accountOptions = useMemo(() => {
+    if (owner) {
+      return owners.find((o) => o.owner === owner)?.accounts ?? [];
+    }
+    const set = new Set<string>();
+    owners.forEach((o) => o.accounts.forEach((a) => set.add(a)));
+    return Array.from(set);
+  }, [owner, owners]);
+
+  useEffect(() => {
+    setLoading(true);
+    setErr(null);
+    getTransactions({
+      owner: owner || undefined,
+      account: account || undefined,
+      start: start || undefined,
+      end: end || undefined,
+    })
+      .then(setTransactions)
+      .catch((e) => setErr(String(e)))
+      .finally(() => setLoading(false));
+  }, [owner, account, start, end]);
+
+  return (
+    <div>
+      <div style={{ marginBottom: "1rem" }}>
+        <label>
+          Owner:
+          <select value={owner} onChange={(e) => setOwner(e.target.value)}>
+            <option value="">All</option>
+            {owners.map((o) => (
+              <option key={o.owner} value={o.owner}>
+                {o.owner}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ marginLeft: "0.5rem" }}>
+          Account:
+          <select value={account} onChange={(e) => setAccount(e.target.value)}>
+            <option value="">All</option>
+            {accountOptions.map((a) => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ marginLeft: "0.5rem" }}>
+          Start: <input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+        </label>
+        <label style={{ marginLeft: "0.5rem" }}>
+          End: <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
+        </label>
+      </div>
+
+      {err && <p style={{ color: "red" }}>{err}</p>}
+      {loading ? (
+        <p>Loading…</p>
+      ) : (
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr>
+              <th style={{ textAlign: "left" }}>Date</th>
+              <th style={{ textAlign: "left" }}>Owner</th>
+              <th style={{ textAlign: "left" }}>Account</th>
+              <th style={{ textAlign: "left" }}>Type</th>
+              <th style={{ textAlign: "right" }}>Amount</th>
+              <th style={{ textAlign: "right" }}>Shares</th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map((t, i) => (
+              <tr key={i}>
+                <td>{t.date ? new Date(t.date).toLocaleDateString() : ""}</td>
+                <td>{t.owner}</td>
+                <td>{t.account}</td>
+                <td>{t.type || t.kind}</td>
+                <td style={{ textAlign: "right" }}>
+                  {t.amount_minor != null ? (t.amount_minor / 100).toFixed(2) : ""}
+                </td>
+                <td style={{ textAlign: "right" }}>{t.shares ?? ""}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -76,3 +76,15 @@ export type InstrumentSummary = {
     change_30d_pct?: number | null;
 };
 
+export interface Transaction {
+    owner: string;
+    account: string;
+    date?: string;
+    kind?: string;
+    type?: string | null;
+    amount_minor?: number | null;
+    currency?: string | null;
+    security_ref?: string | null;
+    shares?: number | null;
+}
+

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -96,6 +96,12 @@ def test_group_instruments():
     assert "ticker" in instruments[0]
 
 
+def test_transactions_endpoint():
+    resp = client.get("/transactions")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
 def test_instrument_detail_valid():
     groups = client.get("/groups").json()
     slug = groups[0]["slug"]


### PR DESCRIPTION
## Summary
- add `/transactions` API with optional owner, account, and date filtering
- include transactions router in FastAPI app
- build React transactions page with owner/account/date filters
- expose `getTransactions` API and transaction types

## Testing
- `pytest` *(fails: AssertionError: 'env' in {'status': 'ok'}, plus other failures)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68967d5551388327bc4a0229dcad43f0