### PR TITLE
Scope owner label queries in pension forecast tests

### DIFF
--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -74,16 +74,15 @@ describe("PensionForecast page", () => {
     renderWithI18n(<PensionForecast />);
 
     await screen.findByText("beth");
-    const ownerSelects = await screen.findAllByLabelText(/owner/i);
-    const ownerSelect = ownerSelects[ownerSelects.length - 1];
+    const form = document.querySelector("form")!;
+    const ownerSelect = within(form).getByLabelText(/owner/i);
     await userEvent.selectOptions(ownerSelect, "beth");
 
-    const growth = screen.getByLabelText(/growth assumption/i);
+    const growth = within(form).getByLabelText(/growth assumption/i);
     await userEvent.selectOptions(growth, "7");
 
-    const [ownerSelect] = await screen.findAllByLabelText(/owner/i);
     fireEvent.change(ownerSelect, { target: { value: "beth" } });
-    const monthly = screen.getByLabelText(/monthly contribution/i);
+    const monthly = within(form).getByLabelText(/monthly contribution/i);
     fireEvent.change(monthly, { target: { value: "100" } });
 
     const btn = screen.getByRole("button", { name: /forecast/i });


### PR DESCRIPTION
## Summary
- scope owner selection to the form using `within` to avoid ambiguous label matches

## Testing
- `CI=1 npm test -- src/pages/PensionForecast.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c2c8b6d3348327bc9cd82d76571bea