### PR TITLE
Handle CASH tickers before validation

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -82,11 +82,6 @@ def fetch_meta_timeseries(
         logger.warning("Ticker pattern looks invalid: %s", ticker)
         return pd.DataFrame(columns=STANDARD_COLUMNS)
 
-    if not is_valid_ticker(ticker, exchange):
-        logger.info("Skipping unrecognized ticker %s.%s", ticker, exchange)
-        record_skipped_ticker(ticker, exchange, reason="unknown")
-        return pd.DataFrame(columns=STANDARD_COLUMNS)
-
     if end_date is None:
         end_date = date.today() - timedelta(days=1)
     if start_date is None:
@@ -111,6 +106,11 @@ def fetch_meta_timeseries(
         )
         df["Date"] = pd.to_datetime(df["Date"]).dt.date
         return df
+
+    if not is_valid_ticker(ticker, exchange):
+        logger.info("Skipping unrecognized ticker %s.%s", ticker, exchange)
+        record_skipped_ticker(ticker, exchange, reason="unknown")
+        return pd.DataFrame(columns=STANDARD_COLUMNS)
 
     # Weekday grid we want to fill
     expected_dates = set(pd.bdate_range(start_date, end_date).date)

--- a/tests/test_cash_timeseries.py
+++ b/tests/test_cash_timeseries.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+import logging
 
 from backend.timeseries.fetch_meta_timeseries import fetch_meta_timeseries
 
@@ -14,3 +15,11 @@ def test_cash_timeseries_constant_one():
     assert (df["Low"] == 1.0).all()
     assert df["Source"].iloc[0] == "cash"
     assert df["Ticker"].iloc[0].upper() == "CASH.GBP"
+
+
+def test_cash_ticker_no_skip_logged(caplog):
+    end = date.today() - timedelta(days=1)
+    start = end - timedelta(days=10)
+    with caplog.at_level(logging.INFO):
+        fetch_meta_timeseries("CASH", "GBP", start_date=start, end_date=end)
+    assert "Skipping unrecognized ticker" not in caplog.text


### PR DESCRIPTION
## Summary
- return synthetic data for CASH tickers before ticker validation
- add regression test ensuring CASH tickers aren't logged as skipped

## Testing
- `pytest tests/test_cash_timeseries.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3a1b5ef1c8327a7215d06e361e6a9