### PR TITLE
Default approval exemption fields when saving user settings

### DIFF
--- a/frontend/src/pages/UserConfig.tsx
+++ b/frontend/src/pages/UserConfig.tsx
@@ -65,7 +65,12 @@ export default function UserConfigPage() {
     if (!owner) return;
     setStatus('saving');
     try {
-      await updateUserConfig(owner, cfg);
+      const payload: any = {
+        ...cfg,
+        approval_exempt_tickers: cfg.approval_exempt_tickers ?? [],
+        approval_exempt_types: cfg.approval_exempt_types ?? null,
+      };
+      await updateUserConfig(owner, payload);
       setStatus('saved');
     } catch {
       setStatus('error');


### PR DESCRIPTION
## Summary
- Default approval_exempt_tickers to empty array and approval_exempt_types to null when saving user config

## Testing
- `npm test -- src/pages/UserConfig.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc8297c94483279bb74d08788f3885