### PR TITLE
feat: improve login error accessibility

### DIFF
--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
-import { API_BASE, setAuthToken } from "./api";
-import { useUser } from "./UserContext";
-import { useAuth } from "./AuthContext";
+import { useEffect, useState } from 'react';
+import { API_BASE, setAuthToken } from './api';
+import { useUser } from './UserContext';
+import { useAuth } from './AuthContext';
 
 interface Props {
   clientId: string;
@@ -15,8 +15,9 @@ declare global {
 }
 
 function sanitize(input: string): string {
-  return new DOMParser().parseFromString(input, 'text/html').body
-    .textContent || ''
+  return (
+    new DOMParser().parseFromString(input, 'text/html').body.textContent || ''
+  );
 }
 
 export default function LoginPage({ clientId, onSuccess }: Props) {
@@ -24,8 +25,8 @@ export default function LoginPage({ clientId, onSuccess }: Props) {
   const { setUser } = useAuth();
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://accounts.google.com/gsi/client";
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
     script.async = true;
     script.defer = true;
     document.head.appendChild(script);
@@ -41,17 +42,17 @@ export default function LoginPage({ clientId, onSuccess }: Props) {
           });
 
           const res = await fetch(`${API_BASE}/token/google`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ token: resp.credential }),
           });
           if (res.ok) {
             const data = await res.json();
             setAuthToken(data.access_token);
             try {
-              const base64Url = resp.credential.split(".")[1];
-              const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
-              const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+              const base64Url = resp.credential.split('.')[1];
+              const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+              const padding = '='.repeat((4 - (base64.length % 4)) % 4);
               const payload = JSON.parse(atob(base64 + padding));
               setUser({
                 email: payload.email,
@@ -59,11 +60,11 @@ export default function LoginPage({ clientId, onSuccess }: Props) {
                 picture: payload.picture,
               });
             } catch (e) {
-              console.error("Failed to decode Google credential", e);
+              console.error('Failed to decode Google credential', e);
             }
             onSuccess();
           } else {
-            let msg = "Login failed";
+            let msg = 'Login failed';
             try {
               const err = await res.json();
               msg = err.detail || msg;
@@ -75,8 +76,8 @@ export default function LoginPage({ clientId, onSuccess }: Props) {
         },
       });
       window.google.accounts.id.renderButton(
-        document.getElementById("google-signin"),
-        { theme: "outline", size: "large" },
+        document.getElementById('google-signin'),
+        { theme: 'outline', size: 'large' }
       );
     };
     return () => {
@@ -87,14 +88,20 @@ export default function LoginPage({ clientId, onSuccess }: Props) {
   return (
     <div
       style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        marginTop: "2rem",
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        marginTop: '2rem',
       }}
     >
       {error && (
-        <div style={{ color: "red", marginBottom: "1rem" }}>{error}</div>
+        <div
+          role="alert"
+          aria-live="assertive"
+          style={{ color: 'red', marginBottom: '1rem' }}
+        >
+          Error: {error}
+        </div>
       )}
       <div id="google-signin"></div>
     </div>
@@ -102,9 +109,9 @@ export default function LoginPage({ clientId, onSuccess }: Props) {
 }
 
 function decodeJwt(token: string) {
-  const payload = token.split(".")[1];
+  const payload = token.split('.')[1];
   try {
-    const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
     const json = atob(base64);
     return JSON.parse(json);
   } catch {


### PR DESCRIPTION
## Summary
- wrap login error message in div with `role="alert"` and `aria-live="assertive"`
- add explicit "Error:" prefix so color isn't the only indicator

## Testing
- `npx vitest run` *(fails: 3 failed, 47 passed)*
- `npm run lint` *(fails: 24 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd82adb17c8327a16919a3866e70fd