### PR TITLE
Trim news payload to headline and url

### DIFF
--- a/backend/routes/news.py
+++ b/backend/routes/news.py
@@ -6,12 +6,11 @@ import json
 import logging
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import requests
 import xml.etree.ElementTree as ET
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
-from email.utils import parsedate_to_datetime
 
 from backend import config_module
 from backend.utils import page_cache
@@ -76,7 +75,24 @@ def _clean_str(value: object) -> Optional[str]:
     return None
 
 
-def fetch_news_yahoo(ticker: str) -> List[Dict[str, Optional[str]]]:
+def _normalise_news_payload(data: object) -> List[Dict[str, str]] | None:
+    """Return a list of ``{"headline", "url"}`` dictionaries or ``None``."""
+
+    if not isinstance(data, list):
+        return None
+
+    trimmed: List[Dict[str, str]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        headline = item.get("headline")
+        url = item.get("url")
+        if isinstance(headline, str) and isinstance(url, str):
+            trimmed.append({"headline": headline, "url": url})
+    return trimmed
+
+
+def fetch_news_yahoo(ticker: str) -> List[Dict[str, str]]:
     """Fetch headlines from Yahoo Finance search API."""
 
     endpoint = cfg.yahoo_news_endpoint or "https://query1.finance.yahoo.com/v1/finance/search"
@@ -85,37 +101,16 @@ def fetch_news_yahoo(ticker: str) -> List[Dict[str, Optional[str]]]:
     resp.raise_for_status()
     data = resp.json()
     items = data.get("news", [])
-    out: List[Dict[str, Optional[str]]] = []
+    out: List[Dict[str, str]] = []
     for item in items:
         title = _clean_str(item.get("title"))
         link = _clean_str(item.get("link"))
         if title and link:
-            source = _clean_str(
-                item.get("publisher") or item.get("source") or item.get("provider")
-            )
-            published_at: Optional[str] = None
-            publish_ts = item.get("providerPublishTime")
-            if isinstance(publish_ts, (int, float)):
-                published_at = _isoformat(datetime.fromtimestamp(publish_ts, tz=timezone.utc))
-            elif isinstance(publish_ts, str):
-                try:
-                    published_at = _isoformat(
-                        datetime.fromtimestamp(float(publish_ts), tz=timezone.utc)
-                    )
-                except (TypeError, ValueError):  # pragma: no cover - defensive
-                    published_at = None
-            out.append(
-                {
-                    "headline": title,
-                    "url": link,
-                    "source": source,
-                    "published_at": published_at,
-                }
-            )
+            out.append({"headline": title, "url": link})
     return out
 
 
-def fetch_news_google(ticker: str) -> List[Dict[str, Optional[str]]]:
+def fetch_news_google(ticker: str) -> List[Dict[str, str]]:
     """Fetch headlines from Google Finance via RSS search."""
 
     endpoint = cfg.google_news_endpoint or "https://news.google.com/rss/search"
@@ -123,27 +118,12 @@ def fetch_news_google(ticker: str) -> List[Dict[str, Optional[str]]]:
     resp = requests.get(endpoint, params=params, timeout=10)
     resp.raise_for_status()
     root = ET.fromstring(resp.text)
-    out: List[Dict[str, Optional[str]]] = []
+    out: List[Dict[str, str]] = []
     for item in root.findall(".//item"):
         title = _clean_str(item.findtext("title"))
         link = _clean_str(item.findtext("link"))
         if title and link:
-            published_at = item.findtext("pubDate")
-            parsed_dt: Optional[datetime] = None
-            if published_at:
-                try:
-                    parsed_dt = parsedate_to_datetime(published_at)
-                except (TypeError, ValueError):  # pragma: no cover - defensive
-                    parsed_dt = None
-            source_text = _clean_str(item.findtext("{http://news.google.com}source"))
-            out.append(
-                {
-                    "headline": title,
-                    "url": link,
-                    "source": source_text,
-                    "published_at": _isoformat(parsed_dt),
-                }
-            )
+            out.append({"headline": title, "url": link})
     return out
 
 
@@ -170,7 +150,7 @@ def _parse_alpha_time(value: Optional[str]) -> Optional[str]:
     return _isoformat(dt)
 
 
-def _fetch_news(ticker: str) -> List[Dict[str, Optional[str]]]:
+def _fetch_news(ticker: str) -> List[Dict[str, str]]:
     """Fetch news from AlphaVantage with fallbacks to Yahoo and Google."""
 
     params = {
@@ -185,20 +165,13 @@ def _fetch_news(ticker: str) -> List[Dict[str, Optional[str]]]:
         data = resp.json()
         feed = data.get("feed") or []
         if feed:
-            enriched: List[Dict[str, Optional[str]]] = []
+            enriched: List[Dict[str, str]] = []
             for item in feed:
                 title = _clean_str(item.get("title"))
                 url = _clean_str(item.get("url"))
                 if not (title and url):
                     continue
-                enriched.append(
-                    {
-                        "headline": title,
-                        "url": url,
-                        "source": _clean_str(item.get("source")),
-                        "published_at": _parse_alpha_time(item.get("time_published")),
-                    }
-                )
+                enriched.append({"headline": title, "url": url})
             if enriched:
                 return enriched
     except Exception as exc:  # pragma: no cover - defensive
@@ -210,7 +183,9 @@ def _fetch_news(ticker: str) -> List[Dict[str, Optional[str]]]:
         try:
             items = fetcher(ticker)
             if items:
-                return items
+                normalised = _normalise_news_payload(items)
+                if normalised is not None and normalised:
+                    return normalised
         except Exception as exc:  # pragma: no cover - defensive
             logging.getLogger(__name__).error(
                 "Fallback news fetch failed for %s: %s", ticker, exc
@@ -221,9 +196,9 @@ def _fetch_news(ticker: str) -> List[Dict[str, Optional[str]]]:
 def get_cached_news(
     ticker: str,
     *,
-    cache_writer: Callable[[str, List[Dict[str, Optional[str]]]], None] | None = None,
+    cache_writer: Callable[[str, List[Dict[str, str]]], None] | None = None,
     raise_on_quota_exhausted: bool = False,
-) -> List[Dict[str, Optional[str]]]:
+) -> List[Dict[str, str]]:
     """Return cached or freshly fetched news for ``ticker``.
 
     The helper mirrors the caching and quota handling used by the ``/news``
@@ -240,7 +215,7 @@ def get_cached_news(
 
     page = f"news_{tkr}"
 
-    def _call() -> List[Dict[str, Optional[str]]]:
+    def _call() -> List[Dict[str, str]]:
         if not _try_consume_quota():
             raise RuntimeError("news quota exceeded")
         return _fetch_news(tkr)
@@ -254,7 +229,10 @@ def get_cached_news(
             initial_delay=initial_delay,
         )
 
-    cached = page_cache.load_cache(page)
+    cached_raw: Any = page_cache.load_cache(page)
+    cached = (
+        _normalise_news_payload(cached_raw) if cached_raw is not None else None
+    )
     cache_fresh = cached is not None and not page_cache.is_stale(page, NEWS_TTL)
 
     if cache_fresh:

--- a/backend/tests/test_news_route.py
+++ b/backend/tests/test_news_route.py
@@ -1,7 +1,7 @@
 import requests
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from backend.routes import news
 from backend.utils import page_cache
@@ -56,14 +56,7 @@ def test_get_news_falls_back(monkeypatch):
 
     resp = client.get("/news", params={"ticker": "AAA"})
     assert resp.status_code == 200
-    assert resp.json() == [
-        {
-            "headline": "h1",
-            "url": "u1",
-            "source": "Yahoo",
-            "published_at": "2023-01-01T00:00:00Z",
-        }
-    ]
+    assert resp.json() == [{"headline": "h1", "url": "u1"}]
 
 
 def test_get_news_includes_metadata_and_caches(monkeypatch):
@@ -73,7 +66,7 @@ def test_get_news_includes_metadata_and_caches(monkeypatch):
     monkeypatch.setattr(page_cache, "is_stale", lambda *a, **k: True)
     monkeypatch.setattr(page_cache, "load_cache", lambda *a, **k: None)
 
-    saved: List[Tuple[str, List[Dict[str, Optional[str]]]]] = []
+    saved: List[Tuple[str, List[Dict[str, str]]]] = []
 
     def fake_save_cache(page: str, payload):
         saved.append((page, payload))
@@ -105,8 +98,6 @@ def test_get_news_includes_metadata_and_caches(monkeypatch):
         {
             "headline": "Alpha headline",
             "url": "https://example.com/article",
-            "source": "AlphaVantage",
-            "published_at": "2023-08-25T16:00:00Z",
         }
     ]
     assert saved == [
@@ -116,8 +107,6 @@ def test_get_news_includes_metadata_and_caches(monkeypatch):
                 {
                     "headline": "Alpha headline",
                     "url": "https://example.com/article",
-                    "source": "AlphaVantage",
-                    "published_at": "2023-08-25T16:00:00Z",
                 }
             ],
         )


### PR DESCRIPTION
## Summary
- trim Yahoo, Google, and AlphaVantage news fetchers to only emit `headline` and `url`
- normalise cached payloads to the stricter schema and update helper type hints
- adjust news route tests to reflect the leaner payload

## Testing
- pytest backend/tests/test_news_route.py --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d1c94ee67c8327aaa020ac3ba76eba