### PR TITLE
Add Python availability check to backend run script

### DIFF
--- a/scripts/run-backend.ps1
+++ b/scripts/run-backend.ps1
@@ -11,6 +11,8 @@ if (-not $pythonCmd) {
   $pythonCmd = Get-Command py -ErrorAction SilentlyContinue
 }
 
+$pythonInstallMessage = 'Python must be installed. Install it from https://www.python.org/downloads/'
+
 function Get-ConfigValue([object]$obj, [object[]]$path, [object]$default) {
   try {
     $cur = $obj
@@ -32,9 +34,24 @@ function Get-ConfigValue([object]$obj, [object[]]$path, [object]$default) {
   }
 }
 if (-not $pythonCmd) {
-  Write-Host 'Python is required but was not found. Install it from https://www.python.org/downloads/' -ForegroundColor Red
+  Write-Host $pythonInstallMessage -ForegroundColor Red
   exit 1
 }
+
+try {
+  $versionOutput = & $pythonCmd.Name --version 2>&1
+} catch {
+  Write-Host $pythonInstallMessage -ForegroundColor Red
+  exit 1
+}
+
+$pythonVersionExit = $LASTEXITCODE
+$versionText = ($versionOutput | Out-String).Trim()
+if ($pythonVersionExit -ne 0 -or $versionText -match 'Microsoft Store') {
+  Write-Host $pythonInstallMessage -ForegroundColor Red
+  exit 1
+}
+
 $PYTHON = $pythonCmd.Name
 
 Write-Host "# -------- Configuration --------" -ForegroundColor DarkCyan


### PR DESCRIPTION
## Summary
- verify the resolved python command by running `--version`
- surface a clear installation error when python is missing or the Microsoft Store alias is hit
- only export the `$PYTHON` variable after the validation succeeds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c846cb43b88327a72cb620db91d36b