### PR TITLE
Respect manual refresh setting in watchlist auto-refresh

### DIFF
--- a/frontend/src/pages/Watchlist.test.tsx
+++ b/frontend/src/pages/Watchlist.test.tsx
@@ -102,7 +102,7 @@ describe("Watchlist page", () => {
     expect(getQuotes).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(60000);
+      await vi.advanceTimersByTimeAsync(10000);
     });
     await act(async () => {
       await Promise.resolve();
@@ -129,7 +129,7 @@ describe("Watchlist page", () => {
     });
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(60000);
+      await vi.advanceTimersByTimeAsync(10000);
     });
     await act(async () => {
       await Promise.resolve();
@@ -141,7 +141,7 @@ describe("Watchlist page", () => {
     });
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(60000);
+      await vi.advanceTimersByTimeAsync(10000);
     });
     await act(async () => {
       await Promise.resolve();
@@ -166,6 +166,7 @@ describe("Watchlist page", () => {
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10000);
+    });
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Markets closed")).toBeInTheDocument();
     expect(getQuotes).toHaveBeenCalledTimes(1);

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -96,12 +96,13 @@ export function Watchlist() {
   }, [fetchData, symbols]);
 
   useEffect(() => {
-    if (intervalMs <= 0) return;
+    if (intervalMs <= 0 || auto) return;
     const id = setInterval(fetchData, intervalMs);
     return () => clearInterval(id);
-  }, [intervalMs, fetchData]);
+  }, [intervalMs, auto, fetchData]);
 
   useEffect(() => {
+    if (intervalMs <= 0) return;
     if (auto) {
       const id = setInterval(fetchData, 10000);
       return () => clearInterval(id);
@@ -110,7 +111,7 @@ export function Watchlist() {
       const id = setInterval(fetchData, 60000);
       return () => clearInterval(id);
     }
-  }, [auto, allClosed, fetchData]);
+  }, [auto, allClosed, fetchData, intervalMs]);
 
   const sorted = useMemo(() => {
     const data = [...rows];


### PR DESCRIPTION
## Summary
- skip background polling when manual refresh mode is selected
- update watchlist tests for new 10s auto-refresh cadence

## Testing
- `npm test` *(fails: Test Files 13 failed | 36 passed (49))*

------
https://chatgpt.com/codex/tasks/task_e_68bd3119f2048327ab8e3b814ca4f1a9