### PR TITLE
feat: define AppProps interface

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,10 @@ import AllocationCharts from "./pages/AllocationCharts";
 import InstrumentAdmin from "./pages/InstrumentAdmin";
 import Menu from "./components/Menu";
 
+interface AppProps {
+  onLogout?: () => void;
+}
+
 type Mode = (typeof orderedTabPlugins)[number]["id"] | "profile";
 
 // derive initial mode + id from path


### PR DESCRIPTION
## Summary
- add `AppProps` interface to describe optional `onLogout` callback
- continue typing `App` component with `{ onLogout }: AppProps`

## Testing
- `npm --prefix frontend run build` *(fails: Cannot find name 'beta' in PortfolioDashboard.tsx; Type 'any[] | null' is not assignable to type 'string[] | undefined' in UserConfig.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bbeebce900832785447cc0c63cc988