### PR TITLE
Add missing translations for trading and allocation modes

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -13,9 +13,11 @@
       "owner": "Mitglied",
       "performance": "Leistung",
       "transactions": "Transaktionen",
+      "trading": "Handel",
       "screener": "Filter & Abfrage",
       "timeseries": "Zeitreihe",
       "watchlist": "Beobachtungsliste",
+      "allocation": "Allokation",
       "movers": "Movers",
       "instrumentadmin": "Instrumentverwaltung",
       "dataadmin": "Datenverwaltung",
@@ -172,6 +174,13 @@
   },
   "watchlist": {
     "refresh": "Aktualisieren"
+  },
+  "trading": {
+    "noPositions": "Keine Positionen.",
+    "noSignals": "Keine Signale."
+  },
+  "timeseries": {
+    "loading": "Laden…"
   },
   "query": {
     "start": "Start",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -13,9 +13,11 @@
       "owner": "Miembro",
       "performance": "Rendimiento",
       "transactions": "Transacciones",
+      "trading": "Trading",
       "screener": "Filtro y consulta",
       "timeseries": "Serie temporal",
       "watchlist": "Lista de seguimiento",
+      "allocation": "Asignación",
       "movers": "Movers",
       "instrumentadmin": "Administración de Instrumentos",
       "dataadmin": "Administración de datos",
@@ -172,6 +174,13 @@
   },
   "watchlist": {
     "refresh": "Actualizar"
+  },
+  "trading": {
+    "noPositions": "Sin posiciones.",
+    "noSignals": "Sin señales."
+  },
+  "timeseries": {
+    "loading": "Cargando…"
   },
   "query": {
     "start": "Inicio",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -13,9 +13,11 @@
       "owner": "Membre",
       "performance": "Performance",
       "transactions": "Transactions",
+      "trading": "Trading",
       "screener": "Filtre & Requête",
       "timeseries": "Séries temporelles",
       "watchlist": "Liste de suivi",
+      "allocation": "Allocation",
       "movers": "Movers",
       "instrumentadmin": "Administration des instruments",
       "dataadmin": "Administration des données",
@@ -172,6 +174,13 @@
   },
   "watchlist": {
     "refresh": "Actualiser"
+  },
+  "trading": {
+    "noPositions": "Aucune position.",
+    "noSignals": "Aucun signal."
+  },
+  "timeseries": {
+    "loading": "Chargement…"
   },
   "query": {
     "start": "Début",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -13,9 +13,11 @@
       "owner": "Membro",
       "performance": "Desempenho",
       "transactions": "Transações",
+      "trading": "Negociação",
       "screener": "Filtro e consulta",
       "timeseries": "Série temporal",
       "watchlist": "Lista de observação",
+      "allocation": "Alocação",
       "movers": "Movers",
       "instrumentadmin": "Administração de instrumentos",
       "dataadmin": "Administração de dados",
@@ -172,6 +174,13 @@
   },
   "watchlist": {
     "refresh": "Atualizar"
+  },
+  "trading": {
+    "noPositions": "Sem posições.",
+    "noSignals": "Sem sinais."
+  },
+  "timeseries": {
+    "loading": "Carregando…"
   },
   "query": {
     "start": "Início",


### PR DESCRIPTION
## Summary
- localize trading and allocation modes in German, French, Spanish, and Portuguese locale files
- add timeseries loading and trading empty-state strings across those locales

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bc090f6a248327840c607a9dc3ed74