### PR TITLE
test: use fake timers in useInstrumentHistory

### DIFF
--- a/frontend/src/hooks/useInstrumentHistory.test.ts
+++ b/frontend/src/hooks/useInstrumentHistory.test.ts
@@ -1,61 +1,68 @@
-import { renderHook, waitFor, act } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
-import * as api from "../api";
+import { renderHook, waitFor, act } from '@testing-library/react';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterAll,
+  afterEach,
+} from 'vitest';
+import * as api from '../api';
 import {
   useInstrumentHistory,
   __clearInstrumentHistoryCache,
-} from "./useInstrumentHistory";
+} from './useInstrumentHistory';
 
-const mockGetInstrumentDetail = vi.spyOn(api, "getInstrumentDetail");
+const mockGetInstrumentDetail = vi.spyOn(api, 'getInstrumentDetail');
 
 afterAll(() => {
   mockGetInstrumentDetail.mockRestore();
 });
 
-describe("useInstrumentHistory", () => {
+describe('useInstrumentHistory', () => {
   beforeEach(() => {
     mockGetInstrumentDetail.mockReset();
     __clearInstrumentHistoryCache();
   });
 
-  it("retries on HTTP 429 responses", async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries on HTTP 429 responses', async () => {
     vi.useFakeTimers();
     mockGetInstrumentDetail.mockRejectedValue(
-      new Error("HTTP 429 – Too Many Requests"),
+      new Error('HTTP 429 – Too Many Requests')
     );
 
-    const { result } = renderHook(() => useInstrumentHistory("ABC", 7));
+    const { result } = renderHook(() => useInstrumentHistory('ABC', 7));
 
     await act(async () => {
+      await vi.runAllTimersAsync();
       await vi.advanceTimersByTimeAsync(2000);
-    });
-
-    await act(async () => {
       await vi.runAllTimersAsync();
     });
 
     await waitFor(() =>
-      expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(3),
+      expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(3)
     );
     expect(result.current.error).toBeTruthy();
-
-    vi.useRealTimers();
   });
 
-  it("uses Retry-After header for backoff", async () => {
+  it('uses Retry-After header for backoff', async () => {
     vi.useFakeTimers();
-    const randSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    const randSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
 
-    const err = new Error("HTTP 429 – Too Many Requests") as any;
-    err.response = { headers: new Headers({ "Retry-After": "2" }) };
+    const err = new Error('HTTP 429 – Too Many Requests') as any;
+    err.response = { headers: new Headers({ 'Retry-After': '2' }) };
 
-    mockGetInstrumentDetail
-      .mockRejectedValueOnce(err)
-      .mockResolvedValueOnce({ mini: { 7: [], 30: [], 180: [] }, positions: [] });
+    mockGetInstrumentDetail.mockRejectedValueOnce(err).mockResolvedValueOnce({
+      mini: { 7: [], 30: [], 180: [] },
+      positions: [],
+    });
 
-    const { result } = renderHook(() => useInstrumentHistory("ABC", 7));
-
-    expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(1);
+    const { result } = renderHook(() => useInstrumentHistory('ABC', 7));
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1500);
@@ -64,23 +71,23 @@ describe("useInstrumentHistory", () => {
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(500);
+      await vi.runAllTimersAsync();
     });
     expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(2);
     expect(result.current.data).not.toBeNull();
 
     randSpy.mockRestore();
-    vi.useRealTimers();
   });
 
-  it("caches detail per ticker regardless of day range", async () => {
+  it('caches detail per ticker regardless of day range', async () => {
     mockGetInstrumentDetail.mockResolvedValue({
       mini: { 7: [], 30: [], 180: [], 365: [] },
       positions: [],
     });
 
     const { result, rerender } = renderHook(
-      ({ days }) => useInstrumentHistory("ABC", days),
-      { initialProps: { days: 7 } },
+      ({ days }) => useInstrumentHistory('ABC', days),
+      { initialProps: { days: 7 } }
     );
 
     await waitFor(() => expect(result.current.data).not.toBeNull());


### PR DESCRIPTION
## Summary
- ensure `useInstrumentHistory` tests use fake timers before rendering
- advance timers and verify retry behavior of `getInstrumentDetail`
- restore real timers after each test

## Testing
- `npx vitest run src/hooks/useInstrumentHistory.test.ts --reporter verbose` *(fails: Test timed out in 5000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c8b506008327b39fe4e3143958cf