### PR TITLE
refactor backend startup config lookup

### DIFF
--- a/scripts/run-backend.ps1
+++ b/scripts/run-backend.ps1
@@ -151,11 +151,11 @@ if (-not $offline) {
 }
 
 # ───────────── env + defaults (PS 5.1) ────────
-$env:ALLOTMINT_ENV = Coalesce $cfg.app_env 'local'
+$env:ALLOTMINT_ENV = Get-ConfigValue $cfg @('server','app_env') 'local'
 $env:DATA_ROOT = Coalesce $env:DATA_ROOT (Coalesce $cfg.paths.data_root 'data')
-$port      = Coalesce $cfg.uvicorn_port $Port
-$logConfig = Coalesce $cfg.log_config   'logging.ini'
-$reloadRaw = Coalesce $cfg.reload       $true
+$port      = Get-ConfigValue $cfg @('server','uvicorn_port') $Port
+$logConfig = Get-ConfigValue $cfg @('paths','log_config') 'logging.ini'
+$reloadRaw = Get-ConfigValue $cfg @('server','reload') $true
 $reload    = [bool]$reloadRaw
 
 if ($env:DATA_BUCKET) {


### PR DESCRIPTION
## Summary
- use `Get-ConfigValue` for server/app settings in run-backend.ps1

## Testing
- `pytest` *(fails: 9 failed, 386 passed, 5 skipped, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d5fc19848327913fe674dc0fe1f3