### PR TITLE
fix frontend script path resolution

### DIFF
--- a/run-frontend.ps1
+++ b/run-frontend.ps1
@@ -1,8 +1,18 @@
 $ErrorActionPreference = 'Stop'
 
 # Determine repository root and navigate to frontend directory
-$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
-Set-Location (Join-Path $SCRIPT_DIR 'frontend')
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Locate repository root whether script lives in repo root or a subdirectory
+if (Test-Path (Join-Path $scriptDir 'frontend')) {
+    $repoRoot = $scriptDir
+} elseif (Test-Path (Join-Path (Split-Path -Parent $scriptDir) 'frontend')) {
+    $repoRoot = Split-Path -Parent $scriptDir
+} else {
+    throw 'Unable to locate the frontend directory.'
+}
+
+Set-Location (Join-Path $repoRoot 'frontend')
 
 Write-Host 'Installing frontend dependencies...' -ForegroundColor Yellow
 npm install


### PR DESCRIPTION
## Summary
- support running run-frontend.ps1 from a subdirectory

## Testing
- `pwsh -NoProfile -File run-frontend.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68bd382edbcc8327812af2df4951c611