### PR TITLE
test: silence constant condition lint warning in useFilterableTable test

### DIFF
--- a/frontend/src/hooks/useFilterableTable.test.tsx
+++ b/frontend/src/hooks/useFilterableTable.test.tsx
@@ -59,6 +59,7 @@ describe("useFilterableTable", () => {
       "Alice",
     ]);
 
+    // eslint-disable-next-line no-constant-condition
     if (false) {
       // @ts-expect-error search filter expects a string
       result.current.setFilter("search", 123);


### PR DESCRIPTION
## Summary
- silence `no-constant-condition` ESLint rule in `useFilterableTable.test.tsx` by adding directive before `if (false)` block

## Testing
- `npm run lint` (fails: Parsing error: ',' expected in TopMoversPage.test.tsx)
- `npx eslint src/hooks/useFilterableTable.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689f9b94b62883278a06120725e5e725