### PR TITLE
Configure pytest asyncio support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,16 @@ dependencies = [
     "reportlab>=4.4.3",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest~=8.4.1",
+    "pytest-cov~=6.2.1",
+    "pytest-asyncio~=0.23",
+]
+
 [tool.pytest.ini_options]
 addopts = "--cov=backend --cov-fail-under=85"
 testpaths = ["tests"]
+asyncio_mode = "auto"
+markers = ["asyncio: mark tests that require asyncio support"]
 


### PR DESCRIPTION
## Summary
- add a pytest-specific optional dependency group including pytest-asyncio
- configure pytest to use asyncio auto mode and register the asyncio marker

## Testing
- pip install -r requirements-dev.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c950e33488832796fbcddb674751cb