### PR TITLE
feat: translate performance dashboard

### DIFF
--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
   getPerformance,
@@ -8,7 +9,6 @@ import {
 } from "../api";
 import type { PerformancePoint } from "../types";
 import { percent } from "../lib/money";
-import i18n from "../i18n";
 
 type Props = {
   owner: string | null;
@@ -22,6 +22,7 @@ export function PerformanceDashboard({ owner }: Props) {
   const [trackingError, setTrackingError] = useState<number | null>(null);
   const [maxDrawdown, setMaxDrawdown] = useState<number | null>(null);
   const [excludeCash, setExcludeCash] = useState<boolean>(false);
+  const { t, i18n } = useTranslation();
 
   useEffect(() => {
     if (!owner) return;
@@ -43,29 +44,29 @@ export function PerformanceDashboard({ owner }: Props) {
       .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
   }, [owner, days, excludeCash]);
 
-  if (!owner) return <p>Select a member.</p>;
+  if (!owner) return <p>{t("dashboard.selectMember")}</p>;
   if (err) return <p style={{ color: "red" }}>{err}</p>;
-  if (!data.length) return <p>Loading…</p>;
+  if (!data.length) return <p>{t("common.loading")}</p>;
 
   return (
     <div style={{ marginTop: "1rem" }}>
       <div style={{ marginBottom: "0.5rem" }}>
         <label style={{ fontSize: "0.85rem" }}>
-          Range:
+          {t("dashboard.range")}
           <select
             value={days}
             onChange={(e) => setDays(Number(e.target.value))}
             style={{ marginLeft: "0.25rem" }}
           >
-            <option value={7}>1W</option>
-            <option value={30}>1M</option>
-            <option value={365}>1Y</option>
-            <option value={3650}>10Y</option>
-            <option value={0}>MAX</option>
+            <option value={7}>{t("dashboard.rangeOptions.1w")}</option>
+            <option value={30}>{t("dashboard.rangeOptions.1m")}</option>
+            <option value={365}>{t("dashboard.rangeOptions.1y")}</option>
+            <option value={3650}>{t("dashboard.rangeOptions.10y")}</option>
+            <option value={0}>{t("dashboard.rangeOptions.max")}</option>
           </select>
         </label>
         <label style={{ fontSize: "0.85rem", marginLeft: "1rem" }}>
-          Exclude cash
+          {t("dashboard.excludeCash")}
           <input
             type="checkbox"
             checked={excludeCash}
@@ -82,25 +83,25 @@ export function PerformanceDashboard({ owner }: Props) {
         }}
       >
         <div>
-          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Alpha vs Benchmark</div>
+          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>{t("dashboard.alphaVsBenchmark")}</div>
           <div style={{ fontSize: "1.1rem", fontWeight: "bold" }}>
             {percent(alpha != null ? alpha * 100 : null)}
           </div>
         </div>
         <div>
-          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Tracking Error</div>
+          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>{t("dashboard.trackingError")}</div>
           <div style={{ fontSize: "1.1rem", fontWeight: "bold" }}>
             {percent(trackingError != null ? trackingError * 100 : null)}
           </div>
         </div>
         <div>
-          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Max Drawdown</div>
+          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>{t("dashboard.maxDrawdown")}</div>
           <div style={{ fontSize: "1.1rem", fontWeight: "bold" }}>
             {percent(maxDrawdown != null ? maxDrawdown * 100 : null)}
           </div>
         </div>
       </div>
-      <h2>Portfolio Value</h2>
+      <h2>{t("dashboard.portfolioValue")}</h2>
       <ResponsiveContainer width="100%" height={240}>
         <LineChart data={data}>
           <XAxis dataKey="date" />
@@ -110,7 +111,7 @@ export function PerformanceDashboard({ owner }: Props) {
         </LineChart>
       </ResponsiveContainer>
 
-      <h2 style={{ marginTop: "2rem" }}>Cumulative Return</h2>
+      <h2 style={{ marginTop: "2rem" }}>{t("dashboard.cumulativeReturn")}</h2>
       <ResponsiveContainer width="100%" height={240}>
         <LineChart data={data}>
           <XAxis dataKey="date" />

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -146,6 +146,23 @@
   "group": {
     "select": "Wählen Sie eine Gruppe."
   },
+  "dashboard": {
+    "selectMember": "Wählen Sie ein Mitglied.",
+    "range": "Zeitraum:",
+    "rangeOptions": {
+      "1w": "1W",
+      "1m": "1M",
+      "1y": "1J",
+      "10y": "10J",
+      "max": "MAX"
+    },
+    "excludeCash": "Bargeld ausschließen",
+    "alphaVsBenchmark": "Alpha vs Benchmark",
+    "trackingError": "Tracking Error",
+    "maxDrawdown": "Max Drawdown",
+    "portfolioValue": "Portfoliowert",
+    "cumulativeReturn": "Kumulierte Rendite"
+  },
   "support": {
     "title": "Support",
     "online": "Online",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -146,6 +146,23 @@
   "group": {
     "select": "Select a group."
   },
+  "dashboard": {
+    "selectMember": "Select a member.",
+    "range": "Range:",
+    "rangeOptions": {
+      "1w": "1W",
+      "1m": "1M",
+      "1y": "1Y",
+      "10y": "10Y",
+      "max": "MAX"
+    },
+    "excludeCash": "Exclude cash",
+    "alphaVsBenchmark": "Alpha vs Benchmark",
+    "trackingError": "Tracking Error",
+    "maxDrawdown": "Max Drawdown",
+    "portfolioValue": "Portfolio Value",
+    "cumulativeReturn": "Cumulative Return"
+  },
   "support": {
     "title": "Support",
     "online": "Online",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -146,6 +146,23 @@
   "group": {
     "select": "Seleccione un grupo."
   },
+  "dashboard": {
+    "selectMember": "Seleccione un miembro.",
+    "range": "Rango:",
+    "rangeOptions": {
+      "1w": "1S",
+      "1m": "1M",
+      "1y": "1A",
+      "10y": "10A",
+      "max": "MÁX"
+    },
+    "excludeCash": "Excluir efectivo",
+    "alphaVsBenchmark": "Alfa vs Referencia",
+    "trackingError": "Error de seguimiento",
+    "maxDrawdown": "Máxima caída",
+    "portfolioValue": "Valor de la cartera",
+    "cumulativeReturn": "Retorno acumulado"
+  },
   "support": {
     "title": "Soporte",
     "online": "En línea",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -146,6 +146,23 @@
   "group": {
     "select": "Sélectionnez un groupe."
   },
+  "dashboard": {
+    "selectMember": "Sélectionnez un membre.",
+    "range": "Plage :",
+    "rangeOptions": {
+      "1w": "1S",
+      "1m": "1M",
+      "1y": "1A",
+      "10y": "10A",
+      "max": "MAX"
+    },
+    "excludeCash": "Exclure la trésorerie",
+    "alphaVsBenchmark": "Alpha vs Indice",
+    "trackingError": "Erreur de suivi",
+    "maxDrawdown": "Drawdown maximal",
+    "portfolioValue": "Valeur du portefeuille",
+    "cumulativeReturn": "Rendement cumulatif"
+  },
   "support": {
     "title": "Support",
     "online": "En ligne",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -146,6 +146,23 @@
   "group": {
     "select": "Selecione um grupo."
   },
+  "dashboard": {
+    "selectMember": "Selecione um membro.",
+    "range": "Intervalo:",
+    "rangeOptions": {
+      "1w": "1S",
+      "1m": "1M",
+      "1y": "1A",
+      "10y": "10A",
+      "max": "MÁX"
+    },
+    "excludeCash": "Excluir caixa",
+    "alphaVsBenchmark": "Alfa vs Referência",
+    "trackingError": "Erro de acompanhamento",
+    "maxDrawdown": "Máxima queda",
+    "portfolioValue": "Valor da carteira",
+    "cumulativeReturn": "Retorno acumulado"
+  },
   "support": {
     "title": "Suporte",
     "online": "Online",


### PR DESCRIPTION
## Summary
- use useTranslation hook in PerformanceDashboard and replace literals with translation keys
- add dashboard translation strings across locales

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `npm run lint` *(fails: 17 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2499ecd08327bb618d9f5bb1d364