### PR TITLE
chore: register service worker only in production

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -73,7 +73,7 @@ createRoot(rootEl).render(
   </StrictMode>,
 )
 
-if ('serviceWorker' in navigator) {
+if (import.meta.env.PROD && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/service-worker.js');
   });


### PR DESCRIPTION
## Summary
- register service worker only when running production build

## Testing
- `npm run build` *(fails: Cannot find module '@testing-library/user-event' and other TS errors)*
- `npm run dev`
- `npm test` *(fails: Failed to resolve import '@testing-library/user-event')*


------
https://chatgpt.com/codex/tasks/task_e_68b61d2f690c83279f0e3c0eae07e1fc