### PR TITLE
Improve Alpha Vantage error handling

### DIFF
--- a/backend/timeseries/fetch_alphavantage_timeseries.py
+++ b/backend/timeseries/fetch_alphavantage_timeseries.py
@@ -53,7 +53,14 @@ def fetch_alphavantage_timeseries_range(
         response.raise_for_status()
         data = response.json()
         if "Time Series (Daily)" not in data:
-            message = data.get("Note") or data.get("Error Message") or "Unexpected response"
+            message = (
+                data.get("Note")
+                or data.get("Error Message")
+                or data.get("Information")
+                or data.get("Message")
+                or "Unexpected response"
+            )
+            logger.debug("Alpha Vantage raw response for %s: %s", symbol, data)
             raise ValueError(message)
 
         ts = data["Time Series (Daily)"]

--- a/tests/test_alphavantage_errors.py
+++ b/tests/test_alphavantage_errors.py
@@ -1,0 +1,33 @@
+import pytest
+from datetime import date
+
+from backend.timeseries.fetch_alphavantage_timeseries import (
+    fetch_alphavantage_timeseries_range,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+def test_information_field_propagated(monkeypatch):
+    def fake_get(url, params=None, timeout=None):
+        return FakeResponse({"Information": "test info"})
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    with pytest.raises(ValueError) as exc:
+        fetch_alphavantage_timeseries_range(
+            "PBR", "US", date(2024, 1, 1), date(2024, 1, 10), api_key="demo"
+        )
+
+    assert str(exc.value) == "test info"


### PR DESCRIPTION
## Summary
- Handle Alpha Vantage responses that include informational messages
- Log raw API responses when expected data is missing
- Test propagation of informational messages from Alpha Vantage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896f88107cc832792e27a0a47602008