### PR TITLE
Load .env for site_snapshot and clarify OpenAI key setup

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ mangum-cli~=0.1.0
 moviepy~=2.2.1
 openai~=1.51.0
 playwright~=1.49.0
+python-dotenv~=1.0.1
 pytest-cov~=6.2.1
 pytest~=8.4.1
 reportlab~=4.2.5

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,10 +8,17 @@ Crawl a website, capture screenshots, run AI analysis on each page and build PDF
 
 1. Install dependencies:
    ```bash
-   pip install beautifulsoup4 fpdf Pillow markdownify playwright tldextract openai
+   pip install beautifulsoup4 fpdf Pillow markdownify playwright tldextract openai python-dotenv
    playwright install
    ```
-2. Set your `OPENAI_API_KEY` environment variable to enable per-page analysis.
+2. Provide your `OPENAI_API_KEY` for per-page analysis. The script will read it
+   from the environment and automatically load a `.env` file if `python-dotenv`
+   is installed. For example:
+   ```bash
+   export OPENAI_API_KEY=your_api_key
+   # or place the key in a .env file:
+   echo "OPENAI_API_KEY=your_api_key" > .env
+   ```
 3. Download the [DejaVuSans.ttf](https://github.com/dejavu-fonts/dejavu-fonts/raw/version_2_37/ttf/DejaVuSans.ttf) font.
    If you download the ZIP release, extract `DejaVuSans.ttf` from the archive.
 4. Save the font and set `FONT_PATH` in `site_snapshot.py` to its location.

--- a/scripts/site_snapshot.py
+++ b/scripts/site_snapshot.py
@@ -11,10 +11,13 @@ Fixes:
 - Embeds screenshots only if Pillow is installed; otherwise skips cleanly.
 
 Install:
-  pip install beautifulsoup4 fpdf markdownify playwright tldextract
+  pip install beautifulsoup4 fpdf markdownify playwright tldextract python-dotenv
   playwright install
 Optional for images in PDF:
   pip install pillow
+
+The script reads `OPENAI_API_KEY` from the environment. If `python-dotenv` is
+installed, variables from a `.env` file are loaded automatically.
 
 Example:
   python site_snapshot.py --base-url http://localhost:5173/movers \
@@ -35,6 +38,14 @@ from pathlib import Path
 from typing import Iterable, Optional, Set, Tuple, List
 from urllib.parse import urljoin, urlparse, urlunparse, parse_qsl
 import shutil
+
+# Load environment variables from .env if available
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except Exception:
+    pass
 
 # Optional Pillow detection (PNG embedding)
 try:


### PR DESCRIPTION
## Summary
- Auto-load `.env` in `scripts/site_snapshot.py` when `python-dotenv` is available
- Document how to provide `OPENAI_API_KEY` and list `python-dotenv` as a dependency
- Add `python-dotenv` to development requirements

## Testing
- `pytest` (fails: test_styles_snapshot)`

------
https://chatgpt.com/codex/tasks/task_e_68bc8cdc853083278ed9cc19ccbb0078