### PR TITLE
fix: harden transaction creation

### DIFF
--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -27,7 +27,7 @@ def test_create_transaction_success(tmp_path, monkeypatch):
         "reason_to_buy": "diversify",
     }
     resp = client.post("/transactions", json=payload)
-    assert resp.status_code == 200
+    assert resp.status_code == 201
     data = resp.json()
     for key, value in payload.items():
         assert data[key] == value
@@ -37,8 +37,10 @@ def test_create_transaction_success(tmp_path, monkeypatch):
     stored = json.loads(file_path.read_text())
     assert stored["owner"] == "alice"
     assert stored["account_type"] == "ISA"
-    assert stored["transactions"][0]["ticker"] == "AAPL"
-    assert "owner" not in stored["transactions"][0]
+    expected_tx = payload.copy()
+    expected_tx.pop("owner")
+    expected_tx.pop("account")
+    assert expected_tx in stored["transactions"]
 
 
 def test_create_transaction_validation_error(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- sanitize owner/account to avoid path traversal
- add file locking and JSON error logging for transaction storage
- update transaction tests for robust validation

## Testing
- `pytest tests/test_transactions_route.py::test_create_transaction_success -q` *(fails: test_post_transaction_persists_and_updates_portfolio, test_post_transaction_invalid_fields[date-not-a-date], test_post_transaction_invalid_fields[units--5])*

------
https://chatgpt.com/codex/tasks/task_e_68b6949e49ec8327be05730a688d69d9