### PR TITLE
Raise coverage threshold to 90

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ dependencies = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=backend --cov-fail-under=85"
+addopts = "--cov=backend --cov-fail-under=90"
 testpaths = ["tests"]
 


### PR DESCRIPTION
## Summary
- raise the pytest coverage fail-under threshold to 90 so the suite enforces the higher requirement

## Testing
- `pytest --cov=backend --cov-fail-under=90` *(fails: coverage total is 85.79% < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68c95126274883278286eaeba7daf2a0