### PR TITLE
Handle missing percent in AllocationCharts label

### DIFF
--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -150,9 +150,10 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
               cx="50%"
               cy="50%"
               outerRadius="80%"
-              label={({ name, value, percent = 0 }) =>
-                `${name}: ${money(value)} (${(percent * 100).toFixed(2)}%)`
-              }
+              label={({ name, value, percent }) => {
+                const pct = percent ?? 0;
+                return `${name}: ${money(value)} (${(pct * 100).toFixed(2)}%)`;
+              }}
             >
               {chartData.map((_, index) => (
                 <Cell


### PR DESCRIPTION
## Summary
- guard `percent` in allocation pie chart labels

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `npm run lint` *(fails: 21 problems (17 errors, 4 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68bbfe3a4efc832795bbc96f458b173d