### PR TITLE
Add tests for batch timeseries loading utilities

### DIFF
--- a/tests/timeseries/test_run_all_and_load_timeseries.py
+++ b/tests/timeseries/test_run_all_and_load_timeseries.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import backend.timeseries.fetch_meta_timeseries as fmt
+from unittest.mock import patch
+
+
+def _df():
+    return pd.DataFrame({"Date": [1], "Close": [2]})
+
+
+def test_run_all_tickers_filters_and_delays(monkeypatch, caplog):
+    calls = []
+
+    def fake_load(sym, ex, days):
+        calls.append((sym, ex, days))
+        if sym == "AAA":
+            return _df()
+        if sym == "BBB":
+            return pd.DataFrame()
+        raise Exception("boom")
+
+    monkeypatch.setattr(fmt.config, "stooq_requests_per_minute", 30, raising=False)
+    sleep_calls = []
+    monkeypatch.setattr(fmt.time, "sleep", lambda s: sleep_calls.append(s))
+
+    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
+        with caplog.at_level("WARNING", logger="meta_timeseries"):
+            out = fmt.run_all_tickers(["AAA", "BBB", "CCC"], days=5)
+
+    assert out == ["AAA"]
+    assert calls == [("AAA", "", 5), ("BBB", "", 5), ("CCC", "", 5)]
+    assert sleep_calls == [2.0, 2.0]
+    assert "CCC" in caplog.text
+
+
+def test_load_timeseries_data_filters_and_warnings(monkeypatch, caplog):
+    def fake_load(sym, ex, days):
+        if sym == "AAA":
+            return _df()
+        if sym == "BBB":
+            return pd.DataFrame()
+        raise Exception("fail")
+
+    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
+        with caplog.at_level("WARNING", logger="meta_timeseries"):
+            out = fmt.load_timeseries_data(["AAA", "BBB", "CCC"], days=5)
+
+    assert list(out.keys()) == ["AAA"]
+    assert "CCC" in caplog.text


### PR DESCRIPTION
## Summary
- add tests for `run_all_tickers` handling rate limits, filtering and errors
- add tests for `load_timeseries_data` to ensure dataframes are filtered and warnings logged

## Testing
- `pytest tests/timeseries/test_run_all_and_load_timeseries.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68c80d0612548327ae153dc054640188