### PR TITLE
Handle resolved tickers that already include an exchange suffix

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -392,8 +392,16 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
                 sym, inferred = (tkr.split(".", 1) + [None])[:2]
                 if not h.get("exchange"):
                     logger.debug("Could not resolve exchange for %s; defaulting to L", tkr)
-            exch = (h.get("exchange") or inferred or "L").upper()
-            full_tkr = f"{sym}.{exch}"
+
+            sym = (sym or "").upper()
+            base_sym = sym.split(".", 1)[0]
+            exchange_value = (h.get("exchange") or inferred or "L")
+            exch = exchange_value.upper() if isinstance(exchange_value, str) else "L"
+
+            if "." in sym:
+                full_tkr = sym
+            else:
+                full_tkr = f"{sym}.{exch}"
 
             instrument_meta = get_instrument_meta(full_tkr) or {}
 
@@ -484,7 +492,7 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
             row["gain_gbp"] += _safe_num(h.get("gain_gbp"))
 
             # attach snapshot if present – overrides derived values above
-            snap = _PRICE_SNAPSHOT.get(full_tkr) or _PRICE_SNAPSHOT.get(sym)
+            snap = _PRICE_SNAPSHOT.get(full_tkr) or _PRICE_SNAPSHOT.get(base_sym)
             price = snap.get("last_price") if isinstance(snap, dict) else None
             if price and price == price:  # guard against None/NaN/0
                 row["last_price_gbp"] = price

--- a/tests/backend/common/test_portfolio_utils.py
+++ b/tests/backend/common/test_portfolio_utils.py
@@ -206,7 +206,31 @@ def test_aggregate_by_ticker_uses_shared_grouping(monkeypatch):
                         "market_value_gbp": 100.0,
                         "gain_gbp": 10.0,
                         "cost_gbp": 90.0,
-                    }
+                        "sector": "Technology",
+                    },
+                    {
+                        "ticker": "BBB.L",
+                        "units": 2.0,
+                        "market_value_gbp": 50.0,
+                        "gain_gbp": 5.0,
+                        "cost_gbp": 45.0,
+                        "currency": "USD",
+                    },
+                    {
+                        "ticker": "CCC.L",
+                        "units": 3.0,
+                        "market_value_gbp": 75.0,
+                        "gain_gbp": 15.0,
+                        "cost_gbp": 60.0,
+                        "region": "Europe",
+                    },
+                    {
+                        "ticker": "DDD.L",
+                        "units": 4.0,
+                        "market_value_gbp": 25.0,
+                        "gain_gbp": 2.0,
+                        "cost_gbp": 23.0,
+                    },
                 ]
             }
         ]
@@ -221,7 +245,12 @@ def test_aggregate_by_ticker_uses_shared_grouping(monkeypatch):
     monkeypatch.setattr(
         portfolio_utils,
         "get_instrument_meta",
-        lambda t: {"name": "Shared", "currency": "GBP", "grouping_id": "shared"},
+        lambda t: {
+            "name": "Shared",
+            "currency": "GBP",
+            "grouping_id": "shared",
+            "grouping": "shared",
+        },
     )
     monkeypatch.setattr(portfolio_utils, "get_security_meta", lambda t: {})
 
@@ -240,6 +269,7 @@ def test_aggregate_by_ticker_uses_shared_grouping(monkeypatch):
     rows = portfolio_utils.aggregate_by_ticker(portfolio, base_currency="GBP")
     rows_by_ticker = {row["ticker"]: row for row in rows}
 
+    assert "AAA.L" in rows_by_ticker
     assert rows_by_ticker["AAA.L"]["grouping"] == "Technology"
     assert rows_by_ticker["BBB.L"]["grouping"] == "USD"
     assert rows_by_ticker["CCC.L"]["grouping"] == "Europe"


### PR DESCRIPTION
## Summary
- treat resolved symbols that already include an exchange suffix as full tickers when aggregating holdings while continuing to use the base symbol for price snapshot fallbacks
- extend the aggregate_by_ticker test portfolio and assertions to cover multiple fallback scenarios and verify the AAA.L key is preserved when the resolver echoes the original ticker

## Testing
- PYTEST_ADDOPTS=--no-cov pytest tests/backend/common/test_portfolio_utils.py::test_aggregate_by_ticker_uses_shared_grouping -q

------
https://chatgpt.com/codex/tasks/task_e_68cb1fdf5abc83279c81ccca853b656a