### PR TITLE
refactor: simplify table hooks generics

### DIFF
--- a/frontend/src/hooks/useFilterableTable.test.tsx
+++ b/frontend/src/hooks/useFilterableTable.test.tsx
@@ -25,7 +25,7 @@ const filters: Record<string, Filter<Row, any>> = {
 describe("useFilterableTable", () => {
   it("filters and sorts rows", () => {
     const { result } = renderHook(() =>
-      useFilterableTable<Row, keyof Row, typeof filters>(rows, "age", filters)
+      useFilterableTable<Row, typeof filters>(rows, "age", filters)
     );
 
     expect(result.current.rows.map((r) => r.name)).toEqual([

--- a/frontend/src/hooks/useFilterableTable.ts
+++ b/frontend/src/hooks/useFilterableTable.ts
@@ -7,14 +7,13 @@ export type Filter<T, V> = {
 
 export function useFilterableTable<
   T,
-  K extends keyof T,
   F extends Record<string, Filter<T, any>>
->(rows: T[], initialSortKey: K, initialFilters: F) {
-  const [sortKey, setSortKey] = useState<K>(initialSortKey);
+>(rows: T[], initialSortKey: keyof T, initialFilters: F) {
+  const [sortKey, setSortKey] = useState<keyof T>(initialSortKey);
   const [asc, setAsc] = useState(true);
   const [filters, setFilters] = useState<F>(initialFilters);
 
-  function handleSort(key: K) {
+  function handleSort(key: keyof T) {
     if (sortKey === key) {
       setAsc(!asc);
     } else {

--- a/frontend/src/hooks/useSortableTable.ts
+++ b/frontend/src/hooks/useSortableTable.ts
@@ -1,13 +1,10 @@
 import { useMemo, useState } from "react";
 
-export function useSortableTable<T, K extends keyof T>(
-  rows: T[],
-  initialSortKey: K,
-) {
-  const [sortKey, setSortKey] = useState<K>(initialSortKey);
+export function useSortableTable<T>(rows: T[], initialSortKey: keyof T) {
+  const [sortKey, setSortKey] = useState<keyof T>(initialSortKey);
   const [asc, setAsc] = useState(true);
 
-  function handleSort(key: K) {
+  function handleSort(key: keyof T) {
     if (sortKey === key) {
       setAsc(!asc);
     } else {

--- a/frontend/src/pages/QueryPage.tsx
+++ b/frontend/src/pages/QueryPage.tsx
@@ -30,7 +30,7 @@ export function QueryPage() {
   const [error, setError] = useState<string | null>(null);
 
   const columns = rows.length ? (Object.keys(rows[0]) as (keyof ResultRow)[]) : [];
-  const { sorted, handleSort } = useSortableTable<ResultRow, keyof ResultRow>(
+  const { sorted, handleSort } = useSortableTable<ResultRow>(
     rows,
     (columns[0] as keyof ResultRow) || ("owner" as keyof ResultRow),
   );


### PR DESCRIPTION
## Summary
- streamline `useSortableTable` by removing redundant sort-key generic and typing sort state as `keyof T`
- simplify `useFilterableTable` to use `keyof T` for sorting and update tests accordingly
- adjust `QueryPage` to invoke `useSortableTable` with new signature

## Testing
- `npm test` *(fails: expected 'GBPUSD=X' to be 'GBPUSD.FX')*

------
https://chatgpt.com/codex/tasks/task_e_689bd05687448327a6553e613b3fb601