### PR TITLE
guard code review workflow for missing api key

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   code_review:
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- avoid failing the Code Review workflow when no `OPENAI_API_KEY` secret is configured

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68970e5e39108327902951c881e31f5a