### PR TITLE
Integrate support page into main app routing

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -202,6 +202,42 @@ describe("App", () => {
     expect(mockTradingSignals).toHaveBeenCalled();
   });
 
+  it("renders support page with navigation", async () => {
+    window.history.pushState({}, "", "/support");
+
+    vi.doMock("./api", () => ({
+      getOwners: vi.fn().mockResolvedValue([]),
+      getGroups: vi.fn().mockResolvedValue([]),
+      getGroupInstruments: vi.fn().mockResolvedValue([]),
+      getPortfolio: vi.fn(),
+      refreshPrices: vi.fn(),
+      getAlerts: vi.fn().mockResolvedValue([]),
+      getCompliance: vi
+        .fn()
+        .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+      getTimeseries: vi.fn().mockResolvedValue([]),
+      saveTimeseries: vi.fn(),
+      listTimeseries: vi.fn().mockResolvedValue([]),
+      getConfig: vi.fn().mockResolvedValue({}),
+      updateConfig: vi.fn(),
+      getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+      getTradingSignals: vi.fn().mockResolvedValue([]),
+    }));
+
+    const { default: App } = await import("./App");
+
+    render(
+      <MemoryRouter initialEntries={["/support"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("navigation")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: /Support/i })
+    ).toBeInTheDocument();
+  });
+
   it("defaults to Movers view and orders tabs correctly", async () => {
     window.history.pushState({}, "", "/");
     mockTradingSignals.mockResolvedValue([]);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import Watchlist from "./pages/Watchlist";
 import TopMovers from "./pages/TopMovers";
 import { useConfig } from "./ConfigContext";
 import DataAdmin from "./pages/DataAdmin";
+import Support from "./pages/Support";
 import ScenarioTester from "./pages/ScenarioTester";
 
 type Mode =
@@ -388,6 +389,7 @@ export default function App() {
       {mode === "dataadmin" && <DataAdmin />}
       {mode === "watchlist" && <Watchlist />}
       {mode === "movers" && <TopMovers />}
+      {mode === "support" && <Support />}
       {mode === "scenario" && <ScenarioTester />}
     </div>
   );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,7 +4,6 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import './i18n'
 import App from './App.tsx'
-import Support from './pages/Support'
 import VirtualPortfolio from './pages/VirtualPortfolio'
 import './i18n'
 import { ConfigProvider } from './ConfigContext'
@@ -14,7 +13,6 @@ createRoot(document.getElementById('root')!).render(
     <ConfigProvider>
       <BrowserRouter>
         <Routes>
-          <Route path="/support" element={<Support />} />
           <Route path="/virtual" element={<VirtualPortfolio />} />
           <Route path="/*" element={<App />} />
         </Routes>


### PR DESCRIPTION
## Summary
- Render Support page through App's mode system
- Route `/support` through App component
- Test Support route shows navigation and content

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1935cb6148327b4dc781015f7a8f0