### PR TITLE
Abortable quote fetch in InstrumentResearch

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -25,6 +25,7 @@ describe("App", () => {
       getPortfolio: vi.fn(),
       refreshPrices: vi.fn(),
         getAlerts: vi.fn().mockResolvedValue([]),
+        getNudges: vi.fn().mockResolvedValue([]),
         getCompliance: vi.fn().mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
         getTimeseries: vi.fn(),
         saveTimeseries: vi.fn(),
@@ -56,6 +57,7 @@ describe("App", () => {
       getPortfolio: vi.fn(),
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
+      getNudges: vi.fn().mockResolvedValue([]),
       getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
       getCompliance: vi
         .fn()
@@ -87,6 +89,7 @@ describe("App", () => {
       getPortfolio: vi.fn(),
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
+      getNudges: vi.fn().mockResolvedValue([]),
       getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
       getCompliance: vi
         .fn()
@@ -121,6 +124,7 @@ describe("App", () => {
         getPortfolio: vi.fn(),
         refreshPrices: vi.fn(),
         getAlerts: vi.fn().mockResolvedValue([]),
+        getNudges: vi.fn().mockResolvedValue([]),
         getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
         getCompliance: vi
           .fn()
@@ -194,6 +198,7 @@ describe("App", () => {
         getPortfolio: vi.fn(),
         refreshPrices: vi.fn(),
         getAlerts: vi.fn().mockResolvedValue([]),
+        getNudges: vi.fn().mockResolvedValue([]),
         getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
         getCompliance: vi
           .fn()
@@ -269,6 +274,7 @@ describe("App", () => {
       getPortfolio: vi.fn(),
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
+      getNudges: vi.fn().mockResolvedValue([]),
       getCompliance: vi
         .fn()
         .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
@@ -308,6 +314,7 @@ describe("App", () => {
       getPortfolio: vi.fn(),
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
+      getNudges: vi.fn().mockResolvedValue([]),
       getCompliance: vi
         .fn()
         .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
@@ -357,6 +364,7 @@ describe("App", () => {
       getPortfolio: vi.fn(),
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
+      getNudges: vi.fn().mockResolvedValue([]),
       getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
       getCompliance: vi
         .fn()
@@ -407,22 +415,23 @@ describe("App", () => {
   it("renders the user avatar when logged in", async () => {
     window.history.pushState({}, "", "/");
 
-    vi.doMock("./api", () => ({
-      getOwners: vi.fn().mockResolvedValue([]),
-      getGroups: vi.fn().mockResolvedValue([]),
-      getGroupInstruments: vi.fn().mockResolvedValue([]),
-      getPortfolio: vi.fn(),
-      refreshPrices: vi.fn(),
-      getAlerts: vi.fn().mockResolvedValue([]),
-      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-      getCompliance: vi
-        .fn()
-        .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
-      getTimeseries: vi.fn().mockResolvedValue([]),
-      saveTimeseries: vi.fn(),
-      refetchTimeseries: vi.fn(),
-      rebuildTimeseriesCache: vi.fn(),
-    }));
+  vi.doMock("./api", () => ({
+    getOwners: vi.fn().mockResolvedValue([]),
+    getGroups: vi.fn().mockResolvedValue([]),
+    getGroupInstruments: vi.fn().mockResolvedValue([]),
+    getPortfolio: vi.fn(),
+    refreshPrices: vi.fn(),
+    getAlerts: vi.fn().mockResolvedValue([]),
+    getNudges: vi.fn().mockResolvedValue([]),
+    getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+    getCompliance: vi
+      .fn()
+      .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+    getTimeseries: vi.fn().mockResolvedValue([]),
+    saveTimeseries: vi.fn(),
+    refetchTimeseries: vi.fn(),
+    rebuildTimeseriesCache: vi.fn(),
+  }));
 
     const { default: App } = await import("./App");
     const { AuthContext } = await import("./AuthContext");

--- a/frontend/src/MainApp.demo.test.tsx
+++ b/frontend/src/MainApp.demo.test.tsx
@@ -23,6 +23,7 @@ describe("MainApp demo view", () => {
       }),
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
+      getNudges: vi.fn().mockResolvedValue([]),
       getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
       getCompliance: vi
         .fn()

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -126,7 +126,7 @@ export const refreshPrices = () =>
   );
 
 /** Fetch quote snapshots for a list of symbols. */
-export const getQuotes = (symbols: string[]) => {
+export const getQuotes = (symbols: string[], signal?: AbortSignal) => {
   const params = new URLSearchParams({ symbols: symbols.join(",") });
   return fetchJson<{
     symbol: string;
@@ -139,7 +139,7 @@ export const getQuotes = (symbols: string[]) => {
     timestamp?: number | null;
     timezone?: string | null;
     market_state?: string | null;
-  }[]>(`${API_BASE}/api/quotes?${params.toString()}`)
+  }[]>(`${API_BASE}/api/quotes?${params.toString()}`, { signal })
     .then((rows) =>
       rows.map((r) => {
         const change =

--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -1,0 +1,54 @@
+import { render, act } from "@testing-library/react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import type { QuoteRow } from "../types";
+
+let quotePromise: Promise<QuoteRow[]>;
+let quoteSignal: AbortSignal | undefined;
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    getInstrumentDetail: vi.fn().mockResolvedValue({ positions: [] }),
+    getScreener: vi.fn().mockResolvedValue([]),
+    getNews: vi.fn().mockResolvedValue([]),
+    getQuotes: vi.fn((symbols: string[], signal?: AbortSignal) => {
+      quoteSignal = signal;
+      quotePromise = new Promise<QuoteRow[]>((_, reject) => {
+        signal?.addEventListener("abort", () => {
+          const err: any = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+      return quotePromise;
+    }),
+  };
+});
+
+vi.mock("../hooks/useInstrumentHistory", () => ({
+  useInstrumentHistory: () => ({ data: { "30": [] }, loading: false, error: null }),
+}));
+
+import InstrumentResearch from "./InstrumentResearch";
+
+describe("InstrumentResearch page", () => {
+  it("aborts quote fetch on unmount", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const router = createMemoryRouter(
+      [{ path: "/research/:ticker", element: <InstrumentResearch /> }],
+      { initialEntries: ["/research/AAA"] },
+    );
+    const { unmount } = render(<RouterProvider router={router} />);
+    await act(async () => {
+      await Promise.resolve();
+    }); // allow effect to run
+    unmount();
+    await expect(quotePromise).rejects.toMatchObject({ name: "AbortError" });
+    expect(quoteSignal?.aborted).toBe(true);
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});
+

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -36,6 +36,7 @@ export default function InstrumentResearch() {
     const detailCtrl = new AbortController();
     const screenerCtrl = new AbortController();
     const newsCtrl = new AbortController();
+    const quoteCtrl = new AbortController();
     getInstrumentDetail(tkr, 365, detailCtrl.signal)
       .then(setDetail)
       .catch((err) => {
@@ -46,9 +47,11 @@ export default function InstrumentResearch() {
       .catch((err) => {
         if (err.name !== "AbortError") console.error(err);
       });
-    getQuotes([tkr])
+    getQuotes([tkr], quoteCtrl.signal)
       .then((rows) => setQuote(rows[0] || null))
-      .catch((err) => console.error(err));
+      .catch((err) => {
+        if (err.name !== "AbortError") console.error(err);
+      });
     getNews(tkr, newsCtrl.signal)
       .then(setNews)
       .catch((err) => {
@@ -58,6 +61,7 @@ export default function InstrumentResearch() {
       detailCtrl.abort();
       screenerCtrl.abort();
       newsCtrl.abort();
+      quoteCtrl.abort();
     };
   }, [tkr]);
 

--- a/frontend/src/pages/Reports.test.tsx
+++ b/frontend/src/pages/Reports.test.tsx
@@ -15,6 +15,7 @@ vi.mock("../api", () => ({
   getPortfolio: vi.fn(),
   refreshPrices: vi.fn(),
   getAlerts: vi.fn().mockResolvedValue([]),
+  getNudges: vi.fn().mockResolvedValue([]),
   getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
   getCompliance: vi
     .fn()


### PR DESCRIPTION
## Summary
- support aborting `getQuotes` with an optional `AbortSignal`
- abort quote request in InstrumentResearch and clean up on unmount
- cover the abort path in a new InstrumentResearch test

## Testing
- `npm test -- --run`
- `cd frontend && npx vitest run src/pages/InstrumentResearch.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf07c759308327803af1de986da640