### PR TITLE
docs: add release notes and screener builder docs

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,16 @@
+# Release Notes
+
+## Milestone 1 – Foundations
+- Portfolio viewer for individual owners and groups
+- Watchlists and basic analytics tools
+- Configurable backend connection and authentication
+
+## Milestone 2 – Analysis Tools
+- Performance, allocation and transaction reports
+- Custom screener and time‑series pages
+- Tab plugin system for modular navigation
+
+## Milestone 3 – Research & Discovery
+- `/discover` route surfaces curated market ideas
+- `/research/:ticker` provides instrument research with screener metrics
+- ScreenerBuilder allows saving and running custom screeners

--- a/docs/screener-builder.md
+++ b/docs/screener-builder.md
@@ -1,0 +1,22 @@
+# Screener Builder
+
+The Screener Builder provides a fluent interface for composing custom equity screeners.
+It outputs a `CustomQuery` object that can be sent to the backend with
+`runCustomQuery` or saved via `saveCustomQuery`.
+
+```ts
+import { ScreenerBuilder, runCustomQuery, saveCustomQuery } from "../frontend";
+
+const query = new ScreenerBuilder()
+  .between("2024-01-01", "2024-06-30")
+  .owners(["alice", "bob"])
+  .tickers(["AAA", "BBB"])
+  .metrics(["market_value_gbp", "gain_gbp"])
+  .build();
+
+const rows = await runCustomQuery(query);
+await saveCustomQuery("H1 performance", query);
+```
+
+Each builder method returns the instance, allowing calls to be chained.
+Calling `build()` returns the `CustomQuery` structure consumed by the API.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,6 +19,15 @@ The app opts into upcoming React Router v7 behavior by enabling the
 `v7_startTransition` and `v7_relativeSplatPath` flags. This allows testing
 future navigation features ahead of the final release.
 
+### Routes
+
+- `/` – portfolio overview
+- `/discover` – browse curated opportunities
+- `/research/:ticker` – research page for a specific ticker
+- `/screener` – build and run custom screeners
+- `/watchlist` – manage personal watchlists
+- `/transactions` – view transaction history
+
 ## Installation
 
 1. Install dependencies with `npm install`.


### PR DESCRIPTION
## Summary
- add user-facing release notes
- document ScreenerBuilder usage
- mention new discovery and research routes in frontend docs

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`
- `npm test` *(fails: 6 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc62cbf820832789e63eb75ad7608d