### PR TITLE
Guard husky prepare script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "prepare": "husky"
+    "prepare": "[ -d .git ] && husky || true"
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.12",


### PR DESCRIPTION
## Summary
- guard Husky `prepare` script to only run when `.git` directory exists

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `npm --prefix frontend run lint` *(fails: 15 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfdb2406c8327ae1fd92dd34e0bbc