### PR TITLE
Use fallback close price when GBP quote missing

### DIFF
--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -105,6 +105,39 @@ describe("InstrumentDetail", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses close when close_gbp missing", async () => {
+    const prices = Array.from({ length: 30 }, (_, i) => ({
+      date: `2024-01-${String(i + 1).padStart(2, "0")}`,
+      close: 100,
+    }));
+    prices.push({ date: "2024-01-31", close: 130 });
+
+    mockGetInstrumentDetail.mockResolvedValue({
+      prices,
+      positions: [],
+      currency: null,
+    });
+
+    i18n.changeLanguage("en");
+
+    render(
+      <MemoryRouter>
+        <InstrumentDetail ticker="ABC.L" name="ABC" onClose={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(
+        `${i18n.t("instrumentDetail.change7d")} 30.0%`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `${i18n.t("instrumentDetail.change30d")} 30.0%`,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("hides absolute columns in relative view", async () => {
     mockGetInstrumentDetail.mockResolvedValue({
       prices: [],

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -27,6 +27,7 @@ type Props = {
 type Price = {
   date: string;
   close_gbp: number | null | undefined;
+  close?: number | null | undefined;
 };
 
 type Position = {
@@ -95,7 +96,7 @@ export function InstrumentDetail({
   const editLink = `/timeseries?ticker=${encodeURIComponent(tickerBase)}&exchange=${encodeURIComponent(exch)}`;
 
   const rawPrices = (data.prices ?? [])
-    .map((p) => ({ date: p.date, close_gbp: toNum(p.close_gbp) }))
+    .map((p) => ({ date: p.date, close_gbp: toNum(p.close_gbp ?? p.close) }))
     .filter((p) => Number.isFinite(p.close_gbp));
 
   const withChanges = rawPrices.map((p, i) => {


### PR DESCRIPTION
## Summary
- fallback to `close` price when `close_gbp` is missing
- cover price fallback with test

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689cfc0560dc83279392c2e044c05bd1