### PR TITLE
Refactor pension forecast layout with interactive controls

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -193,12 +193,49 @@
     "select": "Wählen Sie einen Besitzer."
   },
   "pensionForecast": {
+    "panels": {
+      "now": {
+        "title": "Jetzt",
+        "description": "Passen Sie Ausgaben und Ersparnisse von heute an, um Ihre Basis festzulegen.",
+        "summary": "Sie geben {{spending}} pro Monat aus und legen {{savings}} für die Zukunft zurück."
+      },
+      "future": {
+        "title": "Zukünftiges Ich",
+        "description": "Prognostizieren Sie, wie Ihre Renteneinnahmen mit Ihrem Plan wachsen."
+      }
+    },
+    "monthlySpending": {
+      "label": "Monatliche Ausgaben",
+      "hint": "Wie viel Sie derzeit typischerweise pro Monat ausgeben."
+    },
+    "monthlySavings": {
+      "label": "Monatliche Ersparnisse",
+      "hint": "Was Sie jeden Monat beständig für den Ruhestand investieren können."
+    },
+    "careerPath": {
+      "label": "Karriereweg",
+      "options": {
+        "steady": "Stetig",
+        "balanced": "Ausgewogen",
+        "accelerated": "Beschleunigt"
+      },
+      "descriptions": {
+        "steady": "Geringeres Wachstum und geringeres Risiko für Ihre Anlagen.",
+        "balanced": "Ein ausgewogener Ansatz, der Wachstum und Stabilität verbindet.",
+        "accelerated": "Höheres Wachstum, das eine aggressivere Strategie annimmt."
+      }
+    },
+    "deathAgeLabel": "Plan bis Alter",
+    "statePensionLabel": "Staatliche Rente (£/Jahr)",
+    "forecastCta": "Prognose aktualisieren",
+    "futureSummary": "Ihr zukünftiges Ich folgt dem {{career}}-Pfad mit {{growth}} jährlichem Wachstum.",
+    "plannedIncome": "Sie planen mit {{monthly}} pro Monat ({{annual}} jährlich).",
+    "monthlySavingsSummary": "Sie zahlen monatlich {{value}} für den Ruhestand ein.",
+    "projectedPot": "Prognostiziertes Vermögen mit {{age}}: {{value}}",
     "currentAge": "Aktuelles Alter: {{age}}",
     "birthDate": "Geburtsdatum: {{dob}}",
     "retirementAge": "Renteneintrittsalter: {{age}}",
     "pensionPot": "Pensionsvermögen",
-    "growthAssumption": "Wachstumsannahme (%):",
-    "monthlyContribution": "Monatlicher Beitrag (£):",
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -199,12 +199,49 @@
     "select": "Select an owner."
   },
   "pensionForecast": {
+    "panels": {
+      "now": {
+        "title": "Now",
+        "description": "Adjust today's spending and savings to set your baseline.",
+        "summary": "You're spending {{spending}} each month and setting aside {{savings}} for the future."
+      },
+      "future": {
+        "title": "Future you",
+        "description": "Project how your retirement income grows with your plan."
+      }
+    },
+    "monthlySpending": {
+      "label": "Monthly spending",
+      "hint": "How much you typically spend each month today."
+    },
+    "monthlySavings": {
+      "label": "Monthly savings",
+      "hint": "What you can consistently invest toward retirement each month."
+    },
+    "careerPath": {
+      "label": "Career path",
+      "options": {
+        "steady": "Steady",
+        "balanced": "Balanced",
+        "accelerated": "Accelerated"
+      },
+      "descriptions": {
+        "steady": "Lower growth, lower risk path for your investments.",
+        "balanced": "A balanced approach that blends growth and stability.",
+        "accelerated": "Higher growth path that assumes a more aggressive strategy."
+      }
+    },
+    "deathAgeLabel": "Plan to age",
+    "statePensionLabel": "State pension (£/yr)",
+    "forecastCta": "Update forecast",
+    "futureSummary": "Future you follows the {{career}} path with {{growth}} annual growth.",
+    "plannedIncome": "You're planning for {{monthly}} per month ({{annual}} annually).",
+    "monthlySavingsSummary": "Contributing {{value}} monthly toward retirement.",
+    "projectedPot": "Projected pot at {{age}}: {{value}}",
     "currentAge": "Current age: {{age}}",
     "birthDate": "Birth date: {{dob}}",
     "retirementAge": "Retirement age: {{age}}",
     "pensionPot": "Pension pot",
-    "growthAssumption": "Growth assumption (%):",
-    "monthlyContribution": "Monthly Contribution (£):",
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -193,12 +193,49 @@
     "select": "Seleccione un propietario."
   },
   "pensionForecast": {
+    "panels": {
+      "now": {
+        "title": "Ahora",
+        "description": "Ajusta los gastos y ahorros actuales para definir tu punto de partida.",
+        "summary": "Gastas {{spending}} al mes y reservas {{savings}} para el futuro."
+      },
+      "future": {
+        "title": "Tu yo futuro",
+        "description": "Proyecta cómo crecerán tus ingresos de jubilación con tu plan."
+      }
+    },
+    "monthlySpending": {
+      "label": "Gasto mensual",
+      "hint": "Cuánto sueles gastar cada mes hoy."
+    },
+    "monthlySavings": {
+      "label": "Ahorro mensual",
+      "hint": "Lo que puedes invertir de forma constante cada mes para la jubilación."
+    },
+    "careerPath": {
+      "label": "Trayectoria profesional",
+      "options": {
+        "steady": "Estable",
+        "balanced": "Equilibrada",
+        "accelerated": "Acelerada"
+      },
+      "descriptions": {
+        "steady": "Menor crecimiento y menor riesgo para tus inversiones.",
+        "balanced": "Un enfoque equilibrado que combina crecimiento y estabilidad.",
+        "accelerated": "Mayor crecimiento que asume una estrategia más agresiva."
+      }
+    },
+    "deathAgeLabel": "Plan hasta la edad",
+    "statePensionLabel": "Pensión estatal (£/año)",
+    "forecastCta": "Actualizar pronóstico",
+    "futureSummary": "Tu yo futuro sigue la trayectoria {{career}} con un crecimiento anual de {{growth}}.",
+    "plannedIncome": "Planeas {{monthly}} al mes ({{annual}} al año).",
+    "monthlySavingsSummary": "Aportas {{value}} al mes para la jubilación.",
+    "projectedPot": "Capital previsto a los {{age}}: {{value}}",
     "currentAge": "Edad actual: {{age}}",
     "birthDate": "Fecha de nacimiento: {{dob}}",
     "retirementAge": "Edad de jubilación: {{age}}",
     "pensionPot": "Fondo de pensiones",
-    "growthAssumption": "Suposición de crecimiento (%):",
-    "monthlyContribution": "Contribución mensual (£):",
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -193,12 +193,49 @@
     "select": "Sélectionnez un propriétaire."
   },
   "pensionForecast": {
+    "panels": {
+      "now": {
+        "title": "Maintenant",
+        "description": "Ajustez vos dépenses et économies actuelles pour définir votre point de départ.",
+        "summary": "Vous dépensez {{spending}} par mois et mettez de côté {{savings}} pour l'avenir."
+      },
+      "future": {
+        "title": "Votre futur vous",
+        "description": "Projetez l'évolution de vos revenus de retraite avec votre plan."
+      }
+    },
+    "monthlySpending": {
+      "label": "Dépenses mensuelles",
+      "hint": "Ce que vous dépensez habituellement chaque mois aujourd'hui."
+    },
+    "monthlySavings": {
+      "label": "Épargne mensuelle",
+      "hint": "Ce que vous pouvez investir régulièrement chaque mois pour la retraite."
+    },
+    "careerPath": {
+      "label": "Parcours de carrière",
+      "options": {
+        "steady": "Stable",
+        "balanced": "Équilibré",
+        "accelerated": "Accéléré"
+      },
+      "descriptions": {
+        "steady": "Croissance plus faible avec moins de risque pour vos placements.",
+        "balanced": "Une approche équilibrée qui combine croissance et stabilité.",
+        "accelerated": "Croissance plus élevée supposant une stratégie plus agressive."
+      }
+    },
+    "deathAgeLabel": "Planifier jusqu'à l'âge",
+    "statePensionLabel": "Pension d'État (£/an)",
+    "forecastCta": "Mettre à jour la projection",
+    "futureSummary": "Votre futur vous suit le parcours {{career}} avec une croissance annuelle de {{growth}}.",
+    "plannedIncome": "Vous prévoyez {{monthly}} par mois ({{annual}} par an).",
+    "monthlySavingsSummary": "Vous versez {{value}} par mois pour la retraite.",
+    "projectedPot": "Capital projeté à {{age}} : {{value}}",
     "currentAge": "Âge actuel : {{age}}",
     "birthDate": "Date de naissance : {{dob}}",
     "retirementAge": "Âge de retraite : {{age}}",
     "pensionPot": "Pot de pension",
-    "growthAssumption": "Hypothèse de croissance (%):",
-    "monthlyContribution": "Contribution mensuelle (£):",
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -193,12 +193,49 @@
     "select": "Seleziona un proprietario."
   },
   "pensionForecast": {
+    "panels": {
+      "now": {
+        "title": "Adesso",
+        "description": "Regola le spese e i risparmi attuali per impostare il punto di partenza.",
+        "summary": "Spendi {{spending}} al mese e metti da parte {{savings}} per il futuro."
+      },
+      "future": {
+        "title": "Il tuo futuro",
+        "description": "Proietta come cresceranno i tuoi redditi pensionistici con il piano."
+      }
+    },
+    "monthlySpending": {
+      "label": "Spesa mensile",
+      "hint": "Quanto spendi di solito ogni mese oggi."
+    },
+    "monthlySavings": {
+      "label": "Risparmio mensile",
+      "hint": "Quanto puoi investire con costanza ogni mese per la pensione."
+    },
+    "careerPath": {
+      "label": "Percorso di carriera",
+      "options": {
+        "steady": "Stabile",
+        "balanced": "Bilanciato",
+        "accelerated": "Accelerato"
+      },
+      "descriptions": {
+        "steady": "Crescita più bassa e rischio ridotto per i tuoi investimenti.",
+        "balanced": "Un approccio bilanciato che combina crescita e stabilità.",
+        "accelerated": "Crescita più alta che presume una strategia più aggressiva."
+      }
+    },
+    "deathAgeLabel": "Pianifica fino all'età",
+    "statePensionLabel": "Pensione statale (£/anno)",
+    "forecastCta": "Aggiorna previsione",
+    "futureSummary": "Il tuo futuro segue il percorso {{career}} con una crescita annuale di {{growth}}.",
+    "plannedIncome": "Prevedi {{monthly}} al mese ({{annual}} all'anno).",
+    "monthlySavingsSummary": "Versi {{value}} al mese per la pensione.",
+    "projectedPot": "Capitale previsto a {{age}}: {{value}}",
     "currentAge": "Età attuale: {{age}}",
     "birthDate": "Data di nascita: {{dob}}",
     "retirementAge": "Età pensionistica: {{age}}",
     "pensionPot": "Fondo pensione",
-    "growthAssumption": "Ipotesi di crescita (%):",
-    "monthlyContribution": "Contributo mensile (£):",
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -193,12 +193,49 @@
     "select": "Selecione um proprietário."
   },
   "pensionForecast": {
+    "panels": {
+      "now": {
+        "title": "Agora",
+        "description": "Ajuste os gastos e a poupança atuais para definir sua base.",
+        "summary": "Você gasta {{spending}} por mês e reserva {{savings}} para o futuro."
+      },
+      "future": {
+        "title": "Você no futuro",
+        "description": "Projete como a renda da aposentadoria cresce com seu plano."
+      }
+    },
+    "monthlySpending": {
+      "label": "Gasto mensal",
+      "hint": "Quanto você costuma gastar a cada mês hoje."
+    },
+    "monthlySavings": {
+      "label": "Poupança mensal",
+      "hint": "Quanto você pode investir de forma consistente todo mês para a aposentadoria."
+    },
+    "careerPath": {
+      "label": "Trajetória profissional",
+      "options": {
+        "steady": "Estável",
+        "balanced": "Equilibrada",
+        "accelerated": "Acelerada"
+      },
+      "descriptions": {
+        "steady": "Crescimento menor com menos risco para seus investimentos.",
+        "balanced": "Uma abordagem equilibrada que combina crescimento e estabilidade.",
+        "accelerated": "Maior crescimento que assume uma estratégia mais agressiva."
+      }
+    },
+    "deathAgeLabel": "Planeje até a idade",
+    "statePensionLabel": "Pensão estatal (£/ano)",
+    "forecastCta": "Atualizar projeção",
+    "futureSummary": "Seu futuro segue a trajetória {{career}} com crescimento anual de {{growth}}.",
+    "plannedIncome": "Você planeja {{monthly}} por mês ({{annual}} por ano).",
+    "monthlySavingsSummary": "Você contribui com {{value}} por mês para a aposentadoria.",
+    "projectedPot": "Montante projetado aos {{age}}: {{value}}",
     "currentAge": "Idade atual: {{age}}",
     "birthDate": "Data de nascimento: {{dob}}",
     "retirementAge": "Idade de aposentadoria: {{age}}",
     "pensionPot": "Fundo de pensão",
-    "growthAssumption": "Suposição de crescimento (%):",
-    "monthlyContribution": "Contribuição mensal (£):",
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/pages/PensionForecast.test.tsx
+++ b/frontend/src/pages/PensionForecast.test.tsx
@@ -31,7 +31,7 @@ describe("PensionForecast page", () => {
     vi.clearAllMocks();
   });
 
-  it("renders owner selector", async () => {
+  it("renders owner selector and sliders", async () => {
     mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
     mockGetPensionForecast.mockResolvedValue({
       forecast: [],
@@ -53,10 +53,21 @@ describe("PensionForecast page", () => {
     const form = document.querySelector("form")!;
     const ownerSelect = await within(form).findByLabelText(/owner/i);
     expect(ownerSelect).toBeInTheDocument();
-    const selects = await screen.findAllByLabelText(/owner/i, {
-      selector: 'select',
-    });
-    expect(selects[0]).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /now/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /future you/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      within(form).getByLabelText(/monthly spending/i, { selector: "input" }),
+    ).toHaveAttribute("type", "range");
+    expect(
+      within(form).getByLabelText(/monthly savings/i, { selector: "input" }),
+    ).toHaveAttribute("type", "range");
+    expect(
+      within(form).getByLabelText(/career path/i, { selector: "input" }),
+    ).toHaveAttribute("type", "range");
   });
 
   it("submits with selected owner", async () => {
@@ -90,14 +101,18 @@ describe("PensionForecast page", () => {
     const ownerSelect = await within(form).findByLabelText(/owner/i);
     await userEvent.selectOptions(ownerSelect, "beth");
 
-    const growth = within(form).getByLabelText(/growth assumption/i);
-    await userEvent.selectOptions(growth, "7");
+    const spendingSlider = within(form).getByLabelText(/monthly spending/i);
+    fireEvent.change(spendingSlider, { target: { value: "1200" } });
+
+    const savingsSlider = within(form).getByLabelText(/monthly savings/i);
+    fireEvent.change(savingsSlider, { target: { value: "100" } });
+
+    const careerSlider = within(form).getByLabelText(/career path/i);
+    fireEvent.change(careerSlider, { target: { value: "2" } });
 
     fireEvent.change(ownerSelect, { target: { value: "beth" } });
-    const monthly = within(form).getByLabelText(/monthly contribution/i);
-    fireEvent.change(monthly, { target: { value: "100" } });
 
-    const btn = screen.getByRole("button", { name: /forecast/i });
+    const btn = screen.getByRole("button", { name: /update forecast/i });
     await userEvent.click(btn);
 
     await vi.waitFor(() =>
@@ -106,6 +121,7 @@ describe("PensionForecast page", () => {
           owner: "beth",
           investmentGrowthPct: 7,
           contributionMonthly: 100,
+          desiredIncomeAnnual: 14400,
         }),
       ),
     );
@@ -117,6 +133,19 @@ describe("PensionForecast page", () => {
       screen.getByText(
         "You're on track: projected income of £15,000.00 meets your desired £14,000.00 from age 64.",
       ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Future you follows the Accelerated path with 7% annual growth.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "You're planning for £1,200.00 per month (£14,400.00 annually).",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Contributing £100.00 monthly toward retirement."),
     ).toBeInTheDocument();
     expect(screen.getByText("State pension")).toBeInTheDocument();
     expect(screen.getByText("Defined benefit")).toBeInTheDocument();
@@ -156,10 +185,10 @@ describe("PensionForecast page", () => {
     renderWithI18n(<PensionForecast />);
 
     const form = document.querySelector("form")!;
-    const desired = within(form).getByLabelText(/desired income/i);
-    fireEvent.change(desired, { target: { value: "12000" } });
+    const spendingSlider = within(form).getByLabelText(/monthly spending/i);
+    fireEvent.change(spendingSlider, { target: { value: "1000" } });
 
-    const btn = screen.getByRole("button", { name: /forecast/i });
+    const btn = screen.getByRole("button", { name: /update forecast/i });
     await userEvent.click(btn);
 
     await screen.findByText(

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { type ChangeEvent, type ReactNode, useEffect, useMemo, useState } from "react";
 import {
   LineChart,
   Line,
@@ -16,15 +16,135 @@ import type { OwnerSummary } from "../types";
 import { OwnerSelector } from "../components/OwnerSelector";
 import { useTranslation } from "react-i18next";
 
+type SliderFieldProps = {
+  id: string;
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (value: number) => void;
+  formatValue?: (value: number) => string;
+  hint?: string;
+};
+
+function SliderField({
+  id,
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+  formatValue,
+  hint,
+}: SliderFieldProps) {
+  const formattedValue = formatValue ? formatValue(value) : String(value);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(Number(event.target.value));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <label htmlFor={id} className="text-sm font-medium text-gray-700">
+          {label}
+        </label>
+        <span className="text-sm font-semibold text-gray-900" aria-live="polite">
+          {formattedValue}
+        </span>
+      </div>
+      <input
+        id={id}
+        type="range"
+        className="w-full accent-blue-600"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-valuetext={formattedValue}
+        {...(hint ? { "aria-describedby": `${id}-hint` } : {})}
+      />
+      {hint && (
+        <p id={`${id}-hint`} className="text-xs text-gray-500">
+          {hint}
+        </p>
+      )}
+    </div>
+  );
+}
+
+type CardProps = {
+  title: string;
+  description?: string;
+  children: ReactNode;
+};
+
+function Card({ title, description, children }: CardProps) {
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      <header className="mb-4 space-y-1">
+        <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+        {description && <p className="text-sm text-gray-600">{description}</p>}
+      </header>
+      <div className="space-y-5">{children}</div>
+    </section>
+  );
+}
+
 export default function PensionForecast() {
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
   const [owner, setOwner] = useState("");
   const [deathAge, setDeathAge] = useState(90);
   const [statePension, setStatePension] = useState<string>("");
-  const [contributionAnnual, setContributionAnnual] = useState<string>("");
-  const [contributionMonthly, setContributionMonthly] = useState<string>("");
-  const [desiredIncome, setDesiredIncome] = useState<string>("");
-  const [investmentGrowthPct, setInvestmentGrowthPct] = useState(5);
+  const [monthlySavings, setMonthlySavings] = useState(500);
+  const [monthlySpending, setMonthlySpending] = useState(2000);
+  const { t } = useTranslation();
+
+  const careerPathOptions = useMemo(
+    () => [
+      {
+        key: "steady",
+        label: t("pensionForecast.careerPath.options.steady"),
+        description: t("pensionForecast.careerPath.descriptions.steady"),
+        growth: 3,
+      },
+      {
+        key: "balanced",
+        label: t("pensionForecast.careerPath.options.balanced"),
+        description: t("pensionForecast.careerPath.descriptions.balanced"),
+        growth: 5,
+      },
+      {
+        key: "accelerated",
+        label: t("pensionForecast.careerPath.options.accelerated"),
+        description: t("pensionForecast.careerPath.descriptions.accelerated"),
+        growth: 7,
+      },
+    ],
+    [t],
+  );
+
+  const [careerPathIndex, setCareerPathIndex] = useState(() => {
+    const defaultIndex = careerPathOptions.findIndex((opt) => opt.growth === 5);
+    return defaultIndex >= 0 ? defaultIndex : 0;
+  });
+
+  useEffect(() => {
+    setCareerPathIndex((prev) => {
+      const maxIndex = careerPathOptions.length - 1;
+      return prev > maxIndex ? maxIndex : prev;
+    });
+  }, [careerPathOptions]);
+
+  const investmentGrowthPct =
+    careerPathOptions[careerPathIndex]?.growth ?? careerPathOptions[0].growth;
+
   const [data, setData] = useState<{ age: number; income: number }[]>([]);
   const [projectedPot, setProjectedPot] = useState<number | null>(null);
   const [pensionPot, setPensionPot] = useState<number | null>(null);
@@ -42,7 +162,6 @@ export default function PensionForecast() {
     null,
   );
   const [err, setErr] = useState<string | null>(null);
-  const { t } = useTranslation();
 
   const currencyFormatter = useMemo(
     () =>
@@ -79,24 +198,16 @@ export default function PensionForecast() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const contributionMonthlyVal = contributionMonthly
-        ? parseFloat(contributionMonthly)
+      const statePensionAnnual = statePension
+        ? parseFloat(statePension)
         : undefined;
-      const contributionAnnualVal = contributionAnnual
-        ? parseFloat(contributionAnnual)
-        : undefined;
+      const desiredIncomeAnnual = monthlySpending * 12;
       const res = await getPensionForecast({
         owner,
         deathAge,
-        statePensionAnnual: statePension
-          ? parseFloat(statePension)
-          : undefined,
-        contributionMonthly: contributionMonthlyVal,
-        contributionAnnual:
-          contributionMonthlyVal !== undefined ? undefined : contributionAnnualVal,
-        desiredIncomeAnnual: desiredIncome
-          ? parseFloat(desiredIncome)
-          : undefined,
+        statePensionAnnual,
+        contributionMonthly: monthlySavings,
+        desiredIncomeAnnual,
         investmentGrowthPct,
       });
       setData(res.forecast);
@@ -218,175 +329,239 @@ export default function PensionForecast() {
       }[banner.variant]
     : "";
 
+  const desiredIncomeAnnualFormatted = currencyFormatter.format(
+    monthlySpending * 12,
+  );
+  const desiredIncomeMonthlyFormatted = currencyFormatter.format(monthlySpending);
+  const monthlySavingsFormatted = currencyFormatter.format(monthlySavings);
+  const careerPathDescription =
+    careerPathOptions[careerPathIndex]?.description ?? "";
+  const careerPathLabel = careerPathOptions[careerPathIndex]?.label ?? "";
+
   return (
-    <div>
-      <h1 className="mb-4 text-2xl md:text-4xl">Pension Forecast</h1>
-      <form onSubmit={handleSubmit} className="mb-4 space-y-2">
-        <OwnerSelector owners={owners} selected={owner} onSelect={setOwner} />
-        <div>
-          <label className="mr-2">Death Age:</label>
-          <input
-            type="number"
-            value={deathAge}
-            onChange={(e) => setDeathAge(Number(e.target.value))}
-            required
-          />
-        </div>
-        <div>
-          <label className="mr-2">State Pension (£/yr):</label>
-          <input
-            type="number"
-            value={statePension}
-            onChange={(e) => setStatePension(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="mr-2" htmlFor="contribution-annual">
-            Annual Contribution (£):
-          </label>
-          <input
-            id="contribution-annual"
-            type="number"
-            value={contributionAnnual}
-            onChange={(e) => setContributionAnnual(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="mr-2" htmlFor="contribution-monthly">
-            {t("pensionForecast.monthlyContribution")}
-          </label>
-          <input
-            id="contribution-monthly"
-            type="number"
-            value={contributionMonthly}
-            onChange={(e) => setContributionMonthly(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="mr-2" htmlFor="desired-income">
-            Desired Income (£/yr):
-          </label>
-          <input
-            id="desired-income"
-            type="number"
-            value={desiredIncome}
-            onChange={(e) => setDesiredIncome(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="mr-2" htmlFor="investment-growth">
-            {t("pensionForecast.growthAssumption")}
-          </label>
-          <select
-            id="investment-growth"
-            value={investmentGrowthPct}
-            onChange={(e) => setInvestmentGrowthPct(Number(e.target.value))}
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold text-gray-900 md:text-4xl">
+        {t("app.modes.pension")}
+      </h1>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Card
+            title={t("pensionForecast.panels.now.title")}
+            description={t("pensionForecast.panels.now.description")}
           >
-            {[3, 5, 7].map((g) => (
-              <option key={g} value={g}>
-                {g}%
-              </option>
-            ))}
-          </select>
+            <OwnerSelector owners={owners} selected={owner} onSelect={setOwner} />
+            <SliderField
+              id="monthly-spending"
+              label={t("pensionForecast.monthlySpending.label")}
+              value={monthlySpending}
+              min={500}
+              max={6000}
+              step={50}
+              onChange={setMonthlySpending}
+              formatValue={(val) => currencyFormatter.format(val)}
+              hint={t("pensionForecast.monthlySpending.hint")}
+            />
+            <SliderField
+              id="monthly-savings"
+              label={t("pensionForecast.monthlySavings.label")}
+              value={monthlySavings}
+              min={0}
+              max={3000}
+              step={50}
+              onChange={setMonthlySavings}
+              formatValue={(val) => currencyFormatter.format(val)}
+              hint={t("pensionForecast.monthlySavings.hint")}
+            />
+            <div className="rounded-lg border border-blue-100 bg-blue-50 p-4 text-sm text-blue-900">
+              {t("pensionForecast.panels.now.summary", {
+                spending: desiredIncomeMonthlyFormatted,
+                savings: monthlySavingsFormatted,
+              })}
+            </div>
+          </Card>
+          <Card
+            title={t("pensionForecast.panels.future.title")}
+            description={t("pensionForecast.panels.future.description")}
+          >
+            <SliderField
+              id="career-path"
+              label={t("pensionForecast.careerPath.label")}
+              value={careerPathIndex}
+              min={0}
+              max={careerPathOptions.length - 1}
+              step={1}
+              onChange={(val) => {
+                const nextIndex = Math.round(val);
+                setCareerPathIndex(nextIndex);
+              }}
+              formatValue={(val) => {
+                const option = careerPathOptions[Math.round(val)];
+                return option ? option.label : careerPathLabel;
+              }}
+              hint={careerPathDescription}
+            />
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col gap-2 text-sm font-medium text-gray-700" htmlFor="death-age">
+                <span>{t("pensionForecast.deathAgeLabel")}</span>
+                <input
+                  id="death-age"
+                  type="number"
+                  min={0}
+                  value={deathAge}
+                  onChange={(e) => setDeathAge(Number(e.target.value))}
+                  className="rounded-lg border border-gray-300 px-3 py-2 text-base shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                  required
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-sm font-medium text-gray-700" htmlFor="state-pension">
+                <span>{t("pensionForecast.statePensionLabel")}</span>
+                <div className="flex items-center gap-2">
+                  <input
+                    id="state-pension"
+                    type="number"
+                    min={0}
+                    value={statePension}
+                    onChange={(e) => setStatePension(e.target.value)}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-base shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                  />
+                  <span className="text-xs text-gray-500">£/yr</span>
+                </div>
+              </label>
+            </div>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              {t("pensionForecast.forecastCta")}
+            </button>
+            {err && <p className="text-sm text-red-600">{err}</p>}
+            {banner && (
+              <div
+                className={`rounded-lg border px-4 py-3 text-sm ${bannerClassName}`}
+                role="status"
+              >
+                {banner.message}
+              </div>
+            )}
+            <div className="space-y-2 rounded-lg bg-gray-50 p-4 text-sm text-gray-700">
+              <p className="font-semibold text-gray-900">
+                {t("pensionForecast.futureSummary", {
+                  career: careerPathLabel,
+                  growth: percentFormatter.format(investmentGrowthPct / 100),
+                })}
+              </p>
+              <p>
+                {t("pensionForecast.plannedIncome", {
+                  monthly: desiredIncomeMonthlyFormatted,
+                  annual: desiredIncomeAnnualFormatted,
+                })}
+              </p>
+              <p>
+                {t("pensionForecast.monthlySavingsSummary", {
+                  value: monthlySavingsFormatted,
+                })}
+              </p>
+              {currentAge !== null && dob && (
+                <p>
+                  {t("pensionForecast.currentAge", { age: currentAge })} (
+                  {t("pensionForecast.birthDate", { dob })})
+                </p>
+              )}
+              {retirementAge !== null && (
+                <p>{t("pensionForecast.retirementAge", { age: retirementAge })}</p>
+              )}
+              {pensionPot !== null && (
+                <p>
+                  {t("pensionForecast.pensionPot")}: £{pensionPot.toFixed(2)}
+                </p>
+              )}
+              {projectedPot !== null && retirementAge !== null && (
+                <p>
+                  {t("pensionForecast.projectedPot", {
+                    age: retirementAge,
+                    value: currencyFormatter.format(projectedPot),
+                  })}
+                </p>
+              )}
+            </div>
+            {retirementIncomeBreakdown && (
+              <div className="space-y-3">
+                <h3 className="text-lg font-semibold text-gray-900">
+                  {t("pensionForecast.incomeBreakdownHeading")}
+                </h3>
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead>
+                      <tr className="bg-gray-50">
+                        <th className="px-3 py-2 text-left font-semibold text-gray-700">
+                          {t("pensionForecast.incomeTable.source")}
+                        </th>
+                        <th className="px-3 py-2 text-right font-semibold text-gray-700">
+                          {t("pensionForecast.incomeTable.annual")}
+                        </th>
+                        <th className="px-3 py-2 text-right font-semibold text-gray-700">
+                          {t("pensionForecast.incomeTable.monthly")}
+                        </th>
+                        <th className="px-3 py-2 text-right font-semibold text-gray-700">
+                          {t("pensionForecast.incomeTable.share")}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {breakdownEntries.map(({ key, label, annual, monthly, share }) => (
+                        <tr key={String(key)} className="odd:bg-white even:bg-gray-50">
+                          <td className="px-3 py-2">{label}</td>
+                          <td className="whitespace-nowrap px-3 py-2 text-right">
+                            {currencyFormatter.format(annual)}
+                          </td>
+                          <td className="whitespace-nowrap px-3 py-2 text-right">
+                            {currencyFormatter.format(monthly)}
+                          </td>
+                          <td className="whitespace-nowrap px-3 py-2 text-right">
+                            {share}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+            {!retirementIncomeBreakdown && retirementIncomeTotal != null && (
+              <p className="text-sm text-gray-600">
+                {t("pensionForecast.prediction.noBreakdown")}
+              </p>
+            )}
+            {retirementIncomeTotal != null && (
+              <div className="space-y-1 text-sm text-gray-800">
+                <p>
+                  {t("pensionForecast.totalAnnualIncome")}: {totalAnnualIncomeFormatted}
+                </p>
+                <p>
+                  {t("pensionForecast.totalMonthlyIncome")}: {totalMonthlyIncomeFormatted}
+                </p>
+              </div>
+            )}
+            {data.length > 0 && (
+              <div className="h-72">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={data}>
+                    <XAxis dataKey="age" />
+                    <YAxis />
+                    <Tooltip />
+                    <Line
+                      type="monotone"
+                      dataKey="income"
+                      stroke="#2563eb"
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </Card>
         </div>
-        <button type="submit" className="mt-2 rounded bg-blue-500 px-4 py-2 text-white">
-          Forecast
-        </button>
       </form>
-      {err && <p className="text-red-500">{err}</p>}
-      {banner && (
-        <div
-          className={`mb-4 rounded border px-4 py-3 text-sm ${bannerClassName}`}
-          role="status"
-        >
-          {banner.message}
-        </div>
-      )}
-      {currentAge !== null && dob && (
-        <p className="mb-2">
-          {t("pensionForecast.currentAge", { age: currentAge })} (
-          {t("pensionForecast.birthDate", { dob })})
-        </p>
-      )}
-      {retirementAge !== null && (
-        <p className="mb-2">{t("pensionForecast.retirementAge", { age: retirementAge })}</p>
-      )}
-      {pensionPot !== null && (
-        <p className="mb-2">
-          {t("pensionForecast.pensionPot")}: £{pensionPot.toFixed(2)}
-        </p>
-      )}
-      {projectedPot !== null && retirementAge !== null && (
-        <p className="mb-2">
-          Projected pot at {retirementAge}: £{projectedPot.toFixed(2)}
-        </p>
-      )}
-      {retirementIncomeBreakdown && (
-        <div className="mt-4 overflow-x-auto">
-          <h2 className="mb-2 text-xl">
-            {t("pensionForecast.incomeBreakdownHeading")}
-          </h2>
-          <table className="min-w-full divide-y divide-gray-200 text-sm">
-            <thead>
-              <tr className="bg-gray-50">
-                <th className="px-3 py-2 text-left font-semibold">
-                  {t("pensionForecast.incomeTable.source")}
-                </th>
-                <th className="px-3 py-2 text-right font-semibold">
-                  {t("pensionForecast.incomeTable.annual")}
-                </th>
-                <th className="px-3 py-2 text-right font-semibold">
-                  {t("pensionForecast.incomeTable.monthly")}
-                </th>
-                <th className="px-3 py-2 text-right font-semibold">
-                  {t("pensionForecast.incomeTable.share")}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {breakdownEntries.map(({ key, label, annual, monthly, share }) => (
-                <tr key={String(key)} className="odd:bg-white even:bg-gray-50">
-                  <td className="px-3 py-2">{label}</td>
-                  <td className="whitespace-nowrap px-3 py-2 text-right">
-                    {currencyFormatter.format(annual)}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-2 text-right">
-                    {currencyFormatter.format(monthly)}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-2 text-right">
-                    {share}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-      {!retirementIncomeBreakdown && retirementIncomeTotal != null && (
-        <p className="mt-4 text-sm text-gray-600">
-          {t("pensionForecast.prediction.noBreakdown")}
-        </p>
-      )}
-      {retirementIncomeTotal != null && (
-        <div className="mt-2 text-sm">
-          <p>
-            {t("pensionForecast.totalAnnualIncome")}: {totalAnnualIncomeFormatted}
-          </p>
-          <p>
-            {t("pensionForecast.totalMonthlyIncome")}: {totalMonthlyIncomeFormatted}
-          </p>
-        </div>
-      )}
-      {data.length > 0 && (
-        <ResponsiveContainer width="100%" height={300}>
-          <LineChart data={data}>
-            <XAxis dataKey="age" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="income" stroke="#8884d8" dot={false} />
-          </LineChart>
-        </ResponsiveContainer>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor the pension forecast page into "Now" and "Future you" panels with slider-driven controls for spending, savings, and career path linked to the forecast request
- surface the forecast outputs inside the Future panel with updated copy, formatting, and chart styling
- add the new copy to all locale translation files and expand the unit tests to validate the refreshed layout and interactions

## Testing
- npm run test -- PensionForecast
- npm run lint *(fails: pre-existing lint errors outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d31277f4208327991f1872b79c1b56