### PR TITLE
Configure API rate limit from config

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -41,21 +41,23 @@ from backend.routes.alerts import router as alerts_router
 from backend.routes.approvals import router as approvals_router
 from backend.routes.compliance import router as compliance_router
 from backend.routes.config import router as config_router
+from backend.routes.goals import router as goals_router
 from backend.routes.instrument import router as instrument_router
 from backend.routes.instrument_admin import router as instrument_admin_router
 from backend.routes.logs import router as logs_router
 from backend.routes.metrics import router as metrics_router
-from backend.routes.news import router as news_router
 from backend.routes.movers import router as movers_router
+from backend.routes.news import router as news_router
+from backend.routes.pension import router as pension_router
 from backend.routes.performance import router as performance_router
 from backend.routes.portfolio import public_router as public_portfolio_router
 from backend.routes.portfolio import router as portfolio_router
-from backend.routes.pension import router as pension_router
 from backend.routes.query import router as query_router
 from backend.routes.quotes import router as quotes_router
 from backend.routes.scenario import router as scenario_router
 from backend.routes.screener import router as screener_router
 from backend.routes.support import router as support_router
+from backend.routes.tax import router as tax_router
 from backend.routes.timeseries_admin import router as timeseries_admin_router
 from backend.routes.timeseries_edit import router as timeseries_edit_router
 from backend.routes.timeseries_meta import router as timeseries_router
@@ -63,8 +65,6 @@ from backend.routes.trading_agent import router as trading_agent_router
 from backend.routes.transactions import router as transactions_router
 from backend.routes.user_config import router as user_config_router
 from backend.routes.virtual_portfolio import router as virtual_portfolio_router
-from backend.routes.goals import router as goals_router
-from backend.routes.tax import router as tax_router
 from backend.utils import page_cache
 
 logger = logging.getLogger(__name__)
@@ -97,9 +97,7 @@ def create_app() -> FastAPI:
             from backend.common import instrument_api
 
             instrument_api.update_latest_prices_from_snapshot(snapshot)
-            price_task = asyncio.create_task(
-                asyncio.to_thread(instrument_api.prime_latest_prices)
-            )
+            price_task = asyncio.create_task(asyncio.to_thread(instrument_api.prime_latest_prices))
             app.state.background_tasks.append(price_task)
 
             task = refresh_snapshot_async(days=config.snapshot_warm_days or 30)
@@ -136,7 +134,7 @@ def create_app() -> FastAPI:
 
     limiter = Limiter(
         key_func=get_remote_address,
-        default_limits=["60/minute"],
+        default_limits=[f"{config.rate_limit_per_minute}/minute"],
         storage_uri=storage_uri,
     )
     app.state.limiter = limiter

--- a/backend/config.py
+++ b/backend/config.py
@@ -17,9 +17,7 @@ def validate_google_auth(enabled: Optional[bool], client_id: Optional[str]) -> N
     """Ensure Google auth is configured correctly."""
     if enabled:
         if not client_id or not client_id.strip():
-            raise ConfigValidationError(
-                "google_auth_enabled is true but google_client_id is missing"
-            )
+            raise ConfigValidationError("google_auth_enabled is true but google_client_id is missing")
 
 
 def validate_tabs(tabs_raw: Any) -> TabsConfig:
@@ -87,6 +85,7 @@ class Config:
     transactions_output_root: Optional[Path] = None
     uvicorn_port: Optional[int] = None
     reload: Optional[bool] = None
+    rate_limit_per_minute: int = 60
     log_config: Optional[str] = None
     skip_snapshot_warm: Optional[bool] = None
     snapshot_warm_days: Optional[int] = None
@@ -160,6 +159,7 @@ def _parse_str_list(val: Any) -> Optional[List[str]]:
         return items or []
     return None
 
+
 @lru_cache(maxsize=1)
 def load_config() -> Config:
     """Load configuration from config.yaml with optional env overrides."""
@@ -196,9 +196,7 @@ def load_config() -> Config:
     if env_data_root:
         data_root_raw = env_data_root
     data_root_path = Path(data_root_raw)
