### PR TITLE
Respect holding classifications in aggregate_by_ticker

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -452,20 +452,20 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
                 {
                     "ticker": full_tkr,
                     "name": instrument_meta.get("name") or h.get("name", full_tkr),
-                    "currency": instrument_meta.get("currency") or h.get("currency"),
-                    "sector": instrument_meta.get("sector") or h.get("sector"),
-                    "region": instrument_meta.get("region") or h.get("region"),
+                    "currency": h.get("currency") or instrument_meta.get("currency"),
+                    "sector": h.get("sector") or instrument_meta.get("sector"),
+                    "region": h.get("region") or instrument_meta.get("region"),
                     "grouping": _first_nonempty_str(
-                        instrument_meta.get("grouping"),
                         h.get("grouping"),
-                        instrument_meta.get("sector"),
+                        instrument_meta.get("grouping"),
                         h.get("sector"),
-                        instrument_meta.get("region"),
+                        instrument_meta.get("sector"),
                         h.get("region"),
+                        instrument_meta.get("region"),
                     ),
                     "grouping_id": _first_nonempty_str(
-                        instrument_meta.get("grouping_id"),
                         h.get("grouping_id"),
+                        instrument_meta.get("grouping_id"),
                     ),
                     "units": 0.0,
                     "market_value_gbp": 0.0,
@@ -500,26 +500,26 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
                     row["region"] = security_meta["region"]
                 if security_meta:
                     grouping_value = _first_nonempty_str(
+                        row.get("grouping"),
+                        h.get("grouping"),
                         security_meta.get("grouping"),
                         instrument_meta.get("grouping"),
-                        h.get("grouping"),
+                        row.get("sector"),
+                        h.get("sector"),
                         security_meta.get("sector"),
                         instrument_meta.get("sector"),
-                        h.get("sector"),
+                        row.get("region"),
+                        h.get("region"),
                         security_meta.get("region"),
                         instrument_meta.get("region"),
-                        h.get("region"),
-                        row.get("grouping"),
-                        row.get("sector"),
-                        row.get("region"),
                     )
                     if grouping_value:
                         row["grouping"] = grouping_value
                     grouping_id_value = _first_nonempty_str(
+                        row.get("grouping_id"),
+                        h.get("grouping_id"),
                         security_meta.get("grouping_id"),
                         instrument_meta.get("grouping_id"),
-                        h.get("grouping_id"),
-                        row.get("grouping_id"),
                     )
                     if grouping_id_value:
                         row["grouping_id"] = grouping_id_value

--- a/tests/test_portfolio_utils_aggregate_by_field.py
+++ b/tests/test_portfolio_utils_aggregate_by_field.py
@@ -1,4 +1,5 @@
 import backend.common.portfolio_utils as portfolio_utils
+from backend.common import instrument_api
 import pytest
 
 
@@ -83,3 +84,57 @@ def test_aggregate_by_region_totals_and_percentages():
     assert regions["Unknown"]["gain_gbp"] == 20
     assert regions["Unknown"]["gain_pct"] == pytest.approx(10)
     assert regions["Unknown"]["contribution_pct"] == pytest.approx(5.7143, rel=1e-3)
+
+
+def test_holding_metadata_overrides_instrument_defaults(monkeypatch):
+    monkeypatch.setattr(
+        portfolio_utils,
+        "get_instrument_meta",
+        lambda ticker: {
+            "name": f"{ticker} meta",
+            "sector": "Instrument Sector",
+            "region": "Instrument Region",
+            "currency": "EUR",
+            "grouping": "Instrument Grouping",
+            "grouping_id": "instrument-grouping",
+        },
+    )
+    monkeypatch.setattr(
+        instrument_api,
+        "_resolve_full_ticker",
+        lambda ticker, snapshot: (ticker, None),
+    )
+
+    portfolio = {
+        "accounts": [
+            {
+                "holdings": [
+                    {
+                        "ticker": "ZZZ.L",
+                        "sector": "User Sector",
+                        "region": "User Region",
+                        "grouping": "User Grouping",
+                        "currency": "USD",
+                        "market_value_gbp": 10,
+                        "cost_gbp": 5,
+                        "gain_gbp": 5,
+                    }
+                ]
+            }
+        ]
+    }
+
+    rows = portfolio_utils.aggregate_by_ticker(portfolio)
+    row = {r["ticker"]: r for r in rows}["ZZZ.L"]
+    assert row["sector"] == "User Sector"
+    assert row["region"] == "User Region"
+    assert row["grouping"] == "User Grouping"
+    assert row["currency"] == "USD"
+
+    by_sector = {r["sector"]: r for r in portfolio_utils.aggregate_by_sector(portfolio)}
+    assert "User Sector" in by_sector
+    assert "Instrument Sector" not in by_sector
+
+    by_region = {r["region"]: r for r in portfolio_utils.aggregate_by_region(portfolio)}
+    assert "User Region" in by_region
+    assert "Instrument Region" not in by_region


### PR DESCRIPTION
## Summary
- prefer holding-provided currency, sector, region, grouping, and grouping_id values when building aggregate_by_ticker rows, with metadata only used as a fallback
- preserve user-provided classifications while still filling in missing fields from security metadata
- add regression coverage confirming holding-level classifications override instrument metadata during aggregation

## Testing
- pytest --no-cov tests/test_portfolio_utils_aggregate_by_field.py

------
https://chatgpt.com/codex/tasks/task_e_68cb283419c883278fe40eccf25b3d43