### PR TITLE
Add tests for research search toggle

### DIFF
--- a/frontend/src/components/InstrumentSearchBar.test.tsx
+++ b/frontend/src/components/InstrumentSearchBar.test.tsx
@@ -20,6 +20,8 @@ describe("InstrumentSearchBar", () => {
     const searchMock = searchInstruments as unknown as vi.Mock;
     searchMock.mockResolvedValue([{ ticker: "AAA", name: "AAA Corp" }]);
 
+    const user = userEvent.setup();
+
     render(
       <MemoryRouter initialEntries={["/"]}>
         <Routes>
@@ -28,6 +30,18 @@ describe("InstrumentSearchBar", () => {
         </Routes>
       </MemoryRouter>
     );
+
+    const researchButton = screen.getByRole("button", { name: /Research/i });
+    expect(researchButton).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/Search instruments/i)
+    ).not.toBeInTheDocument();
+
+    await user.click(researchButton);
+
+    expect(
+      await screen.findByLabelText(/Search instruments/i)
+    ).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Filter by sector/i), {
       target: { value: "Energy" },

--- a/frontend/src/components/InstrumentSearchBar.tsx
+++ b/frontend/src/components/InstrumentSearchBar.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useState, useRef, memo } from "react";
+import { useEffect, useState, useRef, memo, useId } from "react";
 import { useNavigate } from "react-router-dom";
 import { searchInstruments } from "../api";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./ui/collapsible";
 
 interface Result {
   ticker: string;
@@ -25,7 +30,13 @@ const SECTORS = [
 
 const REGIONS = ["Africa", "Asia", "Europe", "North America", "South America", "Oceania", "UK", "US"];
 
-export default memo(function InstrumentSearchBar() {
+interface InstrumentSearchBarProps {
+  onNavigate?: () => void;
+}
+
+const InstrumentSearchBar = memo(function InstrumentSearchBar({
+  onNavigate,
+}: InstrumentSearchBarProps) {
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
   const [sector, setSector] = useState("");
@@ -72,6 +83,7 @@ export default memo(function InstrumentSearchBar() {
     setQuery("");
     setResults([]);
     navigate(`/research/${encodeURIComponent(tkr)}`);
+    onNavigate?.();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -88,7 +100,13 @@ export default memo(function InstrumentSearchBar() {
   };
 
   return (
-    <div style={{ position: "relative", marginLeft: "1rem" }}>
+    <div
+      style={{
+        position: "relative",
+        flex: 1,
+        minWidth: "15rem",
+      }}
+    >
       <div style={{ display: "flex", gap: "0.25rem" }}>
         <input
           type="text"
@@ -168,3 +186,62 @@ export default memo(function InstrumentSearchBar() {
     </div>
   );
 });
+
+export function InstrumentSearchBarToggle() {
+  const [open, setOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} style={{ marginLeft: "1rem" }}>
+      <CollapsibleTrigger
+        type="button"
+        aria-controls={contentId}
+        aria-expanded={open}
+        style={{
+          padding: "0.25rem 0.75rem",
+          borderRadius: "0.25rem",
+          border: "1px solid #ccc",
+          background: open ? "#eee" : "#fff",
+          cursor: "pointer",
+        }}
+      >
+        Research
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        id={contentId}
+        style={{
+          marginTop: "0.5rem",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: "0.5rem",
+          }}
+        >
+          <InstrumentSearchBar onNavigate={() => setOpen(false)} />
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            aria-label="Close search"
+            style={{
+              padding: "0.25rem 0.5rem",
+              borderRadius: "0.25rem",
+              border: "1px solid #ccc",
+              background: "#f5f5f5",
+              cursor: "pointer",
+              alignSelf: "center",
+            }}
+          >
+            Close
+          </button>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export default InstrumentSearchBarToggle;
+
+export { InstrumentSearchBar };

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -36,6 +36,44 @@ if (typeof window.ResizeObserver === 'undefined') {
   } as any;
 }
 
+// Basic IntersectionObserver stub for components relying on visibility detection
+if (typeof window.IntersectionObserver === 'undefined') {
+  class MockIntersectionObserver {
+    private readonly callback: IntersectionObserverCallback;
+
+    constructor(callback: IntersectionObserverCallback) {
+      this.callback = callback;
+    }
+
+    observe(target: Element) {
+      this.callback(
+        [
+          {
+            isIntersecting: true,
+            intersectionRatio: 1,
+            target,
+            time: 0,
+            boundingClientRect: target.getBoundingClientRect(),
+            intersectionRect: target.getBoundingClientRect(),
+            rootBounds: null,
+          } as IntersectionObserverEntry,
+        ],
+        this as unknown as IntersectionObserver,
+      );
+    }
+
+    unobserve() {}
+
+    disconnect() {}
+
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+
+  (window as any).IntersectionObserver = MockIntersectionObserver;
+}
+
 // Provide non-zero element sizes so chart libraries (e.g., Recharts) can render
 // and tests relying on layout don't fail due to 0x0 containers in JSDOM.
 const defineSize = (prop: 'offsetWidth' | 'offsetHeight', value: number) => {


### PR DESCRIPTION
## Summary
- wrap the instrument search bar in a collapsible Research toggle with a close control and navigation callback
- update the instrument search bar unit test to open the toggle, assert visibility, and reuse existing interactions
- add an App-level regression test for the Research toggle and stub IntersectionObserver in the shared test setup

## Testing
- `npm test -- run src/components/InstrumentSearchBar.test.tsx -t "searches with filters and navigates on selection"`
- `npm test -- run src/App.test.tsx -t "toggles the research search bar in the header"`


------
https://chatgpt.com/codex/tasks/task_e_68c846ba90988327a854c793cdcb3741