### PR TITLE
Avoid root logger reset during prices import

### DIFF
--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -94,8 +94,6 @@ def get_price_snapshot(tickers: List[str]) -> Dict[str, Dict]:
 
     return snapshot
 
-logging.basicConfig(level=logging.DEBUG)
-
 # ──────────────────────────────────────────────────────────────
 # Securities universe : derived from portfolios
 # ──────────────────────────────────────────────────────────────

--- a/tests/test_prices_logging.py
+++ b/tests/test_prices_logging.py
@@ -1,0 +1,14 @@
+import sys
+import logging
+
+
+def test_prices_import_does_not_configure_root_logger():
+    root_logger = logging.getLogger()
+    original_level = root_logger.level
+    root_logger.setLevel(logging.WARNING)
+
+    sys.modules.pop("backend.common.prices", None)
+    import backend.common.prices  # noqa: F401
+
+    assert root_logger.level == logging.WARNING
+    root_logger.setLevel(original_level)


### PR DESCRIPTION
## Summary
- Remove unguarded `logging.basicConfig` call from `backend.common.prices`
- Add regression test ensuring importing `prices` leaves root logger level unchanged

## Testing
- `pytest tests/test_prices_logging.py -q`
- `pytest tests/test_prices_snapshot.py tests/test_load_latest_prices.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce11451808327b9b62bc988202c23