### PR TITLE
fix: add missing comma in frontend package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "react-toastify": "^10.0.0",
     "recharts": "^3.1.2",
     "vite-plugin-prerender": "^1.0.8",
-    "vite-plugin-ssr": "^0.4.142"
+    "vite-plugin-ssr": "^0.4.142",
     "sharp": "^0.34.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add missing comma in frontend package.json dependencies to restore valid JSON

## Testing
- `npm run build` *(fails: "Cannot find module 'react-helmet'", TypeScript errors)*
- `npm test` *(fails: 4 test files failed, 5 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bab187b43883279335ffafce04dd97