### PR TITLE
fix: address review comments for trading signals

### DIFF
--- a/frontend/src/components/SignalBadge.tsx
+++ b/frontend/src/components/SignalBadge.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
+type Action = "buy" | "sell";
 type Props = {
-  action: string;
+  action: Action;
   onClick?: () => void;
 };
 
 export function SignalBadge({ action, onClick }: Props) {
-  const lower = action.toLowerCase();
-  const isBuy = lower === "buy";
+  const isBuy = action === "buy";
   const color = isBuy ? "#bbf7d0" : "#fecaca"; // tailwind: green-200 / red-200
   return (
     <span

--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -169,8 +169,9 @@ describe("TopMoversPage", () => {
     );
     await waitFor(() => expect(mockGetTradingSignals).toHaveBeenCalled());
     const tickerBtn = await screen.findByRole("button", { name: "AAA" });
-    const row = tickerBtn.closest("tr")!;
-    const badge = within(row).getByText(/buy/i);
+    const row = tickerBtn.closest("tr");
+    expect(row).not.toBeNull();
+    const badge = within(row as HTMLElement).getByText(/buy/i);
     fireEvent.click(badge);
     expect(await screen.findByTestId("detail")).toHaveTextContent("AAA");
     expect(await screen.findByText("go long")).toBeInTheDocument();

--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -121,7 +121,7 @@ export function TopMoversPage() {
 
   const signalMap = useMemo(() => {
     const map = new Map<string, TradingSignal>();
-    for (const s of signals) map.set(s.ticker, s);
+    for (const s of signals ?? []) map.set(s.ticker, s);
     return map;
   }, [signals]);
 
@@ -254,12 +254,12 @@ export function TopMoversPage() {
               </td>
               <td className={tableStyles.cell}>{r.name}</td>
               <td className={tableStyles.cell}>
-                {signalMap.get(r.ticker) && (
-                  <SignalBadge
-                    action={signalMap.get(r.ticker)!.action}
-                    onClick={() => setSelected(r)}
-                  />
-                )}
+                {(() => {
+                  const s = signalMap.get(r.ticker);
+                  return s ? (
+                    <SignalBadge action={s.action} onClick={() => setSelected(r)} />
+                  ) : null;
+                })()}
               </td>
               <td
                 className={`${tableStyles.cell} ${tableStyles.right}`}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -269,7 +269,7 @@ export interface VirtualPortfolio {
 export interface TradingSignal {
     ticker: string;
     name: string;
-    action: string;
+    action: "buy" | "sell";
     reason: string;
     currency?: string | null;
     instrument_type?: string | null;


### PR DESCRIPTION
## Summary
- reset fetch mocks for each test and provide sample trading signal data
- tighten `SignalBadge` typings and guard against missing rows in tests
- validate `TopMovers` components against missing data and handle signal lookups safely

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, `@ts-ignore` ban, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b5333890f4832781f2863405fe9f3f