### PR TITLE
Fix stylesheet snapshot test path resolution

### DIFF
--- a/tests/test_styles_snapshot.py
+++ b/tests/test_styles_snapshot.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 
 
+root = Path(__file__).resolve().parent.parent
+
+
 def test_stylesheet_snapshot():
-    css = Path("frontend/src/index.css").read_text()
-    expected = Path("tests/snapshots/index.css").read_text()
+    css = (root / "frontend/src/index.css").read_text()
+    expected = (root / "tests/snapshots/index.css").read_text()
     assert css == expected


### PR DESCRIPTION
## Summary
- make stylesheet snapshot test independent of working directory by resolving repo root

## Testing
- `pytest tests/test_styles_snapshot.py`
- `cd tests && pytest test_styles_snapshot.py`


------
https://chatgpt.com/codex/tasks/task_e_689f7ef686e88327878547616eee5dab