### PR TITLE
Add Google authentication

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -87,7 +87,7 @@ def create_app() -> FastAPI:
     # ──────────────────────────── Routers ────────────────────────────
     # The API surface is composed of a few routers grouped by concern.
     # Sensitive routes are guarded by a JWT-based dependency.
-    if config.disable_auth or not config.google_auth_enabled:
+    if config.disable_auth:
         protected = []
     else:
         protected = [Depends(get_current_user)]


### PR DESCRIPTION
## Summary
- ensure routes remain protected when Google auth is disabled

## Testing
- `pytest tests/test_timeseries_admin_auth.py tests/test_google_auth.py`
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c8e539f083279742f55a220d8093