### PR TITLE
Resolve exchange via metadata before fetching timeseries

### DIFF
--- a/tests/test_meta_timeseries_exchange_resolution.py
+++ b/tests/test_meta_timeseries_exchange_resolution.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from datetime import date
+
+from backend.timeseries import fetch_meta_timeseries
+
+
+def test_fetch_meta_timeseries_resolves_exchange_from_metadata(monkeypatch):
+    calls = []
+
+    def fake_yahoo(ticker, exchange, start_date, end_date):
+        calls.append((ticker, exchange))
+        return pd.DataFrame(
+            {
+                "Date": [start_date, end_date],
+                "Open": [1.0, 1.0],
+                "High": [1.0, 1.0],
+                "Low": [1.0, 1.0],
+                "Close": [1.0, 1.0],
+                "Volume": [0, 0],
+                "Ticker": [f"{ticker}.{exchange}", f"{ticker}.{exchange}"],
+                "Source": ["Yahoo", "Yahoo"],
+            }
+        )
+
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_yahoo_timeseries_range", fake_yahoo)
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_stooq_timeseries_range", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_alphavantage_timeseries_range", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_ft_timeseries", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(fetch_meta_timeseries, "_is_isin", lambda ticker: False)
+    monkeypatch.setattr(fetch_meta_timeseries, "is_valid_ticker", lambda *a, **k: True)
+
+    df = fetch_meta_timeseries.fetch_meta_timeseries("GSK", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2))
+
+    assert calls == [("GSK", "L")]
+    assert not df.empty

--- a/tests/test_run_all_tickers.py
+++ b/tests/test_run_all_tickers.py
@@ -32,3 +32,17 @@ def test_run_all_tickers_handles_underscore_and_dot():
     assert out == ["ADBE_N", "AZN.L"]
     assert calls == [("ADBE", "N", 5), ("AZN", "L", 5)]
 
+
+def test_run_all_tickers_resolves_exchange_from_metadata():
+    calls = []
+
+    def fake_load(sym, ex, days):
+        calls.append((sym, ex, days))
+        return pd.DataFrame({"Date": [1], "Close": [2]})
+
+    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
+        out = run_all_tickers(["GSK"], days=3)
+
+    assert out == ["GSK"]
+    assert calls == [("GSK", "L", 3)]
+


### PR DESCRIPTION
## Summary
- resolve exchange codes from instrument metadata before fetching timeseries
- add detailed debug logging for ticker/exchange resolution
- update batch helpers and add tests for metadata-based exchange resolution

## Testing
- `pytest tests/test_run_all_tickers.py tests/test_meta_timeseries_exchange_resolution.py tests/test_meta_timeseries_date_filter.py tests/test_cash_timeseries.py tests/test_ticker_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad6a013fc08327868880e1ad0d166d