### PR TITLE
refactor: import BundlingOptions for Lambda layer

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from aws_cdk import (
     Stack,
+    BundlingOptions,
     aws_apigateway as apigw,
     aws_lambda as _lambda,
     aws_events as events,
@@ -24,7 +25,7 @@ class BackendLambdaStack(Stack):
             "BackendDependencies",
             code=_lambda.Code.from_asset(
                 str(backend_path),
-                bundling=_lambda.BundlingOptions(
+                bundling=BundlingOptions(
                     image=_lambda.Runtime.PYTHON_3_11.bundling_image,
                     command=[
                         "bash",


### PR DESCRIPTION
## Summary
- import BundlingOptions directly from aws_cdk
- simplify LayerVersion bundling by using BundlingOptions

## Testing
- `cdk synth` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `pytest` *(fails: tests/test_telegram_utils.py::test_redacts_token_from_errors - Failed: DID NOT RAISE requests.exceptions.RequestException)*

------
https://chatgpt.com/codex/tasks/task_e_689d8736f9f083278d2e4ea43b9f2e44