### PR TITLE
Add backend tests for auth, scenarios, portfolios, and utilities

### DIFF
--- a/backend/tests/test_auth_module.py
+++ b/backend/tests/test_auth_module.py
@@ -1,0 +1,84 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from backend import auth
+
+
+def test_create_and_decode_token():
+    token = auth.create_access_token("user@example.com")
+    assert auth.decode_token(token) == "user@example.com"
+
+
+def test_get_current_user_invalid_token():
+    with pytest.raises(HTTPException):
+        asyncio.run(auth.get_current_user("bad"))
+
+
+def test_get_current_user_valid():
+    token = auth.create_access_token("alice@example.com")
+    assert asyncio.run(auth.get_current_user(token)) == "alice@example.com"
+
+
+def test_verify_google_token_success(monkeypatch):
+    monkeypatch.setattr(
+        auth.id_token,
+        "verify_oauth2_token",
+        lambda token, request, client_id: {"email": "a@b.com", "email_verified": True},
+    )
+    monkeypatch.setattr(auth, "_allowed_emails", lambda: {"a@b.com"})
+    assert auth.verify_google_token("token") == "a@b.com"
+
+
+def test_verify_google_token_unverified(monkeypatch):
+    monkeypatch.setattr(
+        auth.id_token,
+        "verify_oauth2_token",
+        lambda token, request, client_id: {"email": "a@b.com", "email_verified": False},
+    )
+    with pytest.raises(HTTPException) as exc:
+        auth.verify_google_token("token")
+    assert exc.value.status_code == 401
+
+
+def test_verify_google_token_unauthorized(monkeypatch):
+    monkeypatch.setattr(
+        auth.id_token,
+        "verify_oauth2_token",
+        lambda token, request, client_id: {"email": "c@d.com", "email_verified": True},
+    )
+    monkeypatch.setattr(auth, "_allowed_emails", lambda: {"a@b.com"})
+    with pytest.raises(HTTPException) as exc:
+        auth.verify_google_token("token")
+    assert exc.value.status_code == 403
+
+
+def test_verify_google_token_no_allowed(monkeypatch):
+    monkeypatch.setattr(
+        auth.id_token,
+        "verify_oauth2_token",
+        lambda token, request, client_id: {"email": "a@b.com", "email_verified": True},
+    )
+    monkeypatch.setattr(auth, "_allowed_emails", lambda: set())
+    with pytest.raises(HTTPException) as exc:
+        auth.verify_google_token("token")
+    assert exc.value.status_code == 403
+
+
+def test_allowed_emails_local(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        auth,
+        "resolve_paths",
+        lambda repo_root, accounts_root: SimpleNamespace(accounts_root=tmp_path),
+    )
+    monkeypatch.setattr(
+        auth,
+        "config",
+        SimpleNamespace(app_env="local", repo_root=tmp_path, accounts_root=tmp_path),
+    )
+    (tmp_path / "alice").mkdir()
+    monkeypatch.setattr(auth, "load_person_meta", lambda owner, data_root=None: {"email": f"{owner}@example.com"})
+    emails = auth._allowed_emails()
+    assert "alice@example.com" in emails

--- a/backend/tests/test_html_render_utils.py
+++ b/backend/tests/test_html_render_utils.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+from backend.utils.html_render import render_timeseries_html
+
+
+def _df():
+    return pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-01-01"]),
+            "Open": [1.2345],
+            "High": [2.3456],
+            "Low": [1.1234],
+            "Close": [2.2345],
+            "Volume": [12345],
+            "Ticker": ["ABC"],
+            "Source": ["Test"],
+        }
+    )
+
+
+def test_render_timeseries_html_basic():
+    response = render_timeseries_html(_df(), "Title", "Sub")
+    html = response.body.decode()
+    assert "Title" in html and "Sub" in html
+    assert "12,345" in html
+    assert "1.23" in html
+
+
+def test_render_timeseries_html_escapes():
+    response = render_timeseries_html(_df(), "T<script>", "S&b")
+    html = response.body.decode()
+    assert "&lt;script&gt;" in html
+    assert "S&amp;b" in html

