### PR TITLE
Fix grouping metadata lookup in aggregate_by_ticker

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -398,11 +398,11 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
             instrument_meta = get_instrument_meta(full_tkr) or {}
 
             grouping_value = _first_nonempty_str(
-                meta.get("grouping"),
+                instrument_meta.get("grouping"),
                 h.get("grouping"),
-                meta.get("sector"),
+                instrument_meta.get("sector"),
                 h.get("sector"),
-                meta.get("region"),
+                instrument_meta.get("region"),
                 h.get("region"),
             )
 


### PR DESCRIPTION
## Summary
- ensure aggregate_by_ticker looks up grouping metadata from instrument_meta rather than an undefined variable

## Testing
- pytest tests/test_var_route.py::test_var_breakdown tests/test_virtual_portfolio.py::test_aggregate_with_mixed_holdings --cov=backend --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68c9047f683083278384de4fe87529f3