### PR TITLE
Centralize timeseries logging configuration

### DIFF
--- a/backend/timeseries/fetch_alphavantage_timeseries.py
+++ b/backend/timeseries/fetch_alphavantage_timeseries.py
@@ -10,7 +10,6 @@ from backend.config import config
 
 # Setup logger
 logger = logging.getLogger("alphavantage_timeseries")
-logging.basicConfig(level=logging.DEBUG)
 
 BASE_URL = "https://www.alphavantage.co/query"
 

--- a/backend/timeseries/fetch_ft_timeseries.py
+++ b/backend/timeseries/fetch_ft_timeseries.py
@@ -18,7 +18,6 @@ from backend.config import get_config
 from backend.utils.currency_utils import currency_from_isin
 from backend.utils.timeseries_helpers import _is_isin, STANDARD_COLUMNS
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger("ft_timeseries")
 
 def init_driver(headless: Optional[bool] = None, user_agent: Optional[str] = None) -> webdriver.Chrome:


### PR DESCRIPTION
## Summary
- stop timeseries modules from configuring root logging directly
- rely on backend's central `setup_logging` during app creation

## Testing
- `python -m py_compile backend/timeseries/fetch_ft_timeseries.py backend/timeseries/fetch_alphavantage_timeseries.py`
- `pytest` *(fails: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adb187b5e48327ae5db1aa54b7927a