### PR TITLE
Handle cancellation correctly in page cache refresh loop

### DIFF
--- a/backend/utils/page_cache.py
+++ b/backend/utils/page_cache.py
@@ -82,7 +82,9 @@ def schedule_refresh(page_name: str, ttl: int, builder: Callable[[], Any]) -> No
                 try:
                     data = await _call_builder()
                     save_cache(page_name, data)
-                except Exception:
+                except Exception as exc:
+                    if isinstance(exc, asyncio.CancelledError):  # pragma: no cover - defensive
+                        raise
                     logger.exception("Cache refresh failed for %s", page_name)
                     # Immediately retry on failure so the cache can still be
                     # populated without waiting for the next scheduled


### PR DESCRIPTION
## Summary
- avoid swallowing `asyncio.CancelledError` in the page cache refresh loop
- continue to retry builders on ordinary failures while allowing tasks to cancel cleanly

## Testing
- `pytest tests/test_page_cache.py::test_builder_error_logged_and_continues -q`


------
https://chatgpt.com/codex/tasks/task_e_68a620fb905c8327a6b5dcc2e0ca5663