### PR TITLE
Mark sample_portfolio test helper as fixture

### DIFF
--- a/tests/test_portfolio_utils_returns.py
+++ b/tests/test_portfolio_utils_returns.py
@@ -101,6 +101,7 @@ def test_compute_cash_apy_empty(monkeypatch):
 
     assert pu.compute_cash_apy("owner") is None
 
+@pytest.fixture
 def sample_portfolio():
     return {
         "accounts": [


### PR DESCRIPTION
## Summary
- ensure the sample_portfolio helper in the portfolio utils return tests is registered as a pytest fixture

## Testing
- pytest tests/test_portfolio_utils_returns.py --no-cov

------
https://chatgpt.com/codex/tasks/task_e_68cb18808e088327ad448f8fcee55835