### PR TITLE
Add aria-expanded attribute to mobile menu toggle

### DIFF
--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -14,7 +14,9 @@ describe("Menu", () => {
     );
     expect(screen.queryByRole("link", { name: "Support" })).not.toBeInTheDocument();
     const toggle = screen.getByRole("button", { name: i18n.t("app.menu") });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
     fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("link", { name: "Support" })).toHaveAttribute(
       "href",
       "/support",

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -161,6 +161,7 @@ export default function Menu({
     <nav className="mb-4" ref={containerRef}>
       <button
         aria-label={t('app.menu')}
+        aria-expanded={open}
         className="md:hidden mb-2 p-2 border rounded"
         onClick={() => setOpen((o) => !o)}
       >


### PR DESCRIPTION
## Summary
- add an `aria-expanded` attribute to the mobile menu toggle button so assistive tech can detect its state
- extend the menu tests to confirm the expanded state toggles with the button

## Testing
- npm --prefix frontend test -- --run src/components/Menu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9546755c8832781a14cc7f7dbeebb