### PR TITLE
Fix resolve_paths ignoring Windows paths

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -28,12 +28,12 @@ def resolve_paths(
 ) -> ResolvedPaths:
     """Return fully resolved repository and accounts paths."""
 
-    if repo_root and ":" not in str(repo_root) and Path(repo_root).exists():
+    if repo_root and Path(repo_root).exists():
         repo_path = Path(repo_root)
     else:
         repo_path = Path(__file__).resolve().parents[2]
 
-    if accounts_root and ":" not in str(accounts_root) and Path(accounts_root).exists():
+    if accounts_root and Path(accounts_root).exists():
         accounts_path = Path(accounts_root)
     else:
         accounts_path = repo_path / "data" / "accounts"

--- a/tests/test_resolve_paths_windows.py
+++ b/tests/test_resolve_paths_windows.py
@@ -1,0 +1,19 @@
+import backend.common.data_loader as dl
+from pathlib import Path
+
+
+def test_resolve_paths_accepts_windows_accounts_root(monkeypatch):
+    win_path = Path("C:/accounts")
+
+    orig_exists = Path.exists
+
+    def fake_exists(self):
+        if str(self) == str(win_path):
+            return True
+        return orig_exists(self)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(dl.config, "accounts_root", win_path)
+
+    paths = dl.resolve_paths(dl.config.repo_root, dl.config.accounts_root)
+    assert paths.accounts_root == win_path


### PR DESCRIPTION
## Summary
- rely on `Path.exists()` alone to validate repo/accounts roots in `resolve_paths`
- add regression test ensuring Windows-style account path works

## Testing
- `pytest tests/test_resolve_paths_windows.py::test_resolve_paths_accepts_windows_accounts_root -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68b42589c2048327b9ed922667ba76bb