### PR TITLE
feat: add column visibility toggles

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -40,18 +40,18 @@ describe("HoldingsTable", () => {
         render(<HoldingsTable holdings={holdings} relativeView/>);
         expect(screen.getByText("AAA")).toBeInTheDocument();
         expect(screen.getByText("XYZ")).toBeInTheDocument();
-        expect(screen.getByText(/Gain %/)).toBeInTheDocument();
-        expect(screen.getByText(/Weight %/)).toBeInTheDocument();
-        expect(screen.queryByText("Units")).toBeNull();
-        expect(screen.queryByText(/Cost £/)).toBeNull();
-        expect(screen.queryByText(/Gain £/)).toBeNull();
+        expect(screen.getByRole('columnheader', {name: /Gain %/})).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', {name: /Weight %/})).toBeInTheDocument();
+        expect(screen.queryByRole('columnheader', {name: 'Units'})).toBeNull();
+        expect(screen.queryByRole('columnheader', {name: /Cost £/})).toBeNull();
+        expect(screen.queryByRole('columnheader', {name: /Gain £/})).toBeNull();
     });
 
     it("shows absolute columns when relativeView is false", () => {
         render(<HoldingsTable holdings={holdings} relativeView={false}/>);
-        expect(screen.getByText("Units")).toBeInTheDocument();
-        expect(screen.getByText(/Cost £/)).toBeInTheDocument();
-        expect(screen.getByText(/Gain £/)).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', {name: 'Units'})).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', {name: /Cost £/})).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', {name: /Gain £/})).toBeInTheDocument();
     });
 
     it("shows days to go if not eligible", () => {
@@ -86,5 +86,13 @@ describe("HoldingsTable", () => {
         fireEvent.change(select, { target: { value: "true" } });
         expect(screen.getByText("AAA")).toBeInTheDocument();
         expect(screen.queryByText("Test Holding")).toBeNull();
+    });
+
+    it("allows toggling columns", () => {
+        render(<HoldingsTable holdings={holdings}/>);
+        expect(screen.getByRole('columnheader', {name: 'Units'})).toBeInTheDocument();
+        const checkbox = screen.getByLabelText("Units");
+        fireEvent.click(checkbox);
+        expect(screen.queryByRole('columnheader', {name: 'Units'})).toBeNull();
     });
 });

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -26,6 +26,18 @@ export function HoldingsTable({
     sell_eligible: "",
   });
 
