### PR TITLE
feat: expose logs tab in menu

### DIFF
--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -12,17 +12,14 @@ describe("Menu", () => {
         <Menu />
       </MemoryRouter>,
     );
-    expect(screen.queryByRole("link", { name: "Logs" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Support" })).not.toBeInTheDocument();
     const toggle = screen.getByRole("button", { name: i18n.t("app.menu") });
     fireEvent.click(toggle);
     expect(screen.getByRole("link", { name: "Support" })).toHaveAttribute(
       "href",
       "/support",
     );
-    expect(screen.queryByRole("link", { name: "Logs" })).toBeNull();
-    fireEvent.click(screen.getByLabelText(i18n.t("app.menu")));
-    expect(screen.getByRole("link", { name: "Support" })).toHaveAttribute("href", "/support");
-    expect(screen.queryByRole("link", { name: "Logs" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Logs" })).toHaveAttribute("href", "/logs");
   });
 
   it("shows support tabs on support route", () => {

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -8,7 +8,7 @@ import { orderedTabPlugins, SUPPORT_TABS } from '../tabPlugins';
 import PomodoroTimer from './PomodoroTimer';
 import { useFocusMode } from '../FocusModeContext';
 
-const SUPPORT_ONLY_TABS: TabPluginId[] = ['logs'];
+const SUPPORT_ONLY_TABS: TabPluginId[] = [];
 
 interface MenuProps {
   selectedOwner?: string;
@@ -171,7 +171,11 @@ export default function Menu({
           style={style}
         >
           {orderedTabPlugins
-            .filter((p) => p.section === (isSupportMode ? 'support' : 'user'))
+            .filter(
+              (p) =>
+                p.section === (isSupportMode ? 'support' : 'user') ||
+                (supportEnabled && p.id === 'logs'),
+            )
             .slice()
             .sort((a, b) => a.priority - b.priority)
             .filter((p) => {


### PR DESCRIPTION
## Summary
- show Logs tab whenever support features are enabled
- test for Logs link in menu on default and support routes

## Testing
- `npm test` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c723487fdc83278854568b33522d5a