### PR TITLE
Handle error_summary config more safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,17 @@ cd frontend && npm test
 
 Use the `run_with_error_summary.py` script to capture error lines when running
 commands. A log file `error_summary.log` will be created with a summary of
-errors which you can attach when reporting bugs.
+errors which you can attach when reporting bugs. Optionally set a default
+command in `config.yaml` under `error_summary.default_command` so the script
+can run without CLI arguments:
+
+```yaml
+error_summary:
+  default_command: ["pytest"]
+```
+
+Running `python run_with_error_summary.py` with no arguments will then use the
+configured default.
 
 ```bash
 # example

--- a/backend/config.py
+++ b/backend/config.py
@@ -125,6 +125,9 @@ def load_config() -> Config:
         else:
             cors_origins = cors_raw.get("default")
 
+    error_summary_raw = data.get("error_summary")
+    error_summary = error_summary_raw if isinstance(error_summary_raw, dict) else None
+
     return Config(
         app_env=data.get("app_env"),
         sns_topic_arn=data.get("sns_topic_arn"),
@@ -140,7 +143,7 @@ def load_config() -> Config:
         ft_url_template=data.get("ft_url_template"),
         selenium_user_agent=data.get("selenium_user_agent"),
         selenium_headless=data.get("selenium_headless"),
-        error_summary=data.get("error_summary"),
+        error_summary=error_summary,
         offline_mode=data.get("offline_mode"),
         relative_view_enabled=data.get("relative_view_enabled"),
         theme=data.get("theme"),

--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,7 @@ selenium_headless: true
 approval_valid_days: 2
 approval_exempt_types: ETF
 approval_exempt_tickers: ''
-error_summary: '[object Object]'
+error_summary: {}
 
 tabs:
   movers: true


### PR DESCRIPTION
## Summary
- sanitize `error_summary` value when loading config
- use empty mapping for `error_summary` in config.yaml
- document `error_summary` configuration in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a629a4a9508327a83d1840dd99a111