### PR TITLE
Fix VaR validation and owner checks

### DIFF
--- a/backend/common/risk.py
+++ b/backend/common/risk.py
@@ -58,9 +58,11 @@ def compute_portfolio_var(
     # Allow the confidence level to be expressed as a percentage (e.g. 95)
     # or as a decimal fraction (0.95). Convert percentages to a fraction and
     # validate the result.
-    if confidence > 1:
+    if 0 < confidence < 1:
+        pass
+    elif 1 <= confidence <= 100 and float(confidence).is_integer():
         confidence = confidence / 100
-    if not 0 < confidence < 1:
+    else:
         raise ValueError("confidence must be between 0 and 1 or 0 and 100")
 
     # exclude any instruments flagged in the price snapshot until refreshed
@@ -115,9 +117,11 @@ def compute_portfolio_var_breakdown(
     if days <= 0:
         raise ValueError("days must be positive")
 
-    if confidence > 1:
+    if 0 < confidence < 1:
+        pass
+    elif 1 <= confidence <= 100 and float(confidence).is_integer():
         confidence = confidence / 100
-    if not 0 < confidence < 1:
+    else:
         raise ValueError("confidence must be between 0 and 1 or 0 and 100")
 
     portfolio = portfolio_mod.build_owner_portfolio(owner)
@@ -132,7 +136,7 @@ def compute_portfolio_var_breakdown(
         if not include_cash and ticker.startswith("CASH"):
             continue
 
-        sym, exch = (ticker.split(".", 1) + ["L"])[:2]
+        sym, exch = (ticker.rsplit(".", 1) + ["L"])[:2]
         ts = portfolio_utils.load_meta_timeseries(sym, exch, days)
         var_single = portfolio_utils.compute_var(ts, confidence=confidence)
         if var_single is None or ts is None or ts.empty:

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -172,6 +172,8 @@ async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95, e
     Raises 404 if the owner does not exist and 400 for invalid parameters.
     """
 
+    if owner not in portfolio_mod.list_owners():
+        raise HTTPException(status_code=404, detail="Owner not found")
     try:
         var = risk.compute_portfolio_var(owner, days=days, confidence=confidence, include_cash=not exclude_cash)
         sharpe = risk.compute_sharpe_ratio(owner, days=days)
@@ -191,6 +193,8 @@ async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95, e
 async def portfolio_var_breakdown(owner: str, days: int = 365, confidence: float = 0.95, exclude_cash: bool = False):
     """Return VaR totals with per-ticker contribution breakdown."""
 
+    if owner not in portfolio_mod.list_owners():
+        raise HTTPException(status_code=404, detail="Owner not found")
     try:
         var = risk.compute_portfolio_var(owner, days=days, confidence=confidence, include_cash=not exclude_cash)
         breakdown = risk.compute_portfolio_var_breakdown(owner, days=days, confidence=confidence, include_cash=not exclude_cash)

--- a/tests/test_var_route.py
+++ b/tests/test_var_route.py
@@ -23,11 +23,12 @@ def deterministic_setup(monkeypatch):
         "accounts": [
             {
                 "name": "ISA",
-                "holdings": [{"ticker": "ABC", "exchange": "L", "units": 10, "currency": "GBP"}],
+                "holdings": [{"ticker": "ABC.L", "units": 10, "currency": "GBP"}],
             }
         ],
     }
     monkeypatch.setattr(portfolio_mod, "build_owner_portfolio", lambda owner: portfolio)
+    monkeypatch.setattr(portfolio_mod, "list_owners", lambda: ["alice"])
 
     # Closing prices for five consecutive days
     prices = pd.DataFrame(
@@ -79,8 +80,6 @@ def test_var_breakdown_bad_params(deterministic_setup):
 
 def test_var_breakdown_unknown_owner(monkeypatch):
     client = _auth_client()
-    def _fail(_owner):
-        raise FileNotFoundError
-    monkeypatch.setattr(portfolio_mod, "build_owner_portfolio", _fail)
+    monkeypatch.setattr(portfolio_mod, "list_owners", lambda: ["alice"])
     resp = client.get("/var/unknown/breakdown")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- restrict VaR confidence parameter to decimals or integer percentages
- verify owner exists before computing VaR or its breakdown
- adjust tests to use full ticker format and owner existence checks

## Testing
- `GOOGLE_CLIENT_ID=dummy pytest tests/test_var_route.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b8a61157a48327a2183998978a3fdd