### PR TITLE
Run smoke tests in CI

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.parse.outputs.deploy }}
     env:
       SMOKE_TEST_URL: ${{ vars.SMOKE_TEST_URL }}
     steps:
@@ -116,14 +118,31 @@ jobs:
         run: cdk deploy --require-approval never
         working-directory: cdk
 
-      - name: Run smoke tests
-        if: steps.parse.outputs.deploy == 'true'
-        run: ./scripts/smoke-test.sh
-
       - name: Run Lighthouse CI
         if: steps.parse.outputs.deploy == 'true'
         run: |
           npm install --no-save @lhci/cli
           npx lhci autorun --collect.url="$SMOKE_TEST_URL" \
             --upload.target=temporary-public-storage
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: needs.deploy.outputs.deploy == 'true'
+    env:
+      SMOKE_URL: ${{ vars.SMOKE_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run smoke tests
+        run: npm run smoke:test
 

--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -1,0 +1,22 @@
+# Smoke Tests
+
+Run a quick check against key backend endpoints after deployment.
+
+## Environment variables
+
+- `SMOKE_URL` – base URL of the backend to test.
+- `TEST_ID_TOKEN` – optional ID token added as a `Bearer` token for endpoints requiring authentication.
+
+## Usage
+
+```bash
+SMOKE_URL=https://example.com npm run smoke:test
+```
+
+Include `TEST_ID_TOKEN` if the target requires auth:
+
+```bash
+SMOKE_URL=https://example.com TEST_ID_TOKEN=token npm run smoke:test
+```
+
+The script exits non-zero if any endpoint returns an unexpected status, allowing CI to fail fast.

--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -467,16 +467,19 @@ export function fillPath(path: string): string {
 }
 
 export async function runSmoke(base: string) {
+  const authHeaders = process.env.TEST_ID_TOKEN
+    ? { Authorization: `Bearer ${process.env.TEST_ID_TOKEN}` }
+    : {};
   for (const ep of smokeEndpoints) {
     const url = base + fillPath(ep.path);
     let body: any = undefined;
-    let headers: any = undefined;
+    const headers: Record<string, string> = { ...authHeaders };
     if (ep.body !== undefined) {
       if (ep.body instanceof FormData) {
         body = ep.body;
       } else {
         body = JSON.stringify(ep.body);
-        headers = { 'Content-Type': 'application/json' };
+        headers['Content-Type'] = 'application/json';
       }
     }
     const res = await fetch(url, { method: ep.method, body, headers });


### PR DESCRIPTION
## Summary
- add smoke-test job to deploy workflow
- allow smoke script to pass an optional ID token
- document `SMOKE_URL` and `TEST_ID_TOKEN` for reproducing smoke tests

## Testing
- `npm test` *(fails: Metric value out of range, unhandled errors)*
- `pytest backend/tests/test_smoke_endpoint_list.py::test_smoke_endpoint_list_up_to_date -q` *(fails: JSONDecodeError, coverage < 80%)*

------
https://chatgpt.com/codex/tasks/task_e_68c2827757ac8327b33835e198fd44f5