### PR TITLE
Return holdings only when present for account endpoint

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -413,7 +413,9 @@ async def get_account(owner: str, account: str):
             raise HTTPException(status_code=404, detail="Account not found")
         data = data_loader.load_account(owner, match)
         account = match
-    data["holdings"] = data.pop("holdings", data.pop("approvals", []))
+    holdings = data.pop("holdings", data.pop("approvals", None))
+    if holdings is not None:
+        data["holdings"] = holdings
     data.setdefault("account_type", account)
     return data
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -87,10 +87,12 @@ def test_portfolio_group(client, mock_group_portfolio):
 
 
 @patch("backend.common.data_loader.load_account", return_value={"account": "ISA"})
-def test_get_account(mock_load_account, client):
+def test_get_account_no_holdings(mock_load_account, client):
     response = client.get("/account/steve/ISA")
     assert response.status_code == 200
-    assert response.json() == {"account": "ISA", "account_type": "ISA"}
+    data = response.json()
+    assert data == {"account": "ISA", "account_type": "ISA"}
+    assert "holdings" not in data
 
 
 @patch(
@@ -100,7 +102,21 @@ def test_get_account(mock_load_account, client):
 def test_get_account_preserves_type(mock_load_account, client):
     response = client.get("/account/steve/ISA")
     assert response.status_code == 200
-    assert response.json() == {"account": "ISA", "account_type": "test"}
+    data = response.json()
+    assert data == {"account": "ISA", "account_type": "test"}
+    assert "holdings" not in data
+
+
+@patch(
+    "backend.common.data_loader.load_account",
+    return_value={"account": "ISA", "approvals": ["H"]},
+)
+def test_get_account_with_holdings(mock_load_account, client):
+    response = client.get("/account/steve/ISA")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"account": "ISA", "account_type": "ISA", "holdings": ["H"]}
+    assert "approvals" not in data
 
 
 @patch("backend.common.prices.refresh_prices", return_value={"updated": 5})


### PR DESCRIPTION
## Summary
- Return `holdings` from `/account/{owner}/{account}` only when data includes holdings or approvals
- Add tests for account endpoint covering both missing and present holdings

## Testing
- `pytest tests/test_main.py::test_get_account_no_holdings tests/test_main.py::test_get_account_with_holdings -q`
- `pytest -q` *(fails: google auth tests unauthorized, trading agent cache error)*

------
https://chatgpt.com/codex/tasks/task_e_68c1da04172883278c76eb15481281da