### PR TITLE
Add base currency conversion to instrument endpoint

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -127,6 +127,7 @@ class Config:
     accounts_root: Optional[Path] = None
     prices_json: Optional[Path] = None
     risk_free_rate: Optional[float] = None
+    base_currency: Optional[str] = "GBP"
 
     approval_valid_days: Optional[int] = None
     approval_exempt_types: Optional[List[str]] = None

--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -26,6 +26,8 @@ from backend.common.portfolio_loader import list_portfolios
 from backend.common.portfolio_utils import get_security_meta
 from backend.timeseries.cache import load_meta_timeseries_range
 from backend.utils.timeseries_helpers import apply_scaling, get_scaling_override
+from backend.utils.fx_rates import fetch_fx_rate_range
+from backend.config import config
 
 templates_dir = Path(__file__).resolve().parent.parent / "templates"
 env = Environment(
@@ -193,6 +195,9 @@ async def instrument(
     ticker: str = Query(..., description="Full ticker, e.g. VWRL.L"),
     days: int = Query(365, ge=0, le=36500),
     format: str = Query("html", pattern="^(html|json)$"),
+    base_currency: str | None = Query(
+        None, description="Reporting currency for prices"
+    ),
 ):
     """Return price history and portfolio positions for a ticker.
 
@@ -228,6 +233,10 @@ async def instrument(
     sector = meta.get("sector")
     currency = meta.get("currency")
 
+    base_currency = (
+        base_currency or getattr(config, "base_currency", None) or "GBP"
+    ).upper()
+
     ts_is_gbp = currency == "GBP" or "Close_gbp" in df.columns
     if ts_is_gbp and "Close_gbp" not in df.columns and "Close" in df.columns:
         df["Close_gbp"] = df["Close"]
@@ -257,18 +266,54 @@ async def instrument(
             "date": lambda d: d["date"].dt.strftime("%Y-%m-%d"),
             "close": lambda d: d["close"].astype(float),
         }
+        fx_links: Dict[str, str] = {}
+
         is_gbp_ticker = ticker.upper().endswith(".L") or ticker.upper().endswith(".UK")
         if currency == "GBX" or (currency is None and is_gbp_ticker):
             currency = "GBP"
         if "Close_gbp" not in df.columns and "Close" in df.columns and (currency == "GBP" or is_gbp_ticker):
             df["Close_gbp"] = df["Close"]
+
+        if currency not in {"GBP", "GBX"}:
+            pair = f"{currency}GBP"
+            fx_links[pair] = f"/timeseries/meta?ticker={pair}"
+
         if "Close_gbp" in df.columns:
             cols.append("Close_gbp")
             rename["Close_gbp"] = "close_gbp"
             assigns["close_gbp"] = lambda d: d["close_gbp"].astype(float)
             currency = "GBP"
 
-        prices = df[cols].rename(columns=rename).assign(**assigns).to_dict(orient="records")
+        base_lower = base_currency.lower()
+        if base_currency != currency:
+            if "Close_gbp" not in df.columns:
+                df["Close_gbp"] = df["Close"]
+            start_fx = df["Date"].dt.date.min()
+            end_fx = df["Date"].dt.date.max()
+            try:
+                fx = fetch_fx_rate_range(base_currency, start_fx, end_fx)
+                if not fx.empty:
+                    fx["Date"] = pd.to_datetime(fx["Date"])
+                    df = df.merge(fx, on="Date", how="left")
+                    col_name = f"Close_{base_lower}"
+                    df[col_name] = df["Close_gbp"] / pd.to_numeric(df["Rate"], errors="coerce")
+                    df.drop(columns=["Rate"], inplace=True)
+                    cols.append(col_name)
+                    rename[col_name] = f"close_{base_lower}"
+                    assigns[f"close_{base_lower}"] = (
+                        lambda d, c=f"close_{base_lower}": d[c].astype(float)
+                    )
+                    pair = f"{base_currency}GBP"
+                    fx_links[pair] = f"/timeseries/meta?ticker={pair}"
+            except Exception:
+                pass
+
+        prices = (
+            df[cols]
+            .rename(columns=rename)
+            .assign(**assigns)
+            .to_dict(orient="records")
+        )
         mini = {"7": prices[-7:], "30": prices[-30:], "180": prices[-180:]}
         payload = {
             "ticker": ticker,
@@ -281,7 +326,10 @@ async def instrument(
             "currency": currency,
             "name": name,
             "sector": sector,
+            "base_currency": base_currency,
         }
+        if fx_links:
+            payload["fx"] = fx_links
         return JSONResponse(jsonable_encoder(payload))
 
     # ── HTML ───────────────────────────────────────────────────

--- a/tests/test_instrument_route.py
+++ b/tests/test_instrument_route.py
@@ -177,3 +177,93 @@ def test_non_gbp_instrument_has_distinct_close(monkeypatch):
     assert resp.status_code == 200
     prices = resp.json()["prices"]
     assert prices[-1]["close"] != prices[-1]["close_gbp"]
+
+
+def test_base_currency_param_gbp_to_usd(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    app = create_app()
+    df = _make_df()
+    fx_df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-01", periods=2, freq="D"),
+            "Rate": [0.8, 0.8],
+        }
+    )
+    with patch(
+        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
+    ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
+        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
+    ), patch(
+        "backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df
+    ):
+        client = _auth_client(app)
+        resp = client.get(
+            "/instrument?ticker=ABC.L&days=1&format=json&base_currency=USD"
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    prices = data["prices"]
+    assert prices[-1]["close_usd"] == pytest.approx(11.0 / 0.8)
+    assert "USDGBP" in data["fx"]
+
+
+def test_base_currency_param_usd_to_eur(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    app = create_app()
+    df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-01", periods=2, freq="D"),
+            "Close": [10.0, 11.0],
+            "Close_gbp": [8.0, 8.8],
+        }
+    )
+    fx_df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-01", periods=2, freq="D"),
+            "Rate": [0.9, 0.9],
+        }
+    )
+    with patch(
+        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
+    ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
+        "backend.routes.instrument.get_security_meta", return_value={"currency": "USD"}
+    ), patch(
+        "backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df
+    ):
+        client = _auth_client(app)
+        resp = client.get(
+            "/instrument?ticker=ABC.N&days=1&format=json&base_currency=EUR"
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    prices = data["prices"]
+    assert prices[-1]["close_eur"] == pytest.approx(8.8 / 0.9)
+    assert "EURGBP" in data["fx"]
+    assert "USDGBP" in data["fx"]
+
+
+def test_base_currency_from_config(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "base_currency", "USD")
+    app = create_app()
+    df = _make_df()
+    fx_df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-01", periods=2, freq="D"),
+            "Rate": [0.8, 0.8],
+        }
+    )
+    with patch(
+        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
+    ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
+        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
+    ), patch(
+        "backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df
+    ):
+        client = _auth_client(app)
+        resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
+    assert resp.status_code == 200
+    data = resp.json()
+    prices = data["prices"]
+    assert prices[-1]["close_usd"] == pytest.approx(11.0 / 0.8)
+    assert data["base_currency"] == "USD"


### PR DESCRIPTION
## Summary
- allow /instrument route to accept `base_currency` via query or config
- convert instrument prices to requested currency and expose FX links
- cover currency conversion scenarios in instrument route tests

## Testing
- `pytest tests/test_instrument_route.py -q --no-cov`
- `pytest tests/test_fx_conversion.py::test_non_gbp_instrument_on_gbp_exchange -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68c2ffe9b8208327937e3517c7415b02