### PR TITLE
fix: avoid using error after early return in TopMoversPage

### DIFF
--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -130,10 +130,10 @@ export function TopMoversPage() {
     );
   }
 
-  const errorBanner = (error?.message ?? fallbackError)
+  const errorBanner = fallbackError
     ? (() => {
-        const raw = error?.message ?? fallbackError ?? "";
-        const match = raw.match(/^HTTP (\\d+)\\s+[--]\\s+(.*)$/);
+        const raw = fallbackError;
+        const match = raw.match(/^HTTP (\d+)\s+[–-]\s+(.*)$/);
         const status = match?.[1];
         const msg = match?.[2] ?? raw;
         return (


### PR DESCRIPTION
## Summary
- fix TypeScript narrowing by removing error reference after early return in TopMoversPage
- derive error banner solely from fallbackError

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b3c85fac8327b4e2b57d336b9806