### PR TITLE
Enhance trail progress tracking and UI

### DIFF
--- a/backend/quests/trail.py
+++ b/backend/quests/trail.py
@@ -9,7 +9,7 @@ while deployments may swap in other backends.
 """
 
 import os
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Dict, List
 
@@ -63,9 +63,29 @@ _TRAIL_STORAGE = get_storage(os.getenv("TRAIL_URI", _DEFAULT_TRAIL_URI))
 # Data format per user::
 # {
 #   "once": [task_id, ...],
-#   "daily": { "YYYY-MM-DD": [task_id, ...] }
+#   "daily": { "YYYY-MM-DD": [task_id, ...] },
+#   "xp": int,
+#   "streak": int,
+#   "last_completed_day": "YYYY-MM-DD",
+#   "daily_totals": { "YYYY-MM-DD": int }
 # }
 _DATA: Dict[str, Dict] = {}
+
+XP_PER_COMPLETION = 10
+DAILY_TASK_IDS = {t["id"] for t in DEFAULT_TASKS if t["type"] == "daily"}
+
+
+def _user_defaults() -> Dict:
+    """Return the default payload for new users."""
+
+    return {
+        "once": [],
+        "daily": {},
+        "xp": 0,
+        "streak": 0,
+        "last_completed_day": "",
+        "daily_totals": {},
+    }
 
 
 def _load() -> None:
@@ -96,11 +116,15 @@ def _save() -> None:
 # Public API
 # ---------------------------------------------------------------------------
 
-def get_tasks(user: str) -> List[Dict]:
+def get_tasks(user: str) -> Dict:
     """Return tasks and completion state for ``user``."""
     _load()
     today = date.today().isoformat()
-    user_data = _DATA.setdefault(user, {"once": [], "daily": {}})
+    user_data = _DATA.setdefault(user, _user_defaults())
+    # ensure new keys exist for previously stored data
+    for key, default in _user_defaults().items():
+        user_data.setdefault(key, default if not isinstance(default, dict) else {})
+
     daily_completed = set(user_data["daily"].get(today, []))
     once_completed = set(user_data.get("once", []))
     tasks = []
@@ -111,27 +135,48 @@ def get_tasks(user: str) -> List[Dict]:
             else task["id"] in daily_completed
         )
         tasks.append({**task, "completed": completed})
-    return tasks
+    return {
+        "tasks": tasks,
+        "xp": user_data.get("xp", 0),
+        "streak": user_data.get("streak", 0),
+        "daily_totals": dict(user_data.get("daily_totals", {})),
+    }
 
 
-def mark_complete(user: str, task_id: str) -> List[Dict]:
+def mark_complete(user: str, task_id: str) -> Dict:
     """Mark ``task_id`` complete for ``user`` and return updated tasks."""
     if task_id not in TASK_IDS:
         raise KeyError(task_id)
 
     _load()
     today = date.today().isoformat()
-    user_data = _DATA.setdefault(user, {"once": [], "daily": {}})
+    user_data = _DATA.setdefault(user, _user_defaults())
+    for key, default in _user_defaults().items():
+        user_data.setdefault(key, default if not isinstance(default, dict) else {})
 
     task = next(t for t in DEFAULT_TASKS if t["id"] == task_id)
     if task["type"] == "once":
         if task_id not in user_data["once"]:
             user_data["once"].append(task_id)
+            user_data["xp"] = user_data.get("xp", 0) + XP_PER_COMPLETION
     else:
         completed_today = set(user_data["daily"].get(today, []))
         if task_id not in completed_today:
             completed_today.add(task_id)
             user_data["daily"][today] = list(completed_today)
+            user_data["xp"] = user_data.get("xp", 0) + XP_PER_COMPLETION
+            user_data.setdefault("daily_totals", {})[today] = len(completed_today)
+
+            if completed_today.issuperset(DAILY_TASK_IDS):
+                yesterday = (date.fromisoformat(today) - timedelta(days=1)).isoformat()
+                if user_data.get("last_completed_day") == yesterday:
+                    user_data["streak"] = user_data.get("streak", 0) + 1
+                else:
+                    user_data["streak"] = 1
+                user_data["last_completed_day"] = today
+        else:
+            # ensure totals exist even when task already marked complete earlier today
+            user_data.setdefault("daily_totals", {}).setdefault(today, len(completed_today))
 
     _save()
     return get_tasks(user)

--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -12,7 +12,7 @@ if config.disable_auth:
     @router.get("")
     async def list_tasks():
         """Return tasks for the demo user when authentication is disabled."""
-        return {"tasks": trail.get_tasks("demo")}
+        return trail.get_tasks("demo")
 
     @router.post("/{task_id}/complete")
     async def complete_task(task_id: str):
@@ -21,14 +21,14 @@ if config.disable_auth:
             tasks = trail.mark_complete("demo", task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks
 
 else:
 
     @router.get("")
     async def list_tasks(current_user: str = Depends(get_current_user)):
         """Return tasks for the authenticated user."""
-        return {"tasks": trail.get_tasks(current_user)}
+        return trail.get_tasks(current_user)
 
     @router.post("/{task_id}/complete")
     async def complete_task(task_id: str, current_user: str = Depends(get_current_user)):
@@ -37,4 +37,4 @@ else:
             tasks = trail.mark_complete(current_user, task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -40,8 +40,18 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Täglich",
+    "once": "Einmalig",
+    "progressHeading": "Heutiger Fortschritt",
+    "progressSummary": "{{completed}} von {{total}} täglichen Aufgaben erledigt ({{percent}} %)",
+    "noDailyTasks": "Heute stehen keine täglichen Aufgaben an.",
+    "xpTitle": "XP",
+    "xpLabel": "{{xp}} XP",
+    "streakTitle": "Serie",
+    "streakLabel_zero": "Noch keine Serie",
+    "streakLabel_one": "{{count}} Tag Serie",
+    "streakLabel_other": "{{count}} Tage Serie",
+    "celebration": "Alle täglichen Aufgaben erledigt! Großartige Arbeit!"
   },
   "common": {
     "error": "Fehler",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -43,7 +43,17 @@
   },
   "trail": {
     "daily": "Daily",
-    "once": "Once"
+    "once": "Once",
+    "progressHeading": "Today's progress",
+    "progressSummary": "{{completed}} of {{total}} daily tasks complete ({{percent}}%)",
+    "noDailyTasks": "No daily tasks available today.",
+    "xpTitle": "XP",
+    "xpLabel": "{{xp}} XP",
+    "streakTitle": "Streak",
+    "streakLabel_zero": "No streak yet",
+    "streakLabel_one": "{{count}} day streak",
+    "streakLabel_other": "{{count}} day streak",
+    "celebration": "All daily tasks complete! Fantastic work!"
   },
   "common": {
     "error": "Error",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -40,8 +40,18 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Diario",
+    "once": "Una vez",
+    "progressHeading": "Progreso de hoy",
+    "progressSummary": "{{completed}} de {{total}} tareas diarias completadas ({{percent}} %)",
+    "noDailyTasks": "No hay tareas diarias hoy.",
+    "xpTitle": "XP",
+    "xpLabel": "{{xp}} XP",
+    "streakTitle": "Racha",
+    "streakLabel_zero": "Sin racha todavía",
+    "streakLabel_one": "{{count}} día de racha",
+    "streakLabel_other": "{{count}} días de racha",
+    "celebration": "¡Todas las tareas diarias completadas! ¡Excelente trabajo!"
   },
   "common": {
     "error": "Error",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -40,8 +40,18 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Quotidien",
+    "once": "Unique",
+    "progressHeading": "Progression du jour",
+    "progressSummary": "{{completed}} sur {{total}} tâches quotidiennes terminées ({{percent}} %)",
+    "noDailyTasks": "Aucune tâche quotidienne aujourd'hui.",
+    "xpTitle": "XP",
+    "xpLabel": "{{xp}} XP",
+    "streakTitle": "Série",
+    "streakLabel_zero": "Pas encore de série",
+    "streakLabel_one": "Série de {{count}} jour",
+    "streakLabel_other": "Série de {{count}} jours",
+    "celebration": "Toutes les tâches quotidiennes sont terminées ! Beau travail !"
   },
   "common": {
     "error": "Erreur",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -40,8 +40,18 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Quotidiano",
+    "once": "Una volta",
+    "progressHeading": "Progresso di oggi",
+    "progressSummary": "{{completed}} su {{total}} attività quotidiane completate ({{percent}} %)",
+    "noDailyTasks": "Nessuna attività quotidiana oggi.",
+    "xpTitle": "XP",
+    "xpLabel": "{{xp}} XP",
+    "streakTitle": "Serie",
+    "streakLabel_zero": "Ancora nessuna serie",
+    "streakLabel_one": "Serie di {{count}} giorno",
+    "streakLabel_other": "Serie di {{count}} giorni",
+    "celebration": "Tutte le attività quotidiane completate! Ottimo lavoro!"
   },
   "common": {
     "error": "Errore",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -40,8 +40,18 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Diário",
+    "once": "Uma vez",
+    "progressHeading": "Progresso de hoje",
+    "progressSummary": "{{completed}} de {{total}} tarefas diárias concluídas ({{percent}} %)",
+    "noDailyTasks": "Nenhuma tarefa diária hoje.",
+    "xpTitle": "XP",
+    "xpLabel": "{{xp}} XP",
+    "streakTitle": "Sequência",
+    "streakLabel_zero": "Sem sequência ainda",
+    "streakLabel_one": "Sequência de {{count}} dia",
+    "streakLabel_other": "Sequência de {{count}} dias",
+    "celebration": "Todas as tarefas diárias concluídas! Excelente trabalho!"
   },
   "common": {
     "error": "Erro",

--- a/frontend/src/pages/Trail.test.tsx
+++ b/frontend/src/pages/Trail.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { ReactElement } from "react";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { createInstance } from "i18next";
+import en from "../locales/en/translation.json";
+import * as api from "../api";
+
+vi.mock("../api");
+
+const mockGetTrailTasks = vi.mocked(api.getTrailTasks);
+
+function renderWithI18n(ui: ReactElement) {
+  const i18n = createInstance();
+  i18n.use(initReactI18next).init({
+    lng: "en",
+    resources: { en: { translation: en } },
+  });
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
+}
+
+describe("Trail page", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders gamified header with celebration when all dailies are complete", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    mockGetTrailTasks.mockResolvedValueOnce({
+      tasks: [
+        {
+          id: "check_market",
+          title: "Check market overview",
+          type: "daily",
+          commentary: "",
+          completed: true,
+        },
+        {
+          id: "review_portfolio",
+          title: "Review your portfolio",
+          type: "daily",
+          commentary: "",
+          completed: true,
+        },
+        {
+          id: "create_goal",
+          title: "Set up your first goal",
+          type: "once",
+          commentary: "",
+          completed: false,
+        },
+        {
+          id: "add_watchlist",
+          title: "Add a stock to your watchlist",
+          type: "once",
+          commentary: "",
+          completed: false,
+        },
+      ],
+      xp: 20,
+      streak: 3,
+      daily_totals: { [today]: 2 },
+    });
+    const { default: Trail } = await import("./Trail");
+
+    renderWithI18n(<Trail />);
+
+    expect(await screen.findByText("Today's progress")).toBeInTheDocument();
+    expect(
+      screen.getByText("2 of 2 daily tasks complete (100%)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("XP")).toBeInTheDocument();
+    expect(screen.getByText("20 XP")).toBeInTheDocument();
+    expect(screen.getByText("3 day streak")).toBeInTheDocument();
+    expect(
+      screen.getByText("All daily tasks complete! Fantastic work!"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows progress without celebration when tasks remain", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    mockGetTrailTasks.mockResolvedValueOnce({
+      tasks: [
+        {
+          id: "check_market",
+          title: "Check market overview",
+          type: "daily",
+          commentary: "",
+          completed: true,
+        },
+        {
+          id: "review_portfolio",
+          title: "Review your portfolio",
+          type: "daily",
+          commentary: "",
+          completed: false,
+        },
+        {
+          id: "create_goal",
+          title: "Set up your first goal",
+          type: "once",
+          commentary: "",
+          completed: false,
+        },
+        {
+          id: "add_watchlist",
+          title: "Add a stock to your watchlist",
+          type: "once",
+          commentary: "",
+          completed: false,
+        },
+      ],
+      xp: 10,
+      streak: 0,
+      daily_totals: { [today]: 1 },
+    });
+    const { default: Trail } = await import("./Trail");
+
+    renderWithI18n(<Trail />);
+
+    expect(await screen.findByText("Today's progress")).toBeInTheDocument();
+    expect(
+      screen.getByText("1 of 2 daily tasks complete (50%)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("All daily tasks complete! Fantastic work!"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Trail.tsx
+++ b/frontend/src/pages/Trail.tsx
@@ -20,11 +20,29 @@ export default function Trail() {
       .catch((e) => setError(String(e)));
   };
 
-  if (!data) return <div>{t("common.loading")}</div>;
   if (error) return <div style={{ color: "red" }}>{error}</div>;
+  if (!data) return <div>{t("common.loading")}</div>;
 
   const daily = data.tasks.filter((t) => t.type === "daily");
   const once = data.tasks.filter((t) => t.type === "once");
+  const todayKey = new Date().toISOString().slice(0, 10);
+  const completedTodayFromServer = data.daily_totals?.[todayKey] ?? 0;
+  const completedDaily = daily.filter((t) => t.completed).length;
+  const completedCount = Math.max(completedTodayFromServer, completedDaily);
+  const totalDaily = daily.length;
+  const clampedCompleted =
+    totalDaily > 0 ? Math.min(completedCount, totalDaily) : completedCount;
+  const progressPercent =
+    totalDaily > 0 ? Math.round((clampedCompleted / totalDaily) * 100) : 0;
+  const progressSummary =
+    totalDaily > 0
+      ? t("trail.progressSummary", {
+          completed: clampedCompleted,
+          total: totalDaily,
+          percent: progressPercent,
+        })
+      : t("trail.noDailyTasks");
+  const showCelebration = totalDaily > 0 && clampedCompleted === totalDaily;
 
   const renderSection = (items: typeof data.tasks, label: string) => (
     <section>
@@ -52,6 +70,108 @@ export default function Trail() {
 
   return (
     <div style={{ margin: "1rem" }}>
+      <header
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "1rem",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: "1.5rem",
+          border: "1px solid #e5e7eb",
+          borderRadius: "0.75rem",
+          padding: "1.5rem",
+          background: "#f9fafb",
+        }}
+      >
+        <div style={{ flex: "1 1 16rem", minWidth: "16rem" }}>
+          <h1 style={{ margin: "0 0 0.5rem" }}>{t("trail.progressHeading")}</h1>
+          <p style={{ margin: "0 0 1rem", color: "#4b5563" }}>{progressSummary}</p>
+          <div
+            role="progressbar"
+            aria-valuenow={progressPercent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={t("trail.progressHeading")}
+            style={{
+              width: "100%",
+              height: "0.75rem",
+              borderRadius: "999px",
+              background: "#e5e7eb",
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                width: `${progressPercent}%`,
+                height: "100%",
+                background: showCelebration ? "#22c55e" : "#3b82f6",
+                transition: "width 0.3s ease",
+              }}
+            />
+          </div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: "1rem",
+            alignItems: "center",
+            justifyContent: "flex-end",
+            flex: "0 0 auto",
+          }}
+        >
+          <div
+            style={{
+              padding: "0.75rem 1rem",
+              borderRadius: "0.75rem",
+              background: "#eef2ff",
+              textAlign: "center",
+              minWidth: "6rem",
+            }}
+          >
+            <div style={{ fontSize: "0.8rem", color: "#4338ca" }}>
+              {t("trail.xpTitle")}
+            </div>
+            <div style={{ fontWeight: 700, color: "#1e1b4b" }}>
+              {t("trail.xpLabel", { xp: data.xp })}
+            </div>
+          </div>
+          <div
+            style={{
+              padding: "0.75rem 1rem",
+              borderRadius: "999px",
+              background: "#fef3c7",
+              textAlign: "center",
+              minWidth: "8rem",
+            }}
+          >
+            <div style={{ fontSize: "0.8rem", color: "#b45309" }}>
+              {t("trail.streakTitle")}
+            </div>
+            <div style={{ fontWeight: 700, color: "#92400e" }}>
+              {t("trail.streakLabel", { count: data.streak })}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {showCelebration && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            marginBottom: "1.5rem",
+            padding: "1rem 1.25rem",
+            borderRadius: "0.75rem",
+            background: "#ecfccb",
+            color: "#3f6212",
+            fontWeight: 600,
+          }}
+        >
+          {t("trail.celebration")}
+        </div>
+      )}
+
       {renderSection(daily, t("trail.daily"))}
       {renderSection(once, t("trail.once"))}
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -463,4 +463,7 @@ export interface TrailTask {
 
 export interface TrailResponse {
   tasks: TrailTask[];
+  xp: number;
+  streak: number;
+  daily_totals: Record<string, number>;
 }

--- a/tests/quests/test_trail.py
+++ b/tests/quests/test_trail.py
@@ -1,5 +1,6 @@
+from datetime import date, timedelta
+
 import pytest
-from datetime import date
 
 from backend.common.storage import get_storage
 from backend.quests import trail
@@ -25,36 +26,78 @@ def memory_storage(monkeypatch):
 
 
 def test_get_tasks_returns_defaults(memory_storage):
-    tasks = trail.get_tasks("alice")
-    assert [t["id"] for t in tasks] == [t["id"] for t in trail.DEFAULT_TASKS]
-    assert all(not t["completed"] for t in tasks)
+    summary = trail.get_tasks("alice")
+    assert [t["id"] for t in summary["tasks"]] == [
+        t["id"] for t in trail.DEFAULT_TASKS
+    ]
+    assert all(not t["completed"] for t in summary["tasks"])
+    assert summary["xp"] == 0
+    assert summary["streak"] == 0
+    assert summary["daily_totals"] == {}
 
 
 def test_get_tasks_with_completions(memory_storage):
     today = date.today().isoformat()
     memory_storage["bob"] = {"once": ["create_goal"], "daily": {today: ["check_market"]}}
-    tasks = trail.get_tasks("bob")
-    completed = {t["id"]: t["completed"] for t in tasks}
+    summary = trail.get_tasks("bob")
+    completed = {t["id"]: t["completed"] for t in summary["tasks"]}
     assert completed["create_goal"] is True
     assert completed["check_market"] is True
     for task in trail.DEFAULT_TASKS:
         if task["id"] not in {"create_goal", "check_market"}:
             assert completed[task["id"]] is False
+    assert summary["xp"] == 0
+    assert summary["streak"] == 0
+    assert summary["daily_totals"] == {}
 
 
-def test_mark_complete_records_once_and_daily(memory_storage):
+class FakeDate(date):
+    """Helper date subclass to control ``today`` in tests."""
+
+    today_value = date.today()
+
+    @classmethod
+    def today(cls):  # type: ignore[override]
+        return cls.today_value
+
+
+def test_mark_complete_records_once_and_daily(memory_storage, monkeypatch):
     user = "carol"
-    today = date.today().isoformat()
+    monkeypatch.setattr(trail, "date", FakeDate)
 
-    trail.mark_complete(user, "check_market")
-    assert memory_storage[user]["daily"][today] == ["check_market"]
-    trail.mark_complete(user, "check_market")
-    assert memory_storage[user]["daily"][today] == ["check_market"]
+    daily_ids = [t["id"] for t in trail.DEFAULT_TASKS if t["type"] == "daily"]
+    once_id = next(t["id"] for t in trail.DEFAULT_TASKS if t["type"] == "once")
 
-    trail.mark_complete(user, "create_goal")
-    assert memory_storage[user]["once"] == ["create_goal"]
-    trail.mark_complete(user, "create_goal")
-    assert memory_storage[user]["once"] == ["create_goal"]
+    FakeDate.today_value = date(2024, 1, 1)
+    today = FakeDate.today_value.isoformat()
+
+    summary = trail.mark_complete(user, daily_ids[0])
+    assert summary["xp"] == trail.XP_PER_COMPLETION
+    assert summary["streak"] == 0
+    assert summary["daily_totals"][today] == 1
+
+    summary = trail.mark_complete(user, daily_ids[1])
+    assert summary["xp"] == trail.XP_PER_COMPLETION * 2
+    assert summary["streak"] == 1
+    assert summary["daily_totals"][today] == 2
+
+    summary = trail.mark_complete(user, once_id)
+    assert summary["xp"] == trail.XP_PER_COMPLETION * 3
+
+    summary = trail.mark_complete(user, daily_ids[1])
+    assert summary["xp"] == trail.XP_PER_COMPLETION * 3
+    assert summary["daily_totals"][today] == 2
+
+    FakeDate.today_value = FakeDate.today_value + timedelta(days=1)
+    next_day = FakeDate.today_value.isoformat()
+
+    summary = trail.mark_complete(user, daily_ids[0])
+    assert summary["streak"] == 1
+    assert summary["daily_totals"][next_day] == 1
+
+    summary = trail.mark_complete(user, daily_ids[1])
+    assert summary["streak"] == 2
+    assert summary["daily_totals"][next_day] == 2
 
     with pytest.raises(KeyError):
         trail.mark_complete(user, "unknown")

--- a/tests/routes/test_trail_routes.py
+++ b/tests/routes/test_trail_routes.py
@@ -1,10 +1,20 @@
 import importlib
 
+from datetime import date, timedelta
+
 import pytest
 from fastapi.testclient import TestClient
 
 from backend.auth import get_current_user
 from backend.config import config
+
+
+class FakeDate(date):
+    today_value = date.today()
+
+    @classmethod
+    def today(cls):  # type: ignore[override]
+        return cls.today_value
 
 
 @pytest.mark.parametrize("disable_auth", [True, False])
@@ -19,12 +29,47 @@ def test_trail_routes(tmp_path, monkeypatch, disable_auth):
     importlib.reload(trail_route_module)
     importlib.reload(app_mod)
     app = app_mod.create_app()
+    trail_module.date = FakeDate
+
     if not disable_auth:
         app.dependency_overrides[get_current_user] = lambda: "demo"
 
     with TestClient(app) as client:
         resp = client.get("/trail")
         assert resp.status_code == 200
+        payload = resp.json()
+        assert {"tasks", "xp", "streak", "daily_totals"} <= payload.keys()
+        assert payload["xp"] == 0
+        assert payload["streak"] == 0
 
         resp = client.post("/trail/unknown/complete")
         assert resp.status_code == 404
+
+        daily_ids = [t["id"] for t in trail_module.DEFAULT_TASKS if t["type"] == "daily"]
+
+        FakeDate.today_value = date(2024, 1, 1)
+        first_complete = client.post(f"/trail/{daily_ids[0]}/complete")
+        assert first_complete.status_code == 200
+        body = first_complete.json()
+        assert body["xp"] == trail_module.XP_PER_COMPLETION
+        assert body["streak"] == 0
+        today_key = FakeDate.today_value.isoformat()
+        assert body["daily_totals"][today_key] == 1
+
+        second_complete = client.post(f"/trail/{daily_ids[1]}/complete")
+        assert second_complete.status_code == 200
+        body = second_complete.json()
+        assert body["xp"] == trail_module.XP_PER_COMPLETION * 2
+        assert body["streak"] == 1
+        assert body["daily_totals"][today_key] == 2
+
+        FakeDate.today_value = FakeDate.today_value + timedelta(days=1)
+        third_complete = client.post(f"/trail/{daily_ids[0]}/complete")
+        assert third_complete.status_code == 200
+        next_body = third_complete.json()
+        assert next_body["streak"] == 1
+
+        fourth_complete = client.post(f"/trail/{daily_ids[1]}/complete")
+        assert fourth_complete.status_code == 200
+        final_body = fourth_complete.json()
+        assert final_body["streak"] == 2


### PR DESCRIPTION
## Summary
- track XP, streaks, and per-day completion totals for Trail users and expose them via the API
- refresh Trail routes and tests to assert the richer payload and streak progression
- update the Trail page, types, translations, and add focused UI tests for the new gamified header

## Testing
- `pytest --no-cov tests/quests/test_trail.py tests/routes/test_trail_routes.py`
- `npm --prefix frontend test -- --run src/pages/Trail.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d16d78ddb48327890e6815aacc305d