### PR TITLE
Add eslint-config-google dependency for frontend linting

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@vitejs/plugin-react": "^4.6.0",
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.30.1",
+        "eslint-config-google": "^0.14.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
@@ -4952,6 +4953,19 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-google": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
+      "integrity": "sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.16.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.30.1",
+    "eslint-config-google": "^0.14.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",


### PR DESCRIPTION
## Summary
- add missing `eslint-config-google` dev dependency so lint script can resolve Google style config

## Testing
- `npm run lint`
- `npm test` *(fails: Unable to find role="heading" name `/Support/i` in App.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a6357f72e4832792342358ac4d396c