### PR TITLE
Adjust grouping fallbacks for currency

### DIFF
--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -96,7 +96,7 @@ def _derive_grouping(*sources: Optional[Mapping[str, Any]], current: Optional[st
     for src in sources:
         if not src:
             continue
-        for key in ("grouping", "sector", "region"):
+        for key in ("grouping", "sector", "currency", "region"):
             val = src.get(key)
             if isinstance(val, str):
                 candidate = val.strip()

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -540,7 +540,11 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
         if r.get("day_change_gbp") is not None:
             r["day_change_currency"] = base_currency
         if not _first_nonempty_str(r.get("grouping")):
-            fallback = _first_nonempty_str(r.get("sector"), r.get("region"))
+            fallback = _first_nonempty_str(
+                r.get("sector"),
+                r.get("currency"),
+                r.get("region"),
+            )
             r["grouping"] = fallback or "Unknown"
 
     return list(rows.values())

--- a/tests/backend/common/test_instrument_api.py
+++ b/tests/backend/common/test_instrument_api.py
@@ -1,0 +1,13 @@
+from backend.common import instrument_api
+
+
+def test_derive_grouping_prefers_sector_over_currency():
+    meta = {"sector": "Technology", "currency": "USD"}
+
+    assert instrument_api._derive_grouping(meta) == "Technology"
+
+
+def test_derive_grouping_prefers_currency_over_region():
+    meta = {"currency": "EUR", "region": "Europe"}
+
+    assert instrument_api._derive_grouping(meta) == "EUR"


### PR DESCRIPTION
## Summary
- prefer currency immediately after sector when deriving grouping metadata
- adjust aggregate_by_ticker to fall back to sector, currency, region, or Unknown
- add unit tests covering the revised grouping precedence

## Testing
- pytest --cov-fail-under=0 tests/backend/common/test_instrument_api.py tests/backend/common/test_portfolio_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cb15daacfc8327b4c23fb76aacbc2a