### PR TITLE
feat: add toggleable navigation menu

### DIFF
--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -5,12 +5,15 @@ import i18n from "../i18n";
 import Menu from "./Menu";
 
 describe("Menu", () => {
-  it("renders Logs tab", () => {
+  it("hides links by default and shows them after toggle", () => {
     render(
       <MemoryRouter>
         <Menu />
       </MemoryRouter>,
     );
+    expect(screen.queryByRole("link", { name: "Logs" })).not.toBeInTheDocument();
+    const toggle = screen.getByRole("button", { name: /menu/i });
+    fireEvent.click(toggle);
     expect(screen.getByRole("link", { name: "Logs" })).toBeInTheDocument();
   });
 
@@ -22,6 +25,8 @@ describe("Menu", () => {
         <Menu onLogout={onLogout} />
       </MemoryRouter>,
     );
+    const toggle = screen.getByRole("button", { name: /menu/i });
+    fireEvent.click(toggle);
     const btn = screen.getByRole("button", { name: "Déconnexion" });
     fireEvent.click(btn);
     expect(onLogout).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add hamburger menu button that toggles navigation links
- hide links until menu is opened and close on link click or focus out
- test menu toggle functionality

## Testing
- `npm test -- src/components/Menu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc93ef81148327a1d977ebdc5bcddb