### PR TITLE
Fix alerts owner validation when accounts root missing

### DIFF
--- a/backend/routes/alerts.py
+++ b/backend/routes/alerts.py
@@ -7,12 +7,14 @@ from backend import alerts as alert_utils
 from backend.common import data_loader
 from backend.common.alerts import get_recent_alerts
 from backend.common.errors import OWNER_NOT_FOUND
+from backend.routes._accounts import resolve_accounts_root
 
 router = APIRouter(prefix="/alerts", tags=["alerts"])
 
 
 def _validate_owner(user: str, request: Request) -> None:
-    owners = {o["owner"] for o in data_loader.list_plots(request.app.state.accounts_root)}
+    accounts_root = resolve_accounts_root(request)
+    owners = {o["owner"] for o in data_loader.list_plots(accounts_root)}
     if user not in owners:
         raise HTTPException(status_code=404, detail=OWNER_NOT_FOUND)
 

--- a/tests/test_push_subscription_route.py
+++ b/tests/test_push_subscription_route.py
@@ -22,7 +22,7 @@ def client(tmp_path, monkeypatch):
         alert_utils.config.sns_topic_arn = original_arn
 
 
-def test_push_subscription_owner_validation(client):
+def test_push_subscription_owner_validation(client, tmp_path):
     owners = client.get("/owners").json()
     assert any(o["owner"] == "demo" for o in owners)
     owner = "demo"
@@ -35,6 +35,7 @@ def test_push_subscription_owner_validation(client):
     resp_bad = client.post("/alerts/push-subscription/unknown", json=payload)
     assert resp_bad.status_code == 404
 
+    client.app.state.accounts_root = tmp_path / "does-not-exist"
     resp_del = client.delete(f"/alerts/push-subscription/{owner}")
     assert resp_del.status_code == 200
     assert alert_utils.get_user_push_subscription(owner) is None


### PR DESCRIPTION
## Summary
- resolve the request-specific accounts root before validating alert owners
- extend the push subscription route test to cover missing accounts root paths

## Testing
- pytest backend/tests tests/test_push_subscription_route.py *(fails: existing backend test_portfolio_group_movers import error due to bytes not JSON serializable)*
- pytest tests/test_push_subscription_route.py *(fails: coverage threshold 90% not met when running single test)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cf8205e88327ab2dcdb21836a55e