### PR TITLE
feat: use select for exchange in timeseries editor

### DIFF
--- a/frontend/src/lib/exchanges.ts
+++ b/frontend/src/lib/exchanges.ts
@@ -1,0 +1,9 @@
+export const EXCHANGES = [
+  "L",
+  "N",
+  "DE",
+  "TO",
+  "F",
+  "CA",
+] as const;
+export type ExchangeCode = typeof EXCHANGES[number];

--- a/frontend/src/pages/TimeseriesEdit.test.tsx
+++ b/frontend/src/pages/TimeseriesEdit.test.tsx
@@ -16,6 +16,10 @@ describe("TimeseriesEdit page", () => {
     vi.clearAllMocks();
     render(<TimeseriesEdit />);
 
+    expect(
+      (screen.getByLabelText(/Exchange/i) as HTMLSelectElement).value,
+    ).toBe("L");
+
     fireEvent.change(screen.getByLabelText(/Ticker/i), {
       target: { value: "ABC" },
     });
@@ -50,10 +54,10 @@ describe("TimeseriesEdit page", () => {
   });
 
   it("prefills ticker and exchange from URL", async () => {
-    window.history.pushState({}, "", "/timeseries?ticker=XYZ&exchange=US");
+    window.history.pushState({}, "", "/timeseries?ticker=XYZ&exchange=DE");
     render(<TimeseriesEdit />);
     expect(await screen.findByDisplayValue("XYZ")).toBeInTheDocument();
-    expect(await screen.findByDisplayValue("US")).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("DE")).toBeInTheDocument();
     window.history.pushState({}, "", "/");
   });
 });

--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import type { ChangeEvent } from "react";
 import { getTimeseries, saveTimeseries } from "../api";
 import type { PriceEntry } from "../types";
+import { EXCHANGES, type ExchangeCode } from "../lib/exchanges";
 
 function parseCsv(text: string): PriceEntry[] {
   const lines = text.split(/\r?\n/).filter((l) => l.trim());
@@ -46,7 +47,7 @@ function parseCsv(text: string): PriceEntry[] {
 
 export function TimeseriesEdit() {
   const [ticker, setTicker] = useState("");
-  const [exchange, setExchange] = useState("L");
+  const [exchange, setExchange] = useState<ExchangeCode>("L");
   const [rows, setRows] = useState<PriceEntry[]>([]);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -56,7 +57,9 @@ export function TimeseriesEdit() {
     const t = params.get("ticker");
     const e = params.get("exchange");
     if (t) setTicker(t);
-    if (e) setExchange(e);
+    if (e && EXCHANGES.includes(e as ExchangeCode)) {
+      setExchange(e as ExchangeCode);
+    }
   }, []);
 
   async function handleLoad() {
@@ -109,11 +112,17 @@ export function TimeseriesEdit() {
         </label>{" "}
         <label>
           Exchange {" "}
-          <input
+          <select
             value={exchange}
-            onChange={(e) => setExchange(e.target.value)}
+            onChange={(e) => setExchange(e.target.value as ExchangeCode)}
             style={{ width: "4rem" }}
-          />
+          >
+            {EXCHANGES.map((ex) => (
+              <option key={ex} value={ex}>
+                {ex}
+              </option>
+            ))}
+          </select>
         </label>{" "}
         <button onClick={handleLoad} disabled={!ticker}>
           Load


### PR DESCRIPTION
## Summary
- add shared list of valid exchange codes
- switch timeseries editor to use a select element for exchange
- update tests for default L selection and URL prefill

## Testing
- `npm test src/pages/TimeseriesEdit.test.tsx`
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `pytest tests/test_timeseries_edit_route.py -q` *(fails: unrecognized arguments: --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf49bb6248327a53008c453858393