### PR TITLE
Allow wildcard CORS methods and ensure production origin

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -193,14 +193,14 @@ def create_app() -> FastAPI:
         "http://localhost:3000",
         "http://localhost:5173",
     ]
-    cors_origins = _validate_cors_origins(cfg.cors_origins or default_cors)
-    cors_methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
-    cors_headers = ["Authorization", "Content-Type"]
+    cors_origins = _validate_cors_origins(
+        list(dict.fromkeys((cfg.cors_origins or []) + default_cors))
+    )
     app.add_middleware(
         CORSMiddleware,
         allow_origins=cors_origins,
-        allow_methods=cors_methods,
-        allow_headers=cors_headers,
+        allow_methods=["*"],
+        allow_headers=["*"],
         allow_credentials=True,
     )
     # Register SlowAPIMiddleware after CORSMiddleware so CORS preflight requests

--- a/tests/test_cors_preflight.py
+++ b/tests/test_cors_preflight.py
@@ -27,3 +27,19 @@ def test_cors_preflight(monkeypatch):
     assert "Authorization" in allow_headers
     assert "Content-Type" in allow_headers
     assert "*" not in allow_headers
+
+
+def test_cors_preflight_app_origin_always_allowed(monkeypatch):
+    origin = "https://app.allotmint.io"
+    monkeypatch.setattr(config, "cors_origins", ["http://localhost:3000"])
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    app = create_app()
+    with TestClient(app) as client:
+        headers = {
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Authorization,Content-Type",
+        }
+        resp = client.options("/health", headers=headers)
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == origin


### PR DESCRIPTION
## Summary
- Allow any method and header in CORS preflight
- Always include `https://app.allotmint.io` among allowed CORS origins
- Add regression test for default app origin

## Testing
- `PYTEST_ADDOPTS="--cov=backend --cov-fail-under=0" pytest tests/test_cors_preflight.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c716ee25c08327b2c19308081dc79a