### PR TITLE
Add frontend env example for API configuration

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+VITE_ALLOTMINT_API_BASE=http://localhost:8000
+# VITE_API_TOKEN enables authenticated requests and must match the backend API_TOKEN
+VITE_API_TOKEN=


### PR DESCRIPTION
## Summary
- add sample frontend environment variables for API base and auth token

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b34f1fc1748327a99a0c6afade3088