### PR TITLE
Add cash-exclusion toggle for performance metrics

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -9,41 +9,40 @@ by FastAPI.
 
 import asyncio
 import logging
-import os
 
-from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordRequestForm
 
-from backend.routes.instrument import router as instrument_router
-from backend.routes.portfolio import router as portfolio_router
-from backend.routes.timeseries_meta import router as timeseries_router
-from backend.routes.timeseries_edit import router as timeseries_edit_router
-from backend.routes.timeseries_admin import router as timeseries_admin_router
-
-from backend.routes.transactions import router as transactions_router
-from backend.routes.alerts import router as alerts_router
-from backend.routes.compliance import router as compliance_router
-from backend.routes.screener import router as screener_router
-from backend.routes.support import router as support_router
-from backend.routes.query import router as query_router
-from backend.routes.virtual_portfolio import router as virtual_portfolio_router
-from backend.routes.metrics import router as metrics_router
-from backend.routes.agent import router as agent_router
-from backend.routes.trading_agent import router as trading_agent_router
-from backend.routes.config import router as config_router
-from backend.routes.quotes import router as quotes_router
-from backend.routes.movers import router as movers_router
-from backend.routes.scenario import router as scenario_router
+from backend.auth import authenticate_user, create_access_token, get_current_user
+from backend.common.data_loader import resolve_paths
 from backend.common.portfolio_utils import (
     _load_snapshot,
     refresh_snapshot_async,
     refresh_snapshot_in_memory,
 )
 from backend.config import config
-from backend.common.data_loader import resolve_paths
+from backend.routes.agent import router as agent_router
+from backend.routes.alerts import router as alerts_router
+from backend.routes.compliance import router as compliance_router
+from backend.routes.config import router as config_router
+from backend.routes.instrument import router as instrument_router
+from backend.routes.metrics import router as metrics_router
+from backend.routes.movers import router as movers_router
+from backend.routes.performance import router as performance_router
+from backend.routes.portfolio import router as portfolio_router
+from backend.routes.query import router as query_router
+from backend.routes.quotes import router as quotes_router
+from backend.routes.scenario import router as scenario_router
+from backend.routes.screener import router as screener_router
+from backend.routes.support import router as support_router
+from backend.routes.timeseries_admin import router as timeseries_admin_router
+from backend.routes.timeseries_edit import router as timeseries_edit_router
+from backend.routes.timeseries_meta import router as timeseries_router
+from backend.routes.trading_agent import router as trading_agent_router
+from backend.routes.transactions import router as transactions_router
+from backend.routes.virtual_portfolio import router as virtual_portfolio_router
 from backend.utils import page_cache
-from backend.auth import authenticate_user, create_access_token, get_current_user
 
 
 def create_app() -> FastAPI:
@@ -84,6 +83,7 @@ def create_app() -> FastAPI:
     else:
         protected = [Depends(get_current_user)]
     app.include_router(portfolio_router, dependencies=protected)
+    app.include_router(performance_router, dependencies=protected)
     app.include_router(instrument_router)
     app.include_router(timeseries_router)
     app.include_router(timeseries_edit_router)
@@ -107,7 +107,9 @@ def create_app() -> FastAPI:
     async def login(form_data: OAuth2PasswordRequestForm = Depends()):
         user = authenticate_user(form_data.username, form_data.password)
         if not user:
-            raise HTTPException(status_code=400, detail="Incorrect username or password")
+            raise HTTPException(
+                status_code=400, detail="Incorrect username or password"
+            )
         token = create_access_token(user)
         return {"access_token": token, "token_type": "bearer"}
 
@@ -122,6 +124,7 @@ def create_app() -> FastAPI:
     skip_warm = bool(config.skip_snapshot_warm)
 
     if not skip_warm:
+
         @app.on_event("startup")
         async def _warm_snapshot() -> None:
             """Pre-fetch recent price data so the first request is fast."""
@@ -155,6 +158,4 @@ def create_app() -> FastAPI:
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(
-        create_app(), host="0.0.0.0", port=config.uvicorn_port or 8000
-    )
+    uvicorn.run(create_app(), host="0.0.0.0", port=config.uvicorn_port or 8000)

