### PR TITLE
test: force offline mode during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from backend.config import config
+
+
+@pytest.fixture(scope="session", autouse=True)
+def enable_offline_mode():
+    """Force backend to run in offline mode for all tests."""
+    previous = config.offline_mode
+    config.offline_mode = True
+    try:
+        yield
+    finally:
+        config.offline_mode = previous


### PR DESCRIPTION
## Summary
- add session-wide fixture enabling offline_mode for tests

## Testing
- `pytest tests/test_fx_conversion.py::test_offline_mode_uses_fx_cache tests/test_backend_api.py::test_health -q`


------
https://chatgpt.com/codex/tasks/task_e_68adaf624a588327967d21a139fbb46d