### PR TITLE
Support default command via config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+error_summary:
+  default_command:
+    - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,4 @@ mangum~=0.19.0
 mangum-cli~=0.1.0
 aws-cdk-lib~=2.151.0
 constructs~=10.3.0
+PyYAML~=6.0.2

--- a/run_with_error_summary.py
+++ b/run_with_error_summary.py
@@ -2,11 +2,20 @@
 """Run a command and record stderr error lines to error_summary.log.
 
 Usage:
-    python run_with_error_summary.py <command> [args...]
+    python run_with_error_summary.py [<command> [args...]]
+
+When called without a command, the script loads a default command from
+``config.yaml`` under ``error_summary.default_command``. Explicit CLI arguments
+always override the configured default.
 
 The script streams the command's output to the console while capturing any
 stderr lines containing the word "error". These lines are appended to
 ``error_summary.log`` and a frequency summary is written at the end.
+
+Example ``config.yaml``::
+
+    error_summary:
+      default_command: ["pytest"]
 """
 
 import sys
@@ -16,18 +25,38 @@ import pathlib
 import datetime
 import re
 from collections import Counter
+from typing import List, Optional
+
+import yaml
 
 def stream_reader(stream, callback):
     for line in iter(stream.readline, ''):
         callback(line)
     stream.close()
 
+def load_default_command() -> Optional[List[str]]:
+    """Return default command from config.yaml if available."""
+    config_path = pathlib.Path("config.yaml")
+    if not config_path.exists():
+        return None
+    try:
+        with config_path.open() as f:
+            data = yaml.safe_load(f) or {}
+        cmd = data.get("error_summary", {}).get("default_command")
+        if isinstance(cmd, list) and all(isinstance(item, str) for item in cmd):
+            return cmd
+    except Exception:
+        pass
+    return None
 def main() -> int:
     if len(sys.argv) < 2:
-        print(__doc__)
-        return 1
-
-    cmd = sys.argv[1:]
+        default_cmd = load_default_command()
+        if not default_cmd:
+            print(__doc__)
+            return 1
+        cmd = default_cmd
+    else:
+        cmd = sys.argv[1:]
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- allow `run_with_error_summary.py` to load a default command from `config.yaml`
- document and provide example config for `error_summary.default_command`
- add PyYAML dependency and sample configuration

## Testing
- `pytest`
- `python run_with_error_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_6897dba7dbec832794a78d65279a9e77