### PR TITLE
Add glob support for PWA routing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "glob": "^10.3.10",
         "globals": "^16.3.0",
         "husky": "^9.1.7",
         "jest-axe": "^10.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "glob": "^10.3.10",
     "globals": "^16.3.0",
     "husky": "^9.1.7",
     "jest-axe": "^10.0.0",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, type PluginOption, type UserConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import path from 'node:path'
+import { glob } from 'glob'
 
 const staticDir = path.resolve(__dirname, 'dist')
 const pageRoutes: string[] = []
@@ -26,6 +27,13 @@ export default defineConfig(async ({ command }) => {
   ]
 
   if (command === 'build') {
+    const files = await glob('src/pages/**/*.tsx', {
+      cwd: __dirname,
+      ignore: ['**/*.test.tsx']
+    })
+    pageRoutes.push(
+      ...files.map((file) => `/${path.basename(file, '.tsx')}`)
+    )
     const { createRequire } = await import('node:module')
     const require = createRequire(import.meta.url)
     const vitePrerender = require('vite-plugin-prerender')


### PR DESCRIPTION
## Summary
- populate prerender routes using glob in Vite PWA configuration
- add glob dev dependency

## Testing
- `npm test` *(fails: 6 failed, 41 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc829af7548327b40d007f811d9083