### PR TITLE
fix: add missing jwt dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ platformdirs~=3.10.0
 protobuf~=6.31.1
 pyarrow~=21.0.0
 pycparser~=2.21
+pyjwt~=2.9.0
 pydantic~=2.11.7
 pysocks~=1.7.1
 python-dateutil~=2.9.0post0


### PR DESCRIPTION
## Summary
- include PyJWT in backend requirements to satisfy auth module

## Testing
- `pytest tests/test_timeseries_admin_auth.py -q`
- `npm test` *(fails: ReferenceError window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b53497b84c83278a7f8cb3a72cfab9