### PR TITLE
docs: document external data store usage

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -12,13 +12,59 @@ Copy `.env.example` to `.env` and supply the following values:
 | `TELEGRAM_CHAT_ID` | Telegram chat for alerts |
 | `API_TOKEN` | Token securing sensitive routes |
 | `OPENAI_API_KEY` | Optional key for OpenAI features |
+| `DATA_ROOT` | Path to a local checkout of the external data repository |
 | `DATA_BUCKET` | S3 bucket holding account data when deploying the backend. May also be supplied via the script's `-DataBucket` parameter |
 | `METADATA_BUCKET` | Bucket containing instrument metadata |
 | `METADATA_PREFIX` | Prefix within the metadata bucket |
 | `GOOGLE_AUTH_ENABLED` | Toggle Google sign‑in |
 | `GOOGLE_CLIENT_ID` | OAuth client ID when Google sign‑in is enabled |
 
-Install dependencies:
+## Sync external data store
+
+Account and instrument files are managed in a separate repository. Clone it
+next to this project or pull the latest changes before running the backend:
+
+```bash
+# first time
+git clone git@github.com:your-org/allotmint-data.git data
+# fetch updates
+cd data && git pull
+```
+
+For local runs, point the backend at the checkout by setting ``DATA_ROOT`` or
+``accounts_root`` in ``config.yaml``:
+
+```bash
+DATA_ROOT=$(pwd)/data
+```
+
+In AWS, specify the S3 buckets instead:
+
+```bash
+DATA_BUCKET=my-data-bucket
+METADATA_BUCKET=my-metadata-bucket
+METADATA_PREFIX=instruments/
+```
+
+### Updating data
+
+Commit and push changes in the data repository for local development:
+
+```bash
+cd data
+git add accounts/alice/trades.csv
+git commit -m "Update Alice trades"
+git push
+```
+
+To update the S3 bucket, sync the local data and ensure your IAM role allows
+``s3:PutObject`` and ``s3:DeleteObject`` on the target paths:
+
+```bash
+aws s3 sync data/accounts s3://$DATA_BUCKET/accounts/
+```
+
+## Install dependencies
 
 ```bash
 pip install -r requirements.txt -r requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -323,20 +323,64 @@ variables:
 
 When several transports are configured, alerts are sent to each of them.
 
-## AWS data bucket
+## External data store
 
-When running the backend in AWS (``config.app_env: aws``), account and
-metadata JSON files are loaded from an S3 bucket.
+Account and instrument files live in a separate data repository. Clone or
+sync it alongside the application before running the backend:
 
-Set the ``DATA_BUCKET`` environment variable to the name of the bucket
-containing the ``accounts/OWNER/ACCOUNT.json`` objects. The Lambda execution
-role requires the following minimal IAM permissions on that bucket:
+```bash
+# clone once
+git clone git@github.com:your-org/allotmint-data.git data
+# pull updates
+cd data && git pull
+```
+
+### Local development
+
+Point the backend at the checked-out data by setting ``DATA_ROOT`` (or
+``accounts_root`` in ``config.yaml``) to the directory path:
+
+```bash
+# .env or shell
+DATA_ROOT=$(pwd)/data
+```
+
+The backend uses this folder when ``config.app_env: local`` or when
+``DATA_BUCKET`` is unset. Commit changes to update the data set:
+
+```bash
+cd data
+git add accounts/alice/trades.csv
+git commit -m "Update Alice trades"
+git push
+```
+
+### AWS
+
+When running in AWS (``config.app_env: aws``), account and metadata JSON files
+are loaded from S3. Set the following environment variables:
+
+```bash
+DATA_BUCKET=allotmint-prod-data
+METADATA_BUCKET=allotmint-metadata
+METADATA_PREFIX=instruments/
+```
+
+The Lambda execution role requires:
 
 * ``s3:ListBucket`` (with a prefix of ``accounts/``) – discover available
   accounts.
 * ``s3:GetObject`` on ``accounts/*`` – read account and ``person.json`` files.
+* ``s3:PutObject``/``s3:DeleteObject`` on the same paths to push updates.
 
-Instrument metadata can reside in a separate bucket. Set ``METADATA_BUCKET`` to the bucket storing instrument JSON files and ``METADATA_PREFIX`` to the key prefix (default ``instruments/``). Updates made locally will be uploaded to this S3 path when configured.
+Instrument metadata resides under ``METADATA_PREFIX`` in ``METADATA_BUCKET``.
+To upload new data:
+
+```bash
+aws s3 sync data/accounts s3://$DATA_BUCKET/accounts/
+```
+
+Uploading requires IAM permissions matching the above ``s3:PutObject`` rules.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- document cloning and syncing of external data store
- add DATA_ROOT examples for local vs AWS deployments
- outline data update workflow and required S3 permissions

## Testing
- `pytest` *(fails: Interrupted: 32 errors during collection)*
- `npm test` *(fails: multiple failing tests and build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd24f93ee8832785014b7fc56d75ae