### PR TITLE
Return full trail completion payload

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -18,13 +18,12 @@ if config.disable_auth:
     async def complete_task(task_id: str):
         """Mark ``task_id`` complete for the demo user when auth is disabled.
 
-        Returns the updated tasks payload.
+        Returns the updated Trail payload including XP, streak, and daily totals.
         """
         try:
-            tasks = trail.mark_complete("demo", task_id)
+            return trail.mark_complete("demo", task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return tasks
 
 else:
 
@@ -37,10 +36,9 @@ else:
     async def complete_task(task_id: str, current_user: str = Depends(get_current_user)):
         """Mark ``task_id`` complete for the authenticated user.
 
-        Returns the updated tasks payload.
+        Returns the updated Trail payload including XP, streak, and daily totals.
         """
         try:
-            tasks = trail.mark_complete(current_user, task_id)
+            return trail.mark_complete(current_user, task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
-        return tasks


### PR DESCRIPTION
## Summary
- return the complete payload from trail.mark_complete in both trail completion handlers
- refresh the route docstrings to describe the extended response data

## Testing
- pytest -o addopts='' tests/routes/test_trail_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68d1cd6d190c8327a212ecac68d1197d