### PR TITLE
Align virtual portfolio frontend with backend schema

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -147,7 +147,7 @@ export const getCompliance = (owner: string) =>
 export const getVirtualPortfolios = () =>
   fetchJson<VirtualPortfolio[]>(`${API_BASE}/virtual-portfolios`);
 
-export const getVirtualPortfolio = (id: number | string) =>
+export const getVirtualPortfolio = (id: string) =>
   fetchJson<VirtualPortfolio>(`${API_BASE}/virtual-portfolios/${id}`);
 
 export const createVirtualPortfolio = (vp: VirtualPortfolio) =>
@@ -157,17 +157,14 @@ export const createVirtualPortfolio = (vp: VirtualPortfolio) =>
     body: JSON.stringify(vp),
   });
 
-export const updateVirtualPortfolio = (
-  id: number | string,
-  vp: VirtualPortfolio,
-) =>
-  fetchJson<VirtualPortfolio>(`${API_BASE}/virtual-portfolios/${id}`, {
-    method: "PUT",
+export const updateVirtualPortfolio = (vp: VirtualPortfolio) =>
+  fetchJson<VirtualPortfolio>(`${API_BASE}/virtual-portfolios`, {
+    method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(vp),
   });
 
-export const deleteVirtualPortfolio = (id: number | string) =>
+export const deleteVirtualPortfolio = (id: string) =>
   fetchJson<{ status: string }>(`${API_BASE}/virtual-portfolios/${id}`, {
     method: "DELETE",
   });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -141,18 +141,21 @@ export interface ScreenerResult {
     fcf: number | null;
 }
 
-export interface SyntheticHolding {
+export interface VirtualHolding {
     ticker: string;
     units: number;
-    price?: number;
-    purchase_date?: string;
+    name?: string;
+    currency?: string | null;
+    exchange?: string | null;
+    cost_gbp?: number;
+    market_value_gbp?: number;
 }
 
 export interface VirtualPortfolio {
-    id?: number;
+    id: string;
     name: string;
-    accounts: string[];
-    holdings: SyntheticHolding[];
+    holdings: VirtualHolding[];
+}
 
 export interface CustomQuery {
     start?: string;


### PR DESCRIPTION
## Summary
- enforce string IDs and valid holding structure for `VirtualPortfolio`
- post updates to `/virtual-portfolios` and drop unused accounts field
- rewrite virtual portfolio page to edit id, name and holdings only

## Testing
- `npm test` *(fails: Failed to resolve import "@testing-library/user-event"; assertion error in HoldingsTable.test.tsx)*
- `npm run lint` *(fails: Unexpected any / unused vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6898f913922883279c36af0ed6dbd454