### PR TITLE
Move hooks to top in PortfolioView

### DIFF
--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -20,17 +20,17 @@ type Props = {
  * keep the JSX at the bottom easy to follow.
  */
 export function PortfolioView({ data, loading, error }: Props) {
-  if (loading) return <div>Loading portfolio…</div>; // show a quick spinner
-  if (error) return <div style={{ color: "red" }}>{error}</div>; // bubble errors
-  if (!data) return <div>Select an owner.</div>; // nothing chosen yet
-
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
 
   const accountKey = (acct: Account, idx: number) => `${acct.account_type}-${idx}`;
 
   useEffect(() => {
-    setSelectedAccounts(data.accounts.map(accountKey));
+    setSelectedAccounts(data ? data.accounts.map(accountKey) : []);
   }, [data]);
+
+  if (loading) return <div>Loading portfolio…</div>; // show a quick spinner
+  if (error) return <div style={{ color: "red" }}>{error}</div>; // bubble errors
+  if (!data) return <div>Select an owner.</div>; // nothing chosen yet
 
   const allKeys = data.accounts.map(accountKey);
   const activeSet = new Set(


### PR DESCRIPTION
## Summary
- declare `useState` and `useEffect` before any conditional returns in `PortfolioView`
- ensure hooks run safely when `data` is null

## Testing
- `npx eslint src/components/PortfolioView.tsx`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e4e0b03cc8327b2b9d792ed93f0b4