### PR TITLE
chore: add type cast for tabs entries

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -80,7 +80,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
         const disabledTabs = new Set<string>(
           Array.isArray(cfg.disabled_tabs) ? cfg.disabled_tabs : [],
         );
-        for (const [tab, enabled] of Object.entries(tabs)) {
+        for (const [tab, enabled] of Object.entries(tabs) as [keyof TabsConfig, boolean][]) {
           if (!enabled) disabledTabs.add(tab);
         }
         const theme = isTheme(cfg.theme) ? cfg.theme : "system";


### PR DESCRIPTION
## Summary
- cast Object.entries result to typed tuple

## Testing
- `npm run lint` *(fails: parsing error in TopMoversPage.test.tsx; unused vars in TopMoversPage.tsx; constant condition in useFilterableTable.test.tsx)*
- `npx eslint src/ConfigContext.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689f9b95c7408327942b37b2e8fca5aa