### PR TITLE
fix: restore query param support in smoke generator

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -174,7 +174,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/instrument/",
     "query": {
-      "ticker": "test"
+      "ticker": "AAPL"
     }
   },
   {
@@ -219,14 +219,14 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/movers",
     "query": {
-      "tickers": "test"
+      "tickers": "AAPL"
     }
   },
   {
     "method": "GET",
     "path": "/news",
     "query": {
-      "ticker": "test"
+      "ticker": "AAPL"
     }
   },
   {
@@ -256,7 +256,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/pension/forecast",
     "query": {
-      "owner": "test",
+      "owner": "demo-owner",
       "death_age": "0"
     }
   },
@@ -284,7 +284,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/performance/{owner}/holdings",
     "query": {
-      "date": "test"
+      "date": "1970-01-01"
     }
   },
   {
@@ -351,14 +351,14 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/returns/compare",
     "query": {
-      "owner": "test"
+      "owner": "demo-owner"
     }
   },
   {
     "method": "GET",
     "path": "/scenario",
     "query": {
-      "ticker": "test",
+      "ticker": "AAPL",
       "pct": "0"
     }
   },
@@ -373,7 +373,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/screener/",
     "query": {
-      "tickers": "test"
+      "tickers": "AAPL"
     }
   },
   {
@@ -420,28 +420,28 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/timeseries/edit",
     "query": {
-      "ticker": "test"
+      "ticker": "AAPL"
     }
   },
   {
     "method": "POST",
     "path": "/timeseries/edit",
     "query": {
-      "ticker": "test"
+      "ticker": "AAPL"
     }
   },
   {
     "method": "GET",
     "path": "/timeseries/html",
     "query": {
-      "ticker": "test"
+      "ticker": "AAPL"
     }
   },
   {
     "method": "GET",
     "path": "/timeseries/meta",
     "query": {
-      "ticker": "test"
+      "ticker": "AAPL"
     }
   },
   {
@@ -480,7 +480,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/transactions/compliance",
     "query": {
-      "owner": "test"
+      "owner": "demo-owner"
     }
   },
   {

--- a/scripts/update_smoke_endpoints.py
+++ b/scripts/update_smoke_endpoints.py
@@ -78,6 +78,45 @@ MANUAL_BODIES: dict[tuple[str, str], Any] = {
 
 MANUAL_QUERIES: dict[tuple[str, str], dict[str, str]] = {}
 
+SAMPLE_QUERY_VALUES: dict[str, str] = {
+    "owner": "demo-owner",
+    "account": "demo-account",
+    "user": "user@example.com",
+    "email": "user@example.com",
+    "exchange": "NASDAQ",
+    "ticker": "AAPL",
+    "tickers": "AAPL",
+    "id": "1",
+    "vp_id": "1",
+    "quest_id": "check-in",
+    "slug": "demo-slug",
+    "name": "demo",
+}
+
+
+def _example_for_query_param(name: str, ann: Any) -> str:
+    """Return a representative example value for a query parameter.
+
+    A curated value map similar to ``fillPath`` is used so that generated
+    smoke requests reference existing data rather than placeholders like
+    ``ticker=test`` which can trigger 404 errors.
+    """
+
+    k = name.lower()
+    if k in SAMPLE_QUERY_VALUES:
+        return SAMPLE_QUERY_VALUES[k]
+    if "email" in k:
+        return "user@example.com"
+    if "id" in k:
+        return "1"
+    if "user" in k:
+        return "user@example.com"
+    if "date" in k:
+        return "1970-01-01"
+    if "ticker" in k:
+        return "AAPL"
+    return str(_example_for_type(ann))
+
 
 def main() -> None:
     app = create_app()
@@ -103,7 +142,9 @@ def main() -> None:
                             ann = getattr(param, "annotation", None) or getattr(
                                 param, "outer_type_", None
                             ) or param.type_
-                            params[param.name] = str(_example_for_type(ann))
+                            params[param.name] = _example_for_query_param(
+                                param.name, ann
+                            )
                     if params:
                         ep["query"] = params
                 endpoints.append(ep)


### PR DESCRIPTION
## Summary
- include required query parameters in generated smoke endpoint list
- append query strings when invoking smoke endpoints
- use curated query param values so smoke requests reference real data

## Testing
- `pytest backend/tests/test_smoke_endpoint_list.py --cov=backend --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2cb6f6d0c8327bcbc0e97b5563c56