### PR TITLE
Fix language switcher overflow

### DIFF
--- a/frontend/src/components/LanguageSwitcher.css
+++ b/frontend/src/components/LanguageSwitcher.css
@@ -16,8 +16,9 @@
 .language-menu {
   position: absolute;
   top: 100%;
-  right: 0;
+  left: 0;
   display: flex;
+  flex-direction: column;
   gap: 0.5rem;
   margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- stack language options vertically so they stay within the viewport

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, etc.)*
- `npm test` *(fails: IntersectionObserver is not defined; 71 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c80cfa227883279bb2408494b76b13