### PR TITLE
feat(frontend): add API token header

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,6 +25,13 @@ Set one of the following environment variables to tell the UI where the backend 
 
 * `VITE_ALLOTMINT_API_BASE` – full base URL to the backend.
 * `VITE_API_URL` – legacy fallback used when `VITE_ALLOTMINT_API_BASE` is unset.
+* `VITE_API_TOKEN` – optional token sent as `X-API-Token` with every request.
+
+To provide the token, add it to your environment or a `.env` file in `frontend`:
+
+```
+VITE_API_TOKEN=your-token-here
+```
 
 If neither is provided the app falls back to `http://localhost:8000`.
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -35,7 +35,12 @@ export const API_BASE =
 /* Generic fetch helper                                                */
 /* ------------------------------------------------------------------ */
 export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, init);
+  const headers = new Headers(init?.headers);
+  const token = import.meta.env.VITE_API_TOKEN;
+  if (token) {
+    headers.set("X-API-Token", token);
+  }
+  const res = await fetch(url, { ...init, headers });
   if (!res.ok) {
     throw new Error(`HTTP ${res.status} – ${res.statusText} (${url})`);
   }

--- a/frontend/src/api/codingPractice.test.js
+++ b/frontend/src/api/codingPractice.test.js
@@ -17,7 +17,10 @@ describe("coding practice api", () => {
 
   it("fetches puzzles", async () => {
     await getPuzzles();
-    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/codingpractice`, undefined);
+    expect(fetch).toHaveBeenCalledWith(
+      `${API_BASE}/codingpractice`,
+      expect.objectContaining({ headers: expect.any(Headers) })
+    );
   });
 
   it("creates puzzle", async () => {


### PR DESCRIPTION
## Summary
- add support for VITE_API_TOKEN header in fetchJson
- document VITE_API_TOKEN setup in frontend README
- adjust codingPractice API test for new headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b34b7075cc83278ad541160d178d19