### PR TITLE
Cap frontend retries and surface backend errors

### DIFF
--- a/frontend/src/hooks/useFetchWithRetry.ts
+++ b/frontend/src/hooks/useFetchWithRetry.ts
@@ -4,18 +4,25 @@ import useFetch from "./useFetch";
 /**
  * Wraps `useFetch` and automatically retries the request until it succeeds.
  * A failed request schedules another attempt after `delay` milliseconds.
+ * Retries stop after `maxAttempts` attempts and the final error is surfaced
+ * to callers.
  */
-export function useFetchWithRetry<T>(fn: () => Promise<T>, delay = 2000) {
-  const [attempt, setAttempt] = useState(0);
+export function useFetchWithRetry<T>(
+  fn: () => Promise<T>,
+  delay = 2000,
+  maxAttempts = 5,
+) {
+  const [attempt, setAttempt] = useState(1);
   const result = useFetch(fn, [attempt]);
 
   useEffect(() => {
     if (!result.error) return;
+    if (attempt >= maxAttempts) return;
     const timer = setTimeout(() => setAttempt((a) => a + 1), delay);
     return () => clearTimeout(timer);
-  }, [result.error, delay]);
+  }, [result.error, delay, attempt, maxAttempts]);
 
-  return result;
+  return { ...result, attempt, maxAttempts };
 }
 
 export default useFetchWithRetry;


### PR DESCRIPTION
## Summary
- add `maxAttempts` option to `useFetchWithRetry` and stop retrying after limit
- display explicit backend-unreachable message in `App` when retries are exhausted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2acae51b4832793a6fea4e172afbb