### PR TITLE
feat: allow specifying data bucket in deploy script

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -36,15 +36,21 @@ cd ..
 ## Deploy with AWS CDK
 
 Run the helper script from the repository root to bootstrap the environment
-and deploy both stacks:
+and deploy both stacks. Provide the S3 bucket that stores account data via
+the `-DataBucket` parameter or the `DATA_BUCKET` environment variable:
 
 ```powershell
+# Pass bucket name explicitly
+./deploy-to-AWS.ps1 -DataBucket my-data-bucket
+
+# Or rely on the environment variable
+$env:DATA_BUCKET = "my-data-bucket"
 ./deploy-to-AWS.ps1
 ```
 
 The script changes into the `cdk/` directory, runs `cdk bootstrap` if
 necessary, then deploys `BackendLambdaStack` and `StaticSiteStack` with
-`deploy_backend` enabled.
+`deploy_backend` enabled and the supplied data bucket.
 
 Alternatively, run the commands manually:
 

--- a/deploy-to-AWS.ps1
+++ b/deploy-to-AWS.ps1
@@ -1,3 +1,7 @@
+param(
+    [Parameter(Mandatory=$false)][string]$DataBucket
+)
+
 $ErrorActionPreference = 'Stop'
 
 # Navigate to repository root
@@ -14,12 +18,21 @@ try {
     exit 1
   }
 
+  # Determine data bucket
+  if (-not $DataBucket) {
+    $DataBucket = $env:DATA_BUCKET
+  }
+  if (-not $DataBucket) {
+    Write-Error 'DATA_BUCKET must be provided via -DataBucket parameter or DATA_BUCKET environment variable.'
+    exit 1
+  }
+
   # Bootstrap environment (safe to run multiple times)
   cdk bootstrap
   if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   # Deploy backend and frontend stacks
-  cdk deploy BackendLambdaStack StaticSiteStack -c deploy_backend=true
+  cdk deploy BackendLambdaStack StaticSiteStack -c deploy_backend=true -c data_bucket=$DataBucket
   if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 }
 catch {
@@ -30,3 +43,4 @@ finally {
   # Return to repository root
   Set-Location $SCRIPT_DIR
 }
+


### PR DESCRIPTION
## Summary
- allow specifying data bucket via parameter or env var in AWS deploy script
- document how to supply data bucket when using deploy script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc594b78c48327bfa72337ab5fb35f