### PR TITLE
Add conditional auto-refresh in watchlist

### DIFF
--- a/frontend/src/pages/Watchlist.test.tsx
+++ b/frontend/src/pages/Watchlist.test.tsx
@@ -102,7 +102,7 @@ describe("Watchlist page", () => {
     expect(getQuotes).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(60000);
+      await vi.advanceTimersByTimeAsync(10000);
     });
     await act(async () => {
       await Promise.resolve();
@@ -129,7 +129,7 @@ describe("Watchlist page", () => {
     });
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(60000);
+      await vi.advanceTimersByTimeAsync(10000);
     });
     await act(async () => {
       await Promise.resolve();
@@ -141,7 +141,7 @@ describe("Watchlist page", () => {
     });
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(60000);
+      await vi.advanceTimersByTimeAsync(10000);
     });
     await act(async () => {
       await Promise.resolve();
@@ -166,6 +166,7 @@ describe("Watchlist page", () => {
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10000);
+    });
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Markets closed")).toBeInTheDocument();
     expect(getQuotes).toHaveBeenCalledTimes(1);

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -96,12 +96,13 @@ export function Watchlist() {
   }, [fetchData, symbols]);
 
   useEffect(() => {
-    if (intervalMs <= 0) return;
+    if (intervalMs <= 0 || auto) return;
     const id = setInterval(fetchData, intervalMs);
     return () => clearInterval(id);
-  }, [intervalMs, fetchData]);
+  }, [intervalMs, auto, fetchData]);
 
   useEffect(() => {
+    if (intervalMs <= 0) return;
     if (auto) {
       const id = setInterval(fetchData, 10000);
       return () => clearInterval(id);
@@ -110,7 +111,7 @@ export function Watchlist() {
       const id = setInterval(fetchData, 60000);
       return () => clearInterval(id);
     }
-  }, [auto, allClosed, fetchData]);
+  }, [auto, allClosed, fetchData, intervalMs]);
 
   const sorted = useMemo(() => {
     const data = [...rows];


### PR DESCRIPTION
## Summary
- add new effect to schedule watchlist refresh based on auto-refresh and market status

## Testing
- `npm test` *(fails: 14 failed, 35 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2f59a1a08327920e1697261fc2cb