### PR TITLE
test: mock portfolio in MainApp demo test

### DIFF
--- a/frontend/src/MainApp.demo.test.tsx
+++ b/frontend/src/MainApp.demo.test.tsx
@@ -1,26 +1,25 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, vi } from "vitest";
-import { RouteProvider } from "./RouteContext";
-import { ConfigProvider } from "./ConfigContext";
-import { PriceRefreshProvider } from "./PriceRefreshContext";
+import { describe, expect, it, vi } from "vitest";
 
 describe("MainApp demo view", () => {
   it("shows demo portfolio when only demo owner is available", async () => {
+    const mockPortfolio = {
+      owner: "demo",
+      as_of: "2024-01-01",
+      trades_this_month: 0,
+      trades_remaining: 0,
+      total_value_estimate_gbp: 0,
+      accounts: [],
+    };
+
     vi.doMock("./api", () => ({
       getOwners: vi.fn().mockResolvedValue([
         { owner: "demo", accounts: ["isa", "sipp"] },
       ]),
       getGroups: vi.fn().mockRejectedValue(new Error("HTTP 401")),
       getGroupInstruments: vi.fn().mockResolvedValue([]),
-      getPortfolio: vi.fn().mockResolvedValue({
-        owner: "demo",
-        as_of: "2024-01-01",
-        trades_this_month: 0,
-        trades_remaining: 0,
-        total_value_estimate_gbp: 0,
-        accounts: [],
-      }),
+      getPortfolio: vi.fn().mockResolvedValue(mockPortfolio),
       refreshPrices: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
       getNudges: vi.fn().mockResolvedValue([]),
@@ -34,9 +33,16 @@ describe("MainApp demo view", () => {
       saveTimeseries: vi.fn(),
       refetchTimeseries: vi.fn(),
       rebuildTimeseriesCache: vi.fn(),
+      getConfig: vi.fn().mockResolvedValue({}),
     }));
 
-    const { default: MainApp } = await import("./MainApp");
+    const [{ default: MainApp }, { ConfigProvider }, { RouteProvider }, { PriceRefreshProvider }] =
+      await Promise.all([
+        import("./MainApp"),
+        import("./ConfigContext"),
+        import("./RouteContext"),
+        import("./PriceRefreshContext"),
+      ]);
 
     render(
       <MemoryRouter initialEntries={["/"]}>


### PR DESCRIPTION
## Summary
- Mock portfolio API response using `mockPortfolio` before importing `MainApp`
- Import app and providers after establishing mock to avoid unhandled rejections

## Testing
- `npx vitest run --environment=jsdom src/MainApp.demo.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c2c8ba89e883278432cf0dd456e9a1