### PR TITLE
Toggle research button to close search

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -525,8 +525,9 @@ describe("App", () => {
       await screen.findByLabelText(/Search instruments/i)
     ).toBeInTheDocument();
 
-    const closeButton = screen.getByRole("button", { name: /Close search/i });
-    await user.click(closeButton);
+    expect(researchButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(researchButton);
 
     await waitFor(() => {
       expect(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -351,7 +351,7 @@ export default function App({ onLogout }: AppProps) {
           type="button"
           aria-expanded={showSearch ? "true" : "false"}
           aria-controls="instrument-search"
-          onClick={() => setShowSearch(true)}
+          onClick={() => setShowSearch((prev) => !prev)}
           style={{
             marginLeft: "1rem",
             padding: "0.25rem 0.5rem",
@@ -367,7 +367,7 @@ export default function App({ onLogout }: AppProps) {
         {showSearch && (
           <InstrumentSearchBar
             id="instrument-search"
-            onClose={() => setShowSearch(false)}
+            onNavigate={() => setShowSearch(false)}
           />
         )}
         {mode === "owner" && (

--- a/frontend/src/components/InstrumentSearchBar.tsx
+++ b/frontend/src/components/InstrumentSearchBar.tsx
@@ -246,22 +246,6 @@ export function InstrumentSearchBarToggle() {
           }}
         >
           <InstrumentSearchBar onNavigate={() => setOpen(false)} />
-          <button
-            type="button"
-            onClick={() => setOpen(false)}
-            aria-label="Close search"
-            style={{
-              padding: "0.25rem 0.5rem",
-              borderRadius: "0.25rem",
-              border: "1px solid #ccc",
-              background: "#f5f5f5",
-              color: "#213547",
-              cursor: "pointer",
-              alignSelf: "center",
-            }}
-          >
-            Close
-          </button>
         </div>
       </CollapsibleContent>
     </Collapsible>


### PR DESCRIPTION
## Summary
- allow the header Research action to toggle the instrument search bar and close after navigating
- drop the extra close control from the collapsible Research toggle so the trigger handles closing
- update the App test to cover the new toggle behavior

## Testing
- npm test -- --run src/App.test.tsx --testNamePattern "toggles the research search bar in the header"


------
https://chatgpt.com/codex/tasks/task_e_68d1a0ea2a908327a4d2ec786696d14c