### PR TITLE
Translate investment trust instrument type

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -37,7 +37,7 @@
     "cash": "Bargeld",
     "etf": "ETF",
     "fund": "Fonds",
-    "investmentTrust": "Investment Trust",
+    "investmentTrust": "Investmentgesellschaft",
     "realEstate": "Immobilien",
     "other": "Andere"
   },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -37,7 +37,7 @@
     "cash": "Efectivo",
     "etf": "ETF",
     "fund": "Fondo",
-    "investmentTrust": "Investment Trust",
+    "investmentTrust": "Fideicomiso de inversión",
     "realEstate": "Bienes raíces",
     "other": "Otro"
   },


### PR DESCRIPTION
## Summary
- Localize Spanish and German strings for `instrumentType.investmentTrust`
- Review other locale files, which already provided translations

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bc0796aa448327b775a5f0bc67f312