### PR TITLE
Fix lint summary formatting in PowerShell

### DIFF
--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -18,7 +18,7 @@ function Run-Linter {
         $output = & $Command 2>&1
     } catch {
         Write-Host "$Name failed: $($_.Exception.Message)" -ForegroundColor Yellow
-        $script:summary += "$Name: failed to run ($($_.Exception.Message))"
+        $script:summary += "$($Name): failed to run ($($_.Exception.Message))"
         return
     }
     $output | ForEach-Object { Write-Host $_ }


### PR DESCRIPTION
## Summary
- wrap the linter summary message with `$()` to avoid PowerShell scope parsing errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c91801b2b883278cdadf67568b8b0e