### PR TITLE
fix: remove redundant instrument detail fetch

### DIFF
--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -6,15 +6,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import InstrumentResearch from "./InstrumentResearch";
-import type { ScreenerResult, NewsItem, QuoteRow, InstrumentDetail } from "../types";
+import type { ScreenerResult, NewsItem, QuoteRow } from "../types";
 import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
 import * as api from "../api";
 import { configContext, type ConfigContextValue } from "../ConfigContext";
-
-const mockFetchInstrumentDetailWithRetry = vi.spyOn(
-  api,
-  "fetchInstrumentDetailWithRetry",
-);
 const mockGetScreener = vi.spyOn(api, "getScreener");
 const mockGetQuotes = vi.spyOn(api, "getQuotes");
 const mockGetNews = vi.spyOn(api, "getNews");
@@ -87,16 +82,10 @@ describe("InstrumentResearch page", () => {
   });
 
   it("shows loading indicators while fetching data", async () => {
-    let detailResolve: (v: InstrumentDetail) => void;
     let screenerResolve: (v: ScreenerResult[]) => void;
     let quotesResolve: (v: QuoteRow[]) => void;
     let newsResolve: (v: NewsItem[]) => void;
 
-    mockFetchInstrumentDetailWithRetry.mockReturnValueOnce(
-      new Promise((res) => {
-        detailResolve = res;
-      }) as Promise<InstrumentDetail>,
-    );
     mockGetScreener.mockReturnValueOnce(
       new Promise((res) => {
         screenerResolve = res;
@@ -153,10 +142,6 @@ describe("InstrumentResearch page", () => {
       error: new Error("detail fail"),
     } as any);
 
-    mockFetchInstrumentDetailWithRetry.mockRejectedValueOnce(
-      new Error("detail fail"),
-    );
-
     mockGetScreener.mockRejectedValueOnce(new Error("screener fail"));
     mockGetQuotes.mockRejectedValueOnce(new Error("quotes fail"));
     mockGetNews.mockRejectedValueOnce(new Error("news fail"));
@@ -170,10 +155,6 @@ describe("InstrumentResearch page", () => {
   });
 
   it("shows a message when no news is available", async () => {
-    mockFetchInstrumentDetailWithRetry.mockResolvedValue({
-      prices: null,
-      positions: [],
-    } as InstrumentDetail);
     mockGetScreener.mockResolvedValue([]);
     mockGetQuotes.mockResolvedValue([]);
     mockGetNews.mockResolvedValue([]);
@@ -184,10 +165,6 @@ describe("InstrumentResearch page", () => {
   });
 
   it("navigates to screener when link clicked", async () => {
-    mockFetchInstrumentDetailWithRetry.mockResolvedValue({
-      prices: null,
-      positions: [],
-    } as InstrumentDetail);
     mockGetScreener.mockResolvedValue([]);
     mockGetQuotes.mockResolvedValue([]);
     mockGetNews.mockResolvedValue([]);
@@ -198,10 +175,6 @@ describe("InstrumentResearch page", () => {
   });
 
   it("navigates to watchlist when link clicked", async () => {
-    mockFetchInstrumentDetailWithRetry.mockResolvedValue({
-      prices: null,
-      positions: [],
-    } as InstrumentDetail);
     mockGetScreener.mockResolvedValue([]);
     mockGetQuotes.mockResolvedValue([]);
     mockGetNews.mockResolvedValue([]);
@@ -225,9 +198,6 @@ describe("InstrumentResearch page", () => {
   });
 
   it("shows instrument name and additional metrics", async () => {
-    mockFetchInstrumentDetailWithRetry.mockResolvedValue(
-      { prices: null, positions: [] } as InstrumentDetail,
-    );
     mockGetScreener.mockResolvedValue([
       { rank: 1, ticker: "AAA", name: "Acme Corp" } as unknown as ScreenerResult,
     ]);
@@ -303,10 +273,6 @@ describe("InstrumentResearch page", () => {
   });
 
   it("skips state updates when unmounted", async () => {
-    mockFetchInstrumentDetailWithRetry.mockResolvedValue({
-      prices: null,
-      positions: [],
-    } as InstrumentDetail);
     mockGetScreener.mockResolvedValue([]);
     mockGetNews.mockResolvedValue([]);
 

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -3,9 +3,8 @@ import { useParams, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
 import { InstrumentHistoryChart } from "../components/InstrumentHistoryChart";
-import Menu from "../components/Menu";
-import { getInstrumentDetail, getScreener, getNews, getQuotes } from "../api";
-import type { ScreenerResult, InstrumentDetail, NewsItem, QuoteRow } from "../types";
+import { getScreener, getNews, getQuotes } from "../api";
+import type { ScreenerResult, NewsItem, QuoteRow } from "../types";
 import { largeNumber } from "../lib/money";
 import { useConfig } from "../ConfigContext";
 


### PR DESCRIPTION
## Summary
- drop unused InstrumentResearch detail fetch
- update InstrumentResearch tests for new hook usage

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68c1d67e7bd4832798cf77d9ab593790