### PR TITLE
Configure backend linting and formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: format lint
+
+format:
+	isort --sp backend/pyproject.toml backend tests
+	black --config backend/pyproject.toml backend tests
+
+lint:
+	ruff check --config backend/pyproject.toml backend tests
+	black --check --config backend/pyproject.toml backend tests
+	pytest

--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -5,26 +5,24 @@ from __future__ import annotations
 import csv
 import logging
 import os
-from pathlib import Path
-
-from backend.common.alerts import publish_alert
-from backend.utils.telegram_utils import send_message, redact_token
-from backend.config import config
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional
 
 import pandas as pd
 
 from backend.common import prices
+from backend.common.alerts import publish_alert
 from backend.common.portfolio_loader import list_portfolios
 from backend.common.portfolio_utils import (
-    list_all_unique_tickers,
     compute_owner_performance,
+    list_all_unique_tickers,
 )
 from backend.common.trade_metrics import (
     TRADE_LOG_PATH,
     load_and_compute_metrics,
 )
+from backend.config import config
+from backend.utils.telegram_utils import redact_token, send_message
 
 logger = logging.getLogger(__name__)
 
@@ -52,18 +50,15 @@ def send_trade_alert(message: str, publish: bool = True) -> None:
         except RuntimeError:
             logger.info("SNS topic ARN not configured; skipping publish")
 
-    if (
-        os.getenv("TELEGRAM_BOT_TOKEN")
-        and os.getenv("TELEGRAM_CHAT_ID")
-        and config.app_env != "aws"
-    ):
+    if os.getenv("TELEGRAM_BOT_TOKEN") and os.getenv("TELEGRAM_CHAT_ID") and config.app_env != "aws":
         try:
             send_message(message)
         except Exception as exc:  # pragma: no cover - network errors are rare
             logger.warning("Telegram send failed: %s", redact_token(str(exc)))
 
+
 PRICE_DROP_THRESHOLD = -5.0  # percent
-PRICE_GAIN_THRESHOLD = 5.0   # percent
+PRICE_GAIN_THRESHOLD = 5.0  # percent
 DRAWDOWN_ALERT_THRESHOLD = 0.2  # 20% decline; set to 0 to disable
 
 
@@ -106,7 +101,6 @@ def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
     return signals
 
 
-  
 def _log_trade(ticker: str, action: str, price: float, ts: Optional[datetime] = None) -> None:
     """Append a trade record to the trade log.
 
@@ -117,9 +111,7 @@ def _log_trade(ticker: str, action: str, price: float, ts: Optional[datetime] = 
     header = not TRADE_LOG_PATH.exists()
     TRADE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     with TRADE_LOG_PATH.open("a", newline="") as f:
-        writer = csv.DictWriter(
-            f, fieldnames=["timestamp", "ticker", "action", "price"]
-        )
+        writer = csv.DictWriter(f, fieldnames=["timestamp", "ticker", "action", "price"])
         if header:
             writer.writeheader()
         writer.writerow(
@@ -130,6 +122,7 @@ def _log_trade(ticker: str, action: str, price: float, ts: Optional[datetime] = 
                 "price": price,
             }
         )
+
 
 def _alert_on_drawdown(threshold: float = DRAWDOWN_ALERT_THRESHOLD) -> None:
     """Emit an alert if any portfolio drawdown exceeds ``threshold``."""
@@ -146,9 +139,7 @@ def _alert_on_drawdown(threshold: float = DRAWDOWN_ALERT_THRESHOLD) -> None:
         if max_dd is None:
             continue
         if abs(max_dd) >= threshold:
-            send_trade_alert(
-                f"{owner} portfolio drawdown {max_dd*100:.2f}% exceeds {threshold*100:.2f}%"
-            )
+            send_trade_alert(f"{owner} portfolio drawdown {max_dd*100:.2f}% exceeds {threshold*100:.2f}%")
 
 
 def run(tickers: Optional[Iterable[str]] = None) -> List[Dict]:

--- a/backend/alerts.py
+++ b/backend/alerts.py
@@ -7,6 +7,7 @@ percentage an alert is published through :mod:`backend.common.alerts`.
 User thresholds are persisted in a tiny JSON file under ``data`` which acts
 as a lightweight database suitable for tests and development environments.
 """
+
 from __future__ import annotations
 
 import json
@@ -14,17 +15,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
 
-from backend.config import config
 from backend.common.alerts import publish_alert
+from backend.config import config
 
 DEFAULT_THRESHOLD_PCT = 0.05  # default 5% threshold
 
 # Path used to store user specific thresholds
-_SETTINGS_PATH = (
-    (config.repo_root or Path(__file__).resolve().parents[1])
-    / "data"
-    / "alert_thresholds.json"
-)
+_SETTINGS_PATH = (config.repo_root or Path(__file__).resolve().parents[1]) / "data" / "alert_thresholds.json"
 
 # In-memory cache of settings
 _USER_THRESHOLDS: Dict[str, float] = {}
@@ -37,9 +34,7 @@ def _load_settings() -> None:
         return
     try:
         if _SETTINGS_PATH.exists():
-            _USER_THRESHOLDS = {
-                k: float(v) for k, v in json.loads(_SETTINGS_PATH.read_text()).items()
-            }
+            _USER_THRESHOLDS = {k: float(v) for k, v in json.loads(_SETTINGS_PATH.read_text()).items()}
     except Exception:
         _USER_THRESHOLDS = {}
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -15,35 +15,33 @@ from fastapi import Depends, FastAPI, HTTPException, Security, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import APIKeyHeader
 
-from backend.routes.instrument import router as instrument_router
-from backend.routes.portfolio import router as portfolio_router
-from backend.routes.timeseries_meta import router as timeseries_router
-from backend.routes.timeseries_edit import router as timeseries_edit_router
-from backend.routes.timeseries_admin import router as timeseries_admin_router
-
-from backend.routes.transactions import router as transactions_router
-from backend.routes.alerts import router as alerts_router
-from backend.routes.compliance import router as compliance_router
-from backend.routes.screener import router as screener_router
-from backend.routes.support import router as support_router
-from backend.routes.query import router as query_router
-from backend.routes.virtual_portfolio import router as virtual_portfolio_router
-from backend.routes.metrics import router as metrics_router
-from backend.routes.agent import router as agent_router
-from backend.routes.trading_agent import router as trading_agent_router
-from backend.routes.config import router as config_router
-from backend.routes.quotes import router as quotes_router
-from backend.routes.movers import router as movers_router
-from backend.routes.scenario import router as scenario_router
+from backend.common.data_loader import resolve_paths
 from backend.common.portfolio_utils import (
     _load_snapshot,
     refresh_snapshot_async,
     refresh_snapshot_in_memory,
 )
 from backend.config import config
-from backend.common.data_loader import resolve_paths
+from backend.routes.agent import router as agent_router
+from backend.routes.alerts import router as alerts_router
+from backend.routes.compliance import router as compliance_router
+from backend.routes.config import router as config_router
+from backend.routes.instrument import router as instrument_router
+from backend.routes.metrics import router as metrics_router
+from backend.routes.movers import router as movers_router
+from backend.routes.portfolio import router as portfolio_router
+from backend.routes.query import router as query_router
+from backend.routes.quotes import router as quotes_router
+from backend.routes.scenario import router as scenario_router
+from backend.routes.screener import router as screener_router
+from backend.routes.support import router as support_router
+from backend.routes.timeseries_admin import router as timeseries_admin_router
+from backend.routes.timeseries_edit import router as timeseries_edit_router
+from backend.routes.timeseries_meta import router as timeseries_router
+from backend.routes.trading_agent import router as trading_agent_router
+from backend.routes.transactions import router as transactions_router
+from backend.routes.virtual_portfolio import router as virtual_portfolio_router
 from backend.utils import page_cache
-
 
 API_TOKEN = os.getenv("API_TOKEN")
 api_key_header = APIKeyHeader(name="X-API-Token", auto_error=False)
@@ -124,6 +122,7 @@ def create_app() -> FastAPI:
     skip_warm = bool(config.skip_snapshot_warm)
 
     if not skip_warm:
+
         @app.on_event("startup")
         async def _warm_snapshot() -> None:
             """Pre-fetch recent price data so the first request is fast."""
@@ -157,6 +156,4 @@ def create_app() -> FastAPI:
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(
-        create_app(), host="0.0.0.0", port=config.uvicorn_port or 8000
-    )
+    uvicorn.run(create_app(), host="0.0.0.0", port=config.uvicorn_port or 8000)

--- a/backend/common/alerts.py
+++ b/backend/common/alerts.py
@@ -32,6 +32,7 @@ def publish_sns_alert(alert: Dict) -> None:
 def publish_alert(alert: Dict) -> None:
     publish_sns_alert(alert)
 
+
 def get_recent_alerts(limit: int = 50) -> List[Dict]:
     """Return recent alerts, most recent last."""
     return _RECENT_ALERTS[-limit:]

--- a/backend/common/approvals.py
+++ b/backend/common/approvals.py
@@ -7,8 +7,8 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Dict, Optional
 
-from backend.config import config
 from backend.common.data_loader import resolve_paths
+from backend.config import config
 
 
 def load_approvals(owner: str, accounts_root: Optional[Path] = None) -> Dict[str, date]:

--- a/backend/common/clean_accounts.py
+++ b/backend/common/clean_accounts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
+
 import json
 from pathlib import Path
 
@@ -11,12 +12,15 @@ OVERWRITE = True  # set False to write to a new folder
 
 KEEP_FIELDS = {"ticker", "units", "cost_basis_gbp", "acquired_date"}
 
+
 def read_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
 
 def write_json(path: Path, data: dict):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
 
 def simplify_account_file(path: Path, out_dir: Path | None = None):
     acct = read_json(path)
@@ -39,12 +43,14 @@ def simplify_account_file(path: Path, out_dir: Path | None = None):
     write_json(out_path, acct)
     print(f"Simplified: {out_path}")
 
+
 def main():
     out_dir = None
     if not OVERWRITE:
         out_dir = REPO_ROOT / "data" / "accounts_simplified"
     for file in ACCOUNTS_DIR.rglob("*.json"):
         simplify_account_file(file, out_dir)
+
 
 if __name__ == "__main__":
     main()

--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 """Data loading helpers for AllotMint."""
 
-from pathlib import Path
 import json
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.config import config
-
 from backend.common.virtual_portfolio import VirtualPortfolio
+from backend.config import config
 
 
 # ------------------------------------------------------------------
@@ -86,10 +85,12 @@ def _list_local_plots(data_root: Optional[Path] = None) -> List[Dict[str, Any]]:
             seen.add(al)
             dedup.append(a)
 
-        results.append({
-            "owner": owner_dir.name,
-            "accounts": dedup,
-        })
+        results.append(
+            {
+                "owner": owner_dir.name,
+                "accounts": dedup,
+            }
+        )
 
     return results
 
@@ -146,10 +147,7 @@ def _list_aws_plots() -> List[Dict[str, Any]]:
         else:
             break
 
-    return [
-        {"owner": owner, "accounts": accounts}
-        for owner, accounts in sorted(owners.items())
-    ]
+    return [{"owner": owner, "accounts": accounts} for owner, accounts in sorted(owners.items())]
 
 
 # ------------------------------------------------------------------
