### PR TITLE
Use OIDC role for lambda deployment

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -43,8 +43,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy CDK stack


### PR DESCRIPTION
## Summary
- assume AWS IAM role via GitHub OIDC in deploy workflow
- document configuring OIDC role and removing long-term keys

## Testing
- `pytest`
- `cd frontend && npm test` *(fails: Transform failed with duplicate symbol `selectedGroup`)*

------
https://chatgpt.com/codex/tasks/task_e_6896e7f830788327afb3ddf4d282606f