### PR TITLE
Equal weighting for portfolio group movers

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -227,12 +227,10 @@ async def group_movers(
     if not tickers:
         return {"gainers": [], "losers": []}
 
-    # Compute weights in percent for filtering
-    total_mv = sum(float(s.get("market_value_gbp") or 0.0) for s in summaries)
+    # Compute equal weights in percent for filtering
+    n = len(tickers)
     weight_map = {
-        s["ticker"]: (float(s.get("market_value_gbp") or 0.0) / total_mv * 100.0)
-        if total_mv
-        else 0.0
+        s["ticker"]: (100.0 / n) if n else 0.0
         for s in summaries
         if s.get("ticker")
     }

--- a/tests/test_group_movers_route.py
+++ b/tests/test_group_movers_route.py
@@ -1,5 +1,7 @@
 from fastapi.testclient import TestClient
 
+import pytest
+
 import backend.common.instrument_api as ia
 from backend.local_api.main import app
 
@@ -16,14 +18,18 @@ def test_group_movers_endpoint(monkeypatch):
         return [
             {"ticker": "AAA", "market_value_gbp": 100.0},
             {"ticker": "BBB", "market_value_gbp": 50.0},
+            {"ticker": "CCC", "market_value_gbp": 25.0},
         ]
 
     def fake_top_movers(tickers, days, limit, *, min_weight, weights):
-        assert tickers == ["AAA", "BBB"]
+        assert tickers == ["AAA", "BBB", "CCC"]
         assert days == 7
         assert limit == 5
         assert min_weight == 0.5
-        assert weights == {"AAA": 50.0, "BBB": 50.0}
+        expected = pytest.approx(100.0 / 3)
+        assert weights["AAA"] == expected
+        assert weights["BBB"] == expected
+        assert weights["CCC"] == expected
         return {
             "gainers": [{"ticker": "AAA", "name": "AAA", "change_pct": 5}],
             "losers": [{"ticker": "BBB", "name": "BBB", "change_pct": -3}],


### PR DESCRIPTION
## Summary
- weight group movers equally instead of by market value
- test that `instrument_api.top_movers` receives equal weights even when holdings vary

## Testing
- `pytest --no-cov tests/test_group_movers_route.py::test_group_movers_endpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4258c26448327b876746604e8fd43