### PR TITLE
docs: clarify Google OAuth client requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com   # Google OAuth clie
 ALLOWED_EMAILS=user1@example.com,user2@example.com           # comma-separated
 ```
 
+If `GOOGLE_AUTH_ENABLED` is `true`, you must create an OAuth 2.0 Client ID in the [Google Cloud Console](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid) and supply it via the `GOOGLE_CLIENT_ID` environment variable or the `google_client_id` entry in `config.yaml`.
+
 Alternatively export variables in your shell. Unset variables simply disable
 their corresponding integrations.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,7 +16,7 @@ cors:
   production:
     - https://app.allotmint.io
 app_env: local
-google_auth_enabled: false
+google_auth_enabled: false # enable Google sign-in; requires google_client_id
 disable_auth: true
 sns_topic_arn: ''
 telegram_bot_token: "" # set via TELEGRAM_BOT_TOKEN env var
@@ -25,7 +25,7 @@ portfolio_xml_path: data/portfolio/investments.xml
 transactions_output_root: data/accounts
 uvicorn_port: 8000
 reload: true
-google_client_id: ""
+google_client_id: "" # Google OAuth client ID required when google_auth_enabled is true; set via GOOGLE_CLIENT_ID env var or here
 allowed_emails:
   - user@example.com
 relative_view_enabled: false


### PR DESCRIPTION
## Summary
- document that `google_auth_enabled` requires a Google OAuth client ID
- add link to Google docs for creating the client ID and specify where to configure it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6a091e2288327907ae4e24ecf68c6