### PR TITLE
Make menu collapsible via toggle

### DIFF
--- a/frontend/src/components/Menu.test.tsx
+++ b/frontend/src/components/Menu.test.tsx
@@ -12,14 +12,22 @@ describe("Menu", () => {
         <Menu />
       </MemoryRouter>,
     );
-    expect(screen.queryByRole("link", { name: "Support" })).not.toBeInTheDocument();
     const toggle = screen.getByRole("button", { name: i18n.t("app.menu") });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("link", { name: "Support" })).not.toBeInTheDocument();
     fireEvent.click(toggle);
-    expect(screen.getByRole("link", { name: "Support" })).toHaveAttribute(
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    const supportLink = screen.getByRole("link", { name: "Support" });
+    expect(supportLink).toBeVisible();
+    expect(supportLink).toHaveAttribute(
       "href",
       "/support",
     );
-    expect(screen.getByRole("link", { name: "Logs" })).toHaveAttribute("href", "/logs");
+    expect(screen.getByRole("link", { name: "Logs" })).toBeVisible();
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("link", { name: "Support" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Logs" })).not.toBeInTheDocument();
   });
 
   it("shows support tabs on support route", () => {
@@ -78,6 +86,7 @@ describe("Menu", () => {
         </MemoryRouter>
       </configContext.Provider>,
     );
+    fireEvent.click(screen.getByRole("button", { name: i18n.t("app.menu") }));
     expect(screen.queryByRole("link", { name: "Support" })).toBeNull();
   });
 

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -32,11 +32,6 @@ export default function Menu({
 
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [isDesktop, setIsDesktop] = useState<boolean>(() => {
-    const hasMM = typeof window !== 'undefined' && typeof (window as any).matchMedia === 'function';
-    return hasMM ? (window as any).matchMedia('(min-width: 768px)').matches : false;
-  });
-
   useEffect(() => {
     function handleFocus(e: FocusEvent) {
       if (open && containerRef.current && !containerRef.current.contains(e.target as Node)) {
@@ -44,16 +39,8 @@ export default function Menu({
       }
     }
     document.addEventListener('focusin', handleFocus);
-    const mq = typeof window !== 'undefined' && typeof (window as any).matchMedia === 'function'
-      ? (window as any).matchMedia('(min-width: 768px)')
-      : null;
-    const onChange = () => setIsDesktop(!!mq?.matches);
-    mq?.addEventListener?.('change', onChange);
-    // Initialize in case of hydration/mount
-    onChange();
     return () => {
       document.removeEventListener('focusin', handleFocus);
-      mq?.removeEventListener?.('change', onChange);
     };
   }, [open]);
 
@@ -161,7 +148,8 @@ export default function Menu({
     <nav className="mb-4" ref={containerRef}>
       <button
         aria-label={t('app.menu')}
-        className="md:hidden mb-2 p-2 border rounded"
+        aria-expanded={open}
+        className="mb-2 p-2 border rounded"
         onClick={() => setOpen((o) => !o)}
       >
         ☰
@@ -178,9 +166,10 @@ export default function Menu({
           </button>
         </div>
       ) : (
-        (open || isDesktop) && (
         <div
-          className={`flex flex-col gap-2 md:flex md:flex-row md:flex-wrap`}
+          hidden={!open}
+          aria-hidden={!open}
+          className={`${open ? 'flex md:flex' : 'hidden'} flex-col gap-2 md:flex-row md:flex-wrap`}
           style={style}
         >
           {orderedTabPlugins
@@ -237,7 +226,6 @@ export default function Menu({
             {t('app.focusMode')}
           </button>
         </div>
-        )
       )}
     </nav>
   );


### PR DESCRIPTION
## Summary
- remove the desktop matchMedia logic so the menu is controlled entirely by the toggle state
- update the menu markup to hide links behind the toggle button on all screen sizes
- expand the menu unit test coverage to check visibility and aria-expanded behaviour

## Testing
- npx vitest run src/components/Menu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9546596c08327839d3515e5a85721