### PR TITLE
refactor: replace any usage to satisfy eslint

### DIFF
--- a/frontend/src/pages/ScenarioTester.test.tsx
+++ b/frontend/src/pages/ScenarioTester.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import ScenarioTester from "./ScenarioTester";
 import * as api from "../api";
+import type { ScenarioResult } from "../types";
 
 vi.mock("../api");
 
@@ -10,7 +11,12 @@ const mockRunScenario = vi.mocked(api.runScenario);
 describe("ScenarioTester page", () => {
   it("runs scenario and displays results", async () => {
     mockRunScenario.mockResolvedValueOnce([
-      { ticker: "AAA", impact: 123 } as any,
+      {
+        owner: "Test Owner",
+        total_value_estimate_gbp: 123,
+        ticker: "AAA",
+        impact: 123,
+      } as unknown as ScenarioResult,
     ]);
 
     render(<ScenarioTester />);

--- a/frontend/src/pages/VirtualPortfolio.test.tsx
+++ b/frontend/src/pages/VirtualPortfolio.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import VirtualPortfolio from "./VirtualPortfolio";
 import * as api from "../api";
+import type { OwnerSummary, VirtualPortfolio as VirtualPortfolioType } from "../types";
 
 vi.mock("../api");
 
@@ -12,17 +13,22 @@ const mockGetVirtualPortfolio = vi.mocked(api.getVirtualPortfolio);
 describe("VirtualPortfolio page", () => {
   it("loads portfolios and allows selecting one", async () => {
     mockGetVirtualPortfolios.mockResolvedValueOnce([
-      { id: 1, name: "Test VP" } as any,
+      {
+        id: 1,
+        name: "Test VP",
+        accounts: [],
+        holdings: [],
+      } as VirtualPortfolioType,
     ]);
     mockGetOwners.mockResolvedValueOnce([
-      { owner: "Bob", accounts: ["A1"] } as any,
+      { owner: "Bob", accounts: ["A1"] } as OwnerSummary,
     ]);
     mockGetVirtualPortfolio.mockResolvedValueOnce({
       id: 1,
       name: "Test VP",
       accounts: ["Bob:A1"],
       holdings: [],
-    } as any);
+    } as VirtualPortfolioType);
 
     render(<VirtualPortfolio />);
 

--- a/frontend/src/plugins/TabPlugin.ts
+++ b/frontend/src/plugins/TabPlugin.ts
@@ -15,7 +15,7 @@ export interface TabPlugin {
   /** Unique identifier corresponding to the app mode (e.g. "movers"). */
   id: string;
   /** React component rendered when the tab is selected. */
-  component: ComponentType<any>;
+  component: ComponentType<unknown>;
   /** Lower numbers appear further to the left in the navigation bar. */
   priority: number;
   /** Build a URL path for the tab based on current selections. */


### PR DESCRIPTION
## Summary
- remove `any` types from plugin interface
- replace `any` casts in ScenarioTester and VirtualPortfolio tests with strict typings

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a631dd4a308327bba5e62765ec2ac7