### PR TITLE
Add pension forecast summary banner with employer contribution

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -199,6 +199,17 @@
     "pensionPot": "Pensionsvermögen",
     "growthAssumption": "Wachstumsannahme (%):",
     "monthlyContribution": "Monatlicher Beitrag (£):",
+    "employerContributionMonthly": "Arbeitgeberbeitrag (£/Monat):",
+    "summary": {
+      "title": "Pensionsübersicht",
+      "pensionPotLabel": "Aktueller Rententopf",
+      "personalContributionLabel": "Ihr monatlicher Beitrag",
+      "employerContributionLabel": "Arbeitgeberbeitrag",
+      "totalContributionLabel": "Monatlicher Gesamtbeitrag",
+      "valueUnavailable": "—",
+      "addAnotherPension": "Weitere Pension hinzufügen",
+      "additionalPensions": "Zusätzliche Pensionen: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -205,6 +205,17 @@
     "pensionPot": "Pension pot",
     "growthAssumption": "Growth assumption (%):",
     "monthlyContribution": "Monthly Contribution (£):",
+    "employerContributionMonthly": "Employer Contribution (£/mo):",
+    "summary": {
+      "title": "Pension summary",
+      "pensionPotLabel": "Current pension pot",
+      "personalContributionLabel": "Your monthly contribution",
+      "employerContributionLabel": "Employer contribution",
+      "totalContributionLabel": "Total monthly contribution",
+      "valueUnavailable": "—",
+      "addAnotherPension": "Add another pension",
+      "additionalPensions": "Additional pensions: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -199,6 +199,17 @@
     "pensionPot": "Fondo de pensiones",
     "growthAssumption": "Suposición de crecimiento (%):",
     "monthlyContribution": "Contribución mensual (£):",
+    "employerContributionMonthly": "Contribución del empleador (£/mes):",
+    "summary": {
+      "title": "Resumen de pensiones",
+      "pensionPotLabel": "Fondo de pensión actual",
+      "personalContributionLabel": "Tu contribución mensual",
+      "employerContributionLabel": "Contribución del empleador",
+      "totalContributionLabel": "Contribución mensual total",
+      "valueUnavailable": "—",
+      "addAnotherPension": "Añadir otra pensión",
+      "additionalPensions": "Pensiones adicionales: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -199,6 +199,17 @@
     "pensionPot": "Pot de pension",
     "growthAssumption": "Hypothèse de croissance (%):",
     "monthlyContribution": "Contribution mensuelle (£):",
+    "employerContributionMonthly": "Contribution de l'employeur (£/mois):",
+    "summary": {
+      "title": "Résumé de la pension",
+      "pensionPotLabel": "Épargne retraite actuelle",
+      "personalContributionLabel": "Votre contribution mensuelle",
+      "employerContributionLabel": "Contribution de l'employeur",
+      "totalContributionLabel": "Contribution mensuelle totale",
+      "valueUnavailable": "—",
+      "addAnotherPension": "Ajouter une autre pension",
+      "additionalPensions": "Pensions supplémentaires : {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -199,6 +199,17 @@
     "pensionPot": "Fondo pensione",
     "growthAssumption": "Ipotesi di crescita (%):",
     "monthlyContribution": "Contributo mensile (£):",
+    "employerContributionMonthly": "Contributo del datore di lavoro (£/mese):",
+    "summary": {
+      "title": "Riepilogo pensione",
+      "pensionPotLabel": "Fondo pensione attuale",
+      "personalContributionLabel": "Il tuo contributo mensile",
+      "employerContributionLabel": "Contributo del datore di lavoro",
+      "totalContributionLabel": "Contributo mensile totale",
+      "valueUnavailable": "—",
+      "addAnotherPension": "Aggiungi un'altra pensione",
+      "additionalPensions": "Pensioni aggiuntive: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -199,6 +199,17 @@
     "pensionPot": "Fundo de pensão",
     "growthAssumption": "Suposição de crescimento (%):",
     "monthlyContribution": "Contribuição mensal (£):",
+    "employerContributionMonthly": "Contribuição do empregador (£/mês):",
+    "summary": {
+      "title": "Resumo da pensão",
+      "pensionPotLabel": "Fundo de pensão atual",
+      "personalContributionLabel": "Sua contribuição mensal",
+      "employerContributionLabel": "Contribuição do empregador",
+      "totalContributionLabel": "Contribuição mensal total",
+      "valueUnavailable": "—",
+      "addAnotherPension": "Adicionar outra pensão",
+      "additionalPensions": "Pensões adicionais: {{count}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
       "state": "State pension",

--- a/frontend/tests/unit/pages/PensionForecast.test.tsx
+++ b/frontend/tests/unit/pages/PensionForecast.test.tsx
@@ -96,6 +96,8 @@ describe("PensionForecast page", () => {
     fireEvent.change(ownerSelect, { target: { value: "beth" } });
     const monthly = within(form).getByLabelText(/monthly contribution/i);
     fireEvent.change(monthly, { target: { value: "100" } });
+    const employer = within(form).getByLabelText(/employer contribution/i);
+    fireEvent.change(employer, { target: { value: "50" } });
 
     const btn = screen.getByRole("button", { name: /forecast/i });
     await userEvent.click(btn);
@@ -113,6 +115,37 @@ describe("PensionForecast page", () => {
     await screen.findByText(/pension pot: £123.00/i);
     await screen.findByText(/projected pot at 65: £323.00/i);
     await screen.findByText("Retirement income breakdown");
+    const summary = await screen.findByRole("region", {
+      name: /pension summary/i,
+    });
+    expect(summary).toBeInTheDocument();
+    expect(
+      within(summary).getByText("Current pension pot", { exact: false }),
+    ).toBeInTheDocument();
+    expect(within(summary).getByText("£123.00")).toBeInTheDocument();
+    expect(
+      within(summary).getByText("Your monthly contribution", { exact: false }),
+    ).toBeInTheDocument();
+    expect(within(summary).getByText("£100.00")).toBeInTheDocument();
+    expect(
+      within(summary).getByText("Employer contribution", { exact: false }),
+    ).toBeInTheDocument();
+    expect(within(summary).getByText("£50.00")).toBeInTheDocument();
+    expect(
+      within(summary).getByText("Total monthly contribution", { exact: false }),
+    ).toBeInTheDocument();
+    expect(within(summary).getByText("£150.00")).toBeInTheDocument();
+    const addAnother = within(summary).getByRole("button", {
+      name: /add another pension/i,
+    });
+    await userEvent.click(addAnother);
+    await within(summary).findByText("Additional pensions: 1", {
+      exact: true,
+    });
+    await userEvent.click(addAnother);
+    await within(summary).findByText("Additional pensions: 2", {
+      exact: true,
+    });
     expect(
       screen.getByText(
         "You're on track: projected income of £15,000.00 meets your desired £14,000.00 from age 64.",


### PR DESCRIPTION
## Summary
- add a pension forecast header that surfaces the current pot, personal monthly contribution, employer contribution, and a call to add another pension
- derive employer and total monthly contribution values from form state and expose a dedicated employer contribution input
- localise the new summary strings across supported locales and extend the pension forecast unit test for the banner UX

## Testing
- npm --prefix frontend run test:jsdom -- --run --watch=false tests/unit/pages/PensionForecast.test.tsx
- npm --prefix frontend run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d316441bf883278b6cff49cd8c16ca