### PR TITLE
Apply scaling overrides to booked cost basis

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -276,11 +276,15 @@ def get_effective_cost_basis_gbp(
     else:
         exchange = "L"
         logger.debug("Could not resolve exchange for %s; defaulting to L", full)
+    scale = get_scaling_override(ticker, exchange, None)
     booked_raw = h.get(COST_BASIS_GBP)
     try:
         booked = float(booked_raw) if booked_raw is not None else 0.0
     except (TypeError, ValueError):
         booked = 0.0
+    if booked > 0 and scale != 1:
+        booked = round(booked * scale, 2)
+        h[COST_BASIS_GBP] = booked
     if booked > 0:
         return round(booked, 2)
 

--- a/tests/test_holding_utils_price_cost_basis.py
+++ b/tests/test_holding_utils_price_cost_basis.py
@@ -29,7 +29,8 @@ def test_get_price_for_date_scaled_empty_data(monkeypatch):
     assert src is None
 
 
-def test_get_effective_cost_basis_gbp_booked_cost():
+def test_get_effective_cost_basis_gbp_booked_cost(monkeypatch):
+    monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *args, **kwargs: 1.0)
     holding = {TICKER: "AAA.L", UNITS: 10, COST_BASIS_GBP: 123.45}
     assert holding_utils.get_effective_cost_basis_gbp(holding, {}) == 123.45
 


### PR DESCRIPTION
## Summary
- scale booked GBP cost basis values when an instrument-specific override is defined
- persist the scaled value back onto the holding to keep cached data consistent
- stabilize the booked-cost unit test by forcing a neutral scaling override

## Testing
- `pytest tests/test_holding_utils_price_cost_basis.py` *(fails: coverage threshold 90% not met when running the targeted module only)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cca74a408327b193652a0438b628