### PR TITLE
Use default InstrumentSearchBar import

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,7 +40,7 @@ import ScenarioTester from "./pages/ScenarioTester";
 import UserConfigPage from "./pages/UserConfig";
 import { orderedTabPlugins } from "./tabPlugins";
 import { usePriceRefresh } from "./PriceRefreshContext";
-import { InstrumentSearchBar } from "./components/InstrumentSearchBar";
+import InstrumentSearchBar from "./components/InstrumentSearchBar";
 import Logs from "./pages/Logs";
 type Mode = (typeof orderedTabPlugins)[number]["id"];
 


### PR DESCRIPTION
## Summary
- switch App to default import for InstrumentSearchBar

## Testing
- `npm run dev`
- `npm test` *(fails: The current testing environment is not configured to support act(...); unable to find a label with text /owner/i)*

------
https://chatgpt.com/codex/tasks/task_e_68b617de825c832795961110ccd60b98