### PR TITLE
Add Stooq exchange alias mappings

### DIFF
--- a/backend/timeseries/fetch_stooq_timeseries.py
+++ b/backend/timeseries/fetch_stooq_timeseries.py
@@ -23,11 +23,11 @@ STOOQ_DISABLED_UNTIL: date = date.min
 
 def get_stooq_suffix(exchange: str) -> str:
     exchange_map = {
-        "L": ".UK", "LSE": ".UK", "UK": ".UK",
+        "L": ".UK", "LSE": ".UK", "UK": ".UK", "LON": ".UK", "XLON": ".UK",
         "NASDAQ": ".US", "NYSE": ".US", "US": ".US", "AMEX": ".US",
         "XETRA": ".DE", "DE": ".DE",
         "F": ".F",
-        "TO" : ".TO"
+        "TO" : ".TO", "TSX": ".TO"
 
     }
     suffix = exchange_map.get(exchange.upper())

--- a/tests/test_stooq_rate_limit.py
+++ b/tests/test_stooq_rate_limit.py
@@ -12,6 +12,12 @@ def _csv_response():
     return "Date,Open,High,Low,Close,Volume\n2024-01-01,1,1,1,1,0\n"
 
 
+def test_get_stooq_suffix_aliases():
+    assert fst.get_stooq_suffix("LON") == ".UK"
+    assert fst.get_stooq_suffix("XLON") == ".UK"
+    assert fst.get_stooq_suffix("TSX") == ".TO"
+
+
 def test_stooq_rate_limit_disables_until_next_day(monkeypatch):
     class Day1(date):
         @classmethod


### PR DESCRIPTION
## Summary
- map common exchange aliases like LON, XLON, and TSX when fetching Stooq data
- test that new aliases resolve to correct suffixes

## Testing
- `pytest tests/test_stooq_rate_limit.py::test_get_stooq_suffix_aliases -q`
- `pytest tests/test_stooq_rate_limit.py -q` *(fails: StooqRateLimitError not raised on subsequent calls)*

------
https://chatgpt.com/codex/tasks/task_e_68ae241f72d88327be7d706ab483cda5