### PR TITLE
Add allowance tracking endpoint and UI

### DIFF
--- a/backend/common/allowances.py
+++ b/backend/common/allowances.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+"""Allowance tracking utilities.
+
+This module provides helpers to load yearly contribution data from a simple
+JSON structure and compute remaining allowances for different account types.
+The contributions are expected under ``data/allowances/<owner>.json`` with the
+following structure::
+
+    {
+        "2024-2025": {"ISA": 5000, "pension": 10000},
+        "2025-2026": {"ISA": 0, "pension": 0}
+    }
+
+Only the parts required for the tests are implemented; the functions are
+resilient to missing data and return zero contributions by default.
+"""
+
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+from backend.config import config
+
+# Default annual limits (GBP) for supported account types
+ALLOWANCE_LIMITS: Dict[str, float] = {
+    "ISA": 20_000.0,
+    "pension": 40_000.0,
+}
+
+
+def _data_root(root: Optional[Path | str] = None) -> Path:
+    base = (
+        Path(root)
+        if root is not None
+        else Path(config.data_root) if config.data_root else Path(__file__).resolve().parents[2] / "data"
+    )
+    return base / "allowances"
+
+
+def current_tax_year(today: Optional[dt.date] = None) -> str:
+    """Return the UK tax year string for ``today``.
+
+    The UK tax year runs from 6 April to 5 April the following year. The result
+    is formatted as ``"YYYY-YYYY"`` representing the start and end years.
+    """
+
+    today = today or dt.date.today()
+    start_year = today.year if (today.month, today.day) >= (4, 6) else today.year - 1
+    return f"{start_year}-{start_year + 1}"
+
+
+def load_yearly_contributions(
+    owner: str,
+    tax_year: str,
+    root: Optional[Path | str] = None,
+) -> Dict[str, float]:
+    """Load contribution totals for ``owner`` and ``tax_year``.
+
+    Missing files or malformed data result in an empty mapping.
+    """
+
+    path = _data_root(root) / f"{owner}.json"
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    year_data = raw.get(tax_year, {})
+    results: Dict[str, float] = {}
+    for key, value in year_data.items():
+        try:
+            results[key] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return results
+
+
+def remaining_allowances(
+    owner: str,
+    tax_year: str,
+    limits: Optional[Dict[str, float]] = None,
+    root: Optional[Path | str] = None,
+) -> Dict[str, Dict[str, float]]:
+    """Return allowance usage and remaining amounts for ``owner``.
+
+    ``limits`` may override the default :data:`ALLOWANCE_LIMITS`.
+    """
+
+    limits = limits or ALLOWANCE_LIMITS
+    contribs = load_yearly_contributions(owner, tax_year, root)
+    results: Dict[str, Dict[str, float]] = {}
+    for acct, limit in limits.items():
+        used = float(contribs.get(acct, 0.0))
+        remaining = max(0.0, float(limit) - used)
+        results[acct] = {
+            "used": round(used, 2),
+            "limit": float(limit),
+            "remaining": round(remaining, 2),
+        }
+    return results
+
+
+__all__ = [
+    "ALLOWANCE_LIMITS",
+    "current_tax_year",
+    "load_yearly_contributions",
+    "remaining_allowances",
+]

--- a/backend/routes/tax.py
+++ b/backend/routes/tax.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from backend.auth import get_current_user
 from backend.common.tax import harvest_losses
+from backend.common.allowances import (
+    current_tax_year,
+    remaining_allowances,
+)
 
 router = APIRouter(prefix="/tax", tags=["tax"])
 
@@ -29,3 +33,22 @@ async def harvest(req: HarvestRequest, current_user: str = Depends(get_current_u
         [p.model_dump() for p in req.positions], req.threshold or 0.0
     )
     return {"trades": trades}
+
+
+@router.get("/allowances")
+async def allowances(
+    owner: str | None = Query(None),
+    current_user: str = Depends(get_current_user),
+) -> Dict[str, Dict[str, float]]:
+    """Return remaining ISA and pension allowances for ``owner``.
+
+    If ``owner`` is not provided the currently authenticated user is used.
+    The response contains ``used``, ``limit`` and ``remaining`` totals for
+    each supported account type in the current UK tax year.
+    """
+
+    if owner is None:
+        owner = current_user
+    tax_year = current_tax_year()
+    data = remaining_allowances(owner, tax_year)
+    return {"owner": owner, "tax_year": tax_year, "allowances": data}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -825,6 +825,16 @@ export const harvestTax = (
     body: JSON.stringify({ positions, threshold }),
   });
 
+// ───────────── Allowance Tracker ─────────────
+export const getAllowances = (owner?: string) => {
+  const suffix = owner ? `?owner=${encodeURIComponent(owner)}` : "";
+  return fetchJson<{
+    owner: string;
+    tax_year: string;
+    allowances: Record<string, { used: number; limit: number; remaining: number }>;
+  }>(`${API_BASE}/tax/allowances${suffix}`);
+};
+
 // ───────────── Pension Forecast ─────────────
 export const getPensionForecast = (
   dob: string,

--- a/frontend/src/pages/AllowanceTracker.tsx
+++ b/frontend/src/pages/AllowanceTracker.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { getAllowances } from "../api";
+
+interface AllowanceInfo {
+  used: number;
+  limit: number;
+  remaining: number;
+}
+
+export default function AllowanceTracker() {
+  const [data, setData] = useState<Record<string, AllowanceInfo> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getAllowances()
+      .then((res) => {
+        setData(res.allowances);
+        setError(null);
+      })
+      .catch(() => setError("Failed to load allowances"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p className="text-red-500">{error}</p>;
+  if (!data) return <p>No data</p>;
+
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl md:text-4xl">Allowance Tracker</h1>
+      <table className="min-w-full border-collapse border border-gray-300">
+        <thead>
+          <tr>
+            <th className="border p-2 text-left">Account</th>
+            <th className="border p-2 text-right">Used</th>
+            <th className="border p-2 text-right">Available</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(data).map(([type, info]) => (
+            <tr key={type}>
+              <td className="border p-2 capitalize">{type}</td>
+              <td className="border p-2 text-right">{info.used.toFixed(2)}</td>
+              <td className="border p-2 text-right">{info.remaining.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add allowance utilities to compute tax year contributions
- expose `/tax/allowances` API endpoint and frontend API call
- add Allowance Tracker page to display remaining ISA and pension allowances

## Testing
- `pytest`
- `CI=1 npm test` *(fails: No "getQuests" export defined on the "./api" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68be09ceedc88327a01c1caadf289338