### PR TITLE
Add pension forecast insights and breakdowns

### DIFF
--- a/backend/common/pension.py
+++ b/backend/common/pension.py
@@ -192,8 +192,37 @@ def forecast_pension(
                 continue
         forecast.append({"age": age, "income": income})
 
+    desired_income_value = (
+        float(desired_income_annual) if desired_income_annual is not None else None
+    )
+    state_income = float(state_pension_annual or 0.0)
+    db_income_retirement = 0.0
+    for pension in pensions:
+        try:
+            start = int(pension.get("normal_retirement_age", retirement_age))
+        except Exception:
+            continue
+        if retirement_age >= start:
+            try:
+                db_income_retirement += float(pension.get("annual_income_gbp", 0.0))
+            except Exception:
+                continue
+    dc_income_retirement = pot_at_retirement / annuity_multiple if annuity_multiple else 0.0
+    breakdown = {
+        "state_pension_annual": state_income,
+        "defined_benefit_annual": db_income_retirement,
+        "defined_contribution_annual": float(dc_income_retirement),
+    }
+    total_income = float(sum(breakdown.values()))
+
     return {
         "forecast": forecast,
-        "projected_pot_gbp": pot_at_retirement,
+        "projected_pot_gbp": float(pot_at_retirement),
         "earliest_retirement_age": earliest_age,
+        "retirement_income_breakdown": breakdown,
+        "retirement_income_total_annual": total_income,
+        "state_pension_annual": state_income,
+        "contribution_annual": float(contribution_annual),
+        "desired_income_annual": desired_income_value,
+        "annuity_multiple_used": float(annuity_multiple),
     }

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -174,6 +174,7 @@ describe("pension forecast", () => {
             current_age: 30,
             retirement_age: 65,
             dob: "1990-01-01",
+            earliest_retirement_age: null,
           }),
       });
     // @ts-ignore
@@ -199,6 +200,7 @@ describe("pension forecast", () => {
             current_age: 30,
             retirement_age: 65,
             dob: "1990-01-01",
+            earliest_retirement_age: null,
           }),
       });
     // @ts-ignore

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1145,6 +1145,28 @@ export const getAllowances = (owner?: string) => {
 };
 
 // ───────────── Pension Forecast ─────────────
