### PR TITLE
Update lint script to use package formatter

### DIFF
--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -85,7 +85,7 @@ if (Test-Path frontend) {
     if (Get-Command npm -ErrorAction SilentlyContinue) {
         Run-Linter "eslint" {
             Push-Location frontend
-            $r = npm run lint --silent -- --format unix
+            $r = npm run lint --silent
             Pop-Location
             $r
         } ${function:Parse-ESLint}


### PR DESCRIPTION
## Summary
- run the frontend eslint task from lint.ps1 without forcing an extra --format flag so it uses the formatter configured in package.json

## Testing
- npm run lint --silent

------
https://chatgpt.com/codex/tasks/task_e_68cb14f9bd948327b7c1970689703e38