### PR TITLE
Handle disabled route modes gracefully

### DIFF
--- a/frontend/src/hooks/useRouteMode.test.tsx
+++ b/frontend/src/hooks/useRouteMode.test.tsx
@@ -1,0 +1,53 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import {
+  configContext,
+  type ConfigContextValue,
+} from "../ConfigContext";
+import { useRouteMode } from "./useRouteMode";
+import { type ReactNode } from "react";
+
+describe("useRouteMode", () => {
+  it("navigates to first enabled tab when movers is disabled", async () => {
+    window.history.pushState({}, "", "/movers");
+
+    const tabs = {
+      group: false,
+      owner: true,
+      instrument: false,
+      performance: false,
+      transactions: false,
+      screener: false,
+      timeseries: false,
+      watchlist: false,
+      movers: false,
+      dataadmin: false,
+      virtual: false,
+      support: false,
+      scenario: false,
+      reports: false,
+    };
+
+    const config: ConfigContextValue = {
+      relativeViewEnabled: false,
+      disabledTabs: ["movers"],
+      tabs,
+      theme: "system",
+      refreshConfig: async () => {},
+    };
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <configContext.Provider value={config}>
+        <MemoryRouter initialEntries={["/movers"]}>{children}</MemoryRouter>
+      </configContext.Provider>
+    );
+
+    const { result } = renderHook(
+      () => ({ route: useRouteMode(), location: useLocation() }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.route.mode).toBe("owner"));
+    expect(result.current.location.pathname).toBe("/member");
+  });
+});


### PR DESCRIPTION
## Summary
- redirect disabled routes to the first enabled tab instead of hardcoding `/movers`
- add `useRouteMode` unit test when `movers` tab is disabled

## Testing
- `npx vitest run src/hooks/useRouteMode.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68af76d46b108327aba444820e30d43f