### PR TITLE
Prefer GBP prices in load_latest_prices

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -50,7 +50,8 @@ def _lower_name_map(df: pd.DataFrame) -> Dict[str, str]:
 
 def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
     """
-    Returns mapping like {'HFEL.L': 3.21, 'IEFV.L': 5.77} in GBP.
+    Returns mapping like {'HFEL.L': 3.21, 'IEFV.L': 5.77}.
+    Prices are GBP-converted when that column is available.
     - Uses end_date = yesterday
     - Accepts 'HFEL.L' or 'HFEL' (defaults exchange 'L')
     - Skips empties instead of returning 0.00
@@ -80,7 +81,14 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
                 # no data -> don't write a zero; just continue
                 continue
 
-            close_col = "Close"
+            # prefer GBP-close column if present
+            close_col = None
+            for col in ("Close_gbp", "Close", "close_gbp", "close"):
+                if col in df.columns:
+                    close_col = col
+                    break
+            if not close_col:
+                continue
 
             df = df.sort_values(df.columns[0])  # first col is Date in your feeds
             last = df.iloc[-1]

--- a/tests/test_load_latest_prices.py
+++ b/tests/test_load_latest_prices.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from backend.common import holding_utils
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        ({"Date": [1], "Close_gbp": [2.0], "Close": [1.0]}, 2.0),
+        ({"Date": [1], "Close": [1.5]}, 1.5),
+        ({"Date": [1], "close_gbp": [3.0]}, 3.0),
+        ({"Date": [1], "close": [4.0]}, 4.0),
+    ],
+)
+def test_load_latest_prices_selects_close_column(monkeypatch, data, expected):
+    def fake_load_meta_timeseries_range(ticker, exchange, start_date, end_date):
+        return pd.DataFrame(data)
+
+    monkeypatch.setattr(
+        holding_utils, "load_meta_timeseries_range", fake_load_meta_timeseries_range
+    )
+
+    prices = holding_utils.load_latest_prices(["ABC.L"])
+    assert prices["ABC.L"] == expected


### PR DESCRIPTION
## Summary
- Prefer `Close_gbp` over `Close` columns when reading latest prices
- Clarify docstring to note GBP-converted prices when available
- Test load_latest_prices column selection logic

## Testing
- `pytest tests/test_load_latest_prices.py -q`
- `pytest -q` *(fails: fixture 'mock_var' not found, assertion errors in backend API tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689c4371be348327adc5e87df08e66fd