### PR TITLE
feat: centralize data fetching hook

### DIFF
--- a/frontend/src/components/AlertsPanel.tsx
+++ b/frontend/src/components/AlertsPanel.tsx
@@ -3,8 +3,14 @@ import type { Alert } from "../types";
 import { useFetch } from "../hooks/useFetch";
 
 export function AlertsPanel() {
-  const { data: alerts } = useFetch<Alert[]>(getAlerts, []);
-  if (!alerts?.length) return null;
+  const {
+    data: alerts,
+    loading,
+    error,
+  } = useFetch<Alert[]>(getAlerts, []);
+
+  if (loading || error || !alerts?.length) return null;
+
   return (
     <div style={{ border: "1px solid #ccc", padding: "0.5rem", marginBottom: "1rem" }}>
       <strong>Alerts</strong>

--- a/frontend/src/components/ComplianceWarnings.tsx
+++ b/frontend/src/components/ComplianceWarnings.tsx
@@ -7,7 +7,11 @@ interface Props {
 }
 
 export function ComplianceWarnings({ owners }: Props) {
-  const { data } = useFetch<Record<string, string[]>>(
+  const {
+    data,
+    loading,
+    error,
+  } = useFetch<Record<string, string[]>>(
     async () => {
       const entries: Record<string, string[]> = {};
       await Promise.all(
@@ -26,7 +30,7 @@ export function ComplianceWarnings({ owners }: Props) {
     owners.length > 0
   );
 
-  if (!owners.length) return null;
+  if (!owners.length || loading || error) return null;
 
   const ownersWithWarnings = owners.filter((o) => (data?.[o] ?? []).length);
 

--- a/frontend/src/components/ScreenerPage.tsx
+++ b/frontend/src/components/ScreenerPage.tsx
@@ -8,16 +8,20 @@ import { useFetch } from "../hooks/useFetch";
 const WATCHLIST = ["AAPL", "MSFT", "GOOG", "AMZN", "TSLA"];
 
 export function ScreenerPage() {
-  const { data: rows } = useFetch<ScreenerResult[]>(
-    () => getScreener(WATCHLIST),
-    []
-  );
+  const {
+    data: rows,
+    loading,
+    error,
+  } = useFetch<ScreenerResult[]>(() => getScreener(WATCHLIST), []);
   const [ticker, setTicker] = useState<string | null>(null);
 
   const { sorted, handleSort } = useSortableTable(rows ?? [], "peg_ratio");
 
   const cell = { padding: "4px 6px" } as const;
   const right = { ...cell, textAlign: "right", cursor: "pointer" } as const;
+
+  if (loading) return <p>Loading…</p>;
+  if (error) return <p style={{ color: "red" }}>{error.message}</p>;
 
   return (
     <>

--- a/frontend/src/hooks/useFetch.ts
+++ b/frontend/src/hooks/useFetch.ts
@@ -1,5 +1,12 @@
 import { useEffect, useState, type DependencyList } from "react";
 
+/**
+ * Small helper hook that wraps an async function and provides
+ * the resolved `data`, a `loading` indicator and any `error`.
+ *
+ * It automatically re‑runs whenever the dependency list changes
+ * and will reset its state when `enabled` is set to `false`.
+ */
 export function useFetch<T>(
   fn: () => Promise<T>,
   deps: DependencyList = [],


### PR DESCRIPTION
## Summary
- add reusable `useFetch` hook for async calls with loading and error state
- refactor panels and pages to rely on `useFetch`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68973f465f9883279d23424013f2e526