### PR TITLE
Ensure snapshot priming runs during startup

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -140,8 +140,7 @@ def create_app() -> FastAPI:
             from backend.common import instrument_api
 
             instrument_api.update_latest_prices_from_snapshot(snapshot)
-            price_task = asyncio.create_task(asyncio.to_thread(instrument_api.prime_latest_prices))
-            app.state.background_tasks.append(price_task)
+            await asyncio.to_thread(instrument_api.prime_latest_prices)
 
         task = refresh_snapshot_async(days=cfg.snapshot_warm_days)
         if isinstance(task, (asyncio.Task, asyncio.Future)):


### PR DESCRIPTION
## Summary
- ensure the snapshot warmup awaits priming the instrument API so the price cache is populated during startup

## Testing
- pytest tests/test_app.py::test_startup_warms_snapshot --override-ini=addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d1814d92088327acbdadcafa919009