### PR TITLE
feat: extend screener valuation metrics

### DIFF
--- a/backend/routes/screener.py
+++ b/backend/routes/screener.py
@@ -24,6 +24,13 @@ async def screener(
     pe_max: float | None = Query(None),
     de_max: float | None = Query(None),
     fcf_min: float | None = Query(None),
+    pb_max: float | None = Query(None),
+    ps_max: float | None = Query(None),
+    pc_max: float | None = Query(None),
+    pfcf_max: float | None = Query(None),
+    pebitda_max: float | None = Query(None),
+    ev_ebitda_max: float | None = Query(None),
+    ev_revenue_max: float | None = Query(None),
 ):
     """Return tickers that meet the supplied screening criteria."""
 
@@ -31,7 +38,10 @@ async def screener(
     if not symbols:
         raise HTTPException(status_code=400, detail="No tickers supplied")
 
-    params = f"{','.join(symbols)}|{peg_max}|{pe_max}|{de_max}|{fcf_min}"
+    params = (
+        f"{','.join(symbols)}|{peg_max}|{pe_max}|{de_max}|{fcf_min}|"
+        f"{pb_max}|{ps_max}|{pc_max}|{pfcf_max}|{pebitda_max}|{ev_ebitda_max}|{ev_revenue_max}"
+    )
     page = "screener_" + hashlib.sha1(params.encode()).hexdigest()
     page_cache.schedule_refresh(
         page,
@@ -40,7 +50,14 @@ async def screener(
         peg_max=peg_max,
         pe_max=pe_max,
         de_max=de_max,
-        fcf_min=fcf_min: [
+        fcf_min=fcf_min,
+        pb_max=pb_max,
+        ps_max=ps_max,
+        pc_max=pc_max,
+        pfcf_max=pfcf_max,
+        pebitda_max=pebitda_max,
+        ev_ebitda_max=ev_ebitda_max,
+        ev_revenue_max=ev_revenue_max: [
             r.model_dump()
             for r in screen(
                 symbols,
@@ -48,6 +65,13 @@ async def screener(
                 pe_max=pe_max,
                 de_max=de_max,
                 fcf_min=fcf_min,
+                pb_max=pb_max,
+                ps_max=ps_max,
+                pc_max=pc_max,
+                pfcf_max=pfcf_max,
+                pebitda_max=pebitda_max,
+                ev_ebitda_max=ev_ebitda_max,
+                ev_revenue_max=ev_revenue_max,
             )
         ],
     )
@@ -63,6 +87,13 @@ async def screener(
             pe_max=pe_max,
             de_max=de_max,
             fcf_min=fcf_min,
+            pb_max=pb_max,
+            ps_max=ps_max,
+            pc_max=pc_max,
+            pfcf_max=pfcf_max,
+            pebitda_max=pebitda_max,
+            ev_ebitda_max=ev_ebitda_max,
+            ev_revenue_max=ev_revenue_max,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -32,6 +32,13 @@ class Fundamentals(BaseModel):
     pe_ratio: Optional[float] = None
     de_ratio: Optional[float] = None
     fcf: Optional[float] = None
+    pb_ratio: Optional[float] = None
+    ps_ratio: Optional[float] = None
+    pc_ratio: Optional[float] = None
+    pfcf_ratio: Optional[float] = None
+    p_ebitda: Optional[float] = None
+    ev_to_ebitda: Optional[float] = None
+    ev_to_revenue: Optional[float] = None
 
 
 def _parse_float(value: Optional[str]) -> Optional[float]:
@@ -76,6 +83,13 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
         pe_ratio=_parse_float(data.get("PERatio")),
         de_ratio=_parse_float(data.get("DebtToEquityTTM")),
         fcf=_parse_float(data.get("FreeCashFlowTTM")),
+        pb_ratio=_parse_float(data.get("PriceToBookRatio")),
+        ps_ratio=_parse_float(data.get("PriceToSalesRatioTTM")),
+        pc_ratio=_parse_float(data.get("PriceToCashFlowRatio")),
+        pfcf_ratio=_parse_float(data.get("PriceToFreeCashFlowTTM")),
+        p_ebitda=_parse_float(data.get("PriceToEBITDA")),
+        ev_to_ebitda=_parse_float(data.get("EVToEBITDA")),
+        ev_to_revenue=_parse_float(data.get("EVToRevenue")),
     )
 
     _CACHE[key] = (now, result)
@@ -90,6 +104,13 @@ def screen(
     pe_max: Optional[float] = None,
     de_max: Optional[float] = None,
     fcf_min: Optional[float] = None,
+    pb_max: Optional[float] = None,
+    ps_max: Optional[float] = None,
+    pc_max: Optional[float] = None,
+    pfcf_max: Optional[float] = None,
+    pebitda_max: Optional[float] = None,
+    ev_ebitda_max: Optional[float] = None,
+    ev_revenue_max: Optional[float] = None,
 ) -> List[Fundamentals]:
     """Fetch fundamentals for multiple tickers and filter based on thresholds."""
 
@@ -108,6 +129,24 @@ def screen(
         if de_max is not None and (f.de_ratio is None or f.de_ratio > de_max):
             continue
         if fcf_min is not None and (f.fcf is None or f.fcf < fcf_min):
+            continue
+        if pb_max is not None and (f.pb_ratio is None or f.pb_ratio > pb_max):
+            continue
+        if ps_max is not None and (f.ps_ratio is None or f.ps_ratio > ps_max):
+            continue
+        if pc_max is not None and (f.pc_ratio is None or f.pc_ratio > pc_max):
+            continue
+        if pfcf_max is not None and (f.pfcf_ratio is None or f.pfcf_ratio > pfcf_max):
+            continue
+        if pebitda_max is not None and (f.p_ebitda is None or f.p_ebitda > pebitda_max):
+            continue
+        if ev_ebitda_max is not None and (
+            f.ev_to_ebitda is None or f.ev_to_ebitda > ev_ebitda_max
+        ):
+            continue
+        if ev_revenue_max is not None and (
+            f.ev_to_revenue is None or f.ev_to_revenue > ev_revenue_max
+        ):
             continue
 
         results.append(f)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -128,6 +128,13 @@ export const getScreener = (
     pe_max?: number;
     de_max?: number;
     fcf_min?: number;
+    pb_max?: number;
+    ps_max?: number;
+    pc_max?: number;
+    pfcf_max?: number;
+    pebitda_max?: number;
+    ev_ebitda_max?: number;
+    ev_revenue_max?: number;
   } = {},
 ) => {
   const params = new URLSearchParams({ tickers: tickers.join(",") });
@@ -135,6 +142,16 @@ export const getScreener = (
   if (criteria.pe_max != null) params.set("pe_max", String(criteria.pe_max));
   if (criteria.de_max != null) params.set("de_max", String(criteria.de_max));
   if (criteria.fcf_min != null) params.set("fcf_min", String(criteria.fcf_min));
+  if (criteria.pb_max != null) params.set("pb_max", String(criteria.pb_max));
+  if (criteria.ps_max != null) params.set("ps_max", String(criteria.ps_max));
+  if (criteria.pc_max != null) params.set("pc_max", String(criteria.pc_max));
+  if (criteria.pfcf_max != null) params.set("pfcf_max", String(criteria.pfcf_max));
+  if (criteria.pebitda_max != null)
+    params.set("pebitda_max", String(criteria.pebitda_max));
+  if (criteria.ev_ebitda_max != null)
+    params.set("ev_ebitda_max", String(criteria.ev_ebitda_max));
+  if (criteria.ev_revenue_max != null)
+    params.set("ev_revenue_max", String(criteria.ev_revenue_max));
   return fetchJson<ScreenerResult[]>(`${API_BASE}/screener?${params.toString()}`);
 };
 

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -131,6 +131,13 @@
     "maxPe": "Max P/E",
     "maxDe": "Max D/E",
     "minFcf": "Min FCF",
+    "maxPb": "Max P/B",
+    "maxPs": "Max P/S",
+    "maxPc": "Max P/C",
+    "maxPfcf": "Max P/FCF",
+    "maxPebitda": "Max P/EBITDA",
+    "maxEvEbitda": "Max EV/EBITDA",
+    "maxEvRevenue": "Max EV/Revenue",
     "run": "Ausführen",
     "loading": "Laden…"
   }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -140,6 +140,13 @@
     "maxPe": "Max P/E",
     "maxDe": "Max D/E",
     "minFcf": "Min FCF",
+    "maxPb": "Max P/B",
+    "maxPs": "Max P/S",
+    "maxPc": "Max P/C",
+    "maxPfcf": "Max P/FCF",
+    "maxPebitda": "Max P/EBITDA",
+    "maxEvEbitda": "Max EV/EBITDA",
+    "maxEvRevenue": "Max EV/Revenue",
     "run": "Run",
     "loading": "Loading…"
   }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -131,6 +131,13 @@
     "maxPe": "P/E máx",
     "maxDe": "D/E máx",
     "minFcf": "FCF mín",
+    "maxPb": "P/B máx",
+    "maxPs": "P/S máx",
+    "maxPc": "P/C máx",
+    "maxPfcf": "P/FCF máx",
+    "maxPebitda": "P/EBITDA máx",
+    "maxEvEbitda": "EV/EBITDA máx",
+    "maxEvRevenue": "EV/Revenue máx",
     "run": "Ejecutar",
     "loading": "Cargando…"
   }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -131,6 +131,13 @@
     "maxPe": "P/E max",
     "maxDe": "D/E max",
     "minFcf": "FCF min",
+    "maxPb": "P/B max",
+    "maxPs": "P/S max",
+    "maxPc": "P/C max",
+    "maxPfcf": "P/FCF max",
+    "maxPebitda": "P/EBITDA max",
+    "maxEvEbitda": "EV/EBITDA max",
+    "maxEvRevenue": "EV/Revenue max",
     "run": "Exécuter",
     "loading": "Chargement…"
   }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -131,6 +131,13 @@
     "maxPe": "P/E máx",
     "maxDe": "D/E máx",
     "minFcf": "FCF mín",
+    "maxPb": "P/B máx",
+    "maxPs": "P/S máx",
+    "maxPc": "P/C máx",
+    "maxPfcf": "P/FCF máx",
+    "maxPebitda": "P/EBITDA máx",
+    "maxEvEbitda": "EV/EBITDA máx",
+    "maxEvRevenue": "EV/Revenue máx",
     "run": "Executar",
     "loading": "Carregando…"
   }

