### PR TITLE
Fix GBX price scaling in price snapshots

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -81,6 +81,12 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
                 # no data -> don't write a zero; just continue
                 continue
 
+            # apply instrument-specific scaling (e.g., GBX -> GBP)
+            scale = get_scaling_override(ticker, exchange, None)
+            df = apply_scaling(df, scale)
+            if scale != 1 and "Close_gbp" in df.columns:
+                df["Close_gbp"] = pd.to_numeric(df["Close_gbp"], errors="coerce") * scale
+
             # prefer GBP-close column if present
             close_col = None
             for col in ("Close_gbp", "Close", "close_gbp", "close"):

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -22,6 +22,7 @@ from backend.common import portfolio as portfolio_mod
 from backend.common.portfolio_loader import list_portfolios          # existing helper
 from backend.common.instruments import get_instrument_meta
 from backend.timeseries.cache import load_meta_timeseries_range, load_meta_timeseries
+from backend.utils.timeseries_helpers import get_scaling_override, apply_scaling
 from backend.common.virtual_portfolio import (
     VirtualPortfolio,
     list_virtual_portfolios,
@@ -416,8 +417,6 @@ def refresh_snapshot_in_memory_from_timeseries(days: int = 365) -> None:
     and write it to *data/prices/latest_prices.json* in the canonical
     shape used by the rest of the backend.
     """
-    from backend.timeseries.cache import fetch_meta_timeseries
-
     tickers = list_all_unique_tickers()
     snapshot: Dict[str, Dict[str, str | float]] = {}
 
@@ -427,21 +426,34 @@ def refresh_snapshot_in_memory_from_timeseries(days: int = 365) -> None:
             cutoff = today - timedelta(days=days)
             ticker_only, exchange = (t.split(".", 1) + ["L"])[:2]
 
-            df = fetch_meta_timeseries(
-                ticker=ticker_only, exchange=exchange, start_date=cutoff, end_date=today
+            df = load_meta_timeseries_range(
+                ticker=ticker_only,
+                exchange=exchange,
+                start_date=cutoff,
+                end_date=today,
             )
 
             if df is not None and not df.empty:
+                # apply scaling overrides (e.g., GBX -> GBP)
+                scale = get_scaling_override(ticker_only, exchange, None)
+                df = apply_scaling(df, scale)
+                if scale != 1 and "Close_gbp" in df.columns:
+                    df["Close_gbp"] = pd.to_numeric(df["Close_gbp"], errors="coerce") * scale
+
                 # Map lowercase column names to their actual counterparts
                 name_map = {c.lower(): c for c in df.columns}
 
-                # Access the close column in a case-insensitive manner
-                if "close" in name_map:
+                close_col = (
+                    name_map.get("close_gbp")
+                    or name_map.get("close")
+                    or name_map.get("adj close")
+                    or name_map.get("adj_close")
+                )
+                if close_col:
                     latest_row = df.iloc[-1]
-                    close_col = name_map["close"]
                     snapshot[t] = {
                         "last_price": float(latest_row[close_col]),
-                        "last_price_date": latest_row["Date"].strftime("%Y-%m-%d"),
+                        "last_price_date": pd.to_datetime(latest_row["Date"]).strftime("%Y-%m-%d"),
                     }
         except Exception as e:
             logger.warning("Could not get timeseries for %s: %s", t, e)

--- a/tests/test_load_latest_prices.py
+++ b/tests/test_load_latest_prices.py
@@ -23,3 +23,15 @@ def test_load_latest_prices_selects_close_column(monkeypatch, data, expected):
 
     prices = holding_utils.load_latest_prices(["ABC.L"])
     assert prices["ABC.L"] == expected
+
+
+def test_load_latest_prices_applies_scaling(monkeypatch):
+    df = pd.DataFrame({"Date": [1], "Close": [20.0]})
+
+    monkeypatch.setattr(
+        holding_utils, "load_meta_timeseries_range", lambda *a, **k: df
+    )
+    monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 0.5)
+
+    prices = holding_utils.load_latest_prices(["ABC.L"])
+    assert prices["ABC.L"] == 10.0

--- a/tests/test_portfolio_utils_snapshot.py
+++ b/tests/test_portfolio_utils_snapshot.py
@@ -3,7 +3,6 @@ from datetime import date
 import pandas as pd
 
 from backend.common import portfolio_utils
-from backend.timeseries import cache as ts_cache
 
 
 def test_refresh_snapshot_case_insensitive_close(monkeypatch, tmp_path):
@@ -12,7 +11,8 @@ def test_refresh_snapshot_case_insensitive_close(monkeypatch, tmp_path):
     df = pd.DataFrame({"Date": [pd.Timestamp(today)], "Close": [123.45]})
 
     monkeypatch.setattr(portfolio_utils, "list_all_unique_tickers", lambda: [ticker])
-    monkeypatch.setattr(ts_cache, "fetch_meta_timeseries", lambda **kwargs: df)
+    monkeypatch.setattr(portfolio_utils, "load_meta_timeseries_range", lambda **kwargs: df)
+    monkeypatch.setattr(portfolio_utils, "get_scaling_override", lambda *a, **k: 1)
     monkeypatch.setattr(portfolio_utils, "_PRICES_PATH", tmp_path / "latest_prices.json")
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {})
 
@@ -35,7 +35,8 @@ def test_refresh_snapshot_skips_missing_close(monkeypatch, tmp_path):
     df = pd.DataFrame({"Date": [pd.Timestamp(today)], "High": [1.23]})
 
     monkeypatch.setattr(portfolio_utils, "list_all_unique_tickers", lambda: [ticker])
-    monkeypatch.setattr(ts_cache, "fetch_meta_timeseries", lambda **kwargs: df)
+    monkeypatch.setattr(portfolio_utils, "load_meta_timeseries_range", lambda **kwargs: df)
+    monkeypatch.setattr(portfolio_utils, "get_scaling_override", lambda *a, **k: 1)
     monkeypatch.setattr(portfolio_utils, "_PRICES_PATH", tmp_path / "latest_prices.json")
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {})
 


### PR DESCRIPTION
## Summary
- apply scaling overrides when building latest price map
- ensure price snapshot generation uses scaled GBP values
- test GBX scaling behavior

## Testing
- `pytest tests/test_load_latest_prices.py tests/test_portfolio_utils_snapshot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3a852a5948327816d618578304996