### PR TITLE
feat: support flexible FX base/quote pairs

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -89,7 +89,7 @@ def _fx_to_gbp(currency: str, cache: Dict[str, float]) -> float:
     end = date.today()
     start = end - timedelta(days=7)
     try:
-        df = fetch_fx_rate_range(currency, start, end)
+        df = fetch_fx_rate_range(currency, "GBP", start, end)
         if not df.empty:
             rate = float(df["Rate"].iloc[-1])
             cache[currency] = rate

--- a/backend/tests/test_portfolio_utils.py
+++ b/backend/tests/test_portfolio_utils.py
@@ -4,7 +4,7 @@ import backend.common.portfolio_utils as pu
 
 
 def test_fx_to_gbp_logs_warning_on_failure(monkeypatch, caplog):
-    def fake_fetch(currency, start, end):
+    def fake_fetch(base, quote, start, end):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(pu, "fetch_fx_rate_range", fake_fetch)
@@ -20,7 +20,7 @@ def test_fx_to_gbp_logs_warning_on_failure(monkeypatch, caplog):
 def test_fx_to_gbp_uses_cache(monkeypatch):
     calls = {"n": 0}
 
-    def fake_fetch(currency, start, end):
+    def fake_fetch(base, quote, start, end):
         calls["n"] += 1
         return pd.DataFrame({"Rate": [0.5]})
 

