### PR TITLE
Ensure account_type is always present for accounts

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -195,12 +195,16 @@ def load_account(
         txt = body.read().decode("utf-8-sig").strip() if body else ""
         if not txt:
             raise ValueError(f"Empty JSON file: s3://{bucket}/{key}")
-        return json.loads(txt)
+        data = json.loads(txt)
+        data.setdefault("account_type", account)
+        return data
 
     paths = resolve_paths(config.repo_root, config.accounts_root)
     root = data_root or paths.accounts_root
     path = root / owner / f"{account}.json"
-    return _safe_json_load(path)
+    data = _safe_json_load(path)
+    data.setdefault("account_type", account)
+    return data
 
 
 def load_person_meta(owner: str, data_root: Optional[Path] = None) -> Dict[str, Any]:

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -47,3 +47,28 @@ def test_account_route_returns_data(client, owner, accounts):
         assert data["owner"].lower() == owner.lower()
         assert data["account_type"].lower() == acct.lower()
         assert isinstance(data.get("holdings"), list)
+
+
+def test_account_route_adds_missing_account_type(tmp_path):
+    config.skip_snapshot_warm = True
+    config.offline_mode = True
+    prices.refresh_prices = lambda: {}
+    portfolio_utils.list_all_unique_tickers = lambda *a, **k: []
+
+    owner = "temp"
+    acct = "missing"
+    acct_dir = tmp_path / owner
+    acct_dir.mkdir()
+    (acct_dir / f"{acct}.json").write_text(
+        json.dumps({"owner": owner, "currency": "GBP", "holdings": []})
+    )
+
+    old_root = config.accounts_root
+    config.accounts_root = tmp_path
+    app = create_app()
+    with TestClient(app) as c:
+        resp = c.get(f"/account/{owner}/{acct}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account_type"] == acct
+    config.accounts_root = old_root


### PR DESCRIPTION
## Summary
- Ensure `load_account` always returns an `account_type` field
- Add a regression test checking API behavior when the account JSON omits `account_type`

## Testing
- `pytest tests/test_accounts_api.py::test_account_route_adds_missing_account_type -q` *(fails: coverage threshold not met)*
- `pytest -q` *(fails: multiple test failures and coverage below threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68b372ea22388327a31a2936616b086c