### PR TITLE
Memoize owner fetch in QueryPage

### DIFF
--- a/frontend/src/pages/QueryPage.tsx
+++ b/frontend/src/pages/QueryPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
   API_BASE,
@@ -17,7 +17,8 @@ const METRIC_OPTIONS = ["market_value_gbp", "gain_gbp"];
 type ResultRow = Record<string, string | number>;
 
 export function QueryPage() {
-  const { data: owners } = useFetch(getOwners, []);
+  const fetchOwners = useCallback(getOwners, []);
+  const { data: owners } = useFetch(fetchOwners, []);
   const { t } = useTranslation();
 
   const [start, setStart] = useState("");


### PR DESCRIPTION
## Summary
- Use `useCallback` to memoize `getOwners` and provide a stable function to `useFetch`

## Testing
- `npm run lint` *(fails: 12 problems, 11 errors, 1 warning)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689e54b510608327a8e550a0c5878601