### PR TITLE
Use app factory in scenario and VaR route tests

### DIFF
--- a/tests/test_var_route.py
+++ b/tests/test_var_route.py
@@ -4,10 +4,11 @@ from fastapi.testclient import TestClient
 
 from backend.common import portfolio as portfolio_mod
 from backend.common import portfolio_utils
-from backend.local_api.main import app
+from backend.app import create_app
 
 
 def _auth_client():
+    app = create_app()
     client = TestClient(app)
     token = client.post("/token", json={"id_token": "good"}).json()["access_token"]
     client.headers.update({"Authorization": f"Bearer {token}"})


### PR DESCRIPTION
## Summary
- use `create_app` in scenario and VaR route tests to build isolated FastAPI app instances
- stub `apply_historical_event` in scenario tests to avoid signature mismatch

## Testing
- `PYTEST_ADDOPTS="" pytest -q tests/test_scenario_route.py::test_scenario_route tests/test_scenario_route.py::test_historical_scenario_route tests/test_var_route.py::test_var_known_case tests/test_var_route.py::test_var_breakdown tests/test_var_route.py::test_var_breakdown_bad_params tests/test_var_route.py::test_var_breakdown_unknown_owner`


------
https://chatgpt.com/codex/tasks/task_e_68bd5a745c888327b7a8faa9056a8c27