### PR TITLE
refactor: type backend config

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
-import { getConfig } from "./api";
+import { getConfig, type BackendConfig } from "./api";
 
 export interface TabsConfig {
   [key: string]: boolean;
@@ -60,20 +60,20 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     getConfig()
-      .then((cfg) => {
-        const tabs = { ...defaultTabs, ...((cfg as any).tabs ?? {}) };
+      .then((cfg: BackendConfig) => {
+        const tabs: TabsConfig = { ...defaultTabs, ...(cfg.tabs ?? {}) };
         const disabledTabs = new Set<string>(
-          Array.isArray((cfg as any).disabled_tabs)
-            ? ((cfg as any).disabled_tabs as string[])
-            : [],
+          Array.isArray(cfg.disabled_tabs) ? cfg.disabled_tabs : [],
         );
         for (const [tab, enabled] of Object.entries(tabs)) {
           if (!enabled) disabledTabs.add(tab);
         }
-        const theme =
-          typeof (cfg as any).theme === "string" ? ((cfg as any).theme as any) : "system";
+        const theme: "dark" | "light" | "system" =
+          cfg.theme === "dark" || cfg.theme === "light" || cfg.theme === "system"
+            ? cfg.theme
+            : "system";
         setConfig({
-          relativeViewEnabled: Boolean((cfg as any).relative_view_enabled),
+          relativeViewEnabled: Boolean(cfg.relative_view_enabled),
           disabledTabs: Array.from(disabledTabs),
           tabs,
           theme,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -202,8 +202,16 @@ export const deleteVirtualPortfolio = (id: number | string) =>
   });
 
 /** Retrieve backend configuration. */
+export interface BackendConfig {
+  tabs?: Record<string, boolean>;
+  disabled_tabs?: string[];
+  theme?: "dark" | "light" | "system";
+  relative_view_enabled?: boolean;
+  [key: string]: unknown;
+}
+
 export const getConfig = () =>
-  fetchJson<Record<string, unknown>>(`${API_BASE}/config`);
+  fetchJson<BackendConfig>(`${API_BASE}/config`);
 
 /** Persist configuration changes. */
 export const updateConfig = (cfg: Record<string, unknown>) =>

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { API_BASE, getConfig, updateConfig } from "../api";
+import { API_BASE, getConfig, updateConfig, type BackendConfig } from "../api";
 
 export default function Support() {
   const { t } = useTranslation();
@@ -14,7 +14,7 @@ export default function Support() {
 
   useEffect(() => {
     getConfig()
-      .then((cfg) => {
+      .then((cfg: BackendConfig) => {
         const entries: Record<string, string | boolean> = {};
         Object.entries(cfg).forEach(([k, v]) => {
           entries[k] = typeof v === "boolean" ? v : v == null ? "" : String(v);
@@ -49,7 +49,7 @@ export default function Support() {
     }
     try {
       await updateConfig(payload);
-      const fresh = await getConfig();
+      const fresh: BackendConfig = await getConfig();
       const entries: Record<string, string | boolean> = {};
       Object.entries(fresh).forEach(([k, v]) => {
         entries[k] = typeof v === "boolean" ? v : v == null ? "" : String(v);


### PR DESCRIPTION
## Summary
- add `BackendConfig` interface and type `getConfig`
- remove `any` casts in `ConfigContext`
- type config handling in Support page

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689f7c136fe08327b51817678a55e96d