### PR TITLE
feat: add OpenAI flag for trading agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ errors which you can attach when reporting bugs.
 python run_with_error_summary.py pytest
 ```
 
+## Trading Agent
+
+Run the trading agent from the command line. Include the optional
+`--use-openai` flag to enable OpenAI-powered decision making:
+
+```bash
+python scripts/run_trading_agent.py --use-openai
+```
+
 ## Deploy to AWS
 
 The project includes an AWS CDK stack that provisions an S3 bucket and

--- a/scripts/run_trading_agent.py
+++ b/scripts/run_trading_agent.py
@@ -1,0 +1,22 @@
+import argparse
+
+from trading_agent import run as run_trading_agent
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the trading agent")
+    parser.add_argument(
+        "--use-openai",
+        action="store_true",
+        help="Enable OpenAI powered decision making",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_trading_agent(use_openai=args.use_openai)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow run_trading_agent.py to opt into OpenAI using `--use-openai`
- document Trading Agent flag usage in README

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689865e3e458832780ec2e7b22b762a3