### PR TITLE
feat: add instrument search filter

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -220,12 +220,13 @@
     "sector": "Sector",
     "actions": "Actions",
     "add": "Add Instrument",
-    "save": "Save",
-    "saveSuccess": "Saved",
-    "saveError": "Error saving",
-    "validation": {
-      "ticker": "Ticker is required",
-      "name": "Name is required"
-    }
+  "save": "Save",
+  "saveSuccess": "Saved",
+  "saveError": "Error saving",
+  "searchPlaceholder": "Filter instruments…",
+  "validation": {
+    "ticker": "Ticker is required",
+    "name": "Name is required"
   }
+}
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -232,12 +232,13 @@
     "sector": "Sector",
     "actions": "Actions",
     "add": "Add Instrument",
-    "save": "Save",
-    "saveSuccess": "Saved",
-    "saveError": "Error saving",
-    "validation": {
-      "ticker": "Ticker is required",
-      "name": "Name is required"
-    }
+  "save": "Save",
+  "saveSuccess": "Saved",
+  "saveError": "Error saving",
+  "searchPlaceholder": "Filter instruments…",
+  "validation": {
+    "ticker": "Ticker is required",
+    "name": "Name is required"
   }
+}
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -220,12 +220,13 @@
     "sector": "Sector",
     "actions": "Actions",
     "add": "Add Instrument",
-    "save": "Save",
-    "saveSuccess": "Saved",
-    "saveError": "Error saving",
-    "validation": {
-      "ticker": "Ticker is required",
-      "name": "Name is required"
-    }
+  "save": "Save",
+  "saveSuccess": "Saved",
+  "saveError": "Error saving",
+  "searchPlaceholder": "Filter instruments…",
+  "validation": {
+    "ticker": "Ticker is required",
+    "name": "Name is required"
   }
+}
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -220,12 +220,13 @@
     "sector": "Sector",
     "actions": "Actions",
     "add": "Add Instrument",
-    "save": "Save",
-    "saveSuccess": "Saved",
-    "saveError": "Error saving",
-    "validation": {
-      "ticker": "Ticker is required",
-      "name": "Name is required"
-    }
+  "save": "Save",
+  "saveSuccess": "Saved",
+  "saveError": "Error saving",
+  "searchPlaceholder": "Filter instruments…",
+  "validation": {
+    "ticker": "Ticker is required",
+    "name": "Name is required"
   }
+}
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -230,12 +230,13 @@
     "sector": "Sector",
     "actions": "Actions",
     "add": "Add Instrument",
-    "save": "Save",
-    "saveSuccess": "Saved",
-    "saveError": "Error saving",
-    "validation": {
-      "ticker": "Ticker is required",
-      "name": "Name is required"
-    }
+  "save": "Save",
+  "saveSuccess": "Saved",
+  "saveError": "Error saving",
+  "searchPlaceholder": "Filter instruments…",
+  "validation": {
+    "ticker": "Ticker is required",
+    "name": "Name is required"
   }
+}
 }

--- a/frontend/src/pages/InstrumentAdmin.test.tsx
+++ b/frontend/src/pages/InstrumentAdmin.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("../api", () => ({
   listInstrumentMetadata: vi.fn().mockResolvedValue([
     { ticker: "AAA.L", name: "Alpha", region: "EU", sector: "Tech" },
+    { ticker: "BBB.N", name: "Beta", region: "US", sector: "Finance" },
   ]),
   createInstrumentMetadata: vi.fn().mockResolvedValue({}),
   updateInstrumentMetadata: vi.fn().mockResolvedValue({}),
@@ -21,8 +22,28 @@ describe("InstrumentAdmin page", () => {
       </MemoryRouter>,
     );
     expect(await screen.findByDisplayValue("AAA")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    fireEvent.click(screen.getAllByRole("button", { name: /save/i })[0]);
     await waitFor(() => expect(updateInstrumentMetadata).toHaveBeenCalled());
+  });
+
+  it("filters rows based on search", async () => {
+    render(
+      <MemoryRouter>
+        <InstrumentAdmin />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByDisplayValue("AAA")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("BBB")).toBeInTheDocument();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Filter instruments…"),
+      { target: { value: "beta" } },
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue("AAA")).not.toBeInTheDocument();
+      expect(screen.getByDisplayValue("BBB")).toBeInTheDocument();
+    });
   });
 });
 

