### PR TITLE
Preserve case of account holdings paths

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -243,8 +243,11 @@ async def import_holdings(
     account: str = Form(...),
     provider: str = Form(...),
     file: UploadFile = File(...),
-) -> dict:
-    """Parse a holdings export and persist it to the accounts store."""
+) -> str:
+    """Parse a holdings export and persist it to the accounts store.
+
+    Returns the path of the written holdings file.
+    """
 
     data = await file.read()
     try:

--- a/backend/tests/test_update_holdings_from_csv.py
+++ b/backend/tests/test_update_holdings_from_csv.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+from backend.utils import update_holdings_from_csv
+
+
+def test_update_from_csv_returns_case_sensitive_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        update_holdings_from_csv, "config", SimpleNamespace(accounts_root=tmp_path)
+    )
+    monkeypatch.setattr(
+        update_holdings_from_csv,
+        "importers",
+        SimpleNamespace(parse=lambda provider, data: []),
+    )
+    monkeypatch.setattr(
+        update_holdings_from_csv,
+        "portfolio_loader",
+        SimpleNamespace(rebuild_account_holdings=lambda *a, **k: None),
+    )
+
+    path = update_holdings_from_csv.update_from_csv("Alice", "ISA", "dummy", b"")
+
+    expected = tmp_path / "Alice" / "ISA.json"
+    assert path == str(expected)
+    assert expected.exists()

--- a/backend/utils/update_holdings_from_csv.py
+++ b/backend/utils/update_holdings_from_csv.py
@@ -29,10 +29,10 @@ def update_from_csv(
     account: str,
     provider: str,
     data: bytes,
-) -> dict[str, str]:
+) -> str:
     """Parse ``data`` from ``provider`` and update ``owner``/``account`` holdings.
 
-    Returns a mapping with the path to the written holdings file.
+    Returns the path to the written holdings file.
     """
 
     transactions: List[Any] = importers.parse(provider, data)
@@ -49,7 +49,7 @@ def update_from_csv(
 
     base_dir = Path(config.accounts_root) / owner
     base_dir.mkdir(parents=True, exist_ok=True)
-    acct_path = base_dir / f"{account.lower()}.json"
+    acct_path = base_dir / f"{account}.json"
     acct_path.write_text(json.dumps(payload, indent=2))
 
     try:
@@ -57,4 +57,4 @@ def update_from_csv(
     except Exception:  # pragma: no cover - rebuild errors are non-fatal
         pass
 
-    return {"path": str(acct_path)}
+    return str(acct_path)


### PR DESCRIPTION
## Summary
- stop lowercasing account file names when importing holdings and return written file path
- update import_holdings route to forward the path string
- add unit test for case-sensitive holdings path

## Testing
- `pytest backend/tests/test_update_holdings_from_csv.py backend/tests/test_transactions_route.py --no-cov`
- `pytest backend/tests` *(fails: Missing dependencies for async endpoints, rate limiting, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c71e0cd6d88327a3efb4444c294aaf