--- a/backend/tests/test_page_cache_utils.py
+++ b/backend/tests/test_page_cache_utils.py
@@ -1,0 +1,34 @@
+import asyncio
+import json
+
+import pytest
+
+from backend.utils import page_cache
+
+
+@pytest.mark.asyncio
+async def test_save_load_and_is_stale(tmp_path, monkeypatch):
+    monkeypatch.setattr(page_cache, "CACHE_DIR", tmp_path)
+    assert page_cache.load_cache("p") is None
+    page_cache.save_cache("p", {"a": 1})
+    assert page_cache.load_cache("p") == {"a": 1}
+    assert not page_cache.is_stale("p", 9999)
+    assert page_cache.is_stale("missing", 1)
+
+
+@pytest.mark.asyncio
+async def test_schedule_refresh_and_cancel(tmp_path, monkeypatch):
+    monkeypatch.setattr(page_cache, "CACHE_DIR", tmp_path)
+    calls = []
+
+    def builder():
+        calls.append(1)
+        return {"v": len(calls)}
+
+    page_cache.schedule_refresh("pg", 3600, builder)
+    await asyncio.sleep(0)
+    assert json.loads((tmp_path / "pg.json").read_text()) == {"v": 1}
+    page_cache.schedule_refresh("pg", 3600, builder)
+    assert len(page_cache._refresh_tasks) == 1
+    await page_cache.cancel_refresh_tasks()
+    assert page_cache._refresh_tasks == {}

