### PR TITLE
Handle offline transaction posting without rebuilding holdings

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -184,8 +184,10 @@ async def create_transaction(tx: TransactionCreate) -> dict:
         _unlock_file(f)
 
     try:
-        portfolio_loader.rebuild_account_holdings(owner, account, Path(config.accounts_root))
-        portfolio_mod.build_owner_portfolio(owner, Path(config.accounts_root))
+        accounts_root = Path(config.accounts_root)
+        if not config.offline_mode:
+            portfolio_loader.rebuild_account_holdings(owner, account, accounts_root)
+        portfolio_mod.build_owner_portfolio(owner, accounts_root)
     except FileNotFoundError as exc:
         log.warning("Portfolio rebuild failed: %s", exc)
 


### PR DESCRIPTION
## Summary
- skip rebuilding account holdings when transactions are posted in offline mode
- still rebuild portfolio cache to reflect the new transaction

## Testing
- `pytest tests/test_backend_api.py::test_post_transaction_persists_and_updates_portfolio -q`
- `PYTEST_ADDOPTS='' pytest tests/test_transaction_post_updates_portfolio.py::test_post_transaction_updates_portfolio -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc08518538832798d36921b80778ca