### PR TITLE
Include credentials in API fetch calls

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -415,6 +415,7 @@ describe("App", () => {
       "Allocation",
       "Rebalance",
       "Reports",
+      "Alert Settings",
       "User Settings",
       "Pension Forecast",
       "Tax Harvest",

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -52,6 +52,7 @@ describe("login", () => {
     expect(mockFetch).toHaveBeenCalledWith(`${API_BASE}/token`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      credentials: "include",
       body: JSON.stringify({ id_token: "good-id-token" }),
     });
   });


### PR DESCRIPTION
## Summary
- include CSRF token and `credentials: "include"` in API fetch helper
- adjust tests for new fetch options

## Testing
- `npm test`
- `curl http://localhost:8000/owners`
- `curl http://localhost:8000/groups`


------
https://chatgpt.com/codex/tasks/task_e_68c0a04af05483278a9e652d172f6375