### PR TITLE
feat: add skeleton loading and deferred components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, Suspense } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -22,7 +22,9 @@ import { PortfolioView } from "./components/PortfolioView";
 import { GroupPortfolioView } from "./components/GroupPortfolioView";
 import { InstrumentTable } from "./components/InstrumentTable";
 import { TransactionsPage } from "./components/TransactionsPage";
-import PortfolioDashboard from "./pages/PortfolioDashboard";
+import lazyWithDelay from "./utils/lazyWithDelay";
+import PortfolioDashboardSkeleton from "./components/skeletons/PortfolioDashboardSkeleton";
+import Defer from "./components/Defer";
 
 import { NotificationsDrawer } from "./components/NotificationsDrawer";
 import { ComplianceWarnings } from "./components/ComplianceWarnings";
@@ -55,6 +57,7 @@ import PensionForecast from "./pages/PensionForecast";
 import TaxHarvest from "./pages/TaxHarvest";
 import TaxAllowances from "./pages/TaxAllowances";
 import RightRail from "./components/RightRail";
+const PortfolioDashboard = lazyWithDelay(() => import("./pages/PortfolioDashboard"));
 
 interface AppProps {
   onLogout?: () => void;
@@ -474,19 +477,21 @@ export default function App({ onLogout }: AppProps) {
             selected={selectedOwner}
             onSelect={setSelectedOwner}
           />
-          <PortfolioDashboard
-            twr={null}
-            irr={null}
-            bestDay={null}
-            worstDay={null}
-            lastDay={null}
-            alpha={null}
-            trackingError={null}
-            maxDrawdown={null}
-            volatility={null}
-            data={[]}
-            owner={selectedOwner}
-          />
+          <Suspense fallback={<PortfolioDashboardSkeleton />}>
+            <PortfolioDashboard
+              twr={null}
+              irr={null}
+              bestDay={null}
+              worstDay={null}
+              lastDay={null}
+              alpha={null}
+              trackingError={null}
+              maxDrawdown={null}
+              volatility={null}
+              data={[]}
+              owner={selectedOwner}
+            />
+          </Suspense>
         </>
       )}
 
@@ -513,7 +518,9 @@ export default function App({ onLogout }: AppProps) {
       {mode === "scenario" && <ScenarioTester />}
       {mode === "pension" && <PensionForecast />}
       </main>
-      <RightRail owner={selectedOwner} />
+      <Defer>
+        <RightRail owner={selectedOwner} />
+      </Defer>
     </div>
   );
 }

--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, lazy } from "react";
+import { useCallback, useEffect, useState, lazy, Suspense } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { getGroupInstruments, getGroups, getOwners, getPortfolio } from "./api";
@@ -15,7 +15,6 @@ import { PortfolioView } from "./components/PortfolioView";
 import { GroupPortfolioView } from "./components/GroupPortfolioView";
 import { InstrumentTable } from "./components/InstrumentTable";
 import { TransactionsPage } from "./components/TransactionsPage";
-import PortfolioDashboard from "./pages/PortfolioDashboard";
 import QuestBoard from "./components/QuestBoard";
 
 import { NotificationsDrawer } from "./components/NotificationsDrawer";
@@ -28,6 +27,8 @@ import PriceRefreshControls from "./components/PriceRefreshControls";
 import { Header } from "./components/Header";
 import InstallPwaPrompt from "./components/InstallPwaPrompt";
 import BackendUnavailableCard from "./components/BackendUnavailableCard";
