### PR TITLE
feat: add retry wrapper for instrument detail

### DIFF
--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -11,7 +11,10 @@ import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
 import * as api from "../api";
 import { configContext, type ConfigContextValue } from "../ConfigContext";
 
-const mockGetInstrumentDetail = vi.spyOn(api, "getInstrumentDetail");
+const mockFetchInstrumentDetailWithRetry = vi.spyOn(
+  api,
+  "fetchInstrumentDetailWithRetry",
+);
 const mockGetScreener = vi.spyOn(api, "getScreener");
 const mockGetQuotes = vi.spyOn(api, "getQuotes");
 const mockGetNews = vi.spyOn(api, "getNews");
@@ -84,7 +87,7 @@ describe("InstrumentResearch page", () => {
     let quotesResolve: (v: QuoteRow[]) => void;
     let newsResolve: (v: NewsItem[]) => void;
 
-    mockGetInstrumentDetail.mockReturnValueOnce(
+    mockFetchInstrumentDetailWithRetry.mockReturnValueOnce(
       new Promise((res) => {
         detailResolve = res;
       }) as Promise<InstrumentDetail>,
@@ -138,7 +141,9 @@ describe("InstrumentResearch page", () => {
   });
 
   it("renders error messages when requests fail", async () => {
-    mockGetInstrumentDetail.mockRejectedValueOnce(new Error("detail fail"));
+    mockFetchInstrumentDetailWithRetry.mockRejectedValueOnce(
+      new Error("detail fail"),
+    );
     mockGetScreener.mockRejectedValueOnce(new Error("screener fail"));
     mockGetQuotes.mockRejectedValueOnce(new Error("quotes fail"));
     mockGetNews.mockRejectedValueOnce(new Error("news fail"));
@@ -152,7 +157,10 @@ describe("InstrumentResearch page", () => {
   });
 
   it("navigates to screener when link clicked", async () => {
-    mockGetInstrumentDetail.mockResolvedValue({ prices: null, positions: [] } as InstrumentDetail);
+    mockFetchInstrumentDetailWithRetry.mockResolvedValue({
+      prices: null,
+      positions: [],
+    } as InstrumentDetail);
     mockGetScreener.mockResolvedValue([]);
     mockGetQuotes.mockResolvedValue([]);
     mockGetNews.mockResolvedValue([]);
@@ -163,7 +171,10 @@ describe("InstrumentResearch page", () => {
   });
 
   it("navigates to watchlist when link clicked", async () => {
-    mockGetInstrumentDetail.mockResolvedValue({ prices: null, positions: [] } as InstrumentDetail);
+    mockFetchInstrumentDetailWithRetry.mockResolvedValue({
+      prices: null,
+      positions: [],
+    } as InstrumentDetail);
     mockGetScreener.mockResolvedValue([]);
     mockGetQuotes.mockResolvedValue([]);
     mockGetNews.mockResolvedValue([]);
@@ -187,7 +198,7 @@ describe("InstrumentResearch page", () => {
   });
 
   it("shows instrument name and additional metrics", async () => {
-    mockGetInstrumentDetail.mockResolvedValue(
+    mockFetchInstrumentDetailWithRetry.mockResolvedValue(
       { prices: null, positions: [] } as InstrumentDetail,
     );
     mockGetScreener.mockResolvedValue([
@@ -237,7 +248,7 @@ describe("InstrumentResearch page", () => {
   });
 
   it("skips state updates when unmounted", async () => {
-    mockGetInstrumentDetail.mockResolvedValue({
+    mockFetchInstrumentDetailWithRetry.mockResolvedValue({
       prices: null,
       positions: [],
     } as InstrumentDetail);

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -3,7 +3,12 @@ import { useParams, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
 import { InstrumentHistoryChart } from "../components/InstrumentHistoryChart";
-import { getScreener, getNews, getQuotes, getInstrumentDetail } from "../api";
+import {
+  getScreener,
+  getNews,
+  getQuotes,
+  fetchInstrumentDetailWithRetry,
+} from "../api";
 import type { ScreenerResult, NewsItem, QuoteRow, InstrumentDetail } from "../types";
 import { largeNumber } from "../lib/money";
 import { useConfig } from "../ConfigContext";
@@ -49,7 +54,7 @@ export default function InstrumentResearch() {
     const quoteCtrl = new AbortController();
     setDetailLoading(true);
     setDetailError(null);
-    getInstrumentDetail(tkr, 365, detailCtrl.signal)
+    fetchInstrumentDetailWithRetry(tkr, 365, detailCtrl.signal)
       .then(setDetail)
       .catch((err) => {
         if (err.name !== "AbortError") {


### PR DESCRIPTION
## Summary
- add fetchInstrumentDetailWithRetry that retries instrument detail requests with exponential backoff and Retry-After support
- use fetchInstrumentDetailWithRetry in InstrumentResearch page
- expose response metadata in fetchJson and update tests

## Testing
- `npm test` *(fails: App.test.tsx defaults to Group view and orders tabs correctly; Support.test.tsx stringifies fresh config after saving; and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bf523d849c83279f1c2e0545ee04db