### PR TITLE
Run lint modules via python

### DIFF
--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -5,6 +5,14 @@ $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 $REPO_ROOT = Split-Path -Parent $SCRIPT_DIR
 Set-Location $REPO_ROOT
 
+$pythonCommand = $null
+foreach ($candidate in @('python', 'py')) {
+    if (Get-Command $candidate -ErrorAction SilentlyContinue) {
+        $pythonCommand = $candidate
+        break
+    }
+}
+
 $summary = @()
 
 function Run-Linter {
@@ -55,16 +63,16 @@ function Parse-ESLint {
     }
 }
 
-if (Get-Command ruff -ErrorAction SilentlyContinue) {
-    Run-Linter "ruff" { ruff check --config backend/pyproject.toml backend tests cdk scripts } ${function:Parse-Ruff}
+if ($pythonCommand) {
+    Run-Linter "ruff" { & $pythonCommand -m ruff check --config backend/pyproject.toml backend tests cdk scripts } ${function:Parse-Ruff}
 } else {
-    $summary += "ruff: not installed"
+    $summary += "ruff: python not available"
 }
 
-if (Get-Command black -ErrorAction SilentlyContinue) {
-    Run-Linter "black" { black --check --config backend/pyproject.toml backend tests cdk scripts } ${function:Parse-Black}
+if ($pythonCommand) {
+    Run-Linter "black" { & $pythonCommand -m black --check --config backend/pyproject.toml backend tests cdk scripts } ${function:Parse-Black}
 } else {
-    $summary += "black: not installed"
+    $summary += "black: python not available"
 }
 
 if (Test-Path frontend) {


### PR DESCRIPTION
## Summary
- detect an available Python interpreter for linting tasks
- invoke ruff and black through ``python -m`` so they run without relying on PATH executables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9aee5c388832784a2305b9c40cde8