### PR TITLE
Add compliance warnings page and navigation

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -345,6 +345,9 @@ export const getTradingSignals = () =>
 export const getCompliance = (owner: string) =>
   fetchJson<ComplianceResult>(`${API_BASE}/compliance/${owner}`);
 
+/** Alias for compatibility with newer API naming */
+export const complianceForOwner = getCompliance;
+
 /** Virtual portfolio endpoints */
 export const getVirtualPortfolios = () =>
   fetchJson<VirtualPortfolio[]>(`${API_BASE}/virtual-portfolios`);

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import type { Portfolio, Account } from "../types";
 import { AccountBlock } from "./AccountBlock";
 import { ValueAtRisk } from "./ValueAtRisk";
 import { money } from "../lib/money";
 import i18n from "../i18n";
+import { complianceForOwner } from "../api";
 
 // Props accepted by the view. `data` is null until a portfolio is loaded.
 type Props = {
@@ -21,12 +23,33 @@ type Props = {
  */
 export function PortfolioView({ data, loading, error }: Props) {
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
+  const [hasWarnings, setHasWarnings] = useState(false);
 
   const accountKey = (acct: Account, idx: number) => `${acct.account_type}-${idx}`;
 
   useEffect(() => {
     setSelectedAccounts(data ? data.accounts.map(accountKey) : []);
   }, [data]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function check() {
+      if (!data?.owner) {
+        setHasWarnings(false);
+        return;
+      }
+      try {
+        const res = await complianceForOwner(data.owner);
+        if (!cancelled) setHasWarnings(res.warnings.length > 0);
+      } catch {
+        if (!cancelled) setHasWarnings(false);
+      }
+    }
+    check();
+    return () => {
+      cancelled = true;
+    };
+  }, [data?.owner]);
 
   if (loading) return <div>Loading portfolio…</div>; // show a quick spinner
   if (error) return <div style={{ color: "red" }}>{error}</div>; // bubble errors
@@ -56,6 +79,11 @@ export function PortfolioView({ data, loading, error }: Props) {
       <div style={{ marginBottom: "2rem" }}>
         Approx Total: {money(totalValue)}
       </div>
+      {hasWarnings && (
+        <div style={{ marginBottom: "1rem" }}>
+          <Link to={`/compliance/${data.owner}`}>View compliance warnings</Link>
+        </div>
+      )}
       <ValueAtRisk owner={data.owner} />
       {/* Each account is rendered using AccountBlock for clarity */}
       {data.accounts.map((acct, idx) => {

--- a/frontend/src/pages/ComplianceWarnings.tsx
+++ b/frontend/src/pages/ComplianceWarnings.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { complianceForOwner, getOwners } from "../api";
+import type { OwnerSummary, ComplianceResult } from "../types";
+import { OwnerSelector } from "../components/OwnerSelector";
+
+export default function ComplianceWarnings() {
+  const [owners, setOwners] = useState<OwnerSummary[]>([]);
+  const [owner, setOwner] = useState("");
+  const [result, setResult] = useState<ComplianceResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getOwners().then(setOwners).catch(() => setOwners([]));
+  }, []);
+
+  useEffect(() => {
+    if (!owner) {
+      setResult(null);
+      return;
+    }
+    complianceForOwner(owner)
+      .then((res) => {
+        setResult(res);
+        setError(null);
+      })
+      .catch((e) => {
+        setResult(null);
+        setError(e instanceof Error ? e.message : String(e));
+      });
+  }, [owner]);
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
+      <h1>Compliance warnings</h1>
+      <OwnerSelector owners={owners} selected={owner} onSelect={setOwner} />
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      {result && (
+        result.warnings.length ? (
+          <ul>
+            {result.warnings.map((w) => (
+              <li key={w}>{w}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>No warnings.</p>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pluginRegistry.ts
+++ b/frontend/src/pluginRegistry.ts
@@ -1,3 +1,5 @@
+import ComplianceWarnings from "./pages/ComplianceWarnings";
+
 export interface TabPlugin {
   /** Unique identifier for the plugin */
   id: string;
@@ -37,3 +39,9 @@ export function getTabPlugins(): TabPlugin[] {
 export function clearTabPlugins() {
   registry.length = 0;
 }
+
+registerTabPlugin({
+  id: "compliance",
+  Component: ComplianceWarnings,
+  priority: 150,
+});


### PR DESCRIPTION
## Summary
- add ComplianceWarnings page fetching complianceForOwner
- register compliance page in plugin registry
- link from portfolio to compliance page when warnings exist

## Testing
- `npm test` *(fails: No "getGroupMovers" export is defined on the "./api" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68b41c78ea8083279d73e0334dea6be4