### PR TITLE
Add tests for trail routes

### DIFF
--- a/tests/routes/test_trail_routes.py
+++ b/tests/routes/test_trail_routes.py
@@ -1,0 +1,30 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.auth import get_current_user
+from backend.config import config
+
+
+@pytest.mark.parametrize("disable_auth", [True, False])
+def test_trail_routes(tmp_path, monkeypatch, disable_auth):
+    monkeypatch.setenv("TRAIL_URI", f"file://{tmp_path/'trail.json'}")
+    monkeypatch.setattr(config, "disable_auth", disable_auth)
+
+    import backend.quests.trail as trail_module
+    import backend.routes.trail as trail_route_module
+    import backend.app as app_mod
+    importlib.reload(trail_module)
+    importlib.reload(trail_route_module)
+    importlib.reload(app_mod)
+    app = app_mod.create_app()
+    if not disable_auth:
+        app.dependency_overrides[get_current_user] = lambda: "demo"
+
+    with TestClient(app) as client:
+        resp = client.get("/trail")
+        assert resp.status_code == 200
+
+        resp = client.post("/trail/unknown/complete")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- test trail routes under authenticated and unauthenticated configurations
- verify /trail list and /trail/{task_id}/complete 404 on unknown task

## Testing
- `pytest tests/routes/test_trail_routes.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68c700d2b1a48327b755517680223d45