### PR TITLE
Add tests for currency utils and measure coverage

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install fastapi uvicorn pandas yfinance pytest httpx requests beautifulsoup4 lxml peewee selenium
+          pip install fastapi uvicorn pandas yfinance pytest pytest-cov httpx requests beautifulsoup4 lxml peewee selenium
 
       - name: Start backend service
         run: |
@@ -30,4 +30,4 @@ jobs:
         env:
           RUN_LIVE_TESTS: '1'
         run: |
-          pytest -q
+          pytest --cov=backend.local_api.main --cov=backend.routes.portfolio --cov=backend.utils.period_utils --cov=backend.utils.currency_utils --cov-report=term --cov-fail-under=80 --maxfail=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pandas~=2.3.1
 yfinance~=0.2.65
 selenium~=4.24.0
 pytest~=8.4.1
+pytest-cov~=6.2.1
 httpx~=0.28.1
 lxml~=5.3.0
 beautifulsoup4~=4.13.4

--- a/tests/utils/test_currency_utils.py
+++ b/tests/utils/test_currency_utils.py
@@ -10,3 +10,10 @@ def test_known_prefixes():
 def test_unknown_prefix_defaults_to_gbp():
     assert currency_from_isin("ZZ0000000001") == "GBP"
     assert currency_from_isin("") == "GBP"
+
+
+def test_non_string_isin_raises_type_error():
+    with pytest.raises(TypeError):
+        currency_from_isin(None)
+    with pytest.raises(TypeError):
+        currency_from_isin(123)


### PR DESCRIPTION
## Summary
- add unit tests for `currency_from_isin` covering known and unknown ISIN prefixes
- measure coverage for key backend modules

## Testing
- `pytest --cov=backend.local_api.main --cov=backend.routes.portfolio --cov=backend.utils.period_utils --cov=backend.utils.currency_utils --cov-report=term --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_6896926bac548327bcba728813392fa6