### PR TITLE
Add InstrumentDetailMini interface and use typed mini data

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,7 @@
 import type {
   GroupPortfolio,
   GroupSummary,
+  InstrumentDetailMini,
   InstrumentSummary,
   OwnerSummary,
   Portfolio,
@@ -271,7 +272,7 @@ export const getInstrumentDetail = (ticker: string, days = 365) =>
   fetchJson<{
     prices: unknown;
     positions: unknown;
-    mini?: unknown;
+    mini?: InstrumentDetailMini;
     currency?: string | null;
   }>(
     `${API_BASE}/instrument/?ticker=${encodeURIComponent(

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import type { Holding } from "../types";
+import type { Holding, InstrumentDetailMini } from "../types";
 import { money, percent } from "../lib/money";
 import { translateInstrumentType } from "../lib/instrumentType";
 import { useSortableTable } from "../hooks/useSortableTable";
@@ -56,7 +56,7 @@ export function HoldingsTable({
   });
 
   const [sparkRange, setSparkRange] = useState<7 | 30 | 180>(30);
-  const [sparks, setSparks] = useState<Record<string, Record<string, any[]>>>({});
+  const [sparks, setSparks] = useState<Record<string, InstrumentDetailMini>>({});
 
   const toggleColumn = (key: keyof typeof visibleColumns) => {
     setVisibleColumns((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -72,7 +72,7 @@ export function HoldingsTable({
       if (sparks[t]) return;
       getInstrumentDetail(t, 180)
         .then((d) => {
-          const m = (d as any).mini;
+          const m = d?.mini;
           if (m) {
             setSparks((prev) => ({ ...prev, [t]: m }));
           }
@@ -80,6 +80,7 @@ export function HoldingsTable({
         .catch(() => {});
     });
   }, [holdings, sparks]);
+  useEffect(() => {
     if (typeof window !== "undefined") {
       localStorage.setItem(VIEW_PRESET_STORAGE_KEY, viewPreset);
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -116,6 +116,14 @@ export interface ValueAtRiskPoint {
     var: number;
 }
 
+export interface InstrumentDetailMini {
+    [range: string]: {
+        date: string;
+        close: number;
+        close_gbp: number;
+    }[];
+}
+
 export interface Transaction {
     owner: string;
     account: string;


### PR DESCRIPTION
## Summary
- define `InstrumentDetailMini` interface describing the structure of mini price data
- type `getInstrumentDetail` to expose `mini` using the new interface
- use typed `mini` in `HoldingsTable` with null checks when loading spark data

## Testing
- `npm test -- --run` *(fails: Transform failed with Unexpected "}" and other reference errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b37d11b2588327861bd53a91fef376