### PR TITLE
refactor coding practice api to share fetch helper

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -33,7 +33,7 @@ export const API_BASE =
 /* ------------------------------------------------------------------ */
 /* Generic fetch helper                                                */
 /* ------------------------------------------------------------------ */
-async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, init);
   if (!res.ok) {
     throw new Error(`HTTP ${res.status} – ${res.statusText} (${url})`);

--- a/frontend/src/api/codingPractice.js
+++ b/frontend/src/api/codingPractice.js
@@ -1,0 +1,20 @@
+import { API_BASE, fetchJson } from "../api";
+
+export const getPuzzles = () => fetchJson(`${API_BASE}/codingpractice`);
+
+export const createPuzzle = (puzzle) =>
+  fetchJson(`${API_BASE}/codingpractice`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(puzzle),
+  });
+
+export const updatePuzzle = (id, puzzle) =>
+  fetchJson(`${API_BASE}/codingpractice/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(puzzle),
+  });
+
+export const deletePuzzle = (id) =>
+  fetchJson(`${API_BASE}/codingpractice/${id}`, { method: "DELETE" });

--- a/frontend/src/api/codingPractice.test.js
+++ b/frontend/src/api/codingPractice.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getPuzzles,
+  createPuzzle,
+  updatePuzzle,
+  deletePuzzle,
+} from "./codingPractice.js";
+import { API_BASE } from "../api";
+
+describe("coding practice api", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+  });
+
+  it("fetches puzzles", async () => {
+    await getPuzzles();
+    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/codingpractice`, undefined);
+  });
+
+  it("creates puzzle", async () => {
+    await createPuzzle({ title: "x" });
+    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/codingpractice`, expect.objectContaining({ method: "POST" }));
+  });
+
+  it("updates puzzle", async () => {
+    await updatePuzzle("1", { title: "y" });
+    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/codingpractice/1`, expect.objectContaining({ method: "PUT" }));
+  });
+
+  it("deletes puzzle", async () => {
+    await deletePuzzle("1");
+    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/codingpractice/1`, expect.objectContaining({ method: "DELETE" }));
+  });
+});


### PR DESCRIPTION
## Summary
- add coding practice API wrapper that reuses shared fetchJson helper
- export fetchJson from main api module for reuse

## Testing
- `cd frontend && npm test -- src/api/codingPractice.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0d8180c24832791260262b5480743