### PR TITLE
Async snapshot refresh and timestamp tracking

### DIFF
--- a/backend/common/risk.py
+++ b/backend/common/risk.py
@@ -59,7 +59,7 @@ def compute_portfolio_var(owner: str, days: int = 365, confidence: float = 0.95)
         raise ValueError("confidence must be between 0 and 1 or 0 and 100")
 
     perf = portfolio_utils.compute_owner_performance(owner, days=days)
-    history = perf.get("history", [])
+    history = perf.get("history", []) if isinstance(perf, dict) else perf
     if not history:
         return {"window_days": days, "confidence": confidence, "1d": None, "10d": None}
 
@@ -99,6 +99,8 @@ def compute_sharpe_ratio(owner: str, days: int = 365) -> float | None:
         raise ValueError("days must be positive")
 
     perf = portfolio_utils.compute_owner_performance(owner, days=days)
+    if isinstance(perf, dict):
+        perf = perf.get("history", [])
     if not perf:
         return None
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -18,21 +18,24 @@ def test_health_env_variable(monkeypatch):
 def test_startup_warms_snapshot(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", False)
     monkeypatch.setattr(config, "snapshot_warm_days", 30)
-    with patch(
-        "backend.app.refresh_snapshot_in_memory_from_timeseries"
-    ) as mock_refresh:
+    with patch("backend.app.refresh_snapshot_async") as mock_refresh, patch(
+        "backend.app._load_snapshot", return_value=({}, None)
+    ) as mock_load, patch("backend.app.refresh_snapshot_in_memory") as mock_mem:
         app = create_app()
         with TestClient(app):
             pass
     mock_refresh.assert_called_once_with(days=30)
+    mock_load.assert_called_once_with()
+    mock_mem.assert_called_once_with({}, None)
 
 
 def test_skip_snapshot_warm(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
-    with patch(
-        "backend.app.refresh_snapshot_in_memory_from_timeseries"
-    ) as mock_refresh:
+    with patch("backend.app.refresh_snapshot_async") as mock_refresh, patch(
+        "backend.app._load_snapshot"
+    ) as mock_load:
         app = create_app()
         with TestClient(app):
             pass
     mock_refresh.assert_not_called()
+    mock_load.assert_not_called()

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,6 +1,6 @@
 import numpy as np
-import numpy as np
 import pytest
+from unittest.mock import patch
 from backend.common import risk
 
 


### PR DESCRIPTION
## Summary
- track price snapshot file timestamp via `_load_snapshot`
- refresh price snapshot asynchronously on app startup
- ensure risk helpers accept both legacy list and new dict formats

## Testing
- `pytest tests/test_app.py tests/test_portfolio_utils_snapshot.py tests/test_risk.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689a5b88102c83278f4c322a73703f6d