### PR TITLE
Harden auth and transaction handling

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -23,7 +23,8 @@ else:  # pragma: no cover - Unix
 
 from fastapi import APIRouter, HTTPException
 from fastapi import Request
-from pydantic import BaseModel, ConfigDict, Field
+from fastapi.responses import JSONResponse
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from backend.common import portfolio as portfolio_mod
 from backend.common import portfolio_loader
@@ -82,12 +83,22 @@ class TransactionCreate(BaseModel):
     owner: str
     account: str
     ticker: str
-    date: date
-    price_gbp: float
-    units: float = Field(gt=0)
+    # Accept date as a raw string so we can return a 400 on invalid formats
+    date: str
+    price_gbp: Optional[float] = Field(
+        default=None, validation_alias=AliasChoices("price_gbp", "price")
+    )
+    units: Optional[float] = Field(
+        default=None, gt=0, validation_alias=AliasChoices("units", "shares")
+    )
     fees: Optional[float] = None
     comments: Optional[str] = None
-    reason: Optional[str] = None
+    reason: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("reason", "reason_to_buy")
+    )
+    type: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 def _load_all_transactions() -> List[Transaction]:
@@ -134,18 +145,41 @@ def _validate_component(value: str, field: str) -> str:
     return value
 
 
-@router.post("/transactions", status_code=201)
-async def create_transaction(tx: TransactionCreate) -> dict:
+@router.post("/transactions")
+async def create_transaction(tx: TransactionCreate) -> JSONResponse:
     """Store a new transaction and return it."""
 
     if not config.accounts_root:
         raise HTTPException(status_code=400, detail="Accounts root not configured")
 
-    tx_data = tx.model_dump(mode="json")
-    owner = _validate_component(tx_data.pop("owner"), "owner")
-    account = _validate_component(tx_data.pop("account"), "account")
-    if not tx_data.get("reason"):
+    owner = _validate_component(tx.owner, "owner")
+    account = _validate_component(tx.account, "account")
+    if not tx.reason:
         raise HTTPException(status_code=400, detail="reason is required")
+
+    # Validate the provided date string so invalid formats return a 400 rather
+    # than a 422 from Pydantic.
+    try:
+        datetime.fromisoformat(tx.date)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date")
+
+    tx_data: Dict[str, Any] = {
+        "date": tx.date,
+        "ticker": tx.ticker,
+    }
+    if tx.type:
+        tx_data["type"] = tx.type
+    if tx.units is not None:
+        tx_data["shares"] = tx.units
+    if tx.price_gbp is not None:
+        tx_data["price"] = tx.price_gbp
+    if tx.fees is not None:
+        tx_data["fees"] = tx.fees
+    if tx.comments:
+        tx_data["comments"] = tx.comments
+    if tx.reason:
+        tx_data["reason"] = tx.reason
 
     owner_dir = Path(config.accounts_root) / owner
     owner_dir.mkdir(parents=True, exist_ok=True)
@@ -157,7 +191,9 @@ async def create_transaction(tx: TransactionCreate) -> dict:
         try:
             data = json.load(f)
         except json.JSONDecodeError as exc:
-            log.warning("Failed to parse existing transactions file %s: %s", file_path, exc)
+            log.warning(
+                "Failed to parse existing transactions file %s: %s", file_path, exc
+            )
             data = {"owner": owner, "account_type": account, "transactions": []}
         except OSError as exc:
             log.warning("Failed to read transactions file %s: %s", file_path, exc)
@@ -173,15 +209,20 @@ async def create_transaction(tx: TransactionCreate) -> dict:
         json.dump(data, f, indent=2)
         f.flush()
         os.fsync(f.fileno())
-        fcntl.flock(f, fcntl.LOCK_UN)
+        _unlock_file(f)
 
     try:
-        portfolio_loader.rebuild_account_holdings(owner, account, Path(config.accounts_root))
+        portfolio_loader.rebuild_account_holdings(
+            owner, account, Path(config.accounts_root)
+        )
         portfolio_mod.build_owner_portfolio(owner, Path(config.accounts_root))
     except FileNotFoundError as exc:
         log.warning("Portfolio rebuild failed: %s", exc)
 
-    return {"owner": owner, "account": account, **tx_data}
+    status = 201 if tx.price_gbp is not None else 200
+    return JSONResponse(
+        status_code=status, content={"owner": owner, "account": account, **tx_data}
+    )
 
 
 @router.get("/transactions", response_model=List[Transaction])


### PR DESCRIPTION
## Summary
- Enforce allowed email check in `authenticate_user` and reject tokens lacking authorised addresses
- Accept legacy field names in `/transactions` and return appropriate status codes while fixing file locking on Windows

## Testing
- `pytest -q` *(fails: pytest: error: unrecognized arguments: --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b0eee4288327867068a23ae08a72