### PR TITLE
Improve config handling in AI API tester

### DIFF
--- a/scripts/ai_api_tester.py
+++ b/scripts/ai_api_tester.py
@@ -26,9 +26,7 @@ def run_cases(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
         method = case.get("method", "GET")
         url = case.get("url")
         kwargs = {
-            k: case[k]
-            for k in ("headers", "params", "json", "data")
-            if k in case
+            k: case[k] for k in ("headers", "params", "json", "data") if k in case
         }
         entry: dict[str, Any] = {"id": idx, "method": method, "url": url}
         try:
@@ -75,10 +73,11 @@ def summarize_with_ai(log_text: str) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run API test cases from YAML")
+    default_config = Path(__file__).resolve().parent / "api_test_cases.yaml"
     parser.add_argument(
         "--config",
         type=Path,
-        default=Path("api_test_cases.yaml"),
+        default=default_config,
         help="YAML file containing test case definitions.",
     )
     parser.add_argument(
@@ -95,7 +94,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    cases = load_cases(args.config)
+    try:
+        cases = load_cases(args.config)
+    except FileNotFoundError:
+        print("Config file not found. Use --config to specify its location.")
+        raise SystemExit(1)
     results = run_cases(cases)
     log_text = write_log(results, args.log)
     summary = summarize_with_ai(log_text)


### PR DESCRIPTION
## Summary
- compute default config path relative to script
- exit gracefully with message when config is missing

## Testing
- `ruff check scripts/ai_api_tester.py`
- `black --check scripts/ai_api_tester.py`
- `pytest` *(fails: Required test coverage of 80% not reached; 14 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b40c87cd248327bd4a69ead17f36b2