### PR TITLE
Return 404 when approval mutations target missing owners

### DIFF
--- a/backend/routes/approvals.py
+++ b/backend/routes/approvals.py
@@ -42,6 +42,8 @@ async def post_approval_request(owner: str, request: Request):
         owner_dir.relative_to(root)
     except Exception:
         raise_owner_not_found()
+    if not owner_dir.exists():
+        raise_owner_not_found()
     path = owner_dir / "approval_requests.json"
     try:
         raw = json.loads(path.read_text())
@@ -77,6 +79,8 @@ async def post_approval(owner: str, request: Request):
         owner_dir.relative_to(root)
     except Exception:
         raise_owner_not_found()
+    if not owner_dir.exists():
+        raise_owner_not_found()
     approvals = upsert_approval(owner, ticker, approved_on, root)
     entries = [
         {"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()
@@ -94,6 +98,8 @@ async def delete_approval_route(owner: str, request: Request):
         owner_dir = (root / owner).resolve()
         owner_dir.relative_to(root)
     except Exception:
+        raise_owner_not_found()
+    if not owner_dir.exists():
         raise_owner_not_found()
     approvals = delete_approval(owner, ticker, root)
     entries = [

--- a/tests/routes/test_approvals.py
+++ b/tests/routes/test_approvals.py
@@ -52,6 +52,13 @@ def test_post_approval_request_missing_ticker(tmp_path: Path) -> None:
     assert resp.json()["detail"] == "ticker is required"
 
 
+def test_post_approval_request_missing_owner(tmp_path: Path) -> None:
+    client = make_client(tmp_path)
+    resp = client.post("/accounts/missing/approval-requests", json={"ticker": "ADM.L"})
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Owner not found"}
+
+
 def test_post_approval_request_write_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     (tmp_path / "bob").mkdir()
     client = make_client(tmp_path)
@@ -95,6 +102,15 @@ def test_post_approval_success(tmp_path: Path) -> None:
     ]
 
 
+def test_post_approval_missing_owner(tmp_path: Path) -> None:
+    client = make_client(tmp_path)
+    resp = client.post(
+        "/accounts/missing/approvals", json={"ticker": "ADM.L", "approved_on": "2024-06-04"}
+    )
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Owner not found"}
+
+
 def test_post_approval_write_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     (tmp_path / "bob").mkdir()
     client = make_client(tmp_path)
@@ -132,4 +148,11 @@ def test_delete_approval_route_nonexistent_ticker(tmp_path: Path) -> None:
     assert resp.json()["approvals"] == [
         {"ticker": "ADM.L", "approved_on": "2024-06-04"}
     ]
+
+
+def test_delete_approval_missing_owner(tmp_path: Path) -> None:
+    client = make_client(tmp_path)
+    resp = client.request("DELETE", "/accounts/missing/approvals", json={"ticker": "ADM.L"})
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Owner not found"}
 


### PR DESCRIPTION
## Summary
- ensure the approval request, creation, and deletion handlers raise OwnerNotFound when the owner directory is missing
- extend the route tests to cover missing-owner mutations and assert FastAPI returns a 404

## Testing
- PYTEST_ADDOPTS="--cov=backend.routes.approvals --cov-fail-under=0" pytest tests/routes/test_approvals.py


------
https://chatgpt.com/codex/tasks/task_e_68cb2cd2cf6083278e974c847baa701b