### PR TITLE
Prefer instrument currency over holding value in aggregate_by_ticker

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -230,7 +230,7 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio) -> List[dict]:
                 {
                     "ticker":           tkr,
                     "name":             meta.get("name") or h.get("name", tkr),
-                    "currency":         h.get("currency"),
+                    "currency":         meta.get("currency") or h.get("currency"),
                     "units":            0.0,
                     "market_value_gbp": 0.0,
                     "gain_gbp":         0.0,
@@ -239,7 +239,6 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio) -> List[dict]:
                     "last_price_date":  None,
                     "change_7d_pct":    None,
                     "change_30d_pct":   None,
-                    "currency":        meta.get("currency"),
                     "instrument_type": meta.get("instrumentType") or meta.get("instrument_type"),
                 },
             )

--- a/tests/test_portfolio_utils_currency.py
+++ b/tests/test_portfolio_utils_currency.py
@@ -1,0 +1,22 @@
+import backend.common.portfolio_utils as portfolio_utils
+
+
+def test_currency_from_instrument_meta(monkeypatch):
+    portfolio = {
+        "accounts": [
+            {
+                "holdings": [
+                    {"ticker": "ABC", "units": 1}
+                ]
+            }
+        ]
+    }
+
+    monkeypatch.setattr(
+        portfolio_utils, "get_instrument_meta", lambda t: {"currency": "USD"}
+    )
+
+    rows = portfolio_utils.aggregate_by_ticker(portfolio)
+
+    assert len(rows) == 1
+    assert rows[0]["currency"] == "USD"


### PR DESCRIPTION
## Summary
- use instrument metadata for currency when aggregating holdings, falling back to holding currency
- test that holdings without currency adopt mocked instrument currency

## Testing
- `pytest tests/test_portfolio_utils_currency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce11773b883279cde968b4981d08d