### PR TITLE
Add transaction importers and upload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ uvicorn app:app --reload --port 8000 --host 0.0.0.0
 npm i && npm run dev
 ```
 
+## Importing Transactions
+
+The backend can parse transaction exports from supported providers. Upload a
+file and specify the provider name:
+
+```
+curl -F provider=degiro -F file=@transactions.csv \
+     http://localhost:8000/transactions/import
+```
+
+For convenience, use the helper script:
+
+```
+python scripts/import_transactions.py degiro path/to/transactions.csv
+```
+
 ---
 
 ## Backend dependencies

--- a/backend/importers/__init__.py
+++ b/backend/importers/__init__.py
@@ -1,0 +1,37 @@
+"""Provider specific transaction importers."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Dict, List, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from backend.routes.transactions import Transaction
+
+
+class UnknownProvider(Exception):
+    """Raised when no importer exists for the requested provider."""
+
+    pass
+
+
+_IMPORTER_PATHS: Dict[str, str] = {
+    "degiro": "backend.importers.degiro",
+}
+
+
+def parse(provider: str, data: bytes) -> List[Transaction]:
+    """Parse raw file ``data`` from ``provider`` into transactions.
+
+    Parameters
+    ----------
+    provider:
+        Name of the provider, e.g. ``"degiro"``.
+    data:
+        Raw file contents.
+    """
+    module_path = _IMPORTER_PATHS.get(provider.lower())
+    if not module_path:
+        raise UnknownProvider(provider)
+    module: Callable[[bytes], List[Transaction]] = import_module(module_path)
+    return module.parse(data)  # type: ignore[attr-defined]

--- a/backend/importers/degiro.py
+++ b/backend/importers/degiro.py
@@ -1,0 +1,42 @@
+"""Parser for DeGiro transaction exports."""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import List
+
+from backend.routes.transactions import Transaction
+
+
+def _to_float(value: str | None) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def parse(data: bytes) -> List[Transaction]:
+    """Parse a CSV export from DeGiro into transactions."""
+    text = data.decode("utf-8")
+    reader = csv.DictReader(io.StringIO(text))
+    transactions: List[Transaction] = []
+    for row in reader:
+        transactions.append(
+            Transaction(
+                owner=row.get("owner", ""),
+                account=row.get("account", ""),
+                date=row.get("date"),
+                ticker=row.get("ticker"),
+                type=row.get("type"),
+                amount_minor=_to_float(row.get("amount_minor")),
+                price=_to_float(row.get("price")),
+                units=_to_float(row.get("units")),
+                fees=_to_float(row.get("fees")),
+                comments=row.get("comments"),
+                reason_to_buy=row.get("reason_to_buy"),
+            )
+        )
+    return transactions

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -22,12 +22,13 @@ else:  # pragma: no cover - Unix
     msvcrt = None  # type: ignore[assignment]
 
 from fastapi import APIRouter, HTTPException
-from fastapi import Request
+from fastapi import Request, UploadFile, File, Form
 from pydantic import BaseModel, ConfigDict, Field
 
 from backend.common import portfolio as portfolio_mod
 from backend.common import portfolio_loader
 from backend.config import config
+from backend import importers
 
 router = APIRouter(tags=["transactions"])
 log = logging.getLogger("transactions")
@@ -192,6 +193,21 @@ async def create_transaction(tx: TransactionCreate) -> dict:
         log.warning("Portfolio rebuild failed: %s", exc)
 
     return {"owner": owner, "account": account, **tx_data}
+
+
+@router.post("/transactions/import", response_model=List[Transaction])
+async def import_transactions(
+    provider: str = Form(...), file: UploadFile = File(...)
+) -> List[Transaction]:
+    """Parse a transaction export and return the contained transactions."""
+
+    data = await file.read()
+    try:
+        return importers.parse(provider, data)
+    except importers.UnknownProvider as exc:
+        raise HTTPException(status_code=400, detail=f"Unknown provider: {exc}")
+    except Exception as exc:  # pragma: no cover - parsing errors
+        raise HTTPException(status_code=400, detail=f"Failed to parse file: {exc}")
 
 
 @router.get("/transactions", response_model=List[Transaction])

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,3 +31,13 @@ Crawl a website, capture screenshots, run AI analysis on each page and build PDF
 6. Output appears in `site_manual/` with screenshots, per-page Markdown files (including AI analysis) and a combined PDF manual embedding the analysis text under each screenshot.
 
 The script uses Playwright to render pages so that JavaScript-generated links are discovered correctly. Pillow enables image support in FPDF; without it, PDFs are generated without screenshots. If OpenAI analysis fails for a page, the rest of the snapshot continues with an empty analysis.
+
+## import_transactions.py
+
+Upload a local transaction export to the running backend for parsing:
+
+```
+python scripts/import_transactions.py degiro path/to/transactions.csv
+```
+
+Use `--api` to point at a different backend URL. Parsed transactions are printed as JSON.

--- a/scripts/import_transactions.py
+++ b/scripts/import_transactions.py
@@ -1,0 +1,35 @@
+"""CLI helper to import transaction files via the API."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+import requests
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Upload transactions for parsing")
+    parser.add_argument("provider", help="Data provider name, e.g. degiro")
+    parser.add_argument("file", type=Path, help="CSV/PDF file to upload")
+    parser.add_argument(
+        "--api", default="http://localhost:8000", help="Base URL of the backend API"
+    )
+    args = parser.parse_args()
+
+    url = f"{args.api.rstrip('/')}/transactions/import"
+    with args.file.open("rb") as fh:
+        files = {"file": (args.file.name, fh)}
+        data = {"provider": args.provider}
+        resp = requests.post(url, data=data, files=files, timeout=30)
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as exc:  # pragma: no cover - network errors
+        print(f"Request failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print(resp.json())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.config import config
+
+
+def _make_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "accounts_root", tmp_path)
+    app = create_app()
+    return TestClient(app)
+
+
+def test_import_transactions_csv(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    csv_data = (
+        "owner,account,date,ticker,type,price,units,fees,comments,reason_to_buy\n"
+        "alice,ISA,2024-05-01,AAPL,BUY,10.5,2,1.0,test,diversify\n"
+    )
+    resp = client.post(
+        "/transactions/import",
+        data={"provider": "degiro"},
+        files={"file": ("tx.csv", csv_data, "text/csv")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["ticker"] == "AAPL"
+    assert data[0]["owner"] == "alice"


### PR DESCRIPTION
## Summary
- support provider-specific transaction importers
- add `/transactions/import` endpoint for file uploads
- document import workflow and add CLI helper

## Testing
- `pytest tests/test_transactions_import.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc9ef75230832798d72bf3f4d329be