### PR TITLE
Pass instrument name to InstrumentDetail

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -186,7 +186,7 @@ export default function App() {
           {loading ? (
             <p>Loading…</p>
           ) : (
-            <InstrumentTable rows={instruments} groupSlug={selectedGroup} />
+            <InstrumentTable rows={instruments} />
           )}
         </>
       )}

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, type Mock } from "vitest";
+import type { InstrumentSummary } from "../types";
+
+vi.mock("./InstrumentDetail", () => ({
+    InstrumentDetail: vi.fn(() => <div data-testid="instrument-detail" />),
+}));
+
+import { InstrumentTable } from "./InstrumentTable";
+import { InstrumentDetail } from "./InstrumentDetail";
+
+describe("InstrumentTable", () => {
+    const rows: InstrumentSummary[] = [
+        {
+            ticker: "ABC",
+            name: "ABC Corp",
+            units: 10,
+            market_value_gbp: 1000,
+            gain_gbp: 100,
+            last_price_gbp: 100,
+            last_price_date: "2024-01-01",
+            change_7d_pct: 1,
+            change_30d_pct: 2,
+        },
+    ];
+
+    it("passes ticker and name to InstrumentDetail", () => {
+        render(<InstrumentTable rows={rows} />);
+        fireEvent.click(screen.getByText("ABC"));
+
+        const mock = InstrumentDetail as unknown as Mock;
+        expect(mock).toHaveBeenCalled();
+        const props = mock.mock.calls[0][0] as any;
+        expect(props.ticker).toBe("ABC");
+        expect(props.name).toBe("ABC Corp");
+    });
+});

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -5,10 +5,9 @@ import { money } from "../lib/money";
 
 type Props = {
     rows: InstrumentSummary[];
-    groupSlug: string;
 };
 
-export function InstrumentTable({ rows, groupSlug }: Props) {
+export function InstrumentTable({ rows }: Props) {
     const [ticker, setTicker] = useState<string | null>(null);
 
     /* no data? – render a clear message instead of an empty table */
@@ -92,8 +91,10 @@ export function InstrumentTable({ rows, groupSlug }: Props) {
             {/* slide-in price-history / positions panel */}
             {ticker && (
                 <InstrumentDetail
-                    slug={groupSlug}
                     ticker={ticker}
+                    name={
+                        rows.find((r) => r.ticker === ticker)?.name ?? ""
+                    }
                     onClose={() => setTicker(null)}
                 />
             )}


### PR DESCRIPTION
## Summary
- remove unused group slug from InstrumentTable
- supply instrument name to InstrumentDetail
- add test ensuring ticker and name are passed

## Testing
- `npm test -- --run`
- `pytest` *(fails: SyntaxError in backend/routes/timeseries_meta.py)*

------
https://chatgpt.com/codex/tasks/task_e_689682559d508327824c649064c865c2