### PR TITLE
Guard performance metrics before percentage formatting

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -209,6 +209,17 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
     pct: totalValue > 0 ? (value / totalValue) * 100 : 0,
   }));
 
+  const safeAlpha =
+    alpha != null && Math.abs(alpha) > 1 ? alpha / 100 : alpha;
+  const safeTrackingError =
+    trackingError != null && Math.abs(trackingError) > 1
+      ? trackingError / 100
+      : trackingError;
+  const safeMaxDrawdown =
+    maxDrawdown != null && Math.abs(maxDrawdown) > 1
+      ? maxDrawdown / 100
+      : maxDrawdown;
+
   /* ── render ────────────────────────────────────────────── */
   return (
     <div style={{ marginTop: "1rem" }}>
@@ -239,19 +250,19 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Alpha vs Benchmark</div>
           <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
-            {percentOrNa(alpha)}
+            {percentOrNa(safeAlpha)}
           </div>
         </div>
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Tracking Error</div>
           <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
-            {percentOrNa(trackingError)}
+            {percentOrNa(safeTrackingError)}
           </div>
         </div>
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Max Drawdown</div>
           <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
-            {percentOrNa(maxDrawdown)}
+            {percentOrNa(safeMaxDrawdown)}
           </div>
         </div>
       </div>

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -48,6 +48,17 @@ export function PerformanceDashboard({ owner }: Props) {
   if (err) return <p style={{ color: "red" }}>{err}</p>;
   if (!data.length) return <p>{t("common.loading")}</p>;
 
+  const safeAlpha =
+    alpha != null && Math.abs(alpha) > 1 ? alpha / 100 : alpha;
+  const safeTrackingError =
+    trackingError != null && Math.abs(trackingError) > 1
+      ? trackingError / 100
+      : trackingError;
+  const safeMaxDrawdown =
+    maxDrawdown != null && Math.abs(maxDrawdown) > 1
+      ? maxDrawdown / 100
+      : maxDrawdown;
+
   return (
     <div style={{ marginTop: "1rem" }}>
       <div style={{ marginBottom: "0.5rem" }}>
@@ -85,19 +96,19 @@ export function PerformanceDashboard({ owner }: Props) {
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>{t("dashboard.alphaVsBenchmark")}</div>
           <div style={{ fontSize: "1.1rem", fontWeight: "bold" }}>
-            {percentOrNa(alpha)}
+            {percentOrNa(safeAlpha)}
           </div>
         </div>
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>{t("dashboard.trackingError")}</div>
           <div style={{ fontSize: "1.1rem", fontWeight: "bold" }}>
-            {percentOrNa(trackingError)}
+            {percentOrNa(safeTrackingError)}
           </div>
         </div>
         <div>
           <div style={{ fontSize: "0.9rem", color: "#aaa" }}>{t("dashboard.maxDrawdown")}</div>
           <div style={{ fontSize: "1.1rem", fontWeight: "bold" }}>
-            {percentOrNa(maxDrawdown)}
+            {percentOrNa(safeMaxDrawdown)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Avoid formatting errors by scaling alpha, tracking error, and max drawdown metrics when values exceed 1
- Ensure frontend displays percentages correctly for group portfolio and performance dashboard metrics

## Testing
- `npm test -- GroupPortfolioView.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bc89afa7c883279741e910b01fe75f