### PR TITLE
Pin jinja2 version in backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 uvicorn
-jinja2
+jinja2~=3.1.4
 fastapi~=0.116.1
 mangum~=0.19.0
 boto3~=1.37.10


### PR DESCRIPTION
## Summary
- pin jinja2 dependency to version compatible with 3.1.4 in backend requirements

## Testing
- `pip install -r backend/requirements.txt` (succeeds)
- `docker run --rm -v $(pwd):/app -w /app public.ecr.aws/lambda/python:3.12 pip install -r backend/requirements.txt` (fails: Cannot connect to Docker daemon)
- `cdk deploy` (fails: Docker exited with status 125)
- `pytest` (fails: ModuleNotFoundError: No module named 'environs')

------
https://chatgpt.com/codex/tasks/task_e_68b09c3f61f08327bde10d96c6ab07fa