### PR TITLE
Fix dev service worker caching

### DIFF
--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -36,15 +36,18 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
 });
 
 // Runtime caching for same-origin GET requests. Static assets use cache-first and
-// API calls bypass the cache so live data stays fresh.
-registerRoute(
-  ({ request, url }) =>
-    request.method === 'GET' &&
-    url.origin === self.location.origin &&
-    request.destination !== '' &&
-    !url.pathname.startsWith('/api/'),
-  new CacheFirst({ cacheName: CACHE_NAME })
-);
+// API calls bypass the cache so live data stays fresh. Skip the cache in dev to
+// avoid serving stale modules.
+if (!import.meta.env.DEV) {
+  registerRoute(
+    ({ request, url }) =>
+      request.method === 'GET' &&
+      url.origin === self.location.origin &&
+      request.destination !== '' &&
+      !url.pathname.startsWith('/api/'),
+    new CacheFirst({ cacheName: CACHE_NAME })
+  );
+}
 
 registerRoute(
   ({ request, url }) =>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
         srcDir: 'src',
         filename: 'service-worker.ts',
         manifest: false,
-        devOptions: { enabled: true },
+        // enable service worker in dev but avoid caching dev assets
+        devOptions: { enabled: true, disableRuntimeConfig: true },
         workbox: {
           globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}']
         }


### PR DESCRIPTION
## Summary
- avoid caching dev assets by disabling CacheFirst route during development
- disable runtime caching config when enabling service worker in dev

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components, no-unused-vars, etc.)*
- `npm test` *(fails: MainApp demo view > shows demo portfolio when only demo owner is available)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a0cdc4b883278f823d95f01fe003