### PR TITLE
chore: update deploy lambda workflow branch

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -2,7 +2,7 @@ name: Deploy Infrastructure
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- trigger lambda deployment on `main` branch instead of `master`

## Testing
- `npm test` *(fails: 8 failed tests, 3 failed files)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*


------
https://chatgpt.com/codex/tasks/task_e_68b35c0426208327bc8ba43e9edc5beb