### PR TITLE
feat: add investment growth option to pension forecast

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1021,11 +1021,12 @@ export const getPensionForecast = ({
   statePensionAnnual?: number;
   contributionAnnual?: number;
   desiredIncomeAnnual?: number;
-  investmentGrowthPct?: number;
+  investmentGrowthPct: number;
 }) => {
   const params = new URLSearchParams({
     owner,
     death_age: String(deathAge),
+    investment_growth_pct: String(investmentGrowthPct),
   });
   if (statePensionAnnual !== undefined) {
     params.set("state_pension_annual", String(statePensionAnnual));
@@ -1035,9 +1036,6 @@ export const getPensionForecast = ({
   }
   if (desiredIncomeAnnual !== undefined) {
     params.set("desired_income_annual", String(desiredIncomeAnnual));
-  }
-  if (investmentGrowthPct !== undefined) {
-    params.set("investment_growth_pct", String(investmentGrowthPct));
   }
   return fetchJson<{
     forecast: { age: number; income: number }[];

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Aktuelles Alter: {{age}}",
-    "retirementAge": "Renteneintrittsalter: {{age}}"
+    "retirementAge": "Renteneintrittsalter: {{age}}",
+    "growthAssumption": "Anlagewachstum (%/Jahr):"
   },
   "group": {
     "select": "Wählen Sie eine Gruppe."

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -165,7 +165,8 @@
   },
   "pensionForecast": {
     "currentAge": "Current age: {{age}}",
-    "retirementAge": "Retirement age: {{age}}"
+    "retirementAge": "Retirement age: {{age}}",
+    "growthAssumption": "Investment growth (%/yr):"
   },
   "group": {
     "select": "Select a group."

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Edad actual: {{age}}",
-    "retirementAge": "Edad de jubilación: {{age}}"
+    "retirementAge": "Edad de jubilación: {{age}}",
+    "growthAssumption": "Crecimiento de la inversión (%/año):"
   },
   "group": {
     "select": "Seleccione un grupo."

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Âge actuel : {{age}}",
-    "retirementAge": "Âge de retraite : {{age}}"
+    "retirementAge": "Âge de retraite : {{age}}",
+    "growthAssumption": "Croissance de l'investissement (%/an):"
   },
   "group": {
     "select": "Sélectionnez un groupe."

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Età attuale: {{age}}",
-    "retirementAge": "Età pensionistica: {{age}}"
+    "retirementAge": "Età pensionistica: {{age}}",
+    "growthAssumption": "Crescita dell'investimento (%/anno):"
   },
   "group": {
     "select": "Seleziona un gruppo."

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Idade atual: {{age}}",
-    "retirementAge": "Idade de aposentadoria: {{age}}"
+    "retirementAge": "Idade de aposentadoria: {{age}}",
+    "growthAssumption": "Crescimento do investimento (%/ano):"
   },
   "group": {
     "select": "Selecione um grupo."

--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -55,7 +55,34 @@ describe("PensionForecast page", () => {
 
     await vi.waitFor(() =>
       expect(mockGetPensionForecast).toHaveBeenCalledWith(
-        expect.objectContaining({ owner: "beth" }),
+        expect.objectContaining({ owner: "beth", investmentGrowthPct: 5 }),
+      ),
+    );
+  });
+
+  it("submits chosen growth assumption", async () => {
+    mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
+    mockGetPensionForecast.mockResolvedValue({
+      forecast: [],
+      projected_pot_gbp: 0,
+      current_age: 30,
+      retirement_age: 65,
+    });
+
+    const { default: PensionForecast } = await import("./PensionForecast");
+
+    render(<PensionForecast />);
+
+    await screen.findByLabelText(/owner/i);
+    const growth = screen.getByLabelText(/growth/i);
+    fireEvent.change(growth, { target: { value: "7" } });
+
+    const btn = screen.getByRole("button", { name: /forecast/i });
+    fireEvent.click(btn);
+
+    await vi.waitFor(() =>
+      expect(mockGetPensionForecast).toHaveBeenCalledWith(
+        expect.objectContaining({ investmentGrowthPct: 7 }),
       ),
     );
   });

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -19,6 +19,7 @@ export default function PensionForecast() {
   const [statePension, setStatePension] = useState<string>("");
   const [contribution, setContribution] = useState<string>("");
   const [desiredIncome, setDesiredIncome] = useState<string>("");
+  const [investmentGrowthPct, setInvestmentGrowthPct] = useState(5);
   const [data, setData] = useState<{ age: number; income: number }[]>([]);
   const [projectedPot, setProjectedPot] = useState<number | null>(null);
   const [currentAge, setCurrentAge] = useState<number | null>(null);
@@ -52,6 +53,7 @@ export default function PensionForecast() {
         desiredIncomeAnnual: desiredIncome
           ? parseFloat(desiredIncome)
           : undefined,
+        investmentGrowthPct,
       });
       setData(res.forecast);
       setProjectedPot(res.projected_pot_gbp);
@@ -101,6 +103,20 @@ export default function PensionForecast() {
             value={desiredIncome}
             onChange={(e) => setDesiredIncome(e.target.value)}
           />
+        </div>
+        <div>
+          <label className="mr-2" htmlFor="growthPct">
+            {t("pensionForecast.growthAssumption")}
+          </label>
+          <select
+            id="growthPct"
+            value={investmentGrowthPct}
+            onChange={(e) => setInvestmentGrowthPct(Number(e.target.value))}
+          >
+            <option value={3}>3%</option>
+            <option value={5}>5%</option>
+            <option value={7}>7%</option>
+          </select>
         </div>
         <button type="submit" className="mt-2 rounded bg-blue-500 px-4 py-2 text-white">
           Forecast


### PR DESCRIPTION
## Summary
- add investment growth percentage selector to pension forecast page
- forward selected growth assumption to pension forecast API
- localize growth assumption label across locales and test parameter wiring

## Testing
- `npm test` *(fails: Test Files  3 failed | 53 passed (56) – Tests 22 failed | 179 passed | 1 skipped (202))*


------
https://chatgpt.com/codex/tasks/task_e_68c1f0d18fa483279a58f295c11d9ac8