### PR TITLE
chore: type allocation plugin

### DIFF
--- a/frontend/src/plugins/allocation.ts
+++ b/frontend/src/plugins/allocation.ts
@@ -1,7 +1,9 @@
-import AllocationCharts from "../pages/AllocationCharts";
+import AllocationCharts, {
+  type AllocationChartsProps,
+} from "../pages/AllocationCharts";
 import type { TabPlugin } from "./TabPlugin";
 
-const plugin: TabPlugin = {
+const plugin: TabPlugin<AllocationChartsProps> = {
   id: "allocation",
   component: AllocationCharts,
   priority: 85,


### PR DESCRIPTION
## Summary
- type allocation tab plugin with AllocationChartsProps

## Testing
- `npm test -- --run`
- `cd frontend && npm run lint` *(fails: 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b770ed5910832782a2f26e21e6100a