### PR TITLE
test: use userEvent for TopMoversPage selects

### DIFF
--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TopMoversPage } from "./TopMoversPage";
@@ -114,15 +115,11 @@ describe("TopMoversPage", () => {
 
     const selects = screen.getAllByRole("combobox");
     const periodSelect = selects[1];
-    fireEvent.change(periodSelect, { target: { value: "1w" } });
-      await waitFor(() =>
-        expect(mockGetGroupMovers).toHaveBeenLastCalledWith(
-          "all",
-          7,
-          10,
-          0,
-        ),
-      );
+    await userEvent.selectOptions(periodSelect, "1w");
+    await waitFor(() => expect(periodSelect).toHaveValue("1w"));
+    await waitFor(() =>
+      expect(mockGetGroupMovers).toHaveBeenLastCalledWith("all", 7, 10, 0),
+    );
   });
 
   it("fetches watchlist instruments when selecting FTSE 100", async () => {
@@ -138,8 +135,8 @@ describe("TopMoversPage", () => {
 
     const selects = await screen.findAllByRole("combobox");
     const watchlistSelect = selects[0];
-    fireEvent.change(watchlistSelect, { target: { value: "FTSE 100" } });
-
+    await userEvent.selectOptions(watchlistSelect, "FTSE 100");
+    await waitFor(() => expect(watchlistSelect).toHaveValue("FTSE 100"));
     await waitFor(() =>
       expect(mockGetTopMovers).toHaveBeenLastCalledWith(["AAA", "BBB"], 1),
     );


### PR DESCRIPTION
## Summary
- use `userEvent.selectOptions` for period and watchlist selectors in `TopMoversPage` tests
- wait for select value changes before asserting API calls

## Testing
- `npm test` *(fails: 30 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c8b5cc888327a4fac216dddf30c3