### PR TITLE
Require explicit JWT secret with test override

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -36,9 +36,13 @@ from backend.config import config
 logger = logging.getLogger(__name__)
 
 SECRET_KEY = os.getenv("JWT_SECRET")
+_testing = os.getenv("TESTING")
 if not SECRET_KEY:
-    logger.warning("JWT_SECRET not set; generating ephemeral secret")
-    SECRET_KEY = secrets.token_urlsafe(32)
+    if config.disable_auth or _testing:
+        logger.warning("JWT_SECRET not set; using ephemeral secret for tests")
+        SECRET_KEY = secrets.token_urlsafe(32)
+    else:
+        raise RuntimeError("JWT_SECRET environment variable is required")
 ALGORITHM = "HS256"
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")

--- a/backend/tests/test_auth_module.py
+++ b/backend/tests/test_auth_module.py
@@ -82,3 +82,15 @@ def test_allowed_emails_local(monkeypatch, tmp_path):
     monkeypatch.setattr(auth, "load_person_meta", lambda owner, data_root=None: {"email": f"{owner}@example.com"})
     emails = auth._allowed_emails()
     assert "alice@example.com" in emails
+
+
+def test_missing_jwt_secret_raises_error(monkeypatch):
+    import importlib
+
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setattr(auth.config, "disable_auth", False)
+    with pytest.raises(RuntimeError):
+        importlib.reload(auth)
+    monkeypatch.setenv("JWT_SECRET", "restored")
+    importlib.reload(auth)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,9 @@
 import os
-import secrets
 
 import boto3
 import pytest
 
-os.environ.setdefault("JWT_SECRET", secrets.token_urlsafe(32))
+os.environ.setdefault("TESTING", "1")
 
 from backend.config import config
 


### PR DESCRIPTION
## Summary
- require JWT_SECRET to be set and raise a runtime error when missing
- permit TESTING or disable_auth overrides to use an ephemeral secret
- test missing JWT secret handling

## Testing
- `PYTEST_ADDOPTS="" pytest backend/tests/test_auth_module.py::test_missing_jwt_secret_raises_error -q`

------
https://chatgpt.com/codex/tasks/task_e_68bca7f9d1c08327900b9b9c55a33ff8