### PR TITLE
feat: add timeseries editor

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -15,6 +15,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from backend.routes.instrument import router as instrument_router
 from backend.routes.portfolio import router as portfolio_router
 from backend.routes.timeseries_meta import router as timeseries_router
+from backend.routes.timeseries_edit import router as timeseries_edit_router
 
 from backend.routes.transactions import router as transactions_router
 from backend.routes.alerts import router as alerts_router
@@ -54,6 +55,7 @@ def create_app() -> FastAPI:
     app.include_router(portfolio_router)
     app.include_router(instrument_router)
     app.include_router(timeseries_router)
+    app.include_router(timeseries_edit_router)
     app.include_router(transactions_router)
     app.include_router(alerts_router)
     app.include_router(compliance_router)

--- a/backend/routes/timeseries_edit.py
+++ b/backend/routes/timeseries_edit.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import io
+
+import pandas as pd
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+
+from backend.timeseries.cache import (
+    EXPECTED_COLS,
+    _ensure_schema,
+    meta_timeseries_cache_path,
+)
+
+router = APIRouter(prefix="/timeseries", tags=["timeseries"])
+
+
+def _load_timeseries(ticker: str, exchange: str) -> pd.DataFrame:
+    path = meta_timeseries_cache_path(ticker, exchange)
+    if path.exists():
+        try:
+            return _ensure_schema(pd.read_parquet(path))
+        except Exception as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=500, detail=str(exc))
+    return pd.DataFrame(columns=EXPECTED_COLS)
+
+
+@router.get("/edit")
+async def get_timeseries_edit(
+    ticker: str = Query(...), exchange: str = Query("L")
+) -> JSONResponse:
+    df = _load_timeseries(ticker, exchange)
+    if not df.empty:
+        df = df.copy()
+        df["Date"] = pd.to_datetime(df["Date"]).dt.strftime("%Y-%m-%d")
+    return JSONResponse(df.to_dict(orient="records"))
+
+
+@router.post("/edit")
+async def post_timeseries_edit(
+    request: Request, ticker: str = Query(...), exchange: str = Query("L")
+) -> JSONResponse:
+    content_type = request.headers.get("content-type", "")
+    try:
+        if "text/csv" in content_type:
+            body = await request.body()
+            df = pd.read_csv(io.StringIO(body.decode()))
+        else:
+            payload = await request.json()
+            if isinstance(payload, list):
+                df = pd.DataFrame(payload)
+            else:
+                raise ValueError("JSON payload must be a list of records")
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    df = _ensure_schema(df)
+    if "Ticker" not in df.columns or df["Ticker"].isna().all():
+        df["Ticker"] = ticker
+    if "Source" not in df.columns or df["Source"].isna().all():
+        df["Source"] = "Manual"
+
+    path = meta_timeseries_cache_path(ticker, exchange)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(path, index=False)
+    return JSONResponse({"status": "ok", "rows": len(df)})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { PerformanceDashboard } from "./components/PerformanceDashboard";
 import { AlertsPanel } from "./components/AlertsPanel";
 import { ComplianceWarnings } from "./components/ComplianceWarnings";
 import { Screener } from "./pages/Screener";
+import { TimeseriesEdit } from "./pages/TimeseriesEdit";
 
 type Mode =
   | "owner"
@@ -33,7 +34,8 @@ type Mode =
   | "instrument"
   | "transactions"
   | "performance"
-  | "screener";
+  | "screener"
+  | "timeseries";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -43,6 +45,7 @@ const initialMode: Mode =
   path[0] === "transactions" ? "transactions" :
   path[0] === "performance" ? "performance" :
   path[0] === "screener" ? "screener" :
+  path[0] === "timeseries" ? "timeseries" :
   "group";
 const initialSlug = path[1] ?? "";
 
