### PR TITLE
feat: filter top movers by weight

### DIFF
--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -173,13 +173,33 @@ def price_change_pct(ticker: str, days: int) -> Optional[float]:
     return (px_now / px_then - 1.0) * 100.0
 
 
-def top_movers(tickers: List[str], days: int, limit: int = 10) -> Dict[str, List[Dict[str, Any]]]:
-    """Return top gainers and losers for ``tickers`` over ``days``."""
+def top_movers(
+    tickers: List[str],
+    days: int,
+    limit: int = 10,
+    *,
+    min_weight: float = 0.0,
+    weights: Optional[Dict[str, float]] = None,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Return top gainers and losers for ``tickers`` over ``days``.
+
+    Parameters
+    ----------
+    min_weight:
+        Minimum portfolio weight (in percent) required for a ticker to be
+        included.  Set to ``0`` to disable filtering.
+    weights:
+        Optional mapping of ``ticker -> weight_percent`` used for filtering.
+    """
+
     today = dt.date.today()
     yday = today - dt.timedelta(days=1)
     rows: List[Dict[str, Any]] = []
 
     for t in tickers:
+        if min_weight and weights and weights.get(t, 0.0) < min_weight:
+            continue
         change = price_change_pct(t, days)
         if change is None:
             continue
@@ -200,8 +220,15 @@ def top_movers(tickers: List[str], days: int, limit: int = 10) -> Dict[str, List
             }
         )
 
-    pos = sorted([r for r in rows if r["change_pct"] > 0], key=lambda r: r["change_pct"], reverse=True)
-    neg = sorted([r for r in rows if r["change_pct"] < 0], key=lambda r: r["change_pct"])
+    pos = sorted(
+        [r for r in rows if r["change_pct"] > 0],
+        key=lambda r: r["change_pct"],
+        reverse=True,
+    )
+    neg = sorted(
+        [r for r in rows if r["change_pct"] < 0],
+        key=lambda r: r["change_pct"],
+    )
     return {"gainers": pos[:limit], "losers": neg[:limit]}
 
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -124,9 +124,11 @@ export const getGroupMovers = (
   slug: string,
   days: number,
   limit = 10,
+  minWeight = 0,
 ) => {
   const params = new URLSearchParams({ days: String(days) });
   if (limit) params.set("limit", String(limit));
+  if (minWeight) params.set("min_weight", String(minWeight));
   return fetchJson<{ gainers: MoverRow[]; losers: MoverRow[] }>(
     `${API_BASE}/portfolio-group/${slug}/movers?${params.toString()}`,
   );

--- a/tests/test_group_movers_route.py
+++ b/tests/test_group_movers_route.py
@@ -13,12 +13,17 @@ client.headers.update({"Authorization": f"Bearer {token}"})
 def test_group_movers_endpoint(monkeypatch):
     def fake_summaries(slug: str):
         assert slug == "demo"
-        return [{"ticker": "AAA"}, {"ticker": "BBB"}]
+        return [
+            {"ticker": "AAA", "market_value_gbp": 50.0},
+            {"ticker": "BBB", "market_value_gbp": 50.0},
+        ]
 
-    def fake_top_movers(tickers, days, limit):
+    def fake_top_movers(tickers, days, limit, *, min_weight, weights):
         assert tickers == ["AAA", "BBB"]
         assert days == 7
         assert limit == 5
+        assert min_weight == 0.5
+        assert weights == {"AAA": 50.0, "BBB": 50.0}
         return {
             "gainers": [{"ticker": "AAA", "name": "AAA", "change_pct": 5}],
             "losers": [{"ticker": "BBB", "name": "BBB", "change_pct": -3}],
@@ -27,7 +32,7 @@ def test_group_movers_endpoint(monkeypatch):
     monkeypatch.setattr(ia, "instrument_summaries_for_group", fake_summaries)
     monkeypatch.setattr(ia, "top_movers", fake_top_movers)
 
-    resp = client.get("/portfolio-group/demo/movers?days=7&limit=5")
+    resp = client.get("/portfolio-group/demo/movers?days=7&limit=5&min_weight=0.5")
     assert resp.status_code == 200
     data = resp.json()
     assert [g["ticker"] for g in data["gainers"]] == ["AAA"]

--- a/tests/test_movers_backend.py
+++ b/tests/test_movers_backend.py
@@ -58,3 +58,36 @@ def test_top_movers(monkeypatch):
     assert [r["ticker"] for r in res["losers"]] == ["BBB.L"]
     assert res["gainers"][0]["last_price_gbp"] == 100.0
     assert res["gainers"][0]["last_price_date"] == "2023-01-08"
+
+
+def test_top_movers_min_weight(monkeypatch):
+    class FixedDate(dt.date):
+        @classmethod
+        def today(cls):
+            return cls(2023, 1, 9)
+
+    monkeypatch.setattr(ia.dt, "date", FixedDate)
+    monkeypatch.setattr(
+        ia,
+        "_resolve_full_ticker",
+        lambda t, latest: (t.split(".", 1)[0], t.split(".", 1)[1] if "." in t else "L"),
+    )
+    monkeypatch.setattr(ia, "_LATEST_PRICES", {})
+    monkeypatch.setattr(ia, "_close_on", lambda sym, ex, d: 100.0)
+    monkeypatch.setattr(
+        ia,
+        "price_change_pct",
+        lambda t, d: {"AAA.L": 5.0, "BBB.L": -2.0, "CCC.L": 1.0}.get(t),
+    )
+    monkeypatch.setattr(ia, "get_security_meta", lambda t: {"name": f"{t} name"})
+
+    weights = {"AAA.L": 1.0, "BBB.L": 0.4, "CCC.L": 0.6}
+    res = ia.top_movers(
+        ["AAA.L", "BBB.L", "CCC.L"],
+        7,
+        limit=2,
+        min_weight=0.5,
+        weights=weights,
+    )
+    assert [r["ticker"] for r in res["gainers"]] == ["AAA.L", "CCC.L"]
+    assert [r["ticker"] for r in res["losers"]] == []


### PR DESCRIPTION
## Summary
- allow instrument_api.top_movers to filter by minimum weight
- support `min_weight` on group movers API and client
- add checkbox to TopMoversPage to exclude small positions

## Testing
- `pytest` *(fails: SyntaxError in tests/test_screener.py)*
- `npm --prefix frontend test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b360a793388327a5528c5f781a8905