### PR TITLE
feat: support base currency selection

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -13,7 +13,7 @@ import json
 import logging
 import math
 import os
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, date
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -32,6 +32,7 @@ from backend.common.virtual_portfolio import (
 from backend.config import config
 from backend.timeseries.cache import load_meta_timeseries, load_meta_timeseries_range
 from backend.utils.timeseries_helpers import apply_scaling, get_scaling_override
+from backend.utils.fx_rates import fetch_fx_rate_range
 
 logger = logging.getLogger("portfolio_utils")
 
@@ -72,6 +73,28 @@ def _safe_num(val, default: float = 0.0) -> float:
         return float(val)
     except (TypeError, ValueError):
         return default
+
+
+def _fx_to_gbp(currency: str, cache: Dict[str, float]) -> float:
+    """Return GBP per unit of ``currency`` using recent FX rates."""
+    currency = currency.upper()
+    if currency in cache:
+        return cache[currency]
+    if currency == "GBP":
+        cache["GBP"] = 1.0
+        return 1.0
+    end = date.today()
+    start = end - timedelta(days=7)
+    try:
+        df = fetch_fx_rate_range(currency, start, end)
+        if not df.empty:
+            rate = float(df["Rate"].iloc[-1])
+            cache[currency] = rate
+            return rate
+    except Exception:
+        pass
+    cache[currency] = 1.0
+    return 1.0
 
 
 # ──────────────────────────────────────────────────────────────
@@ -320,11 +343,16 @@ def list_all_unique_tickers() -> List[str]:
 # ──────────────────────────────────────────────────────────────
 # Core aggregation
 # ──────────────────────────────────────────────────────────────
-def aggregate_by_ticker(portfolio: dict | VirtualPortfolio) -> List[dict]:
-    """
-    Collapse a nested portfolio tree into one row per ticker,
+def aggregate_by_ticker(
+    portfolio: dict | VirtualPortfolio, base_currency: str = "GBP"
+) -> List[dict]:
+    """Collapse a nested portfolio tree into one row per ticker,
     enriched with latest-price snapshot.
+
+    Values are converted to ``base_currency`` using recent FX rates.
     """
+    base_currency = base_currency.upper()
+    fx_cache: Dict[str, float] = {}
     if isinstance(portfolio, VirtualPortfolio):
         portfolio = portfolio.as_portfolio_dict()
     from backend.common import instrument_api
@@ -362,11 +390,15 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio) -> List[dict]:
                     "gain_gbp": 0.0,
                     "cost_gbp": 0.0,
                     "last_price_gbp": None,
+                    "last_price_currency": base_currency,
                     "last_price_date": None,
                     "change_7d_pct": None,
                     "change_30d_pct": None,
                     "instrument_type": meta.get("instrumentType")
                     or meta.get("instrument_type"),
+                    "cost_currency": base_currency,
+                    "market_value_currency": base_currency,
+                    "gain_currency": base_currency,
                 },
             )
 
@@ -421,16 +453,38 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio) -> List[dict]:
                 if k not in row and h.get(k) is not None:
                     row[k] = h[k]
 
+    gbp_per_base = _fx_to_gbp(base_currency, fx_cache)
     for r in rows.values():
+        if gbp_per_base and gbp_per_base != 1:
+            r["cost_gbp"] = round(r["cost_gbp"] / gbp_per_base, 2)
+            r["market_value_gbp"] = round(r["market_value_gbp"] / gbp_per_base, 2)
+            r["gain_gbp"] = round(r["gain_gbp"] / gbp_per_base, 2)
+            if r.get("last_price_gbp") is not None:
+                r["last_price_gbp"] = round(
+                    _safe_num(r["last_price_gbp"]) / gbp_per_base, 4
+                )
+            if r.get("day_change_gbp") is not None:
+                r["day_change_gbp"] = round(
+                    _safe_num(r["day_change_gbp"]) / gbp_per_base, 2
+                )
         cost = r["cost_gbp"]
         r["gain_pct"] = (r["gain_gbp"] / cost * 100.0) if cost else None
+        r["cost_currency"] = base_currency
+        r["market_value_currency"] = base_currency
+        r["gain_currency"] = base_currency
+        if r.get("last_price_gbp") is not None:
+            r["last_price_currency"] = base_currency
+        if r.get("day_change_gbp") is not None:
+            r["day_change_currency"] = base_currency
 
     return list(rows.values())
 
 
-def _aggregate_by_field(portfolio: dict | VirtualPortfolio, field: str) -> List[dict]:
+def _aggregate_by_field(
+    portfolio: dict | VirtualPortfolio, field: str, base_currency: str = "GBP"
+) -> List[dict]:
     """Helper to aggregate ticker rows by ``field`` (e.g. sector/region)."""
-    rows = aggregate_by_ticker(portfolio)
+    rows = aggregate_by_ticker(portfolio, base_currency)
     groups: Dict[str, dict] = {}
     for r in rows:
         key = r.get(field) or "Unknown"
@@ -441,6 +495,7 @@ def _aggregate_by_field(portfolio: dict | VirtualPortfolio, field: str) -> List[
                 "market_value_gbp": 0.0,
                 "gain_gbp": 0.0,
                 "cost_gbp": 0.0,
+                "currency": base_currency,
             },
         )
         g["market_value_gbp"] += _safe_num(r.get("market_value_gbp"))
@@ -457,14 +512,18 @@ def _aggregate_by_field(portfolio: dict | VirtualPortfolio, field: str) -> List[
     return list(groups.values())
 
 
-def aggregate_by_sector(portfolio: dict | VirtualPortfolio) -> List[dict]:
+def aggregate_by_sector(
+    portfolio: dict | VirtualPortfolio, base_currency: str = "GBP"
+) -> List[dict]:
     """Return aggregated holdings grouped by sector with return contribution."""
-    return _aggregate_by_field(portfolio, "sector")
+    return _aggregate_by_field(portfolio, "sector", base_currency)
 
 
-def aggregate_by_region(portfolio: dict | VirtualPortfolio) -> List[dict]:
+def aggregate_by_region(
+    portfolio: dict | VirtualPortfolio, base_currency: str = "GBP"
+) -> List[dict]:
     """Return aggregated holdings grouped by region with return contribution."""
-    return _aggregate_by_field(portfolio, "region")
+    return _aggregate_by_field(portfolio, "region", base_currency)
 
 
 # ──────────────────────────────────────────────────────────────

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -169,6 +169,8 @@ describe("App", () => {
           tabs: { ...allTabs, movers: false },
           refreshConfig: vi.fn(),
           setRelativeViewEnabled: () => {},
+          baseCurrency: "GBP",
+          setBaseCurrency: () => {},
         }}
       >
         <MemoryRouter initialEntries={["/movers"]}>
@@ -241,6 +243,8 @@ describe("App", () => {
           tabs: allTabs,
           refreshConfig: vi.fn(),
           setRelativeViewEnabled: () => {},
+          baseCurrency: "GBP",
+          setBaseCurrency: () => {},
         }}
       >
         <MemoryRouter initialEntries={["/movers"]}>

--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -8,6 +8,7 @@ import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { money } from "../lib/money";
 import i18n from "../i18n";
+import { useConfig } from "../ConfigContext";
 
 /* ──────────────────────────────────────────────────────────────
  * Component
@@ -27,6 +28,7 @@ export function AccountBlock({
     ticker: string;
     name: string;
   } | null>(null);
+  const { baseCurrency } = useConfig();
 
   return (
     <div className="mb-4 p-2 md:mb-8 md:p-4">
@@ -46,7 +48,11 @@ export function AccountBlock({
       {selected && (
         <>
           <div className="mb-2">
-            Est&nbsp;Value:&nbsp;{money(account.value_estimate_gbp)}
+            Est&nbsp;Value:&nbsp;
+            {money(
+              account.value_estimate_gbp,
+              account.value_estimate_currency || baseCurrency,
+            )}
           </div>
 
           {account.last_updated && (

--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -26,6 +26,7 @@ afterEach(async () => {
 const defaultConfig: AppConfig = {
   relativeViewEnabled: false,
   theme: "system",
+  baseCurrency: "GBP",
   tabs: {
     group: true,
     owner: true,
@@ -53,7 +54,13 @@ const TestProvider = ({ children }: { children: React.ReactNode }) => {
   const [relativeViewEnabled, setRelativeViewEnabled] = useState(false);
   return (
     <configContext.Provider
-      value={{ ...defaultConfig, relativeViewEnabled, setRelativeViewEnabled, refreshConfig: async () => {} }}
+      value={{
+        ...defaultConfig,
+        relativeViewEnabled,
+        setRelativeViewEnabled,
+        refreshConfig: async () => {},
+        setBaseCurrency: () => {},
+      }}
     >
       {children}
     </configContext.Provider>

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -88,7 +88,7 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
 
   const [selected, setSelected] = useState<SelectedInstrument | null>(null);
   const { t } = useTranslation();
-  const { relativeViewEnabled } = useConfig();
+  const { relativeViewEnabled, baseCurrency } = useConfig();
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
   const [alpha, setAlpha] = useState<number | null>(null);
   const [trackingError, setTrackingError] = useState<number | null>(null);
@@ -289,7 +289,12 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
                   />
                 ))}
               </Pie>
-              <Tooltip formatter={(v: number, n: string) => [money(v), n]} />
+              <Tooltip
+                formatter={(v: number, n: string) => [
+                  money(v, baseCurrency),
+                  n,
+                ]}
+              />
               <Legend />
             </PieChart>
           </ResponsiveContainer>
@@ -323,7 +328,7 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
             >
               <XAxis dataKey={contribTab === "sector" ? "sector" : "region"} />
               <YAxis />
-              <Tooltip formatter={(v: number) => money(v)} />
+              <Tooltip formatter={(v: number) => money(v, baseCurrency)} />
               <Bar dataKey="gain_gbp">
                 {(contribTab === "sector" ? sectorContrib : regionContrib)?.map(
                   (row, idx) => (
@@ -373,14 +378,16 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
                 {row.owner}
               </td>
               <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                {relativeViewEnabled ? percent(row.valuePct) : money(row.value)}
+                {relativeViewEnabled
+                  ? percent(row.valuePct)
+                  : money(row.value, baseCurrency)}
               </td>
               {!relativeViewEnabled && (
                 <td
                   className={`${tableStyles.cell} ${tableStyles.right}`}
                   style={{ color: row.dayChange >= 0 ? "lightgreen" : "red" }}
                 >
-                  {money(row.dayChange)}
+                  {money(row.dayChange, baseCurrency)}
                 </td>
               )}
               <td
@@ -394,7 +401,7 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
                   className={`${tableStyles.cell} ${tableStyles.right}`}
                   style={{ color: row.gain >= 0 ? "lightgreen" : "red" }}
                 >
-                  {money(row.gain)}
+                  {money(row.gain, baseCurrency)}
                 </td>
               )}
               <td
@@ -438,7 +445,11 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
               ) : (
                 <>{acct.owner ?? "—"}</>
               )}{" "}
-              • {acct.account_type} — {money(acct.value_estimate_gbp)}
+              • {acct.account_type} —
+              {money(
+                acct.value_estimate_gbp,
+                acct.value_estimate_currency || baseCurrency,
+              )}
             </h3>
 
             {checked && (

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -12,6 +12,7 @@ import { configContext, type AppConfig } from "../ConfigContext";
 const defaultConfig: AppConfig = {
     relativeViewEnabled: false,
     theme: "system",
+    baseCurrency: "GBP",
     tabs: {
         group: true,
         owner: true,
@@ -115,7 +116,15 @@ describe("HoldingsTable", () => {
     const TestProvider = ({ children }: { children: React.ReactNode }) => {
         const [relativeViewEnabled, setRelativeViewEnabled] = useState(false);
         return (
-            <configContext.Provider value={{ ...defaultConfig, relativeViewEnabled, setRelativeViewEnabled, refreshConfig: async () => {} }}>
+            <configContext.Provider
+              value={{
+                ...defaultConfig,
+                relativeViewEnabled,
+                setRelativeViewEnabled,
+                refreshConfig: async () => {},
+                setBaseCurrency: () => {},
+              }}
+            >
                 {children}
             </configContext.Provider>
         );

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -28,7 +28,7 @@ export function HoldingsTable({
   onSelectInstrument,
 }: Props) {
   const { t } = useTranslation();
-  const { relativeViewEnabled } = useConfig();
+  const { relativeViewEnabled, baseCurrency } = useConfig();
 
   const viewPresets = useMemo(
     () => [
@@ -432,7 +432,10 @@ export function HoldingsTable({
                   </td>
                 )}
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                  {money(h.current_price_gbp)}
+                  {money(
+                    h.current_price_gbp,
+                    h.current_price_currency || baseCurrency,
+                  )}
                   {h.last_price_date && (
                     <span
                       className={tableStyles.badge}
@@ -454,19 +457,24 @@ export function HoldingsTable({
                     className={`${tableStyles.cell} ${tableStyles.right}`}
                     title={(h.cost_basis_gbp ?? 0) > 0 ? t("holdingsTable.actualPurchaseCost") : t("holdingsTable.inferredCost")}
                   >
-                    {money(h.cost)}
+                    {money(
+                      h.cost,
+                      h.cost_basis_currency ||
+                        h.effective_cost_basis_currency ||
+                        baseCurrency,
+                    )}
                   </td>
                 )}
                 {!relativeViewEnabled && visibleColumns.market && (
                   <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                    {money(h.market)}
+                    {money(h.market, h.market_value_currency || baseCurrency)}
                   </td>
                 )}
                 {!relativeViewEnabled && visibleColumns.gain && (
                   <td
                     className={`${tableStyles.cell} ${tableStyles.right} ${(h.gain ?? 0) >= 0 ? 'text-positive' : 'text-negative'}`}
                   >
-                    {money(h.gain)}
+                    {money(h.gain, h.gain_currency || baseCurrency)}
                   </td>
                 )}
                 {visibleColumns.gain_pct && (

--- a/frontend/src/components/InstrumentDetail.test.tsx
+++ b/frontend/src/components/InstrumentDetail.test.tsx
@@ -9,6 +9,7 @@ import { configContext, type AppConfig } from "../ConfigContext";
 const defaultConfig: AppConfig = {
   relativeViewEnabled: false,
   theme: "system",
+  baseCurrency: "GBP",
   tabs: {
     group: true,
     owner: true,
@@ -59,7 +60,13 @@ describe("InstrumentDetail", () => {
     const [relativeViewEnabled, setRelativeViewEnabled] = useState(false);
     return (
       <configContext.Provider
-        value={{ ...defaultConfig, relativeViewEnabled, setRelativeViewEnabled, refreshConfig: async () => {} }}
+        value={{
+          ...defaultConfig,
+          relativeViewEnabled,
+          setRelativeViewEnabled,
+          refreshConfig: async () => {},
+          setBaseCurrency: () => {},
+        }}
       >
         <MemoryRouter>{children}</MemoryRouter>
       </configContext.Provider>

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -65,7 +65,7 @@ export function InstrumentDetail({
   onClose,
 }: Props) {
   const { t } = useTranslation();
-  const { relativeViewEnabled } = useConfig();
+  const { relativeViewEnabled, baseCurrency } = useConfig();
   const [data, setData] = useState<{
     prices: Price[];
     positions: Position[];
@@ -346,7 +346,7 @@ export function InstrumentDetail({
                 )}
                 {!relativeViewEnabled && (
                   <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                    {money(pos.market_value_gbp)}
+                    {money(pos.market_value_gbp, baseCurrency)}
                   </td>
                 )}
                 {!relativeViewEnabled && (
@@ -358,7 +358,7 @@ export function InstrumentDetail({
                         : "red",
                     }}
                   >
-                    {money(pos.unrealised_gain_gbp)}
+                    {money(pos.unrealised_gain_gbp, baseCurrency)}
                   </td>
                 )}
                 <td
@@ -426,13 +426,13 @@ export function InstrumentDetail({
                       )}
                     </td>
                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                      {money(p.close_gbp)}
+                      {money(p.close_gbp, baseCurrency)}
                     </td>
                     <td
                       className={`${tableStyles.cell} ${tableStyles.right}`}
                       style={{ color: colour }}
                     >
-                      {money(p.change_gbp)}
+                      {money(p.change_gbp, baseCurrency)}
                     </td>
                     <td
                       className={`${tableStyles.cell} ${tableStyles.right}`}

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -8,6 +8,7 @@ import { configContext, type AppConfig } from "../ConfigContext";
 const defaultConfig: AppConfig = {
     relativeViewEnabled: false,
     theme: "system",
+    baseCurrency: "GBP",
     tabs: {
         group: true,
         owner: true,
@@ -35,7 +36,13 @@ const TestProvider = ({ children }: { children: React.ReactNode }) => {
     const [relativeViewEnabled, setRelativeViewEnabled] = useState(false);
     return (
         <configContext.Provider
-            value={{ ...defaultConfig, relativeViewEnabled, setRelativeViewEnabled, refreshConfig: async () => { } }}
+            value={{
+                ...defaultConfig,
+                relativeViewEnabled,
+                setRelativeViewEnabled,
+                refreshConfig: async () => {},
+                setBaseCurrency: () => {},
+            }}
         >
             {children}
         </configContext.Provider>

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 export function InstrumentTable({ rows }: Props) {
     const { t } = useTranslation();
-    const { relativeViewEnabled } = useConfig();
+    const { relativeViewEnabled, baseCurrency } = useConfig();
     const [selected, setSelected] = useState<InstrumentSummary | null>(null);
     const [visibleColumns, setVisibleColumns] = useState({
         units: true,
@@ -205,14 +205,24 @@ export function InstrumentTable({ rows }: Props) {
                                     </td>
                                 )}
                                 {!relativeViewEnabled && visibleColumns.cost && (
-                                    <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(r.cost)}</td>
+                                    <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                                        {money(
+                                            r.cost,
+                                            r.market_value_currency || baseCurrency,
+                                        )}
+                                    </td>
                                 )}
                                 {!relativeViewEnabled && visibleColumns.market && (
-                                    <td className={`${tableStyles.cell} ${tableStyles.right}`}>{money(r.market_value_gbp)}</td>
+                                    <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                                        {money(
+                                            r.market_value_gbp,
+                                            r.market_value_currency || baseCurrency,
+                                        )}
+                                    </td>
                                 )}
                                 {!relativeViewEnabled && visibleColumns.gain && (
                                     <td className={`${tableStyles.cell} ${tableStyles.right}`} style={{ color: gainColour }}>
-                                        {money(r.gain_gbp)}
+                                        {money(r.gain_gbp, r.gain_currency || baseCurrency)}
                                     </td>
                                 )}
                                 {visibleColumns.gain_pct && (
@@ -225,7 +235,12 @@ export function InstrumentTable({ rows }: Props) {
                                 )}
                                 {!relativeViewEnabled && (
                                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                                        {r.last_price_gbp != null ? money(r.last_price_gbp) : "—"}
+                                        {r.last_price_gbp != null
+                                            ? money(
+                                                  r.last_price_gbp,
+                                                  r.last_price_currency || baseCurrency,
+                                              )
+                                            : "—"}
                                     </td>
                                 )}
                                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>

--- a/frontend/src/components/PortfolioSummary.tsx
+++ b/frontend/src/components/PortfolioSummary.tsx
@@ -1,5 +1,6 @@
 import type { Account } from "../types";
 import { money, percent } from "../lib/money";
+import { useConfig } from "../ConfigContext";
 
 export type PortfolioTotals = {
   totalValue: number;
@@ -64,6 +65,7 @@ export function PortfolioSummary({ totals }: Props) {
     totalGainPct,
     totalDayChangePct,
   } = totals;
+  const { baseCurrency } = useConfig();
 
   return (
     <div
@@ -80,7 +82,7 @@ export function PortfolioSummary({ totals }: Props) {
       <div>
         <div style={{ fontSize: "1rem", color: "#aaa" }}>Total Value</div>
         <div style={{ fontSize: "2rem", fontWeight: "bold" }}>
-          {money(totalValue)}
+          {money(totalValue, baseCurrency)}
         </div>
       </div>
       <div>
@@ -92,7 +94,7 @@ export function PortfolioSummary({ totals }: Props) {
             color: totalDayChange >= 0 ? "lightgreen" : "red",
           }}
         >
-          {money(totalDayChange)} ({percent(totalDayChangePct)})
+          {money(totalDayChange, baseCurrency)} ({percent(totalDayChangePct)})
         </div>
       </div>
       <div>
@@ -104,7 +106,7 @@ export function PortfolioSummary({ totals }: Props) {
             color: totalGain >= 0 ? "lightgreen" : "red",
           }}
         >
-          {money(totalGain)} ({percent(totalGainPct)})
+          {money(totalGain, baseCurrency)} ({percent(totalGainPct)})
         </div>
       </div>
     </div>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -4,6 +4,7 @@ import type { Portfolio, Account } from "../types";
 import { AccountBlock } from "./AccountBlock";
 import { ValueAtRisk } from "./ValueAtRisk";
 import { money } from "../lib/money";
+import { useConfig } from "../ConfigContext";
 import i18n from "../i18n";
 import { complianceForOwner } from "../api";
 
@@ -60,6 +61,8 @@ export function PortfolioView({ data, loading, error }: Props) {
     selectedAccounts.length ? selectedAccounts : allKeys
   );
 
+  const { baseCurrency } = useConfig();
+
   const totalValue = data.accounts.reduce(
     (sum, acct, idx) =>
       activeSet.has(accountKey(acct, idx))
@@ -77,7 +80,7 @@ export function PortfolioView({ data, loading, error }: Props) {
         As of {new Intl.DateTimeFormat(i18n.language).format(new Date(data.as_of))}
       </div>
       <div className="mb-8">
-        Approx Total: {money(totalValue)}
+        Approx Total: {money(totalValue, baseCurrency)}
       </div>
         {hasWarnings && (
           <div className="mb-4">

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -6,6 +6,7 @@ import { Selector } from "./Selector";
 import { useFetch } from "../hooks/useFetch";
 import tableStyles from "../styles/table.module.css";
 import { money } from "../lib/money";
+import { useConfig } from "../ConfigContext";
 import i18n from "../i18n";
 import { useTranslation } from "react-i18next";
 
@@ -19,6 +20,7 @@ export function TransactionsPage({ owners }: Props) {
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");
   const { t } = useTranslation();
+  const { baseCurrency } = useConfig();
   const fetchTransactions = useCallback(
     () =>
       getTransactions({
@@ -112,7 +114,7 @@ export function TransactionsPage({ owners }: Props) {
                 <td className={tableStyles.cell}>{t.type || t.kind}</td>
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                   {t.amount_minor != null
-                    ? money(t.amount_minor / 100, t.currency ?? "GBP")
+                    ? money(t.amount_minor / 100, t.currency ?? baseCurrency)
                     : ""}
                 </td>
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>{t.shares ?? ""}</td>

--- a/frontend/src/components/responsiveRender.test.tsx
+++ b/frontend/src/components/responsiveRender.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../api", () => ({
 const defaultConfig: AppConfig = {
   relativeViewEnabled: false,
   theme: "system",
+  baseCurrency: "GBP",
   tabs: {
     group: true,
     owner: true,
@@ -79,7 +80,14 @@ const portfolio: Portfolio = {
 
 const renderWithConfig = (ui: React.ReactElement) =>
   render(
-    <configContext.Provider value={{ ...defaultConfig, refreshConfig: async () => {}, setRelativeViewEnabled: () => {} }}>
+    <configContext.Provider
+      value={{
+        ...defaultConfig,
+        refreshConfig: async () => {},
+        setRelativeViewEnabled: () => {},
+        setBaseCurrency: () => {},
+      }}
+    >
       {ui}
     </configContext.Provider>,
   );

--- a/frontend/src/hooks/useRouteMode.test.tsx
+++ b/frontend/src/hooks/useRouteMode.test.tsx
@@ -71,6 +71,8 @@ describe("useRouteMode", () => {
       theme: "system",
       refreshConfig: async () => {},
       setRelativeViewEnabled: () => {},
+      baseCurrency: "GBP",
+      setBaseCurrency: () => {},
     };
 
     const wrapper = ({ children }: { children: ReactNode }) => (

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -4,6 +4,7 @@ import { getGroupPortfolio } from "../api";
 import type { Account, GroupPortfolio } from "../types";
 import { translateInstrumentType } from "../lib/instrumentType";
 import { money } from "../lib/money";
+import { useConfig } from "../ConfigContext";
 import {
   PieChart,
   Pie,
@@ -31,6 +32,7 @@ export type AllocationChartsProps = {
 
 export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
   const { t } = useTranslation();
+  const { baseCurrency } = useConfig();
   const [view, setView] = useState<"asset" | "sector" | "region">("asset");
   const [sectorData, setSectorData] = useState<{ name: string; value: number }[]>(
     [],
@@ -158,7 +160,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
               outerRadius="80%"
               // "percent" may be undefined for empty datasets; default it to 0
               label={({ name, value, percent = 0 }) =>
-                `${name}: ${money(value)} (${(percent * 100).toFixed(2)}%)`
+                `${name}: ${money(value, baseCurrency)} (${(percent * 100).toFixed(2)}%)`
               }
             >
               {chartData.map((_, index) => (
@@ -168,10 +170,10 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
                 />
               ))}
             </Pie>
-            <Tooltip formatter={(v: number) => money(v)} />
+            <Tooltip formatter={(v: number) => money(v, baseCurrency)} />
             <Legend
               formatter={(value: string, entry: any) =>
-                `${value}: ${money(entry?.payload?.value)}`
+                `${value}: ${money(entry?.payload?.value, baseCurrency)}`
               }
             />
           </PieChart>

--- a/frontend/src/pages/Reports.test.tsx
+++ b/frontend/src/pages/Reports.test.tsx
@@ -71,6 +71,9 @@ describe("Reports page", () => {
           tabs: allTabs,
           disabledTabs: [],
           refreshConfig: vi.fn(),
+          setRelativeViewEnabled: () => {},
+          baseCurrency: "GBP",
+          setBaseCurrency: () => {},
         }}
       >
         <MemoryRouter initialEntries={["/reports"]}>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,15 +11,21 @@ export interface Holding {
     acquired_date: string;
     price?: number;
     cost_basis_gbp?: number;
+    cost_basis_currency?: string | null;
     effective_cost_basis_gbp?: number;
+    effective_cost_basis_currency?: string | null;
     market_value_gbp?: number;
+    market_value_currency?: string | null;
     gain_gbp?: number;
+    gain_currency?: string | null;
     gain_pct?: number;
     current_price_gbp?: number | null;
+    current_price_currency?: string | null;
     /** Date of the last known price for this holding */
     last_price_date?: string | null;
     latest_source?: string | null;
     day_change_gbp?: number;
+    day_change_currency?: string | null;
     instrument_type?: string | null;
     sector?: string | null;
     region?: string | null;
@@ -35,6 +41,7 @@ export type Account = {
     currency: string;
     last_updated?: string;
     value_estimate_gbp: number;
+    value_estimate_currency?: string | null;
     holdings: Holding[];
     owner?: string;
 };
@@ -45,6 +52,7 @@ export type Portfolio = {
     trades_this_month: number;
     trades_remaining: number;
     total_value_estimate_gbp: number;
+    total_value_estimate_currency?: string | null;
     accounts: Account[];
 };
 
@@ -60,12 +68,14 @@ export type GroupPortfolio = {
     as_of: string;
     members: string[];
     total_value_estimate_gbp: number;
+    total_value_estimate_currency?: string | null;
     trades_this_month?: number;
     trades_remaining?: number;
     accounts: Account[];
     members_summary: {
         owner: string;
         total_value_estimate_gbp: number;
+        total_value_estimate_currency?: string | null;
         trades_this_month: number;
         trades_remaining: number;
     }[];
@@ -78,12 +88,15 @@ export type InstrumentSummary = {
     currency?: string | null;
     units: number;
     market_value_gbp: number;
+    market_value_currency?: string | null;
     gain_gbp: number;
+    gain_currency?: string | null;
     instrument_type?: string | null;
     gain_pct?: number;
 
     /* last-price enrichment */
     last_price_gbp?: number | null;
+    last_price_currency?: string | null;
     last_price_date?: string | null;
     change_7d_pct?: number | null;
     change_30d_pct?: number | null;
@@ -94,6 +107,7 @@ export type SectorContribution = {
     market_value_gbp: number;
     gain_gbp: number;
     cost_gbp: number;
+    currency?: string | null;
     gain_pct?: number | null;
     contribution_pct?: number | null;
 };
@@ -103,6 +117,7 @@ export type RegionContribution = {
     market_value_gbp: number;
     gain_gbp: number;
     cost_gbp: number;
+    currency?: string | null;
     gain_pct?: number | null;
     contribution_pct?: number | null;
 };

--- a/tests/test_portfolio_utils_currency.py
+++ b/tests/test_portfolio_utils_currency.py
@@ -10,3 +10,33 @@ def test_currency_from_instrument_meta(monkeypatch):
 
     assert len(rows) == 1
     assert rows[0]["currency"] == "USD"
+
+
+def test_aggregate_by_ticker_fx_conversion(monkeypatch):
+    portfolio = {
+        "accounts": [
+            {
+                "holdings": [
+                    {"ticker": "ABC", "units": 1, "market_value_gbp": 100, "gain_gbp": 10}
+                ]
+            }
+        ]
+    }
+
+    monkeypatch.setattr(
+        portfolio_utils,
+        "get_instrument_meta",
+        lambda t: {"currency": "USD"},
+    )
+
+    def fake_fetch(base: str, start, end):
+        import pandas as pd
+
+        return pd.DataFrame({"Date": [start], "Rate": [0.5]})
+
+    monkeypatch.setattr(portfolio_utils, "fetch_fx_rate_range", fake_fetch)
+
+    rows = portfolio_utils.aggregate_by_ticker(portfolio, base_currency="USD")
+
+    assert rows[0]["market_value_gbp"] == 200.0
+    assert rows[0]["market_value_currency"] == "USD"


### PR DESCRIPTION
## Summary
- carry currency metadata for holdings and aggregates
- add base currency selector and context support in frontend
- convert portfolio metrics to a selectable base currency

## Testing
- `npm test` *(fails: ScenarioTester page, ScenarioTester inputs, UserConfig page)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9efb7ec0832784e18f0a7929e7ee