### PR TITLE
Refactor screener config import

### DIFF
--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -14,12 +14,12 @@ from typing import Dict, List, Optional, Tuple
 import requests
 from pydantic import BaseModel
 
-import backend.config as config_module
+from backend.config import settings
 
 ALPHA_VANTAGE_URL = "https://www.alphavantage.co/query"
 # Cache configuration
 _MIN_TTL = 24 * 60 * 60  # one day
-ttl_cfg = config_module.settings.fundamentals_cache_ttl_seconds or _MIN_TTL
+ttl_cfg = settings.fundamentals_cache_ttl_seconds or _MIN_TTL
 _CACHE_TTL_SECONDS = max(
     _MIN_TTL,
     min(ttl_cfg, 7 * 24 * 60 * 60),
@@ -80,7 +80,7 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
     endpoint, utilising a simple in-memory cache.
     """
 
-    api_key = config_module.settings.alpha_vantage_key
+    api_key = settings.alpha_vantage_key
     if not api_key:
         raise RuntimeError(
             "Alpha Vantage API key not configured; set ALPHA_VANTAGE_KEY in your environment or .env file"


### PR DESCRIPTION
## Summary
- Import settings directly from backend.config
- Use settings to configure fundamentals cache TTL
- Remove remaining config_module references

## Testing
- `pytest tests/test_screener.py --cov=backend/screener --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_68c711c4bbf48327b7af643cca1301ee