### PR TITLE
Prefer GBP-converted close prices when available

### DIFF
--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -48,8 +48,8 @@ def _close_on(sym: str, exch: str, d: date) -> Optional[float]:
     if df is None or df.empty:
         return None
 
-    # try a few common column names
-    for col in ("close", "Close", "close_gbp", "Close_gbp"):
+    # try a few common column names, prioritising GBP-converted prices
+    for col in ("close_gbp", "Close_gbp", "close", "Close"):
         if col in df.columns:
             try:
                 return float(df[col].iloc[0])


### PR DESCRIPTION
## Summary
- Prioritize GBP-converted columns when selecting daily close values
- Document priority of GBP-converted closes

## Testing
- `pytest tests/test_prices_snapshot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c437039dc8327989f63277724c47f