### PR TITLE
Log row count after Yahoo timeseries fetch

### DIFF
--- a/backend/timeseries/fetch_yahoo_timeseries.py
+++ b/backend/timeseries/fetch_yahoo_timeseries.py
@@ -104,6 +104,8 @@ def fetch_yahoo_timeseries_range(ticker: str, exchange: str, start_date: date, e
         if df.empty:
             raise ValueError(f"No data returned for {full_ticker} between {start_date} and {end_date}")
 
+        logger.info(f"Fetched {len(df)} rows for {full_ticker}")
+
         return normalize_history(df, full_ticker, "Yahoo")
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- log Yahoo fetch results with row count after successful retrieval

## Testing
- `pytest tests/test_accounts_api.py::test_account_route_returns_data -q` *(fails: KeyError: 'account_type')*


------
https://chatgpt.com/codex/tasks/task_e_68ae2cc49c1483278dd6cd83d065e86b