### PR TITLE
Add trading tab to test configs and clean duplicates

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -57,13 +57,14 @@ describe("App", () => {
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
       getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-        getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
-        getTimeseries: vi.fn().mockResolvedValue([]),
-        saveTimeseries: vi.fn(),
-        refetchTimeseries: vi.fn(),
-        rebuildTimeseriesCache: vi.fn(),
-        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-      }));
+      getCompliance: vi
+        .fn()
+        .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+      getTimeseries: vi.fn().mockResolvedValue([]),
+      saveTimeseries: vi.fn(),
+      refetchTimeseries: vi.fn(),
+      rebuildTimeseriesCache: vi.fn(),
+    }));
 
     const { default: App } = await import("./App");
 
@@ -87,13 +88,14 @@ describe("App", () => {
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
       getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-      getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+      getCompliance: vi
+        .fn()
+        .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
       getTimeseries: vi.fn().mockResolvedValue([]),
       saveTimeseries: vi.fn(),
       listTimeseries: vi.fn().mockResolvedValue([]),
       refetchTimeseries: vi.fn(),
       rebuildTimeseriesCache: vi.fn(),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
     }));
 
     const { default: App } = await import("./App");
@@ -120,12 +122,15 @@ describe("App", () => {
         refreshPrices: vi.fn(),
         getAlerts: vi.fn().mockResolvedValue([]),
         getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-        getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [] }),
+        getCompliance: vi
+          .fn()
+          .mockResolvedValue({ owner: "", warnings: [] }),
         getTimeseries: vi.fn().mockResolvedValue([]),
         saveTimeseries: vi.fn(),
         getTradingSignals: vi.fn().mockResolvedValue([]),
-        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
-        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+        getTopMovers: vi
+          .fn()
+          .mockResolvedValue({ gainers: [], losers: [] }),
         listTimeseries: vi.fn().mockResolvedValue([]),
         refetchTimeseries: vi.fn(),
         rebuildTimeseriesCache: vi.fn(),
@@ -148,6 +153,7 @@ describe("App", () => {
       dataadmin: true,
       virtual: true,
       support: true,
+      reports: true,
       scenario: true,
     };
 
@@ -181,12 +187,15 @@ describe("App", () => {
         refreshPrices: vi.fn(),
         getAlerts: vi.fn().mockResolvedValue([]),
         getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-        getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [] }),
+        getCompliance: vi
+          .fn()
+          .mockResolvedValue({ owner: "", warnings: [] }),
         getTimeseries: vi.fn().mockResolvedValue([]),
         saveTimeseries: vi.fn(),
         getTradingSignals: mockTradingSignals,
-        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
-        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+        getTopMovers: vi
+          .fn()
+          .mockResolvedValue({ gainers: [], losers: [] }),
         listTimeseries: vi.fn().mockResolvedValue([]),
         refetchTimeseries: vi.fn(),
         rebuildTimeseriesCache: vi.fn(),
@@ -209,6 +218,7 @@ describe("App", () => {
       dataadmin: true,
       virtual: true,
       support: true,
+      reports: true,
       scenario: true,
     };
 
@@ -330,15 +340,14 @@ describe("App", () => {
       getCompliance: vi
         .fn()
         .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
-        getTimeseries: vi.fn().mockResolvedValue([]),
-        saveTimeseries: vi.fn(),
-        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
-        getTradingSignals: mockTradingSignals,
-        listTimeseries: vi.fn().mockResolvedValue([]),
-        refetchTimeseries: vi.fn(),
-        rebuildTimeseriesCache: vi.fn(),
-        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-      }));
+      getTimeseries: vi.fn().mockResolvedValue([]),
+      saveTimeseries: vi.fn(),
+      getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+      getTradingSignals: mockTradingSignals,
+      listTimeseries: vi.fn().mockResolvedValue([]),
+      refetchTimeseries: vi.fn(),
+      rebuildTimeseriesCache: vi.fn(),
+    }));
 
     const { default: App } = await import("./App");
 

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -18,16 +18,16 @@ const defaultConfig: AppConfig = {
     instrument: true,
     performance: true,
     transactions: true,
+    trading: true,
     screener: true,
     timeseries: true,
     watchlist: true,
     movers: true,
     dataadmin: true,
     virtual: true,
-    reports: true,
     support: true,
-    scenario: true,
     reports: true,
+    scenario: true,
   },
 };
 

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -16,16 +16,16 @@ const defaultConfig: AppConfig = {
         instrument: true,
         performance: true,
         transactions: true,
+        trading: true,
         screener: true,
         timeseries: true,
         watchlist: true,
         movers: true,
         dataadmin: true,
         virtual: true,
-        reports: true,
         support: true,
-        scenario: true,
         reports: true,
+        scenario: true,
     },
 };
 import type { Holding } from "../types";

