### PR TITLE
feat: type-safe timeseries parsing

### DIFF
--- a/frontend/src/pages/TimeseriesEdit.test.tsx
+++ b/frontend/src/pages/TimeseriesEdit.test.tsx
@@ -29,6 +29,35 @@ describe("TimeseriesEdit page", () => {
     expect(getTimeseries).toHaveBeenCalledWith("ABC", "L");
   });
 
+  it("parses numeric and string columns correctly", async () => {
+    vi.clearAllMocks();
+    render(<TimeseriesEdit />);
+
+    fireEvent.change(screen.getByLabelText(/Ticker/i), {
+      target: { value: "ABC" },
+    });
+
+    const csv =
+      "Date,Open,Close,Ticker,Source,Volume\n2024-01-01,1,2,ABC,Feed,3";
+    fireEvent.change(
+      screen.getByPlaceholderText(/Date,Open,High,Low,Close,Volume/),
+      { target: { value: csv } },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(saveTimeseries).toHaveBeenCalledWith("ABC", "L", [
+      {
+        Date: "2024-01-01",
+        Open: 1,
+        Close: 2,
+        Ticker: "ABC",
+        Source: "Feed",
+        Volume: 3,
+      },
+    ]);
+  });
+
   it("prefills ticker and exchange from URL", async () => {
     window.history.pushState({}, "", "/timeseries?ticker=XYZ&exchange=US");
     render(<TimeseriesEdit />);

--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -71,12 +71,13 @@ export function TimeseriesEdit() {
         cols.forEach((col, i) => {
           const key = col as keyof PriceEntry;
           const val = parts[i];
-          obj[key] =
+          const parsed =
             key === "Date" || key === "Ticker" || key === "Source"
               ? val
               : val === undefined || val === ""
               ? null
               : Number(val);
+          obj[key] = parsed as PriceEntry[typeof key];
         });
         return obj as PriceEntry;
       });


### PR DESCRIPTION
## Summary
- ensure TimeseriesEdit parses CSV values with explicit PriceEntry types
- add test covering numeric and string CSV parsing

## Testing
- `npm test -- --run` *(fails: 2 failing tests in src/App.test.tsx)*
- `npm test -- --run src/pages/TimeseriesEdit.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a034ab22448327b6f349d0b302f728