### PR TITLE
fix: align tests with updated config context

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -139,6 +139,7 @@ describe("App", () => {
           theme: "system",
           relativeViewEnabled: false,
           tabs: { ...allTabs, movers: false },
+          refreshConfig: async () => {},
         }}
       >
         <MemoryRouter initialEntries={["/movers"]}>
@@ -188,7 +189,12 @@ describe("App", () => {
 
     render(
       <configContext.Provider
-        value={{ theme: "system", relativeViewEnabled: false, tabs: allTabs }}
+        value={{
+          theme: "system",
+          relativeViewEnabled: false,
+          tabs: allTabs,
+          refreshConfig: async () => {},
+        }}
       >
         <MemoryRouter initialEntries={["/movers"]}>
           <App />

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -80,7 +80,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   const refreshConfig = useCallback(async () => {
     try {
       const cfg = await getConfig<RawConfig>();
-      const tabs: TabsConfig = { ...defaultTabs, ...(cfg.tabs ?? {}) };
+      const tabs = { ...defaultTabs, ...(cfg.tabs ?? {}) } as TabsConfig;
       const disabledTabs = new Set<string>(
         Array.isArray(cfg.disabled_tabs) ? cfg.disabled_tabs : [],
       );

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -20,14 +20,18 @@ const defaultConfig: AppConfig = {
     timeseries: true,
     watchlist: true,
     movers: true,
+    dataadmin: true,
     virtual: true,
     support: true,
+    scenario: true,
   },
 };
 
 const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig> = {}) =>
   render(
-    <configContext.Provider value={{ ...defaultConfig, ...cfg }}>
+    <configContext.Provider
+      value={{ ...defaultConfig, ...cfg, refreshConfig: async () => {} }}
+    >
       {ui}
     </configContext.Provider>,
   );

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -14,8 +14,10 @@ const defaultConfig: AppConfig = {
         timeseries: true,
         watchlist: true,
         movers: true,
+        dataadmin: true,
         virtual: true,
         support: true,
+        scenario: true,
     },
 };
 import type { Holding } from "../types";
@@ -86,7 +88,9 @@ describe("HoldingsTable", () => {
 
     const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig>) =>
         render(
-            <configContext.Provider value={{ ...defaultConfig, ...cfg }}>
+            <configContext.Provider
+                value={{ ...defaultConfig, ...cfg, refreshConfig: async () => {} }}
+            >
                 {ui}
             </configContext.Provider>,
         );

--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -15,8 +15,10 @@ const defaultConfig: AppConfig = {
     timeseries: true,
     watchlist: true,
     movers: true,
+    dataadmin: true,
     virtual: true,
     support: true,
+    scenario: true,
   },
 };
 
@@ -45,7 +47,9 @@ describe("InstrumentDetail", () => {
 
   const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig>) =>
     render(
-      <configContext.Provider value={{ ...defaultConfig, ...cfg }}>
+      <configContext.Provider
+        value={{ ...defaultConfig, ...cfg, refreshConfig: async () => {} }}
+      >
         <MemoryRouter>{ui}</MemoryRouter>
       </configContext.Provider>,
     );

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -14,8 +14,10 @@ const defaultConfig: AppConfig = {
         timeseries: true,
         watchlist: true,
         movers: true,
+        dataadmin: true,
         virtual: true,
         support: true,
+        scenario: true,
     },
 };
 
@@ -138,7 +140,13 @@ describe("InstrumentTable", () => {
 
     it("hides absolute columns in relative view", () => {
         render(
-            <configContext.Provider value={{ ...defaultConfig, relativeViewEnabled: true }}>
+            <configContext.Provider
+                value={{
+                    ...defaultConfig,
+                    relativeViewEnabled: true,
+                    refreshConfig: async () => {},
+                }}
+            >
                 <InstrumentTable rows={rows} />
             </configContext.Provider>,
         );

--- a/frontend/src/pages/Screener.test.tsx
+++ b/frontend/src/pages/Screener.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { Screener } from "./Screener";
 import * as api from "../api";
+import type { ScreenerResult } from "../types";
 
 vi.mock("../api");
 
@@ -21,7 +22,7 @@ describe("Screener", () => {
         current_ratio: 2,
         quick_ratio: 1.5,
         fcf: 1000,
-      },
+      } as ScreenerResult,
     ]);
 
     render(<Screener />);

--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -36,7 +36,9 @@ function parseCsv(text: string): PriceEntry[] {
           : val === undefined || val === ""
           ? null
           : Number(val);
-      obj[key] = parsed as PriceEntry[typeof key];
+      (
+        obj as Record<keyof PriceEntry, PriceEntry[keyof PriceEntry]>
+      )[key] = parsed as PriceEntry[typeof key];
     });
     return obj as PriceEntry;
   });


### PR DESCRIPTION
## Summary
- cast fetched tabs to `TabsConfig` to keep boolean types
- ensure CSV parser assigns typed values
- update tests to include new tabs and mock `refreshConfig`
- import and use `ScreenerResult` in screener test

## Testing
- `npm test` *(fails: no "getAlertSettings" export in ./api mock)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3a68c8430832782d412f250b6dc9e