### PR TITLE
Add models API route and test

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -47,6 +47,7 @@ from backend.routes.instrument_admin import router as instrument_admin_router
 from backend.routes.logs import router as logs_router
 from backend.routes.metrics import router as metrics_router
 from backend.routes.movers import router as movers_router
+from backend.routes.models import router as models_router
 from backend.routes.nudges import router as nudges_router
 from backend.routes.news import router as news_router
 from backend.routes.market import router as market_router
@@ -221,6 +222,7 @@ def create_app() -> FastAPI:
     app.include_router(news_router)
     app.include_router(market_router)
     app.include_router(movers_router)
+    app.include_router(models_router)
     app.include_router(user_config_router, dependencies=protected)
     app.include_router(approvals_router, dependencies=protected)
     app.include_router(events_router)

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -1,0 +1,20 @@
+"""Routes for listing available AI models."""
+
+from fastapi import APIRouter
+
+
+# Static list of supported model identifiers. In a real deployment this could
+# be sourced from configuration or an external registry.
+MODEL_NAMES = ["gpt-4o-mini"]
+
+
+router = APIRouter(prefix="/v1")
+
+
+@router.get("/models")
+def list_models() -> dict:
+    """Return the available model identifiers."""
+    return {
+        "data": [{"id": name, "object": "model"} for name in MODEL_NAMES]
+    }
+

--- a/backend/tests/test_models_route.py
+++ b/backend/tests/test_models_route.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes import models
+
+
+def test_models_route_returns_available_models():
+    app = FastAPI()
+    app.include_router(models.router)
+
+    with TestClient(app) as client:
+        resp = client.get("/v1/models")
+
+    assert resp.status_code == 200
+    expected = {
+        "data": [{"id": name, "object": "model"} for name in models.MODEL_NAMES]
+    }
+    assert resp.json() == expected
+


### PR DESCRIPTION
## Summary
- add `/v1/models` endpoint providing available model identifiers
- register models router with the application
- cover models endpoint with a basic test

## Testing
- `pytest backend/tests/test_models_route.py backend/tests/test_routers.py::test_all_routes_registered -q` *(fails: Required test coverage of 80% not reached)*
- `pytest backend/tests/test_models_route.py backend/tests/test_routers.py::test_all_routes_registered -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68c1dd9b5d0083278b5dd9b5ed7a557e