### PR TITLE
Graceful handling of yfinance failures in quotes route

### DIFF
--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -5,15 +5,21 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 from typing import List, Dict, Any
+import logging
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, HTTPException
 import yfinance as yf
 
 router = APIRouter(prefix="/api")
+log = logging.getLogger("routes.quotes")
 
 
 def _fetch(symbols: List[str]) -> List[Dict[str, Any]]:
-    tickers = yf.Tickers(" ".join(symbols))
+    try:
+        tickers = yf.Tickers(" ".join(symbols))
+    except Exception as exc:
+        log.exception("yf.Tickers failed for %s", symbols)
+        raise HTTPException(status_code=502, detail=f"Failed to fetch quotes: {exc}") from exc
     results: List[Dict[str, Any]] = []
     for sym in symbols:
         t = tickers.tickers.get(sym)

--- a/tests/test_quotes_route.py
+++ b/tests/test_quotes_route.py
@@ -1,0 +1,17 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+
+
+def test_quotes_returns_502_on_yfinance_error(monkeypatch):
+    def mock_tickers(symbols):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("backend.routes.quotes.yf.Tickers", mock_tickers)
+
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/api/quotes?symbols=AAPL")
+    assert resp.status_code == 502
+    assert resp.json()["detail"].startswith("Failed to fetch quotes")


### PR DESCRIPTION
## Summary
- Wrap Yahoo Finance `Tickers` call with error handling in `/quotes`
- Log yfinance errors and return HTTP 502 with helpful message
- Add unit test to ensure failing `yf.Tickers` yields a 502 response

## Testing
- `pytest tests/test_quotes_route.py -q`
- `pytest -q` *(fails: test_backend_api::test_valid_portfolio, test_backend_api::test_invalid_portfolio, test_main::test_portfolio, test_virtual_portfolio::test_performance_with_synthetic_holdings, tests/test_main.py::test_var_invalid_params)*

------
https://chatgpt.com/codex/tasks/task_e_689b2d1f8ae083278deab35323612521