### PR TITLE
refactor: make instrument search filter generic

### DIFF
--- a/frontend/src/pages/InstrumentAdmin.tsx
+++ b/frontend/src/pages/InstrumentAdmin.tsx
@@ -28,10 +28,10 @@ export default function InstrumentAdmin() {
     rows: filteredRows,
     setFilter,
     filters,
-  } = useFilterableTable<Row, { search: Filter<Row, string> }>(rows, "ticker", {
+  } = useFilterableTable<Row, { search: Filter<Row, unknown> }>(rows, "ticker", {
     search: {
-      value: "",
-      predicate: (row, value: unknown) => {
+      value: "" as unknown,
+      predicate: (row, value) => {
         if (!value) return true;
         const q = String(value).toLowerCase();
         return [
@@ -143,7 +143,7 @@ export default function InstrumentAdmin() {
       <input
         type="text"
         placeholder={t("instrumentadmin.searchPlaceholder")}
-        value={filters.search}
+        value={String(filters.search ?? "")}
         onChange={(e) => setFilter("search", e.target.value)}
         style={{ marginBottom: "0.5rem", display: "block" }}
       />


### PR DESCRIPTION
## Summary
- make InstrumentAdmin search filter accept unknown value
- cast search filter value to string when binding input

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bbfe3b8bd88327b7a561ba1d88221d