### PR TITLE
Invoke trading agent after scheduled price refresh

### DIFF
--- a/backend/lambda_api/price_refresh.py
+++ b/backend/lambda_api/price_refresh.py
@@ -1,5 +1,34 @@
-"""Lambda entry point to refresh prices on a schedule."""
+"""Lambda entry point to refresh prices on a schedule.
+
+After refreshing prices the optional trading agent can be triggered. The
+behaviour is controlled via the ``ALLOTMINT_ENABLE_TRADING_AGENT`` environment
+variable so deployments can enable or disable automated trading without code
+changes.
+"""
+
+from __future__ import annotations
+
+import os
+
 from backend.common.prices import refresh_prices
 
+try:  # trading agent is optional; skip if missing
+    import trading_agent  # type: ignore
+except Exception:  # pragma: no cover - only hit when package missing
+    trading_agent = None
+
+
 def lambda_handler(event, context):
-    return refresh_prices()
+    """Lambda handler invoked by the scheduler."""
+
+    result = refresh_prices()
+
+    # honour environment flag so trading agent can be toggled per deployment
+    if (
+        os.getenv("ALLOTMINT_ENABLE_TRADING_AGENT", "").lower()
+        in {"1", "true", "yes"}
+        and trading_agent is not None
+    ):
+        trading_agent.run()
+
+    return result


### PR DESCRIPTION
## Summary
- trigger optional `trading_agent.run()` after scheduled price refresh
- guard trading agent execution behind `ALLOTMINT_ENABLE_TRADING_AGENT` env flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897e2db6b308327b013e9039b5a9815