### PR TITLE
Expose birth date in pension forecast

### DIFF
--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from backend.common.data_loader import load_person_meta
 from backend.common.pension import (
@@ -12,6 +12,7 @@ router = APIRouter(tags=["pension"])
 
 @router.get("/pension/forecast")
 def pension_forecast(
+    request: Request,
     owner: str = Query(..., description="Portfolio owner"),
     death_age: int = Query(..., ge=0),
     state_pension_annual: float | None = Query(None, ge=0),
@@ -21,7 +22,7 @@ def pension_forecast(
     investment_growth_pct: float = Query(5.0),
     desired_income_annual: float | None = Query(None, ge=0),
 ):
-    meta = load_person_meta(owner)
+    meta = load_person_meta(owner, request.app.state.accounts_root)
     dob = meta.get("dob")
     current_age = _age_from_dob(dob)
     if current_age is None:
@@ -56,5 +57,11 @@ def pension_forecast(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    result.update({"retirement_age": retirement_age, "current_age": current_age})
+    result.update(
+        {
+            "retirement_age": retirement_age,
+            "current_age": current_age,
+            "dob": dob,
+        }
+    )
     return result

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1044,6 +1044,7 @@ export const getPensionForecast = ({
     projected_pot_gbp: number;
     current_age: number;
     retirement_age: number;
+    dob: string;
   }>(`${API_BASE}/pension/forecast?${params.toString()}`);
 };
 

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -163,6 +163,7 @@
   },
   "pensionForecast": {
     "currentAge": "Aktuelles Alter: {{age}}",
+    "birthDate": "Geburtsdatum: {{dob}}",
     "retirementAge": "Renteneintrittsalter: {{age}}"
   },
   "group": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -165,6 +165,7 @@
   },
   "pensionForecast": {
     "currentAge": "Current age: {{age}}",
+    "birthDate": "Birth date: {{dob}}",
     "retirementAge": "Retirement age: {{age}}"
   },
   "group": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -163,6 +163,7 @@
   },
   "pensionForecast": {
     "currentAge": "Edad actual: {{age}}",
+    "birthDate": "Fecha de nacimiento: {{dob}}",
     "retirementAge": "Edad de jubilación: {{age}}"
   },
   "group": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -163,6 +163,7 @@
   },
   "pensionForecast": {
     "currentAge": "Âge actuel : {{age}}",
+    "birthDate": "Date de naissance : {{dob}}",
     "retirementAge": "Âge de retraite : {{age}}"
   },
   "group": {

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -163,6 +163,7 @@
   },
   "pensionForecast": {
     "currentAge": "Età attuale: {{age}}",
+    "birthDate": "Data di nascita: {{dob}}",
     "retirementAge": "Età pensionistica: {{age}}"
   },
   "group": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -163,6 +163,7 @@
   },
   "pensionForecast": {
     "currentAge": "Idade atual: {{age}}",
+    "birthDate": "Data de nascimento: {{dob}}",
     "retirementAge": "Idade de aposentadoria: {{age}}"
   },
   "group": {

--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -21,6 +21,7 @@ describe("PensionForecast page", () => {
       projected_pot_gbp: 0,
       current_age: 30,
       retirement_age: 65,
+      dob: "1990-01-01",
     });
 
     const { default: PensionForecast } = await import("./PensionForecast");
@@ -41,6 +42,7 @@ describe("PensionForecast page", () => {
       projected_pot_gbp: 0,
       current_age: 30,
       retirement_age: 65,
+      dob: "1990-01-01",
     });
 
     const { default: PensionForecast } = await import("./PensionForecast");
@@ -58,6 +60,7 @@ describe("PensionForecast page", () => {
         expect.objectContaining({ owner: "beth" }),
       ),
     );
+    await screen.findByText(/birth date: 1990-01-01/i);
   });
 });
 

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -23,6 +23,7 @@ export default function PensionForecast() {
   const [projectedPot, setProjectedPot] = useState<number | null>(null);
   const [currentAge, setCurrentAge] = useState<number | null>(null);
   const [retirementAge, setRetirementAge] = useState<number | null>(null);
+  const [dob, setDob] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const { t } = useTranslation();
 
@@ -57,6 +58,7 @@ export default function PensionForecast() {
       setProjectedPot(res.projected_pot_gbp);
       setCurrentAge(res.current_age);
       setRetirementAge(res.retirement_age);
+      setDob(res.dob || null);
       setErr(null);
     } catch (ex: any) {
       setErr(String(ex));
@@ -107,8 +109,11 @@ export default function PensionForecast() {
         </button>
       </form>
       {err && <p className="text-red-500">{err}</p>}
-      {currentAge !== null && (
-        <p className="mb-2">{t("pensionForecast.currentAge", { age: currentAge })}</p>
+      {currentAge !== null && dob && (
+        <p className="mb-2">
+          {t("pensionForecast.currentAge", { age: currentAge })} (
+          {t("pensionForecast.birthDate", { dob })})
+        </p>
       )}
       {retirementAge !== null && (
         <p className="mb-2">{t("pensionForecast.retirementAge", { age: retirementAge })}</p>

--- a/tests/test_pension_route.py
+++ b/tests/test_pension_route.py
@@ -7,7 +7,7 @@ from backend.common.pension import state_pension_age_uk
 def test_pension_route_uses_owner_metadata(monkeypatch):
     captured_owner = []
 
-    def fake_meta(owner: str):
+    def fake_meta(owner: str, root=None):  # pragma: no cover - signature match
         captured_owner.append(owner)
         return {"dob": "1980-01-01"}
 
@@ -29,11 +29,12 @@ def test_pension_route_uses_owner_metadata(monkeypatch):
     body = resp.json()
     assert body["retirement_age"] == expected_age
     assert isinstance(body["current_age"], float)
+    assert body["dob"] == "1980-01-01"
 
 
 def test_pension_route_missing_dob(monkeypatch):
     monkeypatch.setattr(
-        "backend.routes.pension.load_person_meta", lambda owner: {}
+        "backend.routes.pension.load_person_meta", lambda owner, root=None: {}
     )
     app = create_app()
     with TestClient(app) as client:
@@ -43,7 +44,7 @@ def test_pension_route_missing_dob(monkeypatch):
 
 def test_pension_route_invalid_dob(monkeypatch):
     monkeypatch.setattr(
-        "backend.routes.pension.load_person_meta", lambda owner: {"dob": "bad"}
+        "backend.routes.pension.load_person_meta", lambda owner, root=None: {"dob": "bad"}
     )
     app = create_app()
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary
- include `dob` in `/pension/forecast` response and return it to clients
- show birth date alongside current age in pension forecast page
- localize birth date label in all locales

## Testing
- `pytest tests/test_pension_route.py -q --no-cov`
- `npm test -- --run src/pages/PensionForecast.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c1f5689a4483278bfd65e57b1f7b27