### PR TITLE
Fix InstrumentResearch heading fallback order

### DIFF
--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -120,10 +120,10 @@ export default function InstrumentResearch() {
         {tkr}
         {detail?.name
           ? ` - ${detail.name}`
-          : metrics?.name
-          ? ` - ${metrics.name}`
           : quote?.name
           ? ` - ${quote.name}`
+          : metrics?.name
+          ? ` - ${metrics.name}`
           : ""}
         {detail?.sector || detail?.currency ? (
           <span


### PR DESCRIPTION
## Summary
- update the InstrumentResearch heading fallback to prefer the quote name before screener metrics when detail data is absent

## Testing
- npm test -- InstrumentResearch.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb1c6d59888327bc0e4e1efe59fa1a