### PR TITLE
Handle AWS email listing for Google auth

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -9,7 +9,12 @@ import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 
-from backend.common.data_loader import load_person_meta, resolve_paths, list_plots
+from backend.common.data_loader import (
+    DATA_BUCKET_ENV,
+    PLOTS_PREFIX,
+    load_person_meta,
+    resolve_paths,
+)
 from backend.config import config
 
 SECRET_KEY = os.getenv("JWT_SECRET", "change-me")
@@ -43,10 +48,41 @@ def _allowed_emails() -> Set[str]:
     emails: Set[str] = set()
 
     if config.app_env == "aws":
-        owners = {p["owner"] for p in list_plots()}
+        owners: Set[str] = set()
+        bucket = os.getenv(DATA_BUCKET_ENV)
+        if bucket:
+            try:
+                import boto3  # type: ignore
+
+                s3 = boto3.client("s3")
+                token: str | None = None
+                while True:
+                    params = {"Bucket": bucket, "Prefix": PLOTS_PREFIX}
+                    if token:
+                        params["ContinuationToken"] = token
+                    resp = s3.list_objects_v2(**params)
+                    for item in resp.get("Contents", []):
+                        key = item.get("Key", "")
+                        if not key.lower().endswith(".json"):
+                            continue
+                        if not key.startswith(PLOTS_PREFIX):
+                            continue
+                        rel = key[len(PLOTS_PREFIX) :]
+                        owner = rel.split("/")[0]
+                        if owner:
+                            owners.add(owner)
+                    if resp.get("IsTruncated"):
+                        token = resp.get("NextContinuationToken")
+                    else:
+                        break
+            except Exception:
+                pass
         for owner in owners:
-            meta = load_person_meta(owner)
-            email = meta.get("email")
+            try:
+                meta = load_person_meta(owner)
+            except Exception:
+                meta = {}
+            email = meta.get("email") if isinstance(meta, dict) else None
             if email:
                 emails.add(email.lower())
         return emails


### PR DESCRIPTION
## Summary
- include S3 account owners when building allowed email list
- add test covering AWS allowed email enumeration

## Testing
- `pytest -o addopts= tests/test_auth_google.py tests/test_auth_aws.py tests/test_group_movers_route.py tests/test_reports_pdf.py tests/test_var_route.py tests/test_trading_agent_route.py tests/test_timeseries_edit_route.py tests/test_main.py tests/test_scenario_route.py tests/test_instrument_route.py tests/test_quotes_route.py tests/test_timeseries_admin_auth.py tests/test_backend_api.py`
- `npx vitest run src/api.test.ts --reporter=basic` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68b53b2398688327a3d594aa417b0889