### PR TITLE
docs: add API token placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ ALPHA_VANTAGE_KEY=
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 SNS_TOPIC_ARN=
+
+# Token used to secure sensitive routes via the X-API-Token header
+API_TOKEN=


### PR DESCRIPTION
## Summary
- document API_TOKEN usage in `.env.example` to secure routes via `X-API-Token`

## Testing
- `make lint` *(fails: import block unformatted in backend/config.py and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b34c1555c88327a0ed93a26929ea74