### PR TITLE
Simplify holdings import

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -232,7 +232,6 @@ async def import_transactions(
 
 @router.post("/holdings/import")
 async def import_holdings(
-    request: Request,
     owner: str = Form(...),
     account: str = Form(...),
     provider: str = Form(...),
@@ -242,13 +241,11 @@ async def import_holdings(
 
     data = await file.read()
     try:
-        root = request.app.state.accounts_root
         return update_holdings_from_csv.update_from_csv(
             owner,
             account,
             provider,
             data,
-            accounts_root=root,
         )
     except importers.UnknownProvider as exc:
         raise HTTPException(status_code=400, detail=f"Unknown provider: {exc}")

--- a/tests/test_holdings_import.py
+++ b/tests/test_holdings_import.py
@@ -43,7 +43,7 @@ def test_update_holdings_from_csv(tmp_path: Path, monkeypatch):
     assert h["AAA"]["units"] == 10
     assert h["AAA"]["cost_basis_gbp"] == 15
     assert h["AAA"]["current_price_gbp"] == pytest.approx(1.5)
-    assert result["account_type"].lower() == "isa"
+    assert Path(result["path"]).resolve() == acct_file.resolve()
 
 
 @pytest.fixture()
@@ -62,5 +62,6 @@ def test_holdings_import_endpoint(client: TestClient, tmp_path: Path):
     resp = client.post("/holdings/import", data=data, files=files)
     assert resp.status_code == 200
     body = resp.json()
-    assert body["account_type"].lower() == "isa"
-    assert (tmp_path / "alice" / "isa.json").exists()
+    acct_file = tmp_path / "alice" / "isa.json"
+    assert Path(body["path"]).resolve() == acct_file.resolve()
+    assert acct_file.exists()


### PR DESCRIPTION
## Summary
- write holdings JSON to accounts_root/owner and return its path
- drop accounts_root override in holdings importer endpoint
- adjust holdings import tests for new path-based return value

## Testing
- `pytest tests/test_holdings_import.py -q -o addopts=''`
- `pytest -q` *(fails: DID NOT RAISE <class 'FileNotFoundError'>, assert False is True, AttributeError: 'Config' object has no attribute 'settings', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c716e5490c8327b8eb8df6cd884356