### PR TITLE
style: improve compliance warning readability

### DIFF
--- a/frontend/src/components/ComplianceWarnings.tsx
+++ b/frontend/src/components/ComplianceWarnings.tsx
@@ -41,6 +41,7 @@ export function ComplianceWarnings({ owners }: Props) {
     <div style={{
       background: "#fff4e5",
       border: "1px solid #f0ad4e",
+      color: "#333",
       padding: "0.5rem 1rem",
       marginBottom: "1rem",
     }}>


### PR DESCRIPTION
## Summary
- add explicit text color to compliance warnings to override global white font

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: React Hook "useState" is called conditionally in frontend/src/components/HoldingsTable.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6896f486b62c8327a5c1d7cfda514dbd