### PR TITLE
Default percent in allocation chart labels

### DIFF
--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -150,7 +150,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
               cx="50%"
               cy="50%"
               outerRadius="80%"
-              label={({ name, value, percent }) =>
+              label={({ name, value, percent = 0 }) =>
                 `${name}: ${money(value)} (${(percent * 100).toFixed(2)}%)`
               }
             >


### PR DESCRIPTION
## Summary
- Prevent NaN percentages by defaulting `percent` to 0 in allocation chart labels

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bbf9ea44d08327a0a704540bf5f326