### PR TITLE
Remove duplicate alert settings mocks in tests

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -63,7 +63,6 @@ describe("App", () => {
       getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
       getTimeseries: vi.fn().mockResolvedValue([]),
       saveTimeseries: vi.fn(),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
     }));
 
     const { default: App } = await import("./App");
@@ -92,7 +91,6 @@ describe("App", () => {
       getTimeseries: vi.fn().mockResolvedValue([]),
       saveTimeseries: vi.fn(),
       listTimeseries: vi.fn().mockResolvedValue([]),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
     }));
 
     const { default: App } = await import("./App");
@@ -124,7 +122,6 @@ describe("App", () => {
       saveTimeseries: vi.fn(),
       getTradingSignals: vi.fn().mockResolvedValue([]),
       getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
     }));
 
     const { default: App } = await import("./App");
@@ -182,7 +179,6 @@ describe("App", () => {
       saveTimeseries: vi.fn(),
       getTradingSignals: mockTradingSignals,
       getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
     }));
 
     const { default: App } = await import("./App");
@@ -282,7 +278,6 @@ describe("App", () => {
       getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
       getTradingSignals: mockTradingSignals,
       listTimeseries: vi.fn().mockResolvedValue([]),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
     }));
 
     const { default: App } = await import("./App");


### PR DESCRIPTION
## Summary
- clean up App tests by removing duplicate `getAlertSettings` entries from API mocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a62ec673f88327bf29b8d29b51c720