### PR TITLE
feat: centralize currency and percentage formatting

### DIFF
--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -6,17 +6,7 @@ import { useState } from "react";
 import type { Account } from "../types";
 import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
-
-/* ──────────────────────────────────────────────────────────────
- * Helpers
- * ────────────────────────────────────────────────────────────── */
-const formatGBP = (n: number | undefined) =>
-  (n ?? 0).toLocaleString(undefined, {
-    style: "currency",
-    currency: "GBP",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
+import { money } from "../lib/money";
 
 /* ──────────────────────────────────────────────────────────────
  * Component
@@ -43,7 +33,7 @@ export function AccountBlock({ account }: Props) {
       </h2>
 
       <div style={{ marginBottom: "0.5rem" }}>
-        Est&nbsp;Value:&nbsp;{formatGBP(account.value_estimate_gbp)}
+        Est&nbsp;Value:&nbsp;{money(account.value_estimate_gbp)}
       </div>
 
       {account.last_updated && (

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -3,21 +3,7 @@ import { useEffect, useState } from "react";
 import type { GroupPortfolio } from "../types";
 import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
-
-/* ────────────────────────────────────────────────────────────
- * Small helpers
- * ────────────────────────────────────────────────────────── */
-const fmt = (
-  n?: number | null,
-  opt?: Intl.NumberFormatOptions,
-  dash: string = "—"
-) =>
-  typeof n === "number" && !Number.isNaN(n)
-    ? n.toLocaleString("en-GB", opt)
-    : dash;
-
-const fmtGBP = (n?: number | null) => `£${fmt(n, { maximumFractionDigits: 2 })}`;
-const fmtPct = (n?: number | null) => `${fmt(n, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%`;
+import { money, percent } from "../lib/money";
 
 type SelectedInstrument = {
   ticker: string;
@@ -134,7 +120,7 @@ export function GroupPortfolioView({ slug }: Props) {
       >
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Total Value</div>
-          <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>{fmtGBP(totalValue)}</div>
+          <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>{money(totalValue)}</div>
         </div>
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Day Change</div>
@@ -145,7 +131,7 @@ export function GroupPortfolioView({ slug }: Props) {
               color: totalDayChange >= 0 ? "lightgreen" : "red",
             }}
           >
-            {fmtGBP(totalDayChange)} ({fmtPct(totalDayChangePct)})
+            {money(totalDayChange)} ({percent(totalDayChangePct)})
           </div>
         </div>
         <div>
@@ -157,7 +143,7 @@ export function GroupPortfolioView({ slug }: Props) {
               color: totalGain >= 0 ? "lightgreen" : "red",
             }}
           >
-            {fmtGBP(totalGain)} ({fmtPct(totalGainPct)})
+            {money(totalGain)} ({percent(totalGainPct)})
           </div>
         </div>
       </div>
@@ -184,14 +170,14 @@ export function GroupPortfolioView({ slug }: Props) {
           {ownerRows.map((row) => (
             <tr key={row.owner}>
               <td>{row.owner}</td>
-              <td style={{ textAlign: "right" }}>{fmtGBP(row.value)}</td>
+              <td style={{ textAlign: "right" }}>{money(row.value)}</td>
               <td
                 style={{
                   textAlign: "right",
                   color: row.dayChange >= 0 ? "lightgreen" : "red",
                 }}
               >
-                {fmtGBP(row.dayChange)}
+                {money(row.dayChange)}
               </td>
               <td
                 style={{
@@ -199,7 +185,7 @@ export function GroupPortfolioView({ slug }: Props) {
                   color: row.dayChange >= 0 ? "lightgreen" : "red",
                 }}
               >
-                {fmtPct(row.dayChangePct)}
+                {percent(row.dayChangePct)}
               </td>
               <td
                 style={{
@@ -207,7 +193,7 @@ export function GroupPortfolioView({ slug }: Props) {
                   color: row.gain >= 0 ? "lightgreen" : "red",
                 }}
               >
-                {fmtGBP(row.gain)}
+                {money(row.gain)}
               </td>
               <td
                 style={{
@@ -215,7 +201,7 @@ export function GroupPortfolioView({ slug }: Props) {
                   color: row.gain >= 0 ? "lightgreen" : "red",
                 }}
               >
-                {fmtPct(row.gainPct)}
+                {percent(row.gainPct)}
               </td>
             </tr>
           ))}
@@ -229,7 +215,7 @@ export function GroupPortfolioView({ slug }: Props) {
           style={{ marginBottom: "1.5rem" }}
         >
           <h3>
-            {acct.owner ?? "—"} • {acct.account_type} — {fmtGBP(acct.value_estimate_gbp)}
+            {acct.owner ?? "—"} • {acct.account_type} — {money(acct.value_estimate_gbp)}
           </h3>
 
           <HoldingsTable

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -9,6 +9,7 @@ import {
   YAxis,
 } from "recharts";
 import { getInstrumentDetail } from "../api";
+import { money, percent } from "../lib/money";
 
 type Props = {
   ticker: string;
@@ -41,15 +42,6 @@ const fixed = (v: unknown, dp = 2): string => {
   return Number.isFinite(n) ? n.toFixed(dp) : "—";
 };
 
-const money = (v: unknown): string => {
-  const n = toNum(v);
-  return Number.isFinite(n)
-    ? `£${n.toLocaleString("en-GB", {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })}`
-    : "—";
-};
 
 export function InstrumentDetail({ ticker, name, onClose }: Props) {
   const [data, setData] = useState<{ prices: Price[]; positions: Position[]; currency?: string | null } | null>(null);
@@ -226,13 +218,10 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
               <td
                 align="right"
                 style={{
-                  color:
-                    toNum(pos.gain_pct) >= 0 ? "lightgreen" : "red",
+                  color: toNum(pos.gain_pct) >= 0 ? "lightgreen" : "red",
                 }}
               >
-                {Number.isFinite(toNum(pos.gain_pct))
-                  ? `${toNum(pos.gain_pct).toFixed(1)}%`
-                  : "—"}
+                {percent(pos.gain_pct, 1)}
               </td>
             </tr>
           ))}
@@ -281,11 +270,9 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
                     {fixed(p.change_gbp, 2)}
                   </td>
                   <td align="right" style={{ color: colour }}>
-                    {Number.isFinite(p.change_pct)
-                      ? `${fixed(p.change_pct, 2)}%`
-                      : "—"}
+                    {percent(p.change_pct, 2)}
                   </td>
-                </tr>
+              </tr>
               );
             })}
           {!prices.length && (

--- a/frontend/src/lib/money.ts
+++ b/frontend/src/lib/money.ts
@@ -1,7 +1,23 @@
-export const money = (v: number | null | undefined): string => {
+export const money = (
+    v: number | null | undefined,
+    currency = "GBP",
+): string => {
     if (typeof v !== "number" || !Number.isFinite(v)) return "—";
-    return `£${v.toLocaleString("en-GB", {
+    return v.toLocaleString("en-GB", {
+        style: "currency",
+        currency,
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
-    })}`;
+    });
+};
+
+export const percent = (
+    v: number | null | undefined,
+    fractionDigits = 2,
+): string => {
+    if (typeof v !== "number" || !Number.isFinite(v)) return "—";
+    return `${v.toLocaleString("en-GB", {
+        minimumFractionDigits: fractionDigits,
+        maximumFractionDigits: fractionDigits,
+    })}%`;
 };


### PR DESCRIPTION
## Summary
- add shared `money` and `percent` helpers for GBP and percent formatting
- refactor AccountBlock, InstrumentDetail and GroupPortfolioView to use shared formatters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68971878446483278337ffc6444c670f