### PR TITLE
feat: import mode constants in menu

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -1,7 +1,7 @@
 import { Link, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useConfig } from "../ConfigContext";
-// import { Mode, MODES } from "../modes";
+import { type Mode, MODES } from "../modes";
 
 interface MenuProps {
   selectedOwner?: string;


### PR DESCRIPTION
## Summary
- import type `Mode` and `MODES` in `Menu` component so modes compile correctly

## Testing
- `npm --prefix frontend run build` *(fails: TS errors in other files)*
- `npm test` *(fails: renders support page with navigation, ScreenerQuery)*

------
https://chatgpt.com/codex/tasks/task_e_68b35d8886ec8327a081c934f347a48b