### PR TITLE
Add exchange filtering to instrument table

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -488,6 +488,7 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
                 full_tkr,
                 {
                     "ticker": full_tkr,
+                    "exchange": exch,
                     "name": instrument_meta.get("name") or h.get("name", full_tkr),
                     "currency": h.get("currency") or instrument_meta.get("currency"),
                     "sector": h.get("sector") or instrument_meta.get("sector"),
@@ -517,6 +518,7 @@ def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str =
                     and grouping_source in _GROUPING_FALLBACK_SOURCES,
                 },
             )
+            row["exchange"] = exch
             row.setdefault("_grouping_from_fallback", False)
 
             # accumulate units from the holding

--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -96,6 +96,7 @@ describe("InstrumentTable", () => {
             ticker: "ABC",
             name: "ABC Corp",
             grouping: "Group A",
+            exchange: "L",
             currency: "GBP",
             instrument_type: "Equity",
             units: 10,
@@ -110,6 +111,7 @@ describe("InstrumentTable", () => {
             ticker: "XYZ",
             name: "XYZ Inc",
             grouping: "Group A",
+            exchange: "N",
             currency: "USD",
             instrument_type: "Equity",
             units: 5,
@@ -124,6 +126,7 @@ describe("InstrumentTable", () => {
             ticker: "DEF",
             name: "DEF Ltd",
             grouping: "Group B",
+            exchange: "L",
             currency: "GBX",
             instrument_type: "Equity",
             units: 3,
@@ -137,6 +140,7 @@ describe("InstrumentTable", () => {
         {
             ticker: "CADI",
             name: "CAD Inc",
+            exchange: "T",
             currency: "CAD",
             instrument_type: "Equity",
             units: 2,
@@ -163,7 +167,9 @@ describe("InstrumentTable", () => {
 
     const openGroup = (title: string) => {
         const button = getSummaryButton(title);
-        fireEvent.click(button);
+        if (button.getAttribute("aria-expanded") !== "true") {
+            fireEvent.click(button);
+        }
         return button;
     };
 
@@ -202,6 +208,48 @@ describe("InstrumentTable", () => {
 
         openGroup("Group A");
         expect(screen.getByText("ABC")).toBeInTheDocument();
+    });
+
+    it("filters rows by exchange selection", async () => {
+        render(<InstrumentTable rows={rows} />);
+        expect(screen.getByText("Exchanges:")).toBeInTheDocument();
+
+        const lCheckbox = screen.getByLabelText("L");
+        const nCheckbox = screen.getByLabelText("N");
+        const tCheckbox = screen.getByLabelText("T");
+
+        expect(lCheckbox).toBeChecked();
+        expect(nCheckbox).toBeChecked();
+        expect(tCheckbox).toBeChecked();
+
+        openGroup("Group A");
+        openGroup("Group B");
+        openGroup("Ungrouped");
+
+        expect(screen.getByText("ABC")).toBeInTheDocument();
+        expect(screen.getByText("XYZ")).toBeInTheDocument();
+        expect(screen.getByText("DEF")).toBeInTheDocument();
+        expect(screen.getByText("CADI")).toBeInTheDocument();
+
+        fireEvent.click(lCheckbox);
+        expect(lCheckbox).not.toBeChecked();
+        expect(screen.queryByText("ABC")).toBeNull();
+        expect(screen.queryByText("DEF")).toBeNull();
+        expect(screen.getByText("XYZ")).toBeInTheDocument();
+
+        fireEvent.click(nCheckbox);
+        expect(nCheckbox).not.toBeChecked();
+        expect(screen.queryByText("XYZ")).toBeNull();
+        expect(screen.getByText("CADI")).toBeInTheDocument();
+
+        fireEvent.click(tCheckbox);
+        expect(tCheckbox).not.toBeChecked();
+        await waitFor(() => expect(screen.getByText("No instruments.")).toBeInTheDocument());
+
+        fireEvent.click(lCheckbox);
+        expect(lCheckbox).toBeChecked();
+        openGroup("Group A");
+        await waitFor(() => expect(screen.getByText("ABC")).toBeInTheDocument());
     });
 
     it("passes ticker and name to InstrumentDetail", () => {

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -78,6 +78,7 @@
   "instrumentTable": {
     "noInstruments": "Keine Instrumente.",
     "ungrouped": "Ohne Gruppe",
+    "exchangesLabel": "Börsen:",
     "groupTotals": {
       "market": "Marktwert",
       "gain": "Gewinn",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -72,6 +72,7 @@
   "instrumentTable": {
     "noInstruments": "No instruments.",
     "ungrouped": "Ungrouped",
+    "exchangesLabel": "Exchanges:",
     "groupTotals": {
       "market": "Market",
       "gain": "Gain",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -78,6 +78,7 @@
   "instrumentTable": {
     "noInstruments": "Sin instrumentos.",
     "ungrouped": "Sin grupo",
+    "exchangesLabel": "Bolsas:",
     "groupTotals": {
       "market": "Mercado",
       "gain": "Ganancia",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -78,6 +78,7 @@
   "instrumentTable": {
     "noInstruments": "Aucun instrument.",
     "ungrouped": "Non groupé",
+    "exchangesLabel": "Bourses :",
     "groupTotals": {
       "market": "Valeur",
       "gain": "Gain",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -78,6 +78,7 @@
   "instrumentTable": {
     "noInstruments": "Nessun strumento.",
     "ungrouped": "Senza gruppo",
+    "exchangesLabel": "Borse:",
     "groupTotals": {
       "market": "Mercato",
       "gain": "Guadagno",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -78,6 +78,7 @@
   "instrumentTable": {
     "noInstruments": "Sem instrumentos.",
     "ungrouped": "Sem grupo",
+    "exchangesLabel": "Bolsas:",
     "groupTotals": {
       "market": "Mercado",
       "gain": "Ganho",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -90,6 +90,7 @@ export type InstrumentSummary = {
   ticker: string;
   name: string;
   grouping?: string | null;
+  exchange?: string | null;
   currency?: string | null;
   units: number;
   market_value_gbp: number;


### PR DESCRIPTION
## Summary
- add resolved exchange codes to aggregated portfolio rows
- surface exchange metadata in the frontend with a selectable exchange filter
- update translations and tests to cover the new exchange options

## Testing
- npm test -- --run InstrumentTable

------
https://chatgpt.com/codex/tasks/task_e_68d1ba7035d08327b26f626f04a6a32d