### PR TITLE
chore: stop managing pip dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ packaging~=24.1
 typing_extensions~=4.12.2
 h11~=0.16.0
 pyyaml~=6.0.2
-pip~=24.2
 attrs~=24.3.0
 distro~=1.9.0
 pysocks~=1.7.1

--- a/run-backend.ps1
+++ b/run-backend.ps1
@@ -81,7 +81,6 @@ if ($cfg.PSObject.Properties.Name -contains 'offline_mode') {
 
 if (-not $offline) {
   Write-Host 'Installing backend requirements...' -ForegroundColor Yellow
-  python -m pip install --upgrade pip
   python -m pip install -r .\requirements.txt
 } else {
   Write-Host 'Offline mode detected; skipping dependency installation.' -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- remove pinned pip from Python requirements
- avoid upgrading pip in Windows backend launcher

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1934c09048327a17fbd7bfb553907