### PR TITLE
refactor: remove any types in frontend

### DIFF
--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -43,7 +43,7 @@ describe("GroupPortfolioView", () => {
     vi.spyOn(global, "fetch").mockResolvedValue({
       ok: true,
       json: async () => mockPortfolio,
-    } as any);
+    } as unknown as Response);
 
     render(<GroupPortfolioView slug="all" />);
 

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -61,8 +61,13 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
   useEffect(() => {
     getInstrumentDetail(ticker, days)
       .then((d) => {
-        setData(d as { prices: Price[]; positions: Position[]; currency?: string | null });
-        setCurrency((d as any).currency ?? null);
+        const detail = d as {
+          prices: Price[];
+          positions: Position[];
+          currency?: string | null;
+        };
+        setData(detail);
+        setCurrency(detail.currency ?? null);
       })
       .catch((e: Error) => setErr(e.message));
   }, [ticker, days]);


### PR DESCRIPTION
## Summary
- replace `any` in GroupPortfolioView.test with typed Response cast
- avoid `any` in InstrumentDetail by using typed detail object

## Testing
- `npm run lint`
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68971df468e48327bab75b40f8996627