### PR TITLE
test: ensure VaR tests include mock owner

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -134,9 +134,10 @@ def test_instrument_detail(mock_list, mock_build, mock_positions, mock_timeserie
     assert "positions" in payload
 
 
+@patch("backend.routes.portfolio.portfolio_mod.list_owners", return_value=["steve"])
 @patch("backend.common.risk.compute_sharpe_ratio", return_value=1.23)
 @patch("backend.common.risk.compute_portfolio_var", return_value={"1d": 100.0, "10d": 200.0})
-def test_var_endpoint(mock_var, mock_sharpe, client):
+def test_var_endpoint(mock_var, mock_sharpe, mock_list, client):
     response = client.get("/var/steve")
     assert response.status_code == 200
     payload = response.json()
@@ -145,21 +146,24 @@ def test_var_endpoint(mock_var, mock_sharpe, client):
     assert payload["sharpe_ratio"] == 1.23
 
 
+@patch("backend.routes.portfolio.portfolio_mod.list_owners", return_value=["steve"])
 @patch("backend.common.risk.compute_sharpe_ratio", side_effect=FileNotFoundError)
 @patch("backend.common.risk.compute_portfolio_var", side_effect=FileNotFoundError)
-def test_var_owner_not_found(mock_var, mock_sharpe, client):
+def test_var_owner_not_found(mock_var, mock_sharpe, mock_list, client):
     response = client.get("/var/missing")
     assert response.status_code == 404
 
 
+@patch("backend.routes.portfolio.portfolio_mod.list_owners", return_value=["steve"])
 @patch("backend.common.risk.compute_sharpe_ratio", return_value=1.0)
 @patch("backend.common.risk.compute_portfolio_var", side_effect=ValueError("bad"))
-def test_var_invalid_params(mock_var, mock_sharpe, client):
+def test_var_invalid_params(mock_var, mock_sharpe, mock_list, client):
     response = client.get("/var/steve?confidence=2")
     assert response.status_code == 400
 
 
-def test_var_invalid_confidence_range(client):
+@patch("backend.routes.portfolio.portfolio_mod.list_owners", return_value=["steve"])
+def test_var_invalid_confidence_range(mock_list, client):
     response = client.get("/var/steve?confidence=101")
     assert response.status_code == 400
 


### PR DESCRIPTION
## Summary
- add list_owners monkeypatch for VaR endpoint tests

## Testing
- `pytest tests/test_main.py::test_var_endpoint tests/test_main.py::test_var_owner_not_found tests/test_main.py::test_var_invalid_params tests/test_main.py::test_var_invalid_confidence_range -o addopts= -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd5a7267dc8327a198204c94b08e8e