### PR TITLE
chore: remove React import from SignalBadge

### DIFF
--- a/frontend/src/components/SignalBadge.tsx
+++ b/frontend/src/components/SignalBadge.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 type Action = "buy" | "sell";
 type Props = {
   action: Action;


### PR DESCRIPTION
## Summary
- remove unused React import in SignalBadge component

## Testing
- `npm test` *(fails: Unable to find an element with the text: /google client id missing\. login is unavailable\./i)*

------
https://chatgpt.com/codex/tasks/task_e_68b770e2ed648327b91b603d766e27b9