### PR TITLE
Refine grouping updates from security metadata

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -398,11 +398,11 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
             instrument_meta = get_instrument_meta(full_tkr) or {}
 
             grouping_value = _first_nonempty_str(
-                meta.get("grouping"),
+                instrument_meta.get("grouping"),
                 h.get("grouping"),
-                meta.get("sector"),
+                instrument_meta.get("sector"),
                 h.get("sector"),
-                meta.get("region"),
+                instrument_meta.get("region"),
                 h.get("region"),
             )
 
@@ -450,6 +450,23 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
                     row["sector"] = security_meta["sector"]
                 if row.get("region") is None and security_meta.get("region"):
                     row["region"] = security_meta["region"]
+                if security_meta:
+                    grouping_value = _first_nonempty_str(
+                        security_meta.get("grouping"),
+                        instrument_meta.get("grouping"),
+                        h.get("grouping"),
+                        security_meta.get("sector"),
+                        instrument_meta.get("sector"),
+                        h.get("sector"),
+                        security_meta.get("region"),
+                        instrument_meta.get("region"),
+                        h.get("region"),
+                        row.get("grouping"),
+                        row.get("sector"),
+                        row.get("region"),
+                    )
+                    if grouping_value:
+                        row["grouping"] = grouping_value
 
             # attach snapshot if present
             cost = _safe_num(h.get("cost_gbp") or h.get("cost_basis_gbp") or h.get("effective_cost_basis_gbp"))

--- a/tests/test_virtual_portfolio.py
+++ b/tests/test_virtual_portfolio.py
@@ -54,6 +54,24 @@ def test_aggregate_with_mixed_holdings(monkeypatch):
     assert rows["CCC.L"]["market_value_gbp"] == 40.0
 
 
+def test_grouping_from_security_meta(monkeypatch):
+    from backend.common import instrument_api
+
+    monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {}, raising=False)
+    monkeypatch.setattr(portfolio_utils, "get_instrument_meta", lambda ticker: {"sector": "Legacy Sector"})
+    monkeypatch.setattr(
+        portfolio_utils,
+        "get_security_meta",
+        lambda ticker: {"currency": "GBP", "grouping": "Security Group"},
+    )
+    monkeypatch.setattr(instrument_api, "price_change_pct", lambda *args, **kwargs: None)
+
+    portfolio = {"accounts": [{"holdings": [{"ticker": "XYZ.L", "units": 1}]}]}
+    rows = {r["ticker"]: r for r in portfolio_utils.aggregate_by_ticker(portfolio)}
+
+    assert rows["XYZ.L"]["grouping"] == "Security Group"
+
+
 def test_performance_with_synthetic_holdings(monkeypatch):
     portfolio = {
         "accounts": [


### PR DESCRIPTION
## Summary
- recompute ticker grouping when security metadata enriches portfolio rows
- prefer security metadata for grouping fallback order after updating sector and region
- add regression test ensuring grouping is sourced from security metadata when not provided elsewhere

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c90489cb2883279af63a2ba2e91793