### PR TITLE
Fix Request annotations for user config routes

### DIFF
--- a/backend/common/errors.py
+++ b/backend/common/errors.py
@@ -4,7 +4,7 @@ import inspect
 from functools import wraps
 from typing import Any, Callable, TypeVar
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 
 OWNER_NOT_FOUND = "Owner not found"
 

--- a/backend/routes/user_config.py
+++ b/backend/routes/user_config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from fastapi import APIRouter, Request
 
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found


### PR DESCRIPTION
## Summary
- import `Request` in error decorator to resolve FastAPI type lookup
- drop postponed evaluation from `user_config` routes

## Testing
- `pytest` *(fails: assert 401 == 200, etc.)*
- `curl -s -o /tmp/docs.html -w "%{http_code}" http://localhost:8000/docs`


------
https://chatgpt.com/codex/tasks/task_e_68b8a835727c8327972da0a57e80b7b6