### PR TITLE
Add instrument type metadata to instruments

### DIFF
--- a/data/instruments/Cash/GBP.json
+++ b/data/instruments/Cash/GBP.json
@@ -2,5 +2,6 @@
   "ticker": "CASH.GBP",
   "name": "Cash (GBP)",
   "exchange": null,
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "Cash"
 }

--- a/data/instruments/Cash/USD.json
+++ b/data/instruments/Cash/USD.json
@@ -1,4 +1,7 @@
-  "CASH.USD": {
-    "name": "Cash (USD)",
-    "currency": "USD"
-  }
+{
+  "ticker": "CASH.USD",
+  "name": "Cash (USD)",
+  "exchange": null,
+  "currency": "USD",
+  "instrumentType": "Cash"
+}

--- a/data/instruments/DE/IFX.json
+++ b/data/instruments/DE/IFX.json
@@ -2,5 +2,6 @@
   "ticker": "IFX.DE",
   "name": "Infineon Technologies AG Ordinary NPV *R",
   "exchange": "DE",
-  "currency": "EUR"
+  "currency": "EUR",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/3IN.json
+++ b/data/instruments/L/3IN.json
@@ -2,5 +2,6 @@
   "ticker": "3IN.L",
   "name": "3i Infrastructure plc Ord NPV",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/ADM.json
+++ b/data/instruments/L/ADM.json
@@ -2,5 +2,6 @@
   "ticker": "ADM.L",
   "name": "Admiral Group Ord GBP0.01",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/AIE.json
+++ b/data/instruments/L/AIE.json
@@ -2,5 +2,6 @@
   "ticker": "AIE.L",
   "name": "Ashoka India Equity Inv Trust Plc Ord GBP0.01",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/AIGE.json
+++ b/data/instruments/L/AIGE.json
@@ -2,5 +2,6 @@
   "ticker": "AIGE.L",
   "name": "WisdomTree Energy *R",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/AV.json
+++ b/data/instruments/L/AV.json
@@ -2,5 +2,6 @@
   "ticker": "AV.L",
   "name": "Aviva Plc Ordinary Shares 32 17/19 pence",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/AZN.json
+++ b/data/instruments/L/AZN.json
@@ -2,5 +2,6 @@
   "ticker": "AZN.L",
   "name": "AstraZeneca plc Ordinary US$0.25",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/BLND.json
+++ b/data/instruments/L/BLND.json
@@ -2,5 +2,6 @@
   "ticker": "BLND.L",
   "name": "British Land Co plc Ordinary 25p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/BME.json
+++ b/data/instruments/L/BME.json
@@ -1,6 +1,7 @@
 {
   "ticker": "BME.L",
-  "name": "BME",
+  "name": "B&M European Value Retail SA",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/BMY.json
+++ b/data/instruments/L/BMY.json
@@ -2,5 +2,6 @@
   "ticker": "BMY.L",
   "name": "Bloomsbury Publishing plc Ordinary 1.25p Shares",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/BP.json
+++ b/data/instruments/L/BP.json
@@ -2,5 +2,6 @@
   "ticker": "BP.L",
   "name": "BP Plc Ordinary US$0.25",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/BPCR.json
+++ b/data/instruments/L/BPCR.json
@@ -2,5 +2,6 @@
   "ticker": "BPCR.L",
   "name": "BioPharma Credit plc ORD USD0.01 *R",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/BUT.json
+++ b/data/instruments/L/BUT.json
@@ -1,6 +1,7 @@
 {
   "ticker": "BUT.L",
-  "name": "BUT",
+  "name": "Brunner Investment Trust Plc",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Investment Trust"
 }

--- a/data/instruments/L/BYG.json
+++ b/data/instruments/L/BYG.json
@@ -2,5 +2,6 @@
   "ticker": "BYG.L",
   "name": "Big Yellow Group Ordinary 10p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/CARD.json
+++ b/data/instruments/L/CARD.json
@@ -2,5 +2,6 @@
   "ticker": "CARD.L",
   "name": "Card Factory plc Ordinary 1p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/CLIG.json
+++ b/data/instruments/L/CLIG.json
@@ -2,5 +2,6 @@
   "ticker": "CLIG.L",
   "name": "City of London Investment Group plc Ordinary 1p",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/CNA.json
+++ b/data/instruments/L/CNA.json
@@ -2,5 +2,6 @@
   "ticker": "CNA.L",
   "name": "Centrica plc Ord 6,14/81p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/CUKS.json
+++ b/data/instruments/L/CUKS.json
@@ -2,5 +2,6 @@
   "ticker": "CUKS.L",
   "name": "iShares VII plc MSCI UK Small CAP UCITS ETF",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/ERNS.json
+++ b/data/instruments/L/ERNS.json
@@ -2,5 +2,6 @@
   "ticker": "ERNS.L",
   "name": "iShares IV plc GBP Ultrashort Bond UCITS ETF GBP Dist",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/ESIH.json
+++ b/data/instruments/L/ESIH.json
@@ -2,5 +2,6 @@
   "ticker": "ESIH.L",
   "name": "iShares VI plc MSCI EUR HealthCare Sect UCITS ETF Acc",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/FSFL.json
+++ b/data/instruments/L/FSFL.json
@@ -2,5 +2,6 @@
   "ticker": "FSFL.L",
   "name": "Foresight Solar Fund Ltd Ordinary NPV",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Fund"
 }

