### PR TITLE
feat(frontend): add tab plugins for all modes

### DIFF
--- a/frontend/src/plugins/TabPlugin.ts
+++ b/frontend/src/plugins/TabPlugin.ts
@@ -1,0 +1,23 @@
+import type { ComponentType } from "react";
+
+/** Context passed to route helpers when building URLs. */
+export interface RouteContext {
+  owner?: string;
+  group?: string;
+}
+
+/**
+ * Definition of a tab plugin used to extend the navigation bar.
+ * Each plugin exposes the React component to render when active,
+ * a priority used for ordering, and a helper to build the tab's path.
+ */
+export interface TabPlugin {
+  /** Unique identifier corresponding to the app mode (e.g. "movers"). */
+  id: string;
+  /** React component rendered when the tab is selected. */
+  component: ComponentType<any>;
+  /** Lower numbers appear further to the left in the navigation bar. */
+  priority: number;
+  /** Build a URL path for the tab based on current selections. */
+  path: (ctx: RouteContext) => string;
+}

--- a/frontend/src/plugins/dataadmin.ts
+++ b/frontend/src/plugins/dataadmin.ts
@@ -1,0 +1,11 @@
+import DataAdmin from "../pages/DataAdmin";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "dataadmin",
+  component: DataAdmin,
+  priority: 90,
+  path: () => "/dataadmin",
+};
+
+export default plugin;

--- a/frontend/src/plugins/group.ts
+++ b/frontend/src/plugins/group.ts
@@ -1,0 +1,11 @@
+import { GroupPortfolioView } from "../components/GroupPortfolioView";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "group",
+  component: GroupPortfolioView,
+  priority: 10,
+  path: ({ group }) => (group ? `/?group=${group}` : "/movers"),
+};
+
+export default plugin;

--- a/frontend/src/plugins/instrument.ts
+++ b/frontend/src/plugins/instrument.ts
@@ -1,0 +1,11 @@
+import { InstrumentTable } from "../components/InstrumentTable";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "instrument",
+  component: InstrumentTable,
+  priority: 20,
+  path: ({ group }) => (group ? `/instrument/${group}` : "/instrument"),
+};
+
+export default plugin;

--- a/frontend/src/plugins/movers.ts
+++ b/frontend/src/plugins/movers.ts
@@ -1,0 +1,11 @@
+import TopMovers from "../pages/TopMovers";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "movers",
+  component: TopMovers,
+  priority: 0,
+  path: () => "/movers",
+};
+
+export default plugin;

--- a/frontend/src/plugins/owner.ts
+++ b/frontend/src/plugins/owner.ts
@@ -1,0 +1,11 @@
+import { PortfolioView } from "../components/PortfolioView";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "owner",
+  component: PortfolioView,
+  priority: 30,
+  path: ({ owner }) => (owner ? `/member/${owner}` : "/member"),
+};
+
+export default plugin;

--- a/frontend/src/plugins/performance.ts
+++ b/frontend/src/plugins/performance.ts
@@ -1,0 +1,11 @@
+import { PerformanceDashboard } from "../components/PerformanceDashboard";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "performance",
+  component: PerformanceDashboard,
+  priority: 40,
+  path: ({ owner }) => (owner ? `/performance/${owner}` : "/performance"),
+};
+
+export default plugin;

--- a/frontend/src/plugins/reports.ts
+++ b/frontend/src/plugins/reports.ts
@@ -1,0 +1,11 @@
+import Reports from "../pages/Reports";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "reports",
+  component: Reports,
+  priority: 100,
+  path: () => "/reports",
+};
+
+export default plugin;

--- a/frontend/src/plugins/scenario.ts
+++ b/frontend/src/plugins/scenario.ts
@@ -1,0 +1,11 @@
+import ScenarioTester from "../pages/ScenarioTester";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "scenario",
+  component: ScenarioTester,
+  priority: 120,
+  path: () => "/scenario",
+};
+
+export default plugin;

--- a/frontend/src/plugins/screener.ts
+++ b/frontend/src/plugins/screener.ts
@@ -1,0 +1,11 @@
+import ScreenerQuery from "../pages/ScreenerQuery";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "screener",
+  component: ScreenerQuery,
+  priority: 60,
+  path: () => "/screener",
+};
+
+export default plugin;

--- a/frontend/src/plugins/support.ts
+++ b/frontend/src/plugins/support.ts
@@ -1,0 +1,11 @@
+import Support from "../pages/Support";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "support",
+  component: Support,
+  priority: 110,
+  path: () => "/support",
+};
+
+export default plugin;

--- a/frontend/src/plugins/timeseries.ts
+++ b/frontend/src/plugins/timeseries.ts
@@ -1,0 +1,11 @@
+import { TimeseriesEdit } from "../pages/TimeseriesEdit";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "timeseries",
+  component: TimeseriesEdit,
+  priority: 70,
+  path: () => "/timeseries",
+};
+
+export default plugin;

--- a/frontend/src/plugins/transactions.ts
+++ b/frontend/src/plugins/transactions.ts
@@ -1,0 +1,11 @@
+import { TransactionsPage } from "../components/TransactionsPage";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "transactions",
+  component: TransactionsPage,
+  priority: 50,
+  path: () => "/transactions",
+};
+
+export default plugin;

--- a/frontend/src/plugins/watchlist.ts
+++ b/frontend/src/plugins/watchlist.ts
@@ -1,0 +1,11 @@
+import Watchlist from "../pages/Watchlist";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "watchlist",
+  component: Watchlist,
+  priority: 80,
+  path: () => "/watchlist",
+};
+
+export default plugin;


### PR DESCRIPTION
## Summary
- introduce `TabPlugin` interface for tabbed navigation
- add plugin modules for movers, group, owner and other modes with route helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4664213e883278ea9fe52ab83611d