### PR TITLE
Add UK FTSE indexes to market overview

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -17,6 +17,8 @@ INDEX_SYMBOLS = {
     "S&P 500": "^GSPC",
     "Dow Jones": "^DJI",
     "NASDAQ": "^IXIC",
+    "FTSE 100": "^FTSE",
+    "FTSE 250": "^FTMC",
 }
 
 

--- a/backend/tests/test_market_route.py
+++ b/backend/tests/test_market_route.py
@@ -1,0 +1,18 @@
+import backend.routes.market as market
+
+def test_fetch_indexes_includes_ftse(monkeypatch):
+    prices = {sym: i * 100.0 for i, sym in enumerate(market.INDEX_SYMBOLS.values(), start=1)}
+
+    def fake_Tickers(symbols):
+        assert "^FTSE" in symbols and "^FTMC" in symbols
+        tickers = {
+            sym: type("T", (), {"info": {"regularMarketPrice": price}})()
+            for sym, price in prices.items()
+        }
+        return type("TT", (), {"tickers": tickers})()
+
+    monkeypatch.setattr(market.yf, "Tickers", fake_Tickers)
+
+    out = market._fetch_indexes()
+    for name, sym in market.INDEX_SYMBOLS.items():
+        assert out[name] == prices[sym]

--- a/frontend/src/pages/MarketOverview.test.tsx
+++ b/frontend/src/pages/MarketOverview.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import * as api from "../api";
+import MarketOverview from "./MarketOverview";
+
+vi.mock("../api");
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (_k: string, opts?: any) => opts?.defaultValue ?? _k }),
+}));
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  BarChart: ({ data, children }: any) => (
+    <div>
+      {data.map((d: any) => (
+        <div key={d.name}>{d.name}</div>
+      ))}
+      {children}
+    </div>
+  ),
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+}));
+
+const mockGetMarketOverview = vi.mocked(api.getMarketOverview);
+
+describe("MarketOverview", () => {
+  it("renders UK index entries", async () => {
+    mockGetMarketOverview.mockResolvedValueOnce({
+      indexes: { "S&P 500": 100, "FTSE 100": 200, "FTSE 250": 300 },
+      sectors: [],
+      headlines: [],
+    });
+    render(<MarketOverview />);
+    expect(await screen.findByText("FTSE 100")).toBeInTheDocument();
+    expect(screen.getByText("FTSE 250")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- extend market index constants with FTSE 100 and FTSE 250
- test backend index fetching with new symbols
- verify MarketOverview page renders new UK indexes

## Testing
- `pytest`
- `npm test --prefix frontend` *(fails: 9 failed, ReferenceError setDetailLoading not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bf596524a08327a5fb28ed1d78c272