### PR TITLE
Add ticker validation and skip logging

### DIFF
--- a/backend/timeseries/fetch_alphavantage_timeseries.py
+++ b/backend/timeseries/fetch_alphavantage_timeseries.py
@@ -3,6 +3,8 @@ from datetime import date, timedelta
 
 import pandas as pd
 import requests
+from backend.timeseries.ticker_validator import is_valid_ticker, record_skipped_ticker
+from backend.utils.timeseries_helpers import STANDARD_COLUMNS
 
 from backend.config import config
 
@@ -36,6 +38,10 @@ def fetch_alphavantage_timeseries_range(
     api_key: str | None = None,
 ) -> pd.DataFrame:
     """Fetch historical Alpha Vantage data using a date range."""
+    if not is_valid_ticker(ticker, exchange):
+        logger.info("Skipping Alpha Vantage fetch for unrecognized ticker %s.%s", ticker, exchange)
+        record_skipped_ticker(ticker, exchange, reason="unknown")
+        return pd.DataFrame(columns=STANDARD_COLUMNS)
     symbol = _build_symbol(ticker, exchange)
     key = api_key or config.alpha_vantage_key or "demo"
 

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -30,7 +30,8 @@ from backend.timeseries.fetch_yahoo_timeseries import fetch_yahoo_timeseries_ran
 from backend.timeseries.fetch_alphavantage_timeseries import (
     fetch_alphavantage_timeseries_range,
 )
-from backend.utils.timeseries_helpers import _nearest_weekday, _is_isin, STANDARD_COLUMNS
+from backend.utils.timeseries_helpers import (_nearest_weekday, _is_isin, STANDARD_COLUMNS)
+from backend.timeseries.ticker_validator import is_valid_ticker, record_skipped_ticker
 
 logger = logging.getLogger("meta_timeseries")
 
