### PR TITLE
Log FX rate lookup failures

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -93,8 +93,8 @@ def _fx_to_gbp(currency: str, cache: Dict[str, float]) -> float:
             rate = float(df["Rate"].iloc[-1])
             cache[currency] = rate
             return rate
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Failed to fetch FX rate for %s: %s", currency, exc)
     cache[currency] = 1.0
     return 1.0
 

--- a/backend/tests/test_portfolio_utils.py
+++ b/backend/tests/test_portfolio_utils.py
@@ -1,0 +1,15 @@
+from backend.common.portfolio_utils import _fx_to_gbp
+
+
+def test_fx_to_gbp_logs_warning_on_failure(monkeypatch, caplog):
+    def fake_fetch(currency, start, end):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("backend.common.portfolio_utils.fetch_fx_rate_range", fake_fetch)
+    cache = {}
+    with caplog.at_level("WARNING"):
+        rate = _fx_to_gbp("USD", cache)
+    assert rate == 1.0
+    assert cache["USD"] == 1.0
+    assert "USD" in caplog.text
+    assert "boom" in caplog.text


### PR DESCRIPTION
## Summary
- log exception details when FX rate lookup fails in `_fx_to_gbp`
- test `_fx_to_gbp` logs warning with currency and message

## Testing
- `ruff check --config backend/pyproject.toml backend/common/portfolio_utils.py backend/tests/test_portfolio_utils.py` *(fails: Import block is un-sorted or un-formatted)*
- `black --check --config backend/pyproject.toml backend/common/portfolio_utils.py backend/tests/test_portfolio_utils.py` *(fails: would reformat backend/common/portfolio_utils.py)*
- `pytest --override-ini testpaths=backend/tests backend/tests/test_portfolio_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd58d5d838832786f3a93d1976d844