### PR TITLE
refactor: centralize table cell styles

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -6,6 +6,7 @@ import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { money, percent } from "../lib/money";
 import { useFetch } from "../hooks/useFetch";
+import tableStyles from "../styles/table.module.css";
 
 type SelectedInstrument = {
   ticker: string;
@@ -133,55 +134,49 @@ export function GroupPortfolioView({ slug }: Props) {
       </div>
 
       {/* Per-owner summary */}
-      <table
-        style={{
-          width: "100%",
-          borderCollapse: "collapse",
-          marginBottom: "1rem",
-        }}
-      >
+      <table className={`${tableStyles.table} ${tableStyles.tableMargin}`}>
         <thead>
           <tr>
-            <th style={{ textAlign: "left" }}>Owner</th>
-            <th style={{ textAlign: "right" }}>Total Value</th>
-            <th style={{ textAlign: "right" }}>Day Change</th>
-            <th style={{ textAlign: "right" }}>Day Change %</th>
-            <th style={{ textAlign: "right" }}>Total Gain</th>
-            <th style={{ textAlign: "right" }}>Total Gain %</th>
+            <th className={tableStyles.cell}>Owner</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Total Value</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Day Change</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Day Change %</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Total Gain</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Total Gain %</th>
           </tr>
         </thead>
         <tbody>
           {ownerRows.map((row) => (
             <tr key={row.owner}>
-              <td>{row.owner}</td>
-              <td style={{ textAlign: "right" }}>{money(row.value)}</td>
+              <td className={tableStyles.cell}>{row.owner}</td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(row.value)}</td>
               <td
+                className={`${tableStyles.cell} ${tableStyles.right}`}
                 style={{
-                  textAlign: "right",
                   color: row.dayChange >= 0 ? "lightgreen" : "red",
                 }}
               >
                 {money(row.dayChange)}
               </td>
               <td
+                className={`${tableStyles.cell} ${tableStyles.right}`}
                 style={{
-                  textAlign: "right",
                   color: row.dayChange >= 0 ? "lightgreen" : "red",
                 }}
               >
                 {percent(row.dayChangePct)}
               </td>
               <td
+                className={`${tableStyles.cell} ${tableStyles.right}`}
                 style={{
-                  textAlign: "right",
                   color: row.gain >= 0 ? "lightgreen" : "red",
                 }}
               >
                 {money(row.gain)}
               </td>
               <td
+                className={`${tableStyles.cell} ${tableStyles.right}`}
                 style={{
-                  textAlign: "right",
                   color: row.gain >= 0 ? "lightgreen" : "red",
                 }}
               >

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import type { Holding } from "../types";
 import { money } from "../lib/money";
 import { useSortableTable } from "../hooks/useSortableTable";
+import tableStyles from "../styles/table.module.css";
 
 type Props = {
   holdings: Holding[];
@@ -9,8 +10,6 @@ type Props = {
 };
 
 export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
-  const cell = { padding: "4px 6px" } as const;
-  const right = { ...cell, textAlign: "right" } as const;
 
   const rows = holdings.map((h) => {
     const cost =
@@ -39,57 +38,53 @@ export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
   if (!rows.length) return null;
 
   return (
-    <table
-      style={{
-        width: "100%",
-        borderCollapse: "collapse",
-        marginBottom: "1rem",
-      }}
-    >
+    <table className={`${tableStyles.table} ${tableStyles.tableMargin}`}>
       <thead>
         <tr>
           <th
-            style={{ ...cell, cursor: "pointer" }}
+            className={`${tableStyles.cell} ${tableStyles.clickable}`}
             onClick={() => handleSort("ticker")}
           >
             Ticker{sortKey === "ticker" ? (asc ? " ▲" : " ▼") : ""}
           </th>
           <th
-            style={{ ...cell, cursor: "pointer" }}
+            className={`${tableStyles.cell} ${tableStyles.clickable}`}
             onClick={() => handleSort("name")}
           >
             Name{sortKey === "name" ? (asc ? " ▲" : " ▼") : ""}
           </th>
-          <th style={cell}>CCY</th>
-          <th style={right}>Units</th>
-          <th style={right}>Px £</th>
+          <th className={tableStyles.cell}>CCY</th>
+          <th className={`${tableStyles.cell} ${tableStyles.right}`}>Units</th>
+          <th className={`${tableStyles.cell} ${tableStyles.right}`}>Px £</th>
           <th
-            style={{ ...right, cursor: "pointer" }}
+            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
             onClick={() => handleSort("cost")}
           >
             Cost £{sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
           </th>
-          <th style={right}>Mkt £</th>
+          <th className={`${tableStyles.cell} ${tableStyles.right}`}>Mkt £</th>
           <th
-            style={{ ...right, cursor: "pointer" }}
+            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
             onClick={() => handleSort("gain")}
           >
             Gain £{sortKey === "gain" ? (asc ? " ▲" : " ▼") : ""}
           </th>
           <th
-            style={{ ...right, cursor: "pointer" }}
+            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
             onClick={() => handleSort("gain_pct")}
           >
             Gain %{sortKey === "gain_pct" ? (asc ? " ▲" : " ▼") : ""}
           </th>
-          <th style={cell}>Acquired</th>
+          <th className={tableStyles.cell}>Acquired</th>
           <th
-            style={{ ...right, cursor: "pointer" }}
+            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
             onClick={() => handleSort("days_held")}
           >
             Days&nbsp;Held{sortKey === "days_held" ? (asc ? " ▲" : " ▼") : ""}
           </th>
-          <th style={{ ...cell, textAlign: "center" }}>Eligible?</th>
+          <th className={`${tableStyles.cell} ${tableStyles.center}`}>
+            Eligible?
+          </th>
         </tr>
       </thead>
 
@@ -101,30 +96,26 @@ export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
 
           return (
             <tr key={h.ticker + h.acquired_date}>
-              <td style={cell}>
+              <td className={tableStyles.cell}>
                 <button
                   type="button"
                   onClick={handleClick}
-                  style={{
-                    color: "dodgerblue",
-                    textDecoration: "underline",
-                    background: "none",
-                    border: "none",
-                    padding: 0,
-                    font: "inherit",
-                    cursor: "pointer",
-                  }}
+                  className={tableStyles.linkButton}
                 >
                   {h.ticker}
                 </button>
               </td>
-              <td style={cell}>{h.name}</td>
-              <td style={cell}>{h.currency ?? "—"}</td>
-              <td style={cell}>{h.instrument_type ?? "—"}</td>
-              <td style={right}>{h.units.toLocaleString()}</td>
-              <td style={right}>{money(h.current_price_gbp)}</td>
+              <td className={tableStyles.cell}>{h.name}</td>
+              <td className={tableStyles.cell}>{h.currency ?? "—"}</td>
+              <td className={tableStyles.cell}>{h.instrument_type ?? "—"}</td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {h.units.toLocaleString()}
+              </td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {money(h.current_price_gbp)}
+              </td>
               <td
-                style={right}
+                className={`${tableStyles.cell} ${tableStyles.right}`}
                 title={
                   (h.cost_basis_gbp ?? 0) > 0
                     ? "Actual purchase cost"
@@ -133,29 +124,32 @@ export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
               >
                 {money(h.cost)}
               </td>
-              <td style={right}>{money(h.market)}</td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {money(h.market)}
+              </td>
               <td
+                className={`${tableStyles.cell} ${tableStyles.right}`}
                 style={{
-                  ...right,
                   color: h.gain >= 0 ? "lightgreen" : "red",
                 }}
               >
                 {money(h.gain)}
               </td>
               <td
+                className={`${tableStyles.cell} ${tableStyles.right}`}
                 style={{
-                  ...right,
                   color: h.gain_pct >= 0 ? "lightgreen" : "red",
                 }}
               >
                 {Number.isFinite(h.gain_pct) ? h.gain_pct.toFixed(1) : "—"}
               </td>
-              <td style={cell}>{h.acquired_date}</td>
-              <td style={right}>{h.days_held ?? "—"}</td>
+              <td className={tableStyles.cell}>{h.acquired_date}</td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {h.days_held ?? "—"}
+              </td>
               <td
+                className={`${tableStyles.cell} ${tableStyles.center}`}
                 style={{
-                  ...cell,
-                  textAlign: "center",
                   color: h.sell_eligible ? "lightgreen" : "gold",
                 }}
               >

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -10,6 +10,7 @@ import {
 } from "recharts";
 import { getInstrumentDetail } from "../api";
 import { money, percent } from "../lib/money";
+import tableStyles from "../styles/table.module.css";
 
 type Props = {
   ticker: string;
@@ -183,25 +184,22 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
       {/* Positions */}
       <h3 style={{ marginTop: "1.5rem" }}>Positions</h3>
       <table
-        style={{
-          width: "100%",
-          fontSize: "0.85rem",
-          marginBottom: "1rem",
-        }}
+        className={`${tableStyles.table} ${tableStyles.tableMargin}`}
+        style={{ fontSize: "0.85rem" }}
       >
         <thead>
           <tr>
-            <th>Account</th>
-            <th align="right">Units</th>
-            <th align="right">Mkt £</th>
-            <th align="right">Gain £</th>
-            <th align="right">Gain %</th>
+            <th className={tableStyles.cell}>Account</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Units</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Mkt £</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Gain £</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Gain %</th>
           </tr>
         </thead>
         <tbody>
           {(positions ?? []).map((pos, i) => (
             <tr key={`${pos.owner}-${pos.account}-${i}`}>
-              <td>
+              <td className={tableStyles.cell}>
                 <Link
                   to={`/member/${encodeURIComponent(pos.owner)}`}
                   style={{ color: "#00d8ff", textDecoration: "none" }}
@@ -209,10 +207,10 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
                   {pos.owner} – {pos.account}
                 </Link>
               </td>
-              <td align="right">{fixed(pos.units, 4)}</td>
-              <td align="right">{money(pos.market_value_gbp)}</td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>{fixed(pos.units, 4)}</td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(pos.market_value_gbp)}</td>
               <td
-                align="right"
+                className={`${tableStyles.cell} ${tableStyles.right}`}
                 style={{
                   color:
                     toNum(pos.unrealised_gain_gbp) >= 0 ? "lightgreen" : "red",
@@ -221,7 +219,7 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
                 {money(pos.unrealised_gain_gbp)}
               </td>
               <td
-                align="right"
+                className={`${tableStyles.cell} ${tableStyles.right}`}
                 style={{
                   color: toNum(pos.gain_pct) >= 0 ? "lightgreen" : "red",
                 }}
@@ -232,7 +230,11 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
           ))}
           {!positions.length && (
             <tr>
-              <td colSpan={4} style={{ textAlign: "center", color: "#888" }}>
+              <td
+                colSpan={4}
+                className={`${tableStyles.cell} ${tableStyles.center}`}
+                style={{ color: "#888" }}
+              >
                 No positions
               </td>
             </tr>
@@ -243,18 +245,15 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
       {/* Recent Prices */}
       <h3>Recent Prices</h3>
       <table
-        style={{
-          width: "100%",
-          fontSize: "0.85rem",
-          marginBottom: "1rem",
-        }}
+        className={`${tableStyles.table} ${tableStyles.tableMargin}`}
+        style={{ fontSize: "0.85rem" }}
       >
         <thead>
           <tr>
-            <th>Date</th>
-            <th align="right">£ Close</th>
-            <th align="right">Δ £</th>
-            <th align="right">Δ %</th>
+            <th className={tableStyles.cell}>Date</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>£ Close</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Δ £</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Δ %</th>
           </tr>
         </thead>
         <tbody>
@@ -269,20 +268,30 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
                 : undefined;
               return (
                 <tr key={p.date}>
-                  <td>{p.date}</td>
-                  <td align="right">{fixed(p.close_gbp, 2)}</td>
-                  <td align="right" style={{ color: colour }}>
+                  <td className={tableStyles.cell}>{p.date}</td>
+                  <td className={`${tableStyles.cell} ${tableStyles.right}`}>{fixed(p.close_gbp, 2)}</td>
+                  <td
+                    className={`${tableStyles.cell} ${tableStyles.right}`}
+                    style={{ color: colour }}
+                  >
                     {fixed(p.change_gbp, 2)}
                   </td>
-                  <td align="right" style={{ color: colour }}>
+                  <td
+                    className={`${tableStyles.cell} ${tableStyles.right}`}
+                    style={{ color: colour }}
+                  >
                     {percent(p.change_pct, 2)}
                   </td>
-              </tr>
+                </tr>
               );
             })}
           {!prices.length && (
             <tr>
-              <td colSpan={4} style={{ textAlign: "center", color: "#888" }}>
+              <td
+                colSpan={4}
+                className={`${tableStyles.cell} ${tableStyles.center}`}
+                style={{ color: "#888" }}
+              >
                 No price data
               </td>
             </tr>

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -3,6 +3,7 @@ import type { InstrumentSummary } from "../types";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { money } from "../lib/money";
 import { useSortableTable } from "../hooks/useSortableTable";
+import tableStyles from "../styles/table.module.css";
 
 type Props = {
     rows: InstrumentSummary[];
@@ -29,66 +30,57 @@ export function InstrumentTable({ rows }: Props) {
         return <p>No instruments found for this group.</p>;
     }
 
-    /* simple cell styles */
-    const cell = { padding: "4px 6px" } as const;
-    const right = { ...cell, textAlign: "right" } as const;
-
     return (
         <>
             <table
-                style={{
-                    width: "100%",
-                    borderCollapse: "collapse",
-                    cursor: "pointer",
-                    marginBottom: "1rem",
-                }}
+                className={`${tableStyles.table} ${tableStyles.tableMargin} ${tableStyles.clickable}`}
             >
                 <thead>
                     <tr>
                         <th
-                            style={{ ...cell, cursor: "pointer" }}
+                            className={`${tableStyles.cell} ${tableStyles.clickable}`}
                             onClick={() => handleSort("ticker")}
                         >
                             Ticker
                             {sortKey === "ticker" ? (asc ? " ▲" : " ▼") : ""}
                         </th>
                         <th
-                            style={{ ...cell, cursor: "pointer" }}
+                            className={`${tableStyles.cell} ${tableStyles.clickable}`}
                             onClick={() => handleSort("name")}
                         >
                             Name
                             {sortKey === "name" ? (asc ? " ▲" : " ▼") : ""}
                         </th>
-                        <th style={cell}>CCY</th>
-                        <th style={cell}>Type</th>
-                        <th style={right}>Units</th>
-                        <th style={cell}>CCY</th>
+                        <th className={tableStyles.cell}>CCY</th>
+                        <th className={tableStyles.cell}>Type</th>
+                        <th className={`${tableStyles.cell} ${tableStyles.right}`}>Units</th>
+                        <th className={tableStyles.cell}>CCY</th>
                         <th
-                            style={{ ...right, cursor: "pointer" }}
+                            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
                             onClick={() => handleSort("cost")}
                         >
                             Cost £
                             {sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
                         </th>
-                        <th style={right}>Mkt £</th>
+                        <th className={`${tableStyles.cell} ${tableStyles.right}`}>Mkt £</th>
                         <th
-                            style={{ ...right, cursor: "pointer" }}
+                            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
                             onClick={() => handleSort("gain")}
                         >
                             Gain £
                             {sortKey === "gain" ? (asc ? " ▲" : " ▼") : ""}
                         </th>
                         <th
-                            style={{ ...right, cursor: "pointer" }}
+                            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
                             onClick={() => handleSort("gain_pct")}
                         >
                             Gain %
                             {sortKey === "gain_pct" ? (asc ? " ▲" : " ▼") : ""}
                         </th>
-                        <th style={right}>Last £</th>
-                        <th style={right}>Last&nbsp;Date</th>
-                        <th style={right}>Δ&nbsp;7&nbsp;d&nbsp;%</th>
-                        <th style={right}>Δ&nbsp;1&nbsp;mo&nbsp;%</th>
+                        <th className={`${tableStyles.cell} ${tableStyles.right}`}>Last £</th>
+                        <th className={`${tableStyles.cell} ${tableStyles.right}`}>Last&nbsp;Date</th>
+                        <th className={`${tableStyles.cell} ${tableStyles.right}`}>Δ&nbsp;7&nbsp;d&nbsp;%</th>
+                        <th className={`${tableStyles.cell} ${tableStyles.right}`}>Δ&nbsp;1&nbsp;mo&nbsp;%</th>
                     </tr>
                 </thead>
 
@@ -99,53 +91,51 @@ export function InstrumentTable({ rows }: Props) {
 
                         return (
                             <tr key={r.ticker}>
-                                <td style={cell}>
+                                <td className={tableStyles.cell}>
                                     <button
                                         type="button"
                                         onClick={() => setSelected(r)}
-                                        style={{
-                                            color: "dodgerblue",
-                                            textDecoration: "underline",
-                                            background: "none",
-                                            border: "none",
-                                            padding: 0,
-                                            font: "inherit",
-                                            cursor: "pointer",
-                                        }}
+                                        className={tableStyles.linkButton}
                                     >
                                         {r.ticker}
                                     </button>
                                 </td>
-                                <td style={cell}>{r.name}</td>
-                                <td style={cell}>{r.currency ?? "—"}</td>
-                                <td style={cell}>{r.instrument_type ?? "—"}</td>
-                                <td style={right}>
+                                <td className={tableStyles.cell}>{r.name}</td>
+                                <td className={tableStyles.cell}>{r.currency ?? "—"}</td>
+                                <td className={tableStyles.cell}>{r.instrument_type ?? "—"}</td>
+                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                     {r.units.toLocaleString()}
                                 </td>
-                                <td style={right}>{money(r.cost)}</td>
-                                <td style={right}>
+                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(r.cost)}</td>
+                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                     {money(r.market_value_gbp)}
                                 </td>
-                                <td style={{ ...right, color: gainColour }}>
+                                <td
+                                    className={`${tableStyles.cell} ${tableStyles.right}`}
+                                    style={{ color: gainColour }}
+                                >
                                     {money(r.gain_gbp)}
                                 </td>
-                                <td style={{ ...right, color: r.gain_pct >= 0 ? "lightgreen" : "red" }}>
+                                <td
+                                    className={`${tableStyles.cell} ${tableStyles.right}`}
+                                    style={{ color: r.gain_pct >= 0 ? "lightgreen" : "red" }}
+                                >
                                     {Number.isFinite(r.gain_pct) ? r.gain_pct.toFixed(1) : "—"}
                                 </td>
-                                <td style={right}>
+                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                     {r.last_price_gbp != null
                                         ? money(r.last_price_gbp)
                                         : "—"}
                                 </td>
-                                <td style={right}>
+                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                     {r.last_price_date ?? "—"}
                                 </td>
-                                <td style={right}>
+                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                     {r.change_7d_pct == null
                                         ? "—"
                                         : r.change_7d_pct.toFixed(1)}
                                 </td>
-                                <td style={right}>
+                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                     {r.change_30d_pct == null
                                         ? "—"
                                         : r.change_30d_pct.toFixed(1)}

--- a/frontend/src/components/ScreenerPage.tsx
+++ b/frontend/src/components/ScreenerPage.tsx
@@ -4,6 +4,7 @@ import type { ScreenerResult } from "../types";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { useSortableTable } from "../hooks/useSortableTable";
 import { useFetch } from "../hooks/useFetch";
+import tableStyles from "../styles/table.module.css";
 
 const WATCHLIST = ["AAPL", "MSFT", "GOOG", "AMZN", "TSLA"];
 
@@ -16,29 +17,63 @@ export function ScreenerPage() {
 
   const { sorted, handleSort } = useSortableTable(rows ?? [], "peg_ratio");
 
-  const cell = { padding: "4px 6px" } as const;
-  const right = { ...cell, textAlign: "right", cursor: "pointer" } as const;
-
   return (
     <>
-      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+      <table className={tableStyles.table}>
         <thead>
           <tr>
-            <th style={{ ...cell, cursor: "pointer" }} onClick={() => handleSort("ticker")}>Ticker</th>
-            <th style={right} onClick={() => handleSort("peg_ratio")}>PEG</th>
-            <th style={right} onClick={() => handleSort("pe_ratio")}>P/E</th>
-            <th style={right} onClick={() => handleSort("de_ratio")}>D/E</th>
-            <th style={right} onClick={() => handleSort("fcf")}>FCF</th>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.clickable}`}
+              onClick={() => handleSort("ticker")}
+            >
+              Ticker
+            </th>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort("peg_ratio")}
+            >
+              PEG
+            </th>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort("pe_ratio")}
+            >
+              P/E
+            </th>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort("de_ratio")}
+            >
+              D/E
+            </th>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort("fcf")}
+            >
+              FCF
+            </th>
           </tr>
         </thead>
         <tbody>
           {sorted.map((r) => (
-            <tr key={r.ticker} onClick={() => setTicker(r.ticker)} style={{ cursor: "pointer" }}>
-              <td style={cell}>{r.ticker}</td>
-              <td style={right}>{r.peg_ratio ?? "—"}</td>
-              <td style={right}>{r.pe_ratio ?? "—"}</td>
-              <td style={right}>{r.de_ratio ?? "—"}</td>
-              <td style={right}>{r.fcf != null ? r.fcf.toLocaleString() : "—"}</td>
+            <tr
+              key={r.ticker}
+              onClick={() => setTicker(r.ticker)}
+              className={tableStyles.clickable}
+            >
+              <td className={tableStyles.cell}>{r.ticker}</td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {r.peg_ratio ?? "—"}
+              </td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {r.pe_ratio ?? "—"}
+              </td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {r.de_ratio ?? "—"}
+              </td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {r.fcf != null ? r.fcf.toLocaleString() : "—"}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -3,6 +3,7 @@ import type { OwnerSummary, Transaction } from "../types";
 import { getTransactions } from "../api";
 import { Selector } from "./Selector";
 import { useFetch } from "../hooks/useFetch";
+import tableStyles from "../styles/table.module.css";
 
 type Props = {
   owners: OwnerSummary[];
@@ -66,28 +67,30 @@ export function TransactionsPage({ owners }: Props) {
       {loading ? (
         <p>Loading…</p>
       ) : (
-        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <table className={tableStyles.table}>
           <thead>
             <tr>
-              <th style={{ textAlign: "left" }}>Date</th>
-              <th style={{ textAlign: "left" }}>Owner</th>
-              <th style={{ textAlign: "left" }}>Account</th>
-              <th style={{ textAlign: "left" }}>Type</th>
-              <th style={{ textAlign: "right" }}>Amount</th>
-              <th style={{ textAlign: "right" }}>Shares</th>
+              <th className={tableStyles.cell}>Date</th>
+              <th className={tableStyles.cell}>Owner</th>
+              <th className={tableStyles.cell}>Account</th>
+              <th className={tableStyles.cell}>Type</th>
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}>Amount</th>
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}>Shares</th>
             </tr>
           </thead>
           <tbody>
             {(transactions ?? []).map((t, i) => (
               <tr key={i}>
-                <td>{t.date ? new Date(t.date).toLocaleDateString() : ""}</td>
-                <td>{t.owner}</td>
-                <td>{t.account}</td>
-                <td>{t.type || t.kind}</td>
-                <td style={{ textAlign: "right" }}>
+                <td className={tableStyles.cell}>
+                  {t.date ? new Date(t.date).toLocaleDateString() : ""}
+                </td>
+                <td className={tableStyles.cell}>{t.owner}</td>
+                <td className={tableStyles.cell}>{t.account}</td>
+                <td className={tableStyles.cell}>{t.type || t.kind}</td>
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                   {t.amount_minor != null ? (t.amount_minor / 100).toFixed(2) : ""}
                 </td>
-                <td style={{ textAlign: "right" }}>{t.shares ?? ""}</td>
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{t.shares ?? ""}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -1,0 +1,34 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.tableMargin {
+  margin-bottom: 1rem;
+}
+
+.cell {
+  padding: 4px 6px;
+}
+
+.right {
+  text-align: right;
+}
+
+.center {
+  text-align: center;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.linkButton {
+  color: dodgerblue;
+  text-decoration: underline;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- centralize common table cell styles in `table.module.css`
- refactor table components to reuse shared classes
- replace many inline cursor/alignment declarations with CSS classes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68973f6888c48327ad1c69d63b9925b4