### PR TITLE
Remove unused CLI options from trading agent script

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -5,17 +5,13 @@ from __future__ import annotations
 import csv
 import logging
 import os
-from pathlib import Path
-
-from backend.common.alerts import publish_alert
-from backend.utils.telegram_utils import send_message, redact_token
-from backend.config import config
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional
 
 import pandas as pd
 
 from backend.common import prices
+from backend.common.alerts import publish_alert
 from backend.common.portfolio_loader import list_portfolios
 from backend.common.portfolio_utils import (
     list_all_unique_tickers,
@@ -25,6 +21,8 @@ from backend.common.trade_metrics import (
     TRADE_LOG_PATH,
     load_and_compute_metrics,
 )
+from backend.config import config
+from backend.utils.telegram_utils import send_message, redact_token
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/run_trading_agent.py
+++ b/scripts/run_trading_agent.py
@@ -2,29 +2,17 @@
 """Command-line helper to run the trading agent."""
 
 import argparse
+from typing import Iterable, Optional
 
 from backend.agent.trading_agent import run
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the trading agent")
     parser.add_argument(
         "--tickers", nargs="+", help="List of tickers to analyse", default=None
     )
-    parser.add_argument(
-        "--thresholds",
-        type=float,
-        nargs="+",
-        help="Threshold values for each ticker",
-        default=None,
-    )
-    parser.add_argument(
-        "--indicator",
-        type=str,
-        help="Technical indicator to use",
-        default=None,
-    )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def main() -> None:

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -194,3 +194,13 @@ def test_log_trade_recreates_directory(tmp_path, monkeypatch):
     trading_agent._log_trade("AAA", "BUY", 1.0)
 
     assert trade_path.exists()
+
+
+def test_run_trading_agent_removed_options():
+    from scripts import run_trading_agent
+
+    with pytest.raises(SystemExit):
+        run_trading_agent.parse_args(["--thresholds", "1"])
+
+    with pytest.raises(SystemExit):
+        run_trading_agent.parse_args(["--indicator", "sma"])


### PR DESCRIPTION
## Summary
- reorder imports in trading agent, ensuring logging is available
- strip unused `thresholds` and `indicator` options from CLI helper
- add regression test asserting removed options are rejected

## Testing
- `pytest tests/test_trading_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68a629a2385483278aeb9188815f4bc5