### PR TITLE
Fix trail response payload and stabilise fundamentals test

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -21,7 +21,7 @@ if config.disable_auth:
             tasks = trail.mark_complete("demo", task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks
 
 else:
 
@@ -37,4 +37,4 @@ else:
             tasks = trail.mark_complete(current_user, task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -177,7 +177,7 @@ def test_screen_skips_tickers_with_fetch_errors(monkeypatch):
     assert [r.ticker for r in results] == ["BBB"]
 
 
-def test_fetch_fundamentals_parses_values(monkeypatch):
+def test_fetch_fundamentals_parses_values(monkeypatch, empty_yahoo_ticker):
     sample = {
         "Name": "Foo Corp",
         "PEG": "1.5",


### PR DESCRIPTION
## Summary
- return the full trail progress payload from the completion endpoints instead of only the task list
- make the fundamentals parsing test explicitly disable Yahoo Finance so it always exercises the Alpha Vantage code path

## Testing
- pytest -o addopts= tests/routes/test_trail_routes.py tests/test_screener.py::test_fetch_fundamentals_parses_values

------
https://chatgpt.com/codex/tasks/task_e_68d1c04cfc4c8327b394c8a35e39896e