### PR TITLE
Support filtering group instrument aggregation

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -247,14 +247,81 @@ async def portfolio_group(slug: str):
 # ──────────────────────────────────────────────────────────────
 # Group-level aggregation
 # ──────────────────────────────────────────────────────────────
+def _normalise_filter_values(values: Optional[Sequence[str]]) -> set[str] | None:
+    """Lower-case and strip a query parameter list, dropping empty entries."""
+
+    if values is None:
+        return None
+
+    if isinstance(values, str):
+        values = [values]
+
+    normalised = {
+        str(value).strip().lower()
+        for value in values
+        if value is not None and str(value).strip()
+    }
+    return normalised or None
+
+
+def _account_matches_filters(account: Dict[str, Any], filters: Dict[str, set[str]]) -> bool:
+    """Return ``True`` when the account satisfies all provided filters."""
+
+    for key, allowed_values in filters.items():
+        value = account.get(key)
+        if value is None:
+            return False
+        candidate = str(value).strip().lower()
+        if candidate not in allowed_values:
+            return False
+    return True
+
+
 @router.get("/portfolio-group/{slug}/instruments")
-async def group_instruments(slug: str):
-    """Return holdings for the group aggregated by ticker."""
+async def group_instruments(
+    slug: str,
+    owner: Optional[Sequence[str]] = Query(
+        None,
+        description="Filter holdings to accounts owned by the provided slug(s).",
+    ),
+    account_type: Optional[Sequence[str]] = Query(
+        None,
+        description="Filter holdings to specific account type(s).",
+    ),
+):
+    """Return holdings for the group aggregated by ticker.
+
+    Optional ``owner`` and ``account_type`` query parameters limit the accounts
+    included in the aggregation. Provide the parameters multiple times to match
+    more than one value.
+    """
+
     try:
         gp = group_portfolio.build_group_portfolio(slug)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail="Group not found") from exc
-    return portfolio_utils.aggregate_by_ticker(gp)
+
+    owner_filters = _normalise_filter_values(owner)
+    account_type_filters = _normalise_filter_values(account_type)
+
+    filters: Dict[str, set[str]] = {}
+    if owner_filters:
+        filters["owner"] = owner_filters
+    if account_type_filters:
+        filters["account_type"] = account_type_filters
+
+    portfolio_for_aggregation: Dict[str, Any]
+    if filters:
+        filtered_accounts = [
+            account
+            for account in gp.get("accounts", [])
+            if _account_matches_filters(account, filters)
+        ]
+        portfolio_for_aggregation = {**gp, "accounts": filtered_accounts}
+    else:
+        portfolio_for_aggregation = gp
+
+    return portfolio_utils.aggregate_by_ticker(portfolio_for_aggregation)
 
 
 @router.get("/portfolio-group/{slug}/sectors")

