### PR TITLE
Clarify logging configuration usage

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -2,7 +2,8 @@
 
 ## Logs
 
-- Backend uses Python's `logging` module. Configuration lives in `logging.ini`.
+- Backend uses Python's `logging` module. The main configuration lives in `backend/logging.ini`.
+- A minimal top-level `logging.ini` only overrides noisy third-party loggers such as `yfinance`.
 - When deployed on AWS Lambda, logs are available in CloudWatch log groups named `/aws/lambda/<FunctionName>`.
 - Local runs print logs to the console.
 

--- a/docs/TECHNICAL_SUPPORT.md
+++ b/docs/TECHNICAL_SUPPORT.md
@@ -17,6 +17,7 @@
 ## Log Locations
 - Backend logs are written to `backend.log` as configured in `backend/logging.ini`.
 - The `run_with_error_summary.py` helper records errors in `error_summary.log`.
+- A root-level `logging.ini` exists only to tune third-party loggers like `yfinance`.
 
 ## Escalation Contacts
 - **Primary**: engineering@allotmint.example.com

--- a/logging.ini
+++ b/logging.ini
@@ -1,4 +1,30 @@
+# Minimal logging configuration to override third-party loggers.
+# Primary logging configuration resides in backend/logging.ini.
+
+[loggers]
+keys=root,yfinance
+
+[handlers]
+keys=console
+
+[formatters]
+keys=simple
+
+[logger_root]
+level=WARNING
+handlers=console
+
 [logger_yfinance]
-level = WARNING
-qualname = yfinance
-handlers = console
+level=WARNING
+handlers=console
+qualname=yfinance
+propagate=0
+
+[handler_console]
+class=StreamHandler
+level=NOTSET
+formatter=simple
+args=(sys.stdout,)
+
+[formatter_simple]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s


### PR DESCRIPTION
## Summary
- Expand top-level `logging.ini` with standard sections to override `yfinance` logger
- Document that `backend/logging.ini` is the primary config and root file only tweaks third-party loggers

## Testing
- `pytest` *(fails: Required test coverage of 80% not reached. Total coverage: 79.72%; 6 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d959956483279053ec4b36ea1dc2