### PR TITLE
Guard fundamentals cache TTL when unset

### DIFF
--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -19,9 +19,10 @@ from backend.config import settings
 ALPHA_VANTAGE_URL = "https://www.alphavantage.co/query"
 # Cache configuration
 _MIN_TTL = 24 * 60 * 60  # one day
+ttl_cfg = settings.fundamentals_cache_ttl_seconds or _MIN_TTL
 _CACHE_TTL_SECONDS = max(
     _MIN_TTL,
-    min(settings.fundamentals_cache_ttl_seconds, 7 * 24 * 60 * 60),
+    min(ttl_cfg, 7 * 24 * 60 * 60),
 )
 _CACHE: Dict[Tuple[str, str], Tuple[datetime, "Fundamentals"]] = {}
 


### PR DESCRIPTION
## Summary
- Prevent `None` from being passed into TTL calculation for fundamentals cache by defaulting to `_MIN_TTL`

## Testing
- `isort backend/screener/__init__.py`
- `black backend/screener/__init__.py`
- `ruff check backend/screener/__init__.py`
- `pytest -c backend/pyproject.toml backend/tests/test_screener_route.py::test_screener_success -q` *(fails: assertion; expected minimal dict but received full object)*


------
https://chatgpt.com/codex/tasks/task_e_68bd5a7bc6c083278ec1c3b0bedc0b57