### PR TITLE
Add sample account data and update testing docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,9 @@ cdk/cdk.out.backend/
 .vscode/
 
 # Data directory managed externally
-data/
+data/*
+!data/accounts/
+!data/accounts/**
 
 # Logs
 backend.log

--- a/README.md
+++ b/README.md
@@ -428,6 +428,10 @@ pytest
 cd frontend && npm test
 ```
 
+Sample account JSON files live under `data/accounts/` (for example,
+`data/accounts/alice/savings.json`) so tests can run without additional
+setup.
+
 The `PY_COV_MIN` environment variable lets you enforce a minimum coverage
 percentage during `pytest` runs. Use it together with `PYTEST_ADDOPTS` to pass
 the desired threshold to `pytest`:

--- a/USER_README.md
+++ b/USER_README.md
@@ -89,6 +89,9 @@ If the variable is unset the UI defaults to `http://localhost:8000` (or
 - **Run tests**:
   - Backend: `pytest`
   - Frontend: `cd frontend && npm test`
+  - Sample account data under `data/accounts/` (e.g.,
+    `data/accounts/alice/savings.json`) allows tests to run without extra
+    setup.
 - **Get trading agent signals**: `curl http://localhost:8000/trading-agent/signals` or invoke the `price_refresh` Lambda
 - **Deploy to AWS**:
   1. `cd frontend && npm run build`

--- a/data/accounts/alice/brokerage.json
+++ b/data/accounts/alice/brokerage.json
@@ -1,0 +1,6 @@
+{
+  "owner": "alice",
+  "account_type": "brokerage",
+  "currency": "USD",
+  "holdings": []
+}

--- a/data/accounts/alice/savings.json
+++ b/data/accounts/alice/savings.json
@@ -1,0 +1,6 @@
+{
+  "owner": "alice",
+  "account_type": "savings",
+  "currency": "USD",
+  "holdings": []
+}

--- a/docs/TECHNICAL_SUPPORT.md
+++ b/docs/TECHNICAL_SUPPORT.md
@@ -10,6 +10,8 @@
 - Verify that Python (3.12) and Node.js versions meet project requirements.
 - Clear cached data under `data/cache/` if stale responses cause issues.
 - Run `pytest` and `npm test` to check for failing tests before debugging.
+  Sample account JSON files in `data/accounts/` allow these tests to run
+  without extra setup.
 - Ensure environment variables like `DATA_BUCKET` or API keys are correctly set.
 
 ## Log Locations


### PR DESCRIPTION
## Summary
- track sample accounts in git and add alice savings and brokerage JSON stubs
- reference new sample data in testing docs for backend and frontend
## Testing
- `pytest` (28 failed, 325 passed)
- `npm test` (14 failed, 35 passed)


------
https://chatgpt.com/codex/tasks/task_e_68bd36c92ee88327a4988565f83ccbec