### PR TITLE
feat: add i18n translations for query and screener

### DIFF
--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -6,6 +6,7 @@ import { useFetch } from "../hooks/useFetch";
 import tableStyles from "../styles/table.module.css";
 import { money } from "../lib/money";
 import i18n from "../i18n";
+import { useTranslation } from "react-i18next";
 
 type Props = {
   owners: OwnerSummary[];
@@ -16,6 +17,7 @@ export function TransactionsPage({ owners }: Props) {
   const [account, setAccount] = useState("");
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");
+  const { t } = useTranslation();
   const { data: transactions, loading, error } = useFetch<Transaction[]>(
     () =>
       getTransactions({
@@ -40,7 +42,7 @@ export function TransactionsPage({ owners }: Props) {
     <div>
       <div style={{ marginBottom: "1rem" }}>
         <Selector
-          label="Owner"
+          label={t("owner.label")}
           value={owner}
           onChange={setOwner}
           options={[
@@ -58,16 +60,16 @@ export function TransactionsPage({ owners }: Props) {
           ]}
         />
         <label style={{ marginLeft: "0.5rem" }}>
-          Start: <input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+          {t("query.start")}: <input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
         </label>
         <label style={{ marginLeft: "0.5rem" }}>
-          End: <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
+          {t("query.end")}: <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
         </label>
       </div>
 
       {error && <p style={{ color: "red" }}>{error.message}</p>}
       {loading ? (
-        <p>Loading…</p>
+        <p>{t("common.loading")}</p>
       ) : (
         <table className={tableStyles.table}>
           <thead>

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -108,5 +108,26 @@
   "loadingPortfolio": "Portfolio wird geladen…",
   "portfolio": "Portfolio",
   "asOf": "Stand {{date}} • Trades diesen Monat: {{trades}} / 20 (Verbleibend: {{remaining}})",
-  "approxTotal": "Ungefähre Summe: £{{value}}"
+  "approxTotal": "Ungefähre Summe: £{{value}}",
+  "query": {
+    "start": "Start",
+    "end": "Ende",
+    "owners": "Eigentümer",
+    "tickers": "Ticker",
+    "metrics": "Metriken",
+    "run": "Ausführen",
+    "running": "Wird ausgeführt…",
+    "save": "Speichern",
+    "exportCsv": "CSV exportieren",
+    "exportXlsx": "XLSX exportieren"
+  },
+  "screener": {
+    "tickers": "Ticker",
+    "maxPeg": "Max PEG",
+    "maxPe": "Max P/E",
+    "maxDe": "Max D/E",
+    "minFcf": "Min FCF",
+    "run": "Ausführen",
+    "loading": "Laden…"
+  }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -108,5 +108,26 @@
   "loadingPortfolio": "Loading portfolio…",
   "portfolio": "Portfolio",
   "asOf": "As of {{date}} • Trades this month: {{trades}} / 20 (Remaining: {{remaining}})",
-  "approxTotal": "Approx Total: £{{value}}"
+  "approxTotal": "Approx Total: £{{value}}",
+  "query": {
+    "start": "Start",
+    "end": "End",
+    "owners": "Owners",
+    "tickers": "Tickers",
+    "metrics": "Metrics",
+    "run": "Run",
+    "running": "Running…",
+    "save": "Save",
+    "exportCsv": "Export CSV",
+    "exportXlsx": "Export XLSX"
+  },
+  "screener": {
+    "tickers": "Tickers",
+    "maxPeg": "Max PEG",
+    "maxPe": "Max P/E",
+    "maxDe": "Max D/E",
+    "minFcf": "Min FCF",
+    "run": "Run",
+    "loading": "Loading…"
+  }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -108,5 +108,26 @@
   "loadingPortfolio": "Cargando portafolio…",
   "portfolio": "Portafolio",
   "asOf": "A fecha de {{date}} • Operaciones este mes: {{trades}} / 20 (Restantes: {{remaining}})",
-  "approxTotal": "Total aproximado: £{{value}}"
+  "approxTotal": "Total aproximado: £{{value}}",
+  "query": {
+    "start": "Inicio",
+    "end": "Fin",
+    "owners": "Propietarios",
+    "tickers": "Tickers",
+    "metrics": "Métricas",
+    "run": "Ejecutar",
+    "running": "Ejecutando…",
+    "save": "Guardar",
+    "exportCsv": "Exportar CSV",
+    "exportXlsx": "Exportar XLSX"
+  },
+  "screener": {
+    "tickers": "Tickers",
+    "maxPeg": "PEG máx",
+    "maxPe": "P/E máx",
+    "maxDe": "D/E máx",
+    "minFcf": "FCF mín",
+    "run": "Ejecutar",
+    "loading": "Cargando…"
+  }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -108,5 +108,26 @@
   "loadingPortfolio": "Chargement du portefeuille…",
   "portfolio": "Portefeuille",
   "asOf": "Au {{date}} • Transactions ce mois: {{trades}} / 20 (Restantes: {{remaining}})",
-  "approxTotal": "Total approximatif: £{{value}}"
+  "approxTotal": "Total approximatif: £{{value}}",
+  "query": {
+    "start": "Début",
+    "end": "Fin",
+    "owners": "Propriétaires",
+    "tickers": "Tickers",
+    "metrics": "Métriques",
+    "run": "Exécuter",
+    "running": "Exécution…",
+    "save": "Enregistrer",
+    "exportCsv": "Exporter CSV",
+    "exportXlsx": "Exporter XLSX"
+  },
+  "screener": {
+    "tickers": "Tickers",
+    "maxPeg": "PEG max",
+    "maxPe": "P/E max",
+    "maxDe": "D/E max",
+    "minFcf": "FCF min",
+    "run": "Exécuter",
+    "loading": "Chargement…"
+  }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -108,5 +108,26 @@
   "loadingPortfolio": "Carregando portfólio…",
   "portfolio": "Portfólio",
   "asOf": "Em {{date}} • Negociações este mês: {{trades}} / 20 (Restantes: {{remaining}})",
-  "approxTotal": "Total aproximado: £{{value}}"
+  "approxTotal": "Total aproximado: £{{value}}",
+  "query": {
+    "start": "Início",
+    "end": "Fim",
+    "owners": "Proprietários",
+    "tickers": "Tickers",
+    "metrics": "Métricas",
+    "run": "Executar",
+    "running": "Executando…",
+    "save": "Salvar",
+    "exportCsv": "Exportar CSV",
+    "exportXlsx": "Exportar XLSX"
+  },
+  "screener": {
+    "tickers": "Tickers",
+    "maxPeg": "PEG máx",
+    "maxPe": "P/E máx",
+    "maxDe": "D/E máx",
+    "minFcf": "FCF mín",
+    "run": "Executar",
+    "loading": "Carregando…"
+  }
 }

--- a/frontend/src/pages/QueryPage.tsx
+++ b/frontend/src/pages/QueryPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   API_BASE,
   runCustomQuery,
@@ -17,6 +18,7 @@ type ResultRow = Record<string, string | number>;
 
 export function QueryPage() {
   const { data: owners } = useFetch(() => getOwners(), []);
+  const { t } = useTranslation();
 
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");
@@ -97,9 +99,9 @@ export function QueryPage() {
     <div>
       <form onSubmit={handleSubmit} style={{ marginBottom: "1rem" }}>
         <label style={{ marginRight: "0.5rem" }}>
-          Start
+          {t("query.start")}
           <input
-            aria-label="Start"
+            aria-label={t("query.start")}
             type="date"
             value={start}
             onChange={(e) => setStart(e.target.value)}
@@ -107,9 +109,9 @@ export function QueryPage() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
-          End
+          {t("query.end")}
           <input
-            aria-label="End"
+            aria-label={t("query.end")}
             type="date"
             value={end}
             onChange={(e) => setEnd(e.target.value)}
@@ -117,7 +119,7 @@ export function QueryPage() {
           />
         </label>
         <fieldset style={{ marginBottom: "1rem" }}>
-          <legend>Owners</legend>
+          <legend>{t("query.owners")}</legend>
           {owners?.map((o) => (
             <label key={o.owner} style={{ marginRight: "0.5rem" }}>
               <input
@@ -133,7 +135,7 @@ export function QueryPage() {
           ))}
         </fieldset>
         <fieldset style={{ marginBottom: "1rem" }}>
-          <legend>Tickers</legend>
+          <legend>{t("query.tickers")}</legend>
           {TICKER_OPTIONS.map((t) => (
             <label key={t} style={{ marginRight: "0.5rem" }}>
               <input
@@ -149,7 +151,7 @@ export function QueryPage() {
           ))}
         </fieldset>
         <fieldset style={{ marginBottom: "1rem" }}>
-          <legend>Metrics</legend>
+          <legend>{t("query.metrics")}</legend>
           {METRIC_OPTIONS.map((m) => (
             <label key={m} style={{ marginRight: "0.5rem" }}>
               <input
@@ -163,15 +165,15 @@ export function QueryPage() {
           ))}
         </fieldset>
         <button type="submit" disabled={loading} style={{ marginRight: "0.5rem" }}>
-          {loading ? "Running…" : "Run"}
+          {loading ? t("query.running") : t("query.run")}
         </button>
         <button type="button" onClick={handleSave} style={{ marginRight: "0.5rem" }}>
-          Save
+          {t("query.save")}
         </button>
         {rows.length > 0 && (
           <span>
-            <a href={buildExportUrl("csv")}>Export CSV</a>{" | "}
-            <a href={buildExportUrl("xlsx")}>Export XLSX</a>
+            <a href={buildExportUrl("csv")}>{t("query.exportCsv")}</a>{" | "}
+            <a href={buildExportUrl("xlsx")}>{t("query.exportXlsx")}</a>
           </span>
         )}
       </form>

--- a/frontend/src/pages/Screener.test.tsx
+++ b/frontend/src/pages/Screener.test.tsx
@@ -1,5 +1,9 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { createInstance } from "i18next";
+import type { ReactElement } from "react";
+import en from "../locales/en/translation.json";
 
 vi.mock("../api", () => ({
   getScreener: vi.fn().mockResolvedValue([
@@ -17,18 +21,27 @@ vi.mock("../api", () => ({
 import { Screener } from "./Screener";
 import { getScreener } from "../api";
 
+function renderWithI18n(ui: ReactElement) {
+  const i18n = createInstance();
+  i18n.use(initReactI18next).init({
+    lng: "en",
+    resources: { en: { translation: en } },
+  });
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
+}
+
 describe("Screener page", () => {
   it("submits criteria and renders results", async () => {
-    render(<Screener />);
+    renderWithI18n(<Screener />);
 
-    fireEvent.change(screen.getByLabelText(/Tickers/i), {
+    fireEvent.change(screen.getByLabelText(en.screener.tickers), {
       target: { value: "AAA" },
     });
-    fireEvent.change(screen.getByLabelText(/Max PEG/i), {
+    fireEvent.change(screen.getByLabelText(en.screener.maxPeg), {
       target: { value: "2" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /run/i }));
+    fireEvent.click(screen.getByRole("button", { name: en.screener.run }));
 
     expect(await screen.findByText("AAA")).toBeInTheDocument();
     expect(getScreener).toHaveBeenCalledWith(["AAA"], { peg_max: 2 });

--- a/frontend/src/pages/Screener.tsx
+++ b/frontend/src/pages/Screener.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { getScreener } from "../api";
 import type { ScreenerResult } from "../types";
 import { useSortableTable } from "../hooks/useSortableTable";
@@ -16,6 +17,7 @@ export function Screener() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
+  const { t } = useTranslation();
 
   const { sorted, handleSort } = useSortableTable(rows, "peg_ratio");
 
@@ -52,9 +54,9 @@ export function Screener() {
     <div>
       <form onSubmit={handleSubmit} style={{ marginBottom: "1rem" }}>
         <label style={{ marginRight: "0.5rem" }}>
-          Tickers
+          {t("screener.tickers")}
           <input
-            aria-label="Tickers"
+            aria-label={t("screener.tickers")}
             type="text"
             value={tickers}
             onChange={(e) => setTickers(e.target.value)}
@@ -63,9 +65,9 @@ export function Screener() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
-          Max PEG
+          {t("screener.maxPeg")}
           <input
-            aria-label="Max PEG"
+            aria-label={t("screener.maxPeg")}
             type="number"
             value={pegMax}
             onChange={(e) => setPegMax(e.target.value)}
@@ -74,9 +76,9 @@ export function Screener() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
-          Max P/E
+          {t("screener.maxPe")}
           <input
-            aria-label="Max P/E"
+            aria-label={t("screener.maxPe")}
             type="number"
             value={peMax}
             onChange={(e) => setPeMax(e.target.value)}
@@ -85,9 +87,9 @@ export function Screener() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
-          Max D/E
+          {t("screener.maxDe")}
           <input
-            aria-label="Max D/E"
+            aria-label={t("screener.maxDe")}
             type="number"
             value={deMax}
             onChange={(e) => setDeMax(e.target.value)}
@@ -96,9 +98,9 @@ export function Screener() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
-          Min FCF
+          {t("screener.minFcf")}
           <input
-            aria-label="Min FCF"
+            aria-label={t("screener.minFcf")}
             type="number"
             value={fcfMin}
             onChange={(e) => setFcfMin(e.target.value)}
@@ -107,12 +109,12 @@ export function Screener() {
           />
         </label>
         <button type="submit" disabled={loading} style={{ marginLeft: "0.5rem" }}>
-          {loading ? "Loading…" : "Run"}
+          {loading ? t("screener.loading") : t("screener.run")}
         </button>
       </form>
 
       {error && <p style={{ color: "red" }}>{error}</p>}
-      {loading && <p>Loading…</p>}
+      {loading && <p>{t("screener.loading")}</p>}
 
       {rows.length > 0 && !loading && (
         <table style={{ width: "100%", borderCollapse: "collapse" }}>


### PR DESCRIPTION
## Summary
- replace hardcoded labels with i18n keys on query and screener pages
- add English, French, German, Spanish and Portuguese translations
- update tests to use mock i18n provider and verify translated labels

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_689b2d2cdbfc8327b3d22a55d7a6480d