### PR TITLE
Expose unauthorized flag from useFetchWithRetry

### DIFF
--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -53,9 +53,11 @@ export default function MainApp() {
 
   const [backendUnavailable, setBackendUnavailable] = useState(false);
 
-  const ownersReq = useFetchWithRetry(getOwners);
-  const groupsReq = useFetchWithRetry(getGroups);
-  const unauthorized = ownersReq.unauthorized || groupsReq.unauthorized;
+  const { unauthorized: ownersUnauthorized, ...ownersReq } =
+    useFetchWithRetry(getOwners);
+  const { unauthorized: groupsUnauthorized, ...groupsReq } =
+    useFetchWithRetry(getGroups);
+  const unauthorized = ownersUnauthorized || groupsUnauthorized;
 
   useEffect(() => {
     if (ownersReq.data) setOwners(ownersReq.data);

--- a/frontend/src/hooks/useFetchWithRetry.ts
+++ b/frontend/src/hooks/useFetchWithRetry.ts
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import useFetch from "./useFetch";
 
+interface UseFetchResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+}
+
 /**
  * Wraps `useFetch` and automatically retries the request until it succeeds.
  * A failed request schedules another attempt after `delay` milliseconds.
@@ -11,7 +17,11 @@ export function useFetchWithRetry<T>(
   fn: () => Promise<T>,
   delay = 2000,
   maxAttempts = 5,
-) {
+): UseFetchResult<T> & {
+  attempt: number;
+  maxAttempts: number;
+  unauthorized: boolean;
+} {
   const [attempt, setAttempt] = useState(1);
   const result = useFetch(fn, [attempt]);
   const unauthorized = result.error?.message.includes("HTTP 401") ?? false;
@@ -23,7 +33,7 @@ export function useFetchWithRetry<T>(
     return () => clearTimeout(timer);
   }, [result.error, delay, attempt, maxAttempts]);
 
-  return { ...result, attempt, maxAttempts };
+  return { ...result, attempt, maxAttempts, unauthorized };
 }
 
 export default useFetchWithRetry;


### PR DESCRIPTION
## Summary
- expose an `unauthorized` flag from `useFetchWithRetry`
- surface unauthorized state in `MainApp`

## Testing
- `npm test --prefix frontend` *(fails: Cannot find package '@tailwindcss/postcss')*
- `npm run lint --prefix frontend` *(fails: 9 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a597c4d48327903fb5593ed33a69