### PR TITLE
Fix service worker registration to only run in production

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -91,11 +91,8 @@ createRoot(rootEl).render(
   </StrictMode>,
 )
 
-if ('serviceWorker' in navigator) {
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
   window.addEventListener('load', () => {
-    const swUrl = import.meta.env.PROD
-      ? '/service-worker.js'
-      : '/dev-sw.js?dev-sw'
-    navigator.serviceWorker.register(swUrl, { type: 'module' })
+    navigator.serviceWorker.register('/service-worker.js', { type: 'module' })
   })
 }


### PR DESCRIPTION
## Summary
- Register service worker only when `import.meta.env.PROD` is true

## Testing
- `npm test -- --run` *(fails: 4 failed test files, 6 failed tests)*
- `npm --prefix frontend run lint` *(fails: 21 problems (18 errors, 3 warnings))*
- `npm run build:web` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9677221ec8327bbcaf7a32af38601