### PR TITLE
Add CloudFront response headers policy

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -37,8 +37,9 @@ class StaticSiteStack(Stack):
             "SecurityHeaders",
             comment="Security headers for static site",
             security_headers_behavior=cloudfront.ResponseSecurityHeadersBehavior(
+                # Allow Google Identity Services script and iframe, limited to /gsi paths
                 content_security_policy=cloudfront.ResponseSecurityHeadersContentSecurityPolicy(
-                    content_security_policy="default-src 'self'; script-src 'self' https://accounts.google.com; frame-src 'self' https://accounts.google.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'",
+                    content_security_policy="default-src 'self'; script-src 'self' https://accounts.google.com/gsi/client; frame-src 'self' https://accounts.google.com/gsi/; frame-ancestors 'none'; object-src 'none'; base-uri 'self'",
                     override=True,
                 ),
                 strict_transport_security=cloudfront.ResponseSecurityHeadersStrictTransportSecurity(
@@ -52,6 +53,10 @@ class StaticSiteStack(Stack):
                 ),
                 referrer_policy=cloudfront.ResponseSecurityHeadersReferrerPolicy(
                     referrer_policy=cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+                    override=True,
+                ),
+                permissions_policy=cloudfront.ResponseSecurityHeadersPermissionsPolicy(
+                    permissions_policy="geolocation=(), microphone=(), camera=()",
                     override=True,
                 ),
             ),


### PR DESCRIPTION
## Summary
- permit Google Identity script and iframe in CSP
- drop unused permissions policy to avoid exposing device features
- reinstate permissions policy and tighten CSP paths

## Testing
- `curl -I http://localhost:8000/index.html` (fails: Couldn't connect to server)
- `curl -I http://localhost:8000/app.js` (fails: Couldn't connect to server)
- `pytest --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68ba8aa8df9483279e6e44ebf9c2aaea