### PR TITLE
Make backend CDK stack optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,10 +285,14 @@ npm install
 npm run build
 cd ..
 
-# deploy the static site stack
+# deploy the static site stack only
 cd cdk
 cdk bootstrap   # only required once per AWS account/region
-cdk deploy StaticSiteStack
+DEPLOY_BACKEND=false cdk deploy StaticSiteStack
+
+# or include the backend Lambda stack
+DEPLOY_BACKEND=true cdk deploy BackendLambdaStack StaticSiteStack
+# equivalently: cdk deploy BackendLambdaStack StaticSiteStack -c deploy_backend=true
 ```
 
 The bucket remains private and CloudFront uses an origin access identity

--- a/USER_README.md
+++ b/USER_README.md
@@ -119,5 +119,6 @@ If the variable is unset the UI defaults to `http://localhost:8000` (or
 - **Run the trading agent**: `python scripts/run_trading_agent.py --tickers AAPL MSFT`
 - **Deploy to AWS**:
   1. `cd frontend && npm run build`
-  2. `cd cdk && cdk deploy StaticSiteStack`
+  2. `cd cdk && DEPLOY_BACKEND=false cdk deploy StaticSiteStack`
+  3. To include the backend: `DEPLOY_BACKEND=true cdk deploy BackendLambdaStack StaticSiteStack`
 

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,10 +1,29 @@
 #!/usr/bin/env python3
+import os
+
 import aws_cdk as cdk
 
 from stacks.backend_lambda_stack import BackendLambdaStack
 from stacks.static_site_stack import StaticSiteStack
 
+
+def _is_truthy(value) -> bool:
+    """Return True for common representations of truthy values."""
+
+    if value is None:
+        return False
+    return str(value).lower() in {"1", "true", "y", "yes"}
+
+
 app = cdk.App()
-BackendLambdaStack(app, "BackendLambdaStack")
+
+deploy_backend_value = (
+    app.node.try_get_context("deploy_backend")
+    or os.getenv("DEPLOY_BACKEND")
+)
+
+if _is_truthy(deploy_backend_value):
+    BackendLambdaStack(app, "BackendLambdaStack")
+
 StaticSiteStack(app, "StaticSiteStack")
 app.synth()


### PR DESCRIPTION
## Summary
- allow skipping backend Lambda stack via DEPLOY_BACKEND or context flag
- document how to deploy stacks with the new flag

## Testing
- `pytest` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b3a6b2b8832795d4a03a86400b37