### PR TITLE
Add tests for auto rebalance task

### DIFF
--- a/tests/test_auto_rebalance_task.py
+++ b/tests/test_auto_rebalance_task.py
@@ -1,0 +1,34 @@
+import logging
+from dataclasses import dataclass
+
+
+@dataclass
+class DummyGoal:
+    name: str
+    target_amount: float
+
+
+def test_lambda_handler_suggests_trades(monkeypatch, caplog):
+    goal = DummyGoal(name="vacation", target_amount=100.0)
+
+    def fake_load_all_goals():
+        return {"alice": [goal]}
+
+    def fake_suggest_trades(actual, target):
+        return [{"ticker": "goal", "action": "buy", "amount": 100.0}]
+
+    # Patch both original modules and the task module
+    monkeypatch.setattr("backend.common.goals.load_all_goals", fake_load_all_goals)
+    monkeypatch.setattr("backend.tasks.auto_rebalance.load_all_goals", fake_load_all_goals)
+    monkeypatch.setattr("backend.common.rebalance.suggest_trades", fake_suggest_trades)
+    monkeypatch.setattr("backend.tasks.auto_rebalance.suggest_trades", fake_suggest_trades)
+
+    import backend.tasks.auto_rebalance as auto
+
+    with caplog.at_level(logging.INFO):
+        result = auto.lambda_handler({}, None)
+
+    assert result == {"status": "ok"}
+    assert any(
+        "Suggested trades for alice/vacation" in rec.message for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- add coverage for auto rebalance lambda handler
- ensure logging occurs when trades are suggested

## Testing
- `pytest tests/test_auto_rebalance_task.py -q -o addopts="" --cov=backend.tasks.auto_rebalance --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_e_68c1e62347a48327b895c7e2e6d0c6c8