### PR TITLE
feat: add transaction create endpoint

### DIFF
--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -41,6 +41,8 @@ def test_create_transaction_success(tmp_path, monkeypatch):
     expected_tx.pop("owner")
     expected_tx.pop("account")
     assert expected_tx in stored["transactions"]
+    for tx in stored["transactions"]:
+        assert "owner" not in tx
 
 
 def test_create_transaction_validation_error(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `TransactionCreate` model and POST endpoint for creating transactions
- store transactions under the owner's account file
- test transaction creation and validation

## Testing
- `pytest tests/test_transactions_route.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b62477b0208327b586d654d9c722fe