### PR TITLE
Add frontend smoke Playwright test

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -140,9 +140,20 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install dependencies
+      - name: Install root dependencies
         run: npm ci
 
-      - name: Run smoke tests
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+        working-directory: frontend
+
+      - name: Run backend smoke tests
         run: npm run smoke:test
+
+      - name: Run frontend smoke tests
+        run: npm --prefix frontend run smoke:frontend
 

--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -1,16 +1,21 @@
 # Smoke Tests
 
-Run a quick check against key backend endpoints after deployment.
+Run quick checks against critical backend endpoints and the frontend smoke test page after deployment.
 
 ## Environment variables
 
-- `SMOKE_URL` – base URL of the backend to test.
-- `TEST_ID_TOKEN` – optional ID token added as a `Bearer` token for endpoints requiring authentication.
+- `SMOKE_URL` – base URL of the deployment to exercise.
+- `TEST_ID_TOKEN` – optional ID token added as a `Bearer` token for backend endpoints requiring authentication.
+- `SMOKE_AUTH_TOKEN` – optional bearer token stored in the frontend's `localStorage`; falls back to `TEST_ID_TOKEN` when unset.
 
 ## Usage
 
 ```bash
 SMOKE_URL=https://example.com npm run smoke:test
+```
+
+```bash
+SMOKE_URL=https://example.com npm --prefix frontend run smoke:frontend
 ```
 
 Include `TEST_ID_TOKEN` if the target requires auth:
@@ -19,4 +24,8 @@ Include `TEST_ID_TOKEN` if the target requires auth:
 SMOKE_URL=https://example.com TEST_ID_TOKEN=token npm run smoke:test
 ```
 
-The script exits non-zero if any endpoint returns an unexpected status, allowing CI to fail fast.
+```bash
+SMOKE_URL=https://example.com TEST_ID_TOKEN=token npm --prefix frontend run smoke:frontend
+```
+
+Each command exits non-zero if any check fails, allowing CI to fail fast.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "test:jsdom": "vitest --environment=jsdom",
+    "smoke:frontend": "playwright test tests/smoke.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",
     "deploy:aws:linux": "bash scripts/deploy-to-aws.sh -b $S3_BUCKET ${CLOUDFRONT_DISTRIBUTION_ID:+-d $CLOUDFRONT_DISTRIBUTION_ID}"

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+const baseUrl = process.env.SMOKE_URL ?? 'http://localhost:5173';
+const authToken = process.env.SMOKE_AUTH_TOKEN ?? process.env.TEST_ID_TOKEN ?? null;
+
+const smokePath = new URL('/smoke-test', baseUrl).toString();
+
+test.describe('smoke test page', () => {
+  test('reports ok for every backend check', async ({ page }) => {
+    if (authToken) {
+      await page.addInitScript((token: string) => {
+        window.localStorage.setItem('authToken', token);
+      }, authToken);
+    }
+
+    await page.goto(smokePath);
+    await page.waitForSelector('ul li');
+
+    const items = page.getByRole('listitem');
+    const count = await items.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let index = 0; index < count; index += 1) {
+      await expect(items.nth(index)).toContainText('ok');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright smoke test that checks the `/smoke-test` page reports ok statuses and supports optional auth tokens
- expose a `smoke:frontend` npm script and document how to run both smoke suites and their environment variables
- update the deployment smoke-test job to install Playwright and run both backend and frontend smoke checks

## Testing
- npm --prefix frontend run lint *(fails: existing lint violations in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c91b714c7c8327996dc17d18654706