### PR TITLE
Fix ConfigContext duplication and adjust tests

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -91,9 +91,26 @@ describe("App", () => {
     const { default: App } = await import("./App");
     const { ConfigContext } = await import("./ConfigContext");
 
+    const allTabs = {
+      instrument: true,
+      performance: true,
+      transactions: true,
+      screener: true,
+      query: true,
+      trading: true,
+      timeseries: true,
+      watchlist: true,
+      virtual: true,
+      support: true,
+    };
+
     render(
       <ConfigContext.Provider
-        value={{ relativeViewEnabled: false, disabledTabs: ["trading"] }}
+        value={{
+          relativeViewEnabled: false,
+          disabledTabs: ["trading"],
+          tabs: allTabs,
+        }}
       >
         <MemoryRouter initialEntries={["/trading"]}>
           <App />
@@ -129,8 +146,23 @@ describe("App", () => {
     const { default: App } = await import("./App");
     const { ConfigContext } = await import("./ConfigContext");
 
+    const allTabs = {
+      instrument: true,
+      performance: true,
+      transactions: true,
+      screener: true,
+      query: true,
+      trading: true,
+      timeseries: true,
+      watchlist: true,
+      virtual: true,
+      support: true,
+    };
+
     render(
-      <ConfigContext.Provider value={{ relativeViewEnabled: false }}>
+      <ConfigContext.Provider
+        value={{ relativeViewEnabled: false, tabs: allTabs }}
+      >
         <MemoryRouter initialEntries={["/trading"]}>
           <App />
         </MemoryRouter>

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -25,11 +25,6 @@ export interface AppConfig {
   tabs: TabsConfig;
 }
 
-export const ConfigContext = createContext<AppConfig>({
-  relativeViewEnabled: false,
-  disabledTabs: [],
-});
-
 const defaultTabs: TabsConfig = {
   instrument: true,
   performance: true,
@@ -45,6 +40,7 @@ const defaultTabs: TabsConfig = {
 
 export const ConfigContext = createContext<AppConfig>({
   relativeViewEnabled: false,
+  disabledTabs: [],
   tabs: defaultTabs,
 });
 

--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
-const mockGetConfig = vi.fn();
-const mockUpdateConfig = vi.fn();
+const mockGetConfig = vi.hoisted(() => vi.fn());
+const mockUpdateConfig = vi.hoisted(() => vi.fn());
 
 vi.mock("../api", () => ({
   API_BASE: "",


### PR DESCRIPTION
## Summary
- remove duplicate ConfigContext export and include default tabs
- hoist Support page API mocks to fix tests
- ensure App tests provide full tab configuration

## Testing
- `npm test`
- `npm run lint` (fails: Unexpected any in hooks/tests)
- `pytest` (fails: various backend assertion errors)

------
https://chatgpt.com/codex/tasks/task_e_689c3a93adc08327be1aa171e00513ec