### PR TITLE
Rename Test-Internet host parameter

### DIFF
--- a/scripts/run-backend.ps1
+++ b/scripts/run-backend.ps1
@@ -68,12 +68,12 @@ function Get-HasCommand($name) {
 
 function Test-Internet {
   param(
-    [string]$Host = 'pypi.org'
+    [string]$TargetHost = 'pypi.org'
   )
 
   try {
     if (Get-HasCommand 'Test-Connection') {
-      if (Test-Connection -ComputerName $Host -Count 1 -Quiet -TimeoutSeconds 2 -ErrorAction Stop) {
+      if (Test-Connection -ComputerName $TargetHost -Count 1 -Quiet -TimeoutSeconds 2 -ErrorAction Stop) {
         return $true
       }
     }
@@ -82,7 +82,7 @@ function Test-Internet {
   }
 
   try {
-    $uri = if ($Host -match '^https?://') { $Host } else { "https://$Host/" }
+    $uri = if ($TargetHost -match '^https?://') { $TargetHost } else { "https://$TargetHost/" }
     if (Get-HasCommand 'Invoke-WebRequest') {
       Invoke-WebRequest -Uri $uri -UseBasicParsing -Method Head -TimeoutSec 5 | Out-Null
       return $true


### PR DESCRIPTION
## Summary
- rename the Test-Internet helper parameter to TargetHost to avoid reserved name conflicts
- update the function body to reference the renamed TargetHost parameter

## Testing
- pwsh -File scripts/run-backend.ps1 -Offline *(fails: command not found)*
- powershell -File scripts/run-backend.ps1 -Offline *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c84c1e60c083278db8f82b628d3ca1