@@ -185,12 +183,11 @@ def load_account(
     if config.app_env == "aws":
         bucket = os.getenv(DATA_BUCKET_ENV)
         if not bucket:
-            raise FileNotFoundError(
-                f"Missing {DATA_BUCKET_ENV} env var for AWS account loading"
-            )
+            raise FileNotFoundError(f"Missing {DATA_BUCKET_ENV} env var for AWS account loading")
         key = f"{PLOTS_PREFIX}{owner}/{account}.json"
         try:
             import boto3  # type: ignore
+
             obj = boto3.client("s3").get_object(Bucket=bucket, Key=key)
         except Exception as exc:  # pragma: no cover - exercised via tests
             raise FileNotFoundError(f"s3://{bucket}/{key}") from exc
@@ -215,6 +212,7 @@ def load_person_meta(owner: str, data_root: Optional[Path] = None) -> Dict[str, 
         key = f"{PLOTS_PREFIX}{owner}/person.json"
         try:
             import boto3  # type: ignore
+
             obj = boto3.client("s3").get_object(Bucket=bucket, Key=key)
             body = obj.get("Body")
             txt = body.read().decode("utf-8-sig").strip() if body else ""

--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -15,15 +15,15 @@ from __future__ import annotations
 
 import datetime as dt
 from functools import lru_cache
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
-from backend.common.constants import OWNER, ACCOUNTS, HOLDINGS
+from backend.common.constants import ACCOUNTS, HOLDINGS, OWNER
 from backend.common.group_portfolio import build_group_portfolio
 from backend.common.holding_utils import load_latest_prices
-from backend.common.portfolio_utils import list_all_unique_tickers, get_security_meta
+from backend.common.portfolio_utils import get_security_meta, list_all_unique_tickers
 from backend.timeseries.cache import (
-    load_meta_timeseries_range,
     has_cached_meta_timeseries,
+    load_meta_timeseries_range,
 )
 from backend.timeseries.fetch_meta_timeseries import run_all_tickers
 
@@ -143,17 +143,14 @@ def timeseries_for_ticker(ticker: str, days: int = 365) -> List[Dict[str, Any]]:
 # Last price + %-changes helpers
 # ───────────────────────────────────────────────────────────────
 
+
 def _close_on(sym: str, ex: str, d: dt.date) -> Optional[float]:
     """Return close price for ``sym.ex`` ticker on date ``d`` if available."""
     snap = _nearest_weekday(d, forward=False)
     df = load_meta_timeseries_range(sym, ex, start_date=snap, end_date=snap)
     if df is None or df.empty:
         return None
-    col = (
-        "close_gbp"
-        if "close_gbp" in df.columns
-        else ("Close_gbp" if "Close_gbp" in df.columns else None)
-    )
+    col = "close_gbp" if "close_gbp" in df.columns else ("Close_gbp" if "Close_gbp" in df.columns else None)
     if col is None:
         col = "close" if "close" in df.columns else ("Close" if "Close" in df.columns else None)
     return float(df[col].iloc[0]) if col else None

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -38,6 +38,6 @@ def get_instrument_meta(ticker: str) -> Dict[str, Any]:
     except json.JSONDecodeError as exc:
         logger.warning("Invalid instrument JSON %s: %s", path, exc)
         return {}
-    except Exception as exc:
+    except Exception:
         logger.exception("Unexpected error loading instrument metadata for %s", path)
         raise

--- a/backend/common/metrics.py
+++ b/backend/common/metrics.py
@@ -6,9 +6,8 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from backend.common.compliance import load_transactions
 from backend.common import portfolio as portfolio_mod
-
+from backend.common.compliance import load_transactions
 
 METRICS_DIR = Path(__file__).resolve().parents[2] / "data" / "metrics"
 
@@ -140,4 +139,3 @@ def compute_and_store_metrics(
     }
     _metrics_path(owner).write_text(json.dumps(metrics))
     return metrics
-

--- a/backend/common/pension.py
+++ b/backend/common/pension.py
@@ -14,7 +14,7 @@ Returns dict with fields used in API response.
 """
 
 import datetime as dt
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 DEFAULT_ANNUITY_MULTIPLE = 20  # crude capitalisation proxy
 

--- a/backend/common/portfolio_loader.py
+++ b/backend/common/portfolio_loader.py
@@ -46,12 +46,12 @@ def _build_owner_portfolio(owner_summary: Dict) -> Dict:
                         'accounts': [ {...}, ... ]  # parsed account JSON
                       }
     """
-    owner   = owner_summary["owner"]
-    names   = owner_summary["accounts"]
+    owner = owner_summary["owner"]
+    names = owner_summary["accounts"]
 
     return {
-        "owner"   : owner,
-        "person"  : load_person_meta(owner),
+        "owner": owner,
+        "person": load_person_meta(owner),
         "accounts": _load_accounts_for_owner(owner, names),
     }
 

--- a/backend/common/risk.py
+++ b/backend/common/risk.py
@@ -6,7 +6,6 @@ historical-simulation Value-at-Risk (VaR) for a portfolio owner.
 
 from __future__ import annotations
 
-from datetime import date
 from typing import Dict
 
 import numpy as np

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict, field
+from dataclasses import asdict, dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Optional, Dict, Any, overload, List
+from typing import Any, Dict, List, Optional, overload
+
 import yaml
 
 
@@ -95,14 +96,10 @@ def load_config() -> Config:
     repo_root = (base_dir / repo_root_raw).resolve() if repo_root_raw else base_dir
 
     accounts_root_raw = data.get("accounts_root")
-    accounts_root = (
-        (repo_root / accounts_root_raw).resolve() if accounts_root_raw else None
-    )
+    accounts_root = (repo_root / accounts_root_raw).resolve() if accounts_root_raw else None
 
     prices_json_raw = data.get("prices_json")
-    prices_json = (
-        (repo_root / prices_json_raw).resolve() if prices_json_raw else None
-    )
+    prices_json = (repo_root / prices_json_raw).resolve() if prices_json_raw else None
 
     tabs_raw = data.get("tabs")
     tabs_data = asdict(TabsConfig())
@@ -141,9 +138,7 @@ def load_config() -> Config:
         timeseries_cache_base=data.get("timeseries_cache_base"),
         fx_proxy_url=data.get("fx_proxy_url"),
         alpha_vantage_key=data.get("alpha_vantage_key"),
-        fundamentals_cache_ttl_seconds=data.get(
-            "fundamentals_cache_ttl_seconds"
-        ),
+        fundamentals_cache_ttl_seconds=data.get("fundamentals_cache_ttl_seconds"),
         max_trades_per_month=data.get("max_trades_per_month"),
         hold_days_min=data.get("hold_days_min"),
         repo_root=repo_root,
@@ -173,6 +168,7 @@ def get_config_dict() -> Dict[str, Any]:
 def get_config() -> Dict[str, Any]: ...
 @overload
 def get_config(key: str, default: Any = None) -> Any: ...
+
 
 def get_config(key: Optional[str] = None, default: Any = None):
     """

--- a/backend/lambda_api/handler.py
+++ b/backend/lambda_api/handler.py
@@ -4,6 +4,7 @@ Handler: backend.lambda_api.handler.lambda_handler
 """
 
 from mangum import Mangum
+
 from backend.app import create_app
 
 lambda_handler = Mangum(create_app())

--- a/backend/lambda_api/price_refresh.py
+++ b/backend/lambda_api/price_refresh.py
@@ -24,11 +24,7 @@ def lambda_handler(event, context):
     result = refresh_prices()
 
     # honour environment flag so trading agent can be toggled per deployment
-    if (
-        os.getenv("ALLOTMINT_ENABLE_TRADING_AGENT", "").lower()
-        in {"1", "true", "yes"}
-        and trading_agent is not None
-    ):
+    if os.getenv("ALLOTMINT_ENABLE_TRADING_AGENT", "").lower() in {"1", "true", "yes"} and trading_agent is not None:
         trading_agent.run()
 
     return result

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 120
+target-version = ["py311"]
+
+[tool.isort]
+profile = "black"
+line_length = 120
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+extend-ignore = ["E402"]
+

--- a/backend/routes/alerts.py
+++ b/backend/routes/alerts.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from backend.common.alerts import get_recent_alerts
 from backend import alerts as alert_utils
+from backend.common.alerts import get_recent_alerts
 
 router = APIRouter(prefix="/alerts", tags=["alerts"])
 

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import yaml
 from fastapi import APIRouter, HTTPException
 
-from backend.config import get_config_dict, load_config, _project_config_path
+from backend.config import _project_config_path, get_config_dict, load_config
 
 router = APIRouter(prefix="/config", tags=["config"])
 

--- a/backend/routes/metrics.py
+++ b/backend/routes/metrics.py
@@ -2,8 +2,8 @@
 
 from fastapi import APIRouter
 
-from backend.common.metrics import compute_and_store_metrics, load_metrics
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
+from backend.common.metrics import compute_and_store_metrics, load_metrics
 
 router = APIRouter(tags=["metrics"])
 

--- a/backend/routes/movers.py
+++ b/backend/routes/movers.py
@@ -1,8 +1,6 @@
 # backend/routes/movers.py
 from __future__ import annotations
 
-from typing import List
-
 from fastapi import APIRouter, HTTPException, Query
 
 from backend.common.instrument_api import top_movers

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -20,12 +20,12 @@ from pydantic import BaseModel, Field
 from backend.common import (
     data_loader,
     group_portfolio,
-    portfolio as portfolio_mod,
+    instrument_api,
     portfolio_utils,
     prices,
-    instrument_api,
     risk,
 )
+from backend.common import portfolio as portfolio_mod
 
 log = logging.getLogger("routes.portfolio")
 router = APIRouter(tags=["portfolio"])
@@ -200,6 +200,7 @@ async def instrument_detail(slug: str, ticker: str):
     except Exception:
         raise HTTPException(status_code=404, detail="Instrument not found")
     return {"prices": prices_list, "positions": positions_list}
+
 
 @router.api_route("/prices/refresh", methods=["GET", "POST"])
 async def refresh_prices():

--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -11,8 +11,8 @@ tests can monkeypatch ``yf.Tickers`` using a dotted import path.
 import sys
 from typing import Any, Dict, List
 
-from fastapi import APIRouter, HTTPException, Query
 import yfinance as yf
+from fastapi import APIRouter, HTTPException, Query
 
 # Expose ``yf`` as a submodule for monkeypatching in tests
 sys.modules[__name__ + ".yf"] = yf
@@ -45,4 +45,3 @@ async def get_quotes(symbols: str = Query("")) -> List[Dict[str, Any]]:
             results.append({"symbol": sym, "price": price})
 
     return results
-

--- a/backend/routes/scenario.py
+++ b/backend/routes/scenario.py
@@ -2,8 +2,8 @@
 
 from fastapi import APIRouter, Query
 
-from backend.utils.scenario_tester import apply_price_shock
 from backend.common.portfolio_loader import list_portfolios
+from backend.utils.scenario_tester import apply_price_shock
 
 router = APIRouter(tags=["scenario"])
 

--- a/backend/routes/screener.py
+++ b/backend/routes/screener.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 """API route for basic stock screening based on valuation metrics."""
 
+import hashlib
 from typing import List
 
-import hashlib
-
-from fastapi import APIRouter, HTTPException, Query, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 
 from backend.screener import Fundamentals, screen
 from backend.utils import page_cache
@@ -86,32 +85,7 @@ async def screener(
     page_cache.schedule_refresh(
         page,
         SCREENER_TTL,
-        lambda symbols=symbols,
-               peg_max=peg_max,
-               pe_max=pe_max,
-               de_max=de_max,
-               lt_de_max=lt_de_max,
-               interest_coverage_min=interest_coverage_min,
-               current_ratio_min=current_ratio_min,
-               quick_ratio_min=quick_ratio_min,
-               fcf_min=fcf_min,
-               eps_min=eps_min,
-               gross_margin_min=gross_margin_min,
-               operating_margin_min=operating_margin_min,
-               net_margin_min=net_margin_min,
-               ebitda_margin_min=ebitda_margin_min,
-               roa_min=roa_min,
-               roe_min=roe_min,
-               roi_min=roi_min,
-               dividend_yield_min=dividend_yield_min,
-               dividend_payout_ratio_max=dividend_payout_ratio_max,
-               beta_max=beta_max,
-               shares_outstanding_min=shares_outstanding_min,
-               float_shares_min=float_shares_min,
-               market_cap_min=market_cap_min,
-               high_52w_max=high_52w_max,
-               low_52w_min=low_52w_min,
-               avg_volume_min=avg_volume_min: [
+        lambda: [
             r.model_dump()
             for r in screen(
                 symbols,

--- a/backend/routes/timeseries_admin.py
+++ b/backend/routes/timeseries_admin.py
@@ -34,9 +34,7 @@ async def timeseries_admin() -> list[dict[str, Any]]:
         completeness = len(df) / bdays * 100
         latest_source = df.iloc[-1]["Source"] if "Source" in df.columns else None
         main_source = (
-            df["Source"].value_counts().idxmax()
-            if "Source" in df.columns and not df["Source"].dropna().empty
-            else None
+            df["Source"].value_counts().idxmax() if "Source" in df.columns and not df["Source"].dropna().empty else None
         )
         meta = get_instrument_meta(f"{ticker}.{exchange}")
         summaries.append(

--- a/backend/routes/timeseries_edit.py
+++ b/backend/routes/timeseries_edit.py
@@ -26,9 +26,7 @@ def _load_timeseries(ticker: str, exchange: str) -> pd.DataFrame:
 
 
 @router.get("/edit")
-async def get_timeseries_edit(
-    ticker: str = Query(...), exchange: str = Query("L")
-) -> JSONResponse:
+async def get_timeseries_edit(ticker: str = Query(...), exchange: str = Query("L")) -> JSONResponse:
     df = _load_timeseries(ticker, exchange)
     if not df.empty:
         df = df.copy()
@@ -37,9 +35,7 @@ async def get_timeseries_edit(
 
 
 @router.post("/edit")
-async def post_timeseries_edit(
-    request: Request, ticker: str = Query(...), exchange: str = Query("L")
-) -> JSONResponse:
+async def post_timeseries_edit(request: Request, ticker: str = Query(...), exchange: str = Query("L")) -> JSONResponse:
     content_type = request.headers.get("content-type", "")
     try:
         if "text/csv" in content_type:

--- a/backend/routes/timeseries_meta.py
+++ b/backend/routes/timeseries_meta.py
@@ -14,6 +14,7 @@ from backend.utils.timeseries_helpers import (
 
 router = APIRouter(prefix="/timeseries", tags=["timeseries"])
 
+
 @router.get("/meta", response_class=HTMLResponse)
 async def get_meta_timeseries(
     ticker: str = Query(...),
@@ -29,16 +30,12 @@ async def get_meta_timeseries(
     end_date = date.today() - timedelta(days=1)
 
     try:
-        df = load_meta_timeseries_range(
-            ticker, exchange, start_date=start_date, end_date=end_date
-        )
+        df = load_meta_timeseries_range(ticker, exchange, start_date=start_date, end_date=end_date)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
     if df.empty:
-        raise HTTPException(
-            status_code=404, detail=f"No data found for {ticker}.{exchange}"
-        )
+        raise HTTPException(status_code=404, detail=f"No data found for {ticker}.{exchange}")
 
     df = df.copy()
     df["Date"] = pd.to_datetime(df["Date"])
@@ -52,13 +49,15 @@ async def get_meta_timeseries(
 
     # ── JSON output ───────────────────────────────────────────
     if format == "json":
-        return JSONResponse(content={
-            "ticker": f"{ticker}.{exchange}",
-            "from": start_date.isoformat(),
-            "to": end_date.isoformat(),
-            "scaling": scaling,
-            "prices": df.to_dict(orient="records"),
-        })
+        return JSONResponse(
+            content={
+                "ticker": f"{ticker}.{exchange}",
+                "from": start_date.isoformat(),
+                "to": end_date.isoformat(),
+                "scaling": scaling,
+                "prices": df.to_dict(orient="records"),
+            }
+        )
 
     # ── CSV output ────────────────────────────────────────────
     elif format == "csv":
@@ -91,16 +90,18 @@ async def yahoo_timeseries_html(
         df = fetch_timeseries.fetch_yahoo_timeseries(ticker, period, interval)
     except Exception:
         df = pd.DataFrame(
-            [{
-                "Date": date.today(),
-                "Open": 0.0,
-                "High": 0.0,
-                "Low": 0.0,
-                "Close": 0.0,
-                "Volume": 0,
-                "Ticker": ticker,
-                "Source": "Yahoo",
-            }]
+            [
+                {
+                    "Date": date.today(),
+                    "Open": 0.0,
+                    "High": 0.0,
+                    "Low": 0.0,
+                    "Close": 0.0,
+                    "Volume": 0,
+                    "Ticker": ticker,
+                    "Source": "Yahoo",
+                }
+            ]
         )
 
     scale = get_scaling_override(ticker, "", scaling)

--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -25,6 +25,7 @@ _CACHE_TTL_SECONDS = max(
 )
 _CACHE: Dict[Tuple[str, str], Tuple[datetime, "Fundamentals"]] = {}
 
+
 class Fundamentals(BaseModel):
     ticker: str
     name: Optional[str] = None
@@ -80,9 +81,7 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
 
     api_key = settings.alpha_vantage_key
     if not api_key:
-        raise RuntimeError(
-            "Alpha Vantage API key not configured; set alpha_vantage_key in config.yaml"
-        )
+        raise RuntimeError("Alpha Vantage API key not configured; set alpha_vantage_key in config.yaml")
 
     key = (ticker.upper(), date.today().isoformat())
     now = datetime.utcnow()
@@ -112,9 +111,7 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
         gross_margin=_parse_float(data.get("GrossProfitTTM")),
         operating_margin=_parse_float(data.get("OperatingMarginTTM")),
         net_margin=_parse_float(data.get("NetProfitMarginTTM")),
-        ebitda_margin=_parse_float(
-            data.get("EbitdaMarginTTM") or data.get("EBITDAMarginTTM")
-        ),
+        ebitda_margin=_parse_float(data.get("EbitdaMarginTTM") or data.get("EBITDAMarginTTM")),
         roa=_parse_float(data.get("ReturnOnAssetsTTM")),
         roe=_parse_float(data.get("ReturnOnEquityTTM")),
         roi=_parse_float(data.get("ReturnOnInvestmentTTM")),
@@ -179,42 +176,30 @@ def screen(
             continue
         if de_max is not None and (f.de_ratio is None or f.de_ratio > de_max):
             continue
-        if lt_de_max is not None and (
-            f.lt_de_ratio is None or f.lt_de_ratio > lt_de_max
-        ):
+        if lt_de_max is not None and (f.lt_de_ratio is None or f.lt_de_ratio > lt_de_max):
             continue
         if interest_coverage_min is not None and (
             f.interest_coverage is None or f.interest_coverage < interest_coverage_min
         ):
             continue
-        if current_ratio_min is not None and (
-            f.current_ratio is None or f.current_ratio < current_ratio_min
-        ):
+        if current_ratio_min is not None and (f.current_ratio is None or f.current_ratio < current_ratio_min):
             continue
-        if quick_ratio_min is not None and (
-            f.quick_ratio is None or f.quick_ratio < quick_ratio_min
-        ):
+        if quick_ratio_min is not None and (f.quick_ratio is None or f.quick_ratio < quick_ratio_min):
             continue
         if fcf_min is not None and (f.fcf is None or f.fcf < fcf_min):
             continue
 
         if eps_min is not None and (f.eps is None or f.eps < eps_min):
             continue
-        if gross_margin_min is not None and (
-            f.gross_margin is None or f.gross_margin < gross_margin_min
-        ):
+        if gross_margin_min is not None and (f.gross_margin is None or f.gross_margin < gross_margin_min):
             continue
         if operating_margin_min is not None and (
             f.operating_margin is None or f.operating_margin < operating_margin_min
         ):
             continue
-        if net_margin_min is not None and (
-            f.net_margin is None or f.net_margin < net_margin_min
-        ):
+        if net_margin_min is not None and (f.net_margin is None or f.net_margin < net_margin_min):
             continue
-        if ebitda_margin_min is not None and (
-            f.ebitda_margin is None or f.ebitda_margin < ebitda_margin_min
-        ):
+        if ebitda_margin_min is not None and (f.ebitda_margin is None or f.ebitda_margin < ebitda_margin_min):
             continue
         if roa_min is not None and (f.roa is None or f.roa < roa_min):
             continue
@@ -222,13 +207,10 @@ def screen(
             continue
         if roi_min is not None and (f.roi is None or f.roi < roi_min):
             continue
-        if dividend_yield_min is not None and (
-            f.dividend_yield is None or f.dividend_yield < dividend_yield_min
-        ):
+        if dividend_yield_min is not None and (f.dividend_yield is None or f.dividend_yield < dividend_yield_min):
             continue
         if dividend_payout_ratio_max is not None and (
-            f.dividend_payout_ratio is None
-            or f.dividend_payout_ratio > dividend_payout_ratio_max
+            f.dividend_payout_ratio is None or f.dividend_payout_ratio > dividend_payout_ratio_max
         ):
             continue
         if beta_max is not None and (f.beta is None or f.beta > beta_max):
@@ -237,21 +219,15 @@ def screen(
             f.shares_outstanding is None or f.shares_outstanding < shares_outstanding_min
         ):
             continue
-        if float_shares_min is not None and (
-            f.float_shares is None or f.float_shares < float_shares_min
-        ):
+        if float_shares_min is not None and (f.float_shares is None or f.float_shares < float_shares_min):
             continue
-        if market_cap_min is not None and (
-            f.market_cap is None or f.market_cap < market_cap_min
-        ):
+        if market_cap_min is not None and (f.market_cap is None or f.market_cap < market_cap_min):
             continue
         if high_52w_max is not None and (f.high_52w is None or f.high_52w > high_52w_max):
             continue
         if low_52w_min is not None and (f.low_52w is None or f.low_52w < low_52w_min):
             continue
-        if avg_volume_min is not None and (
-            f.avg_volume is None or f.avg_volume < avg_volume_min
-        ):
+        if avg_volume_min is not None and (f.avg_volume is None or f.avg_volume < avg_volume_min):
             continue
         results.append(f)
 

--- a/backend/tasks/quotes.py
+++ b/backend/tasks/quotes.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import os
 import logging
+import os
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Iterable, Dict, Any
+from typing import Any, Dict, Iterable
 
 import boto3
 import requests

--- a/backend/timeseries/fetch_alphavantage_timeseries.py
+++ b/backend/timeseries/fetch_alphavantage_timeseries.py
@@ -3,10 +3,10 @@ from datetime import date, timedelta
 
 import pandas as pd
 import requests
-from backend.timeseries.ticker_validator import is_valid_ticker, record_skipped_ticker
-from backend.utils.timeseries_helpers import STANDARD_COLUMNS
 
 from backend.config import config
+from backend.timeseries.ticker_validator import is_valid_ticker, record_skipped_ticker
+from backend.utils.timeseries_helpers import STANDARD_COLUMNS
 
 # Setup logger
 logger = logging.getLogger("alphavantage_timeseries")
@@ -17,11 +17,18 @@ BASE_URL = "https://www.alphavantage.co/query"
 
 def _build_symbol(ticker: str, exchange: str) -> str:
     exchange_map = {
-        "L": ".LON", "LSE": ".LON", "UK": ".LON",
-        "NASDAQ": "", "NYSE": "", "US": "", "N": "",
-        "XETRA": ".DE", "DE": ".DE",
-        "TSX": ".TOR", "ASX": ".AX",
-        "F": ".FRA"
+        "L": ".LON",
+        "LSE": ".LON",
+        "UK": ".LON",
+        "NASDAQ": "",
+        "NYSE": "",
+        "US": "",
+        "N": "",
+        "XETRA": ".DE",
+        "DE": ".DE",
+        "TSX": ".TOR",
+        "ASX": ".AX",
+        "F": ".FRA",
     }
     suffix = exchange_map.get(exchange.upper(), "")
     ticker = ticker.upper()
@@ -52,9 +59,7 @@ def fetch_alphavantage_timeseries_range(
         "apikey": key,
     }
 
-    logger.debug(
-        "Fetching Alpha Vantage data for %s from %s to %s", symbol, start_date, end_date
-    )
+    logger.debug("Fetching Alpha Vantage data for %s from %s to %s", symbol, start_date, end_date)
     try:
         response = requests.get(BASE_URL, params=params, timeout=30)
         response.raise_for_status()
@@ -83,7 +88,7 @@ def fetch_alphavantage_timeseries_range(
 
         df.index = pd.to_datetime(df.index)
         df.sort_index(inplace=True)
-        df = df.loc[str(start_date):str(end_date)]
+        df = df.loc[str(start_date) : str(end_date)]
         df.reset_index(inplace=True)
         df.rename(columns={"index": "Date"}, inplace=True)
         df["Date"] = pd.to_datetime(df["Date"]).dt.date

--- a/backend/timeseries/fetch_stooq_timeseries.py
+++ b/backend/timeseries/fetch_stooq_timeseries.py
@@ -4,6 +4,7 @@ from io import StringIO
 
 import pandas as pd
 import requests
+
 from backend.timeseries.ticker_validator import is_valid_ticker, record_skipped_ticker
 from backend.utils.timeseries_helpers import STANDARD_COLUMNS
 
@@ -16,12 +17,17 @@ BASE_URL = "https://stooq.com/q/d/l/"
 
 def get_stooq_suffix(exchange: str) -> str:
     exchange_map = {
-        "L": ".UK", "LSE": ".UK", "UK": ".UK",
-        "NASDAQ": ".US", "NYSE": ".US", "US": ".US", "AMEX": ".US",
-        "XETRA": ".DE", "DE": ".DE",
+        "L": ".UK",
+        "LSE": ".UK",
+        "UK": ".UK",
+        "NASDAQ": ".US",
+        "NYSE": ".US",
+        "US": ".US",
+        "AMEX": ".US",
+        "XETRA": ".DE",
+        "DE": ".DE",
         "F": ".F",
-        "TO" : ".TO"
-
+        "TO": ".TO",
     }
     suffix = exchange_map.get(exchange.upper())
     if suffix is None:
@@ -33,12 +39,7 @@ def format_date(d: date) -> str:
     return d.strftime("%Y%m%d")
 
 
-def fetch_stooq_timeseries_range(
-    ticker: str,
-    exchange: str,
-    start_date: date,
-    end_date: date
-) -> pd.DataFrame:
+def fetch_stooq_timeseries_range(ticker: str, exchange: str, start_date: date, end_date: date) -> pd.DataFrame:
     """
     Fetch historical Stooq data using date range.
     """
@@ -49,16 +50,12 @@ def fetch_stooq_timeseries_range(
     suffix = get_stooq_suffix(exchange)
     full_ticker = ticker + suffix
 
-    logger.debug(f"Preparing request for ticker={ticker}, exchange={exchange}, "
-                 f"full_ticker={full_ticker}, start_date={start_date}, end_date={end_date}")
+    logger.debug(
+        f"Preparing request for ticker={ticker}, exchange={exchange}, "
+        f"full_ticker={full_ticker}, start_date={start_date}, end_date={end_date}"
+    )
 
-    params = {
-        "s": full_ticker,
-        "d1": format_date(start_date),
-        "d2": format_date(end_date),
-        "i": "d",
-        "d": "d"
-    }
+    params = {"s": full_ticker, "d1": format_date(start_date), "d2": format_date(end_date), "i": "d", "d": "d"}
 
     logger.debug(f"Fetching Stooq data with URL: {BASE_URL} and params: {params}")
     try:
@@ -73,13 +70,13 @@ def fetch_stooq_timeseries_range(
         if df.empty:
             raise RuntimeError("No data returned from Stooq")
 
-        if 'Date' not in df.columns or 'Close' not in df.columns:
+        if "Date" not in df.columns or "Close" not in df.columns:
             raise ValueError(f"Unexpected format for {full_ticker}: columns = {df.columns.tolist()}")
 
         df["Date"] = pd.to_datetime(df["Date"]).dt.date
-        df.sort_values('Date', inplace=True)
-        df['Volume'] = df.get('Volume', None)
-        df['Ticker'] = ticker
+        df.sort_values("Date", inplace=True)
+        df["Volume"] = df.get("Volume", None)
+        df["Ticker"] = ticker
 
         logger.info(f"Fetched {len(df)} rows for {full_ticker}")
 

--- a/backend/timeseries/fetch_timeseries.py
+++ b/backend/timeseries/fetch_timeseries.py
@@ -2,9 +2,8 @@
 
 Exposes ``fetch_yahoo_timeseries`` which is patched in tests.
 """
-from __future__ import annotations
 
-from typing import Any
+from __future__ import annotations
 
 from .fetch_yahoo_timeseries import fetch_yahoo_timeseries_period
 
@@ -17,5 +16,6 @@ def fetch_yahoo_timeseries(ticker: str, period: str = "1y", interval: str = "1d"
     """
     symbol, exchange = (ticker.split(".", 1) + ["US"])[:2]
     return fetch_yahoo_timeseries_period(symbol, exchange, period=period, interval=interval)
+
 
 __all__ = ["fetch_yahoo_timeseries"]

--- a/backend/timeseries/fetch_yahoo_timeseries.py
+++ b/backend/timeseries/fetch_yahoo_timeseries.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 
 import pandas as pd
 import yfinance as yf
+
 from backend.timeseries.ticker_validator import (
     is_valid_ticker,
     record_skipped_ticker,
@@ -11,6 +12,7 @@ from backend.utils.timeseries_helpers import STANDARD_COLUMNS
 
 # Setup logger
 logger = logging.getLogger("yahoo_timeseries")
+
 
 def _build_full_ticker(ticker: str, exchange: str) -> str:
     """
@@ -22,19 +24,28 @@ def _build_full_ticker(ticker: str, exchange: str) -> str:
     suffix = get_yahoo_suffix(exchange)
     ticker = ticker.upper()
 
-    if ticker.endswith(suffix):        # already has ".L", ".DE", ...
+    if ticker.endswith(suffix):  # already has ".L", ".DE", ...
         return ticker
     return ticker + suffix
 
+
 def get_yahoo_suffix(exchange: str) -> str:
     exchange_map = {
-        "LSE": ".L", "L": ".L", "UK": ".L",
-        "NASDAQ": "", "NYSE": "", "N": "", "US": "",
-        "PARIS": ".PA", "XETRA": ".DE", "DE": ".DE",
-        "TSX": ".TO", "TO": ".TO",
+        "LSE": ".L",
+        "L": ".L",
+        "UK": ".L",
+        "NASDAQ": "",
+        "NYSE": "",
+        "N": "",
+        "US": "",
+        "PARIS": ".PA",
+        "XETRA": ".DE",
+        "DE": ".DE",
+        "TSX": ".TO",
+        "TO": ".TO",
         "ASX": ".AX",
         "F": ".F",
-        "FX": "=X"
+        "FX": "=X",
     }
     suffix = exchange_map.get(exchange.upper())
     if suffix is None:
@@ -79,12 +90,7 @@ def normalize_history(df: pd.DataFrame, ticker: str, source: str) -> pd.DataFram
     return df[STANDARD_COLUMNS]
 
 
-def fetch_yahoo_timeseries_range(
-    ticker: str,
-    exchange: str,
-    start_date: date,
-    end_date: date
-) -> pd.DataFrame:
+def fetch_yahoo_timeseries_range(ticker: str, exchange: str, start_date: date, end_date: date) -> pd.DataFrame:
     if not is_valid_ticker(ticker, exchange):
         logger.info("Skipping Yahoo fetch for unrecognized ticker %s.%s", ticker, exchange)
         record_skipped_ticker(ticker, exchange, reason="unknown")
@@ -94,15 +100,9 @@ def fetch_yahoo_timeseries_range(
 
     try:
         stock = yf.Ticker(full_ticker)
-        df = stock.history(
-            start=start_date,
-            end=end_date + pd.Timedelta(days=1),  # include end_date
-            interval="1d"
-        )
+        df = stock.history(start=start_date, end=end_date + pd.Timedelta(days=1), interval="1d")  # include end_date
         if df.empty:
-            raise ValueError(
-                f"No data returned for {full_ticker} between {start_date} and {end_date}"
-            )
+            raise ValueError(f"No data returned for {full_ticker} between {start_date} and {end_date}")
 
         return normalize_history(df, full_ticker, "Yahoo")
 
@@ -112,10 +112,7 @@ def fetch_yahoo_timeseries_range(
 
 
 def fetch_yahoo_timeseries_period(
-    ticker: str,
-    exchange: str = "US",
-    period: str = "1y",
-    interval: str = "1d"
+    ticker: str, exchange: str = "US", period: str = "1y", interval: str = "1d"
 ) -> pd.DataFrame:
     """
     Backwards-compatible one-shot period-based fetch. Does NOT use rolling cache.
@@ -134,6 +131,7 @@ def fetch_yahoo_timeseries_period(
     except Exception as e:
         logger.error(f"Failed to fetch Yahoo data for {full_ticker}: {e}")
         raise
+
 
 if __name__ == "__main__":
     # Example usage

--- a/backend/timeseries/ticker_validator.py
+++ b/backend/timeseries/ticker_validator.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-from datetime import datetime
 
 from backend.common.instruments import get_instrument_meta
 

--- a/backend/timeseries/timeseries_api.py
+++ b/backend/timeseries/timeseries_api.py
@@ -15,7 +15,7 @@ import pandas as pd
 import yfinance as yf
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import JSONResponse, StreamingResponse, HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 router = APIRouter(
@@ -49,9 +49,7 @@ env = Environment(
 
 def _render_html(df: pd.DataFrame, title: str) -> str:
     """Return a minimal HTML document with a styled table."""
-    table_html = df.to_html(
-        classes="dataframe table table-striped", index=False, border=0
-    )
+    table_html = df.to_html(classes="dataframe table table-striped", index=False, border=0)
     template = env.get_template("timeseries.html")
     return template.render(title=title, table_html=table_html)
 

--- a/backend/utils/build_instruments_from_accounts.py
+++ b/backend/utils/build_instruments_from_accounts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
+
 import json
 from pathlib import Path
 from typing import Dict, Tuple
@@ -12,12 +13,15 @@ INSTRUMENTS_DIR = DATA_DIR / "instruments"
 SCALING_FILE = DATA_DIR / "scaling_overrides.json"
 # ==============
 
+
 def read_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
 
 def write_json(path: Path, data: dict):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
 
 def split_ticker(ticker: str) -> Tuple[str, str | None]:
     if "." in ticker:
@@ -25,15 +29,20 @@ def split_ticker(ticker: str) -> Tuple[str, str | None]:
         return sym, exch.upper()
     return ticker, None
 
+
 def best_name(a: str | None, b: str | None) -> str | None:
-    if not a: return b
-    if not b: return a
+    if not a:
+        return b
+    if not b:
+        return a
     return a if len(a) >= len(b) else b
+
 
 def load_scaling() -> Dict[str, Dict[str, float]]:
     if SCALING_FILE.exists():
         return read_json(SCALING_FILE)
     return {}
+
 
 def infer_currency(sym: str, exch: str | None, scaling: Dict[str, Dict[str, float]]) -> str | None:
     if sym == "CASH" and exch == "GBP":
@@ -70,6 +79,7 @@ def load_existing_instruments() -> Dict[str, Dict[str, str]]:
             "region": data.get("region") or data.get("Region"),
         }
     return existing
+
 
 def build_instruments() -> Dict[str, dict]:
     scaling = load_scaling()
@@ -116,6 +126,7 @@ def build_instruments() -> Dict[str, dict]:
                 instruments[tkr] = entry
     return instruments
 
+
 def write_instrument_files(instruments: Dict[str, dict]):
     # Special cash file
     if "CASH.GBP" in instruments:
@@ -149,10 +160,12 @@ def write_instrument_files(instruments: Dict[str, dict]):
             },
         )
 
+
 def main():
     instruments = build_instruments()
     write_instrument_files(instruments)
     print(f"Created {len(instruments)} instrument files under {INSTRUMENTS_DIR}")
+
 
 if __name__ == "__main__":
     main()

--- a/backend/utils/convert_portfolio_xml_to_account_transactions.py
+++ b/backend/utils/convert_portfolio_xml_to_account_transactions.py
@@ -16,7 +16,9 @@ override these values on the command line.
 
 Usage
 -----
-    python convert_portfolio_xml_to_account_transactions.py [--xml-path path/to/investments.xml] [--output-root data/accounts]
+    python convert_portfolio_xml_to_account_transactions.py \\
+        [--xml-path path/to/investments.xml] \\
+        [--output-root data/accounts]
 
 Requires `pandas` (install with `pip install pandas`).
 """
@@ -30,13 +32,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-from backend.config import config
-
 import pandas as pd
+
+from backend.config import config
 
 ###############################################################################
 # Helpers
 ###############################################################################
+
 
 def _safe_int(value: str | None) -> int | None:
     try:
@@ -44,9 +47,11 @@ def _safe_int(value: str | None) -> int | None:
     except ValueError:
         return None
 
+
 def _get_ref(elem: ET.Element, tag: str) -> str | None:
     tag_elem = elem.find(tag)
     return tag_elem.get("reference") if tag_elem is not None else None
+
 
 def _normalise_account_name(name: str) -> Tuple[str, str]:
     """Split **"Steve ISA Cash" -> ("steve", "isa")**, used for output paths."""
@@ -55,9 +60,11 @@ def _normalise_account_name(name: str) -> Tuple[str, str]:
         return parts[0].lower(), parts[1].lower()
     return "unknown", "unknown"
 
+
 ###############################################################################
 # Core extraction logic
 ###############################################################################
+
 
 def extract_transactions_by_account(xml_path: str) -> pd.DataFrame:
     """Return *all* transactions as a DataFrame with an *account* column."""
@@ -66,8 +73,7 @@ def extract_transactions_by_account(xml_path: str) -> pd.DataFrame:
 
     # Map account-id -> account-name so we can resolve names later
     account_names: dict[str, str] = {
-        acc.get("id"): acc.findtext("name") or f"Account {acc.get('id')}"
-        for acc in root.findall(".//accounts/account")
+        acc.get("id"): acc.findtext("name") or f"Account {acc.get('id')}" for acc in root.findall(".//accounts/account")
     }
 
     records: List[Dict[str, Any]] = []
@@ -128,9 +134,11 @@ def extract_transactions_by_account(xml_path: str) -> pd.DataFrame:
 
     return pd.DataFrame.from_records(records)
 
+
 ###############################################################################
 # Output helpers
 ###############################################################################
+
 
 def write_account_json(df: pd.DataFrame, out_dir: str) -> None:
     """Write *one JSON file per account* mirroring holdings-generation structure."""
@@ -159,14 +167,14 @@ def write_account_json(df: pd.DataFrame, out_dir: str) -> None:
 
         print(f"Wrote {json_path} ({len(group)} transactions)")
 
+
 ###############################################################################
 # CLI entry-point
 ###############################################################################
 
+
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Extract and normalise transactions per account"
-    )
+    parser = argparse.ArgumentParser(description="Extract and normalise transactions per account")
     parser.add_argument(
         "--xml-path",
         default=config.portfolio_xml_path,
@@ -187,6 +195,7 @@ def main() -> None:
 
     df = extract_transactions_by_account(xml_path=xml)
     write_account_json(df, output_root)
+
 
 if __name__ == "__main__":
     main()

--- a/backend/utils/currency_utils.py
+++ b/backend/utils/currency_utils.py
@@ -14,6 +14,7 @@ ISIN_TO_CURRENCY = {
     # Add more as needed
 }
 
+
 def currency_from_isin(isin: str) -> str:
     """
     Extracts currency from ISIN prefix using ISO 3166 mapping.

--- a/backend/utils/fx_rates.py
+++ b/backend/utils/fx_rates.py
@@ -1,6 +1,6 @@
+import logging
 from datetime import date, timedelta
 from functools import lru_cache
-import logging
 
 import pandas as pd
 import yfinance as yf

--- a/backend/utils/html_render.py
+++ b/backend/utils/html_render.py
@@ -12,7 +12,8 @@ def render_timeseries_html(df: DataFrame, title: str, subtitle: str = "") -> HTM
 
     html_table = df.to_html(index=False, classes="table table-striped text-center", border=0)
 
-    return HTMLResponse(content=f"""
+    return HTMLResponse(
+        content=f"""
     <html>
     <head>
         <title>{title}</title>
@@ -29,4 +30,5 @@ def render_timeseries_html(df: DataFrame, title: str, subtitle: str = "") -> HTM
         {html_table}
     </body>
     </html>
-    """)
+    """
+    )

--- a/backend/utils/period_utils.py
+++ b/backend/utils/period_utils.py
@@ -1,5 +1,6 @@
 import re
 
+
 def parse_period_to_days(period: str) -> int:
     """
     Convert a time period string like '1d', '2w', '3mo', '1y' to number of days.

--- a/backend/utils/positions.py
+++ b/backend/utils/positions.py
@@ -5,10 +5,10 @@ from typing import Union
 
 import pandas as pd
 
-
 # ------------------------------------------------------------------ #
 #  Public helpers
 # ------------------------------------------------------------------ #
+
 
 def get_unique_tickers(xml_file: str, cutoff_date: Union[str, datetime, None] = None) -> list[str]:
     df = extract_holdings_from_transactions(xml_file, by_account=False, cutoff_date=cutoff_date)
@@ -30,7 +30,7 @@ def extract_holdings_from_transactions(
     - Adds acquired_date: most recent BUY or TRANSFER_IN per security
     """
 
-    SHARE_SCALE = 10 ** 8
+    SHARE_SCALE = 10**8
     TYPE_SIGN = {
         "BUY": 1,
         "SELL": -1,
@@ -58,8 +58,8 @@ def extract_holdings_from_transactions(
         if not sid:
             continue
         sec_meta[sid] = {
-            "name":   s.findtext("name", ""),
-            "isin":   s.findtext("isin", ""),
+            "name": s.findtext("name", ""),
+            "isin": s.findtext("isin", ""),
             "ticker": s.findtext("tickerSymbol", ""),
         }
 
@@ -116,12 +116,12 @@ def extract_holdings_from_transactions(
             acq_date = acquisition_dates.get(acct, {}).get(sid, "")
             rows.append(
                 {
-                    "account":       acct,
-                    "securityId":    sid,
-                    "name":          meta.get("name", ""),
-                    "ticker":        meta.get("ticker", ""),
-                    "isin":          meta.get("isin", ""),
-                    "quantity":      qty,
+                    "account": acct,
+                    "securityId": sid,
+                    "name": meta.get("name", ""),
+                    "ticker": meta.get("ticker", ""),
+                    "isin": meta.get("isin", ""),
+                    "quantity": qty,
                     "acquired_date": acq_date,
                 }
             )
@@ -154,5 +154,4 @@ if __name__ == "__main__":
     print(f"\nRebuilt {len(df)} positions")
 
     pd.set_option("display.max_rows", None)
-    print(df.to_string(index=False,
-                       formatters={"quantity": "{:,.4f}".format}))
+    print(df.to_string(index=False, formatters={"quantity": "{:,.4f}".format}))

--- a/backend/utils/scenario_tester.py
+++ b/backend/utils/scenario_tester.py
@@ -6,8 +6,8 @@ from copy import deepcopy
 from typing import Any, Dict
 
 from backend.common.constants import (
-    EFFECTIVE_COST_BASIS_GBP,
     COST_BASIS_GBP,
+    EFFECTIVE_COST_BASIS_GBP,
 )
 from backend.common.prices import get_price_gbp
 
@@ -35,11 +35,7 @@ def apply_price_shock(portfolio: Dict[str, Any], ticker: str, pct_change: float)
                     cached = get_price_gbp(tkr)
                     price = float(cached or 0.0)
                 new_price = price * factor
-                cost = float(
-                    h.get(EFFECTIVE_COST_BASIS_GBP)
-                    or h.get(COST_BASIS_GBP)
-                    or 0.0
-                )
+                cost = float(h.get(EFFECTIVE_COST_BASIS_GBP) or h.get(COST_BASIS_GBP) or 0.0)
                 mv = units * new_price
                 gain = mv - cost
                 h["price"] = h["current_price_gbp"] = round(new_price, 4)

--- a/backend/utils/telegram_utils.py
+++ b/backend/utils/telegram_utils.py
@@ -41,10 +41,7 @@ class RedactTokenFilter(logging.Filter):
             if isinstance(record.msg, str):
                 record.msg = record.msg.replace(token, "***")
             if record.args:
-                record.args = tuple(
-                    arg.replace(token, "***") if isinstance(arg, str) else arg
-                    for arg in record.args
-                )
+                record.args = tuple(arg.replace(token, "***") if isinstance(arg, str) else arg for arg in record.args)
         return True
 
 
@@ -100,9 +97,7 @@ def send_message(text: str) -> None:
 
         if resp.status_code == 429:
             if not warning_logged:
-                logger.warning(
-                    "Telegram rate limit hit; backing off", extra={"skip_telegram": True}
-                )
+                logger.warning("Telegram rate limit hit; backing off", extra={"skip_telegram": True})
                 warning_logged = True
             time.sleep(backoff)
             backoff = min(backoff * 2, 60)
@@ -117,7 +112,6 @@ def send_message(text: str) -> None:
         RECENT_MESSAGES[text] = time.time()
         _NEXT_ALLOWED_TIME = time.time() + RATE_LIMIT_SECONDS
         return
-
 
 
 class TelegramLogHandler(logging.Handler):

--- a/backend/utils/timeseries_helpers.py
+++ b/backend/utils/timeseries_helpers.py
@@ -1,17 +1,16 @@
 import datetime
 import re
+from pathlib import Path
 from typing import Optional
 
 import pandas as pd
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 
-from backend.utils.html_render import render_timeseries_html
 from backend.config import config
-from pathlib import Path
+from backend.utils.html_render import render_timeseries_html
 
-STANDARD_COLUMNS = [
-    "Date", "Open", "High", "Low", "Close", "Volume", "Ticker", "Source"
-]
+STANDARD_COLUMNS = ["Date", "Open", "High", "Low", "Close", "Volume", "Ticker", "Source"]
+
 
 def apply_scaling(df: pd.DataFrame, scale: float, scale_volume: bool = False) -> pd.DataFrame:
     if scale is None or scale == 1:
@@ -32,12 +31,11 @@ def apply_scaling(df: pd.DataFrame, scale: float, scale_volume: bool = False) ->
 
     return df
 
+
 import json
 
 
-def get_scaling_override(
-    ticker: str, exchange: str, requested_scaling: Optional[float]
-) -> float:
+def get_scaling_override(ticker: str, exchange: str, requested_scaling: Optional[float]) -> float:
     if requested_scaling is not None:
         return requested_scaling
 
@@ -58,8 +56,11 @@ def get_scaling_override(
 
     # Try: exact -> base -> per-exchange wildcard -> global wildcard
     candidates = [
-        (ex, ticker), (ex, base),
-        (ex, "*"), ("*", base), ("*", "*"),
+        (ex, ticker),
+        (ex, base),
+        (ex, "*"),
+        ("*", base),
+        ("*", "*"),
     ]
     for ex_key, t_key in candidates:
         if ex_key in ov and t_key in ov[ex_key]:
@@ -68,6 +69,7 @@ def get_scaling_override(
             except Exception:
                 pass
     return 1.0
+
 
 def handle_timeseries_response(
     df: pd.DataFrame,
@@ -89,6 +91,7 @@ def handle_timeseries_response(
     else:
         return render_timeseries_html(df, title, subtitle)
 
+
 # ── new helper ──────────────────────────────────────────────
 def _nearest_weekday(d: datetime.date, forward: bool) -> datetime.date:
     """
@@ -97,9 +100,10 @@ def _nearest_weekday(d: datetime.date, forward: bool) -> datetime.date:
     forward=True  -> Friday->Mon (skip weekend forward)
     forward=False -> Saturday/Sunday->Fri (skip weekend backward)
     """
-    while d.weekday() >= 5:   # 5 = Saturday, 6 = Sunday
+    while d.weekday() >= 5:  # 5 = Saturday, 6 = Sunday
         d += datetime.timedelta(days=1 if forward else -1)
     return d
+
 
 def _is_isin(ticker: str) -> bool:
     base = re.split(r"[.:]", ticker)[0].upper()

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,6 +1,5 @@
 import sys
 from types import SimpleNamespace
-import pytest
 
 import backend.common.alerts as alerts
 
@@ -20,7 +19,9 @@ def test_publish_alert_success(monkeypatch):
 
     def fake_client(name):
         assert name == "sns"
-        return SimpleNamespace(publish=lambda TopicArn, Message: sent.update({"TopicArn": TopicArn, "Message": Message}))
+        return SimpleNamespace(
+            publish=lambda TopicArn, Message: sent.update({"TopicArn": TopicArn, "Message": Message})
+        )
 
     monkeypatch.setattr(alerts.config, "sns_topic_arn", "arn:example")
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))

--- a/tests/test_alphavantage_errors.py
+++ b/tests/test_alphavantage_errors.py
@@ -1,5 +1,6 @@
-import pytest
 from datetime import date
+
+import pytest
 
 import backend.timeseries.fetch_alphavantage_timeseries as av
 from backend.timeseries.fetch_alphavantage_timeseries import (
@@ -28,8 +29,6 @@ def test_information_field_propagated(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
 
     with pytest.raises(ValueError) as exc:
-        fetch_alphavantage_timeseries_range(
-            "PBR", "US", date(2024, 1, 1), date(2024, 1, 10), api_key="demo"
-        )
+        fetch_alphavantage_timeseries_range("PBR", "US", date(2024, 1, 1), date(2024, 1, 10), api_key="demo")
 
     assert str(exc.value) == "test info"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
-from fastapi.testclient import TestClient
 from unittest.mock import patch
+
+from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.config import config
@@ -18,9 +19,11 @@ def test_health_env_variable(monkeypatch):
 def test_startup_warms_snapshot(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", False)
     monkeypatch.setattr(config, "snapshot_warm_days", 30)
-    with patch("backend.app.refresh_snapshot_async") as mock_refresh, patch(
-        "backend.app._load_snapshot", return_value=({}, None)
-    ) as mock_load, patch("backend.app.refresh_snapshot_in_memory") as mock_mem:
+    with (
+        patch("backend.app.refresh_snapshot_async") as mock_refresh,
+        patch("backend.app._load_snapshot", return_value=({}, None)) as mock_load,
+        patch("backend.app.refresh_snapshot_in_memory") as mock_mem,
+    ):
         app = create_app()
         with TestClient(app):
             pass
@@ -31,9 +34,7 @@ def test_startup_warms_snapshot(monkeypatch):
 
 def test_skip_snapshot_warm(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
-    with patch("backend.app.refresh_snapshot_async") as mock_refresh, patch(
-        "backend.app._load_snapshot"
-    ) as mock_load:
+    with patch("backend.app.refresh_snapshot_async") as mock_refresh, patch("backend.app._load_snapshot") as mock_load:
         app = create_app()
         with TestClient(app):
             pass

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -1,9 +1,9 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.local_api.main import app
-from backend.common.instruments import get_instrument_meta
 import backend.common.alerts as alerts
+from backend.common.instruments import get_instrument_meta
+from backend.local_api.main import app
 
 client = TestClient(app)
 
@@ -212,12 +212,13 @@ def test_alerts_endpoint(monkeypatch):
 #         html = resp.text.lower()
 #         assert "<table" in html and "ft time series" in html
 
+
 def test_screener_endpoint(monkeypatch):
     from backend.screener import Fundamentals
 
     def mock_fetch(ticker: str) -> Fundamentals:
         if ticker == "AAA":
-           return Fundamentals(ticker="AAA", peg_ratio=0.5, roe=0.2)
+            return Fundamentals(ticker="AAA", peg_ratio=0.5, roe=0.2)
         return Fundamentals(ticker="BBB", peg_ratio=2.0, roe=0.1)
 
     monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
@@ -227,6 +228,7 @@ def test_screener_endpoint(monkeypatch):
     data = resp.json()
     assert len(data) == 1
     assert data[0]["ticker"] == "AAA"
+
 
 def test_var_endpoint_default():
     owners = client.get("/owners").json()

--- a/tests/test_cash_timeseries.py
+++ b/tests/test_cash_timeseries.py
@@ -1,5 +1,5 @@
-from datetime import date, timedelta
 import logging
+from datetime import date, timedelta
 
 from backend.timeseries.fetch_meta_timeseries import fetch_meta_timeseries
 

--- a/tests/test_custom_query.py
+++ b/tests/test_custom_query.py
@@ -1,6 +1,3 @@
-import io
-
-import pandas as pd
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
@@ -21,6 +18,7 @@ def test_run_query_json():
     data = resp.json()
     assert any(row["ticker"] == "HFEL.L" for row in data["results"])
     assert "var" in data["results"][0]
+
 
 def test_save_and_load_query(tmp_path):
     slug = "test-query"

--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -43,7 +43,7 @@ def test_load_account_from_s3(monkeypatch):
         def get_object(Bucket, Key):
             assert Bucket == "bucket"
             assert Key == "accounts/Alice/ISA.json"
-            return {"Body": io.BytesIO(b"{\"balance\": 10}")}
+            return {"Body": io.BytesIO(b'{"balance": 10}')}
 
         return SimpleNamespace(get_object=get_object)
 
@@ -61,7 +61,7 @@ def test_load_person_meta_from_s3(monkeypatch):
 
         def get_object(Bucket, Key):
             if Key == "accounts/Alice/person.json":
-                return {"Body": io.BytesIO(b"{\"dob\": \"1980\"}")}
+                return {"Body": io.BytesIO(b'{"dob": "1980"}')}
             raise Exception("NoSuchKey")
 
         return SimpleNamespace(get_object=get_object)

--- a/tests/test_fx_conversion.py
+++ b/tests/test_fx_conversion.py
@@ -1,4 +1,5 @@
 import datetime as dt
+
 import pandas as pd
 import pytest
 
@@ -9,20 +10,21 @@ def _sample_df(start: dt.date, end: dt.date):
     dates = pd.bdate_range(start, end)
     n = len(dates)
     base = list(range(1, n + 1))
-    return pd.DataFrame({
-        "Date": pd.to_datetime(dates),
-        "Open": base,
-        "High": base,
-        "Low": base,
-        "Close": base,
-        "Volume": [0] * n,
-        "Ticker": ["T"] * n,
-        "Source": ["test"] * n,
-    })
+    return pd.DataFrame(
+        {
+            "Date": pd.to_datetime(dates),
+            "Open": base,
+            "High": base,
+            "Low": base,
+            "Close": base,
+            "Volume": [0] * n,
+            "Ticker": ["T"] * n,
+            "Source": ["test"] * n,
+        }
+    )
 
 
 @pytest.mark.parametrize("exchange,rate", [("N", 0.8), ("DE", 0.9), ("CA", 0.6), ("TO", 0.6)])
-
 def test_prices_converted_to_gbp(monkeypatch, exchange, rate):
     start = dt.date(2024, 1, 1)
     end = dt.date(2024, 1, 2)

--- a/tests/test_group_movers_route.py
+++ b/tests/test_group_movers_route.py
@@ -1,7 +1,7 @@
-import backend.common.instrument_api as ia
-from backend.local_api.main import app
 from fastapi.testclient import TestClient
 
+import backend.common.instrument_api as ia
+from backend.local_api.main import app
 
 client = TestClient(app)
 
@@ -27,4 +27,4 @@ def test_group_movers_endpoint(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert [g["ticker"] for g in data["gainers"]] == ["AAA"]
-    assert [l["ticker"] for l in data["losers"]] == ["BBB"]
+    assert [loser["ticker"] for loser in data["losers"]] == ["BBB"]

--- a/tests/test_instrument_api_exchange.py
+++ b/tests/test_instrument_api_exchange.py
@@ -1,5 +1,7 @@
 import datetime as dt
+
 import pandas as pd
+
 from backend.common import instrument_api as ia
 
 

--- a/tests/test_instrument_route.py
+++ b/tests/test_instrument_route.py
@@ -1,8 +1,9 @@
+from datetime import date
+from unittest.mock import patch
+
 import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch
-from datetime import date
 
 from backend.app import create_app
 from backend.config import config
@@ -31,23 +32,23 @@ def test_full_history_json(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ) as mock_load, patch(
-        "backend.routes.instrument.list_portfolios",
-        return_value=[
-            {
-                "owner": "alex",
-                "accounts": [
-                    {
-                        "account_type": "isa",
-                        "holdings": [{"ticker": "ABC.L", "units": 2}],
-                    }
-                ],
-            }
-        ],
-    ), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df) as mock_load,
+        patch(
+            "backend.routes.instrument.list_portfolios",
+            return_value=[
+                {
+                    "owner": "alex",
+                    "accounts": [
+                        {
+                            "account_type": "isa",
+                            "holdings": [{"ticker": "ABC.L", "units": 2}],
+                        }
+                    ],
+                }
+            ],
+        ),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
     ):
         client = TestClient(app)
         resp = client.get("/instrument?ticker=ABC.L&days=0&format=json")
@@ -64,10 +65,10 @@ def test_html_response(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch("backend.routes.instrument.list_portfolios", return_value=[]),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
     ):
         client = TestClient(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=html")
@@ -81,25 +82,24 @@ def test_positions_scaled(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch(
-        "backend.routes.instrument.list_portfolios",
-        return_value=[
-            {
-                "owner": "alex",
-                "accounts": [
-                    {
-                        "account_type": "isa",
-                        "holdings": [
-                            {"ticker": "ABC.L", "units": 2, "gain_gbp": 4}
-                        ],
-                    }
-                ],
-            }
-        ],
-    ), patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}), patch(
-        "backend.routes.instrument.get_scaling_override", return_value=0.5
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch(
+            "backend.routes.instrument.list_portfolios",
+            return_value=[
+                {
+                    "owner": "alex",
+                    "accounts": [
+                        {
+                            "account_type": "isa",
+                            "holdings": [{"ticker": "ABC.L", "units": 2, "gain_gbp": 4}],
+                        }
+                    ],
+                }
+            ],
+        ),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
+        patch("backend.routes.instrument.get_scaling_override", return_value=0.5),
     ):
         client = TestClient(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
@@ -116,28 +116,30 @@ def test_positions_gain_from_cost(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch(
-        "backend.routes.instrument.list_portfolios",
-        return_value=[
-            {
-                "owner": "alex",
-                "accounts": [
-                    {
-                        "account_type": "isa",
-                        "holdings": [
-                            {
-                                "ticker": "ABC.L",
-                                "units": 2,
-                                "cost_basis_gbp": 20.0,
-                            }
-                        ],
-                    }
-                ],
-            }
-        ],
-    ), patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}):
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch(
+            "backend.routes.instrument.list_portfolios",
+            return_value=[
+                {
+                    "owner": "alex",
+                    "accounts": [
+                        {
+                            "account_type": "isa",
+                            "holdings": [
+                                {
+                                    "ticker": "ABC.L",
+                                    "units": 2,
+                                    "cost_basis_gbp": 20.0,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        ),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
+    ):
         client = TestClient(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
     assert resp.status_code == 200
@@ -157,12 +159,10 @@ def test_non_gbp_instrument_has_distinct_close(monkeypatch):
             "Close_gbp": [8.0, 8.8],
         }
     )
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch(
-        "backend.routes.instrument.list_portfolios", return_value=[]
-    ), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "USD"}
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch("backend.routes.instrument.list_portfolios", return_value=[]),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "USD"}),
     ):
         client = TestClient(app)
         resp = client.get("/instrument?ticker=ABC.N&days=1&format=json")

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -32,4 +32,3 @@ def test_unexpected_error_propagates(monkeypatch, tmp_path, caplog):
         with pytest.raises(RuntimeError):
             instruments.get_instrument_meta("ERR.TKR")
     assert "Unexpected error loading" in caplog.text
-

--- a/tests/test_load_latest_prices.py
+++ b/tests/test_load_latest_prices.py
@@ -1,7 +1,7 @@
 import pandas as pd
-from backend.common import holding_utils
-
 import pytest
+
+from backend.common import holding_utils
 
 
 @pytest.mark.parametrize(
@@ -17,9 +17,7 @@ def test_load_latest_prices_selects_close_column(monkeypatch, data, expected):
     def fake_load_meta_timeseries_range(ticker, exchange, start_date, end_date):
         return pd.DataFrame(data)
 
-    monkeypatch.setattr(
-        holding_utils, "load_meta_timeseries_range", fake_load_meta_timeseries_range
-    )
+    monkeypatch.setattr(holding_utils, "load_meta_timeseries_range", fake_load_meta_timeseries_range)
 
     prices = holding_utils.load_latest_prices(["ABC.L"])
     assert prices["ABC.L"] == expected
@@ -28,9 +26,7 @@ def test_load_latest_prices_selects_close_column(monkeypatch, data, expected):
 def test_load_latest_prices_applies_scaling(monkeypatch):
     df = pd.DataFrame({"Date": [1], "Close": [20.0]})
 
-    monkeypatch.setattr(
-        holding_utils, "load_meta_timeseries_range", lambda *a, **k: df
-    )
+    monkeypatch.setattr(holding_utils, "load_meta_timeseries_range", lambda *a, **k: df)
     monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 0.5)
 
     prices = holding_utils.load_latest_prices(["ABC.L"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,8 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+
 from backend.local_api.main import app
 
 client = TestClient(app)
@@ -20,26 +22,31 @@ mock_groups = [
     {"slug": "testslug", "name": "Test Group", "members": ["testuser"]},
 ]
 
+
 # Fixtures
 @pytest.fixture
 def mock_list_plots():
     with patch("backend.common.data_loader.list_plots", return_value=mock_owners) as p:
         yield p
 
+
 @pytest.fixture
 def mock_list_groups():
     with patch("backend.common.group_portfolio.list_groups", return_value=mock_groups) as p:
         yield p
+
 
 @pytest.fixture
 def mock_owner_portfolio():
     with patch("backend.common.portfolio.build_owner_portfolio", return_value={"owner": "steve"}) as p:
         yield p
 
+
 @pytest.fixture
 def mock_group_portfolio():
     with patch("backend.common.group_portfolio.build_group_portfolio", return_value={"group": "testslug"}) as p:
         yield p
+
 
 # Tests
 def test_health():
@@ -47,25 +54,30 @@ def test_health():
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
 
+
 def test_owners(mock_list_plots):
     response = client.get("/owners")
     assert response.status_code == 200
     assert response.json() == mock_list_plots.return_value
+
 
 def test_groups(mock_list_groups):
     response = client.get("/groups")
     assert response.status_code == 200
     assert response.json() == mock_list_groups.return_value
 
+
 def test_portfolio(mock_owner_portfolio):
     response = client.get("/portfolio/steve")
     assert response.status_code == 200
     assert response.json() == {"owner": "steve"}
 
+
 def test_portfolio_group(mock_group_portfolio):
     response = client.get("/portfolio-group/children")
     assert response.status_code == 200
     assert response.json() == {"group": "testslug"}
+
 
 @patch("backend.common.data_loader.load_account", return_value={"account": "ISA"})
 def test_get_account(mock_load_account):
@@ -73,11 +85,13 @@ def test_get_account(mock_load_account):
     assert response.status_code == 200
     assert response.json() == {"account": "ISA"}
 
+
 @patch("backend.common.prices.refresh_prices", return_value={"updated": 5})
 def test_prices_refresh(mock_refresh):
     response = client.post("/prices/refresh")
     assert response.status_code == 200
     assert response.json() == {"status": "ok", "updated": 5}
+
 
 @patch("backend.common.portfolio_utils.aggregate_by_ticker", return_value=[{"ticker": "ABC"}])
 @patch("backend.common.group_portfolio.build_group_portfolio", return_value={"group": "testslug"})
@@ -86,6 +100,7 @@ def test_group_by_instrument(mock_groups, mock_build, mock_aggregate):
     response = client.get("/portfolio-group/testslug/instruments")
     assert response.status_code == 200
     assert response.json() == [{"ticker": "ABC"}]
+
 
 @patch("backend.common.instrument_api.timeseries_for_ticker", return_value=[{"date": "2025-01-01"}])
 @patch("backend.common.instrument_api.positions_for_ticker", return_value=[{"ticker": "ABC"}])
@@ -122,9 +137,11 @@ def test_var_invalid_params(mock_var, mock_sharpe):
     response = client.get("/var/steve?confidence=2")
     assert response.status_code == 400
 
+
 def test_var_invalid_confidence_range():
     response = client.get("/var/steve?confidence=101")
     assert response.status_code == 400
+
 
 @patch("backend.timeseries.fetch_timeseries.fetch_yahoo_timeseries")
 @patch("backend.utils.html_render.render_timeseries_html", return_value="<html>OK</html>")

--- a/tests/test_meta_timeseries_date_filter.py
+++ b/tests/test_meta_timeseries_date_filter.py
@@ -1,5 +1,6 @@
-import pandas as pd
 from datetime import date
+
+import pandas as pd
 
 from backend.timeseries import fetch_meta_timeseries
 
@@ -29,9 +30,7 @@ def test_fetch_meta_timeseries_handles_python_dates(monkeypatch):
 
     monkeypatch.setattr(fetch_meta_timeseries, "fetch_ft_timeseries", fake_ft)
 
-    df = fetch_meta_timeseries.fetch_meta_timeseries(
-        "ABC", "L", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2)
-    )
+    df = fetch_meta_timeseries.fetch_meta_timeseries("ABC", "L", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2))
 
     assert not df.empty
     assert pd.to_datetime(df["Date"]).max() <= pd.Timestamp(date(2024, 1, 2))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,10 +1,10 @@
 import datetime as dt
-from pathlib import Path
 
-from backend.common import metrics as metrics_mod
-from backend.app import create_app
-from backend.config import config
 from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.common import metrics as metrics_mod
+from backend.config import config
 
 
 def _sample_txs():
@@ -21,15 +21,11 @@ def test_turnover_and_holding_period(monkeypatch, tmp_path):
     turnover = metrics_mod.calculate_portfolio_turnover("test", txs, portfolio_value=100)
     assert turnover == (10000 + 12000 + 5000) / 100 / 100
 
-    avg = metrics_mod.calculate_average_holding_period(
-        "test", txs, as_of=dt.date(2024, 4, 1)
-    )
+    avg = metrics_mod.calculate_average_holding_period("test", txs, as_of=dt.date(2024, 4, 1))
     # periods: AAA 31 days, BBB 31 days -> average 31
     assert avg == 31
 
-    metrics = metrics_mod.compute_and_store_metrics(
-        "test", txs, as_of=dt.date(2024, 4, 1), portfolio_value=100
-    )
+    metrics = metrics_mod.compute_and_store_metrics("test", txs, as_of=dt.date(2024, 4, 1), portfolio_value=100)
     path = tmp_path / "test_metrics.json"
     assert path.exists()
     assert metrics["turnover"] == turnover

--- a/tests/test_movers_backend.py
+++ b/tests/test_movers_backend.py
@@ -1,6 +1,8 @@
 import datetime as dt
-from backend.common import instrument_api as ia
+
 import pytest
+
+from backend.common import instrument_api as ia
 
 
 def test_price_change_pct(monkeypatch):
@@ -8,6 +10,7 @@ def test_price_change_pct(monkeypatch):
         @classmethod
         def today(cls):
             return cls(2023, 1, 9)
+
     monkeypatch.setattr(ia.dt, "date", FixedDate)
     monkeypatch.setattr(
         ia,
@@ -34,6 +37,7 @@ def test_top_movers(monkeypatch):
         @classmethod
         def today(cls):
             return cls(2023, 1, 9)
+
     monkeypatch.setattr(ia.dt, "date", FixedDate)
     monkeypatch.setattr(
         ia,

--- a/tests/test_page_cache.py
+++ b/tests/test_page_cache.py
@@ -1,7 +1,5 @@
 import asyncio
 
-import pytest
-
 from backend.utils import page_cache
 
 

--- a/tests/test_portfolio_utils_currency.py
+++ b/tests/test_portfolio_utils_currency.py
@@ -2,19 +2,9 @@ import backend.common.portfolio_utils as portfolio_utils
 
 
 def test_currency_from_instrument_meta(monkeypatch):
-    portfolio = {
-        "accounts": [
-            {
-                "holdings": [
-                    {"ticker": "ABC", "units": 1}
-                ]
-            }
-        ]
-    }
+    portfolio = {"accounts": [{"holdings": [{"ticker": "ABC", "units": 1}]}]}
 
-    monkeypatch.setattr(
-        portfolio_utils, "get_instrument_meta", lambda t: {"currency": "USD"}
-    )
+    monkeypatch.setattr(portfolio_utils, "get_instrument_meta", lambda t: {"currency": "USD"})
 
     rows = portfolio_utils.aggregate_by_ticker(portfolio)
 

--- a/tests/test_portfolio_utils_meta.py
+++ b/tests/test_portfolio_utils_meta.py
@@ -6,4 +6,3 @@ def test_get_security_meta_includes_sector_and_region():
     assert meta is not None
     assert "sector" in meta and meta["sector"]
     assert "region" in meta and meta["region"]
-

--- a/tests/test_portfolio_utils_snapshot.py
+++ b/tests/test_portfolio_utils_snapshot.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date
+
 import pandas as pd
 
 from backend.common import portfolio_utils

--- a/tests/test_prices_logging.py
+++ b/tests/test_prices_logging.py
@@ -1,5 +1,5 @@
-import sys
 import logging
+import sys
 
 
 def test_prices_import_does_not_configure_root_logger():

--- a/tests/test_prices_snapshot.py
+++ b/tests/test_prices_snapshot.py
@@ -1,5 +1,6 @@
-import pandas as pd
 from datetime import date, timedelta
+
+import pandas as pd
 import pytest
 
 from backend.common import prices

--- a/tests/test_quotes_route.py
+++ b/tests/test_quotes_route.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi.testclient import TestClient
 
 from backend.app import create_app

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,6 +1,7 @@
-import numpy as np
-import pytest
 from unittest.mock import patch
+
+import numpy as np
+
 from backend.common import risk
 
 
@@ -16,13 +17,14 @@ def test_compute_sharpe_ratio(monkeypatch):
     trading_days = 252
     returns = np.array([0.01, 0.02, -0.01])
     excess = returns - rf / trading_days
-    expected = float(np.round((excess.mean()/excess.std(ddof=1))*np.sqrt(trading_days), 4))
+    expected = float(np.round((excess.mean() / excess.std(ddof=1)) * np.sqrt(trading_days), 4))
     assert risk.compute_sharpe_ratio("steve", days=3) == expected
 
 
 def test_compute_sharpe_ratio_insufficient(monkeypatch):
     monkeypatch.setattr(risk.portfolio_utils, "compute_owner_performance", lambda owner, days=3: [])
     assert risk.compute_sharpe_ratio("steve", days=3) is None
+
 
 @patch("backend.common.portfolio_utils.compute_owner_performance", return_value=[])
 def test_compute_portfolio_var_accepts_percentage(mock_perf):

--- a/tests/test_run_all_tickers.py
+++ b/tests/test_run_all_tickers.py
@@ -1,5 +1,6 @@
-import pandas as pd
 from unittest.mock import patch
+
+import pandas as pd
 
 from backend.timeseries.fetch_meta_timeseries import run_all_tickers
 
@@ -31,4 +32,3 @@ def test_run_all_tickers_handles_underscore_and_dot():
 
     assert out == ["ADBE_N", "AZN.L"]
     assert calls == [("ADBE", "N", 5), ("AZN", "L", 5)]
-

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,5 +1,4 @@
-import pytest
-from backend.screener import fetch_fundamentals, screen, Fundamentals
+from backend.screener import Fundamentals, fetch_fundamentals, screen
 
 
 def test_fetch_fundamentals_parses_values(monkeypatch):
@@ -122,12 +121,12 @@ def test_screen_filters_based_on_thresholds(monkeypatch):
             net_margin=0.02,
             ebitda_margin=0.1,
             roa=0.05,
-              roe=0.04,
-              roi=0.03,
-              lt_de_ratio=2.0,
-              interest_coverage=1.0,
-              current_ratio=0.5,
-              quick_ratio=0.4,
+            roe=0.04,
+            roi=0.03,
+            lt_de_ratio=2.0,
+            interest_coverage=1.0,
+            current_ratio=0.5,
+            quick_ratio=0.4,
             dividend_yield=0.01,
             dividend_payout_ratio=0.8,
             beta=2.0,

--- a/tests/test_styles_snapshot.py
+++ b/tests/test_styles_snapshot.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 root = Path(__file__).resolve().parent.parent
 
 

--- a/tests/test_ticker_validation.py
+++ b/tests/test_ticker_validation.py
@@ -1,7 +1,5 @@
-from pathlib import Path
-
-from backend.timeseries.fetch_meta_timeseries import fetch_meta_timeseries
 from backend.timeseries import ticker_validator
+from backend.timeseries.fetch_meta_timeseries import fetch_meta_timeseries
 
 
 def test_invalid_ticker_skipped(monkeypatch, tmp_path):

--- a/tests/test_timeseries_edit_route.py
+++ b/tests/test_timeseries_edit_route.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi.testclient import TestClient
 
 from backend.app import create_app

--- a/tests/test_trade_approvals.py
+++ b/tests/test_trade_approvals.py
@@ -1,8 +1,8 @@
 import json
 from datetime import date, timedelta
 
-from backend.common.holding_utils import enrich_holding
 from backend.common.compliance import check_owner
+from backend.common.holding_utils import enrich_holding
 from backend.config import config
 
 
@@ -15,9 +15,7 @@ def test_enrich_holding_requires_approval(monkeypatch):
         "units": 1,
         "cost_basis_gbp": 1.0,
     }
-    monkeypatch.setattr(
-        "backend.common.holding_utils._get_price_for_date_scaled", lambda *a, **k: 1.0
-    )
+    monkeypatch.setattr("backend.common.holding_utils._get_price_for_date_scaled", lambda *a, **k: 1.0)
     out = enrich_holding(holding, today, {}, {})
     assert out["sell_eligible"] is False
 

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -1,8 +1,8 @@
-import pytest
 import shutil
-from backend.common import portfolio_utils
-from backend.agent.trading_agent import send_trade_alert, run
+
 from backend.agent import trading_agent
+from backend.agent.trading_agent import run, send_trade_alert
+from backend.common import portfolio_utils
 
 # Alias to match the terminology of "generate_signals"
 generate_signals = portfolio_utils.check_price_alerts
@@ -36,11 +36,7 @@ def test_generate_signals_buy_sell_actions(monkeypatch):
 
 def test_generate_signals_emits_alerts(monkeypatch):
     snapshot = {"AAA": {"last_price": 110.0}}
-    portfolio = {
-        "accounts": [
-            {"holdings": [{"ticker": "AAA", "units": 1, "cost_gbp": 100}]}
-        ]
-    }
+    portfolio = {"accounts": [{"holdings": [{"ticker": "AAA", "units": 1, "cost_gbp": 100}]}]}
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", snapshot)
     monkeypatch.setattr(portfolio_utils, "list_portfolios", lambda: [portfolio])
 
@@ -80,12 +76,8 @@ def test_send_trade_alert_with_telegram(monkeypatch):
     published = {}
     telegram_msgs = []
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", lambda alert: published.update(alert)
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg)
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", lambda alert: published.update(alert))
+    monkeypatch.setattr("backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg))
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "T")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "C")
 
@@ -102,12 +94,8 @@ def test_send_trade_alert_no_publish_with_telegram(monkeypatch):
     def fake_publish(alert):
         published["called"] = True
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", fake_publish
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg)
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", fake_publish)
+    monkeypatch.setattr("backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg))
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "T")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "C")
 
@@ -140,9 +128,7 @@ def test_run_defaults_to_all_known_tickers(monkeypatch):
         "backend.agent.trading_agent.prices.load_prices_for_tickers",
         fake_load_prices,
     )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", lambda alert: None
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", lambda alert: None)
 
     run()
 
@@ -151,9 +137,7 @@ def test_run_defaults_to_all_known_tickers(monkeypatch):
 
 def test_run_sends_telegram_when_not_aws(monkeypatch):
     # Trigger a BUY signal for ticker AAA
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.list_all_unique_tickers", lambda: ["AAA"]
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.list_all_unique_tickers", lambda: ["AAA"])
 
     def fake_load_prices(tickers, days=60):
         import pandas as pd
@@ -161,17 +145,11 @@ def test_run_sends_telegram_when_not_aws(monkeypatch):
         data = {"Ticker": ["AAA"] * 7, "close": [1, 1, 1, 1, 1, 1, 2]}
         return pd.DataFrame(data)
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.prices.load_prices_for_tickers", fake_load_prices
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", lambda alert: None
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.prices.load_prices_for_tickers", fake_load_prices)
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", lambda alert: None)
 
     sent: list[str] = []
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.send_message", lambda msg: sent.append(msg)
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.send_message", lambda msg: sent.append(msg))
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "T")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "C")
     from backend.agent import trading_agent

--- a/tests/test_var_route.py
+++ b/tests/test_var_route.py
@@ -2,9 +2,9 @@ import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.local_api.main import app
 from backend.common import portfolio as portfolio_mod
 from backend.common import portfolio_utils
+from backend.local_api.main import app
 
 client = TestClient(app)
 
@@ -18,15 +18,11 @@ def deterministic_setup(monkeypatch):
         "accounts": [
             {
                 "name": "ISA",
-                "holdings": [
-                    {"ticker": "ABC", "exchange": "L", "units": 10, "currency": "GBP"}
-                ],
+                "holdings": [{"ticker": "ABC", "exchange": "L", "units": 10, "currency": "GBP"}],
             }
         ],
     }
-    monkeypatch.setattr(
-        portfolio_mod, "build_owner_portfolio", lambda owner: portfolio
-    )
+    monkeypatch.setattr(portfolio_mod, "build_owner_portfolio", lambda owner: portfolio)
 
     # Closing prices for five consecutive days
     prices = pd.DataFrame(
@@ -41,9 +37,7 @@ def deterministic_setup(monkeypatch):
             "Source": "test",
         }
     )
-    monkeypatch.setattr(
-        portfolio_utils, "load_meta_timeseries", lambda ticker, exchange, days: prices
-    )
+    monkeypatch.setattr(portfolio_utils, "load_meta_timeseries", lambda ticker, exchange, days: prices)
 
     return portfolio, prices
 

--- a/tests/test_virtual_portfolio.py
+++ b/tests/test_virtual_portfolio.py
@@ -1,9 +1,9 @@
 import datetime as dt
+
 import pandas as pd
 import pytest
 
-from backend.common import portfolio_utils
-from backend.common import holding_utils
+from backend.common import holding_utils, portfolio_utils
 
 
 def test_aggregate_with_mixed_holdings(monkeypatch):

--- a/tests/utils/test_currency_utils.py
+++ b/tests/utils/test_currency_utils.py
@@ -1,4 +1,5 @@
 import pytest
+
 from backend.utils.currency_utils import currency_from_isin
 
 

--- a/tests/utils/test_fx_rates.py
+++ b/tests/utils/test_fx_rates.py
@@ -1,4 +1,5 @@
 import datetime as dt
+
 import pandas as pd
 import pytest
 import yfinance as yf

--- a/tests/utils/test_period_utils.py
+++ b/tests/utils/test_period_utils.py
@@ -1,4 +1,5 @@
 import pytest
+
 from backend.utils.period_utils import parse_period_to_days
 
 
@@ -12,10 +13,10 @@ from backend.utils.period_utils import parse_period_to_days
         ("1y", 365),
         ("2y", 730),
         ("10y", 3650),
-        ("12MO", 360),      # case-insensitive
+        ("12MO", 360),  # case-insensitive
         ("1Y", 365),
-        ("  3mo  ", 90),    # spaces allowed
-    ]
+        ("  3mo  ", 90),  # spaces allowed
+    ],
 )
 def test_valid_periods(period, expected_days):
     assert parse_period_to_days(period) == expected_days

--- a/tests/utils/test_timeseries_helpers.py
+++ b/tests/utils/test_timeseries_helpers.py
@@ -1,8 +1,8 @@
+import builtins
 import datetime as dt
 import json
-import builtins
+
 import pandas as pd
-import pytest
 
 import backend.utils.timeseries_helpers as th
 


### PR DESCRIPTION
## Summary
- add Black, isort, and Ruff configuration for backend
- introduce Makefile targets for formatting and lint checks
- format backend modules and adjust utilities to satisfy lint rules

## Testing
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68a627c1f93c832789a2beb921bd905d