### PR TITLE
Enhance trail progress tracking and UI

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -12,7 +12,7 @@ if config.disable_auth:
     @router.get("")
     async def list_tasks():
         """Return tasks for the demo user when authentication is disabled."""
-        return {"tasks": trail.get_tasks("demo")}
+        return trail.get_tasks("demo")
 
     @router.post("/{task_id}/complete")
     async def complete_task(task_id: str):
@@ -21,14 +21,14 @@ if config.disable_auth:
             tasks = trail.mark_complete("demo", task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks
 
 else:
 
     @router.get("")
     async def list_tasks(current_user: str = Depends(get_current_user)):
         """Return tasks for the authenticated user."""
-        return {"tasks": trail.get_tasks(current_user)}
+        return trail.get_tasks(current_user)
 
     @router.post("/{task_id}/complete")
     async def complete_task(task_id: str, current_user: str = Depends(get_current_user)):
@@ -37,4 +37,4 @@ else:
             tasks = trail.mark_complete(current_user, task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Täglich",
+    "once": "Einmalig",
+    "xp_total": "XP: {{count}}",
+    "streak_label": "Serie",
+    "streak_none": "Noch keine Serie",
+    "streak_value": "{{count}}-Tage-Serie",
+    "progress_label": "Heutiger Fortschritt",
+    "progress_summary": "{{completed}} von {{total}} abgeschlossen ({{percent}} %)",
+    "all_complete": "Alle täglichen Aufgaben erledigt! 🎉"
   },
   "common": {
     "error": "Fehler",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -43,7 +43,14 @@
   },
   "trail": {
     "daily": "Daily",
-    "once": "Once"
+    "once": "Once",
+    "xp_total": "XP: {{count}}",
+    "streak_label": "Streak",
+    "streak_none": "No streak yet",
+    "streak_value": "{{count}} day streak",
+    "progress_label": "Today's progress",
+    "progress_summary": "Completed {{completed}} of {{total}} ({{percent}}%)",
+    "all_complete": "All daily tasks complete! 🎉"
   },
   "common": {
     "error": "Error",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Diario",
+    "once": "Una vez",
+    "xp_total": "XP: {{count}}",
+    "streak_label": "Racha",
+    "streak_none": "Sin racha todavía",
+    "streak_value": "Racha de {{count}} días",
+    "progress_label": "Progreso de hoy",
+    "progress_summary": "{{completed}} de {{total}} completadas ({{percent}} %)",
+    "all_complete": "¡Todas las tareas diarias completadas! 🎉"
   },
   "common": {
     "error": "Error",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Quotidien",
+    "once": "Une fois",
+    "xp_total": "XP : {{count}}",
+    "streak_label": "Série",
+    "streak_none": "Pas encore de série",
+    "streak_value": "Série de {{count}} jours",
+    "progress_label": "Progression du jour",
+    "progress_summary": "{{completed}} sur {{total}} terminées ({{percent}} %)",
+    "all_complete": "Toutes les tâches quotidiennes sont terminées ! 🎉"
   },
   "common": {
     "error": "Erreur",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Giornaliero",
+    "once": "Una volta",
+    "xp_total": "XP: {{count}}",
+    "streak_label": "Serie",
+    "streak_none": "Nessuna serie ancora",
+    "streak_value": "Serie di {{count}} giorni",
+    "progress_label": "Progressi di oggi",
+    "progress_summary": "{{completed}} su {{total}} completati ({{percent}} %)",
+    "all_complete": "Tutte le attività giornaliere completate! 🎉"
   },
   "common": {
     "error": "Errore",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -40,8 +40,15 @@
     }
   },
   "trail": {
-    "daily": "Daily",
-    "once": "Once"
+    "daily": "Diário",
+    "once": "Uma vez",
+    "xp_total": "XP: {{count}}",
+    "streak_label": "Sequência",
+    "streak_none": "Sem sequência ainda",
+    "streak_value": "Sequência de {{count}} dias",
+    "progress_label": "Progresso de hoje",
+    "progress_summary": "{{completed}} de {{total}} concluídas ({{percent}} %)",
+    "all_complete": "Todas as tarefas diárias concluídas! 🎉"
   },
   "common": {
     "error": "Erro",

--- a/frontend/src/pages/Trail.test.tsx
+++ b/frontend/src/pages/Trail.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { axe } from "jest-axe";
+import Trail from "./Trail";
+import * as api from "../api";
+import type { TrailResponse } from "../types";
+
+vi.mock("../api");
+
+const mockGetTrailTasks = vi.mocked(api.getTrailTasks);
+const mockCompleteTrailTask = vi.mocked(api.completeTrailTask);
+
+describe("Trail page", () => {
+  const baseResponse: TrailResponse = {
+    tasks: [
+      {
+        id: "check_market",
+        title: "Check market overview",
+        type: "daily",
+        commentary: "",
+        completed: false,
+      },
+      {
+        id: "review_portfolio",
+        title: "Review your portfolio",
+        type: "daily",
+        commentary: "",
+        completed: false,
+      },
+      {
+        id: "create_goal",
+        title: "Set up your first goal",
+        type: "once",
+        commentary: "",
+        completed: false,
+      },
+    ],
+    xp: 0,
+    streak: 0,
+    today_completed: 0,
+    today_total: 2,
+    daily_totals: {},
+  };
+
+  it("renders progress summary and streak badge", async () => {
+    mockGetTrailTasks.mockResolvedValueOnce(baseResponse);
+
+    const { container } = render(<Trail />);
+
+    await screen.findByText("Check market overview");
+
+    expect(screen.getByText("XP: 0")).toBeInTheDocument();
+    expect(screen.getByText(/No streak yet/i)).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0");
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("celebrates when all daily tasks are completed", async () => {
+    const initial: TrailResponse = {
+      ...baseResponse,
+      today_completed: 1,
+      tasks: [
+        { ...baseResponse.tasks[0], completed: false },
+        { ...baseResponse.tasks[1], completed: true },
+        baseResponse.tasks[2],
+      ],
+    };
+    const completed: TrailResponse = {
+      ...baseResponse,
+      xp: 35,
+      streak: 1,
+      today_completed: 2,
+      tasks: [
+        { ...baseResponse.tasks[0], completed: true },
+        { ...baseResponse.tasks[1], completed: true },
+        baseResponse.tasks[2],
+      ],
+      daily_totals: {
+        [new Date().toISOString().slice(0, 10)]: 2,
+      },
+    };
+
+    mockGetTrailTasks.mockResolvedValueOnce(initial);
+    mockCompleteTrailTask.mockResolvedValueOnce(completed);
+
+    render(<Trail />);
+
+    const action = await screen.findByRole("button", { name: "Check market overview" });
+    fireEvent.click(action);
+
+    expect(mockCompleteTrailTask).toHaveBeenCalledWith("check_market");
+    await screen.findByText(/All daily tasks complete!/i);
+    expect(screen.getByText("XP: 35")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "100");
+  });
+});

--- a/frontend/src/pages/Trail.tsx
+++ b/frontend/src/pages/Trail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getTrailTasks, completeTrailTask } from "../api";
 import type { TrailResponse } from "../types";
@@ -20,11 +20,27 @@ export default function Trail() {
       .catch((e) => setError(String(e)));
   };
 
-  if (!data) return <div>{t("common.loading")}</div>;
-  if (error) return <div style={{ color: "red" }}>{error}</div>;
+  const tasks = data?.tasks ?? [];
+  const daily = useMemo(
+    () => tasks.filter((t) => t.type === "daily"),
+    [tasks],
+  );
+  const once = useMemo(
+    () => tasks.filter((t) => t.type === "once"),
+    [tasks],
+  );
+  const completedDaily = data?.today_completed ?? daily.filter((t) => t.completed).length;
+  const totalDaily = data?.today_total ?? daily.length;
+  const completionRatio = totalDaily > 0 ? completedDaily / totalDaily : 0;
+  const completionPercent = Math.round(completionRatio * 100);
+  const allDailyDone = totalDaily > 0 && completedDaily >= totalDaily;
 
-  const daily = data.tasks.filter((t) => t.type === "daily");
-  const once = data.tasks.filter((t) => t.type === "once");
+  if (error) return <div style={{ color: "red" }}>{error}</div>;
+  if (!data) return <div>{t("common.loading")}</div>;
+
+  const streakLabel = data.streak
+    ? t("trail.streak_value", { count: data.streak })
+    : t("trail.streak_none");
 
   const renderSection = (items: typeof data.tasks, label: string) => (
     <section>
@@ -51,7 +67,100 @@ export default function Trail() {
   );
 
   return (
-    <div style={{ margin: "1rem" }}>
+    <div style={{ margin: "1rem", display: "grid", gap: "1.5rem" }}>
+      <section
+        aria-label={t("trail.progress_label")}
+        style={{
+          backgroundColor: "#f5f5f5",
+          padding: "1rem",
+          borderRadius: "0.75rem",
+          display: "grid",
+          gap: "0.75rem",
+        }}
+      >
+        <header
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "1rem",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ fontWeight: 600 }}>{t("trail.xp_total", { count: data.xp })}</div>
+          <div
+            style={{
+              padding: "0.25rem 0.75rem",
+              borderRadius: "999px",
+              backgroundColor: "#fff",
+              border: "1px solid #ddd",
+              fontSize: "0.9rem",
+            }}
+          >
+            <strong>{t("trail.streak_label")}:</strong> {streakLabel}
+          </div>
+        </header>
+        <div>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              fontSize: "0.95rem",
+              marginBottom: "0.4rem",
+              gap: "0.75rem",
+              flexWrap: "wrap",
+            }}
+          >
+            <span>{t("trail.progress_label")}</span>
+            <span>
+              {t("trail.progress_summary", {
+                completed: completedDaily,
+                total: totalDaily,
+                percent: completionPercent,
+              })}
+            </span>
+          </div>
+          <div
+            style={{
+              width: "100%",
+              height: "12px",
+              backgroundColor: "#e0e0e0",
+              borderRadius: "999px",
+              overflow: "hidden",
+            }}
+            role="progressbar"
+            aria-valuenow={completionPercent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={t("trail.progress_label")}
+          >
+            <div
+              style={{
+                height: "100%",
+                width: `${completionPercent}%`,
+                background: "linear-gradient(90deg, #4caf50, #81c784)",
+                transition: "width 0.3s ease",
+              }}
+            />
+          </div>
+        </div>
+        {allDailyDone && (
+          <div
+            role="status"
+            aria-live="polite"
+            style={{
+              backgroundColor: "#e8f5e9",
+              border: "1px solid #c8e6c9",
+              padding: "0.75rem",
+              borderRadius: "0.5rem",
+            }}
+          >
+            {t("trail.all_complete")}
+          </div>
+        )}
+      </section>
+
       {renderSection(daily, t("trail.daily"))}
       {renderSection(once, t("trail.once"))}
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -463,4 +463,9 @@ export interface TrailTask {
 
 export interface TrailResponse {
   tasks: TrailTask[];
+  xp: number;
+  streak: number;
+  today_completed: number;
+  today_total: number;
+  daily_totals: Record<string, number>;
 }

--- a/tests/quests/test_trail.py
+++ b/tests/quests/test_trail.py
@@ -25,36 +25,65 @@ def memory_storage(monkeypatch):
 
 
 def test_get_tasks_returns_defaults(memory_storage):
-    tasks = trail.get_tasks("alice")
+    data = trail.get_tasks("alice")
+    tasks = data["tasks"]
     assert [t["id"] for t in tasks] == [t["id"] for t in trail.DEFAULT_TASKS]
     assert all(not t["completed"] for t in tasks)
+    assert data["xp"] == 0
+    assert data["streak"] == 0
+    assert data["today_completed"] == 0
+    assert data["today_total"] == len(trail.DAILY_TASK_IDS)
+    assert data["daily_totals"] == {}
 
 
 def test_get_tasks_with_completions(memory_storage):
     today = date.today().isoformat()
     memory_storage["bob"] = {"once": ["create_goal"], "daily": {today: ["check_market"]}}
-    tasks = trail.get_tasks("bob")
-    completed = {t["id"]: t["completed"] for t in tasks}
+    data = trail.get_tasks("bob")
+    completed = {t["id"]: t["completed"] for t in data["tasks"]}
     assert completed["create_goal"] is True
     assert completed["check_market"] is True
     for task in trail.DEFAULT_TASKS:
         if task["id"] not in {"create_goal", "check_market"}:
             assert completed[task["id"]] is False
+    assert data["xp"] == 0
+    assert data["streak"] == 0
+    assert data["daily_totals"][today] == 1
 
 
 def test_mark_complete_records_once_and_daily(memory_storage):
     user = "carol"
     today = date.today().isoformat()
 
-    trail.mark_complete(user, "check_market")
+    result = trail.mark_complete(user, "check_market")
+    assert result["today_completed"] == 1
+    assert result["xp"] == trail.DAILY_XP
     assert memory_storage[user]["daily"][today] == ["check_market"]
-    trail.mark_complete(user, "check_market")
+    result = trail.mark_complete(user, "check_market")
+    assert result["xp"] == trail.DAILY_XP
     assert memory_storage[user]["daily"][today] == ["check_market"]
 
-    trail.mark_complete(user, "create_goal")
+    result = trail.mark_complete(user, "create_goal")
+    assert result["xp"] == trail.DAILY_XP + trail.ONCE_XP
     assert memory_storage[user]["once"] == ["create_goal"]
-    trail.mark_complete(user, "create_goal")
+    result = trail.mark_complete(user, "create_goal")
+    assert result["xp"] == trail.DAILY_XP + trail.ONCE_XP
     assert memory_storage[user]["once"] == ["create_goal"]
 
     with pytest.raises(KeyError):
         trail.mark_complete(user, "unknown")
+
+
+def test_daily_completion_updates_streak_and_bonus(memory_storage):
+    user = "dave"
+    today = date.today().isoformat()
+
+    first = trail.mark_complete(user, "check_market")
+    assert first["streak"] == 0
+    second = trail.mark_complete(user, "review_portfolio")
+
+    assert second["streak"] == 1
+    assert second["today_completed"] == len(trail.DAILY_TASK_IDS)
+    expected_xp = trail.DAILY_XP * len(trail.DAILY_TASK_IDS) + trail.DAILY_COMPLETION_BONUS
+    assert second["xp"] == expected_xp
+    assert memory_storage[user]["daily_totals"][today] == len(trail.DAILY_TASK_IDS)


### PR DESCRIPTION
## Summary
- persist Trail XP, streak, and per-day completion totals while returning summary metrics with task state
- adjust the Trail API routing and backend tests to exercise the enriched payload and streak/XP progression
- surface Trail progress, XP, streak messaging, and celebratory UI on the frontend with updated typing, translations, and tests

## Testing
- pytest tests/quests/test_trail.py tests/routes/test_trail_routes.py --override-ini=addopts=
- npm test -- --run src/pages/Trail.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d180737ec48327af733a5b639bd5f5