### PR TITLE
Add ESLint unix formatter dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "eslint": "^9.30.1",
         "eslint-config-google": "^0.14.0",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-formatter-unix": "^8.40.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "glob": "^10.3.10",
@@ -7134,6 +7135,16 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-formatter-unix": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-unix/-/eslint-formatter-unix-8.40.0.tgz",
+      "integrity": "sha512-gfsmFZ/cb1MobrMfYl2IPFLZEz2tWQVO/tnmziNQdhWJMN85GfZD64dcPsEgaEoeVKgAtK6W9LWLlOxhJWZvDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "eslint": "^9.30.1",
     "eslint-config-google": "^0.14.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-formatter-unix": "^8.40.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "glob": "^10.3.10",


### PR DESCRIPTION
## Summary
- add the eslint-formatter-unix package to the frontend devDependencies
- update the lockfile with npm install so the formatter is pinned

## Testing
- npm run lint -- --format unix

------
https://chatgpt.com/codex/tasks/task_e_68c9545681cc832799737833c6dce086