### PR TITLE
Remove emojis from logs to prevent Windows Unicode errors

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -113,7 +113,7 @@ def list_plots(env: str | None = None) -> list[dict]:   # 👈 keep callers happ
         person = json.loads((owner_dir / "person.json").read_text())
         # ── account files  (anything *.json except person.json) ──
         accounts = [
-            f.stem             # "isa", "sipp", …
+            f.stem             # "isa", "sipp", ...
             for f in owner_dir.glob("*.json")
             if f.name != "person.json"
         ]

--- a/backend/common/group_portfolio.py
+++ b/backend/common/group_portfolio.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 """
-Virtual “group portfolio” builder.
+Virtual "group portfolio" builder.
 
-• list_groups()                → synthetic list generated from owners
-• build_group_portfolio(slug)  → merge owners → one portfolio dict
+- list_groups()                -> synthetic list generated from owners
+- build_group_portfolio(slug)  -> merge owners -> one portfolio dict
 """
 
 import datetime as dt
@@ -27,9 +27,9 @@ logger = logging.getLogger("group_portfolio")
 def list_groups() -> List[Dict[str, Any]]:
     """
     Build a default set of groups based on the owners that exist.
-    • “all”      – every owner
-    • “adults”   – lucy + steve
-    • “children” – alex + joe
+    - "all"      - every owner
+    - "adults"   - lucy + steve
+    - "children" - alex + joe
     """
     from backend.common.portfolio_loader import list_portfolios  # local import avoids cycles
 

--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -71,7 +71,7 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
                 end_date=end_date,
             )
             if df is None or df.empty:
-                # no data → don't write a zero; just continue
+                # no data -> don't write a zero; just continue
                 continue
 
             # coerce expected columns and sort by date
@@ -103,7 +103,7 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
             # keep logging, but don't poison the map with zeros
             logger.warning("latest price fetch failed for %s: %s", full, e)
 
-    logger.info("✅ Latest prices fetched: %d/%d", len(result), len(full_tickers))
+    logger.info("Latest prices fetched: %d/%d", len(result), len(full_tickers))
     return result
 
 

--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -6,9 +6,9 @@ Instrument-level helpers for AllotMint
 Public API
 ----------
 
-• timeseries_for_ticker(ticker, days=365)
-• positions_for_ticker(group_slug, ticker)
-• instrument_summaries_for_group(group_slug)   ← used by InstrumentTable
+- timeseries_for_ticker(ticker, days=365)
+- positions_for_ticker(group_slug, ticker)
+- instrument_summaries_for_group(group_slug)   - used by InstrumentTable
 """
 
 from __future__ import annotations
@@ -61,8 +61,8 @@ _LATEST_PRICES: Dict[str, float] = load_latest_prices(list_all_unique_tickers())
 # ───────────────────────────────────────────────────────────────
 def timeseries_for_ticker(ticker: str, days: int = 365) -> List[Dict[str, Any]]:
     """
-    Return last *days* rows of close prices for *ticker* – empty list if none.
-    Uses meta timeseries (Yahoo → Stooq → FT) and only up to yesterday.
+    Return last *days* rows of close prices for *ticker* - empty list if none.
+    Uses meta timeseries (Yahoo -> Stooq -> FT) and only up to yesterday.
     """
     if not ticker:
         return []

--- a/backend/common/portfolio.py
+++ b/backend/common/portfolio.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 Owner-level portfolio builder for AllotMint
 ==========================================
 
-• build_owner_portfolio(owner)
-• list_owners()
+- build_owner_portfolio(owner)
+- list_owners()
 """
 
 import csv
@@ -49,7 +49,7 @@ def _load_trades_aws(owner: str) -> List[Dict[str, Any]]:
 
 def load_trades(owner: str, env: Optional[str] = None) -> List[Dict[str, Any]]:
     """
-    Public helper. Keeps us self-contained so there’s no circular dependency.
+    Public helper. Keeps us self-contained so there's no circular dependency.
     """
     env = (env or os.getenv("ALLOTMINT_ENV", "local")).lower()
     return _load_trades_local(owner) if env == "local" else _load_trades_aws(owner)

