### PR TITLE
feat: hide absolute values in relative view

### DIFF
--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, it, expect, vi, type Mock } from "vitest";
 import type { InstrumentSummary } from "../types";
+import { ConfigContext } from "../ConfigContext";
 
 vi.mock("./InstrumentDetail", () => ({
     InstrumentDetail: vi.fn(() => <div data-testid="instrument-detail" />),
@@ -69,5 +70,28 @@ describe("InstrumentTable", () => {
         const checkbox = screen.getByLabelText("Gain %");
         fireEvent.click(checkbox);
         expect(screen.queryByRole('columnheader', {name: /Gain %/})).toBeNull();
+    });
+
+    it("shows absolute columns when relative view disabled", () => {
+        render(<InstrumentTable rows={rows} />);
+        expect(screen.getByRole('columnheader', { name: 'Units' })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: 'Cost £' })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: 'Market £' })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: 'Gain £' })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: 'Last £' })).toBeInTheDocument();
+    });
+
+    it("hides absolute columns in relative view", () => {
+        render(
+            <ConfigContext.Provider value={{ relativeViewEnabled: true }}>
+                <InstrumentTable rows={rows} />
+            </ConfigContext.Provider>,
+        );
+        expect(screen.queryByRole('columnheader', { name: 'Units' })).toBeNull();
+        expect(screen.queryByRole('columnheader', { name: 'Cost £' })).toBeNull();
+        expect(screen.queryByRole('columnheader', { name: 'Market £' })).toBeNull();
+        expect(screen.queryByRole('columnheader', { name: 'Gain £' })).toBeNull();
+        expect(screen.queryByRole('columnheader', { name: 'Last £' })).toBeNull();
+        expect(screen.getByRole('columnheader', { name: 'Gain %' })).toBeInTheDocument();
     });
 });

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -7,6 +7,7 @@ import { money, percent } from "../lib/money";
 import { translateInstrumentType } from "../lib/instrumentType";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
+import { useConfig } from "../ConfigContext";
 
 type Props = {
     rows: InstrumentSummary[];
@@ -14,6 +15,7 @@ type Props = {
 
 export function InstrumentTable({ rows }: Props) {
     const { t } = useTranslation();
+    const { relativeViewEnabled } = useConfig();
     const [selected, setSelected] = useState<InstrumentSummary | null>(null);
     const [visibleColumns, setVisibleColumns] = useState({
         units: true,
@@ -94,10 +96,10 @@ export function InstrumentTable({ rows }: Props) {
                         </th>
                         <th className={tableStyles.cell}>{t("instrumentTable.columns.ccy")}</th>
                         <th className={tableStyles.cell}>{t("instrumentTable.columns.type")}</th>
-                        {visibleColumns.units && (
+                        {!relativeViewEnabled && visibleColumns.units && (
                             <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.units")}</th>
                         )}
-                        {visibleColumns.cost && (
+                        {!relativeViewEnabled && visibleColumns.cost && (
                             <th
                                 className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
                                 onClick={() => handleSort("cost")}
@@ -106,10 +108,10 @@ export function InstrumentTable({ rows }: Props) {
                                 {sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
                             </th>
                         )}
-                        {visibleColumns.market && (
+                        {!relativeViewEnabled && visibleColumns.market && (
                             <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.market")}</th>
                         )}
-                        {visibleColumns.gain && (
+                        {!relativeViewEnabled && visibleColumns.gain && (
                             <th
                                 className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
                                 onClick={() => handleSort("gain")}
@@ -127,7 +129,9 @@ export function InstrumentTable({ rows }: Props) {
                                 {sortKey === "gain_pct" ? (asc ? " ▲" : " ▼") : ""}
                             </th>
                         )}
-                        <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.last")}</th>
+                        {!relativeViewEnabled && (
+                            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.last")}</th>
+                        )}
                         <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.lastDate")}</th>
                         <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.delta7d")}</th>
                         <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentTable.columns.delta30d")}</th>
@@ -160,18 +164,18 @@ export function InstrumentTable({ rows }: Props) {
                                 <td className={tableStyles.cell}>{r.name}</td>
                                 <td className={tableStyles.cell}>{r.currency ?? "—"}</td>
                                 <td className={tableStyles.cell}>{translateInstrumentType(t, r.instrument_type)}</td>
-                                {visibleColumns.units && (
+                                {!relativeViewEnabled && visibleColumns.units && (
                                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                         {new Intl.NumberFormat(i18n.language).format(r.units)}
                                     </td>
                                 )}
-                                {visibleColumns.cost && (
+                                {!relativeViewEnabled && visibleColumns.cost && (
                                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(r.cost)}</td>
                                 )}
-                                {visibleColumns.market && (
+                                {!relativeViewEnabled && visibleColumns.market && (
                                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(r.market_value_gbp)}</td>
                                 )}
-                                {visibleColumns.gain && (
+                                {!relativeViewEnabled && visibleColumns.gain && (
                                     <td className={`${tableStyles.cell} ${tableStyles.right}`} style={{ color: gainColour }}>
                                         {money(r.gain_gbp)}
                                     </td>
@@ -184,9 +188,11 @@ export function InstrumentTable({ rows }: Props) {
                                         {percent(r.gain_pct, 1)}
                                     </td>
                                 )}
-                                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                                    {r.last_price_gbp != null ? money(r.last_price_gbp) : "—"}
-                                </td>
+                                {!relativeViewEnabled && (
+                                    <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                                        {r.last_price_gbp != null ? money(r.last_price_gbp) : "—"}
+                                    </td>
+                                )}
                                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                                     {r.last_price_date
                                         ? new Intl.DateTimeFormat(i18n.language).format(


### PR DESCRIPTION
## Summary
- hide absolute-value columns in InstrumentTable when relative view is enabled
- cover both relative and absolute view modes in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b2d47a41c8327bd52d2a7121c7a00