### PR TITLE
test: include logs tab in config mocks

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -156,6 +156,7 @@ describe("App", () => {
       settings: true,
       reports: true,
       scenario: true,
+      logs: true,
     };
 
     render(
@@ -224,6 +225,7 @@ describe("App", () => {
       settings: true,
       reports: true,
       scenario: true,
+      logs: true,
     };
 
     render(

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -42,6 +42,7 @@ const defaultConfig: AppConfig = {
     settings: true,
     reports: true,
     scenario: true,
+    logs: true,
   },
 };
 

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -28,6 +28,7 @@ const defaultConfig: AppConfig = {
         settings: true,
         reports: true,
         scenario: true,
+        logs: true,
     },
 };
 import type { Holding } from "../types";

--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -24,6 +24,7 @@ const defaultConfig: AppConfig = {
     settings: true,
     reports: true,
     scenario: true,
+    logs: true,
   },
 };
 

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -23,6 +23,7 @@ const defaultConfig: AppConfig = {
         settings: true,
         reports: true,
         scenario: true,
+        logs: true,
     },
 };
 

--- a/frontend/src/components/responsiveRender.test.tsx
+++ b/frontend/src/components/responsiveRender.test.tsx
@@ -34,6 +34,7 @@ const defaultConfig: AppConfig = {
     settings: true,
     reports: true,
     scenario: true,
+    logs: true,
   },
 };
 

--- a/frontend/src/hooks/useRouteMode.test.tsx
+++ b/frontend/src/hooks/useRouteMode.test.tsx
@@ -59,6 +59,7 @@ describe("useRouteMode", () => {
       settings: false,
       scenario: false,
       reports: false,
+      logs: false,
     };
 
     const config: ConfigContextValue = {

--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -33,6 +33,7 @@ beforeEach(() => {
       trading: true,
       support: true,
       reports: true,
+      logs: true,
     },
   });
   mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
@@ -80,6 +81,7 @@ describe("Support page", () => {
       trading: true,
       support: true,
       reports: true,
+      logs: true,
     },
   });
   mockGetConfig.mockResolvedValueOnce({
@@ -93,6 +95,7 @@ describe("Support page", () => {
       trading: true,
       support: true,
       reports: true,
+      logs: true,
     },
   });
     mockUpdateConfig.mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- add logs flag to tab configurations in various frontend tests so they match TabsConfig

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /owner/i)*

------
https://chatgpt.com/codex/tasks/task_e_68b61d7113e48327b9d94087daa437ca