### PR TITLE
feat: show instrument name and metrics

### DIFF
--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -185,5 +185,55 @@ describe("InstrumentResearch page", () => {
       screen.queryByRole("link", { name: /Watchlist/i }),
     ).not.toBeInTheDocument();
   });
+
+  it("shows instrument name and additional metrics", async () => {
+    mockGetInstrumentDetail.mockResolvedValue(
+      { prices: null, positions: [] } as InstrumentDetail,
+    );
+    mockGetScreener.mockResolvedValue([
+      { rank: 1, ticker: "AAA", name: "Acme Corp" } as unknown as ScreenerResult,
+    ]);
+    mockGetQuotes.mockResolvedValue([
+      {
+        name: "Acme Corp",
+        symbol: "AAA",
+        last: 100,
+        open: null,
+        high: null,
+        low: null,
+        change: null,
+        changePct: null,
+        volume: null,
+        marketTime: null,
+        marketState: "REGULAR",
+      } as QuoteRow,
+    ]);
+    mockGetNews.mockResolvedValue([]);
+    renderPage();
+
+    expect(
+      await screen.findByRole("heading", { level: 1 })
+    ).toHaveTextContent("AAA - Acme Corp");
+
+    const expected = [
+      "Interest Coverage",
+      "Current Ratio",
+      "Quick Ratio",
+      "FCF",
+      "Gross Margin",
+      "Operating Margin",
+      "Net Margin",
+      "EBITDA Margin",
+      "ROA",
+      "ROE",
+      "ROI",
+      "Dividend Payout Ratio",
+      "Shares Outstanding",
+      "Float Shares",
+    ];
+    for (const heading of expected) {
+      expect(screen.getByText(heading)).toBeInTheDocument();
+    }
+  });
 });
 


### PR DESCRIPTION
## Summary
- show instrument name alongside ticker on InstrumentResearch page
- display full ScreenerResult metrics (interest coverage, margins, ratios, shares) in metrics table
- test InstrumentResearch renders instrument name and new metric rows

## Testing
- `npm test -- --run src/pages/InstrumentResearch.test.tsx`
- `npm test` *(fails: No "getNudges" export is defined on the "./api" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68bf48bb1540832793984aad928f0a77