### PR TITLE
feat(frontend): add smoke test diagnostics page

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,6 +15,16 @@ The backend API must be running and the `VITE_ALLOTMINT_API_BASE` environment va
 - `npm test` – execute the test suite with Vitest and Testing Library.
   Test files should be named `*.test.ts`, `*.test.tsx`, or `*.test.js` to be picked up.
 
+### Smoke test page
+
+For manual diagnostics you can expose a smoke test route that pings key API
+endpoints. Start the dev server with the `VITE_SMOKE_TEST` flag to enable the
+page at `/smoke-test`:
+
+```bash
+VITE_SMOKE_TEST=1 npm run dev
+```
+
 ## Routing
 
 The app opts into upcoming React Router v7 behavior by enabling the

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -30,6 +30,9 @@ const Goals = lazy(() => import('./pages/Goals'))
 const PerformanceDiagnostics = lazy(() => import('./pages/PerformanceDiagnostics'))
 const ReturnComparison = lazy(() => import('./pages/ReturnComparison'))
 const AlertSettings = lazy(() => import('./pages/AlertSettings'))
+const SmokeTest = import.meta.env.VITE_SMOKE_TEST
+  ? lazy(() => import('./pages/SmokeTest'))
+  : null
 
 export function Root() {
   const [ready, setReady] = useState(false)
@@ -78,6 +81,9 @@ export function Root() {
         <Route path="/alerts" element={<Alerts />} />
         <Route path="/alert-settings" element={<AlertSettings />} />
         <Route path="/goals" element={<Goals />} />
+        {import.meta.env.VITE_SMOKE_TEST && SmokeTest && (
+          <Route path="/smoke-test" element={<SmokeTest />} />
+        )}
         <Route path="/performance/:owner/diagnostics" element={<PerformanceDiagnostics />} />
         <Route path="/returns/compare" element={<ReturnComparison />} />
         <Route path="/*" element={<App onLogout={logout} />} />

--- a/frontend/src/pages/SmokeTest.tsx
+++ b/frontend/src/pages/SmokeTest.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { API_BASE, fetchJson } from '../api';
+
+const endpoints = ['/health', '/owners', '/groups'];
+
+interface Result {
+  path: string;
+  ok: boolean;
+  status?: number;
+}
+
+export default function SmokeTest() {
+  const [results, setResults] = useState<Result[]>([]);
+
+  useEffect(() => {
+    const run = async () => {
+      const res = await Promise.all(
+        endpoints.map(async (path) => {
+          try {
+            await fetchJson(`${API_BASE}${path}`);
+            return { path, ok: true, status: 200 };
+          } catch (err: any) {
+            return { path, ok: false, status: err?.status };
+          }
+        })
+      );
+      setResults(res);
+    };
+    run();
+  }, []);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Smoke test</h1>
+      <ul>
+        {results.map((r) => (
+          <li key={r.path} style={{ color: r.ok ? 'green' : 'red' }}>
+            {r.path}: {r.ok ? 'ok' : 'failed'}{' '}
+            {r.status !== undefined && `(${r.status})`}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SmokeTest` page that hits a set of API endpoints and reports success or failure
- gate new `/smoke-test` route behind `VITE_SMOKE_TEST` build flag
- document how to enable the diagnostics page in the frontend README

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb3290d0832795b7a41e9633b06c