### PR TITLE
Fix totals destructuring and restore movers summary

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -149,20 +149,8 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
     activeKeys.has(accountKey(acct, idx))
   );
 
-  const {
-    totalValue,
-    totalDayChange,
-    totalDayChangePct,
-    totalGain,
-    totalGainPct,
-  } = computePortfolioTotals(activeAccounts);
-  const totals = {
-    totalValue,
-    totalDayChange,
-    totalDayChangePct,
-    totalGain,
-    totalGainPct,
-  };
+  const totals = computePortfolioTotals(activeAccounts);
+  const { totalValue } = totals;
 
   for (const acct of activeAccounts) {
     const owner = acct.owner ?? "—";

--- a/frontend/src/components/TopMoversSummary.tsx
+++ b/frontend/src/components/TopMoversSummary.tsx
@@ -20,9 +20,7 @@ export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
   const { data, loading, error } = useFetch(fetchMovers, [slug, days, limit], !!slug);
 
   const [signals, setSignals] = useState<TradingSignal[]>([]);
-  const [selected, setSelected] = useState<{ ticker: string; name: string } | null>(
-    null,
-  );
+  const [selected, setSelected] = useState<{ ticker: string; name: string } | null>(null);
 
   useEffect(() => {
     if (!slug) return;
@@ -80,9 +78,7 @@ export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
                   return s ? (
                     <SignalBadge
                       action={s.action}
-                      onClick={() =>
-                        setSelected({ ticker: r.ticker, name: r.name })
-                      }
+                      onClick={() => setSelected({ ticker: r.ticker, name: r.name })}
                     />
                   ) : null;
                 })()}
@@ -92,72 +88,6 @@ export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
                 style={{ color: r.change_pct >= 0 ? "green" : "red" }}
               >
                 {r.change_pct.toFixed(2)}
-<!-- =======
-import { Link } from "react-router-dom";
-import { useMemo, useState } from "react";
-
-import { getGroupMovers } from "../api";
-import type { MoverRow } from "../types";
-import { useFetch } from "../hooks/useFetch";
-import { percent } from "../lib/money";
-import tableStyles from "../styles/table.module.css";
-import moversPlugin from "../plugins/movers";
-
-interface Props {
-  slug: string;
-  limit?: number;
-}
-
-export function TopMoversSummary({ slug, limit = 5 }: Props) {
-  const [retry, setRetry] = useState(0);
-  const { data, loading, error } = useFetch<{
-    gainers: MoverRow[];
-    losers: MoverRow[];
-  }>(() => getGroupMovers(slug, 1, limit), [slug, limit, retry], !!slug);
-
-  const rows = useMemo(() => {
-    if (!data || !Array.isArray(data.gainers) || !Array.isArray(data.losers))
-      return [] as MoverRow[];
-    return [...data.gainers, ...data.losers]
-      .sort((a, b) => Math.abs(b.change_pct) - Math.abs(a.change_pct))
-      .slice(0, limit);
-  }, [data, limit]);
-
-  if (!slug) return null;
-  if (loading)
-    return (
-      <div role="status" aria-busy="true">
-        Loading movers…
-      </div>
-    );
-  if (error)
-    return (
-      <div style={{ color: "red" }}>
-        <p>Failed to load movers</p>
-        <button onClick={() => setRetry((r) => r + 1)}>Retry</button>
-      </div>
-    );
-  if (!rows.length) return null;
-
-  return (
-    <div style={{ marginBottom: "1rem" }}>
-      <h3>Top Movers</h3>
-      <table className={tableStyles.table}>
-        <thead>
-          <tr>
-            <th className={tableStyles.cell}>Name</th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>Change %</th>
-          </tr>
-        </thead>
-<!--         <tbody>
-//           {rows.map((row) => (
-<!--             <tr key={row.ticker}>
-              <td className={tableStyles.cell}>{row.name}</td>
-              <td
-                className={`${tableStyles.cell} ${tableStyles.right}`}
-                style={{ color: row.change_pct >= 0 ? "lightgreen" : "red" }}
-              >
-<!--                 {percent(row.change_pct)} --> --> --> -->
               </td>
             </tr>
           ))}
@@ -173,13 +103,5 @@ export function TopMoversSummary({ slug, limit = 5 }: Props) {
     </>
   );
 }
-<!-- =======
-      <div style={{ textAlign: "right", marginTop: "0.5rem" }}>
-        <Link to={moversPlugin.path({ group: slug })}>View more</Link>
-      </div>
-    </div>
-  );
-}
- -->
-export default TopMoversSummary;
 
+export default TopMoversSummary;


### PR DESCRIPTION
## Summary
- compute portfolio totals once and preserve totalCost
- clean up TopMoversSummary implementation

## Testing
- `cd frontend && npm test` *(fails: Error: [vitest] No "getTradingSignals" export is defined on the "../api" mock. Did you forget to return it from "vi.mock"?)*

------
https://chatgpt.com/codex/tasks/task_e_68b59b357fac8327a025e491071da762