### PR TITLE
Add sitemap generation script

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,9 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://app.allotmint.io/</loc>
-  </url>
-  <url>
-    <loc>https://app.allotmint.io/portfolio</loc>
   </url>
 </urlset>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,6 +56,27 @@ embedding the analysis text under each screenshot.
 
 The script uses Playwright to render pages so that JavaScript-generated links are discovered correctly. Pillow enables image support in FPDF; without it, PDFs are generated without screenshots. If OpenAI analysis fails for a page, the rest of the snapshot continues with an empty analysis.
 
+## generate_sitemap.py
+
+Crawl a running frontend and build `frontend/public/sitemap.xml` with all internal links.
+
+```bash
+python scripts/generate_sitemap.py --base-url https://app.allotmint.io
+```
+
+Use the PowerShell wrapper for convenience:
+
+```powershell
+# Deployed site
+./scripts/generate-sitemap.ps1
+
+# Local dev server
+./scripts/generate-sitemap.ps1 -Local
+
+# Explicit URL
+./scripts/generate-sitemap.ps1 -BaseUrl http://localhost:5173
+```
+
 ## import_transactions.py
 
 Upload a local transaction export to the running backend for parsing:

--- a/scripts/generate-sitemap.ps1
+++ b/scripts/generate-sitemap.ps1
@@ -1,0 +1,30 @@
+Param(
+  [string]$BaseUrl = '',
+  [switch]$Local
+)
+
+$ErrorActionPreference = 'Stop'
+
+$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+if (-not $pythonCmd) {
+  $pythonCmd = Get-Command py -ErrorAction SilentlyContinue
+}
+if (-not $pythonCmd) {
+  Write-Host 'Python is required but was not found.' -ForegroundColor Red
+  exit 1
+}
+$PYTHON = $pythonCmd.Name
+
+$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+$REPO_ROOT = Split-Path -Parent $SCRIPT_DIR
+Set-Location $REPO_ROOT
+
+if (-not $BaseUrl -or $BaseUrl -eq '') {
+  if ($Local) {
+    $BaseUrl = 'http://localhost:5173'
+  } else {
+    $BaseUrl = 'https://app.allotmint.io'
+  }
+}
+
+& $PYTHON 'scripts/generate_sitemap.py' '--base-url' $BaseUrl

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -1,0 +1,74 @@
+import argparse
+from collections import deque
+from pathlib import Path
+from urllib.parse import urljoin, urlparse, urlunparse
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def crawl_site(base_url: str) -> tuple[list[str], str]:
+    base_url = base_url.rstrip('/')
+    parsed = urlparse(base_url)
+    base_root = f"{parsed.scheme}://{parsed.netloc}"
+
+    start_url = urlunparse((parsed.scheme, parsed.netloc, parsed.path or '/', '', '', ''))
+    visited: set[str] = set()
+    queue = deque([start_url])
+
+    while queue:
+        url = queue.popleft()
+        if url in visited:
+            continue
+        visited.add(url)
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+        except requests.RequestException:
+            continue
+
+        soup = BeautifulSoup(response.text, 'html.parser')
+        for tag in soup.find_all('a', href=True):
+            href = tag['href']
+            abs_url = urljoin(url, href)
+            parsed_href = urlparse(abs_url)
+            if parsed_href.netloc != parsed.netloc:
+                continue
+            cleaned = urlunparse((parsed_href.scheme, parsed_href.netloc, parsed_href.path, '', '', ''))
+            if cleaned not in visited:
+                queue.append(cleaned)
+
+    paths = sorted({urlparse(u).path.rstrip('/') or '/' for u in visited})
+    return paths, base_root
+
+
+def write_sitemap(base: str, paths: list[str], output: Path) -> None:
+    import xml.etree.ElementTree as ET
+    from xml.dom import minidom
+
+    urlset = ET.Element('urlset', xmlns='http://www.sitemaps.org/schemas/sitemap/0.9')
+    for path in paths:
+        url_el = ET.SubElement(urlset, 'url')
+        loc_el = ET.SubElement(url_el, 'loc')
+        loc_el.text = urljoin(base + '/', path.lstrip('/'))
+
+    xml_bytes = ET.tostring(urlset, encoding='utf-8')
+    pretty = minidom.parseString(xml_bytes).toprettyxml(indent="  ")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(pretty, encoding='utf-8')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Generate sitemap.xml by crawling internal links.')
+    parser.add_argument('--base-url', required=True, help='Base URL to crawl, e.g. https://example.com')
+    args = parser.parse_args()
+
+    paths, base = crawl_site(args.base_url)
+    repo_root = Path(__file__).resolve().parents[1]
+    output_path = repo_root / 'frontend' / 'public' / 'sitemap.xml'
+    write_sitemap(base, paths, output_path)
+    print(f'Wrote {len(paths)} paths to {output_path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- crawl frontend links and generate a sitemap via `scripts/generate_sitemap.py`
- add PowerShell helper `scripts/generate-sitemap.ps1`
- document sitemap generation usage and update default `frontend/public/sitemap.xml`

## Testing
- `python scripts/generate_sitemap.py --base-url https://app.allotmint.io`
- `pytest scripts/generate_sitemap.py` *(fails: Coverage failure: total of 0 is less than fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_e_68c28282979483278b238b0b6b94f338