### PR TITLE
fix: correct i18next import in frontend i18n

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,5 +1,4 @@
-
-8n from 'i18next';
+import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
 import en from './locales/en/translation.json';


### PR DESCRIPTION
## Summary
- fix incorrect import in i18n.ts

## Testing
- `cd frontend && npm test` *(fails: Failed to parse JSON file, invalid JSON syntax found)*

------
https://chatgpt.com/codex/tasks/task_e_6898931f05a48327a1e6345166940286