### PR TITLE
Add movers API and frontend page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -30,6 +30,7 @@ from backend.routes.agent import router as agent_router
 from backend.routes.trading_agent import router as trading_agent_router
 from backend.routes.config import router as config_router
 from backend.routes.quotes import router as quotes_router
+from backend.routes.movers import router as movers_router
 from backend.common.portfolio_utils import (
     _load_snapshot,
     refresh_snapshot_async,
@@ -83,6 +84,7 @@ def create_app() -> FastAPI:
     app.include_router(trading_agent_router)
     app.include_router(config_router)
     app.include_router(quotes_router)
+    app.include_router(movers_router)
 
     # ────────────────────── Health-check endpoint ─────────────────────
     @app.get("/health")

--- a/backend/routes/movers.py
+++ b/backend/routes/movers.py
@@ -1,0 +1,26 @@
+# backend/routes/movers.py
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, HTTPException, Query
+
+from backend.common.instrument_api import top_movers
+
+router = APIRouter(tags=["movers"])
+
+_ALLOWED_DAYS = {1, 7, 30, 90, 365}
+
+
+@router.get("/movers")
+def get_movers(
+    tickers: str = Query(..., description="Comma-separated tickers"),
+    days: int = Query(1, description="Lookback window"),
+    limit: int = Query(10, description="Max results per side"),
+):
+    if days not in _ALLOWED_DAYS:
+        raise HTTPException(status_code=400, detail="Invalid days")
+    tlist = [t.strip() for t in tickers.split(",") if t.strip()]
+    if not tlist:
+        raise HTTPException(status_code=400, detail="No tickers provided")
+    return top_movers(tlist, days, limit)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { LanguageSwitcher } from "./components/LanguageSwitcher";
 import { TimeseriesEdit } from "./pages/TimeseriesEdit";
 import { TradingAgent } from "./pages/TradingAgent";
 import Watchlist from "./pages/Watchlist";
+import TopMovers from "./pages/TopMovers";
 import { useConfig } from "./ConfigContext";
 
 type Mode =
@@ -39,7 +40,8 @@ type Mode =
   | "query"
   | "trading"
   | "timeseries"
-  | "watchlist";
+  | "watchlist"
+  | "movers";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -53,6 +55,7 @@ const initialMode: Mode =
   path[0] === "trading" ? "trading" :
   path[0] === "timeseries" ? "timeseries" :
   path[0] === "watchlist" ? "watchlist" :
+  path[0] === "movers" ? "movers" :
   "group";
 const initialSlug = path[1] ?? "";
 
@@ -98,6 +101,7 @@ export default function App() {
     "trading",
     "timeseries",
     "watchlist",
+    "movers",
   ];
 
   function pathFor(m: Mode) {
@@ -110,6 +114,8 @@ export default function App() {
         return selectedOwner ? `/member/${selectedOwner}` : "/member";
       case "performance":
         return selectedOwner ? `/performance/${selectedOwner}` : "/performance";
+      case "movers":
+        return "/movers";
       default:
         return `/${m}`;
     }
@@ -132,11 +138,13 @@ export default function App() {
           ? "query"
           : segs[0] === "trading"
             ? "trading"
-            : segs[0] === "timeseries"
-              ? "timeseries"
-              : segs[0] === "watchlist"
-                ? "watchlist"
-                : "group";
+              : segs[0] === "timeseries"
+                ? "timeseries"
+                : segs[0] === "watchlist"
+                  ? "watchlist"
+                  : segs[0] === "movers"
+                    ? "movers"
+                    : "group";
     if (tabs[newMode] === false) {
       setMode("group");
       navigate("/", { replace: true });
@@ -352,6 +360,7 @@ export default function App() {
       {mode === "trading" && <TradingAgent />}
       {mode === "timeseries" && <TimeseriesEdit />}
       {mode === "watchlist" && <Watchlist />}
+      {mode === "movers" && <TopMovers />}
 
       {mode === "query" && <QueryPage />}
 

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -12,6 +12,7 @@ export interface TabsConfig {
   trading: boolean;
   timeseries: boolean;
   watchlist: boolean;
+  movers: boolean;
   virtual: boolean;
   support: boolean;
 }
@@ -37,6 +38,7 @@ const defaultTabs: TabsConfig = {
   trading: true,
   timeseries: true,
   watchlist: true,
+  movers: true,
   virtual: true,
   support: true,
 };

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -18,6 +18,7 @@ import type {
   QuoteRow,
   TradingSignal,
   ComplianceResult,
+  MoverRow,
 } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -70,6 +71,22 @@ export const refreshPrices = () =>
 export const getQuotes = (symbols: string[]) => {
   const params = new URLSearchParams({ symbols: symbols.join(",") });
   return fetchJson<QuoteRow[]>(`${API_BASE}/api/quotes?${params.toString()}`);
+};
+
+/** Retrieve top movers across tickers for a period. */
+export const getTopMovers = (
+  tickers: string[],
+  days: number,
+  limit = 10,
+) => {
+  const params = new URLSearchParams({
+    tickers: tickers.join(","),
+    days: String(days),
+  });
+  if (limit) params.set("limit", String(limit));
+  return fetchJson<{ gainers: MoverRow[]; losers: MoverRow[] }>(
+    `${API_BASE}/movers?${params.toString()}`,
+  );
 };
 
 /** Retrieve per-ticker aggregation for a group portfolio. */

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -21,6 +21,7 @@ const defaultConfig: AppConfig = {
     trading: true,
     timeseries: true,
     watchlist: true,
+    movers: true,
     virtual: true,
     support: true,
   },

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -15,6 +15,7 @@ const defaultConfig: AppConfig = {
         trading: true,
         timeseries: true,
         watchlist: true,
+        movers: true,
         virtual: true,
         support: true,
     },

--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -16,6 +16,7 @@ const defaultConfig: AppConfig = {
     trading: true,
     timeseries: true,
     watchlist: true,
+    movers: true,
     virtual: true,
     support: true,
   },

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -15,6 +15,7 @@ const defaultConfig: AppConfig = {
         trading: true,
         timeseries: true,
         watchlist: true,
+        movers: true,
         virtual: true,
         support: true,
     },

--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TopMoversPage } from "./TopMoversPage";
+import type { MoverRow } from "../types";
+
+vi.mock("../data/watchlists", () => ({
+  WATCHLISTS: { "FTSE 100": ["AAA", "BBB"] },
+}));
+
+const mockGetTopMovers = vi.fn(() =>
+  Promise.resolve({
+    gainers: [{ ticker: "AAA", name: "AAA", change_pct: 5 } as MoverRow],
+    losers: [{ ticker: "BBB", name: "BBB", change_pct: -2 } as MoverRow],
+  }),
+);
+
+vi.mock("../api", () => ({ getTopMovers: (...args: any[]) => mockGetTopMovers(...args) }));
+
+describe("TopMoversPage", () => {
+  it("renders movers and refetches on period change", async () => {
+    render(<TopMoversPage />);
+
+    await waitFor(() =>
+      expect(mockGetTopMovers).toHaveBeenCalledWith(["AAA", "BBB"], 1),
+    );
+    expect((await screen.findAllByText("AAA")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("BBB")).length).toBeGreaterThan(0);
+
+    const selects = screen.getAllByRole("combobox");
+    const periodSelect = selects[1];
+    fireEvent.change(periodSelect, { target: { value: "1w" } });
+    await waitFor(() => expect(mockGetTopMovers).toHaveBeenLastCalledWith(["AAA", "BBB"], 7));
+  });
+});

--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useMemo, useState } from "react";
+import { getTopMovers } from "../api";
+import type { MoverRow } from "../types";
+import { WATCHLISTS, type WatchlistName } from "../data/watchlists";
+import { useFetch } from "../hooks/useFetch";
+import { useSortableTable } from "../hooks/useSortableTable";
+import tableStyles from "../styles/table.module.css";
+
+const PERIODS = { "1d": 1, "1w": 7, "1m": 30, "3m": 90, "1y": 365 } as const;
+type PeriodKey = keyof typeof PERIODS;
+
+export function TopMoversPage() {
+  const [watchlist, setWatchlist] = useState<WatchlistName>("FTSE 100");
+  const [period, setPeriod] = useState<PeriodKey>("1d");
+
+  const fetchMovers = useCallback(
+    () => getTopMovers(WATCHLISTS[watchlist], PERIODS[period]),
+    [watchlist, period],
+  );
+  const { data, loading, error } = useFetch(fetchMovers, [watchlist, period]);
+  const rows = useMemo(() => {
+    if (!data) return [];
+    return [...data.gainers, ...data.losers];
+  }, [data]);
+
+  const { sorted, handleSort } = useSortableTable<MoverRow>(
+    rows,
+    "change_pct",
+  );
+
+  if (loading) return <p>Loading…</p>;
+  if (error) return <p style={{ color: "red" }}>{error.message}</p>;
+
+  return (
+    <>
+      <div style={{ marginBottom: "0.5rem" }}>
+        <select
+          value={watchlist}
+          onChange={(e) => setWatchlist(e.target.value as WatchlistName)}
+          style={{ marginRight: "0.5rem" }}
+        >
+          {(Object.keys(WATCHLISTS) as WatchlistName[]).map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+        <select
+          value={period}
+          onChange={(e) => setPeriod(e.target.value as PeriodKey)}
+        >
+          {(Object.keys(PERIODS) as PeriodKey[]).map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <table className={tableStyles.table}>
+        <thead>
+          <tr>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.clickable}`}
+              onClick={() => handleSort("ticker")}
+            >
+              Ticker
+            </th>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.clickable}`}
+              onClick={() => handleSort("name")}
+            >
+              Name
+            </th>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort("change_pct")}
+            >
+              %
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((r) => (
+            <tr key={r.ticker}>
+              <td className={tableStyles.cell}>{r.ticker}</td>
+              <td className={tableStyles.cell}>{r.name}</td>
+              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                {r.change_pct.toFixed(2)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -16,7 +16,8 @@
       "query": "Abfrage",
       "trading": "Handel",
       "timeseries": "Zeitreihe",
-      "watchlist": "Watchlist"
+      "watchlist": "Watchlist",
+      "movers": "Movers"
     }
   },
   "common": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -16,7 +16,8 @@
       "query": "Query",
       "trading": "Trading",
       "timeseries": "Timeseries",
-      "watchlist": "Watchlist"
+      "watchlist": "Watchlist",
+      "movers": "Movers"
     }
   },
   "common": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -16,7 +16,8 @@
       "query": "Consulta",
       "trading": "Trading",
       "timeseries": "Serie temporal",
-      "watchlist": "Watchlist"
+      "watchlist": "Watchlist",
+      "movers": "Movers"
     }
   },
   "common": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -16,7 +16,8 @@
       "query": "Requête",
       "trading": "Trading",
       "timeseries": "Séries temporelles",
-      "watchlist": "Watchlist"
+      "watchlist": "Watchlist",
+      "movers": "Movers"
     }
   },
   "common": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -16,7 +16,8 @@
       "query": "Consulta",
       "trading": "Negociação",
       "timeseries": "Série temporal",
