### PR TITLE
feat: make movers default view

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -12,6 +12,53 @@ describe("App", () => {
     mockTradingSignals.mockReset();
   });
 
+  it("defaults to movers view and orders tabs", async () => {
+    window.history.pushState({}, "", "/");
+
+    vi.mock("./api", () => ({
+      getOwners: vi.fn().mockResolvedValue([]),
+      getGroups: vi.fn().mockResolvedValue([]),
+      getGroupInstruments: vi.fn().mockResolvedValue([]),
+      getPortfolio: vi.fn(),
+      refreshPrices: vi.fn(),
+      getAlerts: vi.fn().mockResolvedValue([]),
+      getCompliance: vi
+        .fn()
+        .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+      getTimeseries: vi.fn().mockResolvedValue([]),
+      saveTimeseries: vi.fn(),
+      getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+    }));
+
+    const { default: App } = await import("./App");
+
+    const { container } = render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole("link", { name: /movers/i });
+    const tabs = container.querySelectorAll("nav a");
+    const labels = Array.from(tabs).map((el) => el.textContent);
+    expect(labels).toEqual([
+      "Movers",
+      "Group",
+      "Instrument",
+      "Member",
+      "Performance",
+      "Transactions",
+      "Screener",
+      "Query",
+      "Trading",
+      "Timeseries",
+      "Member Timeseries",
+      "Watchlist",
+      "Support",
+    ]);
+    expect(tabs[0]).toHaveStyle("font-weight: bold");
+  });
+
   it.skip("preselects group from URL", async () => {
     window.history.pushState({}, "", "/instrument/kids");
 
@@ -86,6 +133,7 @@ describe("App", () => {
       getTimeseries: vi.fn().mockResolvedValue([]),
       saveTimeseries: vi.fn(),
       getTradingSignals: vi.fn().mockResolvedValue([]),
+      getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
     }));
 
     const { default: App } = await import("./App");
@@ -103,6 +151,7 @@ describe("App", () => {
       watchlist: true,
       virtual: true,
       support: true,
+      movers: true,
     };
 
     render(
@@ -120,8 +169,8 @@ describe("App", () => {
     );
 
     expect(screen.queryByRole("link", { name: /trading/i })).toBeNull();
-    const groupLink = await screen.findByRole("link", { name: /group/i });
-    expect(groupLink).toHaveStyle("font-weight: bold");
+    const moversLink = await screen.findByRole("link", { name: /movers/i });
+    expect(moversLink).toHaveStyle("font-weight: bold");
   });
 
   it("allows navigation to enabled tabs", async () => {
@@ -142,6 +191,7 @@ describe("App", () => {
       getTimeseries: vi.fn().mockResolvedValue([]),
       saveTimeseries: vi.fn(),
       getTradingSignals: mockTradingSignals,
+      getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
     }));
 
     const { default: App } = await import("./App");
@@ -159,6 +209,7 @@ describe("App", () => {
       watchlist: true,
       virtual: true,
       support: true,
+      movers: true,
     };
 
     render(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,19 +48,31 @@ type Mode =
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
 const initialMode: Mode =
-  path[0] === "member" ? "owner" :
-  path[0] === "instrument" ? "instrument" :
-  path[0] === "transactions" ? "transactions" :
-  path[0] === "performance" ? "performance" :
-  path[0] === "screener" ? "screener" :
-  path[0] === "query" ? "query" :
-  path[0] === "trading" ? "trading" :
-  path[0] === "timeseries" ? "timeseries" :
-  path[0] === "groupInstrumentMemberTimeseries" ? "groupInstrumentMemberTimeseries" :
-  path[0] === "watchlist" ? "watchlist" :
-  path[0] === "movers" ? "movers" :
-  path[0] === "support" ? "support" :
-  "group";
+  path[0] === "member"
+    ? "owner"
+    : path[0] === "instrument"
+      ? "instrument"
+      : path[0] === "transactions"
+        ? "transactions"
+        : path[0] === "performance"
+          ? "performance"
+          : path[0] === "screener"
+            ? "screener"
+            : path[0] === "query"
+              ? "query"
+              : path[0] === "trading"
+                ? "trading"
+                : path[0] === "timeseries"
+                  ? "timeseries"
+                  : path[0] === "groupInstrumentMemberTimeseries"
+                    ? "groupInstrumentMemberTimeseries"
+                    : path[0] === "watchlist"
+                      ? "watchlist"
+                      : path[0] === "movers"
+                        ? "movers"
+                        : path[0] === "support"
+                          ? "support"
+                          : "movers";
 const initialSlug = path[1] ?? "";
 
 export default function App() {
@@ -95,6 +107,7 @@ export default function App() {
   const groupsReq = useFetchWithRetry(getGroups);
 
   const modes: Mode[] = [
+    "movers",
     "group",
     "instrument",
     "owner",
@@ -106,14 +119,14 @@ export default function App() {
     "timeseries",
     "groupInstrumentMemberTimeseries",
     "watchlist",
-    "movers",
     "support",
   ];
 
   function pathFor(m: Mode) {
     switch (m) {
       case "group":
-        return selectedGroup ? `/?group=${selectedGroup}` : "/";
+        if (selectedGroup) return `/?group=${selectedGroup}`;
+        return groups.length ? `/?group=${groups[0].slug}` : "/movers";
       case "instrument":
         return selectedGroup ? `/instrument/${selectedGroup}` : "/instrument";
       case "owner":
@@ -140,24 +153,24 @@ export default function App() {
               ? "performance"
               : segs[0] === "screener"
                 ? "screener"
-        : segs[0] === "query"
-          ? "query"
-          : segs[0] === "trading"
-            ? "trading"
-              : segs[0] === "timeseries"
-                ? "timeseries"
-                : segs[0] === "groupInstrumentMemberTimeseries"
-                  ? "groupInstrumentMemberTimeseries"
-                  : segs[0] === "watchlist"
-                    ? "watchlist"
-                    : segs[0] === "movers"
-                      ? "movers"
-                    : segs[0] === "support"
-                      ? "support"
-                      : "group";
+                : segs[0] === "query"
+                  ? "query"
+                  : segs[0] === "trading"
+                    ? "trading"
+                    : segs[0] === "timeseries"
+                      ? "timeseries"
+                      : segs[0] === "groupInstrumentMemberTimeseries"
+                        ? "groupInstrumentMemberTimeseries"
+                        : segs[0] === "watchlist"
+                          ? "watchlist"
+                          : segs[0] === "movers"
+                            ? "movers"
+                            : segs[0] === "support"
+                              ? "support"
+                              : "movers";
     if (tabs[newMode] === false) {
-      setMode("group");
-      navigate("/", { replace: true });
+      setMode("movers");
+      navigate("/movers", { replace: true });
       return;
     }
     setMode(newMode);
@@ -169,6 +182,8 @@ export default function App() {
       setSelectedGroup(
         new URLSearchParams(location.search).get("group") ?? "",
       );
+    } else if (newMode === "movers" && location.pathname !== "/movers") {
+      navigate("/movers", { replace: true });
     }
   }, [location.pathname, location.search, tabs, navigate]);
 


### PR DESCRIPTION
## Summary
- default to Movers mode and move its tab to the front
- redirect unknown or disabled routes to `/movers`
- update tests for new default and tab order

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fabdf774c83278ddedd42957e4a75