### PR TITLE
Add growth assumption input to pension forecast

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -7,6 +7,7 @@ import {
   subscribeNudges,
   getEvents,
   runScenario,
+  getPensionForecast,
 } from "./api";
 
 describe("auth token handling", () => {
@@ -114,5 +115,32 @@ describe("scenario APIs", () => {
       url,
       expect.objectContaining({ headers: expect.any(Headers) }),
     );
+  });
+});
+
+describe("pension forecast", () => {
+  it("passes investment growth pct", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            forecast: [],
+            projected_pot_gbp: 0,
+            current_age: 30,
+            retirement_age: 65,
+            dob: "1990-01-01",
+          }),
+      });
+    // @ts-ignore
+    global.fetch = mockFetch;
+    await getPensionForecast({
+      owner: "alex",
+      deathAge: 90,
+      investmentGrowthPct: 7,
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("investment_growth_pct=7");
   });
 });

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -164,7 +164,8 @@
   "pensionForecast": {
     "currentAge": "Aktuelles Alter: {{age}}",
     "birthDate": "Geburtsdatum: {{dob}}",
-    "retirementAge": "Renteneintrittsalter: {{age}}"
+    "retirementAge": "Renteneintrittsalter: {{age}}",
+    "growthAssumption": "Wachstumsannahme (%):"
   },
   "group": {
     "select": "Wählen Sie eine Gruppe."

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -166,7 +166,8 @@
   "pensionForecast": {
     "currentAge": "Current age: {{age}}",
     "birthDate": "Birth date: {{dob}}",
-    "retirementAge": "Retirement age: {{age}}"
+    "retirementAge": "Retirement age: {{age}}",
+    "growthAssumption": "Growth assumption (%):"
   },
   "group": {
     "select": "Select a group."

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -164,7 +164,8 @@
   "pensionForecast": {
     "currentAge": "Edad actual: {{age}}",
     "birthDate": "Fecha de nacimiento: {{dob}}",
-    "retirementAge": "Edad de jubilación: {{age}}"
+    "retirementAge": "Edad de jubilación: {{age}}",
+    "growthAssumption": "Suposición de crecimiento (%):"
   },
   "group": {
     "select": "Seleccione un grupo."

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -164,7 +164,8 @@
   "pensionForecast": {
     "currentAge": "Âge actuel : {{age}}",
     "birthDate": "Date de naissance : {{dob}}",
-    "retirementAge": "Âge de retraite : {{age}}"
+    "retirementAge": "Âge de retraite : {{age}}",
+    "growthAssumption": "Hypothèse de croissance (%):"
   },
   "group": {
     "select": "Sélectionnez un groupe."

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -164,7 +164,8 @@
   "pensionForecast": {
     "currentAge": "Età attuale: {{age}}",
     "birthDate": "Data di nascita: {{dob}}",
-    "retirementAge": "Età pensionistica: {{age}}"
+    "retirementAge": "Età pensionistica: {{age}}",
+    "growthAssumption": "Ipotesi di crescita (%):"
   },
   "group": {
     "select": "Seleziona un gruppo."

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -164,7 +164,8 @@
   "pensionForecast": {
     "currentAge": "Idade atual: {{age}}",
     "birthDate": "Data de nascimento: {{dob}}",
-    "retirementAge": "Idade de aposentadoria: {{age}}"
+    "retirementAge": "Idade de aposentadoria: {{age}}",
+    "growthAssumption": "Suposição de crescimento (%):"
   },
   "group": {
     "select": "Selecione um grupo."

--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -52,12 +52,15 @@ describe("PensionForecast page", () => {
     const select = await screen.findByLabelText(/owner/i);
     fireEvent.change(select, { target: { value: "beth" } });
 
+    const growth = screen.getByLabelText(/growth assumption/i);
+    fireEvent.change(growth, { target: { value: "7" } });
+
     const btn = screen.getByRole("button", { name: /forecast/i });
     fireEvent.click(btn);
 
     await vi.waitFor(() =>
       expect(mockGetPensionForecast).toHaveBeenCalledWith(
-        expect.objectContaining({ owner: "beth" }),
+        expect.objectContaining({ owner: "beth", investmentGrowthPct: 7 }),
       ),
     );
     await screen.findByText(/birth date: 1990-01-01/i);

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -19,6 +19,7 @@ export default function PensionForecast() {
   const [statePension, setStatePension] = useState<string>("");
   const [contribution, setContribution] = useState<string>("");
   const [desiredIncome, setDesiredIncome] = useState<string>("");
+  const [investmentGrowthPct, setInvestmentGrowthPct] = useState(5);
   const [data, setData] = useState<{ age: number; income: number }[]>([]);
   const [projectedPot, setProjectedPot] = useState<number | null>(null);
   const [currentAge, setCurrentAge] = useState<number | null>(null);
@@ -53,6 +54,7 @@ export default function PensionForecast() {
         desiredIncomeAnnual: desiredIncome
           ? parseFloat(desiredIncome)
           : undefined,
+        investmentGrowthPct,
       });
       setData(res.forecast);
       setProjectedPot(res.projected_pot_gbp);
@@ -103,6 +105,22 @@ export default function PensionForecast() {
             value={desiredIncome}
             onChange={(e) => setDesiredIncome(e.target.value)}
           />
+        </div>
+        <div>
+          <label className="mr-2" htmlFor="investment-growth">
+            {t("pensionForecast.growthAssumption")}
+          </label>
+          <select
+            id="investment-growth"
+            value={investmentGrowthPct}
+            onChange={(e) => setInvestmentGrowthPct(Number(e.target.value))}
+          >
+            {[3, 5, 7].map((g) => (
+              <option key={g} value={g}>
+                {g}%
+              </option>
+            ))}
+          </select>
         </div>
         <button type="submit" className="mt-2 rounded bg-blue-500 px-4 py-2 text-white">
           Forecast


### PR DESCRIPTION
## Summary
- allow selecting investment growth percentage in pension forecast form
- forward selected growth assumption to pension forecast API
- cover pension forecast growth parameter in tests and translations

## Testing
- `npm test` *(fails: TypeError: Invalid URL: /foo and multiple fetch failed errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f729087c8327a7e40275ce988755