### PR TITLE
Use local logout handler

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -36,7 +36,6 @@ export function Root() {
   const logout = () => {
     apiLogout()
     setUser(null)
-    apiLogout()
     setAuthed(false)
     navigate('/')
   }
@@ -69,7 +68,7 @@ export function Root() {
         <Route path="/research/:ticker" element={<InstrumentResearch />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/alerts" element={<Alerts />} />
-        <Route path="/*" element={<App onLogout={handleLogout} />} />
+        <Route path="/*" element={<App onLogout={logout} />} />
       </Routes>
     </Suspense>
   )


### PR DESCRIPTION
## Summary
- connect App to locally defined logout function
- remove redundant apiLogout call

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bb67d29a4483278c5fc7afba2492ae