### PR TITLE
test: add movers route tests

### DIFF
--- a/backend/tests/test_movers_route.py
+++ b/backend/tests/test_movers_route.py
@@ -1,0 +1,60 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import backend.common.instrument_api as ia
+from backend.routes import movers
+
+
+def test_get_movers_success(monkeypatch):
+    app = FastAPI()
+    app.include_router(movers.router)
+
+    def fake_top_movers(tickers, days, limit):
+        assert tickers == ["AAA", "BBB"]
+        assert days == 7
+        assert limit == 5
+        return {
+            "gainers": [{"ticker": "AAA"}],
+            "losers": [{"ticker": "BBB"}],
+        }
+
+    monkeypatch.setattr(ia, "top_movers", fake_top_movers)
+    monkeypatch.setattr(movers, "top_movers", fake_top_movers)
+
+    with TestClient(app) as client:
+        resp = client.get("/movers?tickers=AAA,BBB&days=7&limit=5")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "gainers": [{"ticker": "AAA"}],
+        "losers": [{"ticker": "BBB"}],
+    }
+
+
+def test_get_movers_invalid_days(monkeypatch):
+    app = FastAPI()
+    app.include_router(movers.router)
+
+    def fail_top_movers(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("top_movers should not be called")
+
+    monkeypatch.setattr(ia, "top_movers", fail_top_movers)
+    monkeypatch.setattr(movers, "top_movers", fail_top_movers)
+
+    with TestClient(app) as client:
+        resp = client.get("/movers?tickers=AAA&days=2")
+    assert resp.status_code == 400
+
+
+def test_get_movers_no_tickers(monkeypatch):
+    app = FastAPI()
+    app.include_router(movers.router)
+
+    def fail_top_movers(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("top_movers should not be called")
+
+    monkeypatch.setattr(ia, "top_movers", fail_top_movers)
+    monkeypatch.setattr(movers, "top_movers", fail_top_movers)
+
+    with TestClient(app) as client:
+        resp = client.get("/movers?tickers= &days=7")
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add unit tests for /movers route validating parameters and output

## Testing
- `pytest backend/tests/test_movers_route.py::test_get_movers_success backend/tests/test_movers_route.py::test_get_movers_invalid_days backend/tests/test_movers_route.py::test_get_movers_no_tickers -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b8b2e671148327bd8334e83decfb1e