### PR TITLE
Expose sell eligibility date and global trade meter

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -299,6 +299,7 @@ def enrich_holding(
         out["sell_eligible"] = True
         out["eligible_on"] = None
         out["days_until_eligible"] = 0
+        out["next_eligible_sell_date"] = None
         out["cost_basis_source"] = "cash"
 
         return out
@@ -331,6 +332,7 @@ def enrich_holding(
         out["sell_eligible"] = False
         out["eligible_on"] = None
         out["days_until_eligible"] = None
+        out["next_eligible_sell_date"] = None
         out["price"] = None
         out["current_price_gbp"] = None
         out["cost_basis_source"] = "none"
@@ -345,13 +347,16 @@ def enrich_holding(
         days = (today - acq).days
         out["days_held"] = days
         eligible = days >= config.hold_days_min
-        out["eligible_on"] = (acq + dt.timedelta(days=config.hold_days_min)).isoformat()
+        next_date = acq + dt.timedelta(days=config.hold_days_min)
+        out["eligible_on"] = next_date.isoformat()
+        out["next_eligible_sell_date"] = next_date.isoformat()
         out["days_until_eligible"] = max(0, config.hold_days_min - days)
     else:
         out["days_held"] = None
         eligible = False
         out["eligible_on"] = None
         out["days_until_eligible"] = None
+        out["next_eligible_sell_date"] = None
 
     instr_type = (meta.get("instrumentType") or meta.get("instrument_type") or "").upper()
     exempt_tickers = {t.upper() for t in (config.approval_exempt_tickers or [])}

--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -269,6 +269,7 @@ def positions_for_ticker(group_slug: str, ticker: str) -> List[Dict[str, Any]]:
                         "sell_eligible": h.get("sell_eligible"),
                         "days_until_eligible": h.get("days_until_eligible"),
                         "eligible_on": h.get("eligible_on"),
+                        "next_eligible_sell_date": h.get("next_eligible_sell_date"),
                     }
                 )
     return rows

--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -24,6 +24,7 @@ import { LanguageSwitcher } from "./components/LanguageSwitcher";
 import Menu from "./components/Menu";
 import { useRoute } from "./RouteContext";
 import PriceRefreshControls from "./components/PriceRefreshControls";
+import { Header } from "./components/Header";
 
 const ScreenerQuery = lazy(() => import("./pages/ScreenerQuery"));
 const TimeseriesEdit = lazy(() =>
@@ -44,6 +45,7 @@ export default function MainApp() {
   const [groups, setGroups] = useState<GroupSummary[]>([]);
   const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
   const [instruments, setInstruments] = useState<InstrumentSummary[]>([]);
+  const [tradeInfo, setTradeInfo] = useState<{ tradesThisMonth: number; tradesRemaining: number } | null>(null);
 
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -99,7 +101,13 @@ export default function MainApp() {
       setLoading(true);
       setErr(null);
       getPortfolio(selectedOwner)
-        .then(setPortfolio)
+        .then((p) => {
+          setPortfolio(p);
+          setTradeInfo({
+            tradesThisMonth: p.trades_this_month,
+            tradesRemaining: p.trades_remaining,
+          });
+        })
         .catch((e) => setErr(String(e)))
         .finally(() => setLoading(false));
     }
@@ -138,6 +146,11 @@ export default function MainApp() {
       {mode !== "support" && (
         <Menu selectedOwner={selectedOwner} selectedGroup={selectedGroup} />
       )}
+
+      <Header
+        tradesThisMonth={tradeInfo?.tradesThisMonth}
+        tradesRemaining={tradeInfo?.tradesRemaining}
+      />
 
       <PriceRefreshControls
         mode={mode}
@@ -180,6 +193,16 @@ export default function MainApp() {
               setSelectedOwner(owner);
               navigate(`/member/${owner}`);
             }}
+            onTradeInfo={(info) =>
+              setTradeInfo(
+                info
+                  ? {
+                      tradesThisMonth: info.trades_this_month ?? 0,
+                      tradesRemaining: info.trades_remaining ?? 0,
+                    }
+                  : null,
+              )
+            }
           />
         </>
       )}

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -39,12 +39,13 @@ type Props = {
   slug: string;
   /** when clicking an owner you may want to jump to the member tab */
   onSelectMember?: (owner: string) => void;
+  onTradeInfo?: (info: { trades_this_month?: number; trades_remaining?: number } | null) => void;
 };
 
 /* ────────────────────────────────────────────────────────────
  * Component
  * ────────────────────────────────────────────────────────── */
-export function GroupPortfolioView({ slug, onSelectMember }: Props) {
+export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props) {
   const fetchPortfolio = useCallback(() => getGroupPortfolio(slug), [slug]);
   const { data: portfolio, loading, error } = useFetch<GroupPortfolio>(
     fetchPortfolio,
@@ -66,6 +67,19 @@ export function GroupPortfolioView({ slug, onSelectMember }: Props) {
       setSelectedAccounts(portfolio.accounts.map(accountKey));
     }
   }, [portfolio]);
+
+  useEffect(() => {
+    if (onTradeInfo) {
+      onTradeInfo(
+        portfolio
+          ? {
+              trades_this_month: portfolio.trades_this_month,
+              trades_remaining: portfolio.trades_remaining,
+            }
+          : null,
+      );
+    }
+  }, [portfolio, onTradeInfo]);
 
   /* ── early‑return states ───────────────────────────────── */
   if (!slug) return <p>{t("group.select")}</p>;

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Header } from "./Header";
+
+describe("Header", () => {
+  it("shows trade meter when data present", () => {
+    render(<Header tradesThisMonth={3} tradesRemaining={17} />);
+    expect(
+      screen.getByText(/Trades this month: 3 \/ 20 \(Remaining: 17\)/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing without data", () => {
+    const { container } = render(<Header />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+interface Props {
+  tradesThisMonth?: number | null;
+  tradesRemaining?: number | null;
+}
+
+export function Header({ tradesThisMonth, tradesRemaining }: Props) {
+  if (tradesThisMonth == null || tradesRemaining == null) return null;
+  return (
+    <div style={{ marginBottom: "1rem" }}>
+      Trades this month: {tradesThisMonth} / 20 (Remaining: {tradesRemaining})
+    </div>
+  );
+}

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -57,6 +57,7 @@ describe("HoldingsTable", () => {
             days_held: 0,
             sell_eligible: false,
             days_until_eligible: 10,
+            next_eligible_sell_date: "2024-07-20",
         },
         {
             ticker: "GBXH",
@@ -124,6 +125,8 @@ describe("HoldingsTable", () => {
         const row = screen.getByText("Test Holding").closest("tr");
         const cell = within(row!).getByText("✗ 10");
         expect(cell).toBeInTheDocument();
+        const expected = new Intl.DateTimeFormat('en').format(new Date('2024-07-20'));
+        expect(cell).toHaveAttribute('title', expected);
     });
 
     it("creates FX pair buttons for currency and skips GBX", () => {

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -340,6 +340,13 @@ export function HoldingsTable({
                 <td
                   className={`${tableStyles.cell} ${tableStyles.center}`}
                   style={{ color: h.sell_eligible ? "lightgreen" : "gold" }}
+                  title={
+                    h.next_eligible_sell_date
+                      ? new Intl.DateTimeFormat(i18n.language).format(
+                          new Date(h.next_eligible_sell_date)
+                        )
+                      : undefined
+                  }
                 >
                   {h.sell_eligible ? "✓ Eligible" : `✗ ${h.days_until_eligible ?? ""}`}
                 </td>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -51,8 +51,7 @@ export function PortfolioView({ data, loading, error }: Props) {
         Portfolio: <span data-testid="owner-name">{data.owner}</span>
       </h1>
       <div style={{ marginBottom: "1rem" }}>
-        As of {new Intl.DateTimeFormat(i18n.language).format(new Date(data.as_of))} •
-        Trades this month: {data.trades_this_month} / 20 (Remaining: {data.trades_remaining})
+        As of {new Intl.DateTimeFormat(i18n.language).format(new Date(data.as_of))}
       </div>
       <div style={{ marginBottom: "2rem" }}>
         Approx Total: {money(totalValue)}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,6 +22,7 @@ export interface Holding {
     days_held?: number;
     sell_eligible?: boolean;
     days_until_eligible?: number | null;
+    next_eligible_sell_date?: string | null;
 }
 
 export type Account = {

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -124,7 +124,7 @@ def test_screen_filters_based_on_thresholds(monkeypatch):
             roa=0.05,
             roe=0.04,
             roi=0.03,
-            lt_de_ratio=2.
+            lt_de_ratio=2.0,
             interest_coverage=1.0,
             current_ratio=0.5,
             quick_ratio=0.4,

--- a/tests/test_trade_approvals.py
+++ b/tests/test_trade_approvals.py
@@ -18,6 +18,8 @@ def test_enrich_holding_requires_approval(monkeypatch):
     monkeypatch.setattr("backend.common.holding_utils._get_price_for_date_scaled", lambda *a, **k: 1.0)
     out = enrich_holding(holding, today, {}, {})
     assert out["sell_eligible"] is False
+    expect_date = (date.fromisoformat(acq) + timedelta(days=config.hold_days_min)).isoformat()
+    assert out["next_eligible_sell_date"] == expect_date
 
     approvals = {"ADM.L": today}
     out = enrich_holding(holding, today, {}, approvals)


### PR DESCRIPTION
## Summary
- add `next_eligible_sell_date` to holding enrichment and instrument API
- show sell eligibility date in holdings table and types
- move monthly trade meter to a new header component shared across routes

## Testing
- `pytest -q` *(fails: KeyError 'Close_gbp' and other missing dependencies)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3609360b88327afc200e091b29f5f