### PR TITLE
Abort quote requests on unmount

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -127,7 +127,7 @@ export const refreshPrices = () =>
   );
 
 /** Fetch quote snapshots for a list of symbols. */
-export const getQuotes = (symbols: string[]) => {
+export const getQuotes = (symbols: string[], signal?: AbortSignal) => {
   const params = new URLSearchParams({ symbols: symbols.join(",") });
   return fetchJson<{
     symbol: string;
@@ -140,7 +140,7 @@ export const getQuotes = (symbols: string[]) => {
     timestamp?: number | null;
     timezone?: string | null;
     market_state?: string | null;
-  }[]>(`${API_BASE}/api/quotes?${params.toString()}`)
+  }[]>(`${API_BASE}/api/quotes?${params.toString()}`, { signal })
     .then((rows) =>
       rows.map((r) => {
         const change =


### PR DESCRIPTION
## Summary
- abort quote fetches in InstrumentResearch when component unmounts
- allow getQuotes API to accept AbortSignal
- test that aborted quote requests don't trigger state updates

## Testing
- `vitest run src/pages/InstrumentResearch.test.tsx`
- `npm test` *(fails: [vitest] No "getNudges" export is defined on the "./api" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68bf48f300588327b699caf841f630ba