### PR TITLE
feat: localize instrument admin actions

### DIFF
--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -238,18 +238,18 @@
   "instrumentadmin": {
     "ticker": "Ticker",
     "exchange": "Exchange",
-    "name": "Name",
-    "region": "Region",
-    "sector": "Sector",
-    "actions": "Actions",
-    "add": "Add Instrument",
-  "save": "Save",
-  "saveSuccess": "Saved",
-  "saveError": "Error saving",
-  "searchPlaceholder": "Filter instruments…",
+    "name": "Nome",
+    "region": "Região",
+    "sector": "Setor",
+    "actions": "Ações",
+    "add": "Adicionar instrumento",
+  "save": "Salvar",
+  "saveSuccess": "Salvo",
+  "saveError": "Erro ao salvar",
+  "searchPlaceholder": "Filtrar instrumentos…",
   "validation": {
-    "ticker": "Ticker is required",
-    "name": "Name is required"
+    "ticker": "Ticker é obrigatório",
+    "name": "Nome é obrigatório"
   }
 }
 }


### PR DESCRIPTION
## Summary
- translate instrument admin labels and validation to Portuguese

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bc22e0e0c48327a40e056b031277b8