### PR TITLE
refactor: wrap vite config

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
+import path from 'node:path'
+
+const staticDir = path.resolve(__dirname, 'dist')
+const pageRoutes: string[] = []
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
+export default defineConfig(async ({ command }) => {
+  const plugins = [
     react(),
     VitePWA({
       registerType: 'autoUpdate',
@@ -22,7 +26,7 @@ export default defineConfig({
   ]
 
   if (command === 'build') {
-    const vitePrerender = require('vite-plugin-prerender')
+    const { default: vitePrerender } = await import('vite-plugin-prerender')
     plugins.push(
       vitePrerender({
         staticDir,
@@ -44,7 +48,6 @@ export default defineConfig({
             }
             return 'assets/[name]-[hash][extname]'
           }
-          return 'assets/[name]-[hash][extname]'
         }
       }
     }


### PR DESCRIPTION
## Summary
- wrap Vite config export in a function and declare plugins
- conditionally add prerender plugin during build
- fix assetFileNames return logic

## Testing
- `cd frontend && npm run lint` *(fails: react-refresh/only-export-components and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc09177f48832792261b7a15f1007e