### PR TITLE
fix: ensure google auth config validation and prevent invalid saves

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -9,6 +9,17 @@ from typing import Any, Dict, List, Optional, overload
 import yaml
 
 
+class ConfigValidationError(ValueError):
+    """Raised when configuration values are invalid."""
+
+
+def validate_google_auth(enabled: Optional[bool], client_id: Optional[str]) -> None:
+    if enabled and not client_id:
+        raise ConfigValidationError(
+            "google_auth_enabled is true but google_client_id is missing"
+        )
+
+
 @dataclass
 class TabsConfig:
     instrument: bool = True
@@ -177,8 +188,7 @@ def load_config() -> Config:
 
     google_client_id = data.get("google_client_id") or os.getenv("GOOGLE_CLIENT_ID")
 
-    if google_auth_enabled and not google_client_id:
-        raise ValueError("google_auth_enabled is true but google_client_id is missing")
+    validate_google_auth(google_auth_enabled, google_client_id)
 
     allowed_emails = data.get("allowed_emails")
     env_allowed = os.getenv("ALLOWED_EMAILS")

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
+import os
 import yaml
 from fastapi import APIRouter, HTTPException
 
-from backend.config import _project_config_path, get_config_dict, load_config
+from backend.config import (
+    ConfigValidationError,
+    _project_config_path,
+    get_config_dict,
+    load_config,
+    validate_google_auth,
+)
 
 router = APIRouter(prefix="/config", tags=["config"])
 
@@ -41,6 +48,17 @@ async def update_config(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     other_updates = {k: v for k, v in payload.items() if k != "tabs"}
     data.update(other_updates)
+
+    google_auth_enabled = data.get("google_auth_enabled")
+    env_google_auth = os.getenv("GOOGLE_AUTH_ENABLED")
+    if env_google_auth is not None:
+        google_auth_enabled = env_google_auth.lower() in {"1", "true", "yes"}
+    google_client_id = data.get("google_client_id") or os.getenv("GOOGLE_CLIENT_ID")
+    try:
+        validate_google_auth(google_auth_enabled, google_client_id)
+    except ConfigValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
     try:
         with path.open("w", encoding="utf-8") as fh:
             yaml.safe_dump(data, fh, sort_keys=False)
@@ -50,5 +68,5 @@ async def update_config(payload: Dict[str, Any]) -> Dict[str, Any]:
     load_config.cache_clear()
     try:
         return get_config_dict()
-    except ValueError as exc:
+    except ConfigValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,10 @@
+import pytest
+from fastapi.testclient import TestClient
+
 from backend import config as config_module
+from backend.app import create_app
+from backend.config import ConfigValidationError
+from backend.routes import config as routes_config
 
 
 def test_config_alias_settings():
@@ -43,8 +49,37 @@ def test_auth_flags(monkeypatch):
     cfg = config_module.load_config()
     assert cfg.google_auth_enabled is True
     assert cfg.disable_auth is False
-    monkeypatch.delenv("GOOGLE_AUTH_ENABLED")
-    monkeypatch.delenv("GOOGLE_CLIENT_ID")
-    monkeypatch.delenv("DISABLE_AUTH")
     config_module.load_config.cache_clear()
     config_module.config = config_module.load_config()
+
+
+def test_google_auth_requires_client_id(monkeypatch):
+    monkeypatch.setenv("GOOGLE_AUTH_ENABLED", "true")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "")
+    config_module.load_config.cache_clear()
+    with pytest.raises(ConfigValidationError):
+        config_module.load_config()
+    monkeypatch.setenv("GOOGLE_AUTH_ENABLED", "false")
+    config_module.load_config.cache_clear()
+    config_module.config = config_module.load_config()
+
+
+def test_update_config_rejects_invalid_google_auth(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("google_auth_enabled: false\n")
+
+    monkeypatch.setattr(config_module, "_project_config_path", lambda: config_path)
+    monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
+
+    config_module.load_config.cache_clear()
+    config_module.config = config_module.load_config()
+
+    client = TestClient(create_app())
+
+    resp = client.put("/config", json={"google_auth_enabled": True})
+    assert resp.status_code == 400
+
+    config_module.load_config.cache_clear()
+    cfg = config_module.load_config()
+    assert cfg.google_auth_enabled is False
+    config_module.config = cfg

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from backend.app import create_app
-from backend.config import config
+from backend.config import ConfigValidationError, config
 from backend.routes import timeseries_admin
 
 
@@ -57,9 +57,9 @@ def test_google_token_rejects_unallowed_email(monkeypatch, tmp_path):
 
 def test_startup_requires_google_client_id(monkeypatch):
     monkeypatch.setenv("GOOGLE_AUTH_ENABLED", "true")
-    monkeypatch.delenv("GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "")
     from backend.config import load_config
 
     load_config.cache_clear()
-    with pytest.raises(ValueError):
+    with pytest.raises(ConfigValidationError):
         load_config()


### PR DESCRIPTION
## Summary
- raise ConfigValidationError when `google_auth_enabled` lacks a client ID
- validate config payloads before writing and return 400 on invalid auth config
- add tests covering missing client IDs and rejected config updates

## Testing
- `python -m pytest -q tests/test_google_auth.py::test_startup_requires_google_client_id tests/test_config.py::test_auth_flags tests/test_config.py::test_google_auth_requires_client_id tests/test_config.py::test_update_config_rejects_invalid_google_auth`


------
https://chatgpt.com/codex/tasks/task_e_68b6e3cabf7c8327bab2cd8cc1060e49