### PR TITLE
Use config-driven environment and snapshot options

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -23,6 +23,8 @@ class Config:
     uvicorn_port: Optional[int] = None
     reload: Optional[bool] = None
     log_config: Optional[str] = None
+    skip_snapshot_warm: Optional[bool] = None
+    snapshot_warm_days: Optional[int] = None
 
     # scraping / automation
     ft_url_template: Optional[str] = None
@@ -73,6 +75,8 @@ def load_config() -> Config:
         uvicorn_port=data.get("uvicorn_port"),
         reload=data.get("reload"),
         log_config=data.get("log_config"),
+        skip_snapshot_warm=data.get("skip_snapshot_warm"),
+        snapshot_warm_days=data.get("snapshot_warm_days"),
         ft_url_template=data.get("ft_url_template"),
         selenium_user_agent=data.get("selenium_user_agent"),
         selenium_headless=data.get("selenium_headless"),

--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,8 @@ transactions_output_root: data/accounts
 uvicorn_port: 8000
 reload: true
 log_config: backend/logging.ini
+skip_snapshot_warm: false
+snapshot_warm_days: 30
 ft_url_template: "https://markets.ft.com/data/funds/tearsheet/historical?s={ticker}"
 selenium_user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"
 selenium_headless: true

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,13 +1,13 @@
-import os
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 
 from backend.app import create_app
+from backend.config import config
 
 
 def test_health_env_variable(monkeypatch):
-    monkeypatch.setenv("ALLOTMINT_ENV", "staging")
-    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    monkeypatch.setattr(config, "app_env", "staging")
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     with TestClient(app) as client:
         resp = client.get("/health")
@@ -16,7 +16,8 @@ def test_health_env_variable(monkeypatch):
 
 
 def test_startup_warms_snapshot(monkeypatch):
-    monkeypatch.delenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", raising=False)
+    monkeypatch.setattr(config, "skip_snapshot_warm", False)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
     with patch(
         "backend.app.refresh_snapshot_in_memory_from_timeseries"
     ) as mock_refresh:
@@ -27,7 +28,7 @@ def test_startup_warms_snapshot(monkeypatch):
 
 
 def test_skip_snapshot_warm(monkeypatch):
-    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
     with patch(
         "backend.app.refresh_snapshot_in_memory_from_timeseries"
     ) as mock_refresh:

--- a/tests/test_instrument_route.py
+++ b/tests/test_instrument_route.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch
 
 from backend.app import create_app
+from backend.config import config
 
 
 def _make_df():
@@ -19,7 +20,7 @@ def _make_df():
 
 @pytest.mark.parametrize("bad", ["", ".L", ".UK"])
 def test_invalid_ticker_rejected(monkeypatch, bad):
-    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     client = TestClient(app)
     resp = client.get(f"/instrument?ticker={bad}&days=1&format=json")
@@ -27,7 +28,7 @@ def test_invalid_ticker_rejected(monkeypatch, bad):
 
 
 def test_full_history_json(monkeypatch):
-    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
     with patch(
@@ -60,7 +61,7 @@ def test_full_history_json(monkeypatch):
 
 
 def test_html_response(monkeypatch):
-    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
     with patch(

--- a/tests/test_timeseries_edit_route.py
+++ b/tests/test_timeseries_edit_route.py
@@ -2,10 +2,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
+from backend.config import config
 
 
 def test_timeseries_edit_roundtrip(tmp_path, monkeypatch):
-    monkeypatch.setenv("ALLOTMINT_SKIP_SNAPSHOT_WARM", "true")
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
     app = create_app()
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- source app environment and snapshot warming settings from config
- support configurable warmup period and uvicorn port

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689886f0cab48327b42b379f692f9673