### PR TITLE
Refactor member owner routing and add tests

### DIFF
--- a/frontend/src/pages/Member.test.tsx
+++ b/frontend/src/pages/Member.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import { describe, beforeEach, it, expect, vi } from "vitest";
+
+import { RouteProvider } from "../RouteContext";
+import Member from "./Member";
+import type {
+  ComplianceResult,
+  Portfolio,
+  ValueAtRiskResponse,
+  VarBreakdown,
+} from "../types";
+import * as api from "../api";
+
+vi.mock("../api", () => ({
+  getOwners: vi.fn(),
+  getPortfolio: vi.fn(),
+  getGroups: vi.fn(),
+  complianceForOwner: vi.fn(),
+  getValueAtRisk: vi.fn(),
+  recomputeValueAtRisk: vi.fn(),
+  getVarBreakdown: vi.fn(),
+}));
+
+const mockGetOwners = vi.mocked(api.getOwners);
+const mockGetPortfolio = vi.mocked(api.getPortfolio);
+const mockGetGroups = vi.mocked(api.getGroups);
+const mockComplianceForOwner = vi.mocked(api.complianceForOwner);
+const mockGetValueAtRisk = vi.mocked(api.getValueAtRisk);
+const mockRecomputeValueAtRisk = vi.mocked(api.recomputeValueAtRisk);
+const mockGetVarBreakdown = vi.mocked(api.getVarBreakdown);
+
+function createPortfolio(owner: string): Portfolio {
+  return {
+    owner,
+    as_of: "2024-01-01",
+    trades_this_month: 0,
+    trades_remaining: 0,
+    total_value_estimate_gbp: 0,
+    accounts: [],
+  };
+}
+
+describe("Member page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGroups.mockResolvedValue([]);
+    mockGetOwners.mockResolvedValue([
+      { owner: "alice", accounts: [] },
+      { owner: "bob", accounts: [] },
+    ]);
+    mockGetPortfolio.mockImplementation(async (owner: string) =>
+      createPortfolio(owner),
+    );
+    mockComplianceForOwner.mockResolvedValue({
+      owner: "",
+      warnings: [],
+      trade_counts: {},
+    } satisfies ComplianceResult);
+    mockGetValueAtRisk.mockResolvedValue({
+      owner: "",
+      as_of: "2024-01-01",
+      var: {},
+    } satisfies ValueAtRiskResponse);
+    mockRecomputeValueAtRisk.mockResolvedValue({ owner: "", var: {} });
+    mockGetVarBreakdown.mockResolvedValue([] satisfies VarBreakdown[]);
+  });
+
+  function renderMember(initialPath = "/member/alice") {
+    window.history.pushState({}, "", initialPath);
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/member/:owner?",
+          element: (
+            <RouteProvider>
+              <Member />
+            </RouteProvider>
+          ),
+        },
+      ],
+      { initialEntries: [initialPath] },
+    );
+    render(<RouterProvider router={router} />);
+    return router;
+  }
+
+  it("renders the owner selector with options from the API", async () => {
+    renderMember();
+
+    const select = await screen.findByLabelText(/owner/i, {
+      selector: "select",
+    });
+
+    await waitFor(() => expect(select).toHaveValue("alice"));
+
+    const options = within(select).getAllByRole("option");
+    expect(options.map((opt) => opt.value)).toEqual(["alice", "bob"]);
+  });
+
+  it("reloads the portfolio when the selected owner changes", async () => {
+    const router = renderMember();
+    const user = userEvent.setup();
+
+    const select = await screen.findByLabelText(/owner/i, {
+      selector: "select",
+    });
+
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+    mockGetPortfolio.mockClear();
+
+    await user.selectOptions(select, "bob");
+
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
+    expect(router.state.location.pathname).toBe("/member/bob");
+  });
+});

--- a/frontend/src/pages/Member.tsx
+++ b/frontend/src/pages/Member.tsx
@@ -1,154 +1,110 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
-        
-import { FixedSizeGrid as Grid } from "react-window";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
 import { getOwners, getPortfolio } from "../api";
-import type { InstrumentSummary, OwnerSummary, Portfolio } from "../types";
-import InstrumentTile from "../components/InstrumentTile";
 import SummaryBar from "../components/SummaryBar";
 import { PortfolioView } from "../components/PortfolioView";
 import { useRoute } from "../RouteContext";
 import useFetchWithRetry from "../hooks/useFetchWithRetry";
