### PR TITLE
Refactor news caching helper and update market headlines

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -10,7 +10,7 @@ import yfinance as yf
 from fastapi import APIRouter, Query
 
 from backend import config_module
-from backend.routes.news import _fetch_news
+from backend.routes.news import get_cached_news
 
 cfg = getattr(config_module, "settings", config_module.config)
 config = cfg
@@ -153,7 +153,14 @@ def _fetch_headlines() -> List[Dict[str, str]]:
     success = False
 
     for sym in INDEX_SYMBOLS.values():
-        items = _fetch_news(sym)
+        try:
+            items = get_cached_news(sym)
+        except RuntimeError:
+            logger.warning(
+                "News quota exhausted while building market headlines; returning partial data"
+            )
+            break
+
         if not items:
             continue
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -41,7 +41,7 @@ market_data:
   fundamentals_cache_ttl_seconds: 86400 # TTL for fundamentals cache (seconds)
   stooq_timeout: 10                   # Timeout for Stooq requests (seconds)
   stooq_requests_per_minute: 60       # Rate limit for Stooq requests
-  news_requests_per_day: 25           # Max AlphaVantage news requests per day
+  news_requests_per_day: 25           # Max AlphaVantage news requests per day (shared with market headlines)
   default_sector_region: US           # Default region for sector performance data (US or UK)
   uk_sector_endpoint: https://www.londonstockexchange.com/api/sectors/ftse350 # LSE sector summary endpoint
   ft_url_template: https://markets.ft.com/data/funds/tearsheet/historical?s={ticker} # FT scraping URL template

--- a/config.yaml
+++ b/config.yaml
@@ -41,7 +41,7 @@ market_data:
   fundamentals_cache_ttl_seconds: 86400 # TTL for fundamentals cache (seconds)
   stooq_timeout: 10                   # Timeout for Stooq requests (seconds)
   stooq_requests_per_minute: 60       # Rate limit for Stooq requests
-  # Max AlphaVantage news requests per day
+  # Max AlphaVantage news requests per day (shared with market headlines)
   news_requests_per_day: 25
   # Sector performance configuration
   default_sector_region: US

--- a/tests/backend/routes/test_market.py
+++ b/tests/backend/routes/test_market.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import List
+
+from backend.routes import market as market_module
+
+
+def _make_payload(symbol: str, label: str) -> List[dict[str, str]]:
+    return [{"headline": f"{symbol} {label}", "url": f"https://example.com/{symbol.lower()}"}]
+
+
+def test_fetch_headlines_uses_cached_helper(monkeypatch):
+    symbols = list(market_module.INDEX_SYMBOLS.values())
+    seen_fresh: set[str] = set()
+
+    def fake_get_cached_news(symbol: str) -> List[dict[str, str]]:
+        if symbol in seen_fresh:
+            return _make_payload(symbol, "cached")
+        seen_fresh.add(symbol)
+        return _make_payload(symbol, "fresh")
+
+    monkeypatch.setattr(market_module, "get_cached_news", fake_get_cached_news)
+
+    first = market_module._fetch_headlines()
+    second = market_module._fetch_headlines()
+
+    assert seen_fresh == set(symbols)
+    assert sorted(item["headline"] for item in first) == sorted(
+        f"{sym} fresh" for sym in symbols
+    )
+    assert sorted(item["headline"] for item in second) == sorted(
+        f"{sym} cached" for sym in symbols
+    )
+
+
+def test_fetch_headlines_stops_on_quota_exhaustion(monkeypatch):
+    symbols = list(market_module.INDEX_SYMBOLS.values())
+    stop_after = symbols[2]
+    calls: list[str] = []
+
+    def fake_get_cached_news(symbol: str) -> List[dict[str, str]]:
+        calls.append(symbol)
+        if symbol == stop_after:
+            raise RuntimeError("news quota exceeded")
+        return _make_payload(symbol, "fresh")
+
+    monkeypatch.setattr(market_module, "get_cached_news", fake_get_cached_news)
+
+    headlines = market_module._fetch_headlines()
+
+    assert calls == symbols[: symbols.index(stop_after) + 1]
+    assert all(stop_after not in item["headline"] for item in headlines)
+    assert all(
+        item["headline"].endswith("fresh")
+        for item in headlines
+    )

--- a/tests/routes/test_market.py
+++ b/tests/routes/test_market.py
@@ -152,11 +152,11 @@ def test_fetch_headlines_with_mocked_news(monkeypatch):
         ],
     }
 
-    def fake_fetch_news(symbol):
+    def fake_get_cached_news(symbol):
         calls.append(symbol)
         return responses[symbol]
 
-    monkeypatch.setattr(market, "_fetch_news", fake_fetch_news)
+    monkeypatch.setattr(market, "get_cached_news", fake_get_cached_news)
 
     headlines = market._fetch_headlines()
 


### PR DESCRIPTION
## Summary
- extract a reusable `get_cached_news` helper that encapsulates quota and cache handling for AlphaVantage news
- update market headline aggregation to use the shared helper and halt when the shared quota is exhausted
- add tests covering market headline caching/quota behaviour and clarify in config comments that the quota is shared

## Testing
- pytest --no-cov tests/routes/test_news.py tests/routes/test_market.py tests/backend/routes/test_market.py

------
https://chatgpt.com/codex/tasks/task_e_68c9d2d2be008327b4e85a1126616cf3