### PR TITLE
Fix approval request route fallback

### DIFF
--- a/backend/routes/approvals.py
+++ b/backend/routes/approvals.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
 
+from backend.common import data_loader
 from backend.common.approvals import delete_approval, load_approvals, upsert_approval
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
 from backend.routes._accounts import resolve_accounts_root
@@ -12,25 +13,47 @@ from backend.routes._accounts import resolve_accounts_root
 router = APIRouter(prefix="/accounts", tags=["approvals"])
 
 
-def _resolve_owner_dir(root: Path, owner: str) -> Path:
-    """Return ``owner``'s directory ensuring it is within ``root``."""
+def _safe_owner_dir(root: Path, owner: str) -> Path | None:
+    """Return ``owner``'s directory when it exists beneath ``root``."""
 
-    resolved_root = root.resolve()
-    owner_dir = (resolved_root / owner).resolve()
+    resolved_root = root.expanduser().resolve()
+    owner_dir = (resolved_root / owner).expanduser().resolve()
     root_path = os.path.abspath(os.fspath(resolved_root))
     owner_path = os.path.abspath(os.fspath(owner_dir))
     try:
         common = os.path.commonpath([root_path, owner_path])
     except ValueError:
-        raise_owner_not_found()
+        return None
     if os.name == "nt":
         if os.path.normcase(common) != os.path.normcase(root_path):
-            raise_owner_not_found()
+            return None
     elif common != root_path:
-        raise_owner_not_found()
+        return None
     if not owner_dir.exists():
-        raise_owner_not_found()
+        return None
     return owner_dir
+
+
+def _resolve_owner_dir(root: Path, owner: str) -> Path:
+    """Return ``owner``'s directory ensuring it is within ``root``.
+
+    When the directory is not present under ``root`` the function falls back to
+    the default accounts directory discovered via :func:`data_loader
+    .resolve_paths`. This mirrors the behaviour of other routes which fall back
+    to the bundled demo data when custom accounts are unavailable.
+    """
+
+    owner_dir = _safe_owner_dir(root, owner)
+    if owner_dir:
+        return owner_dir
+
+    fallback_root = data_loader.resolve_paths(None, None).accounts_root
+    if fallback_root:
+        fallback_dir = _safe_owner_dir(fallback_root, owner)
+        if fallback_dir:
+            return fallback_dir
+
+    raise_owner_not_found()
 
 
 @router.get("/{owner}/approvals")

--- a/backend/tests/test_approvals_route.py
+++ b/backend/tests/test_approvals_route.py
@@ -1,0 +1,38 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.common.data_loader import ResolvedPaths
+
+
+def test_post_approval_request_falls_back_to_default_accounts_root(tmp_path, monkeypatch):
+    primary_root = tmp_path / "primary"
+    primary_root.mkdir()
+
+    fallback_root = tmp_path / "fallback" / "accounts"
+    owner_dir = fallback_root / "demo"
+    owner_dir.mkdir(parents=True)
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    virtual_root = tmp_path / "virtual"
+    virtual_root.mkdir()
+
+    def fake_resolve_paths(repo_root_arg, accounts_root_arg):
+        return ResolvedPaths(repo_root=repo_root, accounts_root=fallback_root, virtual_pf_root=virtual_root)
+
+    monkeypatch.setattr("backend.routes._accounts.data_loader.resolve_paths", fake_resolve_paths)
+    monkeypatch.setattr("backend.routes.approvals.data_loader.resolve_paths", fake_resolve_paths)
+
+    app = create_app()
+    app.state.accounts_root = primary_root
+    client = TestClient(app)
+
+    resp = client.post("/accounts/demo/approval-requests", json={"ticker": "AAPL"})
+    assert resp.status_code == 200
+
+    saved = owner_dir / "approval_requests.json"
+    assert saved.exists()
+    data = json.loads(saved.read_text())
+    assert data["requests"][0]["ticker"] == "AAPL"


### PR DESCRIPTION
## Summary
- ensure approval routes fall back to the default accounts data when an owner is missing in the configured directory
- add a regression test covering the approval request fallback behaviour

## Testing
- pytest -o addopts= backend/tests/test_approvals_route.py

------
https://chatgpt.com/codex/tasks/task_e_68d181a61b008327924b039b9405e963