### PR TITLE
Normalize transaction root paths

### DIFF
--- a/backend/reports.py
+++ b/backend/reports.py
@@ -57,20 +57,23 @@ def _parse_date(value: Optional[str]) -> Optional[date]:
 
 def _transaction_roots() -> Iterable[str]:
     if config.app_env == "aws":
-        yield "transactions"
+        yield Path("transactions").as_posix()
         return
+
     roots: List[str] = []
     if config.transactions_output_root:
-        roots.append(str(config.transactions_output_root))
+        roots.append(Path(config.transactions_output_root).as_posix())
     if config.accounts_root:
-        roots.append(str(config.accounts_root))
-    roots.append(str(config.data_root / "transactions"))
-    seen = set()
+        roots.append(Path(config.accounts_root).as_posix())
+    roots.append((config.data_root / "transactions").as_posix())
+
+    seen: set[str] = set()
     for r in roots:
         path = Path(r)
-        if r not in seen and path.exists():
-            seen.add(r)
-            yield r
+        posix = path.as_posix()
+        if posix not in seen and path.exists():
+            seen.add(posix)
+            yield posix
 
 
 def _load_transactions(owner: str) -> List[dict]:


### PR DESCRIPTION
## Summary
- Normalize transaction root paths to POSIX format for consistency across operating systems
- Deduplicate using normalized POSIX paths

## Testing
- `pytest tests/test_reports_dates.py::test_transaction_roots_local -q --override-ini=addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68c266e062208327ab46cb078e702550