### PR TITLE
Rename Portfolio type alias in Portfolio page

### DIFF
--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { getPortfolio } from "../api";
 import { PortfolioView } from "../components/PortfolioView";
-import type { Portfolio } from "../types";
+import type { Portfolio as PortfolioData } from "../types";
 
 export function Portfolio() {
-  const [data, setData] = useState<Portfolio | null>(null);
+  const [data, setData] = useState<PortfolioData | null>(null);
   useEffect(() => {
     getPortfolio("alice").then(setData).catch(() => setData(null));
   }, []);


### PR DESCRIPTION
## Summary
- alias `Portfolio` as `PortfolioData` in Portfolio page
- update state initialization to use renamed type

## Testing
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4c0d958a8832791322cb11ee91b2f