### PR TITLE
refactor: cast service worker self more safely

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
 
-const sw = self as ServiceWorkerGlobalScope;
+const sw = self as unknown as ServiceWorkerGlobalScope;
 
 // basic service worker for push notifications
 sw.addEventListener('push', (event: PushEvent) => {
@@ -9,7 +9,7 @@ sw.addEventListener('push', (event: PushEvent) => {
   if (payload) {
     try {
       data = JSON.parse(payload);
-    } catch (err) {
+    } catch {
       data = {body: payload};
     }
   }


### PR DESCRIPTION
## Summary
- cast service worker global `self` via `unknown` before `ServiceWorkerGlobalScope`
- drop unused error variable in service worker

## Testing
- `npx tsc --noEmit --skipLibCheck src/sw.ts`
- `npx eslint src/sw.ts`
- `npm test` *(fails: TestingLibraryElementError, AssertionError, and numerous act() warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b3ce2ce88327b659f9ca6f518679