### PR TITLE
Add AWS CDK deployment script and documentation

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -35,6 +35,19 @@ cd ..
 
 ## Deploy with AWS CDK
 
+Run the helper script from the repository root to bootstrap the environment
+and deploy both stacks:
+
+```powershell
+./deploy-to-AWS.ps1
+```
+
+The script changes into the `cdk/` directory, runs `cdk bootstrap` if
+necessary, then deploys `BackendLambdaStack` and `StaticSiteStack` with
+`deploy_backend` enabled.
+
+Alternatively, run the commands manually:
+
 ```bash
 cd cdk
 cdk bootstrap   # once per account/region

--- a/deploy-to-AWS.ps1
+++ b/deploy-to-AWS.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+
+# Navigate to repository root
+$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $SCRIPT_DIR
+
+try {
+  # Move into CDK directory
+  Set-Location (Join-Path $SCRIPT_DIR 'cdk')
+
+  # Ensure CDK CLI is available
+  if (-not (Get-Command 'cdk' -ErrorAction SilentlyContinue)) {
+    Write-Error 'AWS CDK CLI not found. Install it and try again.'
+    exit 1
+  }
+
+  # Bootstrap environment (safe to run multiple times)
+  cdk bootstrap
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  # Deploy backend and frontend stacks
+  cdk deploy BackendLambdaStack StaticSiteStack -c deploy_backend=true
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+catch {
+  Write-Error $_
+  exit 1
+}
+finally {
+  # Return to repository root
+  Set-Location $SCRIPT_DIR
+}


### PR DESCRIPTION
## Summary
- add `deploy-to-AWS.ps1` helper to bootstrap and deploy BackendLambdaStack and StaticSiteStack
- document script usage in DEPLOY.md

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc5ad6b1dc83279ec89743b43930dc