### PR TITLE
feat(frontend): add ticker search suggestions

### DIFF
--- a/frontend/src/pages/TimeseriesEdit.test.tsx
+++ b/frontend/src/pages/TimeseriesEdit.test.tsx
@@ -6,10 +6,11 @@ vi.mock("../api", () => ({
     { Date: "2024-01-01", Open: 1, High: 1, Low: 1, Close: 1, Volume: 1 },
   ]),
   saveTimeseries: vi.fn().mockResolvedValue({ status: "ok", rows: 1 }),
+  searchInstruments: vi.fn().mockResolvedValue([]),
 }));
 
 import { TimeseriesEdit } from "./TimeseriesEdit";
-import { getTimeseries, saveTimeseries } from "../api";
+import { getTimeseries, saveTimeseries, searchInstruments } from "../api";
 
 describe("TimeseriesEdit page", () => {
   it("loads, edits, adds and deletes rows, then saves", async () => {
@@ -55,5 +56,17 @@ describe("TimeseriesEdit page", () => {
     expect(await screen.findByDisplayValue("XYZ")).toBeInTheDocument();
     expect(await screen.findByDisplayValue("US")).toBeInTheDocument();
     window.history.pushState({}, "", "/");
+  });
+
+  it("suggests tickers and updates value when one is selected", async () => {
+    const searchMock = searchInstruments as unknown as vi.Mock;
+    searchMock.mockResolvedValue([{ ticker: "AAA", name: "AAA Corp" }]);
+    render(<TimeseriesEdit />);
+    const input = screen.getByLabelText(/Ticker/i);
+    fireEvent.change(input, { target: { value: "AA" } });
+    await new Promise((r) => setTimeout(r, 350));
+    expect(await screen.findByText("AAA — AAA Corp")).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: "AAA" } });
+    expect(input).toHaveValue("AAA");
   });
 });

--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import type { ChangeEvent } from "react";
-import { getTimeseries, saveTimeseries } from "../api";
+import { getTimeseries, saveTimeseries, searchInstruments } from "../api";
 import type { PriceEntry } from "../types";
 
 function parseCsv(text: string): PriceEntry[] {
@@ -50,6 +50,9 @@ export function TimeseriesEdit() {
   const [rows, setRows] = useState<PriceEntry[]>([]);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<
+    { ticker: string; name: string }[]
+  >([]);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -58,6 +61,29 @@ export function TimeseriesEdit() {
     if (t) setTicker(t);
     if (e) setExchange(e);
   }, []);
+
+  useEffect(() => {
+    const trimmed = ticker.trim();
+    if (trimmed.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      searchInstruments(trimmed, undefined, undefined, controller.signal)
+        .then(setSuggestions)
+        .catch((err) => {
+          if (err.name !== "AbortError") {
+            console.error(err);
+            setSuggestions([]);
+          }
+        });
+    }, 300);
+    return () => {
+      controller.abort();
+      clearTimeout(timeout);
+    };
+  }, [ticker]);
 
   async function handleLoad() {
     setError(null);
@@ -105,7 +131,22 @@ export function TimeseriesEdit() {
       <div className="mb-2">
         <label>
           Ticker {" "}
-          <input value={ticker} onChange={(e) => setTicker(e.target.value)} />
+          <input
+            list="ticker-suggestions"
+            value={ticker}
+            onChange={(e) => {
+              const val = e.target.value;
+              const match = suggestions.find((s) => s.ticker === val);
+              setTicker(match ? match.ticker : val);
+            }}
+          />
+          <datalist id="ticker-suggestions">
+            {suggestions.map((r) => (
+              <option key={r.ticker} value={r.ticker}>
+                {`${r.ticker} — ${r.name}`}
+              </option>
+            ))}
+          </datalist>
         </label>{" "}
         <label>
           Exchange {" "}


### PR DESCRIPTION
## Summary
- show ticker suggestions while typing using searchInstruments
- allow selecting from datalist to populate ticker
- test suggestions and ticker update

## Testing
- `npm test` (fails: Cannot find module '../lightningcss.linux-x64-gnu.node')
- `npx vitest run src/pages/TimeseriesEdit.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bbf49cebc0832795ffeb28223af056