### PR TITLE
Use price refresh context in App

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ import TopMovers from "./pages/TopMovers";
 import MarketOverview from "./pages/MarketOverview";
 import Trading from "./pages/Trading";
 import { useConfig } from "./ConfigContext";
+import { usePriceRefresh } from "./PriceRefreshContext";
 import DataAdmin from "./pages/DataAdmin";
 import Support from "./pages/Support";
 import ScenarioTester from "./pages/ScenarioTester";
@@ -130,6 +131,7 @@ export default function App({ onLogout }: AppProps) {
   const location = useLocation();
   const { t } = useTranslation();
   const { tabs } = useConfig();
+  const { lastRefresh } = usePriceRefresh();
 
   const params = new URLSearchParams(location.search);
   const [mode, setMode] = useState<Mode>(initialMode);


### PR DESCRIPTION
## Summary
- import the price refresh context hook into the main App component
- read the `lastRefresh` timestamp from context so the existing display works again

## Testing
- npm run lint *(fails: pre-existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c94f75feec832788912adc20c6485d