### PR TITLE
feat: expand instrument research metrics

### DIFF
--- a/frontend/src/lib/money.ts
+++ b/frontend/src/lib/money.ts
@@ -39,3 +39,11 @@ export const percentOrNa = (
     }
     return percent(v * 100, fractionDigits, locale);
 };
+
+export const largeNumber = (
+    v: number | null | undefined,
+    locale: string = i18n.language,
+): string => {
+    if (typeof v !== "number" || !Number.isFinite(v)) return "—";
+    return new Intl.NumberFormat(locale).format(v);
+};

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { getInstrumentDetail, getScreener } from "../api";
 import type { ScreenerResult, InstrumentDetail } from "../types";
+import { largeNumber } from "../lib/money";
 
 export default function InstrumentResearch() {
   const { ticker } = useParams<{ ticker: string }>();
@@ -54,6 +55,30 @@ export default function InstrumentResearch() {
             <tr>
               <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>D/E</th>
               <td>{metrics.de_ratio ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>LT D/E</th>
+              <td>{metrics.lt_de_ratio ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Market Cap</th>
+              <td>{largeNumber(metrics.market_cap)}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>EPS</th>
+              <td>{metrics.eps ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Dividend Yield</th>
+              <td>{metrics.dividend_yield ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Beta</th>
+              <td>{metrics.beta ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Avg Volume</th>
+              <td>{largeNumber(metrics.avg_volume)}</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- show additional metrics on InstrumentResearch page including long-term D/E, market cap, EPS, dividend yield, beta, and average volume
- add `largeNumber` helper for consistent large number formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc9fa7be988327bfe7e3c65ea77758