### PR TITLE
Add swagger link to support page

### DIFF
--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -1,9 +1,23 @@
 import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 import Support from "./Support";
 
 describe("Support page", () => {
   it("renders environment heading", () => {
     render(<Support />);
     expect(screen.getByText(/Environment/)).toBeInTheDocument();
+  });
+
+  it("shows swagger link for VITE_API_URL", () => {
+    vi.stubEnv("VITE_API_URL", "http://localhost:8000");
+    render(<Support />);
+    expect(
+      screen.getByRole("link", { name: "http://localhost:8000" })
+    ).toHaveAttribute("href", "http://localhost:8000");
+    expect(screen.getByRole("link", { name: "swagger" })).toHaveAttribute(
+      "href",
+      "http://localhost:8000/docs#/"
+    );
+    vi.unstubAllEnvs();
   });
 });

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -33,12 +33,27 @@ export default function Support() {
       <h2>Environment</h2>
       <table style={{ fontSize: "0.9rem" }}>
         <tbody>
-          {envEntries.map(([k, v]) => (
-            <tr key={k}>
-              <td style={{ paddingRight: "0.5rem", fontWeight: 500 }}>{k}</td>
-              <td>{String(v)}</td>
-            </tr>
-          ))}
+          {envEntries.map(([k, v]) => {
+            const value = String(v);
+            if (k === "VITE_API_URL") {
+              const base = value.replace(/\/$/, "");
+              return (
+                <tr key={k}>
+                  <td style={{ paddingRight: "0.5rem", fontWeight: 500 }}>{k}</td>
+                  <td>
+                    <a href={value}>{value}</a>{" "}
+                    <a href={`${base}/docs#/`}>swagger</a>
+                  </td>
+                </tr>
+              );
+            }
+            return (
+              <tr key={k}>
+                <td style={{ paddingRight: "0.5rem", fontWeight: 500 }}>{k}</td>
+                <td>{value}</td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
       <h2>Telegram Message</h2>


### PR DESCRIPTION
## Summary
- show API URL and swagger docs link on support page
- test that support page lists swagger link for VITE_API_URL

## Testing
- `npx vitest run`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897cec3f4948327a2de8a7fe6261dfa