### PR TITLE
feat: localize instrument detail

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import {
   Line,
   LineChart,
@@ -56,6 +57,7 @@ export function InstrumentDetail({
   instrument_type, // ← comes from props now
   onClose,
 }: Props) {
+  const { t } = useTranslation();
   const [data, setData] = useState<{
     prices: Price[];
     positions: Position[];
@@ -82,7 +84,7 @@ export function InstrumentDetail({
   }, [ticker, days]);
 
   if (err) return <p style={{ color: "red" }}>{err}</p>;
-  if (!data) return <p>Loading…</p>;
+  if (!data) return <p>{t("app.loading")}</p>;
 
   const displayCurrency = currencyFromData ?? currencyProp ?? "?";
 
@@ -166,7 +168,7 @@ export function InstrumentDetail({
       <div style={{ fontSize: "0.85rem", color: "#aaa" }}>
         {ticker} • {displayCurrency} • {instrument_type ?? "?"} • {" "}
         <Link to={editLink} style={{ color: "#00d8ff", textDecoration: "none" }}>
-          edit
+          {t("instrumentDetail.edit")}
         </Link>
       </div>
       <div style={{ fontSize: "0.85rem", marginBottom: "1rem" }}>
@@ -179,7 +181,7 @@ export function InstrumentDetail({
               : undefined,
           }}
         >
-          7d {percent(change7dPct, 1)}
+          {t("instrumentDetail.change7d")} {percent(change7dPct, 1)}
         </span>
         {" • "}
         <span
@@ -191,24 +193,24 @@ export function InstrumentDetail({
               : undefined,
           }}
         >
-          30d {percent(change30dPct, 1)}
+          {t("instrumentDetail.change30d")} {percent(change30dPct, 1)}
         </span>
       </div>
 
       {/* Chart */}
       <div style={{ marginBottom: "0.5rem" }}>
         <label style={{ fontSize: "0.85rem", marginRight: "1rem" }}>
-          Range:
+          {t("instrumentDetail.range")}
           <select
             value={days}
             onChange={(e) => setDays(Number(e.target.value))}
             style={{ marginLeft: "0.25rem" }}
           >
-            <option value={7}>1W</option>
-            <option value={30}>1M</option>
-            <option value={365}>1Y</option>
-            <option value={3650}>10Y</option>
-            <option value={0}>MAX</option>
+            <option value={7}>{t("instrumentDetail.rangeOptions.1w")}</option>
+            <option value={30}>{t("instrumentDetail.rangeOptions.1m")}</option>
+            <option value={365}>{t("instrumentDetail.rangeOptions.1y")}</option>
+            <option value={3650}>{t("instrumentDetail.rangeOptions.10y")}</option>
+            <option value={0}>{t("instrumentDetail.rangeOptions.max")}</option>
           </select>
         </label>
         <label style={{ fontSize: "0.85rem" }}>
@@ -217,7 +219,7 @@ export function InstrumentDetail({
             checked={showBollinger}
             onChange={(e) => setShowBollinger(e.target.checked)}
           />{" "}
-          Bollinger Bands
+          {t("instrumentDetail.bollingerBands")}
         </label>
       </div>
       <ResponsiveContainer width="100%" height={220}>
@@ -255,18 +257,18 @@ export function InstrumentDetail({
       </ResponsiveContainer>
 
       {/* Positions */}
-      <h3 style={{ marginTop: "1.5rem" }}>Positions</h3>
+      <h3 style={{ marginTop: "1.5rem" }}>{t("instrumentDetail.positions")}</h3>
       <table
         className={tableStyles.table}
         style={{ fontSize: "0.85rem", marginBottom: "1rem" }}
       >
         <thead>
           <tr>
-            <th className={tableStyles.cell}>Account</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Units</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Mkt £</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Gain £</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Gain %</th>
+            <th className={tableStyles.cell}>{t("instrumentDetail.columns.account")}</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.units")}</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.market")}</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.gain")}</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.gainPct")}</th>
           </tr>
         </thead>
         <tbody>
@@ -309,7 +311,7 @@ export function InstrumentDetail({
                 className={`${tableStyles.cell} ${tableStyles.center}`}
                 style={{ color: "#888" }}
               >
-                No positions
+                {t("instrumentDetail.noPositions")}
               </td>
             </tr>
           )}
@@ -317,17 +319,17 @@ export function InstrumentDetail({
       </table>
 
       {/* Recent Prices */}
-      <h3>Recent Prices</h3>
+      <h3>{t("instrumentDetail.recentPrices")}</h3>
       <table
         className={tableStyles.table}
         style={{ fontSize: "0.85rem", marginBottom: "1rem" }}
       >
         <thead>
           <tr>
-            <th className={tableStyles.cell}>Date</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>£ Close</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Δ £</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Δ %</th>
+            <th className={tableStyles.cell}>{t("instrumentDetail.priceColumns.date")}</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.priceColumns.close")}</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.priceColumns.delta")}</th>
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.priceColumns.deltaPct")}</th>
           </tr>
         </thead>
         <tbody>
@@ -372,7 +374,7 @@ export function InstrumentDetail({
                 className={`${tableStyles.cell} ${tableStyles.center}`}
                 style={{ color: "#888" }}
               >
-                No price data
+                {t("instrumentDetail.noPriceData")}
               </td>
             </tr>
           )}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -37,6 +37,37 @@
       "delta30d": "30T %"
     }
   },
+  "instrumentDetail": {
+    "edit": "Bearbeiten",
+    "change7d": "7T",
+    "change30d": "30T",
+    "range": "Zeitraum:",
+    "rangeOptions": {
+      "1w": "1W",
+      "1m": "1M",
+      "1y": "1J",
+      "10y": "10J",
+      "max": "MAX"
+    },
+    "bollingerBands": "Bollinger-Bänder",
+    "positions": "Positionen",
+    "columns": {
+      "account": "Konto",
+      "units": "Einheiten",
+      "market": "Markt £",
+      "gain": "Gewinn £",
+      "gainPct": "Gewinn %"
+    },
+    "noPositions": "Keine Positionen",
+    "recentPrices": "Aktuelle Preise",
+    "priceColumns": {
+      "date": "Datum",
+      "close": "£ Schluss",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "noPriceData": "Keine Preisdaten"
+  },
   "owner": {
     "label": "Besitzer",
     "select": "Wählen Sie einen Besitzer."

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -37,6 +37,37 @@
       "delta30d": "30d %"
     }
   },
+  "instrumentDetail": {
+    "edit": "Edit",
+    "change7d": "7d",
+    "change30d": "30d",
+    "range": "Range:",
+    "rangeOptions": {
+      "1w": "1W",
+      "1m": "1M",
+      "1y": "1Y",
+      "10y": "10Y",
+      "max": "MAX"
+    },
+    "bollingerBands": "Bollinger Bands",
+    "positions": "Positions",
+    "columns": {
+      "account": "Account",
+      "units": "Units",
+      "market": "Mkt £",
+      "gain": "Gain £",
+      "gainPct": "Gain %"
+    },
+    "noPositions": "No positions",
+    "recentPrices": "Recent Prices",
+    "priceColumns": {
+      "date": "Date",
+      "close": "£ Close",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "noPriceData": "No price data"
+  },
   "owner": {
     "label": "Owner",
     "select": "Select an owner."

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -37,6 +37,37 @@
       "delta30d": "30d %"
     }
   },
+  "instrumentDetail": {
+    "edit": "Editar",
+    "change7d": "7d",
+    "change30d": "30d",
+    "range": "Rango:",
+    "rangeOptions": {
+      "1w": "1S",
+      "1m": "1M",
+      "1y": "1A",
+      "10y": "10A",
+      "max": "MÁX"
+    },
+    "bollingerBands": "Bandas de Bollinger",
+    "positions": "Posiciones",
+    "columns": {
+      "account": "Cuenta",
+      "units": "Unidades",
+      "market": "Mercado £",
+      "gain": "Ganancia £",
+      "gainPct": "Ganancia %"
+    },
+    "noPositions": "Sin posiciones",
+    "recentPrices": "Precios recientes",
+    "priceColumns": {
+      "date": "Fecha",
+      "close": "£ Cierre",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "noPriceData": "Sin datos de precios"
+  },
   "owner": {
     "label": "Propietario",
     "select": "Seleccione un propietario."

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -37,6 +37,37 @@
       "delta30d": "30j %"
     }
   },
+  "instrumentDetail": {
+    "edit": "Modifier",
+    "change7d": "7j",
+    "change30d": "30j",
+    "range": "Plage :",
+    "rangeOptions": {
+      "1w": "1S",
+      "1m": "1M",
+      "1y": "1A",
+      "10y": "10A",
+      "max": "MAX"
+    },
+    "bollingerBands": "Bandes de Bollinger",
+    "positions": "Positions",
+    "columns": {
+      "account": "Compte",
+      "units": "Unités",
+      "market": "Mkt £",
+      "gain": "Gain £",
+      "gainPct": "Gain %"
+    },
+    "noPositions": "Aucune position",
+    "recentPrices": "Prix récents",
+    "priceColumns": {
+      "date": "Date",
+      "close": "£ Clôture",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "noPriceData": "Pas de données de prix"
+  },
   "owner": {
     "label": "Propriétaire",
     "select": "Sélectionnez un propriétaire."

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -37,6 +37,37 @@
       "delta30d": "30d %"
     }
   },
+  "instrumentDetail": {
+    "edit": "Editar",
+    "change7d": "7d",
+    "change30d": "30d",
+    "range": "Intervalo:",
+    "rangeOptions": {
+      "1w": "1S",
+      "1m": "1M",
+      "1y": "1A",
+      "10y": "10A",
+      "max": "MÁX"
+    },
+    "bollingerBands": "Bandas de Bollinger",
+    "positions": "Posições",
+    "columns": {
+      "account": "Conta",
+      "units": "Unidades",
+      "market": "Mercado £",
+      "gain": "Ganho £",
+      "gainPct": "Ganho %"
+    },
+    "noPositions": "Sem posições",
+    "recentPrices": "Preços recentes",
+    "priceColumns": {
+      "date": "Data",
+      "close": "£ Fechamento",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "noPriceData": "Sem dados de preços"
+  },
   "owner": {
     "label": "Proprietário",
     "select": "Selecione um proprietário."


### PR DESCRIPTION
## Summary
- introduce translation keys for InstrumentDetail component
- replace inline labels with `t()` calls
- test rendering across languages

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68999c2a4dcc83278b4dafbfe8c665a7