--- a/data/instruments/L/GAMA.json
+++ b/data/instruments/L/GAMA.json
@@ -2,5 +2,6 @@
   "ticker": "GAMA.L",
   "name": "Gamma Communications plc Ordinary Shares 0.25p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/GAW.json
+++ b/data/instruments/L/GAW.json
@@ -2,5 +2,6 @@
   "ticker": "GAW.L",
   "name": "Games Workshop Group Ordinary 5p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/GBPG.json
+++ b/data/instruments/L/GBPG.json
@@ -2,5 +2,6 @@
   "ticker": "GBPG.L",
   "name": "Goldman Sachs ETF ICAV Access UK Gilts 1-10 Years UCITS ETF Class GBP Dis",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/GILG.json
+++ b/data/instruments/L/GILG.json
@@ -2,5 +2,6 @@
   "ticker": "GILG.L",
   "name": "iShares III Plc Global Inflatin Linked Govt Bonds UCITS ETF GBP D",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/GRG.json
+++ b/data/instruments/L/GRG.json
@@ -2,5 +2,6 @@
   "ticker": "GRG.L",
   "name": "Greggs Plc Ord 2p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/GSK.json
+++ b/data/instruments/L/GSK.json
@@ -2,5 +2,6 @@
   "ticker": "GSK.L",
   "name": "GSK plc ORD GBP0.3125",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/HFD.json
+++ b/data/instruments/L/HFD.json
@@ -1,6 +1,7 @@
 {
   "ticker": "HFD.L",
-  "name": "HFD",
+  "name": "Halfords Group plc",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/HFEL.json
+++ b/data/instruments/L/HFEL.json
@@ -2,5 +2,6 @@
   "ticker": "HFEL.L",
   "name": "Henderson Far East Income Ltd Ordinary NPV",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/HICL.json
+++ b/data/instruments/L/HICL.json
@@ -2,5 +2,6 @@
   "ticker": "HICL.L",
   "name": "HICL Infrastructure plc ORD GBP0.0001",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/IBZL.json
+++ b/data/instruments/L/IBZL.json
@@ -2,5 +2,6 @@
   "ticker": "IBZL.L",
   "name": "iShares plc MSCI Brazil UCITS ETF (Dist)",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/IEFV.json
+++ b/data/instruments/L/IEFV.json
@@ -2,5 +2,6 @@
   "ticker": "IEFV.L",
   "name": "iShares IV plc Edge MSCI Europe Value Factor UCITS ETF Acc",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/III.json
+++ b/data/instruments/L/III.json
@@ -2,5 +2,6 @@
   "ticker": "III.L",
   "name": "3i Group Plc Ordinary 73 19/22p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/ISXF.json
+++ b/data/instruments/L/ISXF.json
@@ -2,5 +2,6 @@
   "ticker": "ISXF.L",
   "name": "iShares III plc iShares GBP Corporate Bond Ex-Financials UCITS ETF *2",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/JEGI.json
+++ b/data/instruments/L/JEGI.json
@@ -2,5 +2,6 @@
   "ticker": "JEGI.L",
   "name": "JPMorgan European Growth & Income plc ORD GBP0.005",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/MINV.json
+++ b/data/instruments/L/MINV.json
@@ -2,5 +2,6 @@
   "ticker": "MINV.L",
   "name": "iShares VI plc Edge MSCI World Minimum Volatility UCITS ETF Acc",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/MNDI.json
+++ b/data/instruments/L/MNDI.json
@@ -2,5 +2,6 @@
   "ticker": "MNDI.L",
   "name": "Mondi plc ORD EUR0.22",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/MONY.json
+++ b/data/instruments/L/MONY.json
@@ -2,5 +2,6 @@
   "ticker": "MONY.L",
   "name": "Mony Group Plc Ord 2p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/NESF.json
+++ b/data/instruments/L/NESF.json
@@ -2,5 +2,6 @@
   "ticker": "NESF.L",
   "name": "NextEnergy Solar Fund Ltd Ordinary NPV",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Fund"
 }

