### PR TITLE
Ensure user config routes handle missing owners

### DIFF
--- a/backend/routes/user_config.py
+++ b/backend/routes/user_config.py
@@ -6,8 +6,6 @@ from backend.config import config
 
 router = APIRouter(prefix="/user-config", tags=["user-config"])
 
-
-@router.get("/{owner}")
 @handle_owner_not_found
 async def get_user_config(owner: str, request: Request):
     try:
@@ -17,7 +15,6 @@ async def get_user_config(owner: str, request: Request):
     return cfg.to_dict()
 
 
-@router.post("/{owner}")
 @handle_owner_not_found
 async def update_user_config(owner: str, request: Request):
     data = await request.json()
@@ -27,3 +24,7 @@ async def update_user_config(owner: str, request: Request):
         return cfg.to_dict()
     except FileNotFoundError:
         raise_owner_not_found()
+
+
+router.get("/{owner}")(get_user_config)
+router.post("/{owner}")(update_user_config)


### PR DESCRIPTION
## Summary
- Wrap user-config GET and POST handlers with `handle_owner_not_found`
- Convert `FileNotFoundError` from config access into a 404 response

## Testing
- `pytest tests/test_user_config_route.py::test_missing_owner_returns_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68be0c17c528832791a519a43fef1280