+  const [visibleColumns, setVisibleColumns] = useState({
+    units: true,
+    cost: true,
+    market: true,
+    gain: true,
+    gain_pct: true,
+  });
+
+  const toggleColumn = (key: keyof typeof visibleColumns) => {
+    setVisibleColumns((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
   const handleFilterChange = (key: keyof typeof filters, value: string) => {
     setFilters((prev) => ({ ...prev, [key]: value }));
   };
@@ -85,165 +97,231 @@ export function HoldingsTable({
 
   if (!sortedRows.length) return null;
 
+  const columnLabels: [keyof typeof visibleColumns, string][] = [
+    ["units", "Units"],
+    ["cost", "Cost"],
+    ["market", "Market"],
+    ["gain", "Gain"],
+    ["gain_pct", "Gain %"],
+  ];
+
   return (
-    <table className={tableStyles.table} style={{ marginBottom: "1rem" }}>
-      <thead>
-        <tr>
-          <th className={tableStyles.cell}>
+    <>
+      <div style={{ marginBottom: "0.5rem" }}>
+        Columns:
+        {columnLabels.map(([key, label]) => (
+          <label key={key} style={{ marginLeft: "0.5rem" }}>
             <input
-              placeholder="Ticker"
-              value={filters.ticker}
-              onChange={(e) => handleFilterChange("ticker", e.target.value)}
+              type="checkbox"
+              checked={visibleColumns[key]}
+              onChange={() => toggleColumn(key)}
             />
-          </th>
-          <th className={tableStyles.cell}>
-            <input
-              placeholder="Name"
-              value={filters.name}
-              onChange={(e) => handleFilterChange("name", e.target.value)}
-            />
-          </th>
-          <th className={tableStyles.cell}></th>
-          <th className={tableStyles.cell}>
-            <input
-              placeholder="Type"
-              value={filters.instrument_type}
-              onChange={(e) => handleFilterChange("instrument_type", e.target.value)}
-            />
-          </th>
-          {!relativeView && (
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+            {label}
+          </label>
+        ))}
+      </div>
+      <table className={tableStyles.table} style={{ marginBottom: "1rem" }}>
+        <thead>
+          <tr>
+            <th className={tableStyles.cell}>
               <input
-                placeholder="Units"
-                value={filters.units}
-                onChange={(e) => handleFilterChange("units", e.target.value)}
+                placeholder="Ticker"
+                value={filters.ticker}
+                onChange={(e) => handleFilterChange("ticker", e.target.value)}
               />
             </th>
-          )}
-          <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
-          {!relativeView && <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>}
-          <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
-          {!relativeView && <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>}
-          <th className={`${tableStyles.cell} ${tableStyles.right}`}>
-            <input
-              placeholder="Gain %"
-              value={filters.gain_pct}
-              onChange={(e) => handleFilterChange("gain_pct", e.target.value)}
-            />
-          </th>
-          <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
-          <th className={tableStyles.cell}></th>
-          <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
-          <th className={`${tableStyles.cell} ${tableStyles.center}`}>
-            <select
-              aria-label="Sell eligible"
-              value={filters.sell_eligible}
-              onChange={(e) => handleFilterChange("sell_eligible", e.target.value)}
+            <th className={tableStyles.cell}>
+              <input
+                placeholder="Name"
+                value={filters.name}
+                onChange={(e) => handleFilterChange("name", e.target.value)}
+              />
+            </th>
+            <th className={tableStyles.cell}></th>
+            <th className={tableStyles.cell}>
+              <input
+                placeholder="Type"
+                value={filters.instrument_type}
+                onChange={(e) => handleFilterChange("instrument_type", e.target.value)}
+              />
+            </th>
+            {!relativeView && visibleColumns.units && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+                <input
+                  placeholder="Units"
+                  value={filters.units}
+                  onChange={(e) => handleFilterChange("units", e.target.value)}
+                />
+              </th>
+            )}
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+            {!relativeView && visibleColumns.cost && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+            )}
+            {visibleColumns.market && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+            )}
+            {!relativeView && visibleColumns.gain && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+            )}
+            {visibleColumns.gain_pct && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+                <input
+                  placeholder="Gain %"
+                  value={filters.gain_pct}
+                  onChange={(e) => handleFilterChange("gain_pct", e.target.value)}
+                />
+              </th>
+            )}
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+            <th className={tableStyles.cell}></th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+            <th className={`${tableStyles.cell} ${tableStyles.center}`}>
+              <select
+                aria-label="Sell eligible"
+                value={filters.sell_eligible}
+                onChange={(e) => handleFilterChange("sell_eligible", e.target.value)}
+              >
+                <option value="">All</option>
+                <option value="true">Yes</option>
+                <option value="false">No</option>
+              </select>
+            </th>
+          </tr>
+          <tr>
+            <th className={`${tableStyles.cell} ${tableStyles.clickable}`} onClick={() => handleSort("ticker")}>
+              Ticker{sortKey === "ticker" ? (asc ? " ▲" : " ▼") : ""}
+            </th>
+            <th className={`${tableStyles.cell} ${tableStyles.clickable}`} onClick={() => handleSort("name")}>
+              Name{sortKey === "name" ? (asc ? " ▲" : " ▼") : ""}
+            </th>
+            <th className={tableStyles.cell}>CCY</th>
+            <th className={tableStyles.cell}>Type</th>
+            {!relativeView && visibleColumns.units && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}>Units</th>
+            )}
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Px £</th>
+            {!relativeView && visibleColumns.cost && (
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort("cost")}
+              >
+                Cost £{sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
+              </th>
+            )}
+            {visibleColumns.market && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}>Mkt £</th>
+            )}
+            {!relativeView && visibleColumns.gain && (
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort("gain")}
+              >
+                Gain £{sortKey === "gain" ? (asc ? " ▲" : " ▼") : ""}
+              </th>
+            )}
+            {visibleColumns.gain_pct && (
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort("gain_pct")}
+              >
+                Gain %{sortKey === "gain_pct" ? (asc ? " ▲" : " ▼") : ""}
+              </th>
+            )}
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort("weight_pct")}
             >
