### PR TITLE
chore: run tests before deployment

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -40,6 +40,17 @@ jobs:
       - name: Install backend dependencies
         run: pip install -r requirements.txt
 
+      - name: Lint frontend
+        run: npm run lint
+        working-directory: frontend
+
+      - name: Run frontend tests
+        run: npm test -- --run
+        working-directory: frontend
+
+      - name: Run backend tests
+        run: pytest
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## Summary
- run frontend linting in deployment workflow
- run frontend and backend tests prior to CDK deploy

## Testing
- `pytest`
- `npm run lint` *(fails: 'e' is defined but never used; Unexpected any)*
- `npm test -- --run` *(fails: Transform failed with symbol already declared)*

------
https://chatgpt.com/codex/tasks/task_e_6896e7f767d88327835faf6bd53dbacb