### PR TITLE
feat: add defensive fallback for timeseries

### DIFF
--- a/frontend/src/pages/TimeseriesEdit.test.tsx
+++ b/frontend/src/pages/TimeseriesEdit.test.tsx
@@ -9,7 +9,7 @@ import { TimeseriesEdit } from "./TimeseriesEdit";
 import { getTimeseries, saveTimeseries, searchInstruments } from "../api";
 
 vi.mock("../api", () => ({
-  getTimeseries: vi.fn(),
+  getTimeseries: vi.fn().mockResolvedValue([]),
   saveTimeseries: vi.fn().mockResolvedValue({ status: "ok", rows: 1 }),
   searchInstruments: vi.fn().mockResolvedValue([]),
 }));

--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -98,9 +98,10 @@ export function TimeseriesEdit() {
   async function handleLoad() {
     setError(null);
     try {
-      const data = (await getTimeseries(ticker, exchange)) || [];
-      setRows(data);
-      setStatus(t("timeseriesEdit.status.loaded", { count: data.length }));
+      const data = (await getTimeseries(ticker, exchange)) ?? [];
+      const arr = Array.isArray(data) ? data : [];
+      setRows(arr);
+      setStatus(t("timeseriesEdit.status.loaded", { count: arr.length }));
     } catch (e) {
       setError(String(e));
     }
@@ -195,7 +196,7 @@ export function TimeseriesEdit() {
             </tr>
           </thead>
           <tbody>
-            {rows.map((row, i) => (
+            {(Array.isArray(rows) ? rows : []).map((row, i) => (
               <tr key={i}>
                 <td>
                   <input


### PR DESCRIPTION
## Summary
- ensure TimeseriesEdit defensively handles missing timeseries data
- default API mock to return arrays in TimeseriesEdit tests

## Testing
- `npm test` *(fails: Test Files 9 failed (63))*

------
https://chatgpt.com/codex/tasks/task_e_68c2c8bbb4dc8327b07b25dde74194f2