### PR TITLE
Add price utility tests for snapshot and caching

### DIFF
--- a/tests/common/test_prices.py
+++ b/tests/common/test_prices.py
@@ -7,6 +7,42 @@ import pytest
 from backend.common import prices
 
 
+def test_close_on_returns_price(monkeypatch):
+    df = pd.DataFrame({"close": [123.0]})
+    monkeypatch.setattr(prices, "_nearest_weekday", lambda d, forward=False: d)
+    monkeypatch.setattr(
+        prices, "load_meta_timeseries_range", lambda *args, **kwargs: df
+    )
+    assert prices._close_on("ABC", "L", date.today()) == 123.0
+
+
+def test_close_on_missing_columns(monkeypatch):
+    df = pd.DataFrame({"foo": [1.0]})
+    monkeypatch.setattr(prices, "_nearest_weekday", lambda d, forward=False: d)
+    monkeypatch.setattr(
+        prices, "load_meta_timeseries_range", lambda *args, **kwargs: df
+    )
+    assert prices._close_on("ABC", "L", date.today()) is None
+
+
+def test_close_on_empty_df(monkeypatch):
+    df = pd.DataFrame()
+    monkeypatch.setattr(prices, "_nearest_weekday", lambda d, forward=False: d)
+    monkeypatch.setattr(
+        prices, "load_meta_timeseries_range", lambda *args, **kwargs: df
+    )
+    assert prices._close_on("ABC", "L", date.today()) is None
+
+
+def test_close_on_invalid_value(monkeypatch):
+    df = pd.DataFrame({"close": ["bad"]})
+    monkeypatch.setattr(prices, "_nearest_weekday", lambda d, forward=False: d)
+    monkeypatch.setattr(
+        prices, "load_meta_timeseries_range", lambda *args, **kwargs: df
+    )
+    assert prices._close_on("ABC", "L", date.today()) is None
+
+
 def test_get_price_snapshot_calculates_changes(monkeypatch):
     ticker = "ABC.L"
     last_price = 100.0
@@ -15,6 +51,9 @@ def test_get_price_snapshot_calculates_changes(monkeypatch):
     d30 = prices._nearest_weekday(yday - timedelta(days=30), forward=False)
 
     monkeypatch.setattr(prices, "_load_latest_prices", lambda tickers: {ticker: last_price})
+    monkeypatch.setattr(
+        prices.instrument_api, "_resolve_full_ticker", lambda full, latest: None
+    )
 
     price_map = {d7: 90.0, d30: 80.0}
 
@@ -40,6 +79,9 @@ def test_refresh_prices_writes_json_and_updates_cache(tmp_path, monkeypatch):
 
     monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: [ticker])
     monkeypatch.setattr(prices, "_load_latest_prices", lambda tickers: {ticker: last_price})
+    monkeypatch.setattr(
+        prices.instrument_api, "_resolve_full_ticker", lambda full, latest: None
+    )
 
     price_map = {d7: 90.0, d30: 80.0}
 
@@ -64,3 +106,54 @@ def test_refresh_prices_writes_json_and_updates_cache(tmp_path, monkeypatch):
     assert info["change_7d_pct"] == pytest.approx((last_price / 90.0 - 1) * 100)
     assert info["change_30d_pct"] == pytest.approx((last_price / 80.0 - 1) * 100)
     assert prices.get_price_gbp(ticker) == last_price
+
+
+def test_get_price_snapshot_resolved(monkeypatch):
+    ticker = "ABC.L"
+    last_price = 50.0
+    yday = date.today() - timedelta(days=1)
+    d7 = prices._nearest_weekday(yday - timedelta(days=7), forward=False)
+    d30 = prices._nearest_weekday(yday - timedelta(days=30), forward=False)
+    monkeypatch.setattr(prices, "_load_latest_prices", lambda tickers: {ticker: last_price})
+    monkeypatch.setattr(
+        prices.instrument_api, "_resolve_full_ticker", lambda full, latest: ("ABC", "L")
+    )
+    price_map = {d7: 40.0, d30: 30.0}
+
+    def fake_load_meta_timeseries_range(sym, exch, start_date, end_date):
+        assert sym == "ABC"
+        assert exch == "L"
+        return pd.DataFrame({"close": [price_map.get(start_date, last_price)]})
+
+    monkeypatch.setattr(prices, "load_meta_timeseries_range", fake_load_meta_timeseries_range)
+    snap = prices.get_price_snapshot([ticker])
+    info = snap[ticker]
+    assert info["last_price"] == last_price
+    assert info["last_price_date"] == yday.isoformat()
+    assert info["change_7d_pct"] == pytest.approx((last_price / 40.0 - 1) * 100)
+    assert info["change_30d_pct"] == pytest.approx((last_price / 30.0 - 1) * 100)
+
+
+def test_refresh_prices_requires_config(monkeypatch):
+    monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: [])
+    monkeypatch.setattr(prices, "_load_latest_prices", lambda tickers: {})
+    monkeypatch.setattr(prices.config, "prices_json", None)
+    with pytest.raises(RuntimeError):
+        prices.refresh_prices()
+
+
+def test_get_security_meta(monkeypatch):
+    portfolios = [
+        {
+            "accounts": [
+                {
+                    "holdings": [
+                        {"ticker": "XYZ", "name": "XYZ Plc"},
+                        {"ticker": ""},
+                    ]
+                }
+            ]
+        }
+    ]
+    monkeypatch.setattr(prices, "list_portfolios", lambda: portfolios)
+    assert prices.get_security_meta("xyz") == {"ticker": "XYZ", "name": "XYZ Plc"}


### PR DESCRIPTION
## Summary
- add `_close_on` tests for valid data, missing columns, empty frames, and invalid values
- cover `get_price_snapshot` paths for unresolved and resolved tickers
- verify `refresh_prices` JSON output, cache update, and missing-config error
- exercise portfolio-derived security metadata

## Testing
- `pytest tests/common/test_prices.py -q --cov=backend.common.prices --cov-report=term-missing -o "addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68c1f6e088a08327a828425da9523583