### PR TITLE
refactor: import bundlingoptions

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from aws_cdk import (
     Stack,
+    BundlingOptions,
     aws_apigateway as apigw,
     aws_lambda as _lambda,
     aws_events as events,
@@ -24,7 +25,7 @@ class BackendLambdaStack(Stack):
             "BackendDependencies",
             code=_lambda.Code.from_asset(
                 str(backend_path),
-                bundling=_lambda.BundlingOptions(
+                bundling=BundlingOptions(
                     image=_lambda.Runtime.PYTHON_3_12.bundling_image,
                     command=[
                         "bash",


### PR DESCRIPTION
## Summary
- import BundlingOptions from aws_cdk and use it when bundling dependencies

## Testing
- `pytest`
- `cdk deploy StaticSiteStack --require-approval never` (fails: Failed to bundle asset BackendLambdaStack/BackendDependencies/Code/Stage, Error: spawnSync docker ENOENT)


------
https://chatgpt.com/codex/tasks/task_e_68af8078931083279cb8182374b1dfb6