### PR TITLE
Only update alert throttle after successful publish

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -14,6 +14,8 @@ def test_publish_alert_without_config(monkeypatch, caplog):
         alerts.publish_sns_alert({"message": "hi"})
     assert alerts._RECENT_ALERTS[0]["message"] == "hi"
     assert "SNS topic ARN not configured" in caplog.text
+    assert alerts._LAST_ALERT_STATE == {}
+    assert alerts._LAST_ALERT_TIME == {}
 
 
 def test_publish_alert_success(monkeypatch):
@@ -41,7 +43,12 @@ def test_per_instrument_throttling(monkeypatch):
     alerts._LAST_ALERT_STATE.clear()
     alerts._LAST_ALERT_TIME.clear()
 
-    monkeypatch.setattr(alerts.config, "sns_topic_arn", None, raising=False)
+    def fake_client(name):
+        assert name == "sns"
+        return SimpleNamespace(publish=lambda **kwargs: None)
+
+    monkeypatch.setattr(alerts.config, "sns_topic_arn", "arn:example")
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
     class DummyDatetime(datetime):
         current = datetime(2024, 1, 1, 0, 0, 0)
@@ -72,7 +79,12 @@ def test_publish_only_on_state_change(monkeypatch):
     alerts._LAST_ALERT_STATE.clear()
     alerts._LAST_ALERT_TIME.clear()
 
-    monkeypatch.setattr(alerts.config, "sns_topic_arn", None, raising=False)
+    def fake_client(name):
+        assert name == "sns"
+        return SimpleNamespace(publish=lambda **kwargs: None)
+
+    monkeypatch.setattr(alerts.config, "sns_topic_arn", "arn:example")
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
     class DummyDatetime(datetime):
         current = datetime(2024, 1, 1, 0, 0, 0)
@@ -92,3 +104,35 @@ def test_publish_only_on_state_change(monkeypatch):
 
     alerts.publish_sns_alert({"instrument": "IBM", "state": False, "message": "c"})
     assert len(alerts._RECENT_ALERTS) == 2
+
+
+def test_publish_failure_does_not_throttle(monkeypatch):
+    alerts._RECENT_ALERTS.clear()
+    alerts._LAST_ALERT_STATE.clear()
+    alerts._LAST_ALERT_TIME.clear()
+
+    monkeypatch.setattr(alerts.config, "sns_topic_arn", "arn:example")
+
+    def failing_client(name):
+        assert name == "sns"
+        def publish(**kwargs):
+            raise Exception("boom")
+        return SimpleNamespace(publish=publish)
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=failing_client))
+
+    alerts.publish_sns_alert({"instrument": "IBM", "state": True, "message": "a"})
+    assert alerts._LAST_ALERT_STATE == {}
+    assert alerts._LAST_ALERT_TIME == {}
+
+    sent = {}
+
+    def success_client(name):
+        assert name == "sns"
+        return SimpleNamespace(publish=lambda TopicArn, Message: sent.update({"TopicArn": TopicArn, "Message": Message}))
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=success_client))
+
+    alerts.publish_sns_alert({"instrument": "IBM", "state": True, "message": "b"})
+    assert len(alerts._RECENT_ALERTS) == 2
+    assert sent["Message"] == "b"


### PR DESCRIPTION
## Summary
- defer throttle state/time updates until SNS publish succeeds
- extend alert tests for failed publishes and remove throttle when SNS disabled

## Testing
- `pytest tests/test_alerts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b362b078a48327b8bc074f3bbfccd2