### PR TITLE
Skip Stooq requests after daily limit

### DIFF
--- a/backend/timeseries/fetch_stooq_timeseries.py
+++ b/backend/timeseries/fetch_stooq_timeseries.py
@@ -16,8 +16,8 @@ class StooqRateLimitError(RuntimeError):
     """Raised when the Stooq daily hit limit has been exceeded."""
 
 
-# Stooq requests are disabled until this date if the rate limit is hit
-STOOQ_DISABLED_UNTIL: date = date.min
+# Flag indicating whether the daily request limit has been reached
+_STOOQ_LIMIT_REACHED: bool = False
 
 
 def get_stooq_suffix(exchange: str) -> str:
@@ -48,10 +48,10 @@ def fetch_stooq_timeseries_range(
     """
     Fetch historical Stooq data using date range.
     """
-    global STOOQ_DISABLED_UNTIL
-    if date.today() < STOOQ_DISABLED_UNTIL:
-        logger.info("Stooq disabled until %s", STOOQ_DISABLED_UNTIL)
-        raise StooqRateLimitError("Stooq temporarily disabled due to rate limiting")
+    global _STOOQ_LIMIT_REACHED
+    if _STOOQ_LIMIT_REACHED:
+        logger.info("Stooq limit previously reached; skipping fetch")
+        raise StooqRateLimitError("Stooq daily limit previously reached")
     if not is_valid_ticker(ticker, exchange):
         logger.info("Skipping Stooq fetch for unrecognized ticker %s.%s", ticker, exchange)
         record_skipped_ticker(ticker, exchange, reason="unknown")
@@ -78,7 +78,7 @@ def fetch_stooq_timeseries_range(
 
         if "Exceeded the daily hits limit" in response.text:
             logger.warning("Stooq: Exceeded the daily hits limit")
-            STOOQ_DISABLED_UNTIL = date.today() + timedelta(days=1)
+            _STOOQ_LIMIT_REACHED = True
             raise StooqRateLimitError("Exceeded the daily hits limit")
 
         df = pd.read_csv(StringIO(response.text))


### PR DESCRIPTION
## Summary
- Raise `StooqRateLimitError` on daily limit and disable further Stooq calls with a module flag
- Catch rate limit in meta fetcher and skip Stooq for remaining tickers

## Testing
- `pytest` *(fails: Interrupted, 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adb1841bb08327bc24d8b6f4ff550c