-    data_root = (
-        data_root_path if data_root_path.is_absolute() else (repo_root / data_root_path)
-    ).resolve()
+    data_root = (data_root_path if data_root_path.is_absolute() else (repo_root / data_root_path)).resolve()
 
     accounts_root_raw = data.get("accounts_root")
     accounts_root = (data_root / accounts_root_raw).resolve() if accounts_root_raw else None
@@ -207,19 +205,13 @@ def load_config() -> Config:
     prices_json = (data_root / prices_json_raw).resolve() if prices_json_raw else None
 
     ts_cache_raw = data.get("timeseries_cache_base")
-    timeseries_cache_base = (
-        str((data_root / ts_cache_raw).resolve()) if ts_cache_raw else None
-    )
+    timeseries_cache_base = str((data_root / ts_cache_raw).resolve()) if ts_cache_raw else None
 
     portfolio_xml_raw = data.get("portfolio_xml_path")
-    portfolio_xml_path = (
-        (data_root / portfolio_xml_raw).resolve() if portfolio_xml_raw else None
-    )
+    portfolio_xml_path = (data_root / portfolio_xml_raw).resolve() if portfolio_xml_raw else None
 
     tx_output_raw = data.get("transactions_output_root")
-    transactions_output_root = (
-        (data_root / tx_output_raw).resolve() if tx_output_raw else None
-    )
+    transactions_output_root = (data_root / tx_output_raw).resolve() if tx_output_raw else None
 
     tabs_raw = data.get("tabs")
     tabs = validate_tabs(tabs_raw)
@@ -274,6 +266,7 @@ def load_config() -> Config:
         transactions_output_root=transactions_output_root,
         uvicorn_port=data.get("uvicorn_port"),
         reload=data.get("reload"),
+        rate_limit_per_minute=data.get("rate_limit_per_minute", 60),
         log_config=data.get("log_config"),
         skip_snapshot_warm=data.get("skip_snapshot_warm"),
         snapshot_warm_days=data.get("snapshot_warm_days"),

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -29,6 +29,7 @@ server:
   uvicorn_host: 0.0.0.0               # Host interface for the FastAPI server
   uvicorn_port: 8000                  # Port for the FastAPI server
   reload: true                        # Auto-reload during development
+  rate_limit_per_minute: 60           # Max API requests per client per minute
   sns_topic_arn: ''                   # AWS SNS topic for alerts
   telegram_bot_token: ""              # Telegram bot token (TELEGRAM_BOT_TOKEN)
   telegram_chat_id: ""               # Telegram chat id (TELEGRAM_CHAT_ID)

--- a/config.yaml
+++ b/config.yaml
@@ -55,6 +55,8 @@ server:
   uvicorn_port: 8000
   # Auto-reload during development
   reload: true
+  # API request rate limit per client (per minute)
+  rate_limit_per_minute: 60
   # Cross-origin settings by environment
   cors:
     local:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -19,6 +19,20 @@ Copy `.env.example` to `.env` and supply the following values:
 | `GOOGLE_AUTH_ENABLED` | Toggle Google sign‑in |
 | `GOOGLE_CLIENT_ID` | OAuth client ID when Google sign‑in is enabled |
 
+## API rate limiting
+
+The backend throttles requests per client using SlowAPI. The default limit is
+60 requests per minute. Adjust `rate_limit_per_minute` under the `server`
+section of `config.yaml` to raise or lower the limit for each environment:
+
+```yaml
+server:
+  rate_limit_per_minute: 120  # allow 120 requests/minute
+```
+
+Higher values are useful for local development or trusted environments, while
+lower limits help protect production resources.
+
 ## Sync external data store
 
 Account and instrument files are managed in a separate repository. Clone it


### PR DESCRIPTION
## Summary
- make API rate limit configurable via `rate_limit_per_minute`
- document `rate_limit_per_minute` in `config.yaml` and deployment guide

## Testing
- `make lint` *(fails: 93 errors)*
- `ruff check --config backend/pyproject.toml backend/app.py backend/config.py`
- `black --check --config backend/pyproject.toml backend/app.py backend/config.py`
- `pytest` *(fails: tests/test_custom_query.py::test_unknown_metric_rejected, tests/test_styles_snapshot.py::test_stylesheet_snapshot, tests/test_user_config_route.py::test_missing_owner_returns_error)*

------
https://chatgpt.com/codex/tasks/task_e_68bd64426c748327a4f44c41844c5940