### PR TITLE
Add frontend test workflow

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,28 @@
+name: Frontend Tests
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  frontend-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --run


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run frontend tests on pull requests

## Testing
- `npx vitest run --reporter=basic`
- `pytest tests/test_backend_api.py::test_health`

------
https://chatgpt.com/codex/tasks/task_e_68971fbc72dc8327ade849abc1f717fa