### PR TITLE
Hide research links when tabs disabled

### DIFF
--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { configContext, type ConfigContextValue } from "../ConfigContext";
+import InstrumentResearch from "./InstrumentResearch";
+import * as api from "../api";
+
+vi.mock("../components/InstrumentHistoryChart", () => ({
+  InstrumentHistoryChart: () => <div />,
+}));
+
+vi.mock("../hooks/useInstrumentHistory", () => ({
+  useInstrumentHistory: () => ({ data: {}, loading: false, error: null }),
+}));
+
+const baseConfig: ConfigContextValue = {
+  relativeViewEnabled: false,
+  disabledTabs: [],
+  tabs: {
+    group: true,
+    owner: true,
+    instrument: true,
+    performance: true,
+    transactions: true,
+    screener: true,
+    trading: true,
+    timeseries: true,
+    watchlist: true,
+    movers: true,
+    instrumentadmin: true,
+    dataadmin: true,
+    virtual: true,
+    support: true,
+    settings: true,
+    profile: false,
+    reports: true,
+    scenario: true,
+    logs: true,
+  },
+  theme: "system",
+  baseCurrency: "GBP",
+  refreshConfig: async () => {},
+  setRelativeViewEnabled: () => {},
+  setBaseCurrency: () => {},
+};
+
+function renderPage(config: Partial<ConfigContextValue> = {}) {
+  render(
+    <configContext.Provider value={{ ...baseConfig, ...config }}>
+      <MemoryRouter initialEntries={["/research/AAA"]}>
+        <Routes>
+          <Route path="/research/:ticker" element={<InstrumentResearch />} />
+        </Routes>
+      </MemoryRouter>
+    </configContext.Provider>,
+  );
+}
+
+describe("InstrumentResearch navigation", () => {
+  let detailSpy: ReturnType<typeof vi.spyOn>;
+  let screenerSpy: ReturnType<typeof vi.spyOn>;
+  let newsSpy: ReturnType<typeof vi.spyOn>;
+  let quotesSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    detailSpy = vi
+      .spyOn(api, "getInstrumentDetail")
+      .mockResolvedValue(null as any);
+    screenerSpy = vi
+      .spyOn(api, "getScreener")
+      .mockResolvedValue([] as any);
+    newsSpy = vi.spyOn(api, "getNews").mockResolvedValue([]);
+    quotesSpy = vi.spyOn(api, "getQuotes").mockResolvedValue([]);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    detailSpy.mockRestore();
+    screenerSpy.mockRestore();
+    newsSpy.mockRestore();
+    quotesSpy.mockRestore();
+  });
+
+  it("shows screener and watchlist links when enabled", () => {
+    renderPage();
+    expect(screen.getByRole("link", { name: "View Screener" })).toHaveAttribute(
+      "href",
+      "/screener",
+    );
+    expect(screen.getByRole("link", { name: "Watchlist" })).toHaveAttribute(
+      "href",
+      "/watchlist",
+    );
+  });
+
+  it("hides screener link when tab disabled", () => {
+    renderPage({ tabs: { ...baseConfig.tabs, screener: false } });
+    expect(screen.queryByRole("link", { name: "View Screener" })).toBeNull();
+  });
+
+  it("hides screener link when disabled via config", () => {
+    renderPage({ disabledTabs: ["screener"] });
+    expect(screen.queryByRole("link", { name: "View Screener" })).toBeNull();
+  });
+
+  it("hides watchlist link when tab disabled", () => {
+    renderPage({ tabs: { ...baseConfig.tabs, watchlist: false } });
+    expect(screen.queryByRole("link", { name: "Watchlist" })).toBeNull();
+  });
+
+  it("hides watchlist link when disabled via config", () => {
+    renderPage({ disabledTabs: ["watchlist"] });
+    expect(screen.queryByRole("link", { name: "Watchlist" })).toBeNull();
+  });
+});
+

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useConfig } from "../ConfigContext";
 import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
 import { InstrumentHistoryChart } from "../components/InstrumentHistoryChart";
 import { getInstrumentDetail, getScreener, getNews, getQuotes } from "../api";
@@ -14,6 +15,7 @@ export default function InstrumentResearch() {
   const [days, setDays] = useState(30);
   const [showBollinger, setShowBollinger] = useState(false);
   const { t } = useTranslation();
+  const { tabs, disabledTabs } = useConfig();
   const tkr = ticker && /^[A-Za-z0-9.-]{1,10}$/.test(ticker) ? ticker : "";
   const {
     data: history,
@@ -92,10 +94,14 @@ export default function InstrumentResearch() {
     <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
       <h1 style={{ marginBottom: "1rem" }}>{tkr}</h1>
       <div style={{ marginBottom: "1rem" }}>
-        <Link to="/screener" style={{ marginRight: "1rem" }}>
-          View Screener
-        </Link>
-        <Link to="/watchlist">Watchlist</Link>
+        {tabs.screener && !disabledTabs.includes("screener") && (
+          <Link to="/screener" style={{ marginRight: "1rem" }}>
+            View Screener
+          </Link>
+        )}
+        {tabs.watchlist && !disabledTabs.includes("watchlist") && (
+          <Link to="/watchlist">Watchlist</Link>
+        )}
         <button onClick={toggleWatchlist} style={{ marginLeft: "1rem" }}>
           {inWatchlist ? "Remove from Watchlist" : "Add to Watchlist"}
         </button>


### PR DESCRIPTION
## Summary
- conditionally show "View Screener" and "Watchlist" links on Instrument Research page based on config
- add tests ensuring links disappear when tabs disabled

## Testing
- `npm test` *(fails: [vitest] No "getNudges" export is defined on the "./api" mock)*
- `npm run lint` *(fails: 25 errors, e.g. no-unused-vars)*
- `npx vitest run src/pages/InstrumentResearch.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf07b70de4832790692bb30dd77e12