### PR TITLE
Refactor watchlist fetch logic with useCallback and add refresh tests

### DIFF
--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { getQuotes } from "../api";
 import type { QuoteRow } from "../types";
@@ -53,7 +53,7 @@ export function Watchlist() {
     [symbols],
   );
 
-  async function fetchData() {
+  const fetchData = useCallback(async () => {
     if (!symbolList.length) {
       setRows([]);
       return;
@@ -65,18 +65,18 @@ export function Watchlist() {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
-  }
+  }, [symbolList]);
 
   useEffect(() => {
     fetchData();
     localStorage.setItem("watchlistSymbols", symbols);
-  }, [symbols]);
+  }, [fetchData, symbols]);
 
   useEffect(() => {
     if (!auto) return;
     const id = setInterval(fetchData, 10000);
     return () => clearInterval(id);
-  }, [auto, symbols]);
+  }, [auto, fetchData]);
 
   const sorted = useMemo(() => {
     const data = [...rows];


### PR DESCRIPTION
## Summary
- stabilize `fetchData` with `useCallback`
- include `fetchData` in watchlist effects
- test manual and auto refresh behavior

## Testing
- `npm test`
- `npx eslint src/pages/Watchlist.tsx src/pages/Watchlist.test.tsx`
- `npm run lint` *(fails: Unexpected any, React Hooks called conditionally)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e4e17afdc8327bedd2bccd81b4314