### PR TITLE
Add top movers summary and adjust default route

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
@@ -352,6 +352,7 @@ describe("App", () => {
       getTimeseries: vi.fn().mockResolvedValue([]),
       saveTimeseries: vi.fn(),
       getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+      getGroupMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
       getTradingSignals: mockTradingSignals,
       listTimeseries: vi.fn().mockResolvedValue([]),
       refetchTimeseries: vi.fn(),
@@ -367,6 +368,7 @@ describe("App", () => {
     );
 
     const groupLink = await screen.findByRole("link", { name: /group/i });
+    expect(groupLink).toHaveAttribute("href", "/");
     expect(groupLink).toHaveStyle("font-weight: bold");
 
     const nav = screen.getByRole("navigation");
@@ -386,6 +388,7 @@ describe("App", () => {
       "Reports",
       "User Settings",
       "Support",
+      "Logs",
       "Scenario Tester",
     ]);
   });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,7 +61,7 @@ const initialMode: Mode =
   path[0] === "settings" ? "settings" :
   path[0] === "scenario" ? "scenario" :
   path[0] === "logs" ? "logs" :
-  path.length === 0 && params.has("group") ? "group" : "movers";
+  path.length === 0 ? "group" : "movers";
 const initialSlug = path[1] ?? "";
 
 export default function App() {
@@ -174,7 +174,7 @@ export default function App() {
         newMode = "scenario";
         break;
       default:
-        newMode = "group";
+        newMode = segs.length === 0 ? "group" : "movers";
     }
 
     if (tabs[newMode] === false) {

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -44,6 +44,20 @@ const renderWithConfig = (ui: React.ReactElement, cfg: Partial<AppConfig> = {}) 
     </configContext.Provider>,
   );
 
+function mockFetch(portfolio: unknown) {
+  return vi
+    .spyOn(global, "fetch")
+    .mockImplementation((url) =>
+      Promise.resolve({
+        ok: true,
+        json: async () =>
+          typeof url === "string" && url.includes("/movers")
+            ? { gainers: [], losers: [] }
+            : portfolio,
+      } as unknown as Response),
+    );
+}
+
 describe("GroupPortfolioView", () => {
   it("shows per-owner totals with percentages in relative view", async () => {
     const mockPortfolio = {
@@ -78,15 +92,7 @@ describe("GroupPortfolioView", () => {
       ],
     };
 
-    vi.spyOn(global, "fetch").mockImplementation((url) =>
-      Promise.resolve({
-        ok: true,
-        json: async () =>
-          typeof url === "string" && url.includes("/movers")
-            ? { gainers: [], losers: [] }
-            : mockPortfolio,
-      } as unknown as Response),
-    );
+    mockFetch(mockPortfolio);
 
     renderWithConfig(<GroupPortfolioView slug="all" />, {
       relativeViewEnabled: true,
@@ -138,15 +144,7 @@ describe("GroupPortfolioView", () => {
       ],
     };
 
-    vi.spyOn(global, "fetch").mockImplementation((url) =>
-      Promise.resolve({
-        ok: true,
-        json: async () =>
-          typeof url === "string" && url.includes("/movers")
-            ? { gainers: [], losers: [] }
-            : mockPortfolio,
-      } as unknown as Response),
-    );
+    mockFetch(mockPortfolio);
 
     render(<GroupPortfolioView slug="all" />);
 
@@ -169,15 +167,7 @@ describe("GroupPortfolioView", () => {
       ],
     };
 
-    vi.spyOn(global, "fetch").mockImplementation((url) =>
-      Promise.resolve({
-        ok: true,
-        json: async () =>
-          typeof url === "string" && url.includes("/movers")
-            ? { gainers: [], losers: [] }
-            : mockPortfolio,
-      } as unknown as Response),
-    );
+    mockFetch(mockPortfolio);
 
     const handler = vi.fn();
     render(<GroupPortfolioView slug="all" onSelectMember={handler} />);
@@ -236,30 +226,26 @@ describe("GroupPortfolioView", () => {
       ],
     };
 
-    vi.spyOn(global, "fetch").mockImplementation((url) =>
-      Promise.resolve({
-        ok: true,
-        json: async () =>
-          typeof url === "string" && url.includes("/movers")
-            ? { gainers: [], losers: [] }
-            : mockPortfolio,
-      } as unknown as Response),
-    );
+    mockFetch(mockPortfolio);
 
     render(<GroupPortfolioView slug="all" />);
 
     await waitFor(() => screen.getByLabelText(/alice isa/i));
 
-    const totalLabel = screen.getAllByText("Total Value")[0];
-    const valueEl = totalLabel.nextElementSibling as HTMLElement;
-    expect(valueEl).toHaveTextContent("£300.00");
+    await waitFor(() =>
+      expect(screen.getAllByText("Total Value")[0].nextElementSibling).toHaveTextContent(
+        "£300.00",
+      ),
+    );
 
     const bobCheckbox = screen.getByLabelText(/bob isa/i);
     await act(async () => {
       fireEvent.click(bobCheckbox);
     });
-    await waitFor(() => {
-      expect(valueEl).toHaveTextContent("£100.00");
-    });
+    await waitFor(() =>
+      expect(screen.getAllByText("Total Value")[0].nextElementSibling).toHaveTextContent(
+        "£100.00",
+      ),
+    );
   });
 });

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -46,7 +46,7 @@ export default function Menu({
       ? "scenario"
       : path[0] === "logs"
       ? "logs"
-      : path.length === 0 && params.has("group")
+      : path.length === 0
       ? "group"
       : "movers";
 

--- a/frontend/src/components/TopMoversSummary.test.tsx
+++ b/frontend/src/components/TopMoversSummary.test.tsx
@@ -3,11 +3,20 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import { TopMoversSummary } from "./TopMoversSummary";
 import type { MoverRow } from "../types";
+import moversPlugin from "../plugins/movers";
 
 const mockGetGroupMovers = vi.fn(() =>
   Promise.resolve({
-    gainers: [{ ticker: "AAA", name: "AAA", change_pct: 5 } as MoverRow],
-    losers: [{ ticker: "BBB", name: "BBB", change_pct: -3 } as MoverRow],
+    gainers: [
+      { ticker: "AAA", name: "AAA", change_pct: 5 } as MoverRow,
+      { ticker: "CCC", name: "CCC", change_pct: 2 } as MoverRow,
+      { ticker: "EEE", name: "EEE", change_pct: 1 } as MoverRow,
+    ],
+    losers: [
+      { ticker: "BBB", name: "BBB", change_pct: -3 } as MoverRow,
+      { ticker: "DDD", name: "DDD", change_pct: -4 } as MoverRow,
+      { ticker: "FFF", name: "FFF", change_pct: -1 } as MoverRow,
+    ],
   }),
 );
 
@@ -29,8 +38,9 @@ describe("TopMoversSummary", () => {
       expect(mockGetGroupMovers).toHaveBeenCalledWith("all", 1, 5),
     );
     expect(await screen.findByText("AAA")).toBeInTheDocument();
-    expect(await screen.findByText("BBB")).toBeInTheDocument();
+    expect(await screen.findByText("DDD")).toBeInTheDocument();
+    expect(screen.queryByText("FFF")).not.toBeInTheDocument();
     const link = screen.getByRole("link", { name: /view more/i });
-    expect(link).toHaveAttribute("href", "/movers");
+    expect(link).toHaveAttribute("href", moversPlugin.path({ group: "all" }));
   });
 });

--- a/frontend/src/hooks/useRouteMode.ts
+++ b/frontend/src/hooks/useRouteMode.ts
@@ -28,7 +28,7 @@ function deriveInitial() {
     path[0] === "support" ? "support" :
     path[0] === "scenario" ? "scenario" :
     path[0] === "logs" ? "logs" :
-    path.length === 0 && params.has("group") ? "group" : "movers";
+    path.length === 0 ? "group" : "movers";
   const slug = path[1] ?? "";
   const owner = mode === "owner" ? slug : "";
   const group = mode === "instrument" ? slug : params.get("group") ?? "";
@@ -115,7 +115,7 @@ const { tabs, disabledTabs } = useConfig();
         newMode = "scenario";
         break;
       default:
-        newMode = "group";
+        newMode = segs.length === 0 ? "group" : "movers";
     }
 
     if (tabs[newMode] !== true || disabledTabs?.includes(newMode)) {

--- a/frontend/src/plugins/movers.ts
+++ b/frontend/src/plugins/movers.ts
@@ -5,7 +5,7 @@ const plugin: TabPlugin = {
   id: "movers",
   component: TopMovers,
   priority: 0,
-  path: () => "/movers",
+  path: ({ group }) => (group ? `/movers?group=${group}` : "/movers"),
 };
 
 export default plugin;


### PR DESCRIPTION
## Summary
- refine default mode to use group when path is empty
- add TopMoversSummary component with retry and contextual link
- consolidate test fetch mocks and expand test coverage

## Testing
- `npx vitest run src/App.test.tsx src/components/GroupPortfolioView.test.tsx src/components/TopMoversSummary.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b533ed49c883278cae39618f9d9526