### PR TITLE
chore: exclude tests from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 omit =
     backend/tests/*
+    tests/*
+    */tests/*


### PR DESCRIPTION
## Summary
- ignore tests directories in coverage metrics

## Testing
- `python -m coverage run -m pytest -o addopts= --noconftest tests/test_cov_dummy.py`
- `python -m coverage report`


------
https://chatgpt.com/codex/tasks/task_e_68c6e7f9578c832791cafc457f4e1665