### PR TITLE
Return trail completion results at top level

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -21,7 +21,7 @@ if config.disable_auth:
         Returns the updated Trail payload including XP, streak, and daily totals.
         """
         try:
-            return {"tasks": trail.mark_complete("demo", task_id)}
+            return trail.mark_complete("demo", task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
 
@@ -39,6 +39,6 @@ else:
         Returns the updated Trail payload including XP, streak, and daily totals.
         """
         try:
-            return {"tasks": trail.mark_complete(current_user, task_id)}
+            return trail.mark_complete(current_user, task_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")


### PR DESCRIPTION
## Summary
- update trail completion routes to return the mark_complete payload directly
- keep 404 handling intact for unknown task IDs

## Testing
- pytest --cov-fail-under=0 tests/routes/test_trail_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68d2546f335483278c0413f8e1ff2c16