### PR TITLE
fix: initialize event loop for lambda handler

### DIFF
--- a/backend/lambda_api/handler.py
+++ b/backend/lambda_api/handler.py
@@ -3,8 +3,28 @@ AWS Lambda entry-point (Python 3.12 runtime or container).
 Handler: backend.lambda_api.handler.lambda_handler
 """
 
+import asyncio
+
 from mangum import Mangum
 
 from backend.app import create_app
 
-lambda_handler = Mangum(create_app())
+
+def _create_handler() -> Mangum:
+    """Create the Mangum handler ensuring an event loop exists.
+
+    Mangum expects an event loop to be available. On some platforms
+    (e.g. Windows) ``asyncio.get_event_loop()`` may raise a ``RuntimeError``
+    when no loop has been set. The tests run in such an environment so we
+    create and set a new loop if needed before instantiating ``Mangum``.
+    """
+
+    try:  # pragma: no cover - the exception path is platform specific
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+    return Mangum(create_app())
+
+
+lambda_handler = _create_handler()


### PR DESCRIPTION
## Summary
- ensure an asyncio event loop is available before creating Mangum

## Testing
- `PYTEST_ADDOPTS="--no-cov" pytest tests/test_lambda_handler.py::test_lambda_handler -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1eba3b1d88327bc7c97c5bec72453