### PR TITLE
feat: allow disabling Alpha Vantage

### DIFF
--- a/USER_README.md
+++ b/USER_README.md
@@ -17,6 +17,7 @@ Runtime options live in `config.yaml`:
 - `reload`: enables auto-reload for development.
 - `tabs`: enable or disable optional frontend tabs.
 - `offline_mode`: load FX data from local parquet files.
+- `alpha_vantage_enabled`: set to `false` to skip Alpha Vantage API calls.
 
 Additional runtime settings are supplied via environment variables. Copy
 `.env.example` to `.env` and fill in values such as:

--- a/backend/config.py
+++ b/backend/config.py
@@ -61,6 +61,7 @@ class Config:
     theme: Optional[str] = None
     timeseries_cache_base: Optional[str] = None
     fx_proxy_url: Optional[str] = None
+    alpha_vantage_enabled: bool = True
     alpha_vantage_key: Optional[str] = None
     fundamentals_cache_ttl_seconds: Optional[int] = None
 
@@ -157,6 +158,7 @@ def load_config() -> Config:
         theme=data.get("theme"),
         timeseries_cache_base=data.get("timeseries_cache_base"),
         fx_proxy_url=data.get("fx_proxy_url"),
+        alpha_vantage_enabled=data.get("alpha_vantage_enabled", True),
         alpha_vantage_key=env.str(
             "ALPHA_VANTAGE_KEY", default=data.get("alpha_vantage_key")
         ),

--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -77,6 +77,8 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
     """Return key metrics for ``ticker`` using Alpha Vantage's ``OVERVIEW``
     endpoint, utilising a simple in-memory cache.
     """
+    if not settings.alpha_vantage_enabled:
+        raise RuntimeError("Alpha Vantage fetching disabled via config")
 
     api_key = settings.alpha_vantage_key
     if not api_key:

--- a/backend/tasks/quotes.py
+++ b/backend/tasks/quotes.py
@@ -19,6 +19,8 @@ TABLE_NAME = os.environ.get("QUOTES_TABLE", "Quotes")
 
 def fetch_quote(symbol: str, api_key: str | None = None) -> Dict[str, Any]:
     """Fetch a single quote from Alpha Vantage."""
+    if not config.alpha_vantage_enabled:
+        raise RuntimeError("Alpha Vantage fetching disabled via config")
     key = api_key or config.alpha_vantage_key or "demo"
     params = {"function": "GLOBAL_QUOTE", "symbol": symbol, "apikey": key}
     resp = requests.get(BASE_URL, params=params, timeout=10)

--- a/backend/timeseries/fetch_alphavantage_timeseries.py
+++ b/backend/timeseries/fetch_alphavantage_timeseries.py
@@ -38,6 +38,9 @@ def fetch_alphavantage_timeseries_range(
     api_key: str | None = None,
 ) -> pd.DataFrame:
     """Fetch historical Alpha Vantage data using a date range."""
+    if not config.alpha_vantage_enabled:
+        logger.info("Alpha Vantage fetching disabled via config")
+        return pd.DataFrame(columns=STANDARD_COLUMNS)
     if not is_valid_ticker(ticker, exchange):
         logger.info("Skipping Alpha Vantage fetch for unrecognized ticker %s.%s", ticker, exchange)
         record_skipped_ticker(ticker, exchange, reason="unknown")

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -147,17 +147,20 @@ def fetch_meta_timeseries(
         logger.info("Stooq miss for %s.%s: %s", ticker, exchange, exc)
 
     # ── 3 · Alpha Vantage (fill gaps if still needed) ─────────
-    try:
-        av = fetch_alphavantage_timeseries_range(
-            ticker, exchange, start_date, end_date
-        )
-        if not av.empty:
-            combined = _merge([*data, av])
-            if _coverage_ratio(combined, expected_dates) >= min_coverage:
-                return combined
-            data.append(av)
-    except Exception as exc:
-        logger.info("Alpha Vantage miss for %s.%s: %s", ticker, exchange, exc)
+    if config.alpha_vantage_enabled:
+        try:
+            av = fetch_alphavantage_timeseries_range(
+                ticker, exchange, start_date, end_date
+            )
+            if not av.empty:
+                combined = _merge([*data, av])
+                if _coverage_ratio(combined, expected_dates) >= min_coverage:
+                    return combined
+                data.append(av)
+        except Exception as exc:
+            logger.info("Alpha Vantage miss for %s.%s: %s", ticker, exchange, exc)
+    else:
+        logger.info("Alpha Vantage disabled; skipping for %s.%s", ticker, exchange)
 
     # ── 4 · FT fallback – last resort ─────────────────────────
     ft_df = fetch_ft_df(ticker, end_date, start_date)

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ prices_json: data/prices/latest_prices.json
 risk_free_rate: 0.01
 timeseries_cache_base: data/timeseries
 fx_proxy_url: ''
+alpha_vantage_enabled: true
 fundamentals_cache_ttl_seconds: 86400
 cors:
   local:

--- a/tests/test_alphavantage_disabled.py
+++ b/tests/test_alphavantage_disabled.py
@@ -1,0 +1,24 @@
+from datetime import date
+import pytest
+
+from backend import config as cfg
+from backend.timeseries.fetch_alphavantage_timeseries import fetch_alphavantage_timeseries_range
+from backend.tasks.quotes import fetch_quote
+import requests
+
+
+def test_alphavantage_timeseries_disabled(monkeypatch):
+    monkeypatch.setattr(cfg.config, "alpha_vantage_enabled", False)
+
+    def fail_get(*args, **kwargs):
+        raise AssertionError("network call should not be made")
+
+    monkeypatch.setattr(requests, "get", fail_get)
+    df = fetch_alphavantage_timeseries_range("IBM", "US", date(2024, 1, 1), date(2024, 1, 2))
+    assert df.empty
+
+
+def test_fetch_quote_raises_when_disabled(monkeypatch):
+    monkeypatch.setattr(cfg.config, "alpha_vantage_enabled", False)
+    with pytest.raises(RuntimeError):
+        fetch_quote("IBM")


### PR DESCRIPTION
## Summary
- add `alpha_vantage_enabled` flag to configuration
- gate Alpha Vantage timeseries, fundamentals and quote fetchers behind the flag
- document flag and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad66f1d4708327831ba14dd89fa009