### PR TITLE
Handle Stooq rate limits

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -27,7 +27,10 @@ OFFLINE_MODE = config.offline_mode
 # Local imports
 # ──────────────────────────────────────────────────────────────
 from backend.timeseries.fetch_ft_timeseries import fetch_ft_timeseries
-from backend.timeseries.fetch_stooq_timeseries import fetch_stooq_timeseries_range
+from backend.timeseries.fetch_stooq_timeseries import (
+    fetch_stooq_timeseries_range,
+    StooqRateLimitError,
+)
 from backend.timeseries.fetch_yahoo_timeseries import fetch_yahoo_timeseries_range
 from backend.timeseries.fetch_alphavantage_timeseries import (
     fetch_alphavantage_timeseries_range,
@@ -194,6 +197,8 @@ def fetch_meta_timeseries(
             if _coverage_ratio(combined, expected_dates) >= min_coverage:
                 return combined
             data.append(stooq)
+    except StooqRateLimitError as exc:
+        logger.info("Stooq rate limit for %s.%s: %s", ticker, exchange, exc)
     except Exception as exc:
         logger.info("Stooq miss for %s.%s: %s", ticker, exchange, exc)
 

--- a/backend/timeseries/fetch_stooq_timeseries.py
+++ b/backend/timeseries/fetch_stooq_timeseries.py
@@ -14,6 +14,14 @@ logging.basicConfig(level=logging.DEBUG)
 BASE_URL = "https://stooq.com/q/d/l/"
 
 
+class StooqRateLimitError(RuntimeError):
+    """Raised when the Stooq daily hit limit has been exceeded."""
+
+
+# Stooq requests are disabled until this date if the rate limit is hit
+STOOQ_DISABLED_UNTIL: date = date.min
+
+
 def get_stooq_suffix(exchange: str) -> str:
     exchange_map = {
         "L": ".UK", "LSE": ".UK", "UK": ".UK",
@@ -42,6 +50,10 @@ def fetch_stooq_timeseries_range(
     """
     Fetch historical Stooq data using date range.
     """
+    global STOOQ_DISABLED_UNTIL
+    if date.today() < STOOQ_DISABLED_UNTIL:
+        logger.info("Stooq disabled until %s", STOOQ_DISABLED_UNTIL)
+        raise StooqRateLimitError("Stooq temporarily disabled due to rate limiting")
     if not is_valid_ticker(ticker, exchange):
         logger.info("Skipping Stooq fetch for unrecognized ticker %s.%s", ticker, exchange)
         record_skipped_ticker(ticker, exchange, reason="unknown")
@@ -68,6 +80,8 @@ def fetch_stooq_timeseries_range(
 
         if "Exceeded the daily hits limit" in response.text:
             logger.warning("Stooq: Exceeded the daily hits limit")
+            STOOQ_DISABLED_UNTIL = date.today() + timedelta(days=1)
+            raise StooqRateLimitError("Exceeded the daily hits limit")
 
         df = pd.read_csv(StringIO(response.text))
         if df.empty:

--- a/tests/test_stooq_rate_limit.py
+++ b/tests/test_stooq_rate_limit.py
@@ -1,0 +1,91 @@
+import pandas as pd
+import pytest
+from datetime import date
+from types import SimpleNamespace
+
+from backend.timeseries import fetch_stooq_timeseries as fst
+from backend.timeseries import fetch_meta_timeseries
+
+
+def _csv_response():
+    return "Date,Open,High,Low,Close,Volume\n2024-01-01,1,1,1,1,0\n"
+
+
+def test_stooq_rate_limit_disables_until_next_day(monkeypatch):
+    class Day1(date):
+        @classmethod
+        def today(cls):
+            return cls(2024, 1, 1)
+
+    class Day2(date):
+        @classmethod
+        def today(cls):
+            return cls(2024, 1, 2)
+
+    monkeypatch.setattr(fst, "date", Day1)
+    fst.STOOQ_DISABLED_UNTIL = Day1.min
+    monkeypatch.setattr(fst, "is_valid_ticker", lambda *a, **k: True)
+    monkeypatch.setattr(fst, "record_skipped_ticker", lambda *a, **k: None)
+
+    calls = []
+
+    def rate_limit_get(url, params):
+        calls.append("hit")
+        return SimpleNamespace(ok=True, status_code=200, text="Exceeded the daily hits limit")
+
+    monkeypatch.setattr(fst.requests, "get", rate_limit_get)
+
+    with pytest.raises(fst.StooqRateLimitError):
+        fst.fetch_stooq_timeseries_range("AAA", "L", Day1(2024, 1, 1), Day1(2024, 1, 1))
+    assert len(calls) == 1
+
+    def fail_get(url, params):
+        raise AssertionError("should not call requests.get while disabled")
+
+    monkeypatch.setattr(fst.requests, "get", fail_get)
+
+    with pytest.raises(fst.StooqRateLimitError):
+        fst.fetch_stooq_timeseries_range("AAA", "L", Day1(2024, 1, 1), Day1(2024, 1, 1))
+
+    monkeypatch.setattr(fst, "date", Day2)
+
+    def ok_get(url, params):
+        calls.append("ok")
+        return SimpleNamespace(ok=True, status_code=200, text=_csv_response())
+
+    monkeypatch.setattr(fst.requests, "get", ok_get)
+
+    df = fst.fetch_stooq_timeseries_range("AAA", "L", Day1(2024, 1, 1), Day2(2024, 1, 2))
+    assert not df.empty
+    assert len(calls) == 2
+    fst.STOOQ_DISABLED_UNTIL = Day1.min
+
+
+def test_meta_timeseries_handles_stooq_rate_limit(monkeypatch):
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_yahoo_timeseries_range", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_alphavantage_timeseries_range", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(fetch_meta_timeseries, "_is_isin", lambda *a, **k: False)
+    monkeypatch.setattr(fetch_meta_timeseries, "is_valid_ticker", lambda *a, **k: True)
+
+    def raise_limit(*a, **k):
+        raise fst.StooqRateLimitError("limit")
+
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_stooq_timeseries_range", raise_limit)
+
+    def fake_ft(ticker, days):
+        return pd.DataFrame({
+            "Date": [date(2024, 1, 1)],
+            "Open": [1.0],
+            "High": [1.0],
+            "Low": [1.0],
+            "Close": [1.0],
+            "Volume": [0],
+            "Ticker": [ticker],
+            "Source": ["FT"],
+        })
+
+    monkeypatch.setattr(fetch_meta_timeseries, "fetch_ft_timeseries", fake_ft)
+
+    df = fetch_meta_timeseries.fetch_meta_timeseries("AAA", "L", start_date=date(2024,1,1), end_date=date(2024,1,2))
+    assert not df.empty
+    assert df["Source"].iloc[0] == "FT"


### PR DESCRIPTION
## Summary
- add StooqRateLimitError and disable flag to stop Stooq requests for a day after hitting rate limit
- make meta time-series fetcher catch the rate-limit error and fall back to other sources
- test Stooq rate limiting and meta fallback behaviour

## Testing
- `pytest tests/test_stooq_rate_limit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adaf731f508327907bcfd5069a63b0