### PR TITLE
test: add models route test

### DIFF
--- a/tests/test_models_route.py
+++ b/tests/test_models_route.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.routes import models
+
+
+def test_models_route_returns_available_models() -> None:
+    """Models route returns the list of available models."""
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/v1/models")
+
+    assert resp.status_code == 200
+    expected = {"data": [{"id": name, "object": "model"} for name in models.MODEL_NAMES]}
+    assert resp.json() == expected


### PR DESCRIPTION
## Summary
- add regression test for `/v1/models` to ensure available model list is returned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2ffc628ac8327a7385cc1131d0245