### PR TITLE
chore: use main branch for super linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -8,7 +8,7 @@ name: Lint Code Base
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 jobs:
   run-lint:
     runs-on: ubuntu-latest
@@ -23,5 +23,5 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: "master"
+          DEFAULT_BRANCH: "main"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update super-linter workflow to track `main` instead of `master`

## Testing
- `make lint` *(fails: ruff import sorting errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68b35c058bd08327b32cd5fd3d3afe05