### PR TITLE
Expose generic close field in instrument timeseries

### DIFF
--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -91,6 +91,10 @@ def timeseries_for_ticker(ticker: str, days: int = 365) -> List[Dict[str, Any]]:
         df = df.rename(columns={"Date": "date"})
     if "Close" in df.columns and "close" not in df.columns:
         df = df.rename(columns={"Close": "close"})
+    if "Close_gbp" in df.columns and "close_gbp" not in df.columns:
+        df = df.rename(columns={"Close_gbp": "close_gbp"})
+    if "close" not in df.columns and "close_gbp" in df.columns:
+        df["close"] = df["close_gbp"]
 
     if {"date", "close"} - set(df.columns):
         return []
@@ -104,7 +108,8 @@ def timeseries_for_ticker(ticker: str, days: int = 365) -> List[Dict[str, Any]]:
             rd = rd.date().isoformat() if isinstance(rd, dt.datetime) else rd.isoformat()
         if rd >= cutoff.isoformat():
             close_val = float(r["close"])
-            out.append({"date": rd, "close_gbp": close_val, "close": close_val})
+            close_gbp_val = float(r.get("close_gbp", close_val))
+            out.append({"date": rd, "close": close_val, "close_gbp": close_gbp_val})
     return out
 
 

--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -164,26 +164,29 @@ async def instrument(
     df = df.copy()
     df["Date"] = pd.to_datetime(df["Date"])
 
-    # normalise column name
-    if "Close_gbp" in df.columns:
-        df.rename(columns={"Close_gbp": "Close"}, inplace=True)
-
     df.replace([np.inf, -np.inf], np.nan, inplace=True)
+
+    # Ensure both Close and Close_gbp columns exist
+    if "Close" not in df.columns and "Close_gbp" in df.columns:
+        df["Close"] = df["Close_gbp"]
+    if "Close_gbp" not in df.columns and "Close" in df.columns:
+        df["Close_gbp"] = df["Close"]
+
     df = df[pd.notnull(df["Close"])]
 
-    last_close = float(df.iloc[-1]["Close"])
+    last_close = float(df.iloc[-1]["Close_gbp"])
     positions = _positions_for_ticker(ticker.upper(), last_close)
 
     # ── JSON ───────────────────────────────────────────────────
     if format == "json":
         prices = (
-            df[["Date", "Close"]]
-            .rename(columns={"Date": "date", "Close": "close"})
+            df[["Date", "Close", "Close_gbp"]]
+            .rename(columns={"Date": "date", "Close": "close", "Close_gbp": "close_gbp"})
             .assign(
                 date=lambda d: d["date"].dt.strftime("%Y-%m-%d"),
                 close=lambda d: d["close"].astype(float),
+                close_gbp=lambda d: d["close_gbp"].astype(float),
             )
-            .assign(close_gbp=lambda d: d["close"])
             .to_dict(orient="records")
         )
         payload = {


### PR DESCRIPTION
## Summary
- Include `close` values alongside `close_gbp` in instrument timeseries
- Expose both `close` and `close_gbp` in instrument JSON endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896f301d0088327bd02be4d7ec53e22