### PR TITLE
feat: add user link translations

### DIFF
--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -22,7 +22,7 @@ describe("Menu", () => {
       </MemoryRouter>,
     );
     expect(screen.getByRole("link", { name: "Logs" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "App" })).toHaveAttribute("href", "/");
+    expect(screen.getByRole("link", { name: "User" })).toHaveAttribute("href", "/");
   });
 
   it("renders logout button when callback provided", () => {

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -6,7 +6,7 @@
     "last": "Zuletzt:",
     "loading": "Laden…",
     "supportLink": "Support",
-    "userLink": "App",
+    "userLink": "Benutzer",
     "logout": "Abmelden",
     "modes": {
       "group": "Gruppe",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -6,7 +6,7 @@
     "last": "Last:",
     "loading": "Loading…",
     "supportLink": "Support",
-    "userLink": "App",
+    "userLink": "User",
     "logout": "Logout",
     "modes": {
       "group": "Group",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -6,7 +6,7 @@
     "last": "Último:",
     "loading": "Cargando…",
     "supportLink": "Soporte",
-    "userLink": "App",
+    "userLink": "Usuario",
     "logout": "Cerrar sesión",
     "modes": {
       "group": "Grupo",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -6,7 +6,7 @@
     "last": "Dernier :",
     "loading": "Chargement…",
     "supportLink": "Support",
-    "userLink": "App",
+    "userLink": "Utilisateur",
     "logout": "Déconnexion",
     "modes": {
       "group": "Groupe",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -6,7 +6,7 @@
     "last": "Scorso:",
     "loading": "Caricamento…",
     "supportLink": "Supporto",
-    "userLink": "App",
+    "userLink": "Utente",
     "logout": "Logout",
     "modes": {
       "group": "Gruppo",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -6,7 +6,7 @@
     "last": "Último:",
     "loading": "Carregando…",
     "supportLink": "Suporte",
-    "userLink": "App",
+    "userLink": "Usuário",
     "logout": "Sair",
     "modes": {
       "group": "Grupo",


### PR DESCRIPTION
## Summary
- translate support toggle "User" link in all locales
- adjust menu tests for new label

## Testing
- `npx vitest run src/components/Menu.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bca53651088327a6207a3107fcd56b