### PR TITLE
Refactor Google token verification usage

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -26,8 +26,8 @@ from backend.auth import (
     authenticate_user,
     create_access_token,
     get_current_user,
-    verify_google_token,
 )
+import backend.auth as auth
 from backend.common.data_loader import resolve_paths
 from backend.common.portfolio_utils import (
     _load_snapshot,
@@ -263,7 +263,7 @@ def create_app() -> FastAPI:
         if not token:
             raise HTTPException(status_code=400, detail="Missing token")
         try:
-            email = verify_google_token(token)
+            email = auth.verify_google_token(token)
         except HTTPException as exc:
             logger.warning("Google token verification failed: %s", exc.detail)
             raise

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -413,9 +413,8 @@ async def get_account(owner: str, account: str):
             raise HTTPException(status_code=404, detail="Account not found")
         data = data_loader.load_account(owner, match)
         account = match
-    holdings = data.pop("holdings", data.pop("approvals", None))
-    if holdings is not None:
-        data["holdings"] = holdings
+    holdings = data.pop("holdings", data.pop("approvals", [])) or []
+    data["holdings"] = holdings
     data.setdefault("account_type", account)
     return data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,6 @@ def mock_google_verify(monkeypatch, request):
     if fspath and fspath.basename == "test_google_auth.py":
         # Ensure the real function is restored even if a previous test patched it
         monkeypatch.setattr(auth_module, "verify_google_token", _real_verify_google_token)
-        monkeypatch.setattr(app_module, "verify_google_token", _real_verify_google_token)
         return
 
     from fastapi import HTTPException
@@ -60,7 +59,6 @@ def mock_google_verify(monkeypatch, request):
         raise HTTPException(status_code=401, detail="Invalid token")
 
     monkeypatch.setattr(auth_module, "verify_google_token", fake_verify)
-    monkeypatch.setattr(app_module, "verify_google_token", fake_verify)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- import `backend.auth` module and call `auth.verify_google_token`
- ensure account endpoint always includes a holdings list
- adjust test fixture for simplified Google token patching

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1e25a97388327b977ae6ae6b9c250