### PR TITLE
Hide compliance box when there are no warnings

### DIFF
--- a/frontend/src/components/ComplianceWarnings.test.tsx
+++ b/frontend/src/components/ComplianceWarnings.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, type Mock } from "vitest";
+import { ComplianceWarnings } from "./ComplianceWarnings";
+import { getCompliance } from "../api";
+
+vi.mock("../api", () => ({
+    getCompliance: vi.fn(),
+}));
+
+describe("ComplianceWarnings", () => {
+    it("does not render when there are no warnings", async () => {
+        const mock = getCompliance as unknown as Mock;
+        mock.mockResolvedValue({ warnings: [] });
+
+        render(<ComplianceWarnings owners={["alice"]} />);
+
+        await waitFor(() => {
+            expect(mock).toHaveBeenCalled();
+        });
+
+        expect(screen.queryByText("alice")).not.toBeInTheDocument();
+    });
+
+    it("renders warnings when present", async () => {
+        const mock = getCompliance as unknown as Mock;
+        mock.mockResolvedValue({ warnings: ["Issue"] });
+
+        render(<ComplianceWarnings owners={["alice"]} />);
+
+        await screen.findByText("Issue");
+    });
+});

--- a/frontend/src/components/ComplianceWarnings.tsx
+++ b/frontend/src/components/ComplianceWarnings.tsx
@@ -37,28 +37,28 @@ export function ComplianceWarnings({ owners }: Props) {
 
   if (!owners.length) return null;
 
+  const ownersWithWarnings = owners.filter((o) => (data[o] ?? []).length);
+
+  if (!ownersWithWarnings.length) return null;
+
   return (
-    <div style={{
-      background: "#fff4e5",
-      border: "1px solid #f0ad4e",
-      color: "#333",
-      padding: "0.5rem 1rem",
-      marginBottom: "1rem",
-    }}>
-      {owners.map((o) => (
+    <div
+      style={{
+        background: "#fff4e5",
+        border: "1px solid #f0ad4e",
+        color: "#333",
+        padding: "0.5rem 1rem",
+        marginBottom: "1rem",
+      }}
+    >
+      {ownersWithWarnings.map((o) => (
         <div key={o} style={{ marginBottom: "0.5rem" }}>
           <strong>{o}</strong>
-          {data[o] && data[o].length ? (
-            <ul style={{ margin: "0.25rem 0 0 1.25rem" }}>
-              {data[o].map((w, i) => (
-                <li key={i}>{w}</li>
-              ))}
-            </ul>
-          ) : (
-            <div style={{ marginLeft: "0.5rem", display: "inline" }}>
-              No compliance issues
-            </div>
-          )}
+          <ul style={{ margin: "0.25rem 0 0 1.25rem" }}>
+            {data[o].map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- render compliance warning box only when any owner has warnings
- add tests confirming box stays hidden when no warnings

## Testing
- `npm --prefix frontend test -- --run`
- `pytest`
- `npm --prefix frontend run lint` *(fails: React Hook "useState" is called conditionally)*

------
https://chatgpt.com/codex/tasks/task_e_6896fbbbe7c88327875a47f3af1385ad