### PR TITLE
feat: localize goals page

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -326,5 +326,17 @@
     "indexLevels": "Indexstände",
     "sectorPerformance": "Sektorentwicklung",
     "latestHeadlines": "Neueste Schlagzeilen"
+  },
+  "goals": {
+    "title": "Ziele",
+    "targetAmount": "Zielbetrag",
+    "add": "Ziel hinzufügen",
+    "currentAmount": "Aktueller Betrag:",
+    "goalLine": "{{name}} – Ziel {{amount}} bis {{date}}",
+    "view": "Ansehen",
+    "progress": "Fortschritt: {{progress}}%",
+    "suggestedTrades": "Vorgeschlagene Trades",
+    "trade": "{{action}} {{amount}} von {{ticker}}",
+    "back": "Zurück zum Portfolio"
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -328,5 +328,17 @@
     "indexLevels": "Index Levels",
     "sectorPerformance": "Sector Performance",
     "latestHeadlines": "Latest Headlines"
+  },
+  "goals": {
+    "title": "Goals",
+    "targetAmount": "Target Amount",
+    "add": "Add Goal",
+    "currentAmount": "Current Amount:",
+    "goalLine": "{{name}} – target {{amount}} by {{date}}",
+    "view": "View",
+    "progress": "Progress: {{progress}}%",
+    "suggestedTrades": "Suggested Trades",
+    "trade": "{{action}} {{amount}} of {{ticker}}",
+    "back": "Back to Portfolio"
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -326,5 +326,17 @@
     "indexLevels": "Niveles de índices",
     "sectorPerformance": "Rendimiento por sector",
     "latestHeadlines": "Últimos titulares"
+  },
+  "goals": {
+    "title": "Objetivos",
+    "targetAmount": "Monto objetivo",
+    "add": "Agregar objetivo",
+    "currentAmount": "Monto actual:",
+    "goalLine": "{{name}} – objetivo {{amount}} para {{date}}",
+    "view": "Ver",
+    "progress": "Progreso: {{progress}}%",
+    "suggestedTrades": "Operaciones sugeridas",
+    "trade": "{{action}} {{amount}} de {{ticker}}",
+    "back": "Volver al portafolio"
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -327,5 +327,17 @@
     "indexLevels": "Niveaux des indices",
     "sectorPerformance": "Performance des secteurs",
     "latestHeadlines": "Derniers titres"
+  },
+  "goals": {
+    "title": "Objectifs",
+    "targetAmount": "Montant cible",
+    "add": "Ajouter un objectif",
+    "currentAmount": "Montant actuel:",
+    "goalLine": "{{name}} – objectif {{amount}} d'ici {{date}}",
+    "view": "Voir",
+    "progress": "Progrès: {{progress}}%",
+    "suggestedTrades": "Transactions suggérées",
+    "trade": "{{action}} {{amount}} de {{ticker}}",
+    "back": "Retour au portefeuille"
   }
 }

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -327,5 +327,17 @@
     "indexLevels": "Livelli degli indici",
     "sectorPerformance": "Rendimento dei settori",
     "latestHeadlines": "Ultime notizie"
+  },
+  "goals": {
+    "title": "Obiettivi",
+    "targetAmount": "Importo obiettivo",
+    "add": "Aggiungi obiettivo",
+    "currentAmount": "Importo attuale:",
+    "goalLine": "{{name}} – obiettivo {{amount}} entro {{date}}",
+    "view": "Visualizza",
+    "progress": "Progresso: {{progress}}%",
+    "suggestedTrades": "Operazioni suggerite",
+    "trade": "{{action}} {{amount}} di {{ticker}}",
+    "back": "Torna al portafoglio"
   }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -326,5 +326,17 @@
     "indexLevels": "Níveis dos índices",
     "sectorPerformance": "Desempenho por setor",
     "latestHeadlines": "Últimas manchetes"
+  },
+  "goals": {
+    "title": "Metas",
+    "targetAmount": "Valor alvo",
+    "add": "Adicionar meta",
+    "currentAmount": "Valor atual:",
+    "goalLine": "{{name}} – alvo {{amount}} até {{date}}",
+    "view": "Ver",
+    "progress": "Progresso: {{progress}}%",
+    "suggestedTrades": "Negociações sugeridas",
+    "trade": "{{action}} {{amount}} de {{ticker}}",
+    "back": "Voltar ao portfólio"
   }
 }

