### PR TITLE
Schedule trading agent via CloudWatch event

### DIFF
--- a/backend/lambda_api/trading_agent.py
+++ b/backend/lambda_api/trading_agent.py
@@ -1,0 +1,11 @@
+"""Lambda entry point to execute the trading agent on a schedule."""
+
+from __future__ import annotations
+
+from backend.agent.trading_agent import run
+
+
+def lambda_handler(event, context):
+    """Lambda handler invoked by a scheduler."""
+    run()
+    return {"status": "ok"}

--- a/backend/utils/telegram_utils.py
+++ b/backend/utils/telegram_utils.py
@@ -56,18 +56,6 @@ _NEXT_ALLOWED_TIME = 0.0
 
 
 def send_message(text: str) -> None:
-    if app_config.offline_mode:
-        logger.info(f"Offline-alert: {text}")
-        return
-
-    now = time.time()
-    expired = [m for m, ts in RECENT_MESSAGES.items() if now - ts > MESSAGE_TTL_SECONDS]
-    for m in expired:
-        del RECENT_MESSAGES[m]
-
-    if text in RECENT_MESSAGES:
-        return
-
     token = app_config.telegram_bot_token
     chat_id = app_config.telegram_chat_id
 
@@ -82,6 +70,18 @@ def send_message(text: str) -> None:
             ", ".join(missing),
             extra={"skip_telegram": True},
         )
+        return
+
+    if app_config.offline_mode:
+        logger.info(f"Offline-alert: {text}")
+        return
+
+    now = time.time()
+    expired = [m for m, ts in RECENT_MESSAGES.items() if now - ts > MESSAGE_TTL_SECONDS]
+    for m in expired:
+        del RECENT_MESSAGES[m]
+
+    if text in RECENT_MESSAGES:
         return
 
     global _NEXT_ALLOWED_TIME


### PR DESCRIPTION
## Summary
- add Lambda handler and CloudWatch rule to run trading agent daily
- ensure Telegram helper reports missing configuration before offline mode

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c038fa91788327a889da1158fd38f4