### PR TITLE
feat: preload instrument history

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -26,6 +26,7 @@ import tableStyles from "../styles/table.module.css";
 import { useTranslation } from "react-i18next";
 import { useConfig } from "../ConfigContext";
 import { RelativeViewToggle } from "./RelativeViewToggle";
+import { preloadInstrumentHistory } from "../hooks/useInstrumentHistory";
 import {
   PieChart,
   Pie,
@@ -104,6 +105,16 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
   useEffect(() => {
     if (portfolio?.accounts) {
       setSelectedAccounts(portfolio.accounts.map(accountKey));
+    }
+  }, [portfolio]);
+
+  useEffect(() => {
+    const tickers = portfolio?.accounts?.flatMap((acct) =>
+      acct.holdings?.map((h) => h.ticker) ?? [],
+    );
+    const unique = Array.from(new Set(tickers));
+    if (unique.length) {
+      preloadInstrumentHistory(unique, 30).catch(() => {});
     }
   }, [portfolio]);
 

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -18,6 +18,7 @@ import { RelativeViewToggle } from "./RelativeViewToggle";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ResponsiveContainer, LineChart, Line } from "recharts";
 import Sparkline from "./Sparkline";
+import { preloadInstrumentHistory } from "../hooks/useInstrumentHistory";
 
 declare const sparks: Record<string, Record<string, any[]>>;
 
@@ -70,6 +71,13 @@ export function HoldingsTable({
   });
 
   const [sparkRange, setSparkRange] = useState<7 | 30 | 180>(30);
+
+  useEffect(() => {
+    const tickers = Array.from(new Set(holdings.map((h) => h.ticker)));
+    if (tickers.length) {
+      preloadInstrumentHistory(tickers, sparkRange).catch(() => {});
+    }
+  }, [holdings, sparkRange]);
 
   const toggleColumn = (key: keyof typeof visibleColumns) => {
     setVisibleColumns((prev) => ({ ...prev, [key]: !prev[key] }));

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from "react";
-import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
+import {
+  useInstrumentHistory,
+  getCachedInstrumentHistory,
+} from "../hooks/useInstrumentHistory";
 
 type SparklineBaseProps = {
   width?: number;
@@ -109,8 +112,9 @@ function SparklineFromFetch({
   ariaLabel,
   tabIndex,
 }: SparklineFetchProps) {
+  const cached = getCachedInstrumentHistory(ticker, days);
   const { data } = useInstrumentHistory(ticker, days);
-  const points = data?.[String(days)] ?? [];
+  const points = (cached ?? data)?.[String(days)] ?? [];
   const series =
     points
       .map(


### PR DESCRIPTION
## Summary
- preload instrument history with limited concurrency and cache the results
- warm sparkline cache for holdings and group portfolios
- read preloaded history in sparklines to avoid redundant requests

## Testing
- `npm test` *(fails: Transform failed with 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68bd64411c5c832794c2b67c2c938c0b