### PR TITLE
Link FX pairs in instrument and holdings tables

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import { HoldingsTable } from "./HoldingsTable";
 import { ConfigContext, type AppConfig } from "../ConfigContext";
 import type { Holding } from "../types";
@@ -35,6 +36,21 @@ describe("HoldingsTable", () => {
             sell_eligible: false,
             days_until_eligible: 10,
         },
+        {
+            ticker: "GBXH",
+            name: "GBX Holding",
+            currency: "GBX",
+            instrument_type: "Equity",
+            units: 1,
+            price: 0,
+            cost_basis_gbp: 10,
+            market_value_gbp: 10,
+            gain_gbp: 0,
+            acquired_date: "2024-01-05",
+            days_held: 50,
+            sell_eligible: false,
+            days_until_eligible: 5,
+        },
     ];
 
     const renderWithConfig = (ui: React.ReactElement, cfg: AppConfig) =>
@@ -65,6 +81,14 @@ describe("HoldingsTable", () => {
         const row = screen.getByText("Test Holding").closest("tr");
         const cell = within(row!).getByText("✗ 10");
         expect(cell).toBeInTheDocument();
+    });
+
+    it("creates FX pair buttons for currency and skips GBX", () => {
+        const onSelect = vi.fn();
+        render(<HoldingsTable holdings={holdings} onSelectInstrument={onSelect}/>);
+        fireEvent.click(screen.getByRole('button', { name: 'USD' }));
+        expect(onSelect).toHaveBeenCalledWith('GBPUSD=X', 'USD');
+        expect(screen.queryByRole('button', { name: 'GBX' })).toBeNull();
     });
 
     it("sorts by ticker when header clicked", () => {

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -274,7 +274,29 @@ export function HoldingsTable({
                   </button>
                 </td>
                 <td className={tableStyles.cell}>{h.name}</td>
-                <td className={tableStyles.cell}>{h.currency ?? "—"}</td>
+                <td className={tableStyles.cell}>
+                  {h.currency && !["GBP", "GBX"].includes(h.currency) ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        onSelectInstrument?.(`GBP${h.currency}=X`, h.currency)
+                      }
+                      style={{
+                        color: "dodgerblue",
+                        textDecoration: "underline",
+                        background: "none",
+                        border: "none",
+                        padding: 0,
+                        font: "inherit",
+                        cursor: "pointer",
+                      }}
+                    >
+                      {h.currency}
+                    </button>
+                  ) : (
+                    h.currency ?? "—"
+                  )}
+                </td>
                 <td className={tableStyles.cell}>{translateInstrumentType(t, h.instrument_type)}</td>
                 {!relativeViewEnabled && visibleColumns.units && (
                   <td className={`${tableStyles.cell} ${tableStyles.right}`}>

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -38,6 +38,19 @@ describe("InstrumentTable", () => {
             change_7d_pct: -1,
             change_30d_pct: -2,
         },
+        {
+            ticker: "DEF",
+            name: "DEF Ltd",
+            currency: "GBX",
+            instrument_type: "Equity",
+            units: 3,
+            market_value_gbp: 300,
+            gain_gbp: 30,
+            last_price_gbp: 10,
+            last_price_date: "2024-01-03",
+            change_7d_pct: 0.5,
+            change_30d_pct: 1,
+        },
     ];
 
     it("passes ticker and name to InstrumentDetail", () => {
@@ -51,6 +64,18 @@ describe("InstrumentTable", () => {
         const props = mock.mock.calls[0][0] as DetailProps;
         expect(props.ticker).toBe("ABC");
         expect(props.name).toBe("ABC Corp");
+    });
+
+    it("creates FX pair ticker buttons and skips GBX", () => {
+        const mock = InstrumentDetail as unknown as Mock;
+        mock.mockClear();
+        render(<InstrumentTable rows={rows} />);
+        fireEvent.click(screen.getByRole('button', { name: 'USD' }));
+        expect(mock).toHaveBeenCalled();
+        type DetailProps = Parameters<typeof InstrumentDetail>[0];
+        const props = mock.mock.calls[0][0] as DetailProps;
+        expect(props.ticker).toBe('GBPUSD=X');
+        expect(screen.queryByRole('button', { name: 'GBX' })).toBeNull();
     });
 
     it("sorts by ticker when header clicked", () => {

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -162,7 +162,37 @@ export function InstrumentTable({ rows }: Props) {
                                     </button>
                                 </td>
                                 <td className={tableStyles.cell}>{r.name}</td>
-                                <td className={tableStyles.cell}>{r.currency ?? "—"}</td>
+                                <td className={tableStyles.cell}>
+                                    {r.currency && !["GBP", "GBX"].includes(r.currency) ? (
+                                        <button
+                                            type="button"
+                                            onClick={() =>
+                                                setSelected({
+                                                    ticker: `GBP${r.currency}=X`,
+                                                    name: `GBP${r.currency}=X`,
+                                                    currency: r.currency,
+                                                    instrument_type: "FX",
+                                                    units: 0,
+                                                    market_value_gbp: 0,
+                                                    gain_gbp: 0,
+                                                })
+                                            }
+                                            style={{
+                                                color: "dodgerblue",
+                                                textDecoration: "underline",
+                                                background: "none",
+                                                border: "none",
+                                                padding: 0,
+                                                font: "inherit",
+                                                cursor: "pointer",
+                                            }}
+                                        >
+                                            {r.currency}
+                                        </button>
+                                    ) : (
+                                        r.currency ?? "—"
+                                    )}
+                                </td>
                                 <td className={tableStyles.cell}>{translateInstrumentType(t, r.instrument_type)}</td>
                                 {!relativeViewEnabled && visibleColumns.units && (
                                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>


### PR DESCRIPTION
## Summary
- Generate `GBP${currency}=X` tickers for non-GBP currencies and expose them as clickable buttons in InstrumentTable
- Mirror FX ticker logic in HoldingsTable, treating `GBX` like `GBP`
- Add unit tests ensuring new ticker format and non-clickable `GBX` cells

## Testing
- `npx vitest run src/components/InstrumentTable.test.tsx src/components/HoldingsTable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bb0600bfc8327b006cdb1de4b6af5