### PR TITLE
Add state pension age helper tests

### DIFF
--- a/backend/common/pension.py
+++ b/backend/common/pension.py
@@ -33,6 +33,32 @@ def _age_from_dob(
     return (today - dob).days / 365.25
 
 
+def state_pension_age(dob_str: Optional[str]) -> Optional[int]:
+    """Return UK state pension age for a given date of birth.
+
+    The calculation uses current legislated thresholds:
+
+    - DOB before 6 April 1960  -> age 66
+    - DOB before 6 April 1977  -> age 67
+    - DOB on/after 6 April 1977 -> age 68
+
+    Invalid or missing inputs return ``None``.
+    """
+
+    if not dob_str:
+        return None
+    try:
+        dob = dt.date.fromisoformat(dob_str)
+    except ValueError:
+        return None
+
+    if dob < dt.date(1960, 4, 6):
+        return 66
+    if dob < dt.date(1977, 4, 6):
+        return 67
+    return 68
+
+
 def estimate_db_pension_value(
     *,
     annual_income_gbp: float,

--- a/tests/test_state_pension_age.py
+++ b/tests/test_state_pension_age.py
@@ -1,0 +1,20 @@
+import pytest
+
+from backend.common.pension import state_pension_age
+
+
+@pytest.mark.parametrize(
+    "dob, expected",
+    [
+        ("1950-01-01", 66),
+        ("1965-07-23", 67),
+        ("1978-12-31", 68),
+    ],
+)
+def test_state_pension_age_thresholds(dob, expected):
+    assert state_pension_age(dob) == expected
+
+
+@pytest.mark.parametrize("dob", [None, "", "not-a-date"])
+def test_state_pension_age_invalid(dob):
+    assert state_pension_age(dob) is None


### PR DESCRIPTION
## Summary
- add helper for UK state pension age calculation
- cover pension age helper with birth-year threshold tests

## Testing
- `pytest -c /dev/null tests/test_state_pension_age.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf598beac08327a58e896cd87733ef