### PR TITLE
Add focus mode with Pomodoro timer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ import InstrumentAdmin from "./pages/InstrumentAdmin";
 import Menu from "./components/Menu";
 import Rebalance from "./pages/Rebalance";
 import PensionForecast from "./pages/PensionForecast";
+import { useFocusMode } from "./FocusModeContext";
 
 interface AppProps {
   onLogout?: () => void;
@@ -138,6 +139,7 @@ export default function App({ onLogout }: AppProps) {
   const [retryNonce, setRetryNonce] = useState(0);
 
   const { lastRefresh, setLastRefresh } = usePriceRefresh();
+  const { focusMode } = useFocusMode();
   const [notificationsOpen, setNotificationsOpen] = useState(false);
 
   const handleRetry = useCallback(() => {
@@ -331,29 +333,31 @@ export default function App({ onLogout }: AppProps) {
 
   return (
     <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
-        <LanguageSwitcher />
-        <button
-          aria-label="notifications"
-          onClick={() => setNotificationsOpen(true)}
+      {!focusMode && (
+        <div
           style={{
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            fontSize: "1.5rem",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
           }}
         >
-          🔔
-        </button>
-      </div>
+          <LanguageSwitcher />
+          <button
+            aria-label="notifications"
+            onClick={() => setNotificationsOpen(true)}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              fontSize: "1.5rem",
+            }}
+          >
+            🔔
+          </button>
+        </div>
+      )}
       <NotificationsDrawer
-        open={notificationsOpen}
+        open={!focusMode && notificationsOpen}
         onClose={() => setNotificationsOpen(false)}
       />
       <div style={{ display: "flex", alignItems: "center", margin: "1rem 0" }}>
@@ -363,35 +367,41 @@ export default function App({ onLogout }: AppProps) {
           onLogout={onLogout}
           style={{ flexGrow: 1, margin: 0 }}
         />
-        <InstrumentSearchBar />
-        {lastRefresh && (
-          <span
-            style={{
-              background: "#eee",
-              borderRadius: "1rem",
-              padding: "0.25rem 0.5rem",
-              fontSize: "0.75rem",
-            }}
-            title={t("app.last") ?? undefined}
-          >
-            {new Date(lastRefresh).toLocaleString()}
-          </span>
+        {!focusMode && (
+          <>
+            <InstrumentSearchBar />
+            {lastRefresh && (
+              <span
+                style={{
+                  background: "#eee",
+                  borderRadius: "1rem",
+                  padding: "0.25rem 0.5rem",
+                  fontSize: "0.75rem",
+                }}
+                title={t("app.last") ?? undefined}
+              >
+                {new Date(lastRefresh).toLocaleString()}
+              </span>
+            )}
+            <UserAvatar />
+          </>
         )}
-        <UserAvatar />
       </div>
 
-      <div style={{ marginBottom: "1rem" }}>
-        <button onClick={handleRefreshPrices} disabled={refreshingPrices}>
-          {refreshingPrices ? t("app.refreshing") : t("app.refreshPrices")}
-        </button>
-        {priceRefreshError && (
-          <span
-            style={{ marginLeft: "0.5rem", color: "red", fontSize: "0.85rem" }}
-          >
-            {priceRefreshError}
-          </span>
-        )}
-      </div>
+      {!focusMode && (
+        <div style={{ marginBottom: "1rem" }}>
+          <button onClick={handleRefreshPrices} disabled={refreshingPrices}>
+            {refreshingPrices ? t("app.refreshing") : t("app.refreshPrices")}
+          </button>
+          {priceRefreshError && (
+            <span
+              style={{ marginLeft: "0.5rem", color: "red", fontSize: "0.85rem" }}
+            >
+              {priceRefreshError}
+            </span>
+          )}
+        </div>
+      )}
 
       {/* OWNER VIEW */}
       {mode === "owner" && (

--- a/frontend/src/FocusModeContext.tsx
+++ b/frontend/src/FocusModeContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+interface FocusModeContextValue {
+  focusMode: boolean;
+  setFocusMode: (on: boolean) => void;
+}
+
+const defaultValue: FocusModeContextValue = {
+  focusMode: false,
+  setFocusMode: () => {},
+};
+
+export const FocusModeContext = createContext<FocusModeContextValue>(defaultValue);
+
+export function FocusModeProvider({ children }: { children: ReactNode }) {
+  const [focusMode, setFocusMode] = useState(false);
+  return (
+    <FocusModeContext.Provider value={{ focusMode, setFocusMode }}>
+      {children}
+    </FocusModeContext.Provider>
+  );
+}
+
+export function useFocusMode() {
+  return useContext(FocusModeContext);
+}
+

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { useConfig } from '../ConfigContext';
 import type { TabPluginId } from '../tabPlugins';
 import { orderedTabPlugins, SUPPORT_TABS } from '../tabPlugins';
+import { useFocusMode } from '../FocusModeContext';
+import PomodoroTimer from './PomodoroTimer';
 
 const SUPPORT_ONLY_TABS: TabPluginId[] = ['logs'];
 
@@ -28,6 +30,7 @@ export default function Menu({
 
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const { focusMode, setFocusMode } = useFocusMode();
 
   useEffect(() => {
     function handleFocus(e: FocusEvent) {
@@ -133,49 +136,65 @@ export default function Menu({
         ☰
       </button>
       <div
-        className={`${open ? 'flex' : 'hidden'} flex-col gap-2 md:flex md:flex-row md:flex-wrap`}
+        className={`${open || focusMode ? 'flex' : 'hidden'} flex-col gap-2 md:flex md:flex-row md:flex-wrap`}
         style={style}
       >
-        {orderedTabPlugins
-          .filter((p) => p.section === (isSupportMode ? 'support' : 'user'))
-          .slice()
-          .sort((a, b) => a.priority - b.priority)
-          .filter((p) => {
-            if (p.id === 'support') return false;
-            if (!inSupport && SUPPORT_ONLY_TABS.includes(p.id)) return false;
-            return tabs[p.id] !== false && !disabledTabs?.includes(p.id);
-          })
-          .map((p) => (
-            <Link
-              key={p.id}
-              to={pathFor(p.id)}
-              className={`mr-4 ${mode === p.id ? 'font-bold' : ''} break-words`}
-              onClick={() => setOpen(false)}
-            >
-              {t(`app.modes.${p.id}`)}
-            </Link>
-          ))}
-        {supportEnabled && (
-          <Link
-            to={inSupport ? '/' : '/support'}
-            className={`mr-4 ${inSupport ? 'font-bold' : ''} break-words`}
-            onClick={() => setOpen(false)}
-          >
-            {t(inSupport ? 'app.userLink' : 'app.supportLink')}
-          </Link>
+        {focusMode ? (
+          <PomodoroTimer />
+        ) : (
+          <>
+            {orderedTabPlugins
+              .filter((p) => p.section === (isSupportMode ? 'support' : 'user'))
+              .slice()
+              .sort((a, b) => a.priority - b.priority)
+              .filter((p) => {
+                if (p.id === 'support') return false;
+                if (!inSupport && SUPPORT_ONLY_TABS.includes(p.id)) return false;
+                return tabs[p.id] !== false && !disabledTabs?.includes(p.id);
+              })
+              .map((p) => (
+                <Link
+                  key={p.id}
+                  to={pathFor(p.id)}
+                  className={`mr-4 ${mode === p.id ? 'font-bold' : ''} break-words`}
+                  onClick={() => setOpen(false)}
+                >
+                  {t(`app.modes.${p.id}`)}
+                </Link>
+              ))}
+            {supportEnabled && (
+              <Link
+                to={inSupport ? '/' : '/support'}
+                className={`mr-4 ${inSupport ? 'font-bold' : ''} break-words`}
+                onClick={() => setOpen(false)}
+              >
+                {t(inSupport ? 'app.userLink' : 'app.supportLink')}
+              </Link>
+            )}
+            {onLogout && (
+              <button
+                type="button"
+                onClick={() => {
+                  onLogout();
+                  setOpen(false);
+                }}
+                className="mr-4 bg-transparent border-0 p-0 cursor-pointer"
+              >
+                {t('app.logout')}
+              </button>
+            )}
+          </>
         )}
-        {onLogout && (
-          <button
-            type="button"
-            onClick={() => {
-              onLogout();
-              setOpen(false);
-            }}
-            className="mr-4 bg-transparent border-0 p-0 cursor-pointer"
-          >
-            {t('app.logout')}
-          </button>
-        )}
+        <button
+          type="button"
+          onClick={() => {
+            setFocusMode(!focusMode);
+            setOpen(false);
+          }}
+          className="mr-4 bg-transparent border-0 p-0 cursor-pointer"
+        >
+          {focusMode ? 'Exit Focus Mode' : 'Focus Mode'}
+        </button>
       </div>
     </nav>
   );

--- a/frontend/src/components/PomodoroTimer.tsx
+++ b/frontend/src/components/PomodoroTimer.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+
+const SESSION_LENGTH = 25 * 60; // 25 minutes
+const BREAK_LENGTH = 5 * 60; // 5 minutes
+
+type Mode = 'session' | 'break';
+
+function requestNotificationPermission() {
+  if ('Notification' in window && Notification.permission === 'default') {
+    Notification.requestPermission();
+  }
+}
+
+function notify(message: string) {
+  if ('Notification' in window && Notification.permission === 'granted') {
+    new Notification(message);
+  } else {
+    alert(message);
+  }
+}
+
+export default function PomodoroTimer() {
+  const [seconds, setSeconds] = useState(SESSION_LENGTH);
+  const [running, setRunning] = useState(false);
+  const [mode, setMode] = useState<Mode>('session');
+
+  useEffect(() => {
+    requestNotificationPermission();
+  }, []);
+
+  useEffect(() => {
+    if (!running) return;
+    const timer = setInterval(() => {
+      setSeconds((s) => {
+        if (s > 1) return s - 1;
+        const nextMode: Mode = mode === 'session' ? 'break' : 'session';
+        setMode(nextMode);
+        notify(nextMode === 'break' ? 'Time for a break!' : 'Back to work!');
+        return nextMode === 'session' ? SESSION_LENGTH : BREAK_LENGTH;
+      });
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [running, mode]);
+
+  const start = () => setRunning(true);
+  const pause = () => setRunning(false);
+  const reset = () => {
+    setRunning(false);
+    setMode('session');
+    setSeconds(SESSION_LENGTH);
+  };
+
+  const minutes = String(Math.floor(seconds / 60)).padStart(2, '0');
+  const secs = String(seconds % 60).padStart(2, '0');
+
+  return (
+    <div className="flex items-center gap-2">
+      <span>{minutes}:{secs}</span>
+      {running ? (
+        <button onClick={pause}>Pause</button>
+      ) : (
+        <button onClick={start}>Start</button>
+      )}
+      <button onClick={reset}>Reset</button>
+    </div>
+  );
+}
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,6 +13,7 @@ import { AuthProvider, useAuth } from './AuthContext'
 import { getConfig, logout as apiLogout, getStoredAuthToken, setAuthToken } from './api'
 import LoginPage from './LoginPage'
 import { UserProvider } from './UserContext'
+import { FocusModeProvider } from './FocusModeContext'
 
 const storedToken = getStoredAuthToken()
 if (storedToken) setAuthToken(storedToken)
@@ -85,10 +86,12 @@ createRoot(rootEl).render(
         <PriceRefreshProvider>
           <AuthProvider>
             <UserProvider>
-              <BrowserRouter>
-                <Root />
-              </BrowserRouter>
-              <ToastContainer autoClose={5000} />
+              <FocusModeProvider>
+                <BrowserRouter>
+                  <Root />
+                </BrowserRouter>
+                <ToastContainer autoClose={5000} />
+              </FocusModeProvider>
             </UserProvider>
           </AuthProvider>
         </PriceRefreshProvider>


### PR DESCRIPTION
## Summary
- Add Pomodoro timer component with start/pause/reset and notifications
- Provide FocusModeContext and wrap app to track focus state
- Add Focus Mode toggle in menu that hides navigation and shows timer, collapsing auxiliary panels

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd523f3c088327984d904052a24009