### PR TITLE
add value at risk route tests

### DIFF
--- a/frontend/src/components/ValueAtRisk.test.tsx
+++ b/frontend/src/components/ValueAtRisk.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ValueAtRisk from "./ValueAtRisk";
+
+describe("ValueAtRisk component", () => {
+  test("renders VaR value and selectors", async () => {
+    render(<ValueAtRisk value={123.45} days={10} confidence={0.95} />);
+
+    expect(screen.getByText("123.45")).toBeInTheDocument();
+    const periodSel = screen.getByLabelText(/period/i);
+    const confSel = screen.getByLabelText(/confidence/i);
+    expect(periodSel).toBeInTheDocument();
+    expect(confSel).toBeInTheDocument();
+
+    await userEvent.selectOptions(periodSel, "30");
+    await userEvent.selectOptions(confSel, "0.99");
+  });
+});

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -221,3 +221,25 @@ def test_screener_endpoint(monkeypatch):
     data = resp.json()
     assert len(data) == 1
     assert data[0]["ticker"] == "AAA"
+
+def test_var_endpoint_default():
+    owners = client.get("/owners").json()
+    assert owners, "No owners returned"
+    owner = owners[0]["owner"]
+    resp = client.get(f"/var/{owner}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "value_at_risk" in data
+
+
+@pytest.mark.parametrize("days,confidence", [(10, 0.9), (30, 0.99)])
+def test_var_endpoint_params(days, confidence):
+    owners = client.get("/owners").json()
+    assert owners, "No owners returned"
+    owner = owners[0]["owner"]
+    resp = client.get(f"/var/{owner}?days={days}&confidence={confidence}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "value_at_risk" in data
+    assert data.get("days") == days
+    assert data.get("confidence") == confidence

--- a/tests/test_var_route.py
+++ b/tests/test_var_route.py
@@ -1,0 +1,57 @@
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.local_api.main import app
+from backend.common import portfolio_loader
+from backend.timeseries import cache as ts_cache
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def deterministic_setup(monkeypatch):
+    """Set up a tiny deterministic portfolio and price series."""
+
+    portfolio = {
+        "owner": "alice",
+        "accounts": [
+            {
+                "name": "ISA",
+                "holdings": [
+                    {"ticker": "ABC", "exchange": "L", "quantity": 10, "currency": "GBP"}
+                ],
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        portfolio_loader, "load_portfolio", lambda owner, env=None: portfolio
+    )
+
+    # Closing prices for five consecutive days
+    prices = pd.DataFrame(
+        {
+            "Date": pd.date_range("2024-01-01", periods=5, freq="D"),
+            "Open": 0.0,
+            "High": 0.0,
+            "Low": 0.0,
+            "Close": [100, 95, 96, 97, 101],
+            "Volume": 0,
+            "Ticker": "ABC",
+            "Source": "test",
+        }
+    )
+    monkeypatch.setattr(
+        ts_cache, "load_meta_timeseries", lambda ticker, exchange, days: prices
+    )
+
+    return portfolio, prices
+
+
+def test_var_known_case(deterministic_setup):
+    resp = client.get("/var/alice?days=4&confidence=0.95")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "value_at_risk" in data
+    # Expected 5% loss on latest value 101 with quantity 10 -> 50.5
+    assert data["value_at_risk"] == pytest.approx(50.5, rel=1e-3)


### PR DESCRIPTION
## Summary
- add deterministic unit test for Value at Risk route
- add frontend test for ValueAtRisk component selectors
- exercise /var/{owner} endpoint with varying parameters in API tests

## Testing
- `pytest tests/test_var_route.py tests/test_backend_api.py` *(fails: assert 404 == 200)*
- `cd frontend && npm test` *(fails: Failed to resolve import "@testing-library/user-event")*

------
https://chatgpt.com/codex/tasks/task_e_6897da1d8ef08327970e1a3ce847f245