### PR TITLE
feat: configure base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ OPENAI_API_KEY=fake-openai-key
 # S3 location for instrument metadata
 METADATA_BUCKET=
 METADATA_PREFIX=instruments
+
+# Base URL for the deployed frontend
+VITE_APP_BASE_URL=https://app.allotmint.io

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
+    <base href="%VITE_APP_BASE_URL%/"/>
     <link rel="icon" type="image/svg+xml" href="/vite.svg"/>
     <link rel="manifest" href="/manifest.webmanifest"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>


### PR DESCRIPTION
## Summary
- add VITE_APP_BASE_URL to example env file
- point index.html to base URL via %VITE_APP_BASE_URL%

## Testing
- `npm test` *(fails: Failed to resolve import "jest-axe" from "src/setupTests.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68bc82999b848327aaf956af2c4504ae