--- a/backend/common/risk.py
+++ b/backend/common/risk.py
@@ -15,7 +15,9 @@ from backend.common import portfolio_utils
 from backend.config import config
 
 
-def compute_portfolio_var(owner: str, days: int = 365, confidence: float = 0.95) -> Dict:
+def compute_portfolio_var(
+    owner: str, days: int = 365, confidence: float = 0.95, include_cash: bool = True
+) -> Dict:
     """Calculate 1-day and 10-day historical VaR for ``owner``.
 
     Parameters
@@ -31,6 +33,9 @@ def compute_portfolio_var(owner: str, days: int = 365, confidence: float = 0.95)
         fraction between 0 and 1 or a percentage in the range 0–100. For
         example, ``0.95`` and ``95`` are treated equivalently. Values close
         to 95 % and 99 % are commonly used.
+    include_cash:
+        Whether to include cash holdings when reconstructing the portfolio
+        history. Set to ``False`` to exclude cash from the return series.
 
     Returns
     -------
@@ -57,7 +62,9 @@ def compute_portfolio_var(owner: str, days: int = 365, confidence: float = 0.95)
     if not 0 < confidence < 1:
         raise ValueError("confidence must be between 0 and 1 or 0 and 100")
 
-    perf = portfolio_utils.compute_owner_performance(owner, days=days)
+    perf = portfolio_utils.compute_owner_performance(
+        owner, days=days, include_cash=include_cash
+    )
     history = perf.get("history", []) if isinstance(perf, dict) else perf
     if not history:
         return {"window_days": days, "confidence": confidence, "1d": None, "10d": None}
@@ -74,7 +81,11 @@ def compute_portfolio_var(owner: str, days: int = 365, confidence: float = 0.95)
 
     ten_day_returns = returns.add(1).rolling(10).apply(np.prod) - 1
     ten_day_returns = ten_day_returns.dropna()
-    var_10d_pct = -ten_day_returns.quantile(1 - confidence) if not ten_day_returns.empty else np.nan
+    var_10d_pct = (
+        -ten_day_returns.quantile(1 - confidence)
+        if not ten_day_returns.empty
+        else np.nan
+    )
     var_10d = float(var_10d_pct * current_value) if not pd.isna(var_10d_pct) else None
 
     return {

--- a/backend/routes/performance.py
+++ b/backend/routes/performance.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from backend.common import portfolio_utils
+
+router = APIRouter(tags=["performance"])
+
+
+@router.get("/performance/{owner}")
+async def performance(owner: str, days: int = 365, exclude_cash: bool = False):
+    """Return portfolio performance metrics for ``owner``.
+
+    Set ``exclude_cash`` to true to ignore cash holdings when reconstructing the
+    return series.
+    """
+    try:
+        result = portfolio_utils.compute_owner_performance(
+            owner, days=days, include_cash=not exclude_cash
+        )
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Owner not found")
+    return {"owner": owner, **result}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -145,8 +145,17 @@ export const getGroupInstruments = (slug: string) =>
   );
 
 /** Fetch performance metrics for an owner */
-export const getPerformance = (owner: string, days = 365) =>
-  fetchJson<PerformancePoint[]>(`${API_BASE}/performance/${owner}?days=${days}`);
+export const getPerformance = (
+  owner: string,
+  days = 365,
+  excludeCash = false,
+) => {
+  const params = new URLSearchParams({ days: String(days) });
+  if (excludeCash) params.set("exclude_cash", "1");
+  return fetchJson<{ owner: string; history: PerformancePoint[] }>(
+    `${API_BASE}/performance/${owner}?${params.toString()}`,
+  ).then((res) => res.history);
+};
 
 /** Run a simple fundamentals screen across a list of tickers. */
 export const getScreener = (
@@ -372,12 +381,13 @@ export const listSavedQueries = () =>
 /** Fetch rolling Value at Risk series for an owner. */
 export const getValueAtRisk = (
   owner: string,
-  opts: { days?: number; confidence?: number } = {}
+  opts: { days?: number; confidence?: number; excludeCash?: boolean } = {},
 ) => {
   const params = new URLSearchParams();
   if (opts.days != null) params.set("days", String(opts.days));
   if (opts.confidence != null)
     params.set("confidence", String(opts.confidence));
+  if (opts.excludeCash) params.set("exclude_cash", "1");
   const qs = params.toString();
   return fetchJson<ValueAtRiskPoint[]>(
     `${API_BASE}/var/${owner}${qs ? `?${qs}` : ""}`

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -14,6 +14,7 @@ export function PerformanceDashboard({ owner }: Props) {
   const [varData, setVarData] = useState<ValueAtRiskPoint[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [days, setDays] = useState<number>(365);
+  const [excludeCash, setExcludeCash] = useState<boolean>(false);
 
   useEffect(() => {
     if (!owner) return;
@@ -22,15 +23,19 @@ export function PerformanceDashboard({ owner }: Props) {
     setVarData([]);
     const reqDays = days === 0 ? 36500 : days;
     Promise.all([
-      getPerformance(owner, reqDays),
-      getValueAtRisk(owner, { days: reqDays, confidence: 95 }),
+      getPerformance(owner, reqDays, excludeCash),
+      getValueAtRisk(owner, {
+        days: reqDays,
+        confidence: 95,
+        excludeCash,
+      }),
     ])
       .then(([perf, varSeries]) => {
         setData(perf);
         setVarData(varSeries);
       })
       .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
-  }, [owner, days]);
+  }, [owner, days, excludeCash]);
 
   if (!owner) return <p>Select a member.</p>;
   if (err) return <p style={{ color: "red" }}>{err}</p>;
@@ -52,6 +57,15 @@ export function PerformanceDashboard({ owner }: Props) {
             <option value={3650}>10Y</option>
             <option value={0}>MAX</option>
           </select>
+        </label>
+        <label style={{ fontSize: "0.85rem", marginLeft: "1rem" }}>
+          Exclude cash
+          <input
+            type="checkbox"
+            checked={excludeCash}
+            onChange={(e) => setExcludeCash(e.target.checked)}
+            style={{ marginLeft: "0.25rem" }}
+          />
         </label>
       </div>
       <h2>Portfolio Value</h2>

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -11,18 +11,28 @@ def test_compute_sharpe_ratio(monkeypatch):
         {"date": "2024-01-02", "value": 101, "daily_return": 0.02},
         {"date": "2024-01-03", "value": 100, "daily_return": -0.01},
     ]
-    monkeypatch.setattr(risk.portfolio_utils, "compute_owner_performance", lambda owner, days=3: data)
+    monkeypatch.setattr(
+        risk.portfolio_utils,
+        "compute_owner_performance",
+        lambda owner, days=3, include_cash=True: data,
+    )
     monkeypatch.setattr(risk.config, "risk_free_rate", 0.01)
     rf = 0.01
     trading_days = 252
     returns = np.array([0.01, 0.02, -0.01])
     excess = returns - rf / trading_days
-    expected = float(np.round((excess.mean() / excess.std(ddof=1)) * np.sqrt(trading_days), 4))
+    expected = float(
+        np.round((excess.mean() / excess.std(ddof=1)) * np.sqrt(trading_days), 4)
+    )
     assert risk.compute_sharpe_ratio("steve", days=3) == expected
 
 
 def test_compute_sharpe_ratio_insufficient(monkeypatch):
-    monkeypatch.setattr(risk.portfolio_utils, "compute_owner_performance", lambda owner, days=3: [])
+    monkeypatch.setattr(
+        risk.portfolio_utils,
+        "compute_owner_performance",
+        lambda owner, days=3, include_cash=True: [],
+    )
     assert risk.compute_sharpe_ratio("steve", days=3) is None
 
 


### PR DESCRIPTION
## Summary
- allow performance API to exclude cash positions
- add dashboard toggle for cash-adjusted metrics and wire through API wrappers

## Testing
- `ruff check backend/app.py backend/common/portfolio_utils.py backend/common/risk.py backend/routes/portfolio.py backend/routes/performance.py tests/test_risk.py`
- `black --check backend/app.py backend/common/portfolio_utils.py backend/common/risk.py backend/routes/portfolio.py backend/routes/performance.py tests/test_risk.py`
- `pytest tests/test_risk.py` *(fails: Coverage failure: total of 32 is less than fail-under=80)*
- `npm test` *(fails: 1 failed test)*

------
https://chatgpt.com/codex/tasks/task_e_68b360a563d08327b697b58e537f8540