### PR TITLE
Add Hargreaves holdings CSV importer and upload endpoint

### DIFF
--- a/backend/importers/__init__.py
+++ b/backend/importers/__init__.py
@@ -17,6 +17,7 @@ class UnknownProvider(Exception):
 
 _IMPORTER_PATHS: Dict[str, str] = {
     "degiro": "backend.importers.degiro",
+    "hargreaves": "backend.importers.hargreaves",
 }
 
 

--- a/backend/importers/hargreaves.py
+++ b/backend/importers/hargreaves.py
@@ -1,0 +1,53 @@
+"""Parser for Hargreaves Lansdown holdings exports."""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import List
+
+from backend.routes.transactions import Transaction
+
+
+def _to_float(value: str | None) -> float | None:
+    """Convert a string to float, ignoring commas and blanks."""
+    if value is None:
+        return None
+    value = value.strip().replace(",", "")
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def parse(data: bytes) -> List[Transaction]:
+    """Parse a CSV export from Hargreaves Lansdown into holdings.
+
+    The export contains columns such as ``Code``, ``Units held``,
+    ``Price (pence)`` and ``Cost (£)``.  Prices in pence are converted to
+    pounds and costs in pounds are scaled to ``amount_minor`` (pence).
+    """
+
+    text = data.decode("utf-8")
+    reader = csv.DictReader(io.StringIO(text))
+    transactions: List[Transaction] = []
+    for row in reader:
+        code = (row.get("Code") or row.get("code") or "").strip()
+        units = _to_float(row.get("Units held") or row.get("Units"))
+        price_pence = _to_float(row.get("Price (pence)") or row.get("Price"))
+        price = price_pence / 100 if price_pence is not None else None
+        cost = _to_float(row.get("Cost (£)") or row.get("Cost"))
+        amount_minor = cost * 100 if cost is not None else None
+        transactions.append(
+            Transaction(
+                owner="",
+                account="",
+                ticker=code or None,
+                price=price,
+                units=units,
+                amount_minor=amount_minor,
+            )
+        )
+    return transactions

--- a/backend/utils/update_holdings_from_csv.py
+++ b/backend/utils/update_holdings_from_csv.py
@@ -1,1 +1,60 @@
-# Update holdings from CSV placeholder
+"""Utilities to update account holdings from broker CSV exports."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import List, Any
+
+from backend.config import config
+from backend import importers
+from backend.common import portfolio_loader
+
+
+def _to_holding(tx: Any) -> dict[str, object]:
+    cost = (tx.amount_minor or 0.0) / 100.0 if tx.amount_minor is not None else 0.0
+    holding: dict[str, object] = {
+        "ticker": tx.ticker,
+        "units": tx.units or 0.0,
+        "cost_basis_gbp": cost,
+    }
+    if tx.price is not None:
+        holding["current_price_gbp"] = tx.price
+    return holding
+
+
+def update_from_csv(
+    owner: str,
+    account: str,
+    provider: str,
+    data: bytes,
+    *,
+    accounts_root: Path | None = None,
+) -> dict[str, object]:
+    """Parse ``data`` from ``provider`` and update ``owner``/``account`` holdings."""
+
+    transactions: List[Any] = importers.parse(provider, data)
+
+    holdings = [_to_holding(t) for t in transactions if t.ticker]
+
+    payload = {
+        "owner": owner,
+        "account_type": account,
+        "currency": "GBP",
+        "last_updated": date.today().isoformat(),
+        "holdings": holdings,
+    }
+
+    root = Path(accounts_root or config.accounts_root or "")
+    acct_dir = root / owner
+    acct_dir.mkdir(parents=True, exist_ok=True)
+    acct_path = acct_dir / f"{account.lower()}.json"
+    acct_path.write_text(json.dumps(payload, indent=2))
+
+    try:
+        portfolio_loader.rebuild_account_holdings(owner, account, accounts_root or root)
+    except Exception:  # pragma: no cover - rebuild errors are non-fatal
+        pass
+
+    return payload

--- a/tests/test_holdings_import.py
+++ b/tests/test_holdings_import.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.importers import hargreaves
+from backend.utils import update_holdings_from_csv
+from backend.app import create_app
+from backend.config import config
+
+
+SAMPLE_CSV = (
+    "Code,Stock,Units held,Price (pence),Cost (£)\n"
+    "AAA,Alpha,10,150,15\n"
+    "BBB,Beta,5,200,10\n"
+)
+
+
+def test_hargreaves_parse():
+    txs = hargreaves.parse(SAMPLE_CSV.encode())
+    assert len(txs) == 2
+    first = txs[0]
+    assert first.ticker == "AAA"
+    assert first.units == 10
+    assert first.price == pytest.approx(1.5)
+    assert first.amount_minor == pytest.approx(1500)
+
+
+def test_update_holdings_from_csv(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(config, "accounts_root", tmp_path)
+    result = update_holdings_from_csv.update_from_csv(
+        owner="alice",
+        account="isa",
+        provider="hargreaves",
+        data=SAMPLE_CSV.encode(),
+    )
+    acct_file = tmp_path / "alice" / "isa.json"
+    assert acct_file.exists()
+    data = json.loads(acct_file.read_text())
+    assert len(data["holdings"]) == 2
+    h = {h["ticker"]: h for h in data["holdings"]}
+    assert h["AAA"]["units"] == 10
+    assert h["AAA"]["cost_basis_gbp"] == 15
+    assert h["AAA"]["current_price_gbp"] == pytest.approx(1.5)
+    assert result["account_type"].lower() == "isa"
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "accounts_root", tmp_path)
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    app = create_app()
+    app.state.accounts_root = tmp_path
+    with TestClient(app) as c:
+        yield c
+
+
+def test_holdings_import_endpoint(client: TestClient, tmp_path: Path):
+    files = {"file": ("holdings.csv", SAMPLE_CSV.encode())}
+    data = {"provider": "hargreaves", "owner": "alice", "account": "isa"}
+    resp = client.post("/holdings/import", data=data, files=files)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["account_type"].lower() == "isa"
+    assert (tmp_path / "alice" / "isa.json").exists()


### PR DESCRIPTION
## Summary
- parse Hargreaves Lansdown holdings CSVs into internal Transaction records
- expose `/holdings/import` endpoint wiring parsed holdings into account JSON
- add utility to transform holdings CSV into stored account holdings

## Testing
- `pytest tests/test_holdings_import.py --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6ee12ec18832787ec94d807cdf770