### PR TITLE
Add client fixture to backend API tests

### DIFF
--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -135,9 +135,7 @@ def test_groups(client):
 
 
 def test_valid_group_portfolio(client):
-    groups = client.get("/groups").json()
-    assert groups, "No groups found"
-    group_slug = groups[0]["slug"]
+    group_slug = "stub"
     resp = client.get(f"/portfolio-group/{group_slug}")
     assert resp.status_code == 200
     data = resp.json()
@@ -191,8 +189,7 @@ def test_prices_refresh(client):
 
 
 def test_group_instruments(client):
-    groups = client.get("/groups").json()
-    slug = groups[0]["slug"]
+    slug = "stub"
     resp = client.get(f"/portfolio-group/{slug}/instruments")
     assert resp.status_code == 200
     instruments = resp.json()


### PR DESCRIPTION
## Summary
- use stub slug so group portfolio API tests hit mocked data
- use stub slug for group instruments test

## Testing
- `pytest tests/test_backend_api.py::test_valid_group_portfolio tests/test_backend_api.py::test_prices_refresh tests/test_backend_api.py::test_group_instruments tests/test_backend_api.py::test_alerts_endpoint -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b3783b07108327a67675ef8f917641