### PR TITLE
Add sector and region return contributions with charts

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -264,6 +264,8 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio) -> List[dict]:
                     "ticker": full_tkr,
                     "name": meta.get("name") or h.get("name", full_tkr),
                     "currency": meta.get("currency") or h.get("currency"),
+                    "sector": meta.get("sector") or h.get("sector"),
+                    "region": meta.get("region") or h.get("region"),
                     "units": 0.0,
                     "market_value_gbp": 0.0,
                     "gain_gbp": 0.0,
@@ -280,10 +282,19 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio) -> List[dict]:
             # accumulate units & cost (allow for differing field names)
             row["units"] += _safe_num(h.get("units"))
 
-            if row.get("currency") is None:
+            if (
+                row.get("currency") is None
+                or row.get("sector") is None
+                or row.get("region") is None
+            ):
                 meta = get_security_meta(full_tkr)
-                if meta and meta.get("currency"):
-                    row["currency"] = meta["currency"]
+                if meta:
+                    if row.get("currency") is None and meta.get("currency"):
+                        row["currency"] = meta["currency"]
+                    if row.get("sector") is None and meta.get("sector"):
+                        row["sector"] = meta["sector"]
+                    if row.get("region") is None and meta.get("region"):
+                        row["region"] = meta["region"]
 
             # attach snapshot if present
             cost = _safe_num(h.get("cost_gbp") or h.get("cost_basis_gbp") or h.get("effective_cost_basis_gbp"))
@@ -308,7 +319,7 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio) -> List[dict]:
                 )
 
             # pass-through misc attributes (first non-null wins)
-            for k in ("asset_class", "region", "owner"):
+            for k in ("asset_class", "region", "owner", "sector"):
                 if k not in row and h.get(k) is not None:
                     row[k] = h[k]
 
@@ -317,6 +328,45 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio) -> List[dict]:
         r["gain_pct"] = (r["gain_gbp"] / cost * 100.0) if cost else None
 
     return list(rows.values())
+
+
+def _aggregate_by_field(portfolio: dict | VirtualPortfolio, field: str) -> List[dict]:
+    """Helper to aggregate ticker rows by ``field`` (e.g. sector/region)."""
+    rows = aggregate_by_ticker(portfolio)
+    groups: Dict[str, dict] = {}
+    for r in rows:
+        key = r.get(field) or "Unknown"
+        g = groups.setdefault(
+            key,
+            {
+                field: key,
+                "market_value_gbp": 0.0,
+                "gain_gbp": 0.0,
+                "cost_gbp": 0.0,
+            },
+        )
+        g["market_value_gbp"] += _safe_num(r.get("market_value_gbp"))
+        g["gain_gbp"] += _safe_num(r.get("gain_gbp"))
+        g["cost_gbp"] += _safe_num(r.get("cost_gbp"))
+
+    total_cost = sum(g["cost_gbp"] for g in groups.values())
+    for g in groups.values():
+        cost = g["cost_gbp"]
+        g["gain_pct"] = (g["gain_gbp"] / cost * 100.0) if cost else None
+        g["contribution_pct"] = (
+            (g["gain_gbp"] / total_cost * 100.0) if total_cost else None
+        )
+    return list(groups.values())
+
+
+def aggregate_by_sector(portfolio: dict | VirtualPortfolio) -> List[dict]:
+    """Return aggregated holdings grouped by sector with return contribution."""
+    return _aggregate_by_field(portfolio, "sector")
+
+
+def aggregate_by_region(portfolio: dict | VirtualPortfolio) -> List[dict]:
+    """Return aggregated holdings grouped by region with return contribution."""
+    return _aggregate_by_field(portfolio, "region")
 
 
 # ──────────────────────────────────────────────────────────────

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -162,6 +162,22 @@ async def group_instruments(slug: str):
     return portfolio_utils.aggregate_by_ticker(gp)
 
 
