### PR TITLE
feat: use icon for research toggle

### DIFF
--- a/frontend/src/components/InstrumentSearchBar.test.tsx
+++ b/frontend/src/components/InstrumentSearchBar.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Routes, Route, useParams } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import { searchInstruments } from "../api";
+import i18n from "../i18n";
 
 vi.mock("../api", () => ({
   searchInstruments: vi.fn(),
@@ -31,7 +32,8 @@ describe("InstrumentSearchBar", () => {
       </MemoryRouter>
     );
 
-    const researchButton = screen.getByRole("button", { name: /Research/i });
+    const researchLabel = i18n.t("app.research");
+    const researchButton = screen.getByRole("button", { name: researchLabel });
     expect(researchButton).toBeInTheDocument();
     expect(
       screen.queryByLabelText(/Search instruments/i)

--- a/frontend/src/components/InstrumentSearchBar.tsx
+++ b/frontend/src/components/InstrumentSearchBar.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, useRef, memo, useId } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Lightbulb } from "lucide-react";
 import { searchInstruments } from "../api";
 import {
   Collapsible,
@@ -214,6 +216,8 @@ const InstrumentSearchBar = memo(InstrumentSearchBarComponent);
 export function InstrumentSearchBarToggle() {
   const [open, setOpen] = useState(false);
   const contentId = useId();
+  const { t } = useTranslation();
+  const researchLabel = t("app.research");
 
   return (
     <Collapsible open={open} onOpenChange={setOpen} style={{ marginLeft: "1rem" }}>
@@ -221,16 +225,20 @@ export function InstrumentSearchBarToggle() {
         type="button"
         aria-controls={contentId}
         aria-expanded={open}
+        aria-label={researchLabel}
         style={{
-          padding: "0.25rem 0.75rem",
+          padding: "0.25rem",
           borderRadius: "0.25rem",
           border: "1px solid #ccc",
           background: open ? "#eee" : "#fff",
           color: "#213547",
           cursor: "pointer",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
         }}
       >
-        Research
+        <Lightbulb aria-hidden="true" size={18} />
       </CollapsibleTrigger>
       <CollapsibleContent
         id={contentId}


### PR DESCRIPTION
## Summary
- replace the Research trigger text with the Lightbulb icon and translate-based aria label
- update the App and InstrumentSearchBar tests to look up the trigger by its translated accessible name and adjust waits for real timers

## Testing
- `cd frontend && npm run test -- --run App.test.tsx components/InstrumentSearchBar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d1bf4543108327b268cfba6063d923