### PR TITLE
feat: internationalize Screener watchlist label

### DIFF
--- a/frontend/src/components/ScreenerPage.tsx
+++ b/frontend/src/components/ScreenerPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { getScreener } from "../api";
 import type { ScreenerResult } from "../types";
 import { InstrumentDetail } from "./InstrumentDetail";
@@ -10,6 +11,7 @@ import i18n from "../i18n";
 
 
 export function ScreenerPage() {
+  const { t } = useTranslation();
   const [watchlist, setWatchlist] = useState<WatchlistName>("FTSE 100");
   const fetchScreener = useCallback(
     () => getScreener(WATCHLISTS[watchlist]),
@@ -24,13 +26,13 @@ export function ScreenerPage() {
 
   const { sorted, handleSort } = useSortableTable(rows ?? [], "peg_ratio");
 
-  if (loading) return <p>Loading…</p>;
+  if (loading) return <p>{t("common.loading")}</p>;
   if (error) return <p style={{ color: "red" }}>{error.message}</p>;
 
   return (
     <>
       <label style={{ display: "inline-block", marginBottom: "0.5rem" }}>
-        Watchlist:
+        {t("screener.watchlist")}
         <select
           value={watchlist}
           onChange={(e) => setWatchlist(e.target.value as WatchlistName)}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -195,6 +195,7 @@
     "exportXlsx": "XLSX exportieren"
   },
   "screener": {
+    "watchlist": "Beobachtungsliste:",
     "tickers": "Ticker",
     "maxPeg": "Max PEG",
     "maxPe": "Max P/E",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -198,6 +198,7 @@
     "exportXlsx": "Export XLSX"
   },
   "screener": {
+    "watchlist": "Watchlist:",
     "tickers": "Tickers",
     "maxPeg": "Max PEG",
     "maxPe": "Max P/E",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -195,6 +195,7 @@
     "exportXlsx": "Exportar XLSX"
   },
   "screener": {
+    "watchlist": "Lista de seguimiento:",
     "tickers": "Tickers",
     "maxPeg": "PEG máx",
     "maxPe": "P/E máx",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -195,6 +195,7 @@
     "exportXlsx": "Exporter XLSX"
   },
   "screener": {
+    "watchlist": "Liste de suivi:",
     "tickers": "Tickers",
     "maxPeg": "PEG max",
     "maxPe": "P/E max",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -195,6 +195,7 @@
     "exportXlsx": "Exportar XLSX"
   },
   "screener": {
+    "watchlist": "Lista de observação:",
     "tickers": "Tickers",
     "maxPeg": "PEG máx",
     "maxPe": "P/E máx",


### PR DESCRIPTION
## Summary
- use `useTranslation` in `ScreenerPage` and replace hardcoded text
- add `screener.watchlist` translation for all locales

## Testing
- `node frontend/node_modules/vitest/vitest.mjs --run` *(fails: React is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bc249c2d9883279b05d33eca21ca9a