### PR TITLE
docs: add technical support guide

### DIFF
--- a/docs/TECHNICAL_SUPPORT.md
+++ b/docs/TECHNICAL_SUPPORT.md
@@ -1,0 +1,21 @@
+# Technical Support Guide
+
+## Environment Setup
+- **Python**: Install dependencies with `pip install -r requirements.txt`.
+- **Frontend**: From `frontend`, install packages via `npm install`.
+- **Configuration**: Review and adjust `config.yaml` for local or AWS environments.
+
+## Common Troubleshooting Steps
+- Verify that Python (3.12) and Node.js versions meet project requirements.
+- Clear cached data under `data/cache/` if stale responses cause issues.
+- Run `pytest` and `npm test` to check for failing tests before debugging.
+- Ensure environment variables like `DATA_BUCKET` or API keys are correctly set.
+
+## Log Locations
+- Backend logs are written to `backend.log` as configured in `backend/logging.ini`.
+- The `run_with_error_summary.py` helper records errors in `error_summary.log`.
+
+## Escalation Contacts
+- **Primary**: engineering@allotmint.example.com
+- **Backup**: ops@allotmint.example.com
+- **Emergency**: +44-20-0000-0000


### PR DESCRIPTION
## Summary
- document environment setup, troubleshooting, logs, and escalation contacts in a new Technical Support guide

## Testing
- `pytest`
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d81c9aa88327a474b8d7a08e249d