### PR TITLE
Respect runtime account root when loading accounts

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 from datetime import date
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from fastapi import APIRouter, HTTPException, Query, Request, Depends
@@ -397,21 +398,32 @@ async def group_movers(
 
 
 @router.get("/account/{owner}/{account}")
-async def get_account(owner: str, account: str):
-    try:
-        data = data_loader.load_account(owner, account)
-    except FileNotFoundError:
+async def get_account(owner: str, account: str, request: Request):
+    accounts_root_value = getattr(request.app.state, "accounts_root", None)
+    if accounts_root_value:
+        root = Path(accounts_root_value)
+    else:
         paths = data_loader.resolve_paths(config.repo_root, config.accounts_root)
-        owner_dir = paths.accounts_root / owner
+        root = paths.accounts_root
+
+    try:
+        data = data_loader.load_account(owner, account, root)
+    except FileNotFoundError:
+        search_root = root
+        owner_dir = search_root / owner
         if not owner_dir.exists():
-            raise HTTPException(status_code=404, detail="Account not found")
+            fallback_paths = data_loader.resolve_paths(None, None)
+            search_root = fallback_paths.accounts_root
+            owner_dir = search_root / owner
+            if not owner_dir.exists():
+                raise HTTPException(status_code=404, detail="Account not found")
         match = next(
             (f.stem for f in owner_dir.glob("*.json") if f.stem.lower() == account.lower()),
             None,
         )
         if not match:
             raise HTTPException(status_code=404, detail="Account not found")
-        data = data_loader.load_account(owner, match)
+        data = data_loader.load_account(owner, match, search_root)
         account = match
         
     holdings = data.pop("holdings", data.pop("approvals", [])) or []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,12 @@
-from unittest.mock import MagicMock, patch
+import os
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.common import data_loader
 from backend.local_api.main import app
 
 
@@ -130,7 +133,7 @@ def test_get_account_case_insensitive(mock_load_account, mock_resolve, client, t
     (tmp_path / "steve").mkdir()
     (tmp_path / "steve" / "isa.json").write_text("{}", encoding="utf-8")
 
-    def loader(owner, account):
+    def loader(owner, account, data_root=None):
         if loader.calls == 0:
             loader.calls += 1
             raise FileNotFoundError
@@ -143,6 +146,26 @@ def test_get_account_case_insensitive(mock_load_account, mock_resolve, client, t
     resp = client.get("/account/steve/ISA")
     assert resp.status_code == 200
     assert resp.json() == {"account": "isa", "account_type": "isa", "holdings": []}
+
+
+def test_get_account_demo_fallback(client):
+    expected = data_loader.load_account("demo", "isa")
+
+    original_data_root = os.environ.get("DATA_ROOT")
+    original_accounts_root = client.app.state.accounts_root
+    try:
+        os.environ["DATA_ROOT"] = "."
+        client.app.state.accounts_root = Path(".")
+
+        response = client.get("/account/demo/isa")
+        assert response.status_code == 200
+        assert response.json() == expected
+    finally:
+        if original_data_root is None:
+            os.environ.pop("DATA_ROOT", None)
+        else:
+            os.environ["DATA_ROOT"] = original_data_root
+        client.app.state.accounts_root = original_accounts_root
 
 
 @patch("backend.common.prices.refresh_prices", return_value={"updated": 5})


### PR DESCRIPTION
## Summary
- load accounts in the portfolio route using the FastAPI application's configured accounts_root
- fall back to the repository's seeded data when a runtime override lacks the owner directory
- add a regression test covering DATA_ROOT="." to ensure the demo account can still be loaded

## Testing
- pytest tests/test_main.py *(fails: coverage threshold 90% not met for partial suite)*

------
https://chatgpt.com/codex/tasks/task_e_68cb283effdc8327a5e64e458888873a