### PR TITLE
chore: remove unused React import

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 interface Props {
   tradesThisMonth?: number | null;
   tradesRemaining?: number | null;


### PR DESCRIPTION
## Summary
- remove unused React import from Header component

## Testing
- `npm test` *(fails: Cannot find package '@tailwindcss/postcss')*

------
https://chatgpt.com/codex/tasks/task_e_68b4a59ae1748327b3e6f482dcd00f70