### PR TITLE
Use base URL for language flag paths

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -2,13 +2,15 @@ import { useEffect, useState, memo } from "react";
 import i18n from "i18next";
 import "./LanguageSwitcher.css";
 
+const base = import.meta.env.BASE_URL;
+
 const LANGUAGES = [
-  { code: "en", flag: "/flags/en.svg", name: "English" },
-  { code: "fr", flag: "/flags/fr.svg", name: "French" },
-  { code: "de", flag: "/flags/de.svg", name: "German" },
-  { code: "es", flag: "/flags/es.svg", name: "Spanish" },
-  { code: "pt", flag: "/flags/pt.svg", name: "Portuguese" },
-  { code: "it", flag: "/flags/it.svg", name: "Italian" },
+  { code: "en", flag: `${base}flags/en.svg`, name: "English" },
+  { code: "fr", flag: `${base}flags/fr.svg`, name: "French" },
+  { code: "de", flag: `${base}flags/de.svg`, name: "German" },
+  { code: "es", flag: `${base}flags/es.svg`, name: "Spanish" },
+  { code: "pt", flag: `${base}flags/pt.svg`, name: "Portuguese" },
+  { code: "it", flag: `${base}flags/it.svg`, name: "Italian" },
 ];
 
 export const LanguageSwitcher = memo(function LanguageSwitcher() {


### PR DESCRIPTION
## Summary
- derive language flag image paths from Vite's `BASE_URL`
- ensure each language's flag uses base-relative URLs for subpath hosting

## Testing
- `npm --prefix frontend test` *(fails: IntersectionObserver is not defined and other existing test issues)*
- `npm --prefix frontend run lint` *(fails: numerous linter errors in unrelated files)*
- `npm --prefix frontend run dev -- --base=/subpath/` *(started server successfully)*
- `npm --prefix frontend run build -- --base=/subpath/` *(fails: TypeScript errors in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_68c704f3e6448327b42fd16e81c804fc