### PR TITLE
feat(frontend): add pension summary header

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1165,6 +1165,7 @@ export interface PensionForecastResponse {
   contribution_annual?: number | null;
   desired_income_annual?: number | null;
   annuity_multiple_used?: number | null;
+  employer_contribution_monthly?: number | null;
 }
 
 export const getPensionForecast = ({

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -199,6 +199,16 @@
     "pensionPot": "Pensionsvermögen",
     "growthAssumption": "Wachstumsannahme (%):",
     "monthlyContribution": "Monatlicher Beitrag (£):",
+    "employerContributionMonthly": "Arbeitgeberbeitrag (£/Monat):",
+    "summary": {
+      "heading": "Übersicht Ihrer Pension",
+      "pensionPotLabel": "Aktueller Pensionstopf",
+      "userContributionLabel": "Ihr monatlicher Beitrag",
+      "employerContributionLabel": "Arbeitgeberbeitrag",
+      "addAnotherPension": "Weitere Pension hinzufügen",
+      "addedPensions": "Hinzugefügte Pensionen: {{count}}",
+      "addedPensions_plural": "Hinzugefügte Pensionen: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -205,6 +205,16 @@
     "pensionPot": "Pension pot",
     "growthAssumption": "Growth assumption (%):",
     "monthlyContribution": "Monthly Contribution (£):",
+    "employerContributionMonthly": "Employer contribution (£/mo):",
+    "summary": {
+      "heading": "Your pension overview",
+      "pensionPotLabel": "Current pension pot",
+      "userContributionLabel": "Your monthly contribution",
+      "employerContributionLabel": "Employer contribution",
+      "addAnotherPension": "Add another pension",
+      "addedPensions": "Added pensions: {{count}}",
+      "addedPensions_plural": "Added pensions: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -199,6 +199,16 @@
     "pensionPot": "Fondo de pensiones",
     "growthAssumption": "Suposición de crecimiento (%):",
     "monthlyContribution": "Contribución mensual (£):",
+    "employerContributionMonthly": "Contribución del empleador (£/mes):",
+    "summary": {
+      "heading": "Resumen de tu pensión",
+      "pensionPotLabel": "Fondo de pensión actual",
+      "userContributionLabel": "Tu contribución mensual",
+      "employerContributionLabel": "Contribución del empleador",
+      "addAnotherPension": "Agregar otra pensión",
+      "addedPensions": "Pensiones agregadas: {{count}}",
+      "addedPensions_plural": "Pensiones agregadas: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -199,6 +199,16 @@
     "pensionPot": "Pot de pension",
     "growthAssumption": "Hypothèse de croissance (%):",
     "monthlyContribution": "Contribution mensuelle (£):",
+    "employerContributionMonthly": "Contribution employeur (£/mois):",
+    "summary": {
+      "heading": "Aperçu de votre retraite",
+      "pensionPotLabel": "Pot de pension actuel",
+      "userContributionLabel": "Votre contribution mensuelle",
+      "employerContributionLabel": "Contribution employeur",
+      "addAnotherPension": "Ajouter une autre pension",
+      "addedPensions": "Pensions ajoutées : {{count}}",
+      "addedPensions_plural": "Pensions ajoutées : {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -199,6 +199,16 @@
     "pensionPot": "Fondo pensione",
     "growthAssumption": "Ipotesi di crescita (%):",
     "monthlyContribution": "Contributo mensile (£):",
+    "employerContributionMonthly": "Contributo del datore di lavoro (£/mese):",
+    "summary": {
+      "heading": "Panoramica della tua pensione",
+      "pensionPotLabel": "Fondo pensione attuale",
+      "userContributionLabel": "Il tuo contributo mensile",
+      "employerContributionLabel": "Contributo del datore di lavoro",
+      "addAnotherPension": "Aggiungi un'altra pensione",
+      "addedPensions": "Pensioni aggiunte: {{count}}",
+      "addedPensions_plural": "Pensioni aggiunte: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -199,6 +199,16 @@
     "pensionPot": "Fundo de pensão",
     "growthAssumption": "Suposição de crescimento (%):",
     "monthlyContribution": "Contribuição mensal (£):",
+    "employerContributionMonthly": "Contribuição do empregador (£/mês):",
+    "summary": {
+      "heading": "Visão geral da sua pensão",
+      "pensionPotLabel": "Fundo de pensão atual",
+      "userContributionLabel": "Sua contribuição mensal",
+      "employerContributionLabel": "Contribuição do empregador",
+      "addAnotherPension": "Adicionar outra pensão",
+      "addedPensions": "Pensões adicionadas: {{count}}",
+      "addedPensions_plural": "Pensões adicionadas: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",


### PR DESCRIPTION
## Summary
- add a pension forecast summary banner that surfaces the current pot, employee contributions, and employer contributions alongside an action to add another pension
- capture employer contribution input, derive display values from the latest forecast response, and expose the new field on the forecast API response type
- localise the new summary copy across locale bundles and extend the pension forecast tests to cover the banner rendering and interactions

## Testing
- npx vitest run src/pages/PensionForecast.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d311f93954832796727d7b63b74fa8