### PR TITLE
Display instrument name in research view

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -30,6 +30,7 @@ describe("App", () => {
         saveTimeseries: vi.fn(),
         refetchTimeseries: vi.fn(),
         rebuildTimeseriesCache: vi.fn(),
+        getNudges: vi.fn().mockResolvedValue([]),
       }));
 
     const { default: App } = await import("./App");
@@ -64,6 +65,7 @@ describe("App", () => {
       saveTimeseries: vi.fn(),
       refetchTimeseries: vi.fn(),
       rebuildTimeseriesCache: vi.fn(),
+      getNudges: vi.fn().mockResolvedValue([]),
     }));
 
     const { default: App } = await import("./App");
@@ -96,6 +98,7 @@ describe("App", () => {
       listTimeseries: vi.fn().mockResolvedValue([]),
       refetchTimeseries: vi.fn(),
       rebuildTimeseriesCache: vi.fn(),
+      getNudges: vi.fn().mockResolvedValue([]),
     }));
 
     const { default: App } = await import("./App");
@@ -134,6 +137,7 @@ describe("App", () => {
         listTimeseries: vi.fn().mockResolvedValue([]),
         refetchTimeseries: vi.fn(),
         rebuildTimeseriesCache: vi.fn(),
+        getNudges: vi.fn().mockResolvedValue([]),
       }));
 
     const { default: App } = await import("./App");
@@ -208,6 +212,7 @@ describe("App", () => {
         listTimeseries: vi.fn().mockResolvedValue([]),
         refetchTimeseries: vi.fn(),
         rebuildTimeseriesCache: vi.fn(),
+        getNudges: vi.fn().mockResolvedValue([]),
       }));
 
     const { default: App } = await import("./App");
@@ -282,6 +287,7 @@ describe("App", () => {
       getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
       getTradingSignals: vi.fn().mockResolvedValue([]),
       getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+      getNudges: vi.fn().mockResolvedValue([]),
     }));
 
     const { default: App } = await import("./App");
@@ -321,6 +327,7 @@ describe("App", () => {
       getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
       getTradingSignals: vi.fn().mockResolvedValue([]),
       getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+      getNudges: vi.fn().mockResolvedValue([]),
     }));
 
     const { default: App } = await import("./App");
@@ -369,6 +376,7 @@ describe("App", () => {
       listTimeseries: vi.fn().mockResolvedValue([]),
       refetchTimeseries: vi.fn(),
       rebuildTimeseriesCache: vi.fn(),
+      getNudges: vi.fn().mockResolvedValue([]),
     }));
 
     const { default: App } = await import("./App");
@@ -422,6 +430,7 @@ describe("App", () => {
       saveTimeseries: vi.fn(),
       refetchTimeseries: vi.fn(),
       rebuildTimeseriesCache: vi.fn(),
+      getNudges: vi.fn().mockResolvedValue([]),
     }));
 
     const { default: App } = await import("./App");

--- a/frontend/src/MainApp.demo.test.tsx
+++ b/frontend/src/MainApp.demo.test.tsx
@@ -33,6 +33,7 @@ describe("MainApp demo view", () => {
       saveTimeseries: vi.fn(),
       refetchTimeseries: vi.fn(),
       rebuildTimeseriesCache: vi.fn(),
+      getNudges: vi.fn().mockResolvedValue([]),
     }));
 
     const { default: MainApp } = await import("./MainApp");

