### PR TITLE
feat: convert timeseries using instrument currency

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -28,6 +28,7 @@ from backend.timeseries.fetch_meta_timeseries import fetch_meta_timeseries
 from backend.utils.timeseries_helpers import _nearest_weekday, get_scaling_override, apply_scaling
 from backend.utils.fx_rates import fetch_fx_rate_range
 from backend.config import config
+from backend.common.instruments import get_instrument_meta
 
 OFFLINE_MODE = config.offline_mode
 
@@ -286,10 +287,15 @@ def _memoized_range(
     return _memoized_range_cached(ticker, exchange, start_iso, end_iso).copy()
 
 
-def _convert_to_gbp(df: pd.DataFrame, exchange: str, start: date, end: date) -> pd.DataFrame:
-    """Convert OHLC prices to GBP if needed based on exchange."""
-    currency = EXCHANGE_TO_CCY.get((exchange or "").upper(), "GBP")
-    if currency == "GBP" or df.empty:
+def _convert_to_gbp(
+    df: pd.DataFrame, ticker: str, exchange: str, start: date, end: date
+) -> pd.DataFrame:
+    """Convert OHLC prices to GBP if needed based on instrument currency."""
+
+    meta = get_instrument_meta(f"{ticker}.{exchange}")
+    currency = meta.get("currency") or EXCHANGE_TO_CCY.get((exchange or "").upper(), "GBP")
+
+    if currency in ("GBP", "GBX") or df.empty:
         return df
 
     if OFFLINE_MODE:
@@ -305,7 +311,8 @@ def _convert_to_gbp(df: pd.DataFrame, exchange: str, start: date, end: date) -> 
     merged["Rate"] = merged["Rate"].ffill().bfill()
     for col in ["Open", "High", "Low", "Close"]:
         if col in merged.columns:
-            merged[col] = pd.to_numeric(merged[col], errors="coerce") * merged["Rate"]
+            merged[col] = pd.to_numeric(merged[col], errors="coerce")
+            merged[f"{col}_gbp"] = merged[col] * merged["Rate"]
     return merged.drop(columns=["Rate"])
 
 # ──────────────────────────────────────────────────────────────
@@ -322,7 +329,7 @@ def load_meta_timeseries_range(
         e = end_date - timedelta(days=offset)
         df = _memoized_range(ticker, exchange, s.isoformat(), e.isoformat())
         if not df.empty:
-            df = _convert_to_gbp(df, exchange, s, e)
+            df = _convert_to_gbp(df, ticker, exchange, s, e)
             return df
     return _empty_ts()
 

--- a/tests/test_fx_conversion.py
+++ b/tests/test_fx_conversion.py
@@ -37,8 +37,9 @@ def test_prices_converted_to_gbp(monkeypatch, exchange, rate):
     monkeypatch.setattr(cache, "fetch_fx_rate_range", fake_fx)
 
     df = cache.load_meta_timeseries_range("T", exchange, start, end)
-    closes = list(df["Close"].astype(float))
+    closes = list(df["Close_gbp"].astype(float))
     assert closes == [pytest.approx(1 * rate), pytest.approx(2 * rate)]
+    assert list(df["Close"].astype(float)) == [1.0, 2.0]
 
 
 def test_missing_fx_rates_are_filled(monkeypatch):
@@ -56,12 +57,33 @@ def test_missing_fx_rates_are_filled(monkeypatch):
     monkeypatch.setattr(cache, "fetch_fx_rate_range", fake_fx)
 
     df = cache.load_meta_timeseries_range("T", "N", start, end)
-    closes = list(df["Close"].astype(float))
+    closes = list(df["Close_gbp"].astype(float))
     assert closes == [
         pytest.approx(1 * 0.8),
         pytest.approx(2 * 0.8),
         pytest.approx(3 * 0.81),
     ]
+    assert list(df["Close"].astype(float)) == [1.0, 2.0, 3.0]
+
+
+def test_non_gbp_instrument_on_gbp_exchange(monkeypatch):
+    start = dt.date(2024, 1, 1)
+    end = dt.date(2024, 1, 2)
+
+    def fake_memoized_range(ticker, exch, s_iso, e_iso):
+        return _sample_df(start, end)
+
+    def fake_fx(base, s, e):
+        dates = pd.bdate_range(s, e).date
+        return pd.DataFrame({"Date": dates, "Rate": [1.25] * len(dates)})
+
+    monkeypatch.setattr(cache, "_memoized_range", fake_memoized_range)
+    monkeypatch.setattr(cache, "fetch_fx_rate_range", fake_fx)
+    monkeypatch.setattr(cache, "get_instrument_meta", lambda t: {"currency": "USD"})
+
+    df = cache.load_meta_timeseries_range("T", "L", start, end)
+    assert list(df["Close"].astype(float)) == [1.0, 2.0]
+    assert list(df["Close_gbp"].astype(float)) == [pytest.approx(1 * 1.25), pytest.approx(2 * 1.25)]
 
 
 def test_memoized_range_returns_copy(monkeypatch):


### PR DESCRIPTION
## Summary
- convert OHLC data to GBP using instrument metadata currency
- keep original close values and add `Close_gbp`
- test FX conversion including non-GBP instrument on GBP exchange

## Testing
- `pytest`
- `pytest tests/test_fx_conversion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c26a33ca48327af4cd70b45fd080a