### PR TITLE
Use authenticated user for alert settings

### DIFF
--- a/backend/routes/alert_settings.py
+++ b/backend/routes/alert_settings.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
 from backend import alerts as alert_utils
+from backend.auth import get_current_user
 
 router = APIRouter(prefix="/alert-thresholds", tags=["alerts"])
 
@@ -11,13 +12,25 @@ class ThresholdPayload(BaseModel):
 
 
 @router.get("/{user}")
-async def get_threshold(user: str):
+async def get_threshold(user: str, current_user: str = Depends(get_current_user)):
     """Return the alert threshold configured for ``user``."""
+    if user != current_user:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Owner mismatch"
+        )
     return {"threshold": alert_utils.get_user_threshold(user)}
 
 
 @router.post("/{user}")
-async def set_threshold(user: str, payload: ThresholdPayload):
+async def set_threshold(
+    user: str,
+    payload: ThresholdPayload,
+    current_user: str = Depends(get_current_user),
+):
     """Update the alert threshold for ``user``."""
+    if user != current_user:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Owner mismatch"
+        )
     alert_utils.set_user_threshold(user, payload.threshold)
     return {"threshold": payload.threshold}

--- a/backend/tests/test_alert_settings.py
+++ b/backend/tests/test_alert_settings.py
@@ -1,45 +1,50 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from backend.auth import get_current_user
 from backend.routes import alert_settings
 
 
