### PR TITLE
Add backend API test cases

### DIFF
--- a/api_test_cases.yaml
+++ b/api_test_cases.yaml
@@ -1,4 +1,21 @@
-- method: GET
-  url: https://httpbin.org/get
-- method: GET
-  url: https://httpbin.org/status/404
+- name: Get backend configuration
+  method: GET
+  url: http://localhost:8000/config
+
+- name: Retrieve metrics for user "alex"
+  method: GET
+  url: http://localhost:8000/metrics/alex
+
+- name: Fetch instrument data for AZN.L
+  method: GET
+  url: http://localhost:8000/instrument
+  params:
+    ticker: AZN.L
+    days: 30
+    format: json
+
+- name: Request quote for AAPL
+  method: GET
+  url: http://localhost:8000/api/quotes
+  params:
+    symbols: AAPL


### PR DESCRIPTION
## Summary
- point API test cases at local backend endpoints for config, metrics, instrument data and quotes
- give each test case a descriptive name and move query parameters into `params`

## Testing
- `pytest -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68b4a7428c008327949711e1bcd95712