### PR TITLE
feat: enhance section cards and formatting

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.12",
         "i18next": "^25.4.0",
+        "lucide-react": "^0.544.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
@@ -9947,6 +9948,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.12",
     "i18next": "^25.4.0",
+    "lucide-react": "^0.544.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",

--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -49,10 +49,15 @@ export function AccountBlock({
         <>
           <div className="mb-2">
             Est&nbsp;Value:&nbsp;
-            {money(
-              account.value_estimate_gbp,
-              account.value_estimate_currency || baseCurrency,
-            )}
+            {account.value_estimate_gbp != null
+              ? new Intl.NumberFormat(undefined, {
+                  style: "currency",
+                  currency:
+                    account.value_estimate_currency || baseCurrency,
+                  notation: "compact",
+                  maximumFractionDigits: 2,
+                }).format(account.value_estimate_gbp)
+              : "—"}
           </div>
 
           {account.last_updated && (

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -39,6 +39,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { BadgeCheck, LineChart, Shield } from "lucide-react";
 
 const PIE_COLORS = [
   "#8884d8",
@@ -259,19 +260,52 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
         }}
       >
         <div>
-          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Alpha vs Benchmark</div>
+          <div
+            style={{
+              fontSize: "0.9rem",
+              color: "#aaa",
+              display: "flex",
+              alignItems: "center",
+              gap: "0.25rem",
+            }}
+          >
+            <BadgeCheck size={16} />
+            Alpha vs Benchmark
+          </div>
           <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
             {percentOrNa(safeAlpha)}
           </div>
         </div>
         <div>
-          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Tracking Error</div>
+          <div
+            style={{
+              fontSize: "0.9rem",
+              color: "#aaa",
+              display: "flex",
+              alignItems: "center",
+              gap: "0.25rem",
+            }}
+          >
+            <LineChart size={16} />
+            Tracking Error
+          </div>
           <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
             {percentOrNa(safeTrackingError)}
           </div>
         </div>
         <div>
-          <div style={{ fontSize: "0.9rem", color: "#aaa" }}>Max Drawdown</div>
+          <div
+            style={{
+              fontSize: "0.9rem",
+              color: "#aaa",
+              display: "flex",
+              alignItems: "center",
+              gap: "0.25rem",
+            }}
+          >
+            <Shield size={16} />
+            Max Drawdown
+          </div>
           <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
             {percentOrNa(safeMaxDrawdown)}
           </div>

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -10,6 +10,7 @@ import { formatDateISO } from "../lib/date";
 import { useConfig } from "../ConfigContext";
 import type { TradingSignal } from "../types";
 import { RelativeViewToggle } from "./RelativeViewToggle";
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 import {
   ResponsiveContainer,
   LineChart,
@@ -642,7 +643,26 @@ export function InstrumentDetail({
                       className={`${tableStyles.cell} ${tableStyles.right}`}
                       style={{ color: colour }}
                     >
-                      {percent(p.change_pct, 2)}
+                      {Number.isFinite(p.change_pct) ? (
+                        <span
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            justifyContent: "flex-end",
+                            gap: "0.25rem",
+                            fontVariantNumeric: "tabular-nums",
+                          }}
+                        >
+                          {p.change_pct >= 0 ? (
+                            <ArrowUpRight size={12} />
+                          ) : (
+                            <ArrowDownRight size={12} />
+                          )}
+                          {percent(p.change_pct, 2)}
+                        </span>
+                      ) : (
+                        percent(p.change_pct, 2)
+                      )}
                     </td>
                   </tr>
                 );

--- a/frontend/src/components/PortfolioSummary.tsx
+++ b/frontend/src/components/PortfolioSummary.tsx
@@ -1,6 +1,7 @@
 import type { Account } from "../types";
 import { money, percent } from "../lib/money";
 import { useConfig } from "../ConfigContext";
+import { PiggyBank, LineChart, BadgeCheck } from "lucide-react";
 
 export type PortfolioTotals = {
   totalValue: number;
@@ -80,13 +81,35 @@ export function PortfolioSummary({ totals }: Props) {
       }}
     >
       <div>
-        <div style={{ fontSize: "1rem", color: "#aaa" }}>Total Value</div>
+        <div
+          style={{
+            fontSize: "1rem",
+            color: "#aaa",
+            display: "flex",
+            alignItems: "center",
+            gap: "0.25rem",
+          }}
+        >
+          <PiggyBank size={20} />
+          Total Value
+        </div>
         <div style={{ fontSize: "2rem", fontWeight: "bold" }}>
           {money(totalValue, baseCurrency)}
         </div>
       </div>
       <div>
-        <div style={{ fontSize: "1rem", color: "#aaa" }}>Day Change</div>
+        <div
+          style={{
+            fontSize: "1rem",
+            color: "#aaa",
+            display: "flex",
+            alignItems: "center",
+            gap: "0.25rem",
+          }}
+        >
+          <LineChart size={20} />
+          Day Change
+        </div>
         <div
           style={{
             fontSize: "2rem",
@@ -98,7 +121,18 @@ export function PortfolioSummary({ totals }: Props) {
         </div>
       </div>
       <div>
-        <div style={{ fontSize: "1rem", color: "#aaa" }}>Total Gain</div>
+        <div
+          style={{
+            fontSize: "1rem",
+            color: "#aaa",
+            display: "flex",
+            alignItems: "center",
+            gap: "0.25rem",
+          }}
+        >
+          <BadgeCheck size={20} />
+          Total Gain
+        </div>
         <div
           style={{
             fontSize: "2rem",


### PR DESCRIPTION
## Summary
- add lucide icons to section headers for portfolio metrics
- compact-format account estimates
- display delta percentages with aligned arrows and tabular numbers

## Testing
- `npm test` *(fails: numerous metric errors and test assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f22036d48327837169e8bd7cfdd0