### PR TITLE
feat: validate query params and encode share links

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,8 @@
         "react-toastify": "^10.0.0",
         "recharts": "^3.1.2",
         "sharp": "^0.34.3",
-        "vite-plugin-ssr": "^0.4.142"
+        "vite-plugin-ssr": "^0.4.142",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -14219,6 +14220,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "react-toastify": "^10.0.0",
     "recharts": "^3.1.2",
     "sharp": "^0.34.3",
-    "vite-plugin-ssr": "^0.4.142"
+    "vite-plugin-ssr": "^0.4.142",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -250,6 +250,7 @@
     "run": "Run",
     "running": "Running…",
     "save": "Save",
+    "copyLink": "Copy Link",
     "exportCsv": "Export CSV",
     "exportXlsx": "Export XLSX"
   },

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -249,6 +249,7 @@
     "run": "Exécuter",
     "running": "Exécution…",
     "save": "Enregistrer",
+    "copyLink": "Copier le lien",
     "exportCsv": "Exporter CSV",
     "exportXlsx": "Exporter XLSX"
   },

--- a/frontend/src/pages/ScreenerQuery.test.tsx
+++ b/frontend/src/pages/ScreenerQuery.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { I18nextProvider, initReactI18next } from "react-i18next";
 import { createInstance } from "i18next";
 import type { ReactElement } from "react";
@@ -72,6 +72,10 @@ function renderWithI18n(ui: ReactElement) {
 }
 
 describe("Screener & Query page", () => {
+  afterEach(() => {
+    window.history.pushState({}, "", "/");
+    vi.clearAllMocks();
+  });
   it("runs screener and displays results", async () => {
     renderWithI18n(<ScreenerQuery />);
 
@@ -151,6 +155,50 @@ describe("Screener & Query page", () => {
     const btn = await screen.findByText("Saved1");
     fireEvent.click(btn);
     expect(screen.getByLabelText(i18n.t("query.start"))).toHaveValue("2024-01-01");
+  });
+
+  it("initializes form from query string", async () => {
+    window.history.pushState(
+      {},
+      "",
+      "/?start=2024-01-01&owners=Alice&tickers=AAA&metrics=market_value_gbp",
+    );
+    const { i18n } = renderWithI18n(<ScreenerQuery />);
+    await screen.findByLabelText("Alice");
+    expect(screen.getByLabelText(i18n.t("query.start"))).toHaveValue(
+      "2024-01-01",
+    );
+    expect(screen.getByLabelText("Alice")).toBeChecked();
+    expect(screen.getByLabelText("AAA")).toBeChecked();
+    expect(screen.getByLabelText("market_value_gbp")).toBeChecked();
+  });
+
+  it("sanitizes malicious query parameters", async () => {
+    window.history.pushState(
+      {},
+      "",
+      "/?owners=<script>alert(1)</script>&start=not-a-date",
+    );
+    const { i18n } = renderWithI18n(<ScreenerQuery />);
+    await screen.findByLabelText(i18n.t("query.start"));
+    expect(screen.getByLabelText(i18n.t("query.start"))).toHaveValue("");
+    expect(screen.getByLabelText("Alice")).not.toBeChecked();
+    expect(screen.getByLabelText("Bob")).not.toBeChecked();
+  });
+
+  it("copies an encoded link to the clipboard", async () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    const { i18n } = renderWithI18n(<ScreenerQuery />);
+    await screen.findByLabelText("Alice");
+    fireEvent.click(screen.getByLabelText("Alice"));
+    fireEvent.click(screen.getByLabelText("AAA"));
+    fireEvent.click(screen.getByLabelText("market_value_gbp"));
+    fireEvent.click(
+      screen.getByRole("button", { name: i18n.t("query.copyLink") }),
+    );
+    expect(writeText).toHaveBeenCalled();
+    expect(writeText.mock.calls[0][0]).toContain("owners=Alice");
   });
 
   it("switches labels when language changes", async () => {


### PR DESCRIPTION
## Summary
- parse ScreenerQuery URL parameters with a zod schema
- add copy link button with encoded query params
- test malformed query strings and share links

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined)*
- `npm test -- src/pages/ScreenerQuery.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc62c927388327af6bf0ba5925322d