### PR TITLE
fix: default pie label percent value

### DIFF
--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -150,6 +150,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
               cx="50%"
               cy="50%"
               outerRadius="80%"
+              // "percent" may be undefined for empty datasets; default it to 0
               label={({ name, value, percent = 0 }) =>
                 `${name}: ${money(value)} (${(percent * 100).toFixed(2)}%)`
               }


### PR DESCRIPTION
## Summary
- document optional percent value handling in allocation chart labels

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bc0923f7d48327998410bd55c52f5b