### PR TITLE
feat: parameterize crawler URLs

### DIFF
--- a/scripts/crawl_and_analyze.py
+++ b/scripts/crawl_and_analyze.py
@@ -6,7 +6,7 @@ import asyncio
 import base64
 from pathlib import Path
 
-from playwright.async_api import async_playwright
+from playwright.async_api import Error, async_playwright
 from openai import OpenAI
 
 
@@ -18,7 +18,11 @@ async def take_screenshots(urls, out_dir: Path) -> list[Path]:
         browser = await p.chromium.launch(headless=True)
         page = await browser.new_page()
         for idx, url in enumerate(urls, start=1):
-            await page.goto(url, wait_until="networkidle")
+            try:
+                await page.goto(url, wait_until="networkidle")
+            except Error as exc:
+                print(f"Failed to navigate to {url}: {exc}")
+                continue
             file_path = out_dir / f"menu_{idx}.png"
             print(f"Saving screenshot {url} to: {file_path}")
             await page.screenshot(path=file_path, full_page=True)
@@ -52,14 +56,42 @@ def analyze_images(image_paths: list[Path], model: str) -> None:
 
 
 async def main(urls: list[str], out_dir: Path, model: str) -> None:
-    images = await take_screenshots(urls, out_dir)
-    # analyze_images(images, model)
+    _images = await take_screenshots(urls, out_dir)
+    # analyze_images(_images, model)
 
 
+def _parse_urls(raw_urls: list[str]) -> list[str]:
+    """Convert a list of raw URL or port inputs to full URLs."""
+    parsed: list[str] = []
+    for item in raw_urls:
+        if item.isdigit():
+            parsed.append(f"http://localhost:{item}")
+        else:
+            parsed.append(item)
+    return parsed
 
 
 if __name__ == "__main__":
-    urls = ["http://localhost:5174"]
-    out_dir = Path("screenshots")
-    model = "openai"
-    asyncio.run(main(urls, out_dir, model))
+    parser = argparse.ArgumentParser(
+        description="Capture screenshots of one or more URLs and analyze them."
+    )
+    parser.add_argument(
+        "urls",
+        nargs="+",
+        help="Full URLs or port numbers to capture. Port numbers imply http://localhost:<port>.",
+    )
+    parser.add_argument(
+        "-o",
+        "--out-dir",
+        default="screenshots",
+        help="Directory to save screenshots",
+    )
+    parser.add_argument(
+        "-m",
+        "--model",
+        default="openai",
+        help="Model to use for analysis",
+    )
+    args = parser.parse_args()
+    parsed_urls = _parse_urls(args.urls)
+    asyncio.run(main(parsed_urls, Path(args.out_dir), args.model))


### PR DESCRIPTION
## Summary
- allow passing URLs or ports and output directory to crawl_and_analyze script
- handle navigation failures gracefully
- add CLI argument parsing

## Testing
- `ruff check scripts/crawl_and_analyze.py`
- `pytest` *(fails: Required test coverage of 80% not reached. Total coverage: 79.67%)*

------
https://chatgpt.com/codex/tasks/task_e_68b40c933a288327981d42bcc7f276a3