### PR TITLE
Remove BackgroundTasks requirement from portfolio endpoints

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -14,7 +14,7 @@ import logging
 from datetime import date
 from typing import List
 
-from fastapi import APIRouter, HTTPException, BackgroundTasks
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from backend.common import (
@@ -83,7 +83,7 @@ async def groups():
 # ──────────────────────────────────────────────────────────────
 @router.get("/portfolio/{owner}")
 @handle_owner_not_found
-async def portfolio(owner: str, background_tasks: BackgroundTasks):
+async def portfolio(owner: str):
     """Return the fully expanded portfolio for ``owner``.
 
     The helper function :func:`build_owner_portfolio` loads account data from
@@ -105,7 +105,7 @@ async def portfolio(owner: str, background_tasks: BackgroundTasks):
     except FileNotFoundError:
         raise_owner_not_found()
 
-    background_tasks.add_task(page_cache.save_cache, page, data)
+    page_cache.save_cache(page, data)
     return data
 
 
@@ -155,7 +155,7 @@ async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95):
 
 
 @router.get("/portfolio-group/{slug}")
-async def portfolio_group(slug: str, background_tasks: BackgroundTasks):
+async def portfolio_group(slug: str):
     """Return the aggregated portfolio for a group.
 
     Groups are defined in configuration and simply reference a list of owner
@@ -179,7 +179,7 @@ async def portfolio_group(slug: str, background_tasks: BackgroundTasks):
         log.warning(f"Failed to load group {slug}: {e}")
         raise HTTPException(status_code=404, detail="Group not found")
 
-    background_tasks.add_task(page_cache.save_cache, page, data)
+    page_cache.save_cache(page, data)
     return data
 
 
@@ -187,7 +187,7 @@ async def portfolio_group(slug: str, background_tasks: BackgroundTasks):
 # Group-level aggregation
 # ──────────────────────────────────────────────────────────────
 @router.get("/portfolio-group/{slug}/instruments")
-async def group_instruments(slug: str, background_tasks: BackgroundTasks):
+async def group_instruments(slug: str):
     """Return holdings for the group aggregated by ticker."""
 
     page = f"group_instruments_{slug}"
@@ -205,7 +205,7 @@ async def group_instruments(slug: str, background_tasks: BackgroundTasks):
 
     gp = group_portfolio.build_group_portfolio(slug)
     data = portfolio_utils.aggregate_by_ticker(gp)
-    background_tasks.add_task(page_cache.save_cache, page, data)
+    page_cache.save_cache(page, data)
     return data
 
 

--- a/backend/routes/screener.py
+++ b/backend/routes/screener.py
@@ -6,7 +6,7 @@ from typing import List
 
 import hashlib
 
-from fastapi import APIRouter, HTTPException, Query, BackgroundTasks
+from fastapi import APIRouter, HTTPException, Query
 
 from backend.screener import Fundamentals, screen
 from backend.utils import page_cache
@@ -18,7 +18,6 @@ SCREENER_TTL = 900  # seconds
 
 @router.get("/", response_model=List[Fundamentals])
 async def screener(
-    background_tasks: BackgroundTasks,
     tickers: str = Query(..., description="Comma-separated list of tickers"),
     peg_max: float | None = Query(None),
     pe_max: float | None = Query(None),
@@ -70,5 +69,5 @@ async def screener(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
     payload = [r.model_dump() for r in result]
-    background_tasks.add_task(page_cache.save_cache, page, payload)
+    page_cache.save_cache(page, payload)
     return payload


### PR DESCRIPTION
## Summary
- avoid FastAPI 422 errors by dropping `BackgroundTasks` injection from portfolio and screener routes
- save cache synchronously after building responses

## Testing
- `pytest tests/test_backend_api.py::test_valid_portfolio -q`
- `pytest -q` *(fails: fixture 'mock_var' not found; asserts len(perf) == 3)*

------
https://chatgpt.com/codex/tasks/task_e_689b2b8f122883279891bdb428838ba1