### PR TITLE
Preserve config overrides in app factory

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -243,10 +243,10 @@ async def import_holdings(
     account: str = Form(...),
     provider: str = Form(...),
     file: UploadFile = File(...),
-) -> str:
+) -> dict[str, str]:
     """Parse a holdings export and persist it to the accounts store.
 
-    Returns the path of the written holdings file.
+    Returns a mapping containing the path of the written holdings file.
     """
 
     data = await file.read()

--- a/backend/utils/update_holdings_from_csv.py
+++ b/backend/utils/update_holdings_from_csv.py
@@ -29,10 +29,13 @@ def update_from_csv(
     account: str,
     provider: str,
     data: bytes,
-) -> str:
+) -> dict[str, str]:
     """Parse ``data`` from ``provider`` and update ``owner``/``account`` holdings.
 
-    Returns the path to the written holdings file.
+    Returns a mapping containing the path to the written holdings file. A
+    dictionary is returned instead of a plain string so callers (and tests)
+    can easily extend the response with additional metadata in the future
+    without changing the return type again.
     """
 
     transactions: List[Any] = importers.parse(provider, data)
@@ -57,4 +60,4 @@ def update_from_csv(
     except Exception:  # pragma: no cover - rebuild errors are non-fatal
         pass
 
-    return str(acct_path)
+    return {"path": str(acct_path)}


### PR DESCRIPTION
## Summary
- ensure `create_app` retains config overrides applied in tests
- return path metadata from holdings CSV updates
- expose holdings import path via transactions endpoint

## Testing
- `pytest tests/test_accounts_api.py::test_account_route_adds_missing_account_type tests/test_app.py::test_health_env_variable tests/test_app.py::test_skip_snapshot_warm tests/test_holdings_import.py::test_update_holdings_from_csv tests/test_holdings_import.py::test_holdings_import_endpoint tests/test_instrument_route.py::test_base_currency_from_config tests/test_transactions_round_trip.py::test_transaction_round_trip tests/test_transactions_route.py::test_create_transaction_success tests/test_transactions_route.py::test_dividends_endpoint -q -p no:cov --override-ini addopts=`
- `pytest tests/test_config.py::test_timeseries_cache_base_env_override tests/test_config.py::test_auth_flags tests/test_config.py::test_update_config_merges_ui_section tests/test_google_auth.py::test_create_app_guard_raises -q -p no:cov --override-ini addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68c7209dc9588327af26b5d574836408