### PR TITLE
Document empty group movers response

### DIFF
--- a/tests/test_group_movers_route.py
+++ b/tests/test_group_movers_route.py
@@ -23,9 +23,10 @@ def test_group_movers_endpoint(monkeypatch):
         assert days == 7
         assert limit == 5
         assert min_weight == 0.5
-        assert weights["AAA"] == pytest.approx(57.142857, rel=1e-6)
-        assert weights["BBB"] == pytest.approx(28.571429, rel=1e-6)
-        assert weights["CCC"] == pytest.approx(14.285714, rel=1e-6)
+        total = 100.0 + 50.0 + 25.0
+        assert weights["AAA"] == pytest.approx(100.0 / total * 100)
+        assert weights["BBB"] == pytest.approx(50.0 / total * 100)
+        assert weights["CCC"] == pytest.approx(25.0 / total * 100)
         return {
             "gainers": [{"ticker": "AAA", "name": "AAA", "change_pct": 5}],
             "losers": [{"ticker": "BBB", "name": "BBB", "change_pct": -3}],


### PR DESCRIPTION
## Summary
- document empty response for `/portfolio-group/{slug}/movers`
- expose response schema in OpenAPI
- test empty movers response shape

## Testing
- `pytest tests/test_group_movers_route.py::test_group_movers_endpoint tests/test_group_movers_route.py::test_group_movers_endpoint_empty -q -p no:cov -o addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68b43a014da08327894afefc5ee12180