### PR TITLE
fix: handle Python date comparison in meta timeseries

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -144,7 +144,11 @@ def fetch_meta_timeseries(
         return pd.DataFrame(columns=STANDARD_COLUMNS)
 
     df = _merge(data)
-    df = df[df["Date"] <= pd.to_datetime(end_date)]
+    # Ensure we compare like-for-like datatypes. Some sources (e.g. FT) may
+    # return plain ``datetime.date`` objects which cannot be directly
+    # compared against ``pd.Timestamp``. Convert the column on the fly to
+    # Timestamp before applying the end-date filter.
+    df = df[pd.to_datetime(df["Date"]) <= pd.to_datetime(end_date)]
     return df
 
 

--- a/tests/test_meta_timeseries_date_filter.py
+++ b/tests/test_meta_timeseries_date_filter.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from datetime import date
+
+from backend.timeseries import fetch_meta_timeseries
+
+
+def test_fetch_meta_timeseries_handles_python_dates(monkeypatch):
+    """fetch_meta_timeseries should handle date objects without TypeError."""
+    # Make all primary sources return empty to force FT fallback
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_yahoo_timeseries_range", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_stooq_timeseries_range", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_alphavantage_timeseries_range", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(fetch_meta_timeseries, "_is_isin", lambda ticker: False)
+
+    def fake_ft(ticker, days):
+        return pd.DataFrame(
+            {
+                "Date": [date(2024, 1, 1), date(2024, 1, 3)],
+                "Open": [1.0, 1.0],
+                "High": [1.0, 1.0],
+                "Low": [1.0, 1.0],
+                "Close": [1.0, 1.0],
+                "Volume": [0, 0],
+                "Ticker": [ticker, ticker],
+                "Source": ["FT", "FT"],
+            }
+        )
+
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_ft_timeseries", fake_ft)
+
+    df = fetch_meta_timeseries.fetch_meta_timeseries(
+        "ABC", "L", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2)
+    )
+
+    assert not df.empty
+    assert pd.to_datetime(df["Date"]).max() <= pd.Timestamp(date(2024, 1, 2))


### PR DESCRIPTION
## Summary
- prevent TypeError when filtering meta timeseries with plain `datetime.date` values
- add regression test covering FT fallback date filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897164065888327b0304def14067996