### PR TITLE
Clarify current_user usage in data loader

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -57,20 +57,29 @@ def _list_local_plots(
     data_root: Optional[Path] = None,
     current_user: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
+    """List available plots from the local filesystem.
+
+    Parameters
+    ----------
+    data_root:
+        Optional base directory containing account data. If ``None`` the
+        configured accounts root is used.
+    current_user:
+        Username of the authenticated user or ``None`` when unauthenticated.
+    """
+
     paths = resolve_paths(config.repo_root, config.accounts_root)
     root = data_root or paths.accounts_root
     results: List[Dict[str, Any]] = []
     if not root.exists():
         return results
 
-    user = current_user.get(None)
-
     for owner_dir in sorted(root.iterdir()):
         if not owner_dir.is_dir():
             continue
         # When authentication is enabled and no user is authenticated,
         # expose only the "demo" account.
-        if not config.disable_auth and user is None and owner_dir.name != "demo":
+        if not config.disable_auth and current_user is None and owner_dir.name != "demo":
             continue
 
         owner = owner_dir.name
@@ -110,6 +119,11 @@ def _list_local_plots(
 # ------------------------------------------------------------------
 def _list_aws_plots(current_user: Optional[str] = None) -> List[Dict[str, Any]]:
     """List available plots from an S3 bucket.
+
+    Parameters
+    ----------
+    current_user:
+        Username of the authenticated user or ``None`` when unauthenticated.
 
     The bucket name is read from the ``DATA_BUCKET`` environment variable and
     objects are expected under ``accounts/<owner>/<account>.json``. Metadata
@@ -168,16 +182,6 @@ def _list_aws_plots(current_user: Optional[str] = None) -> List[Dict[str, Any]]:
                 continue
         results.append({"owner": owner, "accounts": accounts})
 
-# =======
-#     user = current_user.get(None)
-#     results: List[Dict[str, Any]] = []
-#     for owner, accounts in sorted(owners.items()):
-#         # When authentication is enabled and no user is authenticated,
-#         # expose only the "demo" account.
-#         if not config.disable_auth and user is None and owner != "demo":
-#             continue
-#         results.append({"owner": owner, "accounts": accounts})
-# >>>>>>> main
     return results
 
 
@@ -188,6 +192,22 @@ def list_plots(
     data_root: Optional[Path] = None,
     current_user: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
+    """Public helper to list available account plots.
+
+    Parameters
+    ----------
+    data_root:
+        Optional base directory containing account data when running locally.
+    current_user:
+        Username of the authenticated user or ``None`` if unauthenticated.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        A list of dictionaries each containing an ``owner`` and their
+        available ``accounts``.
+    """
+
     if config.app_env == "aws":
         return _list_aws_plots(current_user)
     return _list_local_plots(data_root, current_user)
@@ -247,12 +267,14 @@ def load_person_meta(owner: str, data_root: Optional[Path] = None) -> Dict[str, 
 
     def _extract(data: Dict[str, Any]) -> Dict[str, Any]:
         meta: Dict[str, Any] = {}
-        for key in ("dob", "email", "holdings"):
+        for key in ("dob", "email", "holdings", "viewers"):
             if key in data:
                 meta[key] = data[key]
+        if "viewers" not in meta:
+            meta["viewers"] = []
         return meta
 
-    if config.app_env == "aws":
+    if config.app_env == "aws" or os.getenv(DATA_BUCKET_ENV):
         bucket = os.getenv(DATA_BUCKET_ENV)
         if not bucket:
             return {}

--- a/backend/config.py
+++ b/backend/config.py
@@ -200,6 +200,7 @@ def load_config() -> Config:
         error_summary=data.get("error_summary"),
         offline_mode=data.get("offline_mode"),
         disable_auth=data.get("disable_auth"),
+        google_auth_enabled=google_auth_enabled,
         google_client_id=google_client_id,
         allowed_emails=allowed_emails,
         relative_view_enabled=data.get("relative_view_enabled"),

--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -37,7 +37,6 @@ def test_list_aws_plots(monkeypatch):
 def test_list_aws_plots_filters_without_auth(monkeypatch):
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
     monkeypatch.setattr(dl.config, "disable_auth", False, raising=False)
-    dl.current_user.set(None)
 
     def fake_client(name):
         assert name == "s3"

--- a/tests/test_push_subscription_route.py
+++ b/tests/test_push_subscription_route.py
@@ -3,11 +3,16 @@ from fastapi.testclient import TestClient
 
 from backend.local_api.main import app
 from backend import alerts as alert_utils
+from backend.common.storage import get_storage
 
 
 @pytest.fixture
 def client(tmp_path, monkeypatch):
-    monkeypatch.setattr(alert_utils, "_SUBSCRIPTIONS_PATH", tmp_path / "push.json")
+    monkeypatch.setattr(
+        alert_utils,
+        "_SUBSCRIPTIONS_STORAGE",
+        get_storage(f"file://{tmp_path / 'push.json'}"),
+    )
     alert_utils._PUSH_SUBSCRIPTIONS.clear()
     original_arn = alert_utils.config.sns_topic_arn
     alert_utils.config.sns_topic_arn = None


### PR DESCRIPTION
## Summary
- type `current_user` parameters as `Optional[str]` across list plot helpers
- document accepted values (`username` or `None`) and tighten filtering logic
- ensure `load_person_meta` exposes `viewers` and checks S3 metadata when available
- update tests to pass usernames directly and patch push subscription storage
- return `google_auth_enabled` from configuration load

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5979f734c8327b2357fc386f04de8