### PR TITLE
feat: add sortable table hook

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import type React from "react";
 import type { Holding } from "../types";
 import { money } from "../lib/money";
+import { useSortableTable } from "../hooks/useSortableTable";
 
 type SortKey = "ticker" | "name" | "cost" | "gain" | "gain_pct" | "days_held";
 
@@ -10,22 +11,8 @@ type Props = {
 };
 
 export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
-  const [sortKey, setSortKey] = useState<SortKey>("ticker");
-  const [asc, setAsc] = useState(true);
-
-  if (!holdings.length) return null;
-
   const cell = { padding: "4px 6px" } as const;
   const right = { ...cell, textAlign: "right" } as const;
-
-  function handleSort(key: SortKey) {
-    if (sortKey === key) {
-      setAsc(!asc);
-    } else {
-      setSortKey(key);
-      setAsc(true);
-    }
-  }
 
   const rows = holdings.map((h) => {
     const cost =
@@ -49,16 +36,9 @@ export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
     return { ...h, cost, market, gain, gain_pct };
   });
 
-  const sorted = [...rows].sort((a, b) => {
-    const va = a[sortKey as keyof typeof a];
-    const vb = b[sortKey as keyof typeof b];
-    if (typeof va === "string" && typeof vb === "string") {
-      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
-    }
-    const na = (va as number) ?? 0;
-    const nb = (vb as number) ?? 0;
-    return asc ? na - nb : nb - na;
-  });
+  const { sorted, sortKey, asc, handleSort } = useSortableTable(rows, "ticker");
+
+  if (!rows.length) return null;
 
   return (
     <table

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { InstrumentSummary } from "../types";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { money } from "../lib/money";
+import { useSortableTable } from "../hooks/useSortableTable";
 
 type SortKey = "ticker" | "name" | "cost" | "gain" | "gain_pct";
 
@@ -11,26 +12,6 @@ type Props = {
 
 export function InstrumentTable({ rows }: Props) {
     const [selected, setSelected] = useState<InstrumentSummary | null>(null);
-    const [sortKey, setSortKey] = useState<SortKey>("ticker");
-    const [asc, setAsc] = useState(true);
-
-    /* no data? – render a clear message instead of an empty table */
-    if (!rows.length) {
-        return <p>No instruments found for this group.</p>;
-    }
-
-    /* simple cell styles */
-    const cell = { padding: "4px 6px" } as const;
-    const right = { ...cell, textAlign: "right" } as const;
-
-    function handleSort(key: SortKey) {
-        if (sortKey === key) {
-            setAsc(!asc);
-        } else {
-            setSortKey(key);
-            setAsc(true);
-        }
-    }
 
     const rowsWithCost = rows.map((r) => {
         const cost = r.market_value_gbp - r.gain_gbp;
@@ -43,16 +24,16 @@ export function InstrumentTable({ rows }: Props) {
         return { ...r, cost, gain_pct };
     });
 
-    const sorted = [...rowsWithCost].sort((a, b) => {
-        const va = a[sortKey as keyof typeof a];
-        const vb = b[sortKey as keyof typeof b];
-        if (typeof va === "string" && typeof vb === "string") {
-            return asc ? va.localeCompare(vb) : vb.localeCompare(va);
-        }
-        const na = (va as number) ?? 0;
-        const nb = (vb as number) ?? 0;
-        return asc ? na - nb : nb - na;
-    });
+    const { sorted, sortKey, asc, handleSort } = useSortableTable(rowsWithCost, "ticker");
+
+    /* no data? – render a clear message instead of an empty table */
+    if (!rowsWithCost.length) {
+        return <p>No instruments found for this group.</p>;
+    }
+
+    /* simple cell styles */
+    const cell = { padding: "4px 6px" } as const;
+    const right = { ...cell, textAlign: "right" } as const;
 
     return (
         <>

--- a/frontend/src/components/ScreenerPage.tsx
+++ b/frontend/src/components/ScreenerPage.tsx
@@ -2,40 +2,19 @@ import { useEffect, useState } from "react";
 import { getScreener } from "../api";
 import type { ScreenerResult } from "../types";
 import { InstrumentDetail } from "./InstrumentDetail";
+import { useSortableTable } from "../hooks/useSortableTable";
 
 const WATCHLIST = ["AAPL", "MSFT", "GOOG", "AMZN", "TSLA"];
 
-type SortKey = "ticker" | "peg_ratio" | "pe_ratio" | "de_ratio" | "fcf";
-
 export function ScreenerPage() {
   const [rows, setRows] = useState<ScreenerResult[]>([]);
-  const [sortKey, setSortKey] = useState<SortKey>("peg_ratio");
-  const [asc, setAsc] = useState(true);
   const [ticker, setTicker] = useState<string | null>(null);
 
   useEffect(() => {
     getScreener(WATCHLIST).then(setRows).catch(() => setRows([]));
   }, []);
 
-  function handleSort(key: SortKey) {
-    if (sortKey === key) {
-      setAsc(!asc);
-    } else {
-      setSortKey(key);
-      setAsc(true);
-    }
-  }
-
-  const sorted = [...rows].sort((a, b) => {
-    const va = a[sortKey];
-    const vb = b[sortKey];
-    if (typeof va === "string" && typeof vb === "string") {
-      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
-    }
-    const na = (va as number) ?? 0;
-    const nb = (vb as number) ?? 0;
-    return asc ? na - nb : nb - na;
-  });
+  const { sorted, handleSort } = useSortableTable(rows, "peg_ratio");
 
   const cell = { padding: "4px 6px" } as const;
   const right = { ...cell, textAlign: "right", cursor: "pointer" } as const;

--- a/frontend/src/hooks/useSortableTable.ts
+++ b/frontend/src/hooks/useSortableTable.ts
@@ -1,0 +1,33 @@
+import { useMemo, useState } from "react";
+
+export function useSortableTable<T, K extends keyof T>(
+  rows: T[],
+  initialSortKey: K,
+) {
+  const [sortKey, setSortKey] = useState<K>(initialSortKey);
+  const [asc, setAsc] = useState(true);
+
+  function handleSort(key: K) {
+    if (sortKey === key) {
+      setAsc(!asc);
+    } else {
+      setSortKey(key);
+      setAsc(true);
+    }
+  }
+
+  const sorted = useMemo(() => {
+    return [...rows].sort((a, b) => {
+      const va = a[sortKey];
+      const vb = b[sortKey];
+      if (typeof va === "string" && typeof vb === "string") {
+        return asc ? va.localeCompare(vb) : vb.localeCompare(va);
+      }
+      const na = (va as number) ?? 0;
+      const nb = (vb as number) ?? 0;
+      return asc ? na - nb : nb - na;
+    });
+  }, [rows, sortKey, asc]);
+
+  return { sorted, sortKey, asc, handleSort };
+}


### PR DESCRIPTION
## Summary
- add reusable `useSortableTable` hook for managing sort state and sorting rows
- refactor HoldingsTable, InstrumentTable, and ScreenerPage to use the new hook

## Testing
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897187e59e48327b92f7e02c334ba1d