### PR TITLE
Refactor historical returns wrapper

### DIFF
--- a/backend/utils/scenario_tester.py
+++ b/backend/utils/scenario_tester.py
@@ -318,10 +318,10 @@ def apply_historical_returns(
     if event is None:
         raise ValueError("event must be provided")
 
-    return apply_historical_returns(portfolio, event, horizons=horizons)
+    return _apply_historical_returns(portfolio, event, horizons=horizons)
 
 
-def apply_historical_returns(
+def _apply_historical_returns(
     portfolio: Dict[str, Any],
     event: Dict[str, Any],
     horizons: Iterable[int] | None = None,

--- a/tests/test_scenario_tester.py
+++ b/tests/test_scenario_tester.py
@@ -3,7 +3,7 @@ import datetime as dt
 import pandas as pd
 import pytest
 import backend.utils.scenario_tester as sc_tester
-from backend.utils.scenario_tester import apply_historical_event, apply_price_shock, apply_historical_returns
+from backend.utils.scenario_tester import apply_price_shock, apply_historical_returns
 from backend.utils import scenario_tester as sc
 import backend.common.prices as prices
 from datetime import date
@@ -83,7 +83,7 @@ def test_apply_historical_event_uses_proxy_for_missing(monkeypatch):
     monkeypatch.setattr(sc_tester, "get_scaling_override", lambda *a, **k: 1.0)
     monkeypatch.setattr(sc_tester, "apply_scaling", lambda df, scale, scale_volume=False: df)
 
-    result = apply_historical_event(portfolio, event, horizons=[1, 365])
+    result = apply_historical_returns(portfolio, event, horizons=[1, 365])
 
     assert result["ABC.L"][1] == pytest.approx(0.1)
     assert result["MISSING.L"][1] == pytest.approx(0.1)
@@ -107,7 +107,7 @@ def test_apply_historical_event_scales_portfolio(monkeypatch):
         "proxy_index": {"ticker": "SPY", "exchange": "N"},
     }
 
-    returns = apply_historical_event(portfolio, event, horizons=[1, 5])
+    returns = apply_historical_returns(portfolio, event, horizons=[1, 5])
 
     assert returns["AAA.L"][1] == pytest.approx(-0.1)
     assert returns["AAA.L"][5] == pytest.approx(-0.2)


### PR DESCRIPTION
## Summary
- Refactor `apply_historical_returns` into a wrapper that delegates to a new internal `_apply_historical_returns` implementation, preventing name shadowing and recursive calls.
- Allow the wrapper to handle optional `event_id`/`date` parameters and dispatch placeholder scaling when event data is absent.
- Update scenario tester tests to use the consolidated `apply_historical_returns` API.

## Testing
- `pytest tests/test_scenario_tester.py -o addopts=''`
- `pytest tests/test_scenario_tester.py tests/test_scenario_route.py` *(fails: AssertionError: 'shocked_total_value_gbp' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09e6bed808327b32f1657d62d176f