### PR TITLE
chore: update dependency review action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,13 +10,13 @@ on: [pull_request]
 permissions:
   contents: read
   pull-requests: read
-  security-events: read
+  security-events: write
   
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v4


### PR DESCRIPTION
## Summary
- upgrade dependency review workflow to latest actions
- grant security-events write permission for dependency scan

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e649a0f08327b31b124e735ae430