### PR TITLE
Define trade interface in TaxHarvest page

### DIFF
--- a/frontend/src/pages/TaxHarvest.tsx
+++ b/frontend/src/pages/TaxHarvest.tsx
@@ -7,8 +7,13 @@ interface Position {
   price: number;
 }
 
+interface Trade {
+  ticker: string;
+  loss: number;
+}
+
 export default function TaxHarvest() {
-  const [trades, setTrades] = useState<any[] | null>(null);
+  const [trades, setTrades] = useState<Trade[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const samplePositions: Position[] = [
     { ticker: "ABC", basis: 100, price: 80 },
@@ -39,8 +44,10 @@ export default function TaxHarvest() {
       {error && <p className="text-red-500">{error}</p>}
       {trades && (
         <ul data-testid="harvest-results">
-          {trades.map((t, idx) => (
-            <li key={idx}>{JSON.stringify(t)}</li>
+          {trades.map(({ ticker, loss }, idx) => (
+            <li key={idx}>
+              {ticker}: {loss}
+            </li>
           ))}
         </ul>
       )}


### PR DESCRIPTION
## Summary
- add explicit `Trade` interface and type trade state
- render harvested trades with ticker and loss fields

## Testing
- `npm test` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c4f5d1b0832798f238277d450fd3