### PR TITLE
fix: add module type to PWA dev options

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(({ command }) => {
       filename: 'service-worker.ts',
       manifest: false,
       // enable service worker in dev but avoid caching dev assets
-      devOptions: { enabled: true, disableRuntimeConfig: true },
+      devOptions: { enabled: true, type: 'module', disableRuntimeConfig: true },
       workbox: {
         globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}']
       }


### PR DESCRIPTION
## Summary
- add module type to PWA dev options

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bb67d3a7ac83279f5b682faf95db1a