### PR TITLE
Add metadata for new instruments and verify lookups

### DIFF
--- a/data/instruments/Cash/GBP.json
+++ b/data/instruments/Cash/GBP.json
@@ -1,0 +1,7 @@
+{
+  "name": "GBP Cash",
+  "ticker": "CASH.GBP",
+  "exchange": "GBP",
+  "asset_class": "cash",
+  "currency": "GBP"
+}

--- a/data/instruments/L/ERNS.json
+++ b/data/instruments/L/ERNS.json
@@ -1,0 +1,8 @@
+{
+  "name": "iShares GBP Ultrashort Bond UCITS ETF",
+  "ticker": "ERNS.L",
+  "exchange": "L",
+  "asset_class": "Bond",
+  "sector": "Fixed Income",
+  "currency": "GBP"
+}

--- a/data/instruments/L/VWRL.json
+++ b/data/instruments/L/VWRL.json
@@ -1,0 +1,8 @@
+{
+  "name": "Vanguard FTSE All-World UCITS ETF",
+  "ticker": "VWRL.L",
+  "exchange": "L",
+  "asset_class": "Equity",
+  "sector": "Global Equity",
+  "currency": "USD"
+}

--- a/data/instruments/N/PFE.json
+++ b/data/instruments/N/PFE.json
@@ -1,0 +1,9 @@
+{
+  "name": "Pfizer Inc.",
+  "ticker": "PFE.N",
+  "exchange": "N",
+  "asset_class": "Equity",
+  "sector": "Healthcare",
+  "industry": "Pharmaceuticals",
+  "currency": "USD"
+}

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -98,3 +98,19 @@ def test_save_instrument_meta_uploads_s3(monkeypatch, tmp_path):
     assert uploaded["Bucket"] == "bucket"
     assert uploaded["Key"] == "meta/L/ABC.json"
     assert json.loads(uploaded["Body"].decode()) == {"bar": 2}
+
+def test_get_instrument_meta_known_records(caplog):
+    tickers = {
+        "CASH.GBP": "GBP Cash",
+        "VWRL.L": "Vanguard FTSE All-World UCITS ETF",
+        "ERNS.L": "iShares GBP Ultrashort Bond UCITS ETF",
+        "PFE.N": "Pfizer Inc.",
+    }
+    for tkr, name in tickers.items():
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            meta = instruments.get_instrument_meta(tkr)
+        assert meta.get("name") == name
+        assert meta.get("exchange") == tkr.split(".")[-1]
+        assert "ticker" in meta
+        assert caplog.text == ""


### PR DESCRIPTION
## Summary
- add instrument metadata for GBP cash, Vanguard FTSE All-World (VWRL), ERNS ETF, and Pfizer
- test `get_instrument_meta` returns these records without warnings

## Testing
- `pytest --override-ini addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_68c26a3a68bc8327a10db3254600a970