### PR TITLE
refactor: reorder approvals imports

### DIFF
--- a/backend/routes/approvals.py
+++ b/backend/routes/approvals.py
@@ -1,6 +1,6 @@
+import json
 from datetime import date
 from pathlib import Path
-import json
 
 from fastapi import APIRouter, HTTPException, Request
 


### PR DESCRIPTION
## Summary
- reorder approvals route imports to include json, date, and Path at top

## Testing
- `pytest backend/tests/test_routers.py::test_all_routes_registered -q --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68c70a1eaf08832783bac415a2aefcd0