### PR TITLE
Ensure cache persists before cancellation

### DIFF
--- a/tests/test_page_cache.py
+++ b/tests/test_page_cache.py
@@ -61,3 +61,36 @@ def test_load_cache_handles_oserror(monkeypatch, tmp_path, caplog):
         assert page_cache.load_cache(page_name) is None
 
     assert f"Cache load failed for {page_name}" in caplog.text
+
+
+def test_first_builder_exception_cache_persisted(monkeypatch, tmp_path):
+    async def run():
+        monkeypatch.setattr(page_cache, "CACHE_DIR", tmp_path)
+
+        calls = {"builder": 0, "save": 0}
+
+        def builder():
+            calls["builder"] += 1
+            if calls["builder"] == 1:
+                raise ValueError("boom")
+            return {"ok": True}
+
+        original_save = page_cache.save_cache
+
+        def flaky_save(page_name, data):
+            calls["save"] += 1
+            if calls["save"] == 1:
+                raise asyncio.CancelledError
+            return original_save(page_name, data)
+
+        monkeypatch.setattr(page_cache, "save_cache", flaky_save)
+
+        page_cache.schedule_refresh("error_page", 0.01, builder)
+        await asyncio.sleep(0.03)
+        await page_cache.cancel_refresh_tasks()
+
+        assert page_cache.load_cache("error_page") == {"ok": True}
+        assert calls["builder"] >= 2
+        assert calls["save"] >= 2
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add retry loop in page cache refresh task so a successful builder run is saved even when cancellation is requested
- add regression test covering initial builder failure with cancellation during save

## Testing
- `pytest tests/test_page_cache.py -k first_builder_exception_cache_persisted -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9547fc788327aecfd1a9023da973