### PR TITLE
Add owner prop to PortfolioDashboard

### DIFF
--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -21,6 +21,7 @@ type Props = {
   maxDrawdown: number | null;
   volatility: number | null;
   data: { date: string; value: number; cumulative_return: number }[];
+  owner?: string;
 };
 
 function PortfolioDashboard({
@@ -34,7 +35,9 @@ function PortfolioDashboard({
   maxDrawdown,
   volatility,
   data,
+  owner,
 }: Props) {
+  void owner;
   return (
     <>
       <div className={metricStyles.metricContainer}>


### PR DESCRIPTION
## Summary
- allow PortfolioDashboard to accept optional `owner`
- destructure `owner` in component for future use

## Testing
- `npm test` *(fails: Failed to resolve import "jest-axe")*
- `npm run lint` *(fails: multiple lint errors including react-refresh/only-export-components)*

------
https://chatgpt.com/codex/tasks/task_e_68bc82895d148327ad6726627df38b83