### PR TITLE
test: cover instrument admin routes

### DIFF
--- a/tests/routes/test_instrument_admin.py
+++ b/tests/routes/test_instrument_admin.py
@@ -1,0 +1,209 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import backend.routes.instrument_admin as instrument_admin
+
+
+def make_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(instrument_admin.router)
+    return TestClient(app)
+
+
+def test_list_instrument_metadata(monkeypatch):
+    monkeypatch.setattr(
+        instrument_admin, "list_instruments", lambda: [{"ticker": "ABC.L"}]
+    )
+    client = make_client()
+    resp = client.get("/instrument/admin")
+    assert resp.status_code == 200
+    assert resp.json() == [{"ticker": "ABC.L"}]
+
+
+def test_get_instrument_ok(monkeypatch, tmp_path):
+    def fake_path(t, e):
+        return tmp_path / f"{e}" / f"{t}.json"
+
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
+    monkeypatch.setattr(
+        instrument_admin, "get_instrument_meta", lambda t: {"ticker": t}
+    )
+    client = make_client()
+    resp = client.get("/instrument/admin/L/ABC")
+    assert resp.status_code == 200
+    assert resp.json() == {"ticker": "ABC.L"}
+
+
+def test_get_instrument_not_found(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        instrument_admin,
+        "instrument_meta_path",
+        lambda t, e: tmp_path / f"{e}" / f"{t}.json",
+    )
+    monkeypatch.setattr(instrument_admin, "get_instrument_meta", lambda t: {})
+    client = make_client()
+    resp = client.get("/instrument/admin/L/ABC")
+    assert resp.status_code == 404
+
+
+def test_get_instrument_invalid(monkeypatch):
+    def bad_path(*_):
+        raise ValueError("bad ticker")
+
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", bad_path)
+    client = make_client()
+    resp = client.get("/instrument/admin/L/ABC")
+    assert resp.status_code == 400
+
+
+def test_post_instrument_create(monkeypatch, tmp_path):
+    def fake_path(t, e):
+        p = tmp_path / f"{e}" / f"{t}.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return p
+
+    saved = {}
+
+    def fake_save(t, e, body):
+        saved["ticker"] = f"{t}.{e}"
+        saved["body"] = body
+
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
+    monkeypatch.setattr(instrument_admin, "save_instrument_meta", fake_save)
+    client = make_client()
+    resp = client.post("/instrument/admin/L/ABC", json={"ticker": "ABC.L"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "created"}
+    assert saved["ticker"] == "ABC.L"
+
+
+def test_post_instrument_conflict(monkeypatch, tmp_path):
+    def fake_path(t, e):
+        p = tmp_path / f"{e}" / f"{t}.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}")
+        return p
+
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
+    monkeypatch.setattr(instrument_admin, "save_instrument_meta", lambda *a, **k: None)
+    client = make_client()
+    resp = client.post("/instrument/admin/L/ABC", json={"ticker": "ABC.L"})
+    assert resp.status_code == 409
+
+
+def test_post_instrument_invalid(monkeypatch):
+    monkeypatch.setattr(
+        instrument_admin,
+        "instrument_meta_path",
+        lambda *a: (_ for _ in ()).throw(ValueError("bad")),
+    )
+    client = make_client()
+    resp = client.post("/instrument/admin/L/ABC", json={"ticker": "ABC.L"})
+    assert resp.status_code == 400
+
+
+def test_post_instrument_ticker_mismatch(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        instrument_admin,
+        "instrument_meta_path",
+        lambda t, e: tmp_path / f"{e}" / f"{t}.json",
+    )
+    monkeypatch.setattr(instrument_admin, "save_instrument_meta", lambda *a, **k: None)
+    client = make_client()
+    resp = client.post("/instrument/admin/L/ABC", json={"ticker": "DEF.L"})
+    assert resp.status_code == 400
+
+
+def test_put_instrument_update(monkeypatch, tmp_path):
+    def fake_path(t, e):
+        p = tmp_path / f"{e}" / f"{t}.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}")
+        return p
+
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
+    monkeypatch.setattr(instrument_admin, "save_instrument_meta", lambda *a, **k: None)
+    client = make_client()
+    resp = client.put("/instrument/admin/L/ABC", json={"ticker": "ABC.L"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "updated"}
+
+
+def test_put_instrument_not_found(monkeypatch, tmp_path):
+    def fake_path(t, e):
+        p = tmp_path / f"{e}" / f"{t}.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return p
+
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
+    monkeypatch.setattr(instrument_admin, "save_instrument_meta", lambda *a, **k: None)
+    client = make_client()
+    resp = client.put("/instrument/admin/L/ABC", json={"ticker": "ABC.L"})
+    assert resp.status_code == 404
+
+
+def test_put_instrument_invalid(monkeypatch):
+    monkeypatch.setattr(
+        instrument_admin, "instrument_meta_path", lambda *a: (_ for _ in ()).throw(ValueError("bad"))
+    )
+    client = make_client()
+    resp = client.put("/instrument/admin/L/ABC", json={"ticker": "ABC.L"})
+    assert resp.status_code == 400
+
+
+def test_put_instrument_ticker_mismatch(monkeypatch, tmp_path):
+    def fake_path(t, e):
+        p = tmp_path / f"{e}" / f"{t}.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}")
+        return p
+
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
+    monkeypatch.setattr(instrument_admin, "save_instrument_meta", lambda *a, **k: None)
+    client = make_client()
+    resp = client.put("/instrument/admin/L/ABC", json={"ticker": "DEF.L"})
+    assert resp.status_code == 400
+
+
+def test_delete_instrument_ok(monkeypatch, tmp_path):
+    def fake_path(t, e):
+        p = tmp_path / f"{e}" / f"{t}.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}")
+        return p
+
+    deleted = {}
+
+    def fake_delete(t, e):
+        deleted["ticker"] = f"{t}.{e}"
+
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
+    monkeypatch.setattr(instrument_admin, "delete_instrument_meta", fake_delete)
+    client = make_client()
+    resp = client.delete("/instrument/admin/L/ABC")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "deleted"}
+    assert deleted["ticker"] == "ABC.L"
+
+
+def test_delete_instrument_not_found(monkeypatch, tmp_path):
+    def fake_path(t, e):
+        p = tmp_path / f"{e}" / f"{t}.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return p
+
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
+    monkeypatch.setattr(instrument_admin, "delete_instrument_meta", lambda *a, **k: None)
+    client = make_client()
+    resp = client.delete("/instrument/admin/L/ABC")
+    assert resp.status_code == 404
+
+
+def test_delete_instrument_invalid(monkeypatch):
+    monkeypatch.setattr(
+        instrument_admin, "instrument_meta_path", lambda *a: (_ for _ in ()).throw(ValueError("bad"))
+    )
+    client = make_client()
+    resp = client.delete("/instrument/admin/L/ABC")
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- test instrument admin list/get/post/put/delete endpoints
- cover error cases for invalid, missing, and duplicate metadata

## Testing
- `pytest tests/routes/test_instrument_admin.py -q --cov=backend --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68c700e0797483279a1be534fed35d32