### PR TITLE
Gracefully handle unauthorized portfolio movers

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -49,29 +49,58 @@ describe("App", () => {
     expect(select).toHaveValue("kids");
   });
 
-  it("renders timeseries editor when path is /timeseries", async () => {
-    window.history.pushState({}, "", "/timeseries?ticker=ABC&exchange=L");
+    it("renders timeseries editor when path is /timeseries", async () => {
+      window.history.pushState({}, "", "/timeseries?ticker=ABC&exchange=L");
 
-    vi.mock("./api", () => ({
-      getOwners: vi.fn().mockResolvedValue([]),
-      getGroups: vi.fn().mockResolvedValue([]),
-      getGroupInstruments: vi.fn().mockResolvedValue([]),
-      getPortfolio: vi.fn(),
-      refreshPrices: vi.fn(),
-      getAlerts: vi.fn().mockResolvedValue([]),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-      getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
-      getTimeseries: vi.fn().mockResolvedValue([]),
-      saveTimeseries: vi.fn(),
-    }));
+      vi.doMock("./api", () => ({
+        getOwners: vi.fn().mockResolvedValue([]),
+        getGroups: vi.fn().mockResolvedValue([]),
+        getGroupInstruments: vi.fn().mockResolvedValue([]),
+        getPortfolio: vi.fn(),
+        refreshPrices: vi.fn(),
+        getAlerts: vi.fn().mockResolvedValue([]),
+        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+        getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+        getTimeseries: vi.fn().mockResolvedValue([]),
+        saveTimeseries: vi.fn(),
+        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+        getTradingSignals: vi.fn().mockResolvedValue([]),
+        getConfig: vi.fn().mockResolvedValue({ tabs: { timeseries: true } }),
+      }));
 
-    const { default: App } = await import("./App");
+      const { default: App } = await import("./App");
+      const { configContext } = await import("./ConfigContext");
+      const allTabs = {
+        group: true,
+        owner: true,
+        instrument: true,
+        performance: true,
+        transactions: true,
+        screener: true,
+        timeseries: true,
+        watchlist: true,
+        movers: true,
+        dataadmin: true,
+        virtual: true,
+        reports: true,
+        support: true,
+        scenario: true,
+      };
 
-    render(
-      <MemoryRouter initialEntries={["/timeseries?ticker=ABC&exchange=L"]}>
-        <App />
-      </MemoryRouter>,
-    );
+      render(
+        <configContext.Provider
+          value={{
+            theme: "system",
+            relativeViewEnabled: false,
+            tabs: allTabs,
+            refreshConfig: async () => {},
+          }}
+        >
+          <MemoryRouter initialEntries={["/timeseries?ticker=ABC&exchange=L"]}>
+            <App />
+          </MemoryRouter>
+        </configContext.Provider>,
+      );
 
     expect(await screen.findByText("Timeseries Editor")).toBeInTheDocument();
   });
@@ -79,27 +108,56 @@ describe("App", () => {
   it("renders data admin when path is /dataadmin", async () => {
     window.history.pushState({}, "", "/dataadmin");
 
-    vi.doMock("./api", () => ({
-      getOwners: vi.fn().mockResolvedValue([]),
-      getGroups: vi.fn().mockResolvedValue([]),
-      getGroupInstruments: vi.fn().mockResolvedValue([]),
-      getPortfolio: vi.fn(),
-      refreshPrices: vi.fn(),
-      getAlerts: vi.fn().mockResolvedValue([]),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-      getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
-      getTimeseries: vi.fn().mockResolvedValue([]),
-      saveTimeseries: vi.fn(),
-      listTimeseries: vi.fn().mockResolvedValue([]),
-    }));
+      vi.doMock("./api", () => ({
+        getOwners: vi.fn().mockResolvedValue([]),
+        getGroups: vi.fn().mockResolvedValue([]),
+        getGroupInstruments: vi.fn().mockResolvedValue([]),
+        getPortfolio: vi.fn(),
+        refreshPrices: vi.fn(),
+        getAlerts: vi.fn().mockResolvedValue([]),
+        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+        getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+        getTimeseries: vi.fn().mockResolvedValue([]),
+        saveTimeseries: vi.fn(),
+        listTimeseries: vi.fn().mockResolvedValue([]),
+        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+        getTradingSignals: vi.fn().mockResolvedValue([]),
+        getConfig: vi.fn().mockResolvedValue({ tabs: { dataadmin: true } }),
+      }));
 
-    const { default: App } = await import("./App");
+      const { default: App } = await import("./App");
+      const { configContext } = await import("./ConfigContext");
+      const allTabs = {
+        group: true,
+        owner: true,
+        instrument: true,
+        performance: true,
+        transactions: true,
+        screener: true,
+        timeseries: true,
+        watchlist: true,
+        movers: true,
+        dataadmin: true,
+        virtual: true,
+        reports: true,
+        support: true,
+        scenario: true,
+      };
 
-    render(
-      <MemoryRouter initialEntries={["/dataadmin"]}>
-        <App />
-      </MemoryRouter>,
-    );
+      render(
+        <configContext.Provider
+          value={{
+            theme: "system",
+            relativeViewEnabled: false,
+            tabs: allTabs,
+            refreshConfig: async () => {},
+          }}
+        >
+          <MemoryRouter initialEntries={["/dataadmin"]}>
+            <App />
+          </MemoryRouter>
+        </configContext.Provider>,
+      );
 
     expect(
       await screen.findByRole("heading", { name: "Data Admin" })
@@ -239,7 +297,7 @@ describe("App", () => {
       getTimeseries: vi.fn().mockResolvedValue([]),
       saveTimeseries: vi.fn(),
       listTimeseries: vi.fn().mockResolvedValue([]),
-      getConfig: vi.fn().mockResolvedValue({}),
+      getConfig: vi.fn().mockResolvedValue({ tabs: { support: true } }),
       updateConfig: vi.fn(),
       getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
       getTradingSignals: vi.fn().mockResolvedValue([]),
@@ -247,11 +305,37 @@ describe("App", () => {
     }));
 
     const { default: App } = await import("./App");
+    const { configContext } = await import("./ConfigContext");
+    const allTabs = {
+      group: true,
+      owner: true,
+      instrument: true,
+      performance: true,
+      transactions: true,
+      screener: true,
+      timeseries: true,
+      watchlist: true,
+      movers: true,
+      dataadmin: true,
+      virtual: true,
+      reports: true,
+      support: true,
+      scenario: true,
+    };
 
     render(
-      <MemoryRouter initialEntries={["/support"]}>
-        <App />
-      </MemoryRouter>,
+      <configContext.Provider
+        value={{
+          theme: "system",
+          relativeViewEnabled: false,
+          tabs: allTabs,
+          refreshConfig: async () => {},
+        }}
+      >
+        <MemoryRouter initialEntries={["/support"]}>
+          <App />
+        </MemoryRouter>
+      </configContext.Provider>,
     );
 
     expect(await screen.findByRole("navigation")).toBeInTheDocument();
@@ -264,31 +348,74 @@ describe("App", () => {
     window.history.pushState({}, "", "/");
     mockTradingSignals.mockResolvedValue([]);
 
-    vi.mock("./api", () => ({
-      getOwners: vi.fn().mockResolvedValue([]),
-      getGroups: vi.fn().mockResolvedValue([]),
-      getGroupInstruments: vi.fn().mockResolvedValue([]),
-      getPortfolio: vi.fn(),
-      refreshPrices: vi.fn(),
-      getAlerts: vi.fn().mockResolvedValue([]),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-      getCompliance: vi
-        .fn()
-        .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
-      getTimeseries: vi.fn().mockResolvedValue([]),
-      saveTimeseries: vi.fn(),
-      getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
-      getTradingSignals: mockTradingSignals,
-      listTimeseries: vi.fn().mockResolvedValue([]),
-    }));
+      vi.doMock("./api", () => ({
+        getOwners: vi.fn().mockResolvedValue([]),
+        getGroups: vi.fn().mockResolvedValue([]),
+        getGroupInstruments: vi.fn().mockResolvedValue([]),
+        getPortfolio: vi.fn(),
+        refreshPrices: vi.fn(),
+        getAlerts: vi.fn().mockResolvedValue([]),
+        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+        getCompliance: vi
+          .fn()
+          .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+        getTimeseries: vi.fn().mockResolvedValue([]),
+        saveTimeseries: vi.fn(),
+        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+        getTradingSignals: mockTradingSignals,
+        listTimeseries: vi.fn().mockResolvedValue([]),
+        getConfig: vi.fn().mockResolvedValue({
+          tabs: {
+            group: true,
+            owner: true,
+            instrument: true,
+            performance: true,
+            transactions: true,
+            screener: true,
+            timeseries: true,
+            watchlist: true,
+            movers: true,
+            dataadmin: true,
+            reports: true,
+            support: true,
+            scenario: true,
+            virtual: true,
+          },
+        }),
+      }));
 
-    const { default: App } = await import("./App");
+      const { default: App } = await import("./App");
+      const { configContext } = await import("./ConfigContext");
 
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <App />
-      </MemoryRouter>,
-    );
+      render(
+        <configContext.Provider
+          value={{
+            theme: "system",
+            relativeViewEnabled: false,
+            tabs: {
+              group: true,
+              owner: true,
+              instrument: true,
+              performance: true,
+              transactions: true,
+              screener: true,
+              timeseries: true,
+              watchlist: true,
+              movers: true,
+              dataadmin: true,
+              reports: true,
+              support: true,
+              scenario: true,
+              virtual: true,
+            },
+            refreshConfig: async () => {},
+          }}
+        >
+          <MemoryRouter initialEntries={["/"]}>
+            <App />
+          </MemoryRouter>
+        </configContext.Provider>,
+      );
 
     const moversLink = await screen.findByRole("link", { name: /movers/i });
     expect(moversLink).toHaveStyle("font-weight: bold");

--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -150,4 +150,27 @@ describe("TopMoversPage", () => {
     );
     expect(await screen.findByText(/HTTP 401/)).toBeInTheDocument();
   });
+
+  it("falls back to FTSE 100 and prompts login on 401", async () => {
+    mockGetGroupInstruments.mockRejectedValueOnce(
+      new Error("HTTP 401 – Unauthorized"),
+    );
+    render(
+      <MemoryRouter>
+        <TopMoversPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(mockGetTopMovers).toHaveBeenCalledWith(["AAA", "BBB"], 1),
+    );
+
+    const selects = await screen.findAllByRole("combobox");
+    const watchlistSelect = selects[0] as HTMLSelectElement;
+    await waitFor(() => expect(watchlistSelect.value).toBe("FTSE 100"));
+
+    expect(
+      await screen.findByText(/log in to view portfolio-based movers/i),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Handle 401 errors from portfolio instrument fetch by falling back to FTSE 100
- Show login prompt when portfolio-based movers are unavailable
- Expand tests and update App tests for new auth handling

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68af7b98746c8327949b05341c703300