### PR TITLE
Restrict CORS to site origin and validate preflight responses

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -85,12 +85,27 @@ def create_app() -> FastAPI:
 
     # ───────────────────────────── CORS ─────────────────────────────
     # The frontend origin varies by environment. Read the whitelist from
-    # configuration and fall back to the production site plus a local
-    # development origin if none are provided to avoid blocking dev requests.
-    cors_origins = config.cors_origins or [
+    # configuration and fall back to the production site plus the local
+    # development servers if none are provided to avoid blocking dev requests.
+    from urllib.parse import urlparse
+
+    def _validate_cors_origins(origins: list[str]) -> list[str]:
+        """Ensure each origin uses http(s) and has a concrete host."""
+        validated: list[str] = []
+        for origin in origins:
+            parsed = urlparse(origin)
+            if parsed.scheme in {"http", "https"} and parsed.netloc and "*" not in parsed.netloc:
+                validated.append(origin)
+            else:
+                raise ValueError(f"Invalid CORS origin: {origin}")
+        return validated
+
+    default_cors = [
         "https://app.allotmint.io",
         "http://localhost:3000",
+        "http://localhost:5173",
     ]
+    cors_origins = _validate_cors_origins(config.cors_origins or default_cors)
     cors_methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
     cors_headers = ["Authorization", "Content-Type"]
     app.add_middleware(

--- a/config.yaml
+++ b/config.yaml
@@ -56,8 +56,9 @@ server:
   # Cross-origin settings by environment
   cors:
     local:
-      # Limit local origins to only the development server to reduce exposure
+      # Limit local origins to only the development server ports to reduce exposure
       - http://localhost:3000
+      - http://localhost:5173
     production:
       - https://app.allotmint.io
 

--- a/tests/test_cors_preflight.py
+++ b/tests/test_cors_preflight.py
@@ -5,20 +5,21 @@ from backend.config import config
 
 
 def test_cors_preflight(monkeypatch):
-    monkeypatch.setattr(config, "cors_origins", ["https://app.allotmint.io"])
+    origin = "https://app.allotmint.io"
+    monkeypatch.setattr(config, "cors_origins", [origin])
     # Skip snapshot warming so tests run quickly without side effects.
     # monkeypatch reverts this change after the test to avoid leaking config.
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     with TestClient(app) as client:
         headers = {
-            "Origin": "https://app.allotmint.io",
+            "Origin": origin,
             "Access-Control-Request-Method": "POST",
             "Access-Control-Request-Headers": "Authorization,Content-Type",
         }
         resp = client.options("/health", headers=headers)
     assert resp.status_code == 200
-    assert resp.headers["access-control-allow-origin"] == "https://app.allotmint.io"
+    assert resp.headers["access-control-allow-origin"] == origin
     allow_methods = [m.strip() for m in resp.headers["access-control-allow-methods"].split(",")]
     assert "POST" in allow_methods
     assert "*" not in allow_methods


### PR DESCRIPTION
## Summary
- validate configured CORS origins and include Vite dev port
- use shared origin variable in CORS preflight test

## Testing
- `pytest -q -- tests/test_cors_preflight.py tests/test_app.py::test_health_env_variable`


------
https://chatgpt.com/codex/tasks/task_e_68ba8aef6ee883278e770f756ed7b921