### PR TITLE
Remove unused mode case from App switch

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -140,9 +140,6 @@ export default function App() {
       case "timeseries":
         newMode = "timeseries";
         break;
-      case "groupInstrumentMemberTimeseries":
-        newMode = "groupInstrumentMemberTimeseries";
-        break;
       case "watchlist":
         newMode = "watchlist";
         break;


### PR DESCRIPTION
## Summary
- drop stray `groupInstrumentMemberTimeseries` case from App route switch

## Testing
- `npm test -- --run` *(fails: App hides disabled tabs, App defaults to Movers view)*

------
https://chatgpt.com/codex/tasks/task_e_68a034b1154c83278188052f2dca78b4