### PR TITLE
Ensure tooltip text is dark for readability

### DIFF
--- a/frontend/src/pages/MarketOverview.tsx
+++ b/frontend/src/pages/MarketOverview.tsx
@@ -41,7 +41,7 @@ export default function MarketOverview() {
     if (active && payload && payload.length) {
       const { value, change } = payload[0].payload;
       return (
-        <div className="rounded border bg-white p-2 text-sm shadow">
+        <div className="rounded border bg-white p-2 text-sm shadow text-gray-900">
           <p className="font-semibold">{label}</p>
           <p>Level: {value.toLocaleString()}</p>
           <p>Change: {change.toFixed(2)}%</p>
@@ -124,7 +124,7 @@ export default function MarketOverview() {
               height={100}
             />
             <YAxis />
-            <Tooltip />
+            <Tooltip contentStyle={{ backgroundColor: '#fff', color: '#213547' }} />
             <Bar dataKey="change" fill="#82ca9d" />
           </BarChart>
         </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- add `text-gray-900` to index-level tooltip so text stays dark on white background
- give sector performance chart tooltip a white background with dark text

## Testing
- `npm test -- --run` (fails: The width(0) and height(0) of chart should be greater than 0)
- `npm run lint` (fails: Fast refresh only works when a file only exports components)


------
https://chatgpt.com/codex/tasks/task_e_68c6f0a56dc48327b296f185f3a8469f