### PR TITLE
Use ISO date formatting

### DIFF
--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -7,7 +7,7 @@ import type { Account } from "../types";
 import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
 import { money } from "../lib/money";
-import i18n from "../i18n";
+import { formatDateISO } from "../lib/date";
 import { useConfig } from "../ConfigContext";
 
 /* ──────────────────────────────────────────────────────────────
@@ -58,9 +58,7 @@ export function AccountBlock({
           {account.last_updated && (
             <div className="text-muted">
               Last updated:&nbsp;
-              {new Intl.DateTimeFormat(i18n.language).format(
-                new Date(account.last_updated),
-              )}
+              {formatDateISO(new Date(account.last_updated))}
             </div>
           )}
 

--- a/frontend/src/components/DividendHistory.tsx
+++ b/frontend/src/components/DividendHistory.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import i18n from "../i18n";
 import { getDividends } from "../api";
 import type { Transaction } from "../types";
 import { useFetch } from "../hooks/useFetch";
 import tableStyles from "../styles/table.module.css";
 import { money } from "../lib/money";
+import { formatDateISO } from "../lib/date";
 import { Sparkline } from "./Sparkline";
 
 export function DividendHistory() {
@@ -59,11 +59,7 @@ export function DividendHistory() {
               {(data ?? []).map((d, i) => (
                 <tr key={i}>
                   <td className={tableStyles.cell}>
-                    {d.date
-                      ? new Intl.DateTimeFormat(i18n.language).format(
-                          new Date(d.date),
-                        )
-                      : ""}
+                    {d.date ? formatDateISO(new Date(d.date)) : ""}
                   </td>
                   <td className={tableStyles.cell}>{d.owner}</td>
                   <td className={tableStyles.cell}>{d.ticker}</td>

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import i18n from "../i18n";
+import { formatDateISO } from "../lib/date";
 import { useState } from "react";
 import { MemoryRouter } from "react-router-dom";
 vi.mock("../api", () => ({
@@ -159,7 +160,7 @@ describe("HoldingsTable", () => {
         const row = (await screen.findByText("Test Holding")).closest("tr");
         const cell = within(row!).getByText("✗ 10");
         expect(cell).toBeInTheDocument();
-        const expected = new Intl.DateTimeFormat('en').format(new Date('2024-07-20'));
+        const expected = formatDateISO(new Date('2024-07-20'));
         expect(cell).toHaveAttribute('title', expected);
     });
 

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -14,6 +14,7 @@ import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
 import { useConfig } from "../ConfigContext";
 import { isSupportedFx } from "../lib/fx";
+import { formatDateISO } from "../lib/date";
 import { RelativeViewToggle } from "./RelativeViewToggle";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ResponsiveContainer, LineChart, Line } from "recharts";
@@ -461,9 +462,7 @@ export function HoldingsTable({
                       className={tableStyles.badge}
                       title={h.last_price_date}
                     >
-                      {new Intl.DateTimeFormat(i18n.language).format(
-                        new Date(h.last_price_date),
-                      )}
+                      {formatDateISO(new Date(h.last_price_date))}
                     </span>
                   )}
                   {h.latest_source && (
@@ -509,9 +508,7 @@ export function HoldingsTable({
                 </td>
                 <td className={tableStyles.cell}>
                   {h.acquired_date && !isNaN(Date.parse(h.acquired_date))
-                    ? new Intl.DateTimeFormat(i18n.language).format(
-                        new Date(h.acquired_date),
-                      )
+                    ? formatDateISO(new Date(h.acquired_date))
                     : "—"}
                 </td>
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
@@ -527,9 +524,7 @@ export function HoldingsTable({
                   className={`${tableStyles.cell} ${tableStyles.center} ${h.sell_eligible ? 'text-positive' : 'text-warning'}`}
                   title={
                     h.next_eligible_sell_date
-                      ? new Intl.DateTimeFormat(i18n.language).format(
-                          new Date(h.next_eligible_sell_date)
-                        )
+                      ? formatDateISO(new Date(h.next_eligible_sell_date))
                       : undefined
                   }
                 >

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -6,6 +6,7 @@ import { money, percent } from "../lib/money";
 import { translateInstrumentType } from "../lib/instrumentType";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
+import { formatDateISO } from "../lib/date";
 import { useConfig } from "../ConfigContext";
 import type { TradingSignal } from "../types";
 import { RelativeViewToggle } from "./RelativeViewToggle";
@@ -536,9 +537,7 @@ export function InstrumentDetail({
                 return (
                   <tr key={p.date}>
                     <td className={tableStyles.cell}>
-                      {new Intl.DateTimeFormat(i18n.language).format(
-                        new Date(p.date),
-                      )}
+                      {formatDateISO(new Date(p.date))}
                     </td>
                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                       {money(p.close_gbp, baseCurrency)}

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -5,6 +5,7 @@ import { InstrumentDetail } from './InstrumentDetail';
 import { useFilterableTable } from '../hooks/useFilterableTable';
 import { money, percent } from '../lib/money';
 import { translateInstrumentType } from '../lib/instrumentType';
+import { formatDateISO } from '../lib/date';
 import tableStyles from '../styles/table.module.css';
 import statusStyles from '../styles/status.module.css';
 import i18n from '../i18n';
@@ -273,9 +274,7 @@ export function InstrumentTable({ rows }: Props) {
                 )}
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                   {r.last_price_date
-                    ? new Intl.DateTimeFormat(i18n.language).format(
-                        new Date(r.last_price_date)
-                      )
+                    ? formatDateISO(new Date(r.last_price_date))
                     : '—'}
                 </td>
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -4,8 +4,8 @@ import type { Portfolio, Account } from "../types";
 import { AccountBlock } from "./AccountBlock";
 import { ValueAtRisk } from "./ValueAtRisk";
 import { money } from "../lib/money";
+import { formatDateISO } from "../lib/date";
 import { useConfig } from "../ConfigContext";
-import i18n from "../i18n";
 import { complianceForOwner } from "../api";
 import { getGrowthStage } from "../utils/growthStage";
 
@@ -78,7 +78,7 @@ export function PortfolioView({ data, loading, error }: Props) {
         Portfolio: <span data-testid="owner-name">{data.owner}</span>
       </h1>
       <div className="mb-4">
-        As of {new Intl.DateTimeFormat(i18n.language).format(new Date(data.as_of))}
+        As of {formatDateISO(new Date(data.as_of))}
       </div>
       <div className="mb-8">
         Approx Total: {money(totalValue, baseCurrency)}

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -6,8 +6,8 @@ import { Selector } from "./Selector";
 import { useFetch } from "../hooks/useFetch";
 import tableStyles from "../styles/table.module.css";
 import { money } from "../lib/money";
+import { formatDateISO } from "../lib/date";
 import { useConfig } from "../ConfigContext";
-import i18n from "../i18n";
 import { useTranslation } from "react-i18next";
 
 type Props = {
@@ -103,11 +103,7 @@ export function TransactionsPage({ owners }: Props) {
             {(transactions ?? []).map((t, i) => (
               <tr key={i}>
                 <td className={tableStyles.cell}>
-                  {t.date
-                    ? new Intl.DateTimeFormat(i18n.language).format(
-                        new Date(t.date),
-                      )
-                    : ""}
+                {t.date ? formatDateISO(new Date(t.date)) : ""}
                 </td>
                 <td className={tableStyles.cell}>{t.owner}</td>
                 <td className={tableStyles.cell}>{t.account}</td>

--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -1,0 +1,3 @@
+export function formatDateISO(date: Date): string {
+  return date.toISOString().split('T')[0];
+}


### PR DESCRIPTION
## Summary
- add a shared `formatDateISO` helper
- replace locale-specific `Intl.DateTimeFormat` calls across UI components
- update HoldingsTable tests for ISO dates

## Testing
- `npm test -- --run` *(fails: ReferenceError setDetailLoading is not defined in InstrumentResearch.test.tsx; Support.test.tsx multiple checkboxes found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5bae46288327bc16b5bff4c0e194