### PR TITLE
Add interactive env setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,17 @@ packages are needed.
 ### Environment variables
 
 Sensitive settings are loaded from environment variables rather than
-`config.yaml`. Create a `.env` file (copy from `.env.example`) to keep them in
-one place:
+`config.yaml`. Create a `.env` file with the helper script:
+
+```bash
+python scripts/setup_env.py
+```
+
+This copies `.env.example` to `.env` and prompts for required values such as
+`ALPHA_VANTAGE_KEY` and `JWT_SECRET`. You can then edit `.env` to set optional
+values like:
 
 ```
-cp .env.example .env
-# then edit .env with values such as
-ALPHA_VANTAGE_KEY=your-alpha-vantage-api-key
 SNS_TOPIC_ARN=arn:aws:sns:us-east-1:123456789012:allotmint   # optional
 TELEGRAM_BOT_TOKEN=123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ      # optional
 TELEGRAM_CHAT_ID=123456789                                  # optional

--- a/scripts/setup_env.py
+++ b/scripts/setup_env.py
@@ -1,0 +1,46 @@
+import shutil
+from pathlib import Path
+
+ENV_EXAMPLE = Path(__file__).resolve().parents[1] / ".env.example"
+ENV_FILE = Path(__file__).resolve().parents[1] / ".env"
+REQUIRED_KEYS = ["ALPHA_VANTAGE_KEY", "JWT_SECRET"]
+
+
+def prompt_values():
+    values = {}
+    for key in REQUIRED_KEYS:
+        values[key] = input(f"Enter value for {key}: ").strip()
+    return values
+
+
+def update_env_file(env_path: Path, values: dict) -> None:
+    lines = env_path.read_text().splitlines()
+    for key, value in values.items():
+        prefix = f"{key}="
+        for i, line in enumerate(lines):
+            if line.startswith(prefix):
+                lines[i] = f"{prefix}{value}"
+                break
+        else:
+            lines.append(f"{prefix}{value}")
+    env_path.write_text("\n".join(lines) + "\n")
+
+
+def main() -> None:
+    if not ENV_EXAMPLE.exists():
+        raise FileNotFoundError(".env.example not found")
+
+    if ENV_FILE.exists():
+        overwrite = input(".env already exists. Overwrite? [y/N]: ").lower()
+        if overwrite != "y":
+            print("Aborting without changes.")
+            return
+    shutil.copy(ENV_EXAMPLE, ENV_FILE)
+    print("Copied .env.example to .env")
+    values = prompt_values()
+    update_env_file(ENV_FILE, values)
+    print("Updated .env with provided values.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_setup_env.py
+++ b/tests/test_setup_env.py
@@ -1,0 +1,6 @@
+import py_compile
+from pathlib import Path
+
+def test_setup_env_compiles():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "setup_env.py"
+    py_compile.compile(str(script), doraise=True)


### PR DESCRIPTION
## Summary
- add `scripts/setup_env.py` to copy `.env.example` and prompt for required values
- document the setup script in the README
- ensure the script compiles via a simple pytest check

## Testing
- `pytest tests/test_setup_env.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bca7ff3eb883279d9a370dd312258e