### PR TITLE
Handle non-array approval exemptions in UserConfig

### DIFF
--- a/frontend/src/pages/UserConfig.test.tsx
+++ b/frontend/src/pages/UserConfig.test.tsx
@@ -5,13 +5,14 @@ import { vi } from "vitest";
 const mockGetOwners = vi.hoisted(() => vi.fn());
 const mockGetUserConfig = vi.hoisted(() => vi.fn());
 const mockGetApprovals = vi.hoisted(() => vi.fn());
+const mockUpdateUserConfig = vi.hoisted(() => vi.fn());
 
 vi.mock("../api", () => ({
   API_BASE: "",
   getOwners: mockGetOwners,
   getUserConfig: mockGetUserConfig,
   getApprovals: mockGetApprovals,
-  updateUserConfig: vi.fn(),
+  updateUserConfig: mockUpdateUserConfig,
   addApproval: vi.fn(),
   removeApproval: vi.fn(),
 }));
@@ -31,6 +32,7 @@ describe("UserConfig page", () => {
       approval_exempt_types: null,
     });
     mockGetApprovals.mockResolvedValue({ approvals: [] });
+    mockUpdateUserConfig.mockResolvedValue(undefined);
 
     render(<UserConfig />);
 
@@ -42,6 +44,15 @@ describe("UserConfig page", () => {
     const inputs = await screen.findAllByRole("textbox");
     expect((inputs[0] as HTMLInputElement).value).toBe("");
     expect((inputs[1] as HTMLInputElement).value).toBe("");
+
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    await act(async () => {
+      await userEvent.click(saveButton);
+    });
+    expect(mockUpdateUserConfig).toHaveBeenCalledWith("alex", {
+      approval_exempt_tickers: [],
+      approval_exempt_types: null,
+    });
   });
 });
 

--- a/frontend/src/pages/UserConfig.tsx
+++ b/frontend/src/pages/UserConfig.tsx
@@ -31,14 +31,12 @@ export default function UserConfigPage() {
     if (owner) {
       getUserConfig(owner)
         .then((res) => {
+          const toArrayOrNull = (val: unknown) =>
+            Array.isArray(val) ? val : val == null ? null : [];
           setCfg({
             ...res,
-            approval_exempt_tickers: Array.isArray(res.approval_exempt_tickers)
-              ? res.approval_exempt_tickers
-              : [],
-            approval_exempt_types: Array.isArray(res.approval_exempt_types)
-              ? res.approval_exempt_types
-              : [],
+            approval_exempt_tickers: toArrayOrNull(res.approval_exempt_tickers),
+            approval_exempt_types: toArrayOrNull(res.approval_exempt_types),
           });
         })
         .catch(() => {


### PR DESCRIPTION
## Summary
- Guard UserConfig against non-array `approval_exempt_*` values
- Normalize server config values to arrays
- Add unit test to ensure component tolerates string or null config responses

## Testing
- `npm test` *(fails: Failed to load native binding for @tailwindcss/oxide)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1e65dffc83278a28e01ef60ee649