### PR TITLE
Add Sortino ratio computation for risk and trading agent diagnostics

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -120,11 +120,17 @@ async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95):
 
     try:
         var = risk.compute_portfolio_var(owner, days=days, confidence=confidence)
+        sortino = risk.compute_sortino_ratio(owner, days=days)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Owner not found")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    return {"owner": owner, "as_of": date.today().isoformat(), "var": var}
+    return {
+        "owner": owner,
+        "as_of": date.today().isoformat(),
+        "var": var,
+        "sortino": sortino,
+    }
 
 
 @router.get("/portfolio-group/{slug}")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,13 +98,15 @@ def test_instrument_detail(mock_list, mock_build, mock_positions, mock_timeserie
     assert "positions" in response.json()
 
 
+@patch("backend.common.risk.compute_sortino_ratio", return_value=1.23)
 @patch("backend.common.risk.compute_portfolio_var", return_value={"1d": 100.0, "10d": 200.0})
-def test_var_endpoint(mock_var):
+def test_var_endpoint(mock_var, mock_sortino):
     response = client.get("/var/steve")
     assert response.status_code == 200
     payload = response.json()
     assert payload["owner"] == "steve"
     assert payload["var"] == {"1d": 100.0, "10d": 200.0}
+    assert payload["sortino"] == 1.23
 
 
 @patch("backend.common.risk.compute_portfolio_var", side_effect=FileNotFoundError)

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+from backend.common import risk
+
+
+def test_compute_sortino_ratio(monkeypatch):
+    perf = [
+        {"date": "2024-01-01", "value": 100.0, "daily_return": None},
+        {"date": "2024-01-02", "value": 101.0, "daily_return": 0.01},
+        {"date": "2024-01-03", "value": 99.0, "daily_return": -0.02},
+        {"date": "2024-01-04", "value": 100.5, "daily_return": 0.015},
+        {"date": "2024-01-05", "value": 99.5, "daily_return": -0.01},
+    ]
+
+    monkeypatch.setattr(
+        "backend.common.portfolio_utils.compute_owner_performance",
+        lambda owner, days=365: perf,
+    )
+
+    ratio = risk.compute_sortino_ratio("alice")
+    returns = pd.Series([0.01, -0.02, 0.015, -0.01])
+    expected = returns.mean() / returns[returns < 0].std()
+    assert ratio == pytest.approx(expected)

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -96,7 +96,6 @@ def test_send_trade_alert_with_telegram(monkeypatch):
 def test_run_defaults_to_all_known_tickers(monkeypatch):
     captured: dict = {}
 
-    # ensure the agent discovers our tickers when none are supplied
     monkeypatch.setattr(
         "backend.agent.trading_agent.list_all_unique_tickers",
         lambda: ["AAA", "BBB"],
@@ -119,7 +118,16 @@ def test_run_defaults_to_all_known_tickers(monkeypatch):
     monkeypatch.setattr(
         "backend.agent.trading_agent.publish_alert", lambda alert: None
     )
+    monkeypatch.setattr(
+        "backend.agent.trading_agent.list_portfolios",
+        lambda: [{"owner": "alex"}],
+    )
+    monkeypatch.setattr(
+        "backend.agent.trading_agent.risk.compute_sortino_ratio",
+        lambda owner: 0.5,
+    )
 
-    run()
+    result = run()
 
     assert captured["tickers"] == ["AAA", "BBB"]
+    assert result["diagnostics"] == {"alex": 0.5}


### PR DESCRIPTION
## Summary
- add `compute_sortino_ratio` helper to evaluate downside risk using negative-return volatility
- expose Sortino ratio in `/var` endpoint for portfolio risk reporting
- include Sortino diagnostics when running the trading agent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689895c2b6fc8327b7b1dbfa8db44ac1