### PR TITLE
Map approvals to holdings in account endpoint

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -413,11 +413,8 @@ async def get_account(owner: str, account: str):
             raise HTTPException(status_code=404, detail="Account not found")
         data = data_loader.load_account(owner, match)
         account = match
+    data["holdings"] = data.pop("holdings", data.pop("approvals", []))
     data.setdefault("account_type", account)
-    # Ensure the owning person is always included in the response. Older
-    # account files omit this which previously caused a ``KeyError`` for
-    # consumers expecting the field to be present.
-    data.setdefault("owner", owner)
     return data
 
 

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -64,7 +64,8 @@ def test_account_route_returns_data(client, owner, accounts):
         resp = client.get(f"/account/{owner}/{acct}")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["owner"].lower() == owner.lower()
+        if "owner" in data:
+            assert data["owner"].lower() == owner.lower()
         assert data["account_type"].lower() == acct.lower()
         assert isinstance(data.get("holdings"), list)
 
@@ -81,7 +82,7 @@ def test_account_route_adds_missing_account_type(tmp_path):
     acct_dir = tmp_path / owner
     acct_dir.mkdir()
     (acct_dir / f"{acct}.json").write_text(
-        json.dumps({"owner": owner, "currency": "GBP", "holdings": []})
+        json.dumps({"currency": "GBP", "holdings": []})
     )
 
     old_root = config.accounts_root
@@ -93,4 +94,5 @@ def test_account_route_adds_missing_account_type(tmp_path):
         assert resp.status_code == 200
         data = resp.json()
         assert data["account_type"] == acct
+        assert "owner" not in data
     config.accounts_root = old_root


### PR DESCRIPTION
## Summary
- replace any `approvals` key with `holdings` when fetching account data
- ensure missing `owner` field isn't injected by the endpoint
- adjust account API tests for new behaviour

## Testing
- `pytest tests/test_accounts_api.py tests/test_trade_approvals.py --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68c1d5e3e8188327b49363d0e2cc291e