### PR TITLE
Use getGroupPortfolio API in GroupPortfolioView

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -1,6 +1,7 @@
 // src/components/GroupPortfolioView.tsx
 import { useEffect, useState } from "react";
 import type { GroupPortfolio } from "../types";
+import { getGroupPortfolio } from "../api";
 import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { money, percent } from "../lib/money";
@@ -31,13 +32,7 @@ export function GroupPortfolioView({ slug }: Props) {
     setError(null);
     setPortfolio(null);
 
-    const API = import.meta.env.VITE_API_URL ?? "";
-
-    fetch(`${API}/portfolio-group/${slug}`)
-      .then((res) => {
-        if (!res.ok) throw new Error(res.statusText);
-        return res.json();
-      })
+    getGroupPortfolio(slug)
       .then(setPortfolio)
       .catch((e) => {
         console.error("failed to load group portfolio", e);


### PR DESCRIPTION
## Summary
- Refactor `GroupPortfolioView` to call `getGroupPortfolio` from the shared API module
- Remove local base URL and manual fetch error handling

## Testing
- `npm test --prefix frontend -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68971879967483278c9ada6547a3c823