### PR TITLE
chore: configure frontend env for build

### DIFF
--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -4,5 +4,17 @@ set -euo pipefail
 # Ensure the script runs from the frontend directory
 cd "$(dirname "$0")"
 
+# Ensure environment variables are populated
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
+# Override .env values with any provided environment variables
+for var in VITE_ALLOTMINT_API_BASE VITE_APP_BASE_URL VITE_API_TOKEN; do
+  if [ -n "${!var:-}" ]; then
+    sed -i "s|^${var}=.*|${var}=${!var}|" .env
+  fi
+done
+
 npm install
 npm run build

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "test": "cd frontend && npm test --",
-    "build:web": "cd frontend && npm run build",
+    "build:web": "cd frontend && ./build.sh",
     "mobile:add": "npx cap add android --config mobile/capacitor.config.ts && npx cap add ios --config mobile/capacitor.config.ts",
     "mobile:sync": "npm run build:web && npx cap sync --config mobile/capacitor.config.ts",
     "mobile:android": "npm run mobile:sync && npx cap open android --config mobile/capacitor.config.ts",


### PR DESCRIPTION
## Summary
- ensure frontend build copies .env.example and uses provided env vars
- wire root build:web script to use frontend build helper

## Testing
- `npm test -- --run` *(fails: TypeError and missing exports)*
- `VITE_APP_BASE_URL=http://example.com npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68bc2b938e008327865a092165516ad1