### PR TITLE
Allow percentage VaR confidence levels

### DIFF
--- a/backend/common/risk.py
+++ b/backend/common/risk.py
@@ -27,8 +27,10 @@ def compute_portfolio_var(owner: str, days: int = 365, confidence: float = 0.95)
         The portfolio value is reconstructed over this window using current
         holdings. VaR is reported for 1-day and 10-day horizons.
     confidence:
-        Confidence level for the VaR quantile. Must be between 0 and 1.
-        Values of 0.95 (95 %) and 0.99 (99 %) are commonly used.
+        Confidence level for the VaR quantile. Accepts either a decimal
+        fraction between 0 and 1 or a percentage in the range 0–100. For
+        example, ``0.95`` and ``95`` are treated equivalently. Values close
+        to 95 % and 99 % are commonly used.
 
     Returns
     -------
@@ -38,15 +40,22 @@ def compute_portfolio_var(owner: str, days: int = 365, confidence: float = 0.95)
     Raises
     ------
     ValueError
-        If ``days`` is not positive or ``confidence`` is outside (0, 1).
+        If ``days`` is not positive or ``confidence`` is outside the accepted
+        ranges.
     FileNotFoundError
         If the owner does not exist.
     """
 
     if days <= 0:
         raise ValueError("days must be positive")
+
+    # Allow the confidence level to be expressed as a percentage (e.g. 95)
+    # or as a decimal fraction (0.95). Convert percentages to a fraction and
+    # validate the result.
+    if confidence > 1:
+        confidence = confidence / 100
     if not 0 < confidence < 1:
-        raise ValueError("confidence must be between 0 and 1")
+        raise ValueError("confidence must be between 0 and 1 or 0 and 100")
 
     perf = portfolio_utils.compute_owner_performance(owner, days=days)
     if not perf:

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -111,8 +111,9 @@ async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95):
         Length of the historical window used for returns. Must be positive.
         VaR is reported for 1-day and 10-day horizons.
     confidence:
-        Quantile for losses in (0, 1). Defaults to 0.95 (95 %); 0.99 is
-        also common.
+        Quantile for losses in (0, 1) or, alternatively, a percentage in the
+        range 0–100. Both ``0.95`` and ``95`` will request the 95 % quantile.
+        Defaults to 0.95 (95 %); 0.99 is also common.
 
     Returns a JSON object ``{"owner": owner, "as_of": <today>, "var": {...}}``.
     Raises 404 if the owner does not exist and 400 for invalid parameters.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -115,7 +115,7 @@ def test_var_owner_not_found(mock_var):
 
 @patch("backend.common.risk.compute_portfolio_var", side_effect=ValueError("bad"))
 def test_var_invalid_params(mock_var):
-    response = client.get("/var/steve?confidence=2")
+    response = client.get("/var/steve?confidence=101")
     assert response.status_code == 400
 
 @patch("backend.timeseries.fetch_timeseries.fetch_yahoo_timeseries")

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,13 @@
+from unittest.mock import patch
+
+from backend.common import risk
+
+
+@patch("backend.common.portfolio_utils.compute_owner_performance", return_value=[])
+def test_compute_portfolio_var_accepts_percentage(mock_perf):
+    """compute_portfolio_var should accept confidence as a percentage."""
+
+    result = risk.compute_portfolio_var("alex", confidence=95)
+
+    # Confidence should be converted to the fractional form internally
+    assert result["confidence"] == 0.95


### PR DESCRIPTION
## Summary
- allow VaR calculations to accept confidence as either decimal or percent
- document percentage usage in portfolio VaR endpoint
- cover percentage confidence with new unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898f8e713908327a900e2b2ad93f8a5