### PR TITLE
Add loading state and error details to TaxHarvest

### DIFF
--- a/frontend/src/pages/TaxHarvest.test.tsx
+++ b/frontend/src/pages/TaxHarvest.test.tsx
@@ -16,4 +16,35 @@ describe("TaxHarvest", () => {
     await screen.findByText(/ABC/);
     expect(mock).toHaveBeenCalled();
   });
+
+  it("disables button and shows spinner while loading", async () => {
+    const mock = harvestTax as unknown as vi.Mock;
+    let resolvePromise: (value: { trades: any[] }) => void;
+    mock.mockImplementation(
+      () => new Promise((resolve) => (resolvePromise = resolve)),
+    );
+    render(<TaxHarvest />);
+    const button = screen.getByRole("button", { name: /run harvest/i });
+    fireEvent.click(button);
+    await screen.findByTestId("spinner");
+    expect(button).toBeDisabled();
+    resolvePromise!({ trades: [{ ticker: "ABC" }] });
+    await screen.findByText(/ABC/);
+  });
+
+  it("shows detailed error message", async () => {
+    const mock = harvestTax as unknown as vi.Mock;
+    mock.mockRejectedValue(new Error("boom"));
+    render(<TaxHarvest />);
+    fireEvent.click(screen.getByRole("button", { name: /run harvest/i }));
+    await screen.findByText(/boom/);
+  });
+
+  it("renders message when no trades qualify", async () => {
+    const mock = harvestTax as unknown as vi.Mock;
+    mock.mockResolvedValue({ trades: [] });
+    render(<TaxHarvest />);
+    fireEvent.click(screen.getByRole("button", { name: /run harvest/i }));
+    await screen.findByText(/No trades qualify/i);
+  });
 });

--- a/frontend/src/pages/TaxHarvest.tsx
+++ b/frontend/src/pages/TaxHarvest.tsx
@@ -10,19 +10,24 @@ interface Position {
 export default function TaxHarvest() {
   const [trades, setTrades] = useState<any[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const samplePositions: Position[] = [
     { ticker: "ABC", basis: 100, price: 80 },
     { ticker: "XYZ", basis: 200, price: 150 },
   ];
 
   const handleHarvest = async () => {
+    setIsLoading(true);
     try {
       const res = await harvestTax(samplePositions, 0);
       setTrades(res.trades);
       setError(null);
     } catch (e) {
-      setError("Failed to harvest");
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
       setTrades(null);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -33,17 +38,22 @@ export default function TaxHarvest() {
         type="button"
         className="mb-4 rounded border px-4 py-2"
         onClick={handleHarvest}
+        disabled={isLoading}
       >
         Run Harvest
       </button>
+      {isLoading && (
+        <div data-testid="spinner">Loading...</div>
+      )}
       {error && <p className="text-red-500">{error}</p>}
-      {trades && (
+      {trades && trades.length > 0 && (
         <ul data-testid="harvest-results">
           {trades.map((t, idx) => (
             <li key={idx}>{JSON.stringify(t)}</li>
           ))}
         </ul>
       )}
+      {trades && trades.length === 0 && <p>No trades qualify</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- disable harvest button while request runs and show loading indicator
- surface detailed API errors and show message when no trades qualify
- test loading, error, and empty-result cases

## Testing
- `npm test` *(fails: ReferenceError: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c4f5d220832796b86560fab492e8