### PR TITLE
chore: import Mode as type

### DIFF
--- a/frontend/src/RouteContext.tsx
+++ b/frontend/src/RouteContext.tsx
@@ -1,6 +1,6 @@
-import { createContext, useContext, ReactNode } from "react";
+import { createContext, useContext, type ReactNode } from "react";
 import { useRouteMode } from "./hooks/useRouteMode";
-import { Mode } from "./modes";
+import type { Mode } from "./modes";
 
 interface RouteContextValue {
   mode: Mode;

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -1,7 +1,7 @@
 import { Link, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useConfig } from "../ConfigContext";
-import { Mode, MODES } from "../modes";
+import { MODES, type Mode } from "../modes";
 
 interface MenuProps {
   selectedOwner?: string;

--- a/frontend/src/hooks/useRouteMode.ts
+++ b/frontend/src/hooks/useRouteMode.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useConfig } from "../ConfigContext";
-import { Mode } from "../modes";
+import type { Mode } from "../modes";
 
 interface RouteState {
   mode: Mode;


### PR DESCRIPTION
## Summary
- mark Mode imports as type-only in Menu, useRouteMode, and RouteContext
- adjust ReactNode import in RouteContext to be type-only

## Testing
- `npm run build` *(fails: object literal duplicate keys and missing properties)*
- `npm run lint` *(fails: ts-ignore usage and unused variable in Screener.tsx)*
- `npm test` *(fails: multiple tests failing such as Support not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b312fcc538832789be0138893b6f8a