### PR TITLE
feat(frontend): pause watchlist when markets closed

### DIFF
--- a/frontend/src/pages/Watchlist.test.tsx
+++ b/frontend/src/pages/Watchlist.test.tsx
@@ -109,5 +109,31 @@ describe("Watchlist page", () => {
 
     vi.useRealTimers();
   });
+
+  it("stops polling when markets are closed", async () => {
+    vi.useFakeTimers();
+    const closedRows = sampleRows.map((r) => ({ ...r, marketState: "CLOSED" }));
+    (getQuotes as ReturnType<typeof vi.fn>).mockResolvedValue(closedRows as any);
+    localStorage.setItem("watchlistSymbols", "AAA,BBB");
+
+    render(<Watchlist />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Markets closed")).toBeInTheDocument();
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getQuotes).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
 });
 

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -3,6 +3,10 @@ import { useTranslation } from "react-i18next";
 import { getQuotes } from "../api";
 import type { QuoteRow } from "../types";
 
+interface QuoteWithState extends QuoteRow {
+  marketState?: string;
+}
+
 const DEFAULT_SYMBOLS =
   "^FTSE,^NDX,^GSPC,^RUT,^NYA,^VIX,^GDAXI,^N225,USDGBP=X,EURGBP=X,BTC-USD,GC=F,SI=F,VUSA.L,IWDA.AS";
 
@@ -42,9 +46,10 @@ export function Watchlist() {
   const [symbols, setSymbols] = useState(() =>
     localStorage.getItem("watchlistSymbols") || DEFAULT_SYMBOLS,
   );
-  const [rows, setRows] = useState<QuoteRow[]>([]);
+  const [rows, setRows] = useState<QuoteWithState[]>([]);
   const [auto, setAuto] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [allClosed, setAllClosed] = useState(false);
   const [sortKey, setSortKey] = useState<keyof QuoteRow>("symbol");
   const [asc, setAsc] = useState(true);
 
@@ -59,9 +64,26 @@ export function Watchlist() {
       return;
     }
     try {
-      const data = await getQuotes(symbolList);
+      const data = (await getQuotes(symbolList)) as QuoteWithState[];
       setRows(data);
       setError(null);
+
+      const closed =
+        data.length > 0 &&
+        data.every((r) => r.marketState && r.marketState !== "REGULAR");
+
+      setAllClosed((prev) => {
+        if (closed) {
+          if (!prev) {
+            setAuto(false);
+          }
+          return true;
+        }
+        if (prev) {
+          setAuto(true);
+        }
+        return false;
+      });
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -73,10 +95,15 @@ export function Watchlist() {
   }, [fetchData, symbols]);
 
   useEffect(() => {
-    if (!auto) return;
-    const id = setInterval(fetchData, 10000);
-    return () => clearInterval(id);
-  }, [auto, fetchData]);
+    if (auto) {
+      const id = setInterval(fetchData, 10000);
+      return () => clearInterval(id);
+    }
+    if (allClosed) {
+      const id = setInterval(fetchData, 60000);
+      return () => clearInterval(id);
+    }
+  }, [auto, allClosed, fetchData]);
 
   const sorted = useMemo(() => {
     const data = [...rows];
@@ -127,6 +154,11 @@ export function Watchlist() {
       </div>
       {error && (
         <div className="mb-2 text-red-500">{error}</div>
+      )}
+      {allClosed && (
+        <div className="mb-2 text-gray-500">
+          {t("watchlist.marketsClosed", { defaultValue: "Markets closed" })}
+        </div>
       )}
       <div className="overflow-x-auto">
         <table className="w-full border-collapse">


### PR DESCRIPTION
## Summary
- disable watchlist auto-refresh when all tracked markets report CLOSED
- periodically check for market reopening and resume polling
- add test ensuring closed markets halt polling and show notice

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bca1ab77e88327974aa329e6d100f6