### PR TITLE
Refactor InstrumentSearchBar to standalone component function

### DIFF
--- a/frontend/src/components/InstrumentSearchBar.tsx
+++ b/frontend/src/components/InstrumentSearchBar.tsx
@@ -35,7 +35,7 @@ interface InstrumentSearchBarProps {
   onNavigate?: () => void;
 }
 
-const InstrumentSearchBar = memo(function InstrumentSearchBar({
+function InstrumentSearchBarComponent({
   onClose,
   onNavigate,
 }: InstrumentSearchBarProps) {


### PR DESCRIPTION
## Summary
- refactor the instrument search bar component into a named function before memoizing it
- ensure the toggle continues to render the memoized InstrumentSearchBar while preserving exports

## Testing
- npm run build *(fails: existing TypeScript errors in Member.tsx and vite.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c918f671f88327b0beee7c664719e7