### PR TITLE
Handle missing flag images in language switcher

### DIFF
--- a/frontend/src/components/LanguageSwitcher.css
+++ b/frontend/src/components/LanguageSwitcher.css
@@ -2,15 +2,33 @@
   background: none;
   border: none;
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.25rem;
-  padding: 0;
+  padding: 0.25rem 0.5rem;
+  min-height: 2.25rem;
+  min-width: 2.25rem;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s ease;
+}
+
+.language-btn:hover,
+.language-btn:focus-visible {
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .language-btn img {
   width: 24px;
   height: 24px;
+  display: block;
+}
+
+.language-btn .language-name {
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .language-menu {
@@ -24,6 +42,12 @@
 }
 
 @media (max-width: 480px) {
+  .language-btn {
+    min-height: 2rem;
+    min-width: 2rem;
+    padding: 0.25rem;
+  }
+
   .language-btn img {
     width: 18px;
     height: 18px;


### PR DESCRIPTION
## Summary
- track image load failures for each language so the switcher knows when to render a text fallback
- hide broken flag icons and show text labels in both the toggle and dropdown when a flag fails to load
- adjust language switcher button styling to accommodate the text fallback while preserving accessible labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1636fea1083278d3bc2966a480540