### PR TITLE
Expose ticker name in quote endpoints

### DIFF
--- a/backend/routes/quotes.py
+++ b/backend/routes/quotes.py
@@ -55,6 +55,7 @@ async def get_quotes(symbols: str = Query("")) -> List[Dict[str, Any]]:
                 "timestamp": info.get("regularMarketTime"),
                 "timezone": info.get("exchangeTimezoneName"),
                 "market_state": info.get("marketState"),
+                "name": info.get("shortName") or info.get("longName"),
             }
         )
 

--- a/backend/tests/test_quotes_route.py
+++ b/backend/tests/test_quotes_route.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes import quotes
+
+
+def test_get_quotes_includes_name(monkeypatch):
+    app = FastAPI()
+    app.include_router(quotes.router)
+
+    def fake_Tickers(symbols):
+        assert symbols == "AAA"
+        ticker = type("T", (), {"info": {"regularMarketPrice": 100.0, "shortName": "Acme"}})()
+        return type("TT", (), {"tickers": {"AAA": ticker}})()
+
+    monkeypatch.setattr(quotes.yf, "Tickers", fake_Tickers)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/quotes?symbols=AAA")
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {
+            "symbol": "AAA",
+            "price": 100.0,
+            "open": None,
+            "high": None,
+            "low": None,
+            "previous_close": None,
+            "volume": None,
+            "timestamp": None,
+            "timezone": None,
+            "market_state": None,
+            "name": "Acme",
+        }
+    ]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -133,6 +133,7 @@ export const refreshPrices = () =>
 export const getQuotes = (symbols: string[], signal?: AbortSignal) => {
   const params = new URLSearchParams({ symbols: symbols.join(",") });
   return fetchJson<{
+    name?: string | null;
     symbol: string;
     price: number | null;
     open?: number | null;
@@ -155,7 +156,7 @@ export const getQuotes = (symbols: string[], signal?: AbortSignal) => {
             ? (change / r.previous_close) * 100
             : null;
         return {
-          name: null,
+          name: r.name ?? null,
           symbol: r.symbol,
           last: r.price ?? null,
           open: r.open ?? null,

--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -124,7 +124,7 @@ describe("InstrumentResearch page", () => {
     ]);
     quotesResolve!([
       {
-        name: null,
+        name: "Acme Corp",
         symbol: "AAA",
         last: 100,
         open: null,
@@ -140,6 +140,9 @@ describe("InstrumentResearch page", () => {
     newsResolve!([{ headline: "headline", url: "http://example.com" }]);
 
     expect(await screen.findByText("Price")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { level: 1 })).toHaveTextContent(
+      "AAA - Acme Corp",
+    );
     expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument();
   });
 
@@ -285,7 +288,7 @@ describe("InstrumentResearch page", () => {
     await Promise.resolve();
     resolveQuotes!([
       {
-        name: null,
+        name: "Acme Corp",
         symbol: "AAA",
         last: 1,
         open: null,


### PR DESCRIPTION
## Summary
- include short or long ticker name in `/api/quotes` responses
- wire frontend `getQuotes` to use returned name
- update InstrumentResearch tests to expect symbol name

## Testing
- `pytest backend/tests/test_quotes_route.py -q`
- `pytest backend/tests -q` *(fails: Object of type bytes is not JSON serializable)*
- `npm test -- --run` *(fails: 2 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0982ac808832784877fbe7baf78dc