### PR TITLE
chore: enforce 80% test coverage

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -39,8 +39,8 @@ jobs:
         env:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
         run: |
-          pytest tests --ignore=tests/live --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=0 -q
-          pytest tests/test_backend_api.py::test_health tests/test_accounts_api.py --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=0 -q
+          pytest tests --ignore=tests/live --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=80 -q
+          pytest tests/test_backend_api.py::test_health tests/test_accounts_api.py --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=80 -q
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -27,6 +27,6 @@ jobs:
         working-directory: frontend
         run: pnpm install --no-frozen-lockfile
 
-      - name: Run tests
+      - name: Run tests with coverage
         working-directory: frontend
-        run: pnpm test -- --run
+        run: pnpm test -- --run --coverage

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
         globals: true,
         environment: 'jsdom',
         setupFiles: './src/setupTests.ts',
-        include: ['src/**/*.test.{ts,tsx,js}']
+        include: ['src/**/*.test.{ts,tsx,js}'],
+        coverage: {
+            reporter: ['text', 'lcov'],
+            lines: 80,
+            statements: 80,
+            functions: 80,
+            branches: 80
+        }
     }
 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.pytest.ini_options]
-addopts = "--cov"
+addopts = "--cov --cov-fail-under=80"
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- ensure pytest requires minimum 80% coverage
- add vitest coverage thresholds and reporters
- run coverage checks in backend and frontend workflows

## Testing
- `pytest tests/test_telegram_utils.py::test_send_message_requires_config -q`
- `pnpm test -- --run --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c038ea1b7883278601a07b698bb59c