### PR TITLE
Replace gain% prompt with quick filter input

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -202,18 +202,13 @@ export function HoldingsTable({
         >
           {t("holdingsTable.quickFiltersSellEligible")}
         </button>
-        <button
-          type="button"
+        <input
+          type="number"
+          placeholder={t("holdingsTable.minimumGainPrompt")}
+          value={filters.gain_pct}
+          onChange={(e) => handleFilterChange("gain_pct", e.target.value)}
           style={{ marginLeft: "0.5rem" }}
-          onClick={() => {
-            const val = prompt(t("holdingsTable.minimumGainPrompt"), "10");
-            if (val !== null) {
-              handleFilterChange("gain_pct", val);
-            }
-          }}
-        >
-          {t("holdingsTable.quickFiltersGainPct")}
-        </button>
+        />
       </div>
       <div style={{ marginBottom: "0.5rem" }}>
         {t("holdingsTable.columnsLabel")}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -65,7 +65,7 @@
     "quickFilters": "Quick Filters:",
     "quickFiltersSellEligible": "Sell-eligible",
     "quickFiltersGainPct": "Gain% > x",
-    "minimumGainPrompt": "Minimum Gain %",
+    "minimumGainPrompt": "Min Gain %",
     "columnsLabel": "Columns:",
     "columns": {
       "ticker": "Ticker",


### PR DESCRIPTION
## Summary
- replace prompt with inline Min Gain % quick filter input
- update translation for gain percentage placeholder

## Testing
- `npm test` *(fails: Test Files 3 failed | 13 passed | 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b40ccf129c8327b15501f1747d1fa4