### PR TITLE
docs: document error summary config

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,13 @@ cd frontend && npm test
 
 ## Error summary helper
 
-Use the `run_with_error_summary.py` script to capture error lines when running
-commands. A log file `error_summary.log` will be created with a summary of
-errors which you can attach when reporting bugs. Optionally set a default
-command in `config.yaml` under `error_summary.default_command` so the script
-can run without CLI arguments:
+An optional `error_summary` section in `config.yaml` stores settings for the
+`run_with_error_summary.py` utility. When the field is missing the backend falls
+back to an empty mapping so the script can still be used with explicit
+arguments. You can capture error lines by running the helper which writes them
+to `error_summary.log`. Optionally set a default command in
+`config.yaml` under `error_summary.default_command` so the script can run
+without CLI arguments:
 
 ```yaml
 error_summary:

--- a/backend/config.py
+++ b/backend/config.py
@@ -52,7 +52,7 @@ class Config:
     selenium_headless: Optional[bool] = None
 
     # misc complex config
-    error_summary: Optional[dict] = None
+    error_summary: Dict[str, Any] = field(default_factory=dict)
     offline_mode: Optional[bool] = None
     relative_view_enabled: Optional[bool] = None
     theme: Optional[str] = None
@@ -126,7 +126,7 @@ def load_config() -> Config:
             cors_origins = cors_raw.get("default")
 
     error_summary_raw = data.get("error_summary")
-    error_summary = error_summary_raw if isinstance(error_summary_raw, dict) else None
+    error_summary = error_summary_raw if isinstance(error_summary_raw, dict) else {}
 
     return Config(
         app_env=data.get("app_env"),

--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,6 @@ selenium_headless: true
 approval_valid_days: 2
 approval_exempt_types: ETF
 approval_exempt_tickers: ''
-error_summary: {}
 
 tabs:
   movers: true


### PR DESCRIPTION
## Summary
- remove `error_summary` from the default config
- ensure config loader returns an empty mapping when the field is missing
- explain `error_summary` usage and defaults in README

## Testing
- `pytest` *(fails: NoSuchKey)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ce6473bc83278d084f139aff5b10