### PR TITLE
fix: scale instrument detail values

### DIFF
--- a/tests/test_instrument_route.py
+++ b/tests/test_instrument_route.py
@@ -1,8 +1,8 @@
-from datetime import date
 import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch
+from datetime import date
 
 from backend.app import create_app
 from backend.config import config
@@ -75,3 +75,38 @@ def test_html_response(monkeypatch):
     text = resp.text
     assert "<table" in text
     assert "ABC.L" in text
+
+
+def test_positions_scaled(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    app = create_app()
+    df = _make_df()
+    with patch(
+        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
+    ), patch(
+        "backend.routes.instrument.list_portfolios",
+        return_value=[
+            {
+                "owner": "alex",
+                "accounts": [
+                    {
+                        "account_type": "isa",
+                        "holdings": [
+                            {"ticker": "ABC.L", "units": 2, "gain_gbp": 4}
+                        ],
+                    }
+                ],
+            }
+        ],
+    ), patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}), patch(
+        "backend.routes.instrument.get_scaling_override", return_value=0.5
+    ):
+        client = TestClient(app)
+        resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
+    assert resp.status_code == 200
+    data = resp.json()
+    pos = data["positions"][0]
+    assert pos["market_value_gbp"] == pytest.approx(11.0)
+    assert pos["unrealised_gain_gbp"] == pytest.approx(2.0)
+    prices = data["prices"]
+    assert prices[-1]["close_gbp"] == pytest.approx(5.5)


### PR DESCRIPTION
## Summary
- apply instrument-specific scaling when generating instrument detail timeseries and positions
- add regression test ensuring market value and gains scale correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898d647d7c08327b526e3a808e4182b