### PR TITLE
fix: default JWT secret for local dev

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -37,9 +37,10 @@ logger = logging.getLogger(__name__)
 
 SECRET_KEY = os.getenv("JWT_SECRET")
 _testing = os.getenv("TESTING")
+app_env = (os.getenv("APP_ENV") or (config.app_env or "")).lower()
 if not SECRET_KEY:
-    if config.disable_auth or _testing:
-        logger.warning("JWT_SECRET not set; using ephemeral secret for tests")
+    if config.disable_auth or _testing or app_env not in {"production", "aws"}:
+        logger.warning("JWT_SECRET not set; using ephemeral secret for development")
         SECRET_KEY = secrets.token_urlsafe(32)
     else:
         raise RuntimeError("JWT_SECRET environment variable is required")

--- a/backend/tests/test_auth_module.py
+++ b/backend/tests/test_auth_module.py
@@ -89,6 +89,7 @@ def test_missing_jwt_secret_raises_error(monkeypatch):
 
     monkeypatch.delenv("JWT_SECRET", raising=False)
     monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setenv("APP_ENV", "production")
     monkeypatch.setattr(auth.config, "disable_auth", False)
     with pytest.raises(RuntimeError):
         importlib.reload(auth)


### PR DESCRIPTION
## Summary
- generate ephemeral JWT secret for non-production environments to ease local development

## Testing
- `python -m py_compile backend/auth.py`
- `pytest` *(fails: 58 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c09c102f108327aa2214afa9e7d94a