### PR TITLE
chore: use explicit PostCSS plugins

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,10 +1,5 @@
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {}
-  }
-}
-import tailwindcss from "@tailwindcss/postcss";
-import autoprefixer from "autoprefixer";
+import tailwindcss from '@tailwindcss/postcss';
+import autoprefixer from 'autoprefixer';
 
 export default {
   plugins: [tailwindcss(), autoprefixer()],


### PR DESCRIPTION
## Summary
- streamline `postcss.config.js` to use explicit Tailwind and Autoprefixer plugins

## Testing
- `npm run dev` (frontend)
- `npm test` (frontend) *(fails: Found multiple elements with the role "navigation")*


------
https://chatgpt.com/codex/tasks/task_e_68b463a452fc8327a7eb36ab2ef8531c