### PR TITLE
Allow environment override for timeseries cache base

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -224,9 +224,13 @@ def load_config() -> Config:
     prices_json = (data_root / prices_json_raw).resolve() if prices_json_raw else None
 
     ts_cache_raw = data.get("timeseries_cache_base")
-    timeseries_cache_base = (
-        str((data_root / ts_cache_raw).resolve()) if ts_cache_raw else None
-    )
+    env_ts_cache = os.getenv("TIMESERIES_CACHE_BASE")
+    if env_ts_cache:
+        timeseries_cache_base = env_ts_cache
+    else:
+        timeseries_cache_base = (
+            str((data_root / ts_cache_raw).resolve()) if ts_cache_raw else None
+        )
 
     portfolio_xml_raw = data.get("portfolio_xml_path")
     portfolio_xml_path = (

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,7 +4,7 @@ paths:
   data_root: data                     # Base directory for application data
   accounts_root: accounts             # Directory containing account files
   prices_json: prices/latest_prices.json # Location for cached price data
-  timeseries_cache_base: timeseries   # Cache directory for time series data
+  timeseries_cache_base: timeseries   # Cache directory for time series data (TIMESERIES_CACHE_BASE overrides)
   portfolio_xml_path: portfolio/investments.xml # Portfolio XML input file
   transactions_output_root: accounts  # Where generated transactions are written
   log_config: backend/logging.ini     # Logging configuration file

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,6 +43,16 @@ def test_stooq_timeout_loaded():
     assert cfg.stooq_timeout == 10
 
 
+def test_timeseries_cache_base_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
+    config_module.load_config.cache_clear()
+    cfg = config_module.load_config()
+    assert cfg.timeseries_cache_base == str(tmp_path)
+    monkeypatch.delenv("TIMESERIES_CACHE_BASE")
+    config_module.load_config.cache_clear()
+    config_module.config = config_module.load_config()
+
+
 def test_auth_flags(monkeypatch):
     cfg = config_module.load_config()
     assert cfg.google_auth_enabled is False


### PR DESCRIPTION
## Summary
- allow `TIMESERIES_CACHE_BASE` env var to override YAML `timeseries_cache_base`
- clarify env var precedence in example config
- add regression test for env-based override

## Testing
- `pytest tests/test_config.py::test_timeseries_cache_base_env_override -q --override-ini=addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68c1be909ecc8327933a7f054e0ba09f