### PR TITLE
Simplify run frontend run configuration

### DIFF
--- a/.run/run-frontend.ps1.run.xml
+++ b/.run/run-frontend.ps1.run.xml
@@ -1,8 +1,4 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="run-frontend.ps1" type="PowerShellRunType" factoryName="PowerShell" scriptUrl="C:\workspaces\github\allotmint\scripts\run-frontend.ps1" workingDirectory="C:\workspaces\github\allotmint" executablePath="$PROJECT_DIR$/../../../WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe">
-    <envs />
-    <method v="2" />
-  </configuration>
   <configuration default="false" name="run-frontend.ps1" type="PowerShellRunType" factoryName="PowerShell" scriptUrl="$PROJECT_DIR$/scripts/run-frontend.ps1" executablePath="$PROJECT_DIR$/../../../WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe">
     <envs />
     <method v="2" />


### PR DESCRIPTION
## Summary
- remove the duplicate run configuration that referenced an absolute Windows path
- keep a single run configuration that invokes scripts/run-frontend.ps1 via PROJECT_DIR

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c919cc0f1c8327904c6180e3c482e4