### PR TITLE
refactor: use BundlingOptions directly

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from aws_cdk import (
     Stack,
+    BundlingOptions,
     aws_apigateway as apigw,
     aws_lambda as _lambda,
     aws_events as events,
@@ -24,7 +25,7 @@ class BackendLambdaStack(Stack):
             "BackendDependencies",
             code=_lambda.Code.from_asset(
                 str(backend_path),
-                bundling=_lambda.BundlingOptions(
+                bundling=BundlingOptions(
                     image=_lambda.Runtime.PYTHON_3_12.bundling_image,
                     command=[
                         "bash",


### PR DESCRIPTION
## Summary
- import BundlingOptions from aws_cdk
- use BundlingOptions when bundling backend dependencies

## Testing
- `pytest` *(fails: 16 failed, 160 passed, 4 skipped)*
- `cdk deploy StaticSiteStack` *(fails: spawnSync docker ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68af7eebc9d88327af385d2791b45e1e