### PR TITLE
chore: clean screener form markup

### DIFF
--- a/frontend/src/pages/Screener.tsx
+++ b/frontend/src/pages/Screener.tsx
@@ -228,34 +228,12 @@ export function Screener() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
-          {t("screener.minDividendYield")}
-          <input
-            aria-label={t("screener.minDividendYield")}
-            type="number"
-            value={dividendYieldMin}
-            onChange={(e) => setDividendYieldMin(e.target.value)}
-            step="any"
-            style={{ marginLeft: "0.25rem" }}
-          />
-        </label>
-        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.minGrossMargin")}
           <input
             aria-label={t("screener.minGrossMargin")}
             type="number"
             value={grossMarginMin}
             onChange={(e) => setGrossMarginMin(e.target.value)}
-            step="any"
-            style={{ marginLeft: "0.25rem" }}
-          />
-        </label>
-        <label style={{ marginRight: "0.5rem" }}>
-          {t("screener.maxDividendPayoutRatio")}
-          <input
-            aria-label={t("screener.maxDividendPayoutRatio")}
-            type="number"
-            value={dividendPayoutRatioMax}
-            onChange={(e) => setDividendPayoutRatioMax(e.target.value)}
             step="any"
             style={{ marginLeft: "0.25rem" }}
           />
@@ -272,34 +250,12 @@ export function Screener() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
-          {t("screener.maxBeta")}
-          <input
-            aria-label={t("screener.maxBeta")}
-            type="number"
-            value={betaMax}
-            onChange={(e) => setBetaMax(e.target.value)}
-            step="any"
-            style={{ marginLeft: "0.25rem" }}
-          />
-        </label>
-        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.minNetMargin")}
           <input
             aria-label={t("screener.minNetMargin")}
             type="number"
             value={netMarginMin}
             onChange={(e) => setNetMarginMin(e.target.value)}
-            step="any"
-            style={{ marginLeft: "0.25rem" }}
-          />
-        </label>
-        <label style={{ marginRight: "0.5rem" }}>
-          {t("screener.minSharesOutstanding")}
-          <input
-            aria-label={t("screener.minSharesOutstanding")}
-            type="number"
-            value={sharesOutstandingMin}
-            onChange={(e) => setSharesOutstandingMin(e.target.value)}
             step="any"
             style={{ marginLeft: "0.25rem" }}
           />
@@ -316,17 +272,6 @@ export function Screener() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
-          {t("screener.minFloatShares")}
-          <input
-            aria-label={t("screener.minFloatShares")}
-            type="number"
-            value={floatSharesMin}
-            onChange={(e) => setFloatSharesMin(e.target.value)}
-            step="any"
-            style={{ marginLeft: "0.25rem" }}
-          />
-        </label>
-        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.minRoa")}
           <input
             aria-label={t("screener.minRoa")}
@@ -338,34 +283,12 @@ export function Screener() {
           />
         </label>
         <label style={{ marginRight: "0.5rem" }}>
-          {t("screener.minMarketCap")}
-          <input
-            aria-label={t("screener.minMarketCap")}
-            type="number"
-            value={marketCapMin}
-            onChange={(e) => setMarketCapMin(e.target.value)}
-            step="any"
-            style={{ marginLeft: "0.25rem" }}
-          />
-        </label>
-        <label style={{ marginRight: "0.5rem" }}>
           {t("screener.minRoe")}
           <input
             aria-label={t("screener.minRoe")}
             type="number"
             value={roeMin}
             onChange={(e) => setRoeMin(e.target.value)}
-            step="any"
-            style={{ marginLeft: "0.25rem" }}
-          />
-        </label>
-        <label style={{ marginRight: "0.5rem" }}>
-          {t("screener.max52WeekHigh")}
-          <input
-            aria-label={t("screener.max52WeekHigh")}
-            type="number"
-            value={high52wMax}
-            onChange={(e) => setHigh52wMax(e.target.value)}
             step="any"
             style={{ marginLeft: "0.25rem" }}
           />
@@ -454,11 +377,6 @@ export function Screener() {
             type="number"
             value={high52wMax}
             onChange={(e) => setHigh52wMax(e.target.value)}
-            step="any"
-            style={{ marginLeft: "0.25rem" }}
-          />
-        </label>
-        <label style={{ marginRight: "0.5rem" }}>
             step="any"
             style={{ marginLeft: "0.25rem" }}
           />


### PR DESCRIPTION
## Summary
- remove stray label and dedupe fields in screener form

## Testing
- `npm test` *(fails: Multiple exports with the same name "tabPlugins")*

------
https://chatgpt.com/codex/tasks/task_e_68b30f5b616c83278b8c90edcd68d085