### PR TITLE
test: import API_BASE in api test

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fetchJson, setAuthToken, login } from "./api";
+import { API_BASE, fetchJson, setAuthToken, login } from "./api";
 
 describe("auth token handling", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- add API_BASE import to API tests

## Testing
- `npm test` *(fails: unable to find label /owner/i and act() warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b61d7436788327995b15173808a689