### PR TITLE
Fix duplicate portfolio units comment

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -437,8 +437,7 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
             if grouping_value and not _first_nonempty_str(row.get("grouping")):
                 row["grouping"] = grouping_value
 
-            # accumulate units & cost
-            # accumulate units & cost (allow for differing field names)
+            # accumulate units from the holding
             row["units"] += _safe_num(h.get("units"))
 
             security_meta: Dict[str, Any] | None = None


### PR DESCRIPTION
## Summary
- remove the duplicate "accumulate units" comment in the portfolio aggregation helper
- clarify the comment so it reflects that only units are accumulated in that block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9048481d08327aadc5e0e5873d1f3