### PR TITLE
Fix approval owner path resolution

### DIFF
--- a/backend/routes/approvals.py
+++ b/backend/routes/approvals.py
@@ -1,4 +1,5 @@
 import json
+import os
 from datetime import date
 from pathlib import Path
 
@@ -10,15 +11,32 @@ from backend.common.errors import handle_owner_not_found, raise_owner_not_found
 router = APIRouter(prefix="/accounts", tags=["approvals"])
 
 
+def _resolve_owner_dir(root: Path, owner: str, *, require_exists: bool = False) -> Path:
+    owner_dir = (root / owner).resolve()
+    root_str = os.fspath(root)
+    owner_str = os.fspath(owner_dir)
+    if os.name == "nt":
+        root_cmp = os.path.normcase(root_str)
+        owner_cmp = os.path.normcase(owner_str)
+    else:
+        root_cmp = root_str
+        owner_cmp = owner_str
+    try:
+        common = os.path.commonpath([root_cmp, owner_cmp])
+    except ValueError:
+        raise_owner_not_found()
+    if common != root_cmp:
+        raise_owner_not_found()
+    if require_exists and not owner_dir.exists():
+        raise_owner_not_found()
+    return owner_dir
+
+
 @router.get("/{owner}/approvals")
 @handle_owner_not_found
 async def get_approvals(owner: str, request: Request):
     root = Path(request.app.state.accounts_root).resolve()
-    try:
-        owner_dir = (root / owner).resolve()
-        owner_dir.relative_to(root)
-    except Exception:
-        raise_owner_not_found()
+    _resolve_owner_dir(root, owner)
     try:
         approvals = load_approvals(owner, root)
     except FileNotFoundError:
@@ -37,13 +55,7 @@ async def post_approval_request(owner: str, request: Request):
     if not ticker:
         raise HTTPException(status_code=400, detail="ticker is required")
     root = Path(request.app.state.accounts_root).resolve()
-    try:
-        owner_dir = (root / owner).resolve()
-        owner_dir.relative_to(root)
-    except Exception:
-        raise_owner_not_found()
-    if not owner_dir.exists():
-        raise_owner_not_found()
+    owner_dir = _resolve_owner_dir(root, owner, require_exists=True)
     path = owner_dir / "approval_requests.json"
     try:
         raw = json.loads(path.read_text())
@@ -74,13 +86,7 @@ async def post_approval(owner: str, request: Request):
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="invalid approved_on") from exc
     root = Path(request.app.state.accounts_root).resolve()
-    try:
-        owner_dir = (root / owner).resolve()
-        owner_dir.relative_to(root)
-    except Exception:
-        raise_owner_not_found()
-    if not owner_dir.exists():
-        raise_owner_not_found()
+    _resolve_owner_dir(root, owner, require_exists=True)
     approvals = upsert_approval(owner, ticker, approved_on, root)
     entries = [
         {"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()
@@ -94,13 +100,7 @@ async def delete_approval_route(owner: str, request: Request):
     data = await request.json()
     ticker = (data.get("ticker") or "").upper()
     root = Path(request.app.state.accounts_root).resolve()
-    try:
-        owner_dir = (root / owner).resolve()
-        owner_dir.relative_to(root)
-    except Exception:
-        raise_owner_not_found()
-    if not owner_dir.exists():
-        raise_owner_not_found()
+    _resolve_owner_dir(root, owner, require_exists=True)
     approvals = delete_approval(owner, ticker, root)
     entries = [
         {"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()


### PR DESCRIPTION
## Summary
- add a helper to resolve owner directories while handling Windows path casing
- reuse the helper across approval routes to keep validation consistent
- add a regression test covering Windows root casing differences

## Testing
- pytest --no-cov tests/routes/test_approvals.py

------
https://chatgpt.com/codex/tasks/task_e_68cbb75a87188327b1288ddaede7f4ac