### PR TITLE
feat: guard useFetch with stable fn

### DIFF
--- a/frontend/src/components/ComplianceWarnings.tsx
+++ b/frontend/src/components/ComplianceWarnings.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { getCompliance } from "../api";
 import type { ComplianceResult } from "../types";
 import { useFetch } from "../hooks/useFetch";
@@ -7,29 +8,27 @@ interface Props {
 }
 
 export function ComplianceWarnings({ owners }: Props) {
-  const {
-    data,
-    loading,
-    error,
-  } = useFetch<Record<string, ComplianceResult>>(
-    async () => {
-      const entries: Record<string, ComplianceResult> = {};
-      await Promise.all(
-        owners.map(async (o) => {
-          try {
-            const res = await getCompliance(o);
-            entries[o] = res;
-          } catch {
-            entries[o] = {
-              owner: o,
-              warnings: ["Failed to load warnings"],
-              trade_counts: {},
-            };
-          }
-        })
-      );
-      return entries;
-    },
+  const fetchCompliance = useCallback(async () => {
+    const entries: Record<string, ComplianceResult> = {};
+    await Promise.all(
+      owners.map(async (o) => {
+        try {
+          const res = await getCompliance(o);
+          entries[o] = res;
+        } catch {
+          entries[o] = {
+            owner: o,
+            warnings: ["Failed to load warnings"],
+            trade_counts: {},
+          };
+        }
+      })
+    );
+    return entries;
+  }, [owners]);
+
+  const { data, loading, error } = useFetch<Record<string, ComplianceResult>>(
+    fetchCompliance,
     [owners],
     owners.length > 0
   );

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -1,5 +1,5 @@
 // src/components/GroupPortfolioView.tsx
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import type { GroupPortfolio, Account } from "../types";
 import { getGroupPortfolio } from "../api";
 import { HoldingsTable } from "./HoldingsTable";
@@ -45,8 +45,9 @@ type Props = {
  * Component
  * ────────────────────────────────────────────────────────── */
 export function GroupPortfolioView({ slug, onSelectMember }: Props) {
+  const fetchPortfolio = useCallback(() => getGroupPortfolio(slug), [slug]);
   const { data: portfolio, loading, error } = useFetch<GroupPortfolio>(
-    () => getGroupPortfolio(slug),
+    fetchPortfolio,
     [slug],
     !!slug
   );

--- a/frontend/src/components/SavedQueries.tsx
+++ b/frontend/src/components/SavedQueries.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { listSavedQueries } from "../api";
 import type { SavedQuery, CustomQuery } from "../types";
 import { useFetch } from "../hooks/useFetch";
@@ -7,8 +8,9 @@ type Props = {
 };
 
 export function SavedQueries({ onLoad }: Props) {
+  const loadQueries = useCallback(() => listSavedQueries(), []);
   const { data: queries, loading, error } = useFetch<SavedQuery[]>(
-    () => listSavedQueries(),
+    loadQueries,
     [],
   );
 

--- a/frontend/src/components/ScreenerPage.tsx
+++ b/frontend/src/components/ScreenerPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { getScreener } from "../api";
 import type { ScreenerResult } from "../types";
 import { InstrumentDetail } from "./InstrumentDetail";
@@ -11,14 +11,15 @@ import i18n from "../i18n";
 
 export function ScreenerPage() {
   const [watchlist, setWatchlist] = useState<WatchlistName>("FTSE 100");
+  const fetchScreener = useCallback(
+    () => getScreener(WATCHLISTS[watchlist]),
+    [watchlist]
+  );
   const {
     data: rows,
     loading,
     error,
-  } = useFetch<ScreenerResult[]>(
-    () => getScreener(WATCHLISTS[watchlist]),
-    [watchlist]
-  );
+  } = useFetch<ScreenerResult[]>(fetchScreener, [watchlist]);
   const [ticker, setTicker] = useState<string | null>(null);
 
   const { sorted, handleSort } = useSortableTable(rows ?? [], "peg_ratio");

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import type { OwnerSummary, Transaction } from "../types";
 import { getTransactions } from "../api";
 import { Selector } from "./Selector";
@@ -18,7 +18,7 @@ export function TransactionsPage({ owners }: Props) {
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");
   const { t } = useTranslation();
-  const { data: transactions, loading, error } = useFetch<Transaction[]>(
+  const fetchTransactions = useCallback(
     () =>
       getTransactions({
         owner: owner || undefined,
@@ -26,6 +26,10 @@ export function TransactionsPage({ owners }: Props) {
         start: start || undefined,
         end: end || undefined,
       }),
+    [owner, account, start, end]
+  );
+  const { data: transactions, loading, error } = useFetch<Transaction[]>(
+    fetchTransactions,
     [owner, account, start, end]
   );
 

--- a/frontend/src/hooks/useFetch.ts
+++ b/frontend/src/hooks/useFetch.ts
@@ -4,8 +4,11 @@ import { useEffect, useState, type DependencyList } from "react";
  * Small helper hook that wraps an async function and provides
  * the resolved `data`, a `loading` indicator and any `error`.
  *
- * It automatically re‑runs whenever the dependency list changes
- * and will reset its state when `enabled` is set to `false`.
+ * It automatically re-runs whenever `enabled`, `fn` or the dependency list
+ * changes and will reset its state when `enabled` is set to `false`.
+ *
+ * Callers should ensure that `fn` is stable (e.g. via `useCallback`) to avoid
+ * unnecessary re-renders.
  */
 export function useFetch<T>(
   fn: () => Promise<T>,
@@ -43,7 +46,7 @@ export function useFetch<T>(
     return () => {
       cancelled = true;
     };
-  }, deps);
+  }, [enabled, fn, ...deps]);
 
   return { data, loading, error };
 }

--- a/frontend/src/pages/QueryPage.tsx
+++ b/frontend/src/pages/QueryPage.tsx
@@ -17,7 +17,7 @@ const METRIC_OPTIONS = ["market_value_gbp", "gain_gbp"];
 type ResultRow = Record<string, string | number>;
 
 export function QueryPage() {
-  const { data: owners } = useFetch(() => getOwners(), []);
+  const { data: owners } = useFetch(getOwners, []);
   const { t } = useTranslation();
 
   const [start, setStart] = useState("");


### PR DESCRIPTION
## Summary
- include `enabled` and request function in `useFetch` dependencies
- advise callers to memoize fetch function with `useCallback`
- wrap hook consumers with `useCallback` for stability

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_689e4e11e3e08327825038e4f96a371a