### PR TITLE
Include pillow dependency for site_snapshot script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,3 +69,4 @@ playwright~=1.49.0
 openai~=1.51.0
 moviepy~=2.2.1
 gTTS~=2.5.4
+pillow~=11.3.0

--- a/scripts/site_snapshot.py
+++ b/scripts/site_snapshot.py
@@ -3,7 +3,7 @@
 
 How to use:
 1. Install dependencies:
-   pip install requests beautifulsoup4 fpdf markdownify playwright
+   pip install requests beautifulsoup4 fpdf markdownify playwright pillow
    playwright install  # downloads headless browsers
 2. Edit BASE_URL to point to your server.
 3. Run: python scripts/site_snapshot.py


### PR DESCRIPTION
## Summary
- add pillow to site snapshot usage instructions and project requirements

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a6358e5ba483279a21b61ee4131fb0