### PR TITLE
Use node entry for smoke test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deploy:local:frontend:ps": "powershell -ExecutionPolicy Bypass -File scripts/deploy-local.ps1 -Target frontend",
     "deploy:local:backend:ps": "powershell -ExecutionPolicy Bypass -File scripts/deploy-local.ps1 -Target backend",
     "deploy:local:both:ps": "powershell -ExecutionPolicy Bypass -File scripts/deploy-local.ps1 -Target both",
-    "smoke:test": "tsx scripts/frontend-backend-smoke.ts",
-    "smoke:test:all": "tsx scripts/smoke-all.ts"
+    "smoke:test": "node node_modules/tsx/dist/cli.mjs scripts/frontend-backend-smoke.ts",
+    "smoke:test:all": "node node_modules/tsx/dist/cli.mjs scripts/smoke-all.ts"
   }
 }


### PR DESCRIPTION
## Summary
- update the smoke test npm scripts to execute tsx through Node to avoid platform shims

## Testing
- SMOKE_URL=http://127.0.0.1:65535 npm run smoke:test
- SMOKE_URL=http://127.0.0.1:65535 npm run smoke:test:all
- pwsh -NoLogo -NoProfile -Command "Set-Location /workspace/allotmint; $env:SMOKE_URL='http://127.0.0.1:65535'; npm run smoke:test"
- pwsh -NoLogo -NoProfile -Command "Set-Location /workspace/allotmint; $env:SMOKE_URL='http://127.0.0.1:65535'; npm run smoke:test:all"

------
https://chatgpt.com/codex/tasks/task_e_68cb16bc23748327a0ad74a04bfc7162