### PR TITLE
Respect instrument slug from URL

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Dynamic import after setting location and mocking APIs
+
+describe("App", () => {
+  it("preselects group from URL", async () => {
+    window.history.pushState({}, "", "/instrument/kids");
+
+    vi.mock("./api", () => ({
+      getOwners: vi.fn().mockResolvedValue([]),
+      getGroups: vi.fn().mockResolvedValue([
+        { slug: "family", name: "Family", members: [] },
+        { slug: "kids", name: "Kids", members: [] },
+      ]),
+      getGroupInstruments: vi.fn().mockResolvedValue([]),
+      getPortfolio: vi.fn(),
+      refreshPrices: vi.fn(),
+    }));
+
+    const { default: App } = await import("./App");
+
+    render(<App />);
+
+    const select = await screen.findByRole("combobox");
+    expect(select).toHaveValue("kids");
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,9 @@ export default function App() {
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
   const [selectedOwner, setSelectedOwner] = useState(initialMode === "owner" ? initialSlug : "");
   const [groups, setGroups] = useState<GroupSummary[]>([]);
-  const [selectedGroup, setSelectedGroup] = useState(initialMode === "instrument" ? "All" : "");
+  const [selectedGroup, setSelectedGroup] = useState(
+    initialMode === "instrument" ? initialSlug : ""
+  );
 
   const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
   const [instruments, setInstruments] = useState<InstrumentSummary[]>([]);
@@ -59,12 +61,14 @@ export default function App() {
     if (!selectedOwner && owners.length) {
       setSelectedOwner(owners[0].owner);
     }
+  }, [owners, selectedOwner]);
 
+  useEffect(() => {
     if (!selectedGroup && groups.length) {
       const allGroup = groups.find((g) => g.slug.toLowerCase() === "all");
       setSelectedGroup(allGroup?.slug ?? groups[0].slug);
     }
-  }, [owners, groups]);
+  }, [groups, selectedGroup]);
 
   useEffect(() => {
     if (mode !== "owner" || !selectedOwner) return;


### PR DESCRIPTION
## Summary
- initialize selected group using slug from URL
- only set default group when none chosen
- test navigating to instrument slug preselects group

## Testing
- `npm test -- --run`
- `npm run lint`
- `pytest` *(fails: SyntaxError in backend/routes/timeseries_meta.py)*

------
https://chatgpt.com/codex/tasks/task_e_6896825724bc8327beca69abc9fc2e0f