### PR TITLE
feat: support S3 metadata storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ TELEGRAM_CHAT_ID=123456789
 # Token used to secure sensitive routes via the X-API-Token header
 API_TOKEN=
 OPENAI_API_KEY=fake-openai-key
+
+# S3 location for instrument metadata
+METADATA_BUCKET=
+METADATA_PREFIX=instruments

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ role requires the following minimal IAM permissions on that bucket:
   accounts.
 * ``s3:GetObject`` on ``accounts/*`` – read account and ``person.json`` files.
 
+Instrument metadata can reside in a separate bucket. Set ``METADATA_BUCKET`` to the bucket storing instrument JSON files and ``METADATA_PREFIX`` to the key prefix (default ``instruments/``). Updates made locally will be uploaded to this S3 path when configured.
+
 ## Tests
 
 Run Python and frontend test suites with:
@@ -385,6 +387,7 @@ prefix:
 - `accounts/<owner>/trades.csv`
 - `accounts/<owner>/<account>.json`
 - `accounts/<owner>/person.json`
+- Instrument metadata files under `METADATA_PREFIX` (default `instruments/`) in the bucket specified by `METADATA_BUCKET`.
 
 Lambdas that read portfolio information require `s3:GetObject` permission for
 these paths. A minimal IAM policy statement is:

--- a/USER_README.md
+++ b/USER_README.md
@@ -29,6 +29,7 @@ Additional runtime settings are supplied via environment variables. Copy
 - `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`: forward alerts to Telegram
   (e.g. `123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ` and `123456789`).
 - `DATA_BUCKET`: S3 bucket containing account data when running in AWS.
+- `METADATA_BUCKET` and `METADATA_PREFIX`: S3 bucket and key prefix for instrument metadata.
 
 
 ## Authentication

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -4,13 +4,27 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict
 
 _INSTRUMENTS_DIR = Path(__file__).resolve().parents[2] / "data" / "instruments"
 
+METADATA_BUCKET_ENV = "METADATA_BUCKET"
+METADATA_PREFIX_ENV = "METADATA_PREFIX"
+
 logger = logging.getLogger(__name__)
+
+
+def _s3_location() -> tuple[str, str] | None:
+    bucket = os.getenv(METADATA_BUCKET_ENV)
+    if not bucket:
+        return None
+    prefix = os.getenv(METADATA_PREFIX_ENV, "instruments").strip("/")
+    if prefix:
+        prefix += "/"
+    return bucket, prefix
 
 
 def _instrument_path(ticker: str) -> Path:
@@ -23,13 +37,35 @@ def _instrument_path(ticker: str) -> Path:
     return _INSTRUMENTS_DIR / folder / f"{sym}.json"
 
 
+def _instrument_key(ticker: str, prefix: str) -> str:
+    rel = _instrument_path(ticker).relative_to(_INSTRUMENTS_DIR).as_posix()
+    return f"{prefix}{rel}"
+
+
 @lru_cache(maxsize=2048)
 def get_instrument_meta(ticker: str) -> Dict[str, Any]:
-    """Return metadata for ``ticker`` from disk.
+    """Return metadata for ``ticker`` from disk or S3.
 
-    The data files live under ``data/instruments``; failures return an empty dict.
+    The data files live under ``data/instruments`` or the configured S3
+    location; failures return an empty dict.
     """
     path = _instrument_path(ticker)
+    s3_loc = _s3_location()
+    if s3_loc:
+        bucket, prefix = s3_loc
+        key = _instrument_key(ticker, prefix)
+        try:
+            import boto3  # type: ignore
+
+            obj = boto3.client("s3").get_object(Bucket=bucket, Key=key)
+            return json.loads(obj["Body"].read())
+        except Exception as exc:
+            logger.warning(
+                "S3 load failed for %s/%s: %s; falling back to local file",
+                bucket,
+                key,
+                exc,
+            )
     try:
         with path.open("r", encoding="utf-8") as f:
             return json.load(f)
@@ -41,3 +77,28 @@ def get_instrument_meta(ticker: str) -> Dict[str, Any]:
     except Exception:
         logger.exception("Unexpected error loading instrument metadata for %s", path)
         raise
+
+
+def save_instrument_meta(ticker: str, data: Dict[str, Any]) -> None:
+    """Persist metadata locally and upload to S3 when configured."""
+    path = _instrument_path(ticker)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+    s3_loc = _s3_location()
+    if s3_loc:
+        bucket, prefix = s3_loc
+        key = _instrument_key(ticker, prefix)
+        try:
+            import boto3  # type: ignore
+
+            body = json.dumps(data).encode("utf-8")
+            boto3.client("s3").put_object(Bucket=bucket, Key=key, Body=body)
+        except Exception as exc:
+            logger.warning(
+                "Failed to upload instrument metadata for %s to s3://%s/%s: %s",
+                ticker,
+                bucket,
+                key,
+                exc,
+            )
+    get_instrument_meta.cache_clear()

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -1,3 +1,9 @@
+import io
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
 from backend.common import instruments
@@ -32,3 +38,54 @@ def test_unexpected_error_propagates(monkeypatch, tmp_path, caplog):
         with pytest.raises(RuntimeError):
             instruments.get_instrument_meta("ERR.TKR")
     assert "Unexpected error loading" in caplog.text
+
+
+def test_get_instrument_meta_from_s3(monkeypatch):
+    monkeypatch.setenv(instruments.METADATA_BUCKET_ENV, "bucket")
+    monkeypatch.setenv(instruments.METADATA_PREFIX_ENV, "meta")
+    root = Path("dummy")
+    monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", root)
+    monkeypatch.setattr(instruments, "_instrument_path", lambda t: root / "L" / "ABC.json")
+
+    def fake_client(name):
+        assert name == "s3"
+
+        def get_object(Bucket, Key):
+            assert Bucket == "bucket"
+            assert Key == "meta/L/ABC.json"
+            return {"Body": io.BytesIO(b'{"foo": 1}')}
+
+        return SimpleNamespace(get_object=get_object)
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
+
+    instruments.get_instrument_meta.cache_clear()
+    assert instruments.get_instrument_meta("ABC.L") == {"foo": 1}
+
+
+def test_save_instrument_meta_uploads_s3(monkeypatch, tmp_path):
+    monkeypatch.setenv(instruments.METADATA_BUCKET_ENV, "bucket")
+    monkeypatch.setenv(instruments.METADATA_PREFIX_ENV, "meta")
+    monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", tmp_path)
+
+    uploaded: dict = {}
+
+    def fake_client(name):
+        assert name == "s3"
+
+        def put_object(Bucket, Key, Body):
+            uploaded["Bucket"] = Bucket
+            uploaded["Key"] = Key
+            uploaded["Body"] = Body
+
+        return SimpleNamespace(put_object=put_object)
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
+
+    instruments.save_instrument_meta("ABC.L", {"bar": 2})
+    path = tmp_path / "L" / "ABC.json"
+    assert path.exists()
+    assert json.loads(path.read_text()) == {"bar": 2}
+    assert uploaded["Bucket"] == "bucket"
+    assert uploaded["Key"] == "meta/L/ABC.json"
+    assert json.loads(uploaded["Body"].decode()) == {"bar": 2}


### PR DESCRIPTION
## Summary
- detect S3 location for instrument metadata via env vars
- mirror instrument metadata updates to S3 when configured
- document METADATA_BUCKET/METADATA_PREFIX in docs and example env file

## Testing
- `pytest tests/test_instruments.py -q` *(fails: KeyError: 'access_token')*


------
https://chatgpt.com/codex/tasks/task_e_68b6a56f0dc48327996bbbf95752976c