### PR TITLE
feat(frontend): flag stale holding prices

### DIFF
--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -168,6 +168,33 @@ describe("HoldingsTable", () => {
         expect(cell).toHaveAttribute('title', expected);
     });
 
+    it("marks stale prices with an asterisk", async () => {
+        const stale: Holding = {
+            ticker: "STALE",
+            name: "Stale Co",
+            currency: "GBP",
+            instrument_type: "Equity",
+            units: 1,
+            price: 0,
+            cost_basis_gbp: 100,
+            market_value_gbp: 100,
+            gain_gbp: 0,
+            current_price_gbp: 100,
+            acquired_date: "2024-01-01",
+            days_held: 10,
+            sell_eligible: true,
+            days_until_eligible: 0,
+            last_price_date: "2024-01-01",
+            last_price_time: "2024-01-01T09:00:00Z",
+            is_stale: true,
+        };
+        render(<HoldingsTable holdings={[stale]} />);
+        const star = await screen.findByTitle("2024-01-01T09:00:00Z");
+        expect(star).toHaveTextContent("*");
+        const price = screen.getByText("£100.00");
+        expect(price).toHaveClass("text-gray");
+    });
+
     it("creates FX pair buttons for currency and skips GBX", async () => {
         const onSelect = vi.fn();
         render(<HoldingsTable holdings={holdings} onSelectInstrument={onSelect}/>);

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -457,9 +457,19 @@ export function HoldingsTable({
                   </td>
                 )}
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                  {money(
-                    h.current_price_gbp,
-                    h.current_price_currency || baseCurrency,
+                  <span className={h.is_stale ? "text-gray" : undefined}>
+                    {money(
+                      h.current_price_gbp,
+                      h.current_price_currency || baseCurrency,
+                    )}
+                  </span>
+                  {h.is_stale && (
+                    <span
+                      className="ml-1 text-warning"
+                      title={h.last_price_time ?? undefined}
+                    >
+                      *
+                    </span>
                   )}
                   {h.last_price_date && (
                     <span

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -23,6 +23,10 @@ export interface Holding {
   current_price_currency?: string | null;
   /** Date of the last known price for this holding */
   last_price_date?: string | null;
+  /** Timestamp of the last known price for this holding */
+  last_price_time?: string | null;
+  /** Whether the current price may be stale */
+  is_stale?: boolean;
   latest_source?: string | null;
   day_change_gbp?: number;
   day_change_currency?: string | null;


### PR DESCRIPTION
## Summary
- extend `Holding` type with `last_price_time` and `is_stale`
- show `*` on stale prices and gray them out in holdings table
- cover stale price metadata in API and table tests

## Testing
- `npm --prefix frontend run lint` *(fails: many lint errors)*
- `npm --prefix frontend run test:jsdom` *(fails: holdings table tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ff1492648327956ab26889a4f3d2