### PR TITLE
Handle zero-unit and synthetic holdings in aggregation

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -189,8 +189,15 @@ def get_effective_cost_basis_gbp(
     If booked cost exists, use it. Otherwise derive:
       units * (close near acquisition OR latest cache price).
     """
-    units = float(h.get(UNITS, 0) or 0)
-    booked = float(h.get(COST_BASIS_GBP) or 0.0)
+    units = float(h.get(UNITS) or 0.0)
+    if units <= 0:
+        return 0.0
+
+    booked_raw = h.get(COST_BASIS_GBP)
+    try:
+        booked = float(booked_raw) if booked_raw is not None else 0.0
+    except (TypeError, ValueError):
+        booked = 0.0
     if booked > 0:
         return round(booked, 2)
 
@@ -273,6 +280,25 @@ def enrich_holding(
 
     out["currency"] = meta.get("currency")
     out["instrument_type"] = meta.get("instrumentType") or meta.get("instrument_type")
+
+    units = float(out.get(UNITS, 0) or 0.0)
+    if units <= 0:
+        out.setdefault(COST_BASIS_GBP, None)
+        out[EFFECTIVE_COST_BASIS_GBP] = 0.0
+        out["market_value_gbp"] = 0.0
+        out["gain_gbp"] = 0.0
+        out["unrealised_gain_gbp"] = 0.0
+        out["unrealized_gain_gbp"] = 0.0
+        out["gain_pct"] = None
+        out["day_change_gbp"] = 0.0
+        out["days_held"] = None
+        out["sell_eligible"] = False
+        out["eligible_on"] = None
+        out["days_until_eligible"] = None
+        out["price"] = None
+        out["current_price_gbp"] = None
+        out["cost_basis_source"] = "none"
+        return out
 
     # default acquired date if missing
     if out.get(ACQUIRED_DATE) is None:

--- a/tests/test_virtual_portfolio.py
+++ b/tests/test_virtual_portfolio.py
@@ -1,0 +1,87 @@
+import datetime as dt
+import pandas as pd
+import pytest
+
+from backend.common import portfolio_utils
+from backend.common import holding_utils
+
+
+def test_aggregate_with_mixed_holdings(monkeypatch):
+    today = dt.date(2024, 1, 10)
+
+    def fake_get_price_for_date_scaled(ticker, exchange, d, field="Close"):
+        prices = {"AAA": 12.0, "CCC": 8.0}
+        if ticker not in prices:
+            raise AssertionError("price lookup should not occur for zero-unit holdings")
+        return prices[ticker]
+
+    def fake_derived_cost_basis_close_px(ticker, exchange, acq, cache):
+        prices = {"AAA": 10.0, "CCC": 7.0}
+        if ticker not in prices:
+            raise AssertionError("cost basis lookup should not occur for zero-unit holdings")
+        return prices[ticker]
+
+    monkeypatch.setattr(holding_utils, "_get_price_for_date_scaled", fake_get_price_for_date_scaled)
+    monkeypatch.setattr(holding_utils, "_derived_cost_basis_close_px", fake_derived_cost_basis_close_px)
+
+    holdings = [
+        {"ticker": "AAA.L", "units": 10, "cost_basis_gbp": 100},
+        {"ticker": "BBB.L", "units": 0},  # watchlist only
+        {"ticker": "CCC.L", "units": 5},  # synthetic, derive cost basis
+    ]
+    price_cache = {}
+    enriched = [holding_utils.enrich_holding(h, today, price_cache) for h in holdings]
+
+    snapshot = {
+        "AAA.L": {"last_price": 12.0, "last_price_date": "2024-01-09"},
+        "BBB.L": {"last_price": 20.0, "last_price_date": "2024-01-09"},
+        "CCC.L": {"last_price": 8.0, "last_price_date": "2024-01-09"},
+    }
+    monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", snapshot, raising=False)
+
+    portfolio = {"accounts": [{"holdings": enriched}]}
+    rows = {r["ticker"]: r for r in portfolio_utils.aggregate_by_ticker(portfolio)}
+
+    assert rows["AAA.L"]["units"] == 10
+    assert rows["AAA.L"]["market_value_gbp"] == 120.0
+    assert rows["AAA.L"]["cost_gbp"] == 100.0
+
+    assert rows["BBB.L"]["units"] == 0
+    assert rows["BBB.L"]["market_value_gbp"] == 0.0
+
+    assert rows["CCC.L"]["units"] == 5
+    assert rows["CCC.L"]["cost_gbp"] == 35.0  # 5 * derived 7.0
+    assert rows["CCC.L"]["market_value_gbp"] == 40.0
+
+
+def test_performance_with_synthetic_holdings(monkeypatch):
+    portfolio = {
+        "accounts": [
+            {
+                "holdings": [
+                    {"ticker": "AAA.L", "units": 10},
+                    {"ticker": "BBB.L", "units": 0},
+                    {"ticker": "CCC.L", "units": 5},
+                ]
+            }
+        ]
+    }
+
+    monkeypatch.setattr(portfolio_utils.portfolio_mod, "build_owner_portfolio", lambda owner: portfolio)
+
+    def fake_load_meta_timeseries(ticker, exchange, days):
+        dates = pd.date_range("2024-01-01", periods=3, freq="D")
+        prices = {
+            "AAA": [10, 11, 12],
+            "CCC": [20, 21, 22],
+        }
+        return pd.DataFrame({"Date": dates, "Close": prices.get(ticker, [0, 0, 0])})
+
+    monkeypatch.setattr(portfolio_utils, "load_meta_timeseries", fake_load_meta_timeseries)
+
+    perf = portfolio_utils.compute_owner_performance("virtual", days=3)
+
+    assert len(perf) == 3
+    assert perf[0]["value"] == 200  # 10*10 + 5*20
+    assert perf[-1]["value"] == 230  # 10*12 + 5*22
+    assert perf[-1]["cumulative_return"] == pytest.approx(0.15, rel=1e-3)


### PR DESCRIPTION
## Summary
- Skip cost basis and price lookups for holdings with no units
- Safely parse missing cost basis and enrich zero-unit holdings without side effects
- Add tests ensuring aggregation and performance work with real, watchlist and synthetic holdings

## Testing
- `pytest tests/test_virtual_portfolio.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6897e2ff583883279294337522405028