### PR TITLE
Fix screener config refresh and trail completion response

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -21,7 +21,7 @@ if config.disable_auth:
             tasks = trail.mark_complete("demo", task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return tasks
+        return {"tasks": tasks}
 
 else:
 
@@ -37,4 +37,4 @@ else:
             tasks = trail.mark_complete(current_user, task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return tasks
+        return {"tasks": tasks}

--- a/backend/screener/__init__.py
+++ b/backend/screener/__init__.py
@@ -17,7 +17,14 @@ from pydantic import BaseModel
 
 from backend import config_module
 
-cfg = getattr(config_module, "settings", config_module.config)
+
+def _current_config():
+    """Return the most up-to-date backend configuration instance."""
+
+    return getattr(config_module, "settings", config_module.config)
+
+
+cfg = _current_config()
 config = cfg
 
 ALPHA_VANTAGE_URL = "https://www.alphavantage.co/query"
@@ -162,6 +169,7 @@ def fetch_fundamentals(ticker: str) -> Fundamentals:
     """Return key metrics for ``ticker`` using Yahoo Finance with Alpha Vantage
     fallback, utilising a simple in-memory cache."""
 
+    cfg = _current_config()
     api_key = cfg.alpha_vantage_key or "demo"
 
     key = (ticker.upper(), date.today().isoformat())


### PR DESCRIPTION
## Summary
- ensure the screener fundamentals fetch reads the latest configuration so offline mode updates force the Alpha Vantage fallback
- return trail completion responses in a consistent {"tasks": [...]} envelope for both authenticated and demo flows

## Testing
- pytest tests/test_screener.py::test_fetch_fundamentals_parses_values tests/test_trail_route.py::test_complete_task_demo tests/test_trail_route.py::test_complete_task_authenticated --cov=backend --cov-fail-under=0 -q

------
https://chatgpt.com/codex/tasks/task_e_68d19e8179fc83279ee65c6f0e2ad379