### PR TITLE
Handle drawdown ValueError

### DIFF
--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -338,7 +338,7 @@ def _alert_on_drawdown(threshold: float = DRAWDOWN_ALERT_THRESHOLD) -> None:
         owner = pf.get("owner")
         try:
             perf = compute_owner_performance(owner)
-        except FileNotFoundError:
+        except (FileNotFoundError, ValueError):
             continue
         max_dd = perf.get("max_drawdown")
         if max_dd is None or not (-1.0 <= max_dd <= 0.0):

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -457,3 +457,19 @@ def test_run_applies_risk_filters(monkeypatch):
     assert signals == []
 
 
+def test_alert_on_drawdown_handles_value_error(monkeypatch):
+    """Ensure ValueError in performance computation doesn't leak."""
+    monkeypatch.setattr(trading_agent, "list_portfolios", lambda: [{"owner": "alice"}])
+
+    def fake_perf(owner: str):
+        raise ValueError("cache gap")
+
+    monkeypatch.setattr(trading_agent, "compute_owner_performance", fake_perf)
+    alerts: list[str] = []
+    monkeypatch.setattr(trading_agent, "send_trade_alert", lambda msg: alerts.append(msg))
+
+    trading_agent._alert_on_drawdown()
+
+    assert alerts == []
+
+


### PR DESCRIPTION
## Summary
- ignore ValueError when computing portfolio drawdowns
- add test ensuring drawdown alert ignores cache gaps

## Testing
- `pytest tests/test_trading_agent.py::test_alert_on_drawdown_handles_value_error -q --cov-fail-under=0`
- `pytest -q` *(fails: tests/test_google_auth.py::test_google_token_flow, tests/test_google_auth.py::test_google_token_rejects_unallowed_email, tests/test_google_auth.py::test_google_token_rejects_when_no_accounts, tests/test_main.py::test_get_account, tests/test_main.py::test_get_account_preserves_type)*

------
https://chatgpt.com/codex/tasks/task_e_68c1da04da148327aa67b51769164aa3