### PR TITLE
Reset TopMovers tests between runs

### DIFF
--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TopMoversPage } from "./TopMoversPage";
 import type { MoverRow } from "../types";
 
@@ -67,6 +67,11 @@ vi.mock("../api", () => ({
     ...args: Parameters<typeof mockGetTradingSignals>
   ) => mockGetTradingSignals(...args),
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
 
 vi.mock("./InstrumentDetail", () => ({
   InstrumentDetail: ({


### PR DESCRIPTION
## Summary
- reset TopMovers tests by clearing mocks and `localStorage` before each run

## Testing
- `npm test -- TopMoversPage.test.tsx --run`


------
https://chatgpt.com/codex/tasks/task_e_68bc8293c9548327b2de62f378084caa