### PR TITLE
Use instrument metadata names in portfolio aggregation

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -176,7 +176,7 @@ def aggregate_by_ticker(portfolio: dict) -> List[dict]:
                 tkr,
                 {
                     "ticker":           tkr,
-                    "name":             h.get("name", tkr),
+                    "name":             meta.get("name") or h.get("name", tkr),
                     "currency":         h.get("currency"),
                     "units":            0.0,
                     "market_value_gbp": 0.0,

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from backend.local_api.main import app
+from backend.common.instruments import get_instrument_meta
 
 client = TestClient(app)
 
@@ -108,6 +109,12 @@ def test_group_instruments():
     # At least one instrument should have a market value once holdings are
     # aggregated, even if no explicit price snapshot exists.
     assert any((inst.get("market_value_gbp") or 0) > 0 for inst in instruments)
+
+    # if metadata contains a name, it should be reflected in the API output
+    for inst in instruments:
+        meta = get_instrument_meta(inst["ticker"])
+        if meta.get("name"):
+            assert inst["name"] == meta["name"]
 
 
 def test_transactions_endpoint():


### PR DESCRIPTION
## Summary
- include instrument metadata names when aggregating holdings
- verify group instruments endpoint uses names from metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689741384ddc832793368ac27132753b