### PR TITLE
Add FX fetch fallback in offline mode

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -354,7 +354,10 @@ def _convert_to_gbp(df: pd.DataFrame, ticker: str, exchange: str, start: date, e
                 logger.warning("FX proxy fetch failed for %s: %s", currency, exc)
 
         if fx.empty:
-            raise ValueError(f"Offline mode: no FX rates for {currency}")
+            fx = fetch_fx_rate_range(currency, start, end).copy()
+            if fx.empty:
+                raise ValueError(f"Offline mode: no FX rates for {currency}")
+            fx["Date"] = pd.to_datetime(fx["Date"])
 
         mask = (fx["Date"].dt.date >= start) & (fx["Date"].dt.date <= end)
         fx = fx.loc[mask]


### PR DESCRIPTION
## Summary
- Allow `_convert_to_gbp` to fetch FX rates when cache and proxy are empty
- Test offline mode FX fallback without local cache files

## Testing
- `pytest tests/test_fx_conversion.py -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b47aeac88483278ec887eb8f6dac44