### PR TITLE
fix: specify quote currency when fetching FX rates

### DIFF
--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -293,7 +293,7 @@ async def instrument(
             start_fx = df["Date"].dt.date.min()
             end_fx = df["Date"].dt.date.max()
             try:
-                fx = fetch_fx_rate_range(base_currency, start_fx, end_fx)
+                fx = fetch_fx_rate_range(base_currency, "GBP", start_fx, end_fx)
                 if not fx.empty:
                     fx["Date"] = pd.to_datetime(fx["Date"])
                     df = df.merge(fx, on="Date", how="left")


### PR DESCRIPTION
## Summary
- Ensure instrument route specifies GBP as quote when fetching FX rate ranges

## Testing
- `pytest -o addopts='' tests/test_instrument_route.py::test_base_currency_param_gbp_to_usd tests/test_instrument_route.py::test_base_currency_param_usd_to_eur tests/test_instrument_route.py::test_base_currency_from_config -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6f14240d48327a86e164cf4cf9983