### PR TITLE
Add missing locale entries for trading and allocation

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -12,9 +12,11 @@
       "owner": "Mitglied",
       "performance": "Leistung",
       "transactions": "Transaktionen",
+      "trading": "Handel",
       "screener": "Screener & Query",
       "timeseries": "Zeitreihe",
       "watchlist": "Watchlist",
+      "allocation": "Allokation",
       "movers": "Movers",
       "instrumentadmin": "Instrument Admin",
       "dataadmin": "Data Admin",
@@ -171,6 +173,13 @@
   },
   "watchlist": {
     "refresh": "Aktualisieren"
+  },
+  "trading": {
+    "noPositions": "Keine Positionen.",
+    "noSignals": "Keine Signale."
+  },
+  "timeseries": {
+    "loading": "Laden…"
   },
   "query": {
     "start": "Start",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -12,9 +12,11 @@
       "owner": "Miembro",
       "performance": "Rendimiento",
       "transactions": "Transacciones",
+      "trading": "Negociación",
       "screener": "Screener & Query",
       "timeseries": "Serie temporal",
       "watchlist": "Watchlist",
+      "allocation": "Asignación",
       "movers": "Movers",
       "instrumentadmin": "Instrument Admin",
       "dataadmin": "Data Admin",
@@ -171,6 +173,13 @@
   },
   "watchlist": {
     "refresh": "Actualizar"
+  },
+  "trading": {
+    "noPositions": "Sin posiciones.",
+    "noSignals": "Sin señales."
+  },
+  "timeseries": {
+    "loading": "Cargando…"
   },
   "query": {
     "start": "Inicio",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -12,9 +12,11 @@
       "owner": "Membre",
       "performance": "Performance",
       "transactions": "Transactions",
+      "trading": "Négociation",
       "screener": "Screener & Query",
       "timeseries": "Séries temporelles",
       "watchlist": "Watchlist",
+      "allocation": "Allocation",
       "movers": "Movers",
       "instrumentadmin": "Instrument Admin",
       "dataadmin": "Data Admin",
@@ -171,6 +173,13 @@
   },
   "watchlist": {
     "refresh": "Actualiser"
+  },
+  "trading": {
+    "noPositions": "Aucune position.",
+    "noSignals": "Aucun signal."
+  },
+  "timeseries": {
+    "loading": "Chargement…"
   },
   "query": {
     "start": "Début",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -12,9 +12,11 @@
       "owner": "Membro",
       "performance": "Desempenho",
       "transactions": "Transações",
+      "trading": "Negociação",
       "screener": "Screener & Query",
       "timeseries": "Série temporal",
       "watchlist": "Watchlist",
+      "allocation": "Alocação",
       "movers": "Movers",
       "instrumentadmin": "Instrument Admin",
       "dataadmin": "Data Admin",
@@ -171,6 +173,13 @@
   },
   "watchlist": {
     "refresh": "Atualizar"
+  },
+  "trading": {
+    "noPositions": "Sem posições.",
+    "noSignals": "Sem sinais."
+  },
+  "timeseries": {
+    "loading": "Carregando…"
   },
   "query": {
     "start": "Início",


### PR DESCRIPTION
## Summary
- add trading and allocation mode labels in German, French, Spanish, and Portuguese locales
- provide translations for trading and timeseries messages in those locales

## Testing
- `CI=true npm test -- --run` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bc07934d6c8327a0fc13e9421c4eff