### PR TITLE
fix: use default Sparkline import in HoldingsTable

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -10,7 +10,7 @@ import { useConfig } from "../ConfigContext";
 import { isSupportedFx } from "../lib/fx";
 import { RelativeViewToggle } from "./RelativeViewToggle";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { Sparkline } from "./Sparkline";
+import Sparkline from "./Sparkline";
 
 const VIEW_PRESET_STORAGE_KEY = "holdingsTableViewPreset";
 


### PR DESCRIPTION
## Summary
- fix Sparkline import in HoldingsTable to use default export

## Testing
- `npm run build` *(fails: Cannot find name 'sparks', etc.)*
- `npm run dev`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc7c5df8f08327b69662de7d8f7730