### PR TITLE
Add link from instrument detail to timeseries editor

### DIFF
--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../api", () => ({
+  getInstrumentDetail: vi.fn().mockResolvedValue({
+    prices: [],
+    positions: [],
+    currency: null,
+  }),
+}));
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+import { InstrumentDetail } from "./InstrumentDetail";
+
+describe("InstrumentDetail", () => {
+  it("links to timeseries edit page", async () => {
+    render(
+      <MemoryRouter>
+        <InstrumentDetail ticker="ABC.L" name="ABC" onClose={() => {}} />
+      </MemoryRouter>
+    );
+    const link = await screen.findByRole("link", { name: /edit/i });
+    expect(link).toHaveAttribute("href", "/timeseries?ticker=ABC&exchange=L");
+  });
+});

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -86,6 +86,9 @@ export function InstrumentDetail({
 
   const displayCurrency = currencyFromData ?? currencyProp ?? "?";
 
+  const [tickerBase, exch = "L"] = ticker.split(".", 2);
+  const editLink = `/timeseries?ticker=${encodeURIComponent(tickerBase)}&exchange=${encodeURIComponent(exch)}`;
+
   const rawPrices = (data.prices ?? [])
     .map((p) => ({ date: p.date, close_gbp: toNum(p.close_gbp) }))
     .filter((p) => Number.isFinite(p.close_gbp));
@@ -136,7 +139,10 @@ export function InstrumentDetail({
       </button>
       <h2 style={{ marginBottom: "0.2rem" }}>{name}</h2>
       <div style={{ fontSize: "0.85rem", color: "#aaa", marginBottom: "1rem" }}>
-        {ticker} • {displayCurrency} • {instrument_type ?? "?"}
+        {ticker} • {displayCurrency} • {instrument_type ?? "?"} • {" "}
+        <Link to={editLink} style={{ color: "#00d8ff", textDecoration: "none" }}>
+          edit
+        </Link>
       </div>
 
       {/* Chart */}

--- a/frontend/src/pages/TimeseriesEdit.test.tsx
+++ b/frontend/src/pages/TimeseriesEdit.test.tsx
@@ -28,4 +28,12 @@ describe("TimeseriesEdit page", () => {
     expect(saveTimeseries).toHaveBeenCalled();
     expect(getTimeseries).toHaveBeenCalledWith("ABC", "L");
   });
+
+  it("prefills ticker and exchange from URL", async () => {
+    window.history.pushState({}, "", "/timeseries?ticker=XYZ&exchange=US");
+    render(<TimeseriesEdit />);
+    expect(await screen.findByDisplayValue("XYZ")).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("US")).toBeInTheDocument();
+    window.history.pushState({}, "", "/");
+  });
 });

--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent } from "react";
+import { useState, ChangeEvent, useEffect } from "react";
 import { getTimeseries, saveTimeseries } from "../api";
 import type { PriceEntry } from "../types";
 
@@ -8,6 +8,14 @@ export function TimeseriesEdit() {
   const [csv, setCsv] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const t = params.get("ticker");
+    const e = params.get("exchange");
+    if (t) setTicker(t);
+    if (e) setExchange(e);
+  }, []);
 
   async function handleLoad() {
     setError(null);


### PR DESCRIPTION
## Summary
- link InstrumentDetail to prefilled TimeseriesEdit page
- load ticker & exchange from URL in TimeseriesEdit
- add unit tests for editor link and URL prefill

## Testing
- `npm test` (fails: missing @testing-library/user-event, HoldingsTable test assertion)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898ed39df188327a9a0e8c922cd1281