### PR TITLE
feat: add logs viewer

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -46,6 +46,7 @@ from backend.routes.trading_agent import router as trading_agent_router
 from backend.routes.transactions import router as transactions_router
 from backend.routes.user_config import router as user_config_router
 from backend.routes.virtual_portfolio import router as virtual_portfolio_router
+from backend.routes.logs import router as logs_router
 from backend.utils import page_cache
 
 
@@ -108,6 +109,7 @@ def create_app() -> FastAPI:
     app.include_router(movers_router)
     app.include_router(user_config_router, dependencies=protected)
     app.include_router(scenario_router)
+    app.include_router(logs_router)
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(request: Request, exc: RequestValidationError):

--- a/backend/config.py
+++ b/backend/config.py
@@ -27,6 +27,7 @@ class TabsConfig:
     settings: bool = True
     reports: bool = True
     scenario: bool = True
+    logs: bool = True
 
 
 @dataclass

--- a/backend/routes/logs.py
+++ b/backend/routes/logs.py
@@ -1,0 +1,32 @@
+from collections import deque
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import PlainTextResponse
+
+from backend.config import config
+
+router = APIRouter(prefix="/logs", tags=["logs"])
+
+_DEFAULT_LINES = 200
+
+
+@router.get("", response_class=PlainTextResponse)
+async def read_logs(lines: int = _DEFAULT_LINES) -> str:
+    """Return the latest lines from ``backend.log``.
+
+    Parameters
+    ----------
+    lines:
+        Maximum number of lines to return, defaults to ``_DEFAULT_LINES``.
+    """
+    root = Path(config.repo_root or Path.cwd())
+    log_file = root / "backend.log"
+    if not log_file.exists():
+        raise HTTPException(status_code=404, detail="Log file not found")
+    try:
+        with log_file.open("r", encoding="utf-8") as fh:
+            content = "".join(deque(fh, maxlen=lines))
+        return content
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/tests/test_logs.py
+++ b/backend/tests/test_logs.py
@@ -1,0 +1,31 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes.logs import router
+from backend.config import config
+
+
+def create_app():
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def test_logs_endpoint_returns_content(tmp_path, monkeypatch):
+    log_file = tmp_path / "backend.log"
+    log_file.write_text("line1\nline2\n", encoding="utf-8")
+    monkeypatch.setattr(config, "repo_root", tmp_path)
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/logs")
+    assert resp.status_code == 200
+    assert "line2" in resp.text
+
+
+def test_logs_endpoint_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "repo_root", tmp_path)
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/logs")
+    assert resp.status_code == 404

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import ScenarioTester from "./pages/ScenarioTester";
 import UserConfigPage from "./pages/UserConfig";
 import { orderedTabPlugins } from "./tabPlugins";
 import { usePriceRefresh } from "./PriceRefreshContext";
+import Logs from "./pages/Logs";
 type Mode = (typeof orderedTabPlugins)[number]["id"];
 
 // derive initial mode + id from path
@@ -59,6 +60,7 @@ const initialMode: Mode =
   path[0] === "support" ? "support" :
   path[0] === "settings" ? "settings" :
   path[0] === "scenario" ? "scenario" :
+  path[0] === "logs" ? "logs" :
   path.length === 0 && params.has("group") ? "group" : "movers";
 const initialSlug = path[1] ?? "";
 
@@ -114,6 +116,8 @@ export default function App() {
         return "/reports";
       case "settings":
         return "/settings";
+      case "logs":
+        return "/logs";
       default:
         return `/${m}`;
     }
