### PR TITLE
feat: add owner-driven pension forecast

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -407,10 +407,11 @@ describe("App", () => {
       "Allocation",
       "Reports",
       "User Settings",
+      "Pension Forecast",
       "Scenario Tester",
       "Support",
     ]);
-    });
+  });
 
   it("renders the user avatar when logged in", async () => {
     window.history.pushState({}, "", "/");

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -930,18 +930,23 @@ export const getAllowances = (owner?: string) => {
 };
 
 // ───────────── Pension Forecast ─────────────
-export const getPensionForecast = (
-  dob: string,
-  retirementAge: number,
-  deathAge: number,
-  statePensionAnnual?: number,
-  contributionAnnual?: number,
-  desiredIncomeAnnual?: number,
-  investmentGrowthPct?: number,
-) => {
+export const getPensionForecast = ({
+  owner,
+  deathAge,
+  statePensionAnnual,
+  contributionAnnual,
+  desiredIncomeAnnual,
+  investmentGrowthPct,
+}: {
+  owner: string;
+  deathAge: number;
+  statePensionAnnual?: number;
+  contributionAnnual?: number;
+  desiredIncomeAnnual?: number;
+  investmentGrowthPct?: number;
+}) => {
   const params = new URLSearchParams({
-    dob,
-    retirement_age: String(retirementAge),
+    owner,
     death_age: String(deathAge),
   });
   if (statePensionAnnual !== undefined) {
@@ -959,7 +964,8 @@ export const getPensionForecast = (
   return fetchJson<{
     forecast: { age: number; income: number }[];
     projected_pot_gbp: number;
-    earliest_retirement_age: number | null;
+    current_age: number;
+    retirement_age: number;
   }>(`${API_BASE}/pension/forecast?${params.toString()}`);
 };
 

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -157,6 +157,10 @@
     "label": "Besitzer",
     "select": "Wählen Sie einen Besitzer."
   },
+  "pensionForecast": {
+    "currentAge": "Aktuelles Alter: {{age}}",
+    "retirementAge": "Renteneintrittsalter: {{age}}"
+  },
   "group": {
     "select": "Wählen Sie eine Gruppe."
   },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -157,6 +157,10 @@
     "label": "Owner",
     "select": "Select an owner."
   },
+  "pensionForecast": {
+    "currentAge": "Current age: {{age}}",
+    "retirementAge": "Retirement age: {{age}}"
+  },
   "group": {
     "select": "Select a group."
   },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -157,6 +157,10 @@
     "label": "Propietario",
     "select": "Seleccione un propietario."
   },
+  "pensionForecast": {
+    "currentAge": "Edad actual: {{age}}",
+    "retirementAge": "Edad de jubilación: {{age}}"
+  },
   "group": {
     "select": "Seleccione un grupo."
   },

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -157,6 +157,10 @@
     "label": "Propriétaire",
     "select": "Sélectionnez un propriétaire."
   },
+  "pensionForecast": {
+    "currentAge": "Âge actuel : {{age}}",
+    "retirementAge": "Âge de retraite : {{age}}"
+  },
   "group": {
     "select": "Sélectionnez un groupe."
   },

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -157,6 +157,10 @@
     "label": "Proprietario",
     "select": "Seleziona un proprietario."
   },
+  "pensionForecast": {
+    "currentAge": "Età attuale: {{age}}",
+    "retirementAge": "Età pensionistica: {{age}}"
+  },
   "group": {
     "select": "Seleziona un gruppo."
   },

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -157,6 +157,10 @@
     "label": "Proprietário",
     "select": "Selecione um proprietário."
   },
+  "pensionForecast": {
+    "currentAge": "Idade atual: {{age}}",
+    "retirementAge": "Idade de aposentadoria: {{age}}"
+  },
   "group": {
     "select": "Selecione um grupo."
   },

--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetOwners = vi.hoisted(() => vi.fn());
+const mockGetPensionForecast = vi.hoisted(() => vi.fn());
+
+vi.mock("../api", () => ({
+  getOwners: mockGetOwners,
+  getPensionForecast: mockGetPensionForecast,
+}));
+
+describe("PensionForecast page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders owner selector", async () => {
+    mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
+    mockGetPensionForecast.mockResolvedValue({
+      forecast: [],
+      projected_pot_gbp: 0,
+      current_age: 30,
+      retirement_age: 65,
+    });
+
+    const { default: PensionForecast } = await import("./PensionForecast");
+
+    render(<PensionForecast />);
+
+    const select = await screen.findByLabelText(/owner/i);
+    expect(select).toBeInTheDocument();
+  });
+
+  it("submits with selected owner", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alex", accounts: [] },
+      { owner: "beth", accounts: [] },
+    ]);
+    mockGetPensionForecast.mockResolvedValue({
+      forecast: [],
+      projected_pot_gbp: 0,
+      current_age: 30,
+      retirement_age: 65,
+    });
+
+    const { default: PensionForecast } = await import("./PensionForecast");
+
+    render(<PensionForecast />);
+
+    const select = await screen.findByLabelText(/owner/i);
+    fireEvent.change(select, { target: { value: "beth" } });
+
+    const btn = screen.getByRole("button", { name: /forecast/i });
+    fireEvent.click(btn);
+
+    await vi.waitFor(() =>
+      expect(mockGetPensionForecast).toHaveBeenCalledWith(
+        expect.objectContaining({ owner: "beth" }),
+      ),
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- update pension forecast API to accept an owner and return ages
- use OwnerSelector on Pension Forecast page and show computed ages
- translate new labels and add tests for owner-based forecasting

## Testing
- `npm test` *(fails: App.test.tsx expected order, InstrumentResearch.test.tsx errors, Support.test.tsx queries)*
- `npx vitest run src/pages/PensionForecast.test.tsx`
- `npx vitest run src/App.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf598ac9b88327bca8abd4e01b4a93