### PR TITLE
Add goals tracking and tax harvesting features

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -62,6 +62,8 @@ from backend.routes.trading_agent import router as trading_agent_router
 from backend.routes.transactions import router as transactions_router
 from backend.routes.user_config import router as user_config_router
 from backend.routes.virtual_portfolio import router as virtual_portfolio_router
+from backend.routes.goals import router as goals_router
+from backend.routes.tax import router as tax_router
 from backend.utils import page_cache
 
 logger = logging.getLogger(__name__)
@@ -215,6 +217,8 @@ def create_app() -> FastAPI:
     app.include_router(approvals_router, dependencies=protected)
     app.include_router(scenario_router)
     app.include_router(logs_router)
+    app.include_router(goals_router, dependencies=protected)
+    app.include_router(tax_router, dependencies=protected)
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(request: Request, exc: RequestValidationError):

--- a/backend/common/goals.py
+++ b/backend/common/goals.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+"""Goal tracking helpers."""
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Dict, List
+import os
+
+from backend.common.storage import get_storage, JSONStorage
+from backend.config import config
+
+_DEFAULT_GOALS_URI = (
+    f"file://{(config.repo_root or Path(__file__).resolve().parents[1]) / 'data' / 'goals.json'}"
+)
+
+try:
+    _STORAGE: JSONStorage = get_storage(os.getenv("GOALS_STORAGE_URI", _DEFAULT_GOALS_URI))
+except Exception:
+    _STORAGE = get_storage(_DEFAULT_GOALS_URI)
+
+
+@dataclass
+class Goal:
+    """Simple savings goal."""
+
+    name: str
+    target_amount: float
+    target_date: date
+
+    def to_dict(self) -> Dict[str, str | float]:
+        return {
+            "name": self.name,
+            "target_amount": self.target_amount,
+            "target_date": self.target_date.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "Goal":
+        return cls(
+            name=str(data.get("name", "")),
+            target_amount=float(data.get("target_amount", 0.0)),
+            target_date=date.fromisoformat(str(data.get("target_date", "1970-01-01"))),
+        )
+
+    def progress(self, current_amount: float) -> float:
+        if self.target_amount <= 0:
+            return 0.0
+        return max(0.0, min(current_amount / self.target_amount, 1.0))
+
+
+# persistence helpers ---------------------------------------------------------
+
+def _load_raw() -> Dict[str, List[Dict[str, object]]]:
+    data = _STORAGE.load()
+    if not isinstance(data, dict):
+        return {}
+    return {k: v for k, v in data.items() if isinstance(v, list)}
+
+
+def _save_raw(data: Dict[str, List[Dict[str, object]]]) -> None:
+    _STORAGE.save(data)
+
+
+def load_goals(user: str) -> List[Goal]:
+    raw = _load_raw().get(user, [])
+    goals: List[Goal] = []
+    for g in raw:
+        try:
+            goals.append(Goal.from_dict(g))
+        except Exception:
+            continue
+    return goals
+
+
+def save_goals(user: str, goals: List[Goal]) -> None:
+    data = _load_raw()
+    data[user] = [g.to_dict() for g in goals]
+    _save_raw(data)
+
+
+def add_goal(user: str, goal: Goal) -> None:
+    goals = load_goals(user)
+    goals = [g for g in goals if g.name != goal.name]
+    goals.append(goal)
+    save_goals(user, goals)
+
+
+def delete_goal(user: str, name: str) -> None:
+    goals = [g for g in load_goals(user) if g.name != name]
+    save_goals(user, goals)
+
+
+def load_all_goals() -> Dict[str, List[Goal]]:
+    data = _load_raw()
+    out: Dict[str, List[Goal]] = {}
+    for user, items in data.items():
+        lst: List[Goal] = []
+        for g in items:
+            try:
+                lst.append(Goal.from_dict(g))
+            except Exception:
+                continue
+        out[user] = lst
+    return out
+
+
+__all__ = [
+    "Goal",
+    "load_goals",
+    "save_goals",
+    "add_goal",
+    "delete_goal",
+    "load_all_goals",
+]

--- a/backend/common/tax.py
+++ b/backend/common/tax.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def harvest_losses(positions: List[Dict[str, float]], threshold: float = 0.0) -> List[Dict[str, float]]:
+    """Return positions that qualify for tax loss harvesting.
+
+    Parameters
+    ----------
+    positions: list of dicts with ``ticker``, ``basis`` and ``price`` fields.
+    threshold: minimum fractional loss required to trigger a harvest.
+    """
+    results: List[Dict[str, float]] = []
+    for pos in positions:
+        try:
+            basis = float(pos.get("basis", 0.0))
+            price = float(pos.get("price", 0.0))
+        except (TypeError, ValueError):
+            continue
+        if basis <= 0:
+            continue
+        loss = basis - price
+        if loss / basis >= threshold:
+            results.append({"ticker": pos.get("ticker"), "loss": round(loss, 2)})
+    return results
+
+
+__all__ = ["harvest_losses"]

--- a/backend/routes/goals.py
+++ b/backend/routes/goals.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from backend.auth import get_current_user
+from backend.common.goals import Goal, add_goal, delete_goal, load_goals, save_goals
+from backend.common.rebalance import suggest_trades
+
+router = APIRouter(prefix="/goals", tags=["goals"])
+
+
+class GoalPayload(BaseModel):
+    name: str
+    target_amount: float
+    target_date: date
+
+
+class GoalResponse(GoalPayload):
+    progress: float | None = None
+    trades: List[dict] | None = None
+
+
+@router.get("/")
+async def list_goals(current_user: str = Depends(get_current_user)) -> List[GoalPayload]:
+    goals = load_goals(current_user)
+    return [GoalPayload(**g.to_dict()) for g in goals]
+
+
+@router.post("/")
+async def create_goal(payload: GoalPayload, current_user: str = Depends(get_current_user)) -> GoalPayload:
+    goal = Goal(payload.name, payload.target_amount, payload.target_date)
+    add_goal(current_user, goal)
+    return GoalPayload(**goal.to_dict())
+
+
+@router.get("/{name}")
+async def get_goal(
+    name: str,
+    current_amount: float,
+    current_user: str = Depends(get_current_user),
+) -> GoalResponse:
+    goals = load_goals(current_user)
+    for g in goals:
+        if g.name == name:
+            progress = g.progress(current_amount)
+            actual = {"goal": current_amount, "cash": max(g.target_amount - current_amount, 0.0)}
+            trades = suggest_trades(actual, {"goal": 1.0})
+            return GoalResponse(**g.to_dict(), progress=progress, trades=trades)
+    raise HTTPException(status_code=404, detail="Goal not found")
+
+
+@router.put("/{name}")
+async def update_goal(
+    name: str,
+    payload: GoalPayload,
+    current_user: str = Depends(get_current_user),
+) -> GoalPayload:
+    goals = load_goals(current_user)
+    found = False
+    for idx, g in enumerate(goals):
+        if g.name == name:
+            goals[idx] = Goal(payload.name, payload.target_amount, payload.target_date)
+            found = True
+            break
+    if not found:
+        raise HTTPException(status_code=404, detail="Goal not found")
+    save_goals(current_user, goals)
+    return GoalPayload(**payload.model_dump())
+
+
+@router.delete("/{name}")
+async def remove_goal(name: str, current_user: str = Depends(get_current_user)) -> dict:
+    goals = load_goals(current_user)
+    if not any(g.name == name for g in goals):
+        raise HTTPException(status_code=404, detail="Goal not found")
+    delete_goal(current_user, name)
+    return {"status": "deleted"}

--- a/backend/routes/tax.py
+++ b/backend/routes/tax.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from backend.auth import get_current_user
+from backend.common.tax import harvest_losses
+
+router = APIRouter(prefix="/tax", tags=["tax"])
+
+
+class Position(BaseModel):
+    ticker: str
+    basis: float
+    price: float
+
+
+class HarvestRequest(BaseModel):
+    positions: List[Position]
+    threshold: float | None = None
+
+
+@router.post("/harvest")
+async def harvest(req: HarvestRequest, current_user: str = Depends(get_current_user)) -> dict:
+    del current_user
+    trades = harvest_losses(
+        [p.model_dump() for p in req.positions], req.threshold or 0.0
+    )
+    return {"trades": trades}

--- a/backend/tasks/auto_rebalance.py
+++ b/backend/tasks/auto_rebalance.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Dict, Any
+
+from backend.common.goals import load_all_goals
+from backend.common.rebalance import suggest_trades
+
+log = logging.getLogger("tasks.auto_rebalance")
+
+
+async def run_once() -> None:
+    """Fetch goals and log rebalance suggestions."""
+    all_goals = load_all_goals()
+    for user, goals in all_goals.items():
+        for g in goals:
+            current = 0.0
+            actual = {"goal": current, "cash": max(g.target_amount - current, 0.0)}
+            trades = suggest_trades(actual, {"goal": 1.0})
+            if trades:
+                log.info("Suggested trades for %s/%s: %s", user, g.name, trades)
+
+
+def lambda_handler(_event: Dict[str, Any], _context: Any) -> Dict[str, str]:
+    """AWS Lambda entry point."""
+    asyncio.run(run_once())
+    return {"status": "ok"}
+
+
+async def schedule(interval_seconds: int = 86400) -> None:
+    while True:
+        await run_once()
+        await asyncio.sleep(interval_seconds)
+
+
+if __name__ == "__main__":
+    asyncio.run(schedule())

--- a/backend/tests/test_goals_route.py
+++ b/backend/tests/test_goals_route.py
@@ -1,0 +1,52 @@
+from datetime import date
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.auth import get_current_user
+from backend.common.storage import get_storage
+from backend.routes import goals as goals_route
+from backend.common import goals as goals_mod
+
+
+def _app(tmp_path, monkeypatch):
+    storage = get_storage(f"file://{tmp_path / 'goals.json'}")
+    storage.save({})
+    monkeypatch.setattr(goals_mod, "_STORAGE", storage)
+    app = FastAPI()
+    app.include_router(goals_route.router)
+    app.dependency_overrides[get_current_user] = lambda: "alice"
+    return TestClient(app)
+
+
+def test_create_and_list(tmp_path, monkeypatch):
+    client = _app(tmp_path, monkeypatch)
+    payload = {"name": "Car", "target_amount": 1000, "target_date": date.today().isoformat()}
+    assert client.post("/goals", json=payload).status_code == 200
+    resp = client.get("/goals")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["name"] == "Car"
+
+
+def test_goal_progress(tmp_path, monkeypatch):
+    client = _app(tmp_path, monkeypatch)
+    payload = {"name": "House", "target_amount": 5000, "target_date": date.today().isoformat()}
+    client.post("/goals", json=payload)
+    resp = client.get("/goals/House", params={"current_amount": 2500})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert round(data["progress"], 2) == 0.5
+    assert any(t["action"] == "buy" for t in data["trades"])
+
+
+def test_update_and_delete(tmp_path, monkeypatch):
+    client = _app(tmp_path, monkeypatch)
+    payload = {"name": "Trip", "target_amount": 2000, "target_date": date.today().isoformat()}
+    client.post("/goals", json=payload)
+    upd = {"name": "Trip", "target_amount": 3000, "target_date": date.today().isoformat()}
+    resp = client.put("/goals/Trip", json=upd)
+    assert resp.status_code == 200
+    resp = client.delete("/goals/Trip")
+    assert resp.status_code == 200
+    assert client.get("/goals").json() == []

--- a/backend/tests/test_tax_route.py
+++ b/backend/tests/test_tax_route.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.auth import get_current_user
+from backend.routes import tax
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(tax.router)
+    app.dependency_overrides[get_current_user] = lambda: "alice"
+    return TestClient(app)
+
+
+def test_harvest():
+    client = _app()
+    payload = {
+        "positions": [
+            {"ticker": "ABC", "basis": 100.0, "price": 80.0},
+            {"ticker": "XYZ", "basis": 100.0, "price": 120.0},
+        ]
+    }
+    resp = client.post("/tax/harvest", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["trades"] == [{"ticker": "ABC", "loss": 20.0}]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -752,3 +752,47 @@ export const getVarBreakdown = (
     `${API_BASE}/var/${owner}/breakdown${qs ? `?${qs}` : ""}`
   );
 };
+
+// ───────────── Goals API ─────────────
+export interface Goal {
+  name: string;
+  target_amount: number;
+  target_date: string;
+}
+
+export const getGoals = () => fetchJson<Goal[]>(`${API_BASE}/goals`);
+
+export const createGoal = (goal: Goal) =>
+  fetchJson<Goal>(`${API_BASE}/goals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(goal),
+  });
+
+export const getGoal = (name: string, current: number) =>
+  fetchJson<Goal & { progress: number; trades: any[] }>(
+    `${API_BASE}/goals/${encodeURIComponent(name)}?current_amount=${current}`,
+  );
+
+export const updateGoal = (name: string, goal: Goal) =>
+  fetchJson<Goal>(`${API_BASE}/goals/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(goal),
+  });
+
+export const deleteGoal = (name: string) =>
+  fetchJson<{ status: string }>(`${API_BASE}/goals/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });
+
+// ───────────── Tax API ─────────────
+export const harvestTax = (
+  positions: { ticker: string; basis: number; price: number }[],
+  threshold = 0,
+) =>
+  fetchJson<{ trades: any[] }>(`${API_BASE}/tax/harvest`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ positions, threshold }),
+  });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -24,6 +24,7 @@ const ComplianceWarnings = lazy(() => import('./pages/ComplianceWarnings'))
 const InstrumentResearch = lazy(() => import('./pages/InstrumentResearch'))
 const Profile = lazy(() => import('./pages/Profile'))
 const Alerts = lazy(() => import('./pages/Alerts'))
+const Goals = lazy(() => import('./pages/Goals'))
 
 export function Root() {
   const [ready, setReady] = useState(false)
@@ -68,6 +69,7 @@ export function Root() {
         <Route path="/research/:ticker" element={<InstrumentResearch />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/goals" element={<Goals />} />
         <Route path="/*" element={<App onLogout={logout} />} />
       </Routes>
     </Suspense>

--- a/frontend/src/pages/Goals.tsx
+++ b/frontend/src/pages/Goals.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { createGoal, getGoal, getGoals } from "../api";
+
+type Goal = {
+  name: string;
+  target_amount: number;
+  target_date: string;
+};
+
+type GoalWithProgress = Goal & { progress: number; trades: { action: string; amount: number; ticker: string }[] };
+
+export default function Goals() {
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [form, setForm] = useState<Goal>({ name: "", target_amount: 0, target_date: "" });
+  const [current, setCurrent] = useState(0);
+  const [selected, setSelected] = useState<GoalWithProgress | null>(null);
+
+  const refresh = () => {
+    getGoals().then(setGoals).catch(() => setGoals([]));
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    createGoal(form).then(() => {
+      setForm({ name: "", target_amount: 0, target_date: "" });
+      refresh();
+    });
+  };
+
+  const view = (name: string) => {
+    getGoal(name, current).then(setSelected).catch(() => setSelected(null));
+  };
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <h1>Goals</h1>
+      <form onSubmit={submit} style={{ marginBottom: "1rem" }}>
+        <input
+          placeholder="Name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          required
+        />
+        <input
+          type="number"
+          placeholder="Target Amount"
+          value={form.target_amount}
+          onChange={(e) => setForm({ ...form, target_amount: parseFloat(e.target.value) })}
+          required
+        />
+        <input
+          type="date"
+          value={form.target_date}
+          onChange={(e) => setForm({ ...form, target_date: e.target.value })}
+          required
+        />
+        <button type="submit">Add Goal</button>
+      </form>
+
+      <div style={{ marginBottom: "1rem" }}>
+        <label>
+          Current Amount:
+          <input
+            type="number"
+            value={current}
+            onChange={(e) => setCurrent(parseFloat(e.target.value))}
+          />
+        </label>
+      </div>
+
+      <ul>
+        {goals.map((g) => (
+          <li key={g.name}>
+            {g.name} – target {g.target_amount} by {g.target_date}
+            <button onClick={() => view(g.name)} style={{ marginLeft: "0.5rem" }}>
+              View
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {selected && (
+        <div style={{ marginTop: "1rem" }}>
+          <h2>{selected.name}</h2>
+          <p>Progress: {Math.round(selected.progress * 100)}%</p>
+          {selected.trades.length > 0 && (
+            <>
+              <h3>Suggested Trades</h3>
+              <ul>
+                {selected.trades.map((t, i) => (
+                  <li key={i}>
+                    {t.action} {t.amount} of {t.ticker}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+
+      <p style={{ marginTop: "2rem" }}>
+        <Link to="/">Back to Portfolio</Link>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -8,6 +8,7 @@ import {
 } from "recharts";
 import { percent, percentOrNa } from "../lib/money";
 import metricStyles from "../styles/metrics.module.css";
+import { Link } from "react-router-dom";
 
 type Props = {
   twr: number | null;
@@ -123,6 +124,9 @@ function PortfolioDashboard({
           />
         </LineChart>
       </ResponsiveContainer>
+      <p className="mt-8">
+        <Link to="/goals">View Goals</Link>
+      </p>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add Goal model with JSON storage helpers
- implement goals CRUD API with progress and trade suggestions
- introduce tax-loss harvesting utilities and endpoint
- schedule automatic rebalancing task
- add Goals frontend page with navigation link

## Testing
- `pytest -c backend/pyproject.toml backend/tests/test_goals_route.py backend/tests/test_tax_route.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcaabf53f08327b94b376e6f0911f3