### PR TITLE
Use Pydantic model_dump for push subscriptions

### DIFF
--- a/backend/common/virtual_portfolio.py
+++ b/backend/common/virtual_portfolio.py
@@ -38,7 +38,7 @@ class VirtualPortfolio(BaseModel):
                 {
                     "account_type": "virtual",
                     "currency": "GBP",
-                    "holdings": [h.dict() for h in self.holdings],
+                    "holdings": [h.model_dump() for h in self.holdings],
                 }
             ],
         }

--- a/backend/routes/alerts.py
+++ b/backend/routes/alerts.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from backend import alerts as alert_utils
@@ -51,7 +51,7 @@ async def set_settings(user: str, payload: ThresholdPayload, request: Request):
 async def add_push_subscription(user: str, payload: PushSubscriptionPayload, request: Request):
     """Persist a Web Push subscription for ``user``."""
     _validate_owner(user, request)
-    alert_utils.set_user_push_subscription(user, payload.dict())
+    alert_utils.set_user_push_subscription(user, payload.model_dump())
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- persist push subscriptions using `model_dump()`
- dump virtual portfolio holdings with `model_dump()` instead of `dict`
- ensure project no longer uses deprecated Pydantic `.dict()`

## Testing
- `ruff check --config backend/pyproject.toml backend/routes/alerts.py backend/common/virtual_portfolio.py`
- `black --check --config backend/pyproject.toml backend/routes/alerts.py backend/common/virtual_portfolio.py`
- `pytest` *(fails: tests/test_accounts_api.py::test_account_route_returns_data[alex-accounts3] - assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf38720e083279b2d332f73412baf