### PR TITLE
Always show menu on support page

### DIFF
--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -197,9 +197,7 @@ export default function MainApp() {
         open={notificationsOpen}
         onClose={() => setNotificationsOpen(false)}
       />
-      {mode !== "support" && (
-        <Menu selectedOwner={selectedOwner} selectedGroup={selectedGroup} />
-      )}
+      <Menu selectedOwner={selectedOwner} selectedGroup={selectedGroup} />
 
       <Header
         tradesThisMonth={tradeInfo?.tradesThisMonth}


### PR DESCRIPTION
## Summary
- Render main navigation menu even when viewing the support page

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `npm run lint` *(fails: 15 errors, 4 warnings)*
- `npm run build` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `curl -I http://localhost:5174/support`


------
https://chatgpt.com/codex/tasks/task_e_68bbf36a4b8083278f0ecd6632d42934