### PR TITLE
feat: support query params in smoke test

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -1,5 +1,5 @@
 // Auto-generated via backend route metadata
-export interface SmokeEndpoint { method: string; path: string; body?: any }
+export interface SmokeEndpoint { method: string; path: string; body?: any; query?: Record<string, string> }
 export const smokeEndpoints: SmokeEndpoint[] = [
   {
     "method": "GET",
@@ -138,7 +138,8 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   },
   {
     "method": "GET",
-    "path": "/instrument/"
+    "path": "/instrument/",
+    "query": { "ticker": "AAPL" }
   },
   {
     "method": "GET",
@@ -164,7 +165,8 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   },
   {
     "method": "GET",
-    "path": "/instrument/search"
+    "path": "/instrument/search",
+    "query": { "q": "alpha" }
   },
   {
     "method": "GET",
@@ -180,11 +182,13 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   },
   {
     "method": "GET",
-    "path": "/movers"
+    "path": "/movers",
+    "query": { "tickers": "AAPL" }
   },
   {
     "method": "GET",
-    "path": "/news"
+    "path": "/news",
+    "query": { "ticker": "AAPL" }
   },
   {
     "method": "GET",
@@ -206,7 +210,8 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   },
   {
     "method": "GET",
-    "path": "/pension/forecast"
+    "path": "/pension/forecast",
+    "query": { "owner": "demo-owner", "death_age": "90" }
   },
   {
     "method": "GET",
@@ -296,19 +301,23 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   },
   {
     "method": "GET",
-    "path": "/returns/compare"
+    "path": "/returns/compare",
+    "query": { "owner": "demo-owner" }
   },
   {
     "method": "GET",
-    "path": "/scenario"
+    "path": "/scenario",
+    "query": { "ticker": "AAPL", "pct": "1" }
   },
   {
     "method": "GET",
-    "path": "/scenario/historical"
+    "path": "/scenario/historical",
+    "query": { "event_id": "test", "horizons": "1" }
   },
   {
     "method": "GET",
-    "path": "/screener/"
+    "path": "/screener/",
+    "query": { "tickers": "AAPL" }
   },
   {
     "method": "POST",
@@ -345,11 +354,13 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   },
   {
     "method": "GET",
-    "path": "/timeseries/edit"
+    "path": "/timeseries/edit",
+    "query": { "ticker": "AAPL", "exchange": "NASDAQ" }
   },
   {
     "method": "POST",
-    "path": "/timeseries/edit?ticker=VOD.L",
+    "path": "/timeseries/edit",
+    "query": { "ticker": "AAPL", "exchange": "NASDAQ" },
     "body": []
   },
   {
@@ -358,7 +369,8 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   },
   {
     "method": "GET",
-    "path": "/timeseries/meta"
+    "path": "/timeseries/meta",
+    "query": { "ticker": "AAPL", "exchange": "NASDAQ" }
   },
   {
     "method": "POST",
@@ -468,7 +480,11 @@ export function fillPath(path: string): string {
 
 export async function runSmoke(base: string) {
   for (const ep of smokeEndpoints) {
-    const url = base + fillPath(ep.path);
+    let url = base + fillPath(ep.path);
+    if (ep.query) {
+      const qs = new URLSearchParams(ep.query).toString();
+      if (qs) url += (url.includes('?') ? '&' : '?') + qs;
+    }
     let body: any = undefined;
     let headers: any = undefined;
     if (ep.body !== undefined) {


### PR DESCRIPTION
## Summary
- add optional query field to smoke test endpoints
- append serialized query parameters when running smoke tests
- provide sample query values for endpoints requiring them

## Testing
- `npm test` *(fails: Test Files 18 failed | 7 passed | 1 skipped (56))*

------
https://chatgpt.com/codex/tasks/task_e_68c2827799fc83278bfad8246b6a570b