### PR TITLE
refactor: separate ChangeEvent import

### DIFF
--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -1,4 +1,5 @@
-import { useState, ChangeEvent, useEffect } from "react";
+import { useState, useEffect } from "react";
+import type { ChangeEvent } from "react";
 import { getTimeseries, saveTimeseries } from "../api";
 import type { PriceEntry } from "../types";
 


### PR DESCRIPTION
## Summary
- refactor TimeseriesEdit type imports to use a separate ChangeEvent type import

## Testing
- `npm test` *(fails: expected 'GBPUSD.FX' to be 'GBPUSD=X')*
- `npm run lint` *(fails: Unexpected any in TimeseriesEdit.tsx and other files)*

------
https://chatgpt.com/codex/tasks/task_e_689bd05feb3c8327ac0bb7a18c9bbba8