### PR TITLE
Remove duplicate ticker variable in InstrumentResearch

### DIFF
--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -19,7 +19,6 @@ export default function InstrumentResearch() {
   const historyPrices = history?.[String(days)] ?? [];
   const [quote, setQuote] = useState<QuoteRow | null>(null);
   const [news, setNews] = useState<NewsItem[]>([]);
-  const tkr = ticker && /^[A-Za-z0-9.-]{1,10}$/.test(ticker) ? ticker : "";
   const [inWatchlist, setInWatchlist] = useState(() => {
     const list = (localStorage.getItem("watchlistSymbols") || "")
       .split(",")


### PR DESCRIPTION
## Summary
- eliminate redundant `tkr` declaration in InstrumentResearch page
- rely on single early ticker validation for all downstream references

## Testing
- `npm test` *(fails: Transform failed; The symbol "prices" has already been declared)*
- `npm run lint` *(fails: 30 problems including parsing errors and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2f5876cc832797ee857b3d662bb7