### PR TITLE
Use S3BucketOrigin for CloudFront distribution

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -36,7 +36,9 @@ class StaticSiteStack(Stack):
             "StaticSiteDistribution",
             default_root_object="index.html",
             default_behavior=cloudfront.BehaviorOptions(
-                origin=origins.S3Origin(site_bucket, origin_access_identity=oai),
+                origin=origins.S3BucketOrigin.with_origin_access_identity(
+                    site_bucket, origin_access_identity=oai
+                ),
                 viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             ),
             price_class=cloudfront.PriceClass.PRICE_CLASS_100,


### PR DESCRIPTION
## Summary
- replace deprecated S3Origin with S3BucketOrigin
- configure CloudFront origin access identity using new API

## Testing
- `cdk synth`


------
https://chatgpt.com/codex/tasks/task_e_68b34c2646008327b8840b6aff589337