### PR TITLE
Remove redundant logging configuration

### DIFF
--- a/backend/timeseries/fetch_yahoo_timeseries.py
+++ b/backend/timeseries/fetch_yahoo_timeseries.py
@@ -8,7 +8,6 @@ from backend.utils.timeseries_helpers import STANDARD_COLUMNS
 
 # Setup logger
 logger = logging.getLogger("yahoo_timeseries")
-logging.basicConfig(level=logging.DEBUG)
 
 def _build_full_ticker(ticker: str, exchange: str) -> str:
     """


### PR DESCRIPTION
## Summary
- Remove `logging.basicConfig` call from Yahoo timeseries fetcher to use centralized logging configuration

## Testing
- `pytest tests/test_quotes_route.py tests/test_timeseries_edit_route.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d81513d083279637745151b6cb86