### PR TITLE
Allow Alpha Vantage fetch with explicit API key

### DIFF
--- a/backend/timeseries/fetch_alphavantage_timeseries.py
+++ b/backend/timeseries/fetch_alphavantage_timeseries.py
@@ -44,7 +44,7 @@ def fetch_alphavantage_timeseries_range(
     api_key: str | None = None,
 ) -> pd.DataFrame:
     """Fetch historical Alpha Vantage data using a date range."""
-    if not config.alpha_vantage_enabled:
+    if api_key is None and not config.alpha_vantage_enabled:
         logger.info("Alpha Vantage fetching disabled via config")
         return pd.DataFrame(columns=STANDARD_COLUMNS)
     if not is_valid_ticker(ticker, exchange):

--- a/tests/test_alphavantage_errors.py
+++ b/tests/test_alphavantage_errors.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import pytest
 
+import backend.config as cfg
 import backend.timeseries.fetch_alphavantage_timeseries as av
 from backend.timeseries.fetch_alphavantage_timeseries import (
     fetch_alphavantage_timeseries_range,
@@ -32,3 +33,21 @@ def test_information_field_propagated(monkeypatch):
         fetch_alphavantage_timeseries_range("PBR", "US", date(2024, 1, 1), date(2024, 1, 10), api_key="demo")
 
     assert str(exc.value) == "test info"
+
+
+def test_information_field_propagated_when_disabled(monkeypatch):
+    def fake_get(url, params=None, timeout=None):
+        return FakeResponse({"Information": "disabled"})
+
+    monkeypatch.setattr(av, "is_valid_ticker", lambda *a, **k: True)
+    monkeypatch.setattr(cfg.config, "alpha_vantage_enabled", False)
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    with pytest.raises(ValueError) as exc:
+        fetch_alphavantage_timeseries_range(
+            "IBM", "US", date(2024, 1, 1), date(2024, 1, 10), api_key="demo"
+        )
+
+    assert str(exc.value) == "disabled"


### PR DESCRIPTION
## Summary
- Bypass Alpha Vantage config disable when a manual API key is supplied
- Add regression test for Information error with explicit key when service is disabled

## Testing
- `pytest tests/test_alphavantage_errors.py tests/test_alphavantage_disabled.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68b372eea380832793105cb115ffe408