### PR TITLE
Strip YAML comments in Read-YamlSimple

### DIFF
--- a/scripts/run-backend.ps1
+++ b/scripts/run-backend.ps1
@@ -84,6 +84,7 @@ function Read-YamlSimple([string]$path) {
     if ($line -match '^\s*([A-Za-z0-9_]+)\s*:\s*(.*)\s*$') {
       $k = $matches[1]
       $v = $matches[2].Trim()
+      if ($v -notmatch '^["''].*["'']$') { $v = $v -replace '\s+#.*$', '' }
       if ($v -match '^["''](.*)["'']$') { $v = $matches[1] } # strip quotes
       switch -Regex ($v.ToLower()) {
         '^(true|yes)$'  { $v = $true;  break }


### PR DESCRIPTION
## Summary
- strip inline `#` comments outside quotes in Read-YamlSimple
- ensure cleaned values are cast to bool/int so `uvicorn_port` parses as an integer

## Testing
- `pytest` *(fails: 9 failed, coverage 79.80%)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d5fb06748327aa7dec041e709dd5