### PR TITLE
Add instrument grouping tests and fallback logic

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -77,6 +77,17 @@ def _safe_num(val, default: float = 0.0) -> float:
     except (TypeError, ValueError):
         return default
 
+
+def _first_nonempty_str(*values: Any) -> str | None:
+    """Return the first non-empty string from ``values`` if present."""
+
+    for value in values:
+        if isinstance(value, str):
+            candidate = value.strip()
+            if candidate:
+                return candidate
+    return None
+
 def _fx_to_base(currency: str | None, base_currency: str, cache: Dict[str, float]) -> float:
     """Return ``base_currency`` per unit of ``currency`` using recent FX rates."""
 
@@ -386,6 +397,15 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
 
             meta = get_instrument_meta(full_tkr)
 
+            grouping_value = _first_nonempty_str(
+                meta.get("grouping"),
+                h.get("grouping"),
+                meta.get("sector"),
+                h.get("sector"),
+                meta.get("region"),
+                h.get("region"),
+            )
+
             row = rows.setdefault(
                 full_tkr,
                 {
@@ -394,6 +414,7 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
                     "currency": meta.get("currency") or h.get("currency"),
                     "sector": meta.get("sector") or h.get("sector"),
                     "region": meta.get("region") or h.get("region"),
+                    "grouping": grouping_value,
                     "units": 0.0,
                     "market_value_gbp": 0.0,
                     "gain_gbp": 0.0,
@@ -411,6 +432,9 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
                     "gain_currency": base_currency,
                 },
             )
+
+            if grouping_value and not _first_nonempty_str(row.get("grouping")):
+                row["grouping"] = grouping_value
 
             # accumulate units & cost
             # accumulate units & cost (allow for differing field names)
@@ -490,6 +514,9 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
             r["last_price_currency"] = base_currency
         if r.get("day_change_gbp") is not None:
             r["day_change_currency"] = base_currency
+        if not _first_nonempty_str(r.get("grouping")):
+            fallback = _first_nonempty_str(r.get("sector"), r.get("region"))
+            r["grouping"] = fallback or "Unknown"
 
     return list(rows.values())
 

