### PR TITLE
Return full compliance result

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -22,7 +22,7 @@ describe("App", () => {
       getPortfolio: vi.fn(),
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
-      getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [] }),
+      getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
       getTimeseries: vi.fn(),
       saveTimeseries: vi.fn(),
     }));
@@ -51,7 +51,7 @@ describe("App", () => {
       getPortfolio: vi.fn(),
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
-      getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [] }),
+      getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
       getTimeseries: vi.fn().mockResolvedValue([]),
       saveTimeseries: vi.fn(),
     }));

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,6 +16,8 @@ import type {
   CustomQuery,
   SavedQuery,
   QuoteRow,
+  TradingSignal,
+  ComplianceResult,
 } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -151,9 +153,7 @@ export const getTradingSignals = () =>
 
 /** Retrieve compliance warnings for an owner */
 export const getCompliance = (owner: string) =>
-  fetchJson<{ owner: string; warnings: string[] }>(
-    `${API_BASE}/compliance/${owner}`
-  );
+  fetchJson<ComplianceResult>(`${API_BASE}/compliance/${owner}`);
 
 /** Virtual portfolio endpoints */
 export const getVirtualPortfolios = () =>

--- a/frontend/src/components/ComplianceWarnings.test.tsx
+++ b/frontend/src/components/ComplianceWarnings.test.tsx
@@ -10,7 +10,7 @@ vi.mock("../api", () => ({
 describe("ComplianceWarnings", () => {
     it("does not render when there are no warnings", async () => {
         const mock = getCompliance as unknown as Mock;
-        mock.mockResolvedValue({ warnings: [] });
+        mock.mockResolvedValue({ owner: "alice", warnings: [], trade_counts: {} });
 
         render(<ComplianceWarnings owners={["alice"]} />);
 
@@ -23,7 +23,7 @@ describe("ComplianceWarnings", () => {
 
     it("renders warnings when present", async () => {
         const mock = getCompliance as unknown as Mock;
-        mock.mockResolvedValue({ warnings: ["Issue"] });
+        mock.mockResolvedValue({ owner: "alice", warnings: ["Issue"], trade_counts: {} });
 
         render(<ComplianceWarnings owners={["alice"]} />);
 
@@ -33,8 +33,8 @@ describe("ComplianceWarnings", () => {
     it("only shows owners with warnings", async () => {
         const mock = getCompliance as unknown as Mock;
         mock
-            .mockResolvedValueOnce({ warnings: [] })
-            .mockResolvedValueOnce({ warnings: ["Issue"] });
+            .mockResolvedValueOnce({ owner: "alice", warnings: [], trade_counts: {} })
+            .mockResolvedValueOnce({ owner: "bob", warnings: ["Issue"], trade_counts: {} });
 
         render(<ComplianceWarnings owners={["alice", "bob"]} />);
 

--- a/frontend/src/components/ComplianceWarnings.tsx
+++ b/frontend/src/components/ComplianceWarnings.tsx
@@ -11,16 +11,20 @@ export function ComplianceWarnings({ owners }: Props) {
     data,
     loading,
     error,
-  } = useFetch<Record<string, string[]>>(
+  } = useFetch<Record<string, ComplianceResult>>(
     async () => {
-      const entries: Record<string, string[]> = {};
+      const entries: Record<string, ComplianceResult> = {};
       await Promise.all(
         owners.map(async (o) => {
           try {
-            const res: ComplianceResult = await getCompliance(o);
-            entries[o] = res.warnings ?? [];
+            const res = await getCompliance(o);
+            entries[o] = res;
           } catch {
-            entries[o] = ["Failed to load warnings"];
+            entries[o] = {
+              owner: o,
+              warnings: ["Failed to load warnings"],
+              trade_counts: {},
+            };
           }
         })
       );
@@ -32,7 +36,9 @@ export function ComplianceWarnings({ owners }: Props) {
 
   if (!owners.length || loading || error) return null;
 
-  const ownersWithWarnings = owners.filter((o) => (data?.[o] ?? []).length);
+  const ownersWithWarnings = owners.filter(
+    (o) => (data?.[o]?.warnings ?? []).length,
+  );
 
   if (!ownersWithWarnings.length) return null;
 
@@ -50,7 +56,7 @@ export function ComplianceWarnings({ owners }: Props) {
         <div key={o} style={{ marginBottom: "0.5rem" }}>
           <strong>{o}</strong>
           <ul style={{ margin: "0.25rem 0 0 1.25rem" }}>
-            {(data?.[o] ?? []).map((w) => (
+            {(data?.[o]?.warnings ?? []).map((w) => (
               <li key={`${o}-${w}`}>{w}</li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- include `trade_counts` in frontend compliance API
- gather full compliance results when rendering warnings
- adjust tests for new compliance shape

## Testing
- `npm test` *(fails: InstrumentTable creates FX pair ticker buttons and skips GBX)*

------
https://chatgpt.com/codex/tasks/task_e_689bd05129ec83278bad7601dfb1e82b