### PR TITLE
test: add moto fixtures and coverage thresholds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+addopts = "--cov --cov-fail-under=80"
+testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ botocore~=1.37.10
 boto3~=1.37.10
 s3transfer~=0.11.2
 jmespath~=1.0.1
+moto~=5.1.10
 numpy~=2.3.1
 openpyxl~=3.1.5
 charset-normalizer~=3.3.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+import boto3
+from moto import mock_aws
+
+import backend.common.data_loader as dl
+
+@pytest.fixture()
+def s3_bucket(monkeypatch):
+    """Create a temporary S3 bucket using moto and set DATA_BUCKET env."""
+    with mock_aws():
+        os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+        os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+        os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+        s3 = boto3.client("s3", region_name="us-east-1")
+        bucket = "bucket"
+        s3.create_bucket(Bucket=bucket)
+        monkeypatch.setenv(dl.DATA_BUCKET_ENV, bucket)
+        yield s3, bucket
+
+
+@pytest.fixture()
+def quotes_table(monkeypatch):
+    """Provision a DynamoDB table for quote storage using moto."""
+    with mock_aws():
+        os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+        os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+        os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = dynamodb.create_table(
+            TableName="Quotes",
+            KeySchema=[{"AttributeName": "symbol", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "symbol", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield table

--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -1,31 +1,12 @@
-import io
-import sys
-from types import SimpleNamespace
-
 import backend.common.data_loader as dl
 
 
-def test_list_aws_plots(monkeypatch):
-    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
-
-    def fake_client(name):
-        assert name == "s3"
-
-        def list_objects_v2(**kwargs):
-            assert kwargs["Bucket"] == "bucket"
-            assert kwargs["Prefix"] == dl.PLOTS_PREFIX
-            return {
-                "Contents": [
-                    {"Key": "accounts/Alice/ISA.json"},
-                    {"Key": "accounts/Alice/person.json"},
-                    {"Key": "accounts/Bob/GIA.json"},
-                ]
-            }
-
-        return SimpleNamespace(list_objects_v2=list_objects_v2)
-
-    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
-
+def test_list_aws_plots(s3_bucket, monkeypatch):
+    s3, bucket = s3_bucket
+    monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
+    s3.put_object(Bucket=bucket, Key="accounts/Alice/ISA.json", Body=b"{}")
+    s3.put_object(Bucket=bucket, Key="accounts/Alice/person.json", Body=b"{}")
+    s3.put_object(Bucket=bucket, Key="accounts/Bob/GIA.json", Body=b"{}")
     expected = [
         {"owner": "Alice", "accounts": ["ISA"]},
         {"owner": "Bob", "accounts": ["GIA"]},
@@ -33,40 +14,16 @@ def test_list_aws_plots(monkeypatch):
     assert dl._list_aws_plots() == expected
 
 
-def test_load_account_from_s3(monkeypatch):
+def test_load_account_from_s3(s3_bucket, monkeypatch):
+    s3, bucket = s3_bucket
     monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
-    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
-
-    def fake_client(name):
-        assert name == "s3"
-
-        def get_object(Bucket, Key):
-            assert Bucket == "bucket"
-            assert Key == "accounts/Alice/ISA.json"
-            return {"Body": io.BytesIO(b'{"balance": 10}')}
-
-        return SimpleNamespace(get_object=get_object)
-
-    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
-
+    s3.put_object(Bucket=bucket, Key="accounts/Alice/ISA.json", Body=b"{\"balance\": 10}")
     assert dl.load_account("Alice", "ISA") == {"balance": 10}
 
 
-def test_load_person_meta_from_s3(monkeypatch):
+def test_load_person_meta_from_s3(s3_bucket, monkeypatch):
+    s3, bucket = s3_bucket
     monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
-    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
-
-    def fake_client(name):
-        assert name == "s3"
-
-        def get_object(Bucket, Key):
-            if Key == "accounts/Alice/person.json":
-                return {"Body": io.BytesIO(b'{"dob": "1980"}')}
-            raise Exception("NoSuchKey")
-
-        return SimpleNamespace(get_object=get_object)
-
-    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
-
+    s3.put_object(Bucket=bucket, Key="accounts/Alice/person.json", Body=b"{\"dob\": \"1980\"}")
     assert dl.load_person_meta("Alice") == {"dob": "1980"}
     assert dl.load_person_meta("Bob") == {}

--- a/tests/test_portfolio_trades.py
+++ b/tests/test_portfolio_trades.py
@@ -1,46 +1,17 @@
-import sys
-from types import SimpleNamespace
-
 import backend.common.portfolio as portfolio
 
 
-def test_load_trades_aws_success(monkeypatch):
-    monkeypatch.setenv("DATA_BUCKET", "bucket")
+def test_load_trades_aws_success(s3_bucket, monkeypatch):
+    s3, bucket = s3_bucket
     monkeypatch.setattr(portfolio.config, "app_env", "aws", raising=False)
-
-    body_bytes = b"date,ticker,units\n2024-02-01,AAPL,5\n"
-
-    class FakeBody:
-        def read(self):
-            return body_bytes
-
-    def fake_get_object(*, Bucket, Key):
-        assert Bucket == "bucket"
-        assert Key == "accounts/alice/trades.csv"
-        return {"Body": FakeBody()}
-
-    def fake_client(name):
-        assert name == "s3"
-        return SimpleNamespace(get_object=fake_get_object)
-
-    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
-
+    body = "date,ticker,units\n2024-02-01,AAPL,5\n"
+    s3.put_object(Bucket=bucket, Key="accounts/alice/trades.csv", Body=body)
     trades = portfolio.load_trades("alice")
     assert trades == [{"date": "2024-02-01", "ticker": "AAPL", "units": "5"}]
 
 
-def test_load_trades_aws_missing(monkeypatch):
-    monkeypatch.setenv("DATA_BUCKET", "bucket")
+def test_load_trades_aws_missing(s3_bucket, monkeypatch):
+    _, _ = s3_bucket  # ensure bucket exists
     monkeypatch.setattr(portfolio.config, "app_env", "aws", raising=False)
-
-    def fake_get_object(*, Bucket, Key):
-        raise Exception("not found")
-
-    def fake_client(name):
-        assert name == "s3"
-        return SimpleNamespace(get_object=fake_get_object)
-
-    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
-
     trades = portfolio.load_trades("bob")
     assert trades == []

--- a/tests/test_quotes_task.py
+++ b/tests/test_quotes_task.py
@@ -1,0 +1,23 @@
+from decimal import Decimal
+
+import backend.tasks.quotes as quotes
+
+
+def test_save_quotes_writes_items(quotes_table):
+    item = {"symbol": "AAPL", "price": Decimal("1"), "volume": 10, "time": "t"}
+    quotes.save_quotes([item])
+    resp = quotes_table.scan()
+    assert resp["Count"] == 1
+    assert resp["Items"][0]["symbol"] == "AAPL"
+
+
+def test_lambda_handler_saves_quotes(quotes_table, monkeypatch):
+    monkeypatch.setattr(
+        quotes,
+        "fetch_quote",
+        lambda sym: {"symbol": sym, "price": Decimal("1"), "volume": 1, "time": "t"},
+    )
+    result = quotes.lambda_handler({"symbols": ["AAPL", "MSFT"]}, None)
+    assert result == {"count": 2}
+    symbols = {item["symbol"] for item in quotes_table.scan()["Items"]}
+    assert symbols == {"AAPL", "MSFT"}


### PR DESCRIPTION
## Summary
- use moto-powered fixtures for S3 and DynamoDB in tests
- add coverage enforcement via pyproject and increase AWS-related tests
- introduce quotes task tests and moto dependency

## Testing
- `pytest --cov --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68a62d0cd1108327b4a20bc24fe8b40b