### PR TITLE
Use regex for local CORS

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -78,15 +78,23 @@ def create_app() -> FastAPI:
     app.state.virtual_pf_root = paths.virtual_pf_root
 
     # ───────────────────────────── CORS ─────────────────────────────
-    # The frontend origin varies by environment. Read the whitelist from
-    # configuration and fall back to permissive settings during development.
-    cors_origins = config.cors_origins or ["*"]
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=cors_origins,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    # The frontend origin varies by environment. Use a whitelist when provided
+    # and fall back to a regex that accepts any localhost port during
+    # development.
+    if config.cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=config.cors_origins,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+    else:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origin_regex=r"http://(localhost|127\.0\.0\.1):\d+",
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
 
     # ──────────────────────────── Routers ────────────────────────────
     # The API surface is composed of a few routers grouped by concern.

--- a/config.yaml
+++ b/config.yaml
@@ -12,13 +12,6 @@ fundamentals_cache_ttl_seconds: 86400
 stooq_timeout: 10
 stooq_requests_per_minute: 60
 cors:
-  local:
-    - http://localhost:3000
-    - http://localhost:5173
-    - http://127.0.0.1:3000
-    - http://127.0.0.1:5173
-    - http://localhost:*
-    - http://127.0.0.1:*
   production:
     - https://app.allotmint.io
 app_env: local


### PR DESCRIPTION
## Summary
- Remove hard-coded localhost origins from config
- Apply FastAPI CORS middleware with regex for localhost on any port

## Testing
- `pytest` *(fails: AttributeError, KeyError, RuntimeError, etc.)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b2b3fc9320832785f19febafa16d41