### PR TITLE
Handle commodity ETFs requiring approval

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -122,10 +122,19 @@ def _check_transactions(owner: str, txs: List[Dict[str, Any]], accounts_root: Op
             instr_type = (
                 meta.get("instrumentType") or meta.get("instrument_type") or ""
             ).upper()
+            asset_class = (
+                meta.get("assetClass") or meta.get("asset_class") or ""
+            ).upper()
+            sector = (meta.get("sector") or "").upper()
+            is_commodity = asset_class == "COMMODITY" or sector == "COMMODITY"
+            is_etf = instr_type == "ETF"
+            exempt_type = instr_type in exempt_types
+            if is_etf and is_commodity:
+                exempt_type = False
             needs_approval = not (
                 ticker in exempt_tickers
                 or ticker.split(".")[0] in exempt_tickers
-                or instr_type in exempt_types
+                or exempt_type
             )
             if needs_approval:
                 appr = approvals.get(ticker) or approvals.get(ticker.split(".")[0])

--- a/backend/utils/convert_portfolio_xml_to_input_files.py
+++ b/backend/utils/convert_portfolio_xml_to_input_files.py
@@ -50,10 +50,19 @@ def generate_json_holdings(xml_path: str, output_base_dir: str | Path = config.a
             meta_tkr = str(row.get("ticker", "")).strip().upper()
             meta = get_instrument_meta(meta_tkr)
             instr_type = (meta.get("instrumentType") or meta.get("instrument_type") or "").upper()
+            asset_class = (
+                meta.get("assetClass") or meta.get("asset_class") or ""
+            ).upper()
+            sector = (meta.get("sector") or "").upper()
+            is_commodity = asset_class == "COMMODITY" or sector == "COMMODITY"
+            is_etf = instr_type == "ETF"
             exempt_tickers = {t.upper() for t in (config.approval_exempt_tickers or [])}
             exempt_types = {t.upper() for t in (config.approval_exempt_types or [])}
+            exempt_type = instr_type in exempt_types
+            if is_etf and is_commodity:
+                exempt_type = False
 
-            needs_approval = not (meta_tkr in exempt_tickers or instr_type in exempt_types)
+            needs_approval = not (meta_tkr in exempt_tickers or exempt_type)
 
             approved = False
             if needs_approval:

--- a/data/instruments/L/COMETF.json
+++ b/data/instruments/L/COMETF.json
@@ -1,0 +1,6 @@
+{
+  "symbol": "COMETF",
+  "exchange": "L",
+  "asset_class": "Commodity",
+  "name": "Commodity ETF"
+}

--- a/tests/utils/test_convert_portfolio_xml_to_input_files.py
+++ b/tests/utils/test_convert_portfolio_xml_to_input_files.py
@@ -54,6 +54,14 @@ def test_generate_json_holdings(monkeypatch, tmp_path):
                 "quantity": 4.0,
                 "acquired_date": acq_date,
             },
+            {
+                "account": "Alex ISA Cash",
+                "name": "Commodity ETF",
+                "ticker": "COMETF",
+                "isin": "ISIN4",
+                "quantity": 5.0,
+                "acquired_date": acq_date,
+            },
         ]
     )
 
@@ -66,6 +74,7 @@ def test_generate_json_holdings(monkeypatch, tmp_path):
         "APPROVED": {"instrumentType": "STOCK"},
         "EXEMPTT": {"instrumentType": "STOCK"},
         "0PFUND": {"instrumentType": "ETF"},
+        "COMETF": {"instrumentType": "ETF", "asset_class": "Commodity"},
     }
     monkeypatch.setattr(conv, "get_instrument_meta", lambda t: meta.get(t, {}))
 
@@ -81,7 +90,7 @@ def test_generate_json_holdings(monkeypatch, tmp_path):
 
     assert data["owner"] == "alex"
     assert data["account_type"] == "ISA"
-    assert len(data["holdings"]) == 4
+    assert len(data["holdings"]) == 5
 
     hold = {h["name"]: h for h in data["holdings"]}
 
@@ -94,3 +103,5 @@ def test_generate_json_holdings(monkeypatch, tmp_path):
 
     assert hold["Type Exempt 0P"]["ticker"] == "ISIN0P"
     assert hold["Type Exempt 0P"]["sell_eligible"] is True
+
+    assert hold["Commodity ETF"]["sell_eligible"] is False


### PR DESCRIPTION
## Summary
- enforce approval for commodity ETFs by checking asset_class and sector
- add commodity ETF metadata and adjust holding and portfolio utilities
- cover approval behavior for commodity vs non-commodity ETFs in tests

## Testing
- `pytest tests/test_compliance_route.py tests/utils/test_convert_portfolio_xml_to_input_files.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd64c03b088327924b60fb6669e1ae