--- a/frontend/src/pages/InstrumentAdmin.tsx
+++ b/frontend/src/pages/InstrumentAdmin.tsx
@@ -5,6 +5,7 @@ import {
   createInstrumentMetadata,
   updateInstrumentMetadata,
 } from "../api";
+import { useFilterableTable, type Filter } from "../hooks/useFilterableTable";
 
 interface Row {
   ticker: string;
@@ -22,6 +23,27 @@ export default function InstrumentAdmin() {
   const [rows, setRows] = useState<Row[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+
+  const {
+    rows: filteredRows,
+    setFilter,
+    filters,
+  } = useFilterableTable<Row, { search: Filter<Row, string> }>(rows, "ticker", {
+    search: {
+      value: "",
+      predicate: (row, value) => {
+        if (!value) return true;
+        const q = value.toLowerCase();
+        return [
+          row.ticker,
+          row.exchange,
+          row.name,
+          row.region ?? "",
+          row.sector ?? "",
+        ].some((field) => field.toLowerCase().includes(q));
+      },
+    },
+  });
 
   useEffect(() => {
     listInstrumentMetadata()
@@ -118,6 +140,13 @@ export default function InstrumentAdmin() {
         {t("app.modes.instrumentadmin")}
       </h2>
       {message && <p>{message}</p>}
+      <input
+        type="text"
+        placeholder={t("instrumentadmin.searchPlaceholder")}
+        value={filters.search}
+        onChange={(e) => setFilter("search", e.target.value)}
+        style={{ marginBottom: "0.5rem", display: "block" }}
+      />
       <button
         type="button"
         onClick={handleAdd}
@@ -137,45 +166,48 @@ export default function InstrumentAdmin() {
           </tr>
         </thead>
         <tbody>
-          {rows.map((r, idx) => (
-            <tr key={r._originalTicker ?? idx}>
-              <td>
-                <input
-                  value={r.ticker}
-                  onChange={(e) => handleChange(idx, "ticker", e.target.value)}
-                />
-              </td>
-              <td>
-                <input
-                  value={r.exchange}
-                  onChange={(e) => handleChange(idx, "exchange", e.target.value)}
-                />
-              </td>
-              <td>
-                <input
-                  value={r.name}
-                  onChange={(e) => handleChange(idx, "name", e.target.value)}
-                />
-              </td>
-              <td>
-                <input
-                  value={r.region ?? ""}
-                  onChange={(e) => handleChange(idx, "region", e.target.value)}
-                />
-              </td>
-              <td>
-                <input
-                  value={r.sector ?? ""}
-                  onChange={(e) => handleChange(idx, "sector", e.target.value)}
-                />
-              </td>
-              <td>
-                <button type="button" onClick={() => handleSave(r)}>
-                  {t("instrumentadmin.save")}
-                </button>
-              </td>
-            </tr>
-          ))}
+          {filteredRows.map((r) => {
+            const idx = rows.indexOf(r);
+            return (
+              <tr key={r._originalTicker ?? idx}>
+                <td>
+                  <input
+                    value={r.ticker}
+                    onChange={(e) => handleChange(idx, "ticker", e.target.value)}
+                  />
+                </td>
+                <td>
+                  <input
+                    value={r.exchange}
+                    onChange={(e) => handleChange(idx, "exchange", e.target.value)}
+                  />
+                </td>
+                <td>
+                  <input
+                    value={r.name}
+                    onChange={(e) => handleChange(idx, "name", e.target.value)}
+                  />
+                </td>
+                <td>
+                  <input
+                    value={r.region ?? ""}
+                    onChange={(e) => handleChange(idx, "region", e.target.value)}
+                  />
+                </td>
+                <td>
+                  <input
+                    value={r.sector ?? ""}
+                    onChange={(e) => handleChange(idx, "sector", e.target.value)}
+                  />
+                </td>
+                <td>
+                  <button type="button" onClick={() => handleSave(r)}>
+                    {t("instrumentadmin.save")}
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- allow filtering instruments via useFilterableTable with a search predicate
- wire up search box and render only filtered instruments
- localize instrument search placeholder across locales
- add test covering search filtering

## Testing
- `npm test` *(fails: Failed to load native binding @tailwindcss/oxide)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf36192cc8327ba902b63bbc4f15e