### PR TITLE
Reorder imports in timeseries helper

### DIFF
--- a/backend/utils/timeseries_helpers.py
+++ b/backend/utils/timeseries_helpers.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import re
 from pathlib import Path
 from typing import Optional
@@ -30,9 +31,6 @@ def apply_scaling(df: pd.DataFrame, scale: float, scale_volume: bool = False) ->
         df[col] = pd.to_numeric(df[col], errors="coerce") * scale
 
     return df
-
-
-import json
 
 
 def get_scaling_override(ticker: str, exchange: str, requested_scaling: Optional[float]) -> float:


### PR DESCRIPTION
## Summary
- Move `json` import into grouped imports
- Maintain import ordering in `timeseries_helpers`

## Testing
- `ruff check backend/utils/timeseries_helpers.py`
- `black --check --config backend/pyproject.toml backend/utils/timeseries_helpers.py`
- `pytest tests/utils/test_timeseries_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68bbf39a2ca48327b93ce4ad452558aa