### PR TITLE
Align FX mocks with new rate signature

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -403,7 +403,7 @@ def _convert_to_base_currency(
 
             if fx.empty:
                 try:
-                    fx = fetch_fx_rate_range(curr, start, end).copy()
+                    fx = fetch_fx_rate_range(curr, "GBP", start, end).copy()
                     if fx.empty:
                         raise ValueError(f"Offline mode: no FX rates for {curr}")
 
@@ -416,7 +416,7 @@ def _convert_to_base_currency(
             if fx.empty:
                 raise ValueError(f"Offline mode: FX cache lacks range for {curr}")
         else:
-            fx = fetch_fx_rate_range(curr, start, end).copy()
+            fx = fetch_fx_rate_range(curr, "GBP", start, end).copy()
             if fx.empty:
                 return pd.DataFrame()
             fx["Date"] = pd.to_datetime(fx["Date"])

--- a/tests/test_fx_conversion.py
+++ b/tests/test_fx_conversion.py
@@ -57,7 +57,7 @@ def test_prices_converted_to_arbitrary_base_currency(monkeypatch):
     def fake_memoized_range(ticker, exch, s_iso, e_iso):
         return _sample_df(start, end)
 
-    def fake_fx(base, s, e):
+    def fake_fx(base, quote, s, e):
         dates = pd.bdate_range(s, e).date
         rates = {"USD": 0.8, "EUR": 0.9}
         return pd.DataFrame({"Date": dates, "Rate": [rates[base]] * len(dates)})


### PR DESCRIPTION
## Summary
- Update FX conversion tests to mock fetch_fx_rate_range(base, quote, s, e)
- Pass GBP quote currency to fetch_fx_rate_range in cache

## Testing
- `pytest tests/test_fx_conversion.py` *(fails: Required test coverage of 80% not reached)*
- `pytest --cov=backend --cov-fail-under=0 tests/test_fx_conversion.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6f09af3d083279e8ad18972e721a7