### PR TITLE
fix tab merging and typing

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -70,12 +70,12 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     getConfig<RawConfig>()
       .then((cfg) => {
-        const tabs = { ...defaultTabs, ...(cfg.tabs ?? {}) };
+        const tabs: TabsConfig = { ...defaultTabs, ...(cfg.tabs ?? {}) };
         const disabledTabs = new Set<string>(
           Array.isArray(cfg.disabled_tabs) ? cfg.disabled_tabs : [],
         );
-        for (const [tab, enabled] of Object.entries(tabs) as [keyof TabsConfig, boolean][]) {
-          if (!enabled) disabledTabs.add(tab);
+        for (const [tab, enabled] of Object.entries(tabs) as [string, boolean][]) {
+          if (!enabled) disabledTabs.add(String(tab));
         }
         const theme = isTheme(cfg.theme) ? cfg.theme : "system";
         setConfig({


### PR DESCRIPTION
## Summary
- fix tab merging to avoid undefined booleans
- ensure disabled tab detection uses string keys

## Testing
- `npm test` (fails: 2 failing tests)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a034b5bad48327a9dc759ed9f2fc3d