### PR TITLE
Allow CORS credentials

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -182,6 +182,7 @@ def create_app() -> FastAPI:
         allow_origins=cors_origins,
         allow_methods=cors_methods,
         allow_headers=cors_headers,
+        allow_credentials=True,
     )
 
     # ──────────────────────────── Routers ────────────────────────────


### PR DESCRIPTION
## Summary
- allow credentials in FastAPI CORS middleware

## Testing
- `make lint` *(fails: Import block is un-sorted or un-formatted)*
- `pytest` *(fails: tests/test_google_auth.py::test_google_token_flow - assert 401 == 200)*
- `black --check --config backend/pyproject.toml backend/app.py`
- `ruff check --config backend/pyproject.toml backend/app.py` *(fails: Import block is un-sorted or un-formatted)*
- `curl -sI -H "Origin: http://localhost:3000" http://localhost:8000/`

------
https://chatgpt.com/codex/tasks/task_e_68c1deb9e6088327bbb5a0a5b22ae598