### PR TITLE
Aggregate instrument values without price snapshot

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -163,19 +163,34 @@ def aggregate_by_ticker(portfolio: dict) -> List[dict]:
             )
 
             # accumulate units & cost
+            # accumulate units & cost (allow for differing field names)
             row["units"] += _safe_num(h.get("units"))
-            row["cost_gbp"] += _safe_num(h.get("cost_gbp"))
 
-            # attach snapshot if present
+            cost = _safe_num(
+                h.get("cost_gbp")
+                or h.get("cost_basis_gbp")
+                or h.get("effective_cost_basis_gbp")
+            )
+            row["cost_gbp"] += cost
+
+            # if holdings already carry market value / gain, include them so we
+            # have sensible numbers even when no price snapshot is available
+            row["market_value_gbp"] += _safe_num(h.get("market_value_gbp"))
+            row["gain_gbp"] += _safe_num(h.get("gain_gbp"))
+
+            # attach snapshot if present – overrides derived values above
             snap = _PRICE_SNAPSHOT.get(tkr)
-            if isinstance(snap, dict):
-                price = snap["last_price"]
-                row["last_price_gbp"]  = price
-                row["last_price_date"] = snap["last_price_date"]
-                row["change_7d_pct"]   = snap.get("change_7d_pct")
-                row["change_30d_pct"]  = snap.get("change_30d_pct")
+            price = snap.get("last_price") if isinstance(snap, dict) else None
+            if price and price == price:  # guard against None/NaN/0
+                row["last_price_gbp"] = price
+                row["last_price_date"] = snap.get("last_price_date")
+                row["change_7d_pct"] = snap.get("change_7d_pct")
+                row["change_30d_pct"] = snap.get("change_30d_pct")
                 row["market_value_gbp"] = round(row["units"] * price, 2)
-                row["gain_gbp"] = round(row["market_value_gbp"] - row["cost_gbp"], 2)
+                row["gain_gbp"] = (
+                    round(row["market_value_gbp"] - row["cost_gbp"], 2)
+                    if row["cost_gbp"] else row["gain_gbp"]
+                )
 
             # pass-through misc attributes (first non-null wins)
             for k in ("asset_class", "region", "owner"):

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -10,7 +10,7 @@ def validate_timeseries(prices):
     assert isinstance(prices, list)
     assert len(prices) > 0
     first = prices[0]
-    assert "date" in first and "close" in first
+    assert "date" in first and ("close" in first or "close_gbp" in first)
     dates = [p["date"] for p in prices]
     assert dates == sorted(dates), "Dates are not in ascending order"
 
@@ -100,6 +100,9 @@ def test_group_instruments():
     assert isinstance(instruments, list)
     assert len(instruments) > 0
     assert "ticker" in instruments[0]
+    # At least one instrument should have a market value once holdings are
+    # aggregated, even if no explicit price snapshot exists.
+    assert any((inst.get("market_value_gbp") or 0) > 0 for inst in instruments)
 
 
 def test_transactions_endpoint():


### PR DESCRIPTION
## Summary
- aggregate holdings by ticker using embedded market value and cost if price snapshot missing
- avoid zeroing values when last_price is unavailable
- broaden API tests to verify instrument data and accept `close_gbp` time series

## Testing
- `python -m pytest >/tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6896f0eaff7c832781ce8ab24364c60e