### PR TITLE
feat: persist top movers preferences

### DIFF
--- a/frontend/docs/architecture.md
+++ b/frontend/docs/architecture.md
@@ -1,0 +1,11 @@
+# Architecture
+
+## Persistence
+
+State that needs to survive page reloads can be stored either in the URL or in
+`localStorage`.
+
+Use URL query parameters when the state should be shareable or bookmarkable and
+forms part of navigation. Prefer `localStorage` for purely client-side
+preferences or state that would clutter the URL. Access `localStorage` via the
+helpers in `src/utils/storage.ts`, which automatically handle JSON encoding.

--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -16,6 +16,7 @@ import { SignalBadge } from "./SignalBadge";
 import { useFetch } from "../hooks/useFetch";
 import { useSortableTable } from "../hooks/useSortableTable";
 import tableStyles from "../styles/table.module.css";
+import { loadJSON, saveJSON } from "../utils/storage";
 
 const PERIODS = { "1d": 1, "1w": 7, "1m": 30, "3m": 90, "1y": 365 } as const;
 type PeriodKey = keyof typeof PERIODS;
@@ -26,8 +27,12 @@ const WATCHLIST_OPTIONS: WatchlistOption[] = [
 ];
 
 export function TopMoversPage() {
-  const [watchlist, setWatchlist] = useState<WatchlistOption>("Portfolio");
-  const [period, setPeriod] = useState<PeriodKey>("1d");
+  const [watchlist, setWatchlist] = useState<WatchlistOption>(() =>
+    loadJSON<WatchlistOption>("topMovers.watchlist", "Portfolio"),
+  );
+  const [period, setPeriod] = useState<PeriodKey>(() =>
+    loadJSON<PeriodKey>("topMovers.period", "1d"),
+  );
   const [selected, setSelected] = useState<
     { row: MoverRow; signal?: TradingSignal } | null
   >(null);
@@ -38,10 +43,22 @@ export function TopMoversPage() {
   const [signalsError, setSignalsError] = useState<string | null>(null);
   const [needsLogin, setNeedsLogin] = useState(false);
   const [portfolioTotal, setPortfolioTotal] = useState<number | null>(null);
-  const [excludeSmall, setExcludeSmall] = useState(false);
+  const [excludeSmall, setExcludeSmall] = useState(() =>
+    loadJSON<boolean>("topMovers.excludeSmall", false),
+  );
   const [fallbackError, setFallbackError] = useState<string | null>(null);
 
   const MIN_WEIGHT = 0.5;
+
+  useEffect(() => {
+    saveJSON("topMovers.watchlist", watchlist);
+  }, [watchlist]);
+  useEffect(() => {
+    saveJSON("topMovers.period", period);
+  }, [period]);
+  useEffect(() => {
+    saveJSON("topMovers.excludeSmall", excludeSmall);
+  }, [excludeSmall]);
 
   const fetchMovers = useCallback(async () => {
     if (watchlist === "Portfolio") {

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,0 +1,16 @@
+export function loadJSON<T>(key: string, fallback: T): T {
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveJSON<T>(key: string, value: T): void {
+  window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+export function remove(key: string): void {
+  window.localStorage.removeItem(key);
+}


### PR DESCRIPTION
## Summary
- add storage helpers for JSON localStorage
- document persistence strategy for URL vs localStorage
- persist TopMoversPage settings across sessions

## Testing
- `npm test` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bc62bd39248327801db9673ca6250f