### PR TITLE
test(lambda): add handler test

### DIFF
--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,0 +1,47 @@
+import importlib
+
+from fastapi import FastAPI
+from mangum import Mangum
+
+
+def test_lambda_handler(monkeypatch):
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root():
+        return {"hello": "world"}
+
+    def mock_create_app():
+        return app
+
+    monkeypatch.setattr("backend.app.create_app", mock_create_app)
+
+    module = importlib.reload(importlib.import_module("backend.lambda_api.handler"))
+
+    lambda_handler = module.lambda_handler
+    assert isinstance(lambda_handler, Mangum)
+    assert callable(lambda_handler)
+
+    event = {
+        "version": "2.0",
+        "routeKey": "$default",
+        "rawPath": "/",
+        "rawQueryString": "",
+        "headers": {},
+        "requestContext": {
+            "http": {
+                "method": "GET",
+                "path": "/",
+                "protocol": "HTTP/1.1",
+                "sourceIp": "test",
+                "userAgent": "test",
+            }
+        },
+        "isBase64Encoded": False,
+    }
+
+    response = lambda_handler(event, {})
+    assert response["statusCode"] == 200
+    assert response["headers"]["content-type"] == "application/json"
+    assert response["body"] == "{\"hello\":\"world\"}"
+    assert response["isBase64Encoded"] is False


### PR DESCRIPTION
## Summary
- test lambda handler wraps FastAPI app and returns API Gateway response

## Testing
- `pytest tests/test_lambda_handler.py --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1e61bb6e48327b16443bf9fb2aa88