### PR TITLE
feat: add sortino ratio for risk diagnostics

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -14,7 +14,7 @@ from typing import Dict, Iterable, List, Optional
 
 import pandas as pd
 
-from backend.common import prices
+from backend.common import prices, risk
 from backend.common.alerts import publish_sns_alert
 from backend.common.portfolio_loader import list_portfolios
 from backend.common.portfolio_utils import (
@@ -203,6 +203,14 @@ def run(tickers: Optional[Iterable[str]] = None) -> List[Dict]:
             metrics["win_rate"] * 100,
             metrics["average_profit"],
         )
+    for pf in list_portfolios():
+        owner = pf.get("owner")
+        try:
+            sortino = risk.compute_sortino_ratio(owner)
+        except FileNotFoundError:
+            continue
+        if sortino is not None:
+            logger.info("Sortino ratio for %s: %.4f", owner, sortino)
     _alert_on_drawdown()
     return signals
 

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -138,6 +138,7 @@ async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95):
     try:
         var = risk.compute_portfolio_var(owner, days=days, confidence=confidence)
         sharpe = risk.compute_sharpe_ratio(owner, days=days)
+        sortino = risk.compute_sortino_ratio(owner, days=days)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Owner not found")
     except ValueError as exc:
@@ -147,6 +148,7 @@ async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95):
         "as_of": date.today().isoformat(),
         "var": var,
         "sharpe_ratio": sharpe,
+        "sortino_ratio": sortino,
     }
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,32 +98,32 @@ def test_instrument_detail(mock_list, mock_build, mock_positions, mock_timeserie
     assert "positions" in response.json()
 
 
+@patch("backend.common.risk.compute_sortino_ratio", return_value=2.34)
 @patch("backend.common.risk.compute_sharpe_ratio", return_value=1.23)
 @patch("backend.common.risk.compute_portfolio_var", return_value={"1d": 100.0, "10d": 200.0})
-def test_var_endpoint(mock_var, mock_sharpe):
+def test_var_endpoint(mock_var, mock_sharpe, mock_sortino):
     response = client.get("/var/steve")
     assert response.status_code == 200
     payload = response.json()
     assert payload["owner"] == "steve"
     assert payload["var"] == {"1d": 100.0, "10d": 200.0}
     assert payload["sharpe_ratio"] == 1.23
+    assert payload["sortino_ratio"] == 2.34
 
 
+@patch("backend.common.risk.compute_sortino_ratio", side_effect=FileNotFoundError)
 @patch("backend.common.risk.compute_sharpe_ratio", side_effect=FileNotFoundError)
 @patch("backend.common.risk.compute_portfolio_var", side_effect=FileNotFoundError)
-def test_var_owner_not_found(mock_var, mock_sharpe):
+def test_var_owner_not_found(mock_var, mock_sharpe, mock_sortino):
     response = client.get("/var/missing")
     assert response.status_code == 404
 
 
+@patch("backend.common.risk.compute_sortino_ratio", return_value=1.0)
 @patch("backend.common.risk.compute_sharpe_ratio", return_value=1.0)
 @patch("backend.common.risk.compute_portfolio_var", side_effect=ValueError("bad"))
-
-def test_var_invalid_params(mock_var, mock_sharpe):
+def test_var_invalid_params(mock_var, mock_sharpe, mock_sortino):
     response = client.get("/var/steve?confidence=2")
-
-def test_var_invalid_params(mock_var):
-    response = client.get("/var/steve?confidence=101")
     assert response.status_code == 400
 
 @patch("backend.timeseries.fetch_timeseries.fetch_yahoo_timeseries")

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -24,6 +24,33 @@ def test_compute_sharpe_ratio_insufficient(monkeypatch):
     monkeypatch.setattr(risk.portfolio_utils, "compute_owner_performance", lambda owner, days=3: [])
     assert risk.compute_sharpe_ratio("steve", days=3) is None
 
+
+def test_compute_sortino_ratio(monkeypatch):
+    data = [
+        {"date": "2024-01-01", "value": 100, "daily_return": 0.01},
+        {"date": "2024-01-02", "value": 101, "daily_return": 0.02},
+        {"date": "2024-01-03", "value": 99, "daily_return": -0.02},
+        {"date": "2024-01-04", "value": 98, "daily_return": -0.01},
+    ]
+    monkeypatch.setattr(risk.portfolio_utils, "compute_owner_performance", lambda owner, days=4: data)
+    monkeypatch.setattr(risk.config, "risk_free_rate", 0.01)
+    rf = 0.01
+    trading_days = 252
+    returns = np.array([0.01, 0.02, -0.02, -0.01])
+    excess = returns - rf / trading_days
+    downside = excess[excess < 0]
+    expected = float(np.round((excess.mean()/downside.std(ddof=1))*np.sqrt(trading_days), 4))
+    assert risk.compute_sortino_ratio("steve", days=4) == expected
+
+
+def test_compute_sortino_ratio_insufficient(monkeypatch):
+    data = [
+        {"date": "2024-01-01", "value": 100, "daily_return": 0.01},
+        {"date": "2024-01-02", "value": 101, "daily_return": 0.02},
+    ]
+    monkeypatch.setattr(risk.portfolio_utils, "compute_owner_performance", lambda owner, days=2: data)
+    assert risk.compute_sortino_ratio("steve", days=2) is None
+
 @patch("backend.common.portfolio_utils.compute_owner_performance", return_value=[])
 def test_compute_portfolio_var_accepts_percentage(mock_perf):
     """compute_portfolio_var should accept confidence as a percentage."""

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -119,6 +119,13 @@ def test_run_defaults_to_all_known_tickers(monkeypatch):
     monkeypatch.setattr(
         "backend.agent.trading_agent.publish_alert", lambda alert: None
     )
+    monkeypatch.setattr(
+        "backend.agent.trading_agent.risk.compute_sortino_ratio", lambda owner: None
+    )
+    monkeypatch.setattr(
+        "backend.agent.trading_agent.compute_owner_performance",
+        lambda owner, days=365: {"history": [], "max_drawdown": None},
+    )
 
     run()
 
@@ -142,6 +149,13 @@ def test_run_sends_telegram_when_not_aws(monkeypatch):
     )
     monkeypatch.setattr(
         "backend.agent.trading_agent.publish_alert", lambda alert: None
+    )
+    monkeypatch.setattr(
+        "backend.agent.trading_agent.risk.compute_sortino_ratio", lambda owner: None
+    )
+    monkeypatch.setattr(
+        "backend.agent.trading_agent.compute_owner_performance",
+        lambda owner, days=365: {"history": [], "max_drawdown": None},
     )
 
     sent: list[str] = []


### PR DESCRIPTION
## Summary
- add `compute_sortino_ratio` helper calculating downside deviation based risk metric
- expose Sortino ratio in portfolio risk endpoint alongside Sharpe
- log Sortino ratio for each portfolio in trading-agent diagnostics

## Testing
- `OFFLINE_MODE=0 pytest`
  - ⚠️ **fails**: missing timeseries cache and offline mode issues (`CASH_L.parquet`)

------
https://chatgpt.com/codex/tasks/task_e_689a68f14818832793cb20a5d641ae9c