### PR TITLE
Fix smoke test sample user

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -593,7 +593,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
 const SAMPLE_PATH_VALUES: Record<string, string> = {
   owner: 'demo',
   account: 'isa',
-  user: 'user@example.com',
+  user: 'demo',
   email: 'user@example.com',
   id: '1',
   vp_id: '1',


### PR DESCRIPTION
## Summary
- use the demo owner for sample values of `user` parameters in the backend/frontend smoke script to match seeded data

## Testing
- `npm run smoke:test:all`


------
https://chatgpt.com/codex/tasks/task_e_68d1c9ef8f90832783999d09f14a3db2