### PR TITLE
Ensure backend API tests use client fixture

### DIFF
--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -33,29 +33,29 @@ def mock_group_portfolio(monkeypatch):
     """Provide a lightweight group portfolio for known slugs."""
 
     def _build(slug: str):
-        if slug == "stub":
-            return {
-                "slug": slug,
-                "accounts": [
-                    {
-                        "name": "stub",
-                        "value_estimate_gbp": 100.0,
-                        "holdings": [
-                            {
-                                "ticker": "STUB",
-                                "name": "Stub Corp",
-                                "units": 1.0,
-                                "market_value_gbp": 100.0,
-                                "gain_gbp": 10.0,
-                                "cost_basis_gbp": 90.0,
-                                "day_change_gbp": 1.0,
-                            }
-                        ],
-                    }
-                ],
-                "total_value_estimate_gbp": 100.0,
-            }
-        raise HTTPException(status_code=404, detail="Group not found")
+        if slug == "doesnotexist":
+            raise HTTPException(status_code=404, detail="Group not found")
+        return {
+            "slug": slug,
+            "accounts": [
+                {
+                    "name": "stub",
+                    "value_estimate_gbp": 100.0,
+                    "holdings": [
+                        {
+                            "ticker": "STUB",
+                            "name": "Stub Corp",
+                            "units": 1.0,
+                            "market_value_gbp": 100.0,
+                            "gain_gbp": 10.0,
+                            "cost_basis_gbp": 90.0,
+                            "day_change_gbp": 1.0,
+                        }
+                    ],
+                }
+            ],
+            "total_value_estimate_gbp": 100.0,
+        }
 
     monkeypatch.setattr(
         "backend.common.group_portfolio.build_group_portfolio", _build
@@ -136,14 +136,14 @@ def test_groups(client):
     assert isinstance(resp.json(), list)
 
 
-def test_valid_group_portfolio():
+def test_valid_group_portfolio(client):
     groups = client.get("/groups").json()
     assert groups, "No groups found"
     group_slug = groups[0]["slug"]
     resp = client.get(f"/portfolio-group/{group_slug}")
     assert resp.status_code == 200
     data = resp.json()
-    assert "slug" in data and data["slug"] == slug
+    assert "slug" in data and data["slug"] == group_slug
     assert "accounts" in data and isinstance(data["accounts"], list)
     assert data["accounts"], "Accounts list should not be empty"
     assert "total_value_estimate_gbp" in data
@@ -186,13 +186,13 @@ def test_invalid_account(client):
     assert resp.status_code == 404
 
 
-def test_prices_refresh():
+def test_prices_refresh(client):
     resp = client.post("/prices/refresh")
     assert resp.status_code == 200
     assert "status" in resp.json()
 
 
-def test_group_instruments():
+def test_group_instruments(client):
     groups = client.get("/groups").json()
     slug = groups[0]["slug"]
     resp = client.get(f"/portfolio-group/{slug}/instruments")


### PR DESCRIPTION
## Summary
- inject client fixture into tests that use the TestClient
- generalize group portfolio stub for arbitrary slugs

## Testing
- `pytest tests/test_backend_api.py --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68b4258f2f7083278f31f77baae7e018