### PR TITLE
Add relative view toggle for holdings table

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -72,3 +72,7 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Relative view mode
+
+The main portfolio view includes a **Relative view** toggle. When enabled (the default), the holdings table hides the "Units", "Cost £", and "Gain £" columns and instead shows percentage-based metrics such as "Gain %" and a new "Weight %" column indicating each holding's share of the account. Uncheck the toggle to restore the absolute value columns.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,6 +66,9 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
+  // when true, holdings table emphasises relative metrics
+  const [relativeView, setRelativeView] = useState(true);
+
   const [refreshingPrices, setRefreshingPrices] = useState(false);
   const [lastPriceRefresh, setLastPriceRefresh] = useState<string | null>(null);
   const [priceRefreshError, setPriceRefreshError] = useState<string | null>(null);
@@ -165,6 +168,18 @@ export default function App() {
         ))}
       </div>
 
+      {/* absolute vs relative toggle */}
+      <div style={{ marginBottom: "1rem" }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={relativeView}
+            onChange={(e) => setRelativeView(e.target.checked)}
+          />{" "}
+          Relative view
+        </label>
+      </div>
+
       <div style={{ marginBottom: "1rem" }}>
         <button onClick={handleRefreshPrices} disabled={refreshingPrices}>
           {refreshingPrices ? "Refreshing…" : "Refresh Prices"}
@@ -190,7 +205,12 @@ export default function App() {
             onSelect={setSelectedOwner}
           />
           <ComplianceWarnings owners={selectedOwner ? [selectedOwner] : []} />
-          <PortfolioView data={portfolio} loading={loading} error={err} />
+          <PortfolioView
+            data={portfolio}
+            loading={loading}
+            error={err}
+            relativeView={relativeView}
+          />
         </>
       )}
 

--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -11,9 +11,9 @@ import { money } from "../lib/money";
 /* ──────────────────────────────────────────────────────────────
  * Component
  * ────────────────────────────────────────────────────────────── */
-type Props = { account: Account };
+type Props = { account: Account; relativeView?: boolean };
 
-export function AccountBlock({ account }: Props) {
+export function AccountBlock({ account, relativeView = false }: Props) {
   const [selected, setSelected] = useState<{
     ticker: string;
     name: string;
@@ -42,6 +42,7 @@ export function AccountBlock({ account }: Props) {
 
       <HoldingsTable
         holdings={account.holdings}
+        relativeView={relativeView}
         onSelectInstrument={(ticker, name) => setSelected({ ticker, name })}
       />
 

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -36,14 +36,22 @@ describe("HoldingsTable", () => {
         },
     ];
 
-    it("displays table rows for each holding", () => {
+    it("displays relative metrics by default", () => {
         render(<HoldingsTable holdings={holdings}/>);
         expect(screen.getByText("AAA")).toBeInTheDocument();
         expect(screen.getByText("XYZ")).toBeInTheDocument();
         expect(screen.getByText(/Gain %/)).toBeInTheDocument();
-        expect(screen.getByText("Test Holding")).toBeInTheDocument();
-        expect(screen.getByText("GBP")).toBeInTheDocument();
-        expect(screen.getAllByText("5").length).toBeGreaterThan(0);
+        expect(screen.getByText(/Weight %/)).toBeInTheDocument();
+        expect(screen.queryByText("Units")).toBeNull();
+        expect(screen.queryByText(/Cost £/)).toBeNull();
+        expect(screen.queryByText(/Gain £/)).toBeNull();
+    });
+
+    it("shows absolute columns when relativeView is false", () => {
+        render(<HoldingsTable holdings={holdings} relativeView={false}/>);
+        expect(screen.getByText("Units")).toBeInTheDocument();
+        expect(screen.getByText(/Cost £/)).toBeInTheDocument();
+        expect(screen.getByText(/Gain £/)).toBeInTheDocument();
     });
 
     it("shows days to go if not eligible", () => {

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -6,6 +6,7 @@ type Props = {
     data: Portfolio | null;
     loading?: boolean;
     error?: string | null;
+    relativeView?: boolean;
 };
 
 /**
@@ -15,7 +16,7 @@ type Props = {
  * relies on its parent for data fetching. Conditional branches early-return to
  * keep the JSX at the bottom easy to follow.
  */
-export function PortfolioView({data, loading, error}: Props) {
+export function PortfolioView({data, loading, error, relativeView = false}: Props) {
     if (loading) return <div>Loading portfolio…</div>; // show a quick spinner
     if (error) return <div style={{color: "red"}}>{error}</div>; // bubble errors
     if (!data) return <div>Select an owner.</div>; // nothing chosen yet
@@ -37,7 +38,7 @@ export function PortfolioView({data, loading, error}: Props) {
             </div>
             {/* Each account is rendered using AccountBlock for clarity */}
             {data.accounts.map((acct) => (
-                <AccountBlock key={acct.account_type} account={acct}/>
+                <AccountBlock key={acct.account_type} account={acct} relativeView={relativeView}/>
             ))}
         </div>
     );


### PR DESCRIPTION
## Summary
- Add `relativeView` state with UI toggle to switch between absolute and relative holdings metrics
- Pass `relativeView` through `PortfolioView` → `AccountBlock` → `HoldingsTable`
- Hide Units/Cost/Gain columns and introduce sortable Weight % in relative mode
- Document new Relative view mode in frontend README

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c9df5314832780cb2f5c93ae32a7