### PR TITLE
Fix Deploy to AWS run configuration script path

### DIFF
--- a/.run/Deploy to AWS.run.xml
+++ b/.run/Deploy to AWS.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Deploy to AWS" type="PowerShellRunType" factoryName="PowerShell" scriptUrl="C:\workspaces\github\allotmint\deploy-to-AWS.ps1" workingDirectory="C:\workspaces\github\allotmint\" executablePath="$PROJECT_DIR$/../../../WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe">
+  <configuration default="false" name="Deploy to AWS" type="PowerShellRunType" factoryName="PowerShell" scriptUrl="$PROJECT_DIR$/scripts/deploy-to-AWS.ps1" workingDirectory="C:\workspaces\github\allotmint\" executablePath="$PROJECT_DIR$/../../../WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe">
     <envs />
     <method v="2" />
   </configuration>


### PR DESCRIPTION
## Summary
- point the Deploy to AWS run configuration to the existing deploy script under scripts using a project-relative path

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68c919cb8f70832781a18272bf926639