### PR TITLE
refactor auth env handling

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -38,9 +38,13 @@ logger = logging.getLogger(__name__)
 
 SECRET_KEY = os.getenv("JWT_SECRET")
 _testing = os.getenv("TESTING")
-app_env = (os.getenv("APP_ENV") or (config.app_env or "")).lower()
 if not SECRET_KEY:
-    if config.disable_auth or _testing or app_env not in {"production", "aws"}:
+    if (
+        config.disable_auth
+        or _testing
+        or (os.getenv("APP_ENV") or (config.app_env or "")).lower()
+        not in {"production", "aws"}
+    ):
         logger.warning("JWT_SECRET not set; using ephemeral secret for development")
         SECRET_KEY = secrets.token_urlsafe(32)
     else:


### PR DESCRIPTION
## Summary
- inline app_env check for JWT secret in auth without module constant

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c70bbe40c48327979747b91619c948