### PR TITLE
Handle case-insensitive owner directories in approvals route

### DIFF
--- a/tests/routes/test_approvals.py
+++ b/tests/routes/test_approvals.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -80,6 +81,16 @@ def test_post_approval_request_write_failure(tmp_path: Path, monkeypatch: pytest
     resp = client.post("/accounts/bob/approval-requests", json={"ticker": "ADM.L"})
     assert resp.status_code == 500
     assert resp.json()["detail"] == "no space left"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires Windows case-insensitive paths")
+def test_post_approval_request_owner_dir_case_insensitive(tmp_path: Path) -> None:
+    owner_dir = tmp_path / "MiXeDCaSe" / "bob"
+    owner_dir.mkdir(parents=True)
+    mixed_case_root = Path(str(owner_dir.parent).lower())
+    client = make_client(tmp_path, accounts_root=mixed_case_root)
+    resp = client.post("/accounts/bob/approval-requests", json={"ticker": "ADM.L"})
+    assert resp.status_code == 200
 
 
 def test_post_approval_request_accounts_root_fallback(


### PR DESCRIPTION
## Summary
- add a helper for resolving account owner directories that verifies containment using `os.path.commonpath` and handles Windows case-insensitive paths
- replace the repeated owner directory validation logic in the approvals routes with the shared helper
- add a regression test to ensure approval requests succeed when the configured accounts root differs only by casing on Windows

## Testing
- pytest --no-cov tests/routes/test_approvals.py

------
https://chatgpt.com/codex/tasks/task_e_68cc80d753b08327bdba71da3775d9e9