### PR TITLE
feat: add historical scenario API

### DIFF
--- a/backend/routes/scenario.py
+++ b/backend/routes/scenario.py
@@ -28,9 +28,7 @@ def run_scenario(
         baseline = pf.get("total_value_estimate_gbp")
         # ensure baseline exists before applying shock
         if baseline is None:
-            baseline = sum(
-                a.get("value_estimate_gbp") or 0.0 for a in pf.get("accounts", [])
-            )
+            baseline = sum(a.get("value_estimate_gbp") or 0.0 for a in pf.get("accounts", []))
             pf["total_value_estimate_gbp"] = baseline
         shocked = apply_price_shock(pf, ticker, pct)
         shocked_total = shocked.get("total_value_estimate_gbp")
@@ -50,16 +48,16 @@ def run_scenario(
 
 @router.get("/scenario/historical")
 def run_historical_scenario(
-    date: str = Query(..., description="Event date (YYYY-MM-DD)"),
+    event_id: str | None = Query(None, description="Historical event identifier"),
+    date: str | None = Query(None, description="Event date (YYYY-MM-DD)"),
     horizons: List[int] = Query(..., description="Event horizons in days"),
-    proxy_ticker: str | None = Query(None, description="Proxy index ticker"),
-    proxy_exchange: str | None = Query(None, description="Proxy index exchange"),
 ):
-    """Calculate holding returns for all portfolios from a historical event."""
+    """Calculate shocked portfolio values for a historical event."""
 
-    event = {"date": date, "horizons": horizons}
-    if proxy_ticker:
-        event["proxy_index"] = {"ticker": proxy_ticker, "exchange": proxy_exchange}
+    if event_id is None and date is None:
+        raise HTTPException(status_code=400, detail="event_id or date must be provided")
+    if not horizons:
+        raise HTTPException(status_code=400, detail="horizons must be provided")
 
     results = []
     owners = [p["owner"] for p in list_plots() if p.get("accounts")]
@@ -68,7 +66,30 @@ def run_historical_scenario(
             pf = build_owner_portfolio(owner)
         except FileNotFoundError:
             continue
-        returns = apply_historical_event(pf, event)
-        results.append({"owner": owner, "returns": returns})
+
+        baseline = pf.get("total_value_estimate_gbp")
+        if baseline is None:
+            baseline = sum(a.get("value_estimate_gbp") or 0.0 for a in pf.get("accounts", []))
+            pf["total_value_estimate_gbp"] = baseline
+
+        shocked = apply_historical_event(pf, event_id=event_id, date=date, horizons=horizons)
+        horizon_map = {}
+        for h, shocked_pf in shocked.items():
+            val = shocked_pf.get("total_value_estimate_gbp")
+            pct_change = None
+            if baseline not in (None, 0) and val is not None:
+                pct_change = (val - baseline) / baseline
+            horizon_map[h] = {
+                "shocked_total_value_gbp": val,
+                "pct_change": pct_change,
+            }
+
+        results.append(
+            {
+                "owner": owner,
+                "baseline_total_value_gbp": baseline,
+                "horizons": horizon_map,
+            }
+        )
 
     return results


### PR DESCRIPTION
## Summary
- add event-id-driven historical scenario endpoint
- compute baseline portfolio value and per-horizon shocked values

## Testing
- `make lint` *(fails: I001 Import block is un-sorted or un-formatted)*
- `PYTEST_ADDOPTS='' pytest tests/test_scenario_route.py::test_historical_scenario_route -q` *(fails: 7 failed, 347 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bd618420008327b84056409a55494b