### PR TITLE
chore: upload coverage to codecov

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -25,4 +25,11 @@ jobs:
         env:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
         run: |
-          pytest tests/test_backend_api.py::test_health --cov=backend.local_api.main --cov=backend.routes.portfolio --cov=backend.utils.period_utils --cov=backend.utils.currency_utils --cov-report=term --cov-fail-under=0 -q
+          pytest tests/test_backend_api.py::test_health --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=0 -q
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          slug: leonarduk/allotmint
+          files: ./coverage.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- run backend health test with coverage report
- upload coverage.xml to Codecov using official action

## Testing
- `ALLOTMINT_SKIP_SNAPSHOT_WARM=true pytest tests/test_backend_api.py::test_health --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_68971f165b8483278c56bc2cd1194e30