### PR TITLE
Fix search toggle button text visibility

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -372,6 +372,7 @@ export default function App({ onLogout }: AppProps) {
               borderRadius: "0.25rem",
               border: "1px solid #ccc",
               background: "#fff",
+              color: "#213547",
               cursor: "pointer",
             }}
           >

--- a/frontend/src/components/InstrumentSearchBar.tsx
+++ b/frontend/src/components/InstrumentSearchBar.tsx
@@ -157,6 +157,7 @@ function InstrumentSearchBarComponent({
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
+              color: "#213547",
               cursor: "pointer",
               padding: 0,
             }}
@@ -223,6 +224,7 @@ export function InstrumentSearchBarToggle() {
           borderRadius: "0.25rem",
           border: "1px solid #ccc",
           background: open ? "#eee" : "#fff",
+          color: "#213547",
           cursor: "pointer",
         }}
       >
@@ -251,6 +253,7 @@ export function InstrumentSearchBarToggle() {
               borderRadius: "0.25rem",
               border: "1px solid #ccc",
               background: "#f5f5f5",
+              color: "#213547",
               cursor: "pointer",
               alignSelf: "center",
             }}


### PR DESCRIPTION
## Summary
- ensure the research toggle button uses a readable text color against its light background
- apply the same readable text color to the search close controls inside the instrument search bar

## Testing
- npm run test -- --run *(fails: upstream Vitest suite has multiple known failures such as HoldingsTable and InstrumentAdmin tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d3665af08327a0c11a323ed60b43