### PR TITLE
fix: hide support toggle when support tab disabled

### DIFF
--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../i18n";
 import Menu from "./Menu";
+import { configContext, type ConfigContextValue } from "../ConfigContext";
 
 describe("Menu", () => {
   it("renders support toggle link", () => {
@@ -29,6 +30,47 @@ describe("Menu", () => {
       "href",
       "/",
     );
+  });
+
+  it("hides support toggle when support tab disabled", () => {
+    const config: ConfigContextValue = {
+      relativeViewEnabled: false,
+      disabledTabs: ["support"],
+      tabs: {
+        group: true,
+        owner: true,
+        instrument: true,
+        performance: true,
+        transactions: true,
+        screener: true,
+        trading: true,
+        timeseries: true,
+        watchlist: true,
+        movers: true,
+        instrumentadmin: true,
+        dataadmin: true,
+        virtual: true,
+        support: false,
+        settings: true,
+        profile: false,
+        reports: true,
+        scenario: true,
+        logs: true,
+      },
+      theme: "system",
+      baseCurrency: "GBP",
+      refreshConfig: async () => {},
+      setRelativeViewEnabled: () => {},
+      setBaseCurrency: () => {},
+    };
+    render(
+      <configContext.Provider value={config}>
+        <MemoryRouter>
+          <Menu />
+        </MemoryRouter>
+      </configContext.Provider>,
+    );
+    expect(screen.queryByRole("link", { name: "Support" })).toBeNull();
   });
 
   it("renders logout button when callback provided", () => {

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -69,6 +69,8 @@ export default function Menu({
 
   const isSupportMode = SUPPORT_TABS.includes(mode);
   const inSupport = mode === 'support';
+  const supportEnabled =
+    tabs.support !== false && !disabledTabs?.includes('support');
 
   function pathFor(m: TabPluginId) {
     switch (m) {
@@ -129,16 +131,18 @@ export default function Menu({
             {t(`app.modes.${p.id}`)}
           </Link>
         ))}
-      <Link
-        to={inSupport ? '/' : '/support'}
-        style={{
-          marginRight: '1rem',
-          fontWeight: inSupport ? 'bold' : undefined,
-          overflowWrap: 'anywhere',
-        }}
-      >
-        {t('app.supportLink')}
-      </Link>
+      {supportEnabled && (
+        <Link
+          to={inSupport ? '/' : '/support'}
+          style={{
+            marginRight: '1rem',
+            fontWeight: inSupport ? 'bold' : undefined,
+            overflowWrap: 'anywhere',
+          }}
+        >
+          {t('app.supportLink')}
+        </Link>
+      )}
       {onLogout && (
         <button
           type="button"


### PR DESCRIPTION
## Summary
- hide support toggle when support tab disabled via configuration
- add test ensuring support toggle is hidden when tab disabled

## Testing
- `npx vitest run` *(fails: 47 failed, 2 passed; 88 failed, 8 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bca7611564832785d6f311bce6bf92