### PR TITLE
Expose uvicorn host in local startup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The repo includes a lightweight Yahoo Finance watchlist. Run it locally with:
 
 ```
 # backend
-uvicorn app:app --reload --port 8000
+uvicorn app:app --reload --port 8000 --host 0.0.0.0
 
 # frontend
 npm i && npm run dev
@@ -139,6 +139,7 @@ side in isolation. Backend runtime options are stored in `config.yaml`:
 
 ```yaml
 app_env: local
+uvicorn_host: 0.0.0.0
 uvicorn_port: 8000
 reload: true
 log_config: backend/logging.ini
@@ -186,7 +187,7 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt -r requirements-dev.txt
 
 # configure API settings
-# (see config.yaml for app_env, uvicorn_port, reload and log_config)
+# (see config.yaml for app_env, uvicorn_host, uvicorn_port, reload and log_config)
 ./run-local-api.sh    # or use run-backend.ps1 on Windows
 
 # in another shell install React deps and start Vite on :5173

--- a/USER_README.md
+++ b/USER_README.md
@@ -13,6 +13,7 @@ AllotMint helps families track and manage investments like tending an allotment.
 Runtime options live in `config.yaml`:
 
 - `app_env`: `local` for local development or `aws` for Lambda.
+- `uvicorn_host`: host interface for the local FastAPI server.
 - `uvicorn_port`: port for the local FastAPI server.
 - `reload`: enables auto-reload for development.
 - `tabs`: enable or disable optional frontend tabs.
@@ -110,7 +111,7 @@ If the variable is unset the UI defaults to `http://localhost:8000` (or
 `VITE_API_URL` if defined).
 
 ## Common workflows
-- **Start the backend**: `uvicorn app:app --reload --port 8000`
+- **Start the backend**: `uvicorn app:app --reload --port 8000 --host 0.0.0.0`
 - **Start the frontend**: `cd frontend && npm run dev`
 - **Run tests**:
   - Backend: `pytest`

--- a/config.yaml
+++ b/config.yaml
@@ -25,6 +25,7 @@ app_env: local
 disable_auth: true
 portfolio_xml_path: data/portfolio/investments.xml
 transactions_output_root: data/accounts
+uvicorn_host: 0.0.0.0
 uvicorn_port: 8000
 reload: true
 relative_view_enabled: false

--- a/run-backend.ps1
+++ b/run-backend.ps1
@@ -88,18 +88,20 @@ if (-not $offline) {
 
 # ───────────── env + defaults (PS 5.1) ────────
 $env:ALLOTMINT_ENV = Coalesce $cfg.app_env 'local'
+$host      = Coalesce $cfg.uvicorn_host '0.0.0.0'
 $port      = Coalesce $cfg.uvicorn_port $Port
 $logConfig = Coalesce $cfg.log_config   'logging.ini'
 $reloadRaw = Coalesce $cfg.reload       $true
 $reload    = [bool]$reloadRaw
 
 # ───────────── start server ───────────────────
-Write-Host "Starting AllotMint Local API on http://localhost:$port ..." -ForegroundColor Green
+Write-Host "Starting AllotMint Local API on http://$host:$port ..." -ForegroundColor Green
 
 $arguments = @(
   'backend.local_api.main:app',
   '--reload-dir', 'backend',
   '--port', $port,
+  '--host', $host,
   '--log-config', $logConfig,
   '--app-dir', '.'
 )

--- a/run-local-api.sh
+++ b/run-local-api.sh
@@ -20,13 +20,15 @@ fi
 # load shared config
 CONFIG_FILE="config.yaml"
 APP_ENV=$(awk -F': ' '/^app_env:/ {print $2}' "$CONFIG_FILE" | tr -d '"')
+UVICORN_HOST=$(awk -F': ' '/^uvicorn_host:/ {print $2}' "$CONFIG_FILE" | tr -d '"')
+UVICORN_HOST=${UVICORN_HOST:-0.0.0.0}
 UVICORN_PORT=$(awk -F': ' '/^uvicorn_port:/ {print $2}' "$CONFIG_FILE" | tr -d '"')
 RELOAD=$(awk -F': ' '/^reload:/ {print $2}' "$CONFIG_FILE" | tr -d '"')
 LOG_CONFIG=$(awk -F': ' '/^log_config:/ {print $2}' "$CONFIG_FILE" | tr -d '"')
 
 export ALLOTMINT_ENV="$APP_ENV"
 
-CMD=(uvicorn backend.local_api.main:app --reload-dir backend --port "$UVICORN_PORT" --log-config "$LOG_CONFIG")
+CMD=(uvicorn backend.local_api.main:app --reload-dir backend --port "$UVICORN_PORT" --host "$UVICORN_HOST" --log-config "$LOG_CONFIG")
 if [[ "$RELOAD" == "true" ]]; then
   CMD+=(--reload)
 fi


### PR DESCRIPTION
## Summary
- Allow configuring uvicorn host via `uvicorn_host` in config
- Pass host to uvicorn in run scripts
- Document host flag for backend startup

## Testing
- `pytest` *(fails: tests/test_alphavantage_errors.py::test_information_field_propagated, tests/test_backend_api.py::test_valid_group_portfolio, tests/test_backend_api.py::test_prices_refresh, tests/test_backend_api.py::test_group_instruments, tests/test_backend_api.py::test_instrument_detail_valid, tests/test_backend_api.py::test_instrument_detail_not_found, tests/test_backend_api.py::test_alerts_endpoint, tests/test_fx_conversion.py::test_prices_converted_to_gbp[N-0.8], tests/test_fx_conversion.py::test_prices_converted_to_gbp[DE-0.9], tests/test_fx_conversion.py::test_prices_converted_to_gbp[CA-0.6], tests/test_fx_conversion.py::test_prices_converted_to_gbp[TO-0.6], tests/test_fx_conversion.py::test_missing_fx_rates_are_filled, tests/test_fx_conversion.py::test_non_gbp_instrument_on_gbp_exchange, tests/test_fx_conversion.py::test_memoized_range_returns_copy, tests/test_screener.py::test_fetch_fundamentals_parses_values, tests/test_stooq_rate_limit.py::test_stooq_rate_limit_disables_until_next_day)*

------
https://chatgpt.com/codex/tasks/task_e_68b2acd921888327a606746ba72c220c