### PR TITLE
Use translations for menu labels

### DIFF
--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -4,6 +4,7 @@ import { Header } from "./Header";
 import Menu from "./Menu";
 import { MemoryRouter } from "react-router-dom";
 import { fireEvent } from "@testing-library/react";
+import i18n from "../i18n";
 
 describe("Header", () => {
   it("shows trade meter when data present", () => {
@@ -24,7 +25,7 @@ describe("Header", () => {
         <Menu />
       </MemoryRouter>
     );
-    const toggle = screen.getByLabelText("menu");
+    const toggle = screen.getByLabelText(i18n.t("app.menu"));
     fireEvent.click(toggle);
     expect(screen.getByRole("link", { name: "Support" })).toBeInTheDocument();
   });

--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -13,14 +13,14 @@ describe("Menu", () => {
       </MemoryRouter>,
     );
     expect(screen.queryByRole("link", { name: "Logs" })).not.toBeInTheDocument();
-    const toggle = screen.getByRole("button", { name: /menu/i });
+    const toggle = screen.getByRole("button", { name: i18n.t("app.menu") });
     fireEvent.click(toggle);
     expect(screen.getByRole("link", { name: "Support" })).toHaveAttribute(
       "href",
       "/support",
     );
     expect(screen.queryByRole("link", { name: "Logs" })).toBeNull();
-    fireEvent.click(screen.getByLabelText("menu"));
+    fireEvent.click(screen.getByLabelText(i18n.t("app.menu")));
     expect(screen.getByRole("link", { name: "Support" })).toHaveAttribute("href", "/support");
     expect(screen.queryByRole("link", { name: "Logs" })).not.toBeInTheDocument();
   });
@@ -31,7 +31,7 @@ describe("Menu", () => {
         <Menu />
       </MemoryRouter>,
     );
-    fireEvent.click(screen.getByLabelText("menu"));
+    fireEvent.click(screen.getByLabelText(i18n.t("app.menu")));
     expect(screen.getByRole("link", { name: "Logs" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Support" })).toHaveAttribute(
       "href",
@@ -88,9 +88,9 @@ describe("Menu", () => {
         <Menu onLogout={onLogout} />
       </MemoryRouter>,
     );
-    const toggle = screen.getByRole("button", { name: /menu/i });
+    const toggle = screen.getByRole("button", { name: i18n.t("app.menu") });
     fireEvent.click(toggle);
-    fireEvent.click(screen.getByLabelText("menu"));
+    fireEvent.click(screen.getByLabelText(i18n.t("app.menu")));
     const btn = screen.getByRole("button", { name: "Déconnexion" });
     fireEvent.click(btn);
     expect(onLogout).toHaveBeenCalled();

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -136,7 +136,7 @@ export default function Menu({
   return (
     <nav className="mb-4" ref={containerRef}>
       <button
-        aria-label="menu"
+        aria-label={t('app.menu')}
         className="md:hidden mb-2 p-2 border rounded"
         onClick={() => setOpen((o) => !o)}
       >
@@ -150,7 +150,7 @@ export default function Menu({
             onClick={() => setFocusMode(false)}
             className="mt-2 mr-4 bg-transparent border-0 p-0 cursor-pointer self-start"
           >
-            Exit Focus Mode
+            {t('app.exitFocusMode')}
           </button>
         </div>
       ) : (
@@ -204,7 +204,7 @@ export default function Menu({
             onClick={() => setFocusMode(true)}
             className="mr-4 bg-transparent border-0 p-0 cursor-pointer"
           >
-            Focus Mode
+            {t('app.focusMode')}
           </button>
         </div>
       )}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -8,6 +8,9 @@
     "supportLink": "Support",
     "userLink": "App",
     "logout": "Abmelden",
+    "menu": "Menü",
+    "focusMode": "Fokusmodus",
+    "exitFocusMode": "Fokusmodus verlassen",
     "modes": {
       "group": "Gruppe",
       "instrument": "Instrument",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -8,6 +8,9 @@
     "supportLink": "Support",
     "userLink": "App",
     "logout": "Logout",
+    "menu": "Menu",
+    "focusMode": "Focus Mode",
+    "exitFocusMode": "Exit Focus Mode",
     "modes": {
       "group": "Group",
       "instrument": "Instrument",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -8,6 +8,9 @@
     "supportLink": "Soporte",
     "userLink": "App",
     "logout": "Cerrar sesión",
+    "menu": "Menú",
+    "focusMode": "Modo de enfoque",
+    "exitFocusMode": "Salir del modo de enfoque",
     "modes": {
       "group": "Grupo",
       "instrument": "Instrumento",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -8,6 +8,9 @@
     "supportLink": "Support",
     "userLink": "App",
     "logout": "Déconnexion",
+    "menu": "Menu",
+    "focusMode": "Mode concentration",
+    "exitFocusMode": "Quitter le mode concentration",
     "modes": {
       "group": "Groupe",
       "instrument": "Instrument",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -8,6 +8,9 @@
     "supportLink": "Supporto",
     "userLink": "App",
     "logout": "Logout",
+    "menu": "Menu",
+    "focusMode": "Modalità concentrazione",
+    "exitFocusMode": "Esci dalla modalità concentrazione",
     "modes": {
       "group": "Gruppo",
       "instrument": "Strumento",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -8,6 +8,9 @@
     "supportLink": "Suporte",
     "userLink": "App",
     "logout": "Sair",
+    "menu": "Menu",
+    "focusMode": "Modo de foco",
+    "exitFocusMode": "Sair do modo de foco",
     "modes": {
       "group": "Grupo",
       "instrument": "Instrumento",


### PR DESCRIPTION
## Summary
- Replace hard-coded menu strings with `t()` lookups
- Add `menu`, `focusMode`, and `exitFocusMode` translations for all locales
- Update Menu and Header tests to use translated menu label

## Testing
- `npx vitest run src/components/Menu.test.tsx src/components/Header.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c038e432888327a8da468a56e824c3