### PR TITLE
Left align instrument group headers

### DIFF
--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -45,9 +45,14 @@
 
 .groupCell {
   font-weight: 600;
+  text-align: left;
   padding-top: 8px;
   padding-bottom: 8px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.groupCell.right {
+  text-align: right;
 }
 
 .groupToggle {


### PR DESCRIPTION
## Summary
- left align grouped header rows in the instrument table
- keep numeric group summary cells right aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1c24d6b0483278e1a30399f866851