### PR TITLE
chore: only run code review when openai key is set

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   code_review:
+    if: secrets.OPENAI_API_KEY != ''
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- run code review workflow only when `OPENAI_API_KEY` secret is set

## Testing
- `npm test -- --run` *(fails: The current testing environment is not configured to support act(...))*
- `pytest` *(fails: pytest: error: unrecognized arguments: --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1b394d188327b04814a2e58abbf4