### PR TITLE
Remove unused URLSearchParams variable

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,7 +46,6 @@ type Mode = (typeof orderedTabPlugins)[number]["id"];
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
-const params = new URLSearchParams(window.location.search);
 const initialMode: Mode =
   path[0] === "member" ? "owner" :
   path[0] === "instrument" ? "instrument" :


### PR DESCRIPTION
## Summary
- remove redundant global URLSearchParams in App

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Fast refresh only works when a file has exports, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b61d755140832780af74e19f26717f