### PR TITLE
feat: show HTTP status for movers errors

### DIFF
--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -138,4 +138,16 @@ describe("TopMoversPage", () => {
     await waitFor(() => expect(mockGetTradingSignals).toHaveBeenCalled());
     expect(await screen.findByText("go long")).toBeInTheDocument();
   });
+
+  it("shows HTTP status when fetch fails", async () => {
+    mockGetTopMovers.mockRejectedValueOnce(
+      new Error("HTTP 401 – Unauthorized"),
+    );
+    render(
+      <MemoryRouter>
+        <TopMoversPage />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/HTTP 401/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -59,7 +59,16 @@ export function TopMoversPage() {
   }, []);
 
   if (loading) return <p>Loading…</p>;
-  if (error) return <p style={{ color: "red" }}>{error.message}</p>;
+  if (error) {
+    const match = error.message.match(/^HTTP (\d+)\s+[–-]\s+(.*)$/);
+    const status = match?.[1];
+    const msg = match?.[2] ?? error.message;
+    return (
+      <p style={{ color: "red" }}>
+        Failed to load movers{status ? ` (HTTP ${status})` : ""}: {msg}
+      </p>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- surface HTTP status when TopMoversPage fails to fetch movers
- test that fetch errors display status code

## Testing
- `npm test -- --run src/components/TopMoversPage.test.tsx`
- `npm test -- --run` *(fails: App.test.tsx unable to mock getTradingSignals, Support.test.tsx missing heading)*

------
https://chatgpt.com/codex/tasks/task_e_68af786e78e483278d6f8aa62daf08af