### PR TITLE
feat: add error boundary for lazy Trail page

### DIFF
--- a/frontend/src/ErrorBoundary.tsx
+++ b/frontend/src/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { Component, ReactNode, ErrorInfo } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Failed to load page</div>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { HelmetProvider } from 'react-helmet-async'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
-import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, useNavigate, useLocation } from 'react-router-dom'
 import './index.css'
 import './styles/responsive.css'
 import './i18n'
@@ -14,6 +14,7 @@ import { getConfig, logout as apiLogout, getStoredAuthToken, setAuthToken } from
 import LoginPage from './LoginPage'
 import { UserProvider } from './UserContext'
 import { FocusModeProvider } from './FocusModeContext'
+import ErrorBoundary from './ErrorBoundary'
 
 const storedToken = getStoredAuthToken()
 if (storedToken) setAuthToken(storedToken)
@@ -42,6 +43,7 @@ export function Root() {
   const [authed, setAuthed] = useState(false)
   const { setUser } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
 
   const logout = () => {
     apiLogout()
@@ -69,28 +71,30 @@ export function Root() {
   }
 
   return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <Routes>
-        <Route path="/support" element={<Support />} />
-        <Route path="/virtual" element={<VirtualPortfolio />} />
-        <Route path="/compliance" element={<ComplianceWarnings />} />
-        <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
-        <Route path="/trade-compliance" element={<TradeCompliance />} />
-        <Route path="/trade-compliance/:owner" element={<TradeCompliance />} />
-        <Route path="/research/:ticker" element={<InstrumentResearch />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/alerts" element={<Alerts />} />
-        <Route path="/alert-settings" element={<AlertSettings />} />
-        <Route path="/goals" element={<Goals />} />
-        <Route path="/trail" element={<Trail />} />
-        {import.meta.env.VITE_SMOKE_TEST && SmokeTest && (
-          <Route path="/smoke-test" element={<SmokeTest />} />
-        )}
-        <Route path="/performance/:owner/diagnostics" element={<PerformanceDiagnostics />} />
-        <Route path="/returns/compare" element={<ReturnComparison />} />
-        <Route path="/*" element={<App onLogout={logout} />} />
-      </Routes>
-    </Suspense>
+    <ErrorBoundary key={location.pathname}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Routes>
+          <Route path="/support" element={<Support />} />
+          <Route path="/virtual" element={<VirtualPortfolio />} />
+          <Route path="/compliance" element={<ComplianceWarnings />} />
+          <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
+          <Route path="/trade-compliance" element={<TradeCompliance />} />
+          <Route path="/trade-compliance/:owner" element={<TradeCompliance />} />
+          <Route path="/research/:ticker" element={<InstrumentResearch />} />
+          <Route path="/profile" element={<Profile />} />
+          <Route path="/alerts" element={<Alerts />} />
+          <Route path="/alert-settings" element={<AlertSettings />} />
+          <Route path="/goals" element={<Goals />} />
+          <Route path="/trail" element={<Trail />} />
+          {import.meta.env.VITE_SMOKE_TEST && SmokeTest && (
+            <Route path="/smoke-test" element={<SmokeTest />} />
+          )}
+          <Route path="/performance/:owner/diagnostics" element={<PerformanceDiagnostics />} />
+          <Route path="/returns/compare" element={<ReturnComparison />} />
+          <Route path="/*" element={<App onLogout={logout} />} />
+        </Routes>
+      </Suspense>
+    </ErrorBoundary>
   )
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig(async ({ command }) => {
       ignore: ['**/*.test.tsx']
     })
     pageRoutes.push(
-      ...files.map((file) => `/${path.basename(file, '.tsx')}`)
+      ...files.map((file) => `/${path.basename(file, '.tsx').toLowerCase()}`)
     )
     const { createRequire } = await import('node:module')
     const require = createRequire(import.meta.url)


### PR DESCRIPTION
## Summary
- add ErrorBoundary component with fallback UI
- wrap routes with ErrorBoundary to catch lazy load failures
- ensure Vite prerender uses lowercase routes so Trail page is included

## Testing
- `npm --prefix frontend run lint` *(fails: Parsing error and other lint errors)*
- `npm test` *(fails: ReferenceError: IntersectionObserver is not defined)*
- `npm --prefix frontend run build` *(fails: TS1128 declaration expected)*

------
https://chatgpt.com/codex/tasks/task_e_68c70679eda08327bafbeb48211ebe09