### PR TITLE
Fix TypeScript build errors and test configuration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -88,19 +88,6 @@ export default function App() {
   const ownersReq = useFetchWithRetry(getOwners);
   const groupsReq = useFetchWithRetry(getGroups);
 
-  const modes: Mode[] = [
-    "group",
-    ...(tabs.instrument ? ["instrument"] : []),
-    "owner",
-    ...(tabs.performance ? ["performance"] : []),
-    ...(tabs.transactions ? ["transactions"] : []),
-    ...(tabs.screener ? ["screener"] : []),
-    ...(tabs.query ? ["query"] : []),
-    ...(tabs.trading ? ["trading"] : []),
-    ...(tabs.timeseries ? ["timeseries"] : []),
-    ...(tabs.watchlist ? ["watchlist"] : []),
-  ];
-
   const links: JSX.Element[] = [];
   if (tabs.virtual) links.push(<a href="/virtual">Virtual Portfolios</a>);
   if (tabs.trading) links.push(<a href="/trading">Trading Agent</a>);

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -9,8 +9,28 @@ afterEach(() => {
   i18n.changeLanguage("en");
 });
 
-const renderWithConfig = (ui: React.ReactElement, cfg: AppConfig) =>
-  render(<ConfigContext.Provider value={cfg}>{ui}</ConfigContext.Provider>);
+const defaultConfig: AppConfig = {
+  relativeViewEnabled: false,
+  tabs: {
+    instrument: true,
+    performance: true,
+    transactions: true,
+    screener: true,
+    query: true,
+    trading: true,
+    timeseries: true,
+    watchlist: true,
+    virtual: true,
+    support: true,
+  },
+};
+
+const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig> = {}) =>
+  render(
+    <ConfigContext.Provider value={{ ...defaultConfig, ...cfg }}>
+      {ui}
+    </ConfigContext.Provider>,
+  );
 
 describe("GroupPortfolioView", () => {
   it("shows per-owner totals with percentages in relative view", async () => {

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -2,6 +2,22 @@ import { render, screen, within, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { HoldingsTable } from "./HoldingsTable";
 import { ConfigContext, type AppConfig } from "../ConfigContext";
+
+const defaultConfig: AppConfig = {
+    relativeViewEnabled: false,
+    tabs: {
+        instrument: true,
+        performance: true,
+        transactions: true,
+        screener: true,
+        query: true,
+        trading: true,
+        timeseries: true,
+        watchlist: true,
+        virtual: true,
+        support: true,
+    },
+};
 import type { Holding } from "../types";
 
 describe("HoldingsTable", () => {
@@ -68,8 +84,12 @@ describe("HoldingsTable", () => {
         },
     ];
 
-    const renderWithConfig = (ui: React.ReactElement, cfg: AppConfig) =>
-        render(<ConfigContext.Provider value={cfg}>{ui}</ConfigContext.Provider>);
+    const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig>) =>
+        render(
+            <ConfigContext.Provider value={{ ...defaultConfig, ...cfg }}>
+                {ui}
+            </ConfigContext.Provider>,
+        );
 
     it("displays relative metrics when relative view is enabled", () => {
         renderWithConfig(<HoldingsTable holdings={holdings} />, { relativeViewEnabled: true });

--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -4,6 +4,22 @@ import { describe, it, expect, vi, type Mock, beforeEach } from "vitest";
 import i18n from "../i18n";
 import { ConfigContext, type AppConfig } from "../ConfigContext";
 
+const defaultConfig: AppConfig = {
+  relativeViewEnabled: false,
+  tabs: {
+    instrument: true,
+    performance: true,
+    transactions: true,
+    screener: true,
+    query: true,
+    trading: true,
+    timeseries: true,
+    watchlist: true,
+    virtual: true,
+    support: true,
+  },
+};
+
 vi.mock("../api", () => ({ getInstrumentDetail: vi.fn() }));
 import { getInstrumentDetail } from "../api";
 
@@ -19,9 +35,9 @@ import { InstrumentDetail } from "./InstrumentDetail";
 describe("InstrumentDetail", () => {
   const mockGetInstrumentDetail = getInstrumentDetail as unknown as Mock;
 
-  const renderWithConfig = (ui: React.ReactElement, cfg: AppConfig) =>
+  const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig>) =>
     render(
-      <ConfigContext.Provider value={cfg}>
+      <ConfigContext.Provider value={{ ...defaultConfig, ...cfg }}>
         <MemoryRouter>{ui}</MemoryRouter>
       </ConfigContext.Provider>,
     );

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -1,7 +1,23 @@
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, it, expect, vi, type Mock } from "vitest";
 import type { InstrumentSummary } from "../types";
-import { ConfigContext } from "../ConfigContext";
+import { ConfigContext, type AppConfig } from "../ConfigContext";
+
+const defaultConfig: AppConfig = {
+    relativeViewEnabled: false,
+    tabs: {
+        instrument: true,
+        performance: true,
+        transactions: true,
+        screener: true,
+        query: true,
+        trading: true,
+        timeseries: true,
+        watchlist: true,
+        virtual: true,
+        support: true,
+    },
+};
 
 vi.mock("./InstrumentDetail", () => ({
     InstrumentDetail: vi.fn(() => <div data-testid="instrument-detail" />),
@@ -122,7 +138,7 @@ describe("InstrumentTable", () => {
 
     it("hides absolute columns in relative view", () => {
         render(
-            <ConfigContext.Provider value={{ relativeViewEnabled: true }}>
+            <ConfigContext.Provider value={{ ...defaultConfig, relativeViewEnabled: true }}>
                 <InstrumentTable rows={rows} />
             </ConfigContext.Provider>,
         );

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -115,10 +115,10 @@ export function InstrumentTable({ rows }: Props) {
                         {!relativeViewEnabled && visibleColumns.gain && (
                             <th
                                 className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
-                                onClick={() => handleSort("gain")}
+                                onClick={() => handleSort("gain_gbp")}
                             >
                                 {t("instrumentTable.columns.gain")}
-                                {sortKey === "gain" ? (asc ? " ▲" : " ▼") : ""}
+                                {sortKey === "gain_gbp" ? (asc ? " ▲" : " ▼") : ""}
                             </th>
                         )}
                         {visibleColumns.gain_pct && (


### PR DESCRIPTION
## Summary
- remove unused modes array causing TypeScript errors
- sort instruments by gain_gbp instead of invalid key
- supply default AppConfig with tab settings in tests

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689c3dfaf79c8327bc060a393e05216e