### PR TITLE
Add Recharts import and declare sparks global

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -10,7 +10,10 @@ import { useConfig } from "../ConfigContext";
 import { isSupportedFx } from "../lib/fx";
 import { RelativeViewToggle } from "./RelativeViewToggle";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { ResponsiveContainer, LineChart, Line } from "recharts";
 import Sparkline from "./Sparkline";
+
+declare const sparks: Record<string, Record<string, any[]>>;
 
 const VIEW_PRESET_STORAGE_KEY = "holdingsTableViewPreset";
 


### PR DESCRIPTION
## Summary
- import Recharts components used for inline spark charts
- declare global `sparks` mapping for sparkline data
- ensure `Sparkline` remains a default import

## Testing
- `npm test` *(fails: Failed to resolve import "jest-axe" from "src/setupTests.ts")*
- `npm run lint` *(fails: 18 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc828a7000832785b58945837d868e