### PR TITLE
Fix Google token auth path resolution and error codes

### DIFF
--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -48,7 +48,10 @@ def test_google_token_flow(monkeypatch, tmp_path):
 
     # exchange google token for JWT
     resp = client.post("/token/google", json={"token": "abc"})
-    token = resp.json()["access_token"]
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["token_type"] == "bearer"
+    token = data["access_token"]
     client.headers.update({"Authorization": f"Bearer {token}"})
     resp = client.post("/timeseries/admin/ABC/L/refetch")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- correctly resolve accounts root when determining allowed emails
- distinguish invalid tokens from unauthorized emails in Google login
- assert Google token exchange returns bearer token JSON

## Testing
- `pytest --no-cov backend/tests/test_auth_module.py tests/test_google_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1d5e4a13483278c609d6ead231619