### PR TITLE
fix push subscription typing

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -384,7 +384,7 @@ export const setAlertThreshold = (user: string, threshold: number) =>
   });
 
 export interface PushSubscriptionJSON {
-  endpoint: string;
+  endpoint?: string;
   keys: {
     p256dh: string;
     auth: string;

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -159,7 +159,10 @@ export default function Support() {
           ? urlBase64ToUint8Array(import.meta.env.VITE_VAPID_PUBLIC_KEY as string)
           : undefined,
       });
-      await savePushSubscription("default", sub.toJSON());
+      await savePushSubscription(
+        "default",
+        sub.toJSON() as import("../api").PushSubscriptionJSON,
+      );
       setPushEnabled(true);
     } catch {
       /* ignore */


### PR DESCRIPTION
## Summary
- cast push subscription JSON and export interface
- make endpoint optional in PushSubscriptionJSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a5a4ed3c8327b6ebe0d0b28d4eb6