### PR TITLE
Add edge case tests for portfolio utilities

### DIFF
--- a/tests/common/test_compute_var.py
+++ b/tests/common/test_compute_var.py
@@ -16,3 +16,8 @@ def test_compute_var_insufficient_data_returns_none():
     df = pd.DataFrame({"Close": [100]})
     assert pu.compute_var(df) is None
 
+
+def test_compute_var_empty_dataframe_returns_none():
+    df = pd.DataFrame()
+    assert pu.compute_var(df) is None
+

--- a/tests/common/test_fx_to_gbp.py
+++ b/tests/common/test_fx_to_gbp.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import pytest
+
+from backend.common import portfolio_utils as pu
+
+
+def test_fx_to_gbp_rate_cached(monkeypatch):
+    cache = {}
+    call_count = {"count": 0}
+
+    def fake_fetch(base, quote, start, end):
+        call_count["count"] += 1
+        return pd.DataFrame({"Rate": [1.4]})
+
+    monkeypatch.setattr(pu, "fetch_fx_rate_range", fake_fetch)
+
+    first = pu._fx_to_base("USD", "GBP", cache)
+    second = pu._fx_to_base("usd", "GBP", cache)
+
+    assert first == second == 1.4
+    assert call_count["count"] == 1
+
+
+def test_fx_to_gbp_fetch_exception(monkeypatch, caplog):
+    def boom(*args, **kwargs):
+        raise RuntimeError("fail")
+
+    cache: dict[str, float] = {}
+    monkeypatch.setattr(pu, "fetch_fx_rate_range", boom)
+
+    with caplog.at_level("WARNING"):
+        rate = pu._fx_to_base("USD", "GBP", cache)
+
+    assert rate == 1.0
+    assert cache["USD"] == 1.0
+    assert "Failed to fetch FX rate" in caplog.text

--- a/tests/common/test_load_snapshot.py
+++ b/tests/common/test_load_snapshot.py
@@ -1,0 +1,52 @@
+import json
+import sys
+from datetime import datetime
+import types
+
+import pytest
+
+from backend.common import portfolio_utils as pu
+
+
+def test_load_snapshot_missing_local_file(tmp_path, monkeypatch, caplog):
+    path = tmp_path / "missing.json"
+    monkeypatch.setattr(pu.config, "app_env", "local")
+    monkeypatch.setattr(pu.config, "prices_json", path)
+    monkeypatch.setattr(pu, "_PRICES_PATH", path)
+
+    with caplog.at_level("WARNING"):
+        data, ts = pu._load_snapshot()
+
+    assert data == {}
+    assert ts is None
+    assert "Price snapshot not found" in caplog.text
+
+
+def test_load_snapshot_aws_failure_falls_back_to_local(tmp_path, monkeypatch, caplog):
+    payload = {"XYZ": {"price": 2}}
+    path = tmp_path / "latest_prices.json"
+    path.write_text(json.dumps(payload))
+
+    class ClientError(Exception):
+        pass
+
+    class FakeS3:
+        def get_object(self, Bucket, Key):  # noqa: N802
+            raise ClientError("boom")
+
+    fake_boto3 = types.SimpleNamespace(client=lambda service: FakeS3())
+    fake_exc = types.SimpleNamespace(BotoCoreError=Exception, ClientError=ClientError)
+
+    monkeypatch.setattr(pu.config, "app_env", "aws")
+    monkeypatch.setenv(pu.DATA_BUCKET_ENV, "bucket")
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", fake_exc)
+    monkeypatch.setattr(pu.config, "prices_json", path)
+    monkeypatch.setattr(pu, "_PRICES_PATH", path)
+
+    with caplog.at_level("ERROR"):
+        data, returned_ts = pu._load_snapshot()
+
+    assert data == payload
+    assert returned_ts == datetime.fromtimestamp(path.stat().st_mtime)
+    assert "Failed to fetch price snapshot" in caplog.text


### PR DESCRIPTION
## Summary
- test compute_var with insufficient data and empty DataFrame
- validate FX rate caching and exception path
- cover snapshot loader missing file and AWS fallback

## Testing
- `pytest -o addopts='' tests/common/test_compute_var.py tests/common/test_fx_to_gbp.py tests/common/test_load_snapshot.py --cov=backend.common.portfolio_utils --cov-report=term-missing --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68c6e7fb0a788327a9e0bb7098f9600a