### PR TITLE
Validate target weights in rebalance trades

### DIFF
--- a/backend/common/rebalance.py
+++ b/backend/common/rebalance.py
@@ -29,6 +29,9 @@ def suggest_trades(actual: Dict[str, float], target: Dict[str, float]) -> List[d
         Each entry has ``ticker`` (str), ``action`` ("buy" or "sell") and
         ``amount`` (float, absolute currency amount to trade).
     """
+    total_weight = sum(target.values())
+    if abs(total_weight - 1.0) > 1e-6:
+        raise ValueError(f"Target weights must sum to 1.0, got {total_weight:.6f}")
 
     total_value = sum(actual.values())
     suggestions: List[dict] = []

--- a/backend/routes/rebalance.py
+++ b/backend/routes/rebalance.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from backend.common.rebalance import suggest_trades
@@ -24,4 +24,7 @@ class TradeSuggestion(BaseModel):
 
 @router.post("/rebalance", response_model=List[TradeSuggestion])
 def rebalance(req: RebalanceRequest) -> List[TradeSuggestion]:
-    return suggest_trades(req.actual, req.target)
+    try:
+        return suggest_trades(req.actual, req.target)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/tests/test_rebalance_route.py
+++ b/tests/test_rebalance_route.py
@@ -2,30 +2,50 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from backend.common.rebalance import suggest_trades
 
-def test_rebalance_route(monkeypatch):
-    sample_actual = {"AAA": 100.0, "BBB": 50.0}
-    sample_target = {"AAA": 0.6, "BBB": 0.4}
-    expected = [
-        {"ticker": "AAA", "action": "buy", "amount": 10.0},
-        {"ticker": "BBB", "action": "sell", "amount": 10.0},
-    ]
 
-    def fake_suggest(actual, target):
-        assert actual == sample_actual
-        assert target == sample_target
-        return expected
-
-    monkeypatch.setattr("backend.common.rebalance.suggest_trades", fake_suggest)
-
+def test_rebalance_route():
     from backend.routes import rebalance as rebalance_route
 
     app = FastAPI()
     app.include_router(rebalance_route.router)
-
     client = TestClient(app)
+
+    sample_actual = {"AAA": 100.0, "BBB": 50.0}
+    sample_target = {"AAA": 0.6, "BBB": 0.4}
+
     resp = client.post("/rebalance", json={"actual": sample_actual, "target": sample_target})
     assert resp.status_code == 200
+    assert resp.json() == [
+        {"ticker": "AAA", "action": "sell", "amount": 10.0},
+        {"ticker": "BBB", "action": "buy", "amount": 10.0},
+    ]
 
-    data = [rebalance_route.TradeSuggestion(**item) for item in resp.json()]
-    assert data == [rebalance_route.TradeSuggestion(**item) for item in expected]
+
+def test_suggest_trades_valid_target_sum():
+    actual = {"AAA": 100.0, "BBB": 50.0}
+    target = {"AAA": 0.5, "BBB": 0.5}
+    trades = suggest_trades(actual, target)
+    assert trades == [
+        {"ticker": "AAA", "action": "sell", "amount": 25.0},
+        {"ticker": "BBB", "action": "buy", "amount": 25.0},
+    ]
+
+
+def test_suggest_trades_invalid_target_sum():
+    actual = {"AAA": 100.0}
+    target = {"AAA": 0.9}
+    with pytest.raises(ValueError):
+        suggest_trades(actual, target)
+
+
+def test_rebalance_route_invalid_target_sum():
+    from backend.routes import rebalance as rebalance_route
+
+    app = FastAPI()
+    app.include_router(rebalance_route.router)
+    client = TestClient(app)
+
+    resp = client.post("/rebalance", json={"actual": {"AAA": 100.0}, "target": {"AAA": 0.9}})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- ensure portfolio rebalance targets sum to 1.0 and raise `ValueError` if not
- return HTTP 400 when target weights are invalid
- add tests for valid trade suggestions and invalid target weights

## Testing
- `pytest --no-cov tests/test_rebalance_route.py backend/tests/test_routers.py::test_rebalance_route -q`

------
https://chatgpt.com/codex/tasks/task_e_68c096a7a768832786d85f7787a5f644