### PR TITLE
Use tab plugin registry for navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { getGroupInstruments, getGroups, getOwners, getPortfolio, refreshPrices } from "./api";
+import {
+  getGroupInstruments,
+  getGroups,
+  getOwners,
+  getPortfolio,
+  refreshPrices,
+} from "./api";
 
 import type {
   GroupSummary,
@@ -30,21 +36,8 @@ import { useConfig } from "./ConfigContext";
 import DataAdmin from "./pages/DataAdmin";
 import Support from "./pages/Support";
 import ScenarioTester from "./pages/ScenarioTester";
-
-type Mode =
-  | "owner"
-  | "group"
-  | "instrument"
-  | "transactions"
-  | "performance"
-  | "screener"
-  | "timeseries"
-  | "watchlist"
-  | "movers"
-  | "dataadmin"
-  | "reports"
-  | "support"
-  | "scenario";
+import { tabPlugins } from "./tabPlugins";
+type Mode = (typeof tabPlugins)[number]["id"];
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -94,22 +87,6 @@ export default function App() {
 
   const ownersReq = useFetchWithRetry(getOwners);
   const groupsReq = useFetchWithRetry(getGroups);
-
-  const modes: Mode[] = [
-    "movers",
-    "group",
-    "instrument",
-    "owner",
-    "performance",
-    "transactions",
-    "screener",
-    "timeseries",
-    "watchlist",
-    "dataadmin",
-    "reports",
-    "support",
-    "scenario",
-  ];
 
   function pathFor(m: Mode) {
     switch (m) {
@@ -290,18 +267,20 @@ export default function App() {
       <LanguageSwitcher />
       <AlertsPanel />
       <nav style={{ margin: "1rem 0" }}>
-        {modes
-          .filter((m) => tabs[m] !== false)
-          .map((m) => (
+        {tabPlugins
+          .slice()
+          .sort((a, b) => a.priority - b.priority)
+          .filter((p) => tabs[p.id] !== false)
+          .map((p) => (
             <Link
-              key={m}
-              to={pathFor(m)}
+              key={p.id}
+              to={pathFor(p.id)}
               style={{
                 marginRight: "1rem",
-                fontWeight: mode === m ? "bold" : undefined,
+                fontWeight: mode === p.id ? "bold" : undefined,
               }}
             >
-              {t(`app.modes.${m}`)}
+              {t(`app.modes.${p.id}`)}
             </Link>
           ))}
       </nav>

--- a/frontend/src/tabPlugins.ts
+++ b/frontend/src/tabPlugins.ts
@@ -1,0 +1,16 @@
+export const tabPlugins = [
+  { id: "movers", priority: 0 },
+  { id: "group", priority: 10 },
+  { id: "instrument", priority: 20 },
+  { id: "owner", priority: 30 },
+  { id: "performance", priority: 40 },
+  { id: "transactions", priority: 50 },
+  { id: "screener", priority: 60 },
+  { id: "timeseries", priority: 70 },
+  { id: "watchlist", priority: 80 },
+  { id: "dataadmin", priority: 90 },
+  { id: "reports", priority: 100 },
+  { id: "support", priority: 110 },
+  { id: "scenario", priority: 120 },
+] as const;
+export type TabPlugin = typeof tabPlugins[number];


### PR DESCRIPTION
## Summary
- derive Mode type and tab order from `tabPlugins` registry
- populate `tabPlugins` with tab ids and priorities
- render navigation links from sorted registry filtered by config

## Testing
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a466435f2c8327a28bfbea7a61c37c