### PR TITLE
Return full trail completion payload

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -18,13 +18,13 @@ if config.disable_auth:
     async def complete_task(task_id: str):
         """Mark ``task_id`` complete for the demo user when auth is disabled.
 
-        Returns the updated tasks payload.
+        Returns the payload produced by :func:`trail.mark_complete`.
         """
         try:
-            tasks = trail.mark_complete("demo", task_id)
+            payload = trail.mark_complete("demo", task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return payload
 
 else:
 
@@ -37,10 +37,10 @@ else:
     async def complete_task(task_id: str, current_user: str = Depends(get_current_user)):
         """Mark ``task_id`` complete for the authenticated user.
 
-        Returns the updated tasks payload.
+        Returns the payload produced by :func:`trail.mark_complete`.
         """
         try:
-            tasks = trail.mark_complete(current_user, task_id)
+            payload = trail.mark_complete(current_user, task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tasks": tasks}
+        return payload


### PR DESCRIPTION
## Summary
- return the `trail.mark_complete` payload directly from the trail completion endpoints regardless of auth mode
- refresh the docstrings to describe the returned payload

## Testing
- pytest tests/routes/test_trail_routes.py *(fails coverage threshold: total coverage 31 < fail-under 90)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cca3de048327a61f63288045c222