### PR TITLE
fix: remove duplicate logout text

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -132,7 +132,6 @@ export default function Menu({
           }}
         >
           {t('app.logout', 'Logout')}
-          {t("app.logout", "Logout")}
         </button>
       )}
     </nav>


### PR DESCRIPTION
## Summary
- remove duplicate logout translation

## Testing
- `npm test` *(fails: Error: Transform failed with 1 error: ... )*


------
https://chatgpt.com/codex/tasks/task_e_68bb67d56f488327a77ff5ef9928510e