### PR TITLE
Add coding practice management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import Watchlist from "./pages/Watchlist";
 import TopMovers from "./pages/TopMovers";
 import { useConfig } from "./ConfigContext";
 import DataAdmin from "./pages/DataAdmin";
+import CodingPracticePage from "./CodingPracticePage.js";
 
 type Mode =
   | "owner"
@@ -40,7 +41,8 @@ type Mode =
   | "watchlist"
   | "movers"
   | "dataadmin"
-  | "support";
+  | "support"
+  | "codingpractice";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -56,6 +58,7 @@ const initialMode: Mode =
   path[0] === "movers" ? "movers" :
   path[0] === "dataadmin" ? "dataadmin" :
   path[0] === "support" ? "support" :
+  path[0] === "coding-practice" ? "codingpractice" :
   path.length === 0 && params.has("group") ? "group" : "movers";
 const initialSlug = path[1] ?? "";
 
@@ -102,6 +105,7 @@ export default function App() {
     "watchlist",
     "dataadmin",
     "support",
+    "codingpractice",
   ];
 
   function pathFor(m: Mode) {
@@ -116,6 +120,8 @@ export default function App() {
         return selectedOwner ? `/performance/${selectedOwner}` : "/performance";
       case "movers":
         return "/movers";
+      case "codingpractice":
+        return "/coding-practice";
       default:
         return `/${m}`;
     }
@@ -158,6 +164,9 @@ export default function App() {
         break;
       case "support":
         newMode = "support";
+        break;
+      case "coding-practice":
+        newMode = "codingpractice";
         break;
       default:
         newMode = segs.length === 0 && params.has("group") ? "group" : "movers";
@@ -381,6 +390,7 @@ export default function App() {
       {mode === "timeseries" && <TimeseriesEdit />}
       {mode === "dataadmin" && <DataAdmin />}
       {mode === "watchlist" && <Watchlist />}
+      {mode === "codingpractice" && <CodingPracticePage />}
       {mode === "movers" && <TopMovers />}
     </div>
   );

--- a/frontend/src/CodingPracticePage.d.ts
+++ b/frontend/src/CodingPracticePage.d.ts
@@ -1,0 +1,5 @@
+declare module "./CodingPracticePage.js" {
+  import type { FunctionComponent } from "react";
+  const Component: FunctionComponent;
+  export default Component;
+}

--- a/frontend/src/CodingPracticePage.js
+++ b/frontend/src/CodingPracticePage.js
@@ -1,0 +1,71 @@
+import { useState, useEffect } from "react";
+import { getPuzzles, createPuzzle, updatePuzzle, deletePuzzle } from "./api/codingPractice";
+
+export default function CodingPracticePage() {
+  const [puzzles, setPuzzles] = useState([]);
+  const [form, setForm] = useState({ title: "", description: "" });
+  const [editing, setEditing] = useState(null);
+
+  const load = async () => {
+    try {
+      const data = await getPuzzles();
+      setPuzzles(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (editing) {
+      await updatePuzzle(editing, form);
+    } else {
+      await createPuzzle(form);
+    }
+    setForm({ title: "", description: "" });
+    setEditing(null);
+    load();
+  };
+
+  const startEdit = (p) => {
+    setEditing(p.id);
+    setForm({ title: p.title, description: p.description });
+  };
+
+  const handleDelete = async (id) => {
+    await deletePuzzle(id);
+    load();
+  };
+
+  return (
+    <div>
+      <h2>Coding Practice</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          placeholder="Title"
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+        />
+        <input
+          placeholder="Description"
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+        />
+        <button type="submit">{editing ? "Update" : "Add"}</button>
+      </form>
+      <ul>
+        {puzzles.map((p) => (
+          <li key={p.id}>
+            <strong>{p.title}</strong> - {p.description}{" "}
+            <button onClick={() => startEdit(p)}>Edit</button>{" "}
+            <button onClick={() => handleDelete(p.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/api/codingPractice.js
+++ b/frontend/src/api/codingPractice.js
@@ -1,0 +1,28 @@
+import { API_BASE } from "../api";
+
+async function fetchJson(url, init) {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export const getPuzzles = () => fetchJson(`${API_BASE}/codingpractice`);
+
+export const createPuzzle = (puzzle) =>
+  fetchJson(`${API_BASE}/codingpractice`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(puzzle),
+  });
+
+export const updatePuzzle = (id, puzzle) =>
+  fetchJson(`${API_BASE}/codingpractice/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(puzzle),
+  });
+
+export const deletePuzzle = (id) =>
+  fetchJson(`${API_BASE}/codingpractice/${id}`, { method: "DELETE" });

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Support"
+      "support": "Support",
+      "codingpractice": "Coding Practice"
     }
   },
   "common": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Support"
+      "support": "Support",
+      "codingpractice": "Coding Practice"
     }
   },
   "common": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Soporte"
+      "support": "Soporte",
+      "codingpractice": "Coding Practice"
     }
   },
   "common": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Support"
+      "support": "Support",
+      "codingpractice": "Coding Practice"
     }
   },
   "common": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Suporte"
+      "support": "Suporte",
+      "codingpractice": "Coding Practice"
     }
   },
   "common": {

--- a/frontend/test/codingPractice.test.js
+++ b/frontend/test/codingPractice.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getPuzzles,
+  createPuzzle,
+  updatePuzzle,
+  deletePuzzle,
+} from "../src/api/codingPractice.js";
+import { API_BASE } from "../src/api";
+
+describe("coding practice api", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+  });
+
+  it("fetches puzzles", async () => {
+    await getPuzzles();
+    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/codingpractice`, undefined);
+  });
+
+  it("creates puzzle", async () => {
+    await createPuzzle({ title: "x" });
+    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/codingpractice`, expect.objectContaining({ method: "POST" }));
+  });
+
+  it("updates puzzle", async () => {
+    await updatePuzzle("1", { title: "y" });
+    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/codingpractice/1`, expect.objectContaining({ method: "PUT" }));
+  });
+
+  it("deletes puzzle", async () => {
+    await deletePuzzle("1");
+    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/codingpractice/1`, expect.objectContaining({ method: "DELETE" }));
+  });
+});

--- a/jd-backend/python/coding_practice.py
+++ b/jd-backend/python/coding_practice.py
@@ -1,0 +1,50 @@
+import os
+import json
+import uuid
+
+import boto3
+
+
+TABLE_NAME = os.environ.get("CODING_PRACTICE_TABLE", "JD_CodingPractice")
+_dynamodb = boto3.resource("dynamodb", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+_table = _dynamodb.Table(TABLE_NAME)
+
+
+def _response(status: int, body):
+    return {"statusCode": status, "body": json.dumps(body)}
+
+
+def list_puzzles(event, context):
+    """Return all coding puzzles from the DynamoDB table."""
+    items = _table.scan().get("Items", [])
+    return _response(200, items)
+
+
+def add_puzzle(event, context):
+    """Insert a new puzzle into the table."""
+    data = json.loads(event.get("body", "{}"))
+    if "id" not in data:
+        data["id"] = str(uuid.uuid4())
+    _table.put_item(Item=data)
+    return _response(200, data)
+
+
+def update_puzzle(event, context):
+    """Replace an existing puzzle with new data."""
+    data = json.loads(event.get("body", "{}"))
+    if "id" not in data:
+        return _response(400, {"error": "id required"})
+    _table.put_item(Item=data)
+    return _response(200, data)
+
+
+def delete_puzzle(event, context):
+    """Delete a puzzle by id."""
+    puzzle_id = event.get("pathParameters", {}).get("id")
+    if not puzzle_id:
+        body = json.loads(event.get("body", "{}"))
+        puzzle_id = body.get("id")
+    if not puzzle_id:
+        return _response(400, {"error": "id required"})
+    _table.delete_item(Key={"id": puzzle_id})
+    return _response(200, {"id": puzzle_id})

--- a/tests/test_coding_practice.py
+++ b/tests/test_coding_practice.py
@@ -1,0 +1,64 @@
+import json
+import pathlib
+import os
+
+# moto requires dummy credentials before importing the module
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+import boto3
+from moto import mock_aws
+
+# dynamically import the coding_practice module
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "jd-backend/python/coding_practice.py"
+spec = None
+if MODULE_PATH.exists():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("coding_practice", MODULE_PATH)
+    coding_practice = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(coding_practice)
+else:  # pragma: no cover - defensive fallback
+    raise FileNotFoundError(MODULE_PATH)
+
+
+@mock_aws
+def test_crud_cycle():
+    table_name = "JD_CodingPractice"
+    dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+    dynamodb.create_table(
+        TableName=table_name,
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    # list should be empty
+    resp = coding_practice.list_puzzles({}, {})
+    assert resp["statusCode"] == 200
+    assert json.loads(resp["body"]) == []
+
+    # add a puzzle
+    body = {"title": "Two Sum", "description": "Find indices"}
+    resp = coding_practice.add_puzzle({"body": json.dumps(body)}, {})
+    data = json.loads(resp["body"])
+    assert "id" in data and data["title"] == "Two Sum"
+    puzzle_id = data["id"]
+
+    # update puzzle
+    updated = {"id": puzzle_id, "title": "Two Sum", "description": "Find indices that add up"}
+    resp = coding_practice.update_puzzle({"body": json.dumps(updated)}, {})
+    assert resp["statusCode"] == 200
+
+    # list should include updated puzzle
+    resp = coding_practice.list_puzzles({}, {})
+    items = json.loads(resp["body"])
+    assert len(items) == 1 and items[0]["description"].startswith("Find")
+
+    # delete puzzle
+    resp = coding_practice.delete_puzzle({"pathParameters": {"id": puzzle_id}}, {})
+    assert resp["statusCode"] == 200
+
+    # list empty again
+    resp = coding_practice.list_puzzles({}, {})
+    assert json.loads(resp["body"]) == []


### PR DESCRIPTION
## Summary
- Implement CodingPracticePage with form and list for puzzles
- Expose API helpers and backend DynamoDB CRUD handlers
- Wire new coding practice route and add basic translations
- Add unit tests for serverless functions and client API

## Testing
- `pytest tests/test_coding_practice.py`
- `npm test test/codingPractice.test.js --silent`

------
https://chatgpt.com/codex/tasks/task_e_68a0b99501148327b874c8127ab64de6