### PR TITLE
refactor: remove unused map param

### DIFF
--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -122,7 +122,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
               outerRadius="80%"
               label
             >
-              {chartData.map((entry, index) => (
+              {chartData.map((_, index) => (
                 <Cell
                   key={`cell-${index}`}
                   fill={COLORS[index % COLORS.length]}


### PR DESCRIPTION
## Summary
- refactor: remove unused map parameter in AllocationCharts map callback

## Testing
- `npm test -- run`


------
https://chatgpt.com/codex/tasks/task_e_68b770e985608327b8819dc2cbfddfaa