### PR TITLE
Expand screener with dividend and market metrics

### DIFF
--- a/backend/routes/screener.py
+++ b/backend/routes/screener.py
@@ -24,6 +24,15 @@ async def screener(
     pe_max: float | None = Query(None),
     de_max: float | None = Query(None),
     fcf_min: float | None = Query(None),
+    dividend_yield_min: float | None = Query(None),
+    dividend_payout_ratio_max: float | None = Query(None),
+    beta_max: float | None = Query(None),
+    shares_outstanding_min: int | None = Query(None),
+    float_shares_min: int | None = Query(None),
+    market_cap_min: int | None = Query(None),
+    high_52w_max: float | None = Query(None),
+    low_52w_min: float | None = Query(None),
+    avg_volume_min: int | None = Query(None),
 ):
     """Return tickers that meet the supplied screening criteria."""
 
@@ -31,7 +40,24 @@ async def screener(
     if not symbols:
         raise HTTPException(status_code=400, detail="No tickers supplied")
 
-    params = f"{','.join(symbols)}|{peg_max}|{pe_max}|{de_max}|{fcf_min}"
+    params = "|".join(
+        [
+            ",".join(symbols),
+            str(peg_max),
+            str(pe_max),
+            str(de_max),
+            str(fcf_min),
+            str(dividend_yield_min),
+            str(dividend_payout_ratio_max),
+            str(beta_max),
+            str(shares_outstanding_min),
+            str(float_shares_min),
+            str(market_cap_min),
+            str(high_52w_max),
+            str(low_52w_min),
+            str(avg_volume_min),
+        ]
+    )
     page = "screener_" + hashlib.sha1(params.encode()).hexdigest()
     page_cache.schedule_refresh(
         page,
@@ -40,7 +66,16 @@ async def screener(
         peg_max=peg_max,
         pe_max=pe_max,
         de_max=de_max,
-        fcf_min=fcf_min: [
+        fcf_min=fcf_min,
+        dividend_yield_min=dividend_yield_min,
+        dividend_payout_ratio_max=dividend_payout_ratio_max,
+        beta_max=beta_max,
+        shares_outstanding_min=shares_outstanding_min,
+        float_shares_min=float_shares_min,
+        market_cap_min=market_cap_min,
+        high_52w_max=high_52w_max,
+        low_52w_min=low_52w_min,
+        avg_volume_min=avg_volume_min: [
             r.model_dump()
             for r in screen(
                 symbols,
@@ -48,6 +83,15 @@ async def screener(
                 pe_max=pe_max,
                 de_max=de_max,
                 fcf_min=fcf_min,
+                dividend_yield_min=dividend_yield_min,
+                dividend_payout_ratio_max=dividend_payout_ratio_max,
+                beta_max=beta_max,
+                shares_outstanding_min=shares_outstanding_min,
+                float_shares_min=float_shares_min,
+                market_cap_min=market_cap_min,
+                high_52w_max=high_52w_max,
+                low_52w_min=low_52w_min,
+                avg_volume_min=avg_volume_min,
             )
         ],
     )
@@ -63,6 +107,15 @@ async def screener(
             pe_max=pe_max,
             de_max=de_max,
             fcf_min=fcf_min,
+            dividend_yield_min=dividend_yield_min,
+            dividend_payout_ratio_max=dividend_payout_ratio_max,
+            beta_max=beta_max,
+            shares_outstanding_min=shares_outstanding_min,
+            float_shares_min=float_shares_min,
+            market_cap_min=market_cap_min,
+            high_52w_max=high_52w_max,
+            low_52w_min=low_52w_min,
+            avg_volume_min=avg_volume_min,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -32,11 +32,27 @@ class Fundamentals(BaseModel):
     pe_ratio: Optional[float] = None
     de_ratio: Optional[float] = None
     fcf: Optional[float] = None
+    dividend_yield: Optional[float] = None
+    dividend_payout_ratio: Optional[float] = None
+    beta: Optional[float] = None
+    shares_outstanding: Optional[int] = None
+    float_shares: Optional[int] = None
+    market_cap: Optional[int] = None
+    high_52w: Optional[float] = None
+    low_52w: Optional[float] = None
+    avg_volume: Optional[int] = None
 
 
 def _parse_float(value: Optional[str]) -> Optional[float]:
     try:
         return float(value) if value not in (None, "None", "") else None
+    except ValueError:
+        return None
+
+
+def _parse_int(value: Optional[str]) -> Optional[int]:
+    try:
+        return int(value) if value not in (None, "None", "") else None
     except ValueError:
         return None
 
@@ -76,6 +92,15 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
         pe_ratio=_parse_float(data.get("PERatio")),
         de_ratio=_parse_float(data.get("DebtToEquityTTM")),
         fcf=_parse_float(data.get("FreeCashFlowTTM")),
+        dividend_yield=_parse_float(data.get("DividendYield")),
+        dividend_payout_ratio=_parse_float(data.get("PayoutRatio")),
+        beta=_parse_float(data.get("Beta")),
+        shares_outstanding=_parse_int(data.get("SharesOutstanding")),
+        float_shares=_parse_int(data.get("SharesFloat")),
+        market_cap=_parse_int(data.get("MarketCapitalization")),
+        high_52w=_parse_float(data.get("52WeekHigh")),
+        low_52w=_parse_float(data.get("52WeekLow")),
+        avg_volume=_parse_int(data.get("AverageDailyVolume10Day")),
     )
 
     _CACHE[key] = (now, result)
@@ -90,6 +115,15 @@ def screen(
     pe_max: Optional[float] = None,
     de_max: Optional[float] = None,
     fcf_min: Optional[float] = None,
+    dividend_yield_min: Optional[float] = None,
+    dividend_payout_ratio_max: Optional[float] = None,
+    beta_max: Optional[float] = None,
+    shares_outstanding_min: Optional[int] = None,
+    float_shares_min: Optional[int] = None,
+    market_cap_min: Optional[int] = None,
+    high_52w_max: Optional[float] = None,
+    low_52w_min: Optional[float] = None,
+    avg_volume_min: Optional[int] = None,
 ) -> List[Fundamentals]:
     """Fetch fundamentals for multiple tickers and filter based on thresholds."""
 
@@ -108,6 +142,37 @@ def screen(
         if de_max is not None and (f.de_ratio is None or f.de_ratio > de_max):
             continue
         if fcf_min is not None and (f.fcf is None or f.fcf < fcf_min):
+            continue
+        if dividend_yield_min is not None and (
+            f.dividend_yield is None or f.dividend_yield < dividend_yield_min
+        ):
+            continue
+        if dividend_payout_ratio_max is not None and (
+            f.dividend_payout_ratio is None
+            or f.dividend_payout_ratio > dividend_payout_ratio_max
+        ):
+            continue
+        if beta_max is not None and (f.beta is None or f.beta > beta_max):
+            continue
+        if shares_outstanding_min is not None and (
+            f.shares_outstanding is None or f.shares_outstanding < shares_outstanding_min
+        ):
+            continue
+        if float_shares_min is not None and (
+            f.float_shares is None or f.float_shares < float_shares_min
+        ):
+            continue
+        if market_cap_min is not None and (
+            f.market_cap is None or f.market_cap < market_cap_min
+        ):
+            continue
+        if high_52w_max is not None and (f.high_52w is None or f.high_52w > high_52w_max):
+            continue
+        if low_52w_min is not None and (f.low_52w is None or f.low_52w < low_52w_min):
+            continue
+        if avg_volume_min is not None and (
+            f.avg_volume is None or f.avg_volume < avg_volume_min
+        ):
             continue
 
         results.append(f)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -128,6 +128,15 @@ export const getScreener = (
     pe_max?: number;
     de_max?: number;
     fcf_min?: number;
+    dividend_yield_min?: number;
+    dividend_payout_ratio_max?: number;
+    beta_max?: number;
+    shares_outstanding_min?: number;
+    float_shares_min?: number;
+    market_cap_min?: number;
+    high_52w_max?: number;
+    low_52w_min?: number;
+    avg_volume_min?: number;
   } = {},
 ) => {
   const params = new URLSearchParams({ tickers: tickers.join(",") });
@@ -135,6 +144,29 @@ export const getScreener = (
   if (criteria.pe_max != null) params.set("pe_max", String(criteria.pe_max));
   if (criteria.de_max != null) params.set("de_max", String(criteria.de_max));
   if (criteria.fcf_min != null) params.set("fcf_min", String(criteria.fcf_min));
+  if (criteria.dividend_yield_min != null)
+    params.set("dividend_yield_min", String(criteria.dividend_yield_min));
+  if (criteria.dividend_payout_ratio_max != null)
+    params.set(
+      "dividend_payout_ratio_max",
+      String(criteria.dividend_payout_ratio_max),
+    );
+  if (criteria.beta_max != null) params.set("beta_max", String(criteria.beta_max));
+  if (criteria.shares_outstanding_min != null)
+    params.set(
+      "shares_outstanding_min",
+      String(criteria.shares_outstanding_min),
+    );
+  if (criteria.float_shares_min != null)
+    params.set("float_shares_min", String(criteria.float_shares_min));
+  if (criteria.market_cap_min != null)
+    params.set("market_cap_min", String(criteria.market_cap_min));
+  if (criteria.high_52w_max != null)
+    params.set("high_52w_max", String(criteria.high_52w_max));
+  if (criteria.low_52w_min != null)
+    params.set("low_52w_min", String(criteria.low_52w_min));
+  if (criteria.avg_volume_min != null)
+    params.set("avg_volume_min", String(criteria.avg_volume_min));
   return fetchJson<ScreenerResult[]>(`${API_BASE}/screener?${params.toString()}`);
 };
 

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -131,6 +131,15 @@
     "maxPe": "Max P/E",
     "maxDe": "Max D/E",
     "minFcf": "Min FCF",
+    "minDividendYield": "Min Dividend Yield",
+    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
+    "maxBeta": "Max Beta",
+    "minSharesOutstanding": "Min Shares Outstanding",
+    "minFloatShares": "Min Float Shares",
+    "minMarketCap": "Min Market Cap",
+    "max52WeekHigh": "Max 52W High",
+    "min52WeekLow": "Min 52W Low",
+    "minAvgVolume": "Min Avg Volume",
     "run": "Ausführen",
     "loading": "Laden…"
   }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -140,6 +140,15 @@
     "maxPe": "Max P/E",
     "maxDe": "Max D/E",
     "minFcf": "Min FCF",
+    "minDividendYield": "Min Dividend Yield",
+    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
+    "maxBeta": "Max Beta",
+    "minSharesOutstanding": "Min Shares Outstanding",
+    "minFloatShares": "Min Float Shares",
+    "minMarketCap": "Min Market Cap",
+    "max52WeekHigh": "Max 52W High",
+    "min52WeekLow": "Min 52W Low",
+    "minAvgVolume": "Min Avg Volume",
     "run": "Run",
     "loading": "Loading…"
   }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -131,6 +131,15 @@
     "maxPe": "P/E máx",
     "maxDe": "D/E máx",
     "minFcf": "FCF mín",
+    "minDividendYield": "Min Dividend Yield",
+    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
+    "maxBeta": "Max Beta",
+    "minSharesOutstanding": "Min Shares Outstanding",
+    "minFloatShares": "Min Float Shares",
+    "minMarketCap": "Min Market Cap",
+    "max52WeekHigh": "Max 52W High",
+    "min52WeekLow": "Min 52W Low",
+    "minAvgVolume": "Min Avg Volume",
     "run": "Ejecutar",
     "loading": "Cargando…"
   }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -131,6 +131,15 @@
     "maxPe": "P/E max",
     "maxDe": "D/E max",
     "minFcf": "FCF min",
+    "minDividendYield": "Min Dividend Yield",
+    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
+    "maxBeta": "Max Beta",
+    "minSharesOutstanding": "Min Shares Outstanding",
+    "minFloatShares": "Min Float Shares",
+    "minMarketCap": "Min Market Cap",
+    "max52WeekHigh": "Max 52W High",
+    "min52WeekLow": "Min 52W Low",
+    "minAvgVolume": "Min Avg Volume",
     "run": "Exécuter",
     "loading": "Chargement…"
   }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -131,6 +131,15 @@
     "maxPe": "P/E máx",
     "maxDe": "D/E máx",
     "minFcf": "FCF mín",
+    "minDividendYield": "Min Dividend Yield",
+    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
+    "maxBeta": "Max Beta",
+    "minSharesOutstanding": "Min Shares Outstanding",
+    "minFloatShares": "Min Float Shares",
+    "minMarketCap": "Min Market Cap",
+    "max52WeekHigh": "Max 52W High",
+    "min52WeekLow": "Min 52W Low",
+    "minAvgVolume": "Min Avg Volume",
     "run": "Executar",
     "loading": "Carregando…"
   }

