### PR TITLE
Fix trail payload, holding scaling heuristics, and fundamentals cache

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -24,7 +24,7 @@ if config.disable_auth:
             tasks = trail.mark_complete("demo", task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks
 
 else:
 
@@ -43,4 +43,4 @@ else:
             tasks = trail.mark_complete(current_user, task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return tasks


### PR DESCRIPTION
## Summary
- return the full trail payload from the POST complete endpoints so XP and streak fields are included
- refine holding enrichment so booked cost scaling honours instrument pricing while keeping gains consistent, using price-informed heuristics
- segregate fundamentals cache entries by offline mode to avoid reusing online data when running offline

## Testing
- pytest --override-ini addopts="" tests/routes/test_trail_routes.py -q
- pytest --override-ini addopts="" tests/test_load_latest_prices.py::test_enrich_holding_uses_scaling_override -q
- pytest --override-ini addopts="" tests/test_screener.py::test_fetch_fundamentals_parses_values -q


------
https://chatgpt.com/codex/tasks/task_e_68d1c7c10d488327a0d978816bad476e