### PR TITLE
Stop scaling booked cost basis

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -276,17 +276,13 @@ def get_effective_cost_basis_gbp(
     else:
         exchange = "L"
         logger.debug("Could not resolve exchange for %s; defaulting to L", full)
-    scale = get_scaling_override(ticker, exchange, None)
-
     booked_raw = h.get(COST_BASIS_GBP)
     try:
         booked = float(booked_raw) if booked_raw is not None else 0.0
     except (TypeError, ValueError):
         booked = 0.0
     if booked > 0:
-        scaled = round(booked * scale, 2)
-        h[COST_BASIS_GBP] = scaled
-        return scaled
+        return round(booked, 2)
 
     acq = _parse_date(h.get(ACQUIRED_DATE))
 


### PR DESCRIPTION
## Summary
- return the recorded GBP cost basis as-is when present instead of applying scaling
- avoid mutating the stored cost basis value while keeping derived price handling unchanged

## Testing
- pytest tests/backend/common *(fails: coverage threshold 90% not met)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c60621e0832791dd538782e89e2d