### PR TITLE
test: type mock parameter forwarding

### DIFF
--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -33,10 +33,15 @@ const mockGetTradingSignals = vi.fn(() =>
 );
 
 vi.mock("../api", () => ({
-  getTopMovers: (...args: unknown[]) => mockGetTopMovers(...args),
-  getGroupInstruments: (...args: unknown[]) =>
-    mockGetGroupInstruments(...args),
-  getTradingSignals: (...args: unknown[]) => mockGetTradingSignals(...args),
+  getTopMovers: (
+    ...args: Parameters<typeof mockGetTopMovers>
+  ) => mockGetTopMovers(...args),
+  getGroupInstruments: (
+    ...args: Parameters<typeof mockGetGroupInstruments>
+  ) => mockGetGroupInstruments(...args),
+  getTradingSignals: (
+    ...args: Parameters<typeof mockGetTradingSignals>
+  ) => mockGetTradingSignals(...args),
 }));
 
 vi.mock("./InstrumentDetail", () => ({


### PR DESCRIPTION
## Summary
- specify parameter types when forwarding mocked API functions in TopMoversPage tests

## Testing
- `npm test` *(fails: 1 test file failed, 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a034b22460832789c3fae1725be4bf