### PR TITLE
Update smoke test documentation

### DIFF
--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -4,7 +4,8 @@ Run quick checks against critical backend endpoints and the frontend smoke test 
 
 ## Environment variables
 
-- `SMOKE_URL` – base URL of the deployment to exercise.
+- `SMOKE_URL` – base URL of the deployment to exercise for both backend and
+  frontend suites.
 - `TEST_ID_TOKEN` – optional ID token added as a `Bearer` token for backend endpoints requiring authentication.
 - `SMOKE_AUTH_TOKEN` – optional bearer token stored in the frontend's `localStorage`; falls back to `TEST_ID_TOKEN` when unset.
 
@@ -28,7 +29,8 @@ Run only the frontend smoke page checks:
 SMOKE_URL=https://example.com npm --prefix frontend run smoke:frontend
 ```
 
-Include `TEST_ID_TOKEN` (and optionally `SMOKE_AUTH_TOKEN`) if the target requires auth:
+Include `TEST_ID_TOKEN` (and optionally `SMOKE_AUTH_TOKEN`) if the target
+requires auth; the backend smoke runner forwards it as a bearer token:
 
 ```bash
 SMOKE_URL=https://example.com TEST_ID_TOKEN=token npm run smoke:test:all

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,7 +18,9 @@ Run a quick smoke test against key backend endpoints. After running any `deploy:
 npm run smoke:test
 ```
 
-Set `API_BASE` to target a different backend URL and `TEST_ID_TOKEN` if needed.
+Set `SMOKE_URL` to point at a different deployment and include `TEST_ID_TOKEN`
+when the target requires authentication (the smoke runner forwards it as a
+bearer token).
 
 ## smoke-test.ps1
 


### PR DESCRIPTION
## Summary
- update the smoke test script README to reference the SMOKE_URL environment variable and document TEST_ID_TOKEN usage
- clarify that SMOKE_URL drives both backend and frontend smoke suites in the smoke test docs and mention how auth tokens are forwarded

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cb318019f48327b9719de3e9e88d52