### PR TITLE
Add scenario tester utility and UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -32,6 +32,7 @@ from backend.routes.trading_agent import router as trading_agent_router
 from backend.routes.config import router as config_router
 from backend.routes.quotes import router as quotes_router
 from backend.routes.movers import router as movers_router
+from backend.routes.scenario import router as scenario_router
 from backend.common.portfolio_utils import (
     _load_snapshot,
     refresh_snapshot_async,
@@ -87,6 +88,7 @@ def create_app() -> FastAPI:
     app.include_router(config_router)
     app.include_router(quotes_router)
     app.include_router(movers_router)
+    app.include_router(scenario_router)
 
     # ────────────────────── Health-check endpoint ─────────────────────
     @app.get("/health")

--- a/backend/routes/scenario.py
+++ b/backend/routes/scenario.py
@@ -1,0 +1,26 @@
+"""Simple scenario testing endpoint."""
+
+from fastapi import APIRouter, Query
+
+from backend.utils.scenario_tester import apply_price_shock
+from backend.common.portfolio_loader import list_portfolios
+
+router = APIRouter(tags=["scenario"])
+
+
+@router.get("/scenario")
+def run_scenario(
+    ticker: str = Query(..., description="Ticker symbol"),
+    pct: float = Query(..., description="Percentage change"),
+):
+    """Apply a percentage price shock to all portfolios for ``ticker``."""
+    results = []
+    for pf in list_portfolios():
+        shocked = apply_price_shock(pf, ticker, pct)
+        results.append(
+            {
+                "owner": pf.get("owner"),
+                "total_value_estimate_gbp": shocked.get("total_value_estimate_gbp"),
+            }
+        )
+    return results

--- a/backend/utils/scenario_tester.py
+++ b/backend/utils/scenario_tester.py
@@ -1,0 +1,54 @@
+"""Utility helpers for simple price-shock scenarios."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict
+
+from backend.common.constants import (
+    EFFECTIVE_COST_BASIS_GBP,
+    COST_BASIS_GBP,
+)
+
+
+def apply_price_shock(portfolio: Dict[str, Any], ticker: str, pct_change: float) -> Dict[str, Any]:
+    """Return a new portfolio with ``ticker`` shocked by ``pct_change`` percent.
+
+    ``pct_change`` is interpreted as a percentage (e.g. ``5`` for +5%).
+    The function recalculates affected holding metrics, account totals and the
+    overall portfolio total.  The original ``portfolio`` is not modified.
+    """
+
+    shocked = deepcopy(portfolio)
+    target = ticker.upper()
+    factor = 1 + pct_change / 100.0
+
+    for acct in shocked.get("accounts", []):
+        total = 0.0
+        for h in acct.get("holdings", []):
+            tkr = (h.get("ticker") or "").upper()
+            units = float(h.get("units") or 0.0)
+            if tkr == target:
+                price = float(h.get("current_price_gbp") or h.get("price") or 0.0)
+                new_price = price * factor
+                cost = float(
+                    h.get(EFFECTIVE_COST_BASIS_GBP)
+                    or h.get(COST_BASIS_GBP)
+                    or 0.0
+                )
+                mv = units * new_price
+                gain = mv - cost
+                h["price"] = h["current_price_gbp"] = round(new_price, 4)
+                h["market_value_gbp"] = round(mv, 2)
+                h["gain_gbp"] = round(gain, 2)
+                h["unrealised_gain_gbp"] = h["unrealized_gain_gbp"] = round(gain, 2)
+                h["gain_pct"] = round((gain / cost * 100.0), 2) if cost else None
+                h["day_change_gbp"] = round((new_price - price) * units, 2)
+            total += float(h.get("market_value_gbp") or 0.0)
+        acct["value_estimate_gbp"] = round(total, 2)
+
+    shocked["total_value_estimate_gbp"] = round(
+        sum(a.get("value_estimate_gbp") or 0.0 for a in shocked.get("accounts", [])),
+        2,
+    )
+    return shocked

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -130,6 +130,7 @@ describe("App", () => {
       dataadmin: true,
       virtual: true,
       support: true,
+      scenario: true,
     };
 
     render(
@@ -182,6 +183,7 @@ describe("App", () => {
       dataadmin: true,
       virtual: true,
       support: true,
+      scenario: true,
     };
 
     render(
@@ -246,6 +248,7 @@ describe("App", () => {
       "Watchlist",
       "Data Admin",
       "Support",
+      "Scenario Tester",
     ]);
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import Watchlist from "./pages/Watchlist";
 import TopMovers from "./pages/TopMovers";
 import { useConfig } from "./ConfigContext";
 import DataAdmin from "./pages/DataAdmin";
+import ScenarioTester from "./pages/ScenarioTester";
 
 type Mode =
   | "owner"
@@ -40,7 +41,8 @@ type Mode =
   | "watchlist"
   | "movers"
   | "dataadmin"
-  | "support";
+  | "support"
+  | "scenario";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -56,6 +58,7 @@ const initialMode: Mode =
   path[0] === "movers" ? "movers" :
   path[0] === "dataadmin" ? "dataadmin" :
   path[0] === "support" ? "support" :
+  path[0] === "scenario" ? "scenario" :
   path.length === 0 && params.has("group") ? "group" : "movers";
 const initialSlug = path[1] ?? "";
 
@@ -102,6 +105,7 @@ export default function App() {
     "watchlist",
     "dataadmin",
     "support",
+    "scenario",
   ];
 
   function pathFor(m: Mode) {
@@ -116,6 +120,8 @@ export default function App() {
         return selectedOwner ? `/performance/${selectedOwner}` : "/performance";
       case "movers":
         return "/movers";
+      case "scenario":
+        return "/scenario";
       default:
         return `/${m}`;
     }
@@ -155,6 +161,9 @@ export default function App() {
         break;
       case "support":
         newMode = "support";
+        break;
+      case "scenario":
+        newMode = "scenario";
         break;
       default:
         newMode = segs.length === 0 && params.has("group") ? "group" : "movers";
@@ -379,6 +388,7 @@ export default function App() {
       {mode === "dataadmin" && <DataAdmin />}
       {mode === "watchlist" && <Watchlist />}
       {mode === "movers" && <TopMovers />}
+      {mode === "scenario" && <ScenarioTester />}
     </div>
   );
 }

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -20,6 +20,7 @@ export interface TabsConfig {
   dataadmin: boolean;
   virtual: boolean;
   support: boolean;
+  scenario: boolean;
 }
 
 export interface AppConfig {
@@ -52,6 +53,7 @@ const defaultTabs: TabsConfig = {
   dataadmin: true,
   virtual: true,
   support: true,
+  scenario: true,
 };
 
 export const configContext = createContext<AppConfig>({

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -20,6 +20,7 @@ import type {
   ComplianceResult,
   MoverRow,
   TimeseriesSummary,
+  ScenarioResult,
 } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -101,6 +102,12 @@ export const getGroupMovers = (
   return fetchJson<{ gainers: MoverRow[]; losers: MoverRow[] }>(
     `${API_BASE}/portfolio-group/${slug}/movers?${params.toString()}`,
   );
+};
+
+/** Apply a price shock scenario to all portfolios. */
+export const runScenario = (ticker: string, pct: number) => {
+  const params = new URLSearchParams({ ticker, pct: String(pct) });
+  return fetchJson<ScenarioResult[]>(`${API_BASE}/scenario?${params.toString()}`);
 };
 
 /** Retrieve per-ticker aggregation for a group portfolio. */

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Support"
+      "support": "Support",
+      "scenario": "Szenario-Tester"
     }
   },
   "common": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Support"
+      "support": "Support",
+      "scenario": "Scenario Tester"
     }
   },
   "common": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Soporte"
+      "support": "Soporte",
+      "scenario": "Probador de Escenarios"
     }
   },
   "common": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Support"
+      "support": "Support",
+      "scenario": "Testeur de Scénario"
     }
   },
   "common": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -17,7 +17,8 @@
       "watchlist": "Watchlist",
       "movers": "Movers",
       "dataadmin": "Data Admin",
-      "support": "Suporte"
+      "support": "Suporte",
+      "scenario": "Testador de Cenários"
     }
   },
   "common": {

--- a/frontend/src/pages/ScenarioTester.tsx
+++ b/frontend/src/pages/ScenarioTester.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { runScenario } from "../api";
+import type { ScenarioResult } from "../types";
+
+export default function ScenarioTester() {
+  const [ticker, setTicker] = useState("");
+  const [pct, setPct] = useState("");
+  const [results, setResults] = useState<ScenarioResult[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleRun() {
+    setError(null);
+    try {
+      const pctNum = parseFloat(pct);
+      const data = await runScenario(ticker, pctNum);
+      setResults(data);
+    } catch (e) {
+      setResults(null);
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: "1rem" }}>
+        <input
+          placeholder="Ticker"
+          value={ticker}
+          onChange={(e) => setTicker(e.target.value)}
+          style={{ marginRight: "0.5rem" }}
+        />
+        <input
+          type="number"
+          placeholder="% Change"
+          value={pct}
+          onChange={(e) => setPct(e.target.value)}
+          style={{ marginRight: "0.5rem" }}
+        />
+        <button onClick={handleRun}>Apply</button>
+      </div>
+      {error && <div style={{ color: "red" }}>{error}</div>}
+      {results && (
+        <pre style={{ maxHeight: "400px", overflow: "auto" }}>
+          {JSON.stringify(results, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -158,6 +158,11 @@ export type Alert = {
     timestamp: string;
 };
 
+export interface ScenarioResult {
+    owner: string;
+    total_value_estimate_gbp: number;
+}
+
 export type ComplianceResult = {
     owner: string;
     warnings: string[];

--- a/tests/test_scenario_route.py
+++ b/tests/test_scenario_route.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from backend.local_api.main import app
+
+client = TestClient(app)
+
+
+def test_scenario_route():
+    resp = client.get("/scenario?ticker=VWRL.L&pct=5")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    if data:
+        first = data[0]
+        assert "owner" in first
+        assert "total_value_estimate_gbp" in first


### PR DESCRIPTION
## Summary
- implement `apply_price_shock` utility to simulate price shocks on a portfolio
- expose `/scenario` API route and wire it into the app
- add Scenario Tester tab on the frontend with basic controls and translations

## Testing
- `pytest tests/test_scenario_route.py -q`
- `pytest tests/test_backend_api.py::test_health tests/test_backend_api.py::test_owners -q`
- `cd frontend && npm test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a0f363669c8327ad54454a8a56c500