### PR TITLE
Add comprehensive price utility tests

### DIFF
--- a/tests/common/test_prices.py
+++ b/tests/common/test_prices.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta, datetime, timezone
 
 import pandas as pd
 import pytest
+from unittest.mock import Mock
 
 from backend.common import prices
 
@@ -43,6 +44,39 @@ def test_close_on_invalid_value(monkeypatch):
     assert prices._close_on("ABC", "L", date.today()) is None
 
 
+def test_close_on_none_df(monkeypatch):
+    monkeypatch.setattr(prices, "_nearest_weekday", lambda d, forward=False: d)
+    monkeypatch.setattr(
+        prices, "load_meta_timeseries_range", lambda *args, **kwargs: None
+    )
+    assert prices._close_on("ABC", "L", date.today()) is None
+
+
+def test_close_on_column_fallbacks(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "Close": [1.0],
+            "close": [2.0],
+            "Close_gbp": [3.0],
+            "close_gbp": [4.0],
+        }
+    )
+    monkeypatch.setattr(prices, "_nearest_weekday", lambda d, forward=False: d)
+    monkeypatch.setattr(
+        prices, "load_meta_timeseries_range", lambda *args, **kwargs: df
+    )
+    assert prices._close_on("ABC", "L", date.today()) == 4.0
+
+
+def test_close_on_fallback_to_close_gbp(monkeypatch):
+    df = pd.DataFrame({"Close_gbp": [5.0]})
+    monkeypatch.setattr(prices, "_nearest_weekday", lambda d, forward=False: d)
+    monkeypatch.setattr(
+        prices, "load_meta_timeseries_range", lambda *args, **kwargs: df
+    )
+    assert prices._close_on("ABC", "L", date.today()) == 5.0
+
+
 def test_get_price_snapshot_calculates_changes(monkeypatch):
     ticker = "ABC.L"
     last_price = 100.0
@@ -69,6 +103,7 @@ def test_get_price_snapshot_calculates_changes(monkeypatch):
     assert info["last_price_date"] == yday.isoformat()
     assert info["change_7d_pct"] == pytest.approx((last_price / 90.0 - 1) * 100)
     assert info["change_30d_pct"] == pytest.approx((last_price / 80.0 - 1) * 100)
+    assert info["is_stale"] is True
 
 
 def test_refresh_prices_writes_json_and_updates_cache(tmp_path, monkeypatch):
@@ -91,8 +126,10 @@ def test_refresh_prices_writes_json_and_updates_cache(tmp_path, monkeypatch):
         return pd.DataFrame({"close": [price_map.get(start_date, last_price)]})
 
     monkeypatch.setattr(prices, "load_meta_timeseries_range", fake_load_meta_timeseries_range)
-    monkeypatch.setattr(prices, "refresh_snapshot_in_memory", lambda snapshot: None)
-    monkeypatch.setattr(prices, "check_price_alerts", lambda: None)
+    refresh_mock = Mock()
+    alerts_mock = Mock()
+    monkeypatch.setattr(prices, "refresh_snapshot_in_memory", refresh_mock)
+    monkeypatch.setattr(prices, "check_price_alerts", alerts_mock)
 
     out_path = tmp_path / "prices.json"
     monkeypatch.setattr(prices.config, "prices_json", out_path)
@@ -108,6 +145,8 @@ def test_refresh_prices_writes_json_and_updates_cache(tmp_path, monkeypatch):
     assert info["change_7d_pct"] == pytest.approx((last_price / 90.0 - 1) * 100)
     assert info["change_30d_pct"] == pytest.approx((last_price / 80.0 - 1) * 100)
     assert prices.get_price_gbp(ticker) == last_price
+    refresh_mock.assert_called_once_with(result["snapshot"])
+    alerts_mock.assert_called_once()
 
 
 def test_get_price_snapshot_resolved(monkeypatch):
@@ -156,6 +195,32 @@ def test_get_price_snapshot_live_data(monkeypatch):
     assert info["last_price"] == last_price
     assert info["last_price_time"] == now.isoformat().replace("+00:00", "Z")
     assert info["is_stale"] is False
+
+
+def test_get_price_snapshot_stale_data(monkeypatch):
+    ticker = "ABC.L"
+    now = datetime.now(timezone.utc)
+    stale_ts = now - timedelta(minutes=20)
+    last_price = 120.0
+
+    monkeypatch.setattr(prices, "_load_latest_prices", lambda tickers: {})
+    monkeypatch.setattr(
+        prices,
+        "load_live_prices",
+        lambda tickers: {ticker: {"price": last_price, "timestamp": stale_ts}},
+    )
+    monkeypatch.setattr(
+        prices.instrument_api, "_resolve_full_ticker", lambda full, latest: None
+    )
+    monkeypatch.setattr(
+        prices, "load_meta_timeseries_range", lambda *a, **k: pd.DataFrame({"close": [100.0]})
+    )
+
+    snap = prices.get_price_snapshot([ticker])
+    info = snap[ticker]
+    assert info["last_price"] == last_price
+    assert info["last_price_time"] == stale_ts.isoformat().replace("+00:00", "Z")
+    assert info["is_stale"] is True
 
 
 def test_refresh_prices_requires_config(monkeypatch):


### PR DESCRIPTION
## Summary
- Expand `_close_on` tests to cover missing data and column fallbacks
- Test `get_price_snapshot` with live vs. stale pricing and `_load_latest_prices`/`load_live_prices` mocks
- Verify `refresh_prices` writes JSON, updates cache, and triggers refresh/alert helpers

## Testing
- `pytest tests/common/test_prices.py --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68c725a169cc83279d455c4bd9cba149