### PR TITLE
Return 404 for missing user config owners

### DIFF
--- a/backend/routes/user_config.py
+++ b/backend/routes/user_config.py
@@ -1,8 +1,7 @@
 from fastapi import APIRouter, Request
 
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
-from backend.common.user_config import UserConfig, load_user_config, save_user_config
-from backend.config import config
+from backend.common.user_config import load_user_config, save_user_config
 
 router = APIRouter(prefix="/user-config", tags=["user-config"])
 
@@ -11,12 +10,7 @@ async def get_user_config(owner: str, request: Request):
     try:
         cfg = load_user_config(owner, request.app.state.accounts_root)
     except FileNotFoundError:
-        cfg = UserConfig(
-            hold_days_min=config.hold_days_min,
-            max_trades_per_month=config.max_trades_per_month,
-            approval_exempt_types=config.approval_exempt_types or [],
-            approval_exempt_tickers=config.approval_exempt_tickers or [],
-        )
+        raise_owner_not_found()
     return cfg.to_dict()
 
 


### PR DESCRIPTION
## Summary
- Return 404 when requesting user config for unknown owner
- Remove unused imports and default fallback logic

## Testing
- `pytest -q tests/test_user_config_route.py -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68bf0b3f7e8c8327afd555da17bb6ae9