### PR TITLE
feat: allow custom ai model and prompt

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,11 +15,12 @@ Crawl a website, capture screenshots, run AI analysis on each page and build PDF
 3. Download the [DejaVuSans.ttf](https://github.com/dejavu-fonts/dejavu-fonts/raw/version_2_37/ttf/DejaVuSans.ttf) font.
    If you download the ZIP release, extract `DejaVuSans.ttf` from the archive.
 4. Save the font and set `FONT_PATH` in `site_snapshot.py` to its location.
-5. Edit `BASE_URL` in the script to point to your server.
-6. Run:
+5. Run:
    ```bash
-   python scripts/site_snapshot.py
+   python scripts/site_snapshot.py --base-url http://localhost:5173 \
+       --ai-model gpt-4o-mini \
+       --ai-prompt "Describe this page."
    ```
-7. Output appears in `site_manual/` with screenshots, per-page Markdown files (including AI analysis) and a combined PDF manual embedding the analysis text under each screenshot.
+6. Output appears in `site_manual/` with screenshots, per-page Markdown files (including AI analysis) and a combined PDF manual embedding the analysis text under each screenshot.
 
 The script uses Playwright to render pages so that JavaScript-generated links are discovered correctly. Pillow enables image support in FPDF; without it, PDFs are generated without screenshots. If OpenAI analysis fails for a page, the rest of the snapshot continues with an empty analysis.


### PR DESCRIPTION
## Summary
- add `--ai-model` and `--ai-prompt` CLI flags
- propagate AI configuration into `snapshot_pages`
- document new options in `scripts/README.md`

## Testing
- `python -m py_compile scripts/site_snapshot.py`
- `pytest scripts/site_snapshot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc6f99399c8327829becaa38ed07b6