### PR TITLE
refactor: tighten filterable table generics

### DIFF
--- a/frontend/src/hooks/useFilterableTable.test.tsx
+++ b/frontend/src/hooks/useFilterableTable.test.tsx
@@ -10,22 +10,22 @@ const rows: Row[] = [
   { name: "Carol", age: 35, active: true },
 ];
 
-const filters: Record<string, Filter<Row, any>> = {
+const filters = {
   search: {
     value: "",
-    predicate: (row, value: string) =>
+    predicate: (row: Row, value: string) =>
       row.name.toLowerCase().includes(value.toLowerCase()),
   },
   onlyActive: {
     value: false,
-    predicate: (row, value: boolean) => (value ? row.active : true),
+    predicate: (row: Row, value: boolean) => (value ? row.active : true),
   },
-};
+} satisfies Record<string, Filter<Row, unknown>>;
 
 describe("useFilterableTable", () => {
   it("filters and sorts rows", () => {
     const { result } = renderHook(() =>
-      useFilterableTable<Row, typeof filters>(rows, "age", filters)
+      useFilterableTable(rows, "age", filters)
     );
 
     expect(result.current.rows.map((r) => r.name)).toEqual([
@@ -55,5 +55,12 @@ describe("useFilterableTable", () => {
       "Carol",
       "Alice",
     ]);
+
+    if (false) {
+      // @ts-expect-error search filter expects a string
+      result.current.setFilter("search", 123);
+      // @ts-expect-error onlyActive filter expects a boolean
+      result.current.setFilter("onlyActive", "true");
+    }
   });
 });

--- a/frontend/src/hooks/useFilterableTable.ts
+++ b/frontend/src/hooks/useFilterableTable.ts
@@ -7,7 +7,7 @@ export type Filter<T, V> = {
 
 export function useFilterableTable<
   T,
-  F extends Record<string, Filter<T, any>>
+  F extends Record<string, Filter<T, unknown>>
 >(rows: T[], initialSortKey: keyof T, initialFilters: F) {
   const [sortKey, setSortKey] = useState<keyof T>(initialSortKey);
   const [asc, setAsc] = useState(true);


### PR DESCRIPTION
## Summary
- use `unknown` for filter value types in `useFilterableTable`
- type `filters` in tests with `unknown` and verify type inference

## Testing
- `npm test --prefix frontend -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689e4e132c9483279868b067a90b78f5