### PR TITLE
Add pre-commit setup for linting and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+default_language_version:
+  python: python3
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.7
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,18 @@ pip install -r requirements.txt -r requirements-dev.txt
 Workflows and helper scripts install from these files, so update them when new
 packages are needed.
 
+### Pre-commit hooks
+
+Install the Git hooks so code style checks and tests run automatically before
+each commit:
+
+```bash
+pre-commit install
+```
+
+The configured hooks format Python code with Black, lint with Ruff, and execute
+the pytest suite.
+
 ### Environment variables
 
 Sensitive settings are loaded from environment variables rather than


### PR DESCRIPTION
## Summary
- add a `.pre-commit-config.yaml` that runs Ruff, Black, and pytest
- update the developer documentation to explain how to install the pre-commit hooks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c94f282918832784dc85a879d51e1f