### PR TITLE
Add test for trading agent lambda handler invocation

### DIFF
--- a/tests/test_trading_agent_lambda.py
+++ b/tests/test_trading_agent_lambda.py
@@ -1,0 +1,16 @@
+import importlib
+
+
+def test_lambda_handler_calls_run_once(monkeypatch):
+    calls = []
+
+    def fake_run():
+        calls.append(True)
+
+    monkeypatch.setattr("backend.agent.trading_agent.run", fake_run)
+    module = importlib.reload(importlib.import_module("backend.lambda_api.trading_agent"))
+
+    result = module.lambda_handler({}, None)
+
+    assert len(calls) == 1
+    assert result == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add unit test verifying trading agent lambda handler calls `run` and returns status dict

## Testing
- `pytest tests/test_trading_agent_lambda.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c1e61feef083278d94ad4aaeea73a1