### PR TITLE
fix: raise minimum CloudFront cache TTLs

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -40,7 +40,10 @@ class StaticSiteStack(Stack):
             self,
             "AssetsCachePolicy",
             default_ttl=Duration.days(30),
-            min_ttl=Duration.seconds(0),
+            # Avoid a cache stampede when invalidating assets by ensuring a
+            # minimal amount of caching instead of allowing completely
+            # uncached requests.
+            min_ttl=Duration.seconds(1),
             max_ttl=Duration.days(30),
             enable_accept_encoding_brotli=True,
             enable_accept_encoding_gzip=True,
@@ -50,7 +53,9 @@ class StaticSiteStack(Stack):
             self,
             "HtmlCachePolicy",
             default_ttl=Duration.seconds(300),
-            min_ttl=Duration.seconds(0),
+            # Provide a small floor to mitigate cache stampedes while keeping
+            # HTML invalidations responsive.
+            min_ttl=Duration.seconds(1),
             max_ttl=Duration.seconds(3600),
             enable_accept_encoding_brotli=True,
             enable_accept_encoding_gzip=True,


### PR DESCRIPTION
## Summary
- ensure CloudFront asset and HTML caches keep at least 1s TTL to avoid stampede

## Testing
- `PYTEST_ADDOPTS="" pytest -p no:cov --override-ini addopts=""`
- `npx -y aws-cdk synth` *(fails: ModuleNotFoundError: No module named 'aws_cdk')*


------
https://chatgpt.com/codex/tasks/task_e_68ba8a858c9c8327b1f6b0456360235e