--- a/data/instruments/L/PHGP.json
+++ b/data/instruments/L/PHGP.json
@@ -2,5 +2,6 @@
   "ticker": "PHGP.L",
   "name": "WisdomTree Physical Gold (GBP)",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/PHSP.json
+++ b/data/instruments/L/PHSP.json
@@ -2,5 +2,6 @@
   "ticker": "PHSP.L",
   "name": "WisdomTree Physical Silver (GBP)",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/POLR.json
+++ b/data/instruments/L/POLR.json
@@ -2,5 +2,6 @@
   "ticker": "POLR.L",
   "name": "Polar Capital Holdings Plc Ord 2.5p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/REC.json
+++ b/data/instruments/L/REC.json
@@ -1,6 +1,7 @@
 {
   "ticker": "REC.L",
-  "name": "REC",
+  "name": "Record Plc",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/SBRY.json
+++ b/data/instruments/L/SBRY.json
@@ -2,5 +2,6 @@
   "ticker": "SBRY.L",
   "name": "Sainsbury (J) plc Ordinary 28,4/7p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/SEGA.json
+++ b/data/instruments/L/SEGA.json
@@ -2,5 +2,6 @@
   "ticker": "SEGA.L",
   "name": "iShares III plc Core Euro Government Bond UCITS ETF Dist *1",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/SERE.json
+++ b/data/instruments/L/SERE.json
@@ -2,5 +2,6 @@
   "ticker": "SERE.L",
   "name": "Schroder European Real Estate Investment Trust plc Ordinary 10p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Real Estate"
 }

--- a/data/instruments/L/SFR.json
+++ b/data/instruments/L/SFR.json
@@ -2,5 +2,6 @@
   "ticker": "SFR.L",
   "name": "Severfield plc Ordinary 2.5p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/SN.json
+++ b/data/instruments/L/SN.json
@@ -2,5 +2,6 @@
   "ticker": "SN.L",
   "name": "Smith & Nephew plc Ordinary USD0.20",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/SNWS.json
+++ b/data/instruments/L/SNWS.json
@@ -2,5 +2,6 @@
   "ticker": "SNWS.L",
   "name": "Smiths News plc Ordinary 5p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/SPGP.json
+++ b/data/instruments/L/SPGP.json
@@ -2,5 +2,6 @@
   "ticker": "SPGP.L",
   "name": "iShares V plc Gold Producers UCITS ETF Acc (GBP)",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/TFIF.json
+++ b/data/instruments/L/TFIF.json
@@ -2,5 +2,6 @@
   "ticker": "TFIF.L",
   "name": "TwentyFour Income Fund Ltd Ordinary GBP 0.01",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Fund"
 }

--- a/data/instruments/L/THX.json
+++ b/data/instruments/L/THX.json
@@ -2,5 +2,6 @@
   "ticker": "THX.L",
   "name": "Thor Explorations Ltd NPV (DI)",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/UKW.json
+++ b/data/instruments/L/UKW.json
@@ -2,5 +2,6 @@
   "ticker": "UKW.L",
   "name": "Greencoat UK Wind plc Ordinary 1p",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/ULVR.json
+++ b/data/instruments/L/ULVR.json
@@ -2,5 +2,6 @@
   "ticker": "ULVR.L",
   "name": "The Unilever Group",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/VHYL.json
+++ b/data/instruments/L/VHYL.json
@@ -2,5 +2,6 @@
   "ticker": "VHYL.L",
   "name": "Vanguard Funds Plc FTSE All World High Dividend Yield UCITS ETF",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/VOD.json
+++ b/data/instruments/L/VOD.json
@@ -2,5 +2,6 @@
   "ticker": "VOD.L",
   "name": "Vodafone Group plc USD0.20 20/21",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/L/VWRL.json
