### PR TITLE
refactor: read offline mode from config

### DIFF
--- a/backend/utils/telegram_utils.py
+++ b/backend/utils/telegram_utils.py
@@ -20,7 +20,6 @@ from backend.config import config as app_config
 
 # expose config for tests/backwards compat
 config = app_config
-OFFLINE_MODE = config.offline_mode
 logger = logging.getLogger(__name__)
 
 
@@ -57,7 +56,7 @@ _NEXT_ALLOWED_TIME = 0.0
 
 
 def send_message(text: str) -> None:
-    if OFFLINE_MODE:
+    if app_config.offline_mode:
         logger.info(f"Offline-alert: {text}")
         return
 
@@ -129,7 +128,7 @@ class TelegramLogHandler(logging.Handler):
             return
         try:
             message = self.format(record)
-            if not OFFLINE_MODE:
+            if not app_config.offline_mode:
                 send_message(message)
         except Exception:
             # Let logging's handleError respect logging.raiseExceptions.

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -9,7 +9,9 @@ import backend.utils.telegram_utils as telegram_utils
 
 def test_send_message_requires_config(monkeypatch):
     telegram_utils.RECENT_MESSAGES.clear()
-    monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", None, raising=False)
+    monkeypatch.setattr(
+        telegram_utils.config, "telegram_bot_token", None, raising=False
+    )
     monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", None, raising=False)
     # should silently return when config missing
     telegram_utils.send_message("hi")
@@ -37,7 +39,7 @@ def test_log_handler_without_config(monkeypatch):
 def test_send_message_success(monkeypatch):
     telegram_utils.RECENT_MESSAGES.clear()
     telegram_utils._NEXT_ALLOWED_TIME = 0
-    monkeypatch.setattr(telegram_utils, "OFFLINE_MODE", False)
+    monkeypatch.setattr(telegram_utils.config, "offline_mode", False)
     monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", "T")
     monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", "C")
     monkeypatch.setattr(telegram_utils.time, "sleep", lambda s: None)
@@ -55,7 +57,7 @@ def test_send_message_success(monkeypatch):
 def test_deduplicates_messages_within_ttl(monkeypatch):
     telegram_utils.RECENT_MESSAGES.clear()
     telegram_utils._NEXT_ALLOWED_TIME = 0
-    monkeypatch.setattr(telegram_utils, "OFFLINE_MODE", False)
+    monkeypatch.setattr(telegram_utils.config, "offline_mode", False)
     monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", "T")
     monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", "C")
     monkeypatch.setattr(telegram_utils.time, "time", lambda: 1000.0)
@@ -77,7 +79,7 @@ def test_deduplicates_messages_within_ttl(monkeypatch):
 def test_sends_messages_after_ttl(monkeypatch):
     telegram_utils.RECENT_MESSAGES.clear()
     telegram_utils._NEXT_ALLOWED_TIME = 0
-    monkeypatch.setattr(telegram_utils, "OFFLINE_MODE", False)
+    monkeypatch.setattr(telegram_utils.config, "offline_mode", False)
     monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", "T")
     monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", "C")
 
@@ -101,7 +103,7 @@ def test_sends_messages_after_ttl(monkeypatch):
 def test_handles_http_429(monkeypatch, caplog):
     telegram_utils.RECENT_MESSAGES.clear()
     telegram_utils._NEXT_ALLOWED_TIME = 0
-    monkeypatch.setattr(telegram_utils, "OFFLINE_MODE", False)
+    monkeypatch.setattr(telegram_utils.config, "offline_mode", False)
     monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", "T")
     monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", "C")
 
@@ -120,7 +122,9 @@ def test_handles_http_429(monkeypatch, caplog):
 
     monkeypatch.setattr(telegram_utils.time, "sleep", lambda s: None)
 
-    with patch("backend.utils.telegram_utils.requests.post", fake_post), caplog.at_level(logging.WARNING):
+    with patch(
+        "backend.utils.telegram_utils.requests.post", fake_post
+    ), caplog.at_level(logging.WARNING):
         telegram_utils.send_message("rate")
 
     assert len(calls) == 2
@@ -130,7 +134,7 @@ def test_handles_http_429(monkeypatch, caplog):
 def test_uses_retry_after_header(monkeypatch):
     telegram_utils.RECENT_MESSAGES.clear()
     telegram_utils._NEXT_ALLOWED_TIME = 0
-    monkeypatch.setattr(telegram_utils, "OFFLINE_MODE", False)
+    monkeypatch.setattr(telegram_utils.config, "offline_mode", False)
     monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", "T")
     monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", "C")
 
@@ -147,7 +151,11 @@ def test_uses_retry_after_header(monkeypatch):
 
     responses = iter(
         [
-            SimpleNamespace(status_code=429, headers={"Retry-After": "5"}, raise_for_status=lambda: None),
+            SimpleNamespace(
+                status_code=429,
+                headers={"Retry-After": "5"},
+                raise_for_status=lambda: None,
+            ),
             SimpleNamespace(status_code=200, headers={}, raise_for_status=lambda: None),
         ]
     )
@@ -162,20 +170,25 @@ def test_uses_retry_after_header(monkeypatch):
         telegram_utils.send_message("rate")
 
     assert sleeps == [5]
-    assert telegram_utils._NEXT_ALLOWED_TIME == start + 5 + telegram_utils.RATE_LIMIT_SECONDS
+    assert (
+        telegram_utils._NEXT_ALLOWED_TIME
+        == start + 5 + telegram_utils.RATE_LIMIT_SECONDS
+    )
 
 
 def test_handles_timeout(monkeypatch, caplog):
     telegram_utils.RECENT_MESSAGES.clear()
     telegram_utils._NEXT_ALLOWED_TIME = 0
-    monkeypatch.setattr(telegram_utils, "OFFLINE_MODE", False)
+    monkeypatch.setattr(telegram_utils.config, "offline_mode", False)
     monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", "T")
     monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", "C")
 
     def fake_post(url, data, timeout):
         raise telegram_utils.req_exc.Timeout()
 
-    with patch("backend.utils.telegram_utils.requests.post", fake_post), caplog.at_level(logging.WARNING):
+    with patch(
+        "backend.utils.telegram_utils.requests.post", fake_post
+    ), caplog.at_level(logging.WARNING):
         telegram_utils.send_message("timeout")
 
     assert any("timeout" in r.message.lower() for r in caplog.records)
@@ -183,7 +196,7 @@ def test_handles_timeout(monkeypatch, caplog):
 
 def test_redacts_token_from_errors(monkeypatch, caplog):
     telegram_utils.RECENT_MESSAGES.clear()
-    monkeypatch.setattr(telegram_utils, "OFFLINE_MODE", False)
+    monkeypatch.setattr(telegram_utils.config, "offline_mode", False)
     token = "SECRET"
     monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", token)
     monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", "C")


### PR DESCRIPTION
## Summary
- drop module-level OFFLINE_MODE constant from telegram utils
- read `app_config.offline_mode` dynamically in send_message and TelegramLogHandler
- update telegram utils tests to patch config.offline_mode

## Testing
- `ruff check backend/utils/telegram_utils.py`
- `ruff check tests/test_telegram_utils.py`
- `black --check backend/utils/telegram_utils.py`
- `black --check tests/test_telegram_utils.py`
- `pytest` *(fails: tests/test_accounts_api.py::test_account_route_returns_data[alice-accounts0], tests/test_backend_api.py::test_valid_account)*

------
https://chatgpt.com/codex/tasks/task_e_68c024107dd48327991f2eef5e3f833e