### PR TITLE
Add pagination and missing source tests for timeseries admin

### DIFF
--- a/tests/routes/test_timeseries_admin.py
+++ b/tests/routes/test_timeseries_admin.py
@@ -1,6 +1,8 @@
 import asyncio
 import builtins
+import io
 import sys
+
 import pandas as pd
 
 from backend.routes import timeseries_admin
@@ -32,6 +34,44 @@ def test_summarize_fields(monkeypatch):
     assert summary["latest"] == "2024-01-03"
     assert summary["completeness"] == 100.0
     assert summary["main_source"] == "A"
+
+
+def test_summarize_missing_source(monkeypatch):
+    monkeypatch.setattr(
+        timeseries_admin,
+        "get_instrument_meta",
+        lambda symbol: {"name": f"Name for {symbol}"},
+    )
+
+    no_source_df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime([
+                "2024-01-05",
+                "2024-01-08",
+            ]),
+            "Price": [1.0, 2.0],
+        }
+    )
+
+    summary_no_source = timeseries_admin._summarize(no_source_df, "AAA", "L")
+
+    assert summary_no_source["latest_source"] is None
+    assert summary_no_source["main_source"] is None
+
+    nan_source_df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime([
+                "2024-02-01",
+                "2024-02-02",
+            ]),
+            "Source": [None, None],
+        }
+    )
+
+    summary_nan_source = timeseries_admin._summarize(nan_source_df, "BBB", "M")
+
+    assert summary_nan_source["latest_source"] is None
+    assert summary_nan_source["main_source"] is None
 
 
 
@@ -123,6 +163,142 @@ def test_timeseries_admin_aws_s3_empty(monkeypatch):
         assert await timeseries_admin.timeseries_admin() == []
 
     asyncio.run(run())
+
+
+def test_timeseries_admin_aws_pagination(monkeypatch):
+    bucket = "bucket"
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", bucket)
+
+    frames_by_key = {
+        "timeseries/meta/AAA_L.parquet": pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+                "Source": ["alpha", "alpha"],
+            }
+        ),
+        "timeseries/meta/CCC_L.parquet": pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2024-02-01"]),
+                "Source": ["gamma"],
+            }
+        ),
+        "timeseries/meta/DDD_M.parquet": pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2024-03-01", "2024-03-04"]),
+                "Source": ["delta", "delta"],
+            }
+        ),
+    }
+
+    read_parquet_keys: list[str] = []
+    ensure_schema_calls: list[pd.DataFrame] = []
+
+    def fake_read_parquet(buffer: io.BytesIO) -> pd.DataFrame:
+        assert isinstance(buffer, io.BytesIO)
+        key = buffer.getvalue().decode()
+        read_parquet_keys.append(key)
+        return frames_by_key[key]
+
+    def fake_ensure_schema(df: pd.DataFrame) -> pd.DataFrame:
+        ensure_schema_calls.append(df)
+        return df
+
+    monkeypatch.setattr(timeseries_admin.pd, "read_parquet", fake_read_parquet)
+    monkeypatch.setattr(timeseries_admin, "_ensure_schema", fake_ensure_schema)
+    monkeypatch.setattr(
+        timeseries_admin,
+        "get_instrument_meta",
+        lambda symbol: {"name": f"Name for {symbol}"},
+    )
+
+    class DummyBody:
+        def __init__(self, key: str) -> None:
+            self._key = key
+
+        def read(self) -> bytes:
+            return self._key.encode()
+
+    class DummyS3:
+        def __init__(self) -> None:
+            self.list_calls: list[dict[str, str]] = []
+            self.get_calls: list[str] = []
+
+        def list_objects_v2(self, **kwargs):
+            self.list_calls.append(kwargs)
+            expected = {"Bucket": bucket, "Prefix": "timeseries/meta/"}
+            if len(self.list_calls) == 1:
+                assert kwargs == expected
+                return {
+                    "Contents": [
+                        {"Key": "timeseries/meta/AAA_L.parquet"},
+                        {"Key": "timeseries/meta/BBB.parquet"},
+                        {"Key": "timeseries/meta/bad.txt"},
+                        {"Key": "timeseries/meta/EMPTY_L.parquet"},
+                    ],
+                    "IsTruncated": True,
+                    "NextContinuationToken": "TOKEN123",
+                }
+            if len(self.list_calls) == 2:
+                assert kwargs == {**expected, "ContinuationToken": "TOKEN123"}
+                return {
+                    "Contents": [
+                        {"Key": "timeseries/meta/CCC_L.parquet"},
+                        {"Key": "timeseries/meta/DDD_M.parquet"},
+                        {"Key": "timeseries/meta/INVALID.parquet"},
+                    ],
+                    "IsTruncated": False,
+                }
+            raise AssertionError("Unexpected pagination request")
+
+        def get_object(self, *, Bucket: str, Key: str):
+            assert Bucket == bucket
+            if Key == "timeseries/meta/EMPTY_L.parquet":
+                self.get_calls.append(Key)
+                return {"Body": None}
+            assert Key in frames_by_key, f"Unexpected key fetched: {Key}"
+            self.get_calls.append(Key)
+            return {"Body": DummyBody(Key)}
+
+    s3_client = DummyS3()
+
+    class DummyBoto3:
+        def client(self, name: str):
+            assert name == "s3"
+            return s3_client
+
+    class DummyExc(Exception):
+        pass
+
+    monkeypatch.setitem(sys.modules, "boto3", DummyBoto3())
+    monkeypatch.setitem(
+        sys.modules,
+        "botocore.exceptions",
+        type("e", (), {"ClientError": DummyExc}),
+    )
+
+    async def run():
+        summaries = await timeseries_admin.timeseries_admin()
+        tickers = [summary["ticker"] for summary in summaries]
+        assert tickers == ["AAA", "CCC", "DDD"]
+        assert "EMPTY" not in tickers
+        assert read_parquet_keys == [
+            "timeseries/meta/AAA_L.parquet",
+            "timeseries/meta/CCC_L.parquet",
+            "timeseries/meta/DDD_M.parquet",
+        ]
+        assert len(ensure_schema_calls) == len(read_parquet_keys)
+
+    asyncio.run(run())
+
+    assert len(s3_client.list_calls) == 2
+    assert s3_client.list_calls[1]["ContinuationToken"] == "TOKEN123"
+    assert s3_client.get_calls == [
+        "timeseries/meta/AAA_L.parquet",
+        "timeseries/meta/EMPTY_L.parquet",
+        "timeseries/meta/CCC_L.parquet",
+        "timeseries/meta/DDD_M.parquet",
+    ]
 
 
 def test_refetch_and_rebuild(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add coverage for _summarize handling of missing source metadata
- exercise AWS pagination flow, skipping invalid/empty objects and asserting continuation behavior

## Testing
- pytest --no-cov tests/routes/test_timeseries_admin.py

------
https://chatgpt.com/codex/tasks/task_e_68cb28123e5c8327b07bc324a597df9c