### PR TITLE
Add watchlist quotes endpoint and frontend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -22,6 +22,7 @@ from backend.routes.screener import router as screener_router
 from backend.routes.support import router as support_router
 from backend.routes.query import router as query_router
 from backend.routes.virtual_portfolio import router as virtual_portfolio_router
+from backend.routes.quotes import router as quotes_router
 from backend.common.portfolio_utils import refresh_snapshot_in_memory_from_timeseries
 from backend.config import config
 
@@ -64,6 +65,7 @@ def create_app() -> FastAPI:
     app.include_router(support_router)
     app.include_router(query_router)
     app.include_router(virtual_portfolio_router)
+    app.include_router(quotes_router)
 
     # ────────────────────── Health-check endpoint ─────────────────────
     @app.get("/health")

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""API route to fetch live quotes from Yahoo Finance."""
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import yfinance as yf
+from fastapi import APIRouter, Query
+
+router = APIRouter(prefix="/api", tags=["quotes"])
+
+
+def _fmt_time(ts: Optional[int]) -> Optional[str]:
+    """Convert UNIX seconds to an ISO-8601 UTC string."""
+    if ts is None:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+@router.get("/quotes")
+async def get_quotes(symbols: str = Query(..., description="Comma-separated tickers")):
+    """Return snapshot quotes for the requested Yahoo Finance symbols."""
+    sym_list: List[str] = [s.strip() for s in symbols.split(",") if s.strip()]
+    if not sym_list:
+        return []
+
+    tickers = yf.Tickers(" ".join(sym_list))
+    rows = []
+
+    for sym in sym_list:
+        t = tickers.tickers.get(sym)
+        if t is None:
+            continue
+
+        info = t.fast_info or {}
+        last = info.get("lastPrice")
+        open_ = info.get("open")
+        high = info.get("dayHigh")
+        low = info.get("dayLow")
+        prev_close = info.get("previousClose")
+        volume = info.get("volume")
+        ts = info.get("lastMarketTime") or info.get("regularMarketTime")
+
+        change = change_pct = None
+        if last is not None and prev_close not in (None, 0):
+            change = last - prev_close
+            change_pct = change / prev_close * 100
+
+        name = info.get("longName") or info.get("shortName") or sym
+
+        rows.append(
+            {
+                "name": name,
+                "symbol": sym,
+                "last": last,
+                "open": open_,
+                "high": high,
+                "low": low,
+                "change": change,
+                "changePct": change_pct,
+                "volume": volume,
+                "time": _fmt_time(ts),
+            }
+        )
+
+    return rows

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -15,6 +15,7 @@ import type {
   VirtualPortfolio,
   CustomQuery,
   SavedQuery,
+  Quote,
 } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -211,4 +212,10 @@ export const getValueAtRisk = (
   return fetchJson<ValueAtRiskPoint[]>(
     `${API_BASE}/var/${owner}${qs ? `?${qs}` : ""}`
   );
+};
+
+/** Fetch live quote snapshots for a list of symbols. */
+export const getQuotes = (symbols: string) => {
+  const params = new URLSearchParams({ symbols });
+  return fetchJson<Quote[]>(`${API_BASE}/api/quotes?${params.toString()}`);
 };

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,5 +1,5 @@
 
-8n from 'i18next';
+import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
 import en from './locales/en/translation.json';

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -48,7 +48,7 @@
       "error": "Failed to send",
       "sending": "Sending…"
     }
-  }
+  },
   "member": "Member",
   "group": "Group",
   "instrument": "Instrument",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -48,7 +48,7 @@
       "error": "Error al enviar",
       "sending": "Enviando…"
     }
-  }
+  },
   "member": "Miembro",
   "group": "Grupo",
   "instrument": "Instrumento",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import './i18n'
 import App from './App.tsx'
 import Support from './pages/Support'
 import VirtualPortfolio from './pages/VirtualPortfolio'
+import { Watchlist } from './pages/Watchlist'
 import './i18n'
 
 createRoot(document.getElementById('root')!).render(
@@ -14,6 +15,7 @@ createRoot(document.getElementById('root')!).render(
       <Routes>
         <Route path="/support" element={<Support />} />
         <Route path="/virtual" element={<VirtualPortfolio />} />
+        <Route path="/watchlist" element={<Watchlist />} />
         <Route path="/*" element={<App />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from "react";
+import { getQuotes } from "../api";
+import type { Quote } from "../types";
+import { useSortableTable } from "../hooks/useSortableTable";
+import "../styles/watchlist.css";
+
+const DEFAULT_SYMBOLS =
+  "^FTSE,^NDX,^GSPC,^RUT,^NYA,^VIX,^GDAXI,^N225,GBPUSD=X,GBPEUR=X,BTC-USD,GC=F,SI=F,VUSA.L,IWDA.AS";
+
+type SortKey = keyof Quote;
+
+function formatPrice(q: Quote): string {
+  if (q.last == null) return "—";
+  let dp = 2;
+  const sym = q.symbol;
+  if (sym.includes("=X")) dp = 5;
+  else if (q.last > 10000) dp = 0;
+  else if (q.last < 1 && (sym.includes("-USD") || sym.endsWith("=F"))) dp = 5;
+  return new Intl.NumberFormat("en-GB", {
+    minimumFractionDigits: dp,
+    maximumFractionDigits: dp,
+  }).format(q.last);
+}
+
+function formatChange(val: number | null, dp = 2): string {
+  return val == null ? "—" : val.toFixed(dp);
+}
+
+function formatVolume(v: number | null): string {
+  return v == null ? "—" : new Intl.NumberFormat("en-GB").format(v);
+}
+
+function formatTime(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString("en-GB", { timeZone: "Europe/London" });
+}
+
+export function Watchlist() {
+  const [symbols, setSymbols] = useState(
+    localStorage.getItem("watchlistSymbols") || DEFAULT_SYMBOLS,
+  );
+  const [rows, setRows] = useState<Quote[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [auto, setAuto] = useState(true);
+
+  const { sorted, handleSort } = useSortableTable<Quote, SortKey>(rows, "symbol");
+
+  async function load() {
+    try {
+      const data = await getQuotes(symbols);
+      setRows(data);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  useEffect(() => {
+    load();
+    if (!auto) return;
+    const id = setInterval(load, 10000);
+    return () => clearInterval(id);
+  }, [symbols, auto]);
+
+  function handleSymbolsChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const v = e.target.value;
+    setSymbols(v);
+    localStorage.setItem("watchlistSymbols", v);
+  }
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <h1>Watchlist</h1>
+      <div style={{ marginBottom: "1rem", display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+        <input
+          value={symbols}
+          onChange={handleSymbolsChange}
+          style={{ minWidth: "400px" }}
+          placeholder="Comma separated symbols"
+        />
+        <label>
+          <input
+            type="checkbox"
+            checked={auto}
+            onChange={(e) => setAuto(e.target.checked)}
+          />
+          Auto refresh
+        </label>
+      </div>
+      {error && <div className="toast">Error: {error}</div>}
+      <table className="watchlist-table">
+        <thead>
+          <tr>
+            {[
+              "name",
+              "symbol",
+              "last",
+              "open",
+              "high",
+              "low",
+              "change",
+              "changePct",
+              "volume",
+              "time",
+            ].map((k) => (
+              <th key={k} onClick={() => handleSort(k as SortKey)}>
+                {k === "changePct" ? "Chg %" : k.charAt(0).toUpperCase() + k.slice(1)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((q) => {
+            const colour = q.change == null || q.change === 0 ? "" : q.change > 0 ? "pos" : "neg";
+            return (
+              <tr key={q.symbol}>
+                <td title={q.name}>{q.name}</td>
+                <td>{q.symbol}</td>
+                <td className="num">{formatPrice(q)}</td>
+                <td className="num">{formatChange(q.open)}</td>
+                <td className="num">{formatChange(q.high)}</td>
+                <td className="num">{formatChange(q.low)}</td>
+                <td className={`num ${colour}`}>{formatChange(q.change)}</td>
+                <td className={`num ${colour}`}>{formatChange(q.changePct)}</td>
+                <td className="num">{formatVolume(q.volume)}</td>
+                <td className="num">{formatTime(q.time)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default Watchlist;

--- a/frontend/src/styles/watchlist.css
+++ b/frontend/src/styles/watchlist.css
@@ -1,0 +1,39 @@
+.watchlist-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.watchlist-table th,
+.watchlist-table td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid #ccc;
+  white-space: nowrap;
+}
+
+.watchlist-table th {
+  cursor: pointer;
+  user-select: none;
+  text-align: left;
+}
+
+.watchlist-table td.num,
+.watchlist-table th.num {
+  text-align: right;
+}
+
+.pos {
+  color: green;
+  background-color: rgba(0, 128, 0, 0.05);
+}
+
+.neg {
+  color: red;
+  background-color: rgba(255, 0, 0, 0.05);
+}
+
+.toast {
+  color: #fff;
+  background-color: #d33;
+  padding: 0.5rem 1rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -168,3 +168,16 @@ export interface SavedQuery {
     params: CustomQuery;
 }
 
+export interface Quote {
+    name: string;
+    symbol: string;
+    last: number | null;
+    open: number | null;
+    high: number | null;
+    low: number | null;
+    change: number | null;
+    changePct: number | null;
+    volume: number | null;
+    time: string | null;
+}
+

--- a/tests/test_quotes_route.py
+++ b/tests/test_quotes_route.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+
+
+def test_quotes_route_returns_data(monkeypatch):
+    """Ensure the /api/quotes endpoint returns structured data."""
+
+    class DummyTicker:
+        fast_info = {
+            "longName": "Apple Inc.",
+            "lastPrice": 190.0,
+            "open": 189.0,
+            "dayHigh": 191.0,
+            "dayLow": 188.0,
+            "previousClose": 188.5,
+            "volume": 100,
+            "regularMarketTime": 0,
+        }
+
+    class DummyTickers:
+        def __init__(self, symbols: str) -> None:
+            self.tickers = {"AAPL": DummyTicker()}
+
+    monkeypatch.setattr("yfinance.Tickers", lambda symbols: DummyTickers(symbols))
+
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/api/quotes", params={"symbols": "AAPL"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["symbol"] == "AAPL"
+    assert data[0]["last"] == 190.0


### PR DESCRIPTION
## Summary
- expose `/api/quotes` FastAPI route that returns Yahoo Finance snapshots
- add React watchlist page with sortable, auto-refreshing table
- wire up frontend API helper and quote types

## Testing
- `pytest`
- `cd frontend && npm test` *(fails: symbol declarations in HoldingsTable and missing @testing-library/user-event)*

------
https://chatgpt.com/codex/tasks/task_e_6898960c44588327b403eadab1d7de89