### PR TITLE
Add historical market events dataset

### DIFF
--- a/data/events/market_events.json
+++ b/data/events/market_events.json
@@ -1,0 +1,45 @@
+{
+  "proxy_index": {
+    "ticker": "SPY",
+    "name": "SPDR S&P 500 ETF",
+    "description": "Used as fallback when holdings lack data for an event date"
+  },
+  "events": [
+    {
+      "date": "1987-10-19",
+      "description": "Black Monday crash; S&P 500 plunged over 20% in a day.",
+      "reference_index": "SPY",
+      "horizons": [1, 5, 21, 63, 126, 252]
+    },
+    {
+      "date": "2000-03-10",
+      "description": "Dot-com bubble peaks before major decline in technology shares.",
+      "reference_index": "SPY",
+      "horizons": [1, 5, 21, 63, 126, 252]
+    },
+    {
+      "date": "2008-09-15",
+      "description": "Lehman Brothers files for bankruptcy during global financial crisis.",
+      "reference_index": "SPY",
+      "horizons": [1, 5, 21, 63, 126, 252]
+    },
+    {
+      "date": "2010-05-06",
+      "description": "Flash crash temporarily wipes nearly 1 trillion dollars in market value.",
+      "reference_index": "SPY",
+      "horizons": [1, 5, 21, 63, 126, 252]
+    },
+    {
+      "date": "2020-03-16",
+      "description": "COVID-19 pandemic triggers historic market volatility and trading halts.",
+      "reference_index": "SPY",
+      "horizons": [1, 5, 21, 63, 126, 252]
+    },
+    {
+      "date": "2022-02-24",
+      "description": "Russian invasion of Ukraine sparks global risk-off move.",
+      "reference_index": "SPY",
+      "horizons": [1, 5, 21, 63, 126, 252]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add market event JSON data with major historical moves
- include proxy S&P 500 index metadata for missing holding data

## Testing
- `pytest tests/test_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcacd4dc788327b92eee68ae62594e