### PR TITLE
fix: remove duplicate alertsettings case

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -124,8 +124,6 @@ export default function Menu({
         return '/alert-settings';
       case 'settings':
         return '/settings';
-      case 'alertsettings':
-        return '/alert-settings';
       case 'logs':
         return '/logs';
       case 'allocation':


### PR DESCRIPTION
## Summary
- remove duplicate `alertsettings` case from Menu pathFor

## Testing
- `npm test` (fails: Test timed out)
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68c1da1578b08327932681f2383ab686