### PR TITLE
Add tests for app startup and instrument route

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,37 @@
+import os
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from backend.app import create_app
+
+
+def test_health_env_variable(monkeypatch):
+    monkeypatch.setenv("ALLOTMINT_ENV", "staging")
+    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["env"] == "staging"
+
+
+def test_startup_warms_snapshot(monkeypatch):
+    monkeypatch.delenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", raising=False)
+    with patch(
+        "backend.app.refresh_snapshot_in_memory_from_timeseries"
+    ) as mock_refresh:
+        app = create_app()
+        with TestClient(app):
+            pass
+    mock_refresh.assert_called_once_with(days=30)
+
+
+def test_skip_snapshot_warm(monkeypatch):
+    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    with patch(
+        "backend.app.refresh_snapshot_in_memory_from_timeseries"
+    ) as mock_refresh:
+        app = create_app()
+        with TestClient(app):
+            pass
+    mock_refresh.assert_not_called()

--- a/tests/test_instrument_route.py
+++ b/tests/test_instrument_route.py
@@ -1,0 +1,76 @@
+from datetime import date
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from backend.app import create_app
+
+
+def _make_df():
+    return pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-01", periods=2, freq="D"),
+            "Close": [10.0, 11.0],
+            "Close_gbp": [10.0, 11.0],
+        }
+    )
+
+
+@pytest.mark.parametrize("bad", ["", ".L", ".UK"])
+def test_invalid_ticker_rejected(monkeypatch, bad):
+    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get(f"/instrument?ticker={bad}&days=1&format=json")
+    assert resp.status_code == 400
+
+
+def test_full_history_json(monkeypatch):
+    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    app = create_app()
+    df = _make_df()
+    with patch(
+        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
+    ) as mock_load, patch(
+        "backend.routes.instrument.list_portfolios",
+        return_value=[
+            {
+                "owner": "alex",
+                "accounts": [
+                    {
+                        "account_type": "isa",
+                        "holdings": [{"ticker": "ABC.L", "units": 2}],
+                    }
+                ],
+            }
+        ],
+    ), patch(
+        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
+    ):
+        client = TestClient(app)
+        resp = client.get("/instrument?ticker=ABC.L&days=0&format=json")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ticker"] == "ABC.L"
+    assert data["rows"] == 2
+    assert data["positions"][0]["owner"] == "alex"
+    assert data["currency"] == "GBP"
+    assert mock_load.call_args.kwargs["start_date"] == date(1900, 1, 1)
+
+
+def test_html_response(monkeypatch):
+    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    app = create_app()
+    df = _make_df()
+    with patch(
+        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
+    ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
+        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
+    ):
+        client = TestClient(app)
+        resp = client.get("/instrument?ticker=ABC.L&days=1&format=html")
+    assert resp.status_code == 200
+    text = resp.text
+    assert "<table" in text
+    assert "ABC.L" in text


### PR DESCRIPTION
## Summary
- add tests verifying create_app health env and snapshot warming behaviour
- add coverage for instrument endpoint including invalid tickers, full history, and HTML output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897c96aebf4832785712fad534af212