### PR TITLE
fix: clean TopMoversSummary component

### DIFF
--- a/frontend/src/components/TopMoversSummary.test.tsx
+++ b/frontend/src/components/TopMoversSummary.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TopMoversSummary } from "./TopMoversSummary";
 import type { MoverRow } from "../types";
 import moversPlugin from "../plugins/movers";
@@ -31,6 +31,11 @@ vi.mock("../api", () => ({
 }));
 
 describe("TopMoversSummary", () => {
+  beforeEach(() => {
+    mockGetGroupMovers.mockClear();
+    mockGetTradingSignals.mockClear();
+  });
+
   it("renders movers and view more link", async () => {
     render(
       <MemoryRouter>
@@ -39,12 +44,23 @@ describe("TopMoversSummary", () => {
     );
 
     await waitFor(() =>
-      expect(mockGetGroupMovers).toHaveBeenCalledWith("all", 1, 5, 0),
+      expect(mockGetGroupMovers).toHaveBeenCalledWith("all", 1, 5),
     );
-    expect(await screen.findByText("AAA")).toBeInTheDocument();
-    expect(await screen.findByText("DDD")).toBeInTheDocument();
-    expect(screen.queryByText("FFF")).not.toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "AAA" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "DDD" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "FFF" })).not.toBeInTheDocument();
     const link = screen.getByRole("link", { name: /view more/i });
     expect(link).toHaveAttribute("href", moversPlugin.path({ group: "all" }));
+  });
+
+  it("handles missing slug", async () => {
+    render(
+      <MemoryRouter>
+        <TopMoversSummary />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockGetGroupMovers).not.toHaveBeenCalled());
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/TopMoversSummary.tsx
+++ b/frontend/src/components/TopMoversSummary.tsx
@@ -17,7 +17,7 @@ interface Props {
 export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
   const fetchMovers = useCallback(() => {
     if (!slug) return Promise.resolve({ gainers: [], losers: [] });
-    return getGroupMovers(slug, days, limit, 0);
+    return getGroupMovers(slug, days, limit);
   }, [slug, days, limit]);
   const { data, loading, error } = useFetch(fetchMovers, [slug, days, limit], !!slug);
 
@@ -28,7 +28,10 @@ export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
     if (!slug) return;
     getTradingSignals()
       .then(setSignals)
-      .catch((e) => console.error(e));
+      .catch((e) => {
+        console.error(e);
+        setSignals([]);
+      });
   }, [slug]);
 
   const signalMap = useMemo(() => {
@@ -37,15 +40,15 @@ export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
     return map;
   }, [signals]);
 
-  if (!slug || loading || error || !data) return null;
-
   const rows = useMemo(() => {
+    if (!data || !Array.isArray(data.gainers) || !Array.isArray(data.losers))
+      return [];
     return [...data.gainers, ...data.losers]
       .sort((a, b) => Math.abs(b.change_pct) - Math.abs(a.change_pct))
       .slice(0, limit);
   }, [data, limit]);
 
-  if (rows.length === 0) return null;
+  if (!slug || loading || error || rows.length === 0) return null;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- handle missing slug and API errors in TopMoversSummary
- validate mover data and ensure stable hook order
- expand tests for slug edge cases

## Testing
- `npm test` *(fails: App component errors, GroupPortfolioView tests, etc.)*
- `npx vitest run src/components/TopMoversSummary.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b59b5237ec832790ba7e114a2db0fa