### PR TITLE
feat: add loading and error states to instrument research page

### DIFF
--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+vi.mock("../hooks/useInstrumentHistory", () => ({
+  useInstrumentHistory: vi.fn(),
+}));
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import InstrumentResearch from "./InstrumentResearch";
+import type { InstrumentDetail, ScreenerResult, NewsItem, QuoteRow } from "../types";
+import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
+import * as api from "../api";
+
+const mockGetInstrumentDetail = vi.spyOn(api, "getInstrumentDetail");
+const mockGetScreener = vi.spyOn(api, "getScreener");
+const mockGetQuotes = vi.spyOn(api, "getQuotes");
+const mockGetNews = vi.spyOn(api, "getNews");
+const mockUseInstrumentHistory = vi.mocked(useInstrumentHistory);
+
+function renderPage() {
+  render(
+    <MemoryRouter initialEntries={["/research/AAA"]}>
+      <Routes>
+        <Route path="/research/:ticker" element={<InstrumentResearch />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("InstrumentResearch page", () => {
+  beforeEach(() => {
+    mockUseInstrumentHistory.mockReturnValue({
+      data: { "30": [] },
+      loading: false,
+      error: null,
+    } as any);
+  });
+
+  it("shows loading indicators while fetching data", async () => {
+    let detailResolve: (v: InstrumentDetail) => void;
+    let screenerResolve: (v: ScreenerResult[]) => void;
+    let quotesResolve: (v: QuoteRow[]) => void;
+    let newsResolve: (v: NewsItem[]) => void;
+
+    mockGetInstrumentDetail.mockReturnValueOnce(
+      new Promise((res) => {
+        detailResolve = res;
+      }) as Promise<InstrumentDetail>,
+    );
+    mockGetScreener.mockReturnValueOnce(
+      new Promise((res) => {
+        screenerResolve = res;
+      }) as Promise<ScreenerResult[]>,
+    );
+    mockGetQuotes.mockReturnValueOnce(
+      new Promise((res) => {
+        quotesResolve = res;
+      }) as Promise<QuoteRow[]>,
+    );
+    mockGetNews.mockReturnValueOnce(
+      new Promise((res) => {
+        newsResolve = res;
+      }) as Promise<NewsItem[]>,
+    );
+
+    renderPage();
+
+    expect(screen.getByText(/Loading instrument details/i)).toBeInTheDocument();
+    expect(screen.getByText(/Loading metrics/i)).toBeInTheDocument();
+    expect(screen.getByText(/Loading quote/i)).toBeInTheDocument();
+    expect(screen.getByText(/Loading news/i)).toBeInTheDocument();
+
+    detailResolve!({ prices: null, positions: [] } as InstrumentDetail);
+    screenerResolve!([
+      { rank: 1, ticker: "AAA" } as unknown as ScreenerResult,
+    ]);
+    quotesResolve!([
+      {
+        name: null,
+        symbol: "AAA",
+        last: 100,
+        open: null,
+        high: 110,
+        low: 90,
+        change: null,
+        changePct: 1,
+        volume: null,
+        marketTime: null,
+        marketState: "REGULAR",
+      } as QuoteRow,
+    ]);
+    newsResolve!([{ headline: "headline", url: "http://example.com" }]);
+
+    expect(await screen.findByText("Price")).toBeInTheDocument();
+    expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument();
+  });
+
+  it("renders error messages when requests fail", async () => {
+    mockGetInstrumentDetail.mockRejectedValueOnce(new Error("detail fail"));
+    mockGetScreener.mockRejectedValueOnce(new Error("screener fail"));
+    mockGetQuotes.mockRejectedValueOnce(new Error("quotes fail"));
+    mockGetNews.mockRejectedValueOnce(new Error("news fail"));
+
+    renderPage();
+
+    expect(await screen.findByText("detail fail")).toBeInTheDocument();
+    expect(await screen.findByText("screener fail")).toBeInTheDocument();
+    expect(await screen.findByText("quotes fail")).toBeInTheDocument();
+    expect(await screen.findByText("news fail")).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -23,6 +23,14 @@ export default function InstrumentResearch() {
   const historyPrices = history?.[String(days)] ?? [];
   const [quote, setQuote] = useState<QuoteRow | null>(null);
   const [news, setNews] = useState<NewsItem[]>([]);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [screenerLoading, setScreenerLoading] = useState(false);
+  const [screenerError, setScreenerError] = useState<string | null>(null);
+  const [quoteLoading, setQuoteLoading] = useState(false);
+  const [quoteError, setQuoteError] = useState<string | null>(null);
+  const [newsLoading, setNewsLoading] = useState(false);
+  const [newsError, setNewsError] = useState<string | null>(null);
   const [inWatchlist, setInWatchlist] = useState(() => {
     const list = (localStorage.getItem("watchlistSymbols") || "")
       .split(",")
@@ -36,24 +44,51 @@ export default function InstrumentResearch() {
     const detailCtrl = new AbortController();
     const screenerCtrl = new AbortController();
     const newsCtrl = new AbortController();
+    setDetailLoading(true);
+    setDetailError(null);
     getInstrumentDetail(tkr, 365, detailCtrl.signal)
       .then(setDetail)
       .catch((err) => {
-        if (err.name !== "AbortError") console.error(err);
-      });
+        if (err.name !== "AbortError") {
+          console.error(err);
+          setDetailError(err.message ?? String(err));
+        }
+      })
+      .finally(() => setDetailLoading(false));
+
+    setScreenerLoading(true);
+    setScreenerError(null);
     getScreener([tkr], {}, screenerCtrl.signal)
       .then((rows) => setMetrics(rows[0] || null))
       .catch((err) => {
-        if (err.name !== "AbortError") console.error(err);
-      });
+        if (err.name !== "AbortError") {
+          console.error(err);
+          setScreenerError(err.message ?? String(err));
+        }
+      })
+      .finally(() => setScreenerLoading(false));
+
+    setQuoteLoading(true);
+    setQuoteError(null);
     getQuotes([tkr])
       .then((rows) => setQuote(rows[0] || null))
-      .catch((err) => console.error(err));
+      .catch((err) => {
+        console.error(err);
+        setQuoteError(err.message ?? String(err));
+      })
+      .finally(() => setQuoteLoading(false));
+
+    setNewsLoading(true);
+    setNewsError(null);
     getNews(tkr, newsCtrl.signal)
       .then(setNews)
       .catch((err) => {
-        if (err.name !== "AbortError") console.error(err);
-      });
+        if (err.name !== "AbortError") {
+          console.error(err);
+          setNewsError(err.message ?? String(err));
+        }
+      })
+      .finally(() => setNewsLoading(false));
     return () => {
       detailCtrl.abort();
       screenerCtrl.abort();
@@ -138,109 +173,145 @@ export default function InstrumentResearch() {
           showBollinger={showBollinger}
         />
       )}
-      {(quote || metrics) && (
-        <table style={{ marginBottom: "1rem" }}>
-          <tbody>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Price</th>
-              <td>{quote?.last ?? "—"}</td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Change %</th>
-              <td>
-                {quote?.changePct != null
-                  ? `${quote.changePct.toFixed(2)}%`
-                  : "—"}
-              </td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>
-                Day Range
-              </th>
-              <td>
-                {quote
-                  ? `${quote.low ?? "—"} - ${quote.high ?? "—"}`
-                  : "—"}
-              </td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>
-                52W Range
-              </th>
-              <td>
-                {metrics
-                  ? `${metrics.low_52w ?? "—"} - ${metrics.high_52w ?? "—"}`
-                  : "—"}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      {quoteLoading || screenerLoading ? (
+        <div>Loading quote...</div>
+      ) : quoteError || screenerError ? (
+        <div>{quoteError || screenerError}</div>
+      ) : (
+        (quote || metrics) && (
+          <table style={{ marginBottom: "1rem" }}>
+            <tbody>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Price</th>
+                <td>{quote?.last ?? "—"}</td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>
+                  Change %
+                </th>
+                <td>
+                  {quote?.changePct != null
+                    ? `${quote.changePct.toFixed(2)}%`
+                    : "—"}
+                </td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>
+                  Day Range
+                </th>
+                <td>
+                  {quote
+                    ? `${quote.low ?? "—"} - ${quote.high ?? "—"}`
+                    : "—"}
+                </td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>
+                  52W Range
+                </th>
+                <td>
+                  {metrics
+                    ? `${metrics.low_52w ?? "—"} - ${metrics.high_52w ?? "—"}`
+                    : "—"}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        )
       )}
-      {metrics && (
-        <table style={{ marginBottom: "1rem" }}>
-          <tbody>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>PEG</th>
-              <td>{metrics.peg_ratio ?? "—"}</td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>P/E</th>
-              <td>{metrics.pe_ratio ?? "—"}</td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>D/E</th>
-              <td>{metrics.de_ratio ?? "—"}</td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>LT D/E</th>
-              <td>{metrics.lt_de_ratio ?? "—"}</td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Market Cap</th>
-              <td>{largeNumber(metrics.market_cap)}</td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>EPS</th>
-              <td>{metrics.eps ?? "—"}</td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Dividend Yield</th>
-              <td>{metrics.dividend_yield ?? "—"}</td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Beta</th>
-              <td>{metrics.beta ?? "—"}</td>
-            </tr>
-            <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Avg Volume</th>
-              <td>{largeNumber(metrics.avg_volume)}</td>
-            </tr>
-          </tbody>
-        </table>
+      {screenerLoading ? (
+        <div>Loading metrics...</div>
+      ) : screenerError ? (
+        <div>{screenerError}</div>
+      ) : (
+        metrics && (
+          <table style={{ marginBottom: "1rem" }}>
+            <tbody>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>PEG</th>
+                <td>{metrics.peg_ratio ?? "—"}</td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>P/E</th>
+                <td>{metrics.pe_ratio ?? "—"}</td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>D/E</th>
+                <td>{metrics.de_ratio ?? "—"}</td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>
+                  LT D/E
+                </th>
+                <td>{metrics.lt_de_ratio ?? "—"}</td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>
+                  Market Cap
+                </th>
+                <td>{largeNumber(metrics.market_cap)}</td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>EPS</th>
+                <td>{metrics.eps ?? "—"}</td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>
+                  Dividend Yield
+                </th>
+                <td>{metrics.dividend_yield ?? "—"}</td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Beta</th>
+                <td>{metrics.beta ?? "—"}</td>
+              </tr>
+              <tr>
+                <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>
+                  Avg Volume
+                </th>
+                <td>{largeNumber(metrics.avg_volume)}</td>
+              </tr>
+            </tbody>
+          </table>
+        )
       )}
-      {detail && detail.positions && detail.positions.length > 0 && (
-        <div>
-          <h2>Positions</h2>
-          <ul>
-            {detail.positions.map((p, i) => (
-              <li key={i}>{p.owner} – {p.account} : {p.units}</li>
-            ))}
-          </ul>
-        </div>
+      {detailLoading ? (
+        <div>Loading instrument details...</div>
+      ) : detailError ? (
+        <div>{detailError}</div>
+      ) : (
+        detail && detail.positions && detail.positions.length > 0 && (
+          <div>
+            <h2>Positions</h2>
+            <ul>
+              {detail.positions.map((p, i) => (
+                <li key={i}>
+                  {p.owner} – {p.account} : {p.units}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
       )}
-      {news.length > 0 && (
-        <div>
-          <h2>News</h2>
-          <ul>
-            {news.map((n, i) => (
-              <li key={i}>
-                <a href={n.url} target="_blank" rel="noopener noreferrer">
-                  {n.headline}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
+      {newsLoading ? (
+        <div>Loading news...</div>
+      ) : newsError ? (
+        <div>{newsError}</div>
+      ) : (
+        news.length > 0 && (
+          <div>
+            <h2>News</h2>
+            <ul>
+              {news.map((n, i) => (
+                <li key={i}>
+                  <a href={n.url} target="_blank" rel="noopener noreferrer">
+                    {n.headline}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- handle loading and error states for instrument detail, screener metrics, quotes, and news
- display placeholders and errors in InstrumentResearch page
- add unit tests for loading and error handling

## Testing
- `npm test -- --run src/pages/InstrumentResearch.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf07c540548327a1d4615c2d49ffa2