### PR TITLE
Honor disable_auth for trail endpoints

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -1,22 +1,40 @@
 from fastapi import APIRouter, Depends, HTTPException
 
 from backend.auth import get_current_user
+from backend.config import config
 from backend.quests import trail
 
 router = APIRouter(prefix="/trail", tags=["trail"])
 
 
-@router.get("")
-async def list_tasks(current_user: str = Depends(get_current_user)):
-    """Return tasks for the authenticated user."""
-    return {"tasks": trail.get_tasks(current_user)}
+if config.disable_auth:
 
+    @router.get("")
+    async def list_tasks():
+        """Return tasks for the demo user when authentication is disabled."""
+        return {"tasks": trail.get_tasks("demo")}
 
-@router.post("/{task_id}/complete")
-async def complete_task(task_id: str, current_user: str = Depends(get_current_user)):
-    """Mark ``task_id`` complete for the authenticated user."""
-    try:
-        tasks = trail.mark_complete(current_user, task_id)
-    except KeyError:
-        raise HTTPException(status_code=404, detail="Task not found")
-    return {"tasks": tasks}
+    @router.post("/{task_id}/complete")
+    async def complete_task(task_id: str):
+        """Mark ``task_id`` complete for the demo user when auth is disabled."""
+        try:
+            tasks = trail.mark_complete("demo", task_id)
+        except KeyError:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return {"tasks": tasks}
+
+else:
+
+    @router.get("")
+    async def list_tasks(current_user: str = Depends(get_current_user)):
+        """Return tasks for the authenticated user."""
+        return {"tasks": trail.get_tasks(current_user)}
+
+    @router.post("/{task_id}/complete")
+    async def complete_task(task_id: str, current_user: str = Depends(get_current_user)):
+        """Mark ``task_id`` complete for the authenticated user."""
+        try:
+            tasks = trail.mark_complete(current_user, task_id)
+        except KeyError:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return {"tasks": tasks}


### PR DESCRIPTION
## Summary
- Allow unauthenticated access to trail tasks when `disable_auth` is enabled, using the demo user
- Preserve authenticated behavior when auth is enabled

## Testing
- `ruff check backend/routes/trail.py`
- `black --check backend/routes/trail.py`
- `pytest` *(fails: TypeError in tests/test_fx_conversion.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f13cc4d8832799b7cf54e7f07b93