### PR TITLE
fix: preserve sell signals during fundamental screening

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -268,9 +268,17 @@ def run(tickers: Optional[Iterable[str]] = None) -> List[Dict]:
     if cfg.de_max is not None:
         fundamental_params["de_max"] = cfg.de_max
     if fundamental_params and signals:
-        fundamentals = screen([s["ticker"] for s in signals], **fundamental_params)
-        allowed = {f.ticker for f in fundamentals}
-        signals = [s for s in signals if s["ticker"] in allowed]
+        buy_signals = [s for s in signals if s["action"] == "BUY"]
+        if buy_signals:
+            fundamentals = screen(
+                [s["ticker"] for s in buy_signals], **fundamental_params
+            )
+            allowed = {f.ticker for f in fundamentals}
+            signals = [
+                s
+                for s in signals
+                if s["action"] != "BUY" or s["ticker"] in allowed
+            ]
     for sig in signals:
         ticker = sig["ticker"]
         price = snapshot[ticker]["last_price"]

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -232,6 +232,32 @@ def test_run_uses_rsi_and_fundamentals(monkeypatch):
     assert "RSI" in signals[0]["reason"]
 
 
+def test_run_does_not_filter_sell_signal(monkeypatch):
+    monkeypatch.setattr(trading_agent, "list_all_unique_tickers", lambda: ["AAA"])
+
+    def fake_load_prices(tickers, days=60):
+        import pandas as pd
+
+        data = {"Ticker": ["AAA"] * 7, "close": [10, 10, 10, 10, 10, 10, 4]}
+        return pd.DataFrame(data)
+
+    monkeypatch.setattr(trading_agent.prices, "load_prices_for_tickers", fake_load_prices)
+    monkeypatch.setattr(trading_agent, "publish_alert", lambda alert: None)
+    monkeypatch.setattr(trading_agent, "send_message", lambda msg: None)
+    monkeypatch.setattr(trading_agent, "_log_trade", lambda *a, **k: None)
+
+    def fake_screen(tickers, **kw):
+        raise AssertionError("screen should not be called for SELL signals")
+
+    monkeypatch.setattr(trading_agent, "screen", fake_screen)
+
+    cfg = trading_agent.config.trading_agent
+    monkeypatch.setattr(cfg, "pe_max", 20.0)
+
+    signals = run()
+    assert signals and signals[0]["action"] == "SELL"
+
+
 def test_run_generates_ma_signal(monkeypatch):
     monkeypatch.setattr(trading_agent, "list_all_unique_tickers", lambda: ["BBB"])
 


### PR DESCRIPTION
## Summary
- avoid filtering SELL signals when applying fundamental screener
- add regression test ensuring SELL signals bypass fundamental checks

## Testing
- `pytest tests/test_trading_agent.py -q -o addopts=`
- `npm test` *(fails: 3 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b45d3d3c888327a49856819380e7b2