### PR TITLE
Refactor Pension Forecast with dual panels and sliders

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -193,12 +193,35 @@
     "select": "Wählen Sie einen Besitzer."
   },
   "pensionForecast": {
+    "nowHeading": "Jetzt",
+    "nowIntro": "Passe die Einstellungen an deine aktuelle Situation an.",
+    "futureHeading": "Zukünftiges Ich",
+    "futureIntro": "Sieh dir an, wie sich diese Entscheidungen auf dein Renteneinkommen auswirken.",
+    "futurePlaceholder": "Starte eine Prognose, um dein zukünftiges Einkommen zu visualisieren.",
+    "perMonthSuffix": "pro Monat",
+    "deathAgeLabel": "Sterbealter",
+    "statePensionLabel": "Staatliche Rente (£/Jahr)",
+    "forecastCta": "Prognose aktualisieren",
+    "monthlySpendingLabel": "Monatliche Ausgaben",
+    "monthlySavingsLabel": "Monatliche Ersparnisse",
+    "desiredIncomeGoal": "Gewünschtes Einkommensziel",
+    "growthAssumptionValue": "Wachstumsannahme: {{value}}%",
+    "projectedPotAtAge": "Prognostiziertes Vermögen mit {{age}} Jahren: {{total}}",
     "currentAge": "Aktuelles Alter: {{age}}",
     "birthDate": "Geburtsdatum: {{dob}}",
     "retirementAge": "Renteneintrittsalter: {{age}}",
     "pensionPot": "Pensionsvermögen",
     "growthAssumption": "Wachstumsannahme (%):",
     "monthlyContribution": "Monatlicher Beitrag (£):",
+    "careerPath": {
+      "label": "Karriereweg",
+      "emerging": "Am Anfang",
+      "emergingDescription": "Start mit stabilen 3% Wachstum.",
+      "steady": "Stetiger Fortschritt",
+      "steadyDescription": "Solide Karriere mit 5% Wachstum.",
+      "accelerating": "Beschleunigt",
+      "acceleratingDescription": "Auf Kurs für schnellere 7% Wachstum."
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",
@@ -414,16 +437,16 @@
     "grouping": "Gruppierung",
     "actions": "Actions",
     "add": "Add Instrument",
-  "save": "Save",
-  "saveSuccess": "Saved",
-  "saveError": "Error saving",
-  "searchPlaceholder": "Filter instruments…",
-  "validation": {
-    "ticker": "Ticker is required",
-    "name": "Name is required",
-    "grouping": "Grouping is required"
-  }
-},
+    "save": "Save",
+    "saveSuccess": "Saved",
+    "saveError": "Error saving",
+    "searchPlaceholder": "Filter instruments…",
+    "validation": {
+      "ticker": "Ticker is required",
+      "name": "Name is required",
+      "grouping": "Grouping is required"
+    }
+  },
   "var": {
     "title": "Value at Risk",
     "details": "Details zur historischen Simulation",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -199,12 +199,35 @@
     "select": "Select an owner."
   },
   "pensionForecast": {
+    "nowHeading": "Now",
+    "nowIntro": "Adjust the controls to match your situation today.",
+    "futureHeading": "Future you",
+    "futureIntro": "See how those choices shape your retirement income.",
+    "futurePlaceholder": "Run a forecast to visualise your future income.",
+    "perMonthSuffix": "per month",
+    "deathAgeLabel": "Death age",
+    "statePensionLabel": "State pension (£/yr)",
+    "forecastCta": "Update forecast",
+    "monthlySpendingLabel": "Monthly spending",
+    "monthlySavingsLabel": "Monthly savings",
+    "desiredIncomeGoal": "Desired income goal",
+    "growthAssumptionValue": "Growth assumption: {{value}}%",
+    "projectedPotAtAge": "Projected pot at age {{age}}: {{total}}",
     "currentAge": "Current age: {{age}}",
     "birthDate": "Birth date: {{dob}}",
     "retirementAge": "Retirement age: {{age}}",
     "pensionPot": "Pension pot",
     "growthAssumption": "Growth assumption (%):",
     "monthlyContribution": "Monthly Contribution (£):",
+    "careerPath": {
+      "label": "Career path",
+      "emerging": "Finding your feet",
+      "emergingDescription": "Starting out with steady 3% growth.",
+      "steady": "Steady progress",
+      "steadyDescription": "Comfortable career with 5% growth.",
+      "accelerating": "Accelerating",
+      "acceleratingDescription": "On track for faster 7% growth."
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",
@@ -429,16 +452,16 @@
     "grouping": "Grouping",
     "actions": "Actions",
     "add": "Add Instrument",
-  "save": "Save",
-  "saveSuccess": "Saved",
-  "saveError": "Error saving",
-  "searchPlaceholder": "Filter instruments…",
-  "validation": {
-    "ticker": "Ticker is required",
-    "name": "Name is required",
-    "grouping": "Grouping is required"
-  }
-},
+    "save": "Save",
+    "saveSuccess": "Saved",
+    "saveError": "Error saving",
+    "searchPlaceholder": "Filter instruments…",
+    "validation": {
+      "ticker": "Ticker is required",
+      "name": "Name is required",
+      "grouping": "Grouping is required"
+    }
+  },
   "var": {
     "title": "Value at Risk",
     "details": "Historical simulation details",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -220,6 +220,29 @@
       "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
       "earliest": "Estimated earliest retirement age: {{age}}",
       "noBreakdown": "No income breakdown available."
+    },
+    "nowHeading": "Ahora",
+    "nowIntro": "Ajusta los controles para que coincidan con tu situación actual.",
+    "futureHeading": "Tu yo futuro",
+    "futureIntro": "Descubre cómo esas elecciones influyen en tus ingresos de jubilación.",
+    "futurePlaceholder": "Ejecuta una proyección para visualizar tus ingresos futuros.",
+    "perMonthSuffix": "al mes",
+    "deathAgeLabel": "Edad de fallecimiento",
+    "statePensionLabel": "Pensión estatal (£/año)",
+    "forecastCta": "Actualizar proyección",
+    "monthlySpendingLabel": "Gasto mensual",
+    "monthlySavingsLabel": "Ahorro mensual",
+    "desiredIncomeGoal": "Objetivo de ingreso deseado",
+    "growthAssumptionValue": "Supuesto de crecimiento: {{value}}%",
+    "projectedPotAtAge": "Ahorro proyectado a los {{age}} años: {{total}}",
+    "careerPath": {
+      "label": "Trayectoria profesional",
+      "emerging": "Comenzando",
+      "emergingDescription": "Empezando con un crecimiento estable del 3%.",
+      "steady": "Progreso constante",
+      "steadyDescription": "Carrera cómoda con un crecimiento del 5%.",
+      "accelerating": "Acelerando",
+      "acceleratingDescription": "En camino a un crecimiento más rápido del 7%."
     }
   },
   "group": {
@@ -414,16 +437,16 @@
     "grouping": "Agrupación",
     "actions": "Actions",
     "add": "Add Instrument",
-  "save": "Save",
-  "saveSuccess": "Saved",
-  "saveError": "Error saving",
-  "searchPlaceholder": "Filter instruments…",
-  "validation": {
-    "ticker": "Ticker is required",
-    "name": "Name is required",
-    "grouping": "Grouping is required"
-  }
-},
+    "save": "Save",
+    "saveSuccess": "Saved",
+    "saveError": "Error saving",
+    "searchPlaceholder": "Filter instruments…",
+    "validation": {
+      "ticker": "Ticker is required",
+      "name": "Name is required",
+      "grouping": "Grouping is required"
+    }
+  },
   "var": {
     "title": "Valor en Riesgo",
     "details": "Detalles de la simulación histórica",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -220,6 +220,29 @@
       "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
       "earliest": "Estimated earliest retirement age: {{age}}",
       "noBreakdown": "No income breakdown available."
+    },
+    "nowHeading": "Aujourd'hui",
+    "nowIntro": "Ajustez les commandes pour refléter votre situation actuelle.",
+    "futureHeading": "Vous futur",
+    "futureIntro": "Voyez comment ces choix façonnent votre revenu de retraite.",
+    "futurePlaceholder": "Lancez une projection pour visualiser vos revenus futurs.",
+    "perMonthSuffix": "par mois",
+    "deathAgeLabel": "Âge au décès",
+    "statePensionLabel": "Pension d'État (£/an)",
+    "forecastCta": "Mettre à jour la projection",
+    "monthlySpendingLabel": "Dépenses mensuelles",
+    "monthlySavingsLabel": "Épargne mensuelle",
+    "desiredIncomeGoal": "Objectif de revenu souhaité",
+    "growthAssumptionValue": "Hypothèse de croissance : {{value}} %",
+    "projectedPotAtAge": "Capital projeté à {{age}} ans : {{total}}",
+    "careerPath": {
+      "label": "Parcours professionnel",
+      "emerging": "Débuts",
+      "emergingDescription": "Commence avec une croissance régulière de 3 %.",
+      "steady": "Progression régulière",
+      "steadyDescription": "Carrière confortable avec une croissance de 5 %.",
+      "accelerating": "Accélération",
+      "acceleratingDescription": "En bonne voie pour une croissance plus rapide de 7 %."
     }
   },
   "group": {
@@ -415,16 +438,16 @@
     "grouping": "Regroupement",
     "actions": "Actions",
     "add": "Add Instrument",
-  "save": "Save",
-  "saveSuccess": "Saved",
-  "saveError": "Error saving",
-  "searchPlaceholder": "Filter instruments…",
-  "validation": {
-    "ticker": "Ticker is required",
-    "name": "Name is required",
-    "grouping": "Grouping is required"
-  }
-},
+    "save": "Save",
+    "saveSuccess": "Saved",
+    "saveError": "Error saving",
+    "searchPlaceholder": "Filter instruments…",
+    "validation": {
+      "ticker": "Ticker is required",
+      "name": "Name is required",
+      "grouping": "Grouping is required"
+    }
+  },
   "var": {
     "title": "Valeur à risque",
     "details": "Détails de la simulation historique",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -220,6 +220,29 @@
       "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
       "earliest": "Estimated earliest retirement age: {{age}}",
       "noBreakdown": "No income breakdown available."
+    },
+    "nowHeading": "Adesso",
+    "nowIntro": "Regola i controlli per rispecchiare la tua situazione attuale.",
+    "futureHeading": "Il tuo futuro",
+    "futureIntro": "Scopri come queste scelte influiscono sul tuo reddito pensionistico.",
+    "futurePlaceholder": "Esegui una previsione per visualizzare il tuo reddito futuro.",
+    "perMonthSuffix": "al mese",
+    "deathAgeLabel": "Età al decesso",
+    "statePensionLabel": "Pensione statale (£/anno)",
+    "forecastCta": "Aggiorna la previsione",
+    "monthlySpendingLabel": "Spesa mensile",
+    "monthlySavingsLabel": "Risparmio mensile",
+    "desiredIncomeGoal": "Obiettivo di reddito desiderato",
+    "growthAssumptionValue": "Ipotesi di crescita: {{value}}%",
+    "projectedPotAtAge": "Capitale previsto a {{age}} anni: {{total}}",
+    "careerPath": {
+      "label": "Percorso professionale",
+      "emerging": "All'inizio",
+      "emergingDescription": "Partenza con una crescita stabile del 3%.",
+      "steady": "Progresso costante",
+      "steadyDescription": "Carriera solida con una crescita del 5%.",
+      "accelerating": "In accelerazione",
+      "acceleratingDescription": "Verso una crescita più rapida del 7%."
     }
   },
   "group": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -220,6 +220,29 @@
       "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
       "earliest": "Estimated earliest retirement age: {{age}}",
       "noBreakdown": "No income breakdown available."
