### PR TITLE
fix: remove undefined beta display from portfolio dashboard

### DIFF
--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -187,12 +187,6 @@ export function PortfolioDashboard({ owner }: Props) {
             {percent(volatility != null ? volatility * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>Beta</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
-            {beta != null ? (beta as number).toFixed(2) : '—'}
-          </div>
-        </div>
       </div>
 
       <h2>Portfolio Value</h2>


### PR DESCRIPTION
## Summary
- remove unused beta metric from portfolio dashboard

## Testing
- `npm run build:web` *(fails: Cannot find name 'AppProps'; Type 'any[] | null' is not assignable to type 'string[] | undefined')*
- `npm test` *(fails: Failed to load PostCSS config: Cannot find module '../lightningcss.linux-x64-gnu.node')*


------
https://chatgpt.com/codex/tasks/task_e_68bbeebdf3a483278a5a697043435c8c