### PR TITLE
Refactor tab disabling to rely on tabs config

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -108,8 +108,7 @@ describe("App", () => {
       <ConfigContext.Provider
         value={{
           relativeViewEnabled: false,
-          disabledTabs: ["trading"],
-          tabs: allTabs,
+          tabs: { ...allTabs, trading: false },
         }}
       >
         <MemoryRouter initialEntries={["/trading"]}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,7 +60,6 @@ export default function App() {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
-  const { disabledTabs = [] } = useConfig();
   const { tabs } = useConfig();
 
   const params = new URLSearchParams(location.search);
@@ -115,7 +114,7 @@ export default function App() {
               : segs[0] === "watchlist"
                 ? "watchlist"
                 : "group";
-    if (disabledTabs.includes(newMode)) {
+    if ((tabs as Record<string, boolean>)[newMode] === false) {
       setMode("group");
       navigate("/", { replace: true });
       return;
@@ -130,7 +129,7 @@ export default function App() {
         new URLSearchParams(location.search).get("group") ?? "",
       );
     }
-  }, [location.pathname, location.search, disabledTabs, navigate]);
+  }, [location.pathname, location.search, tabs, navigate]);
 
   useEffect(() => {
     if (ownersReq.data) setOwners(ownersReq.data);
@@ -238,9 +237,9 @@ export default function App() {
           "trading",
           "timeseries",
           "watchlist",
-        ] as Mode[])
-          .filter((m) => !disabledTabs.includes(m))
-          .map((m) => (
+          ] as Mode[])
+            .filter((m) => (tabs as Record<string, boolean>)[m] !== false)
+            .map((m) => (
             <label key={m} style={{ marginRight: "1rem" }}>
               <input
                 type="radio"

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -53,15 +53,22 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     getConfig()
-      .then((cfg) =>
-        setConfig({
-          relativeViewEnabled: Boolean((cfg as any).relative_view_enabled),
-          disabledTabs: Array.isArray((cfg as any).disabled_tabs)
+      .then((cfg) => {
+        const tabs = { ...defaultTabs, ...((cfg as any).tabs ?? {}) };
+        const disabledTabs = new Set<string>(
+          Array.isArray((cfg as any).disabled_tabs)
             ? ((cfg as any).disabled_tabs as string[])
             : [],
-          tabs: { ...defaultTabs, ...((cfg as any).tabs ?? {}) },
-        })
-      )
+        );
+        for (const [tab, enabled] of Object.entries(tabs)) {
+          if (!enabled) disabledTabs.add(tab);
+        }
+        setConfig({
+          relativeViewEnabled: Boolean((cfg as any).relative_view_enabled),
+          disabledTabs: Array.from(disabledTabs),
+          tabs,
+        });
+      })
       .catch(() => {
         /* ignore */
       });


### PR DESCRIPTION
## Summary
- derive disabledTabs from tabs in ConfigContext
- switch App component to consult `tabs` rather than `disabledTabs`
- adjust App tests to configure tab visibility through `tabs`

## Testing
- `npm test --prefix frontend`
- `npm run lint --prefix frontend` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_689c429c40e08327b758a1e2691575ce