-      "watchlist": "Watchlist"
+      "watchlist": "Watchlist",
+      "movers": "Movers"
     }
   },
   "common": {

--- a/frontend/src/pages/TopMovers.tsx
+++ b/frontend/src/pages/TopMovers.tsx
@@ -1,0 +1,5 @@
+import { TopMoversPage } from "../components/TopMoversPage";
+
+export default function TopMovers() {
+  return <TopMoversPage />;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -132,6 +132,14 @@ export interface QuoteRow {
     time: string | null;
 }
 
+export interface MoverRow {
+    ticker: string;
+    name: string;
+    change_pct: number;
+    last_price_gbp?: number | null;
+    last_price_date?: string | null;
+}
+
 export type Alert = {
     ticker: string;
     change_pct: number;

--- a/tests/test_movers_backend.py
+++ b/tests/test_movers_backend.py
@@ -1,0 +1,48 @@
+import datetime as dt
+from backend.common import instrument_api as ia
+import pytest
+
+
+def test_price_change_pct(monkeypatch):
+    class FixedDate(dt.date):
+        @classmethod
+        def today(cls):
+            return cls(2023, 1, 9)
+    monkeypatch.setattr(ia.dt, "date", FixedDate)
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, latest: t)
+    monkeypatch.setattr(ia, "_LATEST_PRICES", {})
+
+    def fake_close_on(full: str, d: dt.date):
+        if d == dt.date(2023, 1, 8):
+            return 110.0
+        if d == dt.date(2023, 1, 1):
+            return 100.0
+        return None
+
+    monkeypatch.setattr(ia, "_close_on", fake_close_on)
+
+    assert ia.price_change_pct("AAA.L", 7) == pytest.approx(10.0)
+    assert ia.price_change_pct("AAA.L", 30) is None
+
+
+def test_top_movers(monkeypatch):
+    class FixedDate(dt.date):
+        @classmethod
+        def today(cls):
+            return cls(2023, 1, 9)
+    monkeypatch.setattr(ia.dt, "date", FixedDate)
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, latest: t)
+    monkeypatch.setattr(ia, "_LATEST_PRICES", {})
+    monkeypatch.setattr(ia, "_close_on", lambda full, d: 100.0)
+    monkeypatch.setattr(
+        ia,
+        "price_change_pct",
+        lambda t, d: {"AAA.L": 5.0, "BBB.L": -2.0, "CCC.L": 1.0}.get(t),
+    )
+    monkeypatch.setattr(ia, "get_security_meta", lambda t: {"name": f"{t} name"})
+
+    res = ia.top_movers(["AAA.L", "BBB.L", "CCC.L"], 7, limit=2)
+    assert [r["ticker"] for r in res["gainers"]] == ["AAA.L", "CCC.L"]
+    assert [r["ticker"] for r in res["losers"]] == ["BBB.L"]
+    assert res["gainers"][0]["last_price_gbp"] == 100.0
+    assert res["gainers"][0]["last_price_date"] == "2023-01-08"


### PR DESCRIPTION
## Summary
- compute price change percentages and top movers on backend
- expose /movers API and frontend hook
- add Top Movers page with tests

## Testing
- `pytest tests/test_movers_backend.py -q`
- `npm test --prefix frontend -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689e551e5b8883278cde131b59549ce6