### PR TITLE
Fix rebalance router test

### DIFF
--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -63,12 +63,12 @@ def test_rebalance_route(monkeypatch):
     app.include_router(rebalance.router)
 
     suggestions = [
-        {"ticker": "AAA", "action": "buy", "amount": "10.5"},
-        {"ticker": "BBB", "action": "sell", "amount": "1"},
+        {"ticker": "AAA", "action": "buy", "amount": 10.5},
+        {"ticker": "BBB", "action": "sell", "amount": 1.0},
     ]
 
     monkeypatch.setattr(
-        "backend.common.rebalance.suggest_trades",
+        "backend.routes.rebalance.suggest_trades",
         lambda actual, target: suggestions,
     )
 


### PR DESCRIPTION
## Summary
- use floats for trade suggestion amounts
- patch router's `suggest_trades` function directly in rebalance test

## Testing
- `PYTEST_ADDOPTS='--no-cov' pytest backend/tests/test_routers.py::test_rebalance_route -q`
- `pytest` *(fails: tests/test_auth_google.py::test_token_requires_configured_email, tests/test_backend_api.py::test_post_transaction_persists_and_updates_portfolio, tests/test_google_auth.py::test_google_token_rejects_when_no_accounts, tests/test_transaction_post_updates_portfolio.py::test_post_transaction_updates_portfolio, tests/test_transactions_route.py::test_create_transaction_success, tests/test_transactions_route.py::test_create_transaction_validation_error, tests/test_accounts_api.py::test_account_route_returns_data[alex-accounts2])*

------
https://chatgpt.com/codex/tasks/task_e_68b8b52ba02083278a80e79bdb8bf7ee