--- a/frontend/src/pages/Goals.test.tsx
+++ b/frontend/src/pages/Goals.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+import i18n from "../i18n";
+import Goals from "./Goals";
+
+const mockGetGoals = vi.hoisted(() => vi.fn());
+const mockCreateGoal = vi.hoisted(() => vi.fn());
+const mockGetGoal = vi.hoisted(() => vi.fn());
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    getGoals: mockGetGoals,
+    createGoal: mockCreateGoal,
+    getGoal: mockGetGoal,
+  };
+});
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+  mockGetGoals.mockResolvedValue([]);
+});
+
+describe("Goals page", () => {
+  it("renders translated strings", async () => {
+    i18n.changeLanguage("fr");
+    render(<Goals />, { wrapper: MemoryRouter });
+    expect(
+      await screen.findByRole("heading", { name: "Objectifs" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Ajouter un objectif" })
+    ).toBeInTheDocument();
+    i18n.changeLanguage("en");
+  });
+});

--- a/frontend/src/pages/Goals.tsx
+++ b/frontend/src/pages/Goals.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { createGoal, getGoal, getGoals } from "../api";
 
 type Goal = {
@@ -11,6 +12,7 @@ type Goal = {
 type GoalWithProgress = Goal & { progress: number; trades: { action: string; amount: number; ticker: string }[] };
 
 export default function Goals() {
+  const { t } = useTranslation();
   const [goals, setGoals] = useState<Goal[]>([]);
   const [form, setForm] = useState<Goal>({ name: "", target_amount: 0, target_date: "" });
   const [current, setCurrent] = useState(0);
@@ -38,17 +40,17 @@ export default function Goals() {
 
   return (
     <div style={{ padding: "1rem" }}>
-      <h1>Goals</h1>
+      <h1>{t("goals.title")}</h1>
       <form onSubmit={submit} style={{ marginBottom: "1rem" }}>
         <input
-          placeholder="Name"
+          placeholder={t("common.name")}
           value={form.name}
           onChange={(e) => setForm({ ...form, name: e.target.value })}
           required
         />
         <input
           type="number"
-          placeholder="Target Amount"
+          placeholder={t("goals.targetAmount")}
           value={form.target_amount}
           onChange={(e) => setForm({ ...form, target_amount: parseFloat(e.target.value) })}
           required
@@ -59,12 +61,12 @@ export default function Goals() {
           onChange={(e) => setForm({ ...form, target_date: e.target.value })}
           required
         />
-        <button type="submit">Add Goal</button>
+        <button type="submit">{t("goals.add")}</button>
       </form>
 
       <div style={{ marginBottom: "1rem" }}>
         <label>
-          Current Amount:
+          {t("goals.currentAmount")}
           <input
             type="number"
             value={current}
@@ -76,9 +78,13 @@ export default function Goals() {
       <ul>
         {goals.map((g) => (
           <li key={g.name}>
-            {g.name} – target {g.target_amount} by {g.target_date}
+            {t("goals.goalLine", {
+              name: g.name,
+              amount: g.target_amount,
+              date: g.target_date,
+            })}
             <button onClick={() => view(g.name)} style={{ marginLeft: "0.5rem" }}>
-              View
+              {t("goals.view")}
             </button>
           </li>
         ))}
@@ -87,14 +93,20 @@ export default function Goals() {
       {selected && (
         <div style={{ marginTop: "1rem" }}>
           <h2>{selected.name}</h2>
-          <p>Progress: {Math.round(selected.progress * 100)}%</p>
+          <p>
+            {t("goals.progress", { progress: Math.round(selected.progress * 100) })}
+          </p>
           {selected.trades.length > 0 && (
             <>
-              <h3>Suggested Trades</h3>
+              <h3>{t("goals.suggestedTrades")}</h3>
               <ul>
-                {selected.trades.map((t, i) => (
+                {selected.trades.map((trade, i) => (
                   <li key={i}>
-                    {t.action} {t.amount} of {t.ticker}
+                    {t("goals.trade", {
+                      action: trade.action,
+                      amount: trade.amount,
+                      ticker: trade.ticker,
+                    })}
                   </li>
                 ))}
               </ul>
@@ -104,7 +116,7 @@ export default function Goals() {
       )}
 
       <p style={{ marginTop: "2rem" }}>
-        <Link to="/">Back to Portfolio</Link>
+        <Link to="/">{t("goals.back")}</Link>
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- integrate `useTranslation` and replace strings in Goals page
- add goal-related translations across locales
- verify translated text via Goals page test

## Testing
- `npm test` *(fails: 2 failed, 191 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c038e6de988327bd3e59698389540a