### PR TITLE
Send Telegram alerts independent of publish flag

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -15,7 +15,6 @@ from typing import Dict, Iterable, List, Optional
 import pandas as pd
 
 from backend.common import prices
-from backend.common.alerts import publish_sns_alert
 from backend.common.portfolio_loader import list_portfolios
 from backend.common.portfolio_utils import (
     list_all_unique_tickers,
@@ -25,7 +24,6 @@ from backend.common.trade_metrics import (
     TRADE_LOG_PATH,
     load_and_compute_metrics,
 )
-from backend.utils.telegram_utils import send_message
 
 logger = logging.getLogger(__name__)
 
@@ -50,15 +48,15 @@ def send_trade_alert(message: str, publish: bool = True) -> None:
     if publish:
         publish_alert({"message": message})
 
-        if (
-            os.getenv("TELEGRAM_BOT_TOKEN")
-            and os.getenv("TELEGRAM_CHAT_ID")
-            and config.app_env != "aws"
-        ):
-            try:
-                send_message(message)
-            except Exception as exc:  # pragma: no cover - network errors are rare
-                logger.warning("Telegram send failed: %s", exc)
+    if (
+        os.getenv("TELEGRAM_BOT_TOKEN")
+        and os.getenv("TELEGRAM_CHAT_ID")
+        and config.app_env != "aws"
+    ):
+        try:
+            send_message(message)
+        except Exception as exc:  # pragma: no cover - network errors are rare
+            logger.warning("Telegram send failed: %s", exc)
 
 PRICE_DROP_THRESHOLD = -5.0  # percent
 PRICE_GAIN_THRESHOLD = 5.0   # percent

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -93,6 +93,28 @@ def test_send_trade_alert_with_telegram(monkeypatch):
     assert telegram_msgs == ["hi"]
 
 
+def test_send_trade_alert_no_publish_with_telegram(monkeypatch):
+    published = {"called": False}
+    telegram_msgs: list[str] = []
+
+    def fake_publish(alert):
+        published["called"] = True
+
+    monkeypatch.setattr(
+        "backend.agent.trading_agent.publish_alert", fake_publish
+    )
+    monkeypatch.setattr(
+        "backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg)
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "T")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "C")
+
+    send_trade_alert("hi", publish=False)
+
+    assert published["called"] is False
+    assert telegram_msgs == ["hi"]
+
+
 def test_run_defaults_to_all_known_tickers(monkeypatch):
     captured: dict = {}
 


### PR DESCRIPTION
## Summary
- Stop gating Telegram notifications on the `publish` flag in trading agent
- Remove duplicate `send_message` and unused `publish_sns_alert` imports
- Add regression test ensuring alerts skip publishing but still send to Telegram when requested

## Testing
- `pytest tests/test_trading_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce11a2a048327b0a98c8c6e678845