### PR TITLE
Raise error for missing approval owner directory

### DIFF
--- a/scripts/check_portfolio_health.py
+++ b/scripts/check_portfolio_health.py
@@ -114,7 +114,7 @@ def run_check(threshold: float) -> list[dict]:
 
     for owner in owners:
         try:
-            path = approvals._approvals_path(owner)
+            path = approvals.approvals_path(owner)
         except FileNotFoundError:
             continue
         if not path.exists():

--- a/tests/common/test_approvals.py
+++ b/tests/common/test_approvals.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from backend.common.approvals import (
-    _approvals_path,
+    approvals_path,
     delete_approval,
     is_approval_valid,
     load_approvals,
@@ -16,12 +16,12 @@ from backend.common.approvals import (
 def test_approvals_path(tmp_path: Path) -> None:
     """Check path resolution and missing owner handling."""
     with pytest.raises(FileNotFoundError):
-        _approvals_path("alice", accounts_root=tmp_path)
+        approvals_path("alice", accounts_root=tmp_path)
 
     owner_dir = tmp_path / "bob"
     owner_dir.mkdir()
     expect = owner_dir / "approvals.json"
-    assert _approvals_path("bob", accounts_root=tmp_path) == expect
+    assert approvals_path("bob", accounts_root=tmp_path) == expect
 
 
 def test_load_upsert_delete(tmp_path: Path) -> None:

--- a/tests/scripts/test_check_portfolio_health.py
+++ b/tests/scripts/test_check_portfolio_health.py
@@ -47,7 +47,7 @@ def test_run_check_drawdown_and_missing(monkeypatch, tmp_path):
             return tmp_path / owner / "approvals.json"
         raise FileNotFoundError
 
-    monkeypatch.setattr(cph.approvals, "_approvals_path", fake_approvals_path)
+    monkeypatch.setattr(cph.approvals, "approvals_path", fake_approvals_path)
     monkeypatch.setattr(cph.portfolio_utils, "_MISSING_META", {"missing/meta.json"}, raising=False)
 
     findings = cph.run_check(0.2)

--- a/tests/test_trade_approvals.py
+++ b/tests/test_trade_approvals.py
@@ -67,15 +67,13 @@ def test_save_approvals_persists(tmp_path):
     assert loaded == approvals
 
 
-def test_load_approvals_creates_default(tmp_path):
+def test_load_approvals_missing(tmp_path):
     owner_dir = tmp_path / "charlie"
     owner_dir.mkdir()
     loaded = load_approvals("charlie", accounts_root=tmp_path)
     assert loaded == {}
     path = owner_dir / "approvals.json"
-    assert path.exists()
-    data = json.loads(path.read_text())
-    assert data == {"approvals": []}
+    assert not path.exists()
 
 
 def test_approvals_endpoints(tmp_path):
@@ -88,6 +86,8 @@ def test_approvals_endpoints(tmp_path):
     config.skip_snapshot_warm = True
     config.offline_mode = True
     app = create_app()
+    config.accounts_root = tmp_path
+    app.state.accounts_root = tmp_path
     client = TestClient(app)
     try:
         resp = client.get("/accounts/bob/approvals")


### PR DESCRIPTION
## Summary
- replace `_approvals_path` with `approvals_path` that fails when the owner folder is absent
- stop `load_approvals`/`save_approvals` from creating directories; just propagate the `FileNotFoundError`
- adjust health check script and tests for new approval path handling

## Testing
- `pytest` *(fails: 12 failed, 707 passed)*
- `pytest --cov=backend --cov-fail-under=0 tests/common/test_approvals.py tests/test_trade_approvals.py tests/scripts/test_check_portfolio_health.py`


------
https://chatgpt.com/codex/tasks/task_e_68c716e349b08327a89964887ff7ff9d