### PR TITLE
Add returns comparison API and UI

### DIFF
--- a/backend/routes/performance.py
+++ b/backend/routes/performance.py
@@ -120,3 +120,15 @@ async def performance(owner: str, days: int = 365, exclude_cash: bool = False):
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Owner not found")
     return {"owner": owner, **result}
+
+
+@router.get("/returns/compare")
+@handle_owner_not_found
+async def compare_returns(owner: str, days: int = 365):
+    """Return portfolio CAGR and cash APY for ``owner``."""
+    try:
+        cagr = portfolio_utils.compute_cagr(owner, days)
+        cash_apy = portfolio_utils.compute_cash_apy(owner, days)
+        return {"owner": owner, "cagr": cagr, "cash_apy": cash_apy}
+    except FileNotFoundError:
+        raise_owner_not_found()

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -14,6 +14,7 @@ import type {
   AlphaResponse,
   TrackingErrorResponse,
   MaxDrawdownResponse,
+  ReturnComparisonResponse,
   Transaction,
   Alert,
   PriceEntry,
@@ -288,6 +289,11 @@ export const getTrackingError = (
 export const getMaxDrawdown = (owner: string, days = 365) =>
   fetchJson<MaxDrawdownResponse>(
     `${API_BASE}/performance/${owner}/max-drawdown?days=${days}`,
+  );
+
+export const getReturnComparison = (owner: string, days = 365) =>
+  fetchJson<ReturnComparisonResponse>(
+    `${API_BASE}/returns/compare?owner=${encodeURIComponent(owner)}&days=${days}`,
   );
 
 export const getGroupAlphaVsBenchmark = (

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -26,6 +26,7 @@ const Profile = lazy(() => import('./pages/Profile'))
 const Alerts = lazy(() => import('./pages/Alerts'))
 const Goals = lazy(() => import('./pages/Goals'))
 const PerformanceDiagnostics = lazy(() => import('./pages/PerformanceDiagnostics'))
+const ReturnComparison = lazy(() => import('./pages/ReturnComparison'))
 
 export function Root() {
   const [ready, setReady] = useState(false)
@@ -72,6 +73,7 @@ export function Root() {
         <Route path="/alerts" element={<Alerts />} />
         <Route path="/goals" element={<Goals />} />
         <Route path="/performance/:owner/diagnostics" element={<PerformanceDiagnostics />} />
+        <Route path="/returns/compare" element={<ReturnComparison />} />
         <Route path="/*" element={<App onLogout={logout} />} />
       </Routes>
     </Suspense>

--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -37,7 +37,6 @@ function PortfolioDashboard({
   data,
   owner,
 }: Props) {
-  void owner;
   return (
     <>
       <div className="grid grid-cols-2 gap-4 p-4 mb-4 bg-gray-900 border border-gray-700 rounded sm:grid-cols-3 md:grid-cols-5">
@@ -125,7 +124,16 @@ function PortfolioDashboard({
         </LineChart>
       </ResponsiveContainer>
       <p className="mt-8">
-        <Link to="/goals">View Goals</Link> |{" "}
+        <Link
+          to={
+            owner
+              ? `/returns/compare?owner=${encodeURIComponent(owner)}`
+              : "/returns/compare"
+          }
+        >
+          Return Comparison
+        </Link>{" "}
+        | <Link to="/goals">View Goals</Link> |{" "}
         <Link to="/pension/forecast">Pension Forecast</Link>
       </p>
     </>

--- a/frontend/src/pages/ReturnComparison.tsx
+++ b/frontend/src/pages/ReturnComparison.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { getReturnComparison } from "../api";
+import { percent } from "../lib/money";
+
+const OPTIONS = [
+  { label: "1Y", days: 365 },
+  { label: "3Y", days: 365 * 3 },
+  { label: "5Y", days: 365 * 5 },
+];
+
+export default function ReturnComparison() {
+  const [searchParams] = useSearchParams();
+  const owner = searchParams.get("owner") || "";
+  const [days, setDays] = useState(365);
+  const [cagr, setCagr] = useState<number | null>(null);
+  const [cashApy, setCashApy] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!owner) return;
+    getReturnComparison(owner, days).then((res) => {
+      setCagr(res.cagr);
+      setCashApy(res.cash_apy);
+    });
+  }, [owner, days]);
+
+  return (
+    <div className="p-4">
+      <h1>Return Comparison – {owner}</h1>
+      <label className="block mb-4">
+        Timeframe:
+        <select
+          className="ml-2"
+          value={days}
+          onChange={(e) => setDays(Number(e.target.value))}
+        >
+          {OPTIONS.map((o) => (
+            <option key={o.days} value={o.days}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <ul>
+        <li>Portfolio CAGR: {percent(cagr != null ? cagr * 100 : null)}</li>
+        <li>Cash APY: {percent(cashApy != null ? cashApy * 100 : null)}</li>
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -183,6 +183,12 @@ export interface MaxDrawdownResponse {
     max_drawdown: number | null;
 };
 
+export interface ReturnComparisonResponse {
+    owner: string;
+    cagr: number | null;
+    cash_apy: number | null;
+}
+
 export interface InstrumentDetailMini {
     [range: string]: {
         date: string;


### PR DESCRIPTION
## Summary
- add `/returns/compare` endpoint returning portfolio CAGR and cash APY
- expose comparison page with timeframe selector and dashboard link
- include API and type bindings for frontend

## Testing
- `npm test` *(fails: Unable to find an element with the text: bad...; No "getQuests" export is defined)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be09c050cc8327845f886a5afddcd9