### PR TITLE
Handle reports route via App

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import ScenarioTester from "./pages/ScenarioTester";
 import UserConfigPage from "./pages/UserConfig";
 import BackendUnavailableCard from "./components/BackendUnavailableCard";
 import ProfilePage from "./pages/Profile";
+import Reports from "./pages/Reports";
 import { orderedTabPlugins } from "./tabPlugins";
 import { usePriceRefresh } from "./PriceRefreshContext";
 import InstrumentSearchBar from "./components/InstrumentSearchBar";
@@ -493,6 +494,7 @@ export default function App({ onLogout }: { onLogout?: () => void }) {
       {mode === "watchlist" && <Watchlist />}
       {mode === "allocation" && <AllocationCharts />}
       {mode === "movers" && <TopMovers />}
+      {mode === "reports" && <Reports />}
       {mode === "support" && <Support />}
       {mode === "profile" && <ProfilePage />}
       {mode === "settings" && <UserConfigPage />}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,7 +16,6 @@ import { UserProvider } from './UserContext'
 
 const App = lazy(() => import('./App.tsx'))
 const VirtualPortfolio = lazy(() => import('./pages/VirtualPortfolio'))
-const Reports = lazy(() => import('./pages/Reports'))
 const Support = lazy(() => import('./pages/Support'))
 const ComplianceWarnings = lazy(() => import('./pages/ComplianceWarnings'))
 const InstrumentResearch = lazy(() => import('./pages/InstrumentResearch'))
@@ -65,7 +64,6 @@ export function Root() {
     <Suspense fallback={<div>Loading...</div>}>
       <Routes>
         <Route path="/support" element={<Support />} />
-        <Route path="/reports" element={<Reports />} />
         <Route path="/virtual" element={<VirtualPortfolio />} />
         <Route path="/compliance" element={<ComplianceWarnings />} />
         <Route path="/compliance/:owner" element={<ComplianceWarnings />} />


### PR DESCRIPTION
## Summary
- Remove standalone `/reports` route from main entry so the catch-all app handles reports view
- Add `reports` mode rendering in `App` and import the Reports page
- Test that navigating to `/reports` renders the menu and functional report links

## Testing
- `TAILWIND_DISABLE_OXIDE=1 npm test src/pages/Reports.test.tsx` *(fails: Failed to load native binding @tailwindcss/oxide)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1e3216ec832799ff6305d75b9eee