--- a/backend/tests/test_portfolio_routes.py
+++ b/backend/tests/test_portfolio_routes.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes import portfolio
+
+
+def _client(monkeypatch, tmp_path):
+    app = FastAPI()
+    app.include_router(portfolio.router)
+    app.state.accounts_root = tmp_path
+    return TestClient(app)
+
+
+def test_portfolio_success(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "backend.routes.portfolio.portfolio_mod.build_owner_portfolio",
+        lambda owner, root: {"owner": owner},
+    )
+    resp = client.get("/portfolio/alice")
+    assert resp.status_code == 200
+    assert resp.json()["owner"] == "alice"
+
+
+def test_portfolio_not_found(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "backend.routes.portfolio.portfolio_mod.build_owner_portfolio",
+        lambda owner, root: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    resp = client.get("/portfolio/bob")
+    assert resp.status_code == 404
+
+
+def test_portfolio_var(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    monkeypatch.setattr("backend.routes.portfolio.portfolio_mod.list_owners", lambda: ["alice"])
+    monkeypatch.setattr(
+        "backend.routes.portfolio.risk.compute_portfolio_var",
+        lambda owner, days, confidence, include_cash: {"1d": 1.0},
+    )
+    monkeypatch.setattr(
+        "backend.routes.portfolio.risk.compute_sharpe_ratio",
+        lambda owner, days: 0.5,
+    )
+    resp = client.get("/var/alice", params={"days": 10, "confidence": 0.9})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["var"] == {"1d": 1.0}
+    assert data["sharpe_ratio"] == 0.5
+
+
+def test_portfolio_var_owner_missing(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    monkeypatch.setattr("backend.routes.portfolio.portfolio_mod.list_owners", lambda: [])
+    resp = client.get("/var/alice")
+    assert resp.status_code == 404
+
+
+def test_portfolio_var_bad_params(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    monkeypatch.setattr("backend.routes.portfolio.portfolio_mod.list_owners", lambda: ["alice"])
+
+    def _raise(owner, days, confidence, include_cash):
+        raise ValueError("bad")
+
+    monkeypatch.setattr("backend.routes.portfolio.risk.compute_portfolio_var", _raise)
+    resp = client.get("/var/alice")
+    assert resp.status_code == 400

--- a/backend/tests/test_scenario_routes.py
+++ b/backend/tests/test_scenario_routes.py
@@ -1,0 +1,62 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes import scenario
+
+
+def _client(monkeypatch, list_plots_return, build_map=None):
+    app = FastAPI()
+    app.include_router(scenario.router)
+    monkeypatch.setattr("backend.routes.scenario.list_plots", lambda: list_plots_return)
+
+    def build(owner):
+        action = None
+        if build_map:
+            action = build_map.get(owner)
+        if action == "error":
+            raise FileNotFoundError
+        return build_map.get(owner, {
+            "total_value_estimate_gbp": 100.0,
+            "accounts": []
+        }) if build_map and owner in build_map else {
+            "total_value_estimate_gbp": 100.0,
+            "accounts": []
+        }
+
+    monkeypatch.setattr("backend.routes.scenario.build_owner_portfolio", build)
+    monkeypatch.setattr(
+        "backend.routes.scenario.apply_price_shock",
+        lambda pf, ticker, pct: {"total_value_estimate_gbp": pf["total_value_estimate_gbp"] * (1 + pct)},
+    )
+    return TestClient(app)
+
+
+def test_run_scenario_basic(monkeypatch):
+    client = _client(monkeypatch, [{"owner": "alice", "accounts": [1]}])
+    resp = client.get("/scenario", params={"ticker": "ABC", "pct": 0.1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["owner"] == "alice"
+    assert data[0]["delta_gbp"] == 10.0
+
+
+def test_run_scenario_skips_missing_portfolio(monkeypatch):
+    build_map = {"alice": "error"}
+    client = _client(monkeypatch, [{"owner": "alice", "accounts": [1]}], build_map)
+    resp = client.get("/scenario", params={"ticker": "ABC", "pct": 0.1})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_run_scenario_derives_baseline(monkeypatch):
+    build_map = {
+        "bob": {
+            "accounts": [{"value_estimate_gbp": 50}, {"value_estimate_gbp": 70}],
+        }
+    }
+    client = _client(monkeypatch, [{"owner": "bob", "accounts": [1]}], build_map)
+    resp = client.get("/scenario", params={"ticker": "XYZ", "pct": 0.1})
+    assert resp.status_code == 200
+    data = resp.json()[0]
+    assert data["baseline_total_value_gbp"] == 120
+    assert data["delta_gbp"] == 12.0

--- a/backend/tests/test_screener_route.py
+++ b/backend/tests/test_screener_route.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes import screener
+from backend.utils import page_cache
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(screener.router)
+    return TestClient(app)
+
+
+def test_screener_success(monkeypatch):
+    client = _client()
+    monkeypatch.setattr(page_cache, "schedule_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(page_cache, "is_stale", lambda p, ttl: True)
+    monkeypatch.setattr(page_cache, "load_cache", lambda p: None)
+    saved = {}
+    monkeypatch.setattr(page_cache, "save_cache", lambda p, d: saved.setdefault("data", d))
+
+    monkeypatch.setattr(
+        screener,
+        "screen",
+        lambda symbols, **k: [SimpleNamespace(model_dump=lambda: {"ticker": symbols[0]})],
+    )
+    resp = client.get("/screener", params={"tickers": "ABC"})
+    assert resp.status_code == 200
+    assert resp.json() == [{"ticker": "ABC"}]
+    assert saved["data"] == [{"ticker": "ABC"}]
+
+
+def test_screener_uses_cache(monkeypatch):
+    client = _client()
+    monkeypatch.setattr(page_cache, "schedule_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(page_cache, "is_stale", lambda p, ttl: False)
+    monkeypatch.setattr(page_cache, "load_cache", lambda p: [{"ticker": "C"}])
+    called = False
+
+    def _screen(*args, **kwargs):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(screener, "screen", _screen)
+    resp = client.get("/screener", params={"tickers": "ABC"})
+    assert resp.status_code == 200
+    assert resp.json() == [{"ticker": "C"}]
+    assert not called
+
+
+def test_screener_no_tickers(monkeypatch):
+    client = _client()
+    resp = client.get("/screener", params={"tickers": " , "})
+    assert resp.status_code == 400
+
+
+def test_screener_value_error(monkeypatch):
+    client = _client()
+    monkeypatch.setattr(page_cache, "schedule_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(page_cache, "is_stale", lambda p, ttl: True)
+    monkeypatch.setattr(page_cache, "load_cache", lambda p: None)
+    monkeypatch.setattr(
+        screener,
+        "screen",
+        lambda symbols, **k: (_ for _ in ()).throw(ValueError("bad")),
+    )
+    resp = client.get("/screener", params={"tickers": "ABC"})
+    assert resp.status_code == 400

--- a/backend/tests/test_transactions_route.py
+++ b/backend/tests/test_transactions_route.py
@@ -1,0 +1,114 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from backend.routes import transactions
+
+
+def _client(monkeypatch, tmp_path):
+    app = FastAPI()
+    app.include_router(transactions.router)
+    monkeypatch.setattr(transactions, "config", SimpleNamespace(accounts_root=tmp_path))
+    monkeypatch.setattr(
+        transactions,
+        "portfolio_loader",
+        SimpleNamespace(rebuild_account_holdings=lambda *a, **k: None),
+    )
+    monkeypatch.setattr(
+        transactions,
+        "portfolio_mod",
+        SimpleNamespace(build_owner_portfolio=lambda *a, **k: None),
+    )
+    monkeypatch.setattr(transactions, "_lock_file", lambda f: None)
+    monkeypatch.setattr(transactions, "_unlock_file", lambda f: None)
+    return TestClient(app)
+
+
+def test_validate_component():
+    with pytest.raises(HTTPException):
+        transactions._validate_component("bad name!", "owner")
+    assert transactions._validate_component("good_name-1", "owner") == "good_name-1"
+
+
+def test_create_transaction_success(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    data = {
+        "owner": "bob",
+        "account": "isa",
+        "ticker": "ABC",
+        "date": "2024-01-01",
+        "price_gbp": 1.5,
+        "units": 2,
+        "fees": 0.1,
+        "reason": "why",
+    }
+    resp = client.post("/transactions", json=data)
+    assert resp.status_code == 201
+    assert resp.json()["ticker"] == "ABC"
+    file_path = tmp_path / "bob" / "isa_transactions.json"
+    assert file_path.exists()
+    saved = json.loads(file_path.read_text())
+    assert saved["transactions"][0]["ticker"] == "ABC"
+    assert transactions._PORTFOLIO_IMPACT["bob"] == pytest.approx(3.0)
+
+
+def test_create_transaction_missing_reason(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    data = {
+        "owner": "bob",
+        "account": "isa",
+        "ticker": "ABC",
+        "date": "2024-01-01",
+        "price_gbp": 1.5,
+        "units": 2,
+    }
+    resp = client.post("/transactions", json=data)
+    assert resp.status_code == 400
+
+
+def test_create_transaction_no_accounts_root(monkeypatch):
+    app = FastAPI()
+    app.include_router(transactions.router)
+    monkeypatch.setattr(transactions, "config", SimpleNamespace(accounts_root=None))
+    client = TestClient(app)
+    resp = client.post(
+        "/transactions",
+        json={
+            "owner": "a",
+            "account": "b",
+            "ticker": "T",
+            "date": "2024-01-01",
+            "price_gbp": 1,
+            "units": 1,
+            "reason": "r",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_list_transactions_filter(monkeypatch):
+    app = FastAPI()
+    app.include_router(transactions.router)
+    client = TestClient(app)
+    sample = [
+        transactions.Transaction(owner="a", account="isa", date="2024-01-01"),
+        transactions.Transaction(owner="a", account="sipp", date="2024-02-01"),
+        transactions.Transaction(owner="b", account="isa", date="2024-01-01"),
+    ]
+    monkeypatch.setattr(transactions, "_load_all_transactions", lambda: sample)
+    resp = client.get(
+        "/transactions",
+        params={
+            "owner": "a",
+            "account": "isa",
+            "start": "2024-01-01",
+            "end": "2024-01-31",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["account"] == "isa"

--- a/backend/tests/test_user_config.py
+++ b/backend/tests/test_user_config.py
@@ -1,9 +1,33 @@
 import json
+from types import SimpleNamespace
 
-from backend.common.user_config import load_user_config
+import pytest
+
+from backend.common import user_config as uc
 
 
-def test_load_user_config(tmp_path):
+def _patch_defaults(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        uc,
+        "resolve_paths",
+        lambda repo_root, accounts_root: SimpleNamespace(accounts_root=tmp_path),
+    )
+    monkeypatch.setattr(
+        uc,
+        "config",
+        SimpleNamespace(
+            repo_root=tmp_path,
+            accounts_root=tmp_path,
+            hold_days_min=1,
+            max_trades_per_month=2,
+            approval_exempt_types=["T"],
+            approval_exempt_tickers=["XYZ"],
+        ),
+    )
+
+
+def test_load_user_config(tmp_path, monkeypatch):
+    _patch_defaults(monkeypatch, tmp_path)
     owner_dir = tmp_path / "alice"
     owner_dir.mkdir()
     (owner_dir / "settings.json").write_text(
@@ -15,7 +39,47 @@ def test_load_user_config(tmp_path):
             }
         )
     )
-    cfg = load_user_config("alice", tmp_path)
+    cfg = uc.load_user_config("alice", tmp_path)
     assert cfg.hold_days_min == 5
     assert cfg.max_trades_per_month == 3
     assert cfg.approval_exempt_tickers == ["ABC"]
+
+
+def test_parse_str_list():
+    assert uc._parse_str_list(["a", "", None]) == ["a"]
+    assert uc._parse_str_list("a, b ,") == ["a", "b"]
+    assert uc._parse_str_list(123) is None
+
+
+def test_settings_path_missing(tmp_path, monkeypatch):
+    _patch_defaults(monkeypatch, tmp_path)
+    with pytest.raises(FileNotFoundError):
+        uc._settings_path("missing", tmp_path)
+
+
+def test_load_defaults_on_invalid_json(tmp_path, monkeypatch):
+    _patch_defaults(monkeypatch, tmp_path)
+    owner_dir = tmp_path / "bob"
+    owner_dir.mkdir()
+    (owner_dir / "settings.json").write_text("{bad json")
+    cfg = uc.load_user_config("bob", tmp_path)
+    assert cfg.hold_days_min == 1
+    assert cfg.approval_exempt_types == ["T"]
+    assert cfg.approval_exempt_tickers == ["XYZ"]
+
+
+def test_save_user_config_merges(tmp_path, monkeypatch):
+    _patch_defaults(monkeypatch, tmp_path)
+    owner_dir = tmp_path / "carol"
+    owner_dir.mkdir()
+    path = owner_dir / "settings.json"
+    path.write_text(json.dumps({"unknown": 1, "hold_days_min": 5}))
+    uc.save_user_config(
+        "carol",
+        {"hold_days_min": 10, "max_trades_per_month": 3, "unknown": 9},
+        tmp_path,
+    )
+    data = json.loads(path.read_text())
+    assert data["hold_days_min"] == 10
+    assert data["max_trades_per_month"] == 3
+    assert data["unknown"] == 1


### PR DESCRIPTION
## Summary
- fix alert settings test imports and validate threshold endpoints
- add extensive tests for user config parsing and persistence
- cover scenario, portfolio, screener, and transactions routes including error paths
- test auth token handling and allowed emails logic
- add utilities tests for HTML rendering and page cache refresh logic

## Testing
- `pytest backend/tests/test_alert_settings.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68bbf9e194f483278569da5c8ca6863f