### PR TITLE
refactor: route-driven portfolio modes

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -9,40 +9,8 @@ describe("App", () => {
     vi.resetModules();
   });
 
-  it.skip("preselects group from URL", async () => {
-    window.history.pushState({}, "", "/instrument/kids");
-
-    vi.mock("./api", () => ({
-      getOwners: vi.fn().mockResolvedValue([]),
-      getGroups: vi.fn().mockResolvedValue([
-        { slug: "family", name: "Family", members: [] },
-        { slug: "kids", name: "Kids", members: [] },
-      ]),
-      getGroupInstruments: vi.fn().mockResolvedValue([]),
-      getPortfolio: vi.fn(),
-      refreshPrices: vi.fn(),
-      getAlerts: vi.fn().mockResolvedValue([]),
-      getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [] }),
-      getTimeseries: vi.fn(),
-      saveTimeseries: vi.fn(),
-    }));
-
-    const { default: App } = await import("./App");
-
-    render(
-      <MemoryRouter initialEntries={["/instrument/kids"]}>
-        <App />
-      </MemoryRouter>,
-    );
-
-    const select = await screen.findByLabelText(/group/i, {
-      selector: "select",
-    });
-    expect(select).toHaveValue("kids");
-  });
-
-  it("renders timeseries editor when path is /timeseries", async () => {
-    window.history.pushState({}, "", "/timeseries?ticker=ABC&exchange=L");
+  it("renders timeseries editor when path is /portfolio/timeseries", async () => {
+    window.history.pushState({}, "", "/portfolio/timeseries?ticker=ABC&exchange=L");
 
     vi.mock("./api", () => ({
       getOwners: vi.fn().mockResolvedValue([]),
@@ -59,7 +27,9 @@ describe("App", () => {
     const { default: App } = await import("./App");
 
     render(
-      <MemoryRouter initialEntries={["/timeseries?ticker=ABC&exchange=L"]}>
+      <MemoryRouter
+        initialEntries={["/portfolio/timeseries?ticker=ABC&exchange=L"]}
+      >
         <App />
       </MemoryRouter>,
     );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,210 +1,33 @@
-import { useEffect, useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useState } from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
-  getGroupInstruments,
   getGroups,
   getOwners,
-  getPortfolio,
-  refreshPrices,
 } from "./api";
-
-import type {
-  GroupSummary,
-  InstrumentSummary,
-  OwnerSummary,
-  Portfolio,
-} from "./types";
-
-import { OwnerSelector } from "./components/OwnerSelector";
-import { GroupSelector } from "./components/GroupSelector";
-import { PortfolioView } from "./components/PortfolioView";
-import { GroupPortfolioView } from "./components/GroupPortfolioView";
-import { InstrumentTable } from "./components/InstrumentTable";
-import { TransactionsPage } from "./components/TransactionsPage";
-import { PerformanceDashboard } from "./components/PerformanceDashboard";
-
-import { AlertsPanel } from "./components/AlertsPanel";
-import { ComplianceWarnings } from "./components/ComplianceWarnings";
-import { Screener } from "./pages/Screener";
-import { QueryPage } from "./pages/QueryPage";
+import type { GroupSummary, OwnerSummary } from "./types";
 import useFetchWithRetry from "./hooks/useFetchWithRetry";
 import { LanguageSwitcher } from "./components/LanguageSwitcher";
-import i18n from "./i18n";
+import { AlertsPanel } from "./components/AlertsPanel";
+import { NavigationBar } from "./components/NavigationBar";
+import GroupPage from "./pages/GroupPage";
+import InstrumentPage from "./pages/InstrumentPage";
+import OwnerPage from "./pages/OwnerPage";
+import PerformancePage from "./pages/PerformancePage";
+import { TransactionsPage } from "./components/TransactionsPage";
+import { Screener } from "./pages/Screener";
+import { QueryPage } from "./pages/QueryPage";
 import { TimeseriesEdit } from "./pages/TimeseriesEdit";
 import { TradingAgent } from "./pages/TradingAgent";
 
-type Mode =
-  | "owner"
-  | "group"
-  | "instrument"
-  | "transactions"
-  | "performance"
-  | "screener"
-  | "query"
-  | "trading"
-  | "timeseries";
-
-// derive initial mode + id from path
-const path = window.location.pathname.split("/").filter(Boolean);
-const initialMode: Mode =
-  path[0] === "member" ? "owner" :
-  path[0] === "instrument" ? "instrument" :
-  path[0] === "transactions" ? "transactions" :
-  path[0] === "performance" ? "performance" :
-  path[0] === "screener" ? "screener" :
-  path[0] === "query" ? "query" :
-  path[0] === "trading" ? "trading" :
-  path[0] === "timeseries" ? "timeseries" :
-  "group";
-const initialSlug = path[1] ?? "";
-
 export default function App() {
-  const navigate = useNavigate();
-  const location = useLocation();
   const { t } = useTranslation();
-
-  const params = new URLSearchParams(location.search);
-  const [mode, setMode] = useState<Mode>(initialMode);
-  const [selectedOwner, setSelectedOwner] = useState(
-    initialMode === "owner" ? initialSlug : "",
-  );
-  const [selectedGroup, setSelectedGroup] = useState(
-    initialMode === "instrument" ? initialSlug : params.get("group") ?? "",
-  );
-
-  const [owners, setOwners] = useState<OwnerSummary[]>([]);
-  const [groups, setGroups] = useState<GroupSummary[]>([]);
-  const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
-  const [instruments, setInstruments] = useState<InstrumentSummary[]>([]);
-
-  const [loading, setLoading] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-
-  // when true, holdings table emphasises relative metrics
   const [relativeView, setRelativeView] = useState(true);
 
-  const [refreshingPrices, setRefreshingPrices] = useState(false);
-  const [lastPriceRefresh, setLastPriceRefresh] = useState<string | null>(null);
-  const [priceRefreshError, setPriceRefreshError] = useState<string | null>(null);
-  const [backendUnavailable, setBackendUnavailable] = useState(false);
+  const ownersReq = useFetchWithRetry<OwnerSummary[]>(getOwners);
+  const groupsReq = useFetchWithRetry<GroupSummary[]>(getGroups);
 
-  const ownersReq = useFetchWithRetry(getOwners);
-  const groupsReq = useFetchWithRetry(getGroups);
-
-  useEffect(() => {
-    const segs = location.pathname.split("/").filter(Boolean);
-    const newMode: Mode =
-      segs[0] === "member"
-        ? "owner"
-        : segs[0] === "instrument"
-          ? "instrument"
-          : segs[0] === "transactions"
-            ? "transactions"
-            : segs[0] === "performance"
-              ? "performance"
-              : segs[0] === "screener"
-                ? "screener"
-                : segs[0] === "query"
-                  ? "query"
-                  : segs[0] === "trading"
-                    ? "trading"
-                    : segs[0] === "timeseries"
-                      ? "timeseries"
-                      : "group";
-    setMode(newMode);
-    if (newMode === "owner") {
-      setSelectedOwner(segs[1] ?? "");
-    } else if (newMode === "instrument") {
-      setSelectedGroup(segs[1] ?? "");
-    } else if (newMode === "group") {
-      setSelectedGroup(
-        new URLSearchParams(location.search).get("group") ?? "",
-      );
-    }
-  }, [location.pathname, location.search]);
-
-  useEffect(() => {
-    if (ownersReq.data) setOwners(ownersReq.data);
-  }, [ownersReq.data]);
-
-  useEffect(() => {
-    if (groupsReq.data) setGroups(groupsReq.data);
-  }, [groupsReq.data]);
-
-  useEffect(() => {
-    if (ownersReq.error || groupsReq.error) {
-      setBackendUnavailable(true);
-    }
-  }, [ownersReq.error, groupsReq.error]);
-
-  useEffect(() => {
-    if (ownersReq.data && groupsReq.data) {
-      setBackendUnavailable(false);
-    }
-  }, [ownersReq.data, groupsReq.data]);
-  // redirect to defaults if no selection provided
-  useEffect(() => {
-    if (mode === "owner" && !selectedOwner && owners.length) {
-      const owner = owners[0].owner;
-      setSelectedOwner(owner);
-      navigate(`/member/${owner}`, { replace: true });
-    }
-    if (mode === "instrument" && !selectedGroup && groups.length) {
-      const slug = groups[0].slug;
-      setSelectedGroup(slug);
-      navigate(`/instrument/${slug}`, { replace: true });
-    }
-    if (mode === "group" && !selectedGroup && groups.length) {
-      const slug = groups[0].slug;
-      setSelectedGroup(slug);
-      navigate(`/?group=${slug}`, { replace: true });
-    }
-  }, [mode, selectedOwner, selectedGroup, owners, groups, navigate]);
-
-  // data fetching based on route
-  useEffect(() => {
-    if (mode === "owner" && selectedOwner) {
-      setLoading(true);
-      setErr(null);
-      getPortfolio(selectedOwner)
-        .then(setPortfolio)
-        .catch((e) => setErr(String(e)))
-        .finally(() => setLoading(false));
-    }
-  }, [mode, selectedOwner]);
-
-  useEffect(() => {
-    if (mode === "instrument" && selectedGroup) {
-      setLoading(true);
-      setErr(null);
-      getGroupInstruments(selectedGroup)
-        .then(setInstruments)
-        .catch((e) => setErr(String(e)))
-        .finally(() => setLoading(false));
-    }
-  }, [mode, selectedGroup]);
-
-  async function handleRefreshPrices() {
-    setRefreshingPrices(true);
-    setPriceRefreshError(null);
-    try {
-      const resp = await refreshPrices();
-      setLastPriceRefresh(resp.timestamp ?? new Date().toISOString());
-
-      if (mode === "owner" && selectedOwner) {
-        setPortfolio(await getPortfolio(selectedOwner));
-      } else if (mode === "instrument" && selectedGroup) {
-        setInstruments(await getGroupInstruments(selectedGroup));
-      }
-    } catch (e) {
-      setPriceRefreshError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setRefreshingPrices(false);
-    }
-  }
-
-  if (backendUnavailable) {
+  if (ownersReq.error || groupsReq.error) {
     return (
       <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
         Backend unavailable—retrying…
@@ -212,38 +35,14 @@ export default function App() {
     );
   }
 
+  const owners = ownersReq.data ?? [];
+  const groups = groupsReq.data ?? [];
+
   return (
     <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
       <LanguageSwitcher />
       <AlertsPanel />
-      {/* mode toggle */}
-      <div style={{ marginBottom: "1rem" }}>
-        <strong>{t("app.viewBy")}</strong>{" "}
-        {([
-          "group",
-          "instrument",
-          "owner",
-          "performance",
-          "transactions",
-          "screener",
-          "query",
-          "trading",
-          "timeseries",
-        ] as Mode[]).map((m) => (
-          <label key={m} style={{ marginRight: "1rem" }}>
-            <input
-              type="radio"
-              name="mode"
-              value={m}
-              checked={mode === m}
-              onChange={() => setMode(m)}
-            />{" "}
-            {t(`app.modes.${m}`)}
-          </label>
-        ))}
-      </div>
-
-      {/* absolute vs relative toggle */}
+      <NavigationBar />
       <div style={{ marginBottom: "1rem" }}>
         <label>
           <input
@@ -254,112 +53,97 @@ export default function App() {
           {t("app.relativeView")}
         </label>
       </div>
-
-      <div style={{ marginBottom: "1rem" }}>
-        <button onClick={handleRefreshPrices} disabled={refreshingPrices}>
-          {refreshingPrices ? t("app.refreshing") : t("app.refreshPrices")}
-        </button>
-        {lastPriceRefresh && (
-          <span style={{ marginLeft: "0.5rem", fontSize: "0.85rem", color: "#666" }}>
-            {t("app.last")}{" "}
-            {new Date(lastPriceRefresh).toLocaleString()}
-          </span>
-        )}
-        {priceRefreshError && (
-          <span style={{ marginLeft: "0.5rem", color: "red", fontSize: "0.85rem" }}>
-            {priceRefreshError}
-          </span>
-        )}
-      </div>
-
-      {/* OWNER VIEW */}
-      {mode === "owner" && (
-        <>
-          <OwnerSelector
-            owners={owners}
-            selected={selectedOwner}
-            onSelect={setSelectedOwner}
-          />
-          <ComplianceWarnings owners={selectedOwner ? [selectedOwner] : []} />
-          <PortfolioView
-            data={portfolio}
-            loading={loading}
-            error={err}
-            relativeView={relativeView}
-          />
-        </>
-      )}
-
-      {/* GROUP VIEW */}
-      {mode === "group" && groups.length > 0 && (
-        <>
-          <GroupSelector
-            groups={groups}
-            selected={selectedGroup}
-            onSelect={setSelectedGroup}
-          />
-          <label style={{ display: "block", margin: "0.5rem 0" }}>
-            <input
-              type="checkbox"
-              checked={relativeView}
-              onChange={(e) => setRelativeView(e.target.checked)}
-            />{" "}
-            Relative view
-          </label>
-          <ComplianceWarnings
-            owners={
-              groups.find((g) => g.slug === selectedGroup)?.members ?? []
-            }
-          />
-          <GroupPortfolioView
-            slug={selectedGroup}
-            relativeView={relativeView}
-            onSelectMember={(owner) => {
-              setMode("owner");
-              setSelectedOwner(owner);
-              navigate(`/member/${owner}`);
-            }}
-          />
-        </>
-      )}
-
-      {/* INSTRUMENT VIEW */}
-      {mode === "instrument" && groups.length > 0 && (
-        <>
-          <GroupSelector
-            groups={groups}
-            selected={selectedGroup}
-            onSelect={setSelectedGroup}
-          />
-          {err && <p style={{ color: "red" }}>{err}</p>}
-          {loading ? (
-            <p>{t("app.loading")}</p>
-          ) : (
-            <InstrumentTable rows={instruments} />
-          )}
-        </>
-      )}
-
-      {/* PERFORMANCE VIEW */}
-      {mode === "performance" && (
-        <>
-          <OwnerSelector
-            owners={owners}
-            selected={selectedOwner}
-            onSelect={setSelectedOwner}
-          />
-          <PerformanceDashboard owner={selectedOwner} />
-        </>
-      )}
-
-      {mode === "transactions" && <TransactionsPage owners={owners} />}
-
-      {mode === "screener" && <Screener />}
-      {mode === "trading" && <TradingAgent />}
-      {mode === "timeseries" && <TimeseriesEdit />}
-
-      {mode === "query" && <QueryPage />}
-
+      <Routes>
+        <Route
+          path="group"
+          element={
+            <div role="tabpanel" id="tabpanel-group" aria-labelledby="tab-group">
+              <GroupPage groups={groups} relativeView={relativeView} />
+            </div>
+          }
+        />
+        <Route
+          path="instrument"
+          element={
+            <div
+              role="tabpanel"
+              id="tabpanel-instrument"
+              aria-labelledby="tab-instrument"
+            >
+              <InstrumentPage groups={groups} />
+            </div>
+          }
+        />
+        <Route
+          path="owner"
+          element={
+            <div role="tabpanel" id="tabpanel-owner" aria-labelledby="tab-owner">
+              <OwnerPage owners={owners} relativeView={relativeView} />
+            </div>
+          }
+        />
+        <Route
+          path="performance"
+          element={
+            <div
+              role="tabpanel"
+              id="tabpanel-performance"
+              aria-labelledby="tab-performance"
+            >
+              <PerformancePage owners={owners} />
+            </div>
+          }
+        />
+        <Route
+          path="transactions"
+          element={
+            <div
+              role="tabpanel"
+              id="tabpanel-transactions"
+              aria-labelledby="tab-transactions"
+            >
+              <TransactionsPage owners={owners} />
+            </div>
+          }
+        />
+        <Route
+          path="screener"
+          element={
+            <div role="tabpanel" id="tabpanel-screener" aria-labelledby="tab-screener">
+              <Screener />
+            </div>
+          }
+        />
+        <Route
+          path="query"
+          element={
+            <div role="tabpanel" id="tabpanel-query" aria-labelledby="tab-query">
+              <QueryPage />
+            </div>
+          }
+        />
+        <Route
+          path="trading"
+          element={
+            <div role="tabpanel" id="tabpanel-trading" aria-labelledby="tab-trading">
+              <TradingAgent />
+            </div>
+          }
+        />
+        <Route
+          path="timeseries"
+          element={
+            <div
+              role="tabpanel"
+              id="tabpanel-timeseries"
+              aria-labelledby="tab-timeseries"
+            >
+              <TimeseriesEdit />
+            </div>
+          }
+        />
+        <Route path="*" element={<Navigate to="group" replace />} />
+      </Routes>
       <p style={{ marginTop: "2rem", textAlign: "center" }}>
         <a href="/virtual">Virtual Portfolios</a>
         {" • "}
@@ -370,4 +154,3 @@ export default function App() {
     </div>
   );
 }
-

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -1,0 +1,41 @@
+import { NavLink, useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+const modes = [
+  "group",
+  "instrument",
+  "owner",
+  "performance",
+  "transactions",
+  "screener",
+  "query",
+  "trading",
+  "timeseries",
+] as const;
+
+type Mode = (typeof modes)[number];
+
+export function NavigationBar() {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const current = location.pathname.split("/")[2] as Mode | undefined;
+
+  return (
+    <nav role="tablist" aria-label={t("app.viewBy") ?? "Portfolio modes"}>
+      {modes.map((m) => (
+        <NavLink
+          key={m}
+          to={`/portfolio/${m}`}
+          role="tab"
+          id={`tab-${m}`}
+          aria-selected={current === m}
+          tabIndex={current === m ? 0 : -1}
+          aria-controls={`tabpanel-${m}`}
+          style={{ marginRight: "1rem" }}
+        >
+          {t(`app.modes.${m}`)}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import './index.css'
 import './i18n'
 import App from './App.tsx'
@@ -14,7 +14,8 @@ createRoot(document.getElementById('root')!).render(
       <Routes>
         <Route path="/support" element={<Support />} />
         <Route path="/virtual" element={<VirtualPortfolio />} />
-        <Route path="/*" element={<App />} />
+        <Route path="/portfolio/*" element={<App />} />
+        <Route path="/" element={<Navigate to="/portfolio/group" replace />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { GroupSelector } from "../components/GroupSelector";
+import { GroupPortfolioView } from "../components/GroupPortfolioView";
+import { ComplianceWarnings } from "../components/ComplianceWarnings";
+import type { GroupSummary } from "../types";
+
+interface Props {
+  groups: GroupSummary[];
+  relativeView: boolean;
+}
+
+export default function GroupPage({ groups, relativeView }: Props) {
+  const [selectedGroup, setSelectedGroup] = useState("");
+
+  useEffect(() => {
+    if (!selectedGroup && groups.length) {
+      setSelectedGroup(groups[0].slug);
+    }
+  }, [groups, selectedGroup]);
+
+  return (
+    <>
+      <GroupSelector
+        groups={groups}
+        selected={selectedGroup}
+        onSelect={setSelectedGroup}
+      />
+      <ComplianceWarnings
+        owners={groups.find((g) => g.slug === selectedGroup)?.members ?? []}
+      />
+      <GroupPortfolioView slug={selectedGroup} relativeView={relativeView} />
+    </>
+  );
+}

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { GroupSelector } from "../components/GroupSelector";
+import { InstrumentTable } from "../components/InstrumentTable";
+import { getGroupInstruments, refreshPrices } from "../api";
+import type { GroupSummary, InstrumentSummary } from "../types";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  groups: GroupSummary[];
+}
+
+export default function InstrumentPage({ groups }: Props) {
+  const { t } = useTranslation();
+  const [selectedGroup, setSelectedGroup] = useState("");
+  const [instruments, setInstruments] = useState<InstrumentSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastRefresh, setLastRefresh] = useState<string | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedGroup && groups.length) {
+      setSelectedGroup(groups[0].slug);
+    }
+  }, [groups, selectedGroup]);
+
+  useEffect(() => {
+    if (selectedGroup) {
+      setLoading(true);
+      setErr(null);
+      getGroupInstruments(selectedGroup)
+        .then(setInstruments)
+        .catch((e) => setErr(String(e)))
+        .finally(() => setLoading(false));
+    }
+  }, [selectedGroup]);
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    setRefreshError(null);
+    try {
+      const resp = await refreshPrices();
+      setLastRefresh(resp.timestamp ?? new Date().toISOString());
+      if (selectedGroup) {
+        setInstruments(await getGroupInstruments(selectedGroup));
+      }
+    } catch (e) {
+      setRefreshError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  return (
+    <>
+      <GroupSelector
+        groups={groups}
+        selected={selectedGroup}
+        onSelect={setSelectedGroup}
+      />
+      {err && <p style={{ color: "red" }}>{err}</p>}
+      <div style={{ margin: "1rem 0" }}>
+        <button onClick={handleRefresh} disabled={refreshing}>
+          {refreshing ? t("app.refreshing") : t("app.refreshPrices")}
+        </button>
+        {lastRefresh && (
+          <span style={{ marginLeft: "0.5rem", fontSize: "0.85rem", color: "#666" }}>
+            {t("app.last")}{" "}
+            {new Date(lastRefresh).toLocaleString()}
+          </span>
+        )}
+        {refreshError && (
+          <span style={{ marginLeft: "0.5rem", color: "red", fontSize: "0.85rem" }}>
+            {refreshError}
+          </span>
+        )}
+      </div>
+      {loading ? <p>{t("app.loading")}</p> : <InstrumentTable rows={instruments} />}
+    </>
+  );
+}

--- a/frontend/src/pages/OwnerPage.tsx
+++ b/frontend/src/pages/OwnerPage.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { OwnerSelector } from "../components/OwnerSelector";
+import { PortfolioView } from "../components/PortfolioView";
+import { ComplianceWarnings } from "../components/ComplianceWarnings";
+import { getPortfolio, refreshPrices } from "../api";
+import type { OwnerSummary, Portfolio } from "../types";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  owners: OwnerSummary[];
+  relativeView: boolean;
+}
+
+export default function OwnerPage({ owners, relativeView }: Props) {
+  const { t } = useTranslation();
+  const [selectedOwner, setSelectedOwner] = useState("");
+  const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastRefresh, setLastRefresh] = useState<string | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedOwner && owners.length) {
+      setSelectedOwner(owners[0].owner);
+    }
+  }, [owners, selectedOwner]);
+
+  useEffect(() => {
+    if (selectedOwner) {
+      setLoading(true);
+      setErr(null);
+      getPortfolio(selectedOwner)
+        .then(setPortfolio)
+        .catch((e) => setErr(String(e)))
+        .finally(() => setLoading(false));
+    }
+  }, [selectedOwner]);
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    setRefreshError(null);
+    try {
+      const resp = await refreshPrices();
+      setLastRefresh(resp.timestamp ?? new Date().toISOString());
+      if (selectedOwner) {
+        setPortfolio(await getPortfolio(selectedOwner));
+      }
+    } catch (e) {
+      setRefreshError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  return (
+    <>
+      <OwnerSelector owners={owners} selected={selectedOwner} onSelect={setSelectedOwner} />
+      <ComplianceWarnings owners={selectedOwner ? [selectedOwner] : []} />
+      <div style={{ margin: "1rem 0" }}>
+        <button onClick={handleRefresh} disabled={refreshing}>
+          {refreshing ? t("app.refreshing") : t("app.refreshPrices")}
+        </button>
+        {lastRefresh && (
+          <span style={{ marginLeft: "0.5rem", fontSize: "0.85rem", color: "#666" }}>
+            {t("app.last")}{" "}
+            {new Date(lastRefresh).toLocaleString()}
+          </span>
+        )}
+        {refreshError && (
+          <span style={{ marginLeft: "0.5rem", color: "red", fontSize: "0.85rem" }}>
+            {refreshError}
+          </span>
+        )}
+      </div>
+      <PortfolioView
+        data={portfolio}
+        loading={loading}
+        error={err}
+        relativeView={relativeView}
+      />
+    </>
+  );
+}

--- a/frontend/src/pages/PerformancePage.tsx
+++ b/frontend/src/pages/PerformancePage.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { OwnerSelector } from "../components/OwnerSelector";
+import { PerformanceDashboard } from "../components/PerformanceDashboard";
+import type { OwnerSummary } from "../types";
+
+interface Props {
+  owners: OwnerSummary[];
+}
+
+export default function PerformancePage({ owners }: Props) {
+  const [selectedOwner, setSelectedOwner] = useState("");
+
+  useEffect(() => {
+    if (!selectedOwner && owners.length) {
+      setSelectedOwner(owners[0].owner);
+    }
+  }, [owners, selectedOwner]);
+
+  return (
+    <>
+      <OwnerSelector
+        owners={owners}
+        selected={selectedOwner}
+        onSelect={setSelectedOwner}
+      />
+      <PerformanceDashboard owner={selectedOwner} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace radio mode selector with tabbed NavigationBar
- Drive portfolio mode via /portfolio/:mode routes and new mode pages
- Update routing entrypoint and tests for mode-specific routes

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_6899db66ec6c832796f8a84fba05ca0e