### PR TITLE
Add group summary aggregates for sorting

### DIFF
--- a/frontend/src/components/InstrumentTable.test.tsx
+++ b/frontend/src/components/InstrumentTable.test.tsx
@@ -204,6 +204,14 @@ describe("InstrumentTable", () => {
                 return label ? label.replace(/^Toggle\s+/, "") : "";
             });
 
+    const expectGroupsCollapsed = () => {
+        screen
+            .getAllByRole("button", { name: /^Toggle / })
+            .forEach((button) =>
+                expect(button).toHaveAttribute("aria-expanded", "false"),
+            );
+    };
+
     it("renders groups collapsed by default with aggregated totals", () => {
         render(<InstrumentTable rows={rows} />);
         const table = screen.getByRole("table");
@@ -308,7 +316,7 @@ describe("InstrumentTable", () => {
 
     it("sorts by 7d change when header clicked", () => {
         render(<InstrumentTable rows={rows} />);
-        expect(getGroupOrder()).toEqual(["Group A", "Ungrouped", "Group B"]);
+        expect(getGroupOrder()).toEqual(["Group A", "Group B", "Ungrouped"]);
 
         const header = within(screen.getByRole("table")).getByRole("columnheader", { name: "7d %" });
         fireEvent.click(header);
@@ -322,6 +330,40 @@ describe("InstrumentTable", () => {
         expect(getGroupOrder()).toEqual(["Group B", "Group A", "Ungrouped"]);
         tickers = getGroupTickers("Group A");
         expect(tickers[0]).toBe("ABC");
+    });
+
+    it("reorders collapsed groups when sorting by Market £", () => {
+        render(<InstrumentTable rows={rows} />);
+        expectGroupsCollapsed();
+        expect(getGroupOrder()).toEqual(["Group A", "Group B", "Ungrouped"]);
+
+        const header = within(screen.getByRole("table")).getByRole("columnheader", {
+            name: "Market £",
+        });
+        fireEvent.click(header);
+        expect(getGroupOrder()).toEqual(["Ungrouped", "Group B", "Group A"]);
+        expectGroupsCollapsed();
+
+        fireEvent.click(header);
+        expect(getGroupOrder()).toEqual(["Group A", "Group B", "Ungrouped"]);
+        expectGroupsCollapsed();
+    });
+
+    it("reorders collapsed groups when sorting by Ticker", () => {
+        render(<InstrumentTable rows={rows} />);
+        expectGroupsCollapsed();
+        expect(getGroupOrder()).toEqual(["Group A", "Group B", "Ungrouped"]);
+
+        const header = within(screen.getByRole("table")).getByRole("columnheader", {
+            name: /^Ticker/,
+        });
+        fireEvent.click(header);
+        expect(getGroupOrder()).toEqual(["Ungrouped", "Group B", "Group A"]);
+        expectGroupsCollapsed();
+
+        fireEvent.click(header);
+        expect(getGroupOrder()).toEqual(["Group A", "Group B", "Ungrouped"]);
+        expectGroupsCollapsed();
     });
 
     it("allows toggling columns", () => {


### PR DESCRIPTION
## Summary
- include aggregated label, units, cost, market value, and gain values in group totals
- map header sort keys to the new aggregates and handle string-based group sorting
- add regression tests that verify collapsed groups resort correctly for numeric and text sorts

## Testing
- npm --prefix frontend run test -- --run src/components/InstrumentTable.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d2278c0e308327945028cad04a6b95