### PR TITLE
fix profile/settings mode detection in menu

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -57,15 +57,13 @@ export default function Menu({
                                     ? 'support'
                                     : path[0] === 'settings'
                                       ? 'settings'
-                                      : path[0] === 'profile'
-                                        ? 'settings'
-                                        : path[0] === 'scenario'
-                                          ? 'scenario'
-                                          : path[0] === 'logs'
-                                            ? 'logs'
-                                            : path.length === 0
-                                              ? 'group'
-                                              : 'movers';
+                                      : path[0] === 'scenario'
+                                        ? 'scenario'
+                                        : path[0] === 'logs'
+                                          ? 'logs'
+                                          : path.length === 0
+                                            ? 'group'
+                                            : 'movers';
 
   function pathFor(m: TabPluginId) {
     switch (m) {


### PR DESCRIPTION
## Summary
- fix mode selection in Menu to distinguish profile and settings routes

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*


------
https://chatgpt.com/codex/tasks/task_e_68bb67d8ab2c8327a0d565971d16429f