### PR TITLE
Add tab plugin registry tests and docs

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -30,3 +30,24 @@ If neither is provided the app falls back to `http://localhost:8000`.
 
 Runtime feature flags and tab visibility come from the backend's `config.yaml`. See the [backend setup instructions](../README.md#local-quick-start) for configuring and running the server.
 
+## Tab plugins
+
+Tabs in the navigation bar are driven by a small plugin system. A plugin
+provides the component to render and optional metadata such as a
+`priority` value. Plugins are registered in `src/pluginRegistry.ts`.
+
+```ts
+import { registerTabPlugin } from "./pluginRegistry";
+import MyTab from "./pages/MyTab";
+
+registerTabPlugin({
+  id: "myTab",
+  Component: MyTab,
+  priority: 50, // higher numbers appear earlier
+});
+```
+
+Plugins with higher priority numbers are displayed before lower ones. A
+plugin can be disabled by setting `isEnabled` to `false` or providing a
+function that returns `false`.
+

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  clearTabPlugins,
+  getTabPlugins,
+  registerTabPlugin,
+} from "./pluginRegistry";
 
 const mockTradingSignals = vi.fn();
 
@@ -308,5 +313,24 @@ describe("App", () => {
       "Support",
       "Scenario Tester",
     ]);
+  });
+
+  it("orders plugins by priority and ignores disabled ones", () => {
+    clearTabPlugins();
+    registerTabPlugin({ id: "a", Component: () => null, priority: 10 });
+    registerTabPlugin({
+      id: "b",
+      Component: () => null,
+      priority: 5,
+    });
+    registerTabPlugin({
+      id: "c",
+      Component: () => null,
+      priority: 20,
+      isEnabled: () => false,
+    });
+
+    const plugins = getTabPlugins();
+    expect(plugins.map((p) => p.id)).toEqual(["a", "b"]);
   });
 });

--- a/frontend/src/pluginRegistry.ts
+++ b/frontend/src/pluginRegistry.ts
@@ -1,0 +1,39 @@
+export interface TabPlugin {
+  /** Unique identifier for the plugin */
+  id: string;
+  /** React component that renders the tab */
+  Component: React.ComponentType;
+  /** Optional priority used for ordering (higher comes first) */
+  priority?: number;
+  /**
+   * Optional flag or function determining whether the plugin is enabled.
+   * When omitted the plugin is considered enabled.
+   */
+  isEnabled?: boolean | (() => boolean);
+}
+
+const registry: TabPlugin[] = [];
+
+/** Register a new tab plugin. */
+export function registerTabPlugin(plugin: TabPlugin) {
+  registry.push(plugin);
+}
+
+/**
+ * Retrieve all enabled tab plugins ordered by priority.
+ * Plugins with a higher priority value appear earlier.
+ */
+export function getTabPlugins(): TabPlugin[] {
+  return registry
+    .filter((p) => {
+      const enabled =
+        typeof p.isEnabled === "function" ? p.isEnabled() : p.isEnabled;
+      return enabled !== false;
+    })
+    .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+}
+
+/** Clear all registered plugins. Primarily for testing. */
+export function clearTabPlugins() {
+  registry.length = 0;
+}


### PR DESCRIPTION
## Summary
- add simple registry for tab plugins with priority and enable checks
- document how to create tab plugins and set priority
- test registry ordering and disable behaviour

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a466454fb4832786a46a770c801f44