### PR TITLE
feat: add table-based timeseries editor

### DIFF
--- a/frontend/src/pages/TimeseriesEdit.test.tsx
+++ b/frontend/src/pages/TimeseriesEdit.test.tsx
@@ -12,7 +12,8 @@ import { TimeseriesEdit } from "./TimeseriesEdit";
 import { getTimeseries, saveTimeseries } from "../api";
 
 describe("TimeseriesEdit page", () => {
-  it("loads and saves CSV data", async () => {
+  it("loads, edits, adds and deletes rows, then saves", async () => {
+    vi.clearAllMocks();
     render(<TimeseriesEdit />);
 
     fireEvent.change(screen.getByLabelText(/Ticker/i), {
@@ -21,39 +22,29 @@ describe("TimeseriesEdit page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /load/i }));
 
-    expect(await screen.findByText(/Loaded 1 rows/)).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("2024-01-01")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
-
-    expect(saveTimeseries).toHaveBeenCalled();
-    expect(getTimeseries).toHaveBeenCalledWith("ABC", "L");
-  });
-
-  it("parses numeric and string columns correctly", async () => {
-    vi.clearAllMocks();
-    render(<TimeseriesEdit />);
-
-    fireEvent.change(screen.getByLabelText(/Ticker/i), {
-      target: { value: "ABC" },
+    fireEvent.change(screen.getByLabelText("Open"), {
+      target: { value: "2" },
     });
 
-    const csv =
-      "Date,Open,Close,Ticker,Source,Volume\n2024-01-01,1,2,ABC,Feed,3";
-    fireEvent.change(
-      screen.getByPlaceholderText(/Date,Open,High,Low,Close,Volume/),
-      { target: { value: csv } },
-    );
+    fireEvent.click(screen.getByRole("button", { name: /add row/i }));
+    expect(screen.getAllByLabelText("Date")).toHaveLength(2);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /delete/i })[1]);
+    expect(screen.getAllByLabelText("Date")).toHaveLength(1);
 
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
+    expect(getTimeseries).toHaveBeenCalledWith("ABC", "L");
     expect(saveTimeseries).toHaveBeenCalledWith("ABC", "L", [
       {
         Date: "2024-01-01",
-        Open: 1,
-        Close: 2,
-        Ticker: "ABC",
-        Source: "Feed",
-        Volume: 3,
+        Open: 2,
+        High: 1,
+        Low: 1,
+        Close: 1,
+        Volume: 1,
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- replace CSV textarea with table of PriceEntry rows and add row editing and deletion
- support CSV upload into table and save edited rows via API
- test loading, editing, adding, removing, and saving timeseries rows

## Testing
- `npm test` *(fails: Unable to find role="link" and name `/movers/i`; TypeError: Cannot read properties of undefined (reading 'then'))*

------
https://chatgpt.com/codex/tasks/task_e_68a07fa89ef88327a3b7c64288e489ec