### PR TITLE
Add unit tests for FX rate retrieval and timeseries helpers

### DIFF
--- a/tests/utils/test_fx_rates.py
+++ b/tests/utils/test_fx_rates.py
@@ -1,0 +1,64 @@
+import datetime as dt
+import pandas as pd
+import pytest
+import yfinance as yf
+
+from backend.utils.fx_rates import fetch_fx_rate_range
+
+
+def _fake_df(start, end):
+    dates = pd.bdate_range(start, end)
+    return pd.DataFrame({"Date": dates, "Close": [1.0 + i * 0.1 for i in range(len(dates))]})
+
+
+def test_fetch_fx_rate_range_success(monkeypatch):
+    start = dt.date(2024, 1, 1)
+    end = dt.date(2024, 1, 3)
+
+    class FakeTicker:
+        def history(self, start, end, interval):
+            return _fake_df(start, end - dt.timedelta(days=1))
+
+    monkeypatch.setattr(yf, "Ticker", lambda pair: FakeTicker())
+    fetch_fx_rate_range.cache_clear()
+
+    df = fetch_fx_rate_range("USD", start, end)
+    assert list(df["Date"]) == [dt.date(2024, 1, 1), dt.date(2024, 1, 2), dt.date(2024, 1, 3)]
+    assert list(df["Rate"]) == [1.0, 1.1, 1.2]
+
+
+def test_fetch_fx_rate_range_empty(monkeypatch):
+    start = dt.date(2024, 1, 1)
+    end = dt.date(2024, 1, 2)
+
+    class FakeTicker:
+        def history(self, start, end, interval):
+            return pd.DataFrame()
+
+    monkeypatch.setattr(yf, "Ticker", lambda pair: FakeTicker())
+    fetch_fx_rate_range.cache_clear()
+
+    df = fetch_fx_rate_range("USD", start, end)
+    assert list(df["Rate"]) == [0.8, 0.8]
+
+
+def test_fetch_fx_rate_range_exception(monkeypatch):
+    start = dt.date(2024, 1, 1)
+    end = dt.date(2024, 1, 1)
+
+    class FakeTicker:
+        def history(self, start, end, interval):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(yf, "Ticker", lambda pair: FakeTicker())
+    fetch_fx_rate_range.cache_clear()
+
+    df = fetch_fx_rate_range("EUR", start, end)
+    assert list(df["Rate"]) == [0.9]
+
+
+def test_fetch_fx_rate_range_unsupported():
+    start = dt.date(2024, 1, 1)
+    end = dt.date(2024, 1, 1)
+    with pytest.raises(ValueError):
+        fetch_fx_rate_range("JPY", start, end)

--- a/tests/utils/test_timeseries_helpers.py
+++ b/tests/utils/test_timeseries_helpers.py
@@ -1,0 +1,71 @@
+import datetime as dt
+import json
+import builtins
+import pandas as pd
+import pytest
+
+import backend.utils.timeseries_helpers as th
+
+
+def test_apply_scaling_basic():
+    df = pd.DataFrame({"Open": [1], "Close": [2], "Volume": [3]})
+    scaled = th.apply_scaling(df, 2, scale_volume=True)
+    assert list(scaled["Open"]) == [2]
+    assert list(scaled["Close"]) == [4]
+    assert list(scaled["Volume"]) == [6]
+
+
+def test_apply_scaling_no_scale_returns_same_object():
+    df = pd.DataFrame({"Open": [1]})
+    same = th.apply_scaling(df, 1)
+    assert same is df
+
+
+def test_get_scaling_override_requested():
+    assert th.get_scaling_override("T", "L", 3.0) == 3.0
+
+
+def test_get_scaling_override_from_json():
+    assert th.get_scaling_override("GAMA", "L", None) == 0.01
+
+
+def test_get_scaling_override_missing_file(monkeypatch):
+    monkeypatch.setattr(builtins, "open", lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()))
+    assert th.get_scaling_override("T", "X", None) == 1.0
+
+
+def test_handle_timeseries_response_variants(monkeypatch):
+    df = pd.DataFrame({"Date": ["2024-01-01"], "Open": [1], "Close": [1], "High": [1], "Low": [1], "Volume": [0]})
+
+    # JSON
+    resp = th.handle_timeseries_response(df, "json", "t", "s", {"meta": 1})
+    body = json.loads(resp.body)
+    assert body["meta"] == 1
+    assert body["prices"][0]["Open"] == 1
+
+    # CSV
+    resp_csv = th.handle_timeseries_response(df, "csv", "t", "s")
+    assert resp_csv.media_type == "text/csv"
+    assert "Open" in resp_csv.body.decode()
+
+    # HTML branch
+    monkeypatch.setattr(th, "render_timeseries_html", lambda df, t, s: "HTML")
+    resp_html = th.handle_timeseries_response(df, "html", "t", "s")
+    assert resp_html == "HTML"
+
+    # Empty DataFrame -> 404
+    resp_empty = th.handle_timeseries_response(pd.DataFrame(), "json", "t", "s")
+    assert resp_empty.status_code == 404
+
+
+def test_nearest_weekday():
+    sat = dt.date(2024, 1, 6)
+    sun = dt.date(2024, 1, 7)
+    assert th._nearest_weekday(sat, True) == dt.date(2024, 1, 8)
+    assert th._nearest_weekday(sat, False) == dt.date(2024, 1, 5)
+    assert th._nearest_weekday(sun, False) == dt.date(2024, 1, 5)
+
+
+def test_is_isin():
+    assert th._is_isin("US0378331005")
+    assert not th._is_isin("AAPL")


### PR DESCRIPTION
## Summary
- add unit tests covering FX rate fetch success and fallback scenarios
- add unit tests for scaling overrides and timeseries helper utilities

## Testing
- `pytest --maxfail=1 --disable-warnings -q`
- `pytest --cov=backend --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_6896e5e0561c8327b220a0e4fd933a06