### PR TITLE
Handle null metrics without warnings

### DIFF
--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -381,7 +381,11 @@ describe("GroupPortfolioView", () => {
     within(teLabel.parentElement!).getByText("N/A");
     const mdLabel = await screen.findByText("Max Drawdown");
     within(mdLabel.parentElement!).getByText("N/A");
-
-    expect(warnSpy.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith("Metric value out of range:", 2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Metric value out of range:",
+      Infinity,
+    );
   });
 });

--- a/frontend/src/lib/money.test.ts
+++ b/frontend/src/lib/money.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { percentOrNa } from "./money";
+
+describe("percentOrNa", () => {
+  it("returns N/A without warning for null or undefined", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(percentOrNa(null)).toBe("N/A");
+    expect(percentOrNa(undefined)).toBe("N/A");
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("warns and returns N/A for values outside -1..1", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(percentOrNa(2)).toBe("N/A");
+    expect(spy).toHaveBeenCalledWith("Metric value out of range:", 2);
+    spy.mockRestore();
+  });
+
+  it("formats valid percentages", () => {
+    expect(percentOrNa(0.123)).toBe("12.30%");
+  });
+});

--- a/frontend/src/lib/money.ts
+++ b/frontend/src/lib/money.ts
@@ -33,7 +33,8 @@ export const percentOrNa = (
     fractionDigits = 2,
     locale: string = i18n.language,
 ): string => {
-    if (typeof v !== "number" || !Number.isFinite(v) || Math.abs(v) > 1) {
+    if (typeof v !== "number" || !Number.isFinite(v)) return "N/A";
+    if (Math.abs(v) > 1) {
         console.warn("Metric value out of range:", v);
         return "N/A";
     }


### PR DESCRIPTION
## Summary
- Return "N/A" from `percentOrNa` without warning for null/undefined values
- Add unit tests for `percentOrNa` and adjust GroupPortfolioView tests accordingly

## Testing
- `npm test` *(fails: ReferenceError: IntersectionObserver is not defined, other existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c70678571c83278dd75f9bdafe6226