### PR TITLE
docs: add local auth instructions to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ npm run dev
 open http://localhost:5173/
 ```
 
+- **Authentication**:
+  - Set `API_TOKEN` and include it as an `X-API-Token` header in requests, or
+  - Leave `API_TOKEN` unset to disable authentication during local development.
+  See the [Authentication](USER_README.md#authentication) section for details.
+
 ## Alerts
 
 Trading alerts support multiple transports that are enabled via environment


### PR DESCRIPTION
## Summary
- note optional API token setup or disabling auth in Local Quick-start

## Testing
- `pytest -q` *(fails: KeyError: 'account_type', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b34c1689808327b8c0661771152771