### PR TITLE
Improve smoke test preflight handling

### DIFF
--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -8,6 +8,14 @@ Run quick checks against critical backend endpoints and the frontend smoke test 
 - `TEST_ID_TOKEN` – optional ID token added as a `Bearer` token for backend endpoints requiring authentication.
 - `SMOKE_AUTH_TOKEN` – optional bearer token stored in the frontend's `localStorage`; falls back to `TEST_ID_TOKEN` when unset.
 
+If the backend is offline you'll see an error similar to:
+
+```
+Preflight check failed: could not reach http://localhost:8000/health (fetch failed). Start the backend (make run-backend) or provide SMOKE_URL pointing to a running instance.
+```
+
+Start the backend locally or point `SMOKE_URL` at an accessible deployment, then re-run the smoke tests.
+
 ## Usage
 
 Run the backend and frontend suites together with a single command:

--- a/scripts/smoke-all.ts
+++ b/scripts/smoke-all.ts
@@ -22,14 +22,27 @@ for (const variable of forwardedEnvironmentVariables) {
   }
 }
 
+const scriptArgs = process.argv.slice(2).filter((arg) => arg !== '--');
+const cliBase = scriptArgs[0];
+
+if (cliBase) {
+  env.SMOKE_URL = cliBase;
+}
+
+const targetBase = env.SMOKE_URL;
+
 const require = createRequire(import.meta.url);
 
 const tsxCliPath = require.resolve('tsx/cli');
 
+const backendArgs = targetBase
+  ? [tsxCliPath, 'scripts/frontend-backend-smoke.ts', targetBase]
+  : [tsxCliPath, 'scripts/frontend-backend-smoke.ts'];
+
 const commands: Command[] = [
   {
     command: process.execPath,
-    args: [tsxCliPath, 'scripts/frontend-backend-smoke.ts'],
+    args: backendArgs,
     label: 'backend smoke suite',
   },
   {


### PR DESCRIPTION
## Summary
- add a preflight health probe to the backend smoke runner with a clearer offline error
- ensure the smoke orchestrator forwards the chosen base URL to the backend suite
- document how to resolve the new preflight failure message when the API is unreachable

## Testing
- node node_modules/tsx/dist/cli.mjs scripts/frontend-backend-smoke.ts *(fails as expected without a running backend to demonstrate the new preflight error)*

------
https://chatgpt.com/codex/tasks/task_e_68cb317f8bf483278d885e94bc2dc314