### PR TITLE
Stub Yahoo ticker in screener caching tests

### DIFF
--- a/tests/screener/test_screener.py
+++ b/tests/screener/test_screener.py
@@ -11,6 +11,14 @@ from backend.screener import (
 )
 
 
+@pytest.fixture
+def empty_yahoo_ticker(monkeypatch):
+    class _EmptyTicker:
+        info = {}
+
+    monkeypatch.setattr("backend.screener.yf.Ticker", lambda *_args, **_kwargs: _EmptyTicker())
+
+
 def test_parse_float():
     assert _parse_float("1.23") == 1.23
     assert _parse_float("None") is None
@@ -28,7 +36,7 @@ def test_parse_int():
     assert _parse_int("abc") is None
 
 
-def test_fetch_fundamentals_caching_and_ttl(monkeypatch):
+def test_fetch_fundamentals_caching_and_ttl(monkeypatch, empty_yahoo_ticker):
     sample = {"Name": "Foo", "PERatio": "10.2"}
     call_count = {"n": 0}
 

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -17,6 +17,14 @@ def reset_screener_cache():
     screener_module._CACHE_TTL_SECONDS = original_ttl
 
 
+@pytest.fixture
+def empty_yahoo_ticker(monkeypatch):
+    class _EmptyTicker:
+        info = {}
+
+    monkeypatch.setattr("backend.screener.yf.Ticker", lambda *_args, **_kwargs: _EmptyTicker())
+
+
 def _make_base_fundamentals(ticker: str = "AAA") -> Fundamentals:
     return Fundamentals(
         ticker=ticker,
@@ -49,7 +57,7 @@ def _make_base_fundamentals(ticker: str = "AAA") -> Fundamentals:
     )
 
 
-def test_fetch_fundamentals_uses_cache(monkeypatch):
+def test_fetch_fundamentals_uses_cache(monkeypatch, empty_yahoo_ticker):
     sample = {
         "Name": "Cached Corp",
         "PEG": "0.5",
@@ -77,7 +85,7 @@ def test_fetch_fundamentals_uses_cache(monkeypatch):
     assert first is second
 
 
-def test_fetch_fundamentals_refreshes_expired_cache(monkeypatch):
+def test_fetch_fundamentals_refreshes_expired_cache(monkeypatch, empty_yahoo_ticker):
     sample = {
         "Name": "Expired Corp",
         "PEG": "0.7",


### PR DESCRIPTION
## Summary
- add a helper fixture in screener tests to stub out the Yahoo Finance ticker with an empty info payload
- use the fixture in caching and TTL tests so they consistently exercise the Alpha Vantage fallback while keeping existing expectations intact

## Testing
- pytest tests/test_screener.py tests/screener/test_screener.py *(fails: Coverage failure: total of 26 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68d15ec0b1f8832793389283c6e45b1b