### PR TITLE
Improve screener route error handling

### DIFF
--- a/backend/routes/screener.py
+++ b/backend/routes/screener.py
@@ -22,6 +22,9 @@ async def screener(
     """Return tickers that meet the supplied screening criteria."""
 
     symbols = [t.strip().upper() for t in tickers.split(",") if t.strip()]
+    if not symbols:
+        raise HTTPException(status_code=400, detail="No tickers supplied")
+
     try:
         return screen(
             symbols,
@@ -30,5 +33,7 @@ async def screener(
             de_max=de_max,
             fcf_min=fcf_min,
         )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except RuntimeError as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e


### PR DESCRIPTION
## Summary
- ensure `/screener` route validates tickers input and parses comma-separated symbols
- map ValueError to HTTP 400 and runtime errors to HTTP 500

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689711972100832799838c15b455fb6f