### PR TITLE
chore(frontend): dedupe i18n dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,9 +17,7 @@
     "react-dom": "^19.1.0",
     "react-i18next": "^15.6.1",
     "react-router-dom": "^7.7.1",
-    "recharts": "^3.1.0",
-    "i18next": "^25.3.2",
-    "react-i18next": "^15.6.1"
+    "recharts": "^3.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",


### PR DESCRIPTION
## Summary
- remove duplicate i18next and react-i18next entries from frontend package.json

## Testing
- `npm install`
- `npm test` *(fails: Transform failed with 1 error: Expected ";" but found "from")*
- `npm run lint` *(fails: 7 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68989315f234832799f84e652917b27e