### PR TITLE
Localize logout label in menu

### DIFF
--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
+import i18n from "../i18n";
 import Menu from "./Menu";
 
 describe("Menu", () => {
@@ -15,13 +16,15 @@ describe("Menu", () => {
 
   it("renders logout button when callback provided", () => {
     const onLogout = vi.fn();
+    i18n.changeLanguage("fr");
     render(
       <MemoryRouter>
         <Menu onLogout={onLogout} />
       </MemoryRouter>,
     );
-    const btn = screen.getByRole("button", { name: /logout/i });
+    const btn = screen.getByRole("button", { name: "Déconnexion" });
     fireEvent.click(btn);
     expect(onLogout).toHaveBeenCalled();
+    i18n.changeLanguage("en");
   });
 });

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -129,7 +129,7 @@ export default function Menu({
             cursor: 'pointer',
           }}
         >
-          {t('app.logout', 'Logout')}
+          {t('app.logout')}
         </button>
       )}
     </nav>

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -6,6 +6,7 @@
     "last": "Zuletzt:",
     "loading": "Laden…",
     "supportLink": "Support",
+    "logout": "Abmelden",
     "modes": {
       "group": "Gruppe",
       "instrument": "Instrument",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -6,6 +6,7 @@
     "last": "Last:",
     "loading": "Loading…",
     "supportLink": "Support",
+    "logout": "Logout",
     "modes": {
       "group": "Group",
       "instrument": "Instrument",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -6,6 +6,7 @@
     "last": "Último:",
     "loading": "Cargando…",
     "supportLink": "Soporte",
+    "logout": "Cerrar sesión",
     "modes": {
       "group": "Grupo",
       "instrument": "Instrumento",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -6,6 +6,7 @@
     "last": "Dernier :",
     "loading": "Chargement…",
     "supportLink": "Support",
+    "logout": "Déconnexion",
     "modes": {
       "group": "Groupe",
       "instrument": "Instrument",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -6,6 +6,7 @@
     "last": "Último:",
     "loading": "Carregando…",
     "supportLink": "Suporte",
+    "logout": "Sair",
     "modes": {
       "group": "Grupo",
       "instrument": "Instrumento",


### PR DESCRIPTION
## Summary
- add `app.logout` key to all locale files and provide translations
- render logout button using the translated label and test localization

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bc079431d883278d6096aa32717f9e