### PR TITLE
Hide absolute metrics in instrument detail when relative view is enabled

### DIFF
--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, type Mock, beforeEach } from "vitest";
 import i18n from "../i18n";
+import { ConfigContext, type AppConfig } from "../ConfigContext";
 
 vi.mock("../api", () => ({ getInstrumentDetail: vi.fn() }));
 import { getInstrumentDetail } from "../api";
@@ -17,6 +18,13 @@ import { InstrumentDetail } from "./InstrumentDetail";
 
 describe("InstrumentDetail", () => {
   const mockGetInstrumentDetail = getInstrumentDetail as unknown as Mock;
+
+  const renderWithConfig = (ui: React.ReactElement, cfg: AppConfig) =>
+    render(
+      <ConfigContext.Provider value={cfg}>
+        <MemoryRouter>{ui}</MemoryRouter>
+      </ConfigContext.Provider>,
+    );
 
   beforeEach(() => {
     mockGetInstrumentDetail.mockReset();
@@ -78,6 +86,67 @@ describe("InstrumentDetail", () => {
         `${i18n.t("instrumentDetail.change30d")} 30.0%`,
       ),
     ).toBeInTheDocument();
+  });
+
+  it("hides absolute columns in relative view", async () => {
+    mockGetInstrumentDetail.mockResolvedValue({
+      prices: [],
+      positions: [
+        {
+          owner: "Alice",
+          account: "Acct",
+          units: 1,
+          market_value_gbp: 100,
+          unrealised_gain_gbp: 10,
+          gain_pct: 10,
+        },
+      ],
+      currency: null,
+    });
+
+    i18n.changeLanguage("en");
+
+    renderWithConfig(
+      <InstrumentDetail ticker="ABC.L" name="ABC" onClose={() => {}} />,
+      { relativeViewEnabled: true },
+    );
+
+    await screen.findByText("Alice – Acct");
+
+    expect(screen.queryByRole('columnheader', { name: /Units/ })).toBeNull();
+    expect(screen.queryByRole('columnheader', { name: /Mkt £/ })).toBeNull();
+    expect(screen.queryByRole('columnheader', { name: /Gain £/ })).toBeNull();
+    expect(screen.getByRole('columnheader', { name: /Gain %/ })).toBeInTheDocument();
+  });
+
+  it("shows absolute columns when relative view disabled", async () => {
+    mockGetInstrumentDetail.mockResolvedValue({
+      prices: [],
+      positions: [
+        {
+          owner: "Alice",
+          account: "Acct",
+          units: 1,
+          market_value_gbp: 100,
+          unrealised_gain_gbp: 10,
+          gain_pct: 10,
+        },
+      ],
+      currency: null,
+    });
+
+    i18n.changeLanguage("en");
+
+    renderWithConfig(
+      <InstrumentDetail ticker="ABC.L" name="ABC" onClose={() => {}} />,
+      { relativeViewEnabled: false },
+    );
+
+    await screen.findByText("Alice – Acct");
+
+    expect(screen.getByRole('columnheader', { name: /Units/ })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /Mkt £/ })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /Gain £/ })).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -14,6 +14,7 @@ import { money, percent } from "../lib/money";
 import { translateInstrumentType } from "../lib/instrumentType";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
+import { useConfig } from "../ConfigContext";
 
 type Props = {
   ticker: string;
@@ -59,6 +60,7 @@ export function InstrumentDetail({
   onClose,
 }: Props) {
   const { t } = useTranslation();
+  const { relativeViewEnabled } = useConfig();
   const [data, setData] = useState<{
     prices: Price[];
     positions: Position[];
@@ -266,9 +268,15 @@ export function InstrumentDetail({
         <thead>
           <tr>
             <th className={tableStyles.cell}>{t("instrumentDetail.columns.account")}</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.units")}</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.market")}</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.gain")}</th>
+            {!relativeViewEnabled && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.units")}</th>
+            )}
+            {!relativeViewEnabled && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.market")}</th>
+            )}
+            {!relativeViewEnabled && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.gain")}</th>
+            )}
             <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("instrumentDetail.columns.gainPct")}</th>
           </tr>
         </thead>
@@ -283,20 +291,26 @@ export function InstrumentDetail({
                   {pos.owner} – {pos.account}
                 </Link>
               </td>
-              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                {fixed(pos.units, 4)}
-              </td>
-              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                {money(pos.market_value_gbp)}
-              </td>
-              <td
-                className={`${tableStyles.cell} ${tableStyles.right}`}
-                style={{
-                  color: toNum(pos.unrealised_gain_gbp) >= 0 ? "lightgreen" : "red",
-                }}
-              >
-                {money(pos.unrealised_gain_gbp)}
-              </td>
+              {!relativeViewEnabled && (
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                  {fixed(pos.units, 4)}
+                </td>
+              )}
+              {!relativeViewEnabled && (
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                  {money(pos.market_value_gbp)}
+                </td>
+              )}
+              {!relativeViewEnabled && (
+                <td
+                  className={`${tableStyles.cell} ${tableStyles.right}`}
+                  style={{
+                    color: toNum(pos.unrealised_gain_gbp) >= 0 ? "lightgreen" : "red",
+                  }}
+                >
+                  {money(pos.unrealised_gain_gbp)}
+                </td>
+              )}
               <td
                 className={`${tableStyles.cell} ${tableStyles.right}`}
                 style={{ color: toNum(pos.gain_pct) >= 0 ? "lightgreen" : "red" }}
@@ -308,7 +322,7 @@ export function InstrumentDetail({
           {!positions.length && (
             <tr>
               <td
-                colSpan={5} // <- fix: matches 5 columns
+                colSpan={relativeViewEnabled ? 2 : 5}
                 className={`${tableStyles.cell} ${tableStyles.center}`}
                 style={{ color: "#888" }}
               >


### PR DESCRIPTION
## Summary
- Hide Units, Mkt £ and Gain £ columns in InstrumentDetail when relative view toggle is active
- Adjust no-position message colSpan and import ConfigContext
- Add tests to ensure columns behave correctly in relative and absolute modes

## Testing
- `npm test`
- `pytest` *(fails: tests/test_backend_api.py::test_valid_portfolio - assert 422 == 200; tests/test_backend_api.py::test_invalid_portfolio - assert 422 == 404)*

------
https://chatgpt.com/codex/tasks/task_e_689b2db4eacc832786cb1d46cae5c242