### PR TITLE
fix: guard NotificationsDrawer alerts list

### DIFF
--- a/frontend/src/components/NotificationsDrawer.tsx
+++ b/frontend/src/components/NotificationsDrawer.tsx
@@ -13,6 +13,7 @@ export function NotificationsDrawer({ open, onClose }: Props) {
     [],
     open,
   );
+  const alertList = alerts ?? [];
 
   if (!open) return null;
 
@@ -69,10 +70,10 @@ export function NotificationsDrawer({ open, onClose }: Props) {
         </div>
         {loading && <div>Loading...</div>}
         {error && <div>Cannot reach server</div>}
-        {!loading && !error && alerts?.length === 0 && <div>No alerts</div>}
-        {!loading && !error && alerts?.length > 0 && (
+        {!loading && !error && alertList.length === 0 && <div>No alerts</div>}
+        {!loading && !error && alertList.length > 0 && (
           <ul style={{ listStyle: "none", padding: 0 }}>
-            {alerts.map((a, i) => (
+            {alertList.map((a, i) => (
               <li key={i} style={{ marginBottom: "0.5rem" }}>
                 <div>
                   <strong>{a.ticker}</strong>: {a.message}


### PR DESCRIPTION
## Summary
- handle missing alerts by defaulting to empty list and using it for rendering

## Testing
- `npm run build` *(fails: Cannot find name 'AppProps')*

------
https://chatgpt.com/codex/tasks/task_e_68bbfdabd6188327aba8b2bfc7cd547a