### PR TITLE
Limit CDK Docker context to backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Exclude non-backend directories from Docker build context
+node_modules/
+frontend/
+mobile/
+tests/
+docs/
+cdk/
+infra/
+scripts/
+*.md
+*.ps1
+*.sh

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -22,7 +22,7 @@ class BackendLambdaStack(Stack):
 
         # Build a Docker image for the Lambda runtime to avoid large zip/layer sizes
         image_code = _lambda.DockerImageCode.from_image_asset(
-            str(project_root), file="backend/Dockerfile.lambda"
+            str(project_root / "backend"), file="Dockerfile.lambda"
         )
 
         bucket_name = self.node.try_get_context("data_bucket") or os.getenv("DATA_BUCKET")
@@ -52,8 +52,8 @@ class BackendLambdaStack(Stack):
             self,
             "PriceRefreshLambda",
             code=_lambda.DockerImageCode.from_image_asset(
-                str(project_root),
-                file="backend/Dockerfile.lambda",
+                str(project_root / "backend"),
+                file="Dockerfile.lambda",
                 cmd=["backend.lambda_api.price_refresh.lambda_handler"],
             ),
         )


### PR DESCRIPTION
## Summary
- build CDK lambda images from backend directory instead of repo root
- add root-level dockerignore to drop frontend, tests and other non-backend paths from Docker context

## Testing
- `pytest`
- `DATA_BUCKET=test-bucket APP_ENV=dev npx --yes aws-cdk synth` *(fails: KeyboardInterrupt: typing.Union has no attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2f41edb88327844d720ccab2c85d