--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import InstrumentResearch from "./InstrumentResearch";
+import * as api from "../api";
+import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
+
+vi.mock("../hooks/useInstrumentHistory");
+
+const mockUseInstrumentHistory = vi.mocked(useInstrumentHistory);
+const mockGetInstrumentDetail = vi.spyOn(api, "getInstrumentDetail");
+const mockGetScreener = vi.spyOn(api, "getScreener");
+const mockGetNews = vi.spyOn(api, "getNews");
+const mockGetQuotes = vi.spyOn(api, "getQuotes");
+
+describe("InstrumentResearch", () => {
+  it("shows instrument name and metrics rows", async () => {
+    mockUseInstrumentHistory.mockReturnValue({
+      data: {},
+      loading: false,
+      error: null,
+    } as any);
+    mockGetInstrumentDetail.mockResolvedValue({} as any);
+    mockGetScreener.mockResolvedValue([
+      {
+        rank: 1,
+        ticker: "AAA",
+        name: "Alpha Corp",
+        peg_ratio: 1,
+        pe_ratio: 10,
+        de_ratio: 0.5,
+        lt_de_ratio: 0.3,
+        interest_coverage: 10,
+        current_ratio: 2,
+        quick_ratio: 1.5,
+        fcf: 50000,
+        eps: 2,
+        gross_margin: 0.4,
+        operating_margin: 0.2,
+        net_margin: 0.1,
+        ebitda_margin: 0.3,
+        roa: 0.15,
+        roe: 0.2,
+        roi: 0.18,
+        dividend_yield: 0.05,
+        dividend_payout_ratio: 0.4,
+        beta: 1.1,
+        shares_outstanding: 1000000,
+        float_shares: 800000,
+        market_cap: 5000000,
+        high_52w: null,
+        low_52w: null,
+        avg_volume: 100000,
+      },
+    ]);
+    mockGetNews.mockResolvedValue([]);
+    mockGetQuotes.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={["/research/AAA"]}>
+        <Routes>
+          <Route path="/research/:ticker" element={<InstrumentResearch />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByRole("heading", { level: 1 })
+    ).toHaveTextContent(/AAA.*Alpha Corp/);
+    expect(await screen.findByText("Interest Coverage")).toBeInTheDocument();
+    expect(screen.getByText("Current Ratio")).toBeInTheDocument();
+    expect(screen.getByText("Gross Margin")).toBeInTheDocument();
+    expect(screen.getByText("Shares Outstanding")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -88,9 +88,14 @@ export default function InstrumentResearch() {
 
   if (!tkr) return <div>Invalid ticker</div>;
 
+  const displayName = metrics?.name || detail?.name;
+
   return (
     <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
-      <h1 style={{ marginBottom: "1rem" }}>{tkr}</h1>
+      <h1 style={{ marginBottom: "1rem" }}>
+        {tkr}
+        {displayName ? ` – ${displayName}` : ""}
+      </h1>
       <div style={{ marginBottom: "1rem" }}>
         <Link to="/screener" style={{ marginRight: "1rem" }}>
           View Screener
@@ -196,20 +201,76 @@ export default function InstrumentResearch() {
               <td>{metrics.lt_de_ratio ?? "—"}</td>
             </tr>
             <tr>
-              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Market Cap</th>
-              <td>{largeNumber(metrics.market_cap)}</td>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Interest Coverage</th>
+              <td>{metrics.interest_coverage ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Current Ratio</th>
+              <td>{metrics.current_ratio ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Quick Ratio</th>
+              <td>{metrics.quick_ratio ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Free Cash Flow</th>
+              <td>{largeNumber(metrics.fcf)}</td>
             </tr>
             <tr>
               <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>EPS</th>
               <td>{metrics.eps ?? "—"}</td>
             </tr>
             <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Gross Margin</th>
+              <td>{metrics.gross_margin ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Operating Margin</th>
+              <td>{metrics.operating_margin ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Net Margin</th>
+              <td>{metrics.net_margin ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>EBITDA Margin</th>
+              <td>{metrics.ebitda_margin ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>ROA</th>
+              <td>{metrics.roa ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>ROE</th>
+              <td>{metrics.roe ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>ROI</th>
+              <td>{metrics.roi ?? "—"}</td>
+            </tr>
+            <tr>
               <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Dividend Yield</th>
               <td>{metrics.dividend_yield ?? "—"}</td>
             </tr>
             <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Dividend Payout Ratio</th>
+              <td>{metrics.dividend_payout_ratio ?? "—"}</td>
+            </tr>
+            <tr>
               <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Beta</th>
               <td>{metrics.beta ?? "—"}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Shares Outstanding</th>
+              <td>{largeNumber(metrics.shares_outstanding)}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Float Shares</th>
+              <td>{largeNumber(metrics.float_shares)}</td>
+            </tr>
+            <tr>
+              <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Market Cap</th>
+              <td>{largeNumber(metrics.market_cap)}</td>
             </tr>
             <tr>
               <th style={{ textAlign: "left", paddingRight: "0.5rem" }}>Avg Volume</th>

--- a/frontend/src/pages/Reports.test.tsx
+++ b/frontend/src/pages/Reports.test.tsx
@@ -26,6 +26,7 @@ vi.mock("../api", () => ({
   getTradingSignals: vi.fn().mockResolvedValue([]),
   getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
   listTimeseries: vi.fn().mockResolvedValue([]),
+  getNudges: vi.fn().mockResolvedValue([]),
 }));
 
 describe("Reports page", () => {


### PR DESCRIPTION
## Summary
- show instrument name alongside ticker in research header
- expand research metrics table with additional ScreenerResult fields
- add coverage for new research metrics and fix API mocks requiring getNudges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf07c4053083279795979d8284d813