### PR TITLE
feat: add rate limiting to backend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,7 @@ by FastAPI.
 
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -16,6 +17,10 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
 
 from backend.auth import (
     authenticate_user,
@@ -119,6 +124,21 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
     app.state.background_tasks = []
+
+    storage_uri = "memory://"
+    if config.app_env in {"production", "aws"}:
+        redis_url = os.getenv("REDIS_URL")
+        if redis_url:
+            storage_uri = redis_url
+
+    limiter = Limiter(
+        key_func=get_remote_address,
+        default_limits=["60/minute"],
+        storage_uri=storage_uri,
+    )
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_middleware(SlowAPIMiddleware)
 
     paths = resolve_paths(config.repo_root, config.accounts_root)
     app.state.repo_root = paths.repo_root

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 uvicorn
 jinja2
 fastapi~=0.116.1
+slowapi~=0.1.9
 mangum~=0.19.0
 boto3~=1.37.10
 pandas~=2.3.1
@@ -46,3 +47,4 @@ reportlab>=4.2.0
 PyJWT~=2.9.0
 python-multipart~=0.0.20
 google-auth~=2.36.0
+redis~=5.0.1

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from backend.app import create_app
+from backend.config import config
+
+
+def test_rate_limit_enforced(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    app = create_app()
+    app.state.limiter = Limiter(
+        key_func=get_remote_address,
+        default_limits=["2/minute"],
+        storage_uri="memory://",
+    )
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        assert client.get("/health").status_code == 200
+        assert client.get("/health").status_code == 429


### PR DESCRIPTION
## Summary
- add slowapi and redis packages
- enforce 60 req/min via Limiter middleware with optional Redis store
- test rate limiting behaviour

## Testing
- `pytest -c /dev/null backend/tests/test_rate_limit.py`

------
https://chatgpt.com/codex/tasks/task_e_68bca7fc39e483279500f2cd9d4cee2e