### PR TITLE
fix: allow optional rows in useSortableTable

### DIFF
--- a/frontend/src/hooks/useSortableTable.ts
+++ b/frontend/src/hooks/useSortableTable.ts
@@ -1,6 +1,9 @@
 import { useMemo, useState } from "react";
 
-export function useSortableTable<T>(rows: T[], initialSortKey: keyof T) {
+export function useSortableTable<T>(
+  rows: T[] = [],
+  initialSortKey: keyof T,
+) {
   const [sortKey, setSortKey] = useState<keyof T>(initialSortKey);
   const [asc, setAsc] = useState(true);
 

--- a/frontend/src/pages/ScreenerQuery.test.tsx
+++ b/frontend/src/pages/ScreenerQuery.test.tsx
@@ -78,7 +78,7 @@ function renderWithI18n(ui: ReactElement) {
 describe("Screener & Query page", () => {
   beforeEach(() => {
     window.history.pushState({}, "", "/");
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     runCustomQuery.mockResolvedValue([]);
     getScreener.mockResolvedValue([]);
   });


### PR DESCRIPTION
## Summary
- let useSortableTable accept undefined rows by defaulting to an empty array
- reset ScreenerQuery mocks with empty arrays to avoid undefined data

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c8bcab6c8327aaebdde27c7ff8d4