### PR TITLE
Plot market index changes instead of levels

### DIFF
--- a/frontend/src/pages/MarketOverview.test.tsx
+++ b/frontend/src/pages/MarketOverview.test.tsx
@@ -7,21 +7,28 @@ vi.mock("../api");
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (_k: string, opts?: any) => opts?.defaultValue ?? _k }),
 }));
-vi.mock("recharts", () => ({
-  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
-  BarChart: ({ data, children }: any) => (
-    <div>
-      {data.map((d: any) => (
-        <div key={d.name}>{d.name}</div>
-      ))}
-      {children}
-    </div>
-  ),
-  Bar: () => null,
-  XAxis: () => null,
-  YAxis: () => null,
-  Tooltip: () => null,
-}));
+
+var mockBar: any;
+
+vi.mock("recharts", () => {
+  mockBar = vi.fn(() => null);
+  return {
+    ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+    BarChart: ({ data, children }: any) => (
+      <div>
+        {data.map((d: any) => (
+          <div key={d.name}>{d.name}</div>
+        ))}
+        {children}
+      </div>
+    ),
+    Bar: mockBar,
+    XAxis: () => null,
+    YAxis: () => null,
+    Tooltip: () => null,
+    Cell: () => null,
+  };
+});
 
 const mockGetMarketOverview = vi.mocked(api.getMarketOverview);
 
@@ -40,5 +47,7 @@ describe("MarketOverview", () => {
     const ftse = await screen.findAllByText("FTSE 100");
     expect(ftse.length).toBeGreaterThan(0);
     expect(screen.getAllByText("FTSE 250")).toHaveLength(2);
+    expect(mockBar).toHaveBeenCalled();
+    expect(mockBar.mock.calls[0][0].dataKey).toBe("change");
   });
 });

--- a/frontend/src/pages/MarketOverview.tsx
+++ b/frontend/src/pages/MarketOverview.tsx
@@ -9,6 +9,7 @@ import {
   XAxis,
   YAxis,
   Tooltip,
+  Cell,
 } from 'recharts';
 
 export default function MarketOverview() {
@@ -36,6 +37,20 @@ export default function MarketOverview() {
     })
   );
 
+  const renderIndexTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      const { value, change } = payload[0].payload;
+      return (
+        <div className="rounded border bg-white p-2 text-sm shadow">
+          <p className="font-semibold">{label}</p>
+          <p>Level: {value.toLocaleString()}</p>
+          <p>Change: {change.toFixed(2)}%</p>
+        </div>
+      );
+    }
+    return null;
+  };
+
   return (
     <div className="container mx-auto p-4">
       <h1 className="mb-4 text-2xl">
@@ -50,8 +65,15 @@ export default function MarketOverview() {
           <BarChart data={indexData}>
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
-            <Bar dataKey="value" fill="#8884d8" />
+            <Tooltip content={renderIndexTooltip} />
+            <Bar dataKey="change">
+              {indexData.map((entry) => (
+                <Cell
+                  key={entry.name}
+                  fill={entry.change >= 0 ? '#16a34a' : '#dc2626'}
+                />
+              ))}
+            </Bar>
           </BarChart>
         </ResponsiveContainer>
         <table className="mt-4 w-full text-left">


### PR DESCRIPTION
## Summary
- Plot percentage changes for index levels in MarketOverview and color bars by sign
- Add tooltip showing index level and change
- Adjust MarketOverview tests to assert chart uses change field

## Testing
- `npm test` *(fails: Test Files 2 failed | 54 passed)*
- `cd frontend && npx vitest run src/pages/MarketOverview.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c07b0c3ae08327bb1f241284158ceb