### PR TITLE
test: remove unused waitFor import

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within, waitFor } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 


### PR DESCRIPTION
## Summary
- remove unused `waitFor` import from App test

## Testing
- `npm test -- --run src/App.test.tsx` *(fails: Cannot resolve @testing-library/user-event)*

------
https://chatgpt.com/codex/tasks/task_e_68b61d77c4b88327b937fbb28d13d11a