### PR TITLE
refactor: dedupe alertList in NotificationsDrawer

### DIFF
--- a/frontend/src/components/NotificationsDrawer.tsx
+++ b/frontend/src/components/NotificationsDrawer.tsx
@@ -15,8 +15,6 @@ export function NotificationsDrawer({ open, onClose }: Props) {
   );
   const alertList = alerts ?? [];
 
-  const alertList = alerts ?? [];
-
   if (!open) return null;
 
   return (


### PR DESCRIPTION
## Summary
- dedupe `alertList` assignment in `NotificationsDrawer`

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bc09229e088327bc449339d3bd8971