### PR TITLE
Fix cross-platform file unlocking in transactions route

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -181,7 +181,7 @@ async def create_transaction(tx: TransactionCreate) -> dict:
         json.dump(data, f, indent=2)
         f.flush()
         os.fsync(f.fileno())
-        fcntl.flock(f, fcntl.LOCK_UN)
+        _unlock_file(f)
 
     try:
         portfolio_loader.rebuild_account_holdings(owner, account, Path(config.accounts_root))


### PR DESCRIPTION
## Summary
- use platform-aware `_unlock_file` helper when releasing transaction file lock to avoid attribute errors on Windows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8cd385c8327868b1a43a7857b85