### PR TITLE
Use demo account data for smoke endpoints

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -81,7 +81,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "POST",
     "path": "/compliance/validate",
     "body": {
-      "owner": "demo-owner"
+      "owner": "demo"
     }
   },
   {
@@ -171,6 +171,16 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "path": "/health"
   },
   {
+    "method": "POST",
+    "path": "/holdings/import",
+    "body": {
+      "owner": "test",
+      "account": "test",
+      "provider": "test",
+      "file": {}
+    }
+  },
+  {
     "method": "GET",
     "path": "/instrument/",
     "query": {
@@ -180,6 +190,19 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   {
     "method": "GET",
     "path": "/instrument/admin"
+  },
+  {
+    "method": "GET",
+    "path": "/instrument/admin/groupings"
+  },
+  {
+    "method": "GET",
+    "path": "/instrument/admin/groups"
+  },
+  {
+    "method": "POST",
+    "path": "/instrument/admin/groups",
+    "body": {}
   },
   {
     "method": "DELETE",
@@ -198,6 +221,22 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "PUT",
     "path": "/instrument/admin/{exchange}/{ticker}",
     "body": {}
+  },
+  {
+    "method": "DELETE",
+    "path": "/instrument/admin/{exchange}/{ticker}/group"
+  },
+  {
+    "method": "POST",
+    "path": "/instrument/admin/{exchange}/{ticker}/group",
+    "body": {}
+  },
+  {
+    "method": "GET",
+    "path": "/instrument/intraday",
+    "query": {
+      "ticker": "AAPL"
+    }
   },
   {
     "method": "GET",
@@ -256,7 +295,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/pension/forecast",
     "query": {
-      "owner": "demo-owner",
+      "owner": "demo",
       "death_age": "0"
     }
   },
@@ -351,7 +390,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/returns/compare",
     "query": {
-      "owner": "demo-owner"
+      "owner": "demo"
     }
   },
   {
@@ -366,7 +405,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/scenario/historical",
     "query": {
-      "horizons": "[0]"
+      "horizons": "['test']"
     }
   },
   {
@@ -462,6 +501,14 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   },
   {
     "method": "GET",
+    "path": "/trail"
+  },
+  {
+    "method": "POST",
+    "path": "/trail/{task_id}/complete"
+  },
+  {
+    "method": "GET",
     "path": "/transactions"
   },
   {
@@ -480,7 +527,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/transactions/compliance",
     "query": {
-      "owner": "demo-owner"
+      "owner": "demo"
     }
   },
   {
@@ -544,8 +591,8 @@ export const smokeEndpoints: SmokeEndpoint[] = [
 // Values are chosen based on common parameter names. Unknown names default to
 // `1` which parses as an integer or string.
 const SAMPLE_PATH_VALUES: Record<string, string> = {
-  owner: 'demo-owner',
-  account: 'demo-account',
+  owner: 'demo',
+  account: 'isa',
   user: 'user@example.com',
   email: 'user@example.com',
   id: '1',

--- a/scripts/update_smoke_endpoints.py
+++ b/scripts/update_smoke_endpoints.py
@@ -68,7 +68,7 @@ MANUAL_BODIES: dict[tuple[str, str], Any] = {
         "approved_on": "1970-01-01",
     },
     ("DELETE", "/accounts/{owner}/approvals"): {"ticker": "AAPL"},
-    ("POST", "/compliance/validate"): {"owner": "demo-owner"},
+    ("POST", "/compliance/validate"): {"owner": "demo"},
     ("POST", "/user-config/{owner}"): {},
     (
         "POST",
@@ -79,8 +79,8 @@ MANUAL_BODIES: dict[tuple[str, str], Any] = {
 MANUAL_QUERIES: dict[tuple[str, str], dict[str, str]] = {}
 
 SAMPLE_QUERY_VALUES: dict[str, str] = {
-    "owner": "demo-owner",
-    "account": "demo-account",
+    "owner": "demo",
+    "account": "isa",
     "user": "user@example.com",
     "email": "user@example.com",
     "exchange": "NASDAQ",
@@ -165,8 +165,8 @@ def main() -> None:
         "// Values are chosen based on common parameter names. Unknown names default to\n"
         "// `1` which parses as an integer or string.\n"
         "const SAMPLE_PATH_VALUES: Record<string, string> = {\n"
-        "  owner: 'demo-owner',\n"
-        "  account: 'demo-account',\n"
+        "  owner: 'demo',\n"
+        "  account: 'isa',\n"
         "  user: 'user@example.com',\n"
         "  email: 'user@example.com',\n"
         "  id: '1',\n"


### PR DESCRIPTION
## Summary
- replace hard-coded smoke test placeholders with the demo owner and isa account
- regenerate the smoke endpoint list so sample path values align with real data

## Testing
- npm run smoke:test:all *(fails: DELETE /alerts/push-subscription/{user} returned 404, but /account/{owner}/{account} now succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1f574234832781b3094bda6d420b