### PR TITLE
chore: use definite assignment for resolveFetch

### DIFF
--- a/frontend/src/components/ValueAtRisk.test.tsx
+++ b/frontend/src/components/ValueAtRisk.test.tsx
@@ -52,7 +52,7 @@ describe("ValueAtRisk component", () => {
   });
 
   it("skips state updates when unmounted", async () => {
-    let resolveFetch: (value: Response) => void;
+    let resolveFetch!: (value: Response) => void;
     const fetchPromise = new Promise<Response>((resolve) => {
       resolveFetch = resolve;
     });


### PR DESCRIPTION
## Summary
- use definite assignment assertion for `resolveFetch` in ValueAtRisk test to satisfy TypeScript strict checks

## Testing
- `npm test` *(fails: src/LoginPage.test.tsx > Google login guard > shows error when client ID missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b770e5b8ac8327b20e55c88c38b20e