@@ -152,6 +155,7 @@ export default function App() {
           "performance",
           "transactions",
           "screener",
+          "timeseries",
         ] as Mode[]).map((m) => (
           <label key={m} style={{ marginRight: "1rem" }}>
             <input
@@ -270,6 +274,7 @@ export default function App() {
       {mode === "transactions" && <TransactionsPage owners={owners} />}
 
       {mode === "screener" && <Screener />}
+      {mode === "timeseries" && <TimeseriesEdit />}
 
       <p style={{ marginTop: "2rem", textAlign: "center" }}>
         <a href="/support">Support</a>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,6 +9,7 @@ import type {
   PerformancePoint,
   Transaction,
   Alert,
+  PriceEntry,
   ScreenerResult,
 } from "./types";
 
@@ -102,6 +103,18 @@ export const getInstrumentDetail = (ticker: string, days = 365) =>
       ticker
     )}&days=${days}&format=json`
   );
+
+
+export const getTimeseries = (ticker: string, exchange = "L") =>
+  fetchJson<PriceEntry[]>(`${API_BASE}/timeseries/edit?ticker=${encodeURIComponent(ticker)}&exchange=${encodeURIComponent(exchange)}`);
+
+export const saveTimeseries = (ticker: string, exchange: string, rows: PriceEntry[]) =>
+  fetchJson<{ status: string; rows: number }>(`${API_BASE}/timeseries/edit?ticker=${encodeURIComponent(ticker)}&exchange=${encodeURIComponent(exchange)}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(rows),
+  });
+
 
 export const getTransactions = (params: {
   owner?: string;

--- a/frontend/src/pages/TimeseriesEdit.test.tsx
+++ b/frontend/src/pages/TimeseriesEdit.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../api", () => ({
+  getTimeseries: vi.fn().mockResolvedValue([
+    { Date: "2024-01-01", Open: 1, High: 1, Low: 1, Close: 1, Volume: 1 },
+  ]),
+  saveTimeseries: vi.fn().mockResolvedValue({ status: "ok", rows: 1 }),
+}));
+
+import { TimeseriesEdit } from "./TimeseriesEdit";
+import { getTimeseries, saveTimeseries } from "../api";
+
+describe("TimeseriesEdit page", () => {
+  it("loads and saves CSV data", async () => {
+    render(<TimeseriesEdit />);
+
+    fireEvent.change(screen.getByLabelText(/Ticker/i), {
+      target: { value: "ABC" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /load/i }));
+
+    expect(await screen.findByText(/Loaded 1 rows/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(saveTimeseries).toHaveBeenCalled();
+    expect(getTimeseries).toHaveBeenCalledWith("ABC", "L");
+  });
+});

--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -1,0 +1,99 @@
+import { useState, ChangeEvent } from "react";
+import { getTimeseries, saveTimeseries } from "../api";
+import type { PriceEntry } from "../types";
+
+export function TimeseriesEdit() {
+  const [ticker, setTicker] = useState("");
+  const [exchange, setExchange] = useState("L");
+  const [csv, setCsv] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleLoad() {
+    setError(null);
+    try {
+      const rows = await getTimeseries(ticker, exchange);
+      const header = "Date,Open,High,Low,Close,Volume";
+      const lines = rows.map(
+        (r) =>
+          `${r.Date},${r.Open ?? ""},${r.High ?? ""},${r.Low ?? ""},${r.Close ?? ""},${r.Volume ?? ""}`
+      );
+      setCsv([header, ...lines].join("\n"));
+      setStatus(`Loaded ${rows.length} rows`);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  function handleFile(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setCsv(String(reader.result));
+    reader.readAsText(file);
+  }
+
+  async function handleSave() {
+    setError(null);
+    try {
+      const lines = csv.split(/\r?\n/).filter((l) => l.trim());
+      if (!lines.length) throw new Error("No data to save");
+      const [header, ...rows] = lines;
+      const cols = header.split(",");
+      const data: PriceEntry[] = rows.map((line) => {
+        const parts = line.split(",");
+        const obj: any = {};
+        cols.forEach((col, i) => {
+          const val = parts[i];
+          if (col === "Date") obj[col] = val;
+          else obj[col] = val === undefined || val === "" ? null : Number(val);
+        });
+        return obj as PriceEntry;
+      });
+      await saveTimeseries(ticker, exchange, data);
+      setStatus(`Saved ${data.length} rows`);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
+      <h2>Timeseries Editor</h2>
+      <div style={{ marginBottom: "0.5rem" }}>
+        <label>
+          Ticker {" "}
+          <input value={ticker} onChange={(e) => setTicker(e.target.value)} />
+        </label>{" "}
+        <label>
+          Exchange {" "}
+          <input
+            value={exchange}
+            onChange={(e) => setExchange(e.target.value)}
+            style={{ width: "4rem" }}
+          />
+        </label>{" "}
+        <button onClick={handleLoad} disabled={!ticker}>
+          Load
+        </button>
+      </div>
+      <div style={{ marginBottom: "0.5rem" }}>
+        <textarea
+          value={csv}
+          onChange={(e) => setCsv(e.target.value)}
+          rows={20}
+          style={{ width: "100%" }}
+          placeholder="Date,Open,High,Low,Close,Volume"
+        />
+      </div>
+      <div style={{ marginBottom: "0.5rem" }}>
+        <input type="file" accept=".csv" onChange={handleFile} />{" "}
+        <button onClick={handleSave} disabled={!ticker || !csv.trim()}>
+          Save
+        </button>
+      </div>
+      {status && <p style={{ color: "green" }}>{status}</p>}
+      {error && <p style={{ color: "red" }}>{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -103,6 +103,17 @@ export interface Transaction {
     shares?: number | null;
 }
 
+export interface PriceEntry {
+    Date: string;
+    Open?: number | null;
+    High?: number | null;
+    Low?: number | null;
+    Close?: number | null;
+    Volume?: number | null;
+    Ticker?: string;
+    Source?: string;
+}
+
 export type Alert = {
     ticker: string;
     change_pct: number;

--- a/tests/test_timeseries_edit_route.py
+++ b/tests/test_timeseries_edit_route.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+
+
+def test_timeseries_edit_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
+    app = create_app()
+    client = TestClient(app)
+
+    data = [
+        {
+            "Date": "2024-01-01",
+            "Open": 1.0,
+            "High": 2.0,
+            "Low": 0.5,
+            "Close": 1.5,
+            "Volume": 100,
+        },
+        {
+            "Date": "2024-01-02",
+            "Open": 1.1,
+            "High": 2.1,
+            "Low": 0.6,
+            "Close": 1.6,
+            "Volume": 110,
+        },
+    ]
+    resp = client.post("/timeseries/edit?ticker=ABC&exchange=L", json=data)
+    assert resp.status_code == 200
+    assert resp.json()["rows"] == 2
+
+    resp = client.get("/timeseries/edit?ticker=ABC&exchange=L")
+    assert resp.status_code == 200
+    returned = resp.json()
+    assert len(returned) == 2
+    assert returned[0]["Open"] == 1.0


### PR DESCRIPTION
## Summary
- add backend endpoint to edit cached timeseries and save to parquet
- expose API helpers and new Timeseries Editor page to add, edit or import CSV data
- include tests for editor API and page

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897e3707ed4832788a2c2d35e322706