### PR TITLE
Replace gain quick filter prompt with input

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -196,9 +196,9 @@ describe("HoldingsTable", () => {
     });
 
     it("applies gain percentage quick filter", () => {
-        vi.spyOn(window, 'prompt').mockReturnValue('10');
         render(<HoldingsTable holdings={holdings} />);
-        fireEvent.click(screen.getByRole('button', { name: /Gain%/ }));
+        const input = screen.getByPlaceholderText('Min Gain %');
+        fireEvent.change(input, { target: { value: '10' } });
         expect(screen.getByPlaceholderText('Gain %')).toHaveValue('10');
         expect(screen.getByText('AAA')).toBeInTheDocument();
         expect(screen.queryByText('XYZ')).toBeNull();

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -80,6 +80,7 @@ export function HoldingsTable({
         .catch(() => {});
     });
   }, [holdings, sparks]);
+  useEffect(() => {
     if (typeof window !== "undefined") {
       localStorage.setItem(VIEW_PRESET_STORAGE_KEY, viewPreset);
     }
@@ -188,18 +189,16 @@ export function HoldingsTable({
         >
           Sell-eligible
         </button>
-        <button
-          type="button"
-          style={{ marginLeft: "0.5rem" }}
-          onClick={() => {
-            const val = prompt("Minimum Gain %", "10");
-            if (val !== null) {
-              handleFilterChange("gain_pct", val);
-            }
-          }}
-        >
-          Gain% &gt; x
-        </button>
+        <label style={{ marginLeft: "0.5rem" }}>
+          Gain% &gt;
+          <input
+            type="number"
+            placeholder="Min Gain %"
+            value={filters.gain_pct}
+            onChange={(e) => handleFilterChange("gain_pct", e.target.value)}
+            style={{ marginLeft: "0.25rem", width: "4rem" }}
+          />
+        </label>
       </div>
       <div style={{ marginBottom: "0.5rem" }}>
         Columns:


### PR DESCRIPTION
## Summary
- replace Gain% quick filter prompt with a controlled numeric input
- update quick filter test to use the new input

## Testing
- `npm test` *(fails: 4 failed, 4 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b37d173fb88327a4bb118a8975ca77