### PR TITLE
fix: skip None snapshot prices when priming cache

### DIFF
--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -110,7 +110,8 @@ def update_latest_prices_from_snapshot(snapshot: Dict[str, Dict[str, Any]]) -> N
     _LATEST_PRICES = {
         t: float(info.get("last_price"))
         for t, info in snapshot.items()
-        if isinstance(info, dict) and "last_price" in info
+        if isinstance(info, dict)
+        and info.get("last_price") is not None
     }
 
 

--- a/tests/test_update_latest_prices_from_snapshot.py
+++ b/tests/test_update_latest_prices_from_snapshot.py
@@ -1,0 +1,13 @@
+import backend.common.instrument_api as instrument_api
+
+
+def test_update_latest_prices_from_snapshot_skips_none():
+    instrument_api._LATEST_PRICES = {}
+    snapshot = {
+        "AAA.L": {"last_price": 123.45},
+        "BBB.L": {"last_price": None},
+        "CCC.L": {"other": 5},
+        "DDD.L": None,
+    }
+    instrument_api.update_latest_prices_from_snapshot(snapshot)
+    assert instrument_api._LATEST_PRICES == {"AAA.L": 123.45}


### PR DESCRIPTION
## Summary
- skip `None` last_price entries when seeding instrument price cache
- test `update_latest_prices_from_snapshot` skips missing prices

## Testing
- `pytest tests/test_update_latest_prices_from_snapshot.py tests/test_prices_snapshot.py tests/test_app.py -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b4ae0a009083278dc101337a21469f