### PR TITLE
Refactor portfolio view styles

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -25,6 +25,7 @@ import tableStyles from "../styles/table.module.css";
 import { useTranslation } from "react-i18next";
 import { useConfig } from "../ConfigContext";
 import { RelativeViewToggle } from "./RelativeViewToggle";
+import metricStyles from "../styles/metrics.module.css";
 import {
   PieChart,
   Pie,
@@ -133,7 +134,8 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
 
   /* ── early‑return states ───────────────────────────────── */
   if (!slug) return <p>{t("group.select")}</p>;
-  if (error) return <p style={{ color: "red" }}>{t("common.error")}: {error.message}</p>;
+  if (error)
+    return <p className="text-red-500">{t("common.error")}: {error.message}</p>;
   if (loading || !portfolio) return <p>{t("common.loading")}</p>;
 
   const perOwner: Record<
@@ -199,53 +201,37 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
 
   /* ── render ────────────────────────────────────────────── */
   return (
-    <div style={{ marginTop: "1rem" }}>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
+    <div className="mt-4">
+      <div className="flex justify-between items-center">
         <h2>{portfolio.name}</h2>
         <RelativeViewToggle />
       </div>
 
       {!relativeViewEnabled && <PortfolioSummary totals={totals} />}
 
-      <div
-        style={{
-          display: "flex",
-          gap: "2rem",
-          marginBottom: "1rem",
-          padding: "0.75rem 1rem",
-          backgroundColor: "#222",
-          border: "1px solid #444",
-          borderRadius: "6px",
-        }}
-      >
-        <div>
-          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Alpha vs Benchmark</div>
-          <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
+      <div className={metricStyles.metricContainer}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Alpha vs Benchmark</div>
+          <div className={metricStyles.metricValue}>
             {percent(alpha != null ? alpha * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Tracking Error</div>
-          <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Tracking Error</div>
+          <div className={metricStyles.metricValue}>
             {percent(trackingError != null ? trackingError * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Max Drawdown</div>
-          <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Max Drawdown</div>
+          <div className={metricStyles.metricValue}>
             {percent(maxDrawdown != null ? maxDrawdown * 100 : null)}
           </div>
         </div>
       </div>
 
       {typeRows.length > 0 && (
-        <div style={{ width: "100%", height: 240, margin: "1rem 0" }}>
+        <div className="w-full h-60 my-4">
           <ResponsiveContainer>
             <PieChart>
               <Pie
@@ -268,12 +254,12 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
       )}
 
       {(sectorContrib?.length || regionContrib?.length) && (
-        <div style={{ width: "100%", height: 300, margin: "1rem 0" }}>
-          <div style={{ marginBottom: "0.5rem" }}>
+        <div className="w-full h-[300px] my-4">
+          <div className="mb-2">
             <button
               onClick={() => setContribTab("sector")}
               disabled={contribTab === "sector"}
-              style={{ marginRight: "0.5rem" }}
+              className="mr-2"
             >
               Sector
             </button>
@@ -313,7 +299,7 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
       <TopMoversSummary slug={slug} />
 
       {/* Per-owner summary */}
-      <table className={tableStyles.table} style={{ marginBottom: "1rem" }}>
+      <table className={`${tableStyles.table} mb-4`}>
         <thead>
           <tr>
             <th className={tableStyles.cell}>Owner</th>
@@ -348,29 +334,33 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
               </td>
               {!relativeViewEnabled && (
                 <td
-                  className={`${tableStyles.cell} ${tableStyles.right}`}
-                  style={{ color: row.dayChange >= 0 ? "lightgreen" : "red" }}
+                  className={`${tableStyles.cell} ${tableStyles.right} ${
+                    row.dayChange >= 0 ? "text-[lightgreen]" : "text-red-500"
+                  }`}
                 >
                   {money(row.dayChange)}
                 </td>
               )}
               <td
-                className={`${tableStyles.cell} ${tableStyles.right}`}
-                style={{ color: row.dayChange >= 0 ? "lightgreen" : "red" }}
+                className={`${tableStyles.cell} ${tableStyles.right} ${
+                  row.dayChange >= 0 ? "text-[lightgreen]" : "text-red-500"
+                }`}
               >
                 {percent(row.dayChangePct)}
               </td>
               {!relativeViewEnabled && (
                 <td
-                  className={`${tableStyles.cell} ${tableStyles.right}`}
-                  style={{ color: row.gain >= 0 ? "lightgreen" : "red" }}
+                  className={`${tableStyles.cell} ${tableStyles.right} ${
+                    row.gain >= 0 ? "text-[lightgreen]" : "text-red-500"
+                  }`}
                 >
                   {money(row.gain)}
                 </td>
               )}
               <td
-                className={`${tableStyles.cell} ${tableStyles.right}`}
-                style={{ color: row.gain >= 0 ? "lightgreen" : "red" }}
+                className={`${tableStyles.cell} ${tableStyles.right} ${
+                  row.gain >= 0 ? "text-[lightgreen]" : "text-red-500"
+                }`}
               >
                 {percent(row.gainPct)}
               </td>
@@ -384,7 +374,7 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
         const key = accountKey(acct, idx);
         const checked = activeKeys.has(key);
         return (
-          <div key={key} style={{ marginBottom: "1.5rem" }}>
+          <div key={key} className="mb-6">
             <h3>
               <input
                 type="checkbox"
@@ -397,7 +387,7 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
                   )
                 }
                 aria-label={`${acct.owner ?? "—"} ${acct.account_type}`}
-                style={{ marginRight: "0.5rem" }}
+                className="mr-2"
               />
               {onSelectMember ? (
                 <span

--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 import {
   Line,
   LineChart,
@@ -6,16 +6,17 @@ import {
   Tooltip,
   XAxis,
   YAxis,
-} from 'recharts';
+} from "recharts";
 import {
   getPerformance,
   getAlphaVsBenchmark,
   getTrackingError,
   getMaxDrawdown,
-} from '../api';
-import type { PerformancePoint } from '../types';
-import { percent } from '../lib/money';
-import i18n from '../i18n';
+} from "../api";
+import type { PerformancePoint } from "../types";
+import { percent } from "../lib/money";
+import i18n from "../i18n";
+import metricStyles from "../styles/metrics.module.css";
 
 interface Props {
   owner: string | null;
@@ -51,7 +52,7 @@ export function PortfolioDashboard({ owner }: Props) {
   }, [owner, days, excludeCash]);
 
   if (!owner) return <p>Select a member.</p>;
-  if (err) return <p style={{ color: 'red' }}>{err}</p>;
+  if (err) return <p className="text-red-500">{err}</p>;
   if (!data.length) return <p>Loading…</p>;
 
   const last = data[data.length - 1];
@@ -78,14 +79,14 @@ export function PortfolioDashboard({ owner }: Props) {
   }
 
   return (
-    <div style={{ marginTop: '1rem' }}>
-      <div style={{ marginBottom: '0.5rem' }}>
-        <label style={{ fontSize: '0.85rem' }}>
+    <div className="mt-4">
+      <div className="mb-2">
+        <label className="text-[0.85rem]">
           Range:
           <select
             value={days}
             onChange={(e) => setDays(Number(e.target.value))}
-            style={{ marginLeft: '0.25rem' }}
+            className="ml-1"
           >
             <option value={7}>1W</option>
             <option value={30}>1M</option>
@@ -94,96 +95,72 @@ export function PortfolioDashboard({ owner }: Props) {
             <option value={0}>MAX</option>
           </select>
         </label>
-        <label style={{ fontSize: '0.85rem', marginLeft: '1rem' }}>
+        <label className="text-[0.85rem] ml-4">
           Exclude cash
           <input
             type="checkbox"
             checked={excludeCash}
             onChange={(e) => setExcludeCash(e.target.checked)}
-            style={{ marginLeft: '0.25rem' }}
+            className="ml-1"
           />
         </label>
       </div>
 
-      <div
-        style={{
-          display: 'flex',
-          gap: '2rem',
-          marginBottom: '1rem',
-          padding: '0.75rem 1rem',
-          backgroundColor: '#222',
-          border: '1px solid #444',
-          borderRadius: '6px',
-        }}
-      >
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>TWR</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+      <div className={metricStyles.metricContainer}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>TWR</div>
+          <div className={metricStyles.metricValue}>
             {percent(twr != null ? twr * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>IRR</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>IRR</div>
+          <div className={metricStyles.metricValue}>
             {percent(irr != null ? irr * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>Best Day</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Best Day</div>
+          <div className={metricStyles.metricValue}>
             {percent(bestDay != null ? bestDay * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>Worst Day</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Worst Day</div>
+          <div className={metricStyles.metricValue}>
             {percent(worstDay != null ? worstDay * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>Last Day</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Last Day</div>
+          <div className={metricStyles.metricValue}>
             {percent(lastDay != null ? lastDay * 100 : null)}
           </div>
         </div>
       </div>
 
-      <div
-        style={{
-          display: 'flex',
-          gap: '2rem',
-          marginBottom: '1rem',
-          padding: '0.75rem 1rem',
-          backgroundColor: '#222',
-          border: '1px solid #444',
-          borderRadius: '6px',
-        }}
-      >
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>
-            Alpha vs Benchmark
-          </div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+      <div className={metricStyles.metricContainer}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Alpha vs Benchmark</div>
+          <div className={metricStyles.metricValue}>
             {percent(alpha != null ? alpha * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>
-            Tracking Error
-          </div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Tracking Error</div>
+          <div className={metricStyles.metricValue}>
             {percent(trackingError != null ? trackingError * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>Max Drawdown</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Max Drawdown</div>
+          <div className={metricStyles.metricValue}>
             {percent(maxDrawdown != null ? maxDrawdown * 100 : null)}
           </div>
         </div>
-        <div>
-          <div style={{ fontSize: '0.9rem', color: '#aaa' }}>Volatility</div>
-          <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Volatility</div>
+          <div className={metricStyles.metricValue}>
             {percent(volatility != null ? volatility * 100 : null)}
           </div>
         </div>
@@ -199,7 +176,7 @@ export function PortfolioDashboard({ owner }: Props) {
         </LineChart>
       </ResponsiveContainer>
 
-      <h2 style={{ marginTop: '2rem' }}>Cumulative Return</h2>
+      <h2 className="mt-8">Cumulative Return</h2>
       <ResponsiveContainer width="100%" height={240}>
         <LineChart data={data}>
           <XAxis dataKey="date" />

--- a/frontend/src/styles/metrics.module.css
+++ b/frontend/src/styles/metrics.module.css
@@ -1,0 +1,24 @@
+.metricContainer {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background-color: #222;
+  border: 1px solid #444;
+  border-radius: 6px;
+}
+
+.metricCard {
+  display: flex;
+  flex-direction: column;
+}
+
+.metricLabel {
+  font-size: 0.9rem;
+  color: #aaa;
+}
+
+.metricValue {
+  font-size: 1.2rem;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- replace inline styles in GroupPortfolioView and PortfolioDashboard with utility classes
- add shared metrics.module.css for consistent card and container styling

## Testing
- `npm test` (fails: ReferenceError: sparks is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68bc6576c5008327ae5796f944d1f379