### PR TITLE
Add research translation key across locales

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -7,6 +7,7 @@
     "loading": "Laden…",
     "supportLink": "Support",
     "userLink": "App",
+    "research": "Recherche",
     "logout": "Abmelden",
     "menu": "Menü",
     "focusMode": "Fokusmodus",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -7,6 +7,7 @@
     "loading": "Loading…",
     "supportLink": "Support",
     "userLink": "App",
+    "research": "Research",
     "logout": "Logout",
     "menu": "Menu",
     "focusMode": "Focus Mode",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -7,6 +7,7 @@
     "loading": "Cargando…",
     "supportLink": "Soporte",
     "userLink": "App",
+    "research": "Investigación",
     "logout": "Cerrar sesión",
     "menu": "Menú",
     "focusMode": "Modo de enfoque",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -7,6 +7,7 @@
     "loading": "Chargement…",
     "supportLink": "Support",
     "userLink": "App",
+    "research": "Recherche",
     "logout": "Déconnexion",
     "menu": "Menu",
     "focusMode": "Mode concentration",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -7,6 +7,7 @@
     "loading": "Caricamento…",
     "supportLink": "Supporto",
     "userLink": "App",
+    "research": "Ricerca",
     "logout": "Logout",
     "menu": "Menu",
     "focusMode": "Modalità concentrazione",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -7,6 +7,7 @@
     "loading": "Carregando…",
     "supportLink": "Suporte",
     "userLink": "App",
+    "research": "Pesquisa",
     "logout": "Sair",
     "menu": "Menu",
     "focusMode": "Modo de foco",


### PR DESCRIPTION
## Summary
- add the `app.research` string to the English, German, Spanish, French, Italian, and Portuguese locale files so the research label can be translated

## Testing
- npm test -- --globals --run src/pages/Support.test.tsx *(fails: existing expectation that config checkboxes are filtered out)*
- npm test -- --run src/pages/InstrumentResearch.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c846b8ab088327bae6542065c40e24