### PR TITLE
feat: expand screener with additional ratios

### DIFF
--- a/backend/routes/screener.py
+++ b/backend/routes/screener.py
@@ -23,6 +23,10 @@ async def screener(
     peg_max: float | None = Query(None),
     pe_max: float | None = Query(None),
     de_max: float | None = Query(None),
+    lt_de_max: float | None = Query(None),
+    interest_coverage_min: float | None = Query(None),
+    current_ratio_min: float | None = Query(None),
+    quick_ratio_min: float | None = Query(None),
     fcf_min: float | None = Query(None),
 ):
     """Return tickers that meet the supplied screening criteria."""
@@ -31,7 +35,10 @@ async def screener(
     if not symbols:
         raise HTTPException(status_code=400, detail="No tickers supplied")
 
-    params = f"{','.join(symbols)}|{peg_max}|{pe_max}|{de_max}|{fcf_min}"
+    params = (
+        f"{','.join(symbols)}|{peg_max}|{pe_max}|{de_max}|{lt_de_max}|"
+        f"{interest_coverage_min}|{current_ratio_min}|{quick_ratio_min}|{fcf_min}"
+    )
     page = "screener_" + hashlib.sha1(params.encode()).hexdigest()
     page_cache.schedule_refresh(
         page,
@@ -40,6 +47,10 @@ async def screener(
         peg_max=peg_max,
         pe_max=pe_max,
         de_max=de_max,
+        lt_de_max=lt_de_max,
+        interest_coverage_min=interest_coverage_min,
+        current_ratio_min=current_ratio_min,
+        quick_ratio_min=quick_ratio_min,
         fcf_min=fcf_min: [
             r.model_dump()
             for r in screen(
@@ -47,6 +58,10 @@ async def screener(
                 peg_max=peg_max,
                 pe_max=pe_max,
                 de_max=de_max,
+                lt_de_max=lt_de_max,
+                interest_coverage_min=interest_coverage_min,
+                current_ratio_min=current_ratio_min,
+                quick_ratio_min=quick_ratio_min,
                 fcf_min=fcf_min,
             )
         ],
@@ -62,6 +77,10 @@ async def screener(
             peg_max=peg_max,
             pe_max=pe_max,
             de_max=de_max,
+            lt_de_max=lt_de_max,
+            interest_coverage_min=interest_coverage_min,
+            current_ratio_min=current_ratio_min,
+            quick_ratio_min=quick_ratio_min,
             fcf_min=fcf_min,
         )
     except ValueError as e:

--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -31,6 +31,10 @@ class Fundamentals(BaseModel):
     peg_ratio: Optional[float] = None
     pe_ratio: Optional[float] = None
     de_ratio: Optional[float] = None
+    lt_de_ratio: Optional[float] = None
+    interest_coverage: Optional[float] = None
+    current_ratio: Optional[float] = None
+    quick_ratio: Optional[float] = None
     fcf: Optional[float] = None
 
 
@@ -75,6 +79,10 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
         peg_ratio=_parse_float(data.get("PEG")),
         pe_ratio=_parse_float(data.get("PERatio")),
         de_ratio=_parse_float(data.get("DebtToEquityTTM")),
+        lt_de_ratio=_parse_float(data.get("LongTermDebtToEquity")),
+        interest_coverage=_parse_float(data.get("InterestCoverage")),
+        current_ratio=_parse_float(data.get("CurrentRatio")),
+        quick_ratio=_parse_float(data.get("QuickRatio")),
         fcf=_parse_float(data.get("FreeCashFlowTTM")),
     )
 
@@ -89,6 +97,10 @@ def screen(
     peg_max: Optional[float] = None,
     pe_max: Optional[float] = None,
     de_max: Optional[float] = None,
+    lt_de_max: Optional[float] = None,
+    interest_coverage_min: Optional[float] = None,
+    current_ratio_min: Optional[float] = None,
+    quick_ratio_min: Optional[float] = None,
     fcf_min: Optional[float] = None,
 ) -> List[Fundamentals]:
     """Fetch fundamentals for multiple tickers and filter based on thresholds."""
@@ -106,6 +118,22 @@ def screen(
         if pe_max is not None and (f.pe_ratio is None or f.pe_ratio > pe_max):
             continue
         if de_max is not None and (f.de_ratio is None or f.de_ratio > de_max):
+            continue
+        if lt_de_max is not None and (
+            f.lt_de_ratio is None or f.lt_de_ratio > lt_de_max
+        ):
+            continue
+        if interest_coverage_min is not None and (
+            f.interest_coverage is None or f.interest_coverage < interest_coverage_min
+        ):
+            continue
+        if current_ratio_min is not None and (
+            f.current_ratio is None or f.current_ratio < current_ratio_min
+        ):
+            continue
+        if quick_ratio_min is not None and (
+            f.quick_ratio is None or f.quick_ratio < quick_ratio_min
+        ):
             continue
         if fcf_min is not None and (f.fcf is None or f.fcf < fcf_min):
             continue

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -127,6 +127,10 @@ export const getScreener = (
     peg_max?: number;
     pe_max?: number;
     de_max?: number;
+    lt_de_max?: number;
+    interest_coverage_min?: number;
+    current_ratio_min?: number;
+    quick_ratio_min?: number;
     fcf_min?: number;
   } = {},
 ) => {
@@ -134,6 +138,13 @@ export const getScreener = (
   if (criteria.peg_max != null) params.set("peg_max", String(criteria.peg_max));
   if (criteria.pe_max != null) params.set("pe_max", String(criteria.pe_max));
   if (criteria.de_max != null) params.set("de_max", String(criteria.de_max));
+  if (criteria.lt_de_max != null) params.set("lt_de_max", String(criteria.lt_de_max));
+  if (criteria.interest_coverage_min != null)
+    params.set("interest_coverage_min", String(criteria.interest_coverage_min));
+  if (criteria.current_ratio_min != null)
+    params.set("current_ratio_min", String(criteria.current_ratio_min));
+  if (criteria.quick_ratio_min != null)
+    params.set("quick_ratio_min", String(criteria.quick_ratio_min));
   if (criteria.fcf_min != null) params.set("fcf_min", String(criteria.fcf_min));
   return fetchJson<ScreenerResult[]>(`${API_BASE}/screener?${params.toString()}`);
 };

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -130,6 +130,10 @@
     "maxPeg": "Max PEG",
     "maxPe": "Max P/E",
     "maxDe": "Max D/E",
+    "maxLtDe": "Max LT D/E",
+    "minInterestCoverage": "Min Interest Coverage",
+    "minCurrentRatio": "Min Current Ratio",
+    "minQuickRatio": "Min Quick Ratio",
     "minFcf": "Min FCF",
     "run": "Ausführen",
     "loading": "Laden…"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -139,6 +139,10 @@
     "maxPeg": "Max PEG",
     "maxPe": "Max P/E",
     "maxDe": "Max D/E",
+    "maxLtDe": "Max LT D/E",
+    "minInterestCoverage": "Min Interest Coverage",
+    "minCurrentRatio": "Min Current Ratio",
+    "minQuickRatio": "Min Quick Ratio",
     "minFcf": "Min FCF",
     "run": "Run",
     "loading": "Loading…"

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -130,6 +130,10 @@
     "maxPeg": "PEG máx",
     "maxPe": "P/E máx",
     "maxDe": "D/E máx",
+    "maxLtDe": "Max LT D/E",
+    "minInterestCoverage": "Min Interest Coverage",
+    "minCurrentRatio": "Min Current Ratio",
+    "minQuickRatio": "Min Quick Ratio",
     "minFcf": "FCF mín",
     "run": "Ejecutar",
     "loading": "Cargando…"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -130,6 +130,10 @@
     "maxPeg": "PEG max",
     "maxPe": "P/E max",
     "maxDe": "D/E max",
+    "maxLtDe": "Max LT D/E",
+    "minInterestCoverage": "Min Interest Coverage",
+    "minCurrentRatio": "Min Current Ratio",
+    "minQuickRatio": "Min Quick Ratio",
     "minFcf": "FCF min",
     "run": "Exécuter",
     "loading": "Chargement…"

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -130,6 +130,10 @@
     "maxPeg": "PEG máx",
     "maxPe": "P/E máx",
     "maxDe": "D/E máx",
+    "maxLtDe": "Max LT D/E",
+    "minInterestCoverage": "Min Interest Coverage",
+    "minCurrentRatio": "Min Current Ratio",
+    "minQuickRatio": "Min Quick Ratio",
     "minFcf": "FCF mín",
     "run": "Executar",
     "loading": "Carregando…"

--- a/frontend/src/pages/Screener.test.tsx
+++ b/frontend/src/pages/Screener.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Screener } from "./Screener";
+import * as api from "../api";
+
+vi.mock("../api");
+
+const mockGetScreener = vi.mocked(api.getScreener);
+
+describe("Screener", () => {
+  it("renders new ratio columns", async () => {
+    mockGetScreener.mockResolvedValueOnce([
+      {
+        ticker: "AAA",
+        name: "AAA Corp",
+        peg_ratio: 1,
+        pe_ratio: 10,
+        de_ratio: 0.5,
+        lt_de_ratio: 0.3,
+        interest_coverage: 10,
+        current_ratio: 2,
+        quick_ratio: 1.5,
+        fcf: 1000,
+      },
+    ]);
+
+    render(<Screener />);
+
+    fireEvent.change(screen.getByLabelText(/Tickers/i), { target: { value: "AAA" } });
+    fireEvent.change(screen.getByLabelText(/Max LT D\/E/i), { target: { value: "1" } });
+    fireEvent.change(screen.getByLabelText(/Min Interest Coverage/i), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText(/Min Current Ratio/i), { target: { value: "1" } });
+    fireEvent.change(screen.getByLabelText(/Min Quick Ratio/i), { target: { value: "1" } });
+
+    fireEvent.submit(screen.getByText(/Run/i).closest("form")!);
+
+    await waitFor(() => expect(mockGetScreener).toHaveBeenCalled());
+    expect(mockGetScreener).toHaveBeenCalledWith(
+      ["AAA"],
+      expect.objectContaining({
+        lt_de_max: 1,
+        interest_coverage_min: 5,
+        current_ratio_min: 1,
+        quick_ratio_min: 1,
+      })
+    );
+
+    expect(await screen.findByText("LT D/E")).toBeInTheDocument();
+    expect(screen.getByText("IntCov")).toBeInTheDocument();
+    expect(screen.getByText("Curr")).toBeInTheDocument();
+    expect(screen.getByText("Quick")).toBeInTheDocument();
+
+    expect(screen.getByText("0.3")).toBeInTheDocument();
+    expect(screen.getAllByText("10")).toHaveLength(2);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("1.5")).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/pages/Screener.tsx
+++ b/frontend/src/pages/Screener.tsx
@@ -11,6 +11,10 @@ export function Screener() {
   const [pegMax, setPegMax] = useState("");
   const [peMax, setPeMax] = useState("");
   const [deMax, setDeMax] = useState("");
+  const [ltDeMax, setLtDeMax] = useState("");
+  const [interestCoverageMin, setInterestCoverageMin] = useState("");
+  const [currentRatioMin, setCurrentRatioMin] = useState("");
+  const [quickRatioMin, setQuickRatioMin] = useState("");
   const [fcfMin, setFcfMin] = useState("");
 
   const [rows, setRows] = useState<ScreenerResult[]>([]);
@@ -39,6 +43,16 @@ export function Screener() {
         peg_max: pegMax ? parseFloat(pegMax) : undefined,
         pe_max: peMax ? parseFloat(peMax) : undefined,
         de_max: deMax ? parseFloat(deMax) : undefined,
+        lt_de_max: ltDeMax ? parseFloat(ltDeMax) : undefined,
+        interest_coverage_min: interestCoverageMin
+          ? parseFloat(interestCoverageMin)
+          : undefined,
+        current_ratio_min: currentRatioMin
+          ? parseFloat(currentRatioMin)
+          : undefined,
+        quick_ratio_min: quickRatioMin
+          ? parseFloat(quickRatioMin)
+          : undefined,
         fcf_min: fcfMin ? parseFloat(fcfMin) : undefined,
       });
       setRows(data);
@@ -98,6 +112,50 @@ export function Screener() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxLtDe")}
+          <input
+            aria-label={t("screener.maxLtDe")}
+            type="number"
+            value={ltDeMax}
+            onChange={(e) => setLtDeMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.minInterestCoverage")}
+          <input
+            aria-label={t("screener.minInterestCoverage")}
+            type="number"
+            value={interestCoverageMin}
+            onChange={(e) => setInterestCoverageMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.minCurrentRatio")}
+          <input
+            aria-label={t("screener.minCurrentRatio")}
+            type="number"
+            value={currentRatioMin}
+            onChange={(e) => setCurrentRatioMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.minQuickRatio")}
+          <input
+            aria-label={t("screener.minQuickRatio")}
+            type="number"
+            value={quickRatioMin}
+            onChange={(e) => setQuickRatioMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.minFcf")}
           <input
             aria-label={t("screener.minFcf")}
@@ -129,6 +187,10 @@ export function Screener() {
               <th style={right} onClick={() => handleSort("peg_ratio")}>PEG</th>
               <th style={right} onClick={() => handleSort("pe_ratio")}>P/E</th>
               <th style={right} onClick={() => handleSort("de_ratio")}>D/E</th>
+              <th style={right} onClick={() => handleSort("lt_de_ratio")}>LT D/E</th>
+              <th style={right} onClick={() => handleSort("interest_coverage")}>IntCov</th>
+              <th style={right} onClick={() => handleSort("current_ratio")}>Curr</th>
+              <th style={right} onClick={() => handleSort("quick_ratio")}>Quick</th>
               <th style={right} onClick={() => handleSort("fcf")}>FCF</th>
             </tr>
           </thead>
@@ -143,6 +205,10 @@ export function Screener() {
                 <td style={right}>{r.peg_ratio ?? "—"}</td>
                 <td style={right}>{r.pe_ratio ?? "—"}</td>
                 <td style={right}>{r.de_ratio ?? "—"}</td>
+                <td style={right}>{r.lt_de_ratio ?? "—"}</td>
+                <td style={right}>{r.interest_coverage ?? "—"}</td>
+                <td style={right}>{r.current_ratio ?? "—"}</td>
+                <td style={right}>{r.quick_ratio ?? "—"}</td>
                 <td style={right}>
                   {r.fcf != null
                     ? new Intl.NumberFormat(i18n.language).format(r.fcf)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -175,6 +175,10 @@ export interface ScreenerResult {
     peg_ratio: number | null;
     pe_ratio: number | null;
     de_ratio: number | null;
+    lt_de_ratio: number | null;
+    interest_coverage: number | null;
+    current_ratio: number | null;
+    quick_ratio: number | null;
     fcf: number | null;
 }
 

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -8,6 +8,10 @@ def test_fetch_fundamentals_parses_values(monkeypatch):
         "PEG": "1.5",
         "PERatio": "10.2",
         "DebtToEquityTTM": "0.5",
+        "LongTermDebtToEquity": "0.3",
+        "InterestCoverage": "8.5",
+        "CurrentRatio": "2.1",
+        "QuickRatio": "1.8",
         "FreeCashFlowTTM": "1234",
     }
 
@@ -34,16 +38,50 @@ def test_fetch_fundamentals_parses_values(monkeypatch):
     assert f.peg_ratio == 1.5
     assert f.pe_ratio == 10.2
     assert f.de_ratio == 0.5
+    assert f.lt_de_ratio == 0.3
+    assert f.interest_coverage == 8.5
+    assert f.current_ratio == 2.1
+    assert f.quick_ratio == 1.8
     assert f.fcf == 1234.0
 
 
 def test_screen_filters_based_on_thresholds(monkeypatch):
     def mock_fetch(ticker):
         if ticker == "AAA":
-            return Fundamentals(ticker="AAA", peg_ratio=0.5, pe_ratio=10, de_ratio=0.5, fcf=1000)
-        return Fundamentals(ticker="BBB", peg_ratio=2.0, pe_ratio=15, de_ratio=1.5, fcf=500)
+            return Fundamentals(
+                ticker="AAA",
+                peg_ratio=0.5,
+                pe_ratio=10,
+                de_ratio=0.5,
+                lt_de_ratio=0.3,
+                interest_coverage=10,
+                current_ratio=2.0,
+                quick_ratio=1.5,
+                fcf=1000,
+            )
+        return Fundamentals(
+            ticker="BBB",
+            peg_ratio=2.0,
+            pe_ratio=15,
+            de_ratio=1.5,
+            lt_de_ratio=2.0,
+            interest_coverage=1.0,
+            current_ratio=0.5,
+            quick_ratio=0.4,
+            fcf=500,
+        )
 
     monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
 
-    results = screen(["AAA", "BBB"], peg_max=1.0, pe_max=20, de_max=1.0, fcf_min=800)
+    results = screen(
+        ["AAA", "BBB"],
+        peg_max=1.0,
+        pe_max=20,
+        de_max=1.0,
+        lt_de_max=1.0,
+        interest_coverage_min=5.0,
+        current_ratio_min=1.0,
+        quick_ratio_min=1.0,
+        fcf_min=800,
+    )
     assert [r.ticker for r in results] == ["AAA"]


### PR DESCRIPTION
## Summary
- add LT debt, coverage, current and quick ratios to fundamentals API and screen filters
- expose new filters via screener route and frontend UI
- cover new ratios with backend and frontend tests

## Testing
- `pytest tests/test_screener.py`
- `cd frontend && npm test -- src/pages/Screener.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a1950ba0688327b97dd741c53e3d9c