### PR TITLE
Add lint summary PowerShell script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,15 @@
 # Scripts
 
+## lint.ps1
+
+Run all configured linters (Python Ruff/Black and frontend ESLint) and emit a
+Codex-friendly summary of any issues. The output can be pasted directly into
+the Codex fix workflow.
+
+```powershell
+./scripts/lint.ps1
+```
+
 ## frontend-backend-smoke.ts
 
 Run a quick smoke test against key backend endpoints. After running any `deploy:local:*` command to start the stack, execute:

--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -1,0 +1,88 @@
+$ErrorActionPreference = 'Continue'
+
+# Determine repository root
+$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+$REPO_ROOT = Split-Path -Parent $SCRIPT_DIR
+Set-Location $REPO_ROOT
+
+$summary = @()
+
+function Run-Linter {
+    param(
+        [string]$Name,
+        [scriptblock]$Command,
+        [scriptblock]$Parser
+    )
+    Write-Host "Running $Name..." -ForegroundColor Cyan
+    try {
+        $output = & $Command 2>&1
+    } catch {
+        Write-Host "$Name failed: $($_.Exception.Message)" -ForegroundColor Yellow
+        $script:summary += "$Name: failed to run ($($_.Exception.Message))"
+        return
+    }
+    $output | ForEach-Object { Write-Host $_ }
+    if ($Parser) {
+        $parsed = & $Parser $output
+        if ($parsed) { $script:summary += $parsed }
+    }
+}
+
+function Parse-Ruff {
+    param([string[]]$Lines)
+    foreach ($line in $Lines) {
+        if ($line -match '^(.+?:\d+:\d+):\s*(.+)$') {
+            "$($matches[1]) $($matches[2])"
+        }
+    }
+}
+
+function Parse-Black {
+    param([string[]]$Lines)
+    foreach ($line in $Lines) {
+        if ($line -match '^would reformat (.+)$') {
+            "$($matches[1]):1:1 would reformat"
+        }
+    }
+}
+
+function Parse-ESLint {
+    param([string[]]$Lines)
+    foreach ($line in $Lines) {
+        if ($line -match '^(.+?):(\d+):(\d+):\s*(.+)$') {
+            "$($matches[1]):$($matches[2]):$($matches[3]) $($matches[4])"
+        }
+    }
+}
+
+if (Get-Command ruff -ErrorAction SilentlyContinue) {
+    Run-Linter "ruff" { ruff check --config backend/pyproject.toml backend tests cdk scripts } ${function:Parse-Ruff}
+} else {
+    $summary += "ruff: not installed"
+}
+
+if (Get-Command black -ErrorAction SilentlyContinue) {
+    Run-Linter "black" { black --check --config backend/pyproject.toml backend tests cdk scripts } ${function:Parse-Black}
+} else {
+    $summary += "black: not installed"
+}
+
+if (Test-Path frontend) {
+    if (Get-Command npm -ErrorAction SilentlyContinue) {
+        Run-Linter "eslint" {
+            Push-Location frontend
+            $r = npm run lint --silent -- --format unix
+            Pop-Location
+            $r
+        } ${function:Parse-ESLint}
+    } else {
+        $summary += "eslint: npm not available"
+    }
+}
+
+Write-Host "`n===== Lint Summary (copy for Codex) =====" -ForegroundColor Green
+if ($summary) {
+    $summary | ForEach-Object { Write-Host $_ }
+} else {
+    Write-Host "No lint issues found." -ForegroundColor Green
+}


### PR DESCRIPTION
## Summary
- add `scripts/lint.ps1` to run Ruff, Black and ESLint linters and collect results in a Codex-friendly summary
- document the new linter runner in `scripts/README.md`

## Testing
- `pwsh -File scripts/lint.ps1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c909bd9d948327ab9456b287e62d30