### PR TITLE
Expand Vitest test glob to include ts, tsx, and js files

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,6 +12,7 @@ The AllotMint frontend is a React + TypeScript single-page app that visualises f
 
 - `npm run dev` – start the Vite development server.
 - `npm test` – execute the test suite with Vitest and Testing Library.
+  Test files should be named `*.test.ts`, `*.test.tsx`, or `*.test.js` to be picked up.
 
 ## Routing
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
         globals: true,
         environment: 'jsdom',
         setupFiles: './src/setupTests.ts',
-        include: ['src/**/*.test.tsx']
+        include: ['src/**/*.test.{ts,tsx,js}']
     }
 });


### PR DESCRIPTION
## Summary
- broaden Vitest include pattern so `.test.ts`, `.test.tsx`, and `.test.js` files are discovered
- document supported test file extensions in the frontend README

## Testing
- `npm test` *(fails: Failed to resolve import "jest-axe" from "src/setupTests.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68bc81cca31883278f5d3fe95223d03b