### PR TITLE
Default timeseries cache path when config missing

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -86,7 +86,13 @@ def _ensure_schema(df: pd.DataFrame) -> pd.DataFrame:
 # ──────────────────────────────────────────────────────────────
 # Cache base (local path, EFS, or S3)
 # ──────────────────────────────────────────────────────────────
-_CACHE_BASE: str = config.timeseries_cache_base
+# ``config.timeseries_cache_base`` may be ``None`` if configuration failed to
+# load or the setting is omitted.  In that case default to a "timeseries"
+# folder under ``config.data_root`` (which itself has a sensible default).
+_CACHE_BASE: str = (
+    config.timeseries_cache_base
+    or str((config.data_root or Path("data")) / "timeseries")
+)
 
 
 def _cache_path(*parts: str) -> str:


### PR DESCRIPTION
## Summary
- Default the timeseries cache base to a `timeseries` directory under `data_root` when `timeseries_cache_base` is unset
- Avoid AttributeError in offline timeseries lookups when configuration fails to load

## Testing
- `pytest tests/test_fx_conversion.py::test_memoized_range_offline_no_cache_returns_empty -q -o addopts=`
- `pytest tests/test_fx_conversion.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68c0a1e515748327a85ff894bc6fe888