### PR TITLE
feat: add CloudFront canonical redirect

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -51,7 +51,7 @@ class StaticSiteStack(Stack):
                 origin=origins.S3BucketOrigin.with_origin_access_identity(
                     site_bucket, origin_access_identity=oai
                 ),
-                viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.ALLOW_ALL,
+                viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                 function_associations=[
                     cloudfront.FunctionAssociation(
                         function=redirect_fn,


### PR DESCRIPTION
## Summary
- add viewer-request CloudFront Function enforcing https, canonical host and trailing slash
- associate function with static site distribution

## Testing
- `ruff check cdk/stacks/static_site_stack.py`
- `pytest`
- `node -e "const fs=require('fs');eval(fs.readFileSync('cdk/functions/viewer-request.js','utf8'));function run(e){console.log(handler(e));}run({request:{headers:{host:{value:'not-canonical.com'},'cloudfront-forwarded-proto':{value:'https'}},uri:'/about/',querystring:{}}});run({request:{headers:{host:{value:'app.allotmint.io'},'cloudfront-forwarded-proto':{value:'http'}},uri:'/',querystring:{}}});run({request:{headers:{host:{value:'app.allotmint.io'},'cloudfront-forwarded-proto':{value:'https'}},uri:'/about/',querystring:{}}});"`

------
https://chatgpt.com/codex/tasks/task_e_68b94df9583c8327aa006a69e2c997ca