### PR TITLE
refactor tab plugin exports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,8 +36,8 @@ import { useConfig } from "./ConfigContext";
 import DataAdmin from "./pages/DataAdmin";
 import Support from "./pages/Support";
 import ScenarioTester from "./pages/ScenarioTester";
-import { tabPlugins } from "./tabPlugins";
-type Mode = (typeof tabPlugins)[number]["id"];
+import { orderedTabPlugins } from "./tabPlugins";
+type Mode = (typeof orderedTabPlugins)[number]["id"];
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -267,7 +267,7 @@ export default function App() {
       <LanguageSwitcher />
       <AlertsPanel />
       <nav style={{ margin: "1rem 0" }}>
-        {tabPlugins
+        {orderedTabPlugins
           .slice()
           .sort((a, b) => a.priority - b.priority)
           .filter((p) => tabs[p.id] !== false)

--- a/frontend/src/tabPlugins.ts
+++ b/frontend/src/tabPlugins.ts
@@ -1,4 +1,4 @@
-export const tabPlugins = {
+export const tabPluginMap = {
   group: {},
   owner: {},
   instrument: {},
@@ -14,8 +14,8 @@ export const tabPlugins = {
   reports: {},
   scenario: {},
 };
-export type TabPluginId = keyof typeof tabPlugins;
-export const tabPlugins = [
+export type TabPluginId = keyof typeof tabPluginMap;
+export const orderedTabPlugins = [
   { id: "movers", priority: 0 },
   { id: "group", priority: 10 },
   { id: "instrument", priority: 20 },
@@ -30,4 +30,4 @@ export const tabPlugins = [
   { id: "support", priority: 110 },
   { id: "scenario", priority: 120 },
 ] as const;
-export type TabPlugin = typeof tabPlugins[number];
+export type TabPlugin = typeof orderedTabPlugins[number];


### PR DESCRIPTION
## Summary
- give plugin map and list distinct names
- update app to use orderedTabPlugins

## Testing
- `npm test` *(fails: Transform failed with 1 error: Screener.tsx:464)*
- `npm run lint` *(fails: Parsing error in Screener.tsx and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b30f59edc883279b274349f43f341b