### PR TITLE
Fix instrument detail link by passing props correctly

### DIFF
--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+
+vi.mock("../api", () => ({
+  getInstrumentDetail: vi.fn(() =>
+    Promise.resolve({ prices: [], positions: [], currency: "GBP" })
+  ),
+}));
+
+import { InstrumentDetail } from "./InstrumentDetail";
+
+describe("InstrumentDetail", () => {
+  it("renders ticker info", async () => {
+    render(
+      <MemoryRouter>
+        <InstrumentDetail
+          ticker="ABC"
+          name="ABC Corp"
+          currency="GBP"
+          instrument_type="Equity"
+          onClose={() => {}}
+        />
+      </MemoryRouter>
+    );
+    expect(
+      await screen.findByText("ABC • GBP • Equity")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -43,11 +43,20 @@ const fixed = (v: unknown, dp = 2): string => {
   return Number.isFinite(n) ? n.toFixed(dp) : "—";
 };
 
-
-export function InstrumentDetail({ ticker, name, onClose }: Props) {
-  const [data, setData] = useState<{ prices: Price[]; positions: Position[]; currency?: string | null } | null>(null);
+export function InstrumentDetail({
+  ticker,
+  name,
+  currency: currencyProp,
+  instrument_type,
+  onClose,
+}: Props) {
+  const [data, setData] = useState<{
+    prices: Price[];
+    positions: Position[];
+    currency?: string | null;
+  } | null>(null);
   const [err, setErr] = useState<string | null>(null);
-  const [currency, setCurrency] = useState<string | null>(null);
+  const [currency, setCurrency] = useState<string | null>(currencyProp ?? null);
   const [showBollinger, setShowBollinger] = useState(false);
   const [days, setDays] = useState<number>(365);
 
@@ -60,10 +69,10 @@ export function InstrumentDetail({ ticker, name, onClose }: Props) {
           currency?: string | null;
         };
         setData(detail);
-        setCurrency(detail.currency ?? null);
+        setCurrency(detail.currency ?? currencyProp ?? null);
       })
       .catch((e: Error) => setErr(e.message));
-  }, [ticker, days]);
+  }, [ticker, days, currencyProp]);
 
   if (err) return <p style={{ color: "red" }}>{err}</p>;
   if (!data) return <p>Loading…</p>;


### PR DESCRIPTION
## Summary
- correctly pass currency and instrument type into InstrumentDetail and handle fetched currency
- add regression test for InstrumentDetail rendering

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68979199a980832782c21b19564428a9