### PR TITLE
Ensure trail progress summaries persist

### DIFF
--- a/frontend/src/pages/Trail.test.tsx
+++ b/frontend/src/pages/Trail.test.tsx
@@ -102,7 +102,9 @@ describe("Trail page", () => {
 
     render(<Trail />);
 
-    expect(await screen.findByText(en.trail.dailyComplete)).toBeInTheDocument();
+    const celebration = await screen.findByRole("status");
+    expect(celebration).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText(en.trail.dailyComplete)).toBeInTheDocument();
     expect(screen.getByText(en.trail.allDone)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Trail.tsx
+++ b/frontend/src/pages/Trail.tsx
@@ -132,6 +132,7 @@ export default function Trail() {
         {(allDailyComplete || allTasksComplete) && (
           <div
             role="status"
+            aria-live="polite"
             style={{
               marginTop: "1rem",
               padding: "0.75rem",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -466,10 +466,13 @@ export interface TrailCompletionTotals {
   total: number;
 }
 
-export interface TrailResponse {
-  tasks: TrailTask[];
+export interface TrailSummary {
   xp: number;
   streak: number;
   daily_totals: Record<string, TrailCompletionTotals>;
   today: string;
+}
+
+export interface TrailResponse extends TrailSummary {
+  tasks: TrailTask[];
 }

--- a/tests/routes/test_trail_routes.py
+++ b/tests/routes/test_trail_routes.py
@@ -44,3 +44,12 @@ def test_trail_routes(tmp_path, monkeypatch, disable_auth):
         assert final_payload["streak"] == 1
         today = final_payload["today"]
         assert final_payload["daily_totals"][today]["completed"] == trail_module.DAILY_TASK_COUNT
+        assert final_payload["xp"] == len(trail_module.DAILY_TASK_IDS) * trail_module.DAILY_XP_REWARD
+
+        # Ensure a subsequent fetch sees the persisted summary information.
+        resp = client.get("/trail")
+        assert resp.status_code == 200
+        refreshed = resp.json()
+        assert refreshed["xp"] == final_payload["xp"]
+        assert refreshed["streak"] == final_payload["streak"]
+        assert refreshed["daily_totals"][today] == final_payload["daily_totals"][today]


### PR DESCRIPTION
## Summary
- normalise stored Trail progress so XP, streak, and daily totals survive reloads
- extend quest and route tests to assert persisted summaries and XP accumulation
- expose the summary shape to the frontend and ensure the celebratory banner is announced

## Testing
- pytest -c /tmp/pytest_custom.ini tests/quests/test_trail.py tests/routes/test_trail_routes.py --cov=backend.quests.trail --cov=backend.routes.trail --cov-fail-under=90
- npm test -- Trail

------
https://chatgpt.com/codex/tasks/task_e_68d197d003088327ab24dfe3c2491dd5