### PR TITLE
Validate instrument group slug before selection

### DIFF
--- a/frontend/src/hooks/useRouteMode.test.tsx
+++ b/frontend/src/hooks/useRouteMode.test.tsx
@@ -1,5 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
+import { vi } from "vitest";
+vi.mock("../api", () => ({ getGroups: vi.fn().mockResolvedValue([]) }));
 import {
   configContext,
   type ConfigContextValue,


### PR DESCRIPTION
## Summary
- fetch group slugs and ensure instrument URLs use only known slugs
- redirect to research page when instrument slug is invalid
- mock group API in route hook tests

## Testing
- `npm test --prefix frontend -- --run src/hooks/useRouteMode.test.tsx`
- `npm run lint --prefix frontend` *(fails: '__WB_MANIFEST' is defined but never used, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bd59cd69188327a8722e925afe38c5