### PR TITLE
Allow tax harvest without authentication

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -106,11 +106,7 @@ def create_app() -> FastAPI:
             # Pre-fetch recent price data so the first request is fast.
             try:
                 result = _load_snapshot()
-                if (
-                    not isinstance(result, tuple)
-                    or len(result) != 2
-                    or not isinstance(result[0], dict)
-                ):
+                if not isinstance(result, tuple) or len(result) != 2 or not isinstance(result[0], dict):
                     raise ValueError("Malformed snapshot")
                 snapshot, ts = result
             except Exception as exc:
@@ -122,9 +118,7 @@ def create_app() -> FastAPI:
             from backend.common import instrument_api
 
             instrument_api.update_latest_prices_from_snapshot(snapshot)
-            price_task = asyncio.create_task(
-                asyncio.to_thread(instrument_api.prime_latest_prices)
-            )
+            price_task = asyncio.create_task(asyncio.to_thread(instrument_api.prime_latest_prices))
             app.state.background_tasks.append(price_task)
 
         task = refresh_snapshot_async(days=cfg.snapshot_warm_days)
@@ -195,9 +189,7 @@ def create_app() -> FastAPI:
         "http://localhost:3000",
         "http://localhost:5173",
     ]
-    cors_origins = _validate_cors_origins(
-        list(dict.fromkeys((cfg.cors_origins or []) + default_cors))
-    )
+    cors_origins = _validate_cors_origins(list(dict.fromkeys((cfg.cors_origins or []) + default_cors)))
     app.add_middleware(
         CORSMiddleware,
         allow_origins=cors_origins,
@@ -208,7 +200,6 @@ def create_app() -> FastAPI:
     # Register SlowAPIMiddleware after CORSMiddleware so CORS preflight requests
     # are handled before rate limiting or other middleware runs.
     app.add_middleware(SlowAPIMiddleware)
-
 
     # ──────────────────────────── Routers ────────────────────────────
     # The API surface is composed of a few routers grouped by concern.
@@ -255,7 +246,7 @@ def create_app() -> FastAPI:
     app.include_router(scenario_router)
     app.include_router(logs_router)
     app.include_router(goals_router, dependencies=protected)
-    app.include_router(tax_router, dependencies=protected)
+    app.include_router(tax_router)
     app.include_router(pension_router)
 
     @app.exception_handler(RequestValidationError)

--- a/backend/routes/tax.py
+++ b/backend/routes/tax.py
@@ -27,11 +27,8 @@ class HarvestRequest(BaseModel):
 
 
 @router.post("/harvest")
-async def harvest(req: HarvestRequest, current_user: str = Depends(get_current_user)) -> dict:
-    del current_user
-    trades = harvest_losses(
-        [p.model_dump() for p in req.positions], req.threshold or 0.0
-    )
+async def harvest(req: HarvestRequest) -> dict:
+    trades = harvest_losses([p.model_dump() for p in req.positions], req.threshold or 0.0)
     return {"trades": trades}
 
 


### PR DESCRIPTION
## Summary
- make `/tax/harvest` route accessible without auth
- stop including `tax_router` with global auth dependency

## Testing
- `make lint` *(fails: Import block is un-sorted or un-formatted. Found 178 errors.)*
- `pytest tests/test_tax_route.py backend/tests/test_tax_route.py --cov=backend --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68c721132e98832792bea808d7ca5e5a