### PR TITLE
feat: show language names

### DIFF
--- a/frontend/src/components/LanguageSwitcher.css
+++ b/frontend/src/components/LanguageSwitcher.css
@@ -2,6 +2,13 @@
   background: none;
   border: none;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0;
+}
+
+.language-btn img {
   width: 24px;
   height: 24px;
 }
@@ -16,7 +23,7 @@
 }
 
 @media (max-width: 480px) {
-  .language-btn {
+  .language-btn img {
     width: 18px;
     height: 18px;
   }

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -3,12 +3,12 @@ import i18n from "i18next";
 import "./LanguageSwitcher.css";
 
 const LANGUAGES = [
-  { code: "en", flag: "/flags/en.svg" },
-  { code: "fr", flag: "/flags/fr.svg" },
-  { code: "de", flag: "/flags/de.svg" },
-  { code: "es", flag: "/flags/es.svg" },
-  { code: "pt", flag: "/flags/pt.svg" },
-  { code: "it", flag: "/flags/it.svg" },
+  { code: "en", flag: "/flags/en.svg", name: "English" },
+  { code: "fr", flag: "/flags/fr.svg", name: "French" },
+  { code: "de", flag: "/flags/de.svg", name: "German" },
+  { code: "es", flag: "/flags/es.svg", name: "Spanish" },
+  { code: "pt", flag: "/flags/pt.svg", name: "Portuguese" },
+  { code: "it", flag: "/flags/it.svg", name: "Italian" },
 ];
 
 export const LanguageSwitcher = memo(function LanguageSwitcher() {
@@ -49,14 +49,15 @@ export const LanguageSwitcher = memo(function LanguageSwitcher() {
       <button
         onClick={() => setOpen((o) => !o)}
         className="language-btn"
-        aria-label={currentLang.code}
+        aria-label={currentLang.name}
       >
         <img
           src={currentLang.flag}
-          alt={currentLang.code}
+          alt={currentLang.name}
           width={24}
           height={24}
         />
+        <span className="language-name">{currentLang.name}</span>
       </button>
       {open && (
         <div className="language-menu">
@@ -65,9 +66,10 @@ export const LanguageSwitcher = memo(function LanguageSwitcher() {
               key={l.code}
               onClick={() => selectLanguage(l.code)}
               className="language-btn"
-              aria-label={l.code}
+              aria-label={l.name}
             >
-              <img src={l.flag} alt={l.code} width={24} height={24} />
+              <img src={l.flag} alt={l.name} width={24} height={24} />
+              <span className="language-name">{l.name}</span>
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- display full language names with each flag in the language switcher
- improve accessibility by using language names in `aria-label` and `alt`
- adjust switcher styles to accommodate text

## Testing
- `npm test -- --run` *(fails: Transform failed & Sparkline mock not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bd82ae031c83278519b871a36c9029