### PR TITLE
feat: add filtering to holdings table

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -65,10 +65,26 @@ describe("HoldingsTable", () => {
         render(<HoldingsTable holdings={holdings}/>);
         // initially sorted ascending by ticker => AAA first
         let rows = screen.getAllByRole("row");
-        expect(within(rows[1]).getByText("AAA")).toBeInTheDocument();
+        expect(within(rows[2]).getByText("AAA")).toBeInTheDocument();
 
         fireEvent.click(screen.getByText(/^Ticker/));
         rows = screen.getAllByRole("row");
-        expect(within(rows[1]).getByText("XYZ")).toBeInTheDocument();
+        expect(within(rows[2]).getByText("XYZ")).toBeInTheDocument();
+    });
+
+    it("filters by ticker", () => {
+        render(<HoldingsTable holdings={holdings}/>);
+        const input = screen.getByPlaceholderText("Ticker");
+        fireEvent.change(input, { target: { value: "AA" } });
+        expect(screen.getByText("AAA")).toBeInTheDocument();
+        expect(screen.queryByText("XYZ")).toBeNull();
+    });
+
+    it("filters by eligibility", () => {
+        render(<HoldingsTable holdings={holdings}/>);
+        const select = screen.getByLabelText("Sell eligible");
+        fireEvent.change(select, { target: { value: "true" } });
+        expect(screen.getByText("AAA")).toBeInTheDocument();
+        expect(screen.queryByText("Test Holding")).toBeNull();
     });
 });

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useState } from "react";
 import type { Holding } from "../types";
 import { money } from "../lib/money";
 import { useSortableTable } from "../hooks/useSortableTable";
@@ -12,6 +13,18 @@ type Props = {
 };
 
 export function HoldingsTable({ holdings, onSelectInstrument, relativeView = true }: Props) {
+  const [filters, setFilters] = useState({
+    ticker: "",
+    name: "",
+    instrument_type: "",
+    units: "",
+    gain_pct: "",
+    sell_eligible: "",
+  });
+
+  const handleFilterChange = (key: keyof typeof filters, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
 
   const computed = holdings.map((h) => {
     const cost =
@@ -41,13 +54,94 @@ export function HoldingsTable({ holdings, onSelectInstrument, relativeView = tru
     weight_pct: totalMarket ? (h.market / totalMarket) * 100 : 0,
   }));
 
-  const { sorted, sortKey, asc, handleSort } = useSortableTable(rows, "ticker");
+  const filtered = rows.filter((h) => {
+    if (filters.ticker && !h.ticker.toLowerCase().includes(filters.ticker.toLowerCase())) return false;
+    if (filters.name && !(h.name ?? "").toLowerCase().includes(filters.name.toLowerCase())) return false;
+    if (
+      filters.instrument_type &&
+      !(h.instrument_type ?? "").toLowerCase().includes(filters.instrument_type.toLowerCase())
+    )
+      return false;
+    if (filters.units) {
+      const minUnits = parseFloat(filters.units);
+      if (!Number.isNaN(minUnits) && h.units < minUnits) return false;
+    }
+    if (filters.gain_pct) {
+      const minGain = parseFloat(filters.gain_pct);
+      if (!Number.isNaN(minGain) && h.gain_pct < minGain) return false;
+    }
+    if (filters.sell_eligible) {
+      const expect = filters.sell_eligible === "true";
+      if (!!h.sell_eligible !== expect) return false;
+    }
+    return true;
+  });
+
+  const { sorted, sortKey, asc, handleSort } = useSortableTable(filtered, "ticker");
 
   if (!rows.length) return null;
 
   return (
     <table className={tableStyles.table} style={{ marginBottom: "1rem" }}>
       <thead>
+        <tr>
+          <th className={tableStyles.cell}>
+            <input
+              placeholder="Ticker"
+              value={filters.ticker}
+              onChange={(e) => handleFilterChange("ticker", e.target.value)}
+            />
+          </th>
+          <th className={tableStyles.cell}>
+            <input
+              placeholder="Name"
+              value={filters.name}
+              onChange={(e) => handleFilterChange("name", e.target.value)}
+            />
+          </th>
+          <th className={tableStyles.cell}></th>
+          <th className={tableStyles.cell}>
+            <input
+              placeholder="Type"
+              value={filters.instrument_type}
+              onChange={(e) => handleFilterChange("instrument_type", e.target.value)}
+            />
+          </th>
+          {!relativeView && (
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+              <input
+                placeholder="Units"
+                value={filters.units}
+                onChange={(e) => handleFilterChange("units", e.target.value)}
+              />
+            </th>
+          )}
+          <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+          {!relativeView && <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>}
+          <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+          {!relativeView && <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>}
+          <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+            <input
+              placeholder="Gain %"
+              value={filters.gain_pct}
+              onChange={(e) => handleFilterChange("gain_pct", e.target.value)}
+            />
+          </th>
+          <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+          <th className={tableStyles.cell}></th>
+          <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+          <th className={`${tableStyles.cell} ${tableStyles.center}`}>
+            <select
+              aria-label="Sell eligible"
+              value={filters.sell_eligible}
+              onChange={(e) => handleFilterChange("sell_eligible", e.target.value)}
+            >
+              <option value="">All</option>
+              <option value="true">Yes</option>
+              <option value="false">No</option>
+            </select>
+          </th>
+        </tr>
         <tr>
           <th
             className={`${tableStyles.cell} ${tableStyles.clickable}`}


### PR DESCRIPTION
## Summary
- enable per-column filtering in HoldingsTable with filter row
- apply filters before sorting and reuse existing hook
- add tests for ticker and eligibility filtering

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897ce0f7aa88327922085343f9020ee