### PR TITLE
Fix service worker caching and preserve user config defaults

### DIFF
--- a/backend/common/user_config.py
+++ b/backend/common/user_config.py
@@ -57,13 +57,15 @@ def load_user_config(owner: str, accounts_root: Path | None = None) -> UserConfi
 
 def save_user_config(owner: str, cfg: UserConfig | dict[str, object], accounts_root: Path | None = None) -> None:
     path = _settings_path(owner, accounts_root)
+    existing: dict[str, object] = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text()) or {}
+        except Exception:
+            existing = {}
     if isinstance(cfg, UserConfig):
-        data = cfg.to_dict()
+        new_data = {k: v for k, v in cfg.to_dict().items() if v is not None}
     else:
-        data = {
-            "hold_days_min": cfg.get("hold_days_min"),
-            "max_trades_per_month": cfg.get("max_trades_per_month"),
-            "approval_exempt_types": cfg.get("approval_exempt_types"),
-            "approval_exempt_tickers": cfg.get("approval_exempt_tickers"),
-        }
-    path.write_text(json.dumps(data, indent=2, sort_keys=True))
+        new_data = {k: v for k, v in cfg.items() if v is not None}
+    existing.update(new_data)
+    path.write_text(json.dumps(existing, indent=2, sort_keys=True))

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -2,7 +2,7 @@
 
 import { precacheAndRoute } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
-import { CacheFirst } from 'workbox-strategies';
+import { CacheFirst, NetworkFirst } from 'workbox-strategies';
 
 declare const self: ServiceWorkerGlobalScope;
 declare const __WB_MANIFEST: Array<string | { url: string; revision?: string }>;
@@ -35,10 +35,22 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
   );
 });
 
-// Runtime caching for same-origin GET requests not precached.
+// Runtime caching for same-origin static assets and network-first for API requests.
 registerRoute(
-  ({ request, url }) => request.method === 'GET' && url.origin === self.location.origin,
+  ({ request, url }) =>
+    request.method === 'GET' &&
+    url.origin === self.location.origin &&
+    request.destination !== '' &&
+    !url.pathname.startsWith('/api/'),
   new CacheFirst({ cacheName: CACHE_NAME })
+);
+
+registerRoute(
+  ({ request, url }) =>
+    request.method === 'GET' &&
+    url.origin === self.location.origin &&
+    url.pathname.startsWith('/api/'),
+  new NetworkFirst({ cacheName: 'api-cache' })
 );
 
 self.addEventListener('push', (event: PushEvent) => {


### PR DESCRIPTION
## Summary
- limit service worker caching to static assets and use network-first strategy for API requests
- merge user config updates with existing settings to avoid overwriting defaults

## Testing
- `npm test` (fails: Test Files  1 failed | 4 passed | 2 skipped (28); Tests  2 failed | 53 passed | 1 skipped (69))
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4ac4c943c8327a9a7db142e5ddafa