### PR TITLE
feat: add configurable timeseries ranges

### DIFF
--- a/backend/routes/timeseries_meta.py
+++ b/backend/routes/timeseries_meta.py
@@ -18,11 +18,14 @@ router = APIRouter(prefix="/timeseries", tags=["timeseries"])
 async def get_meta_timeseries(
     ticker: str = Query(...),
     exchange: str = Query("L"),
-    days: int = Query(365, ge=30, le=3650),
+    days: int = Query(365, ge=0, le=36500),
     format: str = Query("html", pattern="^(html|json|csv)$"),
     scaling: float = Query(1.0, ge=0.00001, le=1_000_000),
 ):
-    start_date = date.today() - timedelta(days=days)
+    if days <= 0:
+        start_date = date(1900, 1, 1)
+    else:
+        start_date = date.today() - timedelta(days=days)
     end_date = date.today() - timedelta(days=1)
 
     try:

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -56,15 +56,16 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
   const [err, setErr] = useState<string | null>(null);
   const [currency, setCurrency] = useState<string | null>(null);
   const [showBollinger, setShowBollinger] = useState(false);
+  const [days, setDays] = useState<number>(365);
 
   useEffect(() => {
-    getInstrumentDetail(ticker)
+    getInstrumentDetail(ticker, days)
       .then((d) => {
         setData(d as { prices: Price[]; positions: Position[]; currency?: string | null });
         setCurrency((d as any).currency ?? null);
       })
       .catch((e: Error) => setErr(e.message));
-  }, [ticker]);
+  }, [ticker, days]);
 
   if (err) return <p style={{ color: "red" }}>{err}</p>;
   if (!data) return <p>Loading…</p>;
@@ -125,6 +126,20 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
 
       {/* Chart */}
       <div style={{ marginBottom: "0.5rem" }}>
+        <label style={{ fontSize: "0.85rem", marginRight: "1rem" }}>
+          Range:
+          <select
+            value={days}
+            onChange={(e) => setDays(Number(e.target.value))}
+            style={{ marginLeft: "0.25rem" }}
+          >
+            <option value={7}>1W</option>
+            <option value={30}>1M</option>
+            <option value={365}>1Y</option>
+            <option value={3650}>10Y</option>
+            <option value={0}>MAX</option>
+          </select>
+        </label>
         <label style={{ fontSize: "0.85rem" }}>
           <input
             type="checkbox"

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -10,15 +10,17 @@ type Props = {
 export function PerformanceDashboard({ owner }: Props) {
   const [data, setData] = useState<PerformancePoint[]>([]);
   const [err, setErr] = useState<string | null>(null);
+  const [days, setDays] = useState<number>(365);
 
   useEffect(() => {
     if (!owner) return;
     setErr(null);
     setData([]);
-    getPerformance(owner)
+    const reqDays = days === 0 ? 36500 : days;
+    getPerformance(owner, reqDays)
       .then(setData)
       .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
-  }, [owner]);
+  }, [owner, days]);
 
   if (!owner) return <p>Select a member.</p>;
   if (err) return <p style={{ color: "red" }}>{err}</p>;
@@ -26,6 +28,22 @@ export function PerformanceDashboard({ owner }: Props) {
 
   return (
     <div style={{ marginTop: "1rem" }}>
+      <div style={{ marginBottom: "0.5rem" }}>
+        <label style={{ fontSize: "0.85rem" }}>
+          Range:
+          <select
+            value={days}
+            onChange={(e) => setDays(Number(e.target.value))}
+            style={{ marginLeft: "0.25rem" }}
+          >
+            <option value={7}>1W</option>
+            <option value={30}>1M</option>
+            <option value={365}>1Y</option>
+            <option value={3650}>10Y</option>
+            <option value={0}>MAX</option>
+          </select>
+        </label>
+      </div>
       <h2>Portfolio Value</h2>
       <ResponsiveContainer width="100%" height={240}>
         <LineChart data={data}>


### PR DESCRIPTION
## Summary
- allow instrument and timeseries endpoints to fetch variable ranges, including full history
- add date range selector to instrument and performance charts with 1W/1M/1Y/10Y/max options

## Testing
- `npm --prefix frontend test` *(fails: Found multiple elements with the text: 5)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68970263811c83278ea6555891b45235