### PR TITLE
Add tests for instrument builder utilities

### DIFF
--- a/tests/utils/test_build_instruments_from_accounts.py
+++ b/tests/utils/test_build_instruments_from_accounts.py
@@ -1,0 +1,90 @@
+import json
+import pytest
+
+from backend.utils.build_instruments_from_accounts import (
+    split_ticker,
+    best_name,
+    infer_currency,
+)
+
+
+@pytest.mark.parametrize(
+    "ticker,expected",
+    [
+        ("ABC.L", ("ABC", "L")),
+        ("ABC", ("ABC", None)),
+    ],
+)
+def test_split_ticker(ticker, expected):
+    assert split_ticker(ticker) == expected
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ("Short", "LongerName", "LongerName"),
+        ("LongerName", "Short", "LongerName"),
+        (None, "Beta", "Beta"),
+        ("Alpha", None, "Alpha"),
+        (None, None, None),
+    ],
+)
+def test_best_name(a, b, expected):
+    assert best_name(a, b) == expected
+
+
+@pytest.mark.parametrize(
+    "sym,exch,scaling,expected",
+    [
+        ("CASH", "GBP", {}, "GBP"),
+        ("XYZ", "L", {"L": {"XYZ": 0.01}}, "GBX"),
+        ("ABC", "N", {}, "USD"),
+        ("DEF", "DE", {}, "EUR"),
+        ("GHI", "TO", {}, None),
+    ],
+)
+def test_infer_currency(sym, exch, scaling, expected):
+    assert infer_currency(sym, exch, scaling) == expected
+
+
+def test_build_instruments(monkeypatch, tmp_path):
+    accounts_dir = tmp_path / "accounts"
+    owner_dir = accounts_dir / "alice"
+    owner_dir.mkdir(parents=True)
+    acct_file = owner_dir / "acct.json"
+    acct_file.write_text(
+        json.dumps(
+            {
+                "holdings": [
+                    {"ticker": "CASH.GBP"},
+                    {"ticker": "ABC.L", "name": "ABC PLC"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    instruments_dir = tmp_path / "instruments"
+    instruments_dir.mkdir()
+
+    import backend.utils.build_instruments_from_accounts as bia
+
+    monkeypatch.setattr(bia, "ACCOUNTS_DIR", accounts_dir)
+    monkeypatch.setattr(bia, "INSTRUMENTS_DIR", instruments_dir)
+    monkeypatch.setattr(bia, "SCALING_FILE", tmp_path / "scaling.json")
+
+    instruments = bia.build_instruments()
+
+    assert len(instruments) == 2
+
+    cash = instruments["CASH.GBP"]
+    assert cash["ticker"] == "CASH.GBP"
+    assert cash["name"] == "Cash (GBP)"
+    assert cash["currency"] == "GBP"
+    assert cash["exchange"] is None
+
+    equity = instruments["ABC.L"]
+    assert equity["ticker"] == "ABC.L"
+    assert equity["name"] == "ABC PLC"
+    assert equity["currency"] == "GBP"
+    assert equity["exchange"] == "L"


### PR DESCRIPTION
## Summary
- add tests for ticker splitting and name selection helpers
- cover currency inference edge cases
- ensure build_instruments assembles cash and equity metadata from mocked account files

## Testing
- `cd tests/utils && PYTEST_ADDOPTS="" pytest -k build_instruments_from_accounts -q`

------
https://chatgpt.com/codex/tasks/task_e_68b457bf2a3c832798acc3121b1797de