### PR TITLE
Ensure latest prices priming completes during startup

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -140,8 +140,7 @@ def create_app() -> FastAPI:
             from backend.common import instrument_api
 
             instrument_api.update_latest_prices_from_snapshot(snapshot)
-            price_task = asyncio.create_task(asyncio.to_thread(instrument_api.prime_latest_prices))
-            app.state.background_tasks.append(price_task)
+            await asyncio.to_thread(instrument_api.prime_latest_prices)
 
         task = refresh_snapshot_async(days=cfg.snapshot_warm_days)
         if isinstance(task, (asyncio.Task, asyncio.Future)):


### PR DESCRIPTION
## Summary
- await the in-memory pricing prime step during application startup so the task always runs

## Testing
- pytest *(fails: coverage threshold fail-under=90 is enforced and suite reports 89%)*

------
https://chatgpt.com/codex/tasks/task_e_68d1814beb40832781db9582a7311644