### PR TITLE
Handle cash tickers in meta timeseries

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -85,6 +85,23 @@ def fetch_meta_timeseries(
     start_date = _nearest_weekday(start_date, forward=False)
     end_date   = _nearest_weekday(end_date,   forward=True)
 
+    if ticker.upper() == "CASH" or exchange.upper() == "CASH":
+        dates = pd.bdate_range(start_date, end_date)
+        df = pd.DataFrame(
+            {
+                "Date": dates,
+                "Open": 1.0,
+                "High": 1.0,
+                "Low": 1.0,
+                "Close": 1.0,
+                "Volume": 0.0,
+                "Ticker": f"{ticker}.{exchange}",
+                "Source": "cash",
+            }
+        )
+        df["Date"] = pd.to_datetime(df["Date"]).dt.date
+        return df
+
     # Weekday grid we want to fill
     expected_dates = set(pd.bdate_range(start_date, end_date).date)
 

--- a/tests/test_cash_timeseries.py
+++ b/tests/test_cash_timeseries.py
@@ -1,0 +1,16 @@
+from datetime import date, timedelta
+
+from backend.timeseries.fetch_meta_timeseries import fetch_meta_timeseries
+
+
+def test_cash_timeseries_constant_one():
+    end = date.today() - timedelta(days=1)
+    start = end - timedelta(days=10)
+    df = fetch_meta_timeseries("CASH", "GBP", start_date=start, end_date=end)
+    assert not df.empty
+    assert (df["Close"] == 1.0).all()
+    assert (df["Open"] == 1.0).all()
+    assert (df["High"] == 1.0).all()
+    assert (df["Low"] == 1.0).all()
+    assert df["Source"].iloc[0] == "cash"
+    assert df["Ticker"].iloc[0].upper() == "CASH.GBP"


### PR DESCRIPTION
## Summary
- synthesize 1.0 price history for CASH tickers to avoid provider warnings
- test that cash timeseries returns constant values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898f38da718832791cd401df8aa082e