### PR TITLE
Use FTSE symbol for market headlines

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -46,7 +46,7 @@ def _fetch_sectors() -> List[Dict[str, float]]:
 
 
 def _fetch_headlines() -> List[Dict[str, str]]:
-    return _fetch_news("SPY")
+    return _fetch_news("UKX")
 
 
 def _safe(func, default):


### PR DESCRIPTION
## Summary
- Pull market overview headlines from UK FTSE 100 symbol instead of SPY

## Testing
- `pytest -q`
- ⚠️ `python - <<'PY' ...` (Alpha Vantage blocked by proxy)


------
https://chatgpt.com/codex/tasks/task_e_68bf59668ba48327856769def0d08a17