### PR TITLE
test: wrap watchlist selection assertions

### DIFF
--- a/frontend/src/components/TopMoversPage.test.tsx
+++ b/frontend/src/components/TopMoversPage.test.tsx
@@ -134,12 +134,12 @@ describe("TopMoversPage", () => {
     );
 
     const selects = await screen.findAllByRole("combobox");
-    const watchlistSelect = selects[0];
+    const watchlistSelect = selects[0] as HTMLSelectElement;
     await userEvent.selectOptions(watchlistSelect, "FTSE 100");
-    await waitFor(() => expect(watchlistSelect).toHaveValue("FTSE 100"));
-    await waitFor(() =>
-      expect(mockGetTopMovers).toHaveBeenLastCalledWith(["AAA", "BBB"], 1),
-    );
+    await waitFor(() => {
+      expect(watchlistSelect).toHaveValue("FTSE 100");
+      expect(mockGetTopMovers).toHaveBeenLastCalledWith(["AAA", "BBB"], 1);
+    });
   });
 
   it("mounts InstrumentDetail with signal when ticker clicked", async () => {


### PR DESCRIPTION
## Summary
- ensure watchlist selection assertions are wrapped in waitFor
- check mockGetTopMovers is last called with expected tickers and period

## Testing
- `npm test -- src/components/TopMoversPage.test.tsx` *(fails: tests failing, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cdcc5b8083278a4015d117bc4871