### PR TITLE
Use absolute tsx path in smoke runner

### DIFF
--- a/scripts/smoke-all.ts
+++ b/scripts/smoke-all.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { createRequire } from 'module';
 
 type Command = {
   command: string;
@@ -21,10 +22,14 @@ for (const variable of forwardedEnvironmentVariables) {
   }
 }
 
+const require = createRequire(import.meta.url);
+
+const tsxCliPath = require.resolve('tsx/cli');
+
 const commands: Command[] = [
   {
-    command: 'tsx',
-    args: ['scripts/frontend-backend-smoke.ts'],
+    command: process.execPath,
+    args: [tsxCliPath, 'scripts/frontend-backend-smoke.ts'],
     label: 'backend smoke suite',
   },
   {


### PR DESCRIPTION
## Summary
- resolve the local tsx CLI path from scripts/smoke-all.ts so the backend smoke suite runs without relying on PATH
- continue to forward the process environment and stdio options when spawning smoke suite commands

## Testing
- npm run smoke:test:all *(fails: backend dependencies are unavailable in the container, causing ECONNREFUSED during smoke tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1a3e66a48327b1d3225cd869cbe0