### PR TITLE
docs(frontend): document reports route

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,7 @@
 # AllotMint Frontend
 
 The AllotMint frontend is a React + TypeScript single-page app that visualises family investment data fetched from the backend API.
+The backend API must be running and the `VITE_ALLOTMINT_API_BASE` environment variable configured to its base URL.
 
 ## Interface
 
@@ -28,6 +29,7 @@ future navigation features ahead of the final release.
 - `/screener` – build and run custom screeners
 - `/watchlist` – manage personal watchlists
 - `/transactions` – view transaction history
+- `/reports` – after selecting an owner, provides CSV/PDF exports
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- document that backend API must be running and `VITE_ALLOTMINT_API_BASE` set
- add `/reports` route description for exporting CSV/PDF

## Testing
- `npm test` *(fails: ReferenceError: setDetailLoading is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5977f3a08327a71d5ba33d791d25