### PR TITLE
Read Telegram config from environment and use config in trading alerts

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -72,9 +72,9 @@ def send_trade_alert(message: str, publish: bool = True) -> None:
 
     The message is forwarded to Telegram via
     :func:`backend.utils.telegram_utils.send_message` when both
-    ``TELEGRAM_BOT_TOKEN`` and ``TELEGRAM_CHAT_ID`` environment variables are
-    present and the application is not running on AWS (``config.app_env`` is
-    not ``"aws"``).
+    ``config.telegram_bot_token`` and ``config.telegram_chat_id`` are set and
+    the application is not running on AWS (``config.app_env`` is not
+    ``"aws"``).
     """
 
     if publish:
@@ -85,8 +85,8 @@ def send_trade_alert(message: str, publish: bool = True) -> None:
         alert_utils.send_push_notification(message)
 
     if (
-        os.getenv("TELEGRAM_BOT_TOKEN")
-        and os.getenv("TELEGRAM_CHAT_ID")
+        config.telegram_bot_token
+        and config.telegram_chat_id
         and config.app_env != "aws"
     ):
         try:

--- a/backend/config.py
+++ b/backend/config.py
@@ -188,6 +188,14 @@ def load_config() -> Config:
     if disable_auth_env is not None:
         data["disable_auth"] = disable_auth_env
 
+    telegram_token_env = os.getenv("TELEGRAM_BOT_TOKEN")
+    if telegram_token_env is not None:
+        data["telegram_bot_token"] = telegram_token_env
+
+    telegram_chat_id_env = os.getenv("TELEGRAM_CHAT_ID")
+    if telegram_chat_id_env is not None:
+        data["telegram_chat_id"] = telegram_chat_id_env
+
     repo_root_raw = data.get("repo_root")
     repo_root = (base_dir / repo_root_raw).resolve() if repo_root_raw else base_dir
 

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -18,8 +18,8 @@ def test_send_message_requires_config(monkeypatch):
 def test_log_handler_without_config(monkeypatch):
     """Logging via ``TelegramLogHandler`` should not raise without credentials."""
     telegram_utils.RECENT_MESSAGES.clear()
-    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
-    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+    monkeypatch.setattr(telegram_utils.config, "telegram_bot_token", None, raising=False)
+    monkeypatch.setattr(telegram_utils.config, "telegram_chat_id", None, raising=False)
 
     handler = telegram_utils.TelegramLogHandler()
     logger = logging.getLogger("telegram-util-test")

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -99,8 +99,8 @@ def test_send_trade_alert_sns_only(monkeypatch):
 
     monkeypatch.setattr("backend.agent.trading_agent.publish_alert", fake_publish)
     monkeypatch.setattr("backend.agent.trading_agent.send_message", fake_send)
-    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
-    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+    monkeypatch.setattr(trading_agent.config, "telegram_bot_token", None)
+    monkeypatch.setattr(trading_agent.config, "telegram_chat_id", None)
 
     send_trade_alert("hello")
 
@@ -118,8 +118,8 @@ def test_send_trade_alert_with_telegram(monkeypatch):
     monkeypatch.setattr(
         "backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg)
     )
-    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "T")
-    monkeypatch.setenv("TELEGRAM_CHAT_ID", "C")
+    monkeypatch.setattr(trading_agent.config, "telegram_bot_token", "T")
+    monkeypatch.setattr(trading_agent.config, "telegram_chat_id", "C")
 
     send_trade_alert("hi")
 
@@ -140,8 +140,8 @@ def test_send_trade_alert_no_publish_with_telegram(monkeypatch):
     monkeypatch.setattr(
         "backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg)
     )
-    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "T")
-    monkeypatch.setenv("TELEGRAM_CHAT_ID", "C")
+    monkeypatch.setattr(trading_agent.config, "telegram_bot_token", "T")
+    monkeypatch.setattr(trading_agent.config, "telegram_chat_id", "C")
 
     send_trade_alert("hi", publish=False)
 
@@ -218,10 +218,8 @@ def test_run_sends_telegram_when_not_aws(monkeypatch):
     monkeypatch.setattr(
         "backend.agent.trading_agent.send_message", lambda msg: sent.append(msg)
     )
-    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "T")
-    monkeypatch.setenv("TELEGRAM_CHAT_ID", "C")
-    from backend.agent import trading_agent
-
+    monkeypatch.setattr(trading_agent.config, "telegram_bot_token", "T")
+    monkeypatch.setattr(trading_agent.config, "telegram_chat_id", "C")
     monkeypatch.setattr(trading_agent.config, "app_env", "local")
 
     run()


### PR DESCRIPTION
## Summary
- override telegram credentials in `load_config` with `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`
- use `config.telegram_bot_token` and `config.telegram_chat_id` in trading alerts instead of reading environment variables
- update Telegram-related tests to patch config fields

## Testing
- `pytest tests/test_telegram_utils.py`
- `pytest tests/test_trading_agent.py -k 'send_trade_alert or run_sends_telegram_when_not_aws'`


------
https://chatgpt.com/codex/tasks/task_e_68c024106f5083278946c3aeda19c251