@@ -156,6 +160,9 @@ export default function App() {
         break;
       case "support":
         newMode = "support";
+        break;
+      case "logs":
+        newMode = "logs";
         break;
       case "settings":
         newMode = "settings";
@@ -404,6 +411,7 @@ export default function App() {
       {mode === "movers" && <TopMovers />}
       {mode === "support" && <Support />}
       {mode === "settings" && <UserConfigPage />}
+      {mode === "logs" && <Logs />}
       {mode === "scenario" && <ScenarioTester />}
     </div>
   );

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -24,9 +24,10 @@ export interface TabsConfig {
   dataadmin: boolean;
   virtual: boolean;
   support: boolean;
-   settings: boolean;
+  settings: boolean;
   reports: boolean;
   scenario: boolean;
+  logs: boolean;
 }
 
 export interface AppConfig {
@@ -65,6 +66,7 @@ const defaultTabs: TabsConfig = {
   settings: true,
   reports: true,
   scenario: true,
+  logs: true,
 };
 
 export interface ConfigContextValue extends AppConfig {

--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -36,6 +36,7 @@ const TopMovers = lazy(() => import("./pages/TopMovers"));
 const DataAdmin = lazy(() => import("./pages/DataAdmin"));
 const ScenarioTester = lazy(() => import("./pages/ScenarioTester"));
 const SupportPage = lazy(() => import("./pages/Support"));
+const LogsPage = lazy(() => import("./pages/Logs"));
 
 export default function MainApp() {
   const navigate = useNavigate();
@@ -244,6 +245,7 @@ export default function MainApp() {
       {mode === "watchlist" && <Watchlist />}
       {mode === "support" && <SupportPage />}
       {mode === "movers" && <TopMovers />}
+      {mode === "logs" && <LogsPage />}
       {mode === "scenario" && <ScenarioTester />}
     </>
   );

--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Menu from "./Menu";
+
+describe("Menu", () => {
+  it("renders Logs tab", () => {
+    render(
+      <MemoryRouter>
+        <Menu />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("link", { name: "Logs" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -44,6 +44,8 @@ export default function Menu({
       ? "settings"
       : path[0] === "scenario"
       ? "scenario"
+      : path[0] === "logs"
+      ? "logs"
       : path.length === 0 && params.has("group")
       ? "group"
       : "movers";
@@ -66,6 +68,8 @@ export default function Menu({
         return "/scenario";
       case "settings":
         return "/settings";
+      case "logs":
+        return "/logs";
       default:
         return `/${m}`;
     }

--- a/frontend/src/hooks/useRouteMode.ts
+++ b/frontend/src/hooks/useRouteMode.ts
@@ -27,6 +27,7 @@ function deriveInitial() {
     path[0] === "dataadmin" ? "dataadmin" :
     path[0] === "support" ? "support" :
     path[0] === "scenario" ? "scenario" :
+    path[0] === "logs" ? "logs" :
     path.length === 0 && params.has("group") ? "group" : "movers";
   const slug = path[1] ?? "";
   const owner = mode === "owner" ? slug : "";
@@ -62,6 +63,8 @@ const { tabs, disabledTabs } = useConfig();
         return "/scenario";
       case "settings":
         return "/settings";
+      case "logs":
+        return "/logs";
       default:
         return `/${m}`;
     }
@@ -101,6 +104,9 @@ const { tabs, disabledTabs } = useConfig();
         break;
       case "support":
         newMode = "support";
+        break;
+      case "logs":
+        newMode = "logs";
         break;
       case "settings":
         newMode = "settings";

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -20,7 +20,8 @@
       "settings": "User Settings",
       "reports": "Berichte",
       "support": "Support",
-      "scenario": "Szenario-Tester"
+      "scenario": "Szenario-Tester",
+      "logs": "Protokolle"
     }
   },
   "common": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -21,7 +21,8 @@
       "settings": "User Settings",
       "reports": "Reports",
       "support": "Support",
-      "scenario": "Scenario Tester"
+      "scenario": "Scenario Tester",
+      "logs": "Logs"
     }
   },
   "common": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -20,7 +20,8 @@
       "settings": "User Settings",
       "reports": "Informes",
       "support": "Soporte",
-      "scenario": "Probador de Escenarios"
+      "scenario": "Probador de Escenarios",
+      "logs": "Registros"
     }
   },
   "common": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -20,7 +20,8 @@
       "settings": "User Settings",
       "reports": "Rapports",
       "support": "Support",
-      "scenario": "Testeur de Scénario"
+      "scenario": "Testeur de Scénario",
+      "logs": "Journaux"
     }
   },
   "common": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -20,7 +20,8 @@
       "settings": "User Settings",
       "reports": "Relatórios",
       "support": "Suporte",
-      "scenario": "Testador de Cenários"
+      "scenario": "Testador de Cenários",
+      "logs": "Registros"
     }
   },
   "common": {

--- a/frontend/src/modes.ts
+++ b/frontend/src/modes.ts
@@ -11,7 +11,8 @@ export type Mode =
   | "dataadmin"
   | "settings"
   | "support"
-  | "scenario";
+  | "scenario"
+  | "logs";
 
 export const MODES: Mode[] = [
   "movers",
@@ -27,4 +28,5 @@ export const MODES: Mode[] = [
   "settings",
   "support",
   "scenario",
+  "logs",
 ];

--- a/frontend/src/pages/Logs.test.tsx
+++ b/frontend/src/pages/Logs.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import Logs from "./Logs";
+
+vi.mock("../api", () => ({ API_BASE: "" }));
+
+describe("Logs page", () => {
+  it("fetches and displays log text", async () => {
+    const sample = "line1\nline2";
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, text: () => Promise.resolve(sample) } as any);
+    render(<Logs />);
+    expect(await screen.findByText(/line2/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+import { API_BASE } from "../api";
+
+export default function Logs() {
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    fetch(`${API_BASE}/logs`)
+      .then((res) => (res.ok ? res.text() : ""))
+      .then(setText)
+      .catch(() => setText(""));
+  }, []);
+
+  return <pre style={{ whiteSpace: "pre-wrap" }}>{text}</pre>;
+}

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -19,6 +19,7 @@ const TAB_KEYS = [
   "watchlist",
   "virtual",
   "support",
+  "logs",
   "settings",
   "reports",
 ] as const;

--- a/frontend/src/plugins/logs.ts
+++ b/frontend/src/plugins/logs.ts
@@ -1,0 +1,11 @@
+import Logs from "../pages/Logs";
+import type { TabPlugin } from "./TabPlugin";
+
+const plugin: TabPlugin = {
+  id: "logs",
+  component: Logs,
+  priority: 115,
+  path: () => "/logs",
+};
+
+export default plugin;

--- a/frontend/src/tabPlugins.ts
+++ b/frontend/src/tabPlugins.ts
@@ -15,6 +15,7 @@ export const tabPluginMap = {
   settings: {},
   reports: {},
   scenario: {},
+  logs: {},
 };
 export type TabPluginId = keyof typeof tabPluginMap;
 export const orderedTabPlugins = [
@@ -32,6 +33,7 @@ export const orderedTabPlugins = [
   { id: "reports", priority: 100 },
   { id: "settings", priority: 105 },
   { id: "support", priority: 110 },
+  { id: "logs", priority: 115 },
   { id: "scenario", priority: 120 },
 ] as const;
 export type TabPlugin = typeof orderedTabPlugins[number];


### PR DESCRIPTION
## Summary
- expose `/logs` backend API to stream the end of backend.log
- surface new "logs" mode with page and plugin to display backend logs
- localize "Logs" tab and add coverage for backend and frontend

## Testing
- `pytest backend/tests/test_logs.py backend/tests/test_routers.py -q`
- `npm test --silent src/components/Menu.test.tsx src/pages/Logs.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b4ca67155c8327abd399620ec95404