### PR TITLE
docs: update trading agent usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,13 +268,14 @@ python run_with_error_summary.py pytest
 ```
 
 ## Trading Agent
-
-Use the helper script to run the trading agent locally. All arguments are
-optional:
+Retrieve trade signals through the API:
 
 ```bash
-python scripts/run_trading_agent.py --tickers AAPL MSFT --thresholds 0.1 0.2 --indicator RSI
+curl http://localhost:8000/trading-agent/signals
 ```
+
+In production, the `price_refresh` Lambda can invoke the agent after updating
+prices.
 
 ## API endpoint tester
 

--- a/USER_README.md
+++ b/USER_README.md
@@ -124,7 +124,7 @@ If the variable is unset the UI defaults to `http://localhost:8000` (or
 - **Run tests**:
   - Backend: `pytest`
   - Frontend: `cd frontend && npm test`
-- **Run the trading agent**: `python scripts/run_trading_agent.py --tickers AAPL MSFT`
+- **Get trading agent signals**: `curl http://localhost:8000/trading-agent/signals` or invoke the `price_refresh` Lambda
 - **Deploy to AWS**:
   1. `cd frontend && npm run build`
   2. `cd cdk && DEPLOY_BACKEND=false cdk deploy StaticSiteStack`


### PR DESCRIPTION
## Summary
- document trading agent access via API instead of local script
- mention optional price_refresh lambda trigger
- clarify USER_README workflow for retrieving signals

## Testing
- `make lint` *(fails: Import block is un-sorted or un-formatted)*
- `pytest` *(fails: FAIL Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b40db7b134832794dc413ce9ff2c44