### PR TITLE
Handle empty alert state in NotificationsDrawer

### DIFF
--- a/frontend/src/components/NotificationsDrawer.test.tsx
+++ b/frontend/src/components/NotificationsDrawer.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, Mock } from "vitest";
+import { NotificationsDrawer } from "./NotificationsDrawer";
+import { useFetch } from "../hooks/useFetch";
+
+vi.mock("../hooks/useFetch");
+
+describe("NotificationsDrawer", () => {
+  it("shows empty message when there are no alerts", () => {
+    (useFetch as Mock).mockReturnValue({
+      data: [],
+      loading: false,
+      error: undefined,
+    });
+
+    render(<NotificationsDrawer open onClose={() => {}} />);
+
+    expect(screen.getByText(/No alerts/i)).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/NotificationsDrawer.tsx
+++ b/frontend/src/components/NotificationsDrawer.tsx
@@ -69,7 +69,8 @@ export function NotificationsDrawer({ open, onClose }: Props) {
         </div>
         {loading && <div>Loading...</div>}
         {error && <div>Cannot reach server</div>}
-        {!loading && !error && alerts && (
+        {!loading && !error && alerts?.length === 0 && <div>No alerts</div>}
+        {!loading && !error && alerts?.length > 0 && (
           <ul style={{ listStyle: "none", padding: 0 }}>
             {alerts.map((a, i) => (
               <li key={i} style={{ marginBottom: "0.5rem" }}>


### PR DESCRIPTION
## Summary
- show "No alerts" when notifications drawer has no items
- only render alert list when alerts exist
- add test for empty alerts state

## Testing
- `npm test` *(fails: Test Files 4 failed | 36 passed, Tests 6 failed | 127 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb160f2e4c8327b79edc7f05c1e482