### PR TITLE
Left justify group instrument table

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -669,7 +669,18 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
       {instrumentLoading && !instrumentRows && (
         <p>{t("common.loading")}</p>
       )}
-      {instrumentRows && <InstrumentTable rows={instrumentRows} />}
+      {instrumentRows && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-start",
+            width: "100%",
+          }}
+        >
+          <InstrumentTable rows={instrumentRows} />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the group page's instrument table with a flex column container so it anchors to the left edge

## Testing
- npm --prefix frontend test -- --run src/components/GroupPortfolioView.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d15f351a308327a763c243f233cbfb