### PR TITLE
Enhance trail progress tracking and UI

### DIFF
--- a/backend/quests/trail.py
+++ b/backend/quests/trail.py
@@ -9,7 +9,7 @@ while deployments may swap in other backends.
 """
 
 import os
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Dict, List
 
@@ -50,6 +50,12 @@ DEFAULT_TASKS: List[Task] = [
 ]
 
 TASK_IDS = {t["id"] for t in DEFAULT_TASKS}
+DAILY_TASK_IDS = [t["id"] for t in DEFAULT_TASKS if t["type"] == "daily"]
+ONCE_TASK_IDS = [t["id"] for t in DEFAULT_TASKS if t["type"] == "once"]
+DAILY_TASK_COUNT = len(DAILY_TASK_IDS)
+
+DAILY_XP_REWARD = 10
+ONCE_XP_REWARD = 25
 
 # ---------------------------------------------------------------------------
 # Storage helpers
@@ -63,9 +69,26 @@ _TRAIL_STORAGE = get_storage(os.getenv("TRAIL_URI", _DEFAULT_TRAIL_URI))
 # Data format per user::
 # {
 #   "once": [task_id, ...],
-#   "daily": { "YYYY-MM-DD": [task_id, ...] }
+#   "daily": { "YYYY-MM-DD": [task_id, ...] },
+#   "xp": int,
+#   "streak": int,
+#   "last_completed_day": str,
+#   "daily_totals": { "YYYY-MM-DD": {"completed": int, "total": int} }
 # }
 _DATA: Dict[str, Dict] = {}
+
+
+def _ensure_user_data(user: str) -> Dict:
+    """Ensure the cached state for ``user`` has all expected keys."""
+
+    user_data = _DATA.setdefault(user, {})
+    user_data.setdefault("once", [])
+    user_data.setdefault("daily", {})
+    user_data.setdefault("xp", 0)
+    user_data.setdefault("streak", 0)
+    user_data.setdefault("last_completed_day", "")
+    user_data.setdefault("daily_totals", {})
+    return user_data
 
 
 def _load() -> None:
@@ -96,11 +119,11 @@ def _save() -> None:
 # Public API
 # ---------------------------------------------------------------------------
 
-def get_tasks(user: str) -> List[Dict]:
+def get_tasks(user: str) -> Dict:
     """Return tasks and completion state for ``user``."""
     _load()
     today = date.today().isoformat()
-    user_data = _DATA.setdefault(user, {"once": [], "daily": {}})
+    user_data = _ensure_user_data(user)
     daily_completed = set(user_data["daily"].get(today, []))
     once_completed = set(user_data.get("once", []))
     tasks = []
@@ -111,30 +134,76 @@ def get_tasks(user: str) -> List[Dict]:
             else task["id"] in daily_completed
         )
         tasks.append({**task, "completed": completed})
-    return tasks
+
+    daily_totals = dict(user_data.get("daily_totals", {}))
+    daily_totals.setdefault(
+        today,
+        {"completed": len(daily_completed), "total": DAILY_TASK_COUNT},
+    )
+
+    return {
+        "tasks": tasks,
+        "xp": user_data.get("xp", 0),
+        "streak": user_data.get("streak", 0),
+        "daily_totals": daily_totals,
+        "today": today,
+    }
 
 
-def mark_complete(user: str, task_id: str) -> List[Dict]:
+def mark_complete(user: str, task_id: str) -> Dict:
     """Mark ``task_id`` complete for ``user`` and return updated tasks."""
     if task_id not in TASK_IDS:
         raise KeyError(task_id)
 
     _load()
-    today = date.today().isoformat()
-    user_data = _DATA.setdefault(user, {"once": [], "daily": {}})
+    today = date.today()
+    today_str = today.isoformat()
+    user_data = _ensure_user_data(user)
 
     task = next(t for t in DEFAULT_TASKS if t["id"] == task_id)
     if task["type"] == "once":
         if task_id not in user_data["once"]:
             user_data["once"].append(task_id)
+            user_data["xp"] += ONCE_XP_REWARD
     else:
-        completed_today = set(user_data["daily"].get(today, []))
+        completed_today = set(user_data["daily"].get(today_str, []))
         if task_id not in completed_today:
             completed_today.add(task_id)
-            user_data["daily"][today] = list(completed_today)
+            user_data["daily"][today_str] = list(completed_today)
+            user_data["xp"] += DAILY_XP_REWARD
+
+        daily_completed_count = len(completed_today)
+        user_data["daily_totals"][today_str] = {
+            "completed": daily_completed_count,
+            "total": DAILY_TASK_COUNT,
+        }
+
+        if daily_completed_count == DAILY_TASK_COUNT and DAILY_TASK_COUNT:
+            yesterday = (today - timedelta(days=1)).isoformat()
+            if user_data.get("last_completed_day") == yesterday:
+                user_data["streak"] += 1
+            else:
+                user_data["streak"] = 1
+            user_data["last_completed_day"] = today_str
+
+    # Ensure today's totals exist even if only "once" tasks were completed.
+    daily_completed_today = len(set(user_data["daily"].get(today_str, [])))
+    user_data["daily_totals"][today_str] = {
+        "completed": daily_completed_today,
+        "total": DAILY_TASK_COUNT,
+    }
 
     _save()
     return get_tasks(user)
 
 
-__all__ = ["get_tasks", "mark_complete", "DEFAULT_TASKS"]
+__all__ = [
+    "get_tasks",
+    "mark_complete",
+    "DEFAULT_TASKS",
+    "DAILY_TASK_IDS",
+    "ONCE_TASK_IDS",
+    "DAILY_TASK_COUNT",
+    "DAILY_XP_REWARD",
+    "ONCE_XP_REWARD",
+]

--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -12,7 +12,7 @@ if config.disable_auth:
     @router.get("")
     async def list_tasks():
         """Return tasks for the demo user when authentication is disabled."""
-        return {"tasks": trail.get_tasks("demo")}
+        return trail.get_tasks("demo")
 
     @router.post("/{task_id}/complete")
     async def complete_task(task_id: str):
@@ -21,14 +21,14 @@ if config.disable_auth:
             tasks = trail.mark_complete("demo", task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks
 
 else:
 
     @router.get("")
     async def list_tasks(current_user: str = Depends(get_current_user)):
         """Return tasks for the authenticated user."""
-        return {"tasks": trail.get_tasks(current_user)}
+        return trail.get_tasks(current_user)
 
     @router.post("/{task_id}/complete")
     async def complete_task(task_id: str, current_user: str = Depends(get_current_user)):
@@ -37,4 +37,4 @@ else:
             tasks = trail.mark_complete(current_user, task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "title": "Trail-Fortschritt",
+    "daily": "Täglich",
+    "once": "Einmalig",
+    "progressLabel": "Täglicher Fortschritt: {{completed}} / {{total}} ({{percent}}%)",
+    "xpLabel": "XP: {{xp}}",
+    "streakLabel": "Serie: {{count}} Tag",
+    "streakLabel_plural": "Serie: {{count}} Tage",
+    "dailyComplete": "Tägliche Aufgaben erledigt! Weiter so.",
+    "allDone": "Alle Trail-Aufgaben erledigt – großartig!"
   },
   "common": {
     "error": "Fehler",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -42,8 +42,15 @@
     }
   },
   "trail": {
+    "title": "Trail progress",
     "daily": "Daily",
-    "once": "Once"
+    "once": "Once",
+    "progressLabel": "Daily progress: {{completed}} / {{total}} ({{percent}}%)",
+    "xpLabel": "XP: {{xp}}",
+    "streakLabel": "Streak: {{count}} day",
+    "streakLabel_plural": "Streak: {{count}} days",
+    "dailyComplete": "Daily tasks complete! Keep the streak going.",
+    "allDone": "All Trail tasks are complete — fantastic work!"
   },
   "common": {
     "error": "Error",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "title": "Progreso del Trail",
+    "daily": "Diario",
+    "once": "Única vez",
+    "progressLabel": "Progreso diario: {{completed}} / {{total}} ({{percent}}%)",
+    "xpLabel": "XP: {{xp}}",
+    "streakLabel": "Racha: {{count}} día",
+    "streakLabel_plural": "Racha: {{count}} días",
+    "dailyComplete": "¡Tareas diarias completas! Mantén la racha.",
+    "allDone": "Todas las tareas de Trail están completas — ¡excelente!"
   },
   "common": {
     "error": "Error",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "title": "Progression du Trail",
+    "daily": "Quotidien",
+    "once": "Une fois",
+    "progressLabel": "Progression du jour : {{completed}} / {{total}} ({{percent}} %)",
+    "xpLabel": "XP : {{xp}}",
+    "streakLabel": "Série : {{count}} jour",
+    "streakLabel_plural": "Série : {{count}} jours",
+    "dailyComplete": "Tâches quotidiennes terminées ! Continuez la série.",
+    "allDone": "Toutes les tâches du Trail sont terminées — formidable !"
   },
   "common": {
     "error": "Erreur",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "title": "Progressi Trail",
+    "daily": "Quotidiano",
+    "once": "Una volta",
+    "progressLabel": "Avanzamento giornaliero: {{completed}} / {{total}} ({{percent}}%)",
+    "xpLabel": "XP: {{xp}}",
+    "streakLabel": "Serie: {{count}} giorno",
+    "streakLabel_plural": "Serie: {{count}} giorni",
+    "dailyComplete": "Attività giornaliere completate! Continua la serie.",
+    "allDone": "Tutte le attività Trail sono completate — ottimo lavoro!"
   },
   "common": {
     "error": "Errore",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "title": "Progresso do Trail",
+    "daily": "Diário",
+    "once": "Única vez",
+    "progressLabel": "Progresso diário: {{completed}} / {{total}} ({{percent}}%)",
+    "xpLabel": "XP: {{xp}}",
+    "streakLabel": "Sequência: {{count}} dia",
+    "streakLabel_plural": "Sequência: {{count}} dias",
+    "dailyComplete": "Tarefas diárias concluídas! Continue a sequência.",
+    "allDone": "Todas as tarefas do Trail estão concluídas — trabalho incrível!"
   },
   "common": {
     "error": "Erro",

--- a/frontend/src/pages/Trail.test.tsx
+++ b/frontend/src/pages/Trail.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "../i18n";
+import en from "../locales/en/translation.json";
+import Trail from "./Trail";
+
+const mockGetTrailTasks = vi.hoisted(() => vi.fn());
+const mockCompleteTrailTask = vi.hoisted(() => vi.fn());
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    getTrailTasks: mockGetTrailTasks,
+    completeTrailTask: mockCompleteTrailTask,
+  };
+});
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+});
+
+describe("Trail page", () => {
+  it("renders progress header with xp and streak", async () => {
+    const today = "2024-01-15";
+    mockGetTrailTasks.mockResolvedValue({
+      tasks: [
+        {
+          id: "check_market",
+          title: "Check",
+          type: "daily",
+          commentary: "",
+          completed: true,
+        },
+        {
+          id: "review_portfolio",
+          title: "Review",
+          type: "daily",
+          commentary: "",
+          completed: false,
+        },
+      ],
+      xp: 10,
+      streak: 3,
+      daily_totals: { [today]: { completed: 1, total: 2 } },
+      today,
+    });
+
+    render(<Trail />);
+
+    expect(
+      await screen.findByRole("heading", { name: en.trail.title })
+    ).toBeInTheDocument();
+
+    const progressText = en.trail.progressLabel
+      .replace("{{completed}}", "1")
+      .replace("{{total}}", "2")
+      .replace("{{percent}}", "50");
+    expect(await screen.findByText(progressText)).toBeInTheDocument();
+
+    expect(
+      screen.getByText(en.trail.xpLabel.replace("{{xp}}", "10"))
+    ).toBeInTheDocument();
+
+    const streakText = i18n.t("trail.streakLabel", { count: 3 });
+    expect(screen.getByText(streakText)).toBeInTheDocument();
+  });
+
+  it("shows celebration when everything is complete", async () => {
+    const today = "2024-01-16";
+    mockGetTrailTasks.mockResolvedValue({
+      tasks: [
+        {
+          id: "check_market",
+          title: "Check",
+          type: "daily",
+          commentary: "",
+          completed: true,
+        },
+        {
+          id: "review_portfolio",
+          title: "Review",
+          type: "daily",
+          commentary: "",
+          completed: true,
+        },
+        {
+          id: "create_goal",
+          title: "Goal",
+          type: "once",
+          commentary: "",
+          completed: true,
+        },
+      ],
+      xp: 30,
+      streak: 5,
+      daily_totals: { [today]: { completed: 2, total: 2 } },
+      today,
+    });
+
+    render(<Trail />);
+
+    expect(await screen.findByText(en.trail.dailyComplete)).toBeInTheDocument();
+    expect(screen.getByText(en.trail.allDone)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Trail.tsx
+++ b/frontend/src/pages/Trail.tsx
@@ -25,6 +25,17 @@ export default function Trail() {
 
   const daily = data.tasks.filter((t) => t.type === "daily");
   const once = data.tasks.filter((t) => t.type === "once");
+  const todaySummary =
+    data.daily_totals?.[data.today] ?? {
+      completed: daily.filter((task) => task.completed).length,
+      total: daily.length,
+    };
+  const percent = todaySummary.total
+    ? Math.round((todaySummary.completed / todaySummary.total) * 100)
+    : 0;
+  const allDailyComplete =
+    todaySummary.total > 0 && todaySummary.completed === todaySummary.total;
+  const allTasksComplete = data.tasks.every((task) => task.completed);
 
   const renderSection = (items: typeof data.tasks, label: string) => (
     <section>
@@ -37,12 +48,19 @@ export default function Trail() {
               disabled={task.completed}
               style={{
                 textDecoration: task.completed ? "line-through" : undefined,
+                padding: "0.5rem 0.75rem",
+                borderRadius: "0.5rem",
+                border: "1px solid #ccc",
+                background: task.completed ? "#e6f4ea" : "#fff",
+                cursor: task.completed ? "default" : "pointer",
               }}
             >
               {task.title}
             </button>
             {task.commentary && (
-              <div style={{ fontSize: "0.8rem" }}>{task.commentary}</div>
+              <div style={{ fontSize: "0.8rem", marginTop: "0.25rem" }}>
+                {task.commentary}
+              </div>
             )}
           </li>
         ))}
@@ -52,6 +70,81 @@ export default function Trail() {
 
   return (
     <div style={{ margin: "1rem" }}>
+      <header style={{ marginBottom: "1.5rem" }}>
+        <h1 style={{ marginBottom: "0.75rem" }}>{t("trail.title")}</h1>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "1rem",
+            alignItems: "center",
+          }}
+        >
+          <div style={{ flex: "1 1 220px" }}>
+            <div
+              role="progressbar"
+              aria-valuemin={0}
+              aria-valuemax={todaySummary.total}
+              aria-valuenow={todaySummary.completed}
+              style={{
+                background: "#f1f3f4",
+                borderRadius: "999px",
+                height: "0.75rem",
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  width: `${Math.min(percent, 100)}%`,
+                  background: "#0f9d58",
+                  height: "100%",
+                  transition: "width 0.3s ease",
+                }}
+              />
+            </div>
+            <div style={{ fontSize: "0.85rem", marginTop: "0.35rem" }}>
+              {t("trail.progressLabel", {
+                completed: todaySummary.completed,
+                total: todaySummary.total,
+                percent,
+              })}
+            </div>
+          </div>
+          <div style={{ fontWeight: 600 }}>{t("trail.xpLabel", { xp: data.xp })}</div>
+          <div
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.35rem",
+              padding: "0.35rem 0.6rem",
+              borderRadius: "999px",
+              background: "#fde68a",
+              fontWeight: 600,
+            }}
+            aria-label={t("trail.streakLabel", { count: data.streak })}
+          >
+            <span role="img" aria-hidden="true">
+              🔥
+            </span>
+            <span>{t("trail.streakLabel", { count: data.streak })}</span>
+          </div>
+        </div>
+        {(allDailyComplete || allTasksComplete) && (
+          <div
+            role="status"
+            style={{
+              marginTop: "1rem",
+              padding: "0.75rem",
+              borderRadius: "0.75rem",
+              background: "#e8f5e9",
+              color: "#1b5e20",
+            }}
+          >
+            {allDailyComplete && <div>{t("trail.dailyComplete")}</div>}
+            {allTasksComplete && <div>{t("trail.allDone")}</div>}
+          </div>
+        )}
+      </header>
       {renderSection(daily, t("trail.daily"))}
       {renderSection(once, t("trail.once"))}
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -461,6 +461,15 @@ export interface TrailTask {
   completed: boolean;
 }
 
+export interface TrailCompletionTotals {
+  completed: number;
+  total: number;
+}
+
 export interface TrailResponse {
   tasks: TrailTask[];
+  xp: number;
+  streak: number;
+  daily_totals: Record<string, TrailCompletionTotals>;
+  today: string;
 }

--- a/tests/quests/test_trail.py
+++ b/tests/quests/test_trail.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import date
+from datetime import date, timedelta
 
 from backend.common.storage import get_storage
 from backend.quests import trail
@@ -25,36 +25,88 @@ def memory_storage(monkeypatch):
 
 
 def test_get_tasks_returns_defaults(memory_storage):
-    tasks = trail.get_tasks("alice")
+    response = trail.get_tasks("alice")
+    tasks = response["tasks"]
     assert [t["id"] for t in tasks] == [t["id"] for t in trail.DEFAULT_TASKS]
     assert all(not t["completed"] for t in tasks)
+    assert response["xp"] == 0
+    assert response["streak"] == 0
+    assert response["daily_totals"][response["today"]]["completed"] == 0
+    assert response["daily_totals"][response["today"]]["total"] == trail.DAILY_TASK_COUNT
 
 
 def test_get_tasks_with_completions(memory_storage):
     today = date.today().isoformat()
-    memory_storage["bob"] = {"once": ["create_goal"], "daily": {today: ["check_market"]}}
-    tasks = trail.get_tasks("bob")
-    completed = {t["id"]: t["completed"] for t in tasks}
+    memory_storage["bob"] = {
+        "once": ["create_goal"],
+        "daily": {today: ["check_market"]},
+        "xp": trail.DAILY_XP_REWARD,
+        "streak": 2,
+        "last_completed_day": today,
+        "daily_totals": {today: {"completed": 1, "total": trail.DAILY_TASK_COUNT}},
+    }
+    response = trail.get_tasks("bob")
+    completed = {t["id"]: t["completed"] for t in response["tasks"]}
     assert completed["create_goal"] is True
     assert completed["check_market"] is True
     for task in trail.DEFAULT_TASKS:
         if task["id"] not in {"create_goal", "check_market"}:
             assert completed[task["id"]] is False
+    assert response["xp"] == trail.DAILY_XP_REWARD
+    assert response["streak"] == 2
+    assert response["daily_totals"][response["today"]]["completed"] == 1
+    assert response["daily_totals"][response["today"]]["total"] == trail.DAILY_TASK_COUNT
 
 
 def test_mark_complete_records_once_and_daily(memory_storage):
     user = "carol"
     today = date.today().isoformat()
 
-    trail.mark_complete(user, "check_market")
+    result = trail.mark_complete(user, "check_market")
     assert memory_storage[user]["daily"][today] == ["check_market"]
-    trail.mark_complete(user, "check_market")
-    assert memory_storage[user]["daily"][today] == ["check_market"]
+    assert result["xp"] == trail.DAILY_XP_REWARD
+    assert result["daily_totals"][today]["completed"] == 1
 
-    trail.mark_complete(user, "create_goal")
+    result = trail.mark_complete(user, "check_market")
+    assert memory_storage[user]["daily"][today] == ["check_market"]
+    assert result["xp"] == trail.DAILY_XP_REWARD
+
+    result = trail.mark_complete(user, "create_goal")
     assert memory_storage[user]["once"] == ["create_goal"]
-    trail.mark_complete(user, "create_goal")
+    assert result["xp"] == trail.DAILY_XP_REWARD + trail.ONCE_XP_REWARD
+
+    result = trail.mark_complete(user, "create_goal")
     assert memory_storage[user]["once"] == ["create_goal"]
+    assert result["xp"] == trail.DAILY_XP_REWARD + trail.ONCE_XP_REWARD
 
     with pytest.raises(KeyError):
         trail.mark_complete(user, "unknown")
+
+
+def test_mark_complete_updates_streak(memory_storage):
+    user = "dave"
+    today = date.today()
+    today_str = today.isoformat()
+    yesterday = (today - timedelta(days=1)).isoformat()
+
+    memory_storage[user] = {
+        "once": [],
+        "daily": {yesterday: trail.DAILY_TASK_IDS},
+        "xp": len(trail.DAILY_TASK_IDS) * trail.DAILY_XP_REWARD,
+        "streak": 1,
+        "last_completed_day": yesterday,
+        "daily_totals": {
+            yesterday: {
+                "completed": trail.DAILY_TASK_COUNT,
+                "total": trail.DAILY_TASK_COUNT,
+            }
+        },
+    }
+
+    for task_id in trail.DAILY_TASK_IDS:
+        response = trail.mark_complete(user, task_id)
+
+    assert response["streak"] == 2
+    assert response["xp"] == len(trail.DAILY_TASK_IDS) * trail.DAILY_XP_REWARD * 2
+    assert response["daily_totals"][today_str]["completed"] == trail.DAILY_TASK_COUNT
+    assert response["daily_totals"][today_str]["total"] == trail.DAILY_TASK_COUNT


### PR DESCRIPTION
## Summary
- persist XP, streak, and daily completion totals in the trail backend and expose them from the API
- update trail routes/tests to cover the enriched payload and streak progression
- surface progress, XP, and streak on the Trail page with new translations and unit tests

## Testing
- pytest -o addopts="" tests/quests/test_trail.py tests/routes/test_trail_routes.py
- npm test -- --run Trail

------
https://chatgpt.com/codex/tasks/task_e_68d180737f78832780fd367c9114cb4c