### PR TITLE
Enable Alpha Vantage sector data

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,8 +36,8 @@ server:
 market_data:
   offline_mode: false                 # Run without external data fetches
   fx_proxy_url: ''                    # Optional proxy for FX rates
-  alpha_vantage_enabled: false        # Use AlphaVantage for quotes
-  alpha_vantage_key: ""              # AlphaVantage API key (ALPHA_VANTAGE_KEY)
+  alpha_vantage_enabled: true         # Use AlphaVantage for quotes
+  alpha_vantage_key: "demo"          # AlphaVantage API key (ALPHA_VANTAGE_KEY)
   fundamentals_cache_ttl_seconds: 86400 # TTL for fundamentals cache (seconds)
   stooq_timeout: 10                   # Timeout for Stooq requests (seconds)
   stooq_requests_per_minute: 60       # Rate limit for Stooq requests


### PR DESCRIPTION
## Summary
- enable Alpha Vantage integration in the default configuration
- populate the Alpha Vantage API key field with the demo key so sector data requests can succeed by default

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c846dd44208327a757c57563dc55c4