--- a/frontend/src/pages/Screener.tsx
+++ b/frontend/src/pages/Screener.tsx
@@ -12,6 +12,13 @@ export function Screener() {
   const [peMax, setPeMax] = useState("");
   const [deMax, setDeMax] = useState("");
   const [fcfMin, setFcfMin] = useState("");
+  const [pbMax, setPbMax] = useState("");
+  const [psMax, setPsMax] = useState("");
+  const [pcMax, setPcMax] = useState("");
+  const [pfcfMax, setPfcfMax] = useState("");
+  const [pEbitdaMax, setPEbitdaMax] = useState("");
+  const [evEbitdaMax, setEvEbitdaMax] = useState("");
+  const [evRevenueMax, setEvRevenueMax] = useState("");
 
   const [rows, setRows] = useState<ScreenerResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -40,6 +47,13 @@ export function Screener() {
         pe_max: peMax ? parseFloat(peMax) : undefined,
         de_max: deMax ? parseFloat(deMax) : undefined,
         fcf_min: fcfMin ? parseFloat(fcfMin) : undefined,
+        pb_max: pbMax ? parseFloat(pbMax) : undefined,
+        ps_max: psMax ? parseFloat(psMax) : undefined,
+        pc_max: pcMax ? parseFloat(pcMax) : undefined,
+        pfcf_max: pfcfMax ? parseFloat(pfcfMax) : undefined,
+        pebitda_max: pEbitdaMax ? parseFloat(pEbitdaMax) : undefined,
+        ev_ebitda_max: evEbitdaMax ? parseFloat(evEbitdaMax) : undefined,
+        ev_revenue_max: evRevenueMax ? parseFloat(evRevenueMax) : undefined,
       });
       setRows(data);
     } catch (e) {
@@ -108,6 +122,83 @@ export function Screener() {
             style={{ marginLeft: "0.25rem" }}
           />
         </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxPb")}
+          <input
+            aria-label={t("screener.maxPb")}
+            type="number"
+            value={pbMax}
+            onChange={(e) => setPbMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxPs")}
+          <input
+            aria-label={t("screener.maxPs")}
+            type="number"
+            value={psMax}
+            onChange={(e) => setPsMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxPc")}
+          <input
+            aria-label={t("screener.maxPc")}
+            type="number"
+            value={pcMax}
+            onChange={(e) => setPcMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxPfcf")}
+          <input
+            aria-label={t("screener.maxPfcf")}
+            type="number"
+            value={pfcfMax}
+            onChange={(e) => setPfcfMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxPebitda")}
+          <input
+            aria-label={t("screener.maxPebitda")}
+            type="number"
+            value={pEbitdaMax}
+            onChange={(e) => setPEbitdaMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxEvEbitda")}
+          <input
+            aria-label={t("screener.maxEvEbitda")}
+            type="number"
+            value={evEbitdaMax}
+            onChange={(e) => setEvEbitdaMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
+          {t("screener.maxEvRevenue")}
+          <input
+            aria-label={t("screener.maxEvRevenue")}
+            type="number"
+            value={evRevenueMax}
+            onChange={(e) => setEvRevenueMax(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
         <button type="submit" disabled={loading} style={{ marginLeft: "0.5rem" }}>
           {loading ? t("screener.loading") : t("screener.run")}
         </button>
@@ -130,6 +221,13 @@ export function Screener() {
               <th style={right} onClick={() => handleSort("pe_ratio")}>P/E</th>
               <th style={right} onClick={() => handleSort("de_ratio")}>D/E</th>
               <th style={right} onClick={() => handleSort("fcf")}>FCF</th>
+              <th style={right} onClick={() => handleSort("pb_ratio")}>P/B</th>
+              <th style={right} onClick={() => handleSort("ps_ratio")}>P/S</th>
+              <th style={right} onClick={() => handleSort("pc_ratio")}>P/C</th>
+              <th style={right} onClick={() => handleSort("pfcf_ratio")}>P/FCF</th>
+              <th style={right} onClick={() => handleSort("p_ebitda")}>P/EBITDA</th>
+              <th style={right} onClick={() => handleSort("ev_to_ebitda")}>EV/EBITDA</th>
+              <th style={right} onClick={() => handleSort("ev_to_revenue")}>EV/Revenue</th>
             </tr>
           </thead>
           <tbody>
@@ -148,6 +246,13 @@ export function Screener() {
                     ? new Intl.NumberFormat(i18n.language).format(r.fcf)
                     : "—"}
                 </td>
+                <td style={right}>{r.pb_ratio ?? "—"}</td>
+                <td style={right}>{r.ps_ratio ?? "—"}</td>
+                <td style={right}>{r.pc_ratio ?? "—"}</td>
+                <td style={right}>{r.pfcf_ratio ?? "—"}</td>
+                <td style={right}>{r.p_ebitda ?? "—"}</td>
+                <td style={right}>{r.ev_to_ebitda ?? "—"}</td>
+                <td style={right}>{r.ev_to_revenue ?? "—"}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/pages/ScreenerQuery.test.tsx
+++ b/frontend/src/pages/ScreenerQuery.test.tsx
@@ -37,6 +37,13 @@ vi.mock("../api", () => ({
       pe_ratio: 10,
       de_ratio: 0.5,
       fcf: 1000,
+      pb_ratio: 1.2,
+      ps_ratio: 2.3,
+      pc_ratio: 3.4,
+      pfcf_ratio: 4.5,
+      p_ebitda: 5.6,
+      ev_to_ebitda: 6.7,
+      ev_to_revenue: 7.8,
     },
   ]),
 }));
@@ -64,11 +71,15 @@ describe("Screener & Query page", () => {
     fireEvent.change(screen.getByLabelText(en.screener.maxPeg), {
       target: { value: "2" },
     });
+    fireEvent.change(screen.getByLabelText(en.screener.maxPb), {
+      target: { value: "3" },
+    });
 
     fireEvent.click(screen.getAllByRole("button", { name: en.screener.run })[0]);
 
     expect(await screen.findByText("1,000")).toBeInTheDocument();
-    expect(getScreener).toHaveBeenCalledWith(["AAA"], { peg_max: 2 });
+    expect(await screen.findByText("1.2")).toBeInTheDocument();
+    expect(getScreener).toHaveBeenCalledWith(["AAA"], { peg_max: 2, pb_max: 3 });
   });
 
   it("submits query form and renders results with export links", async () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -176,6 +176,13 @@ export interface ScreenerResult {
     pe_ratio: number | null;
     de_ratio: number | null;
     fcf: number | null;
+    pb_ratio: number | null;
+    ps_ratio: number | null;
+    pc_ratio: number | null;
+    pfcf_ratio: number | null;
+    p_ebitda: number | null;
+    ev_to_ebitda: number | null;
+    ev_to_revenue: number | null;
 }
 
 export interface SyntheticHolding {

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -217,12 +217,12 @@ def test_screener_endpoint(monkeypatch):
 
     def mock_fetch(ticker: str) -> Fundamentals:
         if ticker == "AAA":
-            return Fundamentals(ticker="AAA", peg_ratio=0.5)
-        return Fundamentals(ticker="BBB", peg_ratio=2.0)
+            return Fundamentals(ticker="AAA", peg_ratio=0.5, pb_ratio=1.0)
+        return Fundamentals(ticker="BBB", peg_ratio=2.0, pb_ratio=3.0)
 
     monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
 
-    resp = client.get("/screener?tickers=AAA,BBB&peg_max=1")
+    resp = client.get("/screener?tickers=AAA,BBB&peg_max=1&pb_max=2")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -9,6 +9,13 @@ def test_fetch_fundamentals_parses_values(monkeypatch):
         "PERatio": "10.2",
         "DebtToEquityTTM": "0.5",
         "FreeCashFlowTTM": "1234",
+        "PriceToBookRatio": "1.1",
+        "PriceToSalesRatioTTM": "2.2",
+        "PriceToCashFlowRatio": "3.3",
+        "PriceToFreeCashFlowTTM": "4.4",
+        "PriceToEBITDA": "5.5",
+        "EVToEBITDA": "6.6",
+        "EVToRevenue": "7.7",
     }
 
     class MockResp:
@@ -35,15 +42,61 @@ def test_fetch_fundamentals_parses_values(monkeypatch):
     assert f.pe_ratio == 10.2
     assert f.de_ratio == 0.5
     assert f.fcf == 1234.0
+    assert f.pb_ratio == 1.1
+    assert f.ps_ratio == 2.2
+    assert f.pc_ratio == 3.3
+    assert f.pfcf_ratio == 4.4
+    assert f.p_ebitda == 5.5
+    assert f.ev_to_ebitda == 6.6
+    assert f.ev_to_revenue == 7.7
 
 
 def test_screen_filters_based_on_thresholds(monkeypatch):
     def mock_fetch(ticker):
         if ticker == "AAA":
-            return Fundamentals(ticker="AAA", peg_ratio=0.5, pe_ratio=10, de_ratio=0.5, fcf=1000)
-        return Fundamentals(ticker="BBB", peg_ratio=2.0, pe_ratio=15, de_ratio=1.5, fcf=500)
+            return Fundamentals(
+                ticker="AAA",
+                peg_ratio=0.5,
+                pe_ratio=10,
+                de_ratio=0.5,
+                fcf=1000,
+                pb_ratio=1.0,
+                ps_ratio=2.0,
+                pc_ratio=3.0,
+                pfcf_ratio=4.0,
+                p_ebitda=5.0,
+                ev_to_ebitda=6.0,
+                ev_to_revenue=7.0,
+            )
+        return Fundamentals(
+            ticker="BBB",
+            peg_ratio=2.0,
+            pe_ratio=15,
+            de_ratio=1.5,
+            fcf=500,
+            pb_ratio=10.0,
+            ps_ratio=20.0,
+            pc_ratio=30.0,
+            pfcf_ratio=40.0,
+            p_ebitda=50.0,
+            ev_to_ebitda=60.0,
+            ev_to_revenue=70.0,
+        )
 
     monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
 
-    results = screen(["AAA", "BBB"], peg_max=1.0, pe_max=20, de_max=1.0, fcf_min=800)
+    results = screen(
+        ["AAA", "BBB"],
+        peg_max=1.0,
+        pe_max=20,
+        de_max=1.0,
+        fcf_min=800,
+        pb_max=2.0,
+        ps_max=3.0,
+        pc_max=4.0,
+        pfcf_max=5.0,
+        pebitda_max=6.0,
+        ev_ebitda_max=7.0,
+        ev_revenue_max=8.0,
+    )
     assert [r.ticker for r in results] == ["AAA"]


### PR DESCRIPTION
## Summary
- include price-based and enterprise value ratios in Fundamentals parsing and filtering
- expose additional screener parameters through API and UI
- update translations and tests for new metrics

## Testing
- `pytest tests/test_screener.py tests/test_backend_api.py`
- `npm test --prefix frontend -- --run src/pages/ScreenerQuery.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a198012b44832792946a4e8e696f4f