-              <option value="">All</option>
-              <option value="true">Yes</option>
-              <option value="false">No</option>
-            </select>
-          </th>
-        </tr>
-        <tr>
-          <th className={`${tableStyles.cell} ${tableStyles.clickable}`} onClick={() => handleSort("ticker")}>
-            Ticker{sortKey === "ticker" ? (asc ? " ▲" : " ▼") : ""}
-          </th>
-          <th className={`${tableStyles.cell} ${tableStyles.clickable}`} onClick={() => handleSort("name")}>
-            Name{sortKey === "name" ? (asc ? " ▲" : " ▼") : ""}
-          </th>
-          <th className={tableStyles.cell}>CCY</th>
-          <th className={tableStyles.cell}>Type</th>
-          {!relativeView && <th className={`${tableStyles.cell} ${tableStyles.right}`}>Units</th>}
-          <th className={`${tableStyles.cell} ${tableStyles.right}`}>Px £</th>
-          {!relativeView && (
-            <th className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`} onClick={() => handleSort("cost")}>
-              Cost £{sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
+              Weight %{sortKey === "weight_pct" ? (asc ? " ▲" : " ▼") : ""}
             </th>
-          )}
-          <th className={`${tableStyles.cell} ${tableStyles.right}`}>Mkt £</th>
-          {!relativeView && (
-            <th className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`} onClick={() => handleSort("gain")}>
-              Gain £{sortKey === "gain" ? (asc ? " ▲" : " ▼") : ""}
+            <th className={tableStyles.cell}>Acquired</th>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort("days_held")}
+            >
+              Days&nbsp;Held{sortKey === "days_held" ? (asc ? " ▲" : " ▼") : ""}
             </th>
