### PR TITLE
Fix lint errors in TopMovers and useFetch hook

### DIFF
--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -27,12 +27,19 @@ const mockGetGroupInstruments = vi.fn(() =>
 );
 
 vi.mock("../api", () => ({
-  getTopMovers: (...args: any[]) => mockGetTopMovers(...args),
-  getGroupInstruments: (...args: any[]) => mockGetGroupInstruments(...args),
+  getTopMovers: (...args: unknown[]) => mockGetTopMovers(...args),
+  getGroupInstruments: (...args: unknown[]) =>
+    mockGetGroupInstruments(...args),
 }));
 
 vi.mock("./InstrumentDetail", () => ({
-  InstrumentDetail: ({ ticker, onClose }: any) => (
+  InstrumentDetail: ({
+    ticker,
+    onClose,
+  }: {
+    ticker: string;
+    onClose: () => void;
+  }) => (
     <div data-testid="detail">
       Detail for {ticker}
       <button onClick={onClose}>x</button>

--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 
-import { getTopMovers, getGroupInstruments, getGroupMovers } from "../api";
+import { getTopMovers, getGroupInstruments } from "../api";
 import type { MoverRow } from "../types";
 import { WATCHLISTS, type WatchlistName } from "../data/watchlists";
 import { InstrumentDetail } from "./InstrumentDetail";
@@ -12,13 +12,12 @@ import tableStyles from "../styles/table.module.css";
 const PERIODS = { "1d": 1, "1w": 7, "1m": 30, "3m": 90, "1y": 365 } as const;
 type PeriodKey = keyof typeof PERIODS;
 type WatchlistOption = WatchlistName | "Portfolio";
+const WATCHLIST_OPTIONS: WatchlistOption[] = [
+  ...(Object.keys(WATCHLISTS) as WatchlistName[]),
+  "Portfolio",
+];
 
 export function TopMoversPage() {
-  type WatchlistOption = keyof typeof WATCHLISTS | "Portfolio";
-  const WATCHLIST_OPTIONS: WatchlistOption[] = [
-    ...(Object.keys(WATCHLISTS) as (keyof typeof WATCHLISTS)[]),
-    "Portfolio",
-  ];
 
   const [watchlist, setWatchlist] = useState<WatchlistOption>("FTSE 100");
   const [period, setPeriod] = useState<PeriodKey>("1d");
@@ -57,13 +56,11 @@ export function TopMoversPage() {
           onChange={(e) => setWatchlist(e.target.value as WatchlistOption)}
           style={{ marginRight: "0.5rem" }}
         >
-          {([...Object.keys(WATCHLISTS), "Portfolio"] as WatchlistOption[]).map(
-            (name) => (
-              <option key={name} value={name}>
-                {name}
-              </option>
-            ),
-          )}
+          {WATCHLIST_OPTIONS.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
         </select>
         <select
           value={period}

--- a/frontend/src/hooks/useFetch.ts
+++ b/frontend/src/hooks/useFetch.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, type DependencyList } from "react";
+import { useEffect, useState, type DependencyList } from "react";
 
 /**
  * Small helper hook that wraps an async function and provides
@@ -18,7 +18,6 @@ export function useFetch<T>(
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const allDeps = useMemo(() => [enabled, fn, ...deps], [enabled, fn, ...deps]);
 
   useEffect(() => {
     if (!enabled) {
@@ -47,7 +46,9 @@ export function useFetch<T>(
     return () => {
       cancelled = true;
     };
-  }, allDeps);
+  },
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [enabled, fn, ...deps]);
 
   return { data, loading, error };
 }


### PR DESCRIPTION
## Summary
- remove unused imports and vars in TopMoversPage
- tighten types in TopMoversPage tests
- simplify useFetch dependencies and silence exhaustive-deps warning

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9eccd874832791c6ed8aca7e6c8e