### PR TITLE
refactor: simplify metric percentage handling

### DIFF
--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -76,25 +76,25 @@ function PortfolioDashboard({
         <div className={metricStyles.metricCard}>
           <div className={metricStyles.metricLabel}>Alpha vs Benchmark</div>
           <div className={metricStyles.metricValue}>
-            {percentOrNa(alpha != null ? alpha * 100 : null)}
+            {percentOrNa(alpha)}
           </div>
         </div>
         <div className={metricStyles.metricCard}>
           <div className={metricStyles.metricLabel}>Tracking Error</div>
           <div className={metricStyles.metricValue}>
-            {percentOrNa(trackingError != null ? trackingError * 100 : null)}
+            {percentOrNa(trackingError)}
           </div>
         </div>
         <div className={metricStyles.metricCard}>
           <div className={metricStyles.metricLabel}>Max Drawdown</div>
           <div className={metricStyles.metricValue}>
-            {percentOrNa(maxDrawdown != null ? maxDrawdown * 100 : null)}
+            {percentOrNa(maxDrawdown)}
           </div>
         </div>
         <div className={metricStyles.metricCard}>
           <div className={metricStyles.metricLabel}>Volatility</div>
           <div className={metricStyles.metricValue}>
-            {percentOrNa(volatility != null ? volatility * 100 : null)}
+            {percentOrNa(volatility)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- simplify percent conversion in PortfolioDashboard by passing raw values to `percentOrNa`

## Testing
- `npm test` *(fails: Error: Failed to resolve import "jest-axe" from "src/setupTests.ts")*
- `npm run build` *(fails: TypeScript errors and missing modules zod, jest-axe)*

------
https://chatgpt.com/codex/tasks/task_e_68bc89aeabb88327a8d672a4fffe52cd