### PR TITLE
feat: add cognito auth for sensitive endpoints

### DIFF
--- a/USER_README.md
+++ b/USER_README.md
@@ -24,6 +24,22 @@ Additional runtime settings:
 - `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`: forward alerts to Telegram.
 - `DATA_BUCKET` (environment variable): S3 bucket containing account data when running in AWS.
 
+### Authentication
+
+The backend can validate OAuth2/JWT tokens issued by **Amazon Cognito**. The
+user pool ID and app client ID are stored in **AWS Secrets Manager**:
+
+1. Create a secret (e.g. `allotmint-cognito`) with JSON data:
+   ```json
+   {"user_pool_id": "<pool id>", "app_client_id": "<client id>"}
+   ```
+2. Grant the backend IAM role permission to read this secret.
+3. Set environment variables `COGNITO_SECRET_NAME` (secret name) and
+   `AWS_REGION`.
+
+With these values configured the API will verify incoming JWTs using Cognito’s
+JWKS. Local development and tests skip verification when the secret is absent.
+
 ## Common workflows
 - **Start the backend**: `uvicorn app:app --reload --port 8000`
 - **Start the frontend**: `cd frontend && npm run dev`

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional
+
+import boto3
+import httpx
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import jwt
+
+
+security = HTTPBearer(auto_error=False)
+REGION = os.getenv("AWS_REGION")
+SECRET_NAME = os.getenv("COGNITO_SECRET_NAME")
+
+
+@dataclass
+class CognitoSettings:
+    user_pool_id: str
+    app_client_id: str
+
+
+@lru_cache()
+def _load_settings() -> Optional[CognitoSettings]:
+    """Fetch Cognito configuration from AWS Secrets Manager.
+
+    The secret must contain a JSON object with ``user_pool_id`` and
+    ``app_client_id`` fields. When the secret cannot be loaded (e.g. in local
+    development) ``None`` is returned and authentication is bypassed.
+    """
+
+    if not (REGION and SECRET_NAME):
+        return None
+    try:
+        client = boto3.client("secretsmanager", region_name=REGION)
+        resp = client.get_secret_value(SecretId=SECRET_NAME)
+        data = json.loads(resp.get("SecretString") or "{}")
+        return CognitoSettings(
+            user_pool_id=data["user_pool_id"],
+            app_client_id=data["app_client_id"],
+        )
+    except Exception:
+        return None
+
+
+@lru_cache()
+def _load_jwks():
+    settings = _load_settings()
+    if not settings:
+        return []
+    url = (
+        f"https://cognito-idp.{REGION}.amazonaws.com/{settings.user_pool_id}/.well-known/jwks.json"
+    )
+    resp = httpx.get(url, timeout=5.0)
+    resp.raise_for_status()
+    return resp.json().get("keys", [])
+
+
+def _rsa_key(kid: str):
+    for key in _load_jwks():
+        if key.get("kid") == kid:
+            return jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+):
+    """Validate a JWT from AWS Cognito and return its claims.
+
+    When Cognito settings are not configured the function returns a dummy user
+    allowing the API to operate in development and tests.
+    """
+
+    settings = _load_settings()
+    if not settings:
+        return {"sub": "anonymous"}
+
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+    token = credentials.credentials
+    try:
+        headers = jwt.get_unverified_header(token)
+        rsa_key = _rsa_key(headers.get("kid"))
+        issuer = f"https://cognito-idp.{REGION}.amazonaws.com/{settings.user_pool_id}"
+        payload = jwt.decode(
+            token,
+            rsa_key,
+            algorithms=["RS256"],
+            audience=settings.app_client_id,
+            issuer=issuer,
+        )
+        return payload
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -42,3 +42,4 @@ requests~=2.32.3
 peewee~=3.18.2
 numpy~=2.3.1
 pyarrow~=21.0.0
+python-jose[cryptography]~=3.3.0

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -14,7 +14,7 @@ import logging
 from datetime import date
 from typing import List
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from pydantic import BaseModel, Field
 
 from backend.common import (
@@ -26,9 +26,10 @@ from backend.common import (
     instrument_api,
     risk,
 )
+from backend.auth import get_current_user
 
 log = logging.getLogger("routes.portfolio")
-router = APIRouter(tags=["portfolio"])
+router = APIRouter(tags=["portfolio"], dependencies=[Depends(get_current_user)])
 _ALLOWED_DAYS = {1, 7, 30, 90, 365}
 
 

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -5,11 +5,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from backend.config import config
+from backend.auth import get_current_user
 
-router = APIRouter(tags=["transactions"])
+router = APIRouter(tags=["transactions"], dependencies=[Depends(get_current_user)])
 
 
 def _load_all_transactions() -> List[dict]:


### PR DESCRIPTION
## Summary
- add auth module verifying AWS Cognito JWTs
- guard portfolio and transactions routes with auth
- document Cognito secret configuration

## Testing
- `pytest -q` *(fails: tests/test_screener.py SyntaxError)*
- `pytest tests/test_backend_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a19e0bbdb8832787faa7eccdf32374