### PR TITLE
feat: centralize select controls with reusable component

### DIFF
--- a/frontend/src/components/GroupSelector.tsx
+++ b/frontend/src/components/GroupSelector.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { GroupSummary } from "../types";
+import { Selector } from "./Selector";
 
 type Props = {
   groups: GroupSummary[];
@@ -16,18 +17,11 @@ export function GroupSelector({ groups, selected, onSelect }: Props) {
   }, [selected, groups, onSelect]);
 
   return (
-    <div style={{ marginBottom: "1rem" }}>
-      <label style={{ marginRight: "0.5rem" }}>Group:</label>
-      <select
-        value={selected}
-        onChange={(e) => onSelect(e.target.value)}
-      >
-        {groups.map((g) => (
-          <option key={g.slug} value={g.slug}>
-            {g.name}
-          </option>
-        ))}
-      </select>
-    </div>
+    <Selector
+      label="Group"
+      value={selected}
+      onChange={onSelect}
+      options={groups.map((g) => ({ value: g.slug, label: g.name }))}
+    />
   );
 }

--- a/frontend/src/components/OwnerSelector.tsx
+++ b/frontend/src/components/OwnerSelector.tsx
@@ -1,23 +1,20 @@
-import type {OwnerSummary} from "../types";
+import type { OwnerSummary } from "../types";
+import { Selector } from "./Selector";
 
 type Props = {
-    owners: OwnerSummary[];
-    selected: string;
-    onSelect: (owner: string) => void;
+  owners: OwnerSummary[];
+  selected: string;
+  onSelect: (owner: string) => void;
 };
 
-export function OwnerSelector({owners, selected, onSelect}: Props) {
-    return (
-        <div style={{marginBottom: "1rem"}}>
-            <label style={{marginRight: "0.5rem"}}>Owner:</label>
-            <select value={selected} onChange={(e) => onSelect(e.target.value)}>
-                {owners.map((o) => (
-                    <option key={o.owner} value={o.owner}>
-                        {o.owner}
-                    </option>
-                ))}
-            </select>
-        </div>
-    );
+export function OwnerSelector({ owners, selected, onSelect }: Props) {
+  return (
+    <Selector
+      label="Owner"
+      value={selected}
+      onChange={onSelect}
+      options={owners.map((o) => ({ value: o.owner, label: o.owner }))}
+    />
+  );
 }
 

--- a/frontend/src/components/Selector.tsx
+++ b/frontend/src/components/Selector.tsx
@@ -1,0 +1,42 @@
+import type { CSSProperties } from "react";
+
+type Option = {
+  value: string;
+  label: string;
+};
+
+type Props = {
+  label: string;
+  options: Option[];
+  value: string;
+  onChange: (value: string) => void;
+  style?: CSSProperties;
+};
+
+export function Selector({ label, options, value, onChange, style }: Props) {
+  return (
+    <label
+      style={{
+        display: "inline-block",
+        marginRight: "0.5rem",
+        marginBottom: "1rem",
+        ...style,
+      }}
+    >
+      {label}:
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ marginLeft: "0.5rem" }}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export type { Option };

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { OwnerSummary, Transaction } from "../types";
 import { getTransactions } from "../api";
+import { Selector } from "./Selector";
 
 type Props = {
   owners: OwnerSummary[];
@@ -41,28 +42,24 @@ export function TransactionsPage({ owners }: Props) {
   return (
     <div>
       <div style={{ marginBottom: "1rem" }}>
-        <label>
-          Owner:
-          <select value={owner} onChange={(e) => setOwner(e.target.value)}>
-            <option value="">All</option>
-            {owners.map((o) => (
-              <option key={o.owner} value={o.owner}>
-                {o.owner}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label style={{ marginLeft: "0.5rem" }}>
-          Account:
-          <select value={account} onChange={(e) => setAccount(e.target.value)}>
-            <option value="">All</option>
-            {accountOptions.map((a) => (
-              <option key={a} value={a}>
-                {a}
-              </option>
-            ))}
-          </select>
-        </label>
+        <Selector
+          label="Owner"
+          value={owner}
+          onChange={setOwner}
+          options={[
+            { value: "", label: "All" },
+            ...owners.map((o) => ({ value: o.owner, label: o.owner })),
+          ]}
+        />
+        <Selector
+          label="Account"
+          value={account}
+          onChange={setAccount}
+          options={[
+            { value: "", label: "All" },
+            ...accountOptions.map((a) => ({ value: a, label: a })),
+          ]}
+        />
         <label style={{ marginLeft: "0.5rem" }}>
           Start: <input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
         </label>


### PR DESCRIPTION
## Summary
- add `Selector` component for labeled selects with shared spacing styles
- refactor group, owner, and transaction filters to use `Selector`

## Testing
- `cd frontend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_6897187d631c8327a04029f58fd765c1