### PR TITLE
Align frontend FX utilities with backend mapping

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -160,7 +160,7 @@ describe("App", () => {
     };
 
     render(
-      <ConfigContext.Provider
+      <configContext.Provider
         value={{ theme: "system", relativeViewEnabled: false, tabs: allTabs }}
       >
         <MemoryRouter initialEntries={["/trading"]}>

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -123,9 +123,9 @@ describe("HoldingsTable", () => {
         const onSelect = vi.fn();
         render(<HoldingsTable holdings={holdings} onSelectInstrument={onSelect}/>);
         fireEvent.click(screen.getByRole('button', { name: 'USD' }));
-        expect(onSelect).toHaveBeenCalledWith('GBPUSD.FX', 'USD');
+        expect(onSelect).toHaveBeenCalledWith('USDGBP.FX', 'USD');
         expect(screen.queryByRole('button', { name: 'GBX' })).toBeNull();
-        expect(screen.queryByRole('button', { name: 'CAD' })).toBeNull();
+        expect(screen.getByRole('button', { name: 'CAD' })).toBeInTheDocument();
     });
 
     it("sorts by ticker when header clicked", () => {

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -278,7 +278,7 @@ export function HoldingsTable({
                     <button
                       type="button"
                       onClick={() =>
-                        onSelectInstrument?.(`GBP${h.currency!}.FX`, h.currency!)
+                        onSelectInstrument?.(`${h.currency!}GBP.FX`, h.currency!)
                       }
                       style={{
                         color: "dodgerblue",

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -104,9 +104,9 @@ describe("InstrumentTable", () => {
         expect(mock).toHaveBeenCalled();
         type DetailProps = Parameters<typeof InstrumentDetail>[0];
         const props = mock.mock.calls[0][0] as DetailProps;
-        expect(props.ticker).toBe('GBPUSD.FX');
+        expect(props.ticker).toBe('USDGBP.FX');
         expect(screen.queryByRole('button', { name: 'GBX' })).toBeNull();
-        expect(screen.queryByRole('button', { name: 'CAD' })).toBeNull();
+        expect(screen.getByRole('button', { name: 'CAD' })).toBeInTheDocument();
     });
 
     it("sorts by ticker when header clicked", () => {

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -169,8 +169,8 @@ export function InstrumentTable({ rows }: Props) {
                                             type="button"
                                             onClick={() =>
                                                 setSelected({
-                                                    ticker: `GBP${r.currency}.FX`,
-                                                    name: `GBP${r.currency}.FX`,
+                                                    ticker: `${r.currency}GBP.FX`,
+                                                    name: `${r.currency}GBP.FX`,
                                                     currency: r.currency,
                                                     instrument_type: "FX",
                                                     units: 0,

--- a/frontend/src/lib/fx.ts
+++ b/frontend/src/lib/fx.ts
@@ -1,7 +1,13 @@
-export const FX_CURRENCIES = ["USD", "EUR"] as const;
+export const FX_CURRENCIES = [
+  "USD",
+  "EUR",
+  "CHF",
+  "JPY",
+  "CAD",
+] as const;
 export type FxCurrency = typeof FX_CURRENCIES[number];
 
 export const isSupportedFx = (ccy?: string | null): ccy is FxCurrency =>
-  ccy != null && (FX_CURRENCIES as readonly string[]).includes(ccy);
+  ccy != null && FX_CURRENCIES.includes(ccy as FxCurrency);
 
-export const fxTicker = (ccy: FxCurrency): string => `GBP${ccy}=X`;
+export const fxTicker = (ccy: FxCurrency): string => `${ccy}GBP=X`;

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -4,7 +4,7 @@ import { getQuotes } from "../api";
 import type { QuoteRow } from "../types";
 
 const DEFAULT_SYMBOLS =
-  "^FTSE,^NDX,^GSPC,^RUT,^NYA,^VIX,^GDAXI,^N225,GBPUSD=X,GBPEUR=X,BTC-USD,GC=F,SI=F,VUSA.L,IWDA.AS";
+  "^FTSE,^NDX,^GSPC,^RUT,^NYA,^VIX,^GDAXI,^N225,USDGBP=X,EURGBP=X,BTC-USD,GC=F,SI=F,VUSA.L,IWDA.AS";
 
 function formatPrice(symbol: string, val: number | null): string {
   if (val == null) return "—";


### PR DESCRIPTION
## Summary
- expand supported FX currencies and align ticker formatting with backend expectations
- adjust instrument and holdings tables to emit `${ccy}GBP` FX tickers
- update tests and watchlist defaults for the new currency pairs

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_689ca964250c8327a5ad2737d3069d3e