### PR TITLE
Add router and frontend page tests with CI push triggers

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -1,6 +1,7 @@
 name: Backend Integration Tests
 
 on:
+  push:
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,6 +1,7 @@
 name: Frontend Tests
 
 on:
+  push:
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/backend/tests/test_async_endpoints.py
+++ b/backend/tests/test_async_endpoints.py
@@ -1,0 +1,27 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from backend.app import create_app
+
+@pytest.mark.asyncio
+async def test_auth_alerts_portfolio(monkeypatch):
+    app = create_app()
+    monkeypatch.setattr(
+        "backend.common.alerts.get_recent_alerts", lambda: [{"message": "hi"}]
+    )
+    monkeypatch.setattr(
+        "backend.common.data_loader.list_plots",
+        lambda root: [{"owner": "alice", "accounts": ["brokerage"]}],
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        token_resp = await client.post(
+            "/token", data={"username": "testuser", "password": "password"}
+        )
+        token = token_resp.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        alerts_resp = await client.get("/alerts/", headers=headers)
+        owners_resp = await client.get("/owners", headers=headers)
+    assert token
+    assert alerts_resp.status_code == 200
+    assert owners_resp.status_code == 200
+    assert owners_resp.json()[0]["owner"] == "alice"

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -1,0 +1,54 @@
+import importlib
+import pkgutil
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+import backend.routes as routes_pkg
+from backend.routes import compliance, trading_agent
+
+
+def test_all_routes_registered():
+    missing = []
+    for _, name, _ in pkgutil.iter_modules(routes_pkg.__path__):
+        module = importlib.import_module(f"backend.routes.{name}")
+        router = getattr(module, "router", None)
+        if not isinstance(router, APIRouter) or not router.routes:
+            missing.append(name)
+    assert not missing, f"Routers missing routes: {missing}"
+
+
+def test_compliance_routes(monkeypatch):
+    app = FastAPI()
+    app.state.accounts_root = ""
+    app.include_router(compliance.router)
+
+    monkeypatch.setattr(
+        "backend.common.compliance.check_owner",
+        lambda owner, root: {"owner": owner, "warnings": []},
+    )
+    with TestClient(app) as client:
+        resp = client.get("/compliance/alice")
+    assert resp.status_code == 200
+    assert resp.json()["owner"] == "alice"
+
+    monkeypatch.setattr(
+        "backend.common.compliance.check_trade",
+        lambda trade, root: {"warnings": ["ok"]},
+    )
+    with TestClient(app) as client:
+        resp2 = client.post("/compliance/validate", json={})
+    assert resp2.status_code == 200
+    assert resp2.json()["warnings"] == ["ok"]
+
+
+def test_trading_agent_route(monkeypatch):
+    app = FastAPI()
+    app.include_router(trading_agent.router)
+
+    monkeypatch.setattr(
+        "backend.agent.trading_agent.run",
+        lambda: [{"ticker": "AAA", "action": "BUY"}],
+    )
+    with TestClient(app) as client:
+        resp = client.get("/trading-agent/signals")
+    assert resp.status_code == 200
+    assert resp.json() == [{"ticker": "AAA", "action": "BUY"}]

--- a/frontend/src/pages/Portfolio.test.tsx
+++ b/frontend/src/pages/Portfolio.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import Portfolio from "./Portfolio";
+import * as api from "../api";
+
+vi.mock("../api");
+const mockGetPortfolio = vi.mocked(api.getPortfolio);
+
+describe("Portfolio page", () => {
+  it("fetches and displays portfolio data", async () => {
+    mockGetPortfolio.mockResolvedValueOnce({ owner: "alice", as_of: "2024-01-01", accounts: [] } as any);
+    render(<Portfolio />);
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+    expect(await screen.findByTestId("owner-name")).toHaveTextContent("alice");
+  });
+});

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+import { getPortfolio } from "../api";
+import { PortfolioView } from "../components/PortfolioView";
+import type { Portfolio } from "../types";
+
+export function Portfolio() {
+  const [data, setData] = useState<Portfolio | null>(null);
+  useEffect(() => {
+    getPortfolio("alice").then(setData).catch(() => setData(null));
+  }, []);
+  return <PortfolioView data={data} />;
+}
+
+export default Portfolio;


### PR DESCRIPTION
## Summary
- test every backend router and add focused coverage for compliance and trading-agent APIs
- add async integration test for auth, alerts, and portfolio routes
- create Portfolio page with Vitest tests
- run backend and frontend tests on push and pull_request

## Testing
- `pytest backend/tests/test_routers.py backend/tests/test_async_endpoints.py -q -c tmp_pytest.ini`
- `npm --prefix frontend test -- src/pages/Portfolio.test.tsx src/pages/Screener.test.tsx --run`


------
https://chatgpt.com/codex/tasks/task_e_68b479f88b8c832791c50b623249aeb3