### PR TITLE
Add currency cell interactions

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within, fireEvent } from "@testing-library/react";
 import { HoldingsTable } from "./HoldingsTable";
 import { ConfigContext, type AppConfig } from "../ConfigContext";
 import type { Holding } from "../types";
+import { vi } from "vitest";
 
 describe("HoldingsTable", () => {
     const holdings: Holding[] = [
@@ -100,5 +101,21 @@ describe("HoldingsTable", () => {
         const checkbox = screen.getByLabelText("Units");
         fireEvent.click(checkbox);
         expect(screen.queryByRole('columnheader', {name: 'Units'})).toBeNull();
+    });
+
+    it("handles currency cell clicks", () => {
+        const onSelect = vi.fn();
+        render(<HoldingsTable holdings={holdings} onSelectInstrument={onSelect} />);
+
+        const usdRow = screen.getByText("Test Holding").closest("tr");
+        const usdBtn = within(usdRow!).getByRole("button", { name: "USD" });
+        fireEvent.click(usdBtn);
+        expect(onSelect).toHaveBeenCalledWith("USDGBP=X", "USDGBP=X");
+
+        const gbpRow = screen.getByText("Alpha").closest("tr");
+        const gbpCell = within(gbpRow!).getByText("GBP");
+        fireEvent.click(gbpCell);
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(within(gbpRow!).queryByRole("button", { name: "GBP" })).toBeNull();
     });
 });

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -274,7 +274,32 @@ export function HoldingsTable({
                   </button>
                 </td>
                 <td className={tableStyles.cell}>{h.name}</td>
-                <td className={tableStyles.cell}>{h.currency ?? "—"}</td>
+                <td className={tableStyles.cell}>
+                  {h.currency && h.currency !== "GBP" ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        onSelectInstrument?.(
+                          `${h.currency}GBP=X`,
+                          `${h.currency}GBP=X`,
+                        )
+                      }
+                      style={{
+                        color: "dodgerblue",
+                        textDecoration: "underline",
+                        background: "none",
+                        border: "none",
+                        padding: 0,
+                        font: "inherit",
+                        cursor: "pointer",
+                      }}
+                    >
+                      {h.currency}
+                    </button>
+                  ) : (
+                    h.currency ?? "—"
+                  )}
+                </td>
                 <td className={tableStyles.cell}>{translateInstrumentType(t, h.instrument_type)}</td>
                 {!relativeViewEnabled && visibleColumns.units && (
                   <td className={`${tableStyles.cell} ${tableStyles.right}`}>

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -53,6 +53,24 @@ describe("InstrumentTable", () => {
         expect(props.name).toBe("ABC Corp");
     });
 
+    it("opens pair ticker when non-GBP currency clicked", () => {
+        const mock = InstrumentDetail as unknown as Mock;
+        mock.mockClear();
+        render(<InstrumentTable rows={rows} />);
+
+        const usdRow = screen.getByText("XYZ").closest("tr");
+        const usdBtn = within(usdRow!).getByRole("button", { name: "USD" });
+        fireEvent.click(usdBtn);
+
+        expect(mock).toHaveBeenCalled();
+        type DetailProps = Parameters<typeof InstrumentDetail>[0];
+        const props = mock.mock.calls[0][0] as DetailProps;
+        expect(props.ticker).toBe("USDGBP=X");
+
+        const gbpRow = screen.getByText("ABC").closest("tr");
+        expect(within(gbpRow!).queryByRole("button", { name: "GBP" })).toBeNull();
+    });
+
     it("sorts by ticker when header clicked", () => {
         render(<InstrumentTable rows={rows} />);
         // initial sort is ticker ascending => ABC first

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -162,7 +162,34 @@ export function InstrumentTable({ rows }: Props) {
                                     </button>
                                 </td>
                                 <td className={tableStyles.cell}>{r.name}</td>
-                                <td className={tableStyles.cell}>{r.currency ?? "—"}</td>
+                                <td className={tableStyles.cell}>
+                                    {r.currency && r.currency !== "GBP" ? (
+                                        <button
+                                            type="button"
+                                            onClick={() =>
+                                                setSelected(
+                                                    {
+                                                        ticker: `${r.currency}GBP=X`,
+                                                        name: `${r.currency}GBP=X`,
+                                                    } as InstrumentSummary,
+                                                )
+                                            }
+                                            style={{
+                                                color: "dodgerblue",
+                                                textDecoration: "underline",
+                                                background: "none",
+                                                border: "none",
+                                                padding: 0,
+                                                font: "inherit",
+                                                cursor: "pointer",
+                                            }}
+                                        >
+                                            {r.currency}
+                                        </button>
+                                    ) : (
+                                        r.currency ?? "—"
+                                    )}
+                                </td>
                                 <td className={tableStyles.cell}>{translateInstrumentType(t, r.instrument_type)}</td>
                                 {!relativeViewEnabled && visibleColumns.units && (
                                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>


### PR DESCRIPTION
## Summary
- Make currency cells in instrument and holdings tables clickable for non-GBP currencies
- Trigger InstrumentDetail or onSelectInstrument with computed pair tickers
- Add tests for currency cell behavior

## Testing
- `npm --prefix frontend test InstrumentTable.test.tsx`
- `npm --prefix frontend test HoldingsTable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ba1a4fa1c8327bb01926a097083d4