### PR TITLE
Remove duplicate run-backend PowerShell configuration

### DIFF
--- a/.run/run-backend.ps1.run.xml
+++ b/.run/run-backend.ps1.run.xml
@@ -1,8 +1,4 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="run-backend.ps1" type="PowerShellRunType" factoryName="PowerShell" scriptUrl="$PROJECT_DIR$/run-backend.ps1" executablePath="powershell.exe">
-    <envs />
-    <method v="2" />
-  </configuration>
   <configuration default="false" name="run-backend.ps1" type="PowerShellRunType" factoryName="PowerShell" scriptUrl="$PROJECT_DIR$/scripts/run-backend.ps1" executablePath="$PROJECT_DIR$/../../../WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe">
     <envs />
     <method v="2" />


### PR DESCRIPTION
## Summary
- remove the obsolete run-backend configuration that pointed at the repo root script
- keep only the working configuration that executes scripts/run-backend.ps1

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68c919cbe2bc83278e2c04f6e3736294