### PR TITLE
Add alert threshold settings endpoints and UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -24,6 +24,7 @@ from backend.common.portfolio_utils import (
 from backend.config import config
 from backend.routes.agent import router as agent_router
 from backend.routes.alerts import router as alerts_router
+from backend.routes.alert_settings import router as alert_settings_router
 from backend.routes.compliance import router as compliance_router
 from backend.routes.config import router as config_router
 from backend.routes.instrument import router as instrument_router
@@ -90,6 +91,7 @@ def create_app() -> FastAPI:
     app.include_router(timeseries_admin_router, dependencies=protected)
     app.include_router(transactions_router, dependencies=protected)
     app.include_router(alerts_router)
+    app.include_router(alert_settings_router)
     app.include_router(compliance_router)
     app.include_router(screener_router)
     app.include_router(support_router)

--- a/backend/routes/alert_settings.py
+++ b/backend/routes/alert_settings.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from backend import alerts as alert_utils
+
+router = APIRouter(prefix="/alert-thresholds", tags=["alert-thresholds"])
+
+
+class ThresholdPayload(BaseModel):
+    threshold: float
+
+
+@router.get("/{user}")
+async def get_threshold(user: str):
+    """Return the alert threshold configured for ``user``."""
+    return {"threshold": alert_utils.get_user_threshold(user)}
+
+
+@router.post("/{user}")
+async def set_threshold(user: str, payload: ThresholdPayload):
+    """Update the alert threshold for ``user``."""
+    alert_utils.set_user_threshold(user, payload.threshold)
+    return {"threshold": payload.threshold}
+

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -326,12 +326,12 @@ export const getTransactions = (params: {
 export const getAlerts = () => fetchJson<Alert[]>(`${API_BASE}/alerts/`);
 
 /** Retrieve alert threshold for a user. */
-export const getAlertSettings = (user: string) =>
-  fetchJson<{ threshold: number }>(`${API_BASE}/alerts/settings/${user}`);
+export const getAlertThreshold = (user: string) =>
+  fetchJson<{ threshold: number }>(`${API_BASE}/alert-thresholds/${user}`);
 
 /** Update alert threshold for a user. */
-export const setAlertSettings = (user: string, threshold: number) =>
-  fetchJson<{ threshold: number }>(`${API_BASE}/alerts/settings/${user}` , {
+export const setAlertThreshold = (user: string, threshold: number) =>
+  fetchJson<{ threshold: number }>(`${API_BASE}/alert-thresholds/${user}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ threshold }),

--- a/frontend/src/pages/AlertSettings.tsx
+++ b/frontend/src/pages/AlertSettings.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { getAlertThreshold, setAlertThreshold } from "../api";
+
+export function AlertSettings() {
+  const [user, setUser] = useState("");
+  const [threshold, setThreshold] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    setLoading(true);
+    getAlertThreshold(user)
+      .then((res) => {
+        setThreshold(String(res.threshold));
+        setMessage(null);
+        setError(null);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
+  }, [user]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const value = parseFloat(threshold);
+    if (!user || Number.isNaN(value)) return;
+    setLoading(true);
+    try {
+      await setAlertThreshold(user, value);
+      setMessage("Saved");
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setMessage(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ maxWidth: "20rem" }}>
+      <div style={{ marginBottom: "0.5rem" }}>
+        <label>
+          User:
+          <input
+            value={user}
+            onChange={(e) => setUser(e.target.value)}
+            style={{ marginLeft: "0.5rem", width: "100%" }}
+          />
+        </label>
+      </div>
+      <div style={{ marginBottom: "0.5rem" }}>
+        <label>
+          Threshold:
+          <input
+            type="number"
+            step="0.01"
+            value={threshold}
+            onChange={(e) => setThreshold(e.target.value)}
+            style={{ marginLeft: "0.5rem", width: "100%" }}
+          />
+        </label>
+      </div>
+      <button type="submit" disabled={loading || !user}>
+        Save
+      </button>
+      {message && <div style={{ color: "green" }}>{message}</div>}
+      {error && <div style={{ color: "red" }}>{error}</div>}
+    </form>
+  );
+}
+
+export default AlertSettings;
+

--- a/frontend/src/pluginRegistry.ts
+++ b/frontend/src/pluginRegistry.ts
@@ -1,3 +1,5 @@
+import AlertSettings from "./pages/AlertSettings";
+
 export interface TabPlugin {
   /** Unique identifier for the plugin */
   id: string;
@@ -37,3 +39,10 @@ export function getTabPlugins(): TabPlugin[] {
 export function clearTabPlugins() {
   registry.length = 0;
 }
+
+/* Register built-in pages */
+registerTabPlugin({
+  id: "alert-settings",
+  Component: AlertSettings,
+  priority: 130,
+});


### PR DESCRIPTION
## Summary
- expose `/alert-thresholds/{user}` API with GET and POST handlers
- add frontend helpers and `AlertSettings` page
- register new page with plugin system

## Testing
- `pytest -q tests/test_backend_api.py::test_alerts_endpoint -o addopts=`
- `npm test` *(fails: An update to HoldingsTable inside a test was not wrapped in act(...))*

------
https://chatgpt.com/codex/tasks/task_e_68b41a1f9370832791308bea40fd40f4