### PR TITLE
Include navigation menu on support page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, lazy, Suspense } from "react";
-import { useNavigate, useLocation, Link } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { getGroupInstruments, getGroups, getOwners, getPortfolio, refreshPrices } from "./api";
 
@@ -23,6 +23,8 @@ import { ComplianceWarnings } from "./components/ComplianceWarnings";
 import useFetchWithRetry from "./hooks/useFetchWithRetry";
 import { LanguageSwitcher } from "./components/LanguageSwitcher";
 import { useConfig } from "./ConfigContext";
+import Menu from "./components/Menu";
+import { Mode } from "./modes";
 
 const ScreenerQuery = lazy(() => import("./pages/ScreenerQuery"));
 const TimeseriesEdit = lazy(() =>
@@ -32,20 +34,7 @@ const Watchlist = lazy(() => import("./pages/Watchlist"));
 const TopMovers = lazy(() => import("./pages/TopMovers"));
 const DataAdmin = lazy(() => import("./pages/DataAdmin"));
 const ScenarioTester = lazy(() => import("./pages/ScenarioTester"));
-
-type Mode =
-  | "owner"
-  | "group"
-  | "instrument"
-  | "transactions"
-  | "performance"
-  | "screener"
-  | "timeseries"
-  | "watchlist"
-  | "movers"
-  | "dataadmin"
-  | "support"
-  | "scenario";
+const SupportPage = lazy(() => import("./pages/Support"));
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -95,40 +84,6 @@ export default function App() {
 
   const ownersReq = useFetchWithRetry(getOwners);
   const groupsReq = useFetchWithRetry(getGroups);
-
-  const modes: Mode[] = [
-    "movers",
-    "group",
-    "instrument",
-    "owner",
-    "performance",
-    "transactions",
-    "screener",
-    "timeseries",
-    "watchlist",
-    "dataadmin",
-    "support",
-    "scenario",
-  ];
-
-  function pathFor(m: Mode) {
-    switch (m) {
-      case "group":
-        return selectedGroup ? `/?group=${selectedGroup}` : "/movers";
-      case "instrument":
-        return selectedGroup ? `/instrument/${selectedGroup}` : "/instrument";
-      case "owner":
-        return selectedOwner ? `/member/${selectedOwner}` : "/member";
-      case "performance":
-        return selectedOwner ? `/performance/${selectedOwner}` : "/performance";
-      case "movers":
-        return "/movers";
-      case "scenario":
-        return "/scenario";
-      default:
-        return `/${m}`;
-    }
-  }
 
   useEffect(() => {
     const segs = location.pathname.split("/").filter(Boolean);
@@ -285,22 +240,9 @@ export default function App() {
       <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
       <LanguageSwitcher />
       <AlertsPanel />
-      <nav style={{ margin: "1rem 0" }}>
-        {modes
-          .filter((m) => tabs[m] === true && !disabledTabs?.includes(m))
-          .map((m) => (
-            <Link
-              key={m}
-              to={pathFor(m)}
-              style={{
-                marginRight: "1rem",
-                fontWeight: mode === m ? "bold" : undefined,
-              }}
-            >
-              {t(`app.modes.${m}`)}
-            </Link>
-          ))}
-      </nav>
+      {mode !== "support" && (
+        <Menu selectedOwner={selectedOwner} selectedGroup={selectedGroup} />
+      )}
 
       <div style={{ marginBottom: "1rem" }}>
         <button onClick={handleRefreshPrices} disabled={refreshingPrices}>
@@ -391,6 +333,7 @@ export default function App() {
       {mode === "timeseries" && <TimeseriesEdit />}
       {mode === "dataadmin" && <DataAdmin />}
       {mode === "watchlist" && <Watchlist />}
+      {mode === "support" && <SupportPage />}
       {mode === "movers" && <TopMovers />}
       {mode === "scenario" && <ScenarioTester />}
       </div>

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -1,0 +1,88 @@
+import { Link, useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useConfig } from "../ConfigContext";
+import { Mode, MODES } from "../modes";
+
+interface MenuProps {
+  selectedOwner?: string;
+  selectedGroup?: string;
+}
+
+export default function Menu({
+  selectedOwner = "",
+  selectedGroup = "",
+}: MenuProps) {
+  const location = useLocation();
+  const { t } = useTranslation();
+  const { tabs, disabledTabs } = useConfig();
+
+  const params = new URLSearchParams(location.search);
+  const path = location.pathname.split("/").filter(Boolean);
+
+  const mode: Mode =
+    path[0] === "member"
+      ? "owner"
+      : path[0] === "instrument"
+      ? "instrument"
+      : path[0] === "transactions"
+      ? "transactions"
+      : path[0] === "performance"
+      ? "performance"
+      : path[0] === "screener"
+      ? "screener"
+      : path[0] === "timeseries"
+      ? "timeseries"
+      : path[0] === "watchlist"
+      ? "watchlist"
+      : path[0] === "movers"
+      ? "movers"
+      : path[0] === "dataadmin"
+      ? "dataadmin"
+      : path[0] === "support"
+      ? "support"
+      : path[0] === "scenario"
+      ? "scenario"
+      : path.length === 0 && params.has("group")
+      ? "group"
+      : "movers";
+
+  function pathFor(m: Mode) {
+    switch (m) {
+      case "group":
+        return selectedGroup ? `/?group=${selectedGroup}` : "/movers";
+      case "instrument":
+        return selectedGroup ? `/instrument/${selectedGroup}` : "/instrument";
+      case "owner":
+        return selectedOwner ? `/member/${selectedOwner}` : "/member";
+      case "performance":
+        return selectedOwner
+          ? `/performance/${selectedOwner}`
+          : "/performance";
+      case "movers":
+        return "/movers";
+      case "scenario":
+        return "/scenario";
+      default:
+        return `/${m}`;
+    }
+  }
+
+  return (
+    <nav style={{ margin: "1rem 0" }}>
+      {MODES.filter((m) => tabs[m] === true && !disabledTabs?.includes(m)).map(
+        (m) => (
+          <Link
+            key={m}
+            to={pathFor(m)}
+            style={{
+              marginRight: "1rem",
+              fontWeight: mode === m ? "bold" : undefined,
+            }}
+          >
+            {t(`app.modes.${m}`)}
+          </Link>
+        ),
+      )}
+    </nav>
+  );
+}

--- a/frontend/src/modes.ts
+++ b/frontend/src/modes.ts
@@ -1,0 +1,28 @@
+export type Mode =
+  | "owner"
+  | "group"
+  | "instrument"
+  | "transactions"
+  | "performance"
+  | "screener"
+  | "timeseries"
+  | "watchlist"
+  | "movers"
+  | "dataadmin"
+  | "support"
+  | "scenario";
+
+export const MODES: Mode[] = [
+  "movers",
+  "group",
+  "instrument",
+  "owner",
+  "performance",
+  "transactions",
+  "screener",
+  "timeseries",
+  "watchlist",
+  "dataadmin",
+  "support",
+  "scenario",
+];

--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { vi } from "vitest";
 
 const mockGetConfig = vi.hoisted(() => vi.fn());
@@ -23,13 +24,13 @@ beforeEach(() => {
 
 describe("Support page", () => {
   it("renders environment heading", () => {
-    render(<Support />);
+    render(<Support />, { wrapper: MemoryRouter });
     expect(screen.getByText(/Environment/)).toBeInTheDocument();
   });
 
   it("shows swagger link for VITE_API_URL", () => {
     vi.stubEnv("VITE_API_URL", "http://localhost:8000");
-    render(<Support />);
+    render(<Support />, { wrapper: MemoryRouter });
     expect(
       screen.getByRole("link", { name: "http://localhost:8000" })
     ).toHaveAttribute("href", "http://localhost:8000");
@@ -54,7 +55,7 @@ describe("Support page", () => {
     });
     mockUpdateConfig.mockResolvedValue(undefined);
 
-    render(<Support />);
+    render(<Support />, { wrapper: MemoryRouter });
 
     const saveButton = await screen.findByRole("button", { name: "Save" });
     fireEvent.click(saveButton);
@@ -67,7 +68,7 @@ describe("Support page", () => {
   });
 
   it("renders tab toggles and allows toggling", async () => {
-    render(<Support />);
+    render(<Support />, { wrapper: MemoryRouter });
     await screen.findByText(/Tabs Enabled/i);
     const instrument = await screen.findByRole("checkbox", {
       name: /instrument/i,
@@ -82,7 +83,7 @@ describe("Support page", () => {
   });
 
   it("separates switches from other parameters", async () => {
-    render(<Support />);
+    render(<Support />, { wrapper: MemoryRouter });
     const switchesHeading = await screen.findByRole("heading", {
       name: /Other Switches/i,
     });
@@ -107,7 +108,7 @@ describe("Support page", () => {
   });
 
   it("allows selecting theme via radio buttons", async () => {
-    render(<Support />);
+    render(<Support />, { wrapper: MemoryRouter });
     const dark = await screen.findByRole("radio", { name: "dark" });
     const light = screen.getByRole("radio", { name: "light" });
     fireEvent.click(light);

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { API_BASE, getConfig, updateConfig } from "../api";
 import { useConfig } from "../ConfigContext";
+import Menu from "../components/Menu";
 
 const TAB_KEYS = [
   "instrument",
@@ -136,6 +137,7 @@ export default function Support() {
 
   return (
     <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
+      <Menu />
       <h1>{t("support.title")}</h1>
       <p>
         <strong>{t("support.online")}</strong> {online ? t("support.onlineYes") : t("support.onlineNo")}


### PR DESCRIPTION
## Summary
- add reusable Menu component and mode definitions
- render menu on support page and load support content through App
- update tests for router context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a633c1acac8327afc3d0d53a1f1ddd