+export interface PensionIncomeBreakdown {
+  state_pension_annual?: number | null;
+  defined_benefit_annual?: number | null;
+  defined_contribution_annual?: number | null;
+}
+
+export interface PensionForecastResponse {
+  forecast: { age: number; income: number }[];
+  projected_pot_gbp: number;
+  pension_pot_gbp: number;
+  current_age: number;
+  retirement_age: number;
+  dob: string;
+  earliest_retirement_age: number | null;
+  retirement_income_breakdown?: PensionIncomeBreakdown | null;
+  retirement_income_total_annual?: number | null;
+  state_pension_annual?: number | null;
+  contribution_annual?: number | null;
+  desired_income_annual?: number | null;
+  annuity_multiple_used?: number | null;
+}
+
 export const getPensionForecast = ({
   owner,
   deathAge,
@@ -1181,14 +1203,9 @@ export const getPensionForecast = ({
   if (investmentGrowthPct !== undefined) {
     params.set("investment_growth_pct", String(investmentGrowthPct));
   }
-  return fetchJson<{
-    forecast: { age: number; income: number }[];
-    projected_pot_gbp: number;
-    pension_pot_gbp: number;
-    current_age: number;
-    retirement_age: number;
-    dob: string;
-  }>(`${API_BASE}/pension/forecast?${params.toString()}`);
+  return fetchJson<PensionForecastResponse>(
+    `${API_BASE}/pension/forecast?${params.toString()}`,
+  );
 };
 
 // ───────────── Quests API ─────────────

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -198,7 +198,29 @@
     "retirementAge": "Renteneintrittsalter: {{age}}",
     "pensionPot": "Pensionsvermögen",
     "growthAssumption": "Wachstumsannahme (%):",
-    "monthlyContribution": "Monatlicher Beitrag (£):"
+    "monthlyContribution": "Monatlicher Beitrag (£):",
+    "incomeBreakdownHeading": "Retirement income breakdown",
+    "incomeSources": {
+      "state": "State pension",
+      "definedBenefit": "Defined benefit",
+      "definedContribution": "Defined contribution"
+    },
+    "incomeTable": {
+      "source": "Source",
+      "annual": "Annual (£)",
+      "monthly": "Monthly (£)",
+      "share": "Share"
+    },
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income",
+    "prediction": {
+      "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
+      "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
+      "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available."
+    }
   },
   "group": {
     "select": "Wählen Sie eine Gruppe."

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -204,7 +204,29 @@
     "retirementAge": "Retirement age: {{age}}",
     "pensionPot": "Pension pot",
     "growthAssumption": "Growth assumption (%):",
-    "monthlyContribution": "Monthly Contribution (£):"
+    "monthlyContribution": "Monthly Contribution (£):",
+    "incomeBreakdownHeading": "Retirement income breakdown",
+    "incomeSources": {
+      "state": "State pension",
+      "definedBenefit": "Defined benefit",
+      "definedContribution": "Defined contribution"
+    },
+    "incomeTable": {
+      "source": "Source",
+      "annual": "Annual (£)",
+      "monthly": "Monthly (£)",
+      "share": "Share"
+    },
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income",
+    "prediction": {
+      "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
+      "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
+      "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available."
+    }
   },
   "group": {
     "select": "Select a group."

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -198,7 +198,29 @@
     "retirementAge": "Edad de jubilación: {{age}}",
     "pensionPot": "Fondo de pensiones",
     "growthAssumption": "Suposición de crecimiento (%):",
-    "monthlyContribution": "Contribución mensual (£):"
+    "monthlyContribution": "Contribución mensual (£):",
+    "incomeBreakdownHeading": "Retirement income breakdown",
+    "incomeSources": {
+      "state": "State pension",
+      "definedBenefit": "Defined benefit",
+      "definedContribution": "Defined contribution"
+    },
+    "incomeTable": {
+      "source": "Source",
+      "annual": "Annual (£)",
+      "monthly": "Monthly (£)",
+      "share": "Share"
+    },
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income",
+    "prediction": {
+      "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
+      "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
+      "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available."
+    }
   },
   "group": {
     "select": "Seleccione un grupo."

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -198,7 +198,29 @@
     "retirementAge": "Âge de retraite : {{age}}",
     "pensionPot": "Pot de pension",
     "growthAssumption": "Hypothèse de croissance (%):",
-    "monthlyContribution": "Contribution mensuelle (£):"
+    "monthlyContribution": "Contribution mensuelle (£):",
+    "incomeBreakdownHeading": "Retirement income breakdown",
+    "incomeSources": {
+      "state": "State pension",
+      "definedBenefit": "Defined benefit",
+      "definedContribution": "Defined contribution"
+    },
+    "incomeTable": {
+      "source": "Source",
+      "annual": "Annual (£)",
+      "monthly": "Monthly (£)",
+      "share": "Share"
+    },
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income",
+    "prediction": {
+      "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
+      "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
+      "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available."
+    }
   },
   "group": {
     "select": "Sélectionnez un groupe."

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -198,7 +198,29 @@
     "retirementAge": "Età pensionistica: {{age}}",
     "pensionPot": "Fondo pensione",
     "growthAssumption": "Ipotesi di crescita (%):",
-    "monthlyContribution": "Contributo mensile (£):"
+    "monthlyContribution": "Contributo mensile (£):",
+    "incomeBreakdownHeading": "Retirement income breakdown",
+    "incomeSources": {
+      "state": "State pension",
+      "definedBenefit": "Defined benefit",
+      "definedContribution": "Defined contribution"
+    },
+    "incomeTable": {
+      "source": "Source",
+      "annual": "Annual (£)",
+      "monthly": "Monthly (£)",
+      "share": "Share"
+    },
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income",
+    "prediction": {
+      "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
+      "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
+      "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available."
+    }
   },
   "group": {
     "select": "Seleziona un gruppo."

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -198,7 +198,29 @@
     "retirementAge": "Idade de aposentadoria: {{age}}",
     "pensionPot": "Fundo de pensão",
     "growthAssumption": "Suposição de crescimento (%):",
-    "monthlyContribution": "Contribuição mensal (£):"
+    "monthlyContribution": "Contribuição mensal (£):",
+    "incomeBreakdownHeading": "Retirement income breakdown",
+    "incomeSources": {
+      "state": "State pension",
+      "definedBenefit": "Defined benefit",
+      "definedContribution": "Defined contribution"
+    },
+    "incomeTable": {
+      "source": "Source",
+      "annual": "Annual (£)",
+      "monthly": "Monthly (£)",
+      "share": "Share"
+    },
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income",
+    "prediction": {
+      "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
+      "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
+      "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available."
+    }
   },
   "group": {
     "select": "Selecione um grupo."

--- a/tests/backend/common/test_pension.py
+++ b/tests/backend/common/test_pension.py
@@ -133,3 +133,18 @@ def test_forecast_pension_scenario() -> None:
     assert incomes == [0.0, 5000.0, 14000.0, 16000.0, 16000.0]
     assert result["projected_pot_gbp"] == pytest.approx(15059.2)
     assert result["earliest_retirement_age"] == 34
+    assert result["retirement_income_breakdown"]["state_pension_annual"] == pytest.approx(
+        9000
+    )
+    assert result["retirement_income_breakdown"]["defined_benefit_annual"] == pytest.approx(
+        5000
+    )
+    assert result["retirement_income_breakdown"]["defined_contribution_annual"] == pytest.approx(
+        752.96,
+        rel=1e-4,
+    )
+    assert result["retirement_income_total_annual"] == pytest.approx(14752.96, rel=1e-4)
+    assert result["state_pension_annual"] == pytest.approx(9000)
+    assert result["contribution_annual"] == pytest.approx(2000)
+    assert result["desired_income_annual"] == pytest.approx(800)
+    assert result["annuity_multiple_used"] == pytest.approx(20)


### PR DESCRIPTION
## Summary
- enrich the pension forecast API with retirement income breakdown aggregates
- surface income composition, totals, and prediction messaging in the pension forecast page with localisation support
- expand backend and frontend tests to cover the new data and UI insights

## Testing
- npm test -- --run src/pages/PensionForecast.test.tsx src/api.test.ts
- pytest tests/backend/common/test_pension.py *(fails: coverage threshold 90% unmet when collecting only targeted tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d23784a57c832785732a47951200dc