### PR TITLE
fix(frontend): ensure Sparkline exports named component

### DIFF
--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -139,9 +139,11 @@ function SparklineFromFetch({
  * - Accessible with role="img" and aria-label.
  * - No external charting libs; lightweight SVG for easy testing.
  */
-export default function Sparkline(props: SparklineProps) {
+export function Sparkline(props: SparklineProps) {
   if ("data" in props) {
     return <SparklineFromData {...props} />;
   }
   return <SparklineFromFetch {...props} />;
 }
+
+export default Sparkline;


### PR DESCRIPTION
## Summary
- export `Sparkline` as a named function and default export

## Testing
- `npm test -- --run` *(fails: 6 failed, 41 passed)*
- `cd frontend && npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68bc7aed22208327b3878127687119ab