### PR TITLE
Order CORS before SlowAPIMiddleware

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -148,7 +148,6 @@ def create_app() -> FastAPI:
     )
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
-    app.add_middleware(SlowAPIMiddleware)
 
     paths = resolve_paths(config.repo_root, config.accounts_root)
     app.state.repo_root = paths.repo_root
@@ -187,6 +186,9 @@ def create_app() -> FastAPI:
         allow_headers=cors_headers,
         allow_credentials=True,
     )
+    # Register SlowAPIMiddleware after CORSMiddleware so CORS preflight requests
+    # are handled before rate limiting or other middleware runs.
+    app.add_middleware(SlowAPIMiddleware)
 
     # ──────────────────────────── Routers ────────────────────────────
     # The API surface is composed of a few routers grouped by concern.


### PR DESCRIPTION
## Summary
- Register SlowAPIMiddleware after CORSMiddleware so CORS preflight is handled before rate limiting

## Testing
- `pytest backend/tests/test_portfolio_group_movers.py -q` *(fails: Object of type bytes is not JSON serializable)*

------
https://chatgpt.com/codex/tasks/task_e_68c70a1a70f883279881d028325cb4c9