### PR TITLE
test: fix Portfolio page tests

### DIFF
--- a/frontend/src/pages/Portfolio.test.tsx
+++ b/frontend/src/pages/Portfolio.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
-import PortfolioPage from "./Portfolio";
+import PortfolioPage from "./Portfolio.tsx";
 import type { Portfolio } from "../types";
 import * as api from "../api";
 
@@ -9,7 +9,14 @@ const mockGetPortfolio = vi.mocked(api.getPortfolio);
 
 describe("Portfolio page", () => {
   it("fetches and displays portfolio data", async () => {
-    mockGetPortfolio.mockResolvedValueOnce({ owner: "alice", as_of: "2024-01-01", accounts: [] } as Portfolio);
+    mockGetPortfolio.mockResolvedValueOnce({
+      owner: "alice",
+      as_of: "2024-01-01",
+      trades_this_month: 0,
+      trades_remaining: 0,
+      total_value_estimate_gbp: 0,
+      accounts: [],
+    } as Portfolio);
     render(<PortfolioPage />);
     await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
     expect(await screen.findByTestId("owner-name")).toHaveTextContent("alice");


### PR DESCRIPTION
## Summary
- ensure Portfolio page test imports component as a value
- mock all required Portfolio fields in Portfolio page test

## Testing
- `npm test -- --run` *(fails: 1 failed, 27 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b3cc43848327a39bcc15e082995a