### PR TITLE
Fix profile page merge artifact and tab validation

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -20,6 +20,19 @@ def validate_google_auth(enabled: Optional[bool], client_id: Optional[str]) -> N
         )
 
 
+def validate_tabs(tabs_raw: Any) -> TabsConfig:
+    """Validate tab configuration ensuring all keys are known booleans."""
+    tabs_data = asdict(TabsConfig())
+    if isinstance(tabs_raw, dict):
+        for key, val in tabs_raw.items():
+            if key not in tabs_data:
+                raise ConfigValidationError(f"Unknown tab '{key}'")
+            if not isinstance(val, bool):
+                raise ConfigValidationError(f"Tab '{key}' must be a boolean")
+            tabs_data[key] = val
+    return TabsConfig(**tabs_data)
+
+
 @dataclass
 class TabsConfig:
     instrument: bool = True
@@ -38,7 +51,7 @@ class TabsConfig:
     virtual: bool = True
     support: bool = True
     settings: bool = True
-    profile: bool = True
+    profile: bool = False
     reports: bool = True
     scenario: bool = True
     logs: bool = True
@@ -163,10 +176,7 @@ def load_config() -> Config:
     prices_json = (repo_root / prices_json_raw).resolve() if prices_json_raw else None
 
     tabs_raw = data.get("tabs")
-    tabs_data = asdict(TabsConfig())
-    if isinstance(tabs_raw, dict):
-        tabs_data.update(tabs_raw)
-    tabs = TabsConfig(**tabs_data)
+    tabs = validate_tabs(tabs_raw)
 
     ta_raw = data.get("trading_agent")
     ta_data = asdict(TradingAgentConfig())

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -56,3 +56,4 @@ tabs:
   timeseries: true
   instrumentadmin: true
   reports: true
+  profile: true

--- a/config.yaml
+++ b/config.yaml
@@ -59,3 +59,4 @@ tabs:
   support: true
   reports: true
   scenario: true
+  profile: true

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -147,19 +147,19 @@ describe("App", () => {
       transactions: true,
       trading: true,
       screener: true,
-    timeseries: true,
-    watchlist: true,
-    movers: true,
-    instrumentadmin: true,
-    dataadmin: true,
-    virtual: true,
-    support: true,
-    settings: true,
-    profile: true,
-    reports: true,
-    scenario: true,
-    logs: true,
-  };
+      timeseries: true,
+      watchlist: true,
+      movers: true,
+      instrumentadmin: true,
+      dataadmin: true,
+      virtual: true,
+      support: true,
+      settings: true,
+      profile: true,
+      reports: true,
+      scenario: true,
+      logs: true,
+    };
 
     render(
       <configContext.Provider
@@ -218,19 +218,19 @@ describe("App", () => {
       transactions: true,
       trading: true,
       screener: true,
-    timeseries: true,
-    watchlist: true,
-    movers: true,
-    instrumentadmin: true,
-    dataadmin: true,
-    virtual: true,
-    support: true,
-    settings: true,
-    profile: true,
-    reports: true,
-    scenario: true,
-    logs: true,
-  };
+      timeseries: true,
+      watchlist: true,
+      movers: true,
+      instrumentadmin: true,
+      dataadmin: true,
+      virtual: true,
+      support: true,
+      settings: true,
+      profile: true,
+      reports: true,
+      scenario: true,
+      logs: true,
+    };
 
     render(
       <configContext.Provider
@@ -394,11 +394,10 @@ describe("App", () => {
       "Instrument Admin",
       "Data Admin",
       "Reports",
-      "User Settings",
-      "Profile",
-      "Support",
-      "Logs",
-      "Scenario Tester",
-    ]);
-  });
+        "User Settings",
+        "Support",
+        "Logs",
+        "Scenario Tester",
+      ]);
+    });
 });

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -67,7 +67,7 @@ const defaultTabs: TabsConfig = {
   virtual: true,
   support: true,
   settings: true,
-  profile: true,
+  profile: false,
   reports: true,
   scenario: true,
   logs: true,

--- a/frontend/src/hooks/useRouteMode.test.tsx
+++ b/frontend/src/hooks/useRouteMode.test.tsx
@@ -56,13 +56,13 @@ describe("useRouteMode", () => {
       instrumentadmin: false,
       dataadmin: false,
       virtual: false,
-      support: false,
-      settings: false,
-      profile: false,
-      scenario: false,
-      reports: false,
-      logs: false,
-    };
+        support: false,
+        settings: false,
+        profile: true,
+        scenario: false,
+        reports: false,
+        logs: false,
+      };
 
     const config: ConfigContextValue = {
       relativeViewEnabled: false,

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,26 +1,7 @@
-import React from "react";
+import { useConfig } from "../ConfigContext";
+import { useUser } from "../UserContext";
 
 export default function ProfilePage() {
-  const user = {
-    name: "Jane Doe",
-    email: "jane@example.com",
-    avatar: "https://via.placeholder.com/150",
-  };
-
-  return (
-    <div style={{ textAlign: "center" }}>
-      <img
-        src={user.avatar}
-        alt={user.name}
-        style={{ borderRadius: "50%", width: 150, height: 150 }}
-      />
-      <h1>{user.name}</h1>
-      <p>{user.email}</p>
-
-      import { useUser } from "../UserContext";
-import { useConfig } from "../ConfigContext";
-
-export default function Profile() {
   const { profile } = useUser();
   const { theme } = useConfig();
 
@@ -43,3 +24,4 @@ export default function Profile() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- validate tab configuration and disable profile tab by default
- resolve merge artifact in Profile page component
- adjust tests and configs for new profile tab

## Testing
- `npm test -- --run`
- `npm test -- src/App.test.tsx`
- `GOOGLE_AUTH_ENABLED=0 pytest` *(fails: assert 401 == 200, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a5ec82088327846cf34eae582c7c