### PR TITLE
fix: strengthen login authentication

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -160,9 +160,16 @@ def create_app() -> FastAPI:
 
     @app.post("/token")
     async def login(body: TokenIn):
-        email = authenticate_user(body.id_token)
+        try:
+            email = authenticate_user(body.id_token)
+        except HTTPException as exc:
+            logger.warning("User authentication failed: %s", exc.detail)
+            raise
+
         if not email:
-            raise HTTPException(status_code=400, detail="Invalid credentials")
+            logger.warning("authenticate_user returned no email")
+            raise HTTPException(status_code=401, detail="Invalid credentials")
+
         token = create_access_token(email)
         return {"access_token": token, "token_type": "bearer"}
 


### PR DESCRIPTION
## Summary
- add logging and re-raising for failed token authentication
- reject requests with no email and return 401

## Testing
- `isort --sp backend/pyproject.toml backend/app.py -v`
- `black --config backend/pyproject.toml backend/app.py`
- `ruff check --config backend/pyproject.toml backend/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbf5f2059c83278fc27e94e7654dd9