### PR TITLE
Ensure trade log directory exists before logging trades

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import logging
 import os
+from pathlib import Path
 
 from backend.common.alerts import publish_alert
 from backend.utils.telegram_utils import send_message, redact_token
@@ -114,6 +115,7 @@ def _log_trade(ticker: str, action: str, price: float, ts: Optional[datetime] = 
 
     ts = ts or datetime.utcnow()
     header = not TRADE_LOG_PATH.exists()
+    TRADE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     with TRADE_LOG_PATH.open("a", newline="") as f:
         writer = csv.DictWriter(
             f, fieldnames=["timestamp", "ticker", "action", "price"]

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -1,6 +1,8 @@
 import pytest
+import shutil
 from backend.common import portfolio_utils
 from backend.agent.trading_agent import send_trade_alert, run
+from backend.agent import trading_agent
 
 # Alias to match the terminology of "generate_signals"
 generate_signals = portfolio_utils.check_price_alerts
@@ -179,3 +181,16 @@ def test_run_sends_telegram_when_not_aws(monkeypatch):
     run()
 
     assert sent and "AAA" in sent[0]
+
+
+def test_log_trade_recreates_directory(tmp_path, monkeypatch):
+    trade_path = tmp_path / "trades" / "trade_log.csv"
+    trade_path.parent.mkdir(parents=True)
+    shutil.rmtree(trade_path.parent)
+    monkeypatch.setattr(trading_agent, "TRADE_LOG_PATH", trade_path)
+
+    assert not trade_path.parent.exists()
+
+    trading_agent._log_trade("AAA", "BUY", 1.0)
+
+    assert trade_path.exists()


### PR DESCRIPTION
## Summary
- Ensure trade log directory exists before writing trade logs
- Add regression test confirming `_log_trade` recreates missing directory

## Testing
- `pytest tests/test_trading_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3a1bb4f9c83278fdb849ad85631a7