### PR TITLE
feat: wrap menu items

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -99,7 +99,7 @@ export default function Menu({
   }
 
   return (
-    <nav style={{ margin: '1rem 0', ...(style ?? {}) }}>
+    <nav style={{ display: 'flex', flexWrap: 'wrap', margin: '1rem 0', ...(style ?? {}) }}>
       {orderedTabPlugins
         .slice()
         .sort((a, b) => a.priority - b.priority)
@@ -111,6 +111,7 @@ export default function Menu({
             style={{
               marginRight: '1rem',
               fontWeight: mode === p.id ? 'bold' : undefined,
+              overflowWrap: 'anywhere',
             }}
           >
             {t(`app.modes.${p.id}`)}


### PR DESCRIPTION
## Summary
- allow Menu nav to wrap and break long words to prevent overflow

## Testing
- `npm test` *(fails: Failed to load PostCSS config: Error: Failed to load native binding)*
- `npm run build:web` *(fails: vite.config.ts error TS2769 and missing vite-plugin-prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68bc247dffb08327b79b9c5d201102fe