### PR TITLE
Include index change percentages in market overview

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Market overview endpoint aggregating indexes, sectors and headlines."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import requests
 import yfinance as yf
@@ -20,14 +20,18 @@ INDEX_SYMBOLS = {
 }
 
 
-def _fetch_indexes() -> Dict[str, float]:
+def _fetch_indexes() -> Dict[str, Dict[str, Optional[float]]]:
     tickers = yf.Tickers(" ".join(INDEX_SYMBOLS.values())).tickers
-    out: Dict[str, float] = {}
+    out: Dict[str, Dict[str, Optional[float]]] = {}
     for name, sym in INDEX_SYMBOLS.items():
         info = getattr(tickers.get(sym), "info", {})
         price = info.get("regularMarketPrice")
+        change = info.get("regularMarketChangePercent")
         if price is not None:
-            out[name] = float(price)
+            out[name] = {
+                "value": float(price),
+                "change": float(change) if change is not None else None,
+            }
     return out
 
 

--- a/frontend/src/pages/MarketOverview.tsx
+++ b/frontend/src/pages/MarketOverview.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { getMarketOverview } from "../api";
-import type { MarketOverview as MarketOverviewData } from "../types";
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getMarketOverview } from '../api';
+import type { MarketOverview as MarketOverviewData } from '../types';
 import {
   ResponsiveContainer,
   BarChart,
@@ -9,7 +9,7 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-} from "recharts";
+} from 'recharts';
 
 export default function MarketOverview() {
   const { t } = useTranslation();
@@ -24,24 +24,27 @@ export default function MarketOverview() {
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading) return <p>{t("common.loading")}</p>;
+  if (loading) return <p>{t('common.loading')}</p>;
   if (error) return <p className="text-red-500">{error}</p>;
   if (!data) return null;
 
-  const indexData = Object.entries(data.indexes).map(([name, value]) => ({
-    name,
-    value,
-  }));
+  const indexData = Object.entries(data.indexes).map(
+    ([name, { value, change }]) => ({
+      name,
+      value,
+      change,
+    })
+  );
 
   return (
     <div className="container mx-auto p-4">
       <h1 className="mb-4 text-2xl">
-        {t("app.modes.market", { defaultValue: "Market Overview" })}
+        {t('app.modes.market', { defaultValue: 'Market Overview' })}
       </h1>
 
       <div className="mb-8">
         <h2 className="mb-2 text-xl">
-          {t("market.indexLevels", { defaultValue: "Index Levels" })}
+          {t('market.indexLevels', { defaultValue: 'Index Levels' })}
         </h2>
         <ResponsiveContainer width="100%" height={300}>
           <BarChart data={indexData}>
@@ -51,11 +54,43 @@ export default function MarketOverview() {
             <Bar dataKey="value" fill="#8884d8" />
           </BarChart>
         </ResponsiveContainer>
+        <table className="mt-4 w-full text-left">
+          <thead>
+            <tr>
+              <th>{t('market.index', { defaultValue: 'Index' })}</th>
+              <th>{t('market.level', { defaultValue: 'Level' })}</th>
+              <th>{t('market.changePct', { defaultValue: '% Change' })}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {indexData.map((row) => (
+              <tr key={row.name}>
+                <td>{row.name}</td>
+                <td>{row.value.toLocaleString()}</td>
+                <td
+                  className={
+                    row.change !== undefined && row.change !== null
+                      ? row.change >= 0
+                        ? 'text-green-600'
+                        : 'text-red-600'
+                      : undefined
+                  }
+                >
+                  {row.change !== undefined && row.change !== null
+                    ? `${row.change.toFixed(2)}%`
+                    : '-'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
 
       <div className="mb-8">
         <h2 className="mb-2 text-xl">
-          {t("market.sectorPerformance", { defaultValue: "Sector Performance" })}
+          {t('market.sectorPerformance', {
+            defaultValue: 'Sector Performance',
+          })}
         </h2>
         <ResponsiveContainer width="100%" height={300}>
           <BarChart data={data.sectors}>
@@ -75,7 +110,7 @@ export default function MarketOverview() {
 
       <div>
         <h2 className="mb-2 text-xl">
-          {t("market.latestHeadlines", { defaultValue: "Latest Headlines" })}
+          {t('market.latestHeadlines', { defaultValue: 'Latest Headlines' })}
         </h2>
         <ul className="list-disc pl-4">
           {data.headlines.map((h, idx) => (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,436 +1,440 @@
 export type OwnerSummary = {
-    owner: string;
-    accounts: string[];
+  owner: string;
+  accounts: string[];
 };
 
 export interface Holding {
-    ticker: string;
-    name: string;
-    currency?: string | null;
-    units: number;
-    acquired_date: string;
-    price?: number;
-    cost_basis_gbp?: number;
-    cost_basis_currency?: string | null;
-    effective_cost_basis_gbp?: number;
-    effective_cost_basis_currency?: string | null;
-    market_value_gbp?: number;
-    market_value_currency?: string | null;
-    gain_gbp?: number;
-    gain_currency?: string | null;
-    gain_pct?: number;
-    current_price_gbp?: number | null;
-    current_price_currency?: string | null;
-    /** Date of the last known price for this holding */
-    last_price_date?: string | null;
-    latest_source?: string | null;
-    day_change_gbp?: number;
-    day_change_currency?: string | null;
-    instrument_type?: string | null;
-    sector?: string | null;
-    region?: string | null;
+  ticker: string;
+  name: string;
+  currency?: string | null;
+  units: number;
+  acquired_date: string;
+  price?: number;
+  cost_basis_gbp?: number;
+  cost_basis_currency?: string | null;
+  effective_cost_basis_gbp?: number;
+  effective_cost_basis_currency?: string | null;
+  market_value_gbp?: number;
+  market_value_currency?: string | null;
+  gain_gbp?: number;
+  gain_currency?: string | null;
+  gain_pct?: number;
+  current_price_gbp?: number | null;
+  current_price_currency?: string | null;
+  /** Date of the last known price for this holding */
+  last_price_date?: string | null;
+  latest_source?: string | null;
+  day_change_gbp?: number;
+  day_change_currency?: string | null;
+  instrument_type?: string | null;
+  sector?: string | null;
+  region?: string | null;
 
-    days_held?: number;
-    sell_eligible?: boolean;
-    days_until_eligible?: number | null;
-    next_eligible_sell_date?: string | null;
+  days_held?: number;
+  sell_eligible?: boolean;
+  days_until_eligible?: number | null;
+  next_eligible_sell_date?: string | null;
 }
 
 export type Account = {
-    account_type: string;
-    currency: string;
-    last_updated?: string;
-    value_estimate_gbp: number;
-    value_estimate_currency?: string | null;
-    holdings: Holding[];
-    owner?: string;
+  account_type: string;
+  currency: string;
+  last_updated?: string;
+  value_estimate_gbp: number;
+  value_estimate_currency?: string | null;
+  holdings: Holding[];
+  owner?: string;
 };
 
 export type Portfolio = {
-    owner: string;
-    as_of: string;
-    trades_this_month: number;
-    trades_remaining: number;
-    total_value_estimate_gbp: number;
-    total_value_estimate_currency?: string | null;
-    accounts: Account[];
+  owner: string;
+  as_of: string;
+  trades_this_month: number;
+  trades_remaining: number;
+  total_value_estimate_gbp: number;
+  total_value_estimate_currency?: string | null;
+  accounts: Account[];
 };
 
 export type GroupSummary = {
-    slug: string;
-    name: string;
-    members: string[];
+  slug: string;
+  name: string;
+  members: string[];
 };
 
 export type GroupPortfolio = {
-    group: string;
-    name: string;
-    as_of: string;
-    members: string[];
+  group: string;
+  name: string;
+  as_of: string;
+  members: string[];
+  total_value_estimate_gbp: number;
+  total_value_estimate_currency?: string | null;
+  trades_this_month?: number;
+  trades_remaining?: number;
+  accounts: Account[];
+  members_summary: {
+    owner: string;
     total_value_estimate_gbp: number;
     total_value_estimate_currency?: string | null;
-    trades_this_month?: number;
-    trades_remaining?: number;
-    accounts: Account[];
-    members_summary: {
-        owner: string;
-        total_value_estimate_gbp: number;
-        total_value_estimate_currency?: string | null;
-        trades_this_month: number;
-        trades_remaining: number;
-    }[];
-    subtotals_by_account_type: Record<string, number>;
+    trades_this_month: number;
+    trades_remaining: number;
+  }[];
+  subtotals_by_account_type: Record<string, number>;
 };
 
 export type InstrumentSummary = {
-    ticker: string;
-    name: string;
-    currency?: string | null;
-    units: number;
-    market_value_gbp: number;
-    market_value_currency?: string | null;
-    gain_gbp: number;
-    gain_currency?: string | null;
-    instrument_type?: string | null;
-    gain_pct?: number;
+  ticker: string;
+  name: string;
+  currency?: string | null;
+  units: number;
+  market_value_gbp: number;
+  market_value_currency?: string | null;
+  gain_gbp: number;
+  gain_currency?: string | null;
+  instrument_type?: string | null;
+  gain_pct?: number;
 
-    /* last-price enrichment */
-    last_price_gbp?: number | null;
-    last_price_currency?: string | null;
-    last_price_date?: string | null;
-    change_7d_pct?: number | null;
-    change_30d_pct?: number | null;
+  /* last-price enrichment */
+  last_price_gbp?: number | null;
+  last_price_currency?: string | null;
+  last_price_date?: string | null;
+  change_7d_pct?: number | null;
+  change_30d_pct?: number | null;
 };
 
 export type SectorContribution = {
-    sector: string;
-    market_value_gbp: number;
-    gain_gbp: number;
-    cost_gbp: number;
-    currency?: string | null;
-    gain_pct?: number | null;
-    contribution_pct?: number | null;
+  sector: string;
+  market_value_gbp: number;
+  gain_gbp: number;
+  cost_gbp: number;
+  currency?: string | null;
+  gain_pct?: number | null;
+  contribution_pct?: number | null;
 };
 
 export type RegionContribution = {
-    region: string;
-    market_value_gbp: number;
-    gain_gbp: number;
-    cost_gbp: number;
-    currency?: string | null;
-    gain_pct?: number | null;
-    contribution_pct?: number | null;
+  region: string;
+  market_value_gbp: number;
+  gain_gbp: number;
+  cost_gbp: number;
+  currency?: string | null;
+  gain_pct?: number | null;
+  contribution_pct?: number | null;
 };
 
 export interface PerformancePoint {
-    date: string;
-    value: number;
-    daily_return?: number | null;
-    weekly_return?: number | null;
-    cumulative_return?: number | null;
-    running_max?: number;
-    drawdown?: number | null;
+  date: string;
+  value: number;
+  daily_return?: number | null;
+  weekly_return?: number | null;
+  cumulative_return?: number | null;
+  running_max?: number;
+  drawdown?: number | null;
 }
 
 export interface PerformanceResponse {
-    history: PerformancePoint[];
-    time_weighted_return?: number | null;
-    xirr?: number | null;
+  history: PerformancePoint[];
+  time_weighted_return?: number | null;
+  xirr?: number | null;
 }
 
 export interface HoldingValue {
-    ticker: string;
-    exchange: string;
-    units: number;
-    price?: number | null;
-    value?: number | null;
+  ticker: string;
+  exchange: string;
+  units: number;
+  price?: number | null;
+  value?: number | null;
 }
 
 export interface ValueAtRiskPoint {
-    date: string;
-    var: number;
+  date: string;
+  var: number;
 }
 
 export interface VarBreakdown {
-    ticker: string;
-    contribution: number;
-    var?: {
-        [horizon: string]: number | null;
-    };
-    sharpe_ratio?: number | null;
+  ticker: string;
+  contribution: number;
+  var?: {
+    [horizon: string]: number | null;
+  };
+  sharpe_ratio?: number | null;
 }
-  
+
 export interface ValueAtRiskResponse {
-    owner: string;
-    as_of: string;
-    var: {
-        [horizon: string]: number | null;
-    };
-    sharpe_ratio?: number | null;
+  owner: string;
+  as_of: string;
+  var: {
+    [horizon: string]: number | null;
+  };
+  sharpe_ratio?: number | null;
 }
 
 export interface AlphaResponse {
-    alpha_vs_benchmark: number | null;
-    benchmark: string;
+  alpha_vs_benchmark: number | null;
+  benchmark: string;
 }
 
 export interface TrackingErrorResponse {
-    tracking_error: number | null;
-    benchmark: string;
+  tracking_error: number | null;
+  benchmark: string;
 }
 
 export interface MaxDrawdownResponse {
-    max_drawdown: number | null;
-};
+  max_drawdown: number | null;
+}
 
 export interface ReturnComparisonResponse {
-    owner: string;
-    cagr: number | null;
-    cash_apy: number | null;
+  owner: string;
+  cagr: number | null;
+  cash_apy: number | null;
 }
 
 export interface InstrumentDetailMini {
-    [range: string]: {
-        date: string;
-        close: number;
-        close_gbp: number;
-    }[];
+  [range: string]: {
+    date: string;
+    close: number;
+    close_gbp: number;
+  }[];
 }
 
 export interface NewsItem {
-    headline: string;
-    url: string;
+  headline: string;
+  url: string;
 }
 
 export interface SectorPerformance {
-    sector: string;
-    change: number;
+  sector: string;
+  change: number;
+}
+
+export interface IndexPerformance {
+  value: number;
+  change?: number | null;
 }
 
 export interface MarketOverview {
-    indexes: Record<string, number>;
-    sectors: SectorPerformance[];
-    headlines: NewsItem[];
+  indexes: Record<string, IndexPerformance>;
+  sectors: SectorPerformance[];
+  headlines: NewsItem[];
 }
 
 export interface InstrumentPosition {
-    owner: string;
-    account: string;
-    units: number;
+  owner: string;
+  account: string;
+  units: number;
 }
 
 export interface InstrumentDetail {
-    prices: unknown;
-    positions: InstrumentPosition[];
-    mini?: InstrumentDetailMini;
-    currency?: string | null;
+  prices: unknown;
+  positions: InstrumentPosition[];
+  mini?: InstrumentDetailMini;
+  currency?: string | null;
 }
 
 export interface Transaction {
-    owner: string;
-    account: string;
-    date?: string;
-    kind?: string;
-    type?: string | null;
-    amount_minor?: number | null;
-    currency?: string | null;
-    security_ref?: string | null;
-    ticker?: string | null;
-    shares?: number | null;
+  owner: string;
+  account: string;
+  date?: string;
+  kind?: string;
+  type?: string | null;
+  amount_minor?: number | null;
+  currency?: string | null;
+  security_ref?: string | null;
+  ticker?: string | null;
+  shares?: number | null;
 }
 
 export interface PriceEntry {
-    Date: string;
-    Open?: number | null;
-    High?: number | null;
-    Low?: number | null;
-    Close?: number | null;
-    Volume?: number | null;
-    Ticker?: string;
-    Source?: string;
+  Date: string;
+  Open?: number | null;
+  High?: number | null;
+  Low?: number | null;
+  Close?: number | null;
+  Volume?: number | null;
+  Ticker?: string;
+  Source?: string;
 }
 
 export interface UserConfig {
-    hold_days_min?: number;
-    max_trades_per_month?: number;
-    approval_exempt_types?: string[];
-    approval_exempt_tickers?: string[];
+  hold_days_min?: number;
+  max_trades_per_month?: number;
+  approval_exempt_types?: string[];
+  approval_exempt_tickers?: string[];
 }
 
 export interface Approval {
-    ticker: string;
-    approved_on: string;
+  ticker: string;
+  approved_on: string;
 }
 
 export interface ApprovalsResponse {
-    approvals: Approval[];
+  approvals: Approval[];
 }
 
 export interface TimeseriesSummary {
-    ticker: string;
-    exchange: string;
-    name?: string | null;
-    earliest: string;
-    latest: string;
-    completeness: number;
-    latest_source?: string | null;
-    main_source?: string | null;
+  ticker: string;
+  exchange: string;
+  name?: string | null;
+  earliest: string;
+  latest: string;
+  completeness: number;
+  latest_source?: string | null;
+  main_source?: string | null;
 }
 
 export interface InstrumentMetadata {
-    ticker: string;
-    exchange?: string | null;
-    name: string;
-    region?: string | null;
-    sector?: string | null;
+  ticker: string;
+  exchange?: string | null;
+  name: string;
+  region?: string | null;
+  sector?: string | null;
 }
 
 export interface QuoteRow {
-    name: string | null;
-    symbol: string;
-    last: number | null;
-    open: number | null;
-    high: number | null;
-    low: number | null;
-    change: number | null;
-    changePct: number | null;
-    volume: number | null;
-    marketTime: string | null;
-    marketState: string;
+  name: string | null;
+  symbol: string;
+  last: number | null;
+  open: number | null;
+  high: number | null;
+  low: number | null;
+  change: number | null;
+  changePct: number | null;
+  volume: number | null;
+  marketTime: string | null;
+  marketState: string;
 }
 
 export interface MoverRow {
-    ticker: string;
-    name: string;
-    change_pct: number;
-    last_price_gbp?: number | null;
-    last_price_date?: string | null;
-    market_value_gbp?: number | null;
+  ticker: string;
+  name: string;
+  change_pct: number;
+  last_price_gbp?: number | null;
+  last_price_date?: string | null;
+  market_value_gbp?: number | null;
 }
 
 export type Alert = {
-    ticker: string;
-    change_pct: number;
-    message: string;
-    timestamp: string;
+  ticker: string;
+  change_pct: number;
+  message: string;
+  timestamp: string;
 };
 
 export type Nudge = {
-    id: string;
-    message: string;
-    timestamp: string;
+  id: string;
+  message: string;
+  timestamp: string;
 };
 
 export interface ScenarioEvent {
-    id: string;
-    name: string;
+  id: string;
+  name: string;
 }
 
 export interface ScenarioHorizonResult {
-    baseline: number | null;
-    shocked: number | null;
+  baseline: number | null;
+  shocked: number | null;
 }
 
 export interface ScenarioResult {
-    owner: string;
-    horizons: Record<string, ScenarioHorizonResult>;
+  owner: string;
+  horizons: Record<string, ScenarioHorizonResult>;
 }
 
 export type ComplianceResult = {
-    owner: string;
-    warnings: string[];
-    trade_counts: Record<string, number>;
-    hold_countdowns?: Record<string, number>;
-    trades_this_month?: number;
-    trades_remaining?: number;
+  owner: string;
+  warnings: string[];
+  trade_counts: Record<string, number>;
+  hold_countdowns?: Record<string, number>;
+  trades_this_month?: number;
+  trades_remaining?: number;
 };
 
 export interface ScreenerResult {
-    rank: number;
-    ticker: string;
-    name?: string | null;
-    peg_ratio: number | null;
-    pe_ratio: number | null;
-    de_ratio: number | null;
-    lt_de_ratio: number | null;
-    interest_coverage: number | null;
-    current_ratio: number | null;
-    quick_ratio: number | null;
-    fcf: number | null;
-    eps: number | null;
-    gross_margin: number | null;
-    operating_margin: number | null;
-    net_margin: number | null;
-    ebitda_margin: number | null;
-    roa: number | null;
-    roe: number | null;
-    roi: number | null;
-    dividend_yield: number | null;
-    dividend_payout_ratio: number | null;
-    beta: number | null;
-    shares_outstanding: number | null;
-    float_shares: number | null;
-    market_cap: number | null;
-    high_52w: number | null;
-    low_52w: number | null;
-    avg_volume: number | null;
+  rank: number;
+  ticker: string;
+  name?: string | null;
+  peg_ratio: number | null;
+  pe_ratio: number | null;
+  de_ratio: number | null;
+  lt_de_ratio: number | null;
+  interest_coverage: number | null;
+  current_ratio: number | null;
+  quick_ratio: number | null;
+  fcf: number | null;
+  eps: number | null;
+  gross_margin: number | null;
+  operating_margin: number | null;
+  net_margin: number | null;
+  ebitda_margin: number | null;
+  roa: number | null;
+  roe: number | null;
+  roi: number | null;
+  dividend_yield: number | null;
+  dividend_payout_ratio: number | null;
+  beta: number | null;
+  shares_outstanding: number | null;
+  float_shares: number | null;
+  market_cap: number | null;
+  high_52w: number | null;
+  low_52w: number | null;
+  avg_volume: number | null;
 }
 
 export interface SyntheticHolding {
-    ticker: string;
-    units: number;
-    price?: number;
-    purchase_date?: string;
+  ticker: string;
+  units: number;
+  price?: number;
+  purchase_date?: string;
 }
 
 export interface VirtualPortfolio {
-    id?: number;
-    name: string;
-    accounts: string[];
-    holdings: SyntheticHolding[];
+  id?: number;
+  name: string;
+  accounts: string[];
+  holdings: SyntheticHolding[];
 }
 
 export interface TradingSignal {
-    ticker: string;
-    name: string;
-    action: "buy" | "sell";
-    reason: string;
-    confidence?: number;
-    rationale?: string;
-    currency?: string | null;
-    instrument_type?: string | null;
+  ticker: string;
+  name: string;
+  action: 'buy' | 'sell';
+  reason: string;
+  confidence?: number;
+  rationale?: string;
+  currency?: string | null;
+  instrument_type?: string | null;
 }
 
 export interface CustomQuery {
-    start?: string;
-    end?: string;
-    owners?: string[];
-    tickers?: string[];
-    metrics?: string[];
+  start?: string;
+  end?: string;
+  owners?: string[];
+  tickers?: string[];
+  metrics?: string[];
 }
 
 export interface SavedQuery {
-    id: string;
-    name: string;
-    params: CustomQuery;
-};
+  id: string;
+  name: string;
+  params: CustomQuery;
+}
 
 export interface TradeSuggestion {
-    ticker: string;
-    action: string;
-    amount: number;
+  ticker: string;
+  action: string;
+  amount: number;
 }
 
 export interface Quest {
-    id: string;
-    title: string;
-    xp: number;
-    completed: boolean;
+  id: string;
+  title: string;
+  xp: number;
+  completed: boolean;
 }
 
 export interface QuestResponse {
-    quests: Quest[];
-    xp: number;
-    streak: number;
+  quests: Quest[];
+  xp: number;
+  streak: number;
 }
-


### PR DESCRIPTION
## Summary
- include regular market change percentages for major indexes in backend
- expose index change data via MarketOverview type and UI table

## Testing
- `npm test` *(fails: App.test.tsx, InstrumentResearch.test.tsx, Support.test.tsx)*
- `pytest` *(fails: tests/test_accounts_api.py::test_account_route_returns_data[alice-accounts0], tests/test_backend_api.py::test_valid_account)*

------
https://chatgpt.com/codex/tasks/task_e_68bf596797048327bb522d1bb3278c2e