### PR TITLE
Raise Stooq rate limit error while disabled

### DIFF
--- a/backend/timeseries/fetch_stooq_timeseries.py
+++ b/backend/timeseries/fetch_stooq_timeseries.py
@@ -50,9 +50,8 @@ def fetch_stooq_timeseries_range(
     Fetch historical Stooq data using date range.
     """
     global STOOQ_DISABLED_UNTIL
-    if date.today() < STOOQ_DISABLED_UNTIL:
-        logger.debug("Stooq disabled until %s", STOOQ_DISABLED_UNTIL)
-        return pd.DataFrame(columns=STANDARD_COLUMNS)
+    if date.today() <= STOOQ_DISABLED_UNTIL:
+        raise StooqRateLimitError("Exceeded the daily hits limit")
     if not is_valid_ticker(ticker, exchange):
         logger.info("Skipping Stooq fetch for unrecognized ticker %s.%s", ticker, exchange)
         record_skipped_ticker(ticker, exchange, reason="unknown")


### PR DESCRIPTION
## Summary
- Raise `StooqRateLimitError` when Stooq is disabled due to rate limiting
- Extend rate-limit test to cover repeated calls on subsequent days

## Testing
- `pytest tests/test_stooq_rate_limit.py -q --cov=backend/timeseries/fetch_stooq_timeseries.py --cov-report=term --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68b372f8f57483279116fd9a014d5715