### PR TITLE
test: provide refreshConfig to ConfigContext in App tests

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -164,6 +164,7 @@ describe("App", () => {
           theme: "system",
           relativeViewEnabled: false,
           tabs: { ...allTabs, movers: false },
+          refreshConfig: vi.fn(),
         }}
       >
         <MemoryRouter initialEntries={["/movers"]}>
@@ -227,7 +228,12 @@ describe("App", () => {
 
     render(
       <configContext.Provider
-        value={{ theme: "system", relativeViewEnabled: false, tabs: allTabs }}
+        value={{
+          theme: "system",
+          relativeViewEnabled: false,
+          tabs: allTabs,
+          refreshConfig: vi.fn(),
+        }}
       >
         <MemoryRouter initialEntries={["/movers"]}>
           <App />


### PR DESCRIPTION
## Summary
- mock refreshConfig in App tests' ConfigContext providers

## Testing
- `npm test -- --run` (fails: Test Files 28 passed (28); Tests 110 passed | 1 skipped (111); Errors 2 errors)


------
https://chatgpt.com/codex/tasks/task_e_68b4b7eefb608327ad96d264ca9c2bcb