### PR TITLE
Use bundled instrument metadata when configured data directory is missing

### DIFF
--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -12,13 +12,34 @@ from typing import Any, Dict, List
 
 from backend.config import config
 
-_INSTRUMENTS_DIR = config.data_root / "instruments"
+logger = logging.getLogger(__name__)
+
+
+def _resolve_instruments_dir() -> Path:
+    """Return the configured instruments directory or fall back to bundled data."""
+
+    configured_dir = config.data_root / "instruments"
+    if configured_dir.is_dir():
+        return configured_dir
+
+    fallback_dir = Path(__file__).resolve().parents[2] / "data" / "instruments"
+    if fallback_dir.is_dir():
+        logger.warning(
+            "Configured instruments directory %s missing; falling back to %s", configured_dir, fallback_dir
+        )
+        return fallback_dir
+
+    logger.warning(
+        "Configured instruments directory %s missing and fallback %s not found", configured_dir, fallback_dir
+    )
+    return configured_dir
+
+
+_INSTRUMENTS_DIR = _resolve_instruments_dir()
 _VALID_RE = re.compile(r"^[A-Z0-9-]+$")
 
 METADATA_BUCKET_ENV = "METADATA_BUCKET"
 METADATA_PREFIX_ENV = "METADATA_PREFIX"
-
-logger = logging.getLogger(__name__)
 
 
 def _validate_part(value: str) -> str:

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 # File and directory paths
 paths:
   repo_root: .                        # Base path for the repository
-  data_root: ../allotmint-data
+  data_root: data
   accounts_root: accounts             # Directory containing account files
   prices_json: prices/latest_prices.json # Location for cached price data
   timeseries_cache_base: timeseries   # Cache directory for time series data


### PR DESCRIPTION
## Summary
- point the default `paths.data_root` at the repository's bundled `data` directory
- resolve the instruments directory with a fallback to `data/instruments` when the configured path is absent so metadata loads reliably

## Testing
- python -m compileall backend/common/instruments.py
- python - <<'PY' > /tmp/group_route.txt 2>&1  # verify /portfolio-group/all/instruments grouping output


------
https://chatgpt.com/codex/tasks/task_e_68c9d60efffc8327a123975ad9c4da24