### PR TITLE
Move owner selector to header

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -362,36 +362,26 @@ export default function App({ onLogout }: AppProps) {
       <div
         style={{
           display: "flex",
-          justifyContent: "space-between",
           alignItems: "center",
+          gap: "0.5rem",
+          margin: "1rem 0",
         }}
       >
         <LanguageSwitcher />
-        <button
-          aria-label="notifications"
-          onClick={() => setNotificationsOpen(true)}
-          style={{
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            fontSize: "1.5rem",
-          }}
-        >
-          🔔
-        </button>
-      </div>
-      <NotificationsDrawer
-        open={notificationsOpen}
-        onClose={() => setNotificationsOpen(false)}
-      />
-      <div style={{ display: "flex", alignItems: "center", margin: "1rem 0" }}>
         <Menu
           selectedOwner={selectedOwner}
           selectedGroup={selectedGroup}
           onLogout={onLogout}
-          style={{ flexGrow: 1, margin: 0 }}
+          style={{ margin: 0 }}
         />
         <InstrumentSearchBar />
+        {mode === "owner" && (
+          <OwnerSelector
+            owners={owners}
+            selected={selectedOwner}
+            onSelect={setSelectedOwner}
+          />
+        )}
         {lastRefresh && (
           <span
             style={{
@@ -405,8 +395,24 @@ export default function App({ onLogout }: AppProps) {
             {new Date(lastRefresh).toLocaleString()}
           </span>
         )}
+        <button
+          aria-label="notifications"
+          onClick={() => setNotificationsOpen(true)}
+          style={{
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            fontSize: "1.5rem",
+          }}
+        >
+          🔔
+        </button>
         <UserAvatar />
       </div>
+      <NotificationsDrawer
+        open={notificationsOpen}
+        onClose={() => setNotificationsOpen(false)}
+      />
 
       <div style={{ marginBottom: "1rem" }}>
         <button onClick={handleRefreshPrices} disabled={refreshingPrices}>
@@ -424,11 +430,6 @@ export default function App({ onLogout }: AppProps) {
       {/* OWNER VIEW */}
       {mode === "owner" && (
         <>
-          <OwnerSelector
-            owners={owners}
-            selected={selectedOwner}
-            onSelect={setSelectedOwner}
-          />
           <ComplianceWarnings owners={selectedOwner ? [selectedOwner] : []} />
           <PortfolioView data={portfolio} loading={loading} error={err} />
         </>

--- a/frontend/src/components/PortfolioView.test.tsx
+++ b/frontend/src/components/PortfolioView.test.tsx
@@ -27,9 +27,8 @@ describe("PortfolioView", () => {
         ],
     };
 
-    it("renders owner's name and account blocks", () => {
+    it("renders account blocks", () => {
         render(<PortfolioView data={mockOwner}/>);
-        expect(screen.getByTestId("owner-name")).toHaveTextContent("steve");
 
         // Match headings like "ISA (GBP)"
         const isaBlock = screen.getByText((_, el) => {

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -74,9 +74,6 @@ export function PortfolioView({ data, loading, error }: Props) {
 
   return (
     <div>
-      <h1 className="mt-0">
-        Portfolio: <span data-testid="owner-name">{data.owner}</span>
-      </h1>
       <div className="mb-4">
         As of {formatDateISO(new Date(data.as_of))}
       </div>

--- a/frontend/src/components/responsiveRender.test.tsx
+++ b/frontend/src/components/responsiveRender.test.tsx
@@ -109,7 +109,7 @@ describe("mobile viewport rendering", () => {
       ({ container } = renderWithConfig(<PortfolioView data={portfolio} />));
     });
     await waitFor(() =>
-      expect(container.querySelector("h1")).toHaveClass("mt-0"),
+      expect(container.textContent).toContain("Approx Total"),
     );
   });
 

--- a/frontend/src/pages/Portfolio.test.tsx
+++ b/frontend/src/pages/Portfolio.test.tsx
@@ -36,7 +36,7 @@ describe("Portfolio page", () => {
     );
 
     await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
-    expect(await screen.findByTestId("owner-name")).toHaveTextContent("alice");
+    await screen.findByText(/Approx Total:/);
 
     mockGetPortfolio.mockClear();
     mockGetPortfolio.mockResolvedValueOnce({
@@ -53,6 +53,6 @@ describe("Portfolio page", () => {
     });
 
     await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
-    expect(await screen.findByTestId("owner-name")).toHaveTextContent("bob");
+    await screen.findByText(/Approx Total:/);
   });
 });


### PR DESCRIPTION
## Summary
- place language switcher, menu, search and owner selector on single header row
- drop portfolio heading from view to reclaim space
- adjust tests for new layout

## Testing
- `npm test` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c80ee1ae5c832780aa3d08f737e890