### PR TITLE
Scale booked cost basis using overrides

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -284,7 +284,9 @@ def get_effective_cost_basis_gbp(
     except (TypeError, ValueError):
         booked = 0.0
     if booked > 0:
-        return round(booked * scale, 2)
+        scaled = round(booked * scale, 2)
+        h[COST_BASIS_GBP] = scaled
+        return scaled
 
     acq = _parse_date(h.get(ACQUIRED_DATE))
 

--- a/backend/tests/test_holding_utils.py
+++ b/backend/tests/test_holding_utils.py
@@ -35,5 +35,6 @@ def test_enrich_holding_scales_booked_cost_basis(monkeypatch):
 
     enriched = hu.enrich_holding(holding, dt.date(2024, 1, 31), price_cache={}, approvals=None, user_config=None)
 
+    assert enriched[COST_BASIS_GBP] == pytest.approx(1.23)
     assert enriched[EFFECTIVE_COST_BASIS_GBP] == pytest.approx(1.23)
     assert enriched["gain_gbp"] == pytest.approx(0.77)

--- a/tests/test_holding_utils_price_cost_basis.py
+++ b/tests/test_holding_utils_price_cost_basis.py
@@ -34,6 +34,22 @@ def test_get_effective_cost_basis_gbp_booked_cost():
     assert holding_utils.get_effective_cost_basis_gbp(holding, {}) == 123.45
 
 
+def test_get_effective_cost_basis_gbp_updates_booked_cost_when_scaled(monkeypatch):
+    from backend.common import instrument_api
+
+    monkeypatch.setattr(
+        instrument_api,
+        "_resolve_full_ticker",
+        lambda full, cache: (full.split(".")[0], "L"),
+    )
+    monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *args, **kwargs: 0.5)
+
+    holding = {TICKER: "ABC.L", UNITS: 10, COST_BASIS_GBP: 123.45}
+
+    assert holding_utils.get_effective_cost_basis_gbp(holding, {}) == 61.73
+    assert holding[COST_BASIS_GBP] == 61.73
+
+
 def test_get_effective_cost_basis_gbp_derived(monkeypatch):
     def fake_derived(ticker, exchange, acq, cache):
         return 2.0


### PR DESCRIPTION
## Summary
- ensure booked cost bases use the instrument scaling override before being returned
- add a regression test for enrich_holding to verify gains respect scaled booked costs

## Testing
- pytest backend/tests/test_holding_utils.py --cov=backend/common/holding_utils.py --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68d1baa58ba48327b8dc770bc3c5087c