### PR TITLE
Color code movers

### DIFF
--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -38,9 +38,6 @@ vi.mock("./InstrumentDetail", () => ({
       <button onClick={onClose}>x</button>
     </div>
   ),
-vi.mock("../api", () => ({
-  getTopMovers: (...args: any[]) => mockGetTopMovers(...args),
-  getGroupMovers: vi.fn(),
 }));
 
 describe("TopMoversPage", () => {
@@ -81,5 +78,14 @@ describe("TopMoversPage", () => {
     const button = await screen.findByRole("button", { name: "AAA" });
     fireEvent.click(button);
     expect(await screen.findByTestId("detail")).toHaveTextContent("AAA");
+  });
+
+  it("colors gainers green and losers red", async () => {
+    render(<TopMoversPage />);
+
+    const gainerCell = await screen.findByText("5.00");
+    const loserCell = await screen.findByText("-2.00");
+    expect(gainerCell).toHaveStyle({ color: "rgb(0, 128, 0)" });
+    expect(loserCell).toHaveStyle({ color: "rgb(255, 0, 0)" });
   });
 });

--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -121,7 +121,10 @@ export function TopMoversPage() {
                 </button>
               </td>
               <td className={tableStyles.cell}>{r.name}</td>
-              <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+              <td
+                className={`${tableStyles.cell} ${tableStyles.right}`}
+                style={{ color: r.change_pct >= 0 ? "green" : "red" }}
+              >
                 {r.change_pct.toFixed(2)}
               </td>
             </tr>


### PR DESCRIPTION
## Summary
- show movers with green text for gainers and red for losers
- test color styling on movers page

## Testing
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9a15705c8327a427f10dc2baef77