### PR TITLE
feat: introduce jwt auth

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,9 +11,9 @@ import asyncio
 import logging
 import os
 
-from fastapi import Depends, FastAPI, HTTPException, Security, status
+from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.security import APIKeyHeader
+from fastapi.security import OAuth2PasswordRequestForm
 
 from backend.routes.instrument import router as instrument_router
 from backend.routes.portfolio import router as portfolio_router
@@ -45,20 +45,7 @@ from backend.common.portfolio_utils import (
 from backend.config import config
 from backend.common.data_loader import resolve_paths
 from backend.utils import page_cache
-
-
-API_TOKEN = os.getenv("API_TOKEN")
-api_key_header = APIKeyHeader(name="X-API-Token", auto_error=False)
-
-
-async def require_token(token: str = Security(api_key_header)) -> None:
-    """Validate the provided API token if authentication is configured."""
-
-    if API_TOKEN and token != API_TOKEN:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or missing API token",
-        )
+from backend.auth import authenticate_user, create_access_token, get_current_user
 
 
 def create_app() -> FastAPI:
@@ -93,8 +80,8 @@ def create_app() -> FastAPI:
 
     # ──────────────────────────── Routers ────────────────────────────
     # The API surface is composed of a few routers grouped by concern.
-    # Sensitive routes are guarded by a simple API-token dependency.
-    protected = [Depends(require_token)]
+    # Sensitive routes are guarded by a JWT-based dependency.
+    protected = [Depends(get_current_user)]
     app.include_router(portfolio_router, dependencies=protected)
     app.include_router(instrument_router)
     app.include_router(timeseries_router)
@@ -116,6 +103,14 @@ def create_app() -> FastAPI:
     app.include_router(scenario_router)
     app.include_router(rebalance_router)
     app.include_router(reports_router, dependencies=protected)
+
+    @app.post("/token")
+    async def login(form_data: OAuth2PasswordRequestForm = Depends()):
+        user = authenticate_user(form_data.username, form_data.password)
+        if not user:
+            raise HTTPException(status_code=400, detail="Incorrect username or password")
+        token = create_access_token(user)
+        return {"access_token": token, "token_type": "bearer"}
 
     # ────────────────────── Health-check endpoint ─────────────────────
     @app.get("/health")

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,52 @@
+import hashlib
+import os
+from typing import Optional
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+
+# Simple in-memory user store with hashed passwords
+
+def _hash(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+users_db = {
+    "testuser": _hash("password"),
+}
+
+SECRET_KEY = os.getenv("JWT_SECRET", "change-me")
+ALGORITHM = "HS256"
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def authenticate_user(username: str, password: str) -> Optional[str]:
+    hashed = users_db.get(username)
+    if not hashed:
+        return None
+    if _hash(password) != hashed:
+        return None
+    return username
+
+
+def create_access_token(username: str) -> str:
+    return jwt.encode({"sub": username}, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_token(token: str) -> Optional[str]:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        return payload.get("sub")
+    except jwt.PyJWTError:
+        return None
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme)) -> str:
+    username = decode_token(token)
+    if not username:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+        )
+    return username

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -43,3 +43,5 @@ peewee~=3.18.2
 numpy~=2.3.1
 pyarrow~=21.0.0
 reportlab~=3.6.12
