### PR TITLE
Sanitize alpha vs benchmark metric

### DIFF
--- a/frontend/src/components/GroupPortfolioView.test.tsx
+++ b/frontend/src/components/GroupPortfolioView.test.tsx
@@ -368,9 +368,9 @@ describe("GroupPortfolioView", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     mockAllFetches(mockPortfolio, {
-      alpha: 2,
+      alpha: null,
       trackingError: null,
-      maxDrawdown: Infinity,
+      maxDrawdown: null,
     });
 
     renderWithConfig(<GroupPortfolioView slug="all" />);
@@ -381,11 +381,7 @@ describe("GroupPortfolioView", () => {
     within(teLabel.parentElement!).getByText("N/A");
     const mdLabel = await screen.findByText("Max Drawdown");
     within(mdLabel.parentElement!).getByText("N/A");
-    expect(warnSpy).toHaveBeenCalledTimes(2);
-    expect(warnSpy).toHaveBeenCalledWith("Metric value out of range:", 2);
-    expect(warnSpy).toHaveBeenCalledWith(
-      "Metric value out of range:",
-      Infinity,
-    );
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- sanitize alpha vs benchmark calculations to discard infinite and extreme returns
- add a regression test ensuring near-zero benchmark data returns `None` for alpha
- update the group portfolio UI test to expect `N/A` without console warnings when metrics are missing

## Testing
- pytest --no-cov tests/test_performance_routes.py
- cd frontend && npx vitest run src/components/GroupPortfolioView.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c9d6709cac8327a3c60dcc07fc10f7