### PR TITLE
test: include alex in mock user config store

### DIFF
--- a/tests/test_user_config_route.py
+++ b/tests/test_user_config_route.py
@@ -22,7 +22,10 @@ def client(monkeypatch):
 
 @pytest.fixture
 def mock_user_config(monkeypatch):
-    store = {"alice": {"hold_days_min": 5}}
+    store = {
+        "alice": {"hold_days_min": 5},
+        "alex": {},
+    }
 
     def fake_load(owner: str, accounts_root=None):
         if owner not in store:


### PR DESCRIPTION
## Summary
- add empty `alex` entry to `mock_user_config` fixture
- ensure `fake_load` uses `UserConfig.from_dict` for the new entry

## Testing
- `pre-commit run --files tests/test_user_config_route.py` *(fails: command not found)*
- `pytest tests/test_user_config_route.py -q` *(fails: 10 failed, 268 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5a7d25048327ad5e83b9b04cae17