@@ -79,6 +80,11 @@ def fetch_meta_timeseries(
 
     if not _TICKER_RE.match(ticker):
         logger.warning("Ticker pattern looks invalid: %s", ticker)
+        return pd.DataFrame(columns=STANDARD_COLUMNS)
+
+    if not is_valid_ticker(ticker, exchange):
+        logger.info("Skipping unrecognized ticker %s.%s", ticker, exchange)
+        record_skipped_ticker(ticker, exchange, reason="unknown")
         return pd.DataFrame(columns=STANDARD_COLUMNS)
 
     if end_date is None:

--- a/backend/timeseries/fetch_stooq_timeseries.py
+++ b/backend/timeseries/fetch_stooq_timeseries.py
@@ -4,6 +4,8 @@ from io import StringIO
 
 import pandas as pd
 import requests
+from backend.timeseries.ticker_validator import is_valid_ticker, record_skipped_ticker
+from backend.utils.timeseries_helpers import STANDARD_COLUMNS
 
 # Setup logger
 logger = logging.getLogger("stooq_timeseries")
@@ -40,6 +42,10 @@ def fetch_stooq_timeseries_range(
     """
     Fetch historical Stooq data using date range.
     """
+    if not is_valid_ticker(ticker, exchange):
+        logger.info("Skipping Stooq fetch for unrecognized ticker %s.%s", ticker, exchange)
+        record_skipped_ticker(ticker, exchange, reason="unknown")
+        return pd.DataFrame(columns=STANDARD_COLUMNS)
     suffix = get_stooq_suffix(exchange)
     full_ticker = ticker + suffix
 

--- a/backend/timeseries/fetch_yahoo_timeseries.py
+++ b/backend/timeseries/fetch_yahoo_timeseries.py
@@ -3,6 +3,8 @@ from datetime import date, datetime, timedelta
 
 import pandas as pd
 import yfinance as yf
+from backend.timeseries.ticker_validator import is_valid_ticker, record_skipped_ticker
+from backend.utils.timeseries_helpers import STANDARD_COLUMNS
 
 # Setup logger
 logger = logging.getLogger("yahoo_timeseries")
@@ -44,6 +46,10 @@ def fetch_yahoo_timeseries_range(
     start_date: date,
     end_date: date
 ) -> pd.DataFrame:
+    if not is_valid_ticker(ticker, exchange):
+        logger.info("Skipping Yahoo fetch for unrecognized ticker %s.%s", ticker, exchange)
+        record_skipped_ticker(ticker, exchange, reason="unknown")
+        return pd.DataFrame(columns=STANDARD_COLUMNS)
     full_ticker = _build_full_ticker(ticker, exchange)
     logger.debug(f"Fetching Yahoo data for {full_ticker} from {start_date} to {end_date}")
 

--- a/backend/timeseries/ticker_validator.py
+++ b/backend/timeseries/ticker_validator.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+from datetime import datetime
+
+from backend.common.instruments import get_instrument_meta
+
+logger = logging.getLogger("ticker_validator")
+
+# File to record skipped tickers for auditing
+SKIPPED_TICKERS_FILE = Path(__file__).resolve().parents[2] / "data" / "skipped_tickers.log"
+
+
+@lru_cache(maxsize=4096)
+def is_valid_ticker(ticker: str, exchange: str) -> bool:
+    """Return True if ticker has known instrument metadata."""
+    base = ticker.split(".")[0].upper()
+    ex = exchange.upper()
+    full = f"{base}.{ex}"
+    meta = get_instrument_meta(full)
+    return bool(meta)
+
+
+def record_skipped_ticker(ticker: str, exchange: str, *, reason: str = "") -> None:
+    """Append ticker to the skipped log for later auditing."""
+    try:
+        SKIPPED_TICKERS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        ts = datetime.utcnow().isoformat()
+        line = f"{ts},{ticker},{exchange},{reason}\n"
+        with SKIPPED_TICKERS_FILE.open("a", encoding="utf-8") as f:
+            f.write(line)
+    except Exception as exc:
+        logger.warning("Failed to record skipped ticker %s.%s: %s", ticker, exchange, exc)

--- a/tests/test_alphavantage_errors.py
+++ b/tests/test_alphavantage_errors.py
@@ -1,6 +1,7 @@
 import pytest
 from datetime import date
 
+import backend.timeseries.fetch_alphavantage_timeseries as av
 from backend.timeseries.fetch_alphavantage_timeseries import (
     fetch_alphavantage_timeseries_range,
 )
@@ -21,6 +22,7 @@ def test_information_field_propagated(monkeypatch):
     def fake_get(url, params=None, timeout=None):
         return FakeResponse({"Information": "test info"})
 
+    monkeypatch.setattr(av, "is_valid_ticker", lambda *a, **k: True)
     import requests
 
     monkeypatch.setattr(requests, "get", fake_get)

--- a/tests/test_meta_timeseries_date_filter.py
+++ b/tests/test_meta_timeseries_date_filter.py
@@ -11,6 +11,7 @@ def test_fetch_meta_timeseries_handles_python_dates(monkeypatch):
     monkeypatch.setattr(fetch_meta_timeseries, "fetch_stooq_timeseries_range", lambda *a, **k: pd.DataFrame())
     monkeypatch.setattr(fetch_meta_timeseries, "fetch_alphavantage_timeseries_range", lambda *a, **k: pd.DataFrame())
     monkeypatch.setattr(fetch_meta_timeseries, "_is_isin", lambda ticker: False)
+    monkeypatch.setattr(fetch_meta_timeseries, "is_valid_ticker", lambda *a, **k: True)
 
     def fake_ft(ticker, days):
         return pd.DataFrame(

--- a/tests/test_ticker_validation.py
+++ b/tests/test_ticker_validation.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from backend.timeseries.fetch_meta_timeseries import fetch_meta_timeseries
+from backend.timeseries import ticker_validator
+
+
+def test_invalid_ticker_skipped(monkeypatch, tmp_path):
+    log_file = tmp_path / "skipped.log"
+    monkeypatch.setattr(ticker_validator, "SKIPPED_TICKERS_FILE", log_file)
+
+    df = fetch_meta_timeseries("ZZZZZZ", "L")
+    assert df.empty
+    assert log_file.exists()
+    content = log_file.read_text().strip()
+    assert "ZZZZZZ" in content


### PR DESCRIPTION
## Summary
- validate tickers against instrument metadata before fetching timeseries
- log and record unrecognized tickers so they can be audited
- ensure related fetchers and tests handle invalid tickers gracefully

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d045c4b108327b8517643e7052b67