### PR TITLE
Remove unused low52wMax filter from screener

### DIFF
--- a/frontend/src/pages/Screener.tsx
+++ b/frontend/src/pages/Screener.tsx
@@ -31,7 +31,6 @@ export function Screener() {
   const [floatSharesMin, setFloatSharesMin] = useState("");
   const [marketCapMin, setMarketCapMin] = useState("");
   const [high52wMax, setHigh52wMax] = useState("");
-  const [low52wMax, setLow52wMax] = useState("");
   const [low52wMin, setLow52wMin] = useState("");
   const [avgVolumeMin, setAvgVolumeMin] = useState("");
 
@@ -103,7 +102,6 @@ export function Screener() {
           ? parseFloat(marketCapMin)
           : undefined,
         high_52w_max: high52wMax ? parseFloat(high52wMax) : undefined,
-        low_52w_max: low52wMax ? parseFloat(low52wMax) : undefined,
         low_52w_min: low52wMin ? parseFloat(low52wMin) : undefined,
         avg_volume_min: avgVolumeMin ? parseFloat(avgVolumeMin) : undefined,
       });


### PR DESCRIPTION
## Summary
- remove unused low52wMax state and submission parameter from Screener page

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b4a5a42b4c832798ee13dde0e14582