### PR TITLE
Ensure timeseries meta JSON dates are serializable

### DIFF
--- a/backend/routes/timeseries_meta.py
+++ b/backend/routes/timeseries_meta.py
@@ -2,6 +2,7 @@ import logging
 from datetime import date, timedelta
 
 import pandas as pd
+from pandas.api import types as pd_types
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 
@@ -83,6 +84,11 @@ async def get_meta_timeseries(
 
     # ── JSON output ───────────────────────────────────────────
     if format == "json":
+        datetime_columns = [
+            col for col in df.columns if pd_types.is_datetime64_any_dtype(df[col])
+        ]
+        for col in datetime_columns:
+            df[col] = df[col].map(lambda x: x.isoformat() if pd.notnull(x) else None)
         return JSONResponse(
             content={
                 "ticker": f"{ticker}.{exchange}",

--- a/tests/test_timeseries_meta_route.py
+++ b/tests/test_timeseries_meta_route.py
@@ -14,7 +14,6 @@ def _make_client(monkeypatch, tmp_path, df):
     monkeypatch.setattr("backend.timeseries.cache.load_meta_timeseries_range", fake_load)
     import backend.routes.timeseries_meta as ts_meta
     monkeypatch.setattr(ts_meta, "load_meta_timeseries_range", fake_load)
-    monkeypatch.setattr(ts_meta.pd, "to_datetime", lambda x: x)
     from backend.app import create_app
 
     app = create_app()
@@ -41,6 +40,7 @@ def test_timeseries_meta_formats(fmt, monkeypatch, tmp_path):
     if fmt == "json":
         data = resp.json()
         assert data["ticker"] == "ABC.L"
+        assert data["prices"][0]["Date"] == "2024-01-01T00:00:00"
         assert data["prices"][0]["Close"] == 1.5
     elif fmt == "csv":
         assert "Date,Open,High,Low,Close,Volume" in resp.text


### PR DESCRIPTION
## Summary
- convert datetime columns to ISO strings before serializing JSON output from the timeseries meta endpoint
- update the timeseries meta route test to expect ISO-formatted dates in the JSON payload

## Testing
- PYTEST_ADDOPTS="--cov=backend/routes/timeseries_meta.py --cov-fail-under=0" pytest tests/test_timeseries_meta_route.py

------
https://chatgpt.com/codex/tasks/task_e_68d1637cbef083278c2bf0e95951da5c