### PR TITLE
Redact Telegram bot token in logs

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -7,7 +7,7 @@ import logging
 import os
 
 from backend.common.alerts import publish_alert
-from backend.utils.telegram_utils import send_message
+from backend.utils.telegram_utils import send_message, redact_token
 from backend.config import config
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional
@@ -56,7 +56,7 @@ def send_trade_alert(message: str, publish: bool = True) -> None:
         try:
             send_message(message)
         except Exception as exc:  # pragma: no cover - network errors are rare
-            logger.warning("Telegram send failed: %s", exc)
+            logger.warning("Telegram send failed: %s", redact_token(str(exc)))
 
 PRICE_DROP_THRESHOLD = -5.0  # percent
 PRICE_GAIN_THRESHOLD = 5.0   # percent

--- a/backend/logging.ini
+++ b/backend/logging.ini
@@ -7,6 +7,12 @@ keys=consoleHandler,fileHandler,telegramHandler
 [formatters]
 keys=standard
 
+[filters]
+keys=redactToken
+
+[filter_redactToken]
+()=backend.utils.telegram_utils.RedactTokenFilter
+
 [logger_root]
 level=INFO
 handlers=consoleHandler,fileHandler,telegramHandler
@@ -33,18 +39,21 @@ propagate=0
 class=StreamHandler
 level=INFO
 formatter=standard
+filters=redactToken
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=FileHandler
 level=INFO
 formatter=standard
+filters=redactToken
 args=('backend.log','a')
 
 [handler_telegramHandler]
 class=backend.utils.telegram_utils.TelegramLogHandler
 level=WARNING
 formatter=standard
+filters=redactToken
 args=()
 
 [formatter_standard]

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 import logging
+import requests
+import pytest
 
 import backend.utils.telegram_utils as telegram_utils
 
@@ -87,3 +89,25 @@ def test_sends_messages_after_ttl(monkeypatch):
         telegram_utils.send_message("hi")
 
     assert len(calls) == 2
+
+
+def test_redacts_token_from_errors(monkeypatch, caplog):
+    telegram_utils.RECENT_MESSAGES.clear()
+    monkeypatch.setattr(telegram_utils, "OFFLINE_MODE", False)
+    token = "SECRET"
+    monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", token)
+    monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", "C")
+
+    def fake_post(url, data, timeout):
+        raise requests.RequestException(f"boom {url}")
+
+    with patch("backend.utils.telegram_utils.requests.post", fake_post):
+        with pytest.raises(requests.RequestException) as excinfo:
+            telegram_utils.send_message("hi")
+        with caplog.at_level(logging.ERROR):
+            logging.getLogger("caller").error("fail: %s", excinfo.value)
+
+    assert token not in str(excinfo.value)
+    assert "***" in str(excinfo.value)
+    assert token not in caplog.text
+    assert "***" in caplog.text


### PR DESCRIPTION
## Summary
- add reusable helper and logging filter to redact Telegram bot token from all log messages
- sanitize Telegram API errors and prevent token leaks when sending alerts
- cover token redaction behavior with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d045c91908327b3bd22ef14211979