### PR TITLE
Add missing fields to portfolio test

### DIFF
--- a/frontend/src/components/responsiveRender.test.tsx
+++ b/frontend/src/components/responsiveRender.test.tsx
@@ -67,6 +67,9 @@ const account: Account = {
 const portfolio: Portfolio = {
   owner: "Alice",
   as_of: "2024-01-02",
+  trades_this_month: 0,
+  trades_remaining: 0,
+  total_value_estimate_gbp: 150,
   accounts: [account],
 };
 


### PR DESCRIPTION
## Summary
- Include dummy trade and value fields in responsive rendering tests

## Testing
- `npm test` *(fails: Cannot find package '@tailwindcss/postcss')*

------
https://chatgpt.com/codex/tasks/task_e_68b4a5a04ba88327aded0aca23f50cdb