+PyJWT~=2.9.0
+python-multipart~=0.0.20

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchJson, setAuthToken } from "./api";
+
+describe("auth token handling", () => {
+  beforeEach(() => {
+    setAuthToken(null);
+  });
+
+  it("adds Authorization header when token set", async () => {
+    setAuthToken("token123");
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mockFetch;
+    await fetchJson("/foo");
+    expect(mockFetch).toHaveBeenCalled();
+    const args = mockFetch.mock.calls[0];
+    const headers = args[1].headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer token123");
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -32,11 +32,38 @@ export const API_BASE =
   import.meta.env.VITE_API_URL ??
   "http://localhost:8000";
 
+let authToken: string | null = null;
+export const setAuthToken = (token: string | null) => {
+  authToken = token;
+};
+
+export async function login(
+  username: string,
+  password: string,
+): Promise<string> {
+  const body = new URLSearchParams({ username, password });
+  const res = await fetch(`${API_BASE}/token`, {
+    method: "POST",
+    body,
+  });
+  if (!res.ok) {
+    throw new Error("Login failed");
+  }
+  const data = (await res.json()) as { access_token: string };
+  setAuthToken(data.access_token);
+  return data.access_token;
+}
+
 /* ------------------------------------------------------------------ */
 /* Generic fetch helper                                                */
 /* ------------------------------------------------------------------ */
-export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, init);
+export async function fetchJson<T>(
+  url: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const headers = new Headers(init.headers);
+  if (authToken) headers.set("Authorization", `Bearer ${authToken}`);
+  const res = await fetch(url, { ...init, headers });
   if (!res.ok) {
     throw new Error(`HTTP ${res.status} – ${res.statusText} (${url})`);
   }

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -6,6 +6,10 @@ from backend.common.instruments import get_instrument_meta
 import backend.common.alerts as alerts
 
 client = TestClient(app)
+token = client.post(
+    "/token", data={"username": "testuser", "password": "password"}
+).json()["access_token"]
+client.headers.update({"Authorization": f"Bearer {token}"})
 
 # allow alerts to operate without SNS configuration
 alerts.config.sns_topic_arn = None

--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -3,6 +3,7 @@ import sys
 from types import SimpleNamespace
 
 import backend.common.data_loader as dl
+from botocore.exceptions import ClientError
 
 
 def test_list_aws_plots(monkeypatch):
@@ -62,7 +63,7 @@ def test_load_person_meta_from_s3(monkeypatch):
         def get_object(Bucket, Key):
             if Key == "accounts/Alice/person.json":
                 return {"Body": io.BytesIO(b"{\"dob\": \"1980\"}")}
-            raise Exception("NoSuchKey")
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "get_object")
 
         return SimpleNamespace(get_object=get_object)
 

--- a/tests/test_group_movers_route.py
+++ b/tests/test_group_movers_route.py
@@ -4,6 +4,10 @@ from fastapi.testclient import TestClient
 
 
 client = TestClient(app)
+token = client.post(
+    "/token", data={"username": "testuser", "password": "password"}
+).json()["access_token"]
+client.headers.update({"Authorization": f"Bearer {token}"})
 
 
 def test_group_movers_endpoint(monkeypatch):

--- a/tests/test_instrument_route.py
+++ b/tests/test_instrument_route.py
@@ -1,11 +1,21 @@
 import pandas as pd
+import pandas as pd
 import pytest
-from fastapi.testclient import TestClient
 from unittest.mock import patch
 from datetime import date
 
 from backend.app import create_app
 from backend.config import config
+from fastapi.testclient import TestClient
+
+
+def _auth_client(app):
+    client = TestClient(app)
+    token = client.post(
+        "/token", data={"username": "testuser", "password": "password"}
+    ).json()["access_token"]
+    client.headers.update({"Authorization": f"Bearer {token}"})
+    return client
 
 
 def _make_df():
@@ -22,7 +32,7 @@ def _make_df():
 def test_invalid_ticker_rejected(monkeypatch, bad):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
-    client = TestClient(app)
+    client = _auth_client(app)
     resp = client.get(f"/instrument?ticker={bad}&days=1&format=json")
     assert resp.status_code == 400
 
@@ -49,7 +59,7 @@ def test_full_history_json(monkeypatch):
     ), patch(
         "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
     ):
-        client = TestClient(app)
+        client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=0&format=json")
     assert resp.status_code == 200
     data = resp.json()
@@ -69,7 +79,7 @@ def test_html_response(monkeypatch):
     ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
         "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
     ):
-        client = TestClient(app)
+        client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=html")
     assert resp.status_code == 200
     text = resp.text
@@ -101,7 +111,7 @@ def test_positions_scaled(monkeypatch):
     ), patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}), patch(
         "backend.routes.instrument.get_scaling_override", return_value=0.5
     ):
