### PR TITLE
Use trading signals for nudge messages

### DIFF
--- a/tests/test_nudges_persistence.py
+++ b/tests/test_nudges_persistence.py
@@ -18,3 +18,23 @@ def test_nudges_persist_and_load(tmp_path, monkeypatch):
 
     nudges = nudge_utils.get_recent_nudges()
     assert any(n["id"] == "alice" for n in nudges)
+
+
+def test_nudge_message_uses_signals(tmp_path, monkeypatch):
+    storage = get_storage(f"file://{tmp_path / 'nudges.json'}")
+    monkeypatch.setattr(nudge_utils, "_SUBSCRIPTION_STORAGE", storage)
+    nudge_utils._SUBSCRIPTIONS.clear()
+    nudge_utils._RECENT_NUDGES.clear()
+
+    monkeypatch.setattr(nudge_utils, "list_portfolios", lambda: [{"owner": "alice"}])
+    monkeypatch.setattr(nudge_utils, "aggregate_by_ticker", lambda pf: [{"ticker": "XYZ"}])
+    monkeypatch.setattr(
+        nudge_utils,
+        "generate_signals",
+        lambda snapshot: [{"ticker": "XYZ", "action": "BUY", "reason": "r"}],
+    )
+
+    nudge_utils.set_user_nudge("alice", 1)
+    nudge_utils.send_due_nudges()
+    nudges = nudge_utils.get_recent_nudges()
+    assert any("BUY XYZ" in n["message"] for n in nudges)


### PR DESCRIPTION
## Summary
- Generate nudge messages using portfolio snapshots and trading signals instead of static text.
- Add helper and tests to ensure signals are incorporated and fallback works.

## Testing
- `pytest tests/test_nudges_persistence.py -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68c038f8ef8c8327b51a7e65fa84eea7