### PR TITLE
chore: remove duplicate market data configs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,17 +41,13 @@ market_data:
   fundamentals_cache_ttl_seconds: 86400 # TTL for fundamentals cache (seconds)
   stooq_timeout: 10                   # Timeout for Stooq requests (seconds)
   stooq_requests_per_minute: 60       # Rate limit for Stooq requests
-  news_requests_per_day: 25           # Max AlphaVantage news requests per day
-  ft_url_template: "https://markets.ft.com/data/funds/tearsheet/historical?s={ticker}" # FT scraping URL template
-  selenium_user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36" # Selenium user agent
-  selenium_headless: true             # Run Selenium headless
-
-# Max AlphaVantage news requests per day
+  # Max AlphaVantage news requests per day
   news_requests_per_day: 25
-  
-# URL template for Financial Times scraping
-  ft_url_template: https://markets.ft.com/data/funds/tearsheet/historical?s={ticker}
+  # URL template for Financial Times scraping
+  ft_url_template: "https://markets.ft.com/data/funds/tearsheet/historical?s={ticker}"
+  # Selenium user agent
   selenium_user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"
+  # Run Selenium headless
   selenium_headless: true
 
 trading:


### PR DESCRIPTION
## Summary
- tidy market_data section in config.yaml by removing duplicate entries
- move comments above keys for simple YAML parser compatibility

## Testing
- `pytest -o addopts=''` *(fails: tests failing, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d5fd5cd8832792248241edc85638