### PR TITLE
Expand local CORS origins for development

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,10 @@ cors:
   local:
     - http://localhost:3000
     - http://localhost:5173
+    - http://127.0.0.1:3000
+    - http://127.0.0.1:5173
+    - http://localhost:*
+    - http://127.0.0.1:*
   production:
     - https://app.allotmint.io
 app_env: local


### PR DESCRIPTION
## Summary
- expand `cors.local` to cover additional dev origins like `http://127.0.0.1:5173`
- add wildcard localhost entries for flexible local testing

## Testing
- `pytest` *(fails: Alpha Vantage disabled, fixture errors, other environment-specific failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a75a98d48327800015632935ebfc