### PR TITLE
Log errors for missing group summaries

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -204,7 +204,8 @@ async def group_movers(
         raise HTTPException(status_code=400, detail="Invalid days")
     try:
         summaries = instrument_api.instrument_summaries_for_group(slug)
-    except Exception:
+    except Exception as e:
+        log.warning(f"Failed to load instrument summaries for group {slug}: {e}")
         raise HTTPException(status_code=404, detail="Group not found")
 
     market_values = {}


### PR DESCRIPTION
## Summary
- add warning log when group instrument summaries can't be fetched

## Testing
- `pytest tests/test_group_movers_route.py` *(fails: KeyError 'Close_gbp', NameError 'total_mv' and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b43a005bcc83278855b3d234893f60