### PR TITLE
chore: update instrument navigation to research pages

### DIFF
--- a/frontend/src/components/TopMoversPage.tsx
+++ b/frontend/src/components/TopMoversPage.tsx
@@ -384,7 +384,7 @@ export function TopMoversPage() {
                     href="#"
                     onClick={(e) => {
                       e.preventDefault();
-                      navigate(`/instrument/${s.ticker}`);
+                      navigate(`/research/${s.ticker}`);
                     }}
                   >
                     {s.ticker}

--- a/frontend/src/pages/DataAdmin.tsx
+++ b/frontend/src/pages/DataAdmin.tsx
@@ -91,7 +91,7 @@ export default function DataAdmin() {
                 </button>
                 <button
                   type="button"
-                  onClick={() => navigate(`/instrument/${r.ticker}`)}
+                  onClick={() => navigate(`/research/${r.ticker}`)}
                   style={{ marginLeft: "0.25rem" }}
                 >
                   Open instrument


### PR DESCRIPTION
## Summary
- point top movers signal links to `/research/<ticker>`
- open research page from DataAdmin instrument link

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd59cb6ed88327aaaa5cdf7946755a