### PR TITLE
Add agent stats route test

### DIFF
--- a/tests/test_agent_stats_route.py
+++ b/tests/test_agent_stats_route.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes.agent import router
+
+
+def test_agent_stats_route(monkeypatch):
+    sample_payload = {"win_rate": 0.5, "average_profit": 1.23}
+    monkeypatch.setattr(
+        "backend.routes.agent.load_and_compute_metrics",
+        lambda: sample_payload,
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.get("/agent/stats")
+
+    assert response.status_code == 200
+    assert response.json() == sample_payload


### PR DESCRIPTION
## Summary
- add test for /agent/stats route using FastAPI router

## Testing
- `pytest -k agent_stats_route -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b2ce896c83278f70f00682f572d1