### PR TITLE
Memoize selector components and standardize change handlers

### DIFF
--- a/frontend/src/components/GroupSelector.tsx
+++ b/frontend/src/components/GroupSelector.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { useEffect, useCallback, memo } from "react";
+import type { ChangeEventHandler } from "react";
 import type { GroupSummary } from "../types";
 import { Selector } from "./Selector";
 
@@ -8,7 +9,11 @@ type Props = {
   onSelect: (slug: string) => void;
 };
 
-export function GroupSelector({ groups, selected, onSelect }: Props) {
+export const GroupSelector = memo(function GroupSelector({
+  groups,
+  selected,
+  onSelect,
+}: Props) {
   // Auto-select first group if none selected yet
   useEffect(() => {
     if (!selected && groups.length > 0) {
@@ -16,12 +21,17 @@ export function GroupSelector({ groups, selected, onSelect }: Props) {
     }
   }, [selected, groups, onSelect]);
 
+  const handleChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
+    (e) => onSelect(e.target.value),
+    [onSelect],
+  );
+
   return (
     <Selector
       label="Group"
       value={selected}
-      onChange={onSelect}
+      onChange={handleChange}
       options={groups.map((g) => ({ value: g.slug, label: g.name }))}
     />
   );
-}
+});

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, memo } from "react";
 import i18n from "i18next";
 
 const LANGUAGES = [
@@ -9,7 +9,7 @@ const LANGUAGES = [
   { code: "pt", flag: "🇵🇹" },
 ];
 
-export function LanguageSwitcher() {
+export const LanguageSwitcher = memo(function LanguageSwitcher() {
   const [current, setCurrent] = useState(i18n.language);
 
   useEffect(() => {
@@ -53,5 +53,5 @@ export function LanguageSwitcher() {
       ))}
     </div>
   );
-}
+});
 

--- a/frontend/src/components/OwnerSelector.tsx
+++ b/frontend/src/components/OwnerSelector.tsx
@@ -1,6 +1,8 @@
 import type { OwnerSummary } from "../types";
 import { Selector } from "./Selector";
 import { useTranslation } from "react-i18next";
+import { useCallback, memo } from "react";
+import type { ChangeEventHandler } from "react";
 
 type Props = {
   owners: OwnerSummary[];
@@ -8,15 +10,24 @@ type Props = {
   onSelect: (owner: string) => void;
 };
 
-export function OwnerSelector({ owners, selected, onSelect }: Props) {
+export const OwnerSelector = memo(function OwnerSelector({
+  owners,
+  selected,
+  onSelect,
+}: Props) {
   const { t } = useTranslation();
+  const handleChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
+    (e) => onSelect(e.target.value),
+    [onSelect],
+  );
+
   return (
     <Selector
       label={t("owner.label")}
       value={selected}
-      onChange={onSelect}
+      onChange={handleChange}
       options={owners.map((o) => ({ value: o.owner, label: o.owner }))}
     />
   );
-}
+});
 

--- a/frontend/src/components/Selector.tsx
+++ b/frontend/src/components/Selector.tsx
@@ -1,4 +1,5 @@
-import type { CSSProperties } from "react";
+import { memo } from "react";
+import type { CSSProperties, ChangeEventHandler } from "react";
 
 type Option = {
   value: string;
@@ -9,11 +10,11 @@ type Props = {
   label: string;
   options: Option[];
   value: string;
-  onChange: (value: string) => void;
+  onChange: ChangeEventHandler<HTMLSelectElement>;
   style?: CSSProperties;
 };
 
-export function Selector({ label, options, value, onChange, style }: Props) {
+function SelectorComponent({ label, options, value, onChange, style }: Props) {
   return (
     <label
       style={{
@@ -26,7 +27,7 @@ export function Selector({ label, options, value, onChange, style }: Props) {
       {label}:
       <select
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={onChange}
         style={{ marginLeft: "0.5rem" }}
       >
         {options.map((o) => (
@@ -38,5 +39,7 @@ export function Selector({ label, options, value, onChange, style }: Props) {
     </label>
   );
 }
+
+export const Selector = memo(SelectorComponent);
 
 export type { Option };

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useCallback } from "react";
+import type { ChangeEventHandler } from "react";
 import type { OwnerSummary, Transaction } from "../types";
 import { getTransactions } from "../api";
 import { Selector } from "./Selector";
@@ -42,13 +43,23 @@ export function TransactionsPage({ owners }: Props) {
     return Array.from(set);
   }, [owner, owners]);
 
+  const handleOwnerChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
+    (e) => setOwner(e.target.value),
+    [],
+  );
+
+  const handleAccountChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
+    (e) => setAccount(e.target.value),
+    [],
+  );
+
   return (
     <div>
       <div style={{ marginBottom: "1rem" }}>
         <Selector
           label={t("owner.label")}
           value={owner}
-          onChange={setOwner}
+          onChange={handleOwnerChange}
           options={[
             { value: "", label: "All" },
             ...owners.map((o) => ({ value: o.owner, label: o.owner })),
@@ -57,7 +68,7 @@ export function TransactionsPage({ owners }: Props) {
         <Selector
           label="Account"
           value={account}
-          onChange={setAccount}
+          onChange={handleAccountChange}
           options={[
             { value: "", label: "All" },
             ...accountOptions.map((a) => ({ value: a, label: a })),


### PR DESCRIPTION
## Summary
- wrap selector and related components with React.memo
- type select change handlers with `React.ChangeEventHandler` and memoize with `useCallback`
- apply memoization to LanguageSwitcher and other presentational selectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a62d1a5ccc832798e0a005d77f82a4