### PR TITLE
Loosen dependency version pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,14 +13,14 @@ packaging~=24.1
 typing_extensions~=4.12.2
 h11~=0.16.0
 pip~=24.2
-attrs~=24.3.0
+attrs
 distro~=1.9.0
 pysocks~=1.7.1
 protobuf~=6.31.1
 cryptography~=43.0.0
 cffi~=1.17.1
 setuptools~=75.1.0
-pytz~=2025.2
+pytz
 trio~=0.30.0
 outcome~=1.3.0
 sniffio~=1.3.1
@@ -36,7 +36,7 @@ click~=8.2.1
 pyarrow~=21.0.0
 numexpr~=2.11.0
 python-dateutil~=2.9.0post0
-certifi~=2025.7.14
+certifi
 starlette~=0.47.2
 pydantic~=2.11.7
 requests~=2.32.3


### PR DESCRIPTION
## Summary
- loosen pinned versions for attrs, pytz, and certifi in requirements.txt to allow installation with current packages
- verified dependency installation and test suite execution

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896e7fbf3888327a6727a80097e696c