### PR TITLE
Use helper for FX tickers

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -123,7 +123,7 @@ describe("HoldingsTable", () => {
         const onSelect = vi.fn();
         render(<HoldingsTable holdings={holdings} onSelectInstrument={onSelect}/>);
         fireEvent.click(screen.getByRole('button', { name: 'USD' }));
-        expect(onSelect).toHaveBeenCalledWith('GBPUSD.FX', 'USD');
+        expect(onSelect).toHaveBeenCalledWith('USDGBP.FX', 'USD');
         expect(screen.queryByRole('button', { name: 'GBX' })).toBeNull();
         expect(screen.queryByRole('button', { name: 'CAD' })).toBeNull();
     });

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -7,7 +7,7 @@ import { useSortableTable } from "../hooks/useSortableTable";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
 import { useConfig } from "../ConfigContext";
-import { isSupportedFx } from "../lib/fx";
+import { isSupportedFx, fxTicker } from "../lib/fx";
 
 type Props = {
   holdings: Holding[];
@@ -278,7 +278,7 @@ export function HoldingsTable({
                     <button
                       type="button"
                       onClick={() =>
-                        onSelectInstrument?.(`GBP${h.currency!}.FX`, h.currency!)
+                        onSelectInstrument?.(fxTicker(h.currency), h.currency)
                       }
                       style={{
                         color: "dodgerblue",

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -104,7 +104,7 @@ describe("InstrumentTable", () => {
         expect(mock).toHaveBeenCalled();
         type DetailProps = Parameters<typeof InstrumentDetail>[0];
         const props = mock.mock.calls[0][0] as DetailProps;
-        expect(props.ticker).toBe('GBPUSD.FX');
+        expect(props.ticker).toBe('USDGBP.FX');
         expect(screen.queryByRole('button', { name: 'GBX' })).toBeNull();
         expect(screen.queryByRole('button', { name: 'CAD' })).toBeNull();
     });

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -8,7 +8,7 @@ import { translateInstrumentType } from "../lib/instrumentType";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
 import { useConfig } from "../ConfigContext";
-import { isSupportedFx } from "../lib/fx";
+import { isSupportedFx, fxTicker } from "../lib/fx";
 
 type Props = {
     rows: InstrumentSummary[];
@@ -169,8 +169,8 @@ export function InstrumentTable({ rows }: Props) {
                                             type="button"
                                             onClick={() =>
                                                 setSelected({
-                                                    ticker: `GBP${r.currency}.FX`,
-                                                    name: `GBP${r.currency}.FX`,
+                                                    ticker: fxTicker(r.currency),
+                                                    name: fxTicker(r.currency),
                                                     currency: r.currency,
                                                     instrument_type: "FX",
                                                     units: 0,

--- a/frontend/src/lib/fx.ts
+++ b/frontend/src/lib/fx.ts
@@ -4,4 +4,5 @@ export type FxCurrency = typeof FX_CURRENCIES[number];
 export const isSupportedFx = (ccy?: string | null): ccy is FxCurrency =>
   ccy != null && (FX_CURRENCIES as readonly string[]).includes(ccy);
 
-export const fxTicker = (ccy: FxCurrency): string => `GBP${ccy}=X`;
+// Build a currency pair ticker in the format "${ccy}GBP.FX"
+export const fxTicker = (ccy: FxCurrency): string => `${ccy}GBP.FX`;


### PR DESCRIPTION
## Summary
- switch fxTicker to `${ccy}GBP.FX` format
- use fxTicker helper for FX links in holdings and instrument tables
- update tests for new ticker format

## Testing
- `npm test` *(fails: Unexpected closing "configContext.Provider" tag)*
- `npx vitest src/components/InstrumentTable.test.tsx src/components/HoldingsTable.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ca96d90ec8327b7c257c5f7ff3beb