### PR TITLE
feat(frontend): type TabPlugin with generics

### DIFF
--- a/frontend/src/plugins/TabPlugin.ts
+++ b/frontend/src/plugins/TabPlugin.ts
@@ -10,12 +10,15 @@ export interface RouteContext {
  * Definition of a tab plugin used to extend the navigation bar.
  * Each plugin exposes the React component to render when active,
  * a priority used for ordering, and a helper to build the tab's path.
+ *
+ * The component's props type can be specified via the generic `P`, which
+ * defaults to `unknown` for components without props.
  */
-export interface TabPlugin {
+export interface TabPlugin<P = unknown> {
   /** Unique identifier corresponding to the app mode (e.g. "movers"). */
   id: string;
   /** React component rendered when the tab is selected. */
-  component: ComponentType<unknown>;
+  component: ComponentType<P>;
   /** Lower numbers appear further to the left in the navigation bar. */
   priority: number;
   /** Build a URL path for the tab based on current selections. */

--- a/frontend/src/plugins/group.ts
+++ b/frontend/src/plugins/group.ts
@@ -1,7 +1,10 @@
 import { GroupPortfolioView } from "../components/GroupPortfolioView";
+import type { ComponentProps } from "react";
 import type { TabPlugin } from "./TabPlugin";
 
-const plugin: TabPlugin = {
+type Props = ComponentProps<typeof GroupPortfolioView>;
+
+const plugin: TabPlugin<Props> = {
   id: "group",
   component: GroupPortfolioView,
   priority: 10,

--- a/frontend/src/plugins/instrument.ts
+++ b/frontend/src/plugins/instrument.ts
@@ -1,7 +1,10 @@
 import { InstrumentTable } from "../components/InstrumentTable";
+import type { ComponentProps } from "react";
 import type { TabPlugin } from "./TabPlugin";
 
-const plugin: TabPlugin = {
+type Props = ComponentProps<typeof InstrumentTable>;
+
+const plugin: TabPlugin<Props> = {
   id: "instrument",
   component: InstrumentTable,
   priority: 20,

--- a/frontend/src/plugins/owner.ts
+++ b/frontend/src/plugins/owner.ts
@@ -1,7 +1,10 @@
 import { PortfolioView } from "../components/PortfolioView";
+import type { ComponentProps } from "react";
 import type { TabPlugin } from "./TabPlugin";
 
-const plugin: TabPlugin = {
+type Props = ComponentProps<typeof PortfolioView>;
+
+const plugin: TabPlugin<Props> = {
   id: "owner",
   component: PortfolioView,
   priority: 30,

--- a/frontend/src/plugins/performance.ts
+++ b/frontend/src/plugins/performance.ts
@@ -1,7 +1,10 @@
 import { PerformanceDashboard } from "../components/PerformanceDashboard";
+import type { ComponentProps } from "react";
 import type { TabPlugin } from "./TabPlugin";
 
-const plugin: TabPlugin = {
+type Props = ComponentProps<typeof PerformanceDashboard>;
+
+const plugin: TabPlugin<Props> = {
   id: "performance",
   component: PerformanceDashboard,
   priority: 40,

--- a/frontend/src/plugins/transactions.ts
+++ b/frontend/src/plugins/transactions.ts
@@ -1,7 +1,10 @@
 import { TransactionsPage } from "../components/TransactionsPage";
+import type { ComponentProps } from "react";
 import type { TabPlugin } from "./TabPlugin";
 
-const plugin: TabPlugin = {
+type Props = ComponentProps<typeof TransactionsPage>;
+
+const plugin: TabPlugin<Props> = {
   id: "transactions",
   component: TransactionsPage,
   priority: 50,


### PR DESCRIPTION
## Summary
- add generic props parameter to TabPlugin definition
- annotate plugins that pass props with explicit TabPlugin generics

## Testing
- `npm test`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adadf0330c8327a4bdbef741d32cfa