### PR TITLE
feat: expand scenario result fields

### DIFF
--- a/frontend/src/pages/ScenarioTester.test.tsx
+++ b/frontend/src/pages/ScenarioTester.test.tsx
@@ -13,10 +13,10 @@ describe("ScenarioTester page", () => {
     mockRunScenario.mockResolvedValueOnce([
       {
         owner: "Test Owner",
-        total_value_estimate_gbp: 123,
-        ticker: "AAA",
-        impact: 123,
-      } as unknown as ScenarioResult,
+        baseline_total_value_gbp: 1000,
+        shocked_total_value_gbp: 950,
+        delta_gbp: -50,
+      } as ScenarioResult,
     ]);
 
     render(<ScenarioTester />);
@@ -26,7 +26,13 @@ describe("ScenarioTester page", () => {
     fireEvent.click(screen.getByText("Apply"));
 
     await waitFor(() => expect(mockRunScenario).toHaveBeenCalledWith("AAA", 5));
-    expect(screen.getByText(/"ticker": "AAA"/)).toBeInTheDocument();
+
+    const pre = await screen.findByText(/Test Owner/);
+    const data = JSON.parse(pre.textContent || "[]");
+    const result = data[0] as ScenarioResult;
+    expect(typeof result.baseline_total_value_gbp).toBe("number");
+    expect(typeof result.shocked_total_value_gbp).toBe("number");
+    expect(typeof result.delta_gbp).toBe("number");
   });
 
   it("shows error message on failure", async () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -260,7 +260,9 @@ export type Alert = {
 
 export interface ScenarioResult {
     owner: string;
-    total_value_estimate_gbp: number;
+    baseline_total_value_gbp: number | null;
+    shocked_total_value_gbp: number | null;
+    delta_gbp: number | null;
 }
 
 export type ComplianceResult = {


### PR DESCRIPTION
## Summary
- expand `ScenarioResult` with baseline, shocked, and delta values
- ensure scenario tester renders numeric values for new fields

## Testing
- `npm test -- src/pages/ScenarioTester.test.tsx`
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bb1e5a8ac88327bbe1da2e09fd204a