+import lazyWithDelay from "./utils/lazyWithDelay";
+import PortfolioDashboardSkeleton from "./components/skeletons/PortfolioDashboardSkeleton";
 
 const ScreenerQuery = lazy(() => import("./pages/ScreenerQuery"));
 const TimeseriesEdit = lazy(() =>
@@ -40,6 +41,7 @@ const InstrumentAdmin = lazy(() => import("./pages/InstrumentAdmin"));
 const ScenarioTester = lazy(() => import("./pages/ScenarioTester"));
 const SupportPage = lazy(() => import("./pages/Support"));
 const LogsPage = lazy(() => import("./pages/Logs"));
+const PortfolioDashboard = lazyWithDelay(() => import("./pages/PortfolioDashboard"));
 
 export default function MainApp() {
   const navigate = useNavigate();
@@ -283,19 +285,21 @@ export default function MainApp() {
             selected={selectedOwner}
             onSelect={setSelectedOwner}
           />
-          <PortfolioDashboard
-            twr={null}
-            irr={null}
-            bestDay={null}
-            worstDay={null}
-            lastDay={null}
-            alpha={null}
-            trackingError={null}
-            maxDrawdown={null}
-            volatility={null}
-            data={[]}
-            owner={selectedOwner}
-          />
+          <Suspense fallback={<PortfolioDashboardSkeleton />}>
+            <PortfolioDashboard
+              twr={null}
+              irr={null}
+              bestDay={null}
+              worstDay={null}
+              lastDay={null}
+              alpha={null}
+              trackingError={null}
+              maxDrawdown={null}
+              volatility={null}
+              data={[]}
+              owner={selectedOwner}
+            />
+          </Suspense>
         </>
       )}
 

--- a/frontend/src/components/Defer.tsx
+++ b/frontend/src/components/Defer.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+/**
+ * Defers rendering of children until the wrapper enters the viewport.
+ */
+export default function Defer({ children }: Props) {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (visible) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        setVisible(true);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [visible]);
+
+  return <div ref={ref}>{visible ? children : null}</div>;
+}

--- a/frontend/src/components/skeletons/ChartSkeleton.tsx
+++ b/frontend/src/components/skeletons/ChartSkeleton.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+
+/** Skeleton placeholder for charts. */
+export default function ChartSkeleton() {
+  return (
+    <div className="w-full h-60 mb-4 bg-gray-900 border border-gray-700 rounded animate-pulse" />
+  );
+}

--- a/frontend/src/components/skeletons/KPISkeleton.tsx
+++ b/frontend/src/components/skeletons/KPISkeleton.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+/** Skeleton placeholder for KPI metric grids. */
+export default function KPISkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4 p-4 mb-4 bg-gray-900 border border-gray-700 rounded sm:grid-cols-3 md:grid-cols-5">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex flex-col animate-pulse">
+          <div className="h-4 mb-2 bg-gray-700 rounded w-3/4" />
+          <div className="h-6 bg-gray-700 rounded w-1/2" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
+++ b/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import KPISkeleton from "./KPISkeleton";
+import ChartSkeleton from "./ChartSkeleton";
+
+/** Skeleton placeholder mimicking the PortfolioDashboard layout. */
+export default function PortfolioDashboardSkeleton() {
+  return (
+    <>
+      <KPISkeleton />
+      <ChartSkeleton />
+      <ChartSkeleton />
+    </>
+  );
+}

--- a/frontend/src/plugins/performance.ts
+++ b/frontend/src/plugins/performance.ts
@@ -1,7 +1,8 @@
-import PortfolioDashboard from "../pages/PortfolioDashboard";
 import type { ComponentProps } from "react";
+import lazyWithDelay from "../utils/lazyWithDelay";
 import type { TabPlugin } from "./TabPlugin";
 
+const PortfolioDashboard = lazyWithDelay(() => import("../pages/PortfolioDashboard"));
 type Props = ComponentProps<typeof PortfolioDashboard>;
 
 const plugin: TabPlugin<Props> = {

--- a/frontend/src/utils/lazyWithDelay.ts
+++ b/frontend/src/utils/lazyWithDelay.ts
@@ -1,0 +1,16 @@
+import { lazy } from "react";
+
+/**
+ * Wraps React.lazy with a minimum delay to keep skeletons visible.
+ */
+export default function lazyWithDelay<T extends React.ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+  delay = 300,
+) {
+  return lazy(() =>
+    Promise.all([
+      factory(),
+      new Promise((resolve) => setTimeout(resolve, delay)),
+    ]).then(([module]) => module),
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable KPI and chart skeletons and a PortfolioDashboard placeholder
- lazy load PortfolioDashboard with minimum delay and defer off-screen RightRail
- introduce IntersectionObserver-based Defer component

## Testing
- `npm test` (fails: 34 failed, 25 passed)


------
https://chatgpt.com/codex/tasks/task_e_68c6fd053c348327a2a94f46c959c2ed