### PR TITLE
Compute UK state pension age from owner metadata

### DIFF
--- a/backend/common/pension.py
+++ b/backend/common/pension.py
@@ -19,6 +19,28 @@ from typing import Any, Dict, Optional
 DEFAULT_ANNUITY_MULTIPLE = 20  # crude capitalisation proxy
 
 
+def state_pension_age_uk(dob: str) -> int:
+    """Return UK state pension age in years for a given date of birth.
+
+    The schedule is based on currently legislated thresholds and ignores the
+    historic gender differences.  Dates are inclusive of the start and exclusive
+    of the next threshold.
+    """
+
+    try:
+        birth = dt.date.fromisoformat(dob)
+    except ValueError as exc:
+        raise ValueError("Invalid dob") from exc
+
+    if birth < dt.date(1954, 10, 6):
+        return 65
+    if birth < dt.date(1960, 4, 6):
+        return 66
+    if birth < dt.date(1977, 4, 6):
+        return 67
+    return 68
+
+
 def _age_from_dob(
     dob_str: Optional[str], today: Optional[dt.date] = None
 ) -> Optional[float]:

--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -1,14 +1,18 @@
 from fastapi import APIRouter, HTTPException, Query
 
-from backend.common.pension import forecast_pension
+from backend.common.data_loader import load_person_meta
+from backend.common.pension import (
+    _age_from_dob,
+    forecast_pension,
+    state_pension_age_uk,
+)
 
 router = APIRouter(tags=["pension"])
 
 
 @router.get("/pension/forecast")
 def pension_forecast(
-    dob: str = Query(..., description="Date of birth YYYY-MM-DD"),
-    retirement_age: int = Query(..., ge=0),
+    owner: str = Query(..., description="Portfolio owner"),
     death_age: int = Query(..., ge=0),
     state_pension_annual: float | None = Query(None, ge=0),
     db_income_annual: float | None = Query(None, ge=0),
@@ -17,6 +21,13 @@ def pension_forecast(
     investment_growth_pct: float = Query(5.0),
     desired_income_annual: float | None = Query(None, ge=0),
 ):
+    meta = load_person_meta(owner)
+    dob = meta.get("dob")
+    current_age = _age_from_dob(dob)
+    if current_age is None:
+        raise HTTPException(status_code=400, detail="missing or invalid dob")
+
+    retirement_age = state_pension_age_uk(dob)
     if death_age <= retirement_age:
         raise HTTPException(
             status_code=400, detail="death_age must exceed retirement_age"
@@ -45,4 +56,5 @@ def pension_forecast(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    result.update({"retirement_age": retirement_age, "current_age": current_age})
     return result

--- a/tests/test_pension.py
+++ b/tests/test_pension.py
@@ -1,7 +1,27 @@
 import datetime as dt
 
-from backend.common.pension import _age_from_dob
+import pytest
+
+from backend.common.pension import _age_from_dob, state_pension_age_uk
 
 
 def test_age_from_dob_invalid():
     assert _age_from_dob("not-a-date", dt.date(2024, 1, 1)) is None
+
+
+@pytest.mark.parametrize(
+    "dob, expected",
+    [
+        ("1950-01-01", 65),
+        ("1955-06-01", 66),
+        ("1965-07-15", 67),
+        ("1980-12-30", 68),
+    ],
+)
+def test_state_pension_age_uk(dob, expected):
+    assert state_pension_age_uk(dob) == expected
+
+
+def test_state_pension_age_uk_invalid():
+    with pytest.raises(ValueError):
+        state_pension_age_uk("not-a-date")

--- a/tests/test_pension_route.py
+++ b/tests/test_pension_route.py
@@ -1,0 +1,51 @@
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.common.pension import state_pension_age_uk
+
+
+def test_pension_route_uses_owner_metadata(monkeypatch):
+    captured_owner = []
+
+    def fake_meta(owner: str):
+        captured_owner.append(owner)
+        return {"dob": "1980-01-01"}
+
+    called = {}
+
+    def fake_forecast(**kwargs):
+        called.update(kwargs)
+        return {"forecast": []}
+
+    monkeypatch.setattr("backend.routes.pension.load_person_meta", fake_meta)
+    monkeypatch.setattr("backend.routes.pension.forecast_pension", fake_forecast)
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/pension/forecast", params={"owner": "alice", "death_age": 90})
+    assert resp.status_code == 200
+    assert captured_owner == ["alice"]
+    expected_age = state_pension_age_uk("1980-01-01")
+    assert called["retirement_age"] == expected_age
+    body = resp.json()
+    assert body["retirement_age"] == expected_age
+    assert isinstance(body["current_age"], float)
+
+
+def test_pension_route_missing_dob(monkeypatch):
+    monkeypatch.setattr(
+        "backend.routes.pension.load_person_meta", lambda owner: {}
+    )
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/pension/forecast", params={"owner": "bob", "death_age": 90})
+    assert resp.status_code == 400
+
+
+def test_pension_route_invalid_dob(monkeypatch):
+    monkeypatch.setattr(
+        "backend.routes.pension.load_person_meta", lambda owner: {"dob": "bad"}
+    )
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/pension/forecast", params={"owner": "bob", "death_age": 90})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add `state_pension_age_uk` helper implementing UK date thresholds
- derive pension forecast input from owner metadata and include age details
- expand pension tests for new helper and route scenarios

## Testing
- `pytest tests/test_pension.py tests/test_pension_route.py tests/test_pension_forecast.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf59897f388327bc4291acd212e420