### PR TITLE
fix: keep holdings table columns aligned

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -131,11 +131,21 @@ export function HoldingsTable({
   ];
 
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const tableHeaderRef = useRef<HTMLTableSectionElement>(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  useEffect(() => {
+    if (tableHeaderRef.current) {
+      setHeaderHeight(tableHeaderRef.current.getBoundingClientRect().height);
+    }
+  }, []);
+
   const rowVirtualizer = useVirtualizer({
     count: sortedRows.length,
     getScrollElement: () => tableContainerRef.current,
     estimateSize: () => 40,
     overscan: 5,
+    scrollMargin: headerHeight,
   });
   const virtualRows = rowVirtualizer.getVirtualItems();
   const paddingTop = virtualRows.length ? virtualRows[0].start : 0;
@@ -205,7 +215,7 @@ export function HoldingsTable({
           style={{ maxHeight: "400px", overflowY: "auto", marginBottom: "1rem" }}
         >
         <table className={tableStyles.table}>
-        <thead>
+        <thead ref={tableHeaderRef}>
           <tr>
             <th className={tableStyles.cell}>
               <input


### PR DESCRIPTION
## Summary
- ignore sticky header height when virtualizing rows

## Testing
- `npm test` *(fails: An update to AlertsPanel inside a test was not wrapped in act(...).)*

------
https://chatgpt.com/codex/tasks/task_e_68b377d49c048327908646fb6f9acbbf