### PR TITLE
Respect offline mode for screener fundamentals fetch

### DIFF
--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -172,10 +172,12 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
         if now - cached_at < timedelta(seconds=_CACHE_TTL_SECONDS):
             return cached_value
 
-    try:
-        yahoo_result = _fetch_fundamentals_from_yahoo(ticker)
-    except Exception:
-        yahoo_result = None
+    yahoo_result = None
+    if not cfg.offline_mode:
+        try:
+            yahoo_result = _fetch_fundamentals_from_yahoo(ticker)
+        except Exception:
+            yahoo_result = None
 
     if yahoo_result is not None:
         _CACHE[key] = (datetime.now(UTC), yahoo_result)


### PR DESCRIPTION
## Summary
- skip the Yahoo Finance fetch in `fetch_fundamentals` whenever offline mode is enabled
- continue caching fundamentals with the current timestamp regardless of the data source

## Testing
- pytest tests/screener/test_screener.py::test_fetch_fundamentals_caching_and_ttl tests/test_screener.py::test_fetch_fundamentals_uses_cache tests/test_screener.py::test_fetch_fundamentals_refreshes_expired_cache


------
https://chatgpt.com/codex/tasks/task_e_68d15ebc73388327a2971d4be0f6d2fc