### PR TITLE
feat: add compliance result type

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,6 +16,8 @@ import type {
   CustomQuery,
   SavedQuery,
   QuoteRow,
+  TradingSignal,
+  ComplianceResult,
 } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -151,9 +153,7 @@ export const getTradingSignals = () =>
 
 /** Retrieve compliance warnings for an owner */
 export const getCompliance = (owner: string) =>
-  fetchJson<{ owner: string; warnings: string[] }>(
-    `${API_BASE}/compliance/${owner}`
-  );
+  fetchJson<ComplianceResult>(`${API_BASE}/compliance/${owner}`);
 
 /** Virtual portfolio endpoints */
 export const getVirtualPortfolios = () =>


### PR DESCRIPTION
## Summary
- add TradingSignal and ComplianceResult type imports
- use ComplianceResult in getCompliance API helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bd04beaec83278011177a6ac30d23