### PR TITLE
Handle missing SNS configuration gracefully

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -46,7 +46,10 @@ def send_trade_alert(message: str, publish: bool = True) -> None:
     """
 
     if publish:
-        publish_alert({"message": message})
+        try:
+            publish_alert({"message": message})
+        except RuntimeError:
+            logger.info("SNS topic ARN not configured; skipping publish")
 
     if (
         os.getenv("TELEGRAM_BOT_TOKEN")

--- a/backend/common/alerts.py
+++ b/backend/common/alerts.py
@@ -15,7 +15,8 @@ def publish_sns_alert(alert: Dict) -> None:
     _RECENT_ALERTS.append(alert)
     topic_arn = config.sns_topic_arn
     if not topic_arn:
-        raise RuntimeError("missing SNS configuration")
+        logger.info("SNS topic ARN not configured; skipping publish")
+        return
 
     try:
         import boto3  # type: ignore

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -5,11 +5,13 @@ import pytest
 import backend.common.alerts as alerts
 
 
-def test_publish_alert_requires_config(monkeypatch):
+def test_publish_alert_without_config(monkeypatch, caplog):
     alerts._RECENT_ALERTS.clear()
     monkeypatch.setattr(alerts.config, "sns_topic_arn", None, raising=False)
-    with pytest.raises(RuntimeError):
+    with caplog.at_level("INFO"):
         alerts.publish_sns_alert({"message": "hi"})
+    assert alerts._RECENT_ALERTS[0]["message"] == "hi"
+    assert "SNS topic ARN not configured" in caplog.text
 
 
 def test_publish_alert_success(monkeypatch):

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -7,8 +7,8 @@ import backend.common.alerts as alerts
 
 client = TestClient(app)
 
-# ensure alerts do not raise due to missing config
-alerts.config.sns_topic_arn = "arn:dummy"
+# allow alerts to operate without SNS configuration
+alerts.config.sns_topic_arn = None
 
 
 def validate_timeseries(prices):


### PR DESCRIPTION
## Summary
- log and skip when SNS topic ARN not configured
- ensure trading agent ignores missing SNS
- adjust tests for no-SNS case

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a19348277c8327ab5a20a5285ee59a