### PR TITLE
test: refine owner select query in PensionForecast test

### DIFF
--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -75,7 +75,7 @@ describe("PensionForecast page", () => {
 
     await screen.findByText("beth");
     const form = document.querySelector("form")!;
-    const ownerSelect = within(form).getByLabelText(/owner/i);
+    const ownerSelect = await within(form).findByLabelText(/owner/i);
     await userEvent.selectOptions(ownerSelect, "beth");
 
     const growth = within(form).getByLabelText(/growth assumption/i);


### PR DESCRIPTION
## Summary
- ensure PensionForecast test queries owner select within the rendered form using `findByLabelText`

## Testing
- `npm test` *(fails: 26 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cdcd353c8327ae8ae5d7f34574a1