### PR TITLE
Replace view mode radios with navigation bar

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -118,9 +118,9 @@ describe("App", () => {
       </configContext.Provider>,
     );
 
-    expect(screen.queryByLabelText(/trading/i)).toBeNull();
-    const group = await screen.findByLabelText(/group/i);
-    expect((group as HTMLInputElement).checked).toBe(true);
+    expect(screen.queryByRole("link", { name: /trading/i })).toBeNull();
+    const groupLink = await screen.findByRole("link", { name: /group/i });
+    expect(groupLink).toHaveStyle("font-weight: bold");
   });
 
   it("allows navigation to enabled tabs", async () => {
@@ -169,8 +169,8 @@ describe("App", () => {
       </configContext.Provider>,
     );
 
-    const tradingTab = await screen.findByLabelText(/trading/i);
-    expect((tradingTab as HTMLInputElement).checked).toBe(true);
+    const tradingTab = await screen.findByRole("link", { name: /trading/i });
+    expect(tradingTab).toHaveStyle("font-weight: bold");
     expect(await screen.findByText(/No signals\./i)).toBeInTheDocument();
     expect(mockTradingSignals).toHaveBeenCalled();
   });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type JSX } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useNavigate, useLocation, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { getGroupInstruments, getGroups, getOwners, getPortfolio, refreshPrices } from "./api";
 
@@ -87,10 +87,33 @@ export default function App() {
   const ownersReq = useFetchWithRetry(getOwners);
   const groupsReq = useFetchWithRetry(getGroups);
 
-  const links: JSX.Element[] = [];
-  if (tabs.virtual) links.push(<a href="/virtual">Virtual Portfolios</a>);
-  if (tabs.trading) links.push(<a href="/trading">Trading Agent</a>);
-  if (tabs.support) links.push(<a href="/support">{t("app.supportLink")}</a>);
+  const modes: Mode[] = [
+    "group",
+    "instrument",
+    "owner",
+    "performance",
+    "transactions",
+    "screener",
+    "query",
+    "trading",
+    "timeseries",
+    "watchlist",
+  ];
+
+  function pathFor(m: Mode) {
+    switch (m) {
+      case "group":
+        return selectedGroup ? `/?group=${selectedGroup}` : "/";
+      case "instrument":
+        return selectedGroup ? `/instrument/${selectedGroup}` : "/instrument";
+      case "owner":
+        return selectedOwner ? `/member/${selectedOwner}` : "/member";
+      case "performance":
+        return selectedOwner ? `/performance/${selectedOwner}` : "/performance";
+      default:
+        return `/${m}`;
+    }
+  }
 
   useEffect(() => {
     const segs = location.pathname.split("/").filter(Boolean);
@@ -223,35 +246,22 @@ export default function App() {
     <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
       <LanguageSwitcher />
       <AlertsPanel />
-      {/* mode toggle */}
-      <div style={{ marginBottom: "1rem" }}>
-        <strong>{t("app.viewBy")}</strong>{" "}
-        {([
-          "group",
-          "instrument",
-          "owner",
-          "performance",
-          "transactions",
-          "screener",
-          "query",
-          "trading",
-          "timeseries",
-          "watchlist",
-          ] as Mode[])
-            .filter((m) => tabs[m] !== false)
-            .map((m) => (
-            <label key={m} style={{ marginRight: "1rem" }}>
-              <input
-                type="radio"
-                name="mode"
-                value={m}
-                checked={mode === m}
-                onChange={() => setMode(m)}
-              />{" "}
+      <nav style={{ margin: "1rem 0" }}>
+        {modes
+          .filter((m) => tabs[m] !== false)
+          .map((m) => (
+            <Link
+              key={m}
+              to={pathFor(m)}
+              style={{
+                marginRight: "1rem",
+                fontWeight: mode === m ? "bold" : undefined,
+              }}
+            >
               {t(`app.modes.${m}`)}
-            </label>
+            </Link>
           ))}
-      </div>
+      </nav>
 
       <div style={{ marginBottom: "1rem" }}>
         <button onClick={handleRefreshPrices} disabled={refreshingPrices}>
@@ -345,16 +355,6 @@ export default function App() {
 
       {mode === "query" && <QueryPage />}
 
-      {links.length > 0 && (
-        <p style={{ marginTop: "2rem", textAlign: "center" }}>
-          {links.map((link, i) => (
-            <span key={i}>
-              {i > 0 && " • "}
-              {link}
-            </span>
-          ))}
-        </p>
-      )}
     </div>
   );
 }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "viewBy": "Ansicht nach",
     "relativeView": "Relative Ansicht",
     "refreshPrices": "Preise aktualisieren",
     "refreshing": "Aktualisierung…",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "viewBy": "View by",
     "relativeView": "Relative view",
     "refreshPrices": "Refresh Prices",
     "refreshing": "Refreshing…",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "viewBy": "Ver por",
     "relativeView": "Vista relativa",
     "refreshPrices": "Actualizar precios",
     "refreshing": "Actualizando…",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "viewBy": "Voir par",
     "relativeView": "Vue relative",
     "refreshPrices": "Rafraîchir les prix",
     "refreshing": "Rafraîchissement…",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "viewBy": "Ver por",
     "relativeView": "Visão relativa",
     "refreshPrices": "Atualizar preços",
     "refreshing": "Atualizando…",


### PR DESCRIPTION
## Summary
- replace radio-based mode selector and footer links with a top navigation bar of hyperlinks
- remove unused `app.viewBy` translation and reuse existing mode labels
- adjust tests for hyperlink navigation respecting disabled tabs

## Testing
- `npm test --prefix frontend`
- `npm run lint --prefix frontend` *(fails: Unexpected any, React hook rules)*

------
https://chatgpt.com/codex/tasks/task_e_689d8744741c8327809915ac7a73b9b0