### PR TITLE
Fix percent labeling in allocation chart

### DIFF
--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -120,7 +120,9 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
               cx="50%"
               cy="50%"
               outerRadius="80%"
-              label
+              label={({ name, percent = 0 }) =>
+                `${name}: ${(percent * 100).toFixed(2)}%`
+              }
             >
               {chartData.map((_, index) => (
                 <Cell


### PR DESCRIPTION
## Summary
- Show percentage values in allocation pie chart labels
- Default `percent` to 0 to avoid undefined errors

## Testing
- `npm run build` *(fails: Cannot find name 'AppProps', others)*
- `npm test` *(fails: Missing module '../lightningcss.linux-x64-gnu.node')*
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfdad3db0832787c6cdb645426390