### PR TITLE
chore: update reportlab requirement

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -42,6 +42,6 @@ requests~=2.32.3
 peewee~=3.18.2
 numpy~=2.3.1
 pyarrow~=21.0.0
-reportlab~=3.6.12
+reportlab>=4.2.0
 PyJWT~=2.9.0
 python-multipart~=0.0.20


### PR DESCRIPTION
## Summary
- allow using newer reportlab that ships Python 3.12 wheels

## Testing
- `make lint` *(fails: import formatting and other lint issues)*
- `pytest` *(fails: SyntaxError in tests/test_screener.py)*
- `cdk deploy BackendLambdaStack -c deploy_backend=true` *(fails: spawnSync docker ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b360e527e08327855545c7b2daf94a