### PR TITLE
Show instrument in transactions table

### DIFF
--- a/frontend/src/components/TransactionsPage.test.tsx
+++ b/frontend/src/components/TransactionsPage.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import i18n from "../i18n";
+import { TransactionsPage } from "./TransactionsPage";
+
+vi.mock("../api", () => ({
+  getTransactions: vi.fn(() =>
+    Promise.resolve([
+      {
+        owner: "alex",
+        account: "isa",
+        ticker: "AAPL",
+        type: "BUY",
+        amount_minor: 10000,
+        currency: "GBP",
+        shares: 5,
+        date: "2024-01-01",
+      },
+    ])
+  ),
+}));
+
+describe("TransactionsPage", () => {
+  it("displays instrument ticker", async () => {
+    render(<TransactionsPage owners={[{ owner: "alex", accounts: ["isa"] }]} />);
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -94,6 +94,7 @@ export function TransactionsPage({ owners }: Props) {
               <th className={tableStyles.cell}>Date</th>
               <th className={tableStyles.cell}>Owner</th>
               <th className={tableStyles.cell}>Account</th>
+              <th className={tableStyles.cell}>Instrument</th>
               <th className={tableStyles.cell}>Type</th>
               <th className={`${tableStyles.cell} ${tableStyles.right}`}>Amount</th>
               <th className={`${tableStyles.cell} ${tableStyles.right}`}>Shares</th>
@@ -107,6 +108,7 @@ export function TransactionsPage({ owners }: Props) {
                 </td>
                 <td className={tableStyles.cell}>{t.owner}</td>
                 <td className={tableStyles.cell}>{t.account}</td>
+                <td className={tableStyles.cell}>{t.ticker || t.security_ref || ""}</td>
                 <td className={tableStyles.cell}>{t.type || t.kind}</td>
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                   {t.amount_minor != null


### PR DESCRIPTION
## Summary
- Display traded instrument ticker in the transactions table
- Cover transactions page with a test ensuring ticker is shown

## Testing
- `npm test` *(fails: ReferenceError: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c80e8909348327a7eb0510a0bcba67