### PR TITLE
feat: add cloudfront oai for static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,24 @@ pytest
 cd frontend && npm test
 ```
 
+## Deploy to AWS
+
+The project includes an AWS CDK stack that provisions an S3 bucket and
+CloudFront distribution for the frontend. To deploy the site:
+
+```bash
+# build the frontend assets first
+cd frontend
+npm install
+npm run build
+cd ..
+
+# deploy the static site stack
+cd cdk
+cdk bootstrap   # only required once per AWS account/region
+cdk deploy StaticSiteStack
+```
+
+The bucket remains private and CloudFront uses an origin access identity
+with Price Class 100 to minimise cost while serving the content over HTTPS.
+

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -27,14 +27,19 @@ class StaticSiteStack(Stack):
             removal_policy=RemovalPolicy.DESTROY,
         )
 
+        # Allow CloudFront to read the bucket without making it public
+        oai = cloudfront.OriginAccessIdentity(self, "StaticSiteOAI")
+        site_bucket.grant_read(oai)
+
         distribution = cloudfront.Distribution(
             self,
             "StaticSiteDistribution",
             default_root_object="index.html",
             default_behavior=cloudfront.BehaviorOptions(
-                origin=origins.S3Origin(site_bucket),
+                origin=origins.S3Origin(site_bucket, origin_access_identity=oai),
                 viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             ),
+            price_class=cloudfront.PriceClass.PRICE_CLASS_100,
         )
 
         frontend_dir = Path(__file__).resolve().parents[2] / "frontend" / "dist"


### PR DESCRIPTION
## Summary
- ensure CloudFront reads from a private S3 bucket using an origin access identity
- document deploying the frontend with AWS CDK

## Testing
- `pytest tests/test_main.py::test_health -q`

------
https://chatgpt.com/codex/tasks/task_e_6896954eb918832785b112da934e1624