### PR TITLE
Fix configuration handling and exports

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,15 +1,16 @@
 """Backend package public interface.
 
-Expose the :mod:`backend.config` module under ``config_module`` while also
-providing the instantiated configuration object as ``config``. This allows
-consumers to access configuration both via ``backend.config`` (object) and the
-full configuration module via ``backend.config_module``.
+Expose the :mod:`backend.config` module under ``config_module`` and make it
+directly available as ``config`` for convenience. Configuration values can be
+accessed as attributes on this module and the underlying dataclass instance is
+available as ``config.settings``.
 """
 
 from . import config as config_module
 
-# Re-export the configuration instance for convenient access
-config = config_module.config
+# Re-export the configuration module so ``from backend import config`` works
+# consistently in both application code and tests.
+config = config_module
 
 __all__ = ["config", "config_module"]
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -90,7 +90,7 @@ def create_app() -> FastAPI:
     used, even if other tests reload or replace it.
     """
 
-    cfg = reload_config()
+    cfg = config_module.config
     app_env = cfg.app_env or "test"
 
     if cfg.google_auth_enabled and not cfg.google_client_id:

--- a/backend/config.py
+++ b/backend/config.py
@@ -350,6 +350,10 @@ def reload_config() -> Config:
     global config, settings
     load_config.cache_clear()
     new_config = load_config()
+    if isinstance(config, Config):
+        config.__dict__.update(new_config.__dict__)
+        settings = config
+        return config
     config = settings = new_config
     return new_config
 

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -11,7 +11,6 @@ from fastapi import APIRouter, HTTPException
 from backend.config import (
     ConfigValidationError,
     _project_config_path,
-    config,
     reload_config,
     validate_google_auth,
 )
@@ -31,7 +30,7 @@ def deep_merge(dst: Dict[str, Any], src: Dict[str, Any]) -> None:
 @router.get("")
 async def read_config() -> Dict[str, Any]:
     """Return the full application configuration."""
-    return asdict(config)
+    return asdict(config_module.config)
 
 
 @router.put("")
@@ -114,7 +113,7 @@ async def update_config(payload: Dict[str, Any]) -> Dict[str, Any]:
         raise HTTPException(500, f"Failed to write config: {exc}")
 
     try:
-        reload_config()
-        return asdict(config)
+        new_config = reload_config()
+        return asdict(new_config)
     except ConfigValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc))


### PR DESCRIPTION
## Summary
- serve up-to-date config after updates
- expose config module for easier testing
- create app with existing config

## Testing
- `pytest tests/routes/test_config.py::test_update_config_env_valid -q`
- `pytest tests/screener/test_screener.py::test_fetch_fundamentals_caching_and_ttl -q`
- `pytest tests/test_app.py::test_health_env_variable tests/test_app.py::test_skip_snapshot_warm -q`
- `pytest tests/test_holdings_import.py::test_update_holdings_from_csv tests/test_holdings_import.py::test_holdings_import_endpoint -q`
- `pytest tests/test_instrument_route.py::test_base_currency_from_config -q`
- `pytest tests/test_transactions_round_trip.py::test_transaction_round_trip tests/test_transactions_route.py::test_create_transaction_success tests/test_transactions_route.py::test_dividends_endpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71c7d51b48327ad6b9dacf9fdacf0