### PR TITLE
Handle missing Google client ID

### DIFF
--- a/frontend/src/loginClientId.test.tsx
+++ b/frontend/src/loginClientId.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+})
+
+describe('Root login behaviour', () => {
+  it('shows error when clientId is missing', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    vi.doMock('./api', () => ({
+      getConfig: vi.fn().mockResolvedValue({
+        google_auth_enabled: true,
+        google_client_id: ''
+      })
+    }))
+
+    vi.doMock('./LoginPage', () => ({
+      default: () => <div data-testid="login-page">login-page</div>
+    }))
+
+    document.body.innerHTML = '<div id="root"></div>'
+    const { Root } = await import('./main')
+    render(<Root />)
+    expect(await screen.findByText(/google client id missing/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('login-page')).toBeNull()
+  })
+})

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,7 +16,7 @@ import InstrumentResearch from './pages/InstrumentResearch'
 import { getConfig } from './api'
 import LoginPage from './LoginPage'
 
-function Root() {
+export function Root() {
   const [ready, setReady] = useState(false)
   const [needsAuth, setNeedsAuth] = useState(false)
   const [clientId, setClientId] = useState('')
@@ -33,6 +33,10 @@ function Root() {
 
   if (!ready) return null
   if (needsAuth && !authed) {
+    if (!clientId) {
+      console.error('Google client ID is missing; login disabled')
+      return <div>Google client ID missing. Login is unavailable.</div>
+    }
     return <LoginPage clientId={clientId} onSuccess={() => setAuthed(true)} />
   }
 
@@ -44,6 +48,7 @@ function Root() {
         <Route path="/virtual" element={<VirtualPortfolio />} />
         <Route path="/compliance" element={<ComplianceWarnings />} />
         <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
+        <Route path="/research/:ticker" element={<InstrumentResearch />} />
         <Route path="/*" element={<App />} />
       </Routes>
     </BrowserRouter>
@@ -56,18 +61,7 @@ createRoot(rootEl).render(
   <StrictMode>
     <ConfigProvider>
       <PriceRefreshProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/support" element={<Support />} />
-            <Route path="/reports" element={<Reports />} />
-            <Route path="/virtual" element={<VirtualPortfolio />} />
-            <Route path="/compliance" element={<ComplianceWarnings />} />
-            <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
-            <Route path="/research/:ticker" element={<InstrumentResearch />} />
-            {/* Catch-all for app routes; keep last to avoid intercepting above paths */}
-            <Route path="/*" element={<App />} />
-          </Routes>
-        </BrowserRouter>
+        <Root />
       </PriceRefreshProvider>
     </ConfigProvider>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- prevent rendering Google login without configured client ID
- add test ensuring error is shown when client ID is missing

## Testing
- `npm test` *(fails: src/MainApp.demo.test.tsx > MainApp demo view > shows demo portfolio when only demo owner is available)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a08885a4832782d30a50dd7e42d4