### PR TITLE
test: mock getStoredAuthToken in login test

### DIFF
--- a/frontend/src/loginClientId.test.tsx
+++ b/frontend/src/loginClientId.test.tsx
@@ -12,12 +12,17 @@ describe('Root login behaviour', () => {
       createRoot: () => ({ render: vi.fn() })
     }))
 
-    vi.doMock('./api', () => ({
-      getConfig: vi.fn().mockResolvedValue({
-        google_auth_enabled: true,
-        google_client_id: ''
-      })
-    }))
+    vi.doMock('./api', async importOriginal => {
+      const mod = await importOriginal<typeof import('./api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: true,
+          google_client_id: ''
+        }),
+        getStoredAuthToken: vi.fn()
+      }
+    })
 
     vi.doMock('./LoginPage', () => ({
       default: () => <div data-testid="login-page">login-page</div>


### PR DESCRIPTION
## Summary
- partially mock the frontend API in `loginClientId.test.tsx` to include `getStoredAuthToken`
- use `importOriginal` to merge with real exports and mirror production behavior

## Testing
- `npm test -- run src/loginClientId.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc8298d5c48327a8563c608b8c9674