### PR TITLE
refactor: consolidate historical event scenario helper

### DIFF
--- a/tests/test_scenario_tester.py
+++ b/tests/test_scenario_tester.py
@@ -1,11 +1,11 @@
-import datetime as dt
-from datetime import date
-from types import SimpleNamespace
-
 import backend.common.prices as prices
 import pandas as pd
-from backend.utils import scenario_tester as sc
-from backend.utils.scenario_tester import apply_historical_event, apply_price_shock
+import backend.common.prices as prices
+import pandas as pd
+import pytest
+from datetime import date
+
+import backend.utils.scenario_tester as sc_tester
 
 
 def test_price_shock_uses_cached_price_for_missing_current_price(monkeypatch):
@@ -32,59 +32,6 @@ def test_price_shock_uses_cached_price_for_missing_current_price(monkeypatch):
     assert shocked["accounts"][0]["value_estimate_gbp"] > 0
     assert shocked["total_value_estimate_gbp"] > 0
 
-
-def test_apply_historical_event_uses_proxy_for_missing(monkeypatch):
-    portfolio = {
-        "accounts": [
-            {
-                "holdings": [
-                    {"ticker": "ABC.L", "market_value_gbp": 100},
-                    {"ticker": "MISSING.L", "market_value_gbp": 100},
-                ]
-            }
-        ],
-        "total_value_estimate_gbp": 200,
-    }
-
-    event = SimpleNamespace(date=dt.date(2020, 1, 1), proxy="IDX.L")
-
-    dates = [
-        dt.date(2020, 1, 1),
-        dt.date(2020, 1, 2),
-        dt.date(2020, 1, 8),
-        dt.date(2020, 1, 31),
-        dt.date(2020, 3, 31),
-        dt.date(2020, 12, 31),
-    ]
-    abc = pd.DataFrame({"Date": dates, "Close": [10, 11, 12, 15, 20, 30]})
-    idx = pd.DataFrame({"Date": dates, "Close": [100, 110, 120, 150, 200, 300]})
-
-    def fake_load(ticker, exchange, start_date, end_date):
-        if ticker == "ABC":
-            return abc
-        if ticker == "IDX":
-            return idx
-        return pd.DataFrame()
-
-    monkeypatch.setattr(sc, "load_meta_timeseries_range", fake_load)
-    monkeypatch.setattr(sc, "get_scaling_override", lambda *a, **k: 1.0)
-    monkeypatch.setattr(sc, "apply_scaling", lambda df, scale, scale_volume=False: df)
-
-    result = apply_historical_event(portfolio, event)
-
-    assert result["1d"]["total_value_gbp"] == 220.0
-    assert result["1y"]["total_value_gbp"] == 600.0
-
-def test_apply_historical_event_scales_portfolio():
-    portfolio = {
-        "accounts": [{"value_estimate_gbp": 100.0}],
-        "total_value_estimate_gbp": 100.0,
-    }
-
-    shocked = apply_historical_event(portfolio, event_id="dummy", horizons=[1, 5])
-
-    assert 1 in shocked and 5 in shocked
-    assert shocked[1]["total_value_estimate_gbp"] < portfolio["total_value_estimate_gbp"]
 
 def test_historical_event_falls_back_to_proxy(monkeypatch):
     portfolio = {"accounts": [{"holdings": [{"ticker": "AAA.L"}]}]}


### PR DESCRIPTION
## Summary
- remove duplicate `apply_historical_event` implementations
- document and streamline historical event returns logic
- update scenario route and tests for new helper

## Testing
- `pytest -q` *(fails: tests/test_backend_api.py::test_valid_account, tests/test_main.py::test_var_endpoint, tests/test_main.py::test_var_invalid_params, tests/test_main.py::test_var_invalid_confidence_range, tests/test_scenario_route.py::test_historical_scenario_route, tests/test_user_config_route.py::test_defaults_from_config_return_lists, tests/test_var_route.py::test_var_known_case, tests/test_var_route.py::test_var_breakdown, tests/test_var_route.py::test_var_breakdown_bad_params, tests/test_var_route.py::test_var_breakdown_unknown_owner)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5a7a7124832784245e243ea1f90f