### PR TITLE
Fix toast alert text visibility

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -94,4 +94,15 @@ button:focus-visible {
     }
 }
 
+/* Ensure toast notifications are legible in both themes */
+.Toastify__toast {
+    background-color: #333;
+    color: rgba(255, 255, 255, 0.87);
+}
+
+:root[data-theme='light'] .Toastify__toast {
+    background-color: #ffffff;
+    color: #213547;
+}
+
 


### PR DESCRIPTION
## Summary
- ensure toast notifications remain legible by styling Toastify to match light and dark themes

## Testing
- `npm test` *(fails: cannot resolve import "jest-axe" in setupTests.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bc892b170c8327a2442be80e621887