### PR TITLE
Improve mobile responsiveness for portfolio components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,6 @@
     "@tailwindcss/postcss": "^4.1.12",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
-    "@tailwindcss/postcss": "^4.1.12",
     "@types/jsdom": "^21.1.7",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -29,7 +29,7 @@ export function AccountBlock({
   } | null>(null);
 
   return (
-    <div className="mb-8 p-4">
+    <div className="mb-4 p-2 md:mb-8 md:p-4">
       <h2 className="mt-0">
         {onToggle && (
           <input
@@ -76,7 +76,7 @@ export function AccountBlock({
       )}
     </div>
   );
-}
+  }
 
 /* Export default as convenience for `lazy()` / Storybook */
 export default AccountBlock;

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -248,8 +248,8 @@ export function HoldingsTable({
         ))}
       </div>
       {sortedRows.length ? (
-        <div className="table-responsive">
-        <table className={`${tableStyles.table} mb-4`}>
+        <div className="overflow-x-auto md:overflow-visible">
+          <table className={`${tableStyles.table} mb-4 w-full`}>
         <thead ref={tableHeaderRef}>
           <tr>
             <th className={tableStyles.cell}>
@@ -379,7 +379,7 @@ export function HoldingsTable({
         <tbody>
           {paddingTop > 0 && (
             <tr style={{ height: paddingTop }}>
-              <td colSpan={20} style={{ padding: 0, border: "none" }} />
+              <td colSpan={20} className="p-0 border-0" />
             </tr>
           )}
           {items.map((virtualRow) => {
@@ -507,7 +507,7 @@ export function HoldingsTable({
           })}
           {paddingBottom > 0 && (
             <tr style={{ height: paddingBottom }}>
-              <td colSpan={20} style={{ padding: 0, border: "none" }} />
+              <td colSpan={20} className="p-0 border-0" />
             </tr>
           )}
         </tbody>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -79,11 +79,11 @@ export function PortfolioView({ data, loading, error }: Props) {
       <div className="mb-8">
         Approx Total: {money(totalValue)}
       </div>
-      {hasWarnings && (
-        <div style={{ marginBottom: "1rem" }}>
-          <Link to={`/compliance/${data.owner}`}>View compliance warnings</Link>
-        </div>
-      )}
+        {hasWarnings && (
+          <div className="mb-4">
+            <Link to={`/compliance/${data.owner}`}>View compliance warnings</Link>
+          </div>
+        )}
       <ValueAtRisk owner={data.owner} />
       {/* Each account is rendered using AccountBlock for clarity */}
       {data.accounts.map((acct, idx) => {

--- a/frontend/src/components/responsiveRender.test.tsx
+++ b/frontend/src/components/responsiveRender.test.tsx
@@ -88,13 +88,15 @@ describe("mobile viewport rendering", () => {
     expect(container.querySelector("h1")).toHaveClass("mt-0");
   });
 
-  it("renders AccountBlock", () => {
-    const { container } = renderWithConfig(<AccountBlock account={account} />);
-    expect(container.firstChild).toHaveClass("mb-8", "p-4");
-  });
+    it("renders AccountBlock", () => {
+      const { container } = renderWithConfig(<AccountBlock account={account} />);
+      expect(container.firstChild).toHaveClass("mb-4", "p-2", "md:mb-8", "md:p-4");
+    });
 
-  it("renders HoldingsTable", () => {
-    const { container } = renderWithConfig(<HoldingsTable holdings={holdings} />);
-    expect(container.querySelector("table")).toHaveClass("mb-4");
+    it("renders HoldingsTable", () => {
+      const { container } = renderWithConfig(<HoldingsTable holdings={holdings} />);
+      const wrapper = container.querySelector("div.overflow-x-auto");
+      expect(wrapper).toHaveClass("overflow-x-auto");
+      expect(container.querySelector("table")).toHaveClass("mb-4");
+    });
   });
-});

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -59,15 +59,10 @@
 /* Fixed width helpers */
 .w-20 { width: 80px; }
 
-/* Responsive adjustments for small screens */
-@media (max-width: 640px) {
+/* Responsive adjustments for small screens (under 768px) */
+@media (max-width: 768px) {
   .mb-8 { margin-bottom: 1rem; }
   .p-4 { padding: 0.5rem; }
 }
 
-/* Table wrapper for horizontal scrolling on small devices */
-.table-responsive {
-  width: 100%;
-  overflow-x: auto;
-}
 

--- a/frontend/src/styles/responsive.test.tsx
+++ b/frontend/src/styles/responsive.test.tsx
@@ -6,6 +6,10 @@ describe('responsive styles', () => {
   const cssPath = path.resolve(__dirname, 'responsive.css')
   const css = fs.readFileSync(cssPath, 'utf-8')
 
+  it('includes max-width breakpoint for small screens', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)/)
+  })
+
   it('includes mobile breakpoint', () => {
     expect(css).toMatch(/@media\s*\(min-width:\s*480px\)/)
   })

--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -34,3 +34,9 @@
   padding: 0 4px;
   font-size: 0.75rem;
 }
+
+@media (max-width: 768px) {
+  .cell {
+    padding: 2px 4px;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile media query to shared styles and tighten table cell padding
- refactor PortfolioView, AccountBlock, and HoldingsTable to rely on responsive utility classes
- test rendering of key components at mobile widths

## Testing
- `npm test` *(fails: Test Files 1 failed | 12 passed | 2 skipped)*
- `npm --prefix frontend test src/components/responsiveRender.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b475787ff48327a46ec1b4be9e08f4