--- a/backend/tests/test_portfolio_group_instruments_filters.py
+++ b/backend/tests/test_portfolio_group_instruments_filters.py
@@ -1,0 +1,108 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes import portfolio
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(portfolio.router)
+    return TestClient(app)
+
+
+def _sample_portfolio():
+    return {
+        "slug": "demo",
+        "name": "Demo group",
+        "members": ["alice", "bob", "carol"],
+        "as_of": "2024-01-01",
+        "accounts": [
+            {"account_type": "ISA", "owner": "alice", "holdings": []},
+            {"account_type": "SIPP", "owner": "bob", "holdings": []},
+            {"account_type": "BROKERAGE", "owner": "carol", "holdings": []},
+        ],
+    }
+
+
+def test_group_instruments_without_filters(monkeypatch):
+    client = _client()
+    portfolio_data = _sample_portfolio()
+
+    monkeypatch.setattr(
+        portfolio.group_portfolio,
+        "build_group_portfolio",
+        lambda slug: portfolio_data,
+    )
+
+    captured = {}
+
+    def _fake_aggregate(data):
+        captured["portfolio"] = data
+        return [{"ticker": "AAA"}]
+
+    monkeypatch.setattr(portfolio.portfolio_utils, "aggregate_by_ticker", _fake_aggregate)
+
+    resp = client.get("/portfolio-group/demo/instruments")
+    assert resp.status_code == 200
+    assert resp.json() == [{"ticker": "AAA"}]
+    assert captured["portfolio"] is portfolio_data
+
+
+def test_group_instruments_filters_by_owner(monkeypatch):
+    client = _client()
+    portfolio_data = _sample_portfolio()
+
+    monkeypatch.setattr(
+        portfolio.group_portfolio,
+        "build_group_portfolio",
+        lambda slug: portfolio_data,
+    )
+
+    captured = {}
+
+    def _fake_aggregate(data):
+        captured["portfolio"] = data
+        return [{"ticker": "BBB"}]
+
+    monkeypatch.setattr(portfolio.portfolio_utils, "aggregate_by_ticker", _fake_aggregate)
+
+    resp = client.get("/portfolio-group/demo/instruments", params={"owner": "ALICE"})
+    assert resp.status_code == 200
+    assert resp.json() == [{"ticker": "BBB"}]
+
+    filtered = captured["portfolio"]
+    assert filtered is not portfolio_data
+    assert filtered["slug"] == portfolio_data["slug"]
+    assert filtered["name"] == portfolio_data["name"]
+    assert filtered["members"] == portfolio_data["members"]
+    assert filtered["accounts"] == [portfolio_data["accounts"][0]]
+
+
+def test_group_instruments_filters_by_account_type(monkeypatch):
+    client = _client()
+    portfolio_data = _sample_portfolio()
+
+    monkeypatch.setattr(
+        portfolio.group_portfolio,
+        "build_group_portfolio",
+        lambda slug: portfolio_data,
+    )
+
+    captured = {}
+
+    def _fake_aggregate(data):
+        captured["portfolio"] = data
+        return [{"ticker": "CCC"}]
+
+    monkeypatch.setattr(portfolio.portfolio_utils, "aggregate_by_ticker", _fake_aggregate)
+
+    resp = client.get(
+        "/portfolio-group/demo/instruments",
+        params=[("account_type", "isa"), ("account_type", "sipp")],
+    )
+    assert resp.status_code == 200
+    assert resp.json() == [{"ticker": "CCC"}]
+
+    filtered_accounts = captured["portfolio"]["accounts"]
+    assert filtered_accounts == portfolio_data["accounts"][:2]
+

--- a/docs/USER_README.md
+++ b/docs/USER_README.md
@@ -98,3 +98,22 @@ If the variable is unset the UI defaults to `http://localhost:8000` (or
   2. `cd cdk && DEPLOY_BACKEND=false cdk deploy StaticSiteStack`
   3. To include the backend: `DEPLOY_BACKEND=true cdk deploy BackendLambdaStack StaticSiteStack`
 
+## Filtering group instrument holdings
+
+The group instruments endpoint aggregates holdings across the members of a
+portfolio group:
+
+```bash
+curl http://localhost:8000/portfolio-group/all/instruments
+```
+
+Use optional `owner` and `account_type` query parameters to narrow the
+aggregation to specific accounts. Repeat a parameter to match multiple values:
+
+```bash
+curl "http://localhost:8000/portfolio-group/all/instruments?owner=alex&account_type=ISA&account_type=SIPP"
+```
+
+The response continues to include the standard grouping metadata while limiting
+the holdings considered by the request.
+


### PR DESCRIPTION
## Summary
- allow `/portfolio-group/{slug}/instruments` to accept optional `owner` and `account_type` filters before aggregating holdings
- add focused unit tests covering filtered and unfiltered requests to ensure metadata is preserved
- document the new query parameters so API consumers can discover the filtering options

## Testing
- pytest --override-ini="addopts=" backend/tests/test_portfolio_group_instruments_filters.py tests/test_group_instruments_changes.py

------
https://chatgpt.com/codex/tasks/task_e_68cb39feab4c832792b7818339f5695c