### PR TITLE
Resolve ticker exchanges from portfolios

### DIFF
--- a/tests/test_instrument_api_exchange.py
+++ b/tests/test_instrument_api_exchange.py
@@ -1,0 +1,32 @@
+import datetime as dt
+import pandas as pd
+from backend.common import instrument_api as ia
+
+
+def test_timeseries_uses_portfolio_exchange(monkeypatch):
+    class FixedDate(dt.date):
+        @classmethod
+        def today(cls):
+            return cls(2023, 1, 9)
+
+    monkeypatch.setattr(ia.dt, "date", FixedDate)
+    monkeypatch.setattr(ia, "_LATEST_PRICES", {})
+    monkeypatch.setattr(ia, "_TICKER_EXCHANGE_MAP", {"XYZ": "N"})
+
+    captured = {}
+
+    def fake_has_cached(sym, ex):
+        captured["cache_ex"] = ex
+        return True
+
+    def fake_load(sym, ex, start_date, end_date):
+        captured["load_ex"] = ex
+        return pd.DataFrame({"date": [end_date], "close": [1.0]})
+
+    monkeypatch.setattr(ia, "has_cached_meta_timeseries", fake_has_cached)
+    monkeypatch.setattr(ia, "load_meta_timeseries_range", fake_load)
+
+    res = ia.timeseries_for_ticker("XYZ", days=1)
+    assert captured["cache_ex"] == "N"
+    assert captured["load_ex"] == "N"
+    assert res == [{"date": "2023-01-08", "close": 1.0, "close_gbp": 1.0}]

--- a/tests/test_movers_backend.py
+++ b/tests/test_movers_backend.py
@@ -9,10 +9,14 @@ def test_price_change_pct(monkeypatch):
         def today(cls):
             return cls(2023, 1, 9)
     monkeypatch.setattr(ia.dt, "date", FixedDate)
-    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, latest: t)
+    monkeypatch.setattr(
+        ia,
+        "_resolve_full_ticker",
+        lambda t, latest: (t.split(".", 1)[0], t.split(".", 1)[1] if "." in t else "L"),
+    )
     monkeypatch.setattr(ia, "_LATEST_PRICES", {})
 
-    def fake_close_on(full: str, d: dt.date):
+    def fake_close_on(sym: str, ex: str, d: dt.date):
         if d == dt.date(2023, 1, 8):
             return 110.0
         if d == dt.date(2023, 1, 1):
@@ -31,9 +35,13 @@ def test_top_movers(monkeypatch):
         def today(cls):
             return cls(2023, 1, 9)
     monkeypatch.setattr(ia.dt, "date", FixedDate)
-    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, latest: t)
+    monkeypatch.setattr(
+        ia,
+        "_resolve_full_ticker",
+        lambda t, latest: (t.split(".", 1)[0], t.split(".", 1)[1] if "." in t else "L"),
+    )
     monkeypatch.setattr(ia, "_LATEST_PRICES", {})
-    monkeypatch.setattr(ia, "_close_on", lambda full, d: 100.0)
+    monkeypatch.setattr(ia, "_close_on", lambda sym, ex, d: 100.0)
     monkeypatch.setattr(
         ia,
         "price_change_pct",


### PR DESCRIPTION
## Summary
- build a ticker→exchange map from portfolio metadata and use it when latest prices lack the symbol
- propagate resolved exchange through time-series helpers instead of defaulting to LSE
- test that tickers without price data retain their portfolio exchange

## Testing
- `pytest tests/test_movers_backend.py tests/test_instrument_api_exchange.py tests/test_group_movers_route.py tests/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3225a7ad88327982b22d6a61565f8