### PR TITLE
fix: expose custom query endpoint

### DIFF
--- a/backend/routes/query.py
+++ b/backend/routes/query.py
@@ -18,7 +18,8 @@ from backend.common.portfolio_loader import list_portfolios
 from backend.common.portfolio_utils import compute_var, get_security_meta
 from backend.timeseries.cache import load_meta_timeseries_range
 
-router = APIRouter(prefix="/query", tags=["query"])
+# Use "/custom-query" to match frontend expectations
+router = APIRouter(prefix="/custom-query", tags=["query"])
 
 QUERIES_DIR = Path("data/queries")
 

--- a/tests/test_custom_query.py
+++ b/tests/test_custom_query.py
@@ -16,7 +16,7 @@ BASE_QUERY = {
 
 
 def test_run_query_json():
-    resp = client.post("/query/run", json=BASE_QUERY)
+    resp = client.post("/custom-query/run", json=BASE_QUERY)
     assert resp.status_code == 200
     data = resp.json()
     assert any(row["ticker"] == "HFEL.L" for row in data["results"])
@@ -24,13 +24,13 @@ def test_run_query_json():
 
 def test_save_and_load_query(tmp_path):
     slug = "test-query"
-    resp = client.post(f"/query/{slug}", json=BASE_QUERY)
+    resp = client.post(f"/custom-query/{slug}", json=BASE_QUERY)
     assert resp.status_code == 200
 
-    resp = client.get(f"/query/{slug}")
+    resp = client.get(f"/custom-query/{slug}")
     assert resp.status_code == 200
     data = resp.json()
     assert data["tickers"] == BASE_QUERY["tickers"]
 
-    resp = client.get("/query/saved")
+    resp = client.get("/custom-query/saved")
     assert slug in resp.json()


### PR DESCRIPTION
## Summary
- expose `/custom-query` API prefix so custom queries are reachable
- update tests to exercise `/custom-query` endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689901c4156483279d571cd9f365be9e