### PR TITLE
Handle missing price in scenario shocks

### DIFF
--- a/backend/routes/scenario.py
+++ b/backend/routes/scenario.py
@@ -17,10 +17,17 @@ def run_scenario(
     results = []
     for pf in list_portfolios():
         shocked = apply_price_shock(pf, ticker, pct)
+        baseline = pf.get("total_value_estimate_gbp")
+        shocked_total = shocked.get("total_value_estimate_gbp")
+        delta = None
+        if baseline is not None and shocked_total is not None:
+            delta = round(shocked_total - baseline, 2)
         results.append(
             {
                 "owner": pf.get("owner"),
-                "total_value_estimate_gbp": shocked.get("total_value_estimate_gbp"),
+                "baseline_total_value_gbp": baseline,
+                "shocked_total_value_gbp": shocked_total,
+                "delta_gbp": delta,
             }
         )
     return results

--- a/backend/utils/scenario_tester.py
+++ b/backend/utils/scenario_tester.py
@@ -9,6 +9,7 @@ from backend.common.constants import (
     EFFECTIVE_COST_BASIS_GBP,
     COST_BASIS_GBP,
 )
+from backend.common.prices import get_price_gbp
 
 
 def apply_price_shock(portfolio: Dict[str, Any], ticker: str, pct_change: float) -> Dict[str, Any]:
@@ -30,6 +31,9 @@ def apply_price_shock(portfolio: Dict[str, Any], ticker: str, pct_change: float)
             units = float(h.get("units") or 0.0)
             if tkr == target:
                 price = float(h.get("current_price_gbp") or h.get("price") or 0.0)
+                if price == 0:
+                    cached = get_price_gbp(tkr)
+                    price = float(cached or 0.0)
                 new_price = price * factor
                 cost = float(
                     h.get(EFFECTIVE_COST_BASIS_GBP)

--- a/tests/test_scenario_route.py
+++ b/tests/test_scenario_route.py
@@ -13,4 +13,6 @@ def test_scenario_route():
     if data:
         first = data[0]
         assert "owner" in first
-        assert "total_value_estimate_gbp" in first
+        assert "baseline_total_value_gbp" in first
+        assert "shocked_total_value_gbp" in first
+        assert "delta_gbp" in first

--- a/tests/test_scenario_tester.py
+++ b/tests/test_scenario_tester.py
@@ -1,0 +1,27 @@
+import backend.common.prices as prices
+from backend.utils.scenario_tester import apply_price_shock
+
+
+def test_price_shock_uses_cached_price_for_missing_current_price(monkeypatch):
+    portfolio = {
+        "accounts": [
+            {
+                "holdings": [
+                    {
+                        "ticker": "ABC.L",
+                        "units": 10,
+                        "market_value_gbp": 0.0,
+                    }
+                ],
+                "value_estimate_gbp": 0.0,
+            }
+        ],
+        "total_value_estimate_gbp": 0.0,
+    }
+
+    monkeypatch.setattr(prices, "_price_cache", {"ABC.L": 5.0})
+
+    shocked = apply_price_shock(portfolio, "ABC.L", 10)
+
+    assert shocked["accounts"][0]["value_estimate_gbp"] > 0
+    assert shocked["total_value_estimate_gbp"] > 0


### PR DESCRIPTION
## Summary
- fetch cached GBP prices when shocking holdings with no current price
- expose baseline, shocked and delta totals in scenario endpoint
- test scenario route and cached-price shock behavior

## Testing
- `pytest tests/test_scenario_route.py tests/test_scenario_tester.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0ff220c648327bfc564df526c6454