### PR TITLE
Use market value weights in group movers

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -207,6 +207,8 @@ async def group_movers(
     except Exception:
         raise HTTPException(status_code=404, detail="Group not found")
 
+    total_mv = sum(float(s.get("market_value_gbp") or 0.0) for s in summaries)
+
     market_values = {}
     tickers = []
     for s in summaries:
@@ -223,10 +225,11 @@ async def group_movers(
     if not tickers:
         return {"gainers": [], "losers": []}
 
-    # Compute equal weights in percent for filtering
-    n = len(tickers)
+    # Compute weights in percent for filtering
     weight_map = {
-        s["ticker"]: (float(s.get("market_value_gbp") or 0.0) / total_mv * 100.0) if total_mv else 0.0
+        s["ticker"]: (float(s.get("market_value_gbp") or 0.0) / total_mv * 100.0)
+        if total_mv
+        else 0.0
         for s in summaries
         if s.get("ticker")
     }

--- a/tests/test_group_movers_route.py
+++ b/tests/test_group_movers_route.py
@@ -26,10 +26,10 @@ def test_group_movers_endpoint(monkeypatch):
         assert days == 7
         assert limit == 5
         assert min_weight == 0.5
-        expected = pytest.approx(100.0 / 3)
-        assert weights["AAA"] == expected
-        assert weights["BBB"] == expected
-        assert weights["CCC"] == expected
+        total = 100.0 + 50.0 + 25.0
+        assert weights["AAA"] == pytest.approx(100.0 / total * 100.0)
+        assert weights["BBB"] == pytest.approx(50.0 / total * 100.0)
+        assert weights["CCC"] == pytest.approx(25.0 / total * 100.0)
         return {
             "gainers": [{"ticker": "AAA", "name": "AAA", "change_pct": 5}],
             "losers": [{"ticker": "BBB", "name": "BBB", "change_pct": -3}],


### PR DESCRIPTION
## Summary
- compute total group market value in `group_movers`
- weight top mover filtering by market value
- test group movers with market value weights

## Testing
- `pytest tests/test_group_movers_route.py -q -p no:cov --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68b439f3d9d88327a55b56daa0cb56dc