### PR TITLE
Use icon-based trigger for instrument research search

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import i18n from "./i18n";
 
 const mockTradingSignals = vi.fn();
 
@@ -535,8 +536,9 @@ describe("App", () => {
       </MemoryRouter>,
     );
 
+    const researchLabel = i18n.t("app.research");
     const researchButton = await screen.findByRole("button", {
-      name: /Research/i,
+      name: researchLabel,
     });
     expect(researchButton).toBeInTheDocument();
     expect(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,7 +43,10 @@ import UserConfigPage from "./pages/UserConfig";
 import BackendUnavailableCard from "./components/BackendUnavailableCard";
 import Reports from "./pages/Reports";
 import { orderedTabPlugins } from "./tabPlugins";
-import { InstrumentSearchBar } from "./components/InstrumentSearchBar";
+import {
+  InstrumentSearchBar,
+  InstrumentResearchTriggerIcon,
+} from "./components/InstrumentSearchBar";
 import UserAvatar from "./components/UserAvatar";
 import AllocationCharts from "./pages/AllocationCharts";
 import InstrumentAdmin from "./pages/InstrumentAdmin";
@@ -342,6 +345,7 @@ export default function App({ onLogout }: AppProps) {
         />
         <button
           type="button"
+          aria-label={t("app.research")}
           aria-expanded={showSearch ? "true" : "false"}
           aria-controls="instrument-search"
           onClick={() => setShowSearch((prev) => !prev)}
@@ -352,10 +356,13 @@ export default function App({ onLogout }: AppProps) {
             border: "1px solid #ccc",
             background: "#fff",
             color: "#213547",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
             cursor: "pointer",
           }}
         >
-          {t("app.research")}
+          <InstrumentResearchTriggerIcon />
         </button>
         {showSearch && (
           <InstrumentSearchBar

--- a/frontend/src/components/InstrumentSearchBar.test.tsx
+++ b/frontend/src/components/InstrumentSearchBar.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Routes, Route, useParams } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import { searchInstruments } from "../api";
+import i18n from "../i18n";
 
 vi.mock("../api", () => ({
   searchInstruments: vi.fn(),
@@ -31,7 +32,10 @@ describe("InstrumentSearchBar", () => {
       </MemoryRouter>
     );
 
-    const researchButton = screen.getByRole("button", { name: /Research/i });
+    const researchLabel = i18n.t("app.research");
+    const researchButton = screen.getByRole("button", {
+      name: researchLabel,
+    });
     expect(researchButton).toBeInTheDocument();
     expect(
       screen.queryByLabelText(/Search instruments/i)

--- a/frontend/src/components/InstrumentSearchBar.tsx
+++ b/frontend/src/components/InstrumentSearchBar.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, useRef, memo, useId } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Lightbulb } from "lucide-react";
 import { searchInstruments } from "../api";
 import {
   Collapsible,
@@ -211,9 +213,20 @@ function InstrumentSearchBarComponent({
 
 const InstrumentSearchBar = memo(InstrumentSearchBarComponent);
 
+export function InstrumentResearchTriggerIcon() {
+  return (
+    <Lightbulb
+      aria-hidden="true"
+      focusable="false"
+      style={{ width: "1rem", height: "1rem" }}
+    />
+  );
+}
+
 export function InstrumentSearchBarToggle() {
   const [open, setOpen] = useState(false);
   const contentId = useId();
+  const { t } = useTranslation();
 
   return (
     <Collapsible open={open} onOpenChange={setOpen} style={{ marginLeft: "1rem" }}>
@@ -221,16 +234,20 @@ export function InstrumentSearchBarToggle() {
         type="button"
         aria-controls={contentId}
         aria-expanded={open}
+        aria-label={t("app.research")}
         style={{
           padding: "0.25rem 0.75rem",
           borderRadius: "0.25rem",
           border: "1px solid #ccc",
           background: open ? "#eee" : "#fff",
           color: "#213547",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
           cursor: "pointer",
         }}
       >
-        Research
+        <InstrumentResearchTriggerIcon />
       </CollapsibleTrigger>
       <CollapsibleContent
         id={contentId}


### PR DESCRIPTION
## Summary
- replace the Research toggle copy with a shared lightbulb icon and accessible label
- expose the trigger icon for reuse and update App to consume it
- adjust search toggle tests to look up the trigger via the translated accessible label

## Testing
- npm test -- App.test.tsx InstrumentSearchBar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d1ba7f77c08327a13ff8e2d9e96922