### PR TITLE
Use enum for custom query metrics

### DIFF
--- a/tests/test_custom_query.py
+++ b/tests/test_custom_query.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
+from backend.routes.query import Metric
 
 client = TestClient(create_app())
 
@@ -8,7 +9,7 @@ BASE_QUERY = {
     "start": "2025-01-01",
     "end": "2025-01-10",
     "tickers": ["HFEL.L"],
-    "metrics": ["var", "meta"],
+    "metrics": [Metric.VAR, Metric.META],
 }
 
 
@@ -32,3 +33,11 @@ def test_save_and_load_query(tmp_path):
 
     resp = client.get("/custom-query/saved")
     assert slug in resp.json()
+
+
+def test_unknown_metric_rejected():
+    resp = client.post(
+        "/custom-query/run",
+        json={**BASE_QUERY, "metrics": ["bogus"]},
+    )
+    assert resp.status_code == 422

--- a/tests/test_custom_query_aws.py
+++ b/tests/test_custom_query_aws.py
@@ -12,7 +12,7 @@ BASE_QUERY = {
     "start": "2025-01-01",
     "end": "2025-01-10",
     "tickers": ["HFEL.L"],
-    "metrics": ["var", "meta"],
+    "metrics": [qr.Metric.VAR, qr.Metric.META],
 }
 
 


### PR DESCRIPTION
## Summary
- Enumerate supported custom query metrics with a dedicated `Metric` enum
- Validate incoming metrics via the enum and reject unknown values
- Update query route and tests to use the new enum and cover invalid metric case

## Testing
- `pytest` *(fails: KeyError 'access_token' and other missing configuration)*
- `npm test` *(fails: React component errors and missing ResponsiveContainer)*

------
https://chatgpt.com/codex/tasks/task_e_68bd58d8fc30832785de4a1566c9f9ef