### PR TITLE
Remove duplicate chart in InstrumentDetail

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -9,7 +9,6 @@ import i18n from "../i18n";
 import { useConfig } from "../ConfigContext";
 import type { TradingSignal } from "../types";
 import { RelativeViewToggle } from "./RelativeViewToggle";
-import { InstrumentHistoryChart } from "./InstrumentHistoryChart";
 import {
   ResponsiveContainer,
   LineChart,
@@ -325,11 +324,6 @@ export function InstrumentDetail({
           {t("instrumentDetail.rsi")}
         </label>
       </div>
-      <InstrumentHistoryChart
-        data={prices}
-        loading={loading}
-        showBollinger={showBollinger}
-      />
       {loading ? (
         <div
           style={{


### PR DESCRIPTION
## Summary
- show only a single price history chart in InstrumentDetail
- drop unused InstrumentHistoryChart import and component usage

## Testing
- `npm test` *(fails: [vitest] No "getNudges" export is defined on the "./api" mock)*
- `cd frontend && npm test src/components/InstrumentDetail.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf07e537c08327acedf8e122bf4d78