### PR TITLE
feat: pass instrument name to trading detail view

### DIFF
--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -49,7 +49,7 @@ const mockGetGroupInstruments = vi.fn(() =>
 );
 const mockGetTradingSignals = vi.fn(() =>
   Promise.resolve([
-    { ticker: "AAA", action: "buy", reason: "go long" },
+    { ticker: "AAA", name: "AAA", action: "buy", reason: "go long" },
   ]),
 );
 

--- a/frontend/src/pages/Trading.tsx
+++ b/frontend/src/pages/Trading.tsx
@@ -9,7 +9,7 @@ export default function Trading() {
   const { t } = useTranslation();
   const [signals, setSignals] = useState<TradingSignal[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<TradingSignal | null>(null);
 
   useEffect(() => {
     getTradingSignals()
@@ -42,7 +42,7 @@ export default function Trading() {
             <tr key={s.ticker}>
               <td
                 className={`${tableStyles.cell} ${tableStyles.clickable}`}
-                onClick={() => setSelected(s.ticker)}
+                onClick={() => setSelected(s)}
               >
                 {s.ticker}
               </td>
@@ -53,7 +53,13 @@ export default function Trading() {
         </tbody>
       </table>
       {selected && (
-        <InstrumentDetail ticker={selected} onClose={() => setSelected(null)} />
+        <InstrumentDetail
+          ticker={selected.ticker}
+          name={selected.name}
+          currency={selected.currency ?? undefined}
+          instrument_type={selected.instrument_type}
+          onClose={() => setSelected(null)}
+        />
       )}
     </>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -261,8 +261,11 @@ export interface VirtualPortfolio {
 
 export interface TradingSignal {
     ticker: string;
+    name: string;
     action: string;
     reason: string;
+    currency?: string | null;
+    instrument_type?: string | null;
 }
 
 export interface CustomQuery {


### PR DESCRIPTION
## Summary
- extend TradingSignal type with instrument name and optional metadata
- provide name and instrument info to InstrumentDetail on Trading page
- adjust tests for new TradingSignal shape

## Testing
- `npm test` *(fails: Cannot find package '@tailwindcss/postcss')*


------
https://chatgpt.com/codex/tasks/task_e_68b4a5a5b7b08327917e9bc06b36227d