### PR TITLE
feat: add instrument type allocation label

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -166,6 +166,9 @@
   "portfolio": "Portfolio",
   "asOf": "Stand {{date}} • Trades diesen Monat: {{trades}} / 20 (Verbleibend: {{remaining}})",
   "approxTotal": "Ungefähre Summe: £{{value}}",
+  "allocation": {
+    "instrumentTypes": "Instrumenttypen"
+  },
   "watchlist": {
     "refresh": "Aktualisieren"
   },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -168,6 +168,9 @@
   "portfolio": "Portfolio",
   "asOf": "As of {{date}} • Trades this month: {{trades}} / 20 (Remaining: {{remaining}})",
   "approxTotal": "Approx Total: £{{value}}",
+  "allocation": {
+    "instrumentTypes": "Instrument Types"
+  },
   "watchlist": {
     "refresh": "Refresh"
   },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -166,6 +166,9 @@
   "portfolio": "Portafolio",
   "asOf": "A fecha de {{date}} • Operaciones este mes: {{trades}} / 20 (Restantes: {{remaining}})",
   "approxTotal": "Total aproximado: £{{value}}",
+  "allocation": {
+    "instrumentTypes": "Tipos de instrumentos"
+  },
   "watchlist": {
     "refresh": "Actualizar"
   },

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -166,6 +166,9 @@
   "portfolio": "Portefeuille",
   "asOf": "Au {{date}} • Transactions ce mois: {{trades}} / 20 (Restantes: {{remaining}})",
   "approxTotal": "Total approximatif: £{{value}}",
+  "allocation": {
+    "instrumentTypes": "Types d'instruments"
+  },
   "watchlist": {
     "refresh": "Actualiser"
   },

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -166,6 +166,9 @@
   "portfolio": "Portfólio",
   "asOf": "Em {{date}} • Negociações este mês: {{trades}} / 20 (Restantes: {{remaining}})",
   "approxTotal": "Total aproximado: £{{value}}",
+  "allocation": {
+    "instrumentTypes": "Tipos de instrumentos"
+  },
   "watchlist": {
     "refresh": "Atualizar"
   },

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -100,7 +100,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
       </h1>
       <div className="mb-4 flex gap-2">
         <button onClick={() => setView("asset")} disabled={view === "asset"}>
-          {t("instrumentType.other", { defaultValue: "Asset Classes" })}
+          {t("allocation.instrumentTypes", { defaultValue: "Instrument Types" })}
         </button>
         <button onClick={() => setView("sector")} disabled={view === "sector"}>
           {t("Sector", { defaultValue: "Industries" })}


### PR DESCRIPTION
## Summary
- use allocation.instrumentTypes key for first Allocation tab
- define allocation.instrumentTypes translation in all locales

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `npm run build:web` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*


------
https://chatgpt.com/codex/tasks/task_e_68bbf3569e5c8327a3de83ccdb40ec91