### PR TITLE
feat: add frontend build script

### DIFF
--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+# Run from the directory of this script
+cd "$(dirname "$0")"
+
+npm run build


### PR DESCRIPTION
## Summary
- add build.sh for running `npm run build` in the frontend directory

## Testing
- `npm test -- --run`
- `pytest` *(fails: keyword argument repeated in tests/test_screener.py)*
- `bash frontend/build.sh` *(fails: various TypeScript errors)*
- `aws s3 mb s3://allotmint-static-assets` *(fails: Unable to locate credentials)*
- `aws s3 sync frontend/dist s3://allotmint-static-assets` *(fails: The user-provided path frontend/dist does not exist)*
- `aws s3 website s3://allotmint-static-assets --index-document index.html --error-document error.html` *(fails: Unable to locate credentials)*
- `aws cloudfront create-distribution --origin-domain-name allotmint-static-assets.s3.amazonaws.com` *(fails: Unable to locate credentials)*
- `aws route53 change-resource-record-sets --hosted-zone-id ZZZ --change-batch file://dns.json` *(fails: Unable to load paramfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a19de99cd08327a39b1d595bca3c40