### PR TITLE
feat: add logout flow to UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useLocation, Link } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   getGroupInstruments,
@@ -44,6 +44,7 @@ import InstrumentSearchBar from "./components/InstrumentSearchBar";
 import Logs from "./pages/Logs";
 import AllocationCharts from "./pages/AllocationCharts";
 import InstrumentAdmin from "./pages/InstrumentAdmin";
+import Menu from "./components/Menu";
 type Mode = (typeof orderedTabPlugins)[number]["id"];
 
 // derive initial mode + id from path
@@ -68,7 +69,7 @@ const initialMode: Mode =
   path.length === 0 ? "group" : "movers";
 const initialSlug = path[1] ?? "";
 
-export default function App() {
+export default function App({ onLogout }: { onLogout?: () => void }) {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
@@ -99,37 +100,6 @@ export default function App() {
 
   const ownersReq = useFetchWithRetry(getOwners);
   const groupsReq = useFetchWithRetry(getGroups);
-
-  function pathFor(m: Mode) {
-    switch (m) {
-      case "group":
-        return selectedGroup ? `/?group=${selectedGroup}` : "/";
-      case "instrument":
-        return selectedGroup ? `/instrument/${selectedGroup}` : "/instrument";
-      case "owner":
-        return selectedOwner ? `/member/${selectedOwner}` : "/member";
-      case "performance":
-        return selectedOwner ? `/performance/${selectedOwner}` : "/performance";
-      case "movers":
-        return "/movers";
-      case "trading":
-        return "/trading";
-      case "scenario":
-        return "/scenario";
-      case "reports":
-        return "/reports";
-      case "settings":
-        return "/settings";
-      case "logs":
-        return "/logs";
-      case "allocation":
-        return "/allocation";
-      case "instrumentadmin":
-        return "/instrumentadmin";
-      default:
-        return `/${m}`;
-    }
-  }
 
   useEffect(() => {
     const segs = location.pathname.split("/").filter(Boolean);
@@ -312,24 +282,12 @@ export default function App() {
       <LanguageSwitcher />
       <AlertsPanel />
       <div style={{ display: "flex", alignItems: "center", margin: "1rem 0" }}>
-        <nav role="navigation" style={{ flexGrow: 1 }}>
-          {orderedTabPlugins
-            .slice()
-            .sort((a, b) => a.priority - b.priority)
-            .filter((p) => tabs[p.id] !== false)
-            .map((p) => (
-              <Link
-                key={p.id}
-                to={pathFor(p.id)}
-                style={{
-                  marginRight: "1rem",
-                  fontWeight: mode === p.id ? "bold" : undefined,
-                }}
-              >
-                {t(`app.modes.${p.id}`)}
-              </Link>
-            ))}
-        </nav>
+        <Menu
+          selectedOwner={selectedOwner}
+          selectedGroup={selectedGroup}
+          onLogout={onLogout}
+          style={{ flexGrow: 1, margin: 0 }}
+        />
         <InstrumentSearchBar />
         {lastRefresh && (
           <span

--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
 import Menu from "./Menu";
 
 describe("Menu", () => {
@@ -10,5 +11,17 @@ describe("Menu", () => {
       </MemoryRouter>,
     );
     expect(screen.getByRole("link", { name: "Logs" })).toBeInTheDocument();
+  });
+
+  it("renders logout button when callback provided", () => {
+    const onLogout = vi.fn();
+    render(
+      <MemoryRouter>
+        <Menu onLogout={onLogout} />
+      </MemoryRouter>,
+    );
+    const btn = screen.getByRole("button", { name: /logout/i });
+    fireEvent.click(btn);
+    expect(onLogout).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -1,16 +1,21 @@
 import { Link, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useConfig } from "../ConfigContext";
-import { type Mode, MODES } from "../modes";
+import type { TabPluginId } from "../tabPlugins";
+import { orderedTabPlugins } from "../tabPlugins";
 
 interface MenuProps {
   selectedOwner?: string;
   selectedGroup?: string;
+  onLogout?: () => void;
+  style?: React.CSSProperties;
 }
 
 export default function Menu({
   selectedOwner = "",
   selectedGroup = "",
+  onLogout,
+  style,
 }: MenuProps) {
   const location = useLocation();
   const { t } = useTranslation();
@@ -19,13 +24,15 @@ export default function Menu({
   const params = new URLSearchParams(location.search);
   const path = location.pathname.split("/").filter(Boolean);
 
-  const mode: Mode =
+  const mode: TabPluginId =
     path[0] === "member"
       ? "owner"
       : path[0] === "instrument"
       ? "instrument"
       : path[0] === "transactions"
       ? "transactions"
+      : path[0] === "trading"
+      ? "trading"
       : path[0] === "performance"
       ? "performance"
       : path[0] === "screener"
@@ -34,12 +41,18 @@ export default function Menu({
       ? "timeseries"
       : path[0] === "watchlist"
       ? "watchlist"
+      : path[0] === "allocation"
+      ? "allocation"
       : path[0] === "movers"
       ? "movers"
       : path[0] === "instrumentadmin"
       ? "instrumentadmin"
       : path[0] === "dataadmin"
       ? "dataadmin"
+      : path[0] === "virtual"
+      ? "virtual"
+      : path[0] === "reports"
+      ? "reports"
       : path[0] === "support"
       ? "support"
       : path[0] === "settings"
@@ -52,7 +65,7 @@ export default function Menu({
       ? "group"
       : "movers";
 
-  function pathFor(m: Mode) {
+  function pathFor(m: TabPluginId) {
     switch (m) {
       case "group":
         return selectedGroup ? `/?group=${selectedGroup}` : "/";
@@ -66,12 +79,18 @@ export default function Menu({
           : "/performance";
       case "movers":
         return "/movers";
+      case "trading":
+        return "/trading";
       case "scenario":
         return "/scenario";
+      case "reports":
+        return "/reports";
       case "settings":
         return "/settings";
       case "logs":
         return "/logs";
+      case "allocation":
+        return "/allocation";
       case "instrumentadmin":
         return "/instrumentadmin";
       default:
@@ -80,20 +99,38 @@ export default function Menu({
   }
 
   return (
-    <nav style={{ margin: "1rem 0" }}>
-      {MODES.filter((m) => tabs[m] === true && !disabledTabs?.includes(m)).map(
-        (m) => (
+    <nav style={{ margin: "1rem 0", ...(style ?? {}) }}>
+      {orderedTabPlugins
+        .slice()
+        .sort((a, b) => a.priority - b.priority)
+        .filter((p) => tabs[p.id] !== false && !disabledTabs?.includes(p.id))
+        .map((p) => (
           <Link
-            key={m}
-            to={pathFor(m)}
+            key={p.id}
+            to={pathFor(p.id)}
             style={{
               marginRight: "1rem",
-              fontWeight: mode === m ? "bold" : undefined,
+              fontWeight: mode === p.id ? "bold" : undefined,
             }}
           >
-            {t(`app.modes.${m}`)}
+            {t(`app.modes.${p.id}`)}
           </Link>
-        ),
+        ))}
+      {onLogout && (
+        <button
+          type="button"
+          onClick={onLogout}
+          style={{
+            marginRight: "1rem",
+            background: "none",
+            border: "none",
+            padding: 0,
+            font: "inherit",
+            cursor: "pointer",
+          }}
+        >
+          {t("app.logout", "Logout")}
+        </button>
       )}
     </nav>
   );

--- a/frontend/src/loginClientId.test.tsx
+++ b/frontend/src/loginClientId.test.tsx
@@ -25,7 +25,7 @@ describe('Root login behaviour', () => {
     document.body.innerHTML = '<div id="root"></div>'
     const { Root } = await import('./main')
     render(<Root />)
-    expect(await screen.findByText(/google client id missing/i)).toBeInTheDocument()
+    expect(await screen.findByText(/google login is not configured/i)).toBeInTheDocument()
     expect(screen.queryByTestId('login-page')).toBeNull()
   })
 })

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,7 +12,7 @@ import ComplianceWarnings from './pages/ComplianceWarnings'
 import { ConfigProvider } from './ConfigContext'
 import { PriceRefreshProvider } from './PriceRefreshContext'
 import InstrumentResearch from './pages/InstrumentResearch'
-import { getConfig } from './api'
+import { getConfig, setAuthToken } from './api'
 import LoginPage from './LoginPage'
 
 export function Root() {
@@ -20,6 +20,11 @@ export function Root() {
   const [needsAuth, setNeedsAuth] = useState(false)
   const [clientId, setClientId] = useState('')
   const [authed, setAuthed] = useState(false)
+
+  const logout = () => {
+    setAuthToken(null)
+    setAuthed(false)
+  }
 
   useEffect(() => {
     getConfig<Record<string, unknown>>()
@@ -34,7 +39,7 @@ export function Root() {
   if (needsAuth && !authed) {
     if (!clientId) {
       console.error('Google client ID is missing; login disabled')
-      return <div>Google client ID missing. Login is unavailable.</div>
+      return <div>Google login is not configured.</div>
     }
     return <LoginPage clientId={clientId} onSuccess={() => setAuthed(true)} />
   }
@@ -48,7 +53,7 @@ export function Root() {
         <Route path="/compliance" element={<ComplianceWarnings />} />
         <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
         <Route path="/research/:ticker" element={<InstrumentResearch />} />
-        <Route path="/*" element={<App />} />
+        <Route path="/*" element={<App onLogout={logout} />} />
       </Routes>
     </BrowserRouter>
   )


### PR DESCRIPTION
## Summary
- add logout callback wiring from main to navigation menu
- expose logout action in Menu with styled button
- adjust login tests for new error messaging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7632ad07083278f27d756da7a5770