### PR TITLE
Add holding weight percentage and expose in UI

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -348,3 +348,13 @@ def _is_cash(full: str, account_ccy: str = "GBP") -> bool:
 
 def _cash_name(full: str, account_ccy: str = "GBP") -> str:
     return f"Cash ({account_ccy})"
+
+
+def add_weight_pct(h: Dict[str, Any], total_value_estimate_gbp: float) -> Dict[str, Any]:
+    """Compute and add portfolio weight percentage for a holding."""
+    mv = float(h.get("market_value_gbp") or 0.0)
+    if total_value_estimate_gbp > 0:
+        h["weight_pct"] = mv / total_value_estimate_gbp * 100.0
+    else:
+        h["weight_pct"] = None
+    return h

--- a/backend/common/portfolio.py
+++ b/backend/common/portfolio.py
@@ -26,7 +26,7 @@ from backend.common.constants import (
     TICKER,
 )
 from backend.common.data_loader import list_plots, load_account
-from backend.common.holding_utils import enrich_holding
+from backend.common.holding_utils import enrich_holding, add_weight_pct
 
 
 # ───────────────────────── trades helpers ─────────────────────────
@@ -119,11 +119,16 @@ def build_owner_portfolio(owner: str, env: Optional[str] = None) -> Dict[str, An
             }
         )
 
+    total_value = sum(a["value_estimate_gbp"] for a in accounts)
+    for acct in accounts:
+        for h in acct["holdings"]:
+            add_weight_pct(h, total_value)
+
     return {
         "owner": owner,
         "as_of": today.isoformat(),
         "trades_this_month": trades_this,
         "trades_remaining": trades_rem,
         "accounts": accounts,
-        "total_value_estimate_gbp": sum(a["value_estimate_gbp"] for a in accounts),
+        "total_value_estimate_gbp": total_value,
     }

--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -11,9 +11,9 @@ import { money } from "../lib/money";
 /* ──────────────────────────────────────────────────────────────
  * Component
  * ────────────────────────────────────────────────────────────── */
-type Props = { account: Account };
+type Props = { account: Account; total_value_estimate_gbp: number };
 
