### PR TITLE
Protect timeseries admin endpoints with auth

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -87,7 +87,7 @@ def create_app() -> FastAPI:
     app.include_router(instrument_router)
     app.include_router(timeseries_router)
     app.include_router(timeseries_edit_router)
-    app.include_router(timeseries_admin_router)
+    app.include_router(timeseries_admin_router, dependencies=protected)
     app.include_router(transactions_router, dependencies=protected)
     app.include_router(alerts_router)
     app.include_router(compliance_router)

--- a/backend/routes/timeseries_admin.py
+++ b/backend/routes/timeseries_admin.py
@@ -2,7 +2,9 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from backend.auth import get_current_user
 
 from backend.common.instruments import get_instrument_meta
 from backend.timeseries.cache import (
@@ -11,7 +13,9 @@ from backend.timeseries.cache import (
     meta_timeseries_cache_path,
 )
 
-router = APIRouter(prefix="/timeseries", tags=["timeseries"])
+router = APIRouter(
+    prefix="/timeseries", tags=["timeseries"], dependencies=[Depends(get_current_user)]
+)
 
 
 @router.get("/admin")

--- a/tests/test_timeseries_admin_auth.py
+++ b/tests/test_timeseries_admin_auth.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+import pandas as pd
+
+from backend.app import create_app
+from backend.config import config
+from backend.routes import timeseries_admin
+
+
+def test_timeseries_admin_requires_auth(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
+    monkeypatch.setattr(config, "disable_auth", False)
+    app = create_app()
+    client = TestClient(app)
+
+    # Unauthenticated request should be rejected
+    resp = client.post("/timeseries/admin/ABC/L/refetch")
+    assert resp.status_code == 401
+
+    # Mock timeseries fetch to avoid external IO
+    monkeypatch.setattr(
+        timeseries_admin, "load_meta_timeseries", lambda *args, **kwargs: pd.DataFrame()
+    )
+
+    # Acquire auth token and retry
+    token = client.post(
+        "/token", data={"username": "testuser", "password": "password"}
+    ).json()["access_token"]
+    client.headers.update({"Authorization": f"Bearer {token}"})
+    resp = client.post("/timeseries/admin/ABC/L/refetch")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- require authentication for timeseries refetch and rebuild cache endpoints
- add tests to verify timeseries admin routes enforce auth

## Testing
- `pytest tests/test_app.py tests/test_timeseries_admin_auth.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b368897ed08327be2280c8003ed755