### PR TITLE
feat: improve select labeling and row accessibility

### DIFF
--- a/frontend/src/components/ScreenerPage.tsx
+++ b/frontend/src/components/ScreenerPage.tsx
@@ -29,17 +29,20 @@ export function ScreenerPage() {
 
   return (
     <>
-      <select
-        value={watchlist}
-        onChange={(e) => setWatchlist(e.target.value as WatchlistName)}
-        style={{ marginBottom: "0.5rem" }}
-      >
-        {(Object.keys(WATCHLISTS) as WatchlistName[]).map((name) => (
-          <option key={name} value={name}>
-            {name}
-          </option>
-        ))}
-      </select>
+      <label style={{ display: "inline-block", marginBottom: "0.5rem" }}>
+        Watchlist:
+        <select
+          value={watchlist}
+          onChange={(e) => setWatchlist(e.target.value as WatchlistName)}
+          style={{ marginLeft: "0.25rem" }}
+        >
+          {(Object.keys(WATCHLISTS) as WatchlistName[]).map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </label>
 
       <table className={tableStyles.table}>
         <thead>
@@ -82,6 +85,13 @@ export function ScreenerPage() {
               key={r.ticker}
               onClick={() => setTicker(r.ticker)}
               className={tableStyles.clickable}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  setTicker(r.ticker);
+                }
+              }}
             >
               <td className={tableStyles.cell}>{r.ticker}</td>
               <td className={`${tableStyles.cell} ${tableStyles.right}`}>

--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -64,27 +64,34 @@ export function TopMoversPage() {
   return (
     <>
       <div style={{ marginBottom: "0.5rem" }}>
-        <select
-          value={watchlist}
-          onChange={(e) => setWatchlist(e.target.value as WatchlistOption)}
-          style={{ marginRight: "0.5rem" }}
-        >
-          {WATCHLIST_OPTIONS.map((name) => (
-            <option key={name} value={name}>
-              {name}
-            </option>
-          ))}
-        </select>
-        <select
-          value={period}
-          onChange={(e) => setPeriod(e.target.value as PeriodKey)}
-        >
-          {(Object.keys(PERIODS) as PeriodKey[]).map((p) => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
-        </select>
+        <label style={{ marginRight: "0.5rem" }}>
+          Watchlist:
+          <select
+            value={watchlist}
+            onChange={(e) => setWatchlist(e.target.value as WatchlistOption)}
+            style={{ marginLeft: "0.25rem" }}
+          >
+            {WATCHLIST_OPTIONS.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Period:
+          <select
+            value={period}
+            onChange={(e) => setPeriod(e.target.value as PeriodKey)}
+            style={{ marginLeft: "0.25rem" }}
+          >
+            {(Object.keys(PERIODS) as PeriodKey[]).map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
 
       <table className={tableStyles.table}>

--- a/frontend/src/pages/Screener.tsx
+++ b/frontend/src/pages/Screener.tsx
@@ -487,6 +487,13 @@ export function Screener() {
                 key={r.ticker}
                 onClick={() => setSelected(r.ticker)}
                 style={{ cursor: "pointer" }}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    setSelected(r.ticker);
+                  }
+                }}
               >
                 <td style={cell}>{r.ticker}</td>
                 <td style={right}>{r.peg_ratio ?? "—"}</td>


### PR DESCRIPTION
## Summary
- label unlabeled selects for watchlist and period pickers
- make clickable table rows keyboard-accessible with proper roles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62d2096848327b6c02cceca5291d3