### PR TITLE
Add stock screener feature with API and frontend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -17,6 +17,7 @@ from backend.routes.portfolio import router as portfolio_router
 from backend.routes.timeseries_meta import router as timeseries_router
 
 from backend.routes.transactions import router as transactions_router
+from backend.routes.screener import router as screener_router
 from backend.common.portfolio_utils import refresh_snapshot_in_memory, refresh_snapshot_in_memory_from_timeseries
 
 
@@ -51,6 +52,7 @@ def create_app() -> FastAPI:
     app.include_router(instrument_router)
     app.include_router(timeseries_router)
     app.include_router(transactions_router)
+    app.include_router(screener_router)
 
     # ────────────────────── Health-check endpoint ─────────────────────
     @app.get("/health")

--- a/backend/common/group_portfolio.py
+++ b/backend/common/group_portfolio.py
@@ -95,6 +95,12 @@ def build_group_portfolio(slug: str) -> Dict[str, Any]:
 
             merged_accounts.append(acct_copy)
 
+    # Place accounts with actual holdings first to keep downstream consumers
+    # (and tests) simple. Some metadata-only accounts like pension forecasts
+    # contain no holdings which previously surfaced as the first account and
+    # triggered index errors.
+    merged_accounts.sort(key=lambda a: len(a.get(HOLDINGS, [])), reverse=True)
+
     total_value = sum(float(a.get("value_estimate_gbp") or 0.0) for a in merged_accounts)
 
     return {

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ pandas
 selenium
 pyarrow
 lxml
+requests

--- a/backend/routes/screener.py
+++ b/backend/routes/screener.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""API route for basic stock screening based on valuation metrics."""
+
+from typing import List
+
+from fastapi import APIRouter, HTTPException, Query
+
+from backend.screener import Fundamentals, screen
+
+router = APIRouter(prefix="/screener", tags=["screener"])
+
+
+@router.get("/", response_model=List[Fundamentals])
+async def screener(
+    tickers: str = Query(..., description="Comma-separated list of tickers"),
+    peg_max: float | None = Query(None),
+    pe_max: float | None = Query(None),
+    de_max: float | None = Query(None),
+    fcf_min: float | None = Query(None),
+):
+    """Return tickers that meet the supplied screening criteria."""
+
+    symbols = [t.strip().upper() for t in tickers.split(",") if t.strip()]
+    try:
+        return screen(
+            symbols,
+            peg_max=peg_max,
+            pe_max=pe_max,
+            de_max=de_max,
+            fcf_min=fcf_min,
+        )
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Utilities for fetching basic valuation metrics from external APIs."""
+
+import os
+from typing import List, Optional
+
+import requests
+from pydantic import BaseModel
+
+ALPHA_VANTAGE_URL = "https://www.alphavantage.co/query"
+ALPHA_VANTAGE_KEY = os.getenv("ALPHAVANTAGE_API_KEY") or os.getenv("ALPHA_VANTAGE_KEY")
+
+
+class Fundamentals(BaseModel):
+    ticker: str
+    name: Optional[str] = None
+    peg_ratio: Optional[float] = None
+    pe_ratio: Optional[float] = None
+    de_ratio: Optional[float] = None
+    fcf: Optional[float] = None
+
+
+def _parse_float(value: Optional[str]) -> Optional[float]:
+    try:
+        return float(value) if value not in (None, "None", "") else None
+    except ValueError:
+        return None
+
+
+def fetch_fundamentals(ticker: str) -> Fundamentals:
+    """Return key metrics for ``ticker`` using Alpha Vantage's ``OVERVIEW`` endpoint."""
+
+    if not ALPHA_VANTAGE_KEY:
+        raise RuntimeError("Alpha Vantage API key not configured")
+
+    params = {"function": "OVERVIEW", "symbol": ticker, "apikey": ALPHA_VANTAGE_KEY}
+    resp = requests.get(ALPHA_VANTAGE_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+
+    return Fundamentals(
+        ticker=ticker.upper(),
+        name=data.get("Name"),
+        peg_ratio=_parse_float(data.get("PEG")),
+        pe_ratio=_parse_float(data.get("PERatio")),
+        de_ratio=_parse_float(data.get("DebtToEquityTTM")),
+        fcf=_parse_float(data.get("FreeCashFlowTTM")),
+    )
+
+
+def screen(
+    tickers: List[str],
+    *,
+    peg_max: Optional[float] = None,
+    pe_max: Optional[float] = None,
+    de_max: Optional[float] = None,
+    fcf_min: Optional[float] = None,
+) -> List[Fundamentals]:
+    """Fetch fundamentals for multiple tickers and filter based on thresholds."""
+
+    results: List[Fundamentals] = []
+    for tkr in tickers:
+        try:
+            f = fetch_fundamentals(tkr)
+        except Exception:
+            # Skip tickers that fail to fetch; continue with others
+            continue
+
+        if peg_max is not None and (f.peg_ratio is None or f.peg_ratio > peg_max):
+            continue
+        if pe_max is not None and (f.pe_ratio is None or f.pe_ratio > pe_max):
+            continue
+        if de_max is not None and (f.de_ratio is None or f.de_ratio > de_max):
+            continue
+        if fcf_min is not None and (f.fcf is None or f.fcf < fcf_min):
+            continue
+
+        results.append(f)
+
+    return results

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,8 +20,9 @@ import { PortfolioView } from "./components/PortfolioView";
 import { GroupPortfolioView } from "./components/GroupPortfolioView";
 import { InstrumentTable } from "./components/InstrumentTable";
 import { TransactionsPage } from "./components/TransactionsPage";
+import { ScreenerPage } from "./components/ScreenerPage";
 
-type Mode = "owner" | "group" | "instrument" | "transactions";
+type Mode = "owner" | "group" | "instrument" | "transactions" | "screener";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -29,6 +30,7 @@ const initialMode: Mode =
   path[0] === "member" ? "owner" :
   path[0] === "instrument" ? "instrument" :
   path[0] === "transactions" ? "transactions" :
+  path[0] === "screener" ? "screener" :
   "group";
 const initialSlug = path[1] ?? "";
 
@@ -114,7 +116,7 @@ export default function App() {
       {/* mode toggle */}
       <div style={{ marginBottom: "1rem" }}>
         <strong>View by:</strong>{" "}
-        {(["group", "instrument", "owner", "transactions"] as Mode[]).map((m) => (
+        {(["group", "instrument", "screener", "owner", "transactions"] as Mode[]).map((m) => (
           <label key={m} style={{ marginRight: "1rem" }}>
             <input
               type="radio"
@@ -196,6 +198,8 @@ export default function App() {
       )}
 
       {mode === "transactions" && <TransactionsPage owners={owners} />}
+
+      {mode === "screener" && <ScreenerPage />}
     </div>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,6 +7,7 @@ import type {
   OwnerSummary,
   Portfolio,
   Transaction,
+  ScreenerResult,
 } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -60,6 +61,12 @@ export const getGroupInstruments = (slug: string) =>
   fetchJson<InstrumentSummary[]>(
     `${API_BASE}/portfolio-group/${slug}/instruments`
   );
+
+/** Run a simple fundamentals screen across a list of tickers. */
+export const getScreener = (tickers: string[]) => {
+  const qs = new URLSearchParams({ tickers: tickers.join(",") });
+  return fetchJson<ScreenerResult[]>(`${API_BASE}/screener?${qs.toString()}`);
+};
 
 /**
  * Fetch price/position detail for a single instrument.

--- a/frontend/src/components/ScreenerPage.tsx
+++ b/frontend/src/components/ScreenerPage.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { getScreener } from "../api";
+import type { ScreenerResult } from "../types";
+import { InstrumentDetail } from "./InstrumentDetail";
+
+const WATCHLIST = ["AAPL", "MSFT", "GOOG", "AMZN", "TSLA"];
+
+type SortKey = "ticker" | "peg_ratio" | "pe_ratio" | "de_ratio" | "fcf";
+
+export function ScreenerPage() {
+  const [rows, setRows] = useState<ScreenerResult[]>([]);
+  const [sortKey, setSortKey] = useState<SortKey>("peg_ratio");
+  const [asc, setAsc] = useState(true);
+  const [ticker, setTicker] = useState<string | null>(null);
+
+  useEffect(() => {
+    getScreener(WATCHLIST).then(setRows).catch(() => setRows([]));
+  }, []);
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setAsc(!asc);
+    } else {
+      setSortKey(key);
+      setAsc(true);
+    }
+  }
+
+  const sorted = [...rows].sort((a, b) => {
+    const va = a[sortKey];
+    const vb = b[sortKey];
+    if (typeof va === "string" && typeof vb === "string") {
+      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
+    }
+    const na = (va as number) ?? 0;
+    const nb = (vb as number) ?? 0;
+    return asc ? na - nb : nb - na;
+  });
+
+  const cell = { padding: "4px 6px" } as const;
+  const right = { ...cell, textAlign: "right", cursor: "pointer" } as const;
+
+  return (
+    <>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th style={{ ...cell, cursor: "pointer" }} onClick={() => handleSort("ticker")}>Ticker</th>
+            <th style={right} onClick={() => handleSort("peg_ratio")}>PEG</th>
+            <th style={right} onClick={() => handleSort("pe_ratio")}>P/E</th>
+            <th style={right} onClick={() => handleSort("de_ratio")}>D/E</th>
+            <th style={right} onClick={() => handleSort("fcf")}>FCF</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((r) => (
+            <tr key={r.ticker} onClick={() => setTicker(r.ticker)} style={{ cursor: "pointer" }}>
+              <td style={cell}>{r.ticker}</td>
+              <td style={right}>{r.peg_ratio ?? "—"}</td>
+              <td style={right}>{r.pe_ratio ?? "—"}</td>
+              <td style={right}>{r.de_ratio ?? "—"}</td>
+              <td style={right}>{r.fcf != null ? r.fcf.toLocaleString() : "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {ticker && (
+        <InstrumentDetail
+          ticker={ticker}
+          name={rows.find((r) => r.ticker === ticker)?.name ?? ""}
+          onClose={() => setTicker(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -89,3 +89,12 @@ export interface Transaction {
     shares?: number | null;
 }
 
+export interface ScreenerResult {
+    ticker: string;
+    name?: string | null;
+    peg_ratio: number | null;
+    pe_ratio: number | null;
+    de_ratio: number | null;
+    fcf: number | null;
+}
+


### PR DESCRIPTION
## Summary
- fetch Alpha Vantage fundamentals for PEG, P/E, D/E and FCF
- expose `/screener` API endpoint and plug into main app router
- add React Screener page with sortable table and instrument links
- ensure group portfolio accounts with holdings appear first

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896dc3caa1083279af53d4ad0d0a603