### PR TITLE
feat(frontend): link holdings table container to virtualizer

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -360,4 +360,21 @@ describe("HoldingsTable", () => {
               await i18n.changeLanguage('en');
           });
       });
+
+      it("renders rows and keeps header on scroll", async () => {
+          const manyHoldings = Array.from({ length: 50 }, (_, i) => ({
+              ...holdings[0],
+              ticker: `T${i}`,
+              name: `Name${i}`,
+          }));
+          render(<HoldingsTable holdings={manyHoldings} />);
+          await screen.findByText('T0');
+          const container = screen.getByRole('table').parentElement as HTMLElement;
+          act(() => {
+              container.scrollTop = 500;
+              container.dispatchEvent(new Event('scroll'));
+          });
+          expect(screen.getByRole('columnheader', { name: 'Ticker' })).toBeInTheDocument();
+          expect(screen.getByText('T49')).toBeInTheDocument();
+      });
   });

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -247,7 +247,7 @@ export function HoldingsTable({
         ))}
       </div>
       {sortedRows.length ? (
-        <div className="overflow-x-auto md:overflow-visible">
+        <div ref={tableContainerRef} className="overflow-x-auto md:overflow-visible">
           <table className={`${tableStyles.table} mb-4 w-full`}>
         <thead ref={tableHeaderRef}>
           <tr>


### PR DESCRIPTION
## Summary
- add missing ref to holdings table scroll container
- exercise scroll behavior in HoldingsTable tests to ensure header stays aligned

## Testing
- `npm test` *(fails: MarketOverview > renders UK index entries; Support > persists tab selections after save)*

------
https://chatgpt.com/codex/tasks/task_e_68c038d0fb90832792b3f9e8738085ab