+    },
+    "nowHeading": "Agora",
+    "nowIntro": "Ajuste os controles para corresponder à sua situação atual.",
+    "futureHeading": "Você no futuro",
+    "futureIntro": "Veja como essas escolhas moldam sua renda na aposentadoria.",
+    "futurePlaceholder": "Execute uma projeção para visualizar sua renda futura.",
+    "perMonthSuffix": "por mês",
+    "deathAgeLabel": "Idade ao falecer",
+    "statePensionLabel": "Pensão estatal (£/ano)",
+    "forecastCta": "Atualizar projeção",
+    "monthlySpendingLabel": "Gasto mensal",
+    "monthlySavingsLabel": "Poupança mensal",
+    "desiredIncomeGoal": "Meta de renda desejada",
+    "growthAssumptionValue": "Hipótese de crescimento: {{value}}%",
+    "projectedPotAtAge": "Montante projetado aos {{age}} anos: {{total}}",
+    "careerPath": {
+      "label": "Trajetória profissional",
+      "emerging": "Começando",
+      "emergingDescription": "Início com crescimento constante de 3%.",
+      "steady": "Progresso constante",
+      "steadyDescription": "Carreira confortável com crescimento de 5%.",
+      "accelerating": "Acelerando",
+      "acceleratingDescription": "Rumo a um crescimento mais rápido de 7%."
     }
   },
   "group": {
@@ -414,16 +437,16 @@
     "grouping": "Agrupamento",
     "actions": "Ações",
     "add": "Adicionar instrumento",
-  "save": "Salvar",
-  "saveSuccess": "Salvo",
-  "saveError": "Erro ao salvar",
-  "searchPlaceholder": "Filtrar instrumentos…",
-  "validation": {
-    "ticker": "Ticker é obrigatório",
-    "name": "Nome é obrigatório",
-    "grouping": "Agrupamento é obrigatório"
-  }
-},
+    "save": "Salvar",
+    "saveSuccess": "Salvo",
+    "saveError": "Erro ao salvar",
+    "searchPlaceholder": "Filtrar instrumentos…",
+    "validation": {
+      "ticker": "Ticker é obrigatório",
+      "name": "Nome é obrigatório",
+      "grouping": "Agrupamento é obrigatório"
+    }
+  },
   "var": {
     "title": "Valor em Risco",
     "details": "Detalhes da simulação histórica",

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -16,15 +16,70 @@ import type { OwnerSummary } from "../types";
 import { OwnerSelector } from "../components/OwnerSelector";
 import { useTranslation } from "react-i18next";
 
+type SliderControlProps = {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  onChange: (value: number) => void;
+  formatValue?: (value: number) => string;
+  description?: string;
+};
+
+function SliderControl({
+  id,
+  label,
+  min,
+  max,
+  step,
+  value,
+  onChange,
+  formatValue,
+  description,
+}: SliderControlProps) {
+  const formatted = formatValue ? formatValue(value) : String(value);
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-4">
+        <label htmlFor={id} className="text-sm font-medium text-gray-900">
+          {label}
+        </label>
+        <span className="text-sm text-gray-600" data-testid={`${id}-value`}>
+          {formatted}
+        </span>
+      </div>
+      {description && (
+        <p id={`${id}-description`} className="mt-1 text-xs text-gray-500">
+          {description}
+        </p>
+      )}
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        aria-describedby={description ? `${id}-description` : undefined}
+        aria-valuetext={formatted}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="mt-3 w-full accent-blue-600"
+      />
+    </div>
+  );
+}
+
 export default function PensionForecast() {
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
   const [owner, setOwner] = useState("");
   const [deathAge, setDeathAge] = useState(90);
   const [statePension, setStatePension] = useState<string>("");
-  const [contributionAnnual, setContributionAnnual] = useState<string>("");
-  const [contributionMonthly, setContributionMonthly] = useState<string>("");
-  const [desiredIncome, setDesiredIncome] = useState<string>("");
-  const [investmentGrowthPct, setInvestmentGrowthPct] = useState(5);
+  const [careerPathIndex, setCareerPathIndex] = useState(1);
+  const [monthlySpending, setMonthlySpending] = useState(2000);
+  const [monthlySavings, setMonthlySavings] = useState(400);
   const [data, setData] = useState<{ age: number; income: number }[]>([]);
   const [projectedPot, setProjectedPot] = useState<number | null>(null);
   const [pensionPot, setPensionPot] = useState<number | null>(null);
@@ -65,6 +120,46 @@ export default function PensionForecast() {
     [],
   );
 
+  const formatMonthlyValue = (value: number) =>
+    `${currencyFormatter.format(value)} ${t("pensionForecast.perMonthSuffix")}`;
+
+  const careerPathOptions = useMemo(
+    () => [
+      {
+        value: 0,
+        label: t("pensionForecast.careerPath.emerging"),
+        description: t("pensionForecast.careerPath.emergingDescription"),
+        growthPct: 3,
+      },
+      {
+        value: 1,
+        label: t("pensionForecast.careerPath.steady"),
+        description: t("pensionForecast.careerPath.steadyDescription"),
+        growthPct: 5,
+      },
+      {
+        value: 2,
+        label: t("pensionForecast.careerPath.accelerating"),
+        description: t("pensionForecast.careerPath.acceleratingDescription"),
+        growthPct: 7,
+      },
+    ],
+    [t],
+  );
+
+  const boundedCareerIndex = Math.min(
+    Math.max(careerPathIndex, 0),
+    Math.max(careerPathOptions.length - 1, 0),
+  );
+  const selectedCareerPath = careerPathOptions[boundedCareerIndex] ?? careerPathOptions[0];
+  const investmentGrowthPct = selectedCareerPath?.growthPct ?? 5;
+  const contributionMonthlyValue = Number.isFinite(monthlySavings)
+    ? monthlySavings
+    : undefined;
+  const desiredIncomeAnnualValue = Number.isFinite(monthlySpending)
+    ? monthlySpending * 12
+    : undefined;
+
   useEffect(() => {
     getOwners()
       .then((os) => {
@@ -79,24 +174,14 @@ export default function PensionForecast() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const contributionMonthlyVal = contributionMonthly
-        ? parseFloat(contributionMonthly)
-        : undefined;
-      const contributionAnnualVal = contributionAnnual
-        ? parseFloat(contributionAnnual)
-        : undefined;
       const res = await getPensionForecast({
         owner,
         deathAge,
         statePensionAnnual: statePension
           ? parseFloat(statePension)
           : undefined,
-        contributionMonthly: contributionMonthlyVal,
-        contributionAnnual:
-          contributionMonthlyVal !== undefined ? undefined : contributionAnnualVal,
-        desiredIncomeAnnual: desiredIncome
-          ? parseFloat(desiredIncome)
-          : undefined,
+        contributionMonthly: contributionMonthlyValue,
+        desiredIncomeAnnual: desiredIncomeAnnualValue,
         investmentGrowthPct,
       });
       setData(res.forecast);
@@ -218,175 +303,231 @@ export default function PensionForecast() {
       }[banner.variant]
     : "";
 
+  const highlightMetrics: Array<{ label: string; value: string }> = [];
+  if (totalMonthlyIncomeFormatted) {
+    highlightMetrics.push({
+      label: t("pensionForecast.totalMonthlyIncome"),
+      value: totalMonthlyIncomeFormatted,
+    });
+  }
+  if (totalAnnualIncomeFormatted) {
+    highlightMetrics.push({
+      label: t("pensionForecast.totalAnnualIncome"),
+      value: totalAnnualIncomeFormatted,
+    });
+  }
+  if (desiredIncomeUsed != null) {
+    highlightMetrics.push({
+      label: t("pensionForecast.desiredIncomeGoal"),
+      value: currencyFormatter.format(desiredIncomeUsed),
+    });
+  }
+
   return (
-    <div>
-      <h1 className="mb-4 text-2xl md:text-4xl">Pension Forecast</h1>
-      <form onSubmit={handleSubmit} className="mb-4 space-y-2">
-        <OwnerSelector owners={owners} selected={owner} onSelect={setOwner} />
-        <div>
-          <label className="mr-2">Death Age:</label>
-          <input
-            type="number"
-            value={deathAge}
-            onChange={(e) => setDeathAge(Number(e.target.value))}
-            required
-          />
-        </div>
-        <div>
-          <label className="mr-2">State Pension (£/yr):</label>
-          <input
-            type="number"
-            value={statePension}
-            onChange={(e) => setStatePension(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="mr-2" htmlFor="contribution-annual">
-            Annual Contribution (£):
-          </label>
-          <input
-            id="contribution-annual"
-            type="number"
-            value={contributionAnnual}
-            onChange={(e) => setContributionAnnual(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="mr-2" htmlFor="contribution-monthly">
-            {t("pensionForecast.monthlyContribution")}
-          </label>
-          <input
-            id="contribution-monthly"
-            type="number"
-            value={contributionMonthly}
-            onChange={(e) => setContributionMonthly(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="mr-2" htmlFor="desired-income">
-            Desired Income (£/yr):
-          </label>
-          <input
-            id="desired-income"
-            type="number"
-            value={desiredIncome}
-            onChange={(e) => setDesiredIncome(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="mr-2" htmlFor="investment-growth">
-            {t("pensionForecast.growthAssumption")}
-          </label>
-          <select
-            id="investment-growth"
-            value={investmentGrowthPct}
-            onChange={(e) => setInvestmentGrowthPct(Number(e.target.value))}
-          >
-            {[3, 5, 7].map((g) => (
-              <option key={g} value={g}>
-                {g}%
-              </option>
-            ))}
-          </select>
-        </div>
-        <button type="submit" className="mt-2 rounded bg-blue-500 px-4 py-2 text-white">
-          Forecast
-        </button>
-      </form>
-      {err && <p className="text-red-500">{err}</p>}
-      {banner && (
-        <div
-          className={`mb-4 rounded border px-4 py-3 text-sm ${bannerClassName}`}
-          role="status"
+    <div className="space-y-6">
+      <h1 className="text-2xl md:text-4xl">Pension Forecast</h1>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-6 rounded-xl border border-gray-200 bg-white p-6 shadow-sm"
+          aria-labelledby="pension-now-heading"
         >
-          {banner.message}
-        </div>
-      )}
-      {currentAge !== null && dob && (
-        <p className="mb-2">
-          {t("pensionForecast.currentAge", { age: currentAge })} (
-          {t("pensionForecast.birthDate", { dob })})
-        </p>
-      )}
-      {retirementAge !== null && (
-        <p className="mb-2">{t("pensionForecast.retirementAge", { age: retirementAge })}</p>
-      )}
-      {pensionPot !== null && (
-        <p className="mb-2">
-          {t("pensionForecast.pensionPot")}: £{pensionPot.toFixed(2)}
-        </p>
-      )}
-      {projectedPot !== null && retirementAge !== null && (
-        <p className="mb-2">
-          Projected pot at {retirementAge}: £{projectedPot.toFixed(2)}
-        </p>
-      )}
-      {retirementIncomeBreakdown && (
-        <div className="mt-4 overflow-x-auto">
-          <h2 className="mb-2 text-xl">
-            {t("pensionForecast.incomeBreakdownHeading")}
-          </h2>
-          <table className="min-w-full divide-y divide-gray-200 text-sm">
-            <thead>
-              <tr className="bg-gray-50">
-                <th className="px-3 py-2 text-left font-semibold">
-                  {t("pensionForecast.incomeTable.source")}
-                </th>
-                <th className="px-3 py-2 text-right font-semibold">
-                  {t("pensionForecast.incomeTable.annual")}
-                </th>
-                <th className="px-3 py-2 text-right font-semibold">
-                  {t("pensionForecast.incomeTable.monthly")}
-                </th>
-                <th className="px-3 py-2 text-right font-semibold">
-                  {t("pensionForecast.incomeTable.share")}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {breakdownEntries.map(({ key, label, annual, monthly, share }) => (
-                <tr key={String(key)} className="odd:bg-white even:bg-gray-50">
-                  <td className="px-3 py-2">{label}</td>
-                  <td className="whitespace-nowrap px-3 py-2 text-right">
-                    {currencyFormatter.format(annual)}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-2 text-right">
-                    {currencyFormatter.format(monthly)}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-2 text-right">
-                    {share}
-                  </td>
-                </tr>
+          <div>
+            <h2 id="pension-now-heading" className="text-xl font-semibold text-gray-900">
+              {t("pensionForecast.nowHeading")}
+            </h2>
+            <p className="mt-1 text-sm text-gray-600">{t("pensionForecast.nowIntro")}</p>
+          </div>
+          <OwnerSelector owners={owners} selected={owner} onSelect={setOwner} />
+          <SliderControl
+            id="career-path"
+            label={t("pensionForecast.careerPath.label")}
+            min={0}
+            max={Math.max(careerPathOptions.length - 1, 0)}
+            step={1}
+            value={boundedCareerIndex}
+            onChange={(value) => setCareerPathIndex(Math.round(value))}
+            formatValue={(value) => {
+              const option = careerPathOptions[Math.round(value)] ?? careerPathOptions[0];
+              return option ? option.label : "";
+            }}
+            description={selectedCareerPath?.description}
+          />
+          <p className="text-xs text-gray-500">
+            {t("pensionForecast.growthAssumptionValue", { value: investmentGrowthPct })}
+          </p>
+          <SliderControl
+            id="monthly-spending"
+            label={t("pensionForecast.monthlySpendingLabel")}
+            min={0}
+            max={10000}
+            step={50}
+            value={monthlySpending}
+            onChange={setMonthlySpending}
+            formatValue={formatMonthlyValue}
+          />
+          <SliderControl
+            id="monthly-savings"
+            label={t("pensionForecast.monthlySavingsLabel")}
+            min={0}
+            max={5000}
+            step={50}
+            value={monthlySavings}
+            onChange={setMonthlySavings}
+            formatValue={formatMonthlyValue}
+          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="death-age" className="text-sm font-medium text-gray-900">
+                {t("pensionForecast.deathAgeLabel")}
+              </label>
+              <input
+                id="death-age"
+                type="number"
+                className="rounded border border-gray-300 px-3 py-2"
+                value={deathAge}
+                onChange={(e) => setDeathAge(Number(e.target.value))}
+                min={0}
+                required
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label htmlFor="state-pension" className="text-sm font-medium text-gray-900">
+                {t("pensionForecast.statePensionLabel")}
+              </label>
+              <input
+                id="state-pension"
+                type="number"
+                className="rounded border border-gray-300 px-3 py-2"
+                value={statePension}
+                onChange={(e) => setStatePension(e.target.value)}
+                min={0}
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            className="self-start rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          >
+            {t("pensionForecast.forecastCta")}
+          </button>
+        </form>
+        <section
+          className="flex flex-col gap-6 rounded-xl border border-gray-200 bg-white p-6 shadow-sm"
+          aria-labelledby="pension-future-heading"
+        >
+          <div>
+            <h2 id="pension-future-heading" className="text-xl font-semibold text-gray-900">
+              {t("pensionForecast.futureHeading")}
+            </h2>
+            <p className="mt-1 text-sm text-gray-600">{t("pensionForecast.futureIntro")}</p>
+          </div>
+          {err && <p className="text-sm text-red-600">{err}</p>}
+          {banner && (
+            <div className={`rounded border px-4 py-3 text-sm ${bannerClassName}`} role="status">
+              {banner.message}
+            </div>
+          )}
+          {highlightMetrics.length > 0 && (
+            <dl className="grid gap-4 sm:grid-cols-2">
+              {highlightMetrics.map(({ label, value }) => (
+                <div key={label} className="rounded-lg bg-gray-50 p-4">
+                  <dt className="text-sm text-gray-600">{label}</dt>
+                  <dd className="mt-1 text-2xl font-semibold text-gray-900">{value}</dd>
+                </div>
               ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-      {!retirementIncomeBreakdown && retirementIncomeTotal != null && (
-        <p className="mt-4 text-sm text-gray-600">
-          {t("pensionForecast.prediction.noBreakdown")}
-        </p>
-      )}
-      {retirementIncomeTotal != null && (
-        <div className="mt-2 text-sm">
-          <p>
-            {t("pensionForecast.totalAnnualIncome")}: {totalAnnualIncomeFormatted}
-          </p>
-          <p>
-            {t("pensionForecast.totalMonthlyIncome")}: {totalMonthlyIncomeFormatted}
-          </p>
-        </div>
-      )}
-      {data.length > 0 && (
-        <ResponsiveContainer width="100%" height={300}>
-          <LineChart data={data}>
-            <XAxis dataKey="age" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="income" stroke="#8884d8" dot={false} />
-          </LineChart>
-        </ResponsiveContainer>
-      )}
+            </dl>
+          )}
+          <div className="space-y-2 text-sm text-gray-700">
+            {currentAge !== null && dob && (
+              <p>
+                {t("pensionForecast.currentAge", { age: currentAge })} (
+                {t("pensionForecast.birthDate", { dob })})
+              </p>
+            )}
+            {retirementAge !== null && (
+              <p>{t("pensionForecast.retirementAge", { age: retirementAge })}</p>
+            )}
+            {pensionPot !== null && (
+              <p>
+                {t("pensionForecast.pensionPot")}: {currencyFormatter.format(pensionPot)}
+              </p>
+            )}
+            {projectedPot !== null && retirementAge !== null && (
+              <p>
+                {t("pensionForecast.projectedPotAtAge", {
+                  age: retirementAge,
+                  total: currencyFormatter.format(projectedPot),
+                })}
+              </p>
+            )}
+          </div>
+          {retirementIncomeBreakdown && (
+            <div className="overflow-x-auto text-sm">
+              <h3 className="mb-2 text-lg font-semibold text-gray-900">
+                {t("pensionForecast.incomeBreakdownHeading")}
+              </h3>
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr className="bg-gray-50">
+                    <th className="px-3 py-2 text-left font-semibold">
+                      {t("pensionForecast.incomeTable.source")}
+                    </th>
+                    <th className="px-3 py-2 text-right font-semibold">
+                      {t("pensionForecast.incomeTable.annual")}
+                    </th>
+                    <th className="px-3 py-2 text-right font-semibold">
+                      {t("pensionForecast.incomeTable.monthly")}
+                    </th>
+                    <th className="px-3 py-2 text-right font-semibold">
+                      {t("pensionForecast.incomeTable.share")}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {breakdownEntries.map(({ key, label, annual, monthly, share }) => (
+                    <tr key={String(key)} className="odd:bg-white even:bg-gray-50">
+                      <td className="px-3 py-2">{label}</td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right">
+                        {currencyFormatter.format(annual)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right">
+                        {currencyFormatter.format(monthly)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right">{share}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {!retirementIncomeBreakdown && retirementIncomeTotal != null && (
+            <p className="text-sm text-gray-600">
+              {t("pensionForecast.prediction.noBreakdown")}
+            </p>
+          )}
+          {data.length > 0 ? (
+            <div className="h-72">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={data}>
+                  <XAxis dataKey="age" />
+                  <YAxis />
+                  <Tooltip />
+                  <Line type="monotone" dataKey="income" stroke="#8884d8" dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            retirementIncomeTotal == null &&
+            !retirementIncomeBreakdown &&
+            !err && (
+              <p className="text-sm text-gray-500">
+                {t("pensionForecast.futurePlaceholder")}
+              </p>
+            )
+          )}
+        </section>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor the Pension Forecast page into "Now" and "Future you" panels, replacing text inputs with sliders for career path, spending and savings that feed the forecast request
- surface the updated copy, metrics, and placeholders inside the panels and extend translations across supported locales
- refresh the PensionForecast unit tests to cover the new controls and ensure the API request captures slider selections

## Testing
- npm run test -- --run src/pages/PensionForecast.test.tsx
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d31239bd34832783b080e6eb90c297