### PR TITLE
feat: make page cache refresh handle async builders

### DIFF
--- a/tests/test_page_cache.py
+++ b/tests/test_page_cache.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+
+from backend.utils import page_cache
+
+
+def test_async_builder(monkeypatch, tmp_path):
+    async def run():
+        monkeypatch.setattr(page_cache, "CACHE_DIR", tmp_path)
+
+        async def builder():
+            return {"value": 1}
+
+        page_cache.schedule_refresh("async_page", 0, builder)
+        await asyncio.sleep(0.05)
+        assert page_cache.load_cache("async_page") == {"value": 1}
+        await page_cache.cancel_refresh_tasks()
+
+    asyncio.run(run())
+
+
+def test_builder_error_logged_and_continues(monkeypatch, tmp_path, caplog):
+    async def run():
+        monkeypatch.setattr(page_cache, "CACHE_DIR", tmp_path)
+
+        calls = {"count": 0}
+
+        def builder():
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise ValueError("boom")
+            return {"ok": True}
+
+        page_cache.schedule_refresh("error_page", 0.01, builder)
+        await asyncio.sleep(0.03)
+        await page_cache.cancel_refresh_tasks()
+        assert page_cache.load_cache("error_page") == {"ok": True}
+
+    with caplog.at_level("ERROR"):
+        asyncio.run(run())
+
+    assert "Cache refresh failed for error_page" in caplog.text


### PR DESCRIPTION
## Summary
- support async cache builders and run sync builders in `asyncio.to_thread`
- log builder errors without stopping the refresh loop
- add unit tests for async builders and error handling

## Testing
- `pytest tests/test_page_cache.py -q`
- `pytest -q` *(fails: SyntaxError in backend/routes/screener.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a19ceb5400832796d5b5c3277d2495