### PR TITLE
chore: remove unused i18n import

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,6 @@ import { Screener } from "./pages/Screener";
 import { QueryPage } from "./pages/QueryPage";
 import useFetchWithRetry from "./hooks/useFetchWithRetry";
 import { LanguageSwitcher } from "./components/LanguageSwitcher";
-import i18n from "./i18n";
 import { TimeseriesEdit } from "./pages/TimeseriesEdit";
 import { TradingAgent } from "./pages/TradingAgent";
 import Watchlist from "./pages/Watchlist";


### PR DESCRIPTION
## Summary
- remove unused i18n import from App component

## Testing
- `npm test` (failed: InstrumentTable test assertion)
- `npm run lint` (failed: @typescript-eslint/no-explicit-any)


------
https://chatgpt.com/codex/tasks/task_e_689bd04e81c08327845c58ea9634f862