### PR TITLE
Align useFilterableTable test with updated generics

### DIFF
--- a/frontend/src/hooks/useFilterableTable.test.tsx
+++ b/frontend/src/hooks/useFilterableTable.test.tsx
@@ -25,7 +25,7 @@ const filters: Record<string, Filter<Row, any>> = {
 describe("useFilterableTable", () => {
   it("filters and sorts rows", () => {
     const { result } = renderHook(() =>
-      useFilterableTable<Row, keyof Row, typeof filters>(rows, "age", filters)
+      useFilterableTable<Row, typeof filters>(rows, "age", filters)
     );
 
     expect(result.current.rows.map((r) => r.name)).toEqual([

--- a/frontend/src/hooks/useFilterableTable.ts
+++ b/frontend/src/hooks/useFilterableTable.ts
@@ -7,14 +7,13 @@ export type Filter<T, V> = {
 
 export function useFilterableTable<
   T,
-  K extends keyof T,
   F extends Record<string, Filter<T, any>>
->(rows: T[], initialSortKey: K, initialFilters: F) {
-  const [sortKey, setSortKey] = useState<K>(initialSortKey);
+>(rows: T[], initialSortKey: keyof T, initialFilters: F) {
+  const [sortKey, setSortKey] = useState<keyof T>(initialSortKey);
   const [asc, setAsc] = useState(true);
   const [filters, setFilters] = useState<F>(initialFilters);
 
-  function handleSort(key: K) {
+  function handleSort(key: keyof T) {
     if (sortKey === key) {
       setAsc(!asc);
     } else {


### PR DESCRIPTION
## Summary
- simplify useFilterableTable hook generics to infer sort key type
- update useFilterableTable test invocation to match revised generics

## Testing
- `npm test` *(fails: InstrumentTable > creates FX pair ticker buttons and skips GBX)*

------
https://chatgpt.com/codex/tasks/task_e_689bd061d550832789e4036dec00204f