--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -13,16 +13,16 @@ const defaultConfig: AppConfig = {
     instrument: true,
     performance: true,
     transactions: true,
+    trading: true,
     screener: true,
     timeseries: true,
     watchlist: true,
     movers: true,
     dataadmin: true,
     virtual: true,
-    reports: true,
     support: true,
-    scenario: true,
     reports: true,
+    scenario: true,
   },
 };
 

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -12,16 +12,16 @@ const defaultConfig: AppConfig = {
         instrument: true,
         performance: true,
         transactions: true,
+        trading: true,
         screener: true,
         timeseries: true,
         watchlist: true,
         movers: true,
         dataadmin: true,
         virtual: true,
-        reports: true,
         support: true,
-        scenario: true,
         reports: true,
+        scenario: true,
     },
 };
 

--- a/frontend/src/components/responsiveRender.test.tsx
+++ b/frontend/src/components/responsiveRender.test.tsx
@@ -23,16 +23,16 @@ const defaultConfig: AppConfig = {
     instrument: true,
     performance: true,
     transactions: true,
+    trading: true,
     screener: true,
     timeseries: true,
     watchlist: true,
     movers: true,
     dataadmin: true,
     virtual: true,
-    reports: true,
     support: true,
-    scenario: true,
     reports: true,
+    scenario: true,
   },
 };
 

--- a/frontend/src/hooks/useRouteMode.test.tsx
+++ b/frontend/src/hooks/useRouteMode.test.tsx
@@ -17,6 +17,7 @@ describe("useRouteMode", () => {
       instrument: false,
       performance: false,
       transactions: false,
+      trading: false,
       screener: false,
       timeseries: false,
       watchlist: false,

--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -18,7 +18,14 @@ beforeEach(() => {
   mockGetConfig.mockResolvedValue({
     flag: true,
     theme: "system",
-    tabs: { group: true, owner: true, instrument: true, support: true },
+    tabs: {
+      group: true,
+      owner: true,
+      instrument: true,
+      trading: true,
+      support: true,
+      reports: true,
+    },
   });
 });
 
@@ -45,13 +52,27 @@ describe("Support page", () => {
   mockGetConfig.mockResolvedValueOnce({
     flag: true,
     theme: "system",
-    tabs: { group: true, owner: true, instrument: true, support: true },
+    tabs: {
+      group: true,
+      owner: true,
+      instrument: true,
+      trading: true,
+      support: true,
+      reports: true,
+    },
   });
   mockGetConfig.mockResolvedValueOnce({
     flag: false,
     count: 5,
     theme: "dark",
-    tabs: { group: true, owner: true, instrument: false, support: true },
+    tabs: {
+      group: true,
+      owner: true,
+      instrument: false,
+      trading: true,
+      support: true,
+      reports: true,
+    },
   });
     mockUpdateConfig.mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary
- add explicit `trading` tab and ensure single `reports` flag in test tab configs
- remove duplicate API mock properties like repeated `getAlertSettings`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a59cd3b08327b2d137d8a9c4590b