### PR TITLE
Add Pomodoro focus mode timer

### DIFF
--- a/frontend/src/FocusModeContext.tsx
+++ b/frontend/src/FocusModeContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+interface FocusModeContextValue {
+  focusMode: boolean;
+  setFocusMode: (val: boolean) => void;
+}
+
+const defaultValue: FocusModeContextValue = {
+  focusMode: false,
+  setFocusMode: () => {},
+};
+
+export const FocusModeContext = createContext<FocusModeContextValue>(defaultValue);
+
+export function FocusModeProvider({ children }: { children: ReactNode }) {
+  const [focusMode, setFocusMode] = useState(false);
+  return (
+    <FocusModeContext.Provider value={{ focusMode, setFocusMode }}>
+      {children}
+    </FocusModeContext.Provider>
+  );
+}
+
+export function useFocusMode() {
+  return useContext(FocusModeContext);
+}
+

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { useConfig } from '../ConfigContext';
 import type { TabPluginId } from '../tabPlugins';
 import { orderedTabPlugins, SUPPORT_TABS } from '../tabPlugins';
+import PomodoroTimer from './PomodoroTimer';
+import { useFocusMode } from '../FocusModeContext';
 
 const SUPPORT_ONLY_TABS: TabPluginId[] = ['logs'];
 
