### PR TITLE
Add screener unit tests and frontend coverage

### DIFF
--- a/frontend/src/components/ScreenerPage.test.tsx
+++ b/frontend/src/components/ScreenerPage.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../api", () => ({
+  getScreener: vi.fn().mockResolvedValue([
+    { ticker: "AAA", name: "Alpha", peg_ratio: 1, pe_ratio: 10, de_ratio: 0.5, fcf: 1000 },
+  ]),
+}));
+
+import { ScreenerPage } from "./ScreenerPage";
+
+describe("ScreenerPage", () => {
+  it("renders screener results", async () => {
+    render(<ScreenerPage />);
+    expect(await screen.findByText("AAA")).toBeInTheDocument();
+  });
+});

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -198,3 +198,19 @@ def test_alerts_endpoint():
 #     elif format == "html":
 #         html = resp.text.lower()
 #         assert "<table" in html and "ft time series" in html
+
+def test_screener_endpoint(monkeypatch):
+    from backend.screener import Fundamentals
+
+    def mock_fetch(ticker: str) -> Fundamentals:
+        if ticker == "AAA":
+            return Fundamentals(ticker="AAA", peg_ratio=0.5)
+        return Fundamentals(ticker="BBB", peg_ratio=2.0)
+
+    monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
+
+    resp = client.get("/screener?tickers=AAA,BBB&peg_max=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["ticker"] == "AAA"

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,0 +1,48 @@
+import pytest
+from backend.screener import fetch_fundamentals, screen, Fundamentals
+
+
+def test_fetch_fundamentals_parses_values(monkeypatch):
+    sample = {
+        "Name": "Foo Corp",
+        "PEG": "1.5",
+        "PERatio": "10.2",
+        "DebtToEquityTTM": "0.5",
+        "FreeCashFlowTTM": "1234",
+    }
+
+    class MockResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return sample
+
+    def mock_get(url, params, timeout):
+        assert params["function"] == "OVERVIEW"
+        assert params["symbol"] == "aapl"
+        return MockResp()
+
+    monkeypatch.setenv("ALPHAVANTAGE_API_KEY", "demo")
+    monkeypatch.setattr("backend.screener.ALPHA_VANTAGE_KEY", "demo")
+    monkeypatch.setattr("backend.screener.requests.get", mock_get)
+
+    f = fetch_fundamentals("aapl")
+    assert f.ticker == "AAPL"
+    assert f.name == "Foo Corp"
+    assert f.peg_ratio == 1.5
+    assert f.pe_ratio == 10.2
+    assert f.de_ratio == 0.5
+    assert f.fcf == 1234.0
+
+
+def test_screen_filters_based_on_thresholds(monkeypatch):
+    def mock_fetch(ticker):
+        if ticker == "AAA":
+            return Fundamentals(ticker="AAA", peg_ratio=0.5, pe_ratio=10, de_ratio=0.5, fcf=1000)
+        return Fundamentals(ticker="BBB", peg_ratio=2.0, pe_ratio=15, de_ratio=1.5, fcf=500)
+
+    monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
+
+    results = screen(["AAA", "BBB"], peg_max=1.0, pe_max=20, de_max=1.0, fcf_min=800)
+    assert [r.ticker for r in results] == ["AAA"]


### PR DESCRIPTION
## Summary
- add backend screener unit tests with mocked Alpha Vantage data
- cover screener API endpoint via integration test
- ensure ScreenerPage renders fetched results in UI

## Testing
- `pytest`
- `cd frontend && CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_689711a10df08327a93da5ad9f488c4a