### PR TITLE
Use get_running_loop for Lambda handler

### DIFF
--- a/backend/lambda_api/handler.py
+++ b/backend/lambda_api/handler.py
@@ -20,7 +20,7 @@ def _create_handler() -> Mangum:
     """
 
     try:  # pragma: no cover - the exception path is platform specific
-        asyncio.get_event_loop()
+        asyncio.get_running_loop()
     except RuntimeError:
         asyncio.set_event_loop(asyncio.new_event_loop())
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,28 +1,12 @@
+import asyncio
 import importlib
 
 from fastapi import FastAPI
 from mangum import Mangum
 
 
-def test_lambda_handler(monkeypatch):
-    app = FastAPI()
-
-    @app.get("/")
-    def read_root():
-        return {"hello": "world"}
-
-    def mock_create_app():
-        return app
-
-    monkeypatch.setattr("backend.app.create_app", mock_create_app)
-
-    module = importlib.reload(importlib.import_module("backend.lambda_api.handler"))
-
-    lambda_handler = module.lambda_handler
-    assert isinstance(lambda_handler, Mangum)
-    assert callable(lambda_handler)
-
-    event = {
+def _event():
+    return {
         "version": "2.0",
         "routeKey": "$default",
         "rawPath": "/",
@@ -40,8 +24,64 @@ def test_lambda_handler(monkeypatch):
         "isBase64Encoded": False,
     }
 
-    response = lambda_handler(event, {})
+
+def _setup_app(monkeypatch):
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root():
+        return {"hello": "world"}
+
+    monkeypatch.setattr("backend.app.create_app", lambda: app)
+
+
+def _reload_handler():
+    return importlib.reload(importlib.import_module("backend.lambda_api.handler"))
+
+
+def test_lambda_handler_creates_event_loop(monkeypatch):
+    _setup_app(monkeypatch)
+
+    called = False
+    orig_new_event_loop = asyncio.new_event_loop
+
+    def fake_new_event_loop():
+        nonlocal called
+        called = True
+        return orig_new_event_loop()
+
+    monkeypatch.setattr(asyncio, "new_event_loop", fake_new_event_loop)
+
+    module = _reload_handler()
+
+    lambda_handler = module.lambda_handler
+    assert isinstance(lambda_handler, Mangum)
+
+    response = lambda_handler(_event(), {})
     assert response["statusCode"] == 200
     assert response["headers"]["content-type"] == "application/json"
     assert response["body"] == "{\"hello\":\"world\"}"
     assert response["isBase64Encoded"] is False
+    assert called is True
+
+
+def test_lambda_handler_with_running_loop(monkeypatch):
+    _setup_app(monkeypatch)
+
+    called = False
+    orig_new_event_loop = asyncio.new_event_loop
+
+    def fake_new_event_loop():
+        nonlocal called
+        called = True
+        return orig_new_event_loop()
+
+    monkeypatch.setattr(asyncio, "new_event_loop", fake_new_event_loop)
+
+    async def load_handler():
+        module = _reload_handler()
+        return module.lambda_handler
+
+    lambda_handler = asyncio.run(load_handler())
+    assert isinstance(lambda_handler, Mangum)
+    assert called is False


### PR DESCRIPTION
## Summary
- use `asyncio.get_running_loop()` when creating Lambda handler and fallback to a new loop when none running
- expand tests to cover both loop present and loop creation scenarios

## Testing
- `pytest --cov=backend --cov-fail-under=0 tests/test_lambda_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1fe5038b083279e3bf8fa501d0e6a