### PR TITLE
refactor: reorganize locale translations

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1,17 +1,59 @@
 {
-  "member": "Mitglied",
-  "group": "Gruppe",
-  "instrument": "Instrument",
-  "transactions": "Transaktionen",
-  "performance": "Leistung",
-  "screener": "Filter",
-  "relativeView": "Relative Ansicht",
-  "refreshPrices": "Preise aktualisieren",
-  "refreshing": "Aktualisierung…",
-  "loading": "Laden…",
-  "support": "Support",
-  "owner": "Besitzer",
-  "selectOwner": "Wählen Sie einen Besitzer.",
+  "app": {
+    "viewBy": "Ansicht nach",
+    "relativeView": "Relative Ansicht",
+    "refreshPrices": "Preise aktualisieren",
+    "refreshing": "Aktualisierung…",
+    "last": "Zuletzt:",
+    "loading": "Laden…",
+    "supportLink": "Support",
+    "modes": {
+      "group": "Gruppe",
+      "instrument": "Instrument",
+      "owner": "Mitglied",
+      "performance": "Leistung",
+      "transactions": "Transaktionen",
+      "screener": "Filter",
+      "query": "Abfrage",
+      "timeseries": "Zeitreihe"
+    }
+  },
+  "instrumentTable": {
+    "noInstruments": "Keine Instrumente.",
+    "columns": {
+      "ticker": "Ticker",
+      "name": "Name",
+      "ccy": "Währung",
+      "type": "Typ",
+      "units": "Einheiten",
+      "cost": "Kosten £",
+      "market": "Marktwert £",
+      "gain": "Gewinn £",
+      "gainPct": "Gewinn %",
+      "last": "Letzter £",
+      "lastDate": "Letztes Datum",
+      "delta7d": "7T %",
+      "delta30d": "30T %"
+    }
+  },
+  "owner": {
+    "label": "Besitzer",
+    "select": "Wählen Sie einen Besitzer."
+  },
+  "support": {
+    "title": "Support",
+    "online": "Online",
+    "onlineYes": "Ja",
+    "onlineNo": "Nein",
+    "environment": "Umgebung",
+    "telegramMessage": "Telegram-Nachricht",
+    "send": "Senden",
+    "status": {
+      "sent": "Gesendet",
+      "error": "Fehler",
+      "sending": "Wird gesendet..."
+    }
+  },
   "loadingPortfolio": "Portfolio wird geladen…",
   "portfolio": "Portfolio",
   "asOf": "Stand {{date}} • Trades diesen Monat: {{trades}} / 20 (Verbleibend: {{remaining}})",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,17 +1,59 @@
 {
-  "member": "Member",
-  "group": "Group",
-  "instrument": "Instrument",
-  "transactions": "Transactions",
-  "performance": "Performance",
-  "screener": "Screener",
-  "relativeView": "Relative view",
-  "refreshPrices": "Refresh Prices",
-  "refreshing": "Refreshing…",
-  "loading": "Loading…",
-  "support": "Support",
-  "owner": "Owner",
-  "selectOwner": "Select an owner.",
+  "app": {
+    "viewBy": "View by",
+    "relativeView": "Relative view",
+    "refreshPrices": "Refresh Prices",
+    "refreshing": "Refreshing…",
+    "last": "Last:",
+    "loading": "Loading…",
+    "supportLink": "Support",
+    "modes": {
+      "group": "Group",
+      "instrument": "Instrument",
+      "owner": "Member",
+      "performance": "Performance",
+      "transactions": "Transactions",
+      "screener": "Screener",
+      "query": "Query",
+      "timeseries": "Timeseries"
+    }
+  },
+  "instrumentTable": {
+    "noInstruments": "No instruments.",
+    "columns": {
+      "ticker": "Ticker",
+      "name": "Name",
+      "ccy": "CCY",
+      "type": "Type",
+      "units": "Units",
+      "cost": "Cost £",
+      "market": "Market £",
+      "gain": "Gain £",
+      "gainPct": "Gain %",
+      "last": "Last £",
+      "lastDate": "Last Date",
+      "delta7d": "7d %",
+      "delta30d": "30d %"
+    }
+  },
+  "owner": {
+    "label": "Owner",
+    "select": "Select an owner."
+  },
+  "support": {
+    "title": "Support",
+    "online": "Online",
+    "onlineYes": "Yes",
+    "onlineNo": "No",
+    "environment": "Environment",
+    "telegramMessage": "Telegram Message",
+    "send": "Send",
+    "status": {
+      "sent": "Sent",
+      "error": "Error",
+      "sending": "Sending..."
+    }
+  },
   "loadingPortfolio": "Loading portfolio…",
   "portfolio": "Portfolio",
   "asOf": "As of {{date}} • Trades this month: {{trades}} / 20 (Remaining: {{remaining}})",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1,17 +1,59 @@
 {
-  "member": "Miembro",
-  "group": "Grupo",
-  "instrument": "Instrumento",
-  "transactions": "Transacciones",
-  "performance": "Rendimiento",
-  "screener": "Filtro",
-  "relativeView": "Vista relativa",
-  "refreshPrices": "Actualizar precios",
-  "refreshing": "Actualizando…",
-  "loading": "Cargando…",
-  "support": "Soporte",
-  "owner": "Propietario",
-  "selectOwner": "Seleccione un propietario.",
+  "app": {
+    "viewBy": "Ver por",
+    "relativeView": "Vista relativa",
+    "refreshPrices": "Actualizar precios",
+    "refreshing": "Actualizando…",
+    "last": "Último:",
+    "loading": "Cargando…",
+    "supportLink": "Soporte",
+    "modes": {
+      "group": "Grupo",
+      "instrument": "Instrumento",
+      "owner": "Miembro",
+      "performance": "Rendimiento",
+      "transactions": "Transacciones",
+      "screener": "Filtro",
+      "query": "Consulta",
+      "timeseries": "Serie temporal"
+    }
+  },
+  "instrumentTable": {
+    "noInstruments": "Sin instrumentos.",
+    "columns": {
+      "ticker": "Ticker",
+      "name": "Nombre",
+      "ccy": "Moneda",
+      "type": "Tipo",
+      "units": "Unidades",
+      "cost": "Coste £",
+      "market": "Valor de mercado £",
+      "gain": "Ganancia £",
+      "gainPct": "Ganancia %",
+      "last": "Último £",
+      "lastDate": "Última fecha",
+      "delta7d": "7d %",
+      "delta30d": "30d %"
+    }
+  },
+  "owner": {
+    "label": "Propietario",
+    "select": "Seleccione un propietario."
+  },
+  "support": {
+    "title": "Soporte",
+    "online": "En línea",
+    "onlineYes": "Sí",
+    "onlineNo": "No",
+    "environment": "Entorno",
+    "telegramMessage": "Mensaje de Telegram",
+    "send": "Enviar",
+    "status": {
+      "sent": "Enviado",
+      "error": "Error",
+      "sending": "Enviando..."
+    }
+  },
   "loadingPortfolio": "Cargando portafolio…",
   "portfolio": "Portafolio",
   "asOf": "A fecha de {{date}} • Operaciones este mes: {{trades}} / 20 (Restantes: {{remaining}})",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,17 +1,59 @@
 {
-  "member": "Membre",
-  "group": "Groupe",
-  "instrument": "Instrument",
-  "transactions": "Transactions",
-  "performance": "Performance",
-  "screener": "Filtre",
-  "relativeView": "Vue relative",
-  "refreshPrices": "Rafraîchir les prix",
-  "refreshing": "Rafraîchissement…",
-  "loading": "Chargement…",
-  "support": "Support",
-  "owner": "Propriétaire",
-  "selectOwner": "Sélectionnez un propriétaire.",
+  "app": {
+    "viewBy": "Voir par",
+    "relativeView": "Vue relative",
+    "refreshPrices": "Rafraîchir les prix",
+    "refreshing": "Rafraîchissement…",
+    "last": "Dernier :",
+    "loading": "Chargement…",
+    "supportLink": "Support",
+    "modes": {
+      "group": "Groupe",
+      "instrument": "Instrument",
+      "owner": "Membre",
+      "performance": "Performance",
+      "transactions": "Transactions",
+      "screener": "Filtre",
+      "query": "Requête",
+      "timeseries": "Séries temporelles"
+    }
+  },
+  "instrumentTable": {
+    "noInstruments": "Aucun instrument.",
+    "columns": {
+      "ticker": "Ticker",
+      "name": "Nom",
+      "ccy": "Devise",
+      "type": "Type",
+      "units": "Unités",
+      "cost": "Coût £",
+      "market": "Valeur £",
+      "gain": "Gain £",
+      "gainPct": "Gain %",
+      "last": "Dernier £",
+      "lastDate": "Date",
+      "delta7d": "7j %",
+      "delta30d": "30j %"
+    }
+  },
+  "owner": {
+    "label": "Propriétaire",
+    "select": "Sélectionnez un propriétaire."
+  },
+  "support": {
+    "title": "Support",
+    "online": "En ligne",
+    "onlineYes": "Oui",
+    "onlineNo": "Non",
+    "environment": "Environnement",
+    "telegramMessage": "Message Telegram",
+    "send": "Envoyer",
+    "status": {
+      "sent": "Envoyé",
+      "error": "Erreur",
+      "sending": "Envoi..."
+    }
+  },
   "loadingPortfolio": "Chargement du portefeuille…",
   "portfolio": "Portefeuille",
   "asOf": "Au {{date}} • Transactions ce mois: {{trades}} / 20 (Restantes: {{remaining}})",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -1,17 +1,59 @@
 {
-  "member": "Membro",
-  "group": "Grupo",
-  "instrument": "Instrumento",
-  "transactions": "Transações",
-  "performance": "Desempenho",
-  "screener": "Filtro",
-  "relativeView": "Visão relativa",
-  "refreshPrices": "Atualizar preços",
-  "refreshing": "Atualizando…",
-  "loading": "Carregando…",
-  "support": "Suporte",
-  "owner": "Proprietário",
-  "selectOwner": "Selecione um proprietário.",
+  "app": {
+    "viewBy": "Ver por",
+    "relativeView": "Visão relativa",
+    "refreshPrices": "Atualizar preços",
+    "refreshing": "Atualizando…",
+    "last": "Último:",
+    "loading": "Carregando…",
+    "supportLink": "Suporte",
+    "modes": {
+      "group": "Grupo",
+      "instrument": "Instrumento",
+      "owner": "Membro",
+      "performance": "Desempenho",
+      "transactions": "Transações",
+      "screener": "Filtro",
+      "query": "Consulta",
+      "timeseries": "Série temporal"
+    }
+  },
+  "instrumentTable": {
+    "noInstruments": "Sem instrumentos.",
+    "columns": {
+      "ticker": "Ticker",
+      "name": "Nome",
+      "ccy": "Moeda",
+      "type": "Tipo",
+      "units": "Unidades",
+      "cost": "Custo £",
+      "market": "Valor de mercado £",
+      "gain": "Ganho £",
+      "gainPct": "Ganho %",
+      "last": "Último £",
+      "lastDate": "Última data",
+      "delta7d": "7d %",
+      "delta30d": "30d %"
+    }
+  },
+  "owner": {
+    "label": "Proprietário",
+    "select": "Selecione um proprietário."
+  },
+  "support": {
+    "title": "Suporte",
+    "online": "Online",
+    "onlineYes": "Sim",
+    "onlineNo": "Não",
+    "environment": "Ambiente",
+    "telegramMessage": "Mensagem do Telegram",
+    "send": "Enviar",
+    "status": {
+      "sent": "Enviado",
+      "error": "Erro",
+      "sending": "Enviando..."
+    }
+  },
   "loadingPortfolio": "Carregando portfólio…",
   "portfolio": "Portfólio",
   "asOf": "Em {{date}} • Negociações este mês: {{trades}} / 20 (Restantes: {{remaining}})",


### PR DESCRIPTION
## Summary
- reorganize English translations into grouped keys under `app`, `instrumentTable`, `owner`, and `support`
- mirror the new translation structure and add translations for German, French, Spanish, and Portuguese

## Testing
- `npm run lint` *(fails: i18n unused, useSortableTable unused, unexpected any, parsing error)*
- `npm test` *(fails: missing @testing-library/user-event import, one assertion failure in HoldingsTable test)*
- `npm run build` *(fails: src/types.ts(157,1): Property or signature expected)*

------
https://chatgpt.com/codex/tasks/task_e_6898d777b66c832798d1dad9268cf6c1