### PR TITLE
feat: allow dynamic tab lookup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -114,7 +114,7 @@ export default function App() {
               : segs[0] === "watchlist"
                 ? "watchlist"
                 : "group";
-    if ((tabs as Record<string, boolean>)[newMode] === false) {
+    if (tabs[newMode] === false) {
       setMode("group");
       navigate("/", { replace: true });
       return;
@@ -238,7 +238,7 @@ export default function App() {
           "timeseries",
           "watchlist",
           ] as Mode[])
-            .filter((m) => (tabs as Record<string, boolean>)[m] !== false)
+            .filter((m) => tabs[m] !== false)
             .map((m) => (
             <label key={m} style={{ marginRight: "1rem" }}>
               <input

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from "
 import { getConfig } from "./api";
 
 export interface TabsConfig {
+  [key: string]: boolean;
   instrument: boolean;
   performance: boolean;
   transactions: boolean;


### PR DESCRIPTION
## Summary
- allow string-based tab lookups by adding an index signature to `TabsConfig`
- simplify tab conditionals using direct property access

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689c9fca56a48327911f1a7f1da86f89