### PR TITLE
Remove auth requirement from transactions router

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -203,7 +203,7 @@ def create_app() -> FastAPI:
     app.include_router(timeseries_router)
     app.include_router(timeseries_edit_router)
     app.include_router(timeseries_admin_router, dependencies=protected)
-    app.include_router(transactions_router, dependencies=protected)
+    app.include_router(transactions_router)
     app.include_router(alert_settings_router, dependencies=protected)
     app.include_router(alerts_router, dependencies=protected)
     app.include_router(nudges_router, dependencies=protected)


### PR DESCRIPTION
## Summary
- Expose the transactions API without authentication

## Testing
- `make lint` *(fails: ruff reports numerous existing issues in tests)*
- `pytest backend/tests/test_transactions_route.py::test_create_transaction_success` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'offline_mode')*
- `pytest -o addopts="" backend/tests/test_transactions_route.py::test_validate_component`


------
https://chatgpt.com/codex/tasks/task_e_68c1be8437e88327b5fc0eea486bdd27