### PR TITLE
feat: add user link translation and toggle

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -117,6 +117,15 @@ export default function Menu({
             {t(`app.modes.${p.id}`)}
           </Link>
         ))}
+      <Link
+        to={mode === 'support' ? pathFor('group') : '/support'}
+        style={{
+          marginRight: '1rem',
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {t(mode === 'support' ? 'app.userLink' : 'app.supportLink')}
+      </Link>
       {onLogout && (
         <button
           type="button"

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -6,6 +6,7 @@
     "last": "Zuletzt:",
     "loading": "Laden…",
     "supportLink": "Support",
+    "userLink": "Benutzer",
     "logout": "Abmelden",
     "modes": {
       "group": "Gruppe",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -6,6 +6,7 @@
     "last": "Last:",
     "loading": "Loading…",
     "supportLink": "Support",
+    "userLink": "User",
     "logout": "Logout",
     "modes": {
       "group": "Group",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -6,6 +6,7 @@
     "last": "Último:",
     "loading": "Cargando…",
     "supportLink": "Soporte",
+    "userLink": "Usuario",
     "logout": "Cerrar sesión",
     "modes": {
       "group": "Grupo",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -6,6 +6,7 @@
     "last": "Dernier :",
     "loading": "Chargement…",
     "supportLink": "Support",
+    "userLink": "Utilisateur",
     "logout": "Déconnexion",
     "modes": {
       "group": "Groupe",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -6,6 +6,7 @@
     "last": "Scorso:",
     "loading": "Caricamento…",
     "supportLink": "Supporto",
+    "userLink": "Utente",
     "logout": "Logout",
     "modes": {
       "group": "Gruppo",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -6,6 +6,7 @@
     "last": "Último:",
     "loading": "Carregando…",
     "supportLink": "Suporte",
+    "userLink": "Usuário",
     "logout": "Sair",
     "modes": {
       "group": "Grupo",


### PR DESCRIPTION
## Summary
- add `userLink` translation for all locales
- show support/user toggle using new translations in `Menu`

## Testing
- `npm test` *(fails: App defaults to Group view and orders tabs correctly, ScenarioTester page runs scenario, ScenarioTester page disables Apply button until valid inputs provided, UserConfig page handles non-array config values)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9ee37ed083279caf8af152057d59