### PR TITLE
fix: correct config yaml syntax

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,9 +35,8 @@ market_data:
   news_requests_per_day: 25
   
 # URL template for Financial Times scraping
-ft_url_template: https://markets.ft.com/data/funds/tearsheet/historical?s={ticker}
-  selenium_user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
-    (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36
+  ft_url_template: https://markets.ft.com/data/funds/tearsheet/historical?s={ticker}
+  selenium_user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"
   selenium_headless: true
 trading:
   max_trades_per_month: 20


### PR DESCRIPTION
## Summary
- fix YAML syntax in `config.yaml` so configuration loads properly

## Testing
- `pytest tests/test_config.py::test_config_loads_fundamentals_ttl tests/test_config.py::test_theme_loaded tests/test_config.py::test_stooq_timeout_loaded tests/test_config.py::test_auth_flags -q --override-ini=addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68c0a1cbf0b88327984c1e6188471d2a