### PR TITLE
Fix timeseries cache warming and full ticker support

### DIFF
--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -74,7 +74,7 @@ def timeseries_for_ticker(ticker: str, days: int = 365) -> List[Dict[str, Any]]:
     if not has_cached_meta_timeseries(sym, ex):
         try:
             # Best-effort priming; safe to ignore failures since we fall back anyway.
-            run_all_tickers([full])
+            run_all_tickers([sym], exchange=ex)
         except Exception:
             pass
 

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -191,15 +191,22 @@ def fetch_ft_df(ticker, end_date, start_date):
 
 # ──────────────────────────────────────────────────────────────
 # Cache-aware batch helpers (local import) ─────────────────────
-def run_all_tickers(tickers: List[str],
-                    exchange: str = "L",
-                    days: int = 365) -> List[str]:
-    """Warm-up helper - returns tickers that produced data."""
+def run_all_tickers(
+    tickers: List[str], exchange: str = "L", days: int = 365
+) -> List[str]:
+    """Warm-up helper - returns tickers that produced data.
+
+    ``tickers`` may contain base symbols ("VOD") or full tickers ("VOD.L").
+    When a ticker includes an exchange suffix, it takes precedence over the
+    ``exchange`` argument.
+    """
     from backend.timeseries.cache import load_meta_timeseries
+
     ok: list[str] = []
     for t in tickers:
+        sym, ex = (t.split(".", 1) + [exchange])[:2]
         try:
-            if not load_meta_timeseries(t, exchange, days).empty:
+            if not load_meta_timeseries(sym, ex, days).empty:
                 ok.append(t)
         except Exception as exc:
             logger.warning("[WARN] %s: %s", t, exc)

--- a/tests/test_run_all_tickers.py
+++ b/tests/test_run_all_tickers.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from unittest.mock import patch
+
+from backend.timeseries.fetch_meta_timeseries import run_all_tickers
+
+
+def test_run_all_tickers_accepts_full_tickers():
+    calls = []
+
+    def fake_load(sym, ex, days):
+        calls.append((sym, ex, days))
+        # Non-empty dataframe signals success
+        return pd.DataFrame({"Date": [1], "Close": [2]})
+
+    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
+        out = run_all_tickers(["AAA.L", "BBB"], exchange="N", days=10)
+
+    assert out == ["AAA.L", "BBB"]
+    assert calls == [("AAA", "L", 10), ("BBB", "N", 10)]
+


### PR DESCRIPTION
## Summary
- ensure `timeseries_for_ticker` warms cache using symbol and exchange
- allow `run_all_tickers` to accept full tickers with embedded exchange
- add unit test for full-ticker handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0240a08208327b68e04941b62fc54