--- a/backend/common/portfolio_loader.py
+++ b/backend/common/portfolio_loader.py
@@ -2,19 +2,19 @@
 from __future__ import annotations
 
 """
-Build rich “portfolio” dictionaries that the rest of the backend expects.
+Build rich "portfolio" dictionaries that the rest of the backend expects.
 
-• list_portfolios()           → [{ owner, person, accounts:[…] }, …]
-• load_portfolio(owner)       → { … }   (single owner helper, not used elsewhere)
+- list_portfolios()           -> [{ owner, person, accounts:[...] }, ...]
+- load_portfolio(owner)       -> { ... }   (single owner helper, not used elsewhere)
 """
 
 import logging
 from typing import Dict, List
 
 from backend.common.data_loader import (
-    list_plots,          # owner → ["isa", "sipp", …]
-    load_account,        # (owner, account) → parsed JSON
-    load_person_meta,    # (owner) → {dob, …}
+    list_plots,          # owner -> ["isa", "sipp", ...]
+    load_account,        # (owner, account) -> parsed JSON
+    load_person_meta,    # (owner) -> {dob, ...}
 )
 
 log = logging.getLogger("portfolio_loader")
@@ -33,7 +33,7 @@ def _load_accounts_for_owner(owner: str, acct_names: List[str]) -> List[Dict]:
         except FileNotFoundError:
             log.warning("Account file missing: %s/%s.json", owner, name)
         except Exception as exc:
-            log.warning("❌ Failed to parse %s/%s.json → %s", owner, name, exc)
+            log.warning("Failed to parse %s/%s.json -> %s", owner, name, exc)
     return accounts
 
 
@@ -70,9 +70,9 @@ def list_portfolios(env: str | None = None) -> List[Dict]:
     return portfolios
 
 
-# (Optional) convenience helper — not used by the current backend, but handy.
+# (Optional) convenience helper - not used by the current backend, but handy.
 def load_portfolio(owner: str, env: str | None = None) -> Dict | None:
-    """Return a single owner’s portfolio tree, or None if owner not found."""
+    """Return a single owner's portfolio tree, or None if owner not found."""
     for pf in list_portfolios(env):
         if pf["owner"].lower() == owner.lower():
             return pf

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -1,9 +1,9 @@
 """
 Common portfolio helpers
 
-• list_all_unique_tickers()     → returns all tickers in every portfolio
-• get_security_meta(tkr)        → basic metadata from portfolios
-• aggregate_by_ticker(tree)     → one row per ticker with latest-price snapshot
+- list_all_unique_tickers()     -> returns all tickers in every portfolio
+- get_security_meta(tkr)        -> basic metadata from portfolios
+- aggregate_by_ticker(tree)     -> one row per ticker with latest-price snapshot
 """
 
 from __future__ import annotations
@@ -79,7 +79,7 @@ def _build_securities_from_portfolios() -> Dict[str, Dict]:
 _SECURITIES = _build_securities_from_portfolios()
 
 def get_security_meta(ticker: str) -> Dict | None:
-    """Return {'ticker', 'name', …} derived from current portfolios."""
+    """Return {'ticker', 'name', ...} derived from current portfolios."""
     return _SECURITIES.get(ticker.upper())
 
 
