### PR TITLE
Fix heading expectations in InstrumentResearch tests

### DIFF
--- a/frontend/src/pages/InstrumentResearch.test.tsx
+++ b/frontend/src/pages/InstrumentResearch.test.tsx
@@ -129,9 +129,12 @@ describe("InstrumentResearch page", () => {
     newsResolve!([{ headline: "headline", url: "http://example.com" }]);
 
     expect(await screen.findByText("Price")).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { level: 1 })).toHaveTextContent(
-      "AAA - Acme Corp",
-    );
+    expect(
+      await screen.findByRole("heading", {
+        level: 1,
+        name: /AAA - Acme Corp/,
+      }),
+    ).toHaveTextContent("AAA - Acme Corp");
     expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument();
   });
 
@@ -261,7 +264,10 @@ describe("InstrumentResearch page", () => {
     mockGetNews.mockResolvedValue([]);
     renderPage();
 
-    const heading = await screen.findByRole("heading", { level: 1 });
+    const heading = await screen.findByRole("heading", {
+      level: 1,
+      name: /AAA - Acme Corp/,
+    });
     expect(heading).toHaveTextContent("AAA - Acme Corp");
     expect(heading).toHaveTextContent("Tech");
     expect(heading).toHaveTextContent("USD");


### PR DESCRIPTION
## Summary
- ensure InstrumentResearch tests wait for the heading text to include the company name before asserting

## Testing
- npm run test -- InstrumentResearch.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb2e1598e08327b37f0aecf97c7df4