### PR TITLE
Add grouping translations for instrument admin

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -367,6 +367,7 @@
     "name": "Name",
     "region": "Region",
     "sector": "Sector",
+    "grouping": "Grouping",
     "actions": "Actions",
     "add": "Add Instrument",
   "save": "Save",
@@ -375,7 +376,8 @@
   "searchPlaceholder": "Filter instruments…",
   "validation": {
     "ticker": "Ticker is required",
-    "name": "Name is required"
+    "name": "Name is required",
+    "grouping": "Grouping is required"
   }
 },
   "var": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -372,6 +372,7 @@
     "name": "Name",
     "region": "Region",
     "sector": "Sector",
+    "grouping": "Grouping",
     "actions": "Actions",
     "add": "Add Instrument",
   "save": "Save",
@@ -380,7 +381,8 @@
   "searchPlaceholder": "Filter instruments…",
   "validation": {
     "ticker": "Ticker is required",
-    "name": "Name is required"
+    "name": "Name is required",
+    "grouping": "Grouping is required"
   }
 },
   "var": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -367,6 +367,7 @@
     "name": "Name",
     "region": "Region",
     "sector": "Sector",
+    "grouping": "Grouping",
     "actions": "Actions",
     "add": "Add Instrument",
   "save": "Save",
@@ -375,7 +376,8 @@
   "searchPlaceholder": "Filter instruments…",
   "validation": {
     "ticker": "Ticker is required",
-    "name": "Name is required"
+    "name": "Name is required",
+    "grouping": "Grouping is required"
   }
 },
   "var": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -368,6 +368,7 @@
     "name": "Name",
     "region": "Region",
     "sector": "Sector",
+    "grouping": "Grouping",
     "actions": "Actions",
     "add": "Add Instrument",
   "save": "Save",
@@ -376,7 +377,8 @@
   "searchPlaceholder": "Filter instruments…",
   "validation": {
     "ticker": "Ticker is required",
-    "name": "Name is required"
+    "name": "Name is required",
+    "grouping": "Grouping is required"
   }
 },
   "var": {

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -368,6 +368,7 @@
     "name": "Nome",
     "region": "Regione",
     "sector": "Settore",
+    "grouping": "Raggruppamento",
     "actions": "Azioni",
     "add": "Aggiungi strumento",
     "save": "Salva",
@@ -376,7 +377,8 @@
     "searchPlaceholder": "Filtro Strumenti ...",
     "validation": {
       "ticker": "È richiesto il ticker",
-      "name": "È richiesto il nome"
+      "name": "È richiesto il nome",
+      "grouping": "È richiesto il raggruppamento"
     }
   },
   "var": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -367,6 +367,7 @@
     "name": "Nome",
     "region": "Região",
     "sector": "Setor",
+    "grouping": "Agrupamento",
     "actions": "Ações",
     "add": "Adicionar instrumento",
   "save": "Salvar",
@@ -375,7 +376,8 @@
   "searchPlaceholder": "Filtrar instrumentos…",
   "validation": {
     "ticker": "Ticker é obrigatório",
-    "name": "Nome é obrigatório"
+    "name": "Nome é obrigatório",
+    "grouping": "Agrupamento é obrigatório"
   }
 },
   "var": {

--- a/frontend/src/pages/InstrumentAdmin.test.tsx
+++ b/frontend/src/pages/InstrumentAdmin.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 
+import i18n from "../i18n";
+
 vi.mock("../api", () => ({
   listInstrumentMetadata: vi.fn().mockResolvedValue([
     { ticker: "AAA.L", name: "Alpha", region: "EU", sector: "Tech" },
@@ -35,8 +37,10 @@ describe("InstrumentAdmin page", () => {
     expect(await screen.findByDisplayValue("AAA")).toBeInTheDocument();
     expect(screen.getByDisplayValue("BBB")).toBeInTheDocument();
 
+    const searchPlaceholder = i18n.t("instrumentadmin.searchPlaceholder");
+
     fireEvent.change(
-      screen.getByPlaceholderText("Filter instruments…"),
+      screen.getByPlaceholderText(searchPlaceholder),
       { target: { value: "beta" } },
     );
 


### PR DESCRIPTION
## Summary
- add grouping label and validation entries to the instrument admin locale strings across all supported languages
- update the InstrumentAdmin tests to reference the translated placeholder text rather than a hard-coded string

## Testing
- npm test --prefix frontend -- --run InstrumentAdmin.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c8f33410a0832785efecda88e7b70b