### PR TITLE
Unconditionally include backend stack and fix bundling options

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import os
 
 import aws_cdk as cdk
 
@@ -7,23 +6,12 @@ from stacks.backend_lambda_stack import BackendLambdaStack
 from stacks.static_site_stack import StaticSiteStack
 
 
-def _is_truthy(value) -> bool:
-    """Return True for common representations of truthy values."""
-
-    if value is None:
-        return False
-    return str(value).lower() in {"1", "true", "y", "yes"}
-
-
 app = cdk.App()
 
-deploy_backend_value = (
-    app.node.try_get_context("deploy_backend")
-    or os.getenv("DEPLOY_BACKEND")
-)
-
-if _is_truthy(deploy_backend_value):
-    BackendLambdaStack(app, "BackendLambdaStack")
+# Always include the backend stack so it can be deployed without
+# providing a context flag or environment variable.
+BackendLambdaStack(app, "BackendLambdaStack")
 
 StaticSiteStack(app, "StaticSiteStack")
+
 app.synth()

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -6,6 +6,7 @@ from aws_cdk import (
     aws_lambda as _lambda,
     aws_events as events,
     aws_events_targets as targets,
+    BundlingOptions,
 )
 from constructs import Construct
 
@@ -24,7 +25,7 @@ class BackendLambdaStack(Stack):
             "BackendDependencies",
             code=_lambda.Code.from_asset(
                 str(backend_path),
-                bundling=_lambda.BundlingOptions(
+                bundling=BundlingOptions(
                     image=_lambda.Runtime.PYTHON_3_12.bundling_image,
                     command=[
                         "bash",


### PR DESCRIPTION
## Summary
- Always deploy BackendLambdaStack without needing a context flag
- Import BundlingOptions from aws_cdk and use it for backend Lambda dependency layer

## Testing
- `pytest` *(fails: SyntaxError in tests/test_screener.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b34fe58b948327b1243aaf98fda800