### PR TITLE
chore: move cdk synth output outside repo

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -98,6 +98,7 @@ jobs:
         if: steps.parse.outputs.deploy == 'true'
         env:
           DATA_BUCKET: ${{ secrets.DATA_BUCKET }}
+          CDK_OUTDIR: ../.cdk.out
         run: cdk deploy --require-approval never
         working-directory: cdk
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ venv/
 
 # CDK / CloudFormation
 cdk.out/
+.cdk.out/
 
 # IDE / OS
 .DS_Store

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -39,6 +39,9 @@ Run the helper script from the repository root to bootstrap the environment.
 When deploying the backend, provide the S3 bucket for account data either via
 the `-DataBucket` parameter or by setting `DATA_BUCKET`:
 
+CDK writes synthesized templates to `../.cdk.out`, a directory outside the
+repository root that is ignored by git.
+
 ```powershell
 # Deploy backend and frontend stacks
 ./deploy-to-AWS.ps1 -Backend -DataBucket my-bucket

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,3 +1,4 @@
 {
-  "app": "python app.py"
+  "app": "python app.py",
+  "output": "../.cdk.out"
 }

--- a/deploy-to-AWS.ps1
+++ b/deploy-to-AWS.ps1
@@ -18,6 +18,10 @@ $PYTHON = $pythonCmd.Name
 
 # Determine repository root and navigate to CDK directory
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Place synthesized CDK templates outside the repository
+$env:CDK_OUTDIR = Join-Path $SCRIPT_DIR '..\.cdk.out'
+
 Set-Location (Join-Path $SCRIPT_DIR 'cdk')
 
 if ($Backend) {

--- a/run-backend.ps1
+++ b/run-backend.ps1
@@ -23,6 +23,9 @@ Write-Host "# --------------------------------" -ForegroundColor DarkCyan
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location $SCRIPT_DIR
 
+# Place synthesized CDK templates outside the repository
+$env:CDK_OUTDIR = Join-Path $SCRIPT_DIR '..\.cdk.out'
+
 # ───────────────── helpers ───────────────────
 function Get-HasCommand($name) {
   return [bool](Get-Command $name -ErrorAction SilentlyContinue)


### PR DESCRIPTION
## Summary
- redirect CDK synth output to `../.cdk.out`
- set `CDK_OUTDIR` in scripts and CI
- document external CDK output directory

## Testing
- `pytest --override-ini=addopts=` *(fails: 32 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd267298d88327b29f3672274695d3