### PR TITLE
refactor: import prerender plugin properly

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,13 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
-import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { readdirSync } from 'node:fs'
-
-const require = createRequire(import.meta.url)
-const prerender = require('vite-plugin-prerender').default
+import vitePrerender from 'vite-plugin-prerender'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const staticDir = resolve(__dirname, 'dist')
@@ -16,27 +13,28 @@ const pageRoutes = readdirSync(resolve(__dirname, 'src/pages'))
   .map((f) => '/' + f.replace(/\.tsx$/, '').toLowerCase())
 
 // https://vite.dev/config/
-export default defineConfig({
-    plugins: [
-      react(),
-      VitePWA({
-        registerType: 'autoUpdate',
-        includeAssets: ['vite.svg'],
-        strategies: 'injectManifest',
-        srcDir: 'src',
-        filename: 'service-worker.ts',
-        manifest: false,
-        // enable service worker in dev but avoid caching dev assets
-        devOptions: { enabled: true, disableRuntimeConfig: true },
-        workbox: {
-          globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}']
-        }
-      }),
-        prerender({
-          staticDir,
-          routes: ['/', ...pageRoutes]
-        })
-      ],
+export default defineConfig(({ command }) => ({
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['vite.svg'],
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'service-worker.ts',
+      manifest: false,
+      // enable service worker in dev but avoid caching dev assets
+      devOptions: { enabled: true, disableRuntimeConfig: true },
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}']
+      }
+    }),
+    command === 'build' &&
+      vitePrerender({
+        staticDir,
+        routes: ['/', ...pageRoutes]
+      })
+  ].filter(Boolean),
   build: {
     cssCodeSplit: false,
     cssMinify: 'esbuild',
@@ -51,4 +49,4 @@ export default defineConfig({
       }
     }
   }
-})
+}))


### PR DESCRIPTION
## Summary
- switch to direct ES module import for vite-plugin-prerender
- run prerender only on `build` command

## Testing
- `npm test` *(fails: Test Files 4 failed | 35 passed)*
- `cd frontend && npm run lint` *(fails: 22 errors, 4 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68bac08b881c83278806438532078969