### PR TITLE
Refactor instrument search bar exports

### DIFF
--- a/frontend/src/components/InstrumentSearchBar.tsx
+++ b/frontend/src/components/InstrumentSearchBar.tsx
@@ -34,9 +34,9 @@ interface InstrumentSearchBarProps {
   onClose?: () => void;
 }
 
-export default memo(function InstrumentSearchBar({
+const InstrumentSearchBar = memo(function InstrumentSearchBar({
   onClose,
-      
+
 }: InstrumentSearchBarProps) {
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
@@ -260,6 +260,6 @@ export function InstrumentSearchBarToggle() {
   );
 }
 
-export default InstrumentSearchBarToggle;
-
 export { InstrumentSearchBar };
+
+export default InstrumentSearchBarToggle;


### PR DESCRIPTION
## Summary
- convert the memoized InstrumentSearchBar component into a named constant and export it explicitly
- retain InstrumentSearchBarToggle as the default export to avoid duplicate defaults

## Testing
- npm run lint *(fails: pre-existing lint violations throughout the frontend directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c9084d17448327b42419d2879eb9d4