### PR TITLE
Add 7d and 30d gain metrics to instrument detail

### DIFF
--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -1,14 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, type Mock, beforeEach } from "vitest";
 
-vi.mock("../api", () => ({
-  getInstrumentDetail: vi.fn().mockResolvedValue({
-    prices: [],
-    positions: [],
-    currency: null,
-  }),
-}));
+vi.mock("../api", () => ({ getInstrumentDetail: vi.fn() }));
+import { getInstrumentDetail } from "../api";
 
 class ResizeObserver {
   observe() {}
@@ -20,13 +15,49 @@ class ResizeObserver {
 import { InstrumentDetail } from "./InstrumentDetail";
 
 describe("InstrumentDetail", () => {
+  const mockGetInstrumentDetail = getInstrumentDetail as unknown as Mock;
+
+  beforeEach(() => {
+    mockGetInstrumentDetail.mockReset();
+  });
+
   it("links to timeseries edit page", async () => {
+    mockGetInstrumentDetail.mockResolvedValue({
+      prices: [],
+      positions: [],
+      currency: null,
+    });
+
     render(
       <MemoryRouter>
         <InstrumentDetail ticker="ABC.L" name="ABC" onClose={() => {}} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
     const link = await screen.findByRole("link", { name: /edit/i });
     expect(link).toHaveAttribute("href", "/timeseries?ticker=ABC&exchange=L");
   });
+
+  it("displays 7d and 30d changes", async () => {
+    const prices = Array.from({ length: 30 }, (_, i) => ({
+      date: `2024-01-${String(i + 1).padStart(2, "0")}`,
+      close_gbp: 100,
+    }));
+    prices.push({ date: "2024-01-31", close_gbp: 130 });
+
+    mockGetInstrumentDetail.mockResolvedValue({
+      prices,
+      positions: [],
+      currency: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <InstrumentDetail ticker="ABC.L" name="ABC" onClose={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/7d 30\.0%/)).toBeInTheDocument();
+    expect(screen.getByText(/30d 30\.0%/)).toBeInTheDocument();
+  });
 });
+

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -117,6 +117,31 @@ export function InstrumentDetail({
     };
   });
 
+  // 7d / 30d change calculations
+  const latestClose = rawPrices[rawPrices.length - 1]?.close_gbp ?? NaN;
+
+  const lookup = (days: number): number => {
+    if (!rawPrices.length) return NaN;
+    const target = new Date(rawPrices[rawPrices.length - 1].date);
+    target.setDate(target.getDate() - days);
+    for (let i = rawPrices.length - 1; i >= 0; i--) {
+      const d = new Date(rawPrices[i].date);
+      if (d <= target) return rawPrices[i].close_gbp;
+    }
+    return NaN;
+  };
+
+  const close7 = lookup(7);
+  const close30 = lookup(30);
+  const change7dPct =
+    Number.isFinite(latestClose) && Number.isFinite(close7)
+      ? ((latestClose / close7 - 1) * 100)
+      : NaN;
+  const change30dPct =
+    Number.isFinite(latestClose) && Number.isFinite(close30)
+      ? ((latestClose / close30 - 1) * 100)
+      : NaN;
+
   const positions = data.positions ?? [];
 
   return (
@@ -138,11 +163,36 @@ export function InstrumentDetail({
         ✕
       </button>
       <h2 style={{ marginBottom: "0.2rem" }}>{name}</h2>
-      <div style={{ fontSize: "0.85rem", color: "#aaa", marginBottom: "1rem" }}>
+      <div style={{ fontSize: "0.85rem", color: "#aaa" }}>
         {ticker} • {displayCurrency} • {instrument_type ?? "?"} • {" "}
         <Link to={editLink} style={{ color: "#00d8ff", textDecoration: "none" }}>
           edit
         </Link>
+      </div>
+      <div style={{ fontSize: "0.85rem", marginBottom: "1rem" }}>
+        <span
+          style={{
+            color: Number.isFinite(change7dPct)
+              ? change7dPct >= 0
+                ? "lightgreen"
+                : "red"
+              : undefined,
+          }}
+        >
+          7d {percent(change7dPct, 1)}
+        </span>
+        {" • "}
+        <span
+          style={{
+            color: Number.isFinite(change30dPct)
+              ? change30dPct >= 0
+                ? "lightgreen"
+                : "red"
+              : undefined,
+          }}
+        >
+          30d {percent(change30dPct, 1)}
+        </span>
       </div>
 
       {/* Chart */}


### PR DESCRIPTION
## Summary
- compute 7d and 30d percentage changes for instrument price history
- show 7d/30d gain figures on the instrument detail panel
- test that the detail view displays these change metrics

## Testing
- `npm --prefix frontend test` *(fails: HoldingsTable and ValueAtRisk tests)*
- `npm --prefix frontend test src/components/InstrumentDetail.test.tsx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898f8bfa1c483279b7ef1d6f48eeb0d