### PR TITLE
Compute missing change percentages

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -468,14 +468,24 @@ def aggregate_by_ticker(
             if price and price == price:  # guard against None/NaN/0
                 row["last_price_gbp"] = price
                 row["last_price_date"] = snap.get("last_price_date")
-                row["change_7d_pct"] = snap.get("change_7d_pct")
-                row["change_30d_pct"] = snap.get("change_30d_pct")
                 row["market_value_gbp"] = round(row["units"] * price, 2)
                 row["gain_gbp"] = (
                     round(row["market_value_gbp"] - row["cost_gbp"], 2)
                     if row["cost_gbp"]
                     else row["gain_gbp"]
                 )
+
+            # ensure percentage change fields are populated
+            if row.get("change_7d_pct") is None:
+                change_7d = snap.get("change_7d_pct") if isinstance(snap, dict) else None
+                if change_7d is None:
+                    change_7d = instrument_api.price_change_pct(full_tkr, 7)
+                row["change_7d_pct"] = change_7d
+            if row.get("change_30d_pct") is None:
+                change_30d = snap.get("change_30d_pct") if isinstance(snap, dict) else None
+                if change_30d is None:
+                    change_30d = instrument_api.price_change_pct(full_tkr, 30)
+                row["change_30d_pct"] = change_30d
 
             # pass-through misc attributes (first non-null wins)
             for k in ("asset_class", "industry", "region", "owner", "sector"):

--- a/tests/test_group_instruments_changes.py
+++ b/tests/test_group_instruments_changes.py
@@ -1,0 +1,28 @@
+import pytest
+
+from backend.common import group_portfolio, instrument_api, portfolio_utils
+
+
+def test_group_instruments_populates_change_fields(monkeypatch, client):
+    portfolio = {
+        "accounts": [
+            {
+                "account_type": "TEST",
+                "holdings": [
+                    {"ticker": "AAA.L", "units": 1.0, "cost_gbp": 90.0}
+                ],
+            }
+        ]
+    }
+    monkeypatch.setattr(group_portfolio, "build_group_portfolio", lambda slug: portfolio)
+    monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {"AAA.L": {"last_price": 100.0}})
+    monkeypatch.setattr(
+        instrument_api,
+        "price_change_pct",
+        lambda t, d: {7: 5.0, 30: 10.0}.get(d),
+    )
+    resp = client.get("/portfolio-group/testslug/instruments")
+    assert resp.status_code == 200
+    instruments = resp.json()
+    assert instruments[0]["change_7d_pct"] == 5.0
+    assert instruments[0]["change_30d_pct"] == 10.0


### PR DESCRIPTION
## Summary
- backfill 7- and 30-day percentage changes from timeseries when price snapshot lacks them
- test group_instruments to ensure change fields are populated without snapshot data

## Testing
- `python -m pytest tests/test_group_instruments_changes.py tests/test_backend_api.py::test_group_instruments -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd643964e883278bc0e9d11536238c