### PR TITLE
Handle missing price snapshot path

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -145,6 +145,10 @@ def _load_snapshot() -> tuple[Dict[str, Dict], datetime | None]:
                     exc,
                 )
 
+    if config.prices_json is None:
+        logger.info("Price snapshot path not configured; skipping load")
+        return {}, None
+
     if not _PRICES_PATH or not _PRICES_PATH.exists():
         logger.warning("Price snapshot not found: %s", _PRICES_PATH)
         return {}, None

--- a/tests/test_portfolio_utils_snapshot.py
+++ b/tests/test_portfolio_utils_snapshot.py
@@ -4,9 +4,20 @@ from backend.common import portfolio_utils as pu
 def test_load_snapshot_bad_json(tmp_path, monkeypatch, caplog):
     path = tmp_path / "latest_prices.json"
     path.write_text("{bad json")
+    monkeypatch.setattr(pu.config, "prices_json", path)
     monkeypatch.setattr(pu, "_PRICES_PATH", path)
     with caplog.at_level("ERROR"):
         data, ts = pu._load_snapshot()
     assert data == {}
     assert ts is None
     assert "Failed to parse snapshot" in caplog.text
+
+
+def test_load_snapshot_no_path(monkeypatch, caplog):
+    monkeypatch.setattr(pu.config, "prices_json", None)
+    monkeypatch.setattr(pu, "_PRICES_PATH", None)
+    with caplog.at_level("INFO"):
+        data, ts = pu._load_snapshot()
+    assert data == {}
+    assert ts is None
+    assert "Price snapshot path not configured; skipping load" in caplog.text


### PR DESCRIPTION
## Summary
- Skip loading price snapshot when `config.prices_json` is not set
- Log informative message instead of warning when snapshot path is unset
- Test snapshot loader behavior with and without configured path

## Testing
- `pytest tests/test_portfolio_utils_snapshot.py -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68c0a20e0b48832787f6196b0076858f