### PR TITLE
Add web push notifications

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -2,11 +2,26 @@
 
 // basic service worker for push notifications
 self.addEventListener('push', (event: PushEvent) => {
-  const data = event.data?.json() || {};
-  const title = data.title || 'AllotMint';
+  const payload = event.data?.text();
+  let data: Record<string, unknown> = {};
+  if (payload) {
+    try {
+      data = JSON.parse(payload);
+    } catch (err) {
+      data = {body: payload};
+    }
+  }
+
+  const title = typeof data.title === 'string' ? data.title : 'AllotMint';
   const options: NotificationOptions = {
-    body: data.body || data.message || ''
+    body:
+      typeof data.body === 'string'
+        ? data.body
+        : typeof data.message === 'string'
+            ? data.message
+            : ''
   };
+
   event.waitUntil(self.registration.showNotification(title, options));
 });
 


### PR DESCRIPTION
## Summary
- register custom service worker for PWA and push events
- persist user push subscriptions and enqueue notifications
- toggle push alerts from settings page
- parse push payloads as text and fall back to the raw message when JSON parsing fails

## Testing
- `npm test` *(fails: 3 failed, 9 passed, 1 skipped)*
- `pytest tests/test_alerts.py tests/test_trading_agent.py tests/test_trading_agent_route.py`


------
https://chatgpt.com/codex/tasks/task_e_68b45e8b1a2083279f56200d1541a746