### PR TITLE
Translate instrument types

### DIFF
--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -5,6 +5,7 @@ import i18n from "../i18n";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  i18n.changeLanguage("en");
 });
 
 describe("GroupPortfolioView", () => {
@@ -98,10 +99,10 @@ describe("GroupPortfolioView", () => {
 
     render(<GroupPortfolioView slug="all" />);
 
-    await waitFor(() => screen.getByText("Equity"));
+    await waitFor(() => screen.getAllByText("Equity"));
 
-    expect(screen.getByText("Equity")).toBeInTheDocument();
-    expect(screen.getByText("Cash")).toBeInTheDocument();
+    expect(screen.getAllByText("Equity").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Cash").length).toBeGreaterThan(0);
   });
 
 
@@ -129,6 +130,7 @@ describe("GroupPortfolioView", () => {
     );
     render(<GroupPortfolioView slug="all" />);
     expect(screen.getByText(i18n.t("common.loading"))).toBeInTheDocument();
+  });
 
   it("updates totals when accounts are toggled", async () => {
     const mockPortfolio = {

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -5,6 +5,7 @@ import { getGroupPortfolio } from "../api";
 import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { money, percent } from "../lib/money";
+import { translateInstrumentType } from "../lib/instrumentType";
 import { useFetch } from "../hooks/useFetch";
 import tableStyles from "../styles/table.module.css";
 import { useTranslation } from "react-i18next";
@@ -82,12 +83,6 @@ export function GroupPortfolioView({ slug, relativeView }: Props) {
   const perOwner: Record<string, { value: number; dayChange: number; gain: number; cost: number }> = {};
   const perType: Record<string, number> = {};
 
-  const formatType = (type: string | null | undefined) => {
-    if (!type) return t("common.other");
-    const normalized = type.toLowerCase().replace(/_/g, " ");
-    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
-  };
-
   const activeKeys = selectedAccounts.length
     ? new Set(selectedAccounts)
     : new Set(portfolio.accounts?.map(accountKey));
@@ -114,8 +109,8 @@ export function GroupPortfolioView({ slug, relativeView }: Props) {
           : market - cost;
       const dayChg = h.day_change_gbp ?? 0;
 
-      const type = formatType(h.instrument_type);
-      perType[type] = (perType[type] || 0) + market;
+      const typeKey = (h.instrument_type ?? "other").toLowerCase();
+      perType[typeKey] = (perType[typeKey] || 0) + market;
 
       totalCost += cost;
       totalGain += gain;
@@ -141,8 +136,8 @@ export function GroupPortfolioView({ slug, relativeView }: Props) {
     return { owner, ...data, gainPct, dayChangePct };
   });
 
-  const typeRows = Object.entries(perType).map(([name, value]) => ({
-    name,
+  const typeRows = Object.entries(perType).map(([type, value]) => ({
+    name: translateInstrumentType(t, type),
     value,
     pct: totalValue > 0 ? (value / totalValue) * 100 : 0,
   }));

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -1,7 +1,9 @@
 import type React from "react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import type { Holding } from "../types";
 import { money, percent } from "../lib/money";
+import { translateInstrumentType } from "../lib/instrumentType";
 import { useSortableTable } from "../hooks/useSortableTable";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
@@ -17,6 +19,7 @@ export function HoldingsTable({
   onSelectInstrument,
   relativeView = false,
 }: Props) {
+  const { t } = useTranslation();
   const [filters, setFilters] = useState({
     ticker: "",
     name: "",
@@ -269,7 +272,7 @@ export function HoldingsTable({
                 </td>
                 <td className={tableStyles.cell}>{h.name}</td>
                 <td className={tableStyles.cell}>{h.currency ?? "—"}</td>
-                <td className={tableStyles.cell}>{h.instrument_type ?? "—"}</td>
+                <td className={tableStyles.cell}>{translateInstrumentType(t, h.instrument_type)}</td>
                 {!relativeView && visibleColumns.units && (
                   <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                     {new Intl.NumberFormat(i18n.language).format(h.units ?? 0)}

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import { getInstrumentDetail } from "../api";
 import { money, percent } from "../lib/money";
+import { translateInstrumentType } from "../lib/instrumentType";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
 
@@ -166,7 +167,7 @@ export function InstrumentDetail({
       </button>
       <h2 style={{ marginBottom: "0.2rem" }}>{name}</h2>
       <div style={{ fontSize: "0.85rem", color: "#aaa" }}>
-        {ticker} • {displayCurrency} • {instrument_type ?? "?"} • {" "}
+        {ticker} • {displayCurrency} • {translateInstrumentType(t, instrument_type)} • {" "}
         <Link to={editLink} style={{ color: "#00d8ff", textDecoration: "none" }}>
           {t("instrumentDetail.edit")}
         </Link>

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -4,6 +4,7 @@ import type { InstrumentSummary } from "../types";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { useFilterableTable } from "../hooks/useFilterableTable";
 import { money, percent } from "../lib/money";
+import { translateInstrumentType } from "../lib/instrumentType";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
 
@@ -158,7 +159,7 @@ export function InstrumentTable({ rows }: Props) {
                                 </td>
                                 <td className={tableStyles.cell}>{r.name}</td>
                                 <td className={tableStyles.cell}>{r.currency ?? "—"}</td>
-                                <td className={tableStyles.cell}>{r.instrument_type ?? "—"}</td>
+                                <td className={tableStyles.cell}>{translateInstrumentType(t, r.instrument_type)}</td>
                                 {visibleColumns.units && (
                                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                         {new Intl.NumberFormat(i18n.language).format(r.units)}

--- a/frontend/src/lib/instrumentType.ts
+++ b/frontend/src/lib/instrumentType.ts
@@ -1,0 +1,19 @@
+import { TFunction } from "i18next";
+
+const TYPE_KEYS: Record<string, string> = {
+  equity: "instrumentType.equity",
+  bond: "instrumentType.bond",
+  cash: "instrumentType.cash",
+  etf: "instrumentType.etf",
+  fund: "instrumentType.fund",
+  "investment trust": "instrumentType.investmentTrust",
+  "real estate": "instrumentType.realEstate",
+};
+
+export function translateInstrumentType(t: TFunction, type?: string | null) {
+  if (!type) {
+    return t("instrumentType.other", { defaultValue: t("common.other") });
+  }
+  const key = TYPE_KEYS[type.toLowerCase()];
+  return t(key || "instrumentType.other", { defaultValue: type });
+}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -24,6 +24,16 @@
     "loading": "Laden…",
     "other": "Andere"
   },
+  "instrumentType": {
+    "equity": "Aktie",
+    "bond": "Anleihe",
+    "cash": "Bargeld",
+    "etf": "ETF",
+    "fund": "Fonds",
+    "investmentTrust": "Investment Trust",
+    "realEstate": "Immobilien",
+    "other": "Andere"
+  },
   "instrumentTable": {
     "noInstruments": "Keine Instrumente.",
     "columns": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -24,6 +24,16 @@
     "loading": "Loading…",
     "other": "Other"
   },
+  "instrumentType": {
+    "equity": "Equity",
+    "bond": "Bond",
+    "cash": "Cash",
+    "etf": "ETF",
+    "fund": "Fund",
+    "investmentTrust": "Investment Trust",
+    "realEstate": "Real Estate",
+    "other": "Other"
+  },
   "instrumentTable": {
     "noInstruments": "No instruments.",
     "columns": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -24,6 +24,16 @@
     "loading": "Cargando…",
     "other": "Otro"
   },
+  "instrumentType": {
+    "equity": "Acción",
+    "bond": "Bono",
+    "cash": "Efectivo",
+    "etf": "ETF",
+    "fund": "Fondo",
+    "investmentTrust": "Investment Trust",
+    "realEstate": "Bienes raíces",
+    "other": "Otro"
+  },
   "instrumentTable": {
     "noInstruments": "Sin instrumentos.",
     "columns": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -24,6 +24,16 @@
     "loading": "Chargement…",
     "other": "Autre"
   },
+  "instrumentType": {
+    "equity": "Action",
+    "bond": "Obligation",
+    "cash": "Espèces",
+    "etf": "ETF",
+    "fund": "Fonds",
+    "investmentTrust": "Fiducie de placement",
+    "realEstate": "Immobilier",
+    "other": "Autre"
+  },
   "instrumentTable": {
     "noInstruments": "Aucun instrument.",
     "columns": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -24,6 +24,16 @@
     "loading": "Carregando…",
     "other": "Outro"
   },
+  "instrumentType": {
+    "equity": "Ação",
+    "bond": "Título",
+    "cash": "Dinheiro",
+    "etf": "ETF",
+    "fund": "Fundo",
+    "investmentTrust": "Trust de investimento",
+    "realEstate": "Imóveis",
+    "other": "Outro"
+  },
   "instrumentTable": {
     "noInstruments": "Sem instrumentos.",
     "columns": {


### PR DESCRIPTION
## Summary
- add instrumentType translations to all locales
- provide translateInstrumentType helper to map raw types to localized labels
- use translated instrument types across instrument, holdings and portfolio views

## Testing
- `cd frontend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689a5be9aa908327954187c99fc25bd9