### PR TITLE
Wire group member selection to owner rows

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -233,7 +233,11 @@ export function GroupPortfolioView({ slug, onSelectMember }: Props) {
         </thead>
         <tbody>
           {ownerRows.map((row) => (
-            <tr key={row.owner}>
+            <tr
+              key={row.owner}
+              onClick={() => onSelectMember?.(row.owner)}
+              style={{ cursor: onSelectMember ? "pointer" : undefined }}
+            >
               <td className={tableStyles.cell}>{row.owner}</td>
               <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                 {relativeViewEnabled ? percent(row.valuePct) : money(row.value)}


### PR DESCRIPTION
## Summary
- call `onSelectMember` when clicking an owner row in `GroupPortfolioView`

## Testing
- `npm test` (fails: expected 'GBPUSD=X' got 'GBPUSD.FX')
- `npm run lint` (fails: 15 errors, 4 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689bd06428f88327824bcd72e79e37bf