### PR TITLE
Add component tests for key frontend pages

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   frontend-tests:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -22,7 +19,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefix frontend
 
       - name: Run tests
         run: npm test -- --run

--- a/frontend/src/pages/ScenarioTester.test.tsx
+++ b/frontend/src/pages/ScenarioTester.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ScenarioTester from "./ScenarioTester";
+import * as api from "../api";
+
+vi.mock("../api");
+
+const mockRunScenario = vi.mocked(api.runScenario);
+
+describe("ScenarioTester page", () => {
+  it("runs scenario and displays results", async () => {
+    mockRunScenario.mockResolvedValueOnce([
+      { ticker: "AAA", impact: 123 } as any,
+    ]);
+
+    render(<ScenarioTester />);
+
+    fireEvent.change(screen.getByPlaceholderText("Ticker"), { target: { value: "AAA" } });
+    fireEvent.change(screen.getByPlaceholderText("% Change"), { target: { value: "5" } });
+    fireEvent.click(screen.getByText("Apply"));
+
+    await waitFor(() => expect(mockRunScenario).toHaveBeenCalledWith("AAA", 5));
+    expect(screen.getByText(/"ticker": "AAA"/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Screener.test.tsx
+++ b/frontend/src/pages/Screener.test.tsx
@@ -56,5 +56,16 @@ describe("Screener", () => {
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByText("1.5")).toBeInTheDocument();
   });
-});
 
+
+  it("shows error message on failure", async () => {
+    mockGetScreener.mockRejectedValueOnce(new Error("fail"));
+
+    render(<Screener />);
+
+    fireEvent.change(screen.getByLabelText(/Tickers/i), { target: { value: "AAA" } });
+    fireEvent.submit(screen.getByText(/Run/i).closest("form")!);
+
+    expect(await screen.findByText("fail")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/VirtualPortfolio.test.tsx
+++ b/frontend/src/pages/VirtualPortfolio.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import VirtualPortfolio from "./VirtualPortfolio";
+import * as api from "../api";
+
+vi.mock("../api");
+
+const mockGetVirtualPortfolios = vi.mocked(api.getVirtualPortfolios);
+const mockGetOwners = vi.mocked(api.getOwners);
+const mockGetVirtualPortfolio = vi.mocked(api.getVirtualPortfolio);
+
+describe("VirtualPortfolio page", () => {
+  it("loads portfolios and allows selecting one", async () => {
+    mockGetVirtualPortfolios.mockResolvedValueOnce([
+      { id: 1, name: "Test VP" } as any,
+    ]);
+    mockGetOwners.mockResolvedValueOnce([
+      { owner: "Bob", accounts: ["A1"] } as any,
+    ]);
+    mockGetVirtualPortfolio.mockResolvedValueOnce({
+      id: 1,
+      name: "Test VP",
+      accounts: ["Bob:A1"],
+      holdings: [],
+    } as any);
+
+    render(<VirtualPortfolio />);
+
+    // Wait for portfolios to load
+    expect(await screen.findByRole("option", { name: "Test VP" })).toBeInTheDocument();
+
+    // Select the portfolio
+    fireEvent.change(screen.getByLabelText(/Select/i), { target: { value: "1" } });
+
+    await waitFor(() => expect(mockGetVirtualPortfolio).toHaveBeenCalledWith(1));
+
+    expect(screen.getByLabelText(/Name/i)).toHaveValue("Test VP");
+    const accountCheckbox = screen.getByLabelText("A1") as HTMLInputElement;
+    expect(accountCheckbox.checked).toBe(true);
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     test: {
         globals: true,
         environment: 'jsdom',
-        setupFiles: './src/setupTests.ts'
+        setupFiles: './src/setupTests.ts',
+        include: ['src/**/*.test.tsx']
     }
 });

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "devDependencies": {
     "concurrently": "^9.2.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "scripts": {
+    "test": "cd frontend && npm test --"
+  }
 }


### PR DESCRIPTION
## Summary
- add tests for VirtualPortfolio and ScenarioTester pages
- cover Screener error handling
- run frontend tests in CI via root npm test

## Testing
- `npm test -- src/pages/VirtualPortfolio.test.tsx src/pages/ScenarioTester.test.tsx src/pages/Screener.test.tsx --run`

------
https://chatgpt.com/codex/tasks/task_e_68a629c6fb2c83278c2a2b18999101a6