### PR TITLE
chore(frontend): use unix formatter for eslint

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
+    "lint": "eslint --format unix .",
     "preview": "vite preview",
     "test": "vitest",
     "coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- configure the frontend lint script to use eslint's unix formatter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9aee6dc788327bbc1f8d6ea598f36