### PR TITLE
Fix offline range fallback when cache missing

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -300,13 +300,7 @@ def _memoized_range_cached(
         existing = _load_parquet(cache_path)
         if existing.empty:
             logger.warning("Offline mode: no cached data for %s.%s", ticker, exchange)
-            superset = load_meta_timeseries(ticker, exchange, days_needed)
-            if superset.empty or "Date" not in superset.columns:
-                return _empty_ts()
-            mask = (superset["Date"].dt.date >= start_date) & (
-                superset["Date"].dt.date <= end_date
-            )
-            return _ensure_schema(superset.loc[mask].reset_index(drop=True)).copy()
+            return _empty_ts()
         ex = existing.copy()
         ex["Date"] = ex["Date"].dt.date
         mask = (ex["Date"] >= start_date) & (ex["Date"] <= end_date)

--- a/tests/test_fx_conversion.py
+++ b/tests/test_fx_conversion.py
@@ -149,29 +149,24 @@ def test_memoized_range_returns_copy(monkeypatch):
     assert list(second["Close"]) == [1, 2]
 
 
-def test_memoized_range_offline_calls_load_meta_timeseries_once(monkeypatch):
+def test_memoized_range_offline_no_cache_returns_empty(monkeypatch):
     start = dt.date(2024, 1, 1)
     end = dt.date(2024, 1, 2)
 
-    sample = _sample_df(start, end)
     calls = {"n": 0}
 
     def fake_load_meta_timeseries(ticker, exchange, days_span):
         calls["n"] += 1
-        return sample
+        return cache._empty_ts()
 
     monkeypatch.setattr(cache, "load_meta_timeseries", fake_load_meta_timeseries)
     monkeypatch.setattr(cache, "_load_parquet", lambda path: cache._empty_ts())
     monkeypatch.setattr(cache, "OFFLINE_MODE", True)
     cache._memoized_range_cached.cache_clear()
 
-    cache._memoized_range("T", "L", start.isoformat(), end.isoformat())
-    cache._memoized_range("T", "L", start.isoformat(), end.isoformat())
-    assert calls["n"] == 1
-
-    cache._memoized_range_cached.cache_clear()
-    cache._memoized_range("T", "L", start.isoformat(), end.isoformat())
-    assert calls["n"] == 2
+    df = cache._memoized_range("T", "L", start.isoformat(), end.isoformat())
+    assert df.empty
+    assert calls["n"] == 0
 
 def test_offline_mode_uses_fx_cache(tmp_path, monkeypatch):
     start = dt.date(2024, 1, 1)


### PR DESCRIPTION
## Summary
- Avoid calling `load_meta_timeseries` when offline cache is empty, returning an empty schema instead
- Adjust regression test to expect no meta fetch call in offline mode without cache

## Testing
- `pytest -q tests/test_fx_conversion.py::test_memoized_range_returns_copy`
- `pytest -q tests/test_fx_conversion.py::test_memoized_range_offline_no_cache_returns_empty`


------
https://chatgpt.com/codex/tasks/task_e_68b47cdc61d88327a280c986405cdd7a