### PR TITLE
Add summary logs for bulk timeseries operations

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -141,7 +141,7 @@ def _rolling_cache(
     exchange: str,
 ) -> pd.DataFrame:
 
-    logger.info("Rolling cache: %s", cache_path)
+    logger.debug("Rolling cache: %s", cache_path)
     # Only look up to yesterday (we have close prices only)
     cutoff, today = _weekday_range(datetime.today().date() - timedelta(days=1), days)
 

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -210,6 +210,7 @@ def run_all_tickers(
                 ok.append(t)
         except Exception as exc:
             logger.warning("[WARN] %s: %s", t, exc)
+    logger.info("Bulk warm-up complete: %d updated, %d skipped", len(ok), len(tickers) - len(ok))
     return ok
 
 
@@ -226,6 +227,9 @@ def load_timeseries_data(
                 out[t] = df
         except Exception as exc:
             logger.warning("Load fail %s: %s", t, exc)
+    logger.info(
+        "Bulk load complete: %d updated, %d skipped", len(out), len(tickers) - len(out)
+    )
     return out
 
 


### PR DESCRIPTION
## Summary
- Log timeseries cache rolls at DEBUG to reduce noise
- Emit INFO summaries for bulk warmups and loads with counts of updated vs skipped tickers

## Testing
- `pytest` *(fails: duplicate argument 'fcf_min' in backend/routes/screener.py)*
- `pytest tests/test_run_all_tickers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3a1b85ff4832793f3f338f6de334c