### PR TITLE
Escape HTML in timeseries renderer

### DIFF
--- a/backend/utils/html_render.py
+++ b/backend/utils/html_render.py
@@ -1,3 +1,5 @@
+import html
+
 import pandas as pd
 from fastapi.responses import HTMLResponse
 from pandas import DataFrame
@@ -12,11 +14,14 @@ def render_timeseries_html(df: DataFrame, title: str, subtitle: str = "") -> HTM
 
     html_table = df.to_html(index=False, classes="table table-striped text-center", border=0)
 
+    escaped_title = html.escape(title)
+    escaped_subtitle = html.escape(subtitle)
+
     return HTMLResponse(
         content=f"""
     <html>
     <head>
-        <title>{title}</title>
+        <title>{escaped_title}</title>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
         <style>
             body {{ padding: 2rem; }}
@@ -26,7 +31,7 @@ def render_timeseries_html(df: DataFrame, title: str, subtitle: str = "") -> HTM
         </style>
     </head>
     <body>
-        <h2>{title}<br><small>{subtitle}</small></h2>
+        <h2>{escaped_title}<br><small>{escaped_subtitle}</small></h2>
         {html_table}
     </body>
     </html>

--- a/tests/utils/test_html_render.py
+++ b/tests/utils/test_html_render.py
@@ -53,3 +53,26 @@ def test_render_timeseries_html():
     # Snapshot for regression detection
     expected = (ROOT / "tests/snapshots/render_timeseries.html").read_text()
     assert html_str == expected
+
+
+def test_render_timeseries_html_escapes_title_and_subtitle():
+    df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-01-01"]),
+            "Open": [1.0],
+            "High": [1.0],
+            "Low": [1.0],
+            "Close": [1.0],
+            "Volume": [1],
+            "Ticker": ["ABC"],
+            "Source": ["Test"],
+        }
+    )
+
+    response = render_timeseries_html(df, "Title <script>", "Sub <b>")
+    html_str = response.body.decode()
+
+    assert "&lt;script&gt;" in html_str
+    assert "<script>" not in html_str
+    assert "&lt;b&gt;" in html_str
+    assert "<b>" not in html_str


### PR DESCRIPTION
## Summary
- HTML-escape title and subtitle in `render_timeseries_html`
- Add test ensuring angle brackets in title and subtitle are escaped

## Testing
- `pytest --override-ini=addopts= tests/utils/test_html_render.py::test_render_timeseries_html_escapes_title_and_subtitle -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbf39b4e048327ad44af5738b9a5ee