### PR TITLE
Ensure demo account always listed

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -93,7 +93,9 @@ def _list_local_plots(
         owner = owner_dir.name
         meta = load_person_meta(owner, root)
         viewers = meta.get("viewers", [])
-        if user and user != owner and user not in viewers:
+        # Always expose the "demo" owner, even if ``current_user`` is not a
+        # listed viewer. For all other owners, enforce viewer permissions.
+        if owner != "demo" and user and user != owner and user not in viewers:
             continue
 
         acct_names: List[str] = []

--- a/backend/tests/test_async_endpoints.py
+++ b/backend/tests/test_async_endpoints.py
@@ -12,7 +12,10 @@ async def test_auth_alerts_portfolio(monkeypatch):
     )
     monkeypatch.setattr(
         "backend.common.data_loader.list_plots",
-        lambda root, current_user=None: [{"owner": "alice", "accounts": ["brokerage"]}],
+        lambda root, current_user=None: [
+            {"owner": "alice", "accounts": ["brokerage"]},
+            {"owner": "demo", "accounts": ["demo"]},
+        ],
     )
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -26,4 +29,5 @@ async def test_auth_alerts_portfolio(monkeypatch):
     assert token
     assert alerts_resp.status_code == 200
     assert owners_resp.status_code == 200
-    assert owners_resp.json()[0]["owner"] == "alice"
+    owners = owners_resp.json()
+    assert any(o["owner"] == "demo" for o in owners)

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -48,6 +48,7 @@ def test_owners_endpoint_matches_sample_data(client):
     resp = client.get("/owners")
     assert resp.status_code == 200
     owners = {o["owner"]: set(o["accounts"]) for o in resp.json()}
+    assert "demo" in owners
     for owner, accounts in sample_accounts():
         assert owner in owners
         assert set(accounts).issubset(owners[owner])

--- a/tests/test_data_loader_local.py
+++ b/tests/test_data_loader_local.py
@@ -52,4 +52,5 @@ def test_list_local_plots_authenticated(tmp_path, monkeypatch):
     assert owners == [
         {"owner": "alice", "accounts": ["isa"]},
         {"owner": "bob", "accounts": ["gia"]},
+        {"owner": "demo", "accounts": ["demo"]},
     ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ def client():
 
 # Shared mock data
 mock_owners = [
+    {"owner": "demo", "accounts": ["isa"]},
     {"owner": "alex", "accounts": ["isa", "sipp"]},
     {"owner": "joe", "accounts": ["isa", "sipp"]},
     {"owner": "lucy", "accounts": ["isa", "pension-forecast"]},
@@ -24,7 +25,7 @@ mock_owners = [
 mock_groups = [
     {"slug": "children", "name": "Children", "members": ["alex", "joe"]},
     {"slug": "adults", "name": "Adults", "members": ["lucy", "steve"]},
-    {"slug": "all", "name": "All", "members": ["alex", "joe", "lucy", "steve"]},
+    {"slug": "all", "name": "All", "members": ["alex", "joe", "lucy", "steve", "demo"]},
     {"slug": "testslug", "name": "Test Group", "members": ["testuser"]},
 ]
 

--- a/tests/test_push_subscription_route.py
+++ b/tests/test_push_subscription_route.py
@@ -24,8 +24,8 @@ def client(tmp_path, monkeypatch):
 
 def test_push_subscription_owner_validation(client):
     owners = client.get("/owners").json()
-    assert owners, "No owners returned"
-    owner = owners[0]["owner"]
+    assert any(o["owner"] == "demo" for o in owners)
+    owner = "demo"
     payload = {"endpoint": "https://ex", "keys": {"p256dh": "a", "auth": "b"}}
 
     resp = client.post(f"/alerts/push-subscription/{owner}", json=payload)


### PR DESCRIPTION
## Summary
- Always include the `demo` owner when listing local plots, regardless of viewer permissions
- Update tests to expect and verify the `demo` account in `/owners` and `/groups` responses
- Extend mocks to include the demo owner in various API tests

## Testing
- `pytest -q` *(fails: coverage threshold not met; numerous auth-related test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bea2e6848327b8b0679fc9a82e3e