### PR TITLE
docs: fix VaR link path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -217,7 +217,7 @@ rates from `fx_proxy_url` configured in `config.yaml`.
 
 ## Risk reporting
 
- The backend exposes [Value at Risk (VaR)](docs/value_at_risk.md) metrics for each portfolio.
+ The backend exposes [Value at Risk (VaR)](./value_at_risk.md) metrics for each portfolio.
 
 * **Defaults** – 95 % confidence over a 1‑day horizon and 99 % over 10 days.
 * **Query** – `GET /var/{owner}?days=30&confidence=0.99` fetches a 30‑day, 99 % VaR.
@@ -231,7 +231,7 @@ rates from `fx_proxy_url` configured in `config.yaml`.
 
 See [backend/common/portfolio_utils.py](backend/common/portfolio_utils.py) for the return series that feed the calculation
 and [backend/common/constants.py](backend/common/constants.py) for currency labels, and the
-[VaR documentation](docs/value_at_risk.md) for methodology.
+[VaR documentation](./value_at_risk.md) for methodology.
 
 ## Portfolio reports
 


### PR DESCRIPTION
## Summary
- fix Value at Risk link to use relative path in docs README

## Testing
- `pytest` (fails: Form data requires "python-multipart" to be installed -> but we installed; but final failing: 4 failed, 420 passed; but we must show summary of failure) Wait in commit we had after installing dependencies we ran again; summarizing final results: 4 failed etc.
- `npm test` (fails: IntersectionObserver is not defined, 31 failed)


------
https://chatgpt.com/codex/tasks/task_e_68c704e501f4832792478f9b1faf960e