### PR TITLE
Handle empty owners list on Reports page

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -196,7 +196,8 @@
   "reports": {
     "title": "Berichte",
     "csv": "CSV herunterladen",
-    "pdf": "PDF herunterladen"
+    "pdf": "PDF herunterladen",
+    "noOwners": "No owners available—check backend connection"
   },
   "loadingPortfolio": "Portfolio wird geladen…",
   "portfolio": "Portfolio",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -196,7 +196,8 @@
   "reports": {
     "title": "Reports",
     "csv": "Download CSV",
-    "pdf": "Download PDF"
+    "pdf": "Download PDF",
+    "noOwners": "No owners available—check backend connection"
   },
   "loadingPortfolio": "Loading portfolio…",
   "portfolio": "Portfolio",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -196,7 +196,8 @@
   "reports": {
     "title": "Informes",
     "csv": "Descargar CSV",
-    "pdf": "Descargar PDF"
+    "pdf": "Descargar PDF",
+    "noOwners": "No owners available—check backend connection"
   },
   "loadingPortfolio": "Cargando portafolio…",
   "portfolio": "Portafolio",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -196,7 +196,8 @@
   "reports": {
     "title": "Rapports",
     "csv": "Télécharger CSV",
-    "pdf": "Télécharger PDF"
+    "pdf": "Télécharger PDF",
+    "noOwners": "No owners available—check backend connection"
   },
   "loadingPortfolio": "Chargement du portefeuille…",
   "portfolio": "Portefeuille",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -196,7 +196,8 @@
   "reports": {
     "title": "Segnalazioni",
     "csv": "Scarica CSV",
-    "pdf": "Scarica PDF"
+    "pdf": "Scarica PDF",
+    "noOwners": "No owners available—check backend connection"
   },
   "loadingPortfolio": "Caricamento del portafoglio ...",
   "portfolio": "Portfolio",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -196,7 +196,8 @@
   "reports": {
     "title": "Relatórios",
     "csv": "Baixar CSV",
-    "pdf": "Baixar PDF"
+    "pdf": "Baixar PDF",
+    "noOwners": "No owners available—check backend connection"
   },
   "loadingPortfolio": "Carregando portfólio…",
   "portfolio": "Portfólio",

--- a/frontend/src/pages/Reports.test.tsx
+++ b/frontend/src/pages/Reports.test.tsx
@@ -28,6 +28,29 @@ vi.mock("../api", () => ({
   listTimeseries: vi.fn().mockResolvedValue([]),
 }));
 
+const allTabs = {
+  group: true,
+  owner: true,
+  instrument: true,
+  performance: true,
+  transactions: true,
+  trading: true,
+  screener: true,
+  timeseries: true,
+  watchlist: true,
+  allocation: true,
+  movers: true,
+  instrumentadmin: true,
+  dataadmin: true,
+  virtual: true,
+  support: true,
+  settings: true,
+  profile: true,
+  reports: true,
+  scenario: true,
+  logs: true,
+};
+
 describe("Reports page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,29 +62,6 @@ describe("Reports page", () => {
 
     window.history.pushState({}, "", "/reports");
     const { default: Reports } = await import("./Reports");
-
-    const allTabs = {
-      group: true,
-      owner: true,
-      instrument: true,
-      performance: true,
-      transactions: true,
-      trading: true,
-      screener: true,
-      timeseries: true,
-      watchlist: true,
-      allocation: true,
-      movers: true,
-      instrumentadmin: true,
-      dataadmin: true,
-      virtual: true,
-      support: true,
-      settings: true,
-      profile: true,
-      reports: true,
-      scenario: true,
-      logs: true,
-    };
 
     render(
       <configContext.Provider
@@ -90,6 +90,39 @@ describe("Reports page", () => {
       "href",
       expect.stringContaining("/reports/alex")
     );
+  });
+
+  it("shows message when no owners", async () => {
+    mockGetOwners.mockResolvedValue([]);
+    mockGetGroups.mockResolvedValue([]);
+
+    window.history.pushState({}, "", "/reports");
+    const { default: Reports } = await import("./Reports");
+
+    render(
+      <configContext.Provider
+        value={{
+          theme: "system",
+          relativeViewEnabled: false,
+          tabs: allTabs,
+          disabledTabs: [],
+          refreshConfig: vi.fn(),
+          setRelativeViewEnabled: () => {},
+          baseCurrency: "GBP",
+          setBaseCurrency: () => {},
+        }}
+      >
+        <MemoryRouter initialEntries={["/reports"]}>
+          <Reports />
+        </MemoryRouter>
+      </configContext.Provider>
+    );
+
+    const message = await screen.findByText(
+      /No owners available—check backend connection/i
+    );
+    expect(message).toBeInTheDocument();
+    expect(screen.queryByLabelText(/owner/i)).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -7,12 +7,16 @@ import { OwnerSelector } from "../components/OwnerSelector";
 export default function Reports() {
   const { t } = useTranslation();
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
+  const [ownersLoaded, setOwnersLoaded] = useState(false);
   const [owner, setOwner] = useState("");
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");
 
   useEffect(() => {
-    getOwners().then(setOwners).catch(() => setOwners([]));
+    getOwners()
+      .then(setOwners)
+      .catch(() => setOwners([]))
+      .finally(() => setOwnersLoaded(true));
   }, []);
 
   const baseUrl = owner ? `${API_BASE}/reports/${owner}` : null;
@@ -24,7 +28,11 @@ export default function Reports() {
   return (
     <div className="container mx-auto p-4 max-w-3xl">
       <h1 className="mb-4 text-2xl md:text-4xl">{t("reports.title")}</h1>
-      <OwnerSelector owners={owners} selected={owner} onSelect={setOwner} />
+      {ownersLoaded && owners.length === 0 ? (
+        <p>{t("reports.noOwners")}</p>
+      ) : (
+        <OwnerSelector owners={owners} selected={owner} onSelect={setOwner} />
+      )}
       <div className="my-4">
         <label className="mr-2">
           {t("query.start")}:{" "}


### PR DESCRIPTION
## Summary
- Show message when no owners are returned instead of empty selector on Reports page
- Add translation entry for missing owners message
- Test empty-owner scenario in Reports page

## Testing
- `npm test` *(fails: 9 failed tests)*
- `cd frontend && npx vitest run src/pages/Reports.test.tsx`
- `pytest` *(fails: pytest: error: unrecognized arguments: --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5976cf448327a1c9defd3fac22a2