### PR TITLE
Handle unauthorized API responses in frontend

### DIFF
--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -52,6 +52,7 @@ export default function MainApp() {
 
   const ownersReq = useFetchWithRetry(getOwners);
   const groupsReq = useFetchWithRetry(getGroups);
+  const unauthorized = ownersReq.unauthorized || groupsReq.unauthorized;
 
   useEffect(() => {
     if (ownersReq.data) setOwners(ownersReq.data);
@@ -115,6 +116,13 @@ export default function MainApp() {
     }
   }, [mode, selectedGroup]);
 
+  if (unauthorized) {
+    return (
+      <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
+        Unauthorized—check API token.
+      </div>
+    );
+  }
   if (backendUnavailable) {
     return (
       <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>

--- a/frontend/src/hooks/useFetchWithRetry.ts
+++ b/frontend/src/hooks/useFetchWithRetry.ts
@@ -8,14 +8,15 @@ import useFetch from "./useFetch";
 export function useFetchWithRetry<T>(fn: () => Promise<T>, delay = 2000) {
   const [attempt, setAttempt] = useState(0);
   const result = useFetch(fn, [attempt]);
+  const unauthorized = result.error?.message.includes("HTTP 401") ?? false;
 
   useEffect(() => {
-    if (!result.error) return;
+    if (!result.error || unauthorized) return;
     const timer = setTimeout(() => setAttempt((a) => a + 1), delay);
     return () => clearTimeout(timer);
-  }, [result.error, delay]);
+  }, [result.error, delay, unauthorized]);
 
-  return result;
+  return { ...result, unauthorized };
 }
 
 export default useFetchWithRetry;


### PR DESCRIPTION
## Summary
- Detect HTTP 401 errors in `useFetchWithRetry` and stop retrying to surface an unauthorized state
- Show "Unauthorized—check API token" in `MainApp` when requests fail with HTTP 401

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b34f22eeac8327a2157ee485df044a