### PR TITLE
Remove duplicate ProfilePage import

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,7 +46,6 @@ import UserAvatar from "./components/UserAvatar";
 import Logs from "./pages/Logs";
 import AllocationCharts from "./pages/AllocationCharts";
 import InstrumentAdmin from "./pages/InstrumentAdmin";
-import ProfilePage from "./pages/Profile";
 import Menu from "./components/Menu";
 type Mode = (typeof orderedTabPlugins)[number]["id"] | "profile";
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,27 +1,4 @@
-import { useConfig } from "../ConfigContext";
-import { useUser } from "../UserContext";
 import { useAuth } from "../AuthContext";
-
-export default function ProfilePage() {
-  const { profile } = useUser();
-  const { theme } = useConfig();
-
-  if (!profile) {
-    return <div>No profile loaded.</div>;
-  }
-
-  return (
-    <div style={{ padding: "1rem" }}>
-      {profile.picture && (
-        <img
-          src={profile.picture}
-          alt={profile.name}
-          style={{ width: "80px", borderRadius: "50%" }}
-        />
-      )}
-      <h2>{profile.name}</h2>
-      <p>{profile.email}</p>
-      <p>Preferred theme: {theme}</p>
 
 export default function ProfilePage() {
   const { user } = useAuth();


### PR DESCRIPTION
## Summary
- remove duplicate ProfilePage import in App.tsx
- simplify ProfilePage component implementation

## Testing
- `npm run build` *(fails: src/App.tsx(76,11): error TS6196: 'AppProps' is declared but never used. ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b2bff33883279d8741ab95852057