### PR TITLE
Fix owner not found decorator signature handling

### DIFF
--- a/backend/common/errors.py
+++ b/backend/common/errors.py
@@ -32,7 +32,6 @@ def handle_owner_not_found(func: F) -> F:
                 return await func(*args, **kwargs)
             except OwnerNotFoundError as exc:  # pragma: no cover - thin wrapper
                 raise HTTPException(status_code=404, detail=OWNER_NOT_FOUND) from exc
-        async_wrapper.__globals__.update(func.__globals__)
         async_wrapper.__signature__ = inspect.signature(func)
         return async_wrapper  # type: ignore[return-value]
 
@@ -42,6 +41,5 @@ def handle_owner_not_found(func: F) -> F:
             return func(*args, **kwargs)
         except OwnerNotFoundError as exc:  # pragma: no cover - thin wrapper
             raise HTTPException(status_code=404, detail=OWNER_NOT_FOUND) from exc
-    sync_wrapper.__globals__.update(func.__globals__)
     sync_wrapper.__signature__ = inspect.signature(func)
     return sync_wrapper  # type: ignore[return-value]


### PR DESCRIPTION
## Summary
- avoid global namespace mutation in `handle_owner_not_found` decorator to prevent global pollution and rely on signature preservation only

## Testing
- `python - <<'PY'
from fastapi.testclient import TestClient
from backend.config import config
config.offline_mode = True
config.skip_snapshot_warm = True
from backend.app import create_app
app = create_app()
client = TestClient(app)
resp = client.get('/openapi.json')
print('status', resp.status_code)
print('keys', list(resp.json().keys())[:5])
PY` *(fails: `pydantic.errors.PydanticUserError: TypeAdapter[typing.Annotated[ForwardRef('Request'), Query(PydanticUndefined)]] is not fully defined`)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4ae16b8548327a4cc00dcf28f3179