### PR TITLE
feat: disable alert settings when signed out

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -244,6 +244,7 @@
     "description": "Configure when you'll receive alerts. Alerts appear on the Alerts page and in push notifications.",
     "threshold": "Threshold %:",
     "save": "Save",
+    "signInNotice": "Sign in to configure alerts",
     "push": {
       "title": "Push Notifications",
       "notSupported": "Push not supported",

--- a/frontend/src/pages/AlertSettings.test.tsx
+++ b/frontend/src/pages/AlertSettings.test.tsx
@@ -40,3 +40,41 @@ describe("AlertSettings navigation", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("AlertSettings when not signed in", () => {
+  it("shows notice and disables buttons without a profile", async () => {
+    // Mock Push API support so the push button renders
+    Object.defineProperty(window, "PushManager", {
+      value: {},
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        ready: Promise.resolve({
+          pushManager: { getSubscription: () => Promise.resolve(null) },
+        }),
+      },
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <AlertSettings />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText(en.alertSettings.signInNotice),
+    ).toBeInTheDocument();
+
+    const saveButton = screen.getByRole("button", {
+      name: en.alertSettings.save,
+    });
+    expect(saveButton).toBeDisabled();
+
+    const pushButton = await screen.findByRole("button", {
+      name: en.alertSettings.push.enable,
+    });
+    expect(pushButton).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/AlertSettings.tsx
+++ b/frontend/src/pages/AlertSettings.tsx
@@ -117,6 +117,7 @@ export default function AlertSettings() {
       <Menu />
       <h1>{t("alertSettings.title")}</h1>
       <p>{t("alertSettings.description")}</p>
+      {!owner && <p>{t("alertSettings.signInNotice")}</p>}
       <div style={{ marginTop: "1rem" }}>
         <label>
           {t("alertSettings.threshold")}{" "}
@@ -129,7 +130,11 @@ export default function AlertSettings() {
             style={{ width: "4rem" }}
           />
         </label>
-        <button onClick={save} style={{ marginLeft: "0.5rem" }}>
+        <button
+          onClick={save}
+          style={{ marginLeft: "0.5rem" }}
+          disabled={!owner}
+        >
           {t("alertSettings.save")}
         </button>
         {status === "saved" && (


### PR DESCRIPTION
## Summary
- disable saving and push notification controls when no owner
- show sign-in notice when user is not authenticated
- test alert settings without profile

## Testing
- `npm test -- src/pages/AlertSettings.test.tsx` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c703c19bb88327819f8f3ec3153195