### PR TITLE
Add AuthContext and avatar from Google login

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -432,8 +432,7 @@ describe("App", () => {
       </AuthContext.Provider>,
     );
 
-    expect(
-      await screen.findByRole("img", { name: /user avatar/i }),
-    ).toBeInTheDocument();
+    const avatar = await screen.findByRole("img", { name: /user avatar/i });
+    expect(avatar).toHaveAttribute("src", "http://example.com/pic.jpg");
   });
 });

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -40,9 +40,10 @@ export default function LoginPage({ clientId, onSuccess }: Props) {
             const data = await res.json();
             setAuthToken(data.access_token);
             try {
-              const payload = JSON.parse(
-                atob(resp.credential.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")),
-              );
+              const base64Url = resp.credential.split(".")[1];
+              const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+              const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+              const payload = JSON.parse(atob(base64 + padding));
               setUser({
                 email: payload.email,
                 name: payload.name,


### PR DESCRIPTION
## Summary
- decode Google credential with proper padding to avoid decode errors
- ensure avatar test checks image source

## Testing
- `cd frontend && npm test -- --run` *(fails: Google login guard test missing element)*

------
https://chatgpt.com/codex/tasks/task_e_68b76fdc814c8327a4726647cd63edd3