### PR TITLE
Enable sorting across instrument table columns

### DIFF
--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -247,6 +247,20 @@ describe("InstrumentTable", () => {
         expect(tickers[0]).toBe("XYZ");
     });
 
+    it("sorts by 7d change when header clicked", () => {
+        render(<InstrumentTable rows={rows} />);
+        openGroup("Group A");
+
+        const header = within(screen.getByRole("table")).getByRole("columnheader", { name: "7d %" });
+        fireEvent.click(header);
+        let tickers = getGroupTickers("Group A");
+        expect(tickers[0]).toBe("XYZ");
+
+        fireEvent.click(header);
+        tickers = getGroupTickers("Group A");
+        expect(tickers[0]).toBe("ABC");
+    });
+
     it("allows toggling columns", () => {
         render(<InstrumentTable rows={rows} />);
         openGroup("Group A");

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -172,15 +172,27 @@ export function InstrumentTable({ rows }: Props) {
               {t('instrumentTable.columns.name')}
               {sortKey === 'name' ? (asc ? ' ▲' : ' ▼') : ''}
             </th>
-            <th className={tableStyles.cell}>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.clickable}`}
+              onClick={() => handleSort('currency')}
+            >
               {t('instrumentTable.columns.ccy')}
+              {sortKey === 'currency' ? (asc ? ' ▲' : ' ▼') : ''}
             </th>
-            <th className={tableStyles.cell}>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.clickable}`}
+              onClick={() => handleSort('instrument_type')}
+            >
               {t('instrumentTable.columns.type')}
+              {sortKey === 'instrument_type' ? (asc ? ' ▲' : ' ▼') : ''}
             </th>
             {!relativeViewEnabled && visibleColumns.units && (
-              <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort('units')}
+              >
                 {t('instrumentTable.columns.units')}
+                {sortKey === 'units' ? (asc ? ' ▲' : ' ▼') : ''}
               </th>
             )}
             {!relativeViewEnabled && visibleColumns.cost && (
@@ -193,8 +205,12 @@ export function InstrumentTable({ rows }: Props) {
               </th>
             )}
             {!relativeViewEnabled && visibleColumns.market && (
-              <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort('market_value_gbp')}
+              >
                 {t('instrumentTable.columns.market')}
+                {sortKey === 'market_value_gbp' ? (asc ? ' ▲' : ' ▼') : ''}
               </th>
             )}
             {!relativeViewEnabled && visibleColumns.gain && (
@@ -216,18 +232,34 @@ export function InstrumentTable({ rows }: Props) {
               </th>
             )}
             {!relativeViewEnabled && (
-              <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort('last_price_gbp')}
+              >
                 {t('instrumentTable.columns.last')}
+                {sortKey === 'last_price_gbp' ? (asc ? ' ▲' : ' ▼') : ''}
               </th>
             )}
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort('last_price_date')}
+            >
               {t('instrumentTable.columns.lastDate')}
+              {sortKey === 'last_price_date' ? (asc ? ' ▲' : ' ▼') : ''}
             </th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort('change_7d_pct')}
+            >
               {t('instrumentTable.columns.delta7d')}
+              {sortKey === 'change_7d_pct' ? (asc ? ' ▲' : ' ▼') : ''}
             </th>
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>
+            <th
+              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+              onClick={() => handleSort('change_30d_pct')}
+            >
               {t('instrumentTable.columns.delta30d')}
+              {sortKey === 'change_30d_pct' ? (asc ? ' ▲' : ' ▼') : ''}
             </th>
             <th className={tableStyles.cell}>
               {t('instrumentTable.columns.groupActions', { defaultValue: 'Group' })}

--- a/frontend/src/hooks/useFilterableTable.ts
+++ b/frontend/src/hooks/useFilterableTable.ts
@@ -41,8 +41,10 @@ export function useFilterableTable<
     return [...filtered].sort((a, b) => {
       const va = a[sortKey];
       const vb = b[sortKey];
-      if (typeof va === "string" && typeof vb === "string") {
-        return asc ? va.localeCompare(vb) : vb.localeCompare(va);
+      if (typeof va === "string" || typeof vb === "string") {
+        const sa = va == null ? "" : String(va);
+        const sb = vb == null ? "" : String(vb);
+        return asc ? sa.localeCompare(sb) : sb.localeCompare(sa);
       }
       const na = (va as number) ?? 0;
       const nb = (vb as number) ?? 0;


### PR DESCRIPTION
## Summary
- allow every visible instrument table header to toggle sorting and show direction indicators
- make the reusable filterable table hook normalize string comparisons so mixed null/string columns sort correctly
- cover the new sort behaviour with an additional 7d change test

## Testing
- npm test *(fails: existing Vitest suites including App.test.tsx, HoldingsTable.test.tsx, InstrumentAdmin.test.tsx, plus an unhandled error)*

------
https://chatgpt.com/codex/tasks/task_e_68d19f85cae88327a170f8e0e0b2743d