### PR TITLE
fix: replace broken instrument links

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -117,21 +117,28 @@ export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
 
       <tbody>
         {sorted.map((h) => {
-          const handleClick = (e: React.MouseEvent) => {
-            e.preventDefault();
+          const handleClick = () => {
             onSelectInstrument?.(h.ticker, h.name ?? h.ticker);
           };
 
           return (
             <tr key={h.ticker + h.acquired_date}>
               <td style={cell}>
-                <a
-                  href="#"
+                <button
+                  type="button"
                   onClick={handleClick}
-                  style={{ color: "dodgerblue", textDecoration: "underline" }}
+                  style={{
+                    color: "dodgerblue",
+                    textDecoration: "underline",
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    font: "inherit",
+                    cursor: "pointer",
+                  }}
                 >
                   {h.ticker}
-                </a>
+                </button>
               </td>
               <td style={cell}>{h.name}</td>
               <td style={cell}>{h.currency ?? "—"}</td>

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -121,16 +121,21 @@ export function InstrumentTable({ rows }: Props) {
                         return (
                             <tr key={r.ticker}>
                                 <td style={cell}>
-                                    <a
-                                        href="#"
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            setSelected(r);
+                                    <button
+                                        type="button"
+                                        onClick={() => setSelected(r)}
+                                        style={{
+                                            color: "dodgerblue",
+                                            textDecoration: "underline",
+                                            background: "none",
+                                            border: "none",
+                                            padding: 0,
+                                            font: "inherit",
+                                            cursor: "pointer",
                                         }}
-                                        style={{ color: "dodgerblue", textDecoration: "underline" }}
                                     >
                                         {r.ticker}
-                                    </a>
+                                    </button>
                                 </td>
                                 <td style={cell}>{r.name}</td>
                                 <td style={cell}>{r.currency ?? "—"}</td>


### PR DESCRIPTION
## Summary
- replace placeholder anchor tags for instruments with button elements
- ensure holdings list uses buttons to open instrument details

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689718fe47408327b42d63c0d4dbb14d