### PR TITLE
Develop: handle missing owner validation and fix FX fallback

### DIFF
--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException
 
 from backend.common import compliance
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
@@ -21,7 +21,11 @@ async def compliance_for_owner(owner: str, request: Request):
 async def validate_trade(request: Request):
     """Validate a proposed trade for compliance issues."""
     trade = await request.json()
+    if "owner" not in trade:
+        raise HTTPException(status_code=422, detail="owner is required")
     try:
         return compliance.check_trade(trade, request.app.state.accounts_root)
     except FileNotFoundError:
         raise_owner_not_found()
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -35,9 +35,11 @@ def test_compliance_routes(monkeypatch):
         lambda trade, root: {"warnings": ["ok"]},
     )
     with TestClient(app) as client:
-        resp2 = client.post("/compliance/validate", json={})
+        resp2 = client.post("/compliance/validate", json={"owner": "alice"})
+        resp3 = client.post("/compliance/validate", json={})
     assert resp2.status_code == 200
     assert resp2.json()["warnings"] == ["ok"]
+    assert resp3.status_code == 422
 
 
 def test_trading_agent_route(monkeypatch):

--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -376,13 +376,15 @@ def _convert_to_gbp(df: pd.DataFrame, ticker: str, exchange: str, start: date, e
         if fx.empty:
             try:
                 fx = fetch_fx_rate_range(currency, start, end).copy()
-
                 if fx.empty:
-                  raise ValueError(f"Offline mode: no FX rates for {currency}")
-
+                    raise ValueError(
+                        f"Offline mode: no FX rates for {currency}"
+                    )
                 fx["Date"] = pd.to_datetime(fx["Date"])
             except Exception as exc:
-                raise ValueError(f"Offline mode: no FX rates for {currency}") from exc
+                raise ValueError(
+                    f"Offline mode: no FX rates for {currency}"
+                ) from exc
 
         mask = (fx["Date"].dt.date >= start) & (fx["Date"].dt.date <= end)
         fx = fx.loc[mask]

--- a/tests/test_compliance_route.py
+++ b/tests/test_compliance_route.py
@@ -64,3 +64,10 @@ def test_validate_trade(tmp_path, monkeypatch):
         assert resp2.status_code == 200
         data2 = resp2.json()
         assert data2["warnings"] == []
+
+
+def test_validate_trade_missing_owner(tmp_path):
+    app = _setup_app(tmp_path)
+    with TestClient(app) as client:
+        resp = client.post("/compliance/validate", json={})
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- return 422 for trades missing `owner` and map other ValueErrors to HTTP errors in `/compliance/validate`
- add tests covering owner validation in compliance routes
- correct indentation for offline FX-rate fallback in `_convert_to_gbp`

## Testing
- `python -m compileall backend`
- `pytest`
- `npm test` *(fails: Cannot find package '@tailwindcss/postcss')*

------
https://chatgpt.com/codex/tasks/task_e_68b488ede42c8327a609c5c9507ce069