### PR TITLE
chore: run backend layer bundling as root

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -27,6 +27,7 @@ class BackendLambdaStack(Stack):
                 str(backend_path),
                 bundling=BundlingOptions(
                     image=_lambda.Runtime.PYTHON_3_12.bundling_image,
+                    user="root",
                     command=[
                         "bash",
                         "-c",


### PR DESCRIPTION
## Summary
- run backend dependencies bundling as root user so system packages can be installed

## Testing
- `pytest` *(fails: AttributeError and other failures)*
- `cdk deploy BackendLambdaStack --app "python cdk/app.py"` *(fails: Failed to bundle asset ... spawnSync docker ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b3a522d48327a1e2114eb3649643