### PR TITLE
Add slowapi to root requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ requests~=2.32.4
 s3transfer~=0.11.2
 selenium~=4.24.0
 six~=1.17.0
+slowapi~=0.1.9
 sniffio~=1.3.1
 sortedcontainers~=2.4.0
 soupsieve~=2.7


### PR DESCRIPTION
## Summary
- Include slowapi dependency in top-level requirements so backend setup installs it

## Testing
- `pip install -r requirements.txt`
- `python -m uvicorn backend.local_api.main:app --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_68bd2c1cc5e48327847616d42aa52d29