### PR TITLE
refactor: remove unused totals

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -150,13 +150,7 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
   );
 
   const totals = computePortfolioTotals(activeAccounts);
-  const {
-    totalValue,
-    totalDayChange,
-    totalGain,
-    totalGainPct,
-    totalDayChangePct,
-  } = totals;
+  const { totalValue } = totals;
 
   for (const acct of activeAccounts) {
     const owner = acct.owner ?? "—";


### PR DESCRIPTION
## Summary
- remove unused totals fields from GroupPortfolioView

## Testing
- `npm test -- --run` *(fails: MainApp demo view > shows demo portfolio when only demo owner is available)*

------
https://chatgpt.com/codex/tasks/task_e_68b61d6ec4808327be676937828de433