### PR TITLE
feat: add sitemap health check scripts

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -30,3 +30,8 @@ jobs:
       - name: Run tests with coverage
         working-directory: frontend
         run: pnpm test -- --run --coverage
+
+      - name: Sitemap health check
+        run: |
+          pip install requests
+          python scripts/site_healthcheck.py

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,16 @@ $env:SMOKE_TEST_URL = "https://example.com"
 ./scripts/smoke-test.ps1
 ```
 
+
+## site_healthcheck.py
+
+Parse the sitemap and verify that each URL responds with HTTP 200.
+
+```bash
+python scripts/site_healthcheck.py
+# or on Windows PowerShell
+./scripts/site-healthcheck.ps1
+```
 ## site_snapshot.py
 
 Crawl a website, capture screenshots, run AI analysis on each page and build PDF/Markdown docs.

--- a/scripts/site-healthcheck.ps1
+++ b/scripts/site-healthcheck.ps1
@@ -1,0 +1,7 @@
+#!/usr/bin/env pwsh
+$scriptPath = Join-Path $PSScriptRoot 'site_healthcheck.py'
+python $scriptPath @args
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Site health check failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}

--- a/scripts/site_healthcheck.py
+++ b/scripts/site_healthcheck.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Simple sitemap health checker.
+
+This script parses ``frontend/public/sitemap.xml`` for all ``<loc>`` entries
+and requests each URL. Any URL that does not return a HTTP 200 response or
+raises a request exception is reported and the process exits with a non-zero
+status code. It is intended for lightweight smoke tests in CI pipelines.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+import requests
+
+
+SITEMAP_PATH = (
+    Path(__file__).resolve().parents[1] / "frontend" / "public" / "sitemap.xml"
+)
+
+
+def iter_sitemap_urls() -> list[str]:
+    """Return a list of URLs from the sitemap."""
+    tree = ET.parse(SITEMAP_PATH)
+    root = tree.getroot()
+    # The sitemap uses the standard namespace
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    return [
+        elem.text.strip() for elem in root.findall("sm:url/sm:loc", ns) if elem.text
+    ]
+
+
+def check_urls(urls: list[str]) -> list[str]:
+    """Request each URL and return those that didn't respond with HTTP 200."""
+    failures: list[str] = []
+    for url in urls:
+        try:
+            resp = requests.get(url, timeout=10)
+            if resp.status_code != 200:
+                print(f"{url} -> {resp.status_code}")
+                failures.append(url)
+            else:
+                print(f"{url} -> OK")
+        except requests.RequestException as exc:  # pragma: no cover - network failure
+            print(f"{url} -> ERROR: {exc}")
+            failures.append(url)
+    return failures
+
+
+def main() -> int:
+    urls = iter_sitemap_urls()
+    failures = check_urls(urls)
+    if failures:
+        print(f"{len(failures)} URL(s) failed")
+        return 1
+    print("All sitemap URLs responded with HTTP 200")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add Python sitemap health check to request each URL and report failures
- add PowerShell wrapper and document usage
- run sitemap health check during frontend CI tests

## Testing
- `python scripts/site_healthcheck.py` *(fails: ProxyError: 403 Forbidden)*
- `pwsh scripts/site-healthcheck.ps1` *(fails: command not found)*
- `pytest` *(fails: unrecognized arguments: --cov=backend --cov-fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_e_68c2828428a48327be308fb0c6d8f20e