### PR TITLE
ci: conditionally upload codecov reports

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -31,9 +31,11 @@ jobs:
           pytest tests/test_backend_api.py::test_health tests/test_accounts_api.py --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=0 -q
 
       - name: Upload coverage reports to Codecov
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: leonarduk/allotmint
           files: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
+


### PR DESCRIPTION
## Summary
- conditionally upload coverage reports to Codecov only when token exists
- do not fail CI if Codecov upload fails

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable, empty-lines: {max-end: 1}}}' .github/workflows/backend-integration.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bb1b388cc88327a6e8a3c153f1a768