### PR TITLE
Wrap PortfolioDashboard JSX in component

### DIFF
--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -1,73 +1,129 @@
-  <div className={metricStyles.metricContainer}>
-    <div className={metricStyles.metricCard}>
-      <div className={metricStyles.metricLabel}>TWR</div>
-      <div className={metricStyles.metricValue}>
-        {percent(twr != null ? twr * 100 : null)}
-      </div>
-    </div>
-    <div className={metricStyles.metricCard}>
-      <div className={metricStyles.metricLabel}>IRR</div>
-      <div className={metricStyles.metricValue}>
-        {percent(irr != null ? irr * 100 : null)}
-      </div>
-    </div>
-    <div className={metricStyles.metricCard}>
-      <div className={metricStyles.metricLabel}>Best Day</div>
-      <div className={metricStyles.metricValue}>
-        {percent(bestDay != null ? bestDay * 100 : null)}
-      </div>
-    </div>
-    <div className={metricStyles.metricCard}>
-      <div className={metricStyles.metricLabel}>Worst Day</div>
-      <div className={metricStyles.metricValue}>
-        {percent(worstDay != null ? worstDay * 100 : null)}
-      </div>
-    </div>
-    <div className={metricStyles.metricCard}>
-      <div className={metricStyles.metricLabel}>Last Day</div>
-      <div className={metricStyles.metricValue}>
-        {percent(lastDay != null ? lastDay * 100 : null)}
-      </div>
-    </div>
-  </div>
+import React from "react";
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { percent, percentOrNa } from "../lib/money";
+import metricStyles from "../styles/metrics.module.css";
 
-  <div className={metricStyles.metricContainer}>
-    <div className={metricStyles.metricCard}>
-      <div className={metricStyles.metricLabel}>Alpha vs Benchmark</div>
-      <div className={metricStyles.metricValue}>
-        {percentOrNa(alpha != null ? alpha * 100 : null)}
-      </div>
-    </div>
-    <div className={metricStyles.metricCard}>
-      <div className={metricStyles.metricLabel}>Tracking Error</div>
-      <div className={metricStyles.metricValue}>
-        {percentOrNa(trackingError != null ? trackingError * 100 : null)}
-      </div>
-    </div>
-    <div className={metricStyles.metricCard}>
-      <div className={metricStyles.metricLabel}>Max Drawdown</div>
-      <div className={metricStyles.metricValue}>
-        {percentOrNa(maxDrawdown != null ? maxDrawdown * 100 : null)}
-      </div>
-    </div>
-    <div className={metricStyles.metricCard}>
-      <div className={metricStyles.metricLabel}>Volatility</div>
-      <div className={metricStyles.metricValue}>
-        {percentOrNa(volatility != null ? volatility * 100 : null)}
-      </div>
-    </div>
-  </div>
+type Props = {
+  twr: number | null;
+  irr: number | null;
+  bestDay: number | null;
+  worstDay: number | null;
+  lastDay: number | null;
+  alpha: number | null;
+  trackingError: number | null;
+  maxDrawdown: number | null;
+  volatility: number | null;
+  data: { date: string; value: number; cumulative_return: number }[];
+};
 
-  <h2>Portfolio Value</h2>
-  <ResponsiveContainer width="100%" height={240}>
-    <LineChart data={data}>
-      <XAxis dataKey="date" />
-      <YAxis />
-      <Tooltip />
-      <Line type="monotone" dataKey="value" stroke="#8884d8" dot={false} />
-    </LineChart>
-  </ResponsiveContainer>
+function PortfolioDashboard({
+  twr,
+  irr,
+  bestDay,
+  worstDay,
+  lastDay,
+  alpha,
+  trackingError,
+  maxDrawdown,
+  volatility,
+  data,
+}: Props) {
+  return (
+    <>
+      <div className={metricStyles.metricContainer}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>TWR</div>
+          <div className={metricStyles.metricValue}>
+            {percent(twr != null ? twr * 100 : null)}
+          </div>
+        </div>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>IRR</div>
+          <div className={metricStyles.metricValue}>
+            {percent(irr != null ? irr * 100 : null)}
+          </div>
+        </div>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Best Day</div>
+          <div className={metricStyles.metricValue}>
+            {percent(bestDay != null ? bestDay * 100 : null)}
+          </div>
+        </div>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Worst Day</div>
+          <div className={metricStyles.metricValue}>
+            {percent(worstDay != null ? worstDay * 100 : null)}
+          </div>
+        </div>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Last Day</div>
+          <div className={metricStyles.metricValue}>
+            {percent(lastDay != null ? lastDay * 100 : null)}
+          </div>
+        </div>
+      </div>
 
-  <h2 className="mt-8">Cumulative Return</h2>
-  <ResponsiveContainer width="100%" height={240}>
-    <LineChart data={da
+      <div className={metricStyles.metricContainer}>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Alpha vs Benchmark</div>
+          <div className={metricStyles.metricValue}>
+            {percentOrNa(alpha != null ? alpha * 100 : null)}
+          </div>
+        </div>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Tracking Error</div>
+          <div className={metricStyles.metricValue}>
+            {percentOrNa(trackingError != null ? trackingError * 100 : null)}
+          </div>
+        </div>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Max Drawdown</div>
+          <div className={metricStyles.metricValue}>
+            {percentOrNa(maxDrawdown != null ? maxDrawdown * 100 : null)}
+          </div>
+        </div>
+        <div className={metricStyles.metricCard}>
+          <div className={metricStyles.metricLabel}>Volatility</div>
+          <div className={metricStyles.metricValue}>
+            {percentOrNa(volatility != null ? volatility * 100 : null)}
+          </div>
+        </div>
+      </div>
+
+      <h2>Portfolio Value</h2>
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart data={data}>
+          <XAxis dataKey="date" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#8884d8" dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+
+      <h2 className="mt-8">Cumulative Return</h2>
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart data={data}>
+          <XAxis dataKey="date" />
+          <YAxis tickFormatter={(v) => percent(v * 100)} />
+          <Tooltip formatter={(v: number) => percent(v * 100)} />
+          <Line
+            type="monotone"
+            dataKey="cumulative_return"
+            stroke="#82ca9d"
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </>
+  );
+}
+
+export default PortfolioDashboard;
+


### PR DESCRIPTION
## Summary
- convert bare JSX into PortfolioDashboard component
- add missing imports for React, Recharts, helpers and styles

## Testing
- `npm test` *(fails: Failed to resolve import 'jest-axe')*

------
https://chatgpt.com/codex/tasks/task_e_68bc6f5312a483279e8deafb0dd0553d