### PR TITLE
Add compliance warnings page

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import App from './App.tsx'
 import VirtualPortfolio from './pages/VirtualPortfolio'
 import Reports from './pages/Reports'
 import Support from './pages/Support'
+import ComplianceWarnings from './pages/ComplianceWarnings'
 import './i18n'
 import { ConfigProvider } from './ConfigContext'
 import { PriceRefreshProvider } from './PriceRefreshContext'
@@ -21,6 +22,8 @@ createRoot(document.getElementById('root')!).render(
             <Route path="/support" element={<Support />} />
             <Route path="/reports" element={<Reports />} />
             <Route path="/virtual" element={<VirtualPortfolio />} />
+            <Route path="/compliance" element={<ComplianceWarnings />} />
+            <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
             <Route path="/*" element={<App />} />
           </Routes>
         </BrowserRouter>

--- a/frontend/src/pages/ComplianceWarnings.tsx
+++ b/frontend/src/pages/ComplianceWarnings.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { complianceForOwner, getOwners } from "../api";
 import type { OwnerSummary, ComplianceResult } from "../types";
 import { OwnerSelector } from "../components/OwnerSelector";
 
 export default function ComplianceWarnings() {
+  const { owner: ownerParam } = useParams<{ owner?: string }>();
+  const navigate = useNavigate();
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
-  const [owner, setOwner] = useState("");
+  const [owner, setOwner] = useState(ownerParam ?? "");
   const [result, setResult] = useState<ComplianceResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -32,7 +35,14 @@ export default function ComplianceWarnings() {
   return (
     <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
       <h1>Compliance warnings</h1>
-      <OwnerSelector owners={owners} selected={owner} onSelect={setOwner} />
+      <OwnerSelector
+        owners={owners}
+        selected={owner}
+        onSelect={(o) => {
+          setOwner(o);
+          navigate(`/compliance/${o}`);
+        }}
+      />
       {error && <p style={{ color: "red" }}>{error}</p>}
       {result && (
         result.warnings.length ? (

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -8,7 +8,6 @@ import {
   deletePushSubscription,
 } from "../api";
 import { useConfig } from "../ConfigContext";
-import Menu from "../components/Menu";
 
 const TAB_KEYS = [
   "instrument",
@@ -197,7 +196,6 @@ export default function Support() {
 
   return (
     <div className="container mx-auto max-w-3xl space-y-4 p-4">
-      <Menu />
       <h1 className="text-2xl md:text-4xl">{t("support.title")}</h1>
       <p>
         <strong>{t("support.online")}</strong> {online ? t("support.onlineYes") : t("support.onlineNo")}


### PR DESCRIPTION
## Summary
- add ComplianceWarnings page to fetch and show warnings per owner
- expose /compliance routes
- link portfolio view to compliance page when warnings exist
- remove extra menu from support page to avoid duplicate navigation

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b475c506a48327aaa8914db6889eea