-        client = TestClient(app)
+        client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
     assert resp.status_code == 200
     data = resp.json()
@@ -138,7 +148,7 @@ def test_positions_gain_from_cost(monkeypatch):
             }
         ],
     ), patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}):
-        client = TestClient(app)
+        client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
     assert resp.status_code == 200
     data = resp.json()
@@ -164,7 +174,7 @@ def test_non_gbp_instrument_has_distinct_close(monkeypatch):
     ), patch(
         "backend.routes.instrument.get_security_meta", return_value={"currency": "USD"}
     ):
-        client = TestClient(app)
+        client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.N&days=1&format=json")
     assert resp.status_code == 200
     prices = resp.json()["prices"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,10 @@ from unittest.mock import patch, MagicMock
 from backend.local_api.main import app
 
 client = TestClient(app)
+token = client.post(
+    "/token", data={"username": "testuser", "password": "password"}
+).json()["access_token"]
+client.headers.update({"Authorization": f"Bearer {token}"})
 
 # Shared mock data
 mock_owners = [

--- a/tests/test_quotes_route.py
+++ b/tests/test_quotes_route.py
@@ -12,6 +12,10 @@ def test_quotes_returns_502_on_yfinance_error(monkeypatch):
 
     app = create_app()
     client = TestClient(app)
+    token = client.post(
+        "/token", data={"username": "testuser", "password": "password"}
+    ).json()["access_token"]
+    client.headers.update({"Authorization": f"Bearer {token}"})
     resp = client.get("/api/quotes?symbols=AAPL")
     assert resp.status_code == 502
     assert resp.json()["detail"].startswith("Failed to fetch quotes")

--- a/tests/test_scenario_route.py
+++ b/tests/test_scenario_route.py
@@ -3,6 +3,10 @@ from fastapi.testclient import TestClient
 from backend.local_api.main import app
 
 client = TestClient(app)
+token = client.post(
+    "/token", data={"username": "testuser", "password": "password"}
+).json()["access_token"]
+client.headers.update({"Authorization": f"Bearer {token}"})
 
 
 def test_scenario_route():

--- a/tests/test_timeseries_edit_route.py
+++ b/tests/test_timeseries_edit_route.py
@@ -10,6 +10,10 @@ def test_timeseries_edit_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
     app = create_app()
     client = TestClient(app)
+    token = client.post(
+        "/token", data={"username": "testuser", "password": "password"}
+    ).json()["access_token"]
+    client.headers.update({"Authorization": f"Bearer {token}"})
 
     data = [
         {

--- a/tests/test_trading_agent_route.py
+++ b/tests/test_trading_agent_route.py
@@ -8,6 +8,10 @@ def test_trading_agent_signals_route(monkeypatch):
     monkeypatch.setattr("backend.agent.trading_agent.run", lambda: fake_signals)
     app = create_app()
     with TestClient(app) as client:
+        token = client.post(
+            "/token", data={"username": "testuser", "password": "password"}
+        ).json()["access_token"]
+        client.headers.update({"Authorization": f"Bearer {token}"})
         resp = client.get("/trading-agent/signals")
     assert resp.status_code == 200
     assert resp.json() == fake_signals

--- a/tests/test_var_route.py
+++ b/tests/test_var_route.py
@@ -7,6 +7,10 @@ from backend.common import portfolio as portfolio_mod
 from backend.common import portfolio_utils
 
 client = TestClient(app)
+token = client.post(
+    "/token", data={"username": "testuser", "password": "password"}
+).json()["access_token"]
+client.headers.update({"Authorization": f"Bearer {token}"})
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add JWT-based authentication with hashed user credentials
- secure protected routes with user validation and login endpoint
- attach bearer tokens in frontend API calls with tests

## Testing
- `pytest`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce7854f88327a691472ff8229a74