### PR TITLE
Avoid adding default tickers in testing aggregation

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -582,40 +582,27 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
                 row["grouping"] = grouping_name
 
     if os.environ.get("TESTING"):
-        for ticker, meta in _DEFAULT_META.items():
-            if ticker == "CASH.GBP" or ticker in rows:
+        for ticker, row in rows.items():
+            meta = _DEFAULT_META.get(ticker)
+            if not meta:
                 continue
-            grouping_value = _first_nonempty_str(
-                meta.get("grouping"),
-                meta.get("sector"),
-                meta.get("currency"),
-                meta.get("region"),
-            )
-            row = {
-                "ticker": ticker,
-                "name": meta.get("name") or ticker,
-                "currency": meta.get("currency"),
-                "sector": meta.get("sector"),
-                "region": meta.get("region"),
-                "grouping": grouping_value or "Unknown",
-                "grouping_id": None,
-                "units": 0.0,
-                "market_value_gbp": 0.0,
-                "gain_gbp": 0.0,
-                "cost_gbp": 0.0,
-                "last_price_gbp": None,
-                "last_price_currency": base_currency,
-                "last_price_date": None,
-                "last_price_time": None,
-                "is_stale": None,
-                "change_7d_pct": None,
-                "change_30d_pct": None,
-                "instrument_type": meta.get("instrumentType") or meta.get("instrument_type"),
-                "cost_currency": base_currency,
-                "market_value_currency": base_currency,
-                "gain_currency": base_currency,
-            }
-            rows[ticker] = row
+            if not _first_nonempty_str(row.get("name")) and meta.get("name"):
+                row["name"] = meta["name"]
+            if not _first_nonempty_str(row.get("currency")) and meta.get("currency"):
+                row["currency"] = meta["currency"]
+            if not _first_nonempty_str(row.get("sector")) and meta.get("sector"):
+                row["sector"] = meta["sector"]
+            if not _first_nonempty_str(row.get("region")) and meta.get("region"):
+                row["region"] = meta["region"]
+            if not _first_nonempty_str(row.get("grouping")):
+                grouping_value = _first_nonempty_str(
+                    meta.get("grouping"),
+                    meta.get("sector"),
+                    meta.get("currency"),
+                    meta.get("region"),
+                )
+                if grouping_value:
+                    row["grouping"] = grouping_value
 
     rate = _fx_to_base("GBP", base_currency, fx_cache)
     for r in rows.values():

--- a/tests/test_portfolio_utils_currency.py
+++ b/tests/test_portfolio_utils_currency.py
@@ -7,6 +7,7 @@ def test_currency_from_instrument_meta(monkeypatch):
     portfolio = {"accounts": [{"holdings": [{"ticker": "ABC", "units": 1}]}]}
 
     monkeypatch.setattr(portfolio_utils, "get_instrument_meta", lambda t: {"currency": "USD"})
+    monkeypatch.setenv("TESTING", "1")
 
     rows = portfolio_utils.aggregate_by_ticker(portfolio)
 
@@ -41,6 +42,7 @@ def test_aggregate_by_ticker_fx_conversion(monkeypatch):
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {"ABC.L": {"last_price": 100}})
 
     rows_usd = portfolio_utils.aggregate_by_ticker(portfolio, base_currency="USD")
+    assert len(rows_usd) == 1
     rate_usd = 1 / 0.8
     assert rows_usd[0]["market_value_gbp"] == round(100 * rate_usd, 2)
     assert rows_usd[0]["gain_gbp"] == round(10 * rate_usd, 2)
@@ -49,6 +51,7 @@ def test_aggregate_by_ticker_fx_conversion(monkeypatch):
     assert rows_usd[0]["market_value_currency"] == "USD"
 
     rows_eur = portfolio_utils.aggregate_by_ticker(portfolio, base_currency="EUR")
+    assert len(rows_eur) == 1
     rate_eur = 1 / 0.9
     assert rows_eur[0]["market_value_gbp"] == round(100 * rate_eur, 2)
     assert rows_eur[0]["gain_gbp"] == round(10 * rate_eur, 2)
@@ -82,6 +85,7 @@ def test_aggregate_by_ticker_sets_grouping(monkeypatch):
     monkeypatch.setattr(ia, "price_change_pct", lambda ticker, days: None)
 
     rows = portfolio_utils.aggregate_by_ticker(portfolio)
+    assert len(rows) == 3
     by_ticker = {row["ticker"]: row for row in rows}
 
     assert by_ticker["AAA.L"]["grouping"] == "Explicit"


### PR DESCRIPTION
## Summary
- stop aggregate_by_ticker from creating default _DEFAULT_META rows when the TESTING flag is set
- extend portfolio_utils currency tests to assert that only real holdings are returned under TESTING

## Testing
- pytest --no-cov tests/test_portfolio_utils_currency.py

------
https://chatgpt.com/codex/tasks/task_e_68cb28351e0883278bfb04ac05d0e19d