### PR TITLE
feat: toggle portfolio accounts

### DIFF
--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -12,10 +12,20 @@ import i18n from "../i18n";
 /* ──────────────────────────────────────────────────────────────
  * Component
  * ────────────────────────────────────────────────────────────── */
-type Props = { account: Account; relativeView?: boolean };
+type Props = {
+  account: Account;
+  relativeView?: boolean;
+  selected?: boolean;
+  onToggle?: () => void;
+};
 
-export function AccountBlock({ account, relativeView = false }: Props) {
-  const [selected, setSelected] = useState<{
+export function AccountBlock({
+  account,
+  relativeView = false,
+  selected = true,
+  onToggle,
+}: Props) {
+  const [selectedInstrument, setSelectedInstrument] = useState<{
     ticker: string;
     name: string;
   } | null>(null);
@@ -28,34 +38,49 @@ export function AccountBlock({ account, relativeView = false }: Props) {
       }}
     >
       <h2 style={{ marginTop: 0 }}>
+        {onToggle && (
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={onToggle}
+            aria-label={account.account_type}
+            style={{ marginRight: "0.5rem" }}
+          />
+        )}
         {account.account_type} ({account.currency})
       </h2>
 
-      <div style={{ marginBottom: "0.5rem" }}>
-        Est&nbsp;Value:&nbsp;{money(account.value_estimate_gbp)}
-      </div>
-
-      {account.last_updated && (
-        <div style={{ fontSize: "0.8rem", color: "#666" }}>
-          Last updated:&nbsp;
-          {new Intl.DateTimeFormat(i18n.language).format(
-            new Date(account.last_updated),
-          )}
-        </div>
-      )}
-
-      <HoldingsTable
-        holdings={account.holdings}
-        relativeView={relativeView}
-        onSelectInstrument={(ticker, name) => setSelected({ ticker, name })}
-      />
-
       {selected && (
-        <InstrumentDetail
-          ticker={selected.ticker}
-          name={selected.name}
-          onClose={() => setSelected(null)}
-        />
+        <>
+          <div style={{ marginBottom: "0.5rem" }}>
+            Est&nbsp;Value:&nbsp;{money(account.value_estimate_gbp)}
+          </div>
+
+          {account.last_updated && (
+            <div style={{ fontSize: "0.8rem", color: "#666" }}>
+              Last updated:&nbsp;
+              {new Intl.DateTimeFormat(i18n.language).format(
+                new Date(account.last_updated),
+              )}
+            </div>
+          )}
+
+          <HoldingsTable
+            holdings={account.holdings}
+            relativeView={relativeView}
+            onSelectInstrument={(ticker, name) =>
+              setSelectedInstrument({ ticker, name })
+            }
+          />
+
+          {selectedInstrument && (
+            <InstrumentDetail
+              ticker={selectedInstrument.ticker}
+              name={selectedInstrument.name}
+              onClose={() => setSelectedInstrument(null)}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/PortfolioView.test.tsx
+++ b/frontend/src/components/PortfolioView.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from "@testing-library/react";
+import {render, screen, fireEvent} from "@testing-library/react";
 import {PortfolioView} from "./PortfolioView";
 import type {Portfolio} from "../types";
 
@@ -43,5 +43,17 @@ describe("PortfolioView", () => {
 
         expect(screen.getByText(/SIPP.*GBP/)).toBeInTheDocument();
 
+    });
+
+    it("updates total when accounts are toggled", () => {
+        render(<PortfolioView data={mockOwner}/>);
+
+        const total = screen.getByText(/Approx Total:/);
+        expect(total).toHaveTextContent("£14,925.00");
+
+        const sippCheckbox = screen.getByRole("checkbox", {name: /sipp/i});
+        fireEvent.click(sippCheckbox);
+
+        expect(total).toHaveTextContent("£0.00");
     });
 });

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -1,7 +1,8 @@
-import type {Portfolio} from "../types";
-import {AccountBlock} from "./AccountBlock";
-import {ValueAtRisk} from "./ValueAtRisk";
-import {money} from "../lib/money";
+import { useState, useEffect } from "react";
+import type { Portfolio, Account } from "../types";
+import { AccountBlock } from "./AccountBlock";
+import { ValueAtRisk } from "./ValueAtRisk";
+import { money } from "../lib/money";
 import i18n from "../i18n";
 
 // Props accepted by the view. `data` is null until a portfolio is loaded.
@@ -19,31 +20,68 @@ type Props = {
  * relies on its parent for data fetching. Conditional branches early-return to
  * keep the JSX at the bottom easy to follow.
  */
-export function PortfolioView({data, loading, error, relativeView = false}: Props) {
-    if (loading) return <div>Loading portfolio…</div>; // show a quick spinner
-    if (error) return <div style={{color: "red"}}>{error}</div>; // bubble errors
-    if (!data) return <div>Select an owner.</div>; // nothing chosen yet
+export function PortfolioView({ data, loading, error, relativeView = false }: Props) {
+  if (loading) return <div>Loading portfolio…</div>; // show a quick spinner
+  if (error) return <div style={{ color: "red" }}>{error}</div>; // bubble errors
+  if (!data) return <div>Select an owner.</div>; // nothing chosen yet
 
-    return (
-        <div>
-            <div style={{textAlign: "right"}}>
-                <a href="/virtual">Virtual Portfolios</a>
-            </div>
-            <h1 style={{marginTop: 0}}>
-                Portfolio: <span data-testid="owner-name">{data.owner}</span>
-            </h1>
-            <div style={{marginBottom: "1rem"}}>
-                As of {new Intl.DateTimeFormat(i18n.language).format(new Date(data.as_of))} • Trades this month: {data.trades_this_month} / 20
-                (Remaining: {data.trades_remaining})
-            </div>
-            <div style={{marginBottom: "2rem"}}>
-                Approx Total: {money(data.total_value_estimate_gbp)}
-            </div>
-            <ValueAtRisk owner={data.owner}/>
-            {/* Each account is rendered using AccountBlock for clarity */}
-            {data.accounts.map((acct) => (
-                <AccountBlock key={acct.account_type} account={acct} relativeView={relativeView}/>
-            ))}
-        </div>
-    );
+  const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
+
+  const accountKey = (acct: Account, idx: number) => `${acct.account_type}-${idx}`;
+
+  useEffect(() => {
+    setSelectedAccounts(data.accounts.map(accountKey));
+  }, [data]);
+
+  const allKeys = data.accounts.map(accountKey);
+  const activeSet = new Set(
+    selectedAccounts.length ? selectedAccounts : allKeys
+  );
+
+  const totalValue = data.accounts.reduce(
+    (sum, acct, idx) =>
+      activeSet.has(accountKey(acct, idx))
+        ? sum + acct.value_estimate_gbp
+        : sum,
+    0
+  );
+
+  return (
+    <div>
+      <div style={{ textAlign: "right" }}>
+        <a href="/virtual">Virtual Portfolios</a>
+      </div>
+      <h1 style={{ marginTop: 0 }}>
+        Portfolio: <span data-testid="owner-name">{data.owner}</span>
+      </h1>
+      <div style={{ marginBottom: "1rem" }}>
+        As of {new Intl.DateTimeFormat(i18n.language).format(new Date(data.as_of))} •
+        Trades this month: {data.trades_this_month} / 20 (Remaining: {data.trades_remaining})
+      </div>
+      <div style={{ marginBottom: "2rem" }}>
+        Approx Total: {money(totalValue)}
+      </div>
+      <ValueAtRisk owner={data.owner} />
+      {/* Each account is rendered using AccountBlock for clarity */}
+      {data.accounts.map((acct, idx) => {
+        const key = accountKey(acct, idx);
+        const checked = activeSet.has(key);
+        return (
+          <AccountBlock
+            key={key}
+            account={acct}
+            relativeView={relativeView}
+            selected={checked}
+            onToggle={() =>
+              setSelectedAccounts((prev) =>
+                prev.includes(key)
+                  ? prev.filter((k) => k !== key)
+                  : [...prev, key]
+              )
+            }
+          />
+        );
+      })}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- allow selecting individual accounts in group and owner portfolio views
- show checkboxes beside account headers and update aggregate totals
- add tests verifying totals react to account toggles

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68996e4047008327bc013341c1fd86b2