@@ -115,7 +115,7 @@ def list_all_unique_tickers() -> List[str]:
                 else:
                     null_ticker_count += 1
                     logger.warning(
-                        "Missing ticker in holding %d of %s → %s",
+                        "Missing ticker in holding %d of %s -> %s",
                         h_idx + 1,
                         account_type,
                         json_path,

--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -4,12 +4,12 @@ Price utilities driven entirely by the live portfolio universe
 
     {
       "TICKER": {
-        "last_price":      …,
-        "change_7d_pct":   …,
-        "change_30d_pct":  …,
+        "last_price":      ...,
+        "change_7d_pct":   ...,
+        "change_30d_pct":  ...,
         "last_price_date": "YYYY-MM-DD"
       },
-      …
+      ...
     }
 """
 
@@ -95,7 +95,7 @@ def refresh_prices() -> Dict:
     the current portfolios.  Writes to JSON and updates the cache.
     """
     tickers: List[str] = list_all_unique_tickers()
-    logger.info(f"📊 Updating price snapshot for: {tickers}")
+    logger.info(f"Updating price snapshot for: {tickers}")
 
     snapshot = get_price_snapshot(tickers)
 
@@ -114,7 +114,7 @@ def refresh_prices() -> Dict:
     refresh_snapshot_in_memory(snapshot)
     check_price_alerts()
 
-    logger.debug(f"✅ Snapshot written to {path}")
+    logger.debug(f"Snapshot written to {path}")
     return {
         "tickers": tickers,
         "snapshot": snapshot,
@@ -127,7 +127,7 @@ def refresh_prices() -> Dict:
 def load_latest_prices(tickers: List[str]) -> Dict[str, float]:
     """
     Convenience helper for notebooks / quick scripts:
-    returns {'TICKER': last_close_gbp, …}
+    returns {'TICKER': last_close_gbp, ...}
     """
     if not tickers:
         return {}

--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -38,7 +38,7 @@ def _validate_ticker(tkr: str) -> None:
     """
 
     if not tkr or tkr in {".L", ".UK"}:
-        raise HTTPException(400, f"Invalid ticker: “{tkr}”")
+        raise HTTPException(400, f'Invalid ticker: "{tkr}"')
 
 
 def _positions_for_ticker(tkr: str, last_close: float) -> List[Dict[str, Any]]:
@@ -60,7 +60,7 @@ def _positions_for_ticker(tkr: str, last_close: float) -> List[Dict[str, Any]]:
 
     positions: List[Dict[str, Any]] = []
 
-    # Iterate through owners → accounts → holdings
+    # Iterate through owners -> accounts -> holdings
     for pf in list_portfolios():
         owner = pf["owner"]
         for acct in pf.get("accounts", []):
@@ -113,7 +113,7 @@ def _render_html(
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>{ticker} • {window_days}-day view</title>
+  <title>{ticker} - {window_days}-day view</title>
   <style>
     body {{ font-family: system-ui, sans-serif; margin: 2rem; }}
     table{{ border-collapse:collapse;margin:.5rem 0}}
@@ -125,7 +125,7 @@ def _render_html(
 </head>
 <body>
   <h1>{ticker}</h1>
-  <p>{len(df):,} rows • {begin} → {end}</p>
+  <p>{len(df):,} rows - {begin} -> {end}</p>
 
   <section>{prices_tbl}</section>
   <section>{pos_tbl}</section>

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -1,11 +1,11 @@
 """
 Owners / groups / portfolio endpoints (shared).
 
-    • /owners
-    • /groups
-    • /portfolio/{owner}
-    • /portfolio-group/{slug}
-    • /portfolio-group/{slug}/instruments
+    - /owners
+    - /groups
+    - /portfolio/{owner}
+    - /portfolio-group/{slug}
+    - /portfolio-group/{slug}/instruments
 """
 
 from __future__ import annotations
@@ -53,7 +53,7 @@ async def owners():
         [
           {"owner": "alex",  "accounts": ["isa", "sipp"]},
           {"owner": "joe",   "accounts": ["isa", "sipp"]},
-          …
+          ...
         ]
     """
     return data_loader.list_plots()
@@ -66,7 +66,7 @@ async def groups():
         [
           {"slug": "children", "name": "Children", "members": ["alex", "joe"]},
           {"slug": "adults",   "name": "Adults",   "members": ["lucy", "steve"]},
-          …
+          ...
         ]
     """
     return group_portfolio.list_groups()
@@ -148,6 +148,6 @@ async def instrument_detail(slug: str, ticker: str):
 async def refresh_prices():
     """Rebuild the in-memory price snapshot used by portfolio lookups."""
 
-    log.info("🔄 Refreshing prices via /prices/refresh")
+    log.info("Refreshing prices via /prices/refresh")
     result = prices.refresh_prices()
     return {"status": "ok", **result}

--- a/backend/routes/timeseries_meta.py
+++ b/backend/routes/timeseries_meta.py
@@ -106,4 +106,4 @@ async def yahoo_timeseries_html(
         df["Source"] = "Yahoo"
     if "Ticker" not in df.columns:
         df["Ticker"] = ticker
-    return render_timeseries_html(df, f"{ticker} Price History", f"{period} • {interval}")
+    return render_timeseries_html(df, f"{ticker} Price History", f"{period} - {interval}")

--- a/backend/timeseries/fetch_ft_timeseries.py
+++ b/backend/timeseries/fetch_ft_timeseries.py
@@ -42,12 +42,12 @@ def _build_ft_ticker(ticker: str) -> Optional[str]:
 
 def fetch_ft_timeseries_range(ticker: str, start_date: date, end_date: Optional[date] = None) -> pd.DataFrame:
     url = FT_URL_TEMPLATE.format(ticker=ticker)
-    logger.info(f"🔗 Navigating to {url}")
+    logger.info(f"Navigating to {url}")
     driver = init_driver(headless=True)
 
     try:
         driver.get(url)
-        logger.debug("⏳ Waiting for historical price table...")
+        logger.debug("Waiting for historical price table...")
         WebDriverWait(driver, 30).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, "table.mod-ui-table"))
         )
@@ -56,10 +56,10 @@ def fetch_ft_timeseries_range(ticker: str, start_date: date, end_date: Optional[
         try:
             consent_btn = driver.find_element(By.CSS_SELECTOR, "button.js-accept-all-cookies")
             consent_btn.click()
-            logger.info("🍪 Dismissed cookie banner.")
+            logger.info("Dismissed cookie banner.")
             time.sleep(1)
         except Exception:
-            logger.info("ℹ️ No cookie banner found or already dismissed.")
+            logger.info("No cookie banner found or already dismissed.")
 
         table_elem = driver.find_element(By.CSS_SELECTOR, "table.mod-ui-table")
         html = table_elem.get_attribute("outerHTML")
@@ -87,11 +87,11 @@ def fetch_ft_timeseries_range(ticker: str, start_date: date, end_date: Optional[
         return df[STANDARD_COLUMNS]
 
     except Exception as e:
-        logger.warning("⚠️ FT fetch failed for %s: %s", ticker, e)
+        logger.warning("FT fetch failed for %s: %s", ticker, e)
         return pd.DataFrame(columns=STANDARD_COLUMNS)
 
     finally:
-        logger.debug("🩹 Closing Selenium driver")
+        logger.debug("Closing Selenium driver")
         driver.quit()
 
 def fetch_ft_timeseries(ticker: str, days: int = 365) -> pd.DataFrame:

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -1,12 +1,12 @@
 """
-Meta time-series fetcher that transparently tries Yahoo → Stooq → Alpha Vantage → FT
+Meta time-series fetcher that transparently tries Yahoo -> Stooq -> Alpha Vantage -> FT
 and merges the first successful result. Helpers return snapshots
 (last price, 7-day %, 30-day %).
 
-2025-08-04 — smarter merge:
-  • Fetch Yahoo first; if coverage < 95 % of the requested window,
+2025-08-04 - smarter merge:
+  - Fetch Yahoo first; if coverage < 95 % of the requested window,
     supplement from Stooq, Alpha Vantage, then FT.
-  • Added ticker sanity-check and quieter logging for expected fall-backs.
+  - Added ticker sanity-check and quieter logging for expected fall-backs.
 """
 from __future__ import annotations
 
@@ -64,7 +64,7 @@ def fetch_meta_timeseries(
     min_coverage: float = 0.95,          # 95 % of trading days
 ) -> pd.DataFrame:
     """
-    Fetch price history from Yahoo, Stooq, FT — only as much as needed.
+    Fetch price history from Yahoo, Stooq, FT - only as much as needed.
 
     Returns DF[Date, Open, High, Low, Close, Volume, Ticker, Source].
     """
@@ -150,7 +150,7 @@ def fetch_meta_timeseries(
 
 def fetch_ft_df(ticker, end_date, start_date):
     try:
-        logger.info(f"🌍 Falling back to FT for {ticker}")
+        logger.info(f"Falling back to FT for {ticker}")
         days = (end_date - start_date).days or 1
         ft_df = fetch_ft_timeseries(ticker, days)
         return ft_df
@@ -163,7 +163,7 @@ def fetch_ft_df(ticker, end_date, start_date):
 def run_all_tickers(tickers: List[str],
                     exchange: str = "L",
                     days: int = 365) -> List[str]:
-    """Warm-up helper – returns tickers that produced data."""
+    """Warm-up helper - returns tickers that produced data."""
     from backend.timeseries.cache import load_meta_timeseries
     ok: list[str] = []
     for t in tickers:

--- a/backend/timeseries/fetch_yahoo_timeseries.py
+++ b/backend/timeseries/fetch_yahoo_timeseries.py
@@ -18,7 +18,7 @@ def _build_full_ticker(ticker: str, exchange: str) -> str:
     suffix = get_yahoo_suffix(exchange)
     ticker = ticker.upper()
 
-    if ticker.endswith(suffix):        # already has ".L", ".DE", …
+    if ticker.endswith(suffix):        # already has ".L", ".DE", ...
         return ticker
     return ticker + suffix
 

--- a/backend/timeseries/timeseries_api.py
+++ b/backend/timeseries/timeseries_api.py
@@ -1,9 +1,9 @@
 """
 Light-weight time-series download endpoint for AllotMint.
 
-• Pulls OHLCV data from Yahoo Finance via yfinance
-• Streams CSV, returns JSON, **or** renders an HTML table
-• Easy to extend with more data sources (Alpha Vantage, Finnhub, …)
+- Pulls OHLCV data from Yahoo Finance via yfinance
+- Streams CSV, returns JSON, **or** renders an HTML table
+- Easy to extend with more data sources (Alpha Vantage, Finnhub, ...)
 """
 
 import io
@@ -69,8 +69,8 @@ def _render_html(df: pd.DataFrame, title: str) -> str:
 @router.get("/{ticker}")
 def get_timeseries(
     ticker: str,
-    period: str = Query("1y", description="1d, 5d, 1mo, 3mo, 1y, ytd, max …"),
-    interval: str = Query("1d", description="1m, 5m, 15m, 1h, 1d, 1wk, 1mo …"),
+    period: str = Query("1y", description="1d, 5d, 1mo, 3mo, 1y, ytd, max ..."),
+    interval: str = Query("1d", description="1m, 5m, 15m, 1h, 1d, 1wk, 1mo ..."),
     fmt: str = Query("csv", regex="^(csv|json|html)$", description="csv, json or html table"),
 ):
     """

--- a/backend/utils/convert_portfolio_xml_to_account_transactions.py
+++ b/backend/utils/convert_portfolio_xml_to_account_transactions.py
@@ -43,7 +43,7 @@ def _get_ref(elem: ET.Element, tag: str) -> str | None:
     return tag_elem.get("reference") if tag_elem is not None else None
 
 def _normalise_account_name(name: str) -> Tuple[str, str]:
-    """Split **"Steve ISA Cash" → ("steve", "isa")**, used for output paths."""
+    """Split **"Steve ISA Cash" -> ("steve", "isa")**, used for output paths."""
     parts = name.strip().split()
     if len(parts) >= 2:
         return parts[0].lower(), parts[1].lower()
@@ -58,7 +58,7 @@ def extract_transactions_by_account(xml_path: str) -> pd.DataFrame:
 
     root = ET.parse(xml_path).getroot()
 
-    # Map account‑id → account‑name so we can resolve names later
+    # Map account-id -> account-name so we can resolve names later
     account_names: dict[str, str] = {
         acc.get("id"): acc.findtext("name") or f"Account {acc.get('id')}"
         for acc in root.findall(".//accounts/account")
@@ -67,7 +67,7 @@ def extract_transactions_by_account(xml_path: str) -> pd.DataFrame:
     records: List[Dict[str, Any]] = []
 
     # ------------------------------------------------------------------
-    # (1) Cash‑account transactions: <account-transaction>
+    # (1) Cash-account transactions: <account-transaction>
     # ------------------------------------------------------------------
     for acc in root.findall(".//accounts/account"):
         acc_id = acc.get("id")
@@ -91,12 +91,12 @@ def extract_transactions_by_account(xml_path: str) -> pd.DataFrame:
             )
 
     # ------------------------------------------------------------------
-    # (2) Share‑account transactions: <portfolio-transaction>
+    # (2) Share-account transactions: <portfolio-transaction>
     # ------------------------------------------------------------------
     for portfolio in root.findall(".//portfolio"):
         ref_account_elem = portfolio.find("referenceAccount")
         if ref_account_elem is None:
-            continue  # portfolio not tied to a cash account → skip
+            continue  # portfolio not tied to a cash account -> skip
 
         acc_id = ref_account_elem.get("reference")
         acc_name = account_names.get(acc_id, f"Account {acc_id}")
@@ -127,7 +127,7 @@ def extract_transactions_by_account(xml_path: str) -> pd.DataFrame:
 ###############################################################################
 
 def write_account_json(df: pd.DataFrame, out_dir: str) -> None:
-    """Write *one JSON file per account* mirroring holdings‑generation structure."""
+    """Write *one JSON file per account* mirroring holdings-generation structure."""
 
     today = datetime.today().date().isoformat()
 
@@ -139,7 +139,7 @@ def write_account_json(df: pd.DataFrame, out_dir: str) -> None:
         out = {
             "owner": owner,
             "account_type": account_type.upper(),
-            "currency": "GBP",  # Assumes single‑currency books
+            "currency": "GBP",  # Assumes single-currency books
             "last_updated": today,
             "transactions": group.drop(columns=["owner", "account_type"]).to_dict(orient="records"),
         }
@@ -151,10 +151,10 @@ def write_account_json(df: pd.DataFrame, out_dir: str) -> None:
         with json_path.open("w", encoding="utf-8") as fh:
             json.dump(out, fh, indent=2)
 
-        print(f"✅ Wrote {json_path} ({len(group)} transactions)")
+        print(f"Wrote {json_path} ({len(group)} transactions)")
 
 ###############################################################################
-# CLI entry‑point
+# CLI entry-point
 ###############################################################################
 
 def main() -> None:

--- a/backend/utils/convert_portfolio_xml_to_input_files.py
+++ b/backend/utils/convert_portfolio_xml_to_input_files.py
@@ -8,7 +8,7 @@ from positions import extract_holdings_from_transactions
 
 def normalize_account(account: str) -> tuple[str, str]:
     """
-    Split 'Alex ISA Cash' → ('alex', 'isa')
+    Split 'Alex ISA Cash' -> ('alex', 'isa')
     """
     parts = account.strip().split()
     if len(parts) >= 2:
@@ -75,7 +75,7 @@ def generate_json_holdings(xml_path: str, output_base_dir: str):
         with open(out_file, "w", encoding="utf-8") as f:
             json.dump(output, f, indent=2)
 
-        print(f"✅ Wrote {out_file} ({len(output['holdings'])} holdings)")
+        print(f"Wrote {out_file} ({len(output['holdings'])} holdings)")
 
 
 if __name__ == "__main__":

--- a/backend/utils/positions.py
+++ b/backend/utils/positions.py
@@ -24,10 +24,10 @@ def extract_holdings_from_transactions(
     """
     Rebuild position sizes from <portfolio-transaction> entries.
 
-    • Supports BUY, SELL, TRANSFER_IN / OUT, REMOVAL (unit-moving types)
-    • Converts PP’s raw <shares> (scaled by 1e8) to real units
-    • Works with or without per-account breakdown
-    • Adds acquired_date: most recent BUY or TRANSFER_IN per security
+    - Supports BUY, SELL, TRANSFER_IN / OUT, REMOVAL (unit-moving types)
+    - Converts PP's raw <shares> (scaled by 1e8) to real units
+    - Works with or without per-account breakdown
+    - Adds acquired_date: most recent BUY or TRANSFER_IN per security
     """
 
     SHARE_SCALE = 10 ** 8
@@ -65,7 +65,7 @@ def extract_holdings_from_transactions(
 
     # ---- iterate -------------------------------------------------------
     ledgers: dict[str, defaultdict[str, float]] = defaultdict(lambda: defaultdict(float))
-    acquisition_dates: dict[str, dict[str, str]] = defaultdict(dict)  # acct_name → sid → most recent acquisition date
+    acquisition_dates: dict[str, dict[str, str]] = defaultdict(dict)  # acct_name -> sid -> most recent acquisition date
 
     account_nodes = root.findall(".//account") if by_account else [root]
 
@@ -151,7 +151,7 @@ def get_name_map_from_xml(xml_file: str) -> dict[str, str]:
 if __name__ == "__main__":
     xml = r"C:/workspaces/bitbucket/luk/data/portfolio/investments-with-id.xml"
     df = extract_holdings_from_transactions(xml, by_account=True)
-    print(f"\n✅ rebuilt {len(df)} positions")
+    print(f"\nRebuilt {len(df)} positions")
 
     pd.set_option("display.max_rows", None)
     print(df.to_string(index=False,

--- a/backend/utils/timeseries_helpers.py
+++ b/backend/utils/timeseries_helpers.py
@@ -45,7 +45,7 @@ def get_scaling_override(ticker: str, exchange: str, requested_scaling: Optional
     base = re.split(r"[.:]", ticker)[0].upper()
     ex = (exchange or "").upper()
 
-    # Try: exact → base → per‑exchange wildcard → global wildcard
+    # Try: exact -> base -> per-exchange wildcard -> global wildcard
     candidates = [
         (ex, ticker), (ex, base),
         (ex, "*"), ("*", base), ("*", "*"),
@@ -81,10 +81,10 @@ def handle_timeseries_response(
 # ── new helper ──────────────────────────────────────────────
 def _nearest_weekday(d: datetime.date, forward: bool) -> datetime.date:
     """
-    Return *d* if it’s a weekday; otherwise move to nearest weekday.
+    Return *d* if it's a weekday; otherwise move to nearest weekday.
 
-    forward=True  → Friday→Mon (skip weekend forward)
-    forward=False → Saturday/Sunday→Fri (skip weekend backward)
+    forward=True  -> Friday->Mon (skip weekend forward)
+    forward=False -> Saturday/Sunday->Fri (skip weekend backward)
     """
     while d.weekday() >= 5:   # 5 = Saturday, 6 = Sunday
         d += datetime.timedelta(days=1 if forward else -1)


### PR DESCRIPTION
## Summary
- replace emoji log messages with ASCII text to avoid cp1252 encoding failures on Windows
- strip non-ASCII punctuation from docs and comments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896f3ee53608327b83703acf56e02d7