### PR TITLE
Fix search filter typing in InstrumentAdmin

### DIFF
--- a/frontend/src/pages/InstrumentAdmin.tsx
+++ b/frontend/src/pages/InstrumentAdmin.tsx
@@ -31,9 +31,9 @@ export default function InstrumentAdmin() {
   } = useFilterableTable<Row, { search: Filter<Row, string> }>(rows, "ticker", {
     search: {
       value: "",
-      predicate: (row, value) => {
+      predicate: (row, value: unknown) => {
         if (!value) return true;
-        const q = value.toLowerCase();
+        const q = String(value).toLowerCase();
         return [
           row.ticker,
           row.exchange,


### PR DESCRIPTION
## Summary
- Cast search filter predicate parameter to `unknown` and convert via `String` in InstrumentAdmin to satisfy useFilterableTable's filter constraints.

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bbf9eb33e083278854d80177a2d0fe