### PR TITLE
test: add coverage for portfolio, screener, scenario tester

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -19,7 +19,9 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        run: npm ci --prefix frontend
+        working-directory: frontend
+        run: npm ci
 
       - name: Run tests
+        working-directory: frontend
         run: npm test -- --run

--- a/frontend/src/pages/ScenarioTester.test.tsx
+++ b/frontend/src/pages/ScenarioTester.test.tsx
@@ -28,4 +28,16 @@ describe("ScenarioTester page", () => {
     await waitFor(() => expect(mockRunScenario).toHaveBeenCalledWith("AAA", 5));
     expect(screen.getByText(/"ticker": "AAA"/)).toBeInTheDocument();
   });
+
+  it("shows error message on failure", async () => {
+    mockRunScenario.mockRejectedValueOnce(new Error("fail"));
+
+    render(<ScenarioTester />);
+
+    fireEvent.change(screen.getByPlaceholderText("Ticker"), { target: { value: "AAA" } });
+    fireEvent.change(screen.getByPlaceholderText("% Change"), { target: { value: "5" } });
+    fireEvent.click(screen.getByText("Apply"));
+
+    expect(await screen.findByText("fail")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/Screener.test.tsx
+++ b/frontend/src/pages/Screener.test.tsx
@@ -9,6 +9,9 @@ vi.mock("../api");
 const mockGetScreener = vi.mocked(api.getScreener);
 
 describe("Screener", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
   it("renders new ratio columns", async () => {
     mockGetScreener.mockResolvedValueOnce([
       {
@@ -55,6 +58,14 @@ describe("Screener", () => {
     expect(screen.getAllByText("10")).toHaveLength(2);
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByText("1.5")).toBeInTheDocument();
+  });
+
+  it("does not submit without tickers", async () => {
+    render(<Screener />);
+
+    fireEvent.submit(screen.getByText(/Run/i).closest("form")!);
+
+    await waitFor(() => expect(mockGetScreener).not.toHaveBeenCalled());
   });
 
 

--- a/frontend/src/pages/VirtualPortfolio.test.tsx
+++ b/frontend/src/pages/VirtualPortfolio.test.tsx
@@ -44,4 +44,13 @@ describe("VirtualPortfolio page", () => {
     const accountCheckbox = screen.getByLabelText("A1") as HTMLInputElement;
     expect(accountCheckbox.checked).toBe(true);
   });
+
+  it("shows error when loading portfolios fails", async () => {
+    mockGetVirtualPortfolios.mockRejectedValueOnce(new Error("fail"));
+    mockGetOwners.mockResolvedValueOnce([]);
+
+    render(<VirtualPortfolio />);
+
+    expect(await screen.findByText(/fail/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add negative case tests for ScenarioTester
- ensure Screener ignores empty submissions and clear mocks
- cover VirtualPortfolio load errors
- run frontend tests in CI from frontend directory

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a8ce7c261c8327bc3d61848445fa7b