-          )}
-          <th className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`} onClick={() => handleSort("gain_pct")}>
-            Gain %{sortKey === "gain_pct" ? (asc ? " ▲" : " ▼") : ""}
-          </th>
-          <th className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`} onClick={() => handleSort("weight_pct")}>
-            Weight %{sortKey === "weight_pct" ? (asc ? " ▲" : " ▼") : ""}
-          </th>
-          <th className={tableStyles.cell}>Acquired</th>
-          <th className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`} onClick={() => handleSort("days_held")}>
-            Days&nbsp;Held{sortKey === "days_held" ? (asc ? " ▲" : " ▼") : ""}
-          </th>
-          <th className={`${tableStyles.cell} ${tableStyles.center}`}>Eligible?</th>
-        </tr>
-      </thead>
+            <th className={`${tableStyles.cell} ${tableStyles.center}`}>Eligible?</th>
+          </tr>
+        </thead>
 
-      <tbody>
-        {sortedRows.map((h) => {
-          const handleClick = () => onSelectInstrument?.(h.ticker, h.name ?? h.ticker);
-          return (
-            <tr key={h.ticker + h.acquired_date}>
-              <td className={tableStyles.cell}>
-                <button
-                  type="button"
-                  onClick={handleClick}
-                  style={{
-                    color: "dodgerblue",
-                    textDecoration: "underline",
-                    background: "none",
-                    border: "none",
-                    padding: 0,
-                    font: "inherit",
-                    cursor: "pointer",
-                  }}
-                >
-                  {h.ticker}
-                </button>
-              </td>
-              <td className={tableStyles.cell}>{h.name}</td>
-              <td className={tableStyles.cell}>{h.currency ?? "—"}</td>
-              <td className={tableStyles.cell}>{h.instrument_type ?? "—"}</td>
-              {!relativeView && (
-                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                  {new Intl.NumberFormat(i18n.language).format(h.units ?? 0)}
+        <tbody>
+          {sortedRows.map((h) => {
+            const handleClick = () => onSelectInstrument?.(h.ticker, h.name ?? h.ticker);
+            return (
+              <tr key={h.ticker + h.acquired_date}>
+                <td className={tableStyles.cell}>
+                  <button
+                    type="button"
+                    onClick={handleClick}
+                    style={{
+                      color: "dodgerblue",
+                      textDecoration: "underline",
+                      background: "none",
+                      border: "none",
+                      padding: 0,
+                      font: "inherit",
+                      cursor: "pointer",
+                    }}
+                  >
+                    {h.ticker}
+                  </button>
                 </td>
-              )}
-              <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(h.current_price_gbp)}</td>
-              {!relativeView && (
+                <td className={tableStyles.cell}>{h.name}</td>
+                <td className={tableStyles.cell}>{h.currency ?? "—"}</td>
+                <td className={tableStyles.cell}>{h.instrument_type ?? "—"}</td>
+                {!relativeView && visibleColumns.units && (
+                  <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                    {new Intl.NumberFormat(i18n.language).format(h.units ?? 0)}
+                  </td>
+                )}
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(h.current_price_gbp)}</td>
+                {!relativeView && visibleColumns.cost && (
+                  <td
+                    className={`${tableStyles.cell} ${tableStyles.right}`}
+                    title={(h.cost_basis_gbp ?? 0) > 0 ? "Actual purchase cost" : "Inferred from price on acquisition date"}
+                  >
+                    {money(h.cost)}
+                  </td>
+                )}
+                {visibleColumns.market && (
+                  <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(h.market)}</td>
+                )}
+                {!relativeView && visibleColumns.gain && (
+                  <td
+                    className={`${tableStyles.cell} ${tableStyles.right}`}
+                    style={{ color: (h.gain ?? 0) >= 0 ? "lightgreen" : "red" }}
+                  >
+                    {money(h.gain)}
+                  </td>
+                )}
+                {visibleColumns.gain_pct && (
+                  <td
+                    className={`${tableStyles.cell} ${tableStyles.right}`}
+                    style={{ color: (h.gain_pct ?? 0) >= 0 ? "lightgreen" : "red" }}
+                  >
+                    {percent(h.gain_pct ?? 0, 1)}
+                  </td>
+                )}
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{percent(h.weight_pct ?? 0, 1)}</td>
+                <td className={tableStyles.cell}>
+                  {h.acquired_date && !isNaN(Date.parse(h.acquired_date))
+                    ? new Intl.DateTimeFormat(i18n.language).format(new Date(h.acquired_date))
+                    : "—"}
+                </td>
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{h.days_held ?? "—"}</td>
                 <td
-                  className={`${tableStyles.cell} ${tableStyles.right}`}
-                  title={(h.cost_basis_gbp ?? 0) > 0 ? "Actual purchase cost" : "Inferred from price on acquisition date"}
+                  className={`${tableStyles.cell} ${tableStyles.center}`}
+                  style={{ color: h.sell_eligible ? "lightgreen" : "gold" }}
                 >
-                  {money(h.cost)}
+                  {h.sell_eligible ? "✓ Eligible" : `✗ ${h.days_until_eligible ?? ""}`}
                 </td>
-              )}
-              <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(h.market)}</td>
-              {!relativeView && (
-                <td className={`${tableStyles.cell} ${tableStyles.right}`} style={{ color: (h.gain ?? 0) >= 0 ? "lightgreen" : "red" }}>
-                  {money(h.gain)}
-                </td>
-              )}
-              <td className={`${tableStyles.cell} ${tableStyles.right}`} style={{ color: (h.gain_pct ?? 0) >= 0 ? "lightgreen" : "red" }}>
-                {percent(h.gain_pct ?? 0, 1)}
-              </td>
-              <td className={`${tableStyles.cell} ${tableStyles.right}`}>{percent(h.weight_pct ?? 0, 1)}</td>
-              <td className={tableStyles.cell}>
-                {h.acquired_date && !isNaN(Date.parse(h.acquired_date))
-                  ? new Intl.DateTimeFormat(i18n.language).format(new Date(h.acquired_date))
-                  : "—"}
-              </td>
-              <td className={`${tableStyles.cell} ${tableStyles.right}`}>{h.days_held ?? "—"}</td>
-              <td className={`${tableStyles.cell} ${tableStyles.center}`} style={{ color: h.sell_eligible ? "lightgreen" : "gold" }}>
-                {h.sell_eligible ? "✓ Eligible" : `✗ ${h.days_until_eligible ?? ""}`}
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </>
   );
 }
+

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -62,4 +62,12 @@ describe("InstrumentTable", () => {
         dataRows = screen.getAllByRole("row");
         expect(within(dataRows[1]).getByText("XYZ")).toBeInTheDocument();
     });
+
+    it("allows toggling columns", () => {
+        render(<InstrumentTable rows={rows} />);
+        expect(screen.getByRole('columnheader', {name: /Gain %/})).toBeInTheDocument();
+        const checkbox = screen.getByLabelText("Gain %");
+        fireEvent.click(checkbox);
+        expect(screen.queryByRole('columnheader', {name: /Gain %/})).toBeNull();
+    });
 });

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -4,7 +4,6 @@ import type { InstrumentSummary } from "../types";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { useFilterableTable } from "../hooks/useFilterableTable";
 import { money, percent } from "../lib/money";
-import { useSortableTable } from "../hooks/useSortableTable";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
 
@@ -15,6 +14,17 @@ type Props = {
 export function InstrumentTable({ rows }: Props) {
     const { t } = useTranslation();
     const [selected, setSelected] = useState<InstrumentSummary | null>(null);
+    const [visibleColumns, setVisibleColumns] = useState({
+        units: true,
+        cost: true,
+        market: true,
+        gain: true,
+        gain_pct: true,
+    });
+
+    const toggleColumn = (key: keyof typeof visibleColumns) => {
+        setVisibleColumns((prev) => ({ ...prev, [key]: !prev[key] }));
+    };
 
     const rowsWithCost = rows.map((r) => {
         const cost = r.market_value_gbp - r.gain_gbp;
@@ -30,7 +40,7 @@ export function InstrumentTable({ rows }: Props) {
     const { rows: sorted, sortKey, asc, handleSort } = useFilterableTable(
         rowsWithCost,
         "ticker",
-        {}
+        {},
     );
 
     /* no data? – render a clear message instead of an empty table */
@@ -38,8 +48,29 @@ export function InstrumentTable({ rows }: Props) {
         return <p>{t("instrumentTable.noInstruments")}</p>;
     }
 
+    const columnLabels: [keyof typeof visibleColumns, string][] = [
+        ["units", "Units"],
+        ["cost", "Cost"],
+        ["market", "Market"],
+        ["gain", "Gain"],
+        ["gain_pct", "Gain %"],
+    ];
+
     return (
         <>
+            <div style={{ marginBottom: "0.5rem" }}>
+                Columns:
+                {columnLabels.map(([key, label]) => (
+                    <label key={key} style={{ marginLeft: "0.5rem" }}>
+                        <input
+                            type="checkbox"
+                            checked={visibleColumns[key]}
+                            onChange={() => toggleColumn(key)}
+                        />
+                        {label}
+                    </label>
+                ))}
+            </div>
             <table
                 className={`${tableStyles.table} ${tableStyles.clickable}`}
                 style={{ marginBottom: "1rem" }}
@@ -62,29 +93,39 @@ export function InstrumentTable({ rows }: Props) {
                         </th>
                         <th className={tableStyles.cell}>{t("instrumentTable.columns.ccy")}</th>
                         <th className={tableStyles.cell}>{t("instrumentTable.columns.type")}</th>
-                        <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.units")}</th>
-                        <th
-                            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
-                            onClick={() => handleSort("cost")}
-                        >
-                            {t("instrumentTable.columns.cost")}
-                            {sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
-                        </th>
-                        <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.market")}</th>
-                        <th
-                            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
-                            onClick={() => handleSort("gain")}
-                        >
-                            {t("instrumentTable.columns.gain")}
-                            {sortKey === "gain" ? (asc ? " ▲" : " ▼") : ""}
-                        </th>
-                        <th
-                            className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
-                            onClick={() => handleSort("gain_pct")}
-                        >
-                            {t("instrumentTable.columns.gainPct")}
-                            {sortKey === "gain_pct" ? (asc ? " ▲" : " ▼") : ""}
-                        </th>
+                        {visibleColumns.units && (
+                            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.units")}</th>
+                        )}
+                        {visibleColumns.cost && (
+                            <th
+                                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                                onClick={() => handleSort("cost")}
+                            >
+                                {t("instrumentTable.columns.cost")}
+                                {sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
+                            </th>
+                        )}
+                        {visibleColumns.market && (
+                            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.market")}</th>
+                        )}
+                        {visibleColumns.gain && (
+                            <th
+                                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                                onClick={() => handleSort("gain")}
+                            >
+                                {t("instrumentTable.columns.gain")}
+                                {sortKey === "gain" ? (asc ? " ▲" : " ▼") : ""}
+                            </th>
+                        )}
+                        {visibleColumns.gain_pct && (
+                            <th
+                                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                                onClick={() => handleSort("gain_pct")}
+                            >
+                                {t("instrumentTable.columns.gainPct")}
+                                {sortKey === "gain_pct" ? (asc ? " ▲" : " ▼") : ""}
+                            </th>
+                        )}
                         <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.last")}</th>
                         <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.lastDate")}</th>
                         <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.delta7d")}</th>
@@ -94,8 +135,7 @@ export function InstrumentTable({ rows }: Props) {
 
                 <tbody>
                     {sorted.map((r) => {
-                        const gainColour =
-                            r.gain_gbp >= 0 ? "lightgreen" : "red";
+                        const gainColour = r.gain_gbp >= 0 ? "lightgreen" : "red";
 
                         return (
                             <tr key={r.ticker}>
@@ -119,29 +159,32 @@ export function InstrumentTable({ rows }: Props) {
                                 <td className={tableStyles.cell}>{r.name}</td>
                                 <td className={tableStyles.cell}>{r.currency ?? "—"}</td>
                                 <td className={tableStyles.cell}>{r.instrument_type ?? "—"}</td>
+                                {visibleColumns.units && (
+                                    <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                                        {new Intl.NumberFormat(i18n.language).format(r.units)}
+                                    </td>
+                                )}
+                                {visibleColumns.cost && (
+                                    <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(r.cost)}</td>
+                                )}
+                                {visibleColumns.market && (
+                                    <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(r.market_value_gbp)}</td>
+                                )}
+                                {visibleColumns.gain && (
+                                    <td className={`${tableStyles.cell} ${tableStyles.right}`} style={{ color: gainColour }}>
+                                        {money(r.gain_gbp)}
+                                    </td>
+                                )}
+                                {visibleColumns.gain_pct && (
+                                    <td
+                                        className={`${tableStyles.cell} ${tableStyles.right}`}
+                                        style={{ color: r.gain_pct >= 0 ? "lightgreen" : "red" }}
+                                    >
+                                        {percent(r.gain_pct, 1)}
+                                    </td>
+                                )}
                                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                                    {new Intl.NumberFormat(i18n.language).format(r.units)}
-                                </td>
-                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(r.cost)}</td>
-                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                                    {money(r.market_value_gbp)}
-                                </td>
-                                <td
-                                    className={`${tableStyles.cell} ${tableStyles.right}`}
-                                    style={{ color: gainColour }}
-                                >
-                                    {money(r.gain_gbp)}
-                                </td>
-                                <td
-                                    className={`${tableStyles.cell} ${tableStyles.right}`}
-                                    style={{ color: r.gain_pct >= 0 ? "lightgreen" : "red" }}
-                                >
-                                    {percent(r.gain_pct, 1)}
-                                </td>
-                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                                    {r.last_price_gbp != null
-                                        ? money(r.last_price_gbp)
-                                        : "—"}
+                                    {r.last_price_gbp != null ? money(r.last_price_gbp) : "—"}
                                 </td>
                                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                     {r.last_price_date
@@ -151,14 +194,10 @@ export function InstrumentTable({ rows }: Props) {
                                         : "—"}
                                 </td>
                                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                                    {r.change_7d_pct == null
-                                        ? "—"
-                                        : percent(r.change_7d_pct, 1)}
+                                    {r.change_7d_pct == null ? "—" : percent(r.change_7d_pct, 1)}
                                 </td>
                                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                                    {r.change_30d_pct == null
-                                        ? "—"
-                                        : percent(r.change_30d_pct, 1)}
+                                    {r.change_30d_pct == null ? "—" : percent(r.change_30d_pct, 1)}
                                 </td>
                             </tr>
                         );
@@ -179,3 +218,4 @@ export function InstrumentTable({ rows }: Props) {
         </>
     );
 }
+


### PR DESCRIPTION
## Summary
- add column visibility toggles for HoldingsTable and InstrumentTable
- render table columns based on user-selected visibility
- test column toggling in HoldingsTable and InstrumentTable

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68996e45da888327b5604f7a330446d3