### PR TITLE
Add pytest-asyncio dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 dependencies = [
-    "reportlab>=4.5",
+    "reportlab>=4.4.3",
 ]
 
 [tool.pytest.ini_options]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,5 @@ playwright~=1.49.0
 python-dotenv~=1.0.1
 pytest-cov~=6.2.1
 pytest~=8.4.1
-reportlab>=4.5
+pytest-asyncio~=0.23
+reportlab>=4.4.3


### PR DESCRIPTION
## Summary
- add the pytest-asyncio plugin to the dev requirements so asyncio fixtures are available
- relax the reportlab minimum version to 4.4.3 to match the latest published release

## Testing
- pytest tests/routes/test_market.py --cov-fail-under=0


------
https://chatgpt.com/codex/tasks/task_e_68c90b53f3908327978f7bdca265f1c4