### PR TITLE
fix frontend compilation issues

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -462,6 +462,8 @@ export function HoldingsTable({
                       {new Intl.DateTimeFormat(i18n.language).format(
                         new Date(h.last_price_date),
                       )}
+                    </span>
+                  )}
                   {h.latest_source && (
                     <span style={{ marginLeft: "0.25rem", color: "gray" }}>
                       {t("holdingsTable.source")} {h.latest_source}

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -42,7 +42,7 @@ export function PerformanceDashboard({ owner }: Props) {
         excludeCash,
       }),
     ])
-      .then(([perf, varSeries, alphaRes, teRes, mdRes]) => {
+      .then(([alphaRes, teRes, mdRes, perf, varSeries]) => {
         setData(perf);
         setVarData(varSeries);
         setAlpha(alphaRes.alpha_vs_benchmark);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -130,8 +130,8 @@ export interface TrackingErrorResponse {
 
 export interface MaxDrawdownResponse {
     max_drawdown: number | null;
+};
 
-  
 export interface InstrumentDetailMini {
     [range: string]: {
         date: string;


### PR DESCRIPTION
## Summary
- close `MaxDrawdownResponse` interface
- close JSX span and conditional for last price badge
- align Promise results with request order

## Testing
- `npm test --prefix frontend` *(fails: Transform failed and multiple failing tests)*
- `npm run lint --prefix frontend` *(fails: parsing error and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b427d8f1c08327842d42d0a416986e