### PR TITLE
Restrict uvicorn reload scope to backend folder

### DIFF
--- a/run-backend.ps1
+++ b/run-backend.ps1
@@ -40,4 +40,4 @@ $env:ALLOTMINT_ENV = 'local'
 
 # run
 Write-Host "Starting AllotMint Local API on http://localhost:$Port ..." -ForegroundColor Green
-python -m uvicorn backend.local_api.main:app --reload --port $Port --log-config backend/logging.ini --app-dir .
+python -m uvicorn backend.local_api.main:app --reload --reload-dir backend --port $Port --log-config backend/logging.ini --app-dir .

--- a/run-local-api.sh
+++ b/run-local-api.sh
@@ -8,5 +8,6 @@ cd "$SCRIPT_DIR"
 export ALLOTMINT_ENV=local
 uvicorn backend.local_api.main:app \
   --reload \
+  --reload-dir backend \
   --port 8000 \
   --log-config backend/logging.ini


### PR DESCRIPTION
## Summary
- avoid reload loops triggered by log file writes by limiting uvicorn's watch scope to the backend source directory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896f845473883278c38b502ccd6237e