### PR TITLE
test: add account API integration tests and CI step

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
         run: |
-          pytest tests/test_backend_api.py::test_health --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=0 -q
+          pytest tests/test_backend_api.py::test_health tests/test_accounts_api.py --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=0 -q
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.config import config
+import backend.common.prices as prices
+from backend.common import portfolio_utils
+
+
+@pytest.fixture(scope="session")
+def client():
+    """Create a test client with network-heavy operations stubbed."""
+    config.skip_snapshot_warm = True
+    config.offline_mode = True
+    prices.refresh_prices = lambda: {}
+    portfolio_utils.list_all_unique_tickers = lambda *a, **k: []
+    app = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def sample_accounts():
+    root = Path(__file__).resolve().parents[1] / "data" / "accounts"
+    for owner_dir in root.iterdir():
+        if owner_dir.is_dir():
+            accounts = [p.stem for p in owner_dir.glob("*.json") if p.stem != "person"]
+            yield owner_dir.name, accounts
+
+
+def test_owners_endpoint_matches_sample_data(client):
+    resp = client.get("/owners")
+    assert resp.status_code == 200
+    owners = {o["owner"]: set(o["accounts"]) for o in resp.json()}
+    for owner, accounts in sample_accounts():
+        assert owner in owners
+        assert set(accounts).issubset(owners[owner])
+
+
+@pytest.mark.parametrize("owner,accounts", list(sample_accounts()))
+def test_account_route_returns_data(client, owner, accounts):
+    for acct in accounts:
+        resp = client.get(f"/account/{owner}/{acct}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["owner"].lower() == owner.lower()
+        assert data["account_type"].lower() == acct.lower()
+        assert isinstance(data.get("holdings"), list)


### PR DESCRIPTION
## Summary
- add API tests for sample account routes
- run account API tests in backend integration workflow

## Testing
- `pytest tests/test_accounts_api.py -k owners -q` *(fails: AssertionError / coverage < 80)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d543d8b88327a3d1047b4d40e20a