### PR TITLE
feat: show trading signal reasons on hover

### DIFF
--- a/frontend/src/components/SignalBadge.tsx
+++ b/frontend/src/components/SignalBadge.tsx
@@ -1,15 +1,17 @@
 type Action = "buy" | "sell";
 type Props = {
   action: Action;
+  reason?: string;
   onClick?: () => void;
 };
 
-export function SignalBadge({ action, onClick }: Props) {
+export function SignalBadge({ action, reason, onClick }: Props) {
   const isBuy = action === "buy";
   const color = isBuy ? "#bbf7d0" : "#fecaca"; // tailwind: green-200 / red-200
   return (
     <span
       onClick={onClick}
+      title={reason}
       style={{
         backgroundColor: color,
         padding: "2px 6px",

--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -189,6 +189,7 @@ describe("TopMoversPage", () => {
     const row = tickerBtn.closest("tr");
     expect(row).not.toBeNull();
     const badge = within(row as HTMLElement).getByText(/buy/i);
+    expect(badge).toHaveAttribute("title", "go long");
     fireEvent.click(badge);
     const detail = await screen.findByTestId("detail");
     expect(detail).toHaveTextContent("AAA");

--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -326,6 +326,7 @@ export function TopMoversPage() {
                     return s ? (
                       <SignalBadge
                         action={s.action}
+                        reason={s.reason}
                         onClick={() => setSelected({ row: r, signal: s })}
                       />
                     ) : null;

--- a/frontend/src/components/TopMoversSummary.tsx
+++ b/frontend/src/components/TopMoversSummary.tsx
@@ -96,6 +96,7 @@ export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
                   return s ? (
                     <SignalBadge
                       action={s.action}
+                      reason={s.reason}
                       onClick={() => setSelected({ ticker: r.ticker, name: r.name })}
                     />
                   ) : null;


### PR DESCRIPTION
## Summary
- allow SignalBadge to display a reason tooltip
- pass trading signal reasons from TopMovers components
- test tooltip propagation

## Testing
- `npx vitest run src/components/TopMoversPage.test.tsx src/components/TopMoversSummary.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc8e1da438832789945675c161016e