### PR TITLE
Fix ticker hyperlink in instrument table

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -43,7 +43,8 @@ describe("HoldingsTable", () => {
         expect(screen.getByText(/Gain %/)).toBeInTheDocument();
         expect(screen.getByText("Test Holding")).toBeInTheDocument();
         expect(screen.getByText("GBP")).toBeInTheDocument();
-        expect(screen.getByText("5")).toBeInTheDocument();
+        const firstRow = screen.getByText("AAA").closest("tr");
+        expect(within(firstRow!).getByText("5")).toBeInTheDocument();
     });
 
     it("shows days to go if not eligible", () => {
@@ -59,7 +60,7 @@ describe("HoldingsTable", () => {
         let rows = screen.getAllByRole("row");
         expect(within(rows[1]).getByText("AAA")).toBeInTheDocument();
 
-        fireEvent.click(screen.getByText(/^Ticker/));
+        fireEvent.click(screen.getAllByText(/^Ticker/)[1]);
         rows = screen.getAllByRole("row");
         expect(within(rows[1]).getByText("XYZ")).toBeInTheDocument();
     });

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -119,11 +119,19 @@ export function InstrumentTable({ rows }: Props) {
                             r.gain_gbp >= 0 ? "lightgreen" : "red";
 
                         return (
-                            <tr
-                                key={r.ticker}
-                                onClick={() => setSelected(r)}
-                            >
-                                <td style={cell}>{r.ticker}</td>
+                            <tr key={r.ticker}>
+                                <td style={cell}>
+                                    <a
+                                        href="#"
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            setSelected(r);
+                                        }}
+                                        style={{ color: "dodgerblue", textDecoration: "underline" }}
+                                    >
+                                        {r.ticker}
+                                    </a>
+                                </td>
                                 <td style={cell}>{r.name}</td>
                                 <td style={cell}>{r.currency ?? "—"}</td>
                                 <td style={cell}>{r.instrument_type ?? "—"}</td>


### PR DESCRIPTION
## Summary
- make ticker column in instrument table a real hyperlink opening the instrument detail panel
- stabilize holdings table tests to handle repeated values

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689702a3e0bc8327b8fe1b2cda26b1aa