### PR TITLE
Add tests for transaction loading and report compilation

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,65 @@
+import json
+from datetime import date
+
+import pytest
+
+import backend.reports as reports
+
+
+def test_load_transactions_handles_malformed_json(tmp_path, monkeypatch, caplog):
+    owner = "alice"
+    owner_dir = tmp_path / owner
+    owner_dir.mkdir()
+
+    good = owner_dir / "good_transactions.json"
+    good.write_text(json.dumps({"transactions": [{"id": 1}]}))
+
+    bad = owner_dir / "bad_transactions.json"
+    bad.write_text("{not json")
+
+    monkeypatch.setattr(reports, "_transaction_roots", lambda: [str(tmp_path)])
+    monkeypatch.setattr(reports.config, "app_env", "local")
+
+    with caplog.at_level("WARNING"):
+        records = reports._load_transactions(owner)
+
+    assert records == [{"id": 1}]
+    assert "failed to read" in caplog.text
+
+
+def test_compile_report_filters_and_totals(monkeypatch):
+    txs = [
+        {"date": "2024-01-01", "type": "SELL", "amount_minor": 1000},
+        {"date": "2024-01-02", "type": "SELL", "amount_minor": 2000},
+        {"date": "2024-01-03", "type": "DIVIDEND", "amount_minor": 500},
+        {"date": "2024-01-04", "type": "INTEREST", "amount_minor": 300},
+    ]
+
+    monkeypatch.setattr(reports, "_load_transactions", lambda owner: txs)
+    performance = {
+        "history": [
+            {"date": "2024-01-01", "cumulative_return": 0.1},
+            {"date": "2024-01-02", "cumulative_return": 0.2},
+            {"date": "2024-01-03", "cumulative_return": 0.3},
+            {"date": "2024-01-04", "cumulative_return": 0.4},
+        ],
+        "max_drawdown": -0.1,
+    }
+    monkeypatch.setattr("backend.common.portfolio_utils.compute_owner_performance", lambda owner: performance)
+
+    start = date(2024, 1, 2)
+    end = date(2024, 1, 3)
+    data = reports.compile_report("alice", start=start, end=end)
+
+    assert data.realized_gains_gbp == 20.0
+    assert data.income_gbp == 5.0
+    assert data.cumulative_return == 0.3
+    assert data.max_drawdown == -0.1
+
+
+def test_load_transactions_requires_data_bucket(monkeypatch):
+    monkeypatch.setattr(reports.config, "app_env", "aws")
+    monkeypatch.delenv("DATA_BUCKET", raising=False)
+
+    with pytest.raises(RuntimeError, match="DATA_BUCKET environment variable is required in AWS"):
+        reports._load_transactions("alice")


### PR DESCRIPTION
## Summary
- add tests covering `_load_transactions` handling of malformed data
- ensure `compile_report` filters by date and computes totals
- verify AWS environment requires `DATA_BUCKET`

## Testing
- `ruff check --config backend/pyproject.toml tests/test_reports.py`
- `black --check --config backend/pyproject.toml tests/test_reports.py`
- `pytest --no-cov tests/test_reports.py tests/test_reports_pdf.py`
- `pytest` *(fails: Required test coverage of 80% not reached. Total coverage: 65.98%)*


------
https://chatgpt.com/codex/tasks/task_e_68c1ef269470832786f8bae44d8d5848