### PR TITLE
ci: add lighthouse and smoke tests

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      SMOKE_TEST_URL: ${{ vars.SMOKE_TEST_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -104,12 +106,12 @@ jobs:
 
       - name: Run smoke tests
         if: steps.parse.outputs.deploy == 'true'
-        run: ./scripts/smoke-test.sh https://app.allotmint.io
+        run: ./scripts/smoke-test.sh
 
       - name: Run Lighthouse CI
         if: steps.parse.outputs.deploy == 'true'
         run: |
-          npm install -g @lhci/cli
-          lhci autorun --collect.url=https://app.allotmint.io \
+          npm install --no-save @lhci/cli
+          npx lhci autorun --collect.url="$SMOKE_TEST_URL" \
             --upload.target=temporary-public-storage
 

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -135,7 +135,7 @@ class StaticSiteStack(Stack):
             "DeployAssets",
             sources=[s3_deployment.Source.asset(str(frontend_dir))],
             destination_bucket=site_bucket,
-            exclude=["*.html"],
+            exclude=["*.html"],  # HTML deployed separately to control caching
             cache_control=[
                 s3_deployment.CacheControl.max_age(Duration.days(365)),
                 s3_deployment.CacheControl.immutable(),
@@ -148,7 +148,8 @@ class StaticSiteStack(Stack):
             "DeployHtml",
             sources=[s3_deployment.Source.asset(str(frontend_dir))],
             destination_bucket=site_bucket,
-            exclude=["*", "!*.html"],
+            exclude=["*"],
+            include=["*.html"],
             cache_control=[s3_deployment.CacheControl.no_cache()],
             distribution=distribution,
             distribution_paths=["/*.html", "/*/index.html"],

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-URL="${1:-https://app.allotmint.io}"
+URL="${1:-${SMOKE_TEST_URL:-}}"
+if [ -z "$URL" ]; then
+  echo "Usage: SMOKE_TEST_URL=<url> $0 [url]" >&2
+  exit 1
+fi
+
 STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
 if [ "$STATUS" -ne 200 ]; then
   echo "Smoke test failed for $URL with status $STATUS" >&2


### PR DESCRIPTION
## Summary
- deploy static assets and html separately with targeted CloudFront invalidation
- add simple smoke test script and wire into deploy workflow
- run Lighthouse CI after deployment

## Testing
- `npm test -- --run` *(fails: Invalid package.json)*
- `pytest`
- `./scripts/smoke-test.sh http://example.com` *(fails: 403 Forbidden)*
- `lhci autorun --collect.url=http://example.com --upload.target=temporary-public-storage` *(fails: Chrome installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baafaf70048327b12ed64613d5dacb