### PR TITLE
test: mark Filter import as type-only

### DIFF
--- a/frontend/src/hooks/useFilterableTable.test.tsx
+++ b/frontend/src/hooks/useFilterableTable.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { useFilterableTable, Filter } from "./useFilterableTable";
+import { useFilterableTable, type Filter } from "./useFilterableTable";
 
 type Row = { name: string; age: number; active: boolean };
 


### PR DESCRIPTION
## Summary
- mark `Filter` as a type-only import in `useFilterableTable.test`

## Testing
- `npm test -- --run` *(fails: InstrumentTable.test.tsx: expected 'GBPUSD.FX' to be 'GBPUSD=X')*

------
https://chatgpt.com/codex/tasks/task_e_689bd069507083279538645207747aae