### PR TITLE
Fix movers endpoint registration and tab plugin syntax

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -209,16 +209,6 @@ async def group_regions(slug: str):
     return portfolio_utils.aggregate_by_region(gp)
 
 
-@router.get(
-    "/portfolio-group/{slug}/movers",
-    response_model=MoversResponse,
-    responses={
-        200: {
-            "description": 'Top gainers and losers for a group portfolio. Returns {"gainers": [], "losers": []} if the group holds no tickers.'
-        }
-    },
-)
-
 def _calculate_weights_and_market_values(
     summaries: Sequence[Dict[str, Any]],
 ) -> Tuple[List[str], Dict[str, float], Dict[str, float]]:
@@ -260,8 +250,15 @@ def _enrich_movers_with_market_values(
     return movers
 
 
-@router.get("/portfolio-group/{slug}/movers")
-
+@router.get(
+    "/portfolio-group/{slug}/movers",
+    response_model=MoversResponse,
+    responses={
+        200: {
+            "description": 'Top gainers and losers for a group portfolio. Returns {"gainers": [], "losers": []} if the group holds no tickers.'
+        }
+    },
+)
 async def group_movers(
     slug: str,
     days: int = Query(1, description="Lookback window"),

--- a/frontend/src/pluginRegistry.ts
+++ b/frontend/src/pluginRegistry.ts
@@ -47,10 +47,10 @@ registerTabPlugin({
   id: "alert-settings",
   Component: AlertSettings,
   priority: 130,
+});
 
 registerTabPlugin({
   id: "compliance",
   Component: ComplianceWarnings,
   priority: 150,
-
 });


### PR DESCRIPTION
## Summary
- move `/portfolio-group/{slug}/movers` decorator onto `group_movers`
- close `registerTabPlugin` calls in `pluginRegistry`

## Testing
- `pytest` *(fails: KeyError 'Close_gbp')*
- `npm test` *(fails: 2 failed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b45683f488832789b3f608c96f3393