### PR TITLE
feat: allow disabling auth in local config

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -90,8 +90,8 @@ def create_app() -> FastAPI:
 
     # ──────────────────────────── Routers ────────────────────────────
     # The API surface is composed of a few routers grouped by concern.
-    # Sensitive routes are guarded by a JWT-based dependency.
-    protected = [Depends(get_current_user)]
+    # Sensitive routes are guarded by a JWT-based dependency unless disabled.
+    protected = [] if config.disable_auth else [Depends(get_current_user)]
 
     # Public portfolio endpoints that don't require authentication
     public_portfolio_router = APIRouter()

--- a/backend/config.py
+++ b/backend/config.py
@@ -34,6 +34,7 @@ class TabsConfig:
 class Config:
     # basic app environment
     app_env: Optional[str] = None
+    disable_auth: bool = False
 
     # messaging / alerts
     sns_topic_arn: Optional[str] = None
@@ -137,6 +138,7 @@ def load_config() -> Config:
 
     return Config(
         app_env=data.get("app_env"),
+        disable_auth=env.bool("DISABLE_AUTH", default=data.get("disable_auth", False)),
         sns_topic_arn=env.str("SNS_TOPIC_ARN", default=data.get("sns_topic_arn")),
         telegram_bot_token=env.str(
             "TELEGRAM_BOT_TOKEN", default=data.get("telegram_bot_token")

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,7 @@ cors:
   production:
     - https://app.allotmint.io
 app_env: local
+disable_auth: true
 portfolio_xml_path: data/portfolio/investments.xml
 transactions_output_root: data/accounts
 uvicorn_port: 8000


### PR DESCRIPTION
## Summary
- add `disable_auth` option to `Config` and config loader
- skip auth dependencies when disabled
- set `disable_auth: true` in example config for local development

## Testing
- `pytest` *(fails: 16 failed, 160 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68af789956dc8327a5463cd761e12ca3