### PR TITLE
refactor: remove redundant currency fields

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -17,7 +17,6 @@ export interface Holding {
     gain_pct?: number;
     current_price_gbp?: number | null;
     day_change_gbp?: number;
-    currency?: string;
     instrument_type?: string | null;
 
     days_held?: number;
@@ -74,7 +73,6 @@ export type InstrumentSummary = {
     units: number;
     market_value_gbp: number;
     gain_gbp: number;
-    currency?: string;
     instrument_type?: string | null;
     gain_pct?: number;
 


### PR DESCRIPTION
## Summary
- streamline Holding and InstrumentSummary types by removing duplicated `currency` fields

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_689718768f7c8327a5997f48bd99e19e