### PR TITLE
ci: run super-linter only on push to main

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -9,8 +9,8 @@ name: Lint Code Base
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  # pull_request:
+  #   branches: [ "main" ]
 jobs:
   run-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- run super-linter workflow only on push to main branch

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a19809bf1483278552ec88053bd086