### PR TITLE
feat: configure environment-specific CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ log_config: backend/logging.ini
 
 Adjust these values to change the environment or server behaviour.
 
+Environment-specific CORS whitelists are defined in the same file:
+
+```yaml
+cors:
+  local:
+    - http://localhost:3000
+  production:
+    - https://app.allotmint.io
+```
+
+The list matching `app_env` is applied to the backend's CORS middleware.
+
 Optional frontend tabs can be toggled in `config.yaml`:
 
 ```yaml

--- a/backend/app.py
+++ b/backend/app.py
@@ -57,12 +57,12 @@ def create_app() -> FastAPI:
     app.state.background_tasks = []
 
     # ───────────────────────────── CORS ─────────────────────────────
-    # During development the frontend often runs on a different origin. We
-    # therefore allow every origin/method/header. A production deployment
-    # should tighten these values.
+    # The frontend origin varies by environment. Read the whitelist from
+    # configuration and fall back to permissive settings during development.
+    cors_origins = config.cors_origins or ["*"]
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=cors_origins,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/backend/config.py
+++ b/backend/config.py
@@ -67,6 +67,7 @@ class Config:
     approval_exempt_types: Optional[List[str]] = None
     approval_exempt_tickers: Optional[List[str]] = None
     tabs: TabsConfig = field(default_factory=TabsConfig)
+    cors_origins: Optional[List[str]] = None
 
 
 def _project_config_path() -> Path:
@@ -109,6 +110,15 @@ def load_config() -> Config:
         tabs_data.update(tabs_raw)
     tabs = TabsConfig(**tabs_data)
 
+    cors_raw = data.get("cors")
+    cors_origins = None
+    if isinstance(cors_raw, dict):
+        env = data.get("app_env")
+        if env:
+            cors_origins = cors_raw.get(env) or cors_raw.get("default")
+        else:
+            cors_origins = cors_raw.get("default")
+
     return Config(
         app_env=data.get("app_env"),
         sns_topic_arn=data.get("sns_topic_arn"),
@@ -144,6 +154,7 @@ def load_config() -> Config:
         approval_exempt_types=data.get("approval_exempt_types"),
         approval_exempt_tickers=data.get("approval_exempt_tickers"),
         tabs=tabs,
+        cors_origins=cors_origins,
     )
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,11 @@ timeseries_cache_base: data/timeseries
 fx_proxy_url: ''
 alpha_vantage_key: B74N5L0LY87QHKX4
 fundamentals_cache_ttl_seconds: 86400
+cors:
+  local:
+    - http://localhost:3000
+  production:
+    - https://app.allotmint.io
 app_env: local
 sns_topic_arn: ''
 telegram_bot_token: 8491288399:AAGRRuCJtctSQ2igqnW56BxQ3L_c0Jsi_nA


### PR DESCRIPTION
## Summary
- load CORS allowlist from config based on `app_env`
- add `cors` mapping to `config.yaml` and document setup in README

## Testing
- `pytest` *(fails: SyntaxError in backend/routes/screener.py)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a19ce12d248327b2cc136c0f1f15f4