### PR TITLE
Enable PDF report generation with reportlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ The backend exposes Value at Risk (VaR) metrics for each portfolio.
 See [backend/common/portfolio_utils.py](backend/common/portfolio_utils.py) for the return series that feed the calculation
 and [backend/common/constants.py](backend/common/constants.py) for currency labels.
 
+## Portfolio reports
+
+`GET /reports/{owner}` compiles realized gains, income and performance metrics
+for a portfolio. Pass `format=csv` or `format=pdf` to download the report in
+your preferred format.
+
 ## Local Quick-start
 
 The project is split into a Python FastAPI backend and a React/TypeScript

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -7,11 +7,8 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
 import pandas as pd
-# try:
-#     from reportlab.lib.pagesizes import letter
-#     from reportlab.pdfgen import canvas
-# except ModuleNotFoundError:
-#     pass
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
 
 from backend.common import portfolio_utils
 from backend.config import config
@@ -135,12 +132,12 @@ def report_to_csv(data: ReportData) -> bytes:
 
 def report_to_pdf(data: ReportData) -> bytes:
     buf = io.BytesIO()
-    # # c = canvas.Canvas(buf, pagesize=letter)
-    # text = c.beginText(40, 750)
-    # for k, v in data.to_dict().items():
-    #     text.textLine(f"{k}: {v}")
-    # c.drawText(text)
-    # c.showPage()
-    # c.save()
+    c = canvas.Canvas(buf, pagesize=letter)
+    text = c.beginText(40, 750)
+    for k, v in data.to_dict().items():
+        text.textLine(f"{k}: {v}")
+    c.drawText(text)
+    c.showPage()
+    c.save()
     return buf.getvalue()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ openai~=1.51.0
 playwright~=1.49.0
 pytest-cov~=6.2.1
 pytest~=8.4.1
+reportlab~=4.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ python-multipart~=0.0.20
 pytz~=2025.2
 pyyaml~=6.0.2
 requests~=2.32.3
+reportlab~=4.2.5
 s3transfer~=0.11.2
 selenium~=4.24.0
 six~=1.17.0

--- a/tests/test_reports_pdf.py
+++ b/tests/test_reports_pdf.py
@@ -1,0 +1,53 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.common.alerts as alerts
+from backend import config as backend_config
+
+
+@pytest.fixture(scope="module")
+def client():
+    """Return an authenticated TestClient with offline mode enabled."""
+
+    previous = backend_config.config.offline_mode
+    backend_config.config.offline_mode = True
+    from backend.local_api.main import app
+
+    client = TestClient(app)
+    token = client.post(
+        "/token", data={"username": "testuser", "password": "password"}
+    ).json()["access_token"]
+    client.headers.update({"Authorization": f"Bearer {token}"})
+    alerts.config.sns_topic_arn = None
+    try:
+        yield client
+    finally:
+        backend_config.config.offline_mode = previous
+
+
+def test_report_pdf(client, monkeypatch):
+    """PDF reports should be generated using reportlab."""
+
+    def fake_load_transactions(owner):
+        return [
+            {"date": "2024-01-01", "type": "SELL", "amount_minor": 1000},
+            {"date": "2024-01-02", "type": "DIVIDEND", "amount_minor": 500},
+        ]
+
+    def fake_performance(owner):
+        return {
+            "history": [{"date": "2024-01-02", "cumulative_return": 0.1}],
+            "max_drawdown": -0.05,
+        }
+
+    monkeypatch.setattr("backend.reports._load_transactions", fake_load_transactions)
+    monkeypatch.setattr(
+        "backend.common.portfolio_utils.compute_owner_performance", fake_performance
+    )
+
+    resp = client.get("/reports/test?format=pdf")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+    assert resp.content.startswith(b"%PDF")
+    assert len(resp.content) > 100
+


### PR DESCRIPTION
## Summary
- implement PDF export for reports using reportlab
- document PDF report endpoint and add reportlab dependency
- test PDF report generation via API

## Testing
- `pytest tests/test_reports_pdf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2b3a7f734832794d6045a71236898