### PR TITLE
Add pension income forecasting and UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -50,6 +50,7 @@ from backend.routes.movers import router as movers_router
 from backend.routes.performance import router as performance_router
 from backend.routes.portfolio import public_router as public_portfolio_router
 from backend.routes.portfolio import router as portfolio_router
+from backend.routes.pension import router as pension_router
 from backend.routes.query import router as query_router
 from backend.routes.quotes import router as quotes_router
 from backend.routes.scenario import router as scenario_router
@@ -219,6 +220,7 @@ def create_app() -> FastAPI:
     app.include_router(logs_router)
     app.include_router(goals_router, dependencies=protected)
     app.include_router(tax_router, dependencies=protected)
+    app.include_router(pension_router)
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(request: Request, exc: RequestValidationError):

--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, HTTPException, Query
+
+from backend.common.pension import forecast_pension
+
+router = APIRouter(tags=["pension"])
+
+
+@router.get("/pension/forecast")
+def pension_forecast(
+    dob: str = Query(..., description="Date of birth YYYY-MM-DD"),
+    retirement_age: int = Query(..., ge=0),
+    death_age: int = Query(..., ge=0),
+    state_pension_annual: float | None = Query(None, ge=0),
+    db_income_annual: float | None = Query(None, ge=0),
+    db_normal_retirement_age: int | None = Query(None, ge=0),
+):
+    if death_age <= retirement_age:
+        raise HTTPException(
+            status_code=400, detail="death_age must exceed retirement_age"
+        )
+
+    db_pensions = []
+    if db_income_annual is not None and db_normal_retirement_age is not None:
+        db_pensions.append(
+            {
+                "annual_income_gbp": db_income_annual,
+                "normal_retirement_age": db_normal_retirement_age,
+            }
+        )
+
+    try:
+        forecast = forecast_pension(
+            dob=dob,
+            retirement_age=retirement_age,
+            death_age=death_age,
+            db_pensions=db_pensions,
+            state_pension_annual=state_pension_annual,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {"forecast": forecast}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,12 +50,13 @@ import AllocationCharts from "./pages/AllocationCharts";
 import InstrumentAdmin from "./pages/InstrumentAdmin";
 import Menu from "./components/Menu";
 import Rebalance from "./pages/Rebalance";
+import PensionForecast from "./pages/PensionForecast";
 
 interface AppProps {
   onLogout?: () => void;
 }
 
-type Mode = (typeof orderedTabPlugins)[number]["id"] | "profile";
+type Mode = (typeof orderedTabPlugins)[number]["id"] | "profile" | "pension";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -98,6 +99,8 @@ const initialMode: Mode =
     ? "scenario"
     : path[0] === "logs"
     ? "logs"
+    : path[0] === "pension"
+    ? "pension"
     : path.length === 0
     ? "group"
     : "movers";
@@ -196,6 +199,9 @@ export default function App({ onLogout }: AppProps) {
         break;
       case "logs":
         newMode = "logs";
+        break;
+      case "pension":
+        newMode = "pension";
         break;
       case "settings":
         newMode = "settings";
@@ -465,6 +471,7 @@ export default function App({ onLogout }: AppProps) {
       {mode === "settings" && <UserConfigPage />}
       {mode === "logs" && <Logs />}
       {mode === "scenario" && <ScenarioTester />}
+      {mode === "pension" && <PensionForecast />}
     </div>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -796,3 +796,23 @@ export const harvestTax = (
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ positions, threshold }),
   });