+import type { OwnerSummary, Portfolio } from "../types";
 
 export function Member() {
-  const { owner } = useParams<{ owner?: string }>();
-  const [data, setData] = useState<Portfolio | null>(null);
+  const { owner: ownerParam } = useParams<{ owner?: string }>();
+  const navigate = useNavigate();
 
-  const { selectedOwner, setSelectedOwner } = useRoute();
-  const [retryNonce, setRetryNonce] = useState(0);
-
-  const ownersReq = useFetchWithRetry<OwnerSummary[]>(getOwners, 500, 5, [retryNonce]);
-
-  const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
-
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-
-    if (!owner) return;
-    setLoading(true);
-    getPortfolio(owner)
-      .then((p) => {
-        setData(p);
-        setError(null);
-      })
-      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
-      .finally(() => setLoading(false));
-  }, [owner]);
-
-  const instruments: InstrumentSummary[] = useMemo(() => {
-    if (!data) return [];
-    return data.accounts.flatMap((a) =>
-      a.holdings.map((h) => ({
-        ticker: h.ticker,
-        name: h.name,
-        currency: h.currency,
-        units: h.units,
-        market_value_gbp: h.market_value_gbp ?? 0,
-        market_value_currency: h.market_value_currency,
-        gain_gbp: h.gain_gbp ?? 0,
-        gain_currency: h.gain_currency,
-        instrument_type: h.instrument_type,
-        gain_pct: h.gain_pct,
-        last_price_gbp: h.current_price_gbp ?? undefined,
-        last_price_currency: h.current_price_currency ?? undefined,
-        last_price_date: h.last_price_date ?? undefined,
-        change_7d_pct: undefined,
-        change_30d_pct: undefined,
-      })),
-    );
-  }, [data]);
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver((entries) => {
-      const { width, height } = entries[0].contentRect;
-      setDimensions({ width, height });
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
-  const tileW = 250;
-  const tileH = 160;
-  const columnCount = Math.max(1, Math.floor(dimensions.width / tileW));
-  const rowCount = Math.ceil(instruments.length / columnCount);
-
-  if (!owner) return <div>Select a member.</div>;
-  if (loading) return <div>Loading…</div>;
-  if (error) return <div>{error}</div>;
-
-  if (instruments.length > 200) {
-    return (
-      <div
-        ref={containerRef}
-        style={{ width: "100%", height: "80vh" }}
-      >
-        <Grid
-          columnCount={columnCount}
-          columnWidth={tileW}
-          height={dimensions.height || 600}
-          rowCount={rowCount}
-          rowHeight={tileH}
-          width={dimensions.width || 1}
-        >
-          {({ columnIndex, rowIndex, style }) => {
-            const idx = rowIndex * columnCount + columnIndex;
-            const inst = instruments[idx];
-            if (!inst) return null;
-            return (
-              <div style={style}>
-                <InstrumentTile instrument={inst} />
-              </div>
-            );
-          }}
-        </Grid>
-      </div>
-    );
+  let routeSelectedOwner = ownerParam ?? "";
+  let routeContextOwner: string | undefined;
+  let routeSetSelectedOwner: ((owner: string) => void) | undefined;
+  try {
+    const route = useRoute();
+    routeContextOwner = route.selectedOwner;
+    routeSetSelectedOwner = route.setSelectedOwner;
+    if (route.selectedOwner) {
+      routeSelectedOwner = route.selectedOwner;
+    } else if (ownerParam) {
+      routeSelectedOwner = ownerParam;
+    }
+  } catch {
+    // Route context is optional when this page is rendered in isolation.
   }
 
-  return (
-    <div
-      ref={containerRef}
-      style={{
-        display: "grid",
-        gap: "1rem",
-        gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))",
-      }}
-    >
-      {instruments.map((inst) => (
-        <InstrumentTile key={inst.ticker} instrument={inst} />
-      ))}
-    </div>
+  const activeOwner = routeSelectedOwner;
+
+  const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  const ownersReq = useFetchWithRetry<OwnerSummary[]>(
+    () => getOwners(),
+    500,
+    5,
+    [retryNonce],
   );
-}
-    if (!selectedOwner) {
+
+  useEffect(() => {
+    if (!routeSetSelectedOwner) return;
+    if (ownerParam && ownerParam !== routeContextOwner) {
+      routeSetSelectedOwner(ownerParam);
+    } else if (!ownerParam && routeContextOwner) {
+      routeSetSelectedOwner("");
+    }
+  }, [ownerParam, routeContextOwner, routeSetSelectedOwner]);
+
+  useEffect(() => {
+    if (!activeOwner) {
       setPortfolio(null);
+      setError(null);
+      setLoading(false);
       return;
     }
+
+    let cancelled = false;
+
     setLoading(true);
     setError(null);
-    getPortfolio(selectedOwner)
+    setPortfolio(null);
+
+    getPortfolio(activeOwner)
       .then((p) => {
-        setPortfolio(p);
-        setError(null);
+        if (!cancelled) {
+          setPortfolio(p);
+          setError(null);
+        }
       })
-      .catch(() => setError("Failed to load portfolio"))
-      .finally(() => setLoading(false));
-  }, [selectedOwner, retryNonce]);
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeOwner, retryNonce]);
+
+  const handleOwnerChange = useCallback(
+    (owner: string) => {
+      routeSetSelectedOwner?.(owner);
+      navigate(owner ? `/member/${owner}` : "/member");
+    },
+    [navigate, routeSetSelectedOwner],
+  );
+
+  const handleRefresh = useCallback(() => {
+    setRetryNonce((n) => n + 1);
+  }, []);
 
   return (
-    <div className="p-4 md:p-8">
+    <div className="p-4 md:p-8 space-y-4">
       <SummaryBar
         owners={ownersReq.data ?? []}
-        owner={selectedOwner}
-        onOwnerChange={setSelectedOwner}
-        onRefresh={() => setRetryNonce((n) => n + 1)}
+        owner={activeOwner}
+        onOwnerChange={handleOwnerChange}
+        onRefresh={handleRefresh}
       />
       <PortfolioView data={portfolio} loading={loading} error={error} />
     </div>


### PR DESCRIPTION
## Summary
- sync the Member page owner selection with the route context/params and render the summary bar ahead of the portfolio
- wire the summary bar callbacks to update routing, retry the owners fetch, and reload the selected portfolio
- add Member page tests covering the owner selector and ensuring portfolio reloads on owner changes

## Testing
- npm test -- Member

------
https://chatgpt.com/codex/tasks/task_e_68d163b39e9c8327993d7f109ee7932c