### PR TITLE
feat(frontend): add section deduping utility

### DIFF
--- a/frontend/src/lib/dedupeSections.test.ts
+++ b/frontend/src/lib/dedupeSections.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { dedupeSections, type Section } from './dedupeSections';
+
+describe('dedupeSections', () => {
+  it('merges sections with identical titles', () => {
+    const input: Section<number>[] = [
+      { title: 'A', cards: [1] },
+      { title: 'B', cards: [2] },
+      { title: 'A', cards: [3, 4] },
+    ];
+
+    const result = dedupeSections(input);
+
+    expect(result).toEqual([
+      { title: 'A', cards: [1, 3, 4] },
+      { title: 'B', cards: [2] },
+    ]);
+
+    // ensure original array was not mutated
+    expect(input[0].cards).toEqual([1]);
+  });
+});

--- a/frontend/src/lib/dedupeSections.ts
+++ b/frontend/src/lib/dedupeSections.ts
@@ -1,0 +1,24 @@
+export interface Section<T> {
+  /** Human-readable section title */
+  title: string;
+  /** Items belonging to the section */
+  cards: T[];
+}
+
+/**
+ * Merge sections with identical titles by concatenating their card lists.
+ *
+ * A new array is returned and the original input is left unmodified.
+ */
+export function dedupeSections<T>(sections: Section<T>[]): Section<T>[] {
+  const map = new Map<string, T[]>();
+  for (const { title, cards } of sections) {
+    const existing = map.get(title);
+    if (existing) {
+      existing.push(...cards);
+    } else {
+      map.set(title, [...cards]);
+    }
+  }
+  return Array.from(map.entries()).map(([title, cards]) => ({ title, cards }));
+}


### PR DESCRIPTION
## Summary
- add generic `dedupeSections` helper to merge sections with same title
- cover dedupe logic with unit test

## Testing
- `npm test` *(fails: multiple existing test failures in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f21d4f948327a753a6e7bcf6333f