+@router.get("/portfolio-group/{slug}/sectors")
+async def group_sectors(slug: str):
+    """Return return contribution aggregated by sector."""
+
+    gp = group_portfolio.build_group_portfolio(slug)
+    return portfolio_utils.aggregate_by_sector(gp)
+
+
+@router.get("/portfolio-group/{slug}/regions")
+async def group_regions(slug: str):
+    """Return return contribution aggregated by region."""
+
+    gp = group_portfolio.build_group_portfolio(slug)
+    return portfolio_utils.aggregate_by_region(gp)
+
+
 @router.get("/portfolio-group/{slug}/movers")
 async def group_movers(
     slug: str,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -22,6 +22,8 @@ import type {
   TimeseriesSummary,
   ScenarioResult,
   TradeSuggestion,
+  SectorContribution,
+  RegionContribution,
 } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -142,6 +144,18 @@ export const runScenario = (ticker: string, pct: number) => {
 export const getGroupInstruments = (slug: string) =>
   fetchJson<InstrumentSummary[]>(
     `${API_BASE}/portfolio-group/${slug}/instruments`
+  );
+
+/** Retrieve return contribution aggregated by sector for a group portfolio. */
+export const getGroupSectorContributions = (slug: string) =>
+  fetchJson<SectorContribution[]>(
+    `${API_BASE}/portfolio-group/${slug}/sectors`
+  );
+
+/** Retrieve return contribution aggregated by region for a group portfolio. */
+export const getGroupRegionContributions = (slug: string) =>
+  fetchJson<RegionContribution[]>(
+    `${API_BASE}/portfolio-group/${slug}/regions`
   );
 
 /** Fetch performance metrics for an owner */

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -1,7 +1,16 @@
 // src/components/GroupPortfolioView.tsx
 import { useState, useEffect, useCallback } from "react";
-import type { GroupPortfolio, Account } from "../types";
-import { getGroupPortfolio } from "../api";
+import type {
+  GroupPortfolio,
+  Account,
+  SectorContribution,
+  RegionContribution,
+} from "../types";
+import {
+  getGroupPortfolio,
+  getGroupSectorContributions,
+  getGroupRegionContributions,
+} from "../api";
 import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { money, percent } from "../lib/money";
@@ -17,6 +26,10 @@ import {
   ResponsiveContainer,
   Tooltip,
   Legend,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
 } from "recharts";
 
 const PIE_COLORS = [
@@ -51,10 +64,23 @@ export function GroupPortfolioView({ slug, onSelectMember }: Props) {
     [slug],
     !!slug
   );
+  const fetchSector = useCallback(() => getGroupSectorContributions(slug), [slug]);
+  const fetchRegion = useCallback(() => getGroupRegionContributions(slug), [slug]);
+  const { data: sectorContrib } = useFetch<SectorContribution[]>(
+    fetchSector,
+    [slug],
+    !!slug
+  );
+  const { data: regionContrib } = useFetch<RegionContribution[]>(
+    fetchRegion,
+    [slug],
+    !!slug
+  );
   const [selected, setSelected] = useState<SelectedInstrument | null>(null);
   const { t } = useTranslation();
   const { relativeViewEnabled } = useConfig();
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
+  const [contribTab, setContribTab] = useState<"sector" | "region">("sector");
 
   // helper to derive a stable key for each account
   const accountKey = (acct: Account, idx: number) =>
@@ -164,6 +190,49 @@ export function GroupPortfolioView({ slug, onSelectMember }: Props) {
               <Tooltip formatter={(v: number, n: string) => [money(v), n]} />
               <Legend />
             </PieChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {(sectorContrib?.length || regionContrib?.length) && (
+        <div style={{ width: "100%", height: 300, margin: "1rem 0" }}>
+          <div style={{ marginBottom: "0.5rem" }}>
+            <button
+              onClick={() => setContribTab("sector")}
+              disabled={contribTab === "sector"}
+              style={{ marginRight: "0.5rem" }}
+            >
+              Sector
+            </button>
+            <button
+              onClick={() => setContribTab("region")}
+              disabled={contribTab === "region"}
+            >
+              Region
+            </button>
+          </div>
+          <ResponsiveContainer>
+            <BarChart
+              data={
+                contribTab === "sector"
+                  ? sectorContrib || []
+                  : regionContrib || []
+              }
+            >
+              <XAxis dataKey={contribTab === "sector" ? "sector" : "region"} />
+              <YAxis />
+              <Tooltip formatter={(v: number) => money(v)} />
+              <Bar dataKey="gain_gbp">
+                {(contribTab === "sector" ? sectorContrib : regionContrib)?.map(
+                  (row, idx) => (
+                    <Cell
+                      key={`cell-bar-${idx}`}
+                      fill={row.gain_gbp >= 0 ? "lightgreen" : "red"}
+                    />
+                  )
+                )}
+              </Bar>
+            </BarChart>
           </ResponsiveContainer>
         </div>
       )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -83,6 +83,24 @@ export type InstrumentSummary = {
     change_30d_pct?: number | null;
 };
 
+export type SectorContribution = {
+    sector: string;
+    market_value_gbp: number;
+    gain_gbp: number;
+    cost_gbp: number;
+    gain_pct?: number | null;
+    contribution_pct?: number | null;
+};
+
+export type RegionContribution = {
+    region: string;
+    market_value_gbp: number;
+    gain_gbp: number;
+    cost_gbp: number;
+    gain_pct?: number | null;
+    contribution_pct?: number | null;
+};
+
 export interface PerformancePoint {
     date: string;
     value: number;

--- a/tests/test_portfolio_utils_contribution.py
+++ b/tests/test_portfolio_utils_contribution.py
@@ -1,0 +1,47 @@
+import backend.common.portfolio_utils as portfolio_utils
+import pytest
+
+
+def test_aggregate_by_sector_and_region():
+    portfolio = {
+        "accounts": [
+            {
+                "holdings": [
+                    {
+                        "ticker": "AAA",
+                        "units": 1,
+                        "sector": "Tech",
+                        "region": "US",
+                        "market_value_gbp": 150,
+                        "cost_gbp": 100,
+                        "gain_gbp": 50,
+                    },
+                    {
+                        "ticker": "BBB",
+                        "units": 1,
+                        "sector": "Health",
+                        "region": "UK",
+                        "market_value_gbp": 180,
+                        "cost_gbp": 200,
+                        "gain_gbp": -20,
+                    },
+                ]
+            }
+        ]
+    }
+
+    sector_rows = portfolio_utils.aggregate_by_sector(portfolio)
+    region_rows = portfolio_utils.aggregate_by_region(portfolio)
+
+    sectors = {row["sector"]: row for row in sector_rows}
+    regions = {row["region"]: row for row in region_rows}
+
+    assert sectors["Tech"]["gain_gbp"] == 50
+    assert sectors["Health"]["gain_gbp"] == -20
+    assert regions["US"]["gain_gbp"] == 50
+    assert regions["UK"]["gain_gbp"] == -20
+
+    assert sectors["Tech"]["contribution_pct"] == pytest.approx(16.666, rel=1e-3)
+    assert sectors["Health"]["contribution_pct"] == pytest.approx(-6.666, rel=1e-3)
+    assert regions["US"]["contribution_pct"] == pytest.approx(16.666, rel=1e-3)
+    assert regions["UK"]["contribution_pct"] == pytest.approx(-6.666, rel=1e-3)


### PR DESCRIPTION
## Summary
- aggregate portfolio holdings by sector and region with return contribution metrics
- expose sector and region contribution endpoints and API wrappers
- show sector and region contribution bar charts in group portfolio view

## Testing
- `pytest` *(fails: tests/test_screener.py syntax error)*
- `npm test` *(fails: Cannot find package '@vitejs/plugin-react')*


------
https://chatgpt.com/codex/tasks/task_e_68b3609231ec8327a64947fd2c005678