### PR TITLE
Remove unused HoldingsTable stub

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -15,14 +15,8 @@ type Props = {
 };
 
 export function HoldingsTable({ holdings, onSelectInstrument }: Props) {
-  const { relativeViewEnabled } = useConfig();
-
-export function HoldingsTable({
-  holdings,
-  onSelectInstrument,
-  relativeView = false,
-}: Props) {
   const { t } = useTranslation();
+  const { relativeViewEnabled } = useConfig();
 
   const [filters, setFilters] = useState({
     ticker: "",


### PR DESCRIPTION
## Summary
- drop leftover incomplete HoldingsTable definition
- use config hook in main HoldingsTable to read relativeViewEnabled

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a701a3ec083278532fcc8d8ab0c09