### PR TITLE
feat(frontend): add reusable empty state

### DIFF
--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,35 @@
+import type { HTMLAttributes } from "react";
+
+interface Action {
+  label: string;
+  onClick: () => void;
+}
+
+interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
+  message: string;
+  actions?: Action[];
+}
+
+export function EmptyState({ message, actions = [], ...divProps }: EmptyStateProps) {
+  return (
+    <div className="p-4 text-center text-gray-500" {...divProps}>
+      <p>{message}</p>
+      {actions.length > 0 && (
+        <div className="mt-4 flex justify-center gap-2">
+          {actions.map((a) => (
+            <button
+              key={a.label}
+              type="button"
+              onClick={a.onClick}
+              className="rounded bg-blue-500 px-4 py-2 text-white"
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default EmptyState;

--- a/frontend/src/components/HoldingsTable.test.tsx
+++ b/frontend/src/components/HoldingsTable.test.tsx
@@ -327,8 +327,10 @@ describe("HoldingsTable", () => {
           render(<HoldingsTable holdings={holdings} />);
           expect(await screen.findByText('View:')).toBeInTheDocument();
           expect(screen.getByText('No holdings match the current filters.')).toBeInTheDocument();
+          expect(screen.getByRole('button', { name: 'Clear filters' })).toBeInTheDocument();
+          expect(screen.getByRole('button', { name: 'Open Screener' })).toBeInTheDocument();
           await act(async () => {
-              await userEvent.click(screen.getByRole('button', { name: 'All' }));
+              await userEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
           });
           expect(screen.getByText('AAA')).toBeInTheDocument();
       });

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -16,6 +16,8 @@ import { useConfig } from "../ConfigContext";
 import { isSupportedFx } from "../lib/fx";
 import { formatDateISO } from "../lib/date";
 import { RelativeViewToggle } from "./RelativeViewToggle";
+import EmptyState from "./EmptyState";
+import { useNavigate } from "react-router-dom";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ResponsiveContainer, LineChart, Line } from "recharts";
 import Sparkline from "./Sparkline";
@@ -38,6 +40,12 @@ export function HoldingsTable({
 }: Props) {
   const { t } = useTranslation();
   const { relativeViewEnabled, baseCurrency } = useConfig();
+  let navigate: (path: string) => void = () => {};
+  try {
+    navigate = useNavigate();
+  } catch {
+    // no router context
+  }
 
   const viewPresets = useMemo(
     () => [
@@ -49,14 +57,16 @@ export function HoldingsTable({
     [t],
   );
 
-  const [filters, setFilters] = useState({
+  const initialFilters = {
     ticker: "",
     name: "",
     instrument_type: "",
     units: "",
     gain_pct: "",
     sell_eligible: "",
-  });
+  };
+
+  const [filters, setFilters] = useState(initialFilters);
 
   const [viewPreset, setViewPreset] = useState(() =>
     typeof window === "undefined"
@@ -87,6 +97,11 @@ export function HoldingsTable({
 
   const handleFilterChange = (key: keyof typeof filters, value: string) => {
     setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const clearFilters = () => {
+    setFilters(initialFilters);
+    setViewPreset("");
   };
 
 
@@ -558,7 +573,13 @@ export function HoldingsTable({
         </table>
         </div>
       ) : (
-        <p>{t("holdingsTable.noHoldings")}</p>
+        <EmptyState
+          message={t("holdingsTable.noHoldings")}
+          actions={[
+            { label: t("holdingsTable.clearFilters"), onClick: clearFilters },
+            { label: t("holdingsTable.openScreener"), onClick: () => navigate("/screener") },
+          ]}
+        />
       )}
     </>
   );

--- a/frontend/src/components/NotificationsDrawer.tsx
+++ b/frontend/src/components/NotificationsDrawer.tsx
@@ -1,6 +1,7 @@
 import { useFetch } from "../hooks/useFetch";
 import * as api from "../api";
 import type { Alert, Nudge } from "../types";
+import EmptyState from "./EmptyState";
 
 interface Props {
   open: boolean;
@@ -77,7 +78,9 @@ export function NotificationsDrawer({ open, onClose }: Props) {
         </div>
         {alertLoading && <div>Loading...</div>}
         {alertError && <div>Cannot reach server</div>}
-        {!alertLoading && !alertError && alertList.length === 0 && <div>No alerts</div>}
+        {!alertLoading && !alertError && alertList.length === 0 && (
+          <EmptyState message="No alerts" />
+        )}
         {!alertLoading && !alertError && alertList.length > 0 && (
           <ul style={{ listStyle: "none", padding: 0 }}>
             {alertList.map((a, i) => (
@@ -102,7 +105,9 @@ export function NotificationsDrawer({ open, onClose }: Props) {
         </div>
         {nudgeLoading && <div>Loading...</div>}
         {nudgeError && <div>Cannot reach server</div>}
-        {!nudgeLoading && !nudgeError && nudgeList.length === 0 && <div>No nudges</div>}
+        {!nudgeLoading && !nudgeError && nudgeList.length === 0 && (
+          <EmptyState message="No nudges" />
+        )}
         {!nudgeLoading && !nudgeError && nudgeList.length > 0 && (
           <ul style={{ listStyle: "none", padding: 0 }}>
             {nudgeList.map((n) => (

--- a/frontend/src/components/TopMoversSummary.tsx
+++ b/frontend/src/components/TopMoversSummary.tsx
@@ -7,6 +7,7 @@ import tableStyles from "../styles/table.module.css";
 import moversPlugin from "../plugins/movers";
 import { SignalBadge } from "./SignalBadge";
 import { InstrumentDetail } from "./InstrumentDetail";
+import EmptyState from "./EmptyState";
 
 interface Props {
   slug?: string;
@@ -53,7 +54,7 @@ export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
       .slice(0, limit);
   }, [data, limit]);
 
-  if (!slug) return <div>No group selected.</div>;
+  if (!slug) return <EmptyState message="No group selected." />;
   if (loading) return <div>Loading...</div>;
   if (error) return <div>Failed to load movers.</div>;
   if (rows.length === 0) return null;

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -122,6 +122,8 @@
       "no": "Nein"
     },
     "noHoldings": "Keine Bestände entsprechen den aktuellen Filtern.",
+    "clearFilters": "Filter löschen",
+    "openScreener": "Screener öffnen",
     "source": "Quelle:",
     "actualPurchaseCost": "Tatsächliche Anschaffungskosten",
     "inferredCost": "Abgeleitet vom Preis am Erwerbsdatum",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -124,6 +124,8 @@
       "no": "No"
     },
     "noHoldings": "No holdings match the current filters.",
+    "clearFilters": "Clear filters",
+    "openScreener": "Open Screener",
     "source": "Source:",
     "actualPurchaseCost": "Actual purchase cost",
     "inferredCost": "Inferred from price on acquisition date",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -122,6 +122,8 @@
       "no": "No"
     },
     "noHoldings": "No hay posiciones que coincidan con los filtros actuales.",
+    "clearFilters": "Limpiar filtros",
+    "openScreener": "Abrir Screener",
     "source": "Fuente:",
     "actualPurchaseCost": "Costo de compra real",
     "inferredCost": "Inferido del precio en la fecha de adquisición",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -122,6 +122,8 @@
       "no": "Non"
     },
     "noHoldings": "Aucune position ne correspond aux filtres actuels.",
+    "clearFilters": "Effacer les filtres",
+    "openScreener": "Ouvrir le Screener",
     "source": "Source :",
     "actualPurchaseCost": "Coût d'achat réel",
     "inferredCost": "Déduit du prix à la date d'acquisition",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -122,6 +122,8 @@
       "no": "NO"
     },
     "noHoldings": "Nessuna partecipazione corrisponde ai filtri attuali.",
+    "clearFilters": "Cancella filtri",
+    "openScreener": "Apri Screener",
     "source": "Fonte:",
     "actualPurchaseCost": "Costo di acquisto effettivo",
     "inferredCost": "Dedotto dal prezzo alla data di acquisizione",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -122,6 +122,8 @@
       "no": "Não"
     },
     "noHoldings": "Nenhuma posição corresponde aos filtros atuais.",
+    "clearFilters": "Limpar filtros",
+    "openScreener": "Abrir Screener",
     "source": "Fonte:",
     "actualPurchaseCost": "Custo de compra real",
     "inferredCost": "Inferido do preço na data de aquisição",

--- a/frontend/src/pages/Alerts.tsx
+++ b/frontend/src/pages/Alerts.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import * as api from "../api";
 import type { Alert } from "../types";
+import EmptyState from "../components/EmptyState";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import errorToast from "../utils/errorToast";
 
@@ -75,11 +76,7 @@ export default function Alerts() {
   }
 
   if (alerts.length === 0) {
-    return (
-      <div role="status" aria-live="polite">
-        No alerts.
-      </div>
-    );
+    return <EmptyState message="No alerts." role="status" aria-live="polite" />;
   }
 
   return (

--- a/frontend/src/pages/AllowanceTracker.tsx
+++ b/frontend/src/pages/AllowanceTracker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getAllowances } from "../api";
+import EmptyState from "../components/EmptyState";
 
 interface AllowanceInfo {
   used: number;
@@ -24,7 +25,7 @@ export default function AllowanceTracker() {
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p className="text-red-500">{error}</p>;
-  if (!data) return <p>No data</p>;
+  if (!data) return <EmptyState message="No data" />;
 
   return (
     <div>

--- a/frontend/src/pages/ComplianceWarnings.tsx
+++ b/frontend/src/pages/ComplianceWarnings.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { complianceForOwner, getOwners } from "../api";
 import type { OwnerSummary, ComplianceResult } from "../types";
 import { OwnerSelector } from "../components/OwnerSelector";
+import EmptyState from "../components/EmptyState";
 
 export default function ComplianceWarnings() {
   const { owner: ownerParam } = useParams<{ owner?: string }>();
@@ -53,7 +54,7 @@ export default function ComplianceWarnings() {
               ))}
             </ul>
           ) : (
-            <p>No warnings.</p>
+            <EmptyState message="No warnings." />
           )}
 
           {result.hold_countdowns &&

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -5,6 +5,7 @@ import { useInstrumentHistory } from "../hooks/useInstrumentHistory";
 import { InstrumentHistoryChart } from "../components/InstrumentHistoryChart";
 import { getScreener, getNews, getQuotes } from "../api";
 import type { ScreenerResult, NewsItem, QuoteRow } from "../types";
+import EmptyState from "../components/EmptyState";
 import { largeNumber } from "../lib/money";
 import { useConfig } from "../ConfigContext";
 
@@ -401,7 +402,7 @@ export default function InstrumentResearch() {
       ) : newsError ? (
         <div>{newsError}</div>
       ) : news.length === 0 ? (
-        <div>No news available</div>
+        <EmptyState message="No news available" />
       ) : (
         <div>
           <h2>News</h2>

--- a/frontend/src/pages/MarketOverview.tsx
+++ b/frontend/src/pages/MarketOverview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getMarketOverview } from '../api';
 import type { MarketOverview as MarketOverviewData } from '../types';
+import EmptyState from '../components/EmptyState';
 import {
   ResponsiveContainer,
   BarChart,
@@ -135,11 +136,9 @@ export default function MarketOverview() {
           {t('market.latestHeadlines', { defaultValue: 'Latest Headlines' })}
         </h2>
         {data.headlines.length === 0 ? (
-          <p>
-            {t('market.noHeadlines', {
-              defaultValue: 'No headlines available',
-            })}
-          </p>
+          <EmptyState
+            message={t('market.noHeadlines', { defaultValue: 'No headlines available' })}
+          />
         ) : (
           <ul className="list-disc pl-4">
             {data.headlines.map((h, idx) => (

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,11 +1,12 @@
 import { useConfig } from "../ConfigContext";
 import { useAuth } from "../AuthContext";
+import EmptyState from "../components/EmptyState";
 export default function ProfilePage() {
   const { user } = useAuth();
   const { theme } = useConfig();
 
   if (!user) {
-    return <div className="p-4">No user information available.</div>;
+    return <EmptyState message="No user information available." />;
   }
 
   const placeholder =

--- a/frontend/src/pages/Rebalance.tsx
+++ b/frontend/src/pages/Rebalance.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { getRebalance } from '../api';
 import type { TradeSuggestion } from '../types';
+import EmptyState from '../components/EmptyState';
 
 type Row = { ticker: string; current: string; target: string };
 
@@ -155,7 +156,9 @@ export default function Rebalance() {
           </tbody>
         </table>
       )}
-      {trades && trades.length === 0 && <p>No trades required.</p>}
+      {trades && trades.length === 0 && (
+        <EmptyState message="No trades required." />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/TaxAllowances.tsx
+++ b/frontend/src/pages/TaxAllowances.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getAllowances } from "../api";
+import EmptyState from "../components/EmptyState";
 
 interface AllowanceInfo {
   used: number;
@@ -24,7 +25,7 @@ export default function TaxAllowances() {
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p className="text-red-500">{error}</p>;
-  if (!data) return <p>No data</p>;
+  if (!data) return <EmptyState message="No data" />;
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- add `EmptyState` component for consistent messaging and action buttons
- replace scattered fallback messages with `<EmptyState>` usage
- expose clear filter and open screener actions when holdings are empty

## Testing
- `CI=true npm test --silent` *(fails: Metric value out of range and unhandled mock errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f21c83ac83278349b08c6f54db87