### PR TITLE
feat: allow disabling authentication via config flag

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -79,7 +79,10 @@ def create_app() -> FastAPI:
     # ──────────────────────────── Routers ────────────────────────────
     # The API surface is composed of a few routers grouped by concern.
     # Sensitive routes are guarded by a JWT-based dependency.
-    protected = [Depends(get_current_user)]
+    if config.disable_auth:
+        protected = []
+    else:
+        protected = [Depends(get_current_user)]
     app.include_router(portfolio_router, dependencies=protected)
     app.include_router(instrument_router)
     app.include_router(timeseries_router)

--- a/backend/config.py
+++ b/backend/config.py
@@ -54,6 +54,7 @@ class Config:
     # misc complex config
     error_summary: Optional[dict] = None
     offline_mode: Optional[bool] = None
+    disable_auth: Optional[bool] = None
     relative_view_enabled: Optional[bool] = None
     theme: Optional[str] = None
     timeseries_cache_base: Optional[str] = None
@@ -145,6 +146,7 @@ def load_config() -> Config:
         selenium_headless=data.get("selenium_headless"),
         error_summary=data.get("error_summary"),
         offline_mode=data.get("offline_mode"),
+        disable_auth=data.get("disable_auth"),
         relative_view_enabled=data.get("relative_view_enabled"),
         theme=data.get("theme"),
         timeseries_cache_base=data.get("timeseries_cache_base"),


### PR DESCRIPTION
## Summary
- add `disable_auth` flag to backend config
- allow disabling auth when `disable_auth` is true

## Testing
- `pytest -q` *(fails: SyntaxError in tests/test_screener.py)*
- `curl -i http://localhost:8000/owners`
- `curl -i http://localhost:8000/groups`


------
https://chatgpt.com/codex/tasks/task_e_68b353ae3ddc83278ead6ddd344a0aa3