### PR TITLE
feat(frontend): add sector and region translations

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -244,7 +244,9 @@
   "asOf": "Stand {{date}} • Trades diesen Monat: {{trades}} / 20 (Verbleibend: {{remaining}})",
   "approxTotal": "Ungefähre Summe: £{{value}}",
   "allocation": {
-    "instrumentTypes": "Instrumenttypen"
+    "instrumentTypes": "Instrumenttypen",
+    "sector": "Branchen",
+    "region": "Regionen"
   },
   "watchlist": {
     "refresh": "Aktualisieren"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -246,7 +246,9 @@
   "asOf": "As of {{date}} • Trades this month: {{trades}} / 20 (Remaining: {{remaining}})",
   "approxTotal": "Approx Total: £{{value}}",
   "allocation": {
-    "instrumentTypes": "Instrument Types"
+    "instrumentTypes": "Instrument Types",
+    "sector": "Industries",
+    "region": "Regions"
   },
   "watchlist": {
     "refresh": "Refresh"

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -244,7 +244,9 @@
   "asOf": "A fecha de {{date}} • Operaciones este mes: {{trades}} / 20 (Restantes: {{remaining}})",
   "approxTotal": "Total aproximado: £{{value}}",
   "allocation": {
-    "instrumentTypes": "Tipos de instrumentos"
+    "instrumentTypes": "Tipos de instrumentos",
+    "sector": "Industrias",
+    "region": "Regiones"
   },
   "watchlist": {
     "refresh": "Actualizar"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -244,7 +244,9 @@
   "asOf": "Au {{date}} • Transactions ce mois: {{trades}} / 20 (Restantes: {{remaining}})",
   "approxTotal": "Total approximatif: £{{value}}",
   "allocation": {
-    "instrumentTypes": "Types d'instruments"
+    "instrumentTypes": "Types d'instruments",
+    "sector": "Secteurs",
+    "region": "Régions"
   },
   "watchlist": {
     "refresh": "Actualiser"

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -244,7 +244,9 @@
   "asOf": "A partire da {{date}} • scambia questo mese: {{scambi}} / 20 (rimanente: {{rimanente}})",
   "approxTotal": "Circa totale: £ {{value}}",
   "allocation": {
-    "instrumentTypes": "Tipi di strumenti"
+    "instrumentTypes": "Tipi di strumenti",
+    "sector": "Industrie",
+    "region": "Regioni"
   },
   "watchlist": {
     "refresh": "Rinfrescare"

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -244,7 +244,9 @@
   "asOf": "Em {{date}} • Negociações este mês: {{trades}} / 20 (Restantes: {{remaining}})",
   "approxTotal": "Total aproximado: £{{value}}",
   "allocation": {
-    "instrumentTypes": "Tipos de instrumentos"
+    "instrumentTypes": "Tipos de instrumentos",
+    "sector": "Indústrias",
+    "region": "Regiões"
   },
   "watchlist": {
     "refresh": "Atualizar"

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -124,10 +124,10 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
           {t("allocation.instrumentTypes", { defaultValue: "Instrument Types" })}
         </button>
         <button onClick={() => setView("sector")} disabled={view === "sector"}>
-          {t("Sector", { defaultValue: "Industries" })}
+          {t("allocation.sector")}
         </button>
         <button onClick={() => setView("region")} disabled={view === "region"}>
-          {t("Region", { defaultValue: "Regions" })}
+          {t("allocation.region")}
         </button>
       </div>
       {portfolio && (


### PR DESCRIPTION
## Summary
- replace Sector/Region buttons with dedicated allocation translation keys
- add sector and region strings to allocation section in all locales

## Testing
- `npm test` *(fails: 2 failed | 24 passed | 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c0953e064083279a946dcb30021908