@@ -25,6 +27,8 @@ export default function Menu({
   const { t } = useTranslation();
   const { tabs, disabledTabs } = useConfig();
   const path = location.pathname.split('/').filter(Boolean);
+
+  const { focusMode, setFocusMode } = useFocusMode();
 
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -132,52 +136,72 @@ export default function Menu({
       >
         ☰
       </button>
-      <div
-        className={`${open ? 'flex' : 'hidden'} flex-col gap-2 md:flex md:flex-row md:flex-wrap`}
-        style={style}
-      >
-        {orderedTabPlugins
-          .filter((p) => p.section === (isSupportMode ? 'support' : 'user'))
-          .slice()
-          .sort((a, b) => a.priority - b.priority)
-          .filter((p) => {
-            if (p.id === 'support') return false;
-            if (!inSupport && SUPPORT_ONLY_TABS.includes(p.id)) return false;
-            return tabs[p.id] !== false && !disabledTabs?.includes(p.id);
-          })
-          .map((p) => (
-            <Link
-              key={p.id}
-              to={pathFor(p.id)}
-              className={`mr-4 ${mode === p.id ? 'font-bold' : ''} break-words`}
-              style={{ fontWeight: mode === p.id ? 'bold' as const : undefined }}
-              onClick={() => setOpen(false)}
-            >
-              {t(`app.modes.${p.id}`)}
-            </Link>
-          ))}
-        {supportEnabled && (
-          <Link
-            to={inSupport ? '/' : '/support'}
-            className={`mr-4 ${inSupport ? 'font-bold' : ''} break-words`}
-            onClick={() => setOpen(false)}
-          >
-            {t('app.supportLink')}
-          </Link>
-        )}
-        {onLogout && (
+      {focusMode ? (
+        <div className="flex flex-col" style={style}>
+          <PomodoroTimer />
           <button
             type="button"
-            onClick={() => {
-              onLogout();
-              setOpen(false);
-            }}
+            onClick={() => setFocusMode(false)}
+            className="mt-2 mr-4 bg-transparent border-0 p-0 cursor-pointer self-start"
+          >
+            Exit Focus Mode
+          </button>
+        </div>
+      ) : (
+        <div
+          className={`${open ? 'flex' : 'hidden'} flex-col gap-2 md:flex md:flex-row md:flex-wrap`}
+          style={style}
+        >
+          {orderedTabPlugins
+            .filter((p) => p.section === (isSupportMode ? 'support' : 'user'))
+            .slice()
+            .sort((a, b) => a.priority - b.priority)
+            .filter((p) => {
+              if (p.id === 'support') return false;
+              if (!inSupport && SUPPORT_ONLY_TABS.includes(p.id)) return false;
+              return tabs[p.id] !== false && !disabledTabs?.includes(p.id);
+            })
+            .map((p) => (
+              <Link
+                key={p.id}
+                to={pathFor(p.id)}
+                className={`mr-4 ${mode === p.id ? 'font-bold' : ''} break-words`}
+                style={{ fontWeight: mode === p.id ? 'bold' as const : undefined }}
+                onClick={() => setOpen(false)}
+              >
+                {t(`app.modes.${p.id}`)}
+              </Link>
+            ))}
+          {supportEnabled && (
+            <Link
+              to={inSupport ? '/' : '/support'}
+              className={`mr-4 ${inSupport ? 'font-bold' : ''} break-words`}
+              onClick={() => setOpen(false)}
+            >
+              {t('app.supportLink')}
+            </Link>
+          )}
+          {onLogout && (
+            <button
+              type="button"
+              onClick={() => {
+                onLogout();
+                setOpen(false);
+              }}
+              className="mr-4 bg-transparent border-0 p-0 cursor-pointer"
+            >
+              {t('app.logout')}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setFocusMode(true)}
             className="mr-4 bg-transparent border-0 p-0 cursor-pointer"
           >
-            {t('app.logout')}
+            Focus Mode
           </button>
-        )}
-      </div>
+        </div>
+      )}
     </nav>
   );
 }

--- a/frontend/src/components/PomodoroTimer.tsx
+++ b/frontend/src/components/PomodoroTimer.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react';
+
+const SESSION_SECONDS = 25 * 60;
+const BREAK_SECONDS = 5 * 60;
+
+function notify(message: string) {
+  if ('Notification' in window) {
+    if (Notification.permission === 'granted') {
+      new Notification(message);
+    } else if (Notification.permission !== 'denied') {
+      Notification.requestPermission().then((p) => {
+        if (p === 'granted') new Notification(message);
+      });
+    }
+  }
+}
+
+export default function PomodoroTimer() {
+  const [seconds, setSeconds] = useState(SESSION_SECONDS);
+  const [running, setRunning] = useState(false);
+  const [onBreak, setOnBreak] = useState(false);
+  const intervalRef = useRef<number>();
+
+  useEffect(() => {
+    if (!running) return;
+    intervalRef.current = window.setInterval(() => {
+      setSeconds((s) => s - 1);
+    }, 1000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [running]);
+
+  useEffect(() => {
+    if (seconds >= 0) return;
+    const nextBreak = !onBreak;
+    notify(
+      nextBreak
+        ? 'Session complete! Time for a break.'
+        : 'Break over! Back to focus.',
+    );
+    setOnBreak(nextBreak);
+    setSeconds(nextBreak ? BREAK_SECONDS : SESSION_SECONDS);
+  }, [seconds, onBreak]);
+
+  const start = () => setRunning(true);
+  const pause = () => setRunning(false);
+  const reset = () => {
+    setRunning(false);
+    setOnBreak(false);
+    setSeconds(SESSION_SECONDS);
+  };
+
+  const mins = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const secs = (seconds % 60).toString().padStart(2, '0');
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="text-2xl font-mono mb-2">
+        {mins}:{secs}
+      </div>
+      <div className="space-x-2">
+        <button
+          type="button"
+          onClick={start}
+          disabled={running}
+          className="px-2 py-1 border rounded"
+        >
+          Start
+        </button>
+        <button
+          type="button"
+          onClick={pause}
+          disabled={!running}
+          className="px-2 py-1 border rounded"
+        >
+          Pause
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          className="px-2 py-1 border rounded"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,6 +13,7 @@ import { AuthProvider, useAuth } from './AuthContext'
 import { getConfig, logout as apiLogout, getStoredAuthToken, setAuthToken } from './api'
 import LoginPage from './LoginPage'
 import { UserProvider } from './UserContext'
+import { FocusModeProvider } from './FocusModeContext'
 
 const storedToken = getStoredAuthToken()
 if (storedToken) setAuthToken(storedToken)
@@ -87,10 +88,12 @@ createRoot(rootEl).render(
         <PriceRefreshProvider>
           <AuthProvider>
             <UserProvider>
-              <BrowserRouter>
-                <Root />
-              </BrowserRouter>
-              <ToastContainer autoClose={5000} />
+              <FocusModeProvider>
+                <BrowserRouter>
+                  <Root />
+                </BrowserRouter>
+                <ToastContainer autoClose={5000} />
+              </FocusModeProvider>
             </UserProvider>
           </AuthProvider>
         </PriceRefreshProvider>


### PR DESCRIPTION
## Summary
- add PomodoroTimer component with session/break cycle and controls
- introduce FocusModeContext and provider
- integrate focus mode toggle into Menu and wrap app with FocusModeProvider

## Testing
- `cd frontend && npm test` *(fails: LoginPage error handling > shows error message when login fails)*

------
https://chatgpt.com/codex/tasks/task_e_68be05e4c1bc8327a87ce2d2fea41e6a