### PR TITLE
Fix historical scenario event handling

### DIFF
--- a/backend/routes/scenario.py
+++ b/backend/routes/scenario.py
@@ -48,27 +48,16 @@ def run_scenario(
 
 @router.get("/scenario/historical")
 def run_historical_scenario(
-    date: str = Query(..., description="Event date (YYYY-MM-DD)"),
+    event_id: str | None = Query(None, description="Historical event identifier"),
+    date: str | None = Query(None, description="Event date (YYYY-MM-DD)"),
     horizons: List[int] = Query(..., description="Event horizons in days"),
-    proxy_ticker: str | None = Query(None, description="Proxy index ticker"),
-    proxy_exchange: str | None = Query(None, description="Proxy index exchange"),
 ):
-    """Calculate holding returns for all portfolios from a historical event."""
+    """Calculate shocked portfolio values for a historical event."""
 
-    event = {"date": date, "horizons": horizons}
-    if proxy_ticker:
-        event["proxy_index"] = {"ticker": proxy_ticker, "exchange": proxy_exchange}
-
-#     event_id: str | None = Query(None, description="Historical event identifier"),
-#     date: str | None = Query(None, description="Event date (YYYY-MM-DD)"),
-#     horizons: List[int] = Query(..., description="Event horizons in days"),
-# ):
-#     """Calculate shocked portfolio values for a historical event."""
-
-#     if event_id is None and date is None:
-#         raise HTTPException(status_code=400, detail="event_id or date must be provided")
-#     if not horizons:
-#         raise HTTPException(status_code=400, detail="horizons must be provided")
+    if event_id is None and date is None:
+        raise HTTPException(status_code=400, detail="event_id or date must be provided")
+    if not horizons:
+        raise HTTPException(status_code=400, detail="horizons must be provided")
 
     results = []
     owners = [p["owner"] for p in list_plots() if p.get("accounts")]
@@ -77,10 +66,6 @@ def run_historical_scenario(
             pf = build_owner_portfolio(owner)
         except FileNotFoundError:
             continue
-
-#         returns = apply_historical_event(pf, event)
-#         results.append({"owner": owner, "returns": returns})
-# =======
 
         baseline = pf.get("total_value_estimate_gbp")
         if baseline is None:

--- a/backend/utils/scenario_tester.py
+++ b/backend/utils/scenario_tester.py
@@ -183,8 +183,15 @@ def apply_historical_event(
     if baseline == 0.0:
         baseline = sum(float(a.get("value_estimate_gbp") or 0.0) for a in portfolio.get("accounts", []))
 
-    proxy_tkr, proxy_ex = _parse_full_ticker(getattr(event, "proxy", ""))
-    proxy_returns = _forward_returns(proxy_tkr, proxy_ex, event.date)
+    proxy_val = getattr(event, "proxy", None)
+    if proxy_val is None and isinstance(event, dict):
+        proxy_val = event.get("proxy_index")
+    proxy_tkr, proxy_ex = _parse_full_ticker(proxy_val or "")
+
+    event_date = getattr(event, "date", None)
+    if event_date is None and isinstance(event, dict):
+        event_date = event.get("date")
+    proxy_returns = _forward_returns(proxy_tkr, proxy_ex, event_date)
 
     totals = {k: 0.0 for k in _HORIZONS}
     cache: Dict[str, Dict[str, float | None]] = {}
@@ -197,7 +204,7 @@ def apply_historical_event(
             tkr, ex = _parse_full_ticker(full)
             key = f"{tkr}.{ex}"
             if key not in cache:
-                cache[key] = _forward_returns(tkr, ex, event.date)
+                cache[key] = _forward_returns(tkr, ex, event_date)
             rets = cache[key]
             for label in _HORIZONS:
                 r = rets.get(label)


### PR DESCRIPTION
## Summary
- restore `/scenario/historical` endpoint to accept `event_id` or `date` and return baseline and horizon data
- allow `apply_historical_event` helper to accept dict-style events

## Testing
- `python -m pytest tests/test_scenario_route.py::test_historical_scenario_route -q` *(fails: ValueError: Offline mode: no cache available at /workspace/allotmint/data/timeseries/meta/STUB_L.parquet)*

------
https://chatgpt.com/codex/tasks/task_e_68be0b6a84f48327b7d5fa51a04c23fa