### PR TITLE
feat: add summary bar and member page

### DIFF
--- a/frontend/src/components/SummaryBar.tsx
+++ b/frontend/src/components/SummaryBar.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from "react-i18next";
+import { OwnerSelector } from "./OwnerSelector";
+import type { OwnerSummary } from "../types";
+
+interface Props {
+  owners: OwnerSummary[];
+  owner: string;
+  onOwnerChange: (owner: string) => void;
+  onRefresh: () => void;
+}
+
+export default function SummaryBar({ owners, owner, onOwnerChange, onRefresh }: Props) {
+  const { t } = useTranslation();
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        marginBottom: "1rem",
+        gap: "1rem",
+      }}
+    >
+      <OwnerSelector owners={owners} selected={owner} onSelect={onOwnerChange} />
+      <button onClick={onRefresh}>{t("watchlist.refresh")}</button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Member.tsx
+++ b/frontend/src/pages/Member.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { getOwners, getPortfolio } from "../api";
+import SummaryBar from "../components/SummaryBar";
+import { PortfolioView } from "../components/PortfolioView";
+import { useRoute } from "../RouteContext";
+import useFetchWithRetry from "../hooks/useFetchWithRetry";
+import type { OwnerSummary, Portfolio } from "../types";
+
+export function Member() {
+  const { selectedOwner, setSelectedOwner } = useRoute();
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  const ownersReq = useFetchWithRetry<OwnerSummary[]>(getOwners, 500, 5, [retryNonce]);
+
+  const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedOwner) {
+      setPortfolio(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    getPortfolio(selectedOwner)
+      .then((p) => {
+        setPortfolio(p);
+        setError(null);
+      })
+      .catch(() => setError("Failed to load portfolio"))
+      .finally(() => setLoading(false));
+  }, [selectedOwner, retryNonce]);
+
+  return (
+    <div className="p-4 md:p-8">
+      <SummaryBar
+        owners={ownersReq.data ?? []}
+        owner={selectedOwner}
+        onOwnerChange={setSelectedOwner}
+        onRefresh={() => setRetryNonce((n) => n + 1)}
+      />
+      <PortfolioView data={portfolio} loading={loading} error={error} />
+    </div>
+  );
+}
+
+export default Member;

--- a/frontend/src/plugins/owner.ts
+++ b/frontend/src/plugins/owner.ts
@@ -1,12 +1,12 @@
-import { PortfolioView } from "../components/PortfolioView";
+import Member from "../pages/Member";
 import type { ComponentProps } from "react";
 import type { TabPlugin } from "./TabPlugin";
 
-type Props = ComponentProps<typeof PortfolioView>;
+type Props = ComponentProps<typeof Member>;
 
 const plugin: TabPlugin<Props> = {
   id: "owner",
-  component: PortfolioView,
+  component: Member,
   priority: 30,
   path: ({ owner }) => (owner ? `/member/${owner}` : "/member"),
 };


### PR DESCRIPTION
## Summary
- add SummaryBar component with owner selector and refresh button
- create Member page rendering SummaryBar and PortfolioView
- update owner plugin to use new Member page

## Testing
- `npm test` *(fails: 22 failed, 18 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f21459c883278deb6531349b9f02