### PR TITLE
test: await async operations in ScenarioTester tests

### DIFF
--- a/frontend/src/pages/ScenarioTester.test.tsx
+++ b/frontend/src/pages/ScenarioTester.test.tsx
@@ -54,7 +54,7 @@ describe("ScenarioTester page", () => {
     expect(screen.getByText(fmt.format(10))).toBeInTheDocument();
   });
 
-  it("disables Apply button until valid inputs provided", () => {
+  it("disables Apply button until valid inputs provided", async () => {
     render(<ScenarioTester />);
     const apply = screen.getByText("Apply");
 


### PR DESCRIPTION
## Summary
- mark ScenarioTester validation test callback as async so awaiting DOM queries is valid

## Testing
- `npm test -- --run src/pages/ScenarioTester.test.tsx` *(fails: Unable to find an element with expected text)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8291b6e48327b87665d7cefea404