-def test_get_alert_threshold(monkeypatch):
+def _app_for(user: str) -> TestClient:
     app = FastAPI()
     app.include_router(alert_settings.router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    return TestClient(app)
 
+
+def test_get_alert_threshold(monkeypatch):
     monkeypatch.setattr("backend.alerts.get_user_threshold", lambda user: 0.1)
-
-    with TestClient(app) as client:
-        resp = client.get("/alert-thresholds/alice")
+    client = _app_for("alice")
+    resp = client.get("/alert-thresholds/alice")
     assert resp.status_code == 200
     assert resp.json()["threshold"] == 0.1
 
 
-def test_set_alert_threshold(monkeypatch):
-    app = FastAPI()
-    app.include_router(alert_settings.router)
+def test_get_alert_threshold_mismatched_owner(monkeypatch):
+    monkeypatch.setattr("backend.alerts.get_user_threshold", lambda user: 0.1)
+    client = _app_for("alice")
+    resp = client.get("/alert-thresholds/bob")
+    assert resp.status_code == 403
 
+
+def test_set_alert_threshold(monkeypatch):
     called = {}
 
     def set_threshold(user, threshold):
         called["args"] = (user, threshold)
 
     monkeypatch.setattr("backend.alerts.set_user_threshold", set_threshold)
-
-    with TestClient(app) as client:
-        resp = client.post("/alert-thresholds/bob", json={"threshold": 0.2})
+    client = _app_for("bob")
+    resp = client.post("/alert-thresholds/bob", json={"threshold": 0.2})
     assert resp.status_code == 200
     assert resp.json()["threshold"] == 0.2
     assert called["args"] == ("bob", 0.2)
 
 
 def test_set_alert_threshold_invalid_payload(monkeypatch):
-    app = FastAPI()
-    app.include_router(alert_settings.router)
-
-    monkeypatch.setattr("backend.alerts.set_user_threshold", lambda *args, **kwargs: None)
-
-    with TestClient(app) as client:
-        resp = client.post("/alert-thresholds/alice", json={})
+    monkeypatch.setattr(
+        "backend.alerts.set_user_threshold", lambda *args, **kwargs: None
+    )
+    client = _app_for("alice")
+    resp = client.post("/alert-thresholds/alice", json={})
     assert resp.status_code == 422

--- a/frontend/src/pages/AlertSettings.tsx
+++ b/frontend/src/pages/AlertSettings.tsx
@@ -1,22 +1,28 @@
 import { useEffect, useState } from "react";
 import Menu from "../components/Menu";
 import { getAlertThreshold, setAlertThreshold } from "../api";
+import { useUser } from "../UserContext";
 
 export default function AlertSettings() {
-  const [owner, setOwner] = useState("default");
+  const { profile } = useUser();
+  const owner = profile?.email;
   const [threshold, setThreshold] = useState<number | "">("");
   const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">(
     "idle",
   );
 
   useEffect(() => {
+    if (!owner) {
+      setThreshold("");
+      return;
+    }
     getAlertThreshold(owner)
       .then((r) => setThreshold(r.threshold))
       .catch(() => setThreshold(""));
   }, [owner]);
 
   async function save() {
-    if (threshold === "") return;
+    if (threshold === "" || !owner) return;
     setStatus("saving");
     try {
       await setAlertThreshold(owner, Number(threshold));
@@ -30,19 +36,15 @@ export default function AlertSettings() {
     <div style={{ maxWidth: 600, margin: "0 auto", padding: "1rem" }}>
       <Menu />
       <h1>Alert Settings</h1>
-      <div style={{ marginBottom: "1rem" }}>
-        <label>
-          Owner: {" "}
-          <input value={owner} onChange={(e) => setOwner(e.target.value)} />
-        </label>
-      </div>
       <div>
         <label>
           Threshold %:{" "}
           <input
             type="number"
             value={threshold}
-            onChange={(e) => setThreshold(e.target.value === "" ? "" : Number(e.target.value))}
+            onChange={(e) =>
+              setThreshold(e.target.value === "" ? "" : Number(e.target.value))
+            }
             style={{ width: "4rem" }}
           />
         </label>

--- a/tests/test_alert_thresholds_route.py
+++ b/tests/test_alert_thresholds_route.py
@@ -2,18 +2,19 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from backend.routes.alert_settings import router
 import backend.alerts as alerts
+from backend.auth import get_current_user
+from backend.routes.alert_settings import router
 
 
-@pytest.fixture
-def client():
+def _client_for(user: str) -> TestClient:
     app = FastAPI()
     app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
     return TestClient(app, raise_server_exceptions=False)
 
 
-def test_get_threshold_success(client, monkeypatch):
+def test_get_threshold_success(monkeypatch):
     called = {}
 
     def fake_get(user: str):
@@ -21,24 +22,31 @@ def test_get_threshold_success(client, monkeypatch):
         return 0.25
 
     monkeypatch.setattr(alerts, "get_user_threshold", fake_get)
-
+    client = _client_for("alice")
     resp = client.get("/alert-thresholds/alice")
     assert resp.status_code == 200
     assert resp.json() == {"threshold": 0.25}
     assert called["user"] == "alice"
 
 
-def test_get_threshold_error(client, monkeypatch):
+def test_get_threshold_owner_mismatch(monkeypatch):
+    monkeypatch.setattr(alerts, "get_user_threshold", lambda u: 0.2)
+    client = _client_for("alice")
+    resp = client.get("/alert-thresholds/bob")
+    assert resp.status_code == 403
+
+
+def test_get_threshold_error(monkeypatch):
     def boom(user: str):
         raise RuntimeError("fail")
 
     monkeypatch.setattr(alerts, "get_user_threshold", boom)
-
+    client = _client_for("bob")
     resp = client.get("/alert-thresholds/bob")
     assert resp.status_code == 500
 
 
-def test_set_threshold_success(client, monkeypatch):
+def test_set_threshold_success(monkeypatch):
     called = {}
 
     def fake_set(user: str, threshold: float):
@@ -46,7 +54,7 @@ def test_set_threshold_success(client, monkeypatch):
         called["threshold"] = threshold
 
     monkeypatch.setattr(alerts, "set_user_threshold", fake_set)
-
+    client = _client_for("charlie")
     payload = {"threshold": 0.1}
     resp = client.post("/alert-thresholds/charlie", json=payload)
     assert resp.status_code == 200
@@ -54,11 +62,11 @@ def test_set_threshold_success(client, monkeypatch):
     assert called == {"user": "charlie", "threshold": 0.1}
 
 
-def test_set_threshold_error(client, monkeypatch):
+def test_set_threshold_error(monkeypatch):
     def boom(user: str, threshold: float):
         raise RuntimeError("fail")
 
     monkeypatch.setattr(alerts, "set_user_threshold", boom)
-
+    client = _client_for("delta")
     resp = client.post("/alert-thresholds/delta", json={"threshold": 0.5})
     assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- Remove manual owner entry in alert settings page and use logged-in user's profile
- Require authenticated user for alert threshold endpoints and reject mismatches
- Add tests for alert threshold authentication logic

## Testing
- `pytest backend/tests/test_alert_settings.py tests/test_alert_thresholds_route.py`
- `npm test` *(fails: 4 test files, 5 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bac08fc5f48327bac80a175262a570