### PR TITLE
style: theme-aware notifications drawer

### DIFF
--- a/frontend/src/components/NotificationsDrawer.tsx
+++ b/frontend/src/components/NotificationsDrawer.tsx
@@ -38,8 +38,9 @@ export function NotificationsDrawer({ open, onClose }: Props) {
           right: 0,
           width: "300px",
           height: "100%",
-          background: "#fff",
-          borderLeft: "1px solid #ccc",
+          background: "var(--drawer-bg)",
+          color: "var(--drawer-color)",
+          borderLeft: "1px solid var(--drawer-border-color)",
           boxShadow: "-2px 0 5px rgba(0,0,0,0.3)",
           padding: "1rem",
           zIndex: 1000,
@@ -78,7 +79,12 @@ export function NotificationsDrawer({ open, onClose }: Props) {
                 <div>
                   <strong>{a.ticker}</strong>: {a.message}
                 </div>
-                <div style={{ fontSize: "0.8rem", color: "#666" }}>
+                <div
+                  style={{
+                    fontSize: "0.8rem",
+                    color: "var(--drawer-muted-color)",
+                  }}
+                >
                   {new Date(a.timestamp).toLocaleString()}
                 </div>
               </li>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,6 +11,11 @@
     color: rgba(255, 255, 255, 0.87);
     background-color: #242424;
 
+    --drawer-bg: #333;
+    --drawer-color: rgba(255, 255, 255, 0.87);
+    --drawer-border-color: #444;
+    --drawer-muted-color: #aaa;
+
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -21,12 +26,22 @@
     color-scheme: light;
     color: #213547;
     background-color: #ffffff;
+
+    --drawer-bg: #ffffff;
+    --drawer-color: #213547;
+    --drawer-border-color: #ccc;
+    --drawer-muted-color: #666;
 }
 
 :root[data-theme='dark'] {
     color-scheme: dark;
     color: rgba(255, 255, 255, 0.87);
     background-color: #242424;
+
+    --drawer-bg: #333;
+    --drawer-color: rgba(255, 255, 255, 0.87);
+    --drawer-border-color: #444;
+    --drawer-muted-color: #aaa;
 }
 
 a {
@@ -83,6 +98,11 @@ button:focus-visible {
     :root:not([data-theme]) {
         color: #213547;
         background-color: #ffffff;
+
+        --drawer-bg: #ffffff;
+        --drawer-color: #213547;
+        --drawer-border-color: #ccc;
+        --drawer-muted-color: #666;
     }
 
     :root:not([data-theme]) a:hover {


### PR DESCRIPTION
## Summary
- style notifications drawer with theme-aware variables for text, background, and border
- ensure notification timestamps use muted color that adapts to light and dark modes

## Testing
- `npm test` *(fails: Test Files 4 failed | 45 passed (49), Tests 13 failed | 156 passed | 1 skipped (170))*

------
https://chatgpt.com/codex/tasks/task_e_68bd5e4d8a7c83279d1a89ae24ae7b5d