### PR TITLE
Add accessible labels to mobile inputs

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -32,10 +32,12 @@ export default function App() {
   if (!accessToken) {
     return (
       <View style={{ padding: 20 }}>
+        <Text allowFontScaling={true}>ID Token</Text>
         <TextInput
           placeholder="ID Token"
           value={idToken}
           onChangeText={setIdToken}
+          accessibilityLabel="ID Token"
           style={{ borderWidth: 1, marginBottom: 12, padding: 8 }}
         />
         <Button title="Login" onPress={handleLogin} />
@@ -45,10 +47,12 @@ export default function App() {
 
   return (
     <ScrollView style={{ padding: 20 }}>
+      <Text allowFontScaling={true}>Owner</Text>
       <TextInput
         placeholder="Owner"
         value={owner}
         onChangeText={setOwner}
+        accessibilityLabel="Owner"
         style={{ borderWidth: 1, marginBottom: 12, padding: 8 }}
       />
       <Button title="Load Portfolio" onPress={loadPortfolio} />


### PR DESCRIPTION
## Summary
- Add visible labels with `allowFontScaling` for ID Token and Owner inputs in the mobile app
- Provide `accessibilityLabel` attributes to associated `TextInput` components

## Testing
- `npm test` *(fails: Transform failed with unexpected end of file)*

------
https://chatgpt.com/codex/tasks/task_e_68bd82adb2808327b134f01091912a2c