+
+// ───────────── Pension Forecast ─────────────
+export const getPensionForecast = (
+  dob: string,
+  retirementAge: number,
+  deathAge: number,
+  statePensionAnnual?: number,
+) => {
+  const params = new URLSearchParams({
+    dob,
+    retirement_age: String(retirementAge),
+    death_age: String(deathAge),
+  });
+  if (statePensionAnnual !== undefined) {
+    params.set("state_pension_annual", String(statePensionAnnual));
+  }
+  return fetchJson<{ forecast: { age: number; income: number }[] }>(
+    `${API_BASE}/pension/forecast?${params.toString()}`,
+  );
+};

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import {
+  LineChart,
+  Line,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
+import { getPensionForecast } from "../api";
+
+export default function PensionForecast() {
+  const [dob, setDob] = useState("");
+  const [retirementAge, setRetirementAge] = useState(65);
+  const [deathAge, setDeathAge] = useState(90);
+  const [statePension, setStatePension] = useState<string>("");
+  const [data, setData] = useState<{ age: number; income: number }[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const res = await getPensionForecast(
+        dob,
+        retirementAge,
+        deathAge,
+        statePension ? parseFloat(statePension) : undefined,
+      );
+      setData(res.forecast);
+      setErr(null);
+    } catch (ex: any) {
+      setErr(String(ex));
+      setData([]);
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl md:text-4xl">Pension Forecast</h1>
+      <form onSubmit={handleSubmit} className="mb-4 space-y-2">
+        <div>
+          <label className="mr-2">DOB:</label>
+          <input
+            type="date"
+            value={dob}
+            onChange={(e) => setDob(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="mr-2">Retirement Age:</label>
+          <input
+            type="number"
+            value={retirementAge}
+            onChange={(e) => setRetirementAge(Number(e.target.value))}
+            required
+          />
+        </div>
+        <div>
+          <label className="mr-2">Death Age:</label>
+          <input
+            type="number"
+            value={deathAge}
+            onChange={(e) => setDeathAge(Number(e.target.value))}
+            required
+          />
+        </div>
+        <div>
+          <label className="mr-2">State Pension (£/yr):</label>
+          <input
+            type="number"
+            value={statePension}
+            onChange={(e) => setStatePension(e.target.value)}
+          />
+        </div>
+        <button type="submit" className="mt-2 rounded bg-blue-500 px-4 py-2 text-white">
+          Forecast
+        </button>
+      </form>
+      {err && <p className="text-red-500">{err}</p>}
+      {data.length > 0 && (
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={data}>
+            <XAxis dataKey="age" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="income" stroke="#8884d8" dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -125,7 +125,8 @@ function PortfolioDashboard({
         </LineChart>
       </ResponsiveContainer>
       <p className="mt-8">
-        <Link to="/goals">View Goals</Link>
+        <Link to="/goals">View Goals</Link> |{" "}
+        <Link to="/pension/forecast">Pension Forecast</Link>
       </p>
     </>
   );

--- a/tests/test_pension_forecast.py
+++ b/tests/test_pension_forecast.py
@@ -1,0 +1,47 @@
+import datetime as dt
+
+from backend.common.pension import forecast_pension
+
+
+def test_forecast_pre_retirement_without_state():
+    today = dt.date(2024, 1, 1)
+    res = forecast_pension(
+        dob="1984-01-01",
+        retirement_age=65,
+        death_age=70,
+        db_pensions=[{"annual_income_gbp": 10000, "normal_retirement_age": 65}],
+        today=today,
+    )
+    assert res[0]["age"] == 40
+    assert res[0]["income"] == 0
+    assert res[25]["age"] == 65
+    assert res[25]["income"] == 10000
+    assert len(res) == 30
+
+
+def test_forecast_pre_retirement_with_state():
+    today = dt.date(2024, 1, 1)
+    res = forecast_pension(
+        dob="1984-01-01",
+        retirement_age=65,
+        death_age=70,
+        db_pensions=[{"annual_income_gbp": 10000, "normal_retirement_age": 65}],
+        state_pension_annual=9000,
+        today=today,
+    )
+    assert res[25]["income"] == 19000
+
+
+def test_forecast_post_retirement_life_expectancy():
+    today = dt.date(2024, 1, 1)
+    res = forecast_pension(
+        dob="1950-01-01",
+        retirement_age=65,
+        death_age=90,
+        db_pensions=[{"annual_income_gbp": 10000, "normal_retirement_age": 65}],
+        state_pension_annual=9000,
+        today=today,
+    )
+    assert res[0]["age"] == 73
+    assert len(res) == 17
+    assert all(r["income"] == 19000 for r in res)


### PR DESCRIPTION
## Summary
- add `forecast_pension` helper and `/pension/forecast` API endpoint
- create pension forecast React page and link from dashboard
- add test coverage for forecast scenarios

## Testing
- `pytest tests/test_pension_forecast.py -q --override-ini="addopts="`
- `npm test -- src/pages/Portfolio.test.tsx` *(fails: symbol already declared in InstrumentDetail.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bcacea67dc8327bd13c37059dd6620