### PR TITLE
Show backend error when backend unavailable

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -255,9 +255,16 @@ export default function App() {
   }
 
   if (backendUnavailable) {
+    const backendError =
+      ownersReq.error?.message || groupsReq.error?.message;
     return (
       <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
         Backend unavailable—retrying…
+        {backendError && (
+          <div style={{ marginTop: "0.5rem", color: "red" }}>
+            {backendError}
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- display underlying backend error message when owners/groups requests fail

## Testing
- `npm test -- --run` *(fails: numerous React act warnings, process aborted)*
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*


------
https://chatgpt.com/codex/tasks/task_e_68b2a75ba2f483278ca95f741aa0789d