### PR TITLE
Add market mode support to routing and main app

### DIFF
--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -34,6 +34,7 @@ const TimeseriesEdit = lazy(() =>
   import("./pages/TimeseriesEdit").then((m) => ({ default: m.TimeseriesEdit })),
 );
 const Watchlist = lazy(() => import("./pages/Watchlist"));
+const MarketOverview = lazy(() => import("./pages/MarketOverview"));
 const TopMovers = lazy(() => import("./pages/TopMovers"));
 const DataAdmin = lazy(() => import("./pages/DataAdmin"));
 const InstrumentAdmin = lazy(() => import("./pages/InstrumentAdmin"));
@@ -307,6 +308,7 @@ export default function MainApp() {
       {mode === "dataadmin" && <DataAdmin />}
       {mode === "watchlist" && <Watchlist />}
       {mode === "support" && <SupportPage />}
+      {mode === "market" && <MarketOverview />}
       {mode === "movers" && <TopMovers />}
       {mode === "logs" && <LogsPage />}
       {mode === "scenario" && <ScenarioTester />}

--- a/frontend/src/hooks/useRouteMode.ts
+++ b/frontend/src/hooks/useRouteMode.ts
@@ -25,6 +25,7 @@ function deriveInitial() {
     path[0] === "screener" ? "screener" :
     path[0] === "timeseries" ? "timeseries" :
     path[0] === "watchlist" ? "watchlist" :
+    path[0] === "market" ? "market" :
     path[0] === "movers" ? "movers" :
     path[0] === "instrumentadmin" ? "instrumentadmin" :
     path[0] === "dataadmin" ? "dataadmin" :
@@ -64,6 +65,8 @@ export function useRouteMode(): RouteState {
         return selectedOwner
           ? `/performance/${selectedOwner}`
           : "/performance";
+      case "market":
+        return "/market";
       case "movers":
         return "/movers";
       case "scenario":
@@ -108,6 +111,9 @@ export function useRouteMode(): RouteState {
         break;
       case "watchlist":
         newMode = "watchlist";
+        break;
+      case "market":
+        newMode = "market";
         break;
       case "movers":
         newMode = "movers";

--- a/frontend/src/modes.ts
+++ b/frontend/src/modes.ts
@@ -7,6 +7,7 @@ export type Mode =
   | "screener"
   | "timeseries"
   | "watchlist"
+  | "market"
   | "movers"
   | "instrumentadmin"
   | "dataadmin"
@@ -27,6 +28,7 @@ export const MODES: Mode[] = [
   "screener",
   "timeseries",
   "watchlist",
+  "market",
   "instrumentadmin",
   "dataadmin",
   "settings",


### PR DESCRIPTION
## Summary
- extend the Mode definition to include the market view
- update useRouteMode so /market resolves to the market mode and generates proper links
- lazy load the MarketOverview page in MainApp and render it when market mode is active

## Testing
- npx vitest run --globals src/hooks/useRouteMode.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d1638e4b948327ba80b953489b7135