### PR TITLE
Remove duplicate performance router inclusion

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -101,7 +101,6 @@ def create_app() -> FastAPI:
     app.include_router(query_router)
     app.include_router(virtual_portfolio_router, dependencies=protected)
     app.include_router(metrics_router)
-    app.include_router(performance_router, dependencies=protected)
     app.include_router(agent_router)
     app.include_router(trading_agent_router, dependencies=protected)
     app.include_router(config_router)


### PR DESCRIPTION
## Summary
- register performance router only once
- verify performance endpoints exist once

## Testing
- `pytest -q`
- `python - <<'PY'
from backend.app import create_app
app=create_app()
performance_paths=[r.path for r in app.router.routes if 'performance' in r.path]
print('paths', performance_paths)
print('count', len(performance_paths))
PY`
- `python - <<'PY'
from backend.app import create_app
from fastapi.testclient import TestClient
app=create_app()
client=TestClient(app)
resp=client.get('/performance/alex')
print('status', resp.status_code)
if resp.status_code==200:
    data=resp.json()
    print('keys', list(data.keys())[:5])
PY`
- `python - <<'PY'
from fastapi import FastAPI
from backend.routes.performance import router as performance_router
app=FastAPI()
app.include_router(performance_router)
openapi=app.openapi()
perf_paths=[p for p in openapi['paths'] if 'performance' in p]
print(perf_paths)
print('count', len(perf_paths))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b4abee951c83279dbe989435e0270c