### PR TITLE
fix: validate alert settings and handle persistence failures

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -140,10 +140,6 @@ def load_config() -> Config:
     if disable_auth_env is not None:
         data["disable_auth"] = disable_auth_env
 
-    google_auth_env = _env_flag("GOOGLE_AUTH_ENABLED")
-    if google_auth_env is not None:
-        data["google_auth_enabled"] = google_auth_env
-
     repo_root_raw = data.get("repo_root")
     repo_root = (base_dir / repo_root_raw).resolve() if repo_root_raw else base_dir
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,7 +25,6 @@ portfolio_xml_path: data/portfolio/investments.xml
 transactions_output_root: data/accounts
 uvicorn_port: 8000
 reload: true
-google_auth_enabled: false
 google_client_id: ""
 allowed_emails:
   - user@example.com

--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,6 @@ transactions_output_root: data/accounts
 uvicorn_host: 0.0.0.0
 uvicorn_port: 8000
 reload: true
-google_auth_enabled: false
 relative_view_enabled: false
 theme: system
 log_config: backend/logging.ini


### PR DESCRIPTION
## Summary
- validate loaded alert settings and push subscriptions
- log an error when alert settings or subscriptions cannot be saved
- remove duplicate `google_auth_enabled` config field

## Testing
- `/usr/local/bin/ruff check --config backend/pyproject.toml backend/alerts.py`
- `/usr/local/bin/ruff check --config backend/pyproject.toml backend/config.py`
- `/usr/local/bin/pytest tests/test_alerts.py backend/tests/test_alerts.py` *(fails: file or directory not found and missing modules such as `requests`, `fastapi`, and `pandas`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5511abe388327bb5321de0fd4ee63