### PR TITLE
fix: enrich holdings metadata and improve account filtering

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -280,15 +280,16 @@ def enrich_holding(
     # with generic placeholders from security metadata, causing
     # instrument names to appear as tickers on the group page.
     meta = {**sec_meta, **instr_meta}
-    out["currency"] = meta.get("currency")
-    out["name"] = out.get("name") or meta.get("name") or full
 
     if _is_cash(full, account_ccy):
-        out = dict(h)
         units = float(out.get(UNITS, 0) or 0.0)
         out["name"] = out.get("name") or _cash_name(full, account_ccy)
         out["currency"] = meta.get("currency") or account_ccy
-        out["instrument_type"] = meta.get("instrumentType") or meta.get("instrument_type") or "Cash"
+        out["instrument_type"] = (
+            meta.get("instrumentType") or meta.get("instrument_type") or "Cash"
+        )
+        out["sector"] = out.get("sector") or meta.get("sector")
+        out["region"] = out.get("region") or meta.get("region")
 
         # price is 1.0 in account currency
         out["price"] = 1.0
@@ -329,6 +330,9 @@ def enrich_holding(
 
     out["currency"] = meta.get("currency")
     out["instrument_type"] = meta.get("instrumentType") or meta.get("instrument_type")
+    out["name"] = out.get("name") or meta.get("name") or full
+    out["sector"] = out.get("sector") or meta.get("sector")
+    out["region"] = out.get("region") or meta.get("region")
 
     units = float(out.get(UNITS, 0) or 0.0)
     if units <= 0:

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -47,7 +47,12 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
 
   // helper to derive a stable key for each account
   const accountKey = (acct: Account, idx: number) =>
-    `${acct.owner ?? "owner"}-${acct.account_type}-${idx}`;
+    `${acct.owner?.trim() || "unknown"}-${acct.account_type}-${idx}`;
+
+  const toggleAccount = (key: string) =>
+    setSelectedAccounts((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+    );
 
   useEffect(() => {
     getGroupPortfolio(slug)
@@ -126,13 +131,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
                 <input
                   type="checkbox"
                   checked={selectedAccounts.includes(key)}
-                  onChange={() =>
-                    setSelectedAccounts((prev) =>
-                      prev.includes(key)
-                        ? prev.filter((k) => k !== key)
-                        : [...prev, key],
-                    )
-                  }
+                  onChange={() => toggleAccount(key)}
                 />
                 {`${acct.owner ?? "—"} - ${acct.account_type}`}
               </label>
@@ -140,7 +139,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
           })}
         </div>
       )}
-      {error && <p style={{ color: "red" }}>{error}</p>}
+      {error && <p className="text-red-500">{error}</p>}
       <div style={{ width: "100%", height: 400 }}>
         <ResponsiveContainer>
           <PieChart>

--- a/tests/test_holding_utils_sector_region.py
+++ b/tests/test_holding_utils_sector_region.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from backend.common.holding_utils import enrich_holding
+
+
+def test_enrich_holding_includes_sector_and_region():
+    holding = {"ticker": "HFEL.L", "units": 1}
+    out = enrich_holding(holding, date.today(), {}, {})
+    assert out.get("sector")
+    assert out.get("region")


### PR DESCRIPTION
## Summary
- validate account keys and handle checkbox state via functional updates
- show allocation errors with CSS class instead of inline style
- enrich holdings with sector and region metadata and add regression test

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbf8ce8d3483279205e3f2dcc73738