### PR TITLE
test: ensure callback assigned before awaiting in LoginPage test

### DIFF
--- a/frontend/src/LoginPage.test.tsx
+++ b/frontend/src/LoginPage.test.tsx
@@ -25,9 +25,10 @@ describe('LoginPage error handling', () => {
   it('shows error message when login fails', async () => {
     const initialize = vi.fn()
     ;(window as any).google = { accounts: { id: { initialize, renderButton: vi.fn() } } }
-    let callback: (resp: { credential: string }) => Promise<void> | void
+    let callback!: (resp: { credential: string }) => Promise<void> | void
     initialize.mockImplementation((opts: { callback: typeof callback }) => {
       callback = opts.callback
+      return Promise.resolve()
     })
 
     const fetchMock = vi
@@ -41,6 +42,7 @@ describe('LoginPage error handling', () => {
 
     const script = document.head.querySelector('script[src="https://accounts.google.com/gsi/client"]') as HTMLScriptElement
     script.onload?.(new Event('load'))
+    await initialize.mock.results[0].value
     await callback({ credential: 'token' })
 
     expect(await screen.findByText('bad')).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- use definite assignment for callback in LoginPage test
- mock initialize assigns callback and returns a resolved Promise
- wait for initialize before invoking callback

## Testing
- `npm test` *(fails: src/LoginPage.test.tsx > Google login guard > shows error when client ID missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b770e0403c83279553f279b39c0365