### PR TITLE
Pin Google OAuth dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,5 +60,5 @@ wsproto~=1.2.0
 yfinance~=0.2.65
 google-auth~=2.36.0
 
-google-auth-oauthlib
-google-auth-httplib2
+google-auth-oauthlib~=1.2.2
+google-auth-httplib2~=0.2.0


### PR DESCRIPTION
## Summary
- constrain google-auth-oauthlib to the 1.2.x series
- constrain google-auth-httplib2 to the 0.2.x series

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c94f2c68a8832797f39f052ffc5939