### PR TITLE
feat: add success message to coverage test script

### DIFF
--- a/scripts/test-with-coverage.ps1
+++ b/scripts/test-with-coverage.ps1
@@ -71,6 +71,10 @@ if (Test-Path $report) {
   }
 }
 
+if ($exitCode -eq 0) {
+  Write-Host "All tests passed." -ForegroundColor Green
+}
+
 $failurePattern = 'FAILURES'
 if ($exitCode -ne 0 -and $testOutput) {
   $failureStart = $testOutput | Select-String -Pattern $failurePattern | Select-Object -First 1


### PR DESCRIPTION
## Summary
- add green success message when tests pass in test-with-coverage.ps1

## Testing
- `python -m pytest --no-cov tests/test_alphavantage_disabled.py`
- ⚠️ `pwsh scripts/test-with-coverage.ps1 -PytestArgs tests/test_alphavantage_disabled.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7259ecea88327a117d9b706ca775c