### PR TITLE
fix: ignore unknown strategy overrides

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -48,7 +48,12 @@ def load_strategy_config() -> TradingAgentConfig:
         try:
             data = json.loads(prefs_path.read_text())
             if isinstance(data, dict):
-                base.update({k: v for k, v in data.items() if v is not None})
+                allowed_keys = set(base)
+                filtered = {k: v for k, v in data.items() if v is not None and k in allowed_keys}
+                unknown = set(data) - allowed_keys
+                if unknown:
+                    logger.info("Ignoring unknown strategy preference keys: %s", ", ".join(sorted(unknown)))
+                base.update(filtered)
         except Exception as exc:  # pragma: no cover - file errors are rare
             logger.warning("Failed to load strategy preferences: %s", exc)
 

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import shutil
 from backend.common import portfolio_utils
@@ -75,6 +76,16 @@ def test_agent_generate_signals_risk_filters(monkeypatch):
     snapshot = {"AAA": {"rsi": 20, "sharpe": 0.5, "volatility": 0.2}}
     signals = ta_generate_signals(snapshot)
     assert signals == []
+
+
+def test_load_strategy_config_ignores_unknown_keys(tmp_path, monkeypatch):
+    prefs = {"rsi_buy": 25, "unknown": 1}
+    prefs_path = tmp_path / "strategy_prefs.json"
+    prefs_path.write_text(json.dumps(prefs))
+    monkeypatch.setattr(trading_agent.config, "repo_root", tmp_path)
+    cfg = trading_agent.load_strategy_config()
+    assert cfg.rsi_buy == 25
+    assert cfg.rsi_sell == 70.0
 
 
 def test_send_trade_alert_sns_only(monkeypatch):


### PR DESCRIPTION
## Summary
- ignore unknown keys in strategy override file when loading trading strategy config
- add regression test for unknown strategy preference keys

## Testing
- `pytest -p no:pytest_cov --override-ini="addopts=" tests/test_trading_agent.py::test_agent_generate_signals_risk_filters tests/test_trading_agent.py::test_run_applies_risk_filters -q`
- `pytest -p no:pytest_cov --override-ini="addopts=" tests/test_trading_agent.py::test_run_does_not_filter_sell_signal -q`
- `pytest -p no:pytest_cov --override-ini="addopts=" tests/test_trading_agent.py::test_run_defaults_to_all_known_tickers -q`
- `pytest -p no:pytest_cov --override-ini="addopts=" tests/test_trading_agent.py::test_run_compliance_gates_actions -q`
- `pytest -p no:pytest_cov --override-ini="addopts=" tests/test_trading_agent.py::test_load_strategy_config_ignores_unknown_keys -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47e60b1108327a5ff930ae26ccb81