### PR TITLE
Add scenario events endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ data/*
 !data/instruments/
 !data/instruments/**
 !data/scaling_overrides.json
+!data/events.json
 
 # Logs
 backend.log

--- a/backend/app.py
+++ b/backend/app.py
@@ -56,6 +56,7 @@ from backend.routes.portfolio import public_router as public_portfolio_router
 from backend.routes.portfolio import router as portfolio_router
 from backend.routes.query import router as query_router
 from backend.routes.quotes import router as quotes_router
+from backend.routes.events import router as events_router
 from backend.routes.scenario import router as scenario_router
 from backend.routes.screener import router as screener_router
 from backend.routes.support import router as support_router
@@ -222,6 +223,7 @@ def create_app() -> FastAPI:
     app.include_router(movers_router)
     app.include_router(user_config_router, dependencies=protected)
     app.include_router(approvals_router, dependencies=protected)
+    app.include_router(events_router)
     app.include_router(scenario_router)
     app.include_router(logs_router)
     app.include_router(goals_router, dependencies=protected)

--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -1,0 +1,22 @@
+"""Routes for scenario events."""
+
+import json
+from pathlib import Path
+from fastapi import APIRouter
+
+router = APIRouter(tags=["events"])
+
+_events_path = Path(__file__).resolve().parents[2] / "data" / "events.json"
+
+try:
+    with _events_path.open() as fh:
+        _EVENTS = [{"id": e["id"], "name": e["name"]} for e in json.load(fh)]
+except FileNotFoundError:
+    _EVENTS = []
+
+
+@router.get("/events")
+def list_events():
+    """Return configured scenario events."""
+    return _EVENTS
+

--- a/data/events.json
+++ b/data/events.json
@@ -1,0 +1,4 @@
+[
+  {"id": "covid-2020", "name": "COVID-19 Crash"},
+  {"id": "gfc-2008", "name": "Global Financial Crisis"}
+]

--- a/tests/test_scenario_route.py
+++ b/tests/test_scenario_route.py
@@ -1,4 +1,6 @@
 from fastapi.testclient import TestClient
+from pathlib import Path
+import json
 
 from backend.app import create_app
 from backend.routes import scenario as scenario_route
@@ -49,3 +51,15 @@ def test_historical_scenario_route(monkeypatch):
         first_horizon = next(iter(first["horizons"].values()))
         assert "shocked_total_value_gbp" in first_horizon
         assert "pct_change" in first_horizon
+
+
+def test_events_route():
+    client = _auth_client()
+    resp = client.get("/events")
+    assert resp.status_code == 200
+    data = resp.json()
+    events_path = Path(__file__).resolve().parents[1] / "data" / "events.json"
+    with events_path.open() as fh:
+        expected = [{"id": e["id"], "name": e["name"]} for e in json.load(fh)]
+    assert data == expected
+


### PR DESCRIPTION
## Summary
- add /events route serving configured scenario events
- load events from data/events.json and register router
- test /events route

## Testing
- `pytest tests/test_scenario_route.py::test_events_route -q -o addopts= -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_68c096c219e083278c14fa3575b709af