### PR TITLE
feat: improve smoke path parameter filling

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -407,8 +407,33 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   }
 ] as const;
 
+// Provide sample values for path parameters so requests avoid 422/400 errors.
+// Values are chosen based on common parameter names. Unknown names default to
+// ``1`` which parses as an integer or string.
+const SAMPLE_PATH_VALUES: Record<string, string> = {
+  owner: 'demo-owner',
+  account: 'demo-account',
+  user: 'user@example.com',
+  email: 'user@example.com',
+  id: '1',
+  vp_id: '1',
+  quest_id: 'check-in',
+  slug: 'demo-slug',
+  name: 'demo',
+  exchange: 'NASDAQ',
+  ticker: 'AAPL',
+};
+
 export function fillPath(path: string): string {
-  return path.replace(/\{[^}]+\}/g, 'test');
+  return path.replace(/\{([^}]+)\}/g, (_, key: string) => {
+    const k = key.toLowerCase();
+    if (SAMPLE_PATH_VALUES[k]) return SAMPLE_PATH_VALUES[k];
+    if (k.includes('email')) return 'user@example.com';
+    if (k.includes('id')) return '1';
+    if (k.includes('user')) return 'user@example.com';
+    if (k.includes('date')) return '1970-01-01';
+    return '1';
+  });
 }
 
 export async function runSmoke(base: string) {


### PR DESCRIPTION
## Summary
- supply realistic placeholder values for smoke test URLs to avoid 422/400 errors

## Testing
- `timeout 60 npx ts-node scripts/frontend-backend-smoke.ts | head -n 20` *(fails: terminated before completing)*

------
https://chatgpt.com/codex/tasks/task_e_68c202567ca88327a3ee05acf67ebd89