### PR TITLE
Add skeleton placeholders and defer heavy UI loads

### DIFF
--- a/frontend/src/components/Defer.tsx
+++ b/frontend/src/components/Defer.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useRef, useState, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  rootMargin?: string;
+}
+
+export default function Defer({ children, rootMargin = "0px" }: Props) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (visible) return;
+    const el = ref.current;
+    if (!el) return;
+    if (!("IntersectionObserver" in window)) {
+      setVisible(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [visible, rootMargin]);
+
+  return <div ref={ref}>{visible ? children : null}</div>;
+}

--- a/frontend/src/components/skeletons/KPISkeleton.tsx
+++ b/frontend/src/components/skeletons/KPISkeleton.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export default function KPISkeleton() {
+  return (
+    <div className="flex gap-8 mb-4 p-4 bg-gray-900 border border-gray-700 rounded animate-pulse">
+      {Array.from({ length: 3 }).map((_, idx) => (
+        <div key={idx} className="flex flex-col w-24 gap-2">
+          <div className="h-3 bg-gray-700 rounded" />
+          <div className="h-5 bg-gray-700 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/TableSkeleton.tsx
+++ b/frontend/src/components/skeletons/TableSkeleton.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface Props {
+  rows?: number;
+  cols?: number;
+}
+
+export default function TableSkeleton({ rows = 5, cols = 4 }: Props) {
+  return (
+    <table className="w-full border border-gray-700 rounded animate-pulse">
+      <tbody>
+        {Array.from({ length: rows }).map((_, r) => (
+          <tr key={r} className="border-b border-gray-700 last:border-b-0">
+            {Array.from({ length: cols }).map((_, c) => (
+              <td key={c} className="p-2">
+                <div className="h-4 bg-gray-700 rounded" />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- add KPI and table skeleton components
- lazy-load TopMoversSummary with a 300ms minimum fallback
- defer off-screen rendering via IntersectionObserver

## Testing
- `npm --prefix frontend test` *(fails: Metric value out of range; chart dimensions; 13 failed tests)*
- `npm --prefix frontend run lint` *(fails: 35 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f21ce1e48327930b789c0b35fef3