### PR TITLE
fix: show preset controls when no holdings match

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -190,9 +190,9 @@ describe("HoldingsTable", () => {
         expect(screen.queryByText('XYZ')).toBeNull();
     });
 
-    it("persists view preset selection", () => {
-        const mixedHoldings: Holding[] = [
-            ...holdings,
+      it("persists view preset selection", () => {
+          const mixedHoldings: Holding[] = [
+              ...holdings,
             {
                 ticker: 'BND1',
                 name: 'Bond Holding',
@@ -217,6 +217,15 @@ describe("HoldingsTable", () => {
         render(<HoldingsTable holdings={mixedHoldings} />);
         expect(screen.getByPlaceholderText('Type')).toHaveValue('Bond');
         expect(screen.getByText('BND1')).toBeInTheDocument();
-        expect(screen.queryByText('AAA')).toBeNull();
-    });
-});
+          expect(screen.queryByText('AAA')).toBeNull();
+      });
+
+      it("shows controls and fallback when no rows match", () => {
+          localStorage.setItem("holdingsTableViewPreset", "Bond");
+          render(<HoldingsTable holdings={holdings} />);
+          expect(screen.getByText('View:')).toBeInTheDocument();
+          expect(screen.getByText('No holdings match the current filters.')).toBeInTheDocument();
+          fireEvent.click(screen.getByRole('button', { name: 'All' }));
+          expect(screen.getByText('AAA')).toBeInTheDocument();
+      });
+  });

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -121,8 +121,6 @@ export function HoldingsTable({
   // sort
   const { sorted: sortedRows, sortKey, asc, handleSort } = useSortableTable(filtered, "ticker");
 
-  if (!sortedRows.length) return null;
-
   const columnLabels: [keyof typeof visibleColumns, string][] = [
     ["units", "Units"],
     ["cost", "Cost"],
@@ -184,7 +182,8 @@ export function HoldingsTable({
           </label>
         ))}
       </div>
-      <table className={tableStyles.table} style={{ marginBottom: "1rem" }}>
+      {sortedRows.length ? (
+        <table className={tableStyles.table} style={{ marginBottom: "1rem" }}>
         <thead>
           <tr>
             <th className={tableStyles.cell}>
@@ -406,7 +405,10 @@ export function HoldingsTable({
             );
           })}
         </tbody>
-      </table>
+        </table>
+      ) : (
+        <p>No holdings match the current filters.</p>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- keep view preset and quick filter controls visible when no holdings match
- display a fallback message for empty presets
- add regression test for persisted presets with no results

## Testing
- `npm --prefix frontend test -- --run` *(fails: 2 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3657f83e48327b4a643a993eb112e