### PR TITLE
Default to 5-day horizon for historical returns

### DIFF
--- a/backend/utils/scenario_tester.py
+++ b/backend/utils/scenario_tester.py
@@ -288,7 +288,7 @@ def apply_historical_returns(
     """
 
     start = _parse_date(event.get("date"))
-    horizons = list(horizons or event.get("horizons", []))
+    horizons = list(horizons or event.get("horizons") or [5])
     proxy = event.get("proxy_index") or {}
     proxy_ticker = proxy.get("ticker")
     proxy_exchange = proxy.get("exchange")


### PR DESCRIPTION
## Summary
- Ensure `apply_historical_returns` defaults to a 5‑day horizon when none is provided
- Iterate over the resolved horizon list to populate return mappings for each holding

## Testing
- `PYTEST_ADDOPTS= pytest tests/test_scenario_tester.py::test_historical_event_falls_back_to_proxy -k historical_event_falls_back_to_proxy -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd618922f48327ad315a8ebc0d01f9