### PR TITLE
Specify GBP quote for FX rate fetching

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -403,7 +403,7 @@ def _convert_to_base_currency(
 
             if fx.empty:
                 try:
-                    fx = fetch_fx_rate_range(curr, start, end).copy()
+                    fx = fetch_fx_rate_range(curr, "GBP", start, end).copy()
                     if fx.empty:
                         raise ValueError(f"Offline mode: no FX rates for {curr}")
 
@@ -416,7 +416,7 @@ def _convert_to_base_currency(
             if fx.empty:
                 raise ValueError(f"Offline mode: FX cache lacks range for {curr}")
         else:
-            fx = fetch_fx_rate_range(curr, start, end).copy()
+            fx = fetch_fx_rate_range(curr, "GBP", start, end).copy()
             if fx.empty:
                 return pd.DataFrame()
             fx["Date"] = pd.to_datetime(fx["Date"])

--- a/tests/test_fx_conversion.py
+++ b/tests/test_fx_conversion.py
@@ -57,7 +57,7 @@ def test_prices_converted_to_arbitrary_base_currency(monkeypatch):
     def fake_memoized_range(ticker, exch, s_iso, e_iso):
         return _sample_df(start, end)
 
-    def fake_fx(base, s, e):
+    def fake_fx(base, quote, s, e):
         dates = pd.bdate_range(s, e).date
         rates = {"USD": 0.8, "EUR": 0.9}
         return pd.DataFrame({"Date": dates, "Rate": [rates[base]] * len(dates)})


### PR DESCRIPTION
## Summary
- ensure `_load_rates` passes explicit GBP quote when fetching FX rates in both offline and online modes
- adjust FX conversion tests for new `fetch_fx_rate_range` signature

## Testing
- `pytest tests/test_fx_conversion.py::test_prices_converted_to_gbp -q -o addopts=""`
- `pytest tests/test_fx_conversion.py -q -o addopts=""`
- `pytest -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68c6f098e100832795be1a82ab6378da