### PR TITLE
Handle non-zero linter exit codes in lint script

### DIFF
--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -24,12 +24,18 @@ function Run-Linter {
     Write-Host "Running $Name..." -ForegroundColor Cyan
     try {
         $output = & $Command 2>&1
+        $exitCode = $LASTEXITCODE
     } catch {
         Write-Host "$Name failed: $($_.Exception.Message)" -ForegroundColor Yellow
         $script:summary += "$($Name): failed to run ($($_.Exception.Message))"
         return
     }
     $output | ForEach-Object { Write-Host $_ }
+    if ($exitCode -ne 0) {
+        Write-Host "$Name exited with code $exitCode" -ForegroundColor Yellow
+        $script:summary += "$($Name): exited with code $exitCode"
+        return
+    }
     if ($Parser) {
         $parsed = & $Parser $output
         if ($parsed) { $script:summary += $parsed }


### PR DESCRIPTION
## Summary
- capture each linter command's exit code immediately after execution in `Run-Linter`
- emit warnings and summary entries when a linter exits non-zero while keeping parsing for successful runs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9d0aaedc083278ba82edb27fe1c58