### PR TITLE
Expose instrument metadata in research view

### DIFF
--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -224,6 +224,8 @@ async def instrument(
         df["Close"] = df["Close_gbp"]
 
     meta = get_security_meta(ticker) or {}
+    name = meta.get("name")
+    sector = meta.get("sector")
     currency = meta.get("currency")
 
     ts_is_gbp = currency == "GBP" or "Close_gbp" in df.columns
@@ -277,6 +279,8 @@ async def instrument(
             "prices": prices,
             "mini": mini,
             "currency": currency,
+            "name": name,
+            "sector": sector,
         }
         return JSONResponse(jsonable_encoder(payload))
 

--- a/frontend/src/hooks/useInstrumentHistory.ts
+++ b/frontend/src/hooks/useInstrumentHistory.ts
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import { getInstrumentDetail } from "../api";
 import type { InstrumentDetail } from "../types";
 
-// Cache full instrument detail per ticker to reuse for history and positions
+// Cache full instrument detail (including metadata like name, sector and
+// currency) per ticker to reuse for history and positions
 const cache = new Map<string, InstrumentDetail>();
 
 export function getCachedInstrumentHistory(ticker: string) {

--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -257,6 +257,34 @@ describe("InstrumentResearch page", () => {
     }
   });
 
+  it("renders instrument metadata when available", async () => {
+    mockUseInstrumentHistory.mockReturnValue({
+      data: {
+        mini: { "30": [] },
+        positions: [],
+        name: "Acme Corp",
+        sector: "Tech",
+        currency: "USD",
+      },
+      loading: false,
+      error: null,
+    } as any);
+    mockGetScreener.mockResolvedValue([]);
+    mockGetQuotes.mockResolvedValue([]);
+    mockGetNews.mockResolvedValue([]);
+    renderPage();
+
+    const heading = await screen.findByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("AAA - Acme Corp");
+    expect(heading).toHaveTextContent("Tech");
+    expect(heading).toHaveTextContent("USD");
+
+    expect(screen.getByText(/Instrument info/i)).toBeInTheDocument();
+    expect(screen.getByText(/Name:/)).toHaveTextContent("Name: Acme Corp");
+    expect(screen.getByText(/Sector:/)).toHaveTextContent("Sector: Tech");
+    expect(screen.getByText(/Currency:/)).toHaveTextContent("Currency: USD");
+  });
+
   it("skips state updates when unmounted", async () => {
     mockFetchInstrumentDetailWithRetry.mockResolvedValue({
       prices: null,

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -117,11 +117,26 @@ export default function InstrumentResearch() {
     <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
       <h1 style={{ marginBottom: "1rem" }}>
         {tkr}
-        {metrics?.name
+        {detail?.name
+          ? ` - ${detail.name}`
+          : metrics?.name
           ? ` - ${metrics.name}`
           : quote?.name
           ? ` - ${quote.name}`
           : ""}
+        {detail?.sector || detail?.currency ? (
+          <span
+            style={{
+              display: "block",
+              fontSize: "0.8rem",
+              fontWeight: "normal",
+            }}
+          >
+            {detail?.sector ?? ""}
+            {detail?.sector && detail?.currency ? " · " : ""}
+            {detail?.currency ?? ""}
+          </span>
+        ) : null}
       </h1>
       <div style={{ marginBottom: "1rem" }}>
         {tabs.screener && !(disabledTabs ?? []).includes("screener") && (
@@ -136,6 +151,16 @@ export default function InstrumentResearch() {
           {inWatchlist ? "Remove from Watchlist" : "Add to Watchlist"}
         </button>
       </div>
+      {detail && (
+        <div style={{ marginBottom: "1rem" }}>
+          <h2>Instrument info</h2>
+          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+            {detail.name && <li>Name: {detail.name}</li>}
+            {detail.sector && <li>Sector: {detail.sector}</li>}
+            {detail.currency && <li>Currency: {detail.currency}</li>}
+          </ul>
+        </div>
+      )}
       <div style={{ marginBottom: "0.5rem" }}>
         {[7, 30, 180, 365].map((d) => (
           <button

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -228,6 +228,8 @@ export interface InstrumentDetail {
   prices: unknown;
   positions: InstrumentPosition[];
   mini?: InstrumentDetailMini;
+  name?: string | null;
+  sector?: string | null;
   currency?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- Include name, sector and currency in instrument API responses
- Surface instrument metadata in InstrumentResearch page and typings
- Test rendering of instrument metadata in InstrumentResearch

## Testing
- `pytest tests/test_instrument_route.py` *(fails: Required test coverage of 80% not reached. Total coverage: 79.77%; 2 tests failed)*
- `npx vitest run src/pages/InstrumentResearch.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c0982898d08327b4f5a128f40e07be