### PR TITLE
fix: update frontend CSS build dependencies for cross-platform support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
-        "@tailwindcss/oxide-linux-x64-gnu": "^4.1.12",
+        "@tailwindcss/oxide": "^4.1.12",
         "@tailwindcss/postcss": "^4.1.12",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
@@ -42,7 +42,7 @@
         "husky": "^9.1.7",
         "jest-axe": "^10.0.0",
         "jsdom": "^26.1.0",
-        "lightningcss-linux-x64-gnu": "^1.30.1",
+        "lightningcss": "^1.30.1",
         "lint-staged": "^16.1.5",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
@@ -3587,6 +3587,7 @@
       ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -9218,8 +9219,8 @@
       "cpu": [
         "x64"
       ],
-      "devOptional": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "linux"
       ],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
-    "@tailwindcss/oxide-linux-x64-gnu": "^4.1.12",
+    "@tailwindcss/oxide": "^4.1.12",
     "@tailwindcss/postcss": "^4.1.12",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
@@ -46,7 +46,7 @@
     "husky": "^9.1.7",
     "jest-axe": "^10.0.0",
     "jsdom": "^26.1.0",
-    "lightningcss-linux-x64-gnu": "^1.30.1",
+    "lightningcss": "^1.30.1",
     "lint-staged": "^16.1.5",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",


### PR DESCRIPTION
## Summary
- replace platform-specific `@tailwindcss/oxide-linux-x64-gnu` with `@tailwindcss/oxide`
- replace `lightningcss-linux-x64-gnu` with generic `lightningcss`

## Testing
- `npm install`
- `npm ls zod`
- `npm test` *(fails: Element type is invalid: expected a string ... HoldingsTable, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc6f51c670832791a151c57cd7cc98