### PR TITLE
Handle server unreachability

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -71,9 +71,11 @@ export const configContext = createContext<ConfigContextValue>({
 
 export function ConfigProvider({ children }: { children: ReactNode }) {
   const [config, setConfig] = useState<AppConfig>(defaultConfig);
+  const [error, setError] = useState<string | null>(null);
 
   const refreshConfig = useCallback(async () => {
     try {
+      setError(null);
       const cfg = await getConfig<RawConfig>();
       const rawTabs =
         cfg && cfg.tabs && typeof cfg.tabs === "object" && !Array.isArray(cfg.tabs)
@@ -99,6 +101,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     } catch (err) {
       console.warn("Failed to fetch configuration", err);
       setConfig(defaultConfig);
+      setError("Cannot reach server");
     }
   }, []);
 
@@ -112,6 +115,19 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
 
   return (
     <configContext.Provider value={{ ...config, refreshConfig }}>
+      {error && (
+        <div
+          role="alert"
+          style={{
+            background: "#fcc",
+            padding: "0.5rem",
+            textAlign: "center",
+            marginBottom: "0.5rem",
+          }}
+        >
+          {error} <button onClick={refreshConfig}>Retry</button>
+        </div>
+      )}
       {children}
     </configContext.Provider>
   );

--- a/frontend/src/components/AlertsPanel.tsx
+++ b/frontend/src/components/AlertsPanel.tsx
@@ -5,10 +5,14 @@ import { useEffect, useState } from "react";
 export function AlertsPanel({ user = "default" }: { user?: string }) {
   const { data: alerts, loading, error } = useFetch<Alert[]>(api.getAlerts, []);
   const [threshold, setThreshold] = useState<number>();
+  const [settingsError, setSettingsError] = useState(false);
 
   useEffect(() => {
     if (api.getAlertSettings) {
-      api.getAlertSettings(user).then((r) => setThreshold(r.threshold));
+      api
+        .getAlertSettings(user)
+        .then((r) => setThreshold(r.threshold))
+        .catch(() => setSettingsError(true));
     }
   }, [user]);
 
@@ -18,10 +22,20 @@ export function AlertsPanel({ user = "default" }: { user?: string }) {
     }
   };
 
+  if (loading) return null;
+
+  if (error || settingsError) {
+    return (
+      <div style={{ border: "1px solid #ccc", padding: "0.5rem", marginBottom: "1rem" }}>
+        Cannot reach server
+      </div>
+    );
+  }
+
   const importAlert = alerts?.find((a) => a.ticker === "IMPORT");
   const otherAlerts = alerts?.filter((a) => a.ticker !== "IMPORT") ?? [];
 
-  if (loading || error || (!importAlert && otherAlerts.length === 0)) return null;
+  if (!importAlert && otherAlerts.length === 0) return null;
 
   return (
     <div style={{ border: "1px solid #ccc", padding: "0.5rem", marginBottom: "1rem" }}>


### PR DESCRIPTION
## Summary
- show a user-friendly error when alert settings fetch fails
- surface configuration loading errors with a banner and retry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b072b85083278fdfa36e1698dc68