### PR TITLE
Ensure config globals refresh on reload

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -289,7 +289,7 @@ def load_config() -> Config:
     if alpha_key_env:
         data["alpha_vantage_key"] = alpha_key_env
 
-    return Config(
+    cfg = Config(
         app_env=data.get("app_env"),
         sns_topic_arn=data.get("sns_topic_arn"),
         telegram_bot_token=data.get("telegram_bot_token"),
@@ -332,6 +332,11 @@ def load_config() -> Config:
         trading_agent=trading_agent,
         cors_origins=cors_origins,
     )
+
+    globals()["config"] = cfg
+    globals()["settings"] = cfg
+
+    return cfg
 
 
 # New-style usage

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -113,6 +113,7 @@ async def update_config(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     load_config.cache_clear()
     try:
+        load_config()
         return get_config_dict()
     except ConfigValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc))


### PR DESCRIPTION
## Summary
- Update `load_config` to refresh global `config` and `settings` references when building a new configuration
- Explicitly reload config after clearing cache in config update route

## Testing
- `python -m py_compile backend/config.py backend/routes/config.py`
- `pytest -q` *(fails: Alpha Vantage API key not configured; assert 'local' == 'staging'; not enough values to unpack; expected 2, got 0; assert 400 == 200; approvals directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c70a190c4483279ba5255cebde5c4f