### PR TITLE
Remove account block border on member page

### DIFF
--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -24,8 +24,6 @@ export function AccountBlock({ account }: Props) {
       style={{
         marginBottom: "2rem",
         padding: "1rem",
-        border: "1px solid #ddd",
-        borderRadius: "4px",
       }}
     >
       <h2 style={{ marginTop: 0 }}>


### PR DESCRIPTION
## Summary
- remove border around account blocks so member tables display without clipped box

## Testing
- `npx vitest run`
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897432978b0832784c62c0c55dd4681