### PR TITLE
feat: add alert settings route and tests

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -408,6 +408,7 @@ describe("App", () => {
       "Reports",
       "User Settings",
       "Pension Forecast",
+      "Alert Settings",
       "Scenario Tester",
       "Support",
     ]);

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -84,6 +84,8 @@ export default function Menu({
                                     ? 'support'
                                     : path[0] === 'settings'
                                       ? 'settings'
+                                      : path[0] === 'alert-settings'
+                                        ? 'alertsettings'
                                       : path[0] === 'scenario'
                                         ? 'scenario'
                                         : path[0] === 'logs'
@@ -128,6 +130,8 @@ export default function Menu({
         return '/profile';
       case 'pension':
         return '/pension/forecast';
+      case 'alertsettings':
+        return '/alert-settings';
       default:
         return `/${m}`;
     }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -27,6 +27,7 @@
       "settings": "Benutzereinstellungen",
       "profile": "Profil",
       "pension": "Rentenprognose",
+      "alertsettings": "Alarm-Einstellungen",
       "reports": "Berichte",
       "support": "Support",
       "scenario": "Szenario-Tester",
@@ -321,6 +322,12 @@
     "title": "Value at Risk",
     "details": "Details zur historischen Simulation",
     "noData": "Keine VaR-Daten verfügbar."
+  },
+  "alertSettings": {
+    "title": "Alarm-Einstellungen",
+    "threshold": "Schwelle %:",
+    "save": "Speichern",
+    "saved": "Gespeichert"
   },
   "market": {
     "indexLevels": "Indexstände",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -27,6 +27,7 @@
       "settings": "User Settings",
       "profile": "Profile",
       "pension": "Pension Forecast",
+      "alertsettings": "Alert Settings",
       "reports": "Reports",
       "support": "Support",
       "scenario": "Scenario Tester",
@@ -323,6 +324,12 @@
     "title": "Value at Risk",
     "details": "Historical simulation details",
     "noData": "No VaR data available."
+  },
+  "alertSettings": {
+    "title": "Alert Settings",
+    "threshold": "Threshold %:",
+    "save": "Save",
+    "saved": "Saved"
   },
   "market": {
     "indexLevels": "Index Levels",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -27,6 +27,7 @@
       "settings": "Configuración del usuario",
       "profile": "Perfil",
       "pension": "Pronóstico de pensión",
+      "alertsettings": "Configuración de Alertas",
       "reports": "Informes",
       "support": "Soporte",
       "scenario": "Probador de Escenarios",
@@ -321,6 +322,12 @@
     "title": "Valor en Riesgo",
     "details": "Detalles de la simulación histórica",
     "noData": "No hay datos de VaR disponibles."
+  },
+  "alertSettings": {
+    "title": "Configuración de Alertas",
+    "threshold": "Umbral %:",
+    "save": "Guardar",
+    "saved": "Guardado"
   },
   "market": {
     "indexLevels": "Niveles de índices",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -27,6 +27,7 @@
       "settings": "Paramètres utilisateur",
       "profile": "Profil",
       "pension": "Prévision de pension",
+      "alertsettings": "Paramètres d'alerte",
       "reports": "Rapports",
       "support": "Support",
       "scenario": "Testeur de Scénario",
@@ -322,6 +323,12 @@
     "title": "Valeur à risque",
     "details": "Détails de la simulation historique",
     "noData": "Pas de données VaR disponibles."
+  },
+  "alertSettings": {
+    "title": "Paramètres d'alerte",
+    "threshold": "Seuil % :",
+    "save": "Enregistrer",
+    "saved": "Enregistré"
   },
   "market": {
     "indexLevels": "Niveaux des indices",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -27,6 +27,7 @@
       "settings": "Impostazioni utente",
       "profile": "Profilo",
       "pension": "Previsione pensionistica",
+      "alertsettings": "Impostazioni di avviso",
       "reports": "Segnalazioni",
       "support": "Supporto",
       "scenario": "Tester di scenario",
@@ -322,6 +323,12 @@
     "title": "Valore a rischio",
     "details": "Dettagli di simulazione storica",
     "noData": "Nessun dati VAR disponibile."
+  },
+  "alertSettings": {
+    "title": "Impostazioni di avviso",
+    "threshold": "Soglia %:",
+    "save": "Salva",
+    "saved": "Salvato"
   },
   "market": {
     "indexLevels": "Livelli degli indici",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -27,6 +27,7 @@
       "settings": "Configurações do usuário",
       "profile": "Perfil",
       "pension": "Previsão de pensão",
+      "alertsettings": "Configurações de Alerta",
       "reports": "Relatórios",
       "support": "Suporte",
       "scenario": "Testador de Cenários",
@@ -321,6 +322,12 @@
     "title": "Valor em Risco",
     "details": "Detalhes da simulação histórica",
     "noData": "Nenhum dado de VaR disponível."
+  },
+  "alertSettings": {
+    "title": "Configurações de Alerta",
+    "threshold": "Limite %:",
+    "save": "Salvar",
+    "saved": "Salvo"
   },
   "market": {
     "indexLevels": "Níveis dos índices",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -28,6 +28,7 @@ const Alerts = lazy(() => import('./pages/Alerts'))
 const Goals = lazy(() => import('./pages/Goals'))
 const PerformanceDiagnostics = lazy(() => import('./pages/PerformanceDiagnostics'))
 const ReturnComparison = lazy(() => import('./pages/ReturnComparison'))
+const AlertSettings = lazy(() => import('./pages/AlertSettings'))
 
 export function Root() {
   const [ready, setReady] = useState(false)
@@ -71,6 +72,7 @@ export function Root() {
         <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
         <Route path="/research/:ticker" element={<InstrumentResearch />} />
         <Route path="/profile" element={<Profile />} />
+        <Route path="/alert-settings" element={<AlertSettings />} />
         <Route path="/alerts" element={<Alerts />} />
         <Route path="/goals" element={<Goals />} />
         <Route path="/performance/:owner/diagnostics" element={<PerformanceDiagnostics />} />

--- a/frontend/src/pages/AlertSettings.test.tsx
+++ b/frontend/src/pages/AlertSettings.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import i18n from "../i18n";
+import Menu from "../components/Menu";
+import AlertSettings from "./AlertSettings";
+
+vi.mock("../api", () => ({
+  getAlertThreshold: vi.fn().mockResolvedValue({ threshold: 5 }),
+  setAlertThreshold: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../UserContext", () => ({
+  useUser: () => ({ profile: { email: "user@example.com" } }),
+}));
+
+describe("AlertSettings", () => {
+  it("renders translated strings", async () => {
+    i18n.changeLanguage("fr");
+    render(
+      <MemoryRouter>
+        <AlertSettings />
+      </MemoryRouter>,
+    );
+    expect(
+      await screen.findByRole("heading", { name: "Paramètres d'alerte" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Enregistrer" })).toBeInTheDocument();
+    i18n.changeLanguage("en");
+  });
+
+  it("navigates to alert settings via menu", async () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<Menu />} />
+          <Route path="/alert-settings" element={<AlertSettings />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByLabelText(/menu/i));
+    fireEvent.click(screen.getByRole("link", { name: "Alert Settings" }));
+    expect(
+      await screen.findByRole("heading", { name: "Alert Settings" }),
+    ).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/pages/AlertSettings.tsx
+++ b/frontend/src/pages/AlertSettings.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import Menu from "../components/Menu";
 import { getAlertThreshold, setAlertThreshold } from "../api";
 import { useUser } from "../UserContext";
 
 export default function AlertSettings() {
   const { profile } = useUser();
+  const { t } = useTranslation();
   // Owner is determined from the authenticated user's profile
   const owner = profile?.email;
   const [threshold, setThreshold] = useState<number | "">("");
@@ -36,10 +38,10 @@ export default function AlertSettings() {
   return (
     <div style={{ maxWidth: 600, margin: "0 auto", padding: "1rem" }}>
       <Menu />
-      <h1>Alert Settings</h1>
+      <h1>{t("alertSettings.title")}</h1>
       <div>
         <label>
-          Threshold %:{" "}
+          {t("alertSettings.threshold")}{" "}
           <input
             type="number"
             value={threshold}
@@ -50,10 +52,14 @@ export default function AlertSettings() {
           />
         </label>
         <button onClick={save} style={{ marginLeft: "0.5rem" }}>
-          Save
+          {t("alertSettings.save")}
         </button>
-        {status === "saved" && <span style={{ marginLeft: "0.5rem" }}>Saved</span>}
-        {status === "error" && <span style={{ marginLeft: "0.5rem" }}>Error</span>}
+        {status === "saved" && (
+          <span style={{ marginLeft: "0.5rem" }}>{t("alertSettings.saved")}</span>
+        )}
+        {status === "error" && (
+          <span style={{ marginLeft: "0.5rem" }}>{t("common.error")}</span>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/tabPlugins.ts
+++ b/frontend/src/tabPlugins.ts
@@ -20,6 +20,7 @@ export const tabPluginMap = {
   profile: {},
   pension: {},
   reports: {},
+  alertsettings: {},
   scenario: {},
   logs: {},
 };
@@ -43,6 +44,7 @@ export const orderedTabPlugins = [
   { id: "settings", priority: 105, section: "user" },
   { id: "profile", priority: 106, section: "user" },
   { id: "pension", priority: 107, section: "user" },
+  { id: "alertsettings", priority: 108, section: "user" },
   { id: "support", priority: 110, section: "support" },
   { id: "logs", priority: 115, section: "support" },
   { id: "scenario", priority: 120, section: "user" },


### PR DESCRIPTION
## Summary
- add `/alert-settings` route and menu entry
- internationalize Alert Settings page and update locales
- add unit tests for translations and navigation

## Testing
- `npm test -- --run` *(fails: MarketOverview and Support tests)*
- `cd frontend && npx vitest run src/pages/AlertSettings.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c038e778e48327905670ec927b9590