### PR TITLE
Require explicit timeseries cache base

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -90,12 +90,13 @@ def _ensure_schema(df: pd.DataFrame) -> pd.DataFrame:
 # ──────────────────────────────────────────────────────────────
 
 # ``config.timeseries_cache_base`` may be ``None`` if configuration failed to
-# load or the setting is omitted.  In that case default to a "timeseries"
-# folder under ``config.data_root`` (which itself has a sensible default).
-_CACHE_BASE: str = (
-    config.timeseries_cache_base
-    or str((config.data_root or Path("data")) / "timeseries")
-)
+# load or the setting is omitted.  Callers must explicitly provide a base via
+# the ``TIMESERIES_CACHE_BASE`` environment variable or configuration.
+_CACHE_BASE: str | None = os.getenv("TIMESERIES_CACHE_BASE") or config.timeseries_cache_base
+if _CACHE_BASE is None:
+    raise ValueError(
+        "Timeseries cache base is not configured; set TIMESERIES_CACHE_BASE or config.timeseries_cache_base."
+    )
 
 
 def _cache_path(*parts: str) -> str:

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -1,38 +1,38 @@
+import importlib
+import sys
+
 import pytest
 
-import backend.timeseries.cache as cache_module
 import backend.config as config_module
 
 
-def reload_cache():
-    import importlib
-    return importlib.reload(cache_module)
+def import_cache():
+    """Import ``backend.timeseries.cache`` after clearing any previous copy."""
+    sys.modules.pop("backend.timeseries.cache", None)
+    return importlib.import_module("backend.timeseries.cache")
 
 
 def test_missing_cache_base_raises(monkeypatch):
-    import importlib
     importlib.reload(config_module)
     monkeypatch.delenv("TIMESERIES_CACHE_BASE", raising=False)
     monkeypatch.setattr(config_module.config, "timeseries_cache_base", None)
-    cache = reload_cache()
+    sys.modules.pop("backend.timeseries.cache", None)
     with pytest.raises(ValueError, match="TIMESERIES_CACHE_BASE"):
-        cache._cache_path("foo")
+        import_cache()
 
 
 def test_cache_base_from_env(monkeypatch, tmp_path):
-    import importlib
     importlib.reload(config_module)
     monkeypatch.setattr(config_module.config, "timeseries_cache_base", None)
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
-    cache = reload_cache()
+    cache = import_cache()
     assert cache._cache_path("bar") == str(tmp_path / "bar")
 
 
 def test_cache_base_from_config(monkeypatch, tmp_path):
-    import importlib
     importlib.reload(config_module)
     monkeypatch.delenv("TIMESERIES_CACHE_BASE", raising=False)
     monkeypatch.setattr(config_module.config, "timeseries_cache_base", str(tmp_path))
-    cache = reload_cache()
+    cache = import_cache()
     assert cache._cache_path("baz") == str(tmp_path / "baz")
 


### PR DESCRIPTION
## Summary
- Initialize `_CACHE_BASE` from the `TIMESERIES_CACHE_BASE` env var or config
- Fail fast when cache base is unset, removing implicit `data/timeseries` fallback
- Adjust cache base tests for new import-time behaviour

## Testing
- `pytest` *(fails: coverage under 80% and multiple test failures: google auth, news quota, scenario route, trading agent)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d5ec7ad48327baa61c188bf09f59