### PR TITLE
Add PowerShell wrapper for smoke:test:all

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,6 +38,15 @@ SMOKE_TEST_URLS=http://localhost:8000/health,http://localhost:5173 npm run smoke
 ```
 
 
+## run-smoke-tests-all.ps1
+
+Run the combined backend and frontend smoke suites defined in `npm run smoke:test:all`.
+
+```powershell
+./scripts/run-smoke-tests-all.ps1
+```
+
+
 ## site_healthcheck.py
 
 Parse the sitemap and verify that each URL responds with HTTP 200.

--- a/scripts/run-smoke-tests-all.ps1
+++ b/scripts/run-smoke-tests-all.ps1
@@ -1,0 +1,48 @@
+#Requires -Version 5.0
+<#!
+.SYNOPSIS
+    Run the full smoke test suite (backend + frontend) via npm.
+.DESCRIPTION
+    Convenience wrapper that can be launched from any working directory.
+    It locates the repository root, ensures npm is available, and runs
+    `npm run smoke:test:all`, which orchestrates backend HTTP checks and
+    the Playwright frontend smoke suite.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Resolve-RepoRoot {
+    param(
+        [string]$ScriptRoot
+    )
+
+    $current = Resolve-Path -Path $ScriptRoot
+    while ($current -and -not (Test-Path -Path (Join-Path -Path $current -ChildPath 'package.json'))) {
+        $parent = Split-Path -Path $current -Parent
+        if (-not $parent -or $parent -eq $current) {
+            throw "Unable to locate repository root from '$ScriptRoot'."
+        }
+        $current = $parent
+    }
+
+    return $current
+}
+
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    throw "npm is required but was not found in PATH."
+}
+
+$repoRoot = Resolve-RepoRoot -ScriptRoot $PSScriptRoot
+
+Push-Location -Path $repoRoot
+try {
+    Write-Host 'Running npm run smoke:test:all ...' -ForegroundColor Cyan
+    npm run smoke:test:all
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add a PowerShell helper script that runs `npm run smoke:test:all` from any location
- document the new helper in the scripts README for easy discovery

## Testing
- not run (PowerShell wrapper only)


------
https://chatgpt.com/codex/tasks/task_e_68c9d064cfcc8327b854fcd3df55a453