### PR TITLE
chore: import portfolio type in test

### DIFF
--- a/frontend/src/pages/Portfolio.test.tsx
+++ b/frontend/src/pages/Portfolio.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
-import Portfolio from "./Portfolio";
+import PortfolioPage from "./Portfolio";
+import type { Portfolio } from "../types";
 import * as api from "../api";
 
 vi.mock("../api");
@@ -8,8 +9,8 @@ const mockGetPortfolio = vi.mocked(api.getPortfolio);
 
 describe("Portfolio page", () => {
   it("fetches and displays portfolio data", async () => {
-    mockGetPortfolio.mockResolvedValueOnce({ owner: "alice", as_of: "2024-01-01", accounts: [] } as any);
-    render(<Portfolio />);
+    mockGetPortfolio.mockResolvedValueOnce({ owner: "alice", as_of: "2024-01-01", accounts: [] } as Portfolio);
+    render(<PortfolioPage />);
     await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
     expect(await screen.findByTestId("owner-name")).toHaveTextContent("alice");
   });


### PR DESCRIPTION
## Summary
- import Portfolio type in Portfolio page test
- use typed mock data

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b4a5a9553c83279d9fffbbe96f998a