### PR TITLE
Restore excludeSmall filter in TopMoversPage

### DIFF
--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -91,23 +91,26 @@ describe("TopMoversPage", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() =>
-      expect(mockGetGroupInstruments).toHaveBeenCalledWith("all"),
-    );
-    await waitFor(() =>
-      expect(mockGetGroupMovers).toHaveBeenCalledWith("all", 1),
-      expect(mockGetGroupMovers).toHaveBeenCalledWith("all", 1, 10, 0),
-    );
+      await waitFor(() =>
+        expect(mockGetGroupInstruments).toHaveBeenCalledWith("all"),
+      );
+      await waitFor(() =>
+        expect(mockGetGroupMovers).toHaveBeenCalledWith("all", 1, 10, 0),
+      );
     expect((await screen.findAllByText("AAA")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("BBB")).length).toBeGreaterThan(0);
 
     const selects = screen.getAllByRole("combobox");
     const periodSelect = selects[1];
     fireEvent.change(periodSelect, { target: { value: "1w" } });
-    await waitFor(() =>
-      expect(mockGetGroupMovers).toHaveBeenLastCalledWith("all", 7),
-      expect(mockGetGroupMovers).toHaveBeenLastCalledWith("all", 7, 10, 0),
-    );
+      await waitFor(() =>
+        expect(mockGetGroupMovers).toHaveBeenLastCalledWith(
+          "all",
+          7,
+          10,
+          0,
+        ),
+      );
   });
 
   it("fetches watchlist instruments when selecting FTSE 100", async () => {

--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -47,7 +47,12 @@ export function TopMoversPage() {
         );
         setPortfolioTotal(total);
         setNeedsLogin(false);
-        return getGroupMovers("all", PERIODS[period]);
+        return getGroupMovers(
+          "all",
+          PERIODS[period],
+          10,
+          excludeSmall ? MIN_WEIGHT : 0,
+        );
       } catch (e) {
         if (e instanceof Error && /^HTTP 401/.test(e.message)) {
           setNeedsLogin(true);
@@ -60,8 +65,8 @@ export function TopMoversPage() {
     }
     setPortfolioTotal(null);
     return getTopMovers(WATCHLISTS[watchlist], PERIODS[period]);
-  }, [watchlist, period]);
-  const { data, loading, error } = useFetch(fetchMovers, [watchlist, period]);
+  }, [watchlist, period, excludeSmall]);
+  const { data, loading, error } = useFetch(fetchMovers, [watchlist, period, excludeSmall]);
   type ExtendedMoverRow = MoverRow & {
     delta_gbp?: number | null;
     pct_portfolio?: number | null;


### PR DESCRIPTION
## Summary
- include excludeSmall toggle in TopMoversPage fetch dependencies
- forward min_weight to getGroupMovers API call and update tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b376172fd083279e120fe8bbb1b198