### PR TITLE
Send nudges to Telegram when configured

### DIFF
--- a/backend/nudges.py
+++ b/backend/nudges.py
@@ -19,6 +19,7 @@ from typing import Dict, Iterable, List, Optional
 from backend.common.alerts import publish_alert
 from backend.common.storage import get_storage
 from backend.config import config
+from backend.utils.telegram_utils import redact_token, send_message
 
 logger = logging.getLogger("nudges")
 
@@ -32,9 +33,7 @@ _DEFAULT_SUBSCRIPTIONS_URI = (
 )
 
 try:
-    _SUBSCRIPTION_STORAGE = get_storage(
-        os.getenv("NUDGE_SUBSCRIPTIONS_URI", _DEFAULT_SUBSCRIPTIONS_URI)
-    )
+    _SUBSCRIPTION_STORAGE = get_storage(os.getenv("NUDGE_SUBSCRIPTIONS_URI", _DEFAULT_SUBSCRIPTIONS_URI))
 except Exception as exc:  # pragma: no cover - configuration errors
     logger.error("Failed to initialise nudge storage: %s", exc)
     _SUBSCRIPTION_STORAGE = get_storage(_DEFAULT_SUBSCRIPTIONS_URI)
@@ -130,6 +129,11 @@ def send_due_nudges() -> None:
     for user in list(iter_due_users(now)):
         message = f"Reminder for {user}"
         publish_alert({"ticker": "NUDGE", "user": user, "message": message})
+        if config.telegram_bot_token and config.telegram_chat_id and config.app_env != "aws":
+            try:
+                send_message(message)
+            except Exception as exc:  # pragma: no cover - network errors are rare
+                logger.warning("Telegram send failed: %s", redact_token(str(exc)))
         _RECENT_NUDGES.append({"id": user, "message": message, "timestamp": now.isoformat()})
         _SUBSCRIPTIONS[user]["last_sent"] = now.isoformat()
     if _RECENT_NUDGES:


### PR DESCRIPTION
## Summary
- send due nudges to Telegram when bot credentials exist and app isn't running on AWS

## Testing
- `ruff check --config backend/pyproject.toml backend/nudges.py`
- `black --check --config backend/pyproject.toml backend/nudges.py`
- `pytest -o addopts='' tests/test_nudges_persistence.py::test_nudges_persist_and_load -q`


------
https://chatgpt.com/codex/tasks/task_e_68c038f70e748327aef556b685f1c4b6