### PR TITLE
Normalize approval exemptions to lists

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -149,6 +149,16 @@ def _flatten_dict(src: Dict[str, Any], dst: Dict[str, Any]) -> None:
             dst[key] = value
 
 
+def _parse_str_list(val: Any) -> Optional[List[str]]:
+    """Convert comma-separated strings or lists into list of strings."""
+    if isinstance(val, list):
+        items = [str(v).strip() for v in val if str(v).strip()]
+        return items or []
+    if isinstance(val, str):
+        items = [s.strip() for s in val.split(",") if s.strip()]
+        return items or []
+    return None
+
 @lru_cache(maxsize=1)
 def load_config() -> Config:
     """Load configuration from config.yaml with optional env overrides."""
@@ -203,6 +213,9 @@ def load_config() -> Config:
             cors_origins = cors_raw.get(env) or cors_raw.get("default")
         else:
             cors_origins = cors_raw.get("default")
+
+    approval_exempt_types = _parse_str_list(data.get("approval_exempt_types"))
+    approval_exempt_tickers = _parse_str_list(data.get("approval_exempt_tickers"))
 
     google_auth_enabled = data.get("google_auth_enabled")
     env_google_auth = os.getenv("GOOGLE_AUTH_ENABLED")
@@ -261,8 +274,8 @@ def load_config() -> Config:
         prices_json=prices_json,
         risk_free_rate=data.get("risk_free_rate"),
         approval_valid_days=data.get("approval_valid_days"),
-        approval_exempt_types=data.get("approval_exempt_types"),
-        approval_exempt_tickers=data.get("approval_exempt_tickers"),
+        approval_exempt_types=approval_exempt_types,
+        approval_exempt_tickers=approval_exempt_tickers,
         tabs=tabs,
         trading_agent=trading_agent,
         cors_origins=cors_origins,

--- a/tests/test_user_config_route.py
+++ b/tests/test_user_config_route.py
@@ -68,3 +68,11 @@ def test_missing_owner_returns_error(client, mock_user_config):
     resp = client.post("/user-config/bob", json={"hold_days_min": 1})
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Owner not found"
+
+
+def test_defaults_from_config_return_lists(client):
+    resp = client.get("/user-config/alex")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["approval_exempt_types"] == ["ETF"]
+    assert data["approval_exempt_tickers"] == []


### PR DESCRIPTION
## Summary
- parse approval exemption settings in config into string lists
- ensure UserConfig always uses lists for exemption fields
- test that user-config endpoint emits arrays even when config.yaml provides single strings

## Testing
- `pytest tests/test_user_config_route.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb1e6457408327967c2884bd250585