### PR TITLE
chore: add video dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,13 @@ secrets, as they are no longer required.
 
 ## 🎬 Generating the Overview Video
 
+Install the video dependencies first. The `requirements.txt` file includes
+`moviepy` and `gTTS`:
+
+```bash
+pip install -r requirements.txt
+```
+
 Save an image named `presenter.png` in the `scripts` directory, then run:
 
 ```bash

--- a/USER_README.md
+++ b/USER_README.md
@@ -5,7 +5,8 @@ AllotMint helps families track and manage investments like tending an allotment.
 
 ## Installation
 1. **Clone the repository** and move into the project directory.
-2. **Backend dependencies**: `pip install -r requirements.txt`
+2. **Backend dependencies**: `pip install -r requirements.txt` (includes
+   `moviepy` and `gTTS` for video generation)
 3. **Frontend dependencies**: change into the `frontend/` folder and run `npm install`
 
 ## Configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,3 +67,5 @@ jinja2~=3.1.4
 
 playwright~=1.49.0
 openai~=1.51.0
+moviepy~=2.2.1
+gTTS~=2.5.4


### PR DESCRIPTION
## Summary
- include `moviepy` and `gTTS` in backend requirements
- document the new video dependencies in README and user setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0fcdc57d8832790f068b90896e96c