### PR TITLE
refactor: dynamically load vite prerender

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,9 @@ import { VitePWA } from 'vite-plugin-pwa'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { readdirSync } from 'node:fs'
-import vitePrerender from 'vite-plugin-prerender'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const staticDir = resolve(__dirname, 'dist')
@@ -13,8 +15,8 @@ const pageRoutes = readdirSync(resolve(__dirname, 'src/pages'))
   .map((f) => '/' + f.replace(/\.tsx$/, '').toLowerCase())
 
 // https://vite.dev/config/
-export default defineConfig(({ command }) => ({
-  plugins: [
+export default defineConfig(({ command }) => {
+  const plugins = [
     react(),
     VitePWA({
       registerType: 'autoUpdate',
@@ -28,25 +30,34 @@ export default defineConfig(({ command }) => ({
       workbox: {
         globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}']
       }
-    }),
-    command === 'build' &&
+    })
+  ]
+
+  if (command === 'build') {
+    const vitePrerender = require('vite-plugin-prerender').default
+    plugins.push(
       vitePrerender({
         staticDir,
         routes: ['/', ...pageRoutes]
       })
-  ].filter(Boolean),
-  build: {
-    cssCodeSplit: false,
-    cssMinify: 'esbuild',
-    rollupOptions: {
-      output: {
-        assetFileNames: (assetInfo) => {
-          if (assetInfo.name && assetInfo.name.endsWith('.css')) {
-            return 'styles.css'
+    )
+  }
+
+  return {
+    plugins,
+    build: {
+      cssCodeSplit: false,
+      cssMinify: 'esbuild',
+      rollupOptions: {
+        output: {
+          assetFileNames: (assetInfo) => {
+            if (assetInfo.name && assetInfo.name.endsWith('.css')) {
+              return 'styles.css'
+            }
+            return 'assets/[name]-[hash][extname]'
           }
-          return 'assets/[name]-[hash][extname]'
         }
       }
     }
   }
-}))
+})


### PR DESCRIPTION
## Summary
- dynamically require `vite-plugin-prerender` only during build

## Testing
- `npm test -- --run` *(fails: act warnings)*
- `npm run lint` *(fails: multiple lint errors)*
- `npm run dev`
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bafde416008327a18b227e1f811195