### PR TITLE
Fix JSX closing in DataAdmin mapping block

### DIFF
--- a/frontend/src/pages/DataAdmin.tsx
+++ b/frontend/src/pages/DataAdmin.tsx
@@ -98,7 +98,8 @@ export default function DataAdmin() {
                 </button>
               </td>
             </tr>
-          ))}
+            );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- fix JSX closing for mapped rows in DataAdmin page

## Testing
- `npm test -- --run` *(fails: 3 failed, 21 passed)*
- `npx prettier frontend/src/pages/DataAdmin.tsx --check` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36c0dac1c8327811b2c007b71d28a