### PR TITLE
Map GBX currency formatting to pounds

### DIFF
--- a/frontend/src/lib/money.test.ts
+++ b/frontend/src/lib/money.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import { percentOrNa } from "./money";
+import { money, percentOrNa } from "./money";
+
+describe("money", () => {
+  it("formats GBX values using pound units", () => {
+    const value = 123.45;
+    expect(money(value, "GBX", "en-GB")).toBe(
+      money(value, "GBP", "en-GB"),
+    );
+  });
+});
 
 describe("percentOrNa", () => {
   it("returns N/A without warning for null or undefined", () => {

--- a/frontend/src/lib/money.ts
+++ b/frontend/src/lib/money.ts
@@ -6,9 +6,10 @@ export const money = (
     locale: string = i18n.language,
 ): string => {
     if (typeof v !== "number" || !Number.isFinite(v)) return "—";
+    const displayCurrency = currency === "GBX" ? "GBP" : currency;
     return new Intl.NumberFormat(locale, {
         style: "currency",
-        currency,
+        currency: displayCurrency,
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
     }).format(v);


### PR DESCRIPTION
## Summary
- map GBX currency codes to GBP when formatting monetary values so penny-denominated instruments display in pounds
- cover the GBX case with a vitest assertion to ensure parity with GBP formatting

## Testing
- npx vitest run src/lib/money.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d1bfdaeb708327ba98fb72384f8337