### PR TITLE
Use info log when price snapshot path missing

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -1101,7 +1101,9 @@ def refresh_snapshot_in_memory_from_timeseries(days: int = 365) -> None:
             _PRICES_PATH.write_text(json.dumps(snapshot, indent=2))
             logger.info("Wrote %d prices to %s", len(snapshot), _PRICES_PATH)
         else:
-            logger.warning("Price snapshot path not configured; skipping write")
+            logger.info(
+                "Price snapshot path not configured; skipping write (expected when config.prices_json is unset)"
+            )
     except OSError as e:
         logger.warning("Failed to write latest_prices.json: %s", e)
 


### PR DESCRIPTION
## Summary
- log at info level when skipping price snapshot write because `config.prices_json` is unset

## Testing
- `pytest backend/tests/test_portfolio_utils.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68c0a20f40408327b893332cae928d12