### PR TITLE
chore: align Lambda runtime on Python 3.12

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install backend dependencies
         run: pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ For setup and usage instructions, see the [USER_README](USER_README.md).
 | Storage  | S3 JSON / CSV (no RDBMS)                     |
 | IaC      | AWS CDK (Py)                                 |
 
+The backend, CI/CD workflows, and tests all target Python 3.12.
+
 ## Watchlist
 
 The repo includes a lightweight Yahoo Finance watchlist. Run it locally with:

--- a/backend/Dockerfile.lambda
+++ b/backend/Dockerfile.lambda
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.11
+FROM public.ecr.aws/lambda/python:3.12
 
 # Install application dependencies
 COPY backend/requirements.txt ./requirements.txt

--- a/backend/lambda_api/handler.py
+++ b/backend/lambda_api/handler.py
@@ -1,5 +1,5 @@
 """
-AWS Lambda entry-point (Python 3.11 runtime or container).
+AWS Lambda entry-point (Python 3.12 runtime or container).
 Handler: backend.lambda_api.handler.lambda_handler
 """
 

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -25,7 +25,7 @@ class BackendLambdaStack(Stack):
             code=_lambda.Code.from_asset(
                 str(backend_path),
                 bundling=_lambda.BundlingOptions(
-                    image=_lambda.Runtime.PYTHON_3_11.bundling_image,
+                    image=_lambda.Runtime.PYTHON_3_12.bundling_image,
                     command=[
                         "bash",
                         "-c",
@@ -33,7 +33,7 @@ class BackendLambdaStack(Stack):
                     ],
                 ),
             ),
-            compatible_runtimes=[_lambda.Runtime.PYTHON_3_11],
+            compatible_runtimes=[_lambda.Runtime.PYTHON_3_12],
         )
 
         backend_code = _lambda.Code.from_asset(str(backend_path))
@@ -41,7 +41,7 @@ class BackendLambdaStack(Stack):
         backend_fn = _lambda.Function(
             self,
             "BackendLambda",
-            runtime=_lambda.Runtime.PYTHON_3_11,
+            runtime=_lambda.Runtime.PYTHON_3_12,
             handler="backend.lambda_api.handler.lambda_handler",
             code=backend_code,
             layers=[dependencies_layer],
@@ -53,7 +53,7 @@ class BackendLambdaStack(Stack):
         refresh_fn = _lambda.Function(
             self,
             "PriceRefreshLambda",
-            runtime=_lambda.Runtime.PYTHON_3_11,
+            runtime=_lambda.Runtime.PYTHON_3_12,
             handler="backend.lambda_api.price_refresh.lambda_handler",
             code=backend_code,
             layers=[dependencies_layer],

--- a/infra/lambda/quotes.yml
+++ b/infra/lambda/quotes.yml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: backend.tasks.quotes.lambda_handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 60
       MemorySize: 256
       Environment:


### PR DESCRIPTION
## Summary
- use Python 3.12 for Lambda container and CDK stack
- run CI workflows on Python 3.12
- document Python 3.12 as the project-wide backend runtime

## Testing
- `python3.12 -m pytest` *(fails: 12 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a629a7b37c832799b9f32eacd2f3c3