### PR TITLE
Guard tracking error from NaN responses

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List
@@ -497,9 +498,12 @@ def _tracking_error(name: str, benchmark: str, days: int = 365, *, group: bool =
     if port_ret.empty:
         return None
     diff = port_ret - bench_ret
-    if diff.empty:
+    if diff.count() < 2:
         return None
-    return float(diff.std())
+    std = diff.std()
+    if not math.isfinite(std):
+        return None
+    return float(std)
 
 
 def _max_drawdown(name: str, days: int = 365, *, group: bool = False) -> float | None:


### PR DESCRIPTION
## Summary
- return `None` when tracking error has insufficient samples or is non-finite
- import `math` for finite value checks

## Testing
- `ruff check backend/app.py backend/common/portfolio_utils.py backend/routes/performance.py`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37868123c83278cd322037b627f7c