### PR TITLE
Add cash ticker and currency metadata tests

### DIFF
--- a/tests/common/test_portfolio_utils_cash_meta.py
+++ b/tests/common/test_portfolio_utils_cash_meta.py
@@ -1,0 +1,20 @@
+import pytest
+
+from backend.common import portfolio_utils as pu
+
+
+def test_canonicalise_cash_ticker():
+    assert pu._canonicalise_cash_ticker("GBP.CASH") == "CASH.GBP"
+    assert pu._canonicalise_cash_ticker("cash.gbp") == "CASH.GBP"
+
+
+def test_currency_from_file_with_meta(monkeypatch):
+    monkeypatch.setattr(pu, "_MISSING_META", set())
+    monkeypatch.setattr(pu, "get_instrument_meta", lambda t: {"currency": "USD"})
+    assert pu._currency_from_file("ABC.L") == "USD"
+
+
+def test_currency_from_file_without_meta(monkeypatch):
+    monkeypatch.setattr(pu, "_MISSING_META", set())
+    monkeypatch.setattr(pu, "get_instrument_meta", lambda t: {})
+    assert pu._currency_from_file("ABC.L") is None


### PR DESCRIPTION
## Summary
- add tests for canonicalising cash tickers
- add tests for currency lookup from instrument metadata

## Testing
- `pytest tests/common/test_portfolio_utils_cash_meta.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68c80d1c39ec8327a5c09b1fe1109be0