### PR TITLE
Add approvals CRUD endpoints and UI

### DIFF
--- a/backend/common/approvals.py
+++ b/backend/common/approvals.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 """Helpers for loading and validating trade approvals."""
 
 import json
+import logging
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Dict, Optional
 
 from backend.common.data_loader import resolve_paths
 from backend.config import config
+
+logger = logging.getLogger(__name__)
 
 
 def _approvals_path(owner: str, accounts_root: Path | None = None) -> Path:
@@ -18,7 +21,9 @@ def _approvals_path(owner: str, accounts_root: Path | None = None) -> Path:
     root = Path(accounts_root) if accounts_root else paths.accounts_root
     owner_dir = root / owner
     if not owner_dir.exists():
-        raise FileNotFoundError(owner)
+        raise FileNotFoundError(
+            f"approvals directory for '{owner}' not found at {owner_dir}"
+        )
     return owner_dir / "approvals.json"
 
 
@@ -30,15 +35,19 @@ def load_approvals(owner: str, accounts_root: Optional[Path] = None) -> Dict[str
     ``"approvals"`` containing that list.  Ticker symbols are normalised to
     uppercase.
     """
+
     try:
         path = _approvals_path(owner, accounts_root)
-    except FileNotFoundError:
-        return {}
+    except FileNotFoundError as exc:
+        logger.error("approvals directory not found for %s: %s", owner, exc)
+        raise
     if not path.exists():
+        logger.error("approvals file for '%s' not found at %s", owner, path)
         return {}
     try:
         data = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.error("failed to read approvals for %s: %s", owner, exc)
         return {}
     entries = data.get("approvals") if isinstance(data, dict) else data
     if not isinstance(entries, list):
@@ -82,7 +91,11 @@ def save_approvals(
     entries = [
         {"ticker": t.upper(), "approved_on": d.isoformat()} for t, d in approvals.items()
     ]
-    path.write_text(json.dumps({"approvals": entries}, indent=2, sort_keys=True))
+    try:
+        path.write_text(json.dumps({"approvals": entries}, indent=2, sort_keys=True))
+    except OSError as exc:
+        logger.error("failed to write approvals for %s to %s: %s", owner, path, exc)
+        raise
 
 
 def upsert_approval(
@@ -93,9 +106,16 @@ def upsert_approval(
 ) -> Dict[str, date]:
     """Add or update a single ticker approval and return the updated mapping."""
 
-    approvals = load_approvals(owner, accounts_root)
+    try:
+        approvals = load_approvals(owner, accounts_root)
+    except FileNotFoundError:
+        approvals = {}
     approvals[ticker.upper()] = approved_on
-    save_approvals(owner, approvals, accounts_root)
+    try:
+        save_approvals(owner, approvals, accounts_root)
+    except OSError:
+        logger.error("failed to persist approval for %s/%s", owner, ticker)
+        raise
     return approvals
 
 
@@ -104,7 +124,18 @@ def delete_approval(
 ) -> Dict[str, date]:
     """Remove ``ticker`` from approvals and return the updated mapping."""
 
-    approvals = load_approvals(owner, accounts_root)
+    try:
+        approvals = load_approvals(owner, accounts_root)
+    except FileNotFoundError:
+        logger.error(
+            "approvals file for %s missing; cannot delete %s", owner, ticker
+        )
+        raise
     approvals.pop(ticker.upper(), None)
-    save_approvals(owner, approvals, accounts_root)
+    try:
+        save_approvals(owner, approvals, accounts_root)
+    except OSError:
+        logger.error("failed to persist approval removal for %s/%s", owner, ticker)
+        raise
     return approvals
+

--- a/backend/routes/approvals.py
+++ b/backend/routes/approvals.py
@@ -1,7 +1,7 @@
 from datetime import date
 from pathlib import Path
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 
 from backend.common.approvals import delete_approval, load_approvals, upsert_approval
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
@@ -12,11 +12,16 @@ router = APIRouter(prefix="/accounts", tags=["approvals"])
 @router.get("/{owner}/approvals")
 @handle_owner_not_found
 async def get_approvals(owner: str, request: Request):
-    root = request.app.state.accounts_root
-    owner_dir = Path(root) / owner
-    if not owner_dir.exists():
+    root = Path(request.app.state.accounts_root).resolve()
+    try:
+        owner_dir = (root / owner).resolve()
+        owner_dir.relative_to(root)
+    except Exception:
         raise_owner_not_found()
-    approvals = load_approvals(owner, root)
+    try:
+        approvals = load_approvals(owner, root)
+    except FileNotFoundError:
+        approvals = {}
     entries = [
         {"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()
     ]
@@ -29,10 +34,17 @@ async def post_approval(owner: str, request: Request):
     data = await request.json()
     ticker = (data.get("ticker") or "").upper()
     when = data.get("approved_on")
-    approved_on = date.fromisoformat(when) if when else date.today()
-    root = request.app.state.accounts_root
-    owner_dir = Path(root) / owner
-    if not owner_dir.exists():
+    if not when:
+        raise HTTPException(status_code=400, detail="approved_on is required")
+    try:
+        approved_on = date.fromisoformat(when)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid approved_on") from exc
+    root = Path(request.app.state.accounts_root).resolve()
+    try:
+        owner_dir = (root / owner).resolve()
+        owner_dir.relative_to(root)
+    except Exception:
         raise_owner_not_found()
     approvals = upsert_approval(owner, ticker, approved_on, root)
     entries = [
@@ -46,9 +58,11 @@ async def post_approval(owner: str, request: Request):
 async def delete_approval_route(owner: str, request: Request):
     data = await request.json()
     ticker = (data.get("ticker") or "").upper()
-    root = request.app.state.accounts_root
-    owner_dir = Path(root) / owner
-    if not owner_dir.exists():
+    root = Path(request.app.state.accounts_root).resolve()
+    try:
+        owner_dir = (root / owner).resolve()
+        owner_dir.relative_to(root)
+    except Exception:
         raise_owner_not_found()
     approvals = delete_approval(owner, ticker, root)
     entries = [

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -506,26 +506,54 @@ export const updateUserConfig = (owner: string, cfg: UserConfig) =>
     body: JSON.stringify(cfg),
   });
 
-export const getApprovals = (owner: string) =>
-  fetchJson<ApprovalsResponse>(`${API_BASE}/accounts/${owner}/approvals`);
+export const getApprovals = async (owner: string) => {
+  try {
+    return await fetchJson<ApprovalsResponse>(
+      `${API_BASE}/accounts/${owner}/approvals`,
+    );
+  } catch (err) {
+    console.error("failed to fetch approvals for", owner, err);
+    throw err;
+  }
+};
 
-export const addApproval = (
+export const addApproval = async (
   owner: string,
   ticker: string,
-  approved_on?: string,
-) =>
-  fetchJson<ApprovalsResponse>(`${API_BASE}/accounts/${owner}/approvals`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ ticker, approved_on }),
-  });
+  approved_on: string,
+) => {
+  if (!ticker) throw new Error("ticker is required");
+  if (!approved_on) throw new Error("approved_on is required");
+  try {
+    return await fetchJson<ApprovalsResponse>(
+      `${API_BASE}/accounts/${owner}/approvals`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ticker, approved_on }),
+      },
+    );
+  } catch (err) {
+    console.error("failed to add approval for", owner, ticker, err);
+    throw err;
+  }
+};
 
-export const removeApproval = (owner: string, ticker: string) =>
-  fetchJson<ApprovalsResponse>(`${API_BASE}/accounts/${owner}/approvals`, {
-    method: "DELETE",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ ticker }),
-  });
+export const removeApproval = async (owner: string, ticker: string) => {
+  try {
+    return await fetchJson<ApprovalsResponse>(
+      `${API_BASE}/accounts/${owner}/approvals`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ticker }),
+      },
+    );
+  } catch (err) {
+    console.error("failed to remove approval for", owner, ticker, err);
+    throw err;
+  }
+};
 
 
 /** Execute a custom query against the backend. */

--- a/tests/test_trade_approvals.py
+++ b/tests/test_trade_approvals.py
@@ -58,7 +58,8 @@ def test_compliance_checks_approval(monkeypatch, tmp_path):
 def test_save_approvals_persists(tmp_path):
     owner_dir = tmp_path / "alice"
     owner_dir.mkdir()
-    approvals = {"ABC": date(2024, 6, 1)}
+    approvals_list = [{"ticker": "ABC", "approved_on": date(2024, 6, 1)}]
+    approvals = {a["ticker"]: a["approved_on"] for a in approvals_list}
     save_approvals("alice", approvals, accounts_root=tmp_path)
     data = json.loads((owner_dir / "approvals.json").read_text())
     assert data["approvals"][0]["ticker"] == "ABC"


### PR DESCRIPTION
## Summary
- log errors when approvals files are missing or unreadable
- validate owner and approved_on in approvals routes
- add client-side validation and error handling for approvals API and UI

## Testing
- `pytest -k approvals`
- `npm test UserConfig`


------
https://chatgpt.com/codex/tasks/task_e_68b6944041e08327b88f5e2a867ad2d1