### PR TITLE
chore: use cross-platform husky install script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "prepare": "[ -d .git ] && husky || true"
+    "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\""
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.12",


### PR DESCRIPTION
## Summary
- replace frontend `prepare` script with cross-platform Node command to install husky when `.git` is present

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68bc7aee0c108327ba52b727d4fa245b