### PR TITLE
Hide market column in relative-only mode

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -49,6 +49,7 @@ describe("HoldingsTable", () => {
         expect(screen.queryByRole('columnheader', {name: 'Units'})).toBeNull();
         expect(screen.queryByRole('columnheader', {name: /Cost £/})).toBeNull();
         expect(screen.queryByRole('columnheader', {name: /Gain £/})).toBeNull();
+        expect(screen.queryByRole('columnheader', {name: /Mkt £/})).toBeNull();
     });
 
     it("shows absolute columns when relative view is disabled", () => {
@@ -56,6 +57,7 @@ describe("HoldingsTable", () => {
         expect(screen.getByRole('columnheader', {name: 'Units'})).toBeInTheDocument();
         expect(screen.getByRole('columnheader', {name: /Cost £/})).toBeInTheDocument();
         expect(screen.getByRole('columnheader', {name: /Gain £/})).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', {name: /Mkt £/})).toBeInTheDocument();
     });
 
     it("shows days to go if not eligible", () => {

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -164,7 +164,7 @@ export function HoldingsTable({
             {!relativeViewEnabled && visibleColumns.cost && (
               <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
             )}
-            {visibleColumns.market && (
+            {!relativeViewEnabled && visibleColumns.market && (
               <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
             )}
             {!relativeViewEnabled && visibleColumns.gain && (
@@ -215,7 +215,7 @@ export function HoldingsTable({
                 Cost £{sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
               </th>
             )}
-            {visibleColumns.market && (
+            {!relativeViewEnabled && visibleColumns.market && (
               <th className={`${tableStyles.cell} ${tableStyles.right}`}>Mkt £</th>
             )}
             {!relativeViewEnabled && visibleColumns.gain && (
@@ -290,7 +290,7 @@ export function HoldingsTable({
                     {money(h.cost)}
                   </td>
                 )}
-                {visibleColumns.market && (
+                {!relativeViewEnabled && visibleColumns.market && (
                   <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(h.market)}</td>
                 )}
                 {!relativeViewEnabled && visibleColumns.gain && (


### PR DESCRIPTION
## Summary
- hide market value column when relative view is enabled
- cover market column visibility in HoldingsTable tests

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_689b33b53d388327954f477880d74000