### PR TITLE
Include initial pension pot in forecast projections

### DIFF
--- a/backend/common/pension.py
+++ b/backend/common/pension.py
@@ -132,6 +132,7 @@ def forecast_pension(
     investment_growth_pct: float = 5.0,
     desired_income_annual: Optional[float] = None,
     annuity_multiple: float = DEFAULT_ANNUITY_MULTIPLE,
+    initial_pot: float = 0.0,
     today: Optional[dt.date] = None,
 ) -> Dict[str, Any]:
     """Return a simple year-by-year pension income forecast.
@@ -140,9 +141,9 @@ def forecast_pension(
     ``normal_retirement_age`` fields.  The state pension amount, if provided,
     is assumed to start at ``retirement_age``.  ``contribution_annual`` and
     ``investment_growth_pct`` are used to project the size of a defined
-    contribution pot.  ``desired_income_annual`` is compared against the
-    projected pot (via ``annuity_multiple``) to determine the earliest age
-    that the desired income could be supported.
+    contribution pot, starting from ``initial_pot``.  ``desired_income_annual``
+    is compared against the projected pot (via ``annuity_multiple``) to
+    determine the earliest age that the desired income could be supported.
 
     The forecast runs from the current age (rounded down) up to but excluding
     ``death_age``.
@@ -155,12 +156,16 @@ def forecast_pension(
 
     start_age = int(current_age)
     if death_age <= start_age:
-        return {"forecast": [], "projected_pot_gbp": 0.0, "earliest_retirement_age": None}
+        return {
+            "forecast": [],
+            "projected_pot_gbp": float(initial_pot),
+            "earliest_retirement_age": None,
+        }
 
     pensions = db_pensions or []
     forecast: list[Dict[str, float]] = []
-    pot = 0.0
-    pot_at_retirement = 0.0
+    pot = initial_pot
+    pot_at_retirement = initial_pot
     earliest_age: Optional[int] = None
     growth_factor = 1 + investment_growth_pct / 100.0
     for age in range(start_age, death_age):

--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -71,6 +71,7 @@ def pension_forecast(
             contribution_annual=annual_contribution,
             investment_growth_pct=investment_growth_pct,
             desired_income_annual=desired_income_annual,
+            initial_pot=pension_pot,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -62,7 +62,7 @@ describe("PensionForecast page", () => {
     ]);
     mockGetPensionForecast.mockResolvedValue({
       forecast: [],
-      projected_pot_gbp: 0,
+      projected_pot_gbp: 200,
       pension_pot_gbp: 123,
       current_age: 30,
       retirement_age: 65,
@@ -99,6 +99,7 @@ describe("PensionForecast page", () => {
     );
     await screen.findByText(/birth date: 1990-01-01/i);
     await screen.findByText(/pension pot: £123.00/i);
+    await screen.findByText(/projected pot at 65: £323.00/i);
   });
 });
 

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -65,7 +65,7 @@ export default function PensionForecast() {
         investmentGrowthPct,
       });
       setData(res.forecast);
-      setProjectedPot(res.projected_pot_gbp);
+      setProjectedPot(res.projected_pot_gbp + res.pension_pot_gbp);
       setPensionPot(res.pension_pot_gbp);
       setCurrentAge(res.current_age);
       setRetirementAge(res.retirement_age);

--- a/tests/test_pension_forecast.py
+++ b/tests/test_pension_forecast.py
@@ -49,3 +49,17 @@ def test_forecast_post_retirement_life_expectancy():
     assert forecast[0]["age"] == 73
     assert len(forecast) == 17
     assert all(r["income"] == 19000 for r in forecast)
+
+
+def test_forecast_includes_initial_pot():
+    today = dt.date(2024, 1, 1)
+    res = forecast_pension(
+        dob="1984-01-01",
+        retirement_age=65,
+        death_age=66,
+        contribution_annual=0.0,
+        investment_growth_pct=0.0,
+        initial_pot=500.0,
+        today=today,
+    )
+    assert res["projected_pot_gbp"] == 500.0

--- a/tests/test_pension_route.py
+++ b/tests/test_pension_route.py
@@ -15,7 +15,7 @@ def test_pension_route_uses_owner_metadata(monkeypatch):
 
     def fake_forecast(**kwargs):
         called.update(kwargs)
-        return {"forecast": []}
+        return {"forecast": [], "projected_pot_gbp": 0.0}
 
     def fake_portfolio(owner: str, root=None):  # pragma: no cover - signature match
         return {
@@ -45,6 +45,7 @@ def test_pension_route_uses_owner_metadata(monkeypatch):
     assert isinstance(body["current_age"], float)
     assert body["dob"] == "1980-01-01"
     assert body["pension_pot_gbp"] == 150
+    assert called["initial_pot"] == 150
 
 
 def test_pension_route_missing_dob(monkeypatch):


### PR DESCRIPTION
## Summary
- allow pension forecasts to start from an existing pot
- route passes current pension pot into forecast calculation
- frontend shows retirement pot including current holdings

## Testing
- `PYTEST_ADDOPTS="--cov=backend --cov-fail-under=0" pytest tests/test_pension_route.py tests/test_pension_forecast.py`
- `cd frontend && npx vitest run src/pages/PensionForecast.test.tsx`
- ⚠️ `npm test` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c715deeec4832780abd3c539fb42dd