--- a/tests/test_instrument_grouping.py
+++ b/tests/test_instrument_grouping.py
@@ -1,0 +1,162 @@
+from collections import defaultdict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.common import group_portfolio, instrument_api, portfolio_utils
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    client = TestClient(app)
+    token = client.post("/token", json={"id_token": "good"}).json()["access_token"]
+    client.headers.update({"Authorization": f"Bearer {token}"})
+    return client
+
+
+def _prepare_group_portfolio(monkeypatch, portfolio, meta_map):
+    monkeypatch.setattr(group_portfolio, "build_group_portfolio", lambda slug: portfolio)
+    monkeypatch.setattr(portfolio_utils, "get_instrument_meta", lambda ticker: meta_map.get(ticker, {}))
+    monkeypatch.setattr(portfolio_utils, "get_security_meta", lambda ticker: {})
+    monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {})
+    monkeypatch.setattr(instrument_api, "price_change_pct", lambda *args, **kwargs: None)
+
+
+def test_group_instruments_defaults_to_sector_then_region(monkeypatch, client):
+    portfolio = {
+        "accounts": [
+            {
+                "account_type": "TEST",
+                "holdings": [
+                    {
+                        "ticker": "AAA.L",
+                        "name": "Alpha",
+                        "units": 10,
+                        "cost_gbp": 500.0,
+                        "market_value_gbp": 600.0,
+                        "gain_gbp": 100.0,
+                    },
+                    {
+                        "ticker": "BBB.L",
+                        "name": "Beta",
+                        "units": 5,
+                        "cost_gbp": 200.0,
+                        "market_value_gbp": 250.0,
+                        "gain_gbp": 50.0,
+                    },
+                ],
+            }
+        ]
+    }
+
+    meta_map = {
+        "AAA.L": {"ticker": "AAA.L", "name": "Alpha", "sector": "Technology", "region": "US"},
+        "BBB.L": {"ticker": "BBB.L", "name": "Beta", "sector": None, "region": "Asia"},
+    }
+
+    _prepare_group_portfolio(monkeypatch, portfolio, meta_map)
+
+    resp = client.get("/portfolio-group/demo/instruments")
+    assert resp.status_code == 200
+    instruments = {row["ticker"]: row for row in resp.json()}
+    assert instruments["AAA.L"]["grouping"] == "Technology"
+    assert instruments["BBB.L"]["grouping"] == "Asia"
+
+
+def test_group_instruments_preserves_custom_grouping(monkeypatch, client):
+    portfolio = {
+        "accounts": [
+            {
+                "account_type": "TEST",
+                "holdings": [
+                    {
+                        "ticker": "CCC.L",
+                        "name": "Gamma",
+                        "units": 4,
+                        "cost_gbp": 400.0,
+                        "market_value_gbp": 420.0,
+                        "gain_gbp": 20.0,
+                    }
+                ],
+            }
+        ]
+    }
+
+    meta_map = {
+        "CCC.L": {
+            "ticker": "CCC.L",
+            "name": "Gamma",
+            "grouping": "Income ETFs",
+            "sector": "Finance",
+            "region": "Europe",
+        }
+    }
+
+    _prepare_group_portfolio(monkeypatch, portfolio, meta_map)
+
+    resp = client.get("/portfolio-group/demo/instruments")
+    assert resp.status_code == 200
+    instruments = resp.json()
+    assert instruments[0]["grouping"] == "Income ETFs"
+
+
+def test_grouped_instrument_totals(monkeypatch, client):
+    portfolio = {
+        "accounts": [
+            {
+                "account_type": "ONE",
+                "holdings": [
+                    {
+                        "ticker": "AAA.L",
+                        "name": "Alpha",
+                        "units": 10,
+                        "cost_gbp": 300.0,
+                        "market_value_gbp": 400.0,
+                        "gain_gbp": 100.0,
+                    },
+                    {
+                        "ticker": "BBB.L",
+                        "name": "Beta",
+                        "units": 5,
+                        "cost_gbp": 100.0,
+                        "market_value_gbp": 150.0,
+                        "gain_gbp": 50.0,
+                    },
+                ],
+            },
+            {
+                "account_type": "TWO",
+                "holdings": [
+                    {
+                        "ticker": "CCC.L",
+                        "name": "Gamma",
+                        "units": 8,
+                        "cost_gbp": 200.0,
+                        "market_value_gbp": 220.0,
+                        "gain_gbp": 20.0,
+                    }
+                ],
+            },
+        ]
+    }
+
+    meta_map = {
+        "AAA.L": {"ticker": "AAA.L", "name": "Alpha", "grouping": "Growth", "sector": "Tech"},
+        "BBB.L": {"ticker": "BBB.L", "name": "Beta", "grouping": "Growth", "sector": "Tech"},
+        "CCC.L": {"ticker": "CCC.L", "name": "Gamma", "grouping": "Income", "sector": "Finance"},
+    }
+
+    _prepare_group_portfolio(monkeypatch, portfolio, meta_map)
+
+    resp = client.get("/portfolio-group/demo/instruments")
+    assert resp.status_code == 200
+    instruments = resp.json()
+
+    totals = defaultdict(float)
+    for row in instruments:
+        totals[row["grouping"]] += row["market_value_gbp"]
+
+    assert totals["Growth"] == pytest.approx(550.0)
+    assert totals["Income"] == pytest.approx(220.0)


### PR DESCRIPTION
## Summary
- ensure aggregated instrument rows expose a grouping by preferring explicit metadata and falling back to sector/region when absent
- add API tests covering default grouping behaviour, custom grouping metadata, and grouped total calculations

## Testing
- pytest tests/test_instrument_grouping.py --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68c8f33577b48327ba11f36926fb7ea2