### PR TITLE
Use Helvetica font in site snapshot

### DIFF
--- a/scripts/site_snapshot.py
+++ b/scripts/site_snapshot.py
@@ -91,7 +91,7 @@ def build_docs(entries):
 
         # PDF section
         pdf.add_page()
-        pdf.set_font("Arial", size=14)
+        pdf.set_font("Helvetica", size=14)
         pdf.multi_cell(0, 8, md_content)
         pdf.ln(5)
         pdf.image(str(img_path), w=180)


### PR DESCRIPTION
## Summary
- Switch PDF generation in `site_snapshot.py` to use built-in Helvetica instead of Arial

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62c9fe1708327b2f82d610e50f190