### PR TITLE
Add RightRail sidebar with VaR chart and alerts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,6 +54,7 @@ import Rebalance from "./pages/Rebalance";
 import PensionForecast from "./pages/PensionForecast";
 import TaxHarvest from "./pages/TaxHarvest";
 import TaxAllowances from "./pages/TaxAllowances";
+import RightRail from "./components/RightRail";
 
 interface AppProps {
   onLogout?: () => void;
@@ -353,7 +354,8 @@ export default function App({ onLogout }: AppProps) {
   }
 
   return (
-    <div style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
+    <div className="xl:flex xl:justify-center">
+      <main style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
       <div
         style={{
           display: "flex",
@@ -510,6 +512,8 @@ export default function App({ onLogout }: AppProps) {
       {mode === "logs" && <Logs />}
       {mode === "scenario" && <ScenarioTester />}
       {mode === "pension" && <PensionForecast />}
+      </main>
+      <RightRail owner={selectedOwner} />
     </div>
   );
 }

--- a/frontend/src/components/RightRail.tsx
+++ b/frontend/src/components/RightRail.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  Tooltip,
+} from "recharts";
+import { getValueAtRisk, getAlerts } from "../api";
+import type { Alert } from "../types";
+
+interface RightRailProps {
+  owner: string;
+}
+
+interface VarDatum {
+  horizon: string;
+  value: number | null;
+}
+
+export default function RightRail({ owner }: RightRailProps) {
+  const [varData, setVarData] = useState<VarDatum[]>([]);
+  const [open, setOpen] = useState(false);
+  const [alerts, setAlerts] = useState<Alert[]>([]);
+
+  useEffect(() => {
+    if (!owner) {
+      setVarData([]);
+      return;
+    }
+    Promise.resolve(getValueAtRisk?.(owner, { days: 30 }))
+      .then((res) => {
+        const d: VarDatum[] = [
+          { horizon: "1d", value: res.var["1d"] ?? null },
+          { horizon: "10d", value: res.var["10d"] ?? null },
+        ];
+        setVarData(d.filter((v) => v.value != null));
+      })
+      .catch(() => setVarData([]));
+  }, [owner]);
+
+  useEffect(() => {
+    if (typeof getAlerts === "function") {
+      Promise.resolve(getAlerts())
+        .then((res) => setAlerts(res.slice(0, 3)))
+        .catch(() => setAlerts([]));
+    }
+  }, []);
+
+  const content = (
+    <div className="space-y-4">
+      <div>
+        <h3 className="mb-2 text-lg font-semibold">Value at Risk</h3>
+        {varData.length > 0 ? (
+          <ResponsiveContainer width="100%" height={120}>
+            <BarChart data={varData}>
+              <XAxis dataKey="horizon" hide />
+              <Tooltip />
+              <Bar dataKey="value" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <p className="text-sm text-gray-500">No data</p>
+        )}
+      </div>
+      <div>
+        <h3 className="mb-2 text-lg font-semibold">Alerts</h3>
+        {alerts.length > 0 ? (
+          <ul className="list-disc pl-4 text-sm">
+            {alerts.map((a, i) => (
+              <li key={i}>
+                <strong>{a.ticker}</strong>: {a.message}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-gray-500">No alerts</p>
+        )}
+      </div>
+      <div className="flex flex-col space-y-1 text-sm">
+        <a href="/docs" className="text-blue-600 hover:underline">
+          Docs
+        </a>
+        <a href="/support" className="text-blue-600 hover:underline">
+          Help
+        </a>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <aside className="hidden xl:block w-64 p-4" data-testid="right-rail">
+        {content}
+      </aside>
+      <button
+        className="fixed bottom-4 right-4 rounded-full bg-blue-600 p-3 text-white shadow-xl xl:hidden"
+        aria-label="Open info panel"
+        onClick={() => setOpen(true)}
+      >
+        ☰
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-end xl:hidden">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setOpen(false)}
+          />
+          <div className="relative w-full rounded-t-lg bg-white p-4">
+            <button
+              className="mb-2 text-sm text-gray-600"
+              onClick={() => setOpen(false)}
+            >
+              Close
+            </button>
+            {content}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add RightRail component showing Value at Risk mini bar chart, alerts, and helpful links
- display RightRail as desktop sidebar and mobile bottom sheet
- render RightRail within App layout on wide screens

## Testing
- `CI=true npm test -- --run` *(fails to complete due to environment warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f217aaec83279d8ff104da17440e