### PR TITLE
Add combined smoke test orchestrator

### DIFF
--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -10,22 +10,30 @@ Run quick checks against critical backend endpoints and the frontend smoke test 
 
 ## Usage
 
+Run the backend and frontend suites together with a single command:
+
+```bash
+SMOKE_URL=https://example.com npm run smoke:test:all
+```
+
+Run only the backend API checks:
+
 ```bash
 SMOKE_URL=https://example.com npm run smoke:test
 ```
+
+Run only the frontend smoke page checks:
 
 ```bash
 SMOKE_URL=https://example.com npm --prefix frontend run smoke:frontend
 ```
 
-Include `TEST_ID_TOKEN` if the target requires auth:
+Include `TEST_ID_TOKEN` (and optionally `SMOKE_AUTH_TOKEN`) if the target requires auth:
 
 ```bash
-SMOKE_URL=https://example.com TEST_ID_TOKEN=token npm run smoke:test
-```
-
-```bash
-SMOKE_URL=https://example.com TEST_ID_TOKEN=token npm --prefix frontend run smoke:frontend
+SMOKE_URL=https://example.com TEST_ID_TOKEN=token npm run smoke:test:all
 ```
 
 Each command exits non-zero if any check fails, allowing CI to fail fast.
+
+The legacy `scripts/smoke-test.ps1` helper remains available for quick single-endpoint checks—provide one or more URLs via the `SMOKE_TEST_URLS` environment variable or as command-line arguments.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "deploy:local:frontend:ps": "powershell -ExecutionPolicy Bypass -File scripts/deploy-local.ps1 -Target frontend",
     "deploy:local:backend:ps": "powershell -ExecutionPolicy Bypass -File scripts/deploy-local.ps1 -Target backend",
     "deploy:local:both:ps": "powershell -ExecutionPolicy Bypass -File scripts/deploy-local.ps1 -Target both",
-    "smoke:test": "tsx scripts/frontend-backend-smoke.ts"
+    "smoke:test": "tsx scripts/frontend-backend-smoke.ts",
+    "smoke:test:all": "tsx scripts/smoke-all.ts"
   }
 }

--- a/scripts/smoke-all.ts
+++ b/scripts/smoke-all.ts
@@ -1,0 +1,74 @@
+import { spawn } from 'child_process';
+
+type Command = {
+  command: string;
+  args: string[];
+  label: string;
+};
+
+const forwardedEnvironmentVariables = [
+  'SMOKE_URL',
+  'TEST_ID_TOKEN',
+  'SMOKE_AUTH_TOKEN',
+] as const;
+
+const env: NodeJS.ProcessEnv = { ...process.env };
+
+for (const variable of forwardedEnvironmentVariables) {
+  const value = process.env[variable];
+  if (value !== undefined) {
+    env[variable] = value;
+  }
+}
+
+const commands: Command[] = [
+  {
+    command: 'tsx',
+    args: ['scripts/frontend-backend-smoke.ts'],
+    label: 'backend smoke suite',
+  },
+  {
+    command: 'npm',
+    args: ['--prefix', 'frontend', 'run', 'smoke:frontend'],
+    label: 'frontend smoke suite',
+  },
+];
+
+async function runSequentially() {
+  for (const { command, args, label } of commands) {
+    console.log(`\n▶ Running ${label}...`);
+    const exitCode = await runCommand(command, args);
+
+    if (exitCode !== 0) {
+      console.error(`✖ ${label} failed with exit code ${exitCode ?? 'null'}.`);
+      process.exit(exitCode ?? 1);
+    }
+
+    console.log(`✔ ${label} completed successfully.`);
+  }
+
+  console.log('\nAll smoke suites completed successfully.');
+}
+
+function runCommand(command: string, args: string[]): Promise<number | null> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      env,
+    });
+
+    child.on('close', (code) => {
+      resolve(code);
+    });
+
+    child.on('error', (error) => {
+      console.error(`Failed to start command \"${command}\":`, error);
+      resolve(1);
+    });
+  });
+}
+
+runSequentially().catch((error) => {
+  console.error('Unexpected error while orchestrating smoke suites:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a TypeScript orchestrator that forwards smoke-test environment variables and runs the backend then frontend suites
- register an npm alias so both suites can be triggered with a single command
- refresh smoke test documentation with the new combined command and clarify the PowerShell helper’s scope

## Testing
- not run (requires deployment-specific smoke-test targets)


------
https://chatgpt.com/codex/tasks/task_e_68c9b21338ec8327a5029e610aa62ee4