### PR TITLE
Add Lambda Dockerfile and SAM template

### DIFF
--- a/backend/Dockerfile.lambda
+++ b/backend/Dockerfile.lambda
@@ -1,0 +1,11 @@
+FROM public.ecr.aws/lambda/python:3.11
+
+# Install application dependencies
+COPY backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code into the Lambda task root
+COPY backend/ /var/task/
+
+# Set the Lambda handler
+CMD ["backend.lambda_api.handler.lambda_handler"]

--- a/infra/lambda/template.yaml
+++ b/infra/lambda/template.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: SAM template for Allotmint backend Lambda
+
+Parameters:
+  AppEnv:
+    Type: String
+    Default: prod
+
+Resources:
+  BackendFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      Timeout: 30
+      MemorySize: 512
+      Environment:
+        Variables:
+          APP_ENV: !Ref AppEnv
+      Events:
+        ApiProxy:
+          Type: HttpApi
+          Properties:
+            Path: /{proxy+}
+            Method: ANY
+    Metadata:
+      Dockerfile: backend/Dockerfile.lambda
+      DockerContext: ../..
+      DockerTag: latest
+      DockerBuildArgs:
+        APP_ENV: !Ref AppEnv
+
+Outputs:
+  ApiUrl:
+    Description: API Gateway endpoint URL
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com"


### PR DESCRIPTION
## Summary
- add Dockerfile to package FastAPI and Mangum for Lambda
- add AWS SAM template defining Lambda and HttpApi routes

## Testing
- `pytest tests/test_app.py::test_health_env_variable -q`
- `sam build --template-file infra/lambda/template.yaml` *(fails: Building image for BackendFunction requires Docker. is Docker running?)*
- `sam deploy --template-file infra/lambda/template.yaml --no-confirm-changeset --stack-name test` *(fails: No region information found. Please provide --region parameter or configure default region settings.)*

------
https://chatgpt.com/codex/tasks/task_e_68a19e90389883278cb26b7796dce278