### PR TITLE
Ensure smoke test script installs local CLI

### DIFF
--- a/scripts/run-smoke-tests-all.ps1
+++ b/scripts/run-smoke-tests-all.ps1
@@ -40,6 +40,16 @@ $repoRoot = Resolve-RepoRoot -ScriptRoot $PSScriptRoot
 
 Push-Location -Path $repoRoot
 try {
+    $tsxCliGlob = Join-Path -Path $repoRoot -ChildPath 'node_modules/.bin/tsx*'
+    if (-not (Test-Path -Path $tsxCliGlob)) {
+        Write-Host "Local tsx CLI was not found. Installing Node dev dependencies ..." -ForegroundColor Yellow
+        npm install
+
+        if (-not (Test-Path -Path $tsxCliGlob)) {
+            throw "Local tsx CLI is still missing after running 'npm install'. Please ensure Node dev dependencies are installed and rerun the script."
+        }
+    }
+
     Write-Host 'Running npm run smoke:test:all ...' -ForegroundColor Cyan
     npm run smoke:test:all
 }


### PR DESCRIPTION
## Summary
- detect whether the repository has a local tsx CLI before running smoke tests
- automatically run npm install when the CLI is missing and fail with guidance if it remains unavailable

## Testing
- not run (PowerShell script change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb15021f58832783e27993294d625c