### PR TITLE
fix: isolate google auth tests from mock

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,10 @@ os.environ.setdefault("TESTING", "1")
 os.environ.setdefault("DATA_ROOT", str(Path(__file__).resolve().parent.parent / "data"))
 
 from backend.config import config
+from backend import auth as auth_module
+from backend import app as app_module
+
+_real_verify_google_token = auth_module.verify_google_token
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -22,11 +26,31 @@ def enable_offline_mode():
 
 
 @pytest.fixture(autouse=True)
-def mock_google_verify(monkeypatch):
-    """Stub Google ID token verification for tests."""
+def mock_google_verify(monkeypatch, request):
+    """Stub Google ID token verification for tests.
+
+    Some tests exercise the real Google verification logic by patching the
+    low-level :func:`google.oauth2.id_token.verify_oauth2_token` function.
+    Those tests live in ``tests/test_google_auth.py`` and expect the
+    application's :func:`backend.auth.verify_google_token` helper to run
+    unmodified. The original autouse fixture always replaced this helper with a
+    stub, causing the Google-auth tests to receive a ``401`` response instead
+    of exercising the intended code path. To avoid this interference we skip
+    patching for tests defined in that module.
+    """
+
+    # ``request`` points at the currently executing test.  When the test file
+    # is ``test_google_auth.py`` we leave the real ``verify_google_token`` in
+    # place so that those tests can mock the lower level verification function.
+    # ``fspath`` is a py.path object representing the test file path.
+    fspath = getattr(request, "fspath", None)
+    if fspath and fspath.basename == "test_google_auth.py":
+        # Ensure the real function is restored even if a previous test patched it
+        monkeypatch.setattr(auth_module, "verify_google_token", _real_verify_google_token)
+        monkeypatch.setattr(app_module, "verify_google_token", _real_verify_google_token)
+        return
 
     from fastapi import HTTPException
-    from backend import auth
 
     def fake_verify(token: str):
         if token == "good":
@@ -35,7 +59,8 @@ def mock_google_verify(monkeypatch):
             raise HTTPException(status_code=403, detail="Unauthorized email")
         raise HTTPException(status_code=401, detail="Invalid token")
 
-    monkeypatch.setattr(auth, "verify_google_token", fake_verify)
+    monkeypatch.setattr(auth_module, "verify_google_token", fake_verify)
+    monkeypatch.setattr(app_module, "verify_google_token", fake_verify)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- avoid autouse google token mock when running google auth tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1dc88698483278d5585a127e3d6ae