--- a/frontend/src/pages/Screener.tsx
+++ b/frontend/src/pages/Screener.tsx
@@ -12,6 +12,15 @@ export function Screener() {
   const [peMax, setPeMax] = useState("");
   const [deMax, setDeMax] = useState("");
   const [fcfMin, setFcfMin] = useState("");
+  const [dividendYieldMin, setDividendYieldMin] = useState("");
+  const [dividendPayoutRatioMax, setDividendPayoutRatioMax] = useState("");
+  const [betaMax, setBetaMax] = useState("");
+  const [sharesOutstandingMin, setSharesOutstandingMin] = useState("");
+  const [floatSharesMin, setFloatSharesMin] = useState("");
+  const [marketCapMin, setMarketCapMin] = useState("");
+  const [high52wMax, setHigh52wMax] = useState("");
+  const [low52wMin, setLow52wMin] = useState("");
+  const [avgVolumeMin, setAvgVolumeMin] = useState("");
 
   const [rows, setRows] = useState<ScreenerResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -40,6 +49,25 @@ export function Screener() {
         pe_max: peMax ? parseFloat(peMax) : undefined,
         de_max: deMax ? parseFloat(deMax) : undefined,
         fcf_min: fcfMin ? parseFloat(fcfMin) : undefined,
+        dividend_yield_min: dividendYieldMin
+          ? parseFloat(dividendYieldMin)
+          : undefined,
+        dividend_payout_ratio_max: dividendPayoutRatioMax
+          ? parseFloat(dividendPayoutRatioMax)
+          : undefined,
+        beta_max: betaMax ? parseFloat(betaMax) : undefined,
+        shares_outstanding_min: sharesOutstandingMin
+          ? parseFloat(sharesOutstandingMin)
+          : undefined,
+        float_shares_min: floatSharesMin
+          ? parseFloat(floatSharesMin)
+          : undefined,
+        market_cap_min: marketCapMin
+          ? parseFloat(marketCapMin)
+          : undefined,
+        high_52w_max: high52wMax ? parseFloat(high52wMax) : undefined,
+        low_52w_min: low52wMin ? parseFloat(low52wMin) : undefined,
+        avg_volume_min: avgVolumeMin ? parseFloat(avgVolumeMin) : undefined,
       });
       setRows(data);
     } catch (e) {
@@ -108,6 +136,105 @@ export function Screener() {
             style={{ marginLeft: "0.25rem" }}
           />
         </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.minDividendYield")}
+          <input
+            aria-label={t("screener.minDividendYield")}
+            type="number"
+            value={dividendYieldMin}
+            onChange={(e) => setDividendYieldMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxDividendPayoutRatio")}
+          <input
+            aria-label={t("screener.maxDividendPayoutRatio")}
+            type="number"
+            value={dividendPayoutRatioMax}
+            onChange={(e) => setDividendPayoutRatioMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxBeta")}
+          <input
+            aria-label={t("screener.maxBeta")}
+            type="number"
+            value={betaMax}
+            onChange={(e) => setBetaMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.minSharesOutstanding")}
+          <input
+            aria-label={t("screener.minSharesOutstanding")}
+            type="number"
+            value={sharesOutstandingMin}
+            onChange={(e) => setSharesOutstandingMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.minFloatShares")}
+          <input
+            aria-label={t("screener.minFloatShares")}
+            type="number"
+            value={floatSharesMin}
+            onChange={(e) => setFloatSharesMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.minMarketCap")}
+          <input
+            aria-label={t("screener.minMarketCap")}
+            type="number"
+            value={marketCapMin}
+            onChange={(e) => setMarketCapMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.max52WeekHigh")}
+          <input
+            aria-label={t("screener.max52WeekHigh")}
+            type="number"
+            value={high52wMax}
+            onChange={(e) => setHigh52wMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.min52WeekLow")}
+          <input
+            aria-label={t("screener.min52WeekLow")}
+            type="number"
+            value={low52wMin}
+            onChange={(e) => setLow52wMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.minAvgVolume")}
+          <input
+            aria-label={t("screener.minAvgVolume")}
+            type="number"
+            value={avgVolumeMin}
+            onChange={(e) => setAvgVolumeMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
         <button type="submit" disabled={loading} style={{ marginLeft: "0.5rem" }}>
           {loading ? t("screener.loading") : t("screener.run")}
         </button>
@@ -130,6 +257,40 @@ export function Screener() {
               <th style={right} onClick={() => handleSort("pe_ratio")}>P/E</th>
               <th style={right} onClick={() => handleSort("de_ratio")}>D/E</th>
               <th style={right} onClick={() => handleSort("fcf")}>FCF</th>
+              <th style={right} onClick={() => handleSort("dividend_yield")}>
+                Div%
+              </th>
+              <th
+                style={right}
+                onClick={() => handleSort("dividend_payout_ratio")}
+              >
+                Payout
+              </th>
+              <th style={right} onClick={() => handleSort("beta")}>Beta</th>
+              <th
+                style={right}
+                onClick={() => handleSort("shares_outstanding")}
+              >
+                Shares
+              </th>
+              <th
+                style={right}
+                onClick={() => handleSort("float_shares")}
+              >
+                Float
+              </th>
+              <th style={right} onClick={() => handleSort("market_cap")}>
+                MktCap
+              </th>
+              <th style={right} onClick={() => handleSort("high_52w")}>
+                52wH
+              </th>
+              <th style={right} onClick={() => handleSort("low_52w")}>
+                52wL
+              </th>
+              <th style={right} onClick={() => handleSort("avg_volume")}>
+                AvgVol
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -146,6 +307,35 @@ export function Screener() {
                 <td style={right}>
                   {r.fcf != null
                     ? new Intl.NumberFormat(i18n.language).format(r.fcf)
+                    : "—"}
+                </td>
+                <td style={right}>{r.dividend_yield ?? "—"}</td>
+                <td style={right}>{r.dividend_payout_ratio ?? "—"}</td>
+                <td style={right}>{r.beta ?? "—"}</td>
+                <td style={right}>
+                  {r.shares_outstanding != null
+                    ? new Intl.NumberFormat(i18n.language).format(
+                        r.shares_outstanding,
+                      )
+                    : "—"}
+                </td>
+                <td style={right}>
+                  {r.float_shares != null
+                    ? new Intl.NumberFormat(i18n.language).format(
+                        r.float_shares,
+                      )
+                    : "—"}
+                </td>
+                <td style={right}>
+                  {r.market_cap != null
+                    ? new Intl.NumberFormat(i18n.language).format(r.market_cap)
+                    : "—"}
+                </td>
+                <td style={right}>{r.high_52w ?? "—"}</td>
+                <td style={right}>{r.low_52w ?? "—"}</td>
+                <td style={right}>
+                  {r.avg_volume != null
+                    ? new Intl.NumberFormat(i18n.language).format(r.avg_volume)
                     : "—"}
                 </td>
               </tr>

--- a/frontend/src/pages/ScreenerQuery.test.tsx
+++ b/frontend/src/pages/ScreenerQuery.test.tsx
@@ -37,6 +37,15 @@ vi.mock("../api", () => ({
       pe_ratio: 10,
       de_ratio: 0.5,
       fcf: 1000,
+      dividend_yield: 2,
+      dividend_payout_ratio: 40,
+      beta: 1.2,
+      shares_outstanding: 1000,
+      float_shares: 800,
+      market_cap: 5000,
+      high_52w: 150,
+      low_52w: 90,
+      avg_volume: 2000,
     },
   ]),
 }));
@@ -64,11 +73,17 @@ describe("Screener & Query page", () => {
     fireEvent.change(screen.getByLabelText(en.screener.maxPeg), {
       target: { value: "2" },
     });
+    fireEvent.change(screen.getByLabelText(en.screener.minDividendYield), {
+      target: { value: "1" },
+    });
 
     fireEvent.click(screen.getAllByRole("button", { name: en.screener.run })[0]);
 
-    expect(await screen.findByText("1,000")).toBeInTheDocument();
-    expect(getScreener).toHaveBeenCalledWith(["AAA"], { peg_max: 2 });
+    expect(await screen.findByText("1.2")).toBeInTheDocument();
+    expect(getScreener).toHaveBeenCalledWith(["AAA"], {
+      peg_max: 2,
+      dividend_yield_min: 1,
+    });
   });
 
   it("submits query form and renders results with export links", async () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -176,6 +176,15 @@ export interface ScreenerResult {
     pe_ratio: number | null;
     de_ratio: number | null;
     fcf: number | null;
+    dividend_yield: number | null;
+    dividend_payout_ratio: number | null;
+    beta: number | null;
+    shares_outstanding: number | null;
+    float_shares: number | null;
+    market_cap: number | null;
+    high_52w: number | null;
+    low_52w: number | null;
+    avg_volume: number | null;
 }
 
 export interface SyntheticHolding {

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -217,12 +217,12 @@ def test_screener_endpoint(monkeypatch):
 
     def mock_fetch(ticker: str) -> Fundamentals:
         if ticker == "AAA":
-            return Fundamentals(ticker="AAA", peg_ratio=0.5)
-        return Fundamentals(ticker="BBB", peg_ratio=2.0)
+            return Fundamentals(ticker="AAA", peg_ratio=0.5, beta=1.0)
+        return Fundamentals(ticker="BBB", peg_ratio=2.0, beta=2.0)
 
     monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
 
-    resp = client.get("/screener?tickers=AAA,BBB&peg_max=1")
+    resp = client.get("/screener?tickers=AAA,BBB&peg_max=1&beta_max=1.5")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -9,6 +9,15 @@ def test_fetch_fundamentals_parses_values(monkeypatch):
         "PERatio": "10.2",
         "DebtToEquityTTM": "0.5",
         "FreeCashFlowTTM": "1234",
+        "DividendYield": "0.02",
+        "PayoutRatio": "0.4",
+        "Beta": "1.1",
+        "SharesOutstanding": "1000",
+        "SharesFloat": "800",
+        "MarketCapitalization": "5000000",
+        "52WeekHigh": "150",
+        "52WeekLow": "100",
+        "AverageDailyVolume10Day": "9000",
     }
 
     class MockResp:
@@ -35,15 +44,69 @@ def test_fetch_fundamentals_parses_values(monkeypatch):
     assert f.pe_ratio == 10.2
     assert f.de_ratio == 0.5
     assert f.fcf == 1234.0
+    assert f.dividend_yield == 0.02
+    assert f.dividend_payout_ratio == 0.4
+    assert f.beta == 1.1
+    assert f.shares_outstanding == 1000
+    assert f.float_shares == 800
+    assert f.market_cap == 5000000
+    assert f.high_52w == 150.0
+    assert f.low_52w == 100.0
+    assert f.avg_volume == 9000
 
 
 def test_screen_filters_based_on_thresholds(monkeypatch):
     def mock_fetch(ticker):
         if ticker == "AAA":
-            return Fundamentals(ticker="AAA", peg_ratio=0.5, pe_ratio=10, de_ratio=0.5, fcf=1000)
-        return Fundamentals(ticker="BBB", peg_ratio=2.0, pe_ratio=15, de_ratio=1.5, fcf=500)
+            return Fundamentals(
+                ticker="AAA",
+                peg_ratio=0.5,
+                pe_ratio=10,
+                de_ratio=0.5,
+                fcf=1000,
+                dividend_yield=0.03,
+                dividend_payout_ratio=0.4,
+                beta=1.0,
+                shares_outstanding=1000,
+                float_shares=800,
+                market_cap=5000,
+                high_52w=200,
+                low_52w=100,
+                avg_volume=10000,
+            )
+        return Fundamentals(
+            ticker="BBB",
+            peg_ratio=2.0,
+            pe_ratio=15,
+            de_ratio=1.5,
+            fcf=500,
+            dividend_yield=0.01,
+            dividend_payout_ratio=0.8,
+            beta=2.0,
+            shares_outstanding=500,
+            float_shares=300,
+            market_cap=1000,
+            high_52w=300,
+            low_52w=50,
+            avg_volume=5000,
+        )
 
     monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
 
-    results = screen(["AAA", "BBB"], peg_max=1.0, pe_max=20, de_max=1.0, fcf_min=800)
+    results = screen(
+        ["AAA", "BBB"],
+        peg_max=1.0,
+        pe_max=20,
+        de_max=1.0,
+        fcf_min=800,
+        dividend_yield_min=0.02,
+        dividend_payout_ratio_max=0.5,
+        beta_max=1.5,
+        shares_outstanding_min=800,
+        float_shares_min=700,
+        market_cap_min=2000,
+        high_52w_max=250,
+        low_52w_min=80,
+        avg_volume_min=8000,
+    )
     assert [r.ticker for r in results] == ["AAA"]


### PR DESCRIPTION
## Summary
- parse dividend, beta, share, market cap, 52w range, and volume metrics from Alpha Vantage
- expose corresponding min/max filters via API and UI
- extend tests and translations for new screener fields

## Testing
- `pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1950eec2c83279465a022db5ae3b9