### PR TITLE
Add indicator utilities and per-trade compliance checks

### DIFF
--- a/backend/common/indicators.py
+++ b/backend/common/indicators.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+
+def rsi(series: pd.Series, window: int) -> pd.Series:
+    """Return the Relative Strength Index for ``series``."""
+    delta = series.diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(window=window, min_periods=window).mean()
+    avg_loss = loss.rolling(window=window, min_periods=window).mean()
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def sma(series: pd.Series, window: int) -> pd.Series:
+    """Simple moving average for ``series`` over ``window`` periods."""
+    return series.rolling(window=window).mean()


### PR DESCRIPTION
## Summary
- factor out RSI and moving average calculations into backend.common.indicators
- gate trading actions with compliance.check_owner for each signal
- test compliance gating and indicator-driven signals

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts="" tests/test_trading_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b475b7b6c08327a5d4e2b3f1320675