### PR TITLE
fix: avoid ConfigContext redeclaration

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -38,7 +38,7 @@ const defaultTabs: TabsConfig = {
   support: true,
 };
 
-export const ConfigContext = createContext<AppConfig>({
+const ConfigContext = createContext<AppConfig>({
   relativeViewEnabled: false,
   disabledTabs: [],
   tabs: defaultTabs,
@@ -80,4 +80,6 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
 export function useConfig() {
   return useContext(ConfigContext);
 }
+
+export { ConfigContext };
 


### PR DESCRIPTION
## Summary
- separate `ConfigContext` declaration from its export to prevent redeclaration errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c46d4aea083278ef707f8ae2f503f