### PR TITLE
Add trading agent CLI script

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ errors which you can attach when reporting bugs.
 python run_with_error_summary.py pytest
 ```
 
+## Trading Agent
+
+Use the helper script to run the trading agent locally. All arguments are
+optional:
+
+```bash
+python scripts/run_trading_agent.py --tickers AAPL MSFT --thresholds 0.1 0.2 --indicator RSI
+```
+
 ## Deploy to AWS
 
 The project includes an AWS CDK stack that provisions an S3 bucket and

--- a/scripts/run_trading_agent.py
+++ b/scripts/run_trading_agent.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Command-line helper to run the trading agent."""
+
+import argparse
+
+from backend.agent.trading_agent import run
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the trading agent")
+    parser.add_argument(
+        "--tickers", nargs="+", help="List of tickers to analyse", default=None
+    )
+    parser.add_argument(
+        "--thresholds",
+        type=float,
+        nargs="+",
+        help="Threshold values for each ticker",
+        default=None,
+    )
+    parser.add_argument(
+        "--indicator",
+        type=str,
+        help="Technical indicator to use",
+        default=None,
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run(tickers=args.tickers, thresholds=args.thresholds, indicator=args.indicator)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/run_trading_agent.py` for running the backend trading agent with optional ticker, threshold and indicator arguments
- document how to invoke the trading agent in a new README section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897e2d98ee8832797f81a4ef86fae7a