### PR TITLE
warn when missing API token

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -41,6 +41,11 @@ export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> 
     headers.set("X-API-Token", token);
   }
   const res = await fetch(url, { ...init, headers });
+  if (res.status === 401 && !token) {
+    console.warn(
+      "VITE_API_TOKEN is not set and request returned 401. See README.md#local-quick-start for configuration."
+    );
+  }
   if (!res.ok) {
     throw new Error(`HTTP ${res.status} – ${res.statusText} (${url})`);
   }


### PR DESCRIPTION
## Summary
- warn if VITE_API_TOKEN is missing when a request returns HTTP 401 and point developers to configuration docs

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b34f25ed4c8327a5bf67a14b069dc3