### PR TITLE
Rework Support page config layout into grid

### DIFF
--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { vi } from "vitest";
 
 const mockGetConfig = vi.hoisted(() => vi.fn());
@@ -68,7 +68,7 @@ describe("Support page", () => {
 
   it("renders tab toggles and allows toggling", async () => {
     render(<Support />);
-    await screen.findByText(/Feature Switches/i);
+    await screen.findByText(/Tabs Enabled/i);
     const instrument = await screen.findByRole("checkbox", {
       name: /instrument/i,
     });
@@ -79,6 +79,31 @@ describe("Support page", () => {
     fireEvent.click(support);
     expect(instrument).not.toBeChecked();
     expect(support).not.toBeChecked();
+  });
+
+  it("separates switches from other parameters", async () => {
+    render(<Support />);
+    const switchesHeading = await screen.findByRole("heading", {
+      name: /Other Switches/i,
+    });
+    const switchesSection = switchesHeading.parentElement as HTMLElement;
+    expect(
+      within(switchesSection).getByRole("checkbox", { name: /flag/i })
+    ).toBeInTheDocument();
+    expect(
+      within(switchesSection).queryByRole("radio", { name: /dark/i })
+    ).toBeNull();
+
+    const paramsHeading = screen.getByRole("heading", {
+      name: /Other parameters/i,
+    });
+    const paramsSection = paramsHeading.parentElement as HTMLElement;
+    expect(
+      within(paramsSection).getByRole("radio", { name: /dark/i })
+    ).toBeInTheDocument();
+    expect(
+      within(paramsSection).queryByRole("checkbox", { name: /flag/i })
+    ).toBeNull();
   });
 
   it("allows selecting theme via radio buttons", async () => {

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -169,58 +169,76 @@ export default function Support() {
         <p>Loading…</p>
       ) : (
         <form onSubmit={saveConfig}>
-          <div style={{ marginBottom: "0.5rem" }}>
-            <h3>Feature Switches</h3>
-            {TAB_KEYS.map((tab) => (
-              <label key={tab} style={{ display: "block", fontWeight: 500 }}>
-                <input
-                  type="checkbox"
-                  checked={tabs[tab]}
-                  onChange={(e) => handleTabChange(tab, e.target.checked)}
-                />
-                {tab}
-              </label>
-            ))}
-          </div>
-          {Object.entries(config)
-            .filter(([k]) => k !== "tabs")
-            .map(([key, value]) => (
-              <div key={key} style={{ marginBottom: "0.5rem" }}>
-                {key === "theme" && typeof value === "string" ? (
-                  <div>
-                    <label style={{ display: "block", fontWeight: 500 }}>{key}</label>
-                    {["dark", "light", "system"].map((opt) => (
-                      <label key={opt} style={{ marginRight: "0.5rem" }}>
-                        <input
-                          type="radio"
-                          name="theme"
-                          value={opt}
-                          checked={value === opt}
-                          onChange={(e) => handleConfigChange(key, e.target.value)}
-                        />
-                        {opt}
-                      </label>
-                    ))}
-                  </div>
-                ) : typeof value === "boolean" ? (
-                  <label style={{ display: "block", fontWeight: 500 }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: "1rem",
+              marginBottom: "1rem",
+            }}
+          >
+            <div>
+              <h3>Tabs Enabled</h3>
+              {TAB_KEYS.map((tab) => (
+                <label key={tab} style={{ display: "block", fontWeight: 500 }}>
+                  <input
+                    type="checkbox"
+                    checked={tabs[tab]}
+                    onChange={(e) => handleTabChange(tab, e.target.checked)}
+                  />
+                  {tab}
+                </label>
+              ))}
+            </div>
+            <div>
+              <h3>Other Switches</h3>
+              {Object.entries(config)
+                .filter(([k, v]) => k !== "tabs" && typeof v === "boolean")
+                .map(([key, value]) => (
+                  <label key={key} style={{ display: "block", fontWeight: 500 }}>
                     <input
                       type="checkbox"
-                      checked={value}
+                      checked={value as boolean}
                       onChange={(e) => handleConfigChange(key, e.target.checked)}
                     />
                     {key}
                   </label>
-                ) : (
-                  <input
-                    type="text"
-                    value={String(value ?? "")}
-                    onChange={(e) => handleConfigChange(key, e.target.value)}
-                    style={{ width: "100%" }}
-                  />
-                )}
-              </div>
-            ))}
+                ))}
+            </div>
+          </div>
+          <div style={{ marginBottom: "0.5rem" }}>
+            <h3>Other parameters</h3>
+            {Object.entries(config)
+              .filter(([k, v]) => k !== "tabs" && typeof v !== "boolean")
+              .map(([key, value]) => (
+                <div key={key} style={{ marginBottom: "0.5rem" }}>
+                  {key === "theme" && typeof value === "string" ? (
+                    <div>
+                      <label style={{ display: "block", fontWeight: 500 }}>{key}</label>
+                      {["dark", "light", "system"].map((opt) => (
+                        <label key={opt} style={{ marginRight: "0.5rem" }}>
+                          <input
+                            type="radio"
+                            name="theme"
+                            value={opt}
+                            checked={value === opt}
+                            onChange={(e) => handleConfigChange(key, e.target.value)}
+                          />
+                          {opt}
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
+                    <input
+                      type="text"
+                      value={String(value ?? "")}
+                      onChange={(e) => handleConfigChange(key, e.target.value)}
+                      style={{ width: "100%" }}
+                    />
+                  )}
+                </div>
+              ))}
+          </div>
           <button type="submit">Save</button>
           {configStatus === "saved" && (
             <span style={{ marginLeft: "0.5rem", color: "green" }}>Saved</span>


### PR DESCRIPTION
## Summary
- Split Support page configuration into grid with separate sections for tabs, switches, and parameters
- Update Support page tests for new layout and headings

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0ff2334048327ad67f487ce354e7b