### PR TITLE
Add site plan generation workflow

### DIFF
--- a/.github/workflows/siteplan.yml
+++ b/.github/workflows/siteplan.yml
@@ -1,0 +1,43 @@
+name: Site Plan
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  siteplan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install bs4 fpdf markdownify playwright tldextract Pillow openai
+          playwright install
+
+      - name: Generate site plan
+        run: python scripts/site_snapshot.py --base-url https://app.allotmint.io --output-dir docs/siteplan
+
+      - name: Commit site snapshots
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/siteplan
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update site snapshots"
+            git push origin main
+          fi


### PR DESCRIPTION
## Summary
- add site plan workflow that snapshots production site and pushes results

## Testing
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c65887748327bb5242ea6ac35b50