### PR TITLE
Filter AWS plot listings by viewer

### DIFF
--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -34,6 +34,45 @@ def test_list_aws_plots(monkeypatch):
     assert dl._list_aws_plots() == expected
 
 
+def test_list_aws_plots_filters_by_viewer(monkeypatch):
+    monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
+    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
+
+    def fake_client(name):
+        assert name == "s3"
+
+        def list_objects_v2(**kwargs):
+            assert kwargs["Bucket"] == "bucket"
+            assert kwargs["Prefix"] == dl.PLOTS_PREFIX
+            return {
+                "Contents": [
+                    {"Key": "accounts/Alice/ISA.json"},
+                    {"Key": "accounts/Alice/person.json"},
+                    {"Key": "accounts/Bob/GIA.json"},
+                    {"Key": "accounts/Eve/JISA.json"},
+                    {"Key": "accounts/Eve/person.json"},
+                ]
+            }
+
+        def get_object(Bucket, Key):
+            assert Bucket == "bucket"
+            if Key == "accounts/Alice/person.json":
+                return {"Body": io.BytesIO(b'{"viewers": ["Bob"]}')}
+            if Key == "accounts/Eve/person.json":
+                return {"Body": io.BytesIO(b'{"viewers": []}')}
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "get_object")
+
+        return SimpleNamespace(list_objects_v2=list_objects_v2, get_object=get_object)
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
+
+    expected = [
+        {"owner": "Alice", "accounts": ["ISA"]},
+        {"owner": "Bob", "accounts": ["GIA"]},
+    ]
+    assert dl._list_aws_plots(current_user="Bob") == expected
+
+
 def test_load_account_from_s3(monkeypatch):
     monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")


### PR DESCRIPTION
## Summary
- filter AWS plot listings by viewer access
- test viewer filtering for AWS plot listings

## Testing
- `pytest tests/test_data_loader_aws.py`


------
https://chatgpt.com/codex/tasks/task_e_68b53170124483278cc2803cd02e454f