### PR TITLE
Remove Virtual Portfolios callout from portfolio view

### DIFF
--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -47,9 +47,6 @@ export function PortfolioView({ data, loading, error }: Props) {
 
   return (
     <div>
-      <div style={{ textAlign: "right" }}>
-        <a href="/virtual">Virtual Portfolios</a>
-      </div>
       <h1 style={{ marginTop: 0 }}>
         Portfolio: <span data-testid="owner-name">{data.owner}</span>
       </h1>


### PR DESCRIPTION
## Summary
- remove hardcoded Virtual Portfolios link from PortfolioView so navigation relies on the main menu entry

## Testing
- `npm test` *(fails: GroupPortfolioView > updates totals when accounts are toggled)*
- `npm test src/components/PortfolioView.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e10de65c88327a144463ab3dcc300