### PR TITLE
Update market route test for new index shape

### DIFF
--- a/backend/tests/test_market_route.py
+++ b/backend/tests/test_market_route.py
@@ -15,4 +15,5 @@ def test_fetch_indexes_includes_ftse(monkeypatch):
 
     out = market._fetch_indexes()
     for name, sym in market.INDEX_SYMBOLS.items():
-        assert out[name] == prices[sym]
+        assert out[name]["value"] == prices[sym]
+        assert out[name]["change"] is None


### PR DESCRIPTION
## Summary
- update the market index route test to validate the new value/change shape while keeping FTSE coverage

## Testing
- pytest backend/tests/test_market_route.py *(fails: missing pytest-cov plugin configured in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d1638852188327b8b16d6962152c85