### PR TITLE
Add per-instrument alert throttling and state tracking

### DIFF
--- a/backend/common/alerts.py
+++ b/backend/common/alerts.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List
 
 from backend.config import config
@@ -8,9 +8,38 @@ logger = logging.getLogger("alerts")
 
 _RECENT_ALERTS: List[Dict] = []
 
+# Track last published state and time per instrument to throttle alerts and only
+# emit notifications when the state changes (e.g. threshold crossed vs. not).
+_LAST_ALERT_STATE: Dict[str, bool] = {}
+_LAST_ALERT_TIME: Dict[str, datetime] = {}
+
 
 def publish_sns_alert(alert: Dict) -> None:
-    """Store alert and send via SNS if configured."""
+    """Store alert and send via SNS if configured.
+
+    Alerts may include ``instrument`` and ``state`` fields indicating the
+    subject of the alert and whether a threshold was crossed.  When present,
+    alerts are throttled to one per instrument per hour and are only published
+    when the state changes.
+    """
+
+    instrument = alert.get("instrument")
+    state = alert.get("state")
+
+    if instrument is not None and state is not None:
+        previous_state = _LAST_ALERT_STATE.get(instrument)
+        last_time = _LAST_ALERT_TIME.get(instrument)
+        now = datetime.utcnow()
+
+        # Only publish when state changes and at most once per hour.
+        if previous_state == state:
+            return
+        if last_time and now - last_time < timedelta(hours=1):
+            return
+
+        _LAST_ALERT_STATE[instrument] = bool(state)
+        _LAST_ALERT_TIME[instrument] = now
+
     alert["timestamp"] = datetime.utcnow().isoformat()
     _RECENT_ALERTS.append(alert)
     topic_arn = config.sns_topic_arn

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import backend.common.alerts as alerts
@@ -6,6 +7,8 @@ import backend.common.alerts as alerts
 
 def test_publish_alert_without_config(monkeypatch, caplog):
     alerts._RECENT_ALERTS.clear()
+    alerts._LAST_ALERT_STATE.clear()
+    alerts._LAST_ALERT_TIME.clear()
     monkeypatch.setattr(alerts.config, "sns_topic_arn", None, raising=False)
     with caplog.at_level("INFO"):
         alerts.publish_sns_alert({"message": "hi"})
@@ -15,6 +18,8 @@ def test_publish_alert_without_config(monkeypatch, caplog):
 
 def test_publish_alert_success(monkeypatch):
     alerts._RECENT_ALERTS.clear()
+    alerts._LAST_ALERT_STATE.clear()
+    alerts._LAST_ALERT_TIME.clear()
     sent = {}
 
     def fake_client(name):
@@ -29,3 +34,61 @@ def test_publish_alert_success(monkeypatch):
     alerts.publish_sns_alert({"message": "hello"})
     assert alerts._RECENT_ALERTS[0]["message"] == "hello"
     assert sent["TopicArn"] == "arn:example" and sent["Message"] == "hello"
+
+
+def test_per_instrument_throttling(monkeypatch):
+    alerts._RECENT_ALERTS.clear()
+    alerts._LAST_ALERT_STATE.clear()
+    alerts._LAST_ALERT_TIME.clear()
+
+    monkeypatch.setattr(alerts.config, "sns_topic_arn", None, raising=False)
+
+    class DummyDatetime(datetime):
+        current = datetime(2024, 1, 1, 0, 0, 0)
+
+        @classmethod
+        def utcnow(cls):
+            return cls.current
+
+    monkeypatch.setattr(alerts, "datetime", DummyDatetime)
+
+    alerts.publish_sns_alert({"instrument": "IBM", "state": True, "message": "a"})
+    assert len(alerts._RECENT_ALERTS) == 1
+
+    DummyDatetime.current += timedelta(minutes=30)
+    alerts.publish_sns_alert({"instrument": "IBM", "state": False, "message": "b"})
+    assert len(alerts._RECENT_ALERTS) == 1  # throttled
+
+    alerts.publish_sns_alert({"instrument": "AAPL", "state": True, "message": "c"})
+    assert len(alerts._RECENT_ALERTS) == 2  # different instrument
+
+    DummyDatetime.current += timedelta(minutes=40)
+    alerts.publish_sns_alert({"instrument": "IBM", "state": False, "message": "d"})
+    assert len(alerts._RECENT_ALERTS) == 3
+
+
+def test_publish_only_on_state_change(monkeypatch):
+    alerts._RECENT_ALERTS.clear()
+    alerts._LAST_ALERT_STATE.clear()
+    alerts._LAST_ALERT_TIME.clear()
+
+    monkeypatch.setattr(alerts.config, "sns_topic_arn", None, raising=False)
+
+    class DummyDatetime(datetime):
+        current = datetime(2024, 1, 1, 0, 0, 0)
+
+        @classmethod
+        def utcnow(cls):
+            return cls.current
+
+    monkeypatch.setattr(alerts, "datetime", DummyDatetime)
+
+    alerts.publish_sns_alert({"instrument": "IBM", "state": True, "message": "a"})
+    assert len(alerts._RECENT_ALERTS) == 1
+
+    DummyDatetime.current += timedelta(hours=2)
+    alerts.publish_sns_alert({"instrument": "IBM", "state": True, "message": "b"})
+    assert len(alerts._RECENT_ALERTS) == 1  # no state change
+
+    alerts.publish_sns_alert({"instrument": "IBM", "state": False, "message": "c"})
+    assert len(alerts._RECENT_ALERTS) == 2


### PR DESCRIPTION
## Summary
- throttle alerts to at most one per instrument per hour
- track last alert state to only publish when instrument state changes
- test throttling and state change behavior

## Testing
- `pytest tests/test_alerts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b36094889c8327ac5debbd69f6bf90