### PR TITLE
Add settings tab to tab configuration tests

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -153,6 +153,7 @@ describe("App", () => {
       dataadmin: true,
       virtual: true,
       support: true,
+      settings: true,
       reports: true,
       scenario: true,
     };
@@ -196,6 +197,7 @@ describe("App", () => {
         getTopMovers: vi
           .fn()
           .mockResolvedValue({ gainers: [], losers: [] }),
+        getGroupMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
         listTimeseries: vi.fn().mockResolvedValue([]),
         refetchTimeseries: vi.fn(),
         rebuildTimeseriesCache: vi.fn(),
@@ -218,6 +220,7 @@ describe("App", () => {
       dataadmin: true,
       virtual: true,
       support: true,
+      settings: true,
       reports: true,
       scenario: true,
     };
@@ -375,6 +378,7 @@ describe("App", () => {
       "Watchlist",
       "Data Admin",
       "Reports",
+      "User Settings",
       "Support",
       "Scenario Tester",
     ]);

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -26,6 +26,7 @@ const defaultConfig: AppConfig = {
     dataadmin: true,
     virtual: true,
     support: true,
+    settings: true,
     reports: true,
     scenario: true,
   },

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -24,6 +24,7 @@ const defaultConfig: AppConfig = {
         dataadmin: true,
         virtual: true,
         support: true,
+        settings: true,
         reports: true,
         scenario: true,
     },

--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -21,6 +21,7 @@ const defaultConfig: AppConfig = {
     dataadmin: true,
     virtual: true,
     support: true,
+    settings: true,
     reports: true,
     scenario: true,
   },

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -20,6 +20,7 @@ const defaultConfig: AppConfig = {
         dataadmin: true,
         virtual: true,
         support: true,
+        settings: true,
         reports: true,
         scenario: true,
     },

--- a/frontend/src/components/responsiveRender.test.tsx
+++ b/frontend/src/components/responsiveRender.test.tsx
@@ -31,6 +31,7 @@ const defaultConfig: AppConfig = {
     dataadmin: true,
     virtual: true,
     support: true,
+    settings: true,
     reports: true,
     scenario: true,
   },


### PR DESCRIPTION
## Summary
- include `settings: true` in tab configurations across tests
- update App tests and mocks for new User Settings tab

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68b4b3c7c9f48327996bd916117074c0