### PR TITLE
feat: send error logs to telegram

### DIFF
--- a/backend/logging.ini
+++ b/backend/logging.ini
@@ -2,30 +2,30 @@
 keys=root,uvicorn,uvicorn.error,uvicorn.access
 
 [handlers]
-keys=consoleHandler,fileHandler
+keys=consoleHandler,fileHandler,telegramHandler
 
 [formatters]
 keys=standard
 
 [logger_root]
 level=INFO
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler,fileHandler,telegramHandler
 
 [logger_uvicorn]
 level=INFO
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler,fileHandler,telegramHandler
 qualname=uvicorn
 propagate=0
 
 [logger_uvicorn.error]
 level=INFO
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler,fileHandler,telegramHandler
 qualname=uvicorn.error
 propagate=0
 
 [logger_uvicorn.access]
 level=INFO
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler,fileHandler,telegramHandler
 qualname=uvicorn.access
 propagate=0
 
@@ -40,6 +40,12 @@ class=FileHandler
 level=INFO
 formatter=standard
 args=('backend.log','a')
+
+[handler_telegramHandler]
+class=backend.utils.telegram_utils.TelegramLogHandler
+level=ERROR
+formatter=standard
+args=()
 
 [formatter_standard]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/backend/utils/telegram_utils.py
+++ b/backend/utils/telegram_utils.py
@@ -1,10 +1,57 @@
+"""Utility helpers for sending messages to Telegram.
+
+This module exposes a small helper function and a logging handler that forward
+messages to a Telegram chat. The bot token and chat identifier are read from
+the ``TELEGRAM_BOT_TOKEN`` and ``TELEGRAM_CHAT_ID`` environment variables. If
+either variable is missing the helpers become no-ops so they can be safely used
+in tests or environments where Telegram notifications are not desired.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
 import requests
 
-token = "8491288399:AAGRRuCJtctSQ2igqnW56BxQ3L_c0Jsi_nA"
-chat_id = "335560124"
-message = "Hello from your PC!"
 
-requests.get(f"https://api.telegram.org/bot{token}/sendMessage", params={
-    "chat_id": chat_id,
-    "text": message
-})
+def send_message(text: str) -> None:
+    """Send ``text`` to the configured Telegram chat.
+
+    The message is only sent when both ``TELEGRAM_BOT_TOKEN`` and
+    ``TELEGRAM_CHAT_ID`` environment variables are present.  Failure to send
+    the message is deliberately ignored so that logging remains best-effort.
+    """
+
+    token: Optional[str] = os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id: Optional[str] = os.getenv("TELEGRAM_CHAT_ID")
+
+    if not token or not chat_id:
+        return
+
+    try:
+        requests.get(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            params={"chat_id": chat_id, "text": text},
+            timeout=5,
+        )
+    except Exception:
+        # Errors here should not disrupt the application flow; logging failures
+        # are ignored.
+        pass
+
+
+class TelegramLogHandler(logging.Handler):
+    """A logging handler that forwards records to Telegram."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - thin wrapper
+        try:
+            message = self.format(record)
+            send_message(message)
+        except Exception:
+            # ``logging`` will invoke ``handleError`` which respects the module's
+            # ``raiseExceptions`` flag. We rely on that behaviour rather than
+            # emitting anything ourselves to avoid recursive logging.
+            self.handleError(record)
+


### PR DESCRIPTION
## Summary
- forward backend error logs to Telegram via bot
- add helper and logging handler using TELEGRAM_BOT_TOKEN/CHAT_ID env vars

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896f57e5eb883279bf0823941c6be68