### PR TITLE
Handle case-insensitive close column when refreshing snapshot

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -347,11 +347,17 @@ def refresh_snapshot_in_memory_from_timeseries(days: int = 365) -> None:
                                         start_date=cutoff, end_date=today)
 
             if df is not None and not df.empty:
-                latest_row = df.iloc[-1]
-                snapshot[t] = {
-                    "last_price":     float(latest_row["close"]),
-                    "last_price_date": latest_row["Date"].strftime("%Y-%m-%d"),
-                }
+                # Map lowercase column names to their actual counterparts
+                name_map = {c.lower(): c for c in df.columns}
+
+                # Access the close column in a case-insensitive manner
+                if "close" in name_map:
+                    latest_row = df.iloc[-1]
+                    close_col = name_map["close"]
+                    snapshot[t] = {
+                        "last_price": float(latest_row[close_col]),
+                        "last_price_date": latest_row["Date"].strftime("%Y-%m-%d"),
+                    }
         except Exception as e:
             logger.warning("Could not get timeseries for %s: %s", t, e)
 

--- a/tests/test_portfolio_utils_snapshot.py
+++ b/tests/test_portfolio_utils_snapshot.py
@@ -1,0 +1,48 @@
+import json
+from datetime import date
+import pandas as pd
+
+from backend.common import portfolio_utils
+from backend.timeseries import cache as ts_cache
+
+
+def test_refresh_snapshot_case_insensitive_close(monkeypatch, tmp_path):
+    ticker = "ABC.L"
+    today = date.today()
+    df = pd.DataFrame({"Date": [pd.Timestamp(today)], "Close": [123.45]})
+
+    monkeypatch.setattr(portfolio_utils, "list_all_unique_tickers", lambda: [ticker])
+    monkeypatch.setattr(ts_cache, "fetch_meta_timeseries", lambda **kwargs: df)
+    monkeypatch.setattr(portfolio_utils, "_PRICES_PATH", tmp_path / "latest_prices.json")
+    monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {})
+
+    portfolio_utils.refresh_snapshot_in_memory_from_timeseries(days=1)
+
+    snapshot = portfolio_utils._PRICE_SNAPSHOT
+    assert ticker in snapshot
+    info = snapshot[ticker]
+    assert info["last_price"] == 123.45
+    assert info["last_price_date"] == today.strftime("%Y-%m-%d")
+
+    file_data = json.loads((tmp_path / "latest_prices.json").read_text())
+    assert ticker in file_data
+    assert file_data[ticker]["last_price"] == 123.45
+
+
+def test_refresh_snapshot_skips_missing_close(monkeypatch, tmp_path):
+    ticker = "XYZ.L"
+    today = date.today()
+    df = pd.DataFrame({"Date": [pd.Timestamp(today)], "High": [1.23]})
+
+    monkeypatch.setattr(portfolio_utils, "list_all_unique_tickers", lambda: [ticker])
+    monkeypatch.setattr(ts_cache, "fetch_meta_timeseries", lambda **kwargs: df)
+    monkeypatch.setattr(portfolio_utils, "_PRICES_PATH", tmp_path / "latest_prices.json")
+    monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {})
+
+    portfolio_utils.refresh_snapshot_in_memory_from_timeseries(days=1)
+
+    snapshot = portfolio_utils._PRICE_SNAPSHOT
+    assert ticker not in snapshot
+
+    file_data = json.loads((tmp_path / "latest_prices.json").read_text())
+    assert ticker not in file_data


### PR DESCRIPTION
## Summary
- Prevent KeyErrors when timeseries uses non-standard close column casing by mapping dataframe columns to lowercase names.
- Skip tickers missing a close column when building the price snapshot.
- Add unit tests for case-insensitive close column handling and missing close column.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897d18550dc8327b5c1572317277d92