### PR TITLE
Retain exchange suffix in price alerts

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -564,7 +564,7 @@ def check_price_alerts(threshold_pct: float = 0.1) -> List[Dict]:
                 continue
             change_pct = (mv - cost) / cost
             if abs(change_pct) >= threshold_pct:
-                ticker = row["ticker"].split(".")[0]
+                ticker = row["ticker"]
                 alert = {
                     "ticker": ticker,
                     "change_pct": round(change_pct, 4),

--- a/tests/test_price_alerts_suffix.py
+++ b/tests/test_price_alerts_suffix.py
@@ -1,0 +1,12 @@
+import backend.common.portfolio_utils as pu
+
+
+def test_check_price_alerts_retains_exchange_suffix(monkeypatch):
+    snapshot = {"AAA.L": {"last_price": 110.0}}
+    portfolio = {"accounts": [{"holdings": [{"ticker": "AAA", "units": 1, "cost_gbp": 100}]}]}
+    monkeypatch.setattr(pu, "_PRICE_SNAPSHOT", snapshot)
+    monkeypatch.setattr(pu, "list_portfolios", lambda: [portfolio])
+    monkeypatch.setattr("backend.common.alerts.publish_alert", lambda alert: None)
+
+    alerts = pu.check_price_alerts(threshold_pct=0.05)
+    assert alerts and alerts[0]["ticker"] == "AAA.L"


### PR DESCRIPTION
## Summary
- keep full ticker symbol including exchange suffix in `check_price_alerts`
- add regression test ensuring price alerts keep their exchange suffix

## Testing
- `pytest tests/test_price_alerts_suffix.py::test_check_price_alerts_retains_exchange_suffix tests/test_trading_agent.py::test_generate_signals_buy_sell_actions tests/test_trading_agent.py::test_generate_signals_emits_alerts -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68b372f2cd5883279133fe23c263f768