### PR TITLE
Support underscore separators in run_all_tickers

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -204,7 +204,7 @@ def run_all_tickers(
 
     ok: list[str] = []
     for t in tickers:
-        sym, ex = (t.split(".", 1) + [exchange])[:2]
+        sym, ex = (re.split(r"[._]", t, 1) + [exchange])[:2]
         try:
             if not load_meta_timeseries(sym, ex, days).empty:
                 ok.append(t)

--- a/tests/test_run_all_tickers.py
+++ b/tests/test_run_all_tickers.py
@@ -18,3 +18,17 @@ def test_run_all_tickers_accepts_full_tickers():
     assert out == ["AAA.L", "BBB"]
     assert calls == [("AAA", "L", 10), ("BBB", "N", 10)]
 
+
+def test_run_all_tickers_handles_underscore_and_dot():
+    calls = []
+
+    def fake_load(sym, ex, days):
+        calls.append((sym, ex, days))
+        return pd.DataFrame({"Date": [1], "Close": [2]})
+
+    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
+        out = run_all_tickers(["ADBE_N", "AZN.L"], exchange="Q", days=5)
+
+    assert out == ["ADBE_N", "AZN.L"]
+    assert calls == [("ADBE", "N", 5), ("AZN", "L", 5)]
+


### PR DESCRIPTION
## Summary
- handle underscores and dots when splitting ticker/exchange in `run_all_tickers`
- add regression test verifying underscore and dot separation

## Testing
- `pytest tests/test_run_all_tickers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3a1b7118c8327929a821e45607785