### PR TITLE
fix: remove redundant img style in language switcher

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -49,7 +49,6 @@ export const LanguageSwitcher = memo(function LanguageSwitcher() {
             alt={l.code}
             width={24}
             height={24}
-            style={{ width: "100%", height: "100%" }}
           />
         </button>
       ))}


### PR DESCRIPTION
## Summary
- remove redundant inline width/height style from language switcher flag images

## Testing
- `npm test` *(fails: updates not wrapped in act, waitFor issues)*
- `make lint` *(fails: import block unsorted, line too long, unused imports)*

------
https://chatgpt.com/codex/tasks/task_e_68b966e20c808327be9a9fa12ee52967