### PR TITLE
fix: merge duplicate query translations

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -183,9 +183,7 @@
     "loading": "Loading…"
   },
   "query": {
-    "noResults": "No results."
-  },
-  "query": {
+    "noResults": "No results.",
     "start": "Start",
     "end": "End",
     "owners": "Owners",


### PR DESCRIPTION
## Summary
- merge duplicate `query` translations into single object so "No results" appears

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*
- `npm run build:web` *(fails: Cannot find module 'vite-plugin-prerender')*

------
https://chatgpt.com/codex/tasks/task_e_68bc233882988327b59ea0830f24d4ec