### PR TITLE
Allow local frontend on port 5173

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ fundamentals_cache_ttl_seconds: 86400
 cors:
   local:
     - http://localhost:3000
+    - http://localhost:5173
   production:
     - https://app.allotmint.io
 app_env: local


### PR DESCRIPTION
## Summary
- expand CORS allowed origins for local environment to include `http://localhost:5173`

## Testing
- `pytest tests/test_config.py -q`
- `bash run-local-api.sh` *(fails: 403 ProxyError fetching remote data)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a177f3fc8327a9eb234af0211c3a