### PR TITLE
Support multiple URLs in smoke test script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,15 +22,19 @@ Set `API_BASE` to target a different backend URL and `TEST_ID_TOKEN` if needed.
 
 ## smoke-test.ps1
 
-Check a single endpoint for an HTTP 200 response.
+Check one or more endpoints for an HTTP 200 response.
 
 ```powershell
-# Pass URL as a parameter
-./scripts/smoke-test.ps1 https://example.com
+# Pass URLs as parameters
+./scripts/smoke-test.ps1 https://example.com https://example.com/health
 
 # or rely on the environment variable
-$env:SMOKE_TEST_URL = "https://example.com"
+$env:SMOKE_TEST_URLS = "https://example.com,https://example.com/health"
 ./scripts/smoke-test.ps1
+```
+
+```bash
+SMOKE_TEST_URLS=http://localhost:8000/health,http://localhost:5173 npm run smoke:test
 ```
 
 

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -1,22 +1,26 @@
 Param(
-  [string]$Url = $env:SMOKE_TEST_URL
+  [string[]]$Urls = $env:SMOKE_TEST_URLS -split ','
 )
 
-if (-not $Url) {
-  Write-Error "Usage: SMOKE_TEST_URL=<url> .\\smoke-test.ps1 [url]"
+$Urls = $Urls | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+if (-not $Urls) {
+  Write-Error "Usage: SMOKE_TEST_URLS=<url>[,<url>...] .\\smoke-test.ps1 [url ...]"
   exit 1
 }
 
-try {
-  $response = Invoke-WebRequest -Uri $Url -UseBasicParsing
-} catch {
-  Write-Error ("Smoke test failed for {0}: {1}" -f $Url, $_.Exception.Message)
-  exit 1
-}
+foreach ($Url in $Urls) {
+  try {
+    $response = Invoke-WebRequest -Uri $Url -UseBasicParsing
+  } catch {
+    Write-Error ("Smoke test failed for {0}: {1}" -f $Url, $_.Exception.Message)
+    exit 1
+  }
 
-if ($response.StatusCode -ne 200) {
-  Write-Error ("Smoke test failed for {0} with status {1}" -f $Url, $response.StatusCode)
-  exit 1
-}
+  if ($response.StatusCode -ne 200) {
+    Write-Error ("Smoke test failed for {0} with status {1}" -f $Url, $response.StatusCode)
+    exit 1
+  }
 
-Write-Output ("Smoke test passed for {0}" -f $Url)
+  Write-Output ("Smoke test passed for {0}" -f $Url)
+}


### PR DESCRIPTION
## Summary
- allow `smoke-test.ps1` to accept multiple URLs and fall back to `SMOKE_TEST_URLS`
- iterate through each provided URL, preserving the existing HTTP 200 validation
- document how to supply multiple URLs, including the `SMOKE_TEST_URLS=... npm run smoke:test` example

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9ae94a36483279f2a71bddb9dd201