### PR TITLE
Allow overriding coverage threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,11 @@ cd frontend && npm test
 ```
 
 The `PY_COV_MIN` environment variable lets you enforce a minimum coverage
-percentage during `pytest` runs. It defaults to `0`, so set it when you want a
-threshold:
+percentage during `pytest` runs. Use it together with `PYTEST_ADDOPTS` to pass
+the desired threshold to `pytest`:
 
 ```bash
-PY_COV_MIN=80 pytest
+PY_COV_MIN=80 PYTEST_ADDOPTS="--cov-fail-under=$PY_COV_MIN" pytest
 ```
 
 ## Error summary helper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=${PY_COV_MIN:-0}"
+addopts = "--cov"
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- drop unsupported `${PY_COV_MIN}` expansion from pytest configuration
- document using `PYTEST_ADDOPTS` with `PY_COV_MIN` to set coverage threshold

## Testing
- `pytest -q` *(fails: 20 failed, 167 passed, 4 skipped, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b37853cbcc8327b06c0c41216da69e