### PR TITLE
Fix sparkline import in HoldingsTable

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -10,6 +10,7 @@ import { useConfig } from "../ConfigContext";
 import { isSupportedFx } from "../lib/fx";
 import { RelativeViewToggle } from "./RelativeViewToggle";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { ResponsiveContainer, LineChart, Line } from "recharts";
 import Sparkline from "./Sparkline";
 
 const VIEW_PRESET_STORAGE_KEY = "holdingsTableViewPreset";


### PR DESCRIPTION
## Summary
- import ResponsiveContainer, LineChart, Line from Recharts for HoldingsTable sparkline

## Testing
- `npm test -- --run` *(fails: 6 failed, 41 passed; missing mocks and act warnings)*
- `npm test -- --run src/components/HoldingsTable.test.tsx`
- `npm run build:web` *(fails: TypeScript cannot find name 'sparks' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc818e17048327962837fcaec8f39d