### PR TITLE
Add scripts to install deps and start frontend dev server

### DIFF
--- a/run-frontend.ps1
+++ b/run-frontend.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = 'Stop'
+
+# Determine repository root and navigate to frontend directory
+$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location (Join-Path $SCRIPT_DIR 'frontend')
+
+Write-Host 'Installing frontend dependencies...' -ForegroundColor Yellow
+npm install
+
+Write-Host 'Starting frontend development server...' -ForegroundColor Green
+npm run dev

--- a/run-frontend.sh
+++ b/run-frontend.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure the script runs from repository root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/frontend"
+
+# Install dependencies
+npm install
+
+# Start the Vite development server
+npm run dev


### PR DESCRIPTION
## Summary
- add shell and PowerShell helpers to install frontend dependencies and start Vite dev server

## Testing
- `npm install`
- `npm test` *(fails: No "getAlertSettings" export is defined on the "./api" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68a22fd6e43883278d24cea1bebc6b33