### PR TITLE
Wrap trail completion response in tasks payload

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -21,7 +21,7 @@ if config.disable_auth:
         Returns the updated Trail payload including XP, streak, and daily totals.
         """
         try:
-            return trail.mark_complete("demo", task_id)
+            return {"tasks": trail.mark_complete("demo", task_id)}
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
 
@@ -39,6 +39,6 @@ else:
         Returns the updated Trail payload including XP, streak, and daily totals.
         """
         try:
-            return trail.mark_complete(current_user, task_id)
+            return {"tasks": trail.mark_complete(current_user, task_id)}
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")


### PR DESCRIPTION
## Summary
- wrap the task completion response payloads so they return a `tasks` key for both authenticated and demo users
- keep the existing 404 error handling unchanged

## Testing
- `pytest tests/test_trail_route.py` *(fails: coverage threshold --cov-fail-under=90 is not met in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d227a6cca4832780b43803ef1a893b