### PR TITLE
Mock portfolio and compliance in MA signal test

### DIFF
--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -414,6 +414,9 @@ def test_run_generates_ma_signal(monkeypatch):
     monkeypatch.setattr(trading_agent, "publish_alert", lambda alert: None)
     monkeypatch.setattr(trading_agent, "send_message", lambda msg: None)
     monkeypatch.setattr(trading_agent, "_log_trade", lambda *a, **k: None)
+    monkeypatch.setattr(trading_agent, "list_portfolios", lambda: [{"owner": "alice"}])
+    monkeypatch.setattr(trading_agent.compliance, "check_trade", lambda trade: {"warnings": []})
+    monkeypatch.setattr(trading_agent, "compute_owner_performance", lambda owner: {"max_drawdown": None})
 
     class F:
         def __init__(self, ticker: str):


### PR DESCRIPTION
## Summary
- ensure `test_run_generates_ma_signal` mocks portfolio, compliance, and performance calls to keep test lightweight
## Testing
- `pytest tests/test_trading_agent.py::test_run_generates_ma_signal -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b936e5e2148327b71755b607e3a7e5