### PR TITLE
feat: add per-user compliance settings

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -107,7 +107,7 @@ def create_app() -> FastAPI:
     app.include_router(config_router)
     app.include_router(quotes_router)
     app.include_router(movers_router)
-    app.include_router(user_config_router)
+    app.include_router(user_config_router, dependencies=protected)
     app.include_router(scenario_router)
 
     @app.exception_handler(RequestValidationError)


### PR DESCRIPTION
## Summary
- externalize trade limits and approval exemptions to per-user config files
- expose API and UI tab for editing per-user compliance settings
- log compliance rule violations with timestamps and rule references
- protect per-user config endpoints with auth dependency

## Testing
- `pytest`
- `npm test` *(fails: App > defaults to Movers view and orders tabs correctly)*

------
https://chatgpt.com/codex/tasks/task_e_68b49ff3a34c83279d76867b42a37047