### PR TITLE
Add drawdown reconciliation tests

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -763,6 +763,7 @@ def _portfolio_value_series(name: str, days: int = 365, *, group: bool = False) 
 
     from backend.common import instrument_api
 
+    flagged = {k.upper() for k, v in _PRICE_SNAPSHOT.items() if v.get("flagged")}
     holdings: List[tuple[str, str, float]] = []
     for acct in pf.get("accounts", []):
         for h in acct.get("holdings", []):
@@ -780,6 +781,10 @@ def _portfolio_value_series(name: str, days: int = 365, *, group: bool = False) 
                 if not h.get("exchange"):
                     logger.debug("Could not resolve exchange for %s; defaulting to L", tkr)
             exch = (h.get("exchange") or inferred or "L").upper()
+            full = f"{sym}.{exch}".upper()
+            if full in flagged:
+                logger.debug("Skipping flagged instrument %s", full)
+                continue
             holdings.append((sym, exch, units))
 
     total = pd.Series(dtype=float)

--- a/backend/tests/test_drawdown_reconciliation.py
+++ b/backend/tests/test_drawdown_reconciliation.py
@@ -1,0 +1,79 @@
+import logging
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from backend.common import portfolio_utils
+from backend.common import portfolio as portfolio_mod
+
+
+@pytest.fixture
+def price_data():
+    idx = pd.date_range("2024-01-01", periods=5, freq="D").date
+    return {
+        "AAA": pd.DataFrame({"Date": idx, "Close": [100, 120, 110, 130, 115]}),
+        "BADZERO": pd.DataFrame({"Date": idx, "Close": [100, 0, 95, 105, 100]}),
+        "FLAG": pd.DataFrame({"Date": idx, "Close": [50, 40, 30, 20, 10]}),
+    }
+
+
+@pytest.fixture
+def mock_env(monkeypatch, price_data):
+    owners = {
+        "normal": [{"ticker": "AAA", "exchange": "L", "units": 1}],
+        "mixed": [
+            {"ticker": "AAA", "exchange": "L", "units": 1},
+            {"ticker": "BADZERO", "exchange": "L", "units": 1},
+            {"ticker": "FLAG", "exchange": "L", "units": 1},
+        ],
+    }
+
+    def fake_build_owner_portfolio(owner):
+        return {"accounts": [{"holdings": owners[owner]}]}
+
+    monkeypatch.setattr(portfolio_mod, "build_owner_portfolio", fake_build_owner_portfolio)
+
+    def fake_resolve(ticker, latest):
+        return ticker.split(".")[0], "L"
+
+    monkeypatch.setattr("backend.common.instrument_api._resolve_full_ticker", fake_resolve)
+
+    calls = []
+
+    def fake_load_meta_timeseries(ticker, exchange, days):
+        calls.append((ticker, exchange))
+        return price_data.get(ticker, pd.DataFrame())
+
+    monkeypatch.setattr(portfolio_utils, "load_meta_timeseries", fake_load_meta_timeseries)
+
+    portfolio_utils._PRICE_SNAPSHOT = {"FLAG.L": {"flagged": True}}
+
+    return calls
+
+
+def test_compute_max_drawdown_normal_series(mock_env):
+    val = portfolio_utils.compute_max_drawdown("normal", days=5)
+    assert val == pytest.approx(-0.11538, rel=1e-4)
+    assert mock_env == [("AAA", "L")]
+
+
+def test_compute_max_drawdown_ignores_flagged(mock_env):
+    val = portfolio_utils.compute_max_drawdown("mixed", days=5)
+    assert val == pytest.approx(-0.4, rel=1e-4)
+    assert ("FLAG", "L") not in mock_env
+
+
+def reconcile(owner, price_data):
+    for tkr, df in price_data.items():
+        bad = df[df["Close"] <= 0]
+        if not bad.empty:
+            d = bad.iloc[0]["Date"]
+            logging.warning("Bad series for %s on %s", tkr, d)
+    return portfolio_utils.compute_max_drawdown(owner, days=5)
+
+
+def test_reconciliation_warns_bad_series(price_data, mock_env, caplog):
+    with caplog.at_level("WARNING"):
+        reconcile("mixed", price_data)
+    assert any("BADZERO" in r.message and "2024-01-02" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- skip flagged instruments when building portfolio value series
- add tests for drawdown reconciliation covering flagged and invalid price data

## Testing
- `pytest backend/tests/test_drawdown_reconciliation.py -q -p no:cov --override-ini=addopts=`
- `pytest backend/tests/test_portfolio_utils.py -q -p no:cov --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68bf08d06c848327ac500ac7540cc42f