### PR TITLE
Handle monthly pension contributions

### DIFF
--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -20,6 +20,7 @@ def pension_forecast(
     db_income_annual: float | None = Query(None, ge=0),
     db_normal_retirement_age: int | None = Query(None, ge=0),
     contribution_annual: float | None = Query(None, ge=0),
+    contribution_monthly: float | None = Query(None, ge=0),
     investment_growth_pct: float = Query(5.0),
     desired_income_annual: float | None = Query(None, ge=0),
 ):
@@ -54,6 +55,12 @@ def pension_forecast(
             }
         )
 
+    annual_contribution = (
+        (contribution_monthly or 0.0) * 12
+        if contribution_monthly is not None
+        else contribution_annual or 0.0
+    )
+
     try:
         result = forecast_pension(
             dob=dob,
@@ -61,7 +68,7 @@ def pension_forecast(
             death_age=death_age,
             db_pensions=db_pensions,
             state_pension_annual=state_pension_annual,
-            contribution_annual=contribution_annual or 0.0,
+            contribution_annual=annual_contribution,
             investment_growth_pct=investment_growth_pct,
             desired_income_annual=desired_income_annual,
         )

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -143,4 +143,30 @@ describe("pension forecast", () => {
     const url = mockFetch.mock.calls[0][0] as string;
     expect(url).toContain("investment_growth_pct=7");
   });
+
+  it("sets monthly contribution when provided", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            forecast: [],
+            projected_pot_gbp: 0,
+            current_age: 30,
+            retirement_age: 65,
+            dob: "1990-01-01",
+          }),
+      });
+    // @ts-ignore
+    global.fetch = mockFetch;
+    await getPensionForecast({
+      owner: "alex",
+      deathAge: 90,
+      contributionMonthly: 100,
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("contribution_monthly=100");
+    expect(url).not.toContain("contribution_annual");
+  });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1027,6 +1027,7 @@ export const getPensionForecast = ({
   deathAge,
   statePensionAnnual,
   contributionAnnual,
+  contributionMonthly,
   desiredIncomeAnnual,
   investmentGrowthPct,
 }: {
@@ -1034,6 +1035,7 @@ export const getPensionForecast = ({
   deathAge: number;
   statePensionAnnual?: number;
   contributionAnnual?: number;
+  contributionMonthly?: number;
   desiredIncomeAnnual?: number;
   investmentGrowthPct?: number;
 }) => {
@@ -1046,6 +1048,9 @@ export const getPensionForecast = ({
   }
   if (contributionAnnual !== undefined) {
     params.set("contribution_annual", String(contributionAnnual));
+  }
+  if (contributionMonthly !== undefined) {
+    params.set("contribution_monthly", String(contributionMonthly));
   }
   if (desiredIncomeAnnual !== undefined) {
     params.set("desired_income_annual", String(desiredIncomeAnnual));

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -166,7 +166,8 @@
     "birthDate": "Geburtsdatum: {{dob}}",
     "retirementAge": "Renteneintrittsalter: {{age}}",
     "pensionPot": "Pensionsvermögen",
-    "growthAssumption": "Wachstumsannahme (%):"
+    "growthAssumption": "Wachstumsannahme (%):",
+    "monthlyContribution": "Monatlicher Beitrag (£):"
   },
   "group": {
     "select": "Wählen Sie eine Gruppe."

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -168,7 +168,8 @@
     "birthDate": "Birth date: {{dob}}",
     "retirementAge": "Retirement age: {{age}}",
     "pensionPot": "Pension pot",
-    "growthAssumption": "Growth assumption (%):"
+    "growthAssumption": "Growth assumption (%):",
+    "monthlyContribution": "Monthly Contribution (£):"
   },
   "group": {
     "select": "Select a group."

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -166,7 +166,8 @@
     "birthDate": "Fecha de nacimiento: {{dob}}",
     "retirementAge": "Edad de jubilación: {{age}}",
     "pensionPot": "Fondo de pensiones",
-    "growthAssumption": "Suposición de crecimiento (%):"
+    "growthAssumption": "Suposición de crecimiento (%):",
+    "monthlyContribution": "Contribución mensual (£):"
   },
   "group": {
     "select": "Seleccione un grupo."

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -166,7 +166,8 @@
     "birthDate": "Date de naissance : {{dob}}",
     "retirementAge": "Âge de retraite : {{age}}",
     "pensionPot": "Pot de pension",
-    "growthAssumption": "Hypothèse de croissance (%):"
+    "growthAssumption": "Hypothèse de croissance (%):",
+    "monthlyContribution": "Contribution mensuelle (£):"
   },
   "group": {
     "select": "Sélectionnez un groupe."

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -166,7 +166,8 @@
     "birthDate": "Data di nascita: {{dob}}",
     "retirementAge": "Età pensionistica: {{age}}",
     "pensionPot": "Fondo pensione",
-    "growthAssumption": "Ipotesi di crescita (%):"
+    "growthAssumption": "Ipotesi di crescita (%):",
+    "monthlyContribution": "Contributo mensile (£):"
   },
   "group": {
     "select": "Seleziona un gruppo."

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -166,7 +166,8 @@
     "birthDate": "Data de nascimento: {{dob}}",
     "retirementAge": "Idade de aposentadoria: {{age}}",
     "pensionPot": "Fundo de pensão",
-    "growthAssumption": "Suposição de crescimento (%):"
+    "growthAssumption": "Suposição de crescimento (%):",
+    "monthlyContribution": "Contribuição mensal (£):"
   },
   "group": {
     "select": "Selecione um grupo."

--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -57,12 +57,19 @@ describe("PensionForecast page", () => {
     const growth = screen.getByLabelText(/growth assumption/i);
     fireEvent.change(growth, { target: { value: "7" } });
 
+    const monthly = screen.getByLabelText(/monthly contribution/i);
+    fireEvent.change(monthly, { target: { value: "100" } });
+
     const btn = screen.getByRole("button", { name: /forecast/i });
     fireEvent.click(btn);
 
     await vi.waitFor(() =>
       expect(mockGetPensionForecast).toHaveBeenCalledWith(
-        expect.objectContaining({ owner: "beth", investmentGrowthPct: 7 }),
+        expect.objectContaining({
+          owner: "beth",
+          investmentGrowthPct: 7,
+          contributionMonthly: 100,
+        }),
       ),
     );
     await screen.findByText(/birth date: 1990-01-01/i);

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -17,7 +17,8 @@ export default function PensionForecast() {
   const [owner, setOwner] = useState("");
   const [deathAge, setDeathAge] = useState(90);
   const [statePension, setStatePension] = useState<string>("");
-  const [contribution, setContribution] = useState<string>("");
+  const [contributionAnnual, setContributionAnnual] = useState<string>("");
+  const [contributionMonthly, setContributionMonthly] = useState<string>("");
   const [desiredIncome, setDesiredIncome] = useState<string>("");
   const [investmentGrowthPct, setInvestmentGrowthPct] = useState(5);
   const [data, setData] = useState<{ age: number; income: number }[]>([]);
@@ -43,15 +44,21 @@ export default function PensionForecast() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
+      const contributionMonthlyVal = contributionMonthly
+        ? parseFloat(contributionMonthly)
+        : undefined;
+      const contributionAnnualVal = contributionAnnual
+        ? parseFloat(contributionAnnual)
+        : undefined;
       const res = await getPensionForecast({
         owner,
         deathAge,
         statePensionAnnual: statePension
           ? parseFloat(statePension)
           : undefined,
-        contributionAnnual: contribution
-          ? parseFloat(contribution)
-          : undefined,
+        contributionMonthly: contributionMonthlyVal,
+        contributionAnnual:
+          contributionMonthlyVal !== undefined ? undefined : contributionAnnualVal,
         desiredIncomeAnnual: desiredIncome
           ? parseFloat(desiredIncome)
           : undefined,
@@ -93,11 +100,25 @@ export default function PensionForecast() {
           />
         </div>
         <div>
-          <label className="mr-2">Annual Contribution (£):</label>
+          <label className="mr-2" htmlFor="contribution-annual">
+            Annual Contribution (£):
+          </label>
           <input
+            id="contribution-annual"
             type="number"
-            value={contribution}
-            onChange={(e) => setContribution(e.target.value)}
+            value={contributionAnnual}
+            onChange={(e) => setContributionAnnual(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="mr-2" htmlFor="contribution-monthly">
+            {t("pensionForecast.monthlyContribution")}
+          </label>
+          <input
+            id="contribution-monthly"
+            type="number"
+            value={contributionMonthly}
+            onChange={(e) => setContributionMonthly(e.target.value)}
           />
         </div>
         <div>


### PR DESCRIPTION
## Summary
- support `contribution_monthly` query param for pension forecasts and convert to annual
- allow frontend API and page to send monthly contributions and normalize inputs
- add translation keys and tests for monthly pension contributions

## Testing
- `pytest tests/test_pension_route.py tests/test_pension_forecast.py -q --no-cov`
- `cd frontend && npm test -- --run src/api.test.ts src/pages/PensionForecast.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c1f0d1314c83278f8b1b50c7ac2ed8