### PR TITLE
Import HTTPException in news route

### DIFF
--- a/backend/routes/news.py
+++ b/backend/routes/news.py
@@ -10,7 +10,7 @@ from datetime import date
 from pathlib import Path
 
 import requests
-from fastapi import APIRouter, BackgroundTasks, Query
+from fastapi import APIRouter, BackgroundTasks, Query, HTTPException
 
 from backend.config import config
 from backend.utils import page_cache


### PR DESCRIPTION
## Summary
- Ensure news route handles quota errors by importing HTTPException from FastAPI

## Testing
- `pytest tests/test_news_route.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c1d5e76f7c8327bdbb0ff627852eed