### PR TITLE
feat: add toast alerts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^19.1.0",
         "react-i18next": "^15.7.0",
         "react-router-dom": "^7.8.1",
+        "react-toastify": "^11.0.5",
         "recharts": "^3.1.2"
       },
       "devDependencies": {
@@ -8153,6 +8154,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/recharts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^19.1.0",
     "react-i18next": "^15.7.0",
     "react-router-dom": "^7.8.1",
+    "react-toastify": "^11.0.5",
     "recharts": "^3.1.2"
   },
   "devDependencies": {

--- a/frontend/src/components/AlertsPanel.tsx
+++ b/frontend/src/components/AlertsPanel.tsx
@@ -1,75 +1,27 @@
+import { useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "react-toastify";
 import * as api from "../api";
 import type { Alert } from "../types";
 import { useFetch } from "../hooks/useFetch";
-import { useEffect, useState } from "react";
-export function AlertsPanel({ user = "default" }: { user?: string }) {
-  const { data: alerts, loading, error } = useFetch<Alert[]>(api.getAlerts, []);
-  const [threshold, setThreshold] = useState<number>();
-  const [settingsError, setSettingsError] = useState(false);
+
+export function AlertsPanel() {
+  const { data: alerts } = useFetch<Alert[]>(api.getAlerts, []);
+  const shown = useRef(new Set<string>());
 
   useEffect(() => {
-    if (api.getAlertSettings) {
-      api
-        .getAlertSettings(user)
-        .then((r) => setThreshold(r.threshold))
-        .catch(() => setSettingsError(true));
-    }
-  }, [user]);
-
-  const save = () => {
-    if (threshold !== undefined && api.setAlertSettings) {
-      api.setAlertSettings(user, threshold);
-    }
-  };
-
-  if (loading) return null;
-
-  if (error || settingsError) {
-    return (
-      <div style={{ border: "1px solid #ccc", padding: "0.5rem", marginBottom: "1rem" }}>
-        Cannot reach server
-      </div>
-    );
-  }
-
-  const importAlert = alerts?.find((a) => a.ticker === "IMPORT");
-  const otherAlerts = alerts?.filter((a) => a.ticker !== "IMPORT") ?? [];
-
-  if (!importAlert && otherAlerts.length === 0) return null;
+    alerts?.forEach((a) => {
+      const key = `${a.ticker}:${a.message}`;
+      if (!shown.current.has(key)) {
+        shown.current.add(key);
+        toast(`${a.ticker}: ${a.message}`);
+      }
+    });
+  }, [alerts]);
 
   return (
-    <div style={{ border: "1px solid #ccc", padding: "0.5rem", marginBottom: "1rem" }}>
-      <strong>Alerts</strong>
-      {importAlert && (
-        <div data-testid="import-status" style={{ marginTop: "0.5rem" }}>
-          {importAlert.message}
-        </div>
-      )}
-      {otherAlerts.length > 0 && (
-        <>
-          <div style={{ marginTop: "0.5rem" }}>
-            <label>
-              Threshold %:{" "}
-              <input
-                type="number"
-                value={threshold ?? ""}
-                onChange={(e) => setThreshold(parseFloat(e.target.value))}
-                style={{ width: "4rem" }}
-              />
-            </label>
-            <button onClick={save} style={{ marginLeft: "0.5rem" }}>
-              Save
-            </button>
-          </div>
-          <ul style={{ margin: 0, paddingLeft: "1.2rem" }}>
-            {otherAlerts.map((a, i) => (
-              <li key={i}>
-                <strong>{a.ticker}</strong>: {a.message}
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+    <div style={{ marginBottom: "1rem" }}>
+      <Link to="/alerts">View all alerts</Link>
     </div>
   );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,6 +14,9 @@ import { PriceRefreshProvider } from './PriceRefreshContext'
 import InstrumentResearch from './pages/InstrumentResearch'
 import { getConfig } from './api'
 import LoginPage from './LoginPage'
+import Alerts from './pages/Alerts'
+import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
 
 export function Root() {
   const [ready, setReady] = useState(false)
@@ -48,6 +51,7 @@ export function Root() {
         <Route path="/compliance" element={<ComplianceWarnings />} />
         <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
         <Route path="/research/:ticker" element={<InstrumentResearch />} />
+        <Route path="/alerts" element={<Alerts />} />
         <Route path="/*" element={<App />} />
       </Routes>
     </BrowserRouter>
@@ -61,6 +65,7 @@ createRoot(rootEl).render(
     <ConfigProvider>
       <PriceRefreshProvider>
         <Root />
+        <ToastContainer autoClose={5000} />
       </PriceRefreshProvider>
     </ConfigProvider>
   </StrictMode>,

--- a/frontend/src/pages/Alerts.tsx
+++ b/frontend/src/pages/Alerts.tsx
@@ -1,0 +1,76 @@
+import * as api from "../api";
+import type { Alert } from "../types";
+import { useFetch } from "../hooks/useFetch";
+import { useEffect, useState } from "react";
+
+export default function Alerts({ user = "default" }: { user?: string }) {
+  const { data: alerts, loading, error } = useFetch<Alert[]>(api.getAlerts, []);
+  const [threshold, setThreshold] = useState<number>();
+  const [settingsError, setSettingsError] = useState(false);
+
+  useEffect(() => {
+    if (api.getAlertSettings) {
+      api
+        .getAlertSettings(user)
+        .then((r) => setThreshold(r.threshold))
+        .catch(() => setSettingsError(true));
+    }
+  }, [user]);
+
+  const save = () => {
+    if (threshold !== undefined && api.setAlertSettings) {
+      api.setAlertSettings(user, threshold);
+    }
+  };
+
+  if (loading) return null;
+
+  if (error || settingsError) {
+    return (
+      <div style={{ border: "1px solid #ccc", padding: "0.5rem", marginBottom: "1rem" }}>
+        Cannot reach server
+      </div>
+    );
+  }
+
+  const importAlert = alerts?.find((a) => a.ticker === "IMPORT");
+  const otherAlerts = alerts?.filter((a) => a.ticker !== "IMPORT") ?? [];
+
+  if (!importAlert && otherAlerts.length === 0) return <div>No alerts</div>;
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
+      <h1>Alerts</h1>
+      {importAlert && (
+        <div data-testid="import-status" style={{ marginTop: "0.5rem" }}>
+          {importAlert.message}
+        </div>
+      )}
+      {otherAlerts.length > 0 && (
+        <>
+          <div style={{ marginTop: "0.5rem" }}>
+            <label>
+              Threshold %:{" "}
+              <input
+                type="number"
+                value={threshold ?? ""}
+                onChange={(e) => setThreshold(parseFloat(e.target.value))}
+                style={{ width: "4rem" }}
+              />
+            </label>
+            <button onClick={save} style={{ marginLeft: "0.5rem" }}>
+              Save
+            </button>
+          </div>
+          <ul style={{ margin: 0, paddingLeft: "1.2rem" }}>
+            {otherAlerts.map((a, i) => (
+              <li key={i}>
+                <strong>{a.ticker}</strong>: {a.message}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- use react-toastify to show auto-dismissable alert toasts
- add View all alerts link and dedicated alerts page
- wire up ToastContainer in app entry

## Testing
- `npm test`
- `npm run lint` *(fails: 'params' is assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a090897483279d36bd8be358f033