### PR TITLE
chore: remove unused params from menu

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -20,8 +20,6 @@ export default function Menu({
   const location = useLocation();
   const { t } = useTranslation();
   const { tabs, disabledTabs } = useConfig();
-
-  const params = new URLSearchParams(location.search);
   const path = location.pathname.split("/").filter(Boolean);
 
   const mode: TabPluginId =


### PR DESCRIPTION
## Summary
- remove unused `URLSearchParams` from Menu component

## Testing
- `npm test` *(fails: Google login guard > shows error when client ID missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b770e1a4d083278778c0325ad47cf0