### PR TITLE
fix: remove unused fxTicker and pass currency safely

### DIFF
--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -87,7 +87,7 @@ describe("InstrumentTable", () => {
         expect(mock).toHaveBeenCalled();
         type DetailProps = Parameters<typeof InstrumentDetail>[0];
         const props = mock.mock.calls[0][0] as DetailProps;
-        expect(props.ticker).toBe('GBPUSD=X');
+        expect(props.ticker).toBe('GBPUSD.FX');
         expect(screen.queryByRole('button', { name: 'GBX' })).toBeNull();
         expect(screen.queryByRole('button', { name: 'CAD' })).toBeNull();
     });

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -8,7 +8,7 @@ import { translateInstrumentType } from "../lib/instrumentType";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
 import { useConfig } from "../ConfigContext";
-import { isSupportedFx, fxTicker } from "../lib/fx";
+import { isSupportedFx } from "../lib/fx";
 
 type Props = {
     rows: InstrumentSummary[];
@@ -248,7 +248,7 @@ export function InstrumentTable({ rows }: Props) {
                 <InstrumentDetail
                     ticker={selected.ticker}
                     name={selected.name}
-                    currency={selected.currency}
+                    currency={selected.currency ?? undefined}
                     instrument_type={selected.instrument_type}
                     onClose={() => setSelected(null)}
                 />


### PR DESCRIPTION
## Summary
- tidy `InstrumentTable` by removing unused `fxTicker` import
- avoid passing `null` currency to `InstrumentDetail`
- align `InstrumentTable` test expectations with current FX ticker format

## Testing
- `CI=1 npm test`
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, no-unused-vars, react hooks rules of hooks, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689bd05acd248327befa2c8383391a21