### PR TITLE
chore: remove redundant React imports

### DIFF
--- a/frontend/src/components/AllocationCharts.tsx
+++ b/frontend/src/components/AllocationCharts.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import { useMemo } from "react";
+import type { FC } from "react";
 
 /**
  * Build a three-level hierarchy (asset_class -> industry -> region) from
@@ -59,10 +60,10 @@ export function buildAllocationHierarchy(
  * Simple component that renders the hierarchy as JSON.  Charting libraries
  * can consume the ``buildAllocationHierarchy`` result instead.
  */
-const AllocationCharts: React.FC<{ instruments: InstrumentSummary[] }> = ({
+const AllocationCharts: FC<{ instruments: InstrumentSummary[] }> = ({
   instruments,
 }) => {
-  const data = React.useMemo(
+  const data = useMemo(
     () => buildAllocationHierarchy(instruments),
     [instruments],
   );

--- a/frontend/src/components/CriteriaBuilder.tsx
+++ b/frontend/src/components/CriteriaBuilder.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export interface Criterion {
   field: string;
   operator: string;

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
 
 type SparklineBaseProps = {
@@ -141,9 +141,9 @@ function SparklineFromFetch({
  */
 export function Sparkline(props: SparklineProps) {
   if ("data" in props) {
-    return <SparklineFromData {...props} />;
+    return <SparklineFromData {...(props as SparklineDataProps)} />;
   }
-  return <SparklineFromFetch {...props} />;
+  return <SparklineFromFetch {...(props as SparklineFetchProps)} />;
 }
 
 export default Sparkline;

--- a/frontend/src/pages/Discover.tsx
+++ b/frontend/src/pages/Discover.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
-import { CriteriaBuilder, Criterion } from "../components/CriteriaBuilder";
+import { useState } from "react";
+import { CriteriaBuilder } from "../components/CriteriaBuilder";
+import type { Criterion } from "../components/CriteriaBuilder";
 import { Sparkline } from "../components/Sparkline";
 
 /**

--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Line,
   LineChart,


### PR DESCRIPTION
## Summary
- remove default React imports now that JSX runtime is automatic
- treat `Criterion` as a type-only import in Discover page
- use React hooks and types without namespaced default imports

## Testing
- `npm run build` *(fails: Cannot find module 'zod'; other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc828b353c832791b9832460ebab89