### PR TITLE
docs: add authenticated owners example

### DIFF
--- a/USER_README.md
+++ b/USER_README.md
@@ -49,6 +49,14 @@ Sensitive endpoints such as portfolio or transaction data can be secured with a 
    curl -H "X-API-Token: $API_TOKEN" http://localhost:8000/portfolio/alex
    ```
 
+   Another example fetching the list of owners:
+
+   ```bash
+   curl -H "X-API-Token: $API_TOKEN" http://localhost:8000/owners
+   ```
+
+   Omitting the header when `API_TOKEN` is set will result in `401 Unauthorized`.
+
 If `API_TOKEN` is unset, the API remains open which is convenient for local development and tests.
 
 ## Common workflows


### PR DESCRIPTION
## Summary
- document GET /owners example using `X-API-Token`
- note that missing the token header returns `401 Unauthorized`

## Testing
- `pytest -q` *(fails: KeyError: 'account_type', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b34c17c10c8327a018972b9797a55a