### PR TITLE
Wrap onTradeInfo handler in effect hook

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -115,6 +115,7 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
       .catch(() => {});
   }, [slug]);
 
+  useEffect(() => {
     if (onTradeInfo) {
       onTradeInfo(
         portfolio


### PR DESCRIPTION
## Summary
- Wrap onTradeInfo handler in a dedicated `useEffect` so trade data updates when portfolio changes

## Testing
- `npm test` (fails: Transform failed with errors in HoldingsTable.tsx)
- `npm run lint` (fails: ESLint parsing errors and unused variables)
- `npx tsc src/components/GroupPortfolioView.tsx --noEmit` (fails: error in src/types.ts)


------
https://chatgpt.com/codex/tasks/task_e_68b4278a3538832791515e22b0f358d3