### PR TITLE
Refactor screener parameter hashing

### DIFF
--- a/backend/routes/screener.py
+++ b/backend/routes/screener.py
@@ -16,6 +16,104 @@ router = APIRouter(prefix="/screener", tags=["screener"])
 SCREENER_TTL = 900  # seconds
 
 
+def _hash_params(
+    symbols: List[str],
+    peg_max: float | None,
+    pe_max: float | None,
+    de_max: float | None,
+    lt_de_max: float | None,
+    interest_coverage_min: float | None,
+    current_ratio_min: float | None,
+    quick_ratio_min: float | None,
+    fcf_min: float | None,
+    eps_min: float | None,
+    gross_margin_min: float | None,
+    operating_margin_min: float | None,
+    net_margin_min: float | None,
+    ebitda_margin_min: float | None,
+    roa_min: float | None,
+    roe_min: float | None,
+    roi_min: float | None,
+    dividend_yield_min: float | None,
+    dividend_payout_ratio_max: float | None,
+    beta_max: float | None,
+    shares_outstanding_min: int | None,
+    float_shares_min: int | None,
+    market_cap_min: int | None,
+    high_52w_max: float | None,
+    low_52w_min: float | None,
+    avg_volume_min: int | None,
+):
+    params = "|".join(
+        [
+            ",".join(symbols),
+            str(peg_max),
+            str(pe_max),
+            str(de_max),
+            str(fcf_min),
+            str(eps_min),
+            str(fcf_min),
+            str(gross_margin_min),
+            str(operating_margin_min),
+            str(net_margin_min),
+            str(ebitda_margin_min),
+            str(roa_min),
+            str(roe_min),
+            str(roi_min),
+            str(lt_de_max),
+            str(interest_coverage_min),
+            str(current_ratio_min),
+            str(quick_ratio_min),
+            str(fcf_min),
+            str(dividend_yield_min),
+            str(dividend_payout_ratio_max),
+            str(beta_max),
+            str(shares_outstanding_min),
+            str(float_shares_min),
+            str(market_cap_min),
+            str(high_52w_max),
+            str(low_52w_min),
+            str(avg_volume_min),
+        ]
+    )
+    page = "screener_" + hashlib.sha1(params.encode()).hexdigest()
+
+    def _call():
+        return [
+            r.model_dump()
+            for r in screen(
+                symbols,
+                peg_max=peg_max,
+                pe_max=pe_max,
+                de_max=de_max,
+                lt_de_max=lt_de_max,
+                interest_coverage_min=interest_coverage_min,
+                current_ratio_min=current_ratio_min,
+                quick_ratio_min=quick_ratio_min,
+                fcf_min=fcf_min,
+                eps_min=eps_min,
+                gross_margin_min=gross_margin_min,
+                operating_margin_min=operating_margin_min,
+                net_margin_min=net_margin_min,
+                ebitda_margin_min=ebitda_margin_min,
+                roa_min=roa_min,
+                roe_min=roe_min,
+                roi_min=roi_min,
+                dividend_yield_min=dividend_yield_min,
+                dividend_payout_ratio_max=dividend_payout_ratio_max,
+                beta_max=beta_max,
+                shares_outstanding_min=shares_outstanding_min,
+                float_shares_min=float_shares_min,
+                market_cap_min=market_cap_min,
+                high_52w_max=high_52w_max,
+                low_52w_min=low_52w_min,
+                avg_volume_min=avg_volume_min,
+            )
+        ]
+
+    return page, _call
+
+
 @router.get("/", response_model=List[Fundamentals])
 async def screener(
     background_tasks: BackgroundTasks,
@@ -52,56 +150,12 @@ async def screener(
     if not symbols:
         raise HTTPException(status_code=400, detail="No tickers supplied")
 
-    params = (
-        f"{','.join(symbols)}|{peg_max}|{pe_max}|{de_max}|{fcf_min}|"
-        f"{eps_min}|{gross_margin_min}|{operating_margin_min}|{net_margin_min}|"
-        f"{ebitda_margin_min}|{roa_min}|{roe_min}|{roi_min}"
-        f"{peg_max}|{pe_max}|{de_max}|{lt_de_max}|"
-        f"{interest_coverage_min}|{current_ratio_min}|{quick_ratio_min}|{fcf_min}"
-    )
-    params = "|".join(
-        [
-            ",".join(symbols),
-            str(peg_max),
-            str(pe_max),
-            str(de_max),
-            str(fcf_min),
-            str(eps_min),
-            str(fcf_min),
-            str(gross_margin_min),
-            str(operating_margin_min),
-            str(net_margin_min),        
-            str(ebitda_margin_min),
-            str(roa_min),
-            str(roe_min),
-            str(roi_min),
-            str(lt_de_max),
-            str(interest_coverage_min),
-            str(current_ratio_min),
-            str(quick_ratio_min),
-            str(fcf_min),
-            str(dividend_yield_min),
-            str(dividend_payout_ratio_max),
-            str(beta_max),
-            str(shares_outstanding_min),
-            str(float_shares_min),
-            str(market_cap_min),
-            str(high_52w_max),
-            str(low_52w_min),
-            str(avg_volume_min),
-        ]
-    )
-    page = "screener_" + hashlib.sha1(params.encode()).hexdigest()
-    page_cache.schedule_refresh(
-        page,
-        SCREENER_TTL,
-        lambda symbols=symbols,
-
-      peg_max=peg_max,
+    page, call = _hash_params(
+        symbols,
+        peg_max=peg_max,
         pe_max=pe_max,
         de_max=de_max,
-
-      lt_de_max=lt_de_max,
+        lt_de_max=lt_de_max,
         interest_coverage_min=interest_coverage_min,
         current_ratio_min=current_ratio_min,
         quick_ratio_min=quick_ratio_min,
@@ -122,59 +176,21 @@ async def screener(
         market_cap_min=market_cap_min,
         high_52w_max=high_52w_max,
         low_52w_min=low_52w_min,
-        avg_volume_min=avg_volume_min: [
-            r.model_dump()
-            for r in screen(
-                symbols,
-                peg_max=peg_max,
-                pe_max=pe_max,
-                de_max=de_max,
-                lt_de_max=lt_de_max,
-                interest_coverage_min=interest_coverage_min,
-                current_ratio_min=current_ratio_min,
-                quick_ratio_min=quick_ratio_min,
-                fcf_min=fcf_min,
-                eps_min=eps_min,
-                gross_margin_min=gross_margin_min,
-                operating_margin_min=operating_margin_min,
-                net_margin_min=net_margin_min,
-                ebitda_margin_min=ebitda_margin_min,
-                roa_min=roa_min,
-                roe_min=roe_min,
-                roi_min=roi_min,
-            )
-        ],
+        avg_volume_min=avg_volume_min,
     )
+
+    page_cache.schedule_refresh(page, SCREENER_TTL, call)
     if not page_cache.is_stale(page, SCREENER_TTL):
         cached = page_cache.load_cache(page)
         if cached is not None:
             return cached
 
     try:
-        result = screen(
-            symbols,
-            peg_max=peg_max,
-            pe_max=pe_max,
-            de_max=de_max,
-            lt_de_max=lt_de_max,
-            interest_coverage_min=interest_coverage_min,
-            current_ratio_min=current_ratio_min,
-            quick_ratio_min=quick_ratio_min,
-            fcf_min=fcf_min,
-            eps_min=eps_min,
-            gross_margin_min=gross_margin_min,
-            operating_margin_min=operating_margin_min,
-            net_margin_min=net_margin_min,
-            ebitda_margin_min=ebitda_margin_min,
-            roa_min=roa_min,
-            roe_min=roe_min,
-            roi_min=roi_min,
-        )
+        payload = call()
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except RuntimeError as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
 
-    payload = [r.model_dump() for r in result]
     background_tasks.add_task(page_cache.save_cache, page, payload)
     return payload

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -363,6 +363,43 @@ def test_screener_endpoint(client, monkeypatch):
     assert data[0]["ticker"] == "AAA"
 
 
+def test_hash_params_helper(monkeypatch):
+    from backend.screener import Fundamentals
+    from backend.routes.screener import _hash_params
+
+    def mock_fetch(ticker: str) -> Fundamentals:
+        if ticker == "AAA":
+            return Fundamentals(ticker="AAA", peg_ratio=0.5, roe=0.2)
+        return Fundamentals(ticker="BBB", peg_ratio=2.0, roe=0.1)
+
+    monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
+
+    symbols = ["AAA", "BBB"]
+    page1, call1 = _hash_params(symbols, peg_max=1, pe_max=None, de_max=None, lt_de_max=None,
+                                interest_coverage_min=None, current_ratio_min=None,
+                                quick_ratio_min=None, fcf_min=None, eps_min=None,
+                                gross_margin_min=None, operating_margin_min=None,
+                                net_margin_min=None, ebitda_margin_min=None, roa_min=None,
+                                roe_min=0.15, roi_min=None, dividend_yield_min=None,
+                                dividend_payout_ratio_max=None, beta_max=None,
+                                shares_outstanding_min=None, float_shares_min=None,
+                                market_cap_min=None, high_52w_max=None, low_52w_min=None,
+                                avg_volume_min=None)
+    page2, _ = _hash_params(symbols, peg_max=1, pe_max=None, de_max=None, lt_de_max=None,
+                             interest_coverage_min=None, current_ratio_min=None,
+                             quick_ratio_min=None, fcf_min=None, eps_min=None,
+                             gross_margin_min=None, operating_margin_min=None,
+                             net_margin_min=None, ebitda_margin_min=None, roa_min=None,
+                             roe_min=0.15, roi_min=None, dividend_yield_min=None,
+                             dividend_payout_ratio_max=None, beta_max=None,
+                             shares_outstanding_min=None, float_shares_min=None,
+                             market_cap_min=None, high_52w_max=None, low_52w_min=None,
+                             avg_volume_min=None)
+    assert page1 == page2
+    payload = call1()
+    assert [d["ticker"] for d in payload] == ["AAA"]
+
+
 def test_var_endpoint_default(client):
     if backend_config.config.offline_mode:
         pytest.skip("VaR endpoint requires data unavailable in offline mode")


### PR DESCRIPTION
## Summary
- remove unused params string in screener endpoint
- add _hash_params to compute cache key and screen callable
- update tests to cover new helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbf39c7bec8327950a50035f2ef4e5