### PR TITLE
Fix account endpoint and historical event utilities

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -414,6 +414,10 @@ async def get_account(owner: str, account: str):
         data = data_loader.load_account(owner, match)
         account = match
     data.setdefault("account_type", account)
+    # Ensure the owning person is always included in the response. Older
+    # account files omit this which previously caused a ``KeyError`` for
+    # consumers expecting the field to be present.
+    data.setdefault("owner", owner)
     return data
 
 

--- a/backend/routes/scenario.py
+++ b/backend/routes/scenario.py
@@ -6,7 +6,10 @@ from fastapi import APIRouter, HTTPException, Query
 
 from backend.common.data_loader import list_plots
 from backend.common.portfolio import build_owner_portfolio
-from backend.utils.scenario_tester import apply_historical_event, apply_price_shock
+from backend.utils.scenario_tester import (
+    apply_historical_event_portfolio as apply_historical_event,
+    apply_price_shock,
+)
 
 router = APIRouter(tags=["scenario"])
 

--- a/backend/utils/scenario_tester.py
+++ b/backend/utils/scenario_tester.py
@@ -168,7 +168,7 @@ def _forward_returns(ticker: str, exchange: str, event_date: dt.date) -> Dict[st
     return results
 
 
-def apply_historical_event(
+def apply_historical_event_portfolio(
     portfolio: Dict[str, Any],
     event: Any | None = None,
     *,
@@ -176,11 +176,13 @@ def apply_historical_event(
     date: str | None = None,
     horizons: Iterable[int] | None = None,
 ) -> Dict[Any, Any]:
-    """Apply a historical event to a portfolio.
+    """Return shocked portfolio valuations for a historical event.
 
-    When ``event`` is supplied, per-holding returns are calculated for the
-    requested ``horizons``. If ``event`` is omitted but an ``event_id``/``date``
-    is provided, a simple placeholder scaling is applied instead.
+    This helper aggregates holding-level returns into portfolio totals for a
+    number of preset horizons. It is primarily used by API endpoints that need
+    to display the portfolio value and change after an event.  When ``event`` is
+    omitted but an ``event_id`` or ``date`` is supplied a simple scaling
+    placeholder is returned instead.
     """
 
     if event is None and (event_id or date):
@@ -191,7 +193,10 @@ def apply_historical_event(
 
     baseline = float(portfolio.get("total_value_estimate_gbp") or 0.0)
     if baseline == 0.0:
-        baseline = sum(float(a.get("value_estimate_gbp") or 0.0) for a in portfolio.get("accounts", []))
+        baseline = sum(
+            float(a.get("value_estimate_gbp") or 0.0)
+            for a in portfolio.get("accounts", [])
+        )
 
     proxy_val = getattr(event, "proxy", None)
     if proxy_val is None and isinstance(event, dict):
@@ -291,7 +296,7 @@ def _calc_return(ticker: str, exchange: str | None, start: dt.date, horizon: int
         return None
 
 
-def apply_historical_returns(
+def apply_historical_event(
     portfolio: Dict[str, Any],
     event: Dict[str, Any] | None = None,
     *,
@@ -301,10 +306,9 @@ def apply_historical_returns(
 ) -> Dict[Any, Any]:
     """Apply a historical event to ``portfolio``.
 
-    When ``event`` is provided, per-holding returns are calculated for the
-    requested ``horizons`` (or those defined within ``event``) and returned as
-    ``{ticker: {horizon: return}}``.  If ``event`` is omitted but an
-    ``event_id`` or ``date`` is supplied, a simple placeholder scaling is
+    Returns per-holding forward returns for the requested ``horizons`` in the
+    shape ``{ticker: {horizon: return}}``. If ``event`` is omitted but an
+    ``event_id`` or ``date`` is supplied a simple placeholder scaling is
     applied instead.
     """
 


### PR DESCRIPTION
## Summary
- ensure account API responses always include the owner field
- restore historical-event helper to return per-holding returns and export portfolio-level variant
- adapt scenario route to new helper name

## Testing
- `pytest allotmint/tests/test_accounts_api.py allotmint/tests/test_scenario_tester.py::test_apply_historical_event_uses_proxy_for_missing allotmint/tests/test_scenario_tester.py::test_apply_historical_event_scales_portfolio -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68c094cf30f48327b4b6be7aa4fbe757