### PR TITLE
Expose SIPP pot in pension forecast

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1042,6 +1042,7 @@ export const getPensionForecast = ({
   return fetchJson<{
     forecast: { age: number; income: number }[];
     projected_pot_gbp: number;
+    pension_pot_gbp: number;
     current_age: number;
     retirement_age: number;
   }>(`${API_BASE}/pension/forecast?${params.toString()}`);

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Aktuelles Alter: {{age}}",
-    "retirementAge": "Renteneintrittsalter: {{age}}"
+    "retirementAge": "Renteneintrittsalter: {{age}}",
+    "pensionPot": "Pensionsvermögen"
   },
   "group": {
     "select": "Wählen Sie eine Gruppe."

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -165,7 +165,8 @@
   },
   "pensionForecast": {
     "currentAge": "Current age: {{age}}",
-    "retirementAge": "Retirement age: {{age}}"
+    "retirementAge": "Retirement age: {{age}}",
+    "pensionPot": "Pension pot"
   },
   "group": {
     "select": "Select a group."

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Edad actual: {{age}}",
-    "retirementAge": "Edad de jubilación: {{age}}"
+    "retirementAge": "Edad de jubilación: {{age}}",
+    "pensionPot": "Fondo de pensión"
   },
   "group": {
     "select": "Seleccione un grupo."

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Âge actuel : {{age}}",
-    "retirementAge": "Âge de retraite : {{age}}"
+    "retirementAge": "Âge de retraite : {{age}}",
+    "pensionPot": "Épargne retraite"
   },
   "group": {
     "select": "Sélectionnez un groupe."

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Età attuale: {{age}}",
-    "retirementAge": "Età pensionistica: {{age}}"
+    "retirementAge": "Età pensionistica: {{age}}",
+    "pensionPot": "Fondo pensione"
   },
   "group": {
     "select": "Seleziona un gruppo."

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -163,7 +163,8 @@
   },
   "pensionForecast": {
     "currentAge": "Idade atual: {{age}}",
-    "retirementAge": "Idade de aposentadoria: {{age}}"
+    "retirementAge": "Idade de aposentadoria: {{age}}",
+    "pensionPot": "Fundo de pensão"
   },
   "group": {
     "select": "Selecione um grupo."

--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -19,6 +19,7 @@ describe("PensionForecast page", () => {
     mockGetPensionForecast.mockResolvedValue({
       forecast: [],
       projected_pot_gbp: 0,
+      pension_pot_gbp: 0,
       current_age: 30,
       retirement_age: 65,
     });
@@ -39,6 +40,7 @@ describe("PensionForecast page", () => {
     mockGetPensionForecast.mockResolvedValue({
       forecast: [],
       projected_pot_gbp: 0,
+      pension_pot_gbp: 0,
       current_age: 30,
       retirement_age: 65,
     });
@@ -58,6 +60,27 @@ describe("PensionForecast page", () => {
         expect.objectContaining({ owner: "beth" }),
       ),
     );
+  });
+
+  it("shows aggregated SIPP pot", async () => {
+    mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
+    mockGetPensionForecast.mockResolvedValue({
+      forecast: [],
+      projected_pot_gbp: 1000,
+      pension_pot_gbp: 500,
+      current_age: 30,
+      retirement_age: 65,
+    });
+
+    const { default: PensionForecast } = await import("./PensionForecast");
+
+    render(<PensionForecast />);
+
+    const btn = await screen.findByRole("button", { name: /forecast/i });
+    fireEvent.click(btn);
+
+    const pot = await screen.findByText(/pension pot/i);
+    expect(pot).toHaveTextContent("£500");
   });
 });
 

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -21,6 +21,7 @@ export default function PensionForecast() {
   const [desiredIncome, setDesiredIncome] = useState<string>("");
   const [data, setData] = useState<{ age: number; income: number }[]>([]);
   const [projectedPot, setProjectedPot] = useState<number | null>(null);
+  const [pensionPot, setPensionPot] = useState<number | null>(null);
   const [currentAge, setCurrentAge] = useState<number | null>(null);
   const [retirementAge, setRetirementAge] = useState<number | null>(null);
   const [err, setErr] = useState<string | null>(null);
@@ -55,6 +56,7 @@ export default function PensionForecast() {
       });
       setData(res.forecast);
       setProjectedPot(res.projected_pot_gbp);
+      setPensionPot(res.pension_pot_gbp);
       setCurrentAge(res.current_age);
       setRetirementAge(res.retirement_age);
       setErr(null);
@@ -112,6 +114,11 @@ export default function PensionForecast() {
       )}
       {retirementAge !== null && (
         <p className="mb-2">{t("pensionForecast.retirementAge", { age: retirementAge })}</p>
+      )}
+      {pensionPot !== null && (
+        <p className="mb-2">
+          {t("pensionForecast.pensionPot")}: £{pensionPot.toFixed(2)}
+        </p>
       )}
       {projectedPot !== null && retirementAge !== null && (
         <p className="mb-2">

--- a/tests/test_pension_route.py
+++ b/tests/test_pension_route.py
@@ -19,6 +19,16 @@ def test_pension_route_uses_owner_metadata(monkeypatch):
 
     monkeypatch.setattr("backend.routes.pension.load_person_meta", fake_meta)
     monkeypatch.setattr("backend.routes.pension.forecast_pension", fake_forecast)
+    monkeypatch.setattr(
+        "backend.routes.pension.build_owner_portfolio",
+        lambda owner: {
+            "accounts": [
+                {"account_type": "sipp", "value_estimate_gbp": 100.0},
+                {"account_type": "isa", "value_estimate_gbp": 50.0},
+                {"account_type": "SIPP", "value_estimate_gbp": 200.0},
+            ]
+        },
+    )
     app = create_app()
     with TestClient(app) as client:
         resp = client.get("/pension/forecast", params={"owner": "alice", "death_age": 90})
@@ -29,6 +39,7 @@ def test_pension_route_uses_owner_metadata(monkeypatch):
     body = resp.json()
     assert body["retirement_age"] == expected_age
     assert isinstance(body["current_age"], float)
+    assert body["pension_pot_gbp"] == 300.0
 
 
 def test_pension_route_missing_dob(monkeypatch):


### PR DESCRIPTION
## Summary
- include SIPP account values in pension forecast API response
- show current pension pot in PensionForecast page and API types
- localise new "Pension pot" label and test coverage

## Testing
- `pytest --no-cov tests/test_pension_route.py::test_pension_route_uses_owner_metadata -q`
- `npm test --prefix frontend -- --run src/pages/PensionForecast.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c1f5b17b748327921e19b874b2fc0f