### PR TITLE
Guard ScreenerQuery rows and reset mocks in tests

### DIFF
--- a/frontend/src/pages/ScreenerQuery.test.tsx
+++ b/frontend/src/pages/ScreenerQuery.test.tsx
@@ -1,10 +1,42 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
 import { I18nextProvider, initReactI18next } from "react-i18next";
 import { createInstance } from "i18next";
 import type { ReactElement } from "react";
 import en from "../locales/en/translation.json";
 import fr from "../locales/fr/translation.json";
+
+const mockQueryData = [
+  { owner: "Alice", ticker: "AAA", market_value_gbp: 100 },
+];
+const mockScreenerData = [
+  {
+    ticker: "AAA",
+    name: "Alpha",
+    peg_ratio: 1,
+    pe_ratio: 10,
+    de_ratio: 0.5,
+    fcf: 1000,
+    eps: 2,
+    gross_margin: 0.4,
+    operating_margin: 0.2,
+    net_margin: 0.1,
+    ebitda_margin: 0.3,
+    roa: 0.1,
+    roe: 0.2,
+    roi: 0.15,
+    dividend_yield: 2,
+    dividend_payout_ratio: 40,
+    beta: 1.2,
+    shares_outstanding: 1000,
+    float_shares: 800,
+    market_cap: 5000,
+    high_52w: 150,
+    low_52w: 90,
+    avg_volume: 2000,
+  },
+];
 
 vi.mock("../api", () => ({
   API_BASE: "http://api",
@@ -12,9 +44,7 @@ vi.mock("../api", () => ({
     { owner: "Alice", accounts: [] },
     { owner: "Bob", accounts: [] },
   ]),
-  runCustomQuery: vi.fn().mockResolvedValue([
-    { owner: "Alice", ticker: "AAA", market_value_gbp: 100 },
-  ]),
+  runCustomQuery: vi.fn(),
   saveCustomQuery: vi.fn().mockResolvedValue({}),
   listSavedQueries: vi.fn().mockResolvedValue([
     {
@@ -29,33 +59,7 @@ vi.mock("../api", () => ({
       },
     },
   ]),
-  getScreener: vi.fn().mockResolvedValue([
-    {
-      ticker: "AAA",
-      name: "Alpha",
-      peg_ratio: 1,
-      pe_ratio: 10,
-      de_ratio: 0.5,
-      fcf: 1000,
-      eps: 2,
-      gross_margin: 0.4,
-      operating_margin: 0.2,
-      net_margin: 0.1,
-      ebitda_margin: 0.3,
-      roa: 0.1,
-      roe: 0.2,
-      roi: 0.15,
-      dividend_yield: 2,
-      dividend_payout_ratio: 40,
-      beta: 1.2,
-      shares_outstanding: 1000,
-      float_shares: 800,
-      market_cap: 5000,
-      high_52w: 150,
-      low_52w: 90,
-      avg_volume: 2000,
-    },
-  ]),
+  getScreener: vi.fn(),
 }));
 
 import { getScreener, runCustomQuery } from "../api";
@@ -75,8 +79,11 @@ describe("Screener & Query page", () => {
   afterEach(() => {
     window.history.pushState({}, "", "/");
     vi.clearAllMocks();
+    runCustomQuery.mockResolvedValue([]);
+    getScreener.mockResolvedValue([]);
   });
   it("runs screener and displays results", async () => {
+    getScreener.mockResolvedValue(mockScreenerData);
     renderWithI18n(<ScreenerQuery />);
 
     fireEvent.change(screen.getByLabelText(en.screener.tickers), {
@@ -114,6 +121,7 @@ describe("Screener & Query page", () => {
   });
 
   it("submits query form and renders results with export links", async () => {
+    runCustomQuery.mockResolvedValue(mockQueryData);
     const { i18n } = renderWithI18n(<ScreenerQuery />);
 
     await screen.findByLabelText("Alice");
@@ -151,6 +159,7 @@ describe("Screener & Query page", () => {
   });
 
   it("persists selected parameters in export URLs", async () => {
+    runCustomQuery.mockResolvedValue(mockQueryData);
     const { i18n } = renderWithI18n(<ScreenerQuery />);
 
     await screen.findByLabelText("Alice");

--- a/frontend/src/pages/ScreenerQuery.tsx
+++ b/frontend/src/pages/ScreenerQuery.tsx
@@ -58,9 +58,12 @@ function QuerySection() {
     }
   }, []);
 
-  const columns = rows.length ? (Object.keys(rows[0]) as (keyof ResultRow)[]) : [];
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const columns = safeRows.length
+    ? (Object.keys(safeRows[0]) as (keyof ResultRow)[])
+    : [];
   const { sorted, handleSort } = useSortableTable<ResultRow>(
-    rows,
+    safeRows,
     (columns[0] as keyof ResultRow) || ("owner" as keyof ResultRow),
   );
 
@@ -227,7 +230,7 @@ function QuerySection() {
         <button type="button" onClick={handleCopyLink} className="mr-2">
           {t("query.copyLink")}
         </button>
-        {rows.length > 0 && (
+        {safeRows.length > 0 && (
           <span>
             <a href={buildExportUrl("csv")}>{t("query.exportCsv")}</a>{" | "}
             <a href={buildExportUrl("xlsx")}>{t("query.exportXlsx")}</a>
@@ -235,7 +238,7 @@ function QuerySection() {
         )}
       </form>
       {error && <p className="text-red-500">{error}</p>}
-      {rows.length > 0 && (
+      {safeRows.length > 0 && (
         <table className="w-full border-collapse">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- Reset `runCustomQuery` and `getScreener` mocks after each test and explicitly mock required data
- Import jest-dom matchers and default mock data for ScreenerQuery tests
- Guard against non-array `rows` before sorting/rendering in `ScreenerQuery`

## Testing
- `npm run test:jsdom -- src/pages/ScreenerQuery.test.tsx` *(fails: Tests failed. Watching for file changes)*

------
https://chatgpt.com/codex/tasks/task_e_68c26a225bc08327ab8057f5f40993e9