### PR TITLE
Improve text contrast for Profile and Watchlist pages

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -32,8 +32,12 @@ export default function ProfilePage() {
         />
       )}
       {user.name && <div className="text-xl">{user.name}</div>}
-      {user.email && <div className="text-gray-600">{user.email}</div>}
-      <p className="text-gray-600">Preferred theme: {theme}</p>
+      {user.email && (
+        <div className="text-gray-800 dark:text-gray-200">{user.email}</div>
+      )}
+      <p className="text-gray-800 dark:text-gray-200">
+        Preferred theme: {theme}
+      </p>
     </div>
   );
 }

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -171,7 +171,7 @@ export function Watchlist() {
         <div className="mb-2 text-red-500">{error}</div>
       )}
       {allClosed && (
-        <div className="mb-2 text-gray-500">
+        <div className="mb-2 text-gray-800 dark:text-gray-200">
           {t("watchlist.marketsClosed", { defaultValue: "Markets closed" })}
         </div>
       )}


### PR DESCRIPTION
## Summary
- use higher-contrast text color for email and theme on profile page
- ensure "Markets closed" message uses high-contrast colors in both light and dark modes
- review remaining `text-gray` usages for adequate contrast

## Testing
- `npm test` *(fails: ScenarioTester.test.tsx parse error; Sparkline.test.tsx missing mocked export)*
- `pytest` *(fails: backend API and config tests, styles snapshot; 4 failed, 1 error)*
- `npm run lint` *(fails: existing lint errors in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68bd82ae0fdc832796c38b411bffd301