### PR TITLE
refactor: rename config context

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -89,7 +89,7 @@ describe("App", () => {
     }));
 
     const { default: App } = await import("./App");
-    const { ConfigContext } = await import("./ConfigContext");
+    const { configContext } = await import("./ConfigContext");
 
     const allTabs = {
       instrument: true,
@@ -105,7 +105,7 @@ describe("App", () => {
     };
 
     render(
-      <ConfigContext.Provider
+      <configContext.Provider
         value={{
           relativeViewEnabled: false,
           tabs: { ...allTabs, trading: false },
@@ -114,7 +114,7 @@ describe("App", () => {
         <MemoryRouter initialEntries={["/trading"]}>
           <App />
         </MemoryRouter>
-      </ConfigContext.Provider>,
+      </configContext.Provider>,
     );
 
     expect(screen.queryByLabelText(/trading/i)).toBeNull();
@@ -143,7 +143,7 @@ describe("App", () => {
     }));
 
     const { default: App } = await import("./App");
-    const { ConfigContext } = await import("./ConfigContext");
+    const { configContext } = await import("./ConfigContext");
 
     const allTabs = {
       instrument: true,
@@ -159,13 +159,13 @@ describe("App", () => {
     };
 
     render(
-      <ConfigContext.Provider
+      <configContext.Provider
         value={{ relativeViewEnabled: false, tabs: allTabs }}
       >
         <MemoryRouter initialEntries={["/trading"]}>
           <App />
         </MemoryRouter>
-      </ConfigContext.Provider>,
+      </configContext.Provider>,
     );
 
     const tradingTab = await screen.findByLabelText(/trading/i);

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import { getConfig } from "./api";
 
@@ -39,7 +40,7 @@ const defaultTabs: TabsConfig = {
   support: true,
 };
 
-const ConfigContext = createContext<AppConfig>({
+export const configContext = createContext<AppConfig>({
   relativeViewEnabled: false,
   disabledTabs: [],
   tabs: defaultTabs,
@@ -85,14 +86,12 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     applyTheme(config.theme);
   }, [config.theme]);
 
-  return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>;
+  return <configContext.Provider value={config}>{children}</configContext.Provider>;
 }
 
 export function useConfig() {
-  return useContext(ConfigContext);
+  return useContext(configContext);
 }
-
-export { ConfigContext };
 
 function applyTheme(theme: string) {
   const root = document.documentElement;

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { GroupPortfolioView } from "./GroupPortfolioView";
 import i18n from "../i18n";
-import { ConfigContext, type AppConfig } from "../ConfigContext";
+import { configContext, type AppConfig } from "../ConfigContext";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -28,9 +28,9 @@ const defaultConfig: AppConfig = {
 
 const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig> = {}) =>
   render(
-    <ConfigContext.Provider value={{ ...defaultConfig, ...cfg }}>
+    <configContext.Provider value={{ ...defaultConfig, ...cfg }}>
       {ui}
-    </ConfigContext.Provider>,
+    </configContext.Provider>,
   );
 
 describe("GroupPortfolioView", () => {

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { HoldingsTable } from "./HoldingsTable";
-import { ConfigContext, type AppConfig } from "../ConfigContext";
+import { configContext, type AppConfig } from "../ConfigContext";
 
 const defaultConfig: AppConfig = {
     relativeViewEnabled: false,
@@ -87,9 +87,9 @@ describe("HoldingsTable", () => {
 
     const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig>) =>
         render(
-            <ConfigContext.Provider value={{ ...defaultConfig, ...cfg }}>
+            <configContext.Provider value={{ ...defaultConfig, ...cfg }}>
                 {ui}
-            </ConfigContext.Provider>,
+            </configContext.Provider>,
         );
 
     it("displays relative metrics when relative view is enabled", () => {

--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, type Mock, beforeEach } from "vitest";
 import i18n from "../i18n";
-import { ConfigContext, type AppConfig } from "../ConfigContext";
+import { configContext, type AppConfig } from "../ConfigContext";
 
 const defaultConfig: AppConfig = {
   relativeViewEnabled: false,
@@ -38,9 +38,9 @@ describe("InstrumentDetail", () => {
 
   const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig>) =>
     render(
-      <ConfigContext.Provider value={{ ...defaultConfig, ...cfg }}>
+      <configContext.Provider value={{ ...defaultConfig, ...cfg }}>
         <MemoryRouter>{ui}</MemoryRouter>
-      </ConfigContext.Provider>,
+      </configContext.Provider>,
     );
 
   beforeEach(() => {

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, it, expect, vi, type Mock } from "vitest";
 import type { InstrumentSummary } from "../types";
-import { ConfigContext, type AppConfig } from "../ConfigContext";
+import { configContext, type AppConfig } from "../ConfigContext";
 
 const defaultConfig: AppConfig = {
     relativeViewEnabled: false,
@@ -139,9 +139,9 @@ describe("InstrumentTable", () => {
 
     it("hides absolute columns in relative view", () => {
         render(
-            <ConfigContext.Provider value={{ ...defaultConfig, relativeViewEnabled: true }}>
+            <configContext.Provider value={{ ...defaultConfig, relativeViewEnabled: true }}>
                 <InstrumentTable rows={rows} />
-            </ConfigContext.Provider>,
+            </configContext.Provider>,
         );
         expect(screen.queryByRole('columnheader', { name: 'Units' })).toBeNull();
         expect(screen.queryByRole('columnheader', { name: 'Cost £' })).toBeNull();


### PR DESCRIPTION
## Summary
- rename ConfigContext to configContext and export it as a constant
- update tests to use the new configContext provider
- mark config context file to bypass react-refresh component-only rule

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689c9fcbba888327a7bcd7c144d4add0