### PR TITLE
Ensure instrument names are populated in group holdings

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -229,8 +229,11 @@ def enrich_holding(
 
     account_ccy = (h.get("currency") or "GBP").upper()
     from backend.common.portfolio_utils import get_security_meta  # local import to avoid circular
-    meta = get_security_meta(full)
-    out["currency"] = (meta or {}).get("currency")
+    sec_meta = get_security_meta(full) or {}
+    instr_meta = meta or {}
+    meta = {**instr_meta, **sec_meta}
+    out["currency"] = meta.get("currency")
+    out["name"] = out.get("name") or meta.get("name") or full
 
     if _is_cash(full, account_ccy):
         out = dict(h)


### PR DESCRIPTION
## Summary
- include instrument and security metadata when enriching holdings so names are always available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c0fc9860832798eff21e2a840b3f