### PR TITLE
Use globalThis for ResizeObserver

### DIFF
--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -29,7 +29,7 @@ class ResizeObserver {
   unobserve() {}
   disconnect() {}
 }
-(global as any).ResizeObserver = ResizeObserver;
+globalThis.ResizeObserver = ResizeObserver;
 
 import { InstrumentDetail } from "./InstrumentDetail";
 

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -13,4 +13,10 @@ class ResizeObserver {
   unobserve() {}
   disconnect() {}
 }
-(global as any).ResizeObserver = ResizeObserver;
+declare global {
+  interface GlobalThis {
+    ResizeObserver: typeof ResizeObserver;
+  }
+}
+
+globalThis.ResizeObserver = ResizeObserver;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+declare global {
+  interface GlobalThis {
+    ResizeObserver: typeof ResizeObserver;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- extend globalThis interface with ResizeObserver
- use globalThis.ResizeObserver instead of (global as any)

## Testing
- `npm test --prefix frontend -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689e4e18688c8327bd7b583fbdcc24aa