### PR TITLE
Derive support tab list from plugin registry

### DIFF
--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -9,14 +9,18 @@ const mockGetOwners = vi.hoisted(() => vi.fn());
 const mockSavePushSubscription = vi.hoisted(() => vi.fn());
 const mockDeletePushSubscription = vi.hoisted(() => vi.fn());
 
-vi.mock("../api", () => ({
-  API_BASE: "",
-  getConfig: mockGetConfig,
-  updateConfig: mockUpdateConfig,
-  getOwners: mockGetOwners,
-  savePushSubscription: mockSavePushSubscription,
-  deletePushSubscription: mockDeletePushSubscription,
-}));
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    API_BASE: "",
+    getConfig: mockGetConfig,
+    updateConfig: mockUpdateConfig,
+    getOwners: mockGetOwners,
+    savePushSubscription: mockSavePushSubscription,
+    deletePushSubscription: mockDeletePushSubscription,
+  };
+});
 
 import Support from "./Support";
 
@@ -35,6 +39,8 @@ beforeEach(() => {
       reports: true,
       logs: true,
       profile: true,
+      allocation: false,
+      scenario: false,
     },
   });
   mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
@@ -84,6 +90,8 @@ describe("Support page", () => {
       reports: true,
       logs: true,
       profile: true,
+      allocation: false,
+      scenario: false,
     },
   });
   mockGetConfig.mockResolvedValueOnce({
@@ -99,6 +107,8 @@ describe("Support page", () => {
       reports: true,
       logs: true,
       profile: true,
+      allocation: false,
+      scenario: false,
     },
   });
     mockUpdateConfig.mockResolvedValue(undefined);
@@ -121,11 +131,19 @@ describe("Support page", () => {
     render(<Support />, { wrapper: MemoryRouter });
     await screen.findByText(/Tabs Enabled/i);
     const instrument = await screen.findByRole("checkbox", {
-      name: /instrument/i,
+      name: /^instrument$/i,
     });
-    const support = screen.getByRole("checkbox", { name: /support/i });
+    const support = screen.getByRole("checkbox", { name: /^support$/i });
+    const group = screen.getByRole("checkbox", { name: /^group$/i });
+    const owner = screen.getByRole("checkbox", { name: /^owner$/i });
+    const allocation = screen.getByRole("checkbox", { name: /^allocation$/i });
+    const scenario = screen.getByRole("checkbox", { name: /^scenario$/i });
     expect(instrument).toBeChecked();
     expect(support).toBeChecked();
+    expect(group).toBeChecked();
+    expect(owner).toBeChecked();
+    expect(allocation).not.toBeChecked();
+    expect(scenario).not.toBeChecked();
     await act(async () => {
       await userEvent.click(instrument);
     });

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -11,24 +11,11 @@ import {
 import { useConfig } from "../ConfigContext";
 import { OwnerSelector } from "../components/OwnerSelector";
 import type { OwnerSummary } from "../types";
+import { orderedTabPlugins, type TabPluginId } from "../tabPlugins";
 
-const TAB_KEYS = [
-  "instrument",
-  "performance",
-  "transactions",
-  "screener",
-  "trading",
-  "timeseries",
-  "watchlist",
-  "virtual",
-  "support",
-  "logs",
-  "settings",
-  "profile",
-  "reports",
-] as const;
+const TAB_KEYS = orderedTabPlugins.map((p) => p.id) as TabPluginId[];
 const EMPTY_TABS = Object.fromEntries(TAB_KEYS.map((k) => [k, false])) as Record<
-  (typeof TAB_KEYS)[number],
+  TabPluginId,
   boolean
 >;
 
@@ -41,7 +28,7 @@ export default function Support() {
   const [message, setMessage] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [config, setConfig] = useState<ConfigState>({});
-  const [tabs, setTabs] = useState<Record<string, boolean>>(EMPTY_TABS);
+  const [tabs, setTabs] = useState<Record<TabPluginId, boolean>>(EMPTY_TABS);
   const [configStatus, setConfigStatus] = useState<string | null>(null);
   const [pushEnabled, setPushEnabled] = useState(false);
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
@@ -107,7 +94,7 @@ export default function Support() {
     setConfig((prev) => ({ ...prev, [key]: value }));
   }
 
-  function handleTabChange(key: string, value: boolean) {
+  function handleTabChange(key: TabPluginId, value: boolean) {
     setTabs((prev) => ({ ...prev, [key]: value }));
   }
 


### PR DESCRIPTION
## Summary
- build Support page tab toggles from `orderedTabPlugins` instead of hard-coded array
- type tabs with `TabPluginId`
- extend tests to cover additional tab ids like group, owner, allocation and scenario

## Testing
- `npm test -- --run src/pages/Support.test.tsx`
- `npm test -- --run` *(fails: [vitest] No "getNudges" export is defined on the "./api" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68bf07ab37e8832799c830964e111db6