### PR TITLE
feat: expose cached config loader

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import asdict, dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -168,8 +169,14 @@ def _parse_str_list(val: Any) -> Optional[List[str]]:
     return None
 
 
-def _load_config() -> Config:
-    """Load configuration from config.yaml with optional env overrides."""
+@lru_cache(maxsize=None)
+def load_config() -> Config:
+    """Load configuration from config.yaml with optional env overrides.
+
+    This function is cached so repeated calls avoid re-parsing configuration
+    files. Tests and callers that need a fresh configuration can clear the
+    cache via ``load_config.cache_clear()``.
+    """
     path = _project_config_path()
     data: Dict[str, Any] = {}
 
@@ -337,13 +344,13 @@ def _load_config() -> Config:
     return cfg
 
 
-config = _load_config()
+config = load_config()
 settings = config
 
 
 def reload_config() -> Config:
     """Reload configuration and update module-level ``config``."""
     global config, settings
-    new_config = _load_config()
-    config = settings = new_config
-    return new_config
+    load_config.cache_clear()
+    config = settings = load_config()
+    return config


### PR DESCRIPTION
## Summary
- expose `load_config` from `backend.config` and decorate with `lru_cache`
- ensure `reload_config` clears cached configuration before reloading

## Testing
- `pytest` *(fails: tests/common/test_approvals.py::test_approvals_path, tests/routes/test_config.py::test_update_config_env_valid, tests/screener/test_screener.py::test_fetch_fundamentals_caching_and_ttl, tests/test_app.py::test_health_env_variable, tests/test_app.py::test_skip_snapshot_warm, tests/test_cors_preflight.py::test_cors_preflight, tests/test_holdings_import.py::test_update_holdings_from_csv, tests/test_instrument_route.py::test_base_currency_from_config, tests/test_transactions_round_trip.py::test_transaction_round_trip, tests/test_transactions_route.py::test_create_transaction_success, tests/test_transactions_route.py::test_dividends_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68c716eeeec48327af63c7a9b336a708