### PR TITLE
Convert Toronto stock prices from CAD

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -48,6 +48,7 @@ EXCHANGE_TO_CCY = {
     "F": "EUR",
     "PARIS": "EUR",
     "XETRA": "EUR",
+    "TO": "CAD",
 }
 
 

--- a/tests/test_fx_conversion.py
+++ b/tests/test_fx_conversion.py
@@ -21,7 +21,7 @@ def _sample_df(start: dt.date, end: dt.date):
     })
 
 
-@pytest.mark.parametrize("exchange,rate", [("N", 0.8), ("DE", 0.9)])
+@pytest.mark.parametrize("exchange,rate", [("N", 0.8), ("DE", 0.9), ("TO", 0.6)])
 def test_prices_converted_to_gbp(monkeypatch, exchange, rate):
     start = dt.date(2024, 1, 1)
     end = dt.date(2024, 1, 2)


### PR DESCRIPTION
## Summary
- handle Toronto Stock Exchange prices as CAD
- test CAD-to-GBP conversion for Toronto equities

## Testing
- `pytest` *(fails: Accounts list should not be empty, No owners returned, etc.)*
- `cd frontend && npm test` *(fails: Support.test.tsx mocking error)*

------
https://chatgpt.com/codex/tasks/task_e_689c29e4eac08327a10896669193e365