### PR TITLE
feat: add portfolio health check endpoint and UI

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -971,3 +971,16 @@ export const completeQuest = (id: string) =>
   fetchJson<QuestResponse>(`${API_BASE}/quests/${encodeURIComponent(id)}/complete`, {
     method: "POST",
   });
+
+// ───────────── Support tools ─────────────
+export interface Finding {
+  level: "info" | "warning" | "error";
+  message: string;
+  suggestion?: string;
+}
+
+export const checkPortfolioHealth = () =>
+  fetchJson<{ findings: Finding[] }>(
+    `${API_BASE}/support/portfolio-health`,
+    { method: "POST" },
+  );

--- a/scripts/check_portfolio_health.py
+++ b/scripts/check_portfolio_health.py
@@ -25,7 +25,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import requests
 
-from backend.common import portfolio, group_portfolio, portfolio_utils
+from backend.common import approvals, group_portfolio, portfolio, portfolio_utils
 from backend.common.alerts import publish_alert
 
 logger = logging.getLogger("check_portfolio_health")
@@ -42,28 +42,116 @@ def notify_slack(message: str) -> None:
         logger.warning("Failed to send Slack notification: %s", exc)
 
 
-def _check(name: str, drawdown: Optional[float], threshold: float, *, label: str) -> None:
-    """Log drawdown for ``name`` and alert if it exceeds ``threshold``."""
-    if drawdown is None:
-        logger.info("%s %s max drawdown unavailable", label, name)
-        return
-    logger.info("%s %s max drawdown %.2f%%", label, name, drawdown * 100)
-    if drawdown < -threshold:
-        msg = f"{label} {name} drawdown {drawdown*100:.2f}% exceeds {threshold*100:.2f}%"
-        logger.warning(msg)
-        publish_alert({"message": msg})
-        notify_slack(msg)
+def run_check(threshold: float) -> list[dict]:
+    """Run the portfolio health check and return structured findings.
+
+    ``threshold`` is the absolute drawdown percentage that triggers an alert.
+    """
+
+    findings: list[dict] = []
+
+    owners = portfolio.list_owners()
+    for owner in owners:
+        dd = portfolio_utils.compute_max_drawdown(owner)
+        entry: dict = {
+            "type": "owner",
+            "name": owner,
+            "drawdown": dd,
+            "alert": bool(dd is not None and dd < -threshold),
+        }
+        if dd is None:
+            entry.update(
+                {
+                    "level": "info",
+                    "message": f"Owner {owner} max drawdown unavailable",
+                }
+            )
+        else:
+            msg = f"Owner {owner} max drawdown {dd*100:.2f}%"
+            if dd < -threshold:
+                msg = (
+                    f"Owner {owner} drawdown {dd*100:.2f}% exceeds "
+                    f"{threshold*100:.2f}%"
+                )
+                publish_alert({"message": msg})
+                notify_slack(msg)
+                entry["level"] = "warning"
+            else:
+                entry["level"] = "info"
+            entry["message"] = msg
+        findings.append(entry)
+
+    for grp in group_portfolio.list_groups():
+        slug = grp.get("slug")
+        dd = portfolio_utils.compute_group_max_drawdown(slug)
+        entry: dict = {
+            "type": "group",
+            "name": slug,
+            "drawdown": dd,
+            "alert": bool(dd is not None and dd < -threshold),
+        }
+        if dd is None:
+            entry.update(
+                {
+                    "level": "info",
+                    "message": f"Group {slug} max drawdown unavailable",
+                }
+            )
+        else:
+            msg = f"Group {slug} max drawdown {dd*100:.2f}%"
+            if dd < -threshold:
+                msg = (
+                    f"Group {slug} drawdown {dd*100:.2f}% exceeds "
+                    f"{threshold*100:.2f}%"
+                )
+                publish_alert({"message": msg})
+                notify_slack(msg)
+                entry["level"] = "warning"
+            else:
+                entry["level"] = "info"
+            entry["message"] = msg
+        findings.append(entry)
+
+    for owner in owners:
+        try:
+            path = approvals._approvals_path(owner)
+        except FileNotFoundError:
+            continue
+        if not path.exists():
+            msg = f"approvals file for '{owner}' not found at {path}"
+            findings.append(
+                {
+                    "type": "missing_approvals",
+                    "level": "warning",
+                    "owner": owner,
+                    "path": str(path),
+                    "message": msg,
+                }
+            )
+
+    for path in sorted(portfolio_utils._MISSING_META):
+        msg = f"Instrument metadata {path} not found"
+        findings.append(
+            {
+                "type": "missing_metadata",
+                "level": "warning",
+                "path": path,
+                "message": msg,
+            }
+        )
+
+    return findings
 
 
 def main() -> None:
     threshold = float(os.getenv("DRAWDOWN_THRESHOLD", "0.2"))
-    for owner in portfolio.list_owners():
-        dd = portfolio_utils.compute_max_drawdown(owner)
-        _check(owner, dd, threshold, label="Owner")
-    for grp in group_portfolio.list_groups():
-        slug = grp.get("slug")
-        dd = portfolio_utils.compute_group_max_drawdown(slug)
-        _check(slug, dd, threshold, label="Group")
+    for finding in run_check(threshold):
+        level = finding.get("level")
+        msg = finding.get("message")
+        if level == "warning":
+            logger.warning(msg)
+        else:
+            logger.info(msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose `run_check` function to collect portfolio health issues
- add `/support/portfolio-health` endpoint returning structured findings
- wire up frontend API and Support page with health check UI and tests

## Testing
- `pytest`
- `npm test` *(fails: App.test.tsx, InstrumentResearch.test.tsx, Support.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5a72ace883279ca18991dd75eb2f