### PR TITLE
Normalize config after saving

### DIFF
--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -1,13 +1,21 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
+
+const mockGetConfig = vi.fn();
+const mockUpdateConfig = vi.fn();
 
 vi.mock("../api", () => ({
   API_BASE: "",
-  getConfig: vi.fn().mockResolvedValue({ flag: true }),
-  updateConfig: vi.fn(),
+  getConfig: mockGetConfig,
+  updateConfig: mockUpdateConfig,
 }));
 
 import Support from "./Support";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockResolvedValue({ flag: true });
+});
 
 describe("Support page", () => {
   it("renders environment heading", () => {
@@ -27,4 +35,21 @@ describe("Support page", () => {
     );
     vi.unstubAllEnvs();
   });
+
+  it("stringifies fresh config after saving", async () => {
+    mockGetConfig.mockResolvedValueOnce({ flag: true });
+    mockGetConfig.mockResolvedValueOnce({ flag: false, count: 5 });
+    mockUpdateConfig.mockResolvedValue(undefined);
+
+    render(<Support />);
+
+    const saveButton = await screen.findByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
+
+    await screen.findByDisplayValue("5");
+
+    expect(screen.getByDisplayValue("false")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("5")).toBeInTheDocument();
+  });
 });
+

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -50,7 +50,11 @@ export default function Support() {
     try {
       await updateConfig(payload);
       const fresh = await getConfig();
-      setConfig(fresh);
+      const entries: Record<string, string | boolean> = {};
+      Object.entries(fresh).forEach(([k, v]) => {
+        entries[k] = typeof v === "boolean" ? v : v == null ? "" : String(v);
+      });
+      setConfig(entries);
       setConfigStatus("saved");
     } catch {
       setConfigStatus("error");


### PR DESCRIPTION
## Summary
- ensure Support page stringifies config after saving
- add regression test for config normalization

## Testing
- `npm --prefix frontend test` *(fails: expected 'GBPUSD.FX' to be 'GBPUSD=X')*
- `npm --prefix frontend run lint` *(fails: Unexpected any. Specify a different type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689bd05e17708327b13f83453c08549b