### PR TITLE
fix: ensure service worker loads in dev

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -31,5 +31,3 @@ sw.addEventListener('notificationclick', (event: NotificationEvent) => {
   event.notification.close();
   event.waitUntil(sw.clients.openWindow('/'));
 });
-
-export {};


### PR DESCRIPTION
## Summary
- remove extraneous module export from service worker so it registers correctly during development

## Testing
- `npm test` *(fails: Link is not defined)*
- `npm run build:web` *(fails: TypeScript errors in App and other files)*

------
https://chatgpt.com/codex/tasks/task_e_68b936d591cc8327a7b38ea3623cf2c0