### PR TITLE
Fix unreadable tooltip label on ticker timeseries

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -162,7 +162,7 @@ export function InstrumentDetail({
         <LineChart data={prices}>
           <XAxis dataKey="date" hide />
           <YAxis domain={["auto", "auto"]} />
-          <Tooltip />
+          <Tooltip wrapperStyle={{ color: "#000" }} labelStyle={{ color: "#000" }} />
           {showBollinger && (
             <>
               <Line


### PR DESCRIPTION
## Summary
- ensure tooltip text in `InstrumentDetail` chart renders in black for readability against white background

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c414d9948327805db77e61dcc550