### PR TITLE
Fix screener filter markup and update test

### DIFF
--- a/frontend/src/pages/Screener.tsx
+++ b/frontend/src/pages/Screener.tsx
@@ -223,6 +223,11 @@ export function Screener() {
             type="number"
             value={epsMin}
             onChange={(e) => setEpsMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.minDividendYield")}
           <input
             aria-label={t("screener.minDividendYield")}
@@ -240,6 +245,11 @@ export function Screener() {
             type="number"
             value={grossMarginMin}
             onChange={(e) => setGrossMarginMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.maxDividendPayoutRatio")}
           <input
             aria-label={t("screener.maxDividendPayoutRatio")}
@@ -257,6 +267,11 @@ export function Screener() {
             type="number"
             value={operatingMarginMin}
             onChange={(e) => setOperatingMarginMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.maxBeta")}
           <input
             aria-label={t("screener.maxBeta")}
@@ -274,6 +289,11 @@ export function Screener() {
             type="number"
             value={netMarginMin}
             onChange={(e) => setNetMarginMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.minSharesOutstanding")}
           <input
             aria-label={t("screener.minSharesOutstanding")}
@@ -291,6 +311,11 @@ export function Screener() {
             type="number"
             value={ebitdaMarginMin}
             onChange={(e) => setEbitdaMarginMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.minFloatShares")}
           <input
             aria-label={t("screener.minFloatShares")}
@@ -308,6 +333,11 @@ export function Screener() {
             type="number"
             value={roaMin}
             onChange={(e) => setRoaMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.minMarketCap")}
           <input
             aria-label={t("screener.minMarketCap")}
@@ -325,6 +355,11 @@ export function Screener() {
             type="number"
             value={roeMin}
             onChange={(e) => setRoeMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.max52WeekHigh")}
           <input
             aria-label={t("screener.max52WeekHigh")}
@@ -342,6 +377,11 @@ export function Screener() {
             type="number"
             value={roiMin}
             onChange={(e) => setRoiMin(e.target.value)}
+            step="any"
+            style={{ marginLeft: "0.25rem" }}
+          />
+        </label>
+        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.min52WeekLow")}
           <input
             aria-label={t("screener.min52WeekLow")}

--- a/frontend/src/pages/ScreenerQuery.test.tsx
+++ b/frontend/src/pages/ScreenerQuery.test.tsx
@@ -83,14 +83,18 @@ describe("Screener & Query page", () => {
     });
     fireEvent.change(screen.getByLabelText(en.screener.minRoe), {
       target: { value: "5" },
-    fireEvent.change(screen.getByLabelText(en.screener.minDividendYield), {
-      target: { value: "1" },
     });
 
     fireEvent.click(screen.getAllByRole("button", { name: en.screener.run })[0]);
 
     expect(await screen.findByText("1,000")).toBeInTheDocument();
     expect(getScreener).toHaveBeenCalledWith(["AAA"], { peg_max: 2, roe_min: 5 });
+
+    fireEvent.change(screen.getByLabelText(en.screener.minDividendYield), {
+      target: { value: "1" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: en.screener.run })[0]);
+
     expect(await screen.findByText("1.2")).toBeInTheDocument();
     expect(getScreener).toHaveBeenCalledWith(["AAA"], {
       peg_max: 2,


### PR DESCRIPTION
## Summary
- close and separate screener filter inputs to restore valid JSX
- extend ScreenerQuery test to run screener twice with different filters

## Testing
- `npm run build` *(fails: Property 'refreshConfig' is missing ...)*
- `npm test` *(fails: No "getAlertSettings" export is defined on the "./api" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a178e3748327a609cf8c5b597be2