### PR TITLE
Fix InstrumentAdmin update for edited ticker/exchange

### DIFF
--- a/frontend/src/pages/InstrumentAdmin.tsx
+++ b/frontend/src/pages/InstrumentAdmin.tsx
@@ -84,11 +84,7 @@ export default function InstrumentAdmin() {
       if (row.isNew) {
         await createInstrumentMetadata(row.ticker, row.exchange, payload);
       } else {
-        await updateInstrumentMetadata(
-          row._originalTicker ?? row.ticker,
-          row._originalExchange ?? row.exchange,
-          payload,
-        );
+        await updateInstrumentMetadata(row.ticker, row.exchange, payload);
       }
       setMessage(t("instrumentadmin.saveSuccess"));
       const fresh = await listInstrumentMetadata();


### PR DESCRIPTION
## Summary
- use edited ticker and exchange in updateInstrumentMetadata request

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb515799548327bf4175abbf8c7ca1