### PR TITLE
frontend: import Link for navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   getGroupInstruments,


### PR DESCRIPTION
## Summary
- import Link from `react-router-dom` so navigation links render correctly in `App`

## Testing
- `npm test -- --run` *(fails: Google login guard / ValueAtRisk tests)*
- `npm run build` *(fails: TypeScript errors such as unused AppProps and missing types)*

------
https://chatgpt.com/codex/tasks/task_e_68b936d5d1d8832783c5db391d2711a4