-export function AccountBlock({ account }: Props) {
+export function AccountBlock({ account, total_value_estimate_gbp }: Props) {
   const [selected, setSelected] = useState<{
     ticker: string;
     name: string;
@@ -42,6 +42,7 @@ export function AccountBlock({ account }: Props) {
 
       <HoldingsTable
         holdings={account.holdings}
+        total_value_estimate_gbp={total_value_estimate_gbp}
         onSelectInstrument={(ticker, name) => setSelected({ ticker, name })}
       />
 

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -10,6 +10,7 @@ describe("GroupPortfolioView", () => {
   it("shows per-owner totals with percentages", async () => {
     const mockPortfolio = {
       name: "All owners combined",
+      total_value_estimate_gbp: 300,
       accounts: [
         {
           owner: "alice",

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -191,6 +191,7 @@ export function GroupPortfolioView({ slug }: Props) {
 
           <HoldingsTable
             holdings={acct.holdings ?? []}
+            total_value_estimate_gbp={portfolio.total_value_estimate_gbp}
             onSelectInstrument={(ticker, name) => setSelected({ ticker, name })}
           />
         </div>

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -37,24 +37,25 @@ describe("HoldingsTable", () => {
     ];
 
     it("displays table rows for each holding", () => {
-        render(<HoldingsTable holdings={holdings}/>);
+        render(<HoldingsTable holdings={holdings} total_value_estimate_gbp={150}/>);
         expect(screen.getByText("AAA")).toBeInTheDocument();
         expect(screen.getByText("XYZ")).toBeInTheDocument();
         expect(screen.getByText(/Gain %/)).toBeInTheDocument();
+        expect(screen.getByText(/Weight %/)).toBeInTheDocument();
         expect(screen.getByText("Test Holding")).toBeInTheDocument();
         expect(screen.getByText("GBP")).toBeInTheDocument();
         expect(screen.getAllByText("5").length).toBeGreaterThan(0);
     });
 
     it("shows days to go if not eligible", () => {
-        render(<HoldingsTable holdings={holdings}/>);
+        render(<HoldingsTable holdings={holdings} total_value_estimate_gbp={150}/>);
         const row = screen.getByText("Test Holding").closest("tr");
         const cell = within(row!).getByText("✗ 10");
         expect(cell).toBeInTheDocument();
     });
 
     it("sorts by ticker when header clicked", () => {
-        render(<HoldingsTable holdings={holdings}/>);
+        render(<HoldingsTable holdings={holdings} total_value_estimate_gbp={150}/>);
         // initially sorted ascending by ticker => AAA first
         let rows = screen.getAllByRole("row");
         expect(within(rows[1]).getByText("AAA")).toBeInTheDocument();

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -6,10 +6,11 @@ import tableStyles from "../styles/table.module.css";
 
 type Props = {
   holdings: Holding[];
+  total_value_estimate_gbp?: number;
   onSelectInstrument?: (ticker: string, name: string) => void;
 };
 
-export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
+export function HoldingsTable({ holdings, total_value_estimate_gbp, onSelectInstrument }: Props) {
 
   const rows = holdings.map((h) => {
     const cost =
@@ -30,7 +31,14 @@ export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
           ? (gain / cost) * 100
           : 0;
 
-    return { ...h, cost, market, gain, gain_pct };
+    const weight_pct =
+      h.weight_pct !== undefined && h.weight_pct !== null
+        ? h.weight_pct
+        : total_value_estimate_gbp
+          ? ((h.market_value_gbp ?? 0) / total_value_estimate_gbp) * 100
+          : undefined;
+
+    return { ...h, cost, market, gain, gain_pct, weight_pct };
   });
 
   const { sorted, sortKey, asc, handleSort } = useSortableTable(rows, "ticker");
@@ -75,6 +83,12 @@ export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
             onClick={() => handleSort("gain_pct")}
           >
             Gain %{sortKey === "gain_pct" ? (asc ? " ▲" : " ▼") : ""}
+          </th>
+          <th
+            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+            onClick={() => handleSort("weight_pct")}
+          >
+            Weight %{sortKey === "weight_pct" ? (asc ? " ▲" : " ▼") : ""}
           </th>
           <th className={tableStyles.cell}>Acquired</th>
           <th
@@ -139,6 +153,9 @@ export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
                 style={{ color: h.gain_pct >= 0 ? "lightgreen" : "red" }}
               >
                 {Number.isFinite(h.gain_pct) ? h.gain_pct.toFixed(1) : "—"}
+              </td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {Number.isFinite(h.weight_pct) ? h.weight_pct.toFixed(1) : "—"}
               </td>
               <td className={tableStyles.cell}>{h.acquired_date}</td>
               <td className={`${tableStyles.cell} ${tableStyles.right}`}>{h.days_held ?? "—"}</td>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -37,7 +37,11 @@ export function PortfolioView({data, loading, error}: Props) {
             </div>
             {/* Each account is rendered using AccountBlock for clarity */}
             {data.accounts.map((acct) => (
-                <AccountBlock key={acct.account_type} account={acct}/>
+                <AccountBlock
+                    key={acct.account_type}
+                    account={acct}
+                    total_value_estimate_gbp={data.total_value_estimate_gbp}
+                />
             ))}
         </div>
     );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -15,6 +15,7 @@ export interface Holding {
     market_value_gbp?: number;
     gain_gbp?: number;
     gain_pct?: number;
+    weight_pct?: number;
     current_price_gbp?: number | null;
     day_change_gbp?: number;
     instrument_type?: string | null;


### PR DESCRIPTION
## Summary
- compute `weight_pct` for each holding and propagate through API
- pass total portfolio value to holdings table and render new Weight % column
- update tests for new props and column

## Testing
- `npm test --prefix frontend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c9dda70883278ff7d81b07612ddd