### PR TITLE
Enable Google auth in production

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 
 from aws_cdk import (
     BundlingOptions,
@@ -47,6 +48,11 @@ class BackendLambdaStack(Stack):
             code=backend_code,
             layers=[dependencies_layer],
         )
+
+        env = self.node.try_get_context("app_env") or os.getenv("APP_ENV")
+        if env == "production":
+            backend_fn.add_environment("GOOGLE_AUTH_ENABLED", "true")
+            backend_fn.add_environment("DISABLE_AUTH", "false")
 
         apigw.LambdaRestApi(self, "BackendApi", handler=backend_fn)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,8 @@ cors:
   production:
     - https://app.allotmint.io
 app_env: local
+google_auth_enabled: false
+disable_auth: true
 sns_topic_arn: ''
 telegram_bot_token: "" # set via TELEGRAM_BOT_TOKEN env var
 telegram_chat_id: "" # set via TELEGRAM_CHAT_ID env var

--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,7 @@ cors:
   production:
     - https://app.allotmint.io
 app_env: local
+google_auth_enabled: false
 disable_auth: true
 portfolio_xml_path: data/portfolio/investments.xml
 transactions_output_root: data/accounts

--- a/infra/lambda/quotes.yml
+++ b/infra/lambda/quotes.yml
@@ -21,6 +21,8 @@ Resources:
       Environment:
         Variables:
           QUOTES_TABLE: !Ref QuotesTable
+          GOOGLE_AUTH_ENABLED: 'true'
+          DISABLE_AUTH: 'false'
       Code:
         S3Bucket: your-bucket
         S3Key: quotes.zip

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,3 +29,20 @@ def test_theme_loaded():
 def test_stooq_timeout_loaded():
     cfg = config_module.load_config()
     assert cfg.stooq_timeout == 10
+
+
+def test_auth_flags(monkeypatch):
+    cfg = config_module.load_config()
+    assert cfg.google_auth_enabled is False
+    assert cfg.disable_auth is True
+
+    monkeypatch.setenv("GOOGLE_AUTH_ENABLED", "true")
+    monkeypatch.setenv("DISABLE_AUTH", "false")
+    config_module.load_config.cache_clear()
+    cfg = config_module.load_config()
+    assert cfg.google_auth_enabled is True
+    assert cfg.disable_auth is False
+    monkeypatch.delenv("GOOGLE_AUTH_ENABLED")
+    monkeypatch.delenv("DISABLE_AUTH")
+    config_module.load_config.cache_clear()
+    config_module.config = config_module.load_config()


### PR DESCRIPTION
## Summary
- support `google_auth_enabled` config flag with environment overrides
- keep local auth disabled while enabling Google auth in production lambdas
- inject production auth settings via CDK and CloudFormation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4c49cd9a08327ba286bc1a5815c4f