### PR TITLE
feat(frontend): add app link to support page

### DIFF
--- a/frontend/src/pages/Support.test.tsx
+++ b/frontend/src/pages/Support.test.tsx
@@ -47,6 +47,12 @@ beforeEach(() => {
 });
 
 describe("Support page", () => {
+  it("renders app link", async () => {
+    render(<Support />, { wrapper: MemoryRouter });
+    const link = await screen.findByRole("link", { name: /App/i });
+    expect(link).toHaveAttribute("href", "/");
+  });
+
   it("renders environment heading", async () => {
     render(<Support />, { wrapper: MemoryRouter });
     expect(await screen.findByText(/Environment/)).toBeInTheDocument();

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   API_BASE,
@@ -240,6 +241,12 @@ export default function Support() {
   return (
     <div className="container mx-auto max-w-3xl space-y-8 p-4">
       <header>
+        <Link
+          to="/"
+          className="mb-2 inline-block text-blue-500 hover:underline"
+        >
+          {t("app.userLink")}
+        </Link>
         <h1 className="mb-1 text-2xl font-bold md:text-4xl">
           {t("support.title")}
         </h1>


### PR DESCRIPTION
## Summary
- add `Link` to return home in support page header
- verify support page renders link to `/`

## Testing
- `npm test` *(fails: 3 failed | 5 passed | 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5950904083278e1462a79a5d827b