--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -382,7 +382,7 @@ def _convert_to_gbp(df: pd.DataFrame, ticker: str, exchange: str, start: date, e
 
         if fx.empty and getattr(config, "fx_proxy_url", None):
             try:
-                url = f"{config.fx_proxy_url.rstrip('/')}/{currency}"
+                url = f"{config.fx_proxy_url.rstrip('/')}/{currency}/GBP"
                 params = {"start": start.isoformat(), "end": end.isoformat()}
                 resp = requests.get(url, params=params, timeout=5)
                 if resp.ok:
@@ -395,7 +395,7 @@ def _convert_to_gbp(df: pd.DataFrame, ticker: str, exchange: str, start: date, e
         # monkeypatch this function so no real network calls occur.
         if fx.empty:
             try:
-                fx = fetch_fx_rate_range(currency, start, end).copy()
+                fx = fetch_fx_rate_range(currency, "GBP", start, end).copy()
                 if fx.empty:
                     raise ValueError(f"Offline mode: no FX rates for {currency}")
                 fx["Date"] = pd.to_datetime(fx["Date"])
@@ -407,7 +407,7 @@ def _convert_to_gbp(df: pd.DataFrame, ticker: str, exchange: str, start: date, e
         if fx.empty:
             raise ValueError(f"Offline mode: FX cache lacks range for {currency}")
     else:
-        fx = fetch_fx_rate_range(currency, start, end).copy()
+        fx = fetch_fx_rate_range(currency, "GBP", start, end).copy()
         if fx.empty:
             return df
         fx["Date"] = pd.to_datetime(fx["Date"])

--- a/backend/utils/fx_rates.py
+++ b/backend/utils/fx_rates.py
@@ -7,47 +7,62 @@ import yfinance as yf
 
 logger = logging.getLogger(__name__)
 
-PAIR_MAP = {
-    "USD": "USDGBP=X",
-    "EUR": "EURGBP=X",
-    "CHF": "CHFGBP=X",
-    "JPY": "JPYGBP=X",
-    "CAD": "CADGBP=X",
+# Map of base -> quote -> ticker used by yfinance.  When a pair is missing we
+# fall back to the generic "BASEQUOTE=X" symbol which Yahoo Finance supports for
+# most combinations.
+PAIR_MAP: dict[str, dict[str, str]] = {
+    "USD": {"GBP": "USDGBP=X", "EUR": "USDEUR=X"},
+    "EUR": {"GBP": "EURGBP=X", "USD": "EURUSD=X"},
+    "GBP": {"USD": "GBPUSD=X", "EUR": "GBPEUR=X"},
+    "CHF": {"GBP": "CHFGBP=X"},
+    "JPY": {"GBP": "JPYGBP=X"},
+    "CAD": {"GBP": "CADGBP=X"},
 }
 
 
 # Fallback constants used when remote fetch fails. Values are approximate and
 # only intended for tests/offline scenarios.
-FALLBACK_RATES = {
-    "USD": 0.8,
-    "EUR": 0.9,
-    "CHF": 0.8,
-    "JPY": 0.006,
-    "CAD": 0.6,
+FALLBACK_RATES: dict[tuple[str, str], float] = {
+    ("USD", "GBP"): 0.8,
+    ("EUR", "GBP"): 0.9,
+    ("GBP", "USD"): 1.25,
+    ("EUR", "USD"): 1.1,
 }
 
 
 @lru_cache(maxsize=32)
-def fetch_fx_rate_range(base: str, start_date: date, end_date: date) -> pd.DataFrame:
-    """Return GBP conversion rates for *base* currency.
+def fetch_fx_rate_range(base: str, quote: str, start_date: date, end_date: date) -> pd.DataFrame:
+    """Return FX rates expressed as ``quote`` per unit of ``base``.
 
-    Falls back to a constant if remote fetch fails.
+    Falls back to a constant for common pairs if the remote fetch fails.
     """
+
     base = base.upper()
-    pair = PAIR_MAP.get(base)
+    quote = quote.upper()
+
+    if base == quote:
+        dates = pd.bdate_range(start_date, end_date).date
+        return pd.DataFrame({"Date": dates, "Rate": [1.0] * len(dates)})
+
+    pair = PAIR_MAP.get(base, {}).get(quote)
     if pair is None:
-        raise ValueError(f"Unsupported currency: {base}")
+        pair = f"{base}{quote}=X"
 
     try:
         ticker = yf.Ticker(pair)
-        df = ticker.history(start=start_date, end=end_date + timedelta(days=1), interval="1d")
+        df = ticker.history(
+            start=start_date, end=end_date + timedelta(days=1), interval="1d"
+        )
         if not df.empty:
             df.reset_index(inplace=True)
             df["Date"] = pd.to_datetime(df["Date"]).dt.date
             return df[["Date", "Close"]].rename(columns={"Close": "Rate"}).copy()
     except Exception as exc:
-        logger.info("FX fetch failed for %s: %s", base, exc)
+        logger.info("FX fetch failed for %s/%s: %s", base, quote, exc)
 
     dates = pd.bdate_range(start_date, end_date).date
-    const = FALLBACK_RATES.get(base, 1.0)
+    const = FALLBACK_RATES.get((base, quote))
+    if const is None:
+        inv = FALLBACK_RATES.get((quote, base))
+        const = 1 / inv if inv else 1.0
     return pd.DataFrame({"Date": dates, "Rate": [const] * len(dates)})

--- a/docs/README.md
+++ b/docs/README.md
@@ -207,7 +207,7 @@ from datetime import date
 import pandas as pd
 from backend.utils.fx_rates import fetch_fx_rate_range
 
-df = fetch_fx_rate_range("USD", date(2024,1,1), date.today())
+df = fetch_fx_rate_range("USD", "GBP", date(2024,1,1), date.today())
 df.to_parquet("data/timeseries/fx/USD.parquet", index=False)
 PY
 ```

--- a/tests/common/test_portfolio_utils_risk.py
+++ b/tests/common/test_portfolio_utils_risk.py
@@ -35,7 +35,7 @@ def test_fx_to_gbp_fetch_exception(monkeypatch):
 def test_fx_to_gbp_rate_cached(monkeypatch):
     calls = {"n": 0}
 
-    def fake_fetch(currency, start, end):
+    def fake_fetch(base, quote, start, end):
         calls["n"] += 1
         return pd.DataFrame({"Rate": [1.1, 1.2]})
 

--- a/tests/test_fx_conversion.py
+++ b/tests/test_fx_conversion.py
@@ -32,7 +32,7 @@ def test_prices_converted_to_gbp(monkeypatch, exchange, rate):
     def fake_memoized_range(ticker, exch, s_iso, e_iso):
         return _sample_df(start, end)
 
-    def fake_fx(base, s, e):
+    def fake_fx(base, quote, s, e):
         dates = pd.bdate_range(s, e).date
         return pd.DataFrame({"Date": dates, "Rate": [rate] * len(dates)})
 
@@ -57,7 +57,7 @@ def test_missing_fx_rates_are_filled(monkeypatch):
     def fake_memoized_range(ticker, exch, s_iso, e_iso):
         return _sample_df(start, end)
 
-    def fake_fx(base, s, e):
+    def fake_fx(base, quote, s, e):
         dates = pd.bdate_range(s, e).date
         return pd.DataFrame({"Date": dates, "Rate": ["0.8", None, "0.81"]})
 
@@ -82,7 +82,7 @@ def test_string_fx_rates_are_converted(monkeypatch):
     def fake_memoized_range(ticker, exch, s_iso, e_iso):
         return _sample_df(start, end)
 
-    def fake_fx(base, s, e):
+    def fake_fx(base, quote, s, e):
         dates = pd.bdate_range(s, e).date
         return pd.DataFrame({"Date": dates, "Rate": ["0.8", "0.81"]})
 
@@ -107,7 +107,7 @@ def test_non_gbp_instrument_on_gbp_exchange(monkeypatch):
     def fake_memoized_range(ticker, exch, s_iso, e_iso):
         return _sample_df(start, end)
 
-    def fake_fx(base, s, e):
+    def fake_fx(base, quote, s, e):
         dates = pd.bdate_range(s, e).date
         return pd.DataFrame({"Date": dates, "Rate": [1.25] * len(dates)})
 
@@ -128,7 +128,7 @@ def test_unsupported_currency_skips_conversion(monkeypatch):
     def fake_memoized_range(ticker, exch, s_iso, e_iso):
         return _sample_df(start, end)
 
-    def fake_fx(base, s, e):
+    def fake_fx(base, quote, s, e):
         raise ValueError("Unsupported currency")
 
     monkeypatch.setattr(cache, "_memoized_range", fake_memoized_range)
@@ -239,7 +239,7 @@ def test_offline_mode_fetch_fallback(monkeypatch, tmp_path):
     def fake_memoized_range(ticker, exch, s_iso, e_iso):
         return _sample_df(start, end)
 
-    def fake_fx(base, s, e):
+    def fake_fx(base, quote, s, e):
         dates = pd.bdate_range(s, e).date
         return pd.DataFrame({"Date": dates, "Rate": [0.8] * len(dates)})
 

--- a/tests/test_portfolio_utils_currency.py
+++ b/tests/test_portfolio_utils_currency.py
@@ -29,7 +29,7 @@ def test_aggregate_by_ticker_fx_conversion(monkeypatch):
         lambda t: {"currency": "USD"},
     )
 
-    def fake_fetch(base: str, start, end):
+    def fake_fetch(base: str, quote: str, start, end):
         import pandas as pd
 
         return pd.DataFrame({"Date": [start], "Rate": [0.5]})


### PR DESCRIPTION
## Summary
- allow `fetch_fx_rate_range` to handle arbitrary base/quote pairs with fallbacks
- update portfolio and timeseries modules to specify quote currency
- adjust tests and docs for new FX API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2ffe8cebc8327b3893a49f41373de