### PR TITLE
Enable React Router v7 future flags

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,7 +12,7 @@ import { ConfigProvider } from './ConfigContext'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ConfigProvider>
-      <BrowserRouter>
+      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Routes>
           <Route path="/virtual" element={<VirtualPortfolio />} />
           <Route path="/*" element={<App />} />


### PR DESCRIPTION
## Summary
- enable React Router v7_startTransition and v7_relativeSplatPath future flags in main entrypoint to silence upgrade warnings

## Testing
- `npm test` (fails: No "getAlertSettings" export is defined on the "./api" mock)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6245ccd9c8327b4a99762233c45cc