### PR TITLE
Handle loading state in AllocationCharts

### DIFF
--- a/frontend/src/pages/AllocationCharts.test.tsx
+++ b/frontend/src/pages/AllocationCharts.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import AllocationCharts from "./AllocationCharts";
+import * as api from "../api";
+import type { GroupPortfolio } from "../types";
+
+vi.mock("../api");
+const mockGetGroupPortfolio = vi.mocked(api.getGroupPortfolio);
+
+const samplePortfolio: GroupPortfolio = {
+  group: "g",
+  name: "Group",
+  as_of: "2024-01-01",
+  members: [],
+  total_value_estimate_gbp: 100,
+  trades_this_month: 0,
+  trades_remaining: 0,
+  accounts: [
+    {
+      account_type: "taxable",
+      currency: "GBP",
+      value_estimate_gbp: 100,
+      owner: "alice",
+      holdings: [
+        {
+          ticker: "AAA",
+          name: "Alpha",
+          units: 1,
+          acquired_date: "2024-01-01",
+          market_value_gbp: 100,
+          instrument_type: "equity",
+          sector: "Tech",
+          region: "UK",
+        },
+      ],
+    },
+  ],
+  members_summary: [],
+  subtotals_by_account_type: {},
+};
+
+describe("AllocationCharts page", () => {
+  it("shows loading indicator while fetching", async () => {
+    let resolveFn: (p: GroupPortfolio) => void;
+    const promise = new Promise<GroupPortfolio>((resolve) => {
+      resolveFn = resolve;
+    });
+    mockGetGroupPortfolio.mockReturnValueOnce(promise);
+
+    render(<AllocationCharts />);
+    expect(screen.getByText(/Loading/)).toBeInTheDocument();
+
+    resolveFn!(samplePortfolio);
+    expect(await screen.findByText(/Instrument Types/)).toBeInTheDocument();
+    expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
+  });
+
+  it("displays an error message when API call fails", async () => {
+    mockGetGroupPortfolio.mockRejectedValueOnce(new Error("boom"));
+    render(<AllocationCharts />);
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+    expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -44,6 +44,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
   const [portfolio, setPortfolio] = useState<GroupPortfolio | null>(null);
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   // helper to derive a stable key for each account
   const accountKey = (acct: Account, idx: number) =>
@@ -55,12 +56,15 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
     );
 
   useEffect(() => {
+    setLoading(true);
+    setError(null);
     getGroupPortfolio(slug)
       .then((p: GroupPortfolio) => {
         setPortfolio(p);
         setSelectedAccounts(p.accounts.map(accountKey));
       })
-      .catch((e) => setError(e instanceof Error ? e.message : String(e)));
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
   }, [slug]);
 
   useEffect(() => {
@@ -102,6 +106,8 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
     setSectorData(sector);
     setRegionData(region);
   }, [portfolio, selectedAccounts, t]);
+
+  if (loading && !portfolio) return <div>Loading...</div>;
 
   const chartData =
     view === "asset" ? assetData : view === "sector" ? sectorData : regionData;

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -20,3 +20,7 @@ declare global {
 }
 
 globalThis.ResizeObserver = ResizeObserver;
+
+// Some components expect a global `sparks` object with sparkline data.
+// Provide an empty stub to satisfy references in tests.
+(globalThis as any).sparks = {};


### PR DESCRIPTION
## Summary
- add loading flag and spinner while group portfolio is fetched
- provide global `sparks` stub for tests
- test AllocationCharts loading and error states

## Testing
- `npm test` *(fails: TopMoversPage test expectations)*
- `cd frontend && npm test -- src/pages/AllocationCharts.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc65701ff88327bbb2b94e25f178ff