### PR TITLE
Localize ValueAtRisk component

### DIFF
--- a/frontend/src/components/ValueAtRisk.tsx
+++ b/frontend/src/components/ValueAtRisk.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   getValueAtRisk,
   recomputeValueAtRisk,
@@ -12,6 +13,7 @@ interface Props {
 }
 
 export function ValueAtRisk({ owner }: Props) {
+  const { t } = useTranslation();
   const [days, setDays] = useState<number>(30);
   const [var95, setVar95] = useState<number | null>(null);
   const [var99, setVar99] = useState<number | null>(null);
@@ -55,15 +57,15 @@ export function ValueAtRisk({ owner }: Props) {
 
   return (
     <div style={{ marginBottom: "2rem" }}>
-      <h2>Value at Risk</h2>
+      <h2>{t('var.title')}</h2>
       <p style={{ fontSize: "0.85rem", marginTop: "-0.5rem" }}>
         <a href="/docs/value_at_risk.md" target="_blank" rel="noopener noreferrer">
-          Historical simulation details
+          {t('var.details')}
         </a>
       </p>
       <div style={{ marginBottom: "0.5rem" }}>
         <label style={{ fontSize: "0.85rem" }}>
-          Period:
+          {t('common.period')}
           <select
             value={days}
             onChange={(e) => setDays(Number(e.target.value))}
@@ -76,11 +78,11 @@ export function ValueAtRisk({ owner }: Props) {
           </select>
         </label>
       </div>
-      {loading && <div>Loading…</div>}
+      {loading && <div>{t('common.loading')}</div>}
       {err && <div style={{ color: "red" }}>{err}</div>}
       {!loading && !err && var95 == null && var99 == null && (
         <div style={{ fontStyle: "italic", color: "#666" }}>
-          No VaR data available.
+          {t('var.noData')}
         </div>
       )}
       {!loading && !err && !(var95 == null && var99 == null) && (

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -32,7 +32,8 @@
   "common": {
     "error": "Fehler",
     "loading": "Laden…",
-    "other": "Andere"
+    "other": "Andere",
+    "period": "Zeitraum:"
   },
   "instrumentType": {
     "equity": "Aktie",
@@ -241,5 +242,10 @@
     "ticker": "Ticker is required",
     "name": "Name is required"
   }
-}
+  },
+  "var": {
+    "title": "Value at Risk",
+    "details": "Details der historischen Simulation",
+    "noData": "Keine VaR-Daten verfügbar."
+  }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -32,7 +32,8 @@
   "common": {
     "error": "Error",
     "loading": "Loading…",
-    "other": "Other"
+    "other": "Other",
+    "period": "Period:"
   },
   "instrumentType": {
     "equity": "Equity",
@@ -244,5 +245,10 @@
     "ticker": "Ticker is required",
     "name": "Name is required"
   }
-}
+  },
+  "var": {
+    "title": "Value at Risk",
+    "details": "Historical simulation details",
+    "noData": "No VaR data available."
+  }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -32,7 +32,8 @@
   "common": {
     "error": "Error",
     "loading": "Cargando…",
-    "other": "Otro"
+    "other": "Otro",
+    "period": "Período:"
   },
   "instrumentType": {
     "equity": "Acción",
@@ -241,5 +242,10 @@
     "ticker": "Ticker is required",
     "name": "Name is required"
   }
-}
+  },
+  "var": {
+    "title": "Valor en Riesgo",
+    "details": "Detalles de la simulación histórica",
+    "noData": "No hay datos de VaR disponibles."
+  }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -32,7 +32,8 @@
   "common": {
     "error": "Erreur",
     "loading": "Chargement…",
-    "other": "Autre"
+    "other": "Autre",
+    "period": "Période :"
   },
   "instrumentType": {
     "equity": "Action",
@@ -241,5 +242,10 @@
     "ticker": "Ticker is required",
     "name": "Name is required"
   }
-}
+  },
+  "var": {
+    "title": "Valeur à Risque",
+    "details": "Détails de la simulation historique",
+    "noData": "Pas de données VaR disponibles."
+  }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -32,7 +32,8 @@
   "common": {
     "error": "Erro",
     "loading": "Carregando…",
-    "other": "Outro"
+    "other": "Outro",
+    "period": "Período:"
   },
   "instrumentType": {
     "equity": "Ação",
@@ -251,5 +252,10 @@
     "ticker": "Ticker is required",
     "name": "Name is required"
   }
-}
+  },
+  "var": {
+    "title": "Valor em Risco",
+    "details": "Detalhes da simulação histórica",
+    "noData": "Sem dados de VaR disponíveis."
+  }
 }


### PR DESCRIPTION
## Summary
- internationalize ValueAtRisk component
- add Value at Risk strings to all locales

## Testing
- `CI=true npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2494af1c83278923fdcdc80df429