### PR TITLE
Handle missing spark data in holdings table

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -366,9 +366,10 @@ export function HoldingsTable({
             const h = sortedRows[virtualRow.index];
             const handleClick = () =>
               onSelectInstrument?.(h.ticker, h.name ?? h.ticker);
-            const sparkData = sparks[h.ticker]?.[String(sparkRange)];
+            const sparkData =
+              (globalThis as any).sparks?.[h.ticker]?.[String(sparkRange)] ?? [];
             const sparkColor =
-              sparkData && sparkData.length > 1
+              sparkData.length > 1
                 ? sparkData[sparkData.length - 1].close_gbp >= sparkData[0].close_gbp
                   ? "lightgreen"
                   : "red"
@@ -387,10 +388,19 @@ export function HoldingsTable({
                 <td className={tableStyles.cell}>{h.name}</td>
                 <td className={`${tableStyles.cell} w-20`}>
                   <Sparkline ticker={h.ticker} days={sparkRange} />
-                  {sparkData?.length ? (
+                  {sparkData.length ? (
                     <ResponsiveContainer width="100%" height={40}>
-                      <LineChart data={sparkData} margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
-                        <Line type="monotone" dataKey="close_gbp" stroke={sparkColor} dot={false} strokeWidth={1} />
+                      <LineChart
+                        data={sparkData}
+                        margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
+                      >
+                        <Line
+                          type="monotone"
+                          dataKey="close_gbp"
+                          stroke={sparkColor}
+                          dot={false}
+                          strokeWidth={1}
+                        />
                       </LineChart>
                     </ResponsiveContainer>
                   ) : null}

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,0 +1,5 @@
+export {};
+
+declare global {
+  var sparks: Record<string, Record<string, any[]>> | undefined;
+}


### PR DESCRIPTION
## Summary
- safely read spark data from globalThis with fallback
- declare global sparks type for TypeScript

## Testing
- `npx vitest run` *(fails: 6 failed, 41 passed)*
- `npm run lint` *(fails: 18 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc819380f4832781354016d5c9e3de