### PR TITLE
Enable service worker in Vite dev

### DIFF
--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -36,15 +36,18 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
 });
 
 // Runtime caching for same-origin GET requests. Static assets use cache-first and
-// API calls bypass the cache so live data stays fresh.
-registerRoute(
-  ({ request, url }) =>
-    request.method === 'GET' &&
-    url.origin === self.location.origin &&
-    request.destination !== '' &&
-    !url.pathname.startsWith('/api/'),
-  new CacheFirst({ cacheName: CACHE_NAME })
-);
+// API calls bypass the cache so live data stays fresh. Skip the cache in dev to
+// avoid serving stale modules.
+if (!import.meta.env.DEV) {
+  registerRoute(
+    ({ request, url }) =>
+      request.method === 'GET' &&
+      url.origin === self.location.origin &&
+      request.destination !== '' &&
+      !url.pathname.startsWith('/api/'),
+    new CacheFirst({ cacheName: CACHE_NAME })
+  );
+}
 
 registerRoute(
   ({ request, url }) =>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
         srcDir: 'src',
         filename: 'service-worker.ts',
         manifest: false,
-        devOptions: { enabled: true },
+        // enable service worker in dev but avoid caching dev assets
+        devOptions: { enabled: true, disableRuntimeConfig: true },
         workbox: {
           globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}']
         }


### PR DESCRIPTION
## Summary
- enable Vite PWA service worker during development

## Testing
- `npm run lint` *(fails: no-unused-vars, react-refresh/only-export-components, etc.)*
- `npm test` *(fails: missing @testing-library/user-event and failing assertions)*
- `curl -i http://localhost:5173/dev-sw.js?dev-sw | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b61d31078883279763248973f7d718