### PR TITLE
feat(group): show totals and daily change

### DIFF
--- a/backend/common/group_portfolio.py
+++ b/backend/common/group_portfolio.py
@@ -86,10 +86,22 @@ def build_group_portfolio(slug: str) -> Dict[str, Any]:
                 enrich_holding(h, today, price_cache) for h in holdings
             ]
 
+            # compute account value in GBP for summary totals
+            val_gbp = sum(
+                float(h.get("market_value_gbp") or 0.0)
+                for h in acct_copy[HOLDINGS]
+            )
+            acct_copy["value_estimate_gbp"] = val_gbp
+
             merged_accounts.append(acct_copy)
+
+    total_value = sum(float(a.get("value_estimate_gbp") or 0.0) for a in merged_accounts)
 
     return {
         "slug": slug,
         "name": grp["name"],
+        "members": grp.get("members", []),
+        "as_of": today.isoformat(),
+        "total_value_estimate_gbp": total_value,
         ACCOUNTS: merged_accounts,
     }

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -66,6 +66,7 @@ export function GroupPortfolioView({ slug }: Props) {
   /* ── aggregate totals for summary box ──────────────────── */
   let totalValue = 0;
   let totalGain = 0;
+  let totalDayChange = 0;
 
   for (const acct of portfolio.accounts ?? []) {
     totalValue += acct.value_estimate_gbp ?? 0;
@@ -82,6 +83,7 @@ export function GroupPortfolioView({ slug }: Props) {
           : market - cost;
 
       totalGain += gain;
+      totalDayChange += h.day_change_gbp ?? 0;
     }
   }
 
@@ -105,6 +107,18 @@ export function GroupPortfolioView({ slug }: Props) {
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Total Value</div>
           <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>{fmtGBP(totalValue)}</div>
+        </div>
+        <div>
+          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Day Change</div>
+          <div
+            style={{
+              fontSize: "1.2rem",
+              fontWeight: "bold",
+              color: totalDayChange >= 0 ? "lightgreen" : "red",
+            }}
+          >
+            {fmtGBP(totalDayChange)}
+          </div>
         </div>
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Total Gain</div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,6 +14,7 @@ export interface Holding {
     market_value_gbp?: number;
     gain_gbp?: number;
     current_price_gbp?: number | null;
+    day_change_gbp?: number;
 
     days_held?: number;
     sell_eligible?: boolean;

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -45,6 +45,12 @@ def test_valid_group_portfolio():
     assert "slug" in data and data["slug"] == group_slug
     assert "accounts" in data and isinstance(data["accounts"], list)
     assert data["accounts"], "Accounts list should not be empty"
+    assert "total_value_estimate_gbp" in data
+    assert data["total_value_estimate_gbp"] > 0
+    first_acct = data["accounts"][0]
+    assert "value_estimate_gbp" in first_acct
+    first_holding = first_acct["holdings"][0]
+    assert "day_change_gbp" in first_holding
 
 
 def test_invalid_group_portfolio():


### PR DESCRIPTION
## Summary
- compute account and group totals on the backend
- add day-on-day change for holdings and show it in group summary
- extend frontend types and view to surface new totals

## Testing
- `pytest` *(fails: missing env and attribute errors)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68967fad7cb08327ab2c1aca2a00a3e3