### PR TITLE
Include reports tab in config tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ tabs:
   timeseries: true
   watchlist: true
   virtual: true
+  reports: true
   support: true
 ```
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -142,6 +142,7 @@ describe("App", () => {
       movers: true,
       dataadmin: true,
       virtual: true,
+      reports: true,
       support: true,
       scenario: true,
     };
@@ -200,6 +201,7 @@ describe("App", () => {
       movers: true,
       dataadmin: true,
       virtual: true,
+      reports: true,
       support: true,
       scenario: true,
     };

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -24,6 +24,7 @@ const defaultConfig: AppConfig = {
     movers: true,
     dataadmin: true,
     virtual: true,
+    reports: true,
     support: true,
     scenario: true,
   },

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -18,6 +18,7 @@ const defaultConfig: AppConfig = {
         movers: true,
         dataadmin: true,
         virtual: true,
+        reports: true,
         support: true,
         scenario: true,
     },

--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -19,6 +19,7 @@ const defaultConfig: AppConfig = {
     movers: true,
     dataadmin: true,
     virtual: true,
+    reports: true,
     support: true,
     scenario: true,
   },

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -18,6 +18,7 @@ const defaultConfig: AppConfig = {
         movers: true,
         dataadmin: true,
         virtual: true,
+        reports: true,
         support: true,
         scenario: true,
     },

--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -17,7 +17,7 @@ beforeEach(() => {
   mockGetConfig.mockResolvedValue({
     flag: true,
     theme: "system",
-    tabs: { group: true, owner: true, instrument: true, support: true },
+    tabs: { group: true, owner: true, instrument: true, support: true, reports: true },
   });
 });
 
@@ -44,13 +44,13 @@ describe("Support page", () => {
   mockGetConfig.mockResolvedValueOnce({
     flag: true,
     theme: "system",
-    tabs: { group: true, owner: true, instrument: true, support: true },
+    tabs: { group: true, owner: true, instrument: true, support: true, reports: true },
   });
   mockGetConfig.mockResolvedValueOnce({
     flag: false,
     count: 5,
     theme: "dark",
-    tabs: { group: true, owner: true, instrument: false, support: true },
+    tabs: { group: true, owner: true, instrument: false, support: true, reports: true },
   });
     mockUpdateConfig.mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary
- add `reports` flag to README example tabs
- update test configs to include `reports`

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a62ec7e9148327b9ddbc61759f9072