### PR TITLE
Handle missing Telegram credentials gracefully

### DIFF
--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -1,15 +1,40 @@
 from types import SimpleNamespace
 from unittest.mock import patch
-import pytest
+import logging
 
-from backend.utils.telegram_utils import send_message
+from backend.utils.telegram_utils import send_message, TelegramLogHandler
 
 
-def test_send_message_requires_config(monkeypatch):
+def test_send_message_skips_without_config(monkeypatch):
+    """The helper should be a no-op when credentials are missing."""
+
     monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
     monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
-    with pytest.raises(RuntimeError):
+
+    def fake_post(*args, **kwargs):  # pragma: no cover - shouldn't be called
+        raise AssertionError("requests.post should not be called")
+
+    with patch("backend.utils.telegram_utils.requests.post", fake_post):
         send_message("hi")
+
+
+def test_log_handler_without_config(monkeypatch):
+    """Logging via ``TelegramLogHandler`` should not raise without credentials."""
+
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+
+    handler = TelegramLogHandler()
+    logger = logging.getLogger("telegram-util-test")
+    logger.addHandler(handler)
+    try:
+        with patch(
+            "backend.utils.telegram_utils.requests.post",
+            side_effect=AssertionError("requests.post should not be called"),
+        ):
+            logger.error("oops")
+    finally:
+        logger.removeHandler(handler)
 
 
 def test_send_message_success(monkeypatch):


### PR DESCRIPTION
## Summary
- Avoid raising `RuntimeError` when Telegram credentials are absent; `send_message` now skips silently.
- Update `TelegramLogHandler` tests to ensure logging is skipped without credentials.
- Extend tests covering both helper and log handler behaviour.

## Testing
- `pytest tests/test_telegram_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d186c7b48327b75e101ee4c52a12