### PR TITLE
test: verify health env and config alias

### DIFF
--- a/backend/tests/test_config_alias.py
+++ b/backend/tests/test_config_alias.py
@@ -1,0 +1,5 @@
+from backend import config as config_module
+
+
+def test_config_alias_settings():
+    assert config_module.settings is config_module.config

--- a/backend/tests/test_health_env.py
+++ b/backend/tests/test_health_env.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.config import config
+
+
+def test_health_env_variable(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "patched")
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["env"] == "patched"


### PR DESCRIPTION
## Summary
- assert `/health` returns patched `config.app_env`
- ensure `backend.config.settings` aliases `backend.config.config`

## Testing
- `pytest backend/tests/test_health_env.py backend/tests/test_config_alias.py -o addopts=`
- `pytest backend/tests/test_health_env.py backend/tests/test_config_alias.py` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68c70bbf64788327adc0c96ce54bd24f