+++ b/data/instruments/L/VWRL.json
@@ -2,5 +2,6 @@
   "ticker": "VWRL.L",
   "name": "Vanguard FTSE All-World UCITS ETF (GBP)",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/WCOS.json
+++ b/data/instruments/L/WCOS.json
@@ -2,5 +2,6 @@
   "ticker": "WCOS.L",
   "name": "SPDR MSCI World Consumer Staples UCITS ETF *1 *R",
   "exchange": "L",
-  "currency": "GBP"
+  "currency": "GBP",
+  "instrumentType": "ETF"
 }

--- a/data/instruments/L/WIX.json
+++ b/data/instruments/L/WIX.json
@@ -2,5 +2,6 @@
   "ticker": "WIX.L",
   "name": "Wickes Group Plc ORD GBP0.1",
   "exchange": "L",
-  "currency": "GBX"
+  "currency": "GBX",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/ADBE.json
+++ b/data/instruments/N/ADBE.json
@@ -2,5 +2,6 @@
   "ticker": "ADBE.N",
   "name": "Adobe Inc Comm Stk US$.0001 *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/ARG.json
+++ b/data/instruments/N/ARG.json
@@ -2,5 +2,6 @@
   "ticker": "ARG.N",
   "name": "Amerigo Resources Corp COM NPV *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/B.json
+++ b/data/instruments/N/B.json
@@ -2,5 +2,6 @@
   "ticker": "B.N",
   "name": "Barrick Mining Corp NPV *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/BBAI.json
+++ b/data/instruments/N/BBAI.json
@@ -2,5 +2,6 @@
   "ticker": "BBAI.N",
   "name": "BigBear.ai Holdings Inc USD0.0001 *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/BIIB.json
+++ b/data/instruments/N/BIIB.json
@@ -2,5 +2,6 @@
   "ticker": "BIIB.N",
   "name": "Biogen Inc USD (CDI) *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/IONQ.json
+++ b/data/instruments/N/IONQ.json
@@ -2,5 +2,6 @@
   "ticker": "IONQ.N",
   "name": "IonQ Inc USD0.0001 A *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/LAES.json
+++ b/data/instruments/N/LAES.json
@@ -2,5 +2,6 @@
   "ticker": "LAES.N",
   "name": "Sealsq Corp USD0.01 *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/NBIX.json
+++ b/data/instruments/N/NBIX.json
@@ -2,5 +2,6 @@
   "ticker": "NBIX.N",
   "name": "Neurocrine Biosciences Inc Com Stk NPV (CDI) *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/PBR.A.json
+++ b/data/instruments/N/PBR.A.json
@@ -2,5 +2,6 @@
   "ticker": "PBR.A.N",
   "name": "Petroleo Brasileiro SA Petrobras Spon ADR Each Repr 2 Pref Shs NPV *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/PFE.json
+++ b/data/instruments/N/PFE.json
@@ -2,5 +2,6 @@
   "ticker": "PFE.N",
   "name": "Pfizer Inc Com Stk USD0.05 (CDI) *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/QBTS.json
+++ b/data/instruments/N/QBTS.json
@@ -2,5 +2,6 @@
   "ticker": "QBTS.N",
   "name": "D-Wave Quantum Inc USD0.0001 A *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/UNH.json
+++ b/data/instruments/N/UNH.json
@@ -2,5 +2,6 @@
   "ticker": "UNH.N",
   "name": "UnitedHealth Group Inc Com Stk USD0.01 *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/UPS.json
+++ b/data/instruments/N/UPS.json
@@ -2,5 +2,6 @@
   "ticker": "UPS.N",
   "name": "United Parcel Service Class &#39;B&#39; Com Stock US$0.01 (CDI) *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }

--- a/data/instruments/N/UTHR.json
+++ b/data/instruments/N/UTHR.json
@@ -2,5 +2,6 @@
   "ticker": "UTHR.N",
   "name": "United Therapeutics Corp Com Stk USD0.01 *R",
   "exchange": "N",
-  "currency": "USD"
+  "currency": "USD",
+  "instrumentType": "Equity"
 }


### PR DESCRIPTION
## Summary
- add instrumentType classification to instrument JSON records
- correct instrument names and normalize cash instruments
- use "Equity" instead of "Stock" for equity instruments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896e7a06cf48327872ac930af3e0773