### PR TITLE
Normalize cash ticker format

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -217,7 +217,8 @@ def _get_price_for_date_scaled(
     d: dt.date,
     field: str = "Close_gbp",
 ) -> tuple[Optional[float], Optional[str]]:
-    if ticker.upper() in {"CASH", "GBP.CASH", "CASH.GBP"}:
+    parts = ticker.upper().split(".")
+    if "CASH" in parts:
         return 1.0, None
 
     """

--- a/tests/test_portfolio_utils_meta.py
+++ b/tests/test_portfolio_utils_meta.py
@@ -1,3 +1,5 @@
+import logging
+
 from backend.common import portfolio_utils
 
 
@@ -6,3 +8,17 @@ def test_get_security_meta_includes_sector_and_region():
     assert meta is not None
     assert "sector" in meta and meta["sector"]
     assert "region" in meta and meta["region"]
+
+
+def test_cash_meta_has_no_warning(caplog):
+    caplog.set_level(logging.WARNING)
+    meta = portfolio_utils._meta_from_file("CASH.GBP")
+    assert meta and meta["asset_class"] == "cash"
+    assert caplog.text == ""
+
+
+def test_cash_alias_meta_has_no_warning(caplog):
+    caplog.set_level(logging.WARNING)
+    meta = portfolio_utils._meta_from_file("GBP.CASH")
+    assert meta and meta["asset_class"] == "cash"
+    assert caplog.text == ""


### PR DESCRIPTION
## Summary
- standardize cash ticker to `CASH.GBP` and normalize legacy `<ccy>.CASH`
- load instrument metadata via shared helpers with cash-aware canonicalisation
- ensure cash tickers treated as cash in price helper
- test cash metadata loads without warnings

## Testing
- `pytest tests/test_portfolio_utils_meta.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7120bccbc8327ac6f16c915d32326