### PR TITLE
feat: enhance alert settings

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -237,8 +237,17 @@
   },
   "alertSettings": {
     "title": "Alert Settings",
+    "description": "Konfigurieren Sie, wann Sie Benachrichtigungen erhalten. Die Alarme erscheinen auf der Alerts-Seite und als Push-Benachrichtigungen.",
     "threshold": "Threshold %:",
     "save": "Save",
+    "push": {
+      "title": "Push-Benachrichtigungen",
+      "notSupported": "Push wird nicht unterstützt",
+      "enable": "Push-Alerts aktivieren",
+      "disable": "Push-Alerts deaktivieren",
+      "denied": "Push-Berechtigung verweigert.",
+      "error": "Fehler bei der Verarbeitung der Push-Anmeldung."
+    },
     "status": {
       "saved": "Saved",
       "error": "Error"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -239,8 +239,17 @@
   },
   "alertSettings": {
     "title": "Alert Settings",
+    "description": "Configure when you'll receive alerts. Alerts appear on the Alerts page and in push notifications.",
     "threshold": "Threshold %:",
     "save": "Save",
+    "push": {
+      "title": "Push Notifications",
+      "notSupported": "Push not supported",
+      "enable": "Enable Push Alerts",
+      "disable": "Disable Push Alerts",
+      "denied": "Push permission denied.",
+      "error": "Error handling push subscription."
+    },
     "status": {
       "saved": "Saved",
       "error": "Error"

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -237,8 +237,17 @@
   },
   "alertSettings": {
     "title": "Alert Settings",
+    "description": "Configura cuándo recibirás alertas. Las alertas aparecen en la página de alertas y en las notificaciones push.",
     "threshold": "Threshold %:",
     "save": "Save",
+    "push": {
+      "title": "Notificaciones push",
+      "notSupported": "Push no soportado",
+      "enable": "Activar alertas push",
+      "disable": "Desactivar alertas push",
+      "denied": "Permiso de push denegado.",
+      "error": "Error al manejar la suscripción push."
+    },
     "status": {
       "saved": "Saved",
       "error": "Error"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -237,8 +237,17 @@
   },
   "alertSettings": {
     "title": "Alert Settings",
+    "description": "Configurez quand vous recevrez des alertes. Les alertes apparaissent sur la page des alertes et dans les notifications push.",
     "threshold": "Threshold %:",
     "save": "Save",
+    "push": {
+      "title": "Notifications push",
+      "notSupported": "Push non supporté",
+      "enable": "Activer les alertes Push",
+      "disable": "Désactiver les alertes Push",
+      "denied": "Permission de push refusée.",
+      "error": "Erreur lors de la gestion de l'abonnement push."
+    },
     "status": {
       "saved": "Saved",
       "error": "Error"

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -237,8 +237,17 @@
   },
   "alertSettings": {
     "title": "Alert Settings",
+    "description": "Configura quando riceverai avvisi. Gli avvisi compaiono nella pagina degli avvisi e nelle notifiche push.",
     "threshold": "Threshold %:",
     "save": "Save",
+    "push": {
+      "title": "Notifiche push",
+      "notSupported": "Push non supportato",
+      "enable": "Attiva avvisi push",
+      "disable": "Disattiva avvisi push",
+      "denied": "Autorizzazione push negata.",
+      "error": "Errore nella gestione dell'iscrizione push."
+    },
     "status": {
       "saved": "Saved",
       "error": "Error"

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -237,8 +237,17 @@
   },
   "alertSettings": {
     "title": "Alert Settings",
+    "description": "Configure quando receber alertas. Os alertas aparecem na página de alertas e nas notificações push.",
     "threshold": "Threshold %:",
     "save": "Save",
+    "push": {
+      "title": "Notificações push",
+      "notSupported": "Push não suportado",
+      "enable": "Ativar alertas push",
+      "disable": "Desativar alertas push",
+      "denied": "Permissão de push negada.",
+      "error": "Erro ao lidar com a assinatura de push."
+    },
     "status": {
       "saved": "Saved",
       "error": "Error"

--- a/frontend/src/pages/AlertSettings.test.tsx
+++ b/frontend/src/pages/AlertSettings.test.tsx
@@ -34,5 +34,9 @@ describe("AlertSettings navigation", () => {
     expect(
       screen.getByRole("button", { name: en.alertSettings.save }),
     ).toBeInTheDocument();
+    expect(screen.getByText(en.alertSettings.description)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: en.alertSettings.push.title })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/AlertSettings.tsx
+++ b/frontend/src/pages/AlertSettings.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Menu from "../components/Menu";
-import { getAlertThreshold, setAlertThreshold } from "../api";
+import {
+  getAlertThreshold,
+  setAlertThreshold,
+  savePushSubscription,
+  deletePushSubscription,
+} from "../api";
 import { useUser } from "../UserContext";
 
 export default function AlertSettings() {
@@ -13,6 +18,11 @@ export default function AlertSettings() {
   const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">(
     "idle",
   );
+  const [pushSupported, setPushSupported] = useState(false);
+  const [pushEnabled, setPushEnabled] = useState(false);
+  const [pushStatus, setPushStatus] = useState<
+    "idle" | "enabled" | "disabled" | "denied" | "error"
+  >("idle");
 
   useEffect(() => {
     if (!owner) {
@@ -23,6 +33,73 @@ export default function AlertSettings() {
       .then((r) => setThreshold(r.threshold))
       .catch(() => setThreshold(""));
   }, [owner]);
+
+  useEffect(() => {
+    if (
+      typeof navigator !== "undefined" &&
+      "serviceWorker" in navigator &&
+      "PushManager" in window
+    ) {
+      setPushSupported(true);
+      navigator.serviceWorker.ready
+        .then((reg) => reg.pushManager.getSubscription())
+        .then((sub) => setPushEnabled(!!sub))
+        .catch(() => {
+          /* ignore */
+        });
+    }
+  }, []);
+
+  function urlBase64ToUint8Array(base64String: string) {
+    const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+    const rawData = atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+    for (let i = 0; i < rawData.length; ++i) {
+      outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray;
+  }
+
+  async function enablePush() {
+    if (!owner) return;
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        setPushStatus("denied");
+        return;
+      }
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: import.meta.env.VITE_VAPID_PUBLIC_KEY
+          ? urlBase64ToUint8Array(import.meta.env.VITE_VAPID_PUBLIC_KEY as string)
+          : undefined,
+      });
+      await savePushSubscription(
+        owner,
+        sub.toJSON() as import("../api").PushSubscriptionJSON,
+      );
+      setPushEnabled(true);
+      setPushStatus("enabled");
+    } catch {
+      setPushStatus("error");
+    }
+  }
+
+  async function disablePush() {
+    if (!owner) return;
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) await sub.unsubscribe();
+      await deletePushSubscription(owner);
+      setPushEnabled(false);
+      setPushStatus("disabled");
+    } catch {
+      setPushStatus("error");
+    }
+  }
 
   async function save() {
     if (threshold === "" || !owner) return;
@@ -39,7 +116,8 @@ export default function AlertSettings() {
     <div style={{ maxWidth: 600, margin: "0 auto", padding: "1rem" }}>
       <Menu />
       <h1>{t("alertSettings.title")}</h1>
-      <div>
+      <p>{t("alertSettings.description")}</p>
+      <div style={{ marginTop: "1rem" }}>
         <label>
           {t("alertSettings.threshold")}{" "}
           <input
@@ -63,6 +141,30 @@ export default function AlertSettings() {
           <span style={{ marginLeft: "0.5rem" }}>
             {t("alertSettings.status.error")}
           </span>
+        )}
+      </div>
+      <div style={{ marginTop: "2rem" }}>
+        <h2>{t("alertSettings.push.title")}</h2>
+        {!pushSupported ? (
+          <p>{t("alertSettings.push.notSupported")}</p>
+        ) : (
+          <div>
+            <button
+              onClick={pushEnabled ? disablePush : enablePush}
+              style={{ marginTop: "0.5rem" }}
+              disabled={!owner}
+            >
+              {pushEnabled
+                ? t("alertSettings.push.disable")
+                : t("alertSettings.push.enable")}
+            </button>
+            {pushStatus === "denied" && (
+              <p>{t("alertSettings.push.denied")}</p>
+            )}
+            {pushStatus === "error" && (
+              <p>{t("alertSettings.push.error")}</p>
+            )}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add description and push notification settings to alert settings page
- localize new strings across supported languages
- extend tests for new content

## Testing
- `npm run lint` (fails: Fast refresh only works..., etc.)
- `npm test` (fails: numerous vitest failures)


------
https://chatgpt.com/codex/tasks/task_e_68c6f2dd8e308327902539d9db196c50