### PR TITLE
feat: show formatted chart labels

### DIFF
--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -120,7 +120,9 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
               cx="50%"
               cy="50%"
               outerRadius="80%"
-              label
+              label={({ name, value, percent }) =>
+                `${name}: ${money(value)} (${(percent * 100).toFixed(2)}%)`
+              }
             >
               {chartData.map((_, index) => (
                 <Cell
@@ -130,7 +132,11 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
               ))}
             </Pie>
             <Tooltip formatter={(v: number) => money(v)} />
-            <Legend />
+            <Legend
+              formatter={(value: string, entry: any) =>
+                `${value}: ${money(entry?.payload?.value)}`
+              }
+            />
           </PieChart>
         </ResponsiveContainer>
       </div>


### PR DESCRIPTION
## Summary
- format pie chart labels with name, money value, and percent
- show money-formatted values in legend

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*


------
https://chatgpt.com/codex/tasks/task_e_68bbf34d8f848327ae5857359ed77481