### PR TITLE
Use PerformanceDashboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,7 +57,9 @@ import PensionForecast from "./pages/PensionForecast";
 import TaxHarvest from "./pages/TaxHarvest";
 import TaxAllowances from "./pages/TaxAllowances";
 import RightRail from "./components/RightRail";
-const PortfolioDashboard = lazyWithDelay(() => import("./pages/PortfolioDashboard"));
+const PerformanceDashboard = lazyWithDelay(
+  () => import("./components/PerformanceDashboard"),
+);
 
 interface AppProps {
   onLogout?: () => void;
@@ -478,19 +480,7 @@ export default function App({ onLogout }: AppProps) {
             onSelect={setSelectedOwner}
           />
           <Suspense fallback={<PortfolioDashboardSkeleton />}>
-            <PortfolioDashboard
-              twr={null}
-              irr={null}
-              bestDay={null}
-              worstDay={null}
-              lastDay={null}
-              alpha={null}
-              trackingError={null}
-              maxDrawdown={null}
-              volatility={null}
-              data={[]}
-              owner={selectedOwner}
-            />
+            <PerformanceDashboard owner={selectedOwner} />
           </Suspense>
         </>
       )}

--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -41,7 +41,9 @@ const InstrumentAdmin = lazy(() => import("./pages/InstrumentAdmin"));
 const ScenarioTester = lazy(() => import("./pages/ScenarioTester"));
 const SupportPage = lazy(() => import("./pages/Support"));
 const LogsPage = lazy(() => import("./pages/Logs"));
-const PortfolioDashboard = lazyWithDelay(() => import("./pages/PortfolioDashboard"));
+const PerformanceDashboard = lazyWithDelay(
+  () => import("./components/PerformanceDashboard"),
+);
 
 export default function MainApp() {
   const navigate = useNavigate();
@@ -286,19 +288,7 @@ export default function MainApp() {
             onSelect={setSelectedOwner}
           />
           <Suspense fallback={<PortfolioDashboardSkeleton />}>
-            <PortfolioDashboard
-              twr={null}
-              irr={null}
-              bestDay={null}
-              worstDay={null}
-              lastDay={null}
-              alpha={null}
-              trackingError={null}
-              maxDrawdown={null}
-              volatility={null}
-              data={[]}
-              owner={selectedOwner}
-            />
+            <PerformanceDashboard owner={selectedOwner} />
           </Suspense>
         </>
       )}

--- a/frontend/src/plugins/performance.ts
+++ b/frontend/src/plugins/performance.ts
@@ -2,12 +2,14 @@ import type { ComponentProps } from "react";
 import lazyWithDelay from "../utils/lazyWithDelay";
 import type { TabPlugin } from "./TabPlugin";
 
-const PortfolioDashboard = lazyWithDelay(() => import("../pages/PortfolioDashboard"));
-type Props = ComponentProps<typeof PortfolioDashboard>;
+const PerformanceDashboard = lazyWithDelay(
+  () => import("../components/PerformanceDashboard"),
+);
+type Props = ComponentProps<typeof PerformanceDashboard>;
 
 const plugin: TabPlugin<Props> = {
   id: "performance",
-  component: PortfolioDashboard,
+  component: PerformanceDashboard,
   priority: 40,
   path: ({ owner }) => (owner ? `/performance/${owner}` : "/performance"),
 };


### PR DESCRIPTION
## Summary
- use PerformanceDashboard in performance view
- drop hard-coded null props for dashboard
- update performance plugin to reference PerformanceDashboard

## Testing
- `npm test` *(fails: IntersectionObserver is not defined, multiple other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c8100c6320832787aac73550bf6444