### PR TITLE
Fix configuration paths and data loading

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -8,13 +8,14 @@ from typing import Any, Dict, List
 
 from backend.config import config
 
-from backend.common.virtual_portfolio import VirtualPortfolio>>>>>>> main
+from backend.common.virtual_portfolio import VirtualPortfolio
 
 # ------------------------------------------------------------------
 # Paths
 # ------------------------------------------------------------------
 REPO_ROOT = Path(config.repo_root)
 DATA_ROOT = Path(config.accounts_root)
+_VIRTUAL_PF_ROOT = REPO_ROOT / "data" / "virtual_portfolios"
 
 # For future AWS use
 DATA_BUCKET_ENV = "DATA_BUCKET"
@@ -128,7 +129,7 @@ def load_person_meta(owner: str) -> Dict[str, Any]:
 # ------------------------------------------------------------------
 
 
-def _virtual_portfolio_path(name: str) -> pathlib.Path:
+def _virtual_portfolio_path(name: str) -> Path:
     return _VIRTUAL_PF_ROOT / f"{name}.json"
 
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -65,6 +65,21 @@ def load_config() -> Config:
         except Exception:
             pass
 
+    base_dir = path.parent
+
+    repo_root_raw = data.get("repo_root")
+    repo_root = (base_dir / repo_root_raw).resolve() if repo_root_raw else base_dir
+
+    accounts_root_raw = data.get("accounts_root")
+    accounts_root = (
+        (repo_root / accounts_root_raw).resolve() if accounts_root_raw else None
+    )
+
+    prices_json_raw = data.get("prices_json")
+    prices_json = (
+        (repo_root / prices_json_raw).resolve() if prices_json_raw else None
+    )
+
     return Config(
         app_env=data.get("app_env"),
         sns_topic_arn=data.get("sns_topic_arn"),
@@ -89,9 +104,9 @@ def load_config() -> Config:
         ),
         max_trades_per_month=data.get("max_trades_per_month"),
         hold_days_min=data.get("hold_days_min"),
-        repo_root=Path(data["repo_root"]) if data.get("repo_root") else None,
-        accounts_root=Path(data["accounts_root"]) if data.get("accounts_root") else None,
-        prices_json=Path(data["prices_json"]) if data.get("prices_json") else None,
+        repo_root=repo_root,
+        accounts_root=accounts_root,
+        prices_json=prices_json,
     )
 
 

--- a/backend/utils/timeseries_helpers.py
+++ b/backend/utils/timeseries_helpers.py
@@ -6,6 +6,8 @@ import pandas as pd
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 
 from backend.utils.html_render import render_timeseries_html
+from backend.config import config
+from pathlib import Path
 
 STANDARD_COLUMNS = [
     "Date", "Open", "High", "Low", "Close", "Volume", "Ticker", "Source"
@@ -32,12 +34,16 @@ def apply_scaling(df: pd.DataFrame, scale: float, scale_volume: bool = False) ->
 
 import json
 
-def get_scaling_override(ticker: str, exchange: str, requested_scaling: Optional[float]) -> float:
+
+def get_scaling_override(
+    ticker: str, exchange: str, requested_scaling: Optional[float]
+) -> float:
     if requested_scaling is not None:
         return requested_scaling
 
+    path = Path(config.repo_root) / "data" / "scaling_overrides.json"
     try:
-        with open("data/scaling_overrides.json") as f:
+        with path.open() as f:
             ov = json.load(f)
     except Exception:
         return 1.0

--- a/config.yaml
+++ b/config.yaml
@@ -9,8 +9,8 @@ alpha_vantage_key: "demo"
 fundamentals_cache_ttl_seconds: 86400
 app_env: local
 sns_topic_arn: ""
-telegram_bot_token: "8491288399:AAGRRuCJtctSQ2igqnW56BxQ3L_c0Jsi_nA"
-telegram_chat_id: "335560124"
+telegram_bot_token: ""
+telegram_chat_id: ""
 portfolio_xml_path: data/portfolio/investments.xml
 transactions_output_root: data/accounts
 uvicorn_port: 8000


### PR DESCRIPTION
## Summary
- resolve repo-relative paths in configuration to ensure data files load regardless of CWD
- fix data loader merge artifact and add virtual portfolio path constant
- read scaling overrides using repo root path and strip default Telegram credentials

## Testing
- `pytest tests/utils/test_timeseries_helpers.py::test_get_scaling_override_from_json -q`
- `pytest tests/test_backend_api.py::test_valid_group_portfolio -q`
- `pytest tests/test_custom_query.py::test_export_csv_and_xlsx -q`


------
https://chatgpt.com/codex/tasks/task_e_6898920931c08327a80492e8eb1dd5d0