### PR TITLE
Install optional lightningcss binaries for frontend

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm ci
+        run: npm ci --include=optional
 
       - name: Run tests
         working-directory: frontend

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "^4.1.12",
         "@tailwindcss/postcss": "^4.1.12",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
@@ -39,6 +40,7 @@
         "globals": "^16.3.0",
         "husky": "^9.1.7",
         "jsdom": "^26.1.0",
+        "lightningcss-linux-x64-gnu": "^1.30.1",
         "lint-staged": "^16.1.5",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
@@ -3552,6 +3554,22 @@
         "@tailwindcss/oxide-wasm32-wasi": "4.1.12",
         "@tailwindcss/oxide-win32-arm64-msvc": "4.1.12",
         "@tailwindcss/oxide-win32-x64-msvc": "4.1.12"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.12.tgz",
+      "integrity": "sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
@@ -9021,6 +9039,26 @@
         "lightningcss-linux-x64-musl": "1.30.1",
         "lightningcss-win32-arm64-msvc": "1.30.1",
         "lightningcss-win32-x64-msvc": "1.30.1"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "cpu": [
+        "x64"
+      ],
+      "devOptional": true,
+      "license": "MPL-2.0",
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@tailwindcss/oxide-linux-x64-gnu": "^4.1.12",
     "@tailwindcss/postcss": "^4.1.12",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
@@ -43,6 +44,7 @@
     "globals": "^16.3.0",
     "husky": "^9.1.7",
     "jsdom": "^26.1.0",
+    "lightningcss-linux-x64-gnu": "^1.30.1",
     "lint-staged": "^16.1.5",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
@@ -51,8 +53,8 @@
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4",
     "vite-imagetools": "^8.0.0",
-    "vite-plugin-pwa": "^1.0.2",
     "vite-plugin-prerender": "^1.0.8",
+    "vite-plugin-pwa": "^1.0.2",
     "vitest": "^3.2.4"
   },
   "lint-staged": {


### PR DESCRIPTION
## Summary
- install optional lightningcss and tailwind oxide binaries for Linux
- ensure frontend CI installs optional dependencies

## Testing
- `npm ci --include=optional`
- `npm run build` *(fails: Unable to start Puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68bc592af3548327acf96bacc3ab90d9