### PR TITLE
Refactor Alpha Vantage configuration access

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 """Market overview endpoint aggregating indexes, sectors and headlines."""
 
+import logging
 from typing import Any, Dict, List, Optional
 
-import logging
 import requests
 import yfinance as yf
 from fastapi import APIRouter
 
-from backend.config import config
+from backend import config_module
 from backend.routes.news import _fetch_news
+
+cfg = getattr(config_module, "settings", config_module.config)
+config = cfg
 
 router = APIRouter(tags=["market"])
 
@@ -39,7 +42,7 @@ def _fetch_indexes() -> Dict[str, Dict[str, Optional[float]]]:
 
 
 def _fetch_sectors() -> List[Dict[str, float]]:
-    params = {"function": "SECTOR", "apikey": config.alpha_vantage_key or "demo"}
+    params = {"function": "SECTOR", "apikey": cfg.alpha_vantage_key or "demo"}
     resp = requests.get("https://www.alphavantage.co/query", params=params, timeout=10)
     resp.raise_for_status()
     data = resp.json().get("Rank A: Real-Time Performance", {})

--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -15,12 +15,14 @@ import requests
 from pydantic import BaseModel
 
 from backend import config_module
-from backend.config import settings
+
+cfg = getattr(config_module, "settings", config_module.config)
+config = cfg
 
 ALPHA_VANTAGE_URL = "https://www.alphavantage.co/query"
 # Cache configuration
 _MIN_TTL = 24 * 60 * 60  # one day
-ttl_cfg = settings.fundamentals_cache_ttl_seconds or _MIN_TTL
+ttl_cfg = cfg.fundamentals_cache_ttl_seconds or _MIN_TTL
 _CACHE_TTL_SECONDS = max(
     _MIN_TTL,
     min(ttl_cfg, 7 * 24 * 60 * 60),
@@ -81,11 +83,7 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
     endpoint, utilising a simple in-memory cache.
     """
 
-    api_key = settings.alpha_vantage_key
-    if not api_key:
-        raise RuntimeError(
-            "Alpha Vantage API key not configured; set ALPHA_VANTAGE_KEY in your environment or .env file"
-        )
+    api_key = cfg.alpha_vantage_key or "demo"
 
     key = (ticker.upper(), date.today().isoformat())
     now = datetime.now(UTC)

--- a/backend/tasks/quotes.py
+++ b/backend/tasks/quotes.py
@@ -9,7 +9,10 @@ from typing import Any, Dict, Iterable
 import boto3
 import requests
 
-from backend.config import config
+from backend import config_module
+
+cfg = getattr(config_module, "settings", config_module.config)
+config = cfg
 
 log = logging.getLogger("tasks.quotes")
 
@@ -19,9 +22,9 @@ TABLE_NAME = os.environ.get("QUOTES_TABLE", "Quotes")
 
 def fetch_quote(symbol: str, api_key: str | None = None) -> Dict[str, Any]:
     """Fetch a single quote from Alpha Vantage."""
-    if not config.alpha_vantage_enabled:
+    if not cfg.alpha_vantage_enabled:
         raise RuntimeError("Alpha Vantage fetching disabled via config")
-    key = api_key or config.alpha_vantage_key or "demo"
+    key = api_key or cfg.alpha_vantage_key or "demo"
     params = {"function": "GLOBAL_QUOTE", "symbol": symbol, "apikey": key}
     resp = requests.get(BASE_URL, params=params, timeout=10)
     resp.raise_for_status()

--- a/backend/timeseries/fetch_alphavantage_timeseries.py
+++ b/backend/timeseries/fetch_alphavantage_timeseries.py
@@ -5,9 +5,12 @@ from datetime import date, timedelta
 import pandas as pd
 import requests
 
-from backend.config import config
+from backend import config_module
 from backend.timeseries.ticker_validator import is_valid_ticker, record_skipped_ticker
 from backend.utils.timeseries_helpers import STANDARD_COLUMNS
+
+cfg = getattr(config_module, "settings", config_module.config)
+config = cfg
 
 # Setup logger
 logger = logging.getLogger("alphavantage_timeseries")
@@ -71,7 +74,7 @@ def fetch_alphavantage_timeseries_range(
     api_key: str | None = None,
 ) -> pd.DataFrame:
     """Fetch historical Alpha Vantage data using a date range."""
-    if api_key is None and not config.alpha_vantage_enabled:
+    if api_key is None and not cfg.alpha_vantage_enabled:
         logger.info("Alpha Vantage fetching disabled via config")
         return pd.DataFrame(columns=STANDARD_COLUMNS)
     if not is_valid_ticker(ticker, exchange):
@@ -79,7 +82,7 @@ def fetch_alphavantage_timeseries_range(
         record_skipped_ticker(ticker, exchange, reason="unknown")
         return pd.DataFrame(columns=STANDARD_COLUMNS)
     symbol = _build_symbol(ticker, exchange)
-    key = api_key or config.alpha_vantage_key or "demo"
+    key = api_key or cfg.alpha_vantage_key or "demo"
 
     params = {
         "function": "TIME_SERIES_DAILY_ADJUSTED",


### PR DESCRIPTION
## Summary
- standardize configuration lookup via `cfg = getattr(config_module, "settings", config_module.config)`
- fall back to `"demo"` when the Alpha Vantage API key is missing
- expose `config` aliases for backward compatibility

## Testing
- `ruff check --config backend/pyproject.toml backend/routes/news.py backend/routes/market.py backend/screener/__init__.py backend/tasks/quotes.py backend/timeseries/fetch_alphavantage_timeseries.py`
- `black --check --config backend/pyproject.toml backend/routes/news.py backend/routes/market.py backend/screener/__init__.py backend/tasks/quotes.py backend/timeseries/fetch_alphavantage_timeseries.py`
- `pytest` *(fails: tests/common/test_approvals.py::test_approvals_path, tests/routes/test_config.py::test_update_config_env_valid, tests/screener/test_screener.py::test_fetch_fundamentals_caching_and_ttl, tests/test_app.py::test_health_env_variable, tests/test_app.py::test_skip_snapshot_warm, tests/test_cors_preflight.py::test_cors_preflight, tests/test_holdings_import.py::test_update_holdings_from_csv, tests/test_instrument_route.py::test_base_currency_from_config, tests/test_transactions_round_trip.py::test_transaction_round_trip, tests/test_transactions_route.py::test_create_transaction_success, tests/test_transactions_route.py::test_dividends_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68c716e964d0832791d858ba87071bbb