### PR TITLE
refactor: centralize startup scripts in scripts directory

### DIFF
--- a/.run/run frontend.run.xml
+++ b/.run/run frontend.run.xml
@@ -1,16 +1,16 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="run frontend" type="ShConfigurationType">
-    <option name="SCRIPT_TEXT" value="npm run dev" />
+    <option name="SCRIPT_TEXT" value="" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
-    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/run-frontend.sh" />
     <option name="SCRIPT_OPTIONS" value="" />
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
-    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/frontend" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
-    <option name="INTERPRETER_PATH" value="powershell.exe" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="EXECUTE_IN_TERMINAL" value="true" />
-    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
     <envs />
     <method v="2" />
   </configuration>

--- a/.run/run-backend.ps1.run.xml
+++ b/.run/run-backend.ps1.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="run-backend.ps1" type="PowerShellRunType" factoryName="PowerShell" scriptUrl="$PROJECT_DIR$/run-backend.ps1" executablePath="powershell.exe">
+  <configuration default="false" name="run-backend.ps1" type="PowerShellRunType" factoryName="PowerShell" scriptUrl="$PROJECT_DIR$/scripts/run-backend.ps1" executablePath="powershell.exe">
     <envs />
     <method v="2" />
   </configuration>

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ pip install -r requirements.txt -r requirements-dev.txt
 
 # configure API settings
 # (see config.yaml for app_env, uvicorn_host, uvicorn_port, reload and log_config)
-./run-local-api.sh    # or use run-backend.ps1 on Windows
+./scripts/run-local-api.sh    # or use scripts/run-backend.ps1 on Windows
 
 # in another shell install React deps and start Vite on :5173
 cd frontend
@@ -362,7 +362,7 @@ aws s3 sync s3://$DATA_BUCKET/ data/
 When running the backend in AWS (``config.app_env: aws``), account and
 metadata JSON files are loaded from this bucket.
 
-The local startup scripts (`run-local-api.sh` and `run-backend.ps1`) perform
+The local startup scripts (`scripts/run-local-api.sh` and `scripts/run-backend.ps1`) perform
 this sync automatically when `DATA_BUCKET` is set.
 
 ```bash
@@ -439,7 +439,7 @@ PY_COV_MIN=80 PYTEST_ADDOPTS="--cov-fail-under=$PY_COV_MIN" pytest
 ## Error summary helper
 
 An optional `error_summary` section in `config.yaml` stores settings for the
-`run_with_error_summary.py` utility. When the field is missing the backend falls
+`scripts/run_with_error_summary.py` utility. When the field is missing the backend falls
 back to an empty mapping so the script can still be used with explicit
 arguments. You can capture error lines by running the helper which writes them
 to `error_summary.log`. Optionally set a default command in
@@ -451,12 +451,12 @@ error_summary:
   default_command: ["pytest"]
 ```
 
-Running `python run_with_error_summary.py` with no arguments will then use the
+Running `python scripts/run_with_error_summary.py` with no arguments will then use the
 configured default.
 
 ```bash
 # example
-python run_with_error_summary.py pytest
+python scripts/run_with_error_summary.py pytest
 ```
 
 

--- a/docs/TECHNICAL_SUPPORT.md
+++ b/docs/TECHNICAL_SUPPORT.md
@@ -14,7 +14,7 @@
 
 ## Log Locations
 - Backend logs are written to `backend.log` as configured in `backend/logging.ini`.
-- The `run_with_error_summary.py` helper records errors in `error_summary.log`.
+- The `scripts/run_with_error_summary.py` helper records errors in `error_summary.log`.
 
 ## Escalation Contacts
 - **Primary**: engineering@allotmint.example.com

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,7 +32,7 @@ future navigation features ahead of the final release.
 ## Installation
 
 1. Install dependencies with `npm install`.
-2. Ensure the backend API is running. From the repository root you can start it with `./run-local-api.sh`, which serves `http://localhost:8000` by default.
+2. Ensure the backend API is running. From the repository root you can start it with `./scripts/run-local-api.sh`, which serves `http://localhost:8000` by default.
 3. If the backend runs elsewhere, set `VITE_ALLOTMINT_API_BASE` (or the legacy `VITE_API_URL`) before starting the dev server, e.g.:
 
    ```bash

--- a/scripts/run-backend.ps1
+++ b/scripts/run-backend.ps1
@@ -21,10 +21,11 @@ Write-Host "# --------------------------------" -ForegroundColor DarkCyan
 
 # ───────────────── repo root ─────────────────
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
-Set-Location $SCRIPT_DIR
+$REPO_ROOT = Split-Path $SCRIPT_DIR -Parent
+Set-Location $REPO_ROOT
 
 # Place synthesized CDK templates outside the repository
-$env:CDK_OUTDIR = Join-Path $SCRIPT_DIR '..\.cdk.out'
+$env:CDK_OUTDIR = Join-Path $REPO_ROOT '.cdk.out'
 
 # ───────────────── helpers ───────────────────
 function Get-HasCommand($name) {
@@ -84,7 +85,7 @@ Write-Host 'Activating virtual environment...' -ForegroundColor Cyan
 . .\.venv\Scripts\Activate.ps1
 
 # ───────────────── load config ────────────────
-$configPath = Join-Path $SCRIPT_DIR 'config.yaml'
+$configPath = Join-Path $REPO_ROOT 'config.yaml'
 $cfg = Read-Config $configPath
 
 # ───────────── offline mode & installs ────────

--- a/scripts/run-frontend.ps1
+++ b/scripts/run-frontend.ps1
@@ -2,7 +2,8 @@ $ErrorActionPreference = 'Stop'
 
 # Determine repository root and navigate to frontend directory
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
-Set-Location (Join-Path $SCRIPT_DIR 'frontend')
+$REPO_ROOT = Split-Path $SCRIPT_DIR -Parent
+Set-Location (Join-Path $REPO_ROOT 'frontend')
 
 Write-Host 'Installing frontend dependencies...' -ForegroundColor Yellow
 npm install

--- a/scripts/run-frontend.sh
+++ b/scripts/run-frontend.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # Ensure the script runs from repository root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR/frontend"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT/frontend"
 
 # Install dependencies
 npm install

--- a/scripts/run-local-api.sh
+++ b/scripts/run-local-api.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # ensure script runs from repository root so log files are written consistently
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
 
 # Load Telegram credentials if available
 if [[ -f .env ]]; then

--- a/scripts/run_with_error_summary.py
+++ b/scripts/run_with_error_summary.py
@@ -2,7 +2,7 @@
 """Run a command and record stderr error lines to error_summary.log.
 
 Usage:
-    python run_with_error_summary.py [<command> [args...]]
+    python scripts/run_with_error_summary.py [<command> [args...]]
 
 When called without a command, the script loads a default command from
 ``config.yaml`` under ``error_summary.default_command``. Explicit CLI arguments


### PR DESCRIPTION
## Summary
- move backend, frontend, local API, and helper scripts into `scripts/`
- update IntelliJ run configs to call scripts and adjust paths
- refresh documentation to reference new script locations

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/allotmint/data/accounts')*
- `timeout 5 bash scripts/run-frontend.sh` *(fails: esbuild Unexpected "," parse error)*
- `timeout 5 bash scripts/run-local-api.sh` *(fails: Invalid value for '--port': '' is not a valid integer)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2cc7c4988327a0ca6a52f4fed602