### PR TITLE
feat: load offline FX rates from cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ Adjust the `PORTFOLIO_TTL` and `SCREENER_TTL` constants in
 `backend/routes/portfolio.py` and `backend/routes/screener.py` to change these
 intervals. The cache helpers live in `backend/utils/page_cache.py`.
 
+## FX rate cache & offline mode
+
+FX conversions use daily GBP rates. When `offline_mode: true` in
+`config.yaml`, rates are loaded from parquet files under
+`data/timeseries/fx/<CCY>.parquet`. Each file must contain `Date` and `Rate`
+columns. Populate the cache before going offline:
+
+```bash
+python - <<'PY'
+from datetime import date
+import pandas as pd
+from backend.utils.fx_rates import fetch_fx_rate_range
+
+df = fetch_fx_rate_range("USD", date(2024,1,1), date.today())
+df.to_parquet("data/timeseries/fx/USD.parquet", index=False)
+PY
+```
+
+If a currency file is missing, `_convert_to_gbp` falls back to requesting
+rates from `fx_proxy_url` configured in `config.yaml`.
+
 ## Risk reporting
 
 The backend exposes Value at Risk (VaR) metrics for each portfolio.

--- a/backend/config.py
+++ b/backend/config.py
@@ -50,6 +50,7 @@ class Config:
     offline_mode: Optional[bool] = None
     relative_view_enabled: Optional[bool] = None
     timeseries_cache_base: Optional[str] = None
+    fx_proxy_url: Optional[str] = None
     alpha_vantage_key: Optional[str] = None
     fundamentals_cache_ttl_seconds: Optional[int] = None
 
@@ -126,6 +127,7 @@ def load_config() -> Config:
         offline_mode=data.get("offline_mode"),
         relative_view_enabled=data.get("relative_view_enabled"),
         timeseries_cache_base=data.get("timeseries_cache_base"),
+        fx_proxy_url=data.get("fx_proxy_url"),
         alpha_vantage_key=data.get("alpha_vantage_key"),
         fundamentals_cache_ttl_seconds=data.get(
             "fundamentals_cache_ttl_seconds"

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ accounts_root: C:\workspaces\github\allotmint\data\accounts
 prices_json: C:\workspaces\github\allotmint\data\prices\latest_prices.json
 risk_free_rate: 0.01
 timeseries_cache_base: data/timeseries
+fx_proxy_url: ''
 alpha_vantage_key: B74N5L0LY87QHKX4
 fundamentals_cache_ttl_seconds: 86400
 app_env: local


### PR DESCRIPTION
## Summary
- add offline GBP conversion using cached FX rates with optional proxy fallback
- document how to populate the FX cache and configure proxy
- test offline FX conversion via cached rates

## Testing
- `pytest tests/test_fx_conversion.py tests/utils/test_fx_rates.py`


------
https://chatgpt.com/codex/tasks/task_e_689c645ef5988327931e11410841c20c