### PR TITLE
Add debug logging for missing Telegram config

### DIFF
--- a/backend/utils/telegram_utils.py
+++ b/backend/utils/telegram_utils.py
@@ -72,7 +72,17 @@ def send_message(text: str) -> None:
     token = app_config.telegram_bot_token
     chat_id = app_config.telegram_chat_id
 
-    if not token or not chat_id:
+    missing = []
+    if not token:
+        missing.append("token")
+    if not chat_id:
+        missing.append("chat_id")
+    if missing:
+        logger.debug(
+            "Missing Telegram configuration: %s",
+            ", ".join(missing),
+            extra={"skip_telegram": True},
+        )
         return
 
     global _NEXT_ALLOWED_TIME

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -7,12 +7,14 @@ import requests
 import backend.utils.telegram_utils as telegram_utils
 
 
-def test_send_message_requires_config(monkeypatch):
+def test_send_message_requires_config(monkeypatch, caplog):
     telegram_utils.RECENT_MESSAGES.clear()
     monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", None, raising=False)
     monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", None, raising=False)
-    # should silently return when config missing
-    telegram_utils.send_message("hi")
+    # should log missing config and return
+    with caplog.at_level(logging.DEBUG):
+        telegram_utils.send_message("hi")
+    assert "Missing Telegram configuration: token, chat_id" in caplog.text
 
 
 def test_log_handler_without_config(monkeypatch):


### PR DESCRIPTION
## Summary
- log missing Telegram bot token or chat ID in send_message for easier configuration troubleshooting
- test that missing configuration is logged

## Testing
- `pytest tests/test_telegram_utils.py::test_send_message_requires_config -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0241092748327b356da2be4e750e9