### PR TITLE
fix: replace placeholder domain and improve SEO setup

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,5 @@
 VITE_ALLOTMINT_API_BASE=http://localhost:8000
+# Base URL of the deployed frontend
+VITE_APP_BASE_URL=https://app.allotmint.io
 # VITE_API_TOKEN enables authenticated requests and must match the backend API_TOKEN
 VITE_API_TOKEN=

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,11 +9,11 @@
     <link rel="apple-touch-icon" href="https://raw.githubusercontent.com/facebook/create-react-app/main/packages/cra-template/template/public/logo192.png"/>
     <title>AllotMint - Watch your money grow</title>
     <meta name="description" content="AllotMint investment platform"/>
-    <link rel="canonical" href="https://example.com/"/>
+    <link rel="canonical" href="%VITE_APP_BASE_URL%/"/>
     <meta property="og:title" content="AllotMint - Watch your money grow"/>
     <meta property="og:description" content="AllotMint investment platform"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:url" content="https://example.com/"/>
+    <meta property="og:url" content="%VITE_APP_BASE_URL%/"/>
     <meta name="twitter:title" content="AllotMint - Watch your money grow"/>
     <meta name="twitter:description" content="AllotMint investment platform"/>
     <script type="application/ld+json">
@@ -21,14 +21,14 @@
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "AllotMint",
-        "url": "https://example.com"
+        "url": "%VITE_APP_BASE_URL%"
       }
     </script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "Organization",
-        "url": "https://example.com",
+        "url": "%VITE_APP_BASE_URL%",
         "name": "AllotMint"
       }
     </script>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://example.com/sitemap.xml
+Sitemap: https://app.allotmint.io/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://example.com/</loc>
+    <loc>https://app.allotmint.io/</loc>
   </url>
   <url>
-    <loc>https://example.com/portfolio</loc>
+    <loc>https://app.allotmint.io/portfolio</loc>
   </url>
 </urlset>

--- a/frontend/src/components/Meta.tsx
+++ b/frontend/src/components/Meta.tsx
@@ -7,7 +7,26 @@ interface MetaProps {
   jsonLd?: Record<string, unknown>
 }
 
+function isSafe(value: unknown): boolean {
+  if (value === null) return true
+  const t = typeof value
+  if (t === 'string' || t === 'number' || t === 'boolean') return true
+  if (Array.isArray(value)) return value.every(isSafe)
+  if (t === 'object') return Object.values(value as Record<string, unknown>).every(isSafe)
+  return false
+}
+
+function serializeJsonLd(data: Record<string, unknown>): string | null {
+  if (!isSafe(data)) return null
+  try {
+    return JSON.stringify(data).replace(/</g, '\\u003c')
+  } catch {
+    return null
+  }
+}
+
 export default function Meta({ title, description, canonical, jsonLd }: MetaProps) {
+  const serialized = jsonLd ? serializeJsonLd(jsonLd) : null
   return (
     <Helmet>
       <title>{title}</title>
@@ -17,8 +36,8 @@ export default function Meta({ title, description, canonical, jsonLd }: MetaProp
       <meta property="og:description" content={description} />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
-      {jsonLd && (
-        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      {serialized && (
+        <script type="application/ld+json">{serialized}</script>
       )}
     </Helmet>
   )

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -6,23 +6,35 @@ import type { Portfolio as PortfolioData } from "../types";
 
 export function Portfolio() {
   const [data, setData] = useState<PortfolioData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const BASE_URL = import.meta.env.VITE_APP_BASE_URL || "https://app.allotmint.io";
+
   useEffect(() => {
-    getPortfolio("alice").then(setData).catch(() => setData(null));
+    getPortfolio("alice")
+      .then((d) => {
+        setData(d);
+        setError(null);
+      })
+      .catch(() => setError("Failed to load portfolio"))
+      .finally(() => setLoading(false));
   }, []);
   return (
     <>
       <Meta
         title="Portfolio"
         description="View and manage your investment portfolio"
-        canonical="https://example.com/portfolio"
+        canonical={`${BASE_URL}/portfolio`}
         jsonLd={{
           '@context': 'https://schema.org',
           '@type': 'WebPage',
           name: 'Portfolio',
-          url: 'https://example.com/portfolio'
+          url: `${BASE_URL}/portfolio`,
+          description: 'View and manage your investment portfolio',
+          image: `${BASE_URL}/vite.svg`
         }}
       />
-      <PortfolioView data={data} />
+      <PortfolioView data={data} loading={loading} error={error} />
     </>
   );
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,15 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import prerender from 'vite-plugin-prerender'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { readdirSync } from 'node:fs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const staticDir = resolve(__dirname, 'dist')
+const pageRoutes = readdirSync(resolve(__dirname, 'src/pages'))
+  .filter((f) => f.endsWith('.tsx') && !f.endsWith('.test.tsx'))
+  .map((f) => '/' + f.replace(/\.tsx$/, '').toLowerCase())
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -21,8 +30,8 @@ export default defineConfig({
         }
       }),
         prerender({
-          staticDir: './dist',
-          routes: ['/', '/portfolio']
+          staticDir,
+          routes: ['/', ...pageRoutes]
         })
       ],
   build: {


### PR DESCRIPTION
## Summary
- derive canonical and JSON-LD URLs from `VITE_APP_BASE_URL`
- sanitize JSON-LD data and add error handling to Portfolio page
- use absolute prerender output path with dynamic route discovery

## Testing
- `npm test src/pages/Portfolio.test.tsx` *(fails: Failed to resolve import "react-helmet")*
- `npm run build` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b9671e3174832794cf0c644388daf4