### PR TITLE
feat: throttle stooq warm-up requests

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -65,6 +65,7 @@ class Config:
     alpha_vantage_key: Optional[str] = None
     fundamentals_cache_ttl_seconds: Optional[int] = None
     stooq_timeout: Optional[int] = None
+    stooq_requests_per_minute: Optional[int] = None
 
     # new vars
     max_trades_per_month: Optional[int] = None
@@ -167,6 +168,7 @@ def load_config() -> Config:
             "fundamentals_cache_ttl_seconds"
         ),
         stooq_timeout=data.get("stooq_timeout"),
+        stooq_requests_per_minute=data.get("stooq_requests_per_minute"),
         max_trades_per_month=data.get("max_trades_per_month"),
         hold_days_min=data.get("hold_days_min"),
         repo_root=repo_root,

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -261,9 +261,21 @@ def run_all_tickers(
     instrument metadata.
     """
     from backend.timeseries.cache import load_meta_timeseries
+    import time
 
     ok: list[str] = []
-    for t in tickers:
+    delay = 0.0
+    if getattr(config, "stooq_requests_per_minute", None):
+        try:
+            rpm = float(config.stooq_requests_per_minute)
+            if rpm > 0:
+                delay = 60.0 / rpm
+        except Exception:
+            pass
+
+    for idx, t in enumerate(tickers):
+        if delay and idx:
+            time.sleep(delay)
         sym, ex = _resolve_ticker_exchange(t, exchange)
         logger.debug("run_all_tickers resolved %s -> %s.%s", t, sym, ex)
         try:

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ fx_proxy_url: ''
 alpha_vantage_enabled: false
 fundamentals_cache_ttl_seconds: 86400
 stooq_timeout: 10
+stooq_requests_per_minute: 60
 cors:
   local:
     - http://localhost:3000


### PR DESCRIPTION
## Summary
- throttle bulk Stooq requests in `run_all_tickers`
- expose `stooq_requests_per_minute` in config

## Testing
- `pytest tests/test_run_all_tickers.py tests/test_config.py`
- `pytest tests/test_stooq_rate_limit.py::test_stooq_rate_limit_disables_until_next_day` *(fails: DID NOT RAISE StooqRateLimitError)*

------
https://chatgpt.com/codex/tasks/task_e_68ae241e457c8327b3102419a0567bfe