### PR TITLE
docs: add data bucket deployment options

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -39,8 +39,11 @@ cd ..
 cd cdk
 cdk bootstrap   # once per account/region
 DEPLOY_BACKEND=false cdk deploy StaticSiteStack
-# or deploy backend and frontend together
-DEPLOY_BACKEND=true cdk deploy BackendLambdaStack StaticSiteStack
+# or deploy backend and frontend together. Supply the name of your
+# data bucket either via environment variable:
+DATA_BUCKET=my-data-bucket DEPLOY_BACKEND=true cdk deploy BackendLambdaStack StaticSiteStack
+# or as a CDK context parameter:
+DEPLOY_BACKEND=true cdk deploy BackendLambdaStack StaticSiteStack -c data_bucket=my-data-bucket
 ```
 
 ## CloudFront cache invalidation


### PR DESCRIPTION
## Summary
- document ways to provide DATA_BUCKET when deploying with AWS CDK

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc5a37adc883278e61b4cbca29a11c