### PR TITLE
Render research route inside main app

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,7 @@ import InstrumentSearchBarToggle from "./components/InstrumentSearchBar";
 import UserAvatar from "./components/UserAvatar";
 import AllocationCharts from "./pages/AllocationCharts";
 import InstrumentAdmin from "./pages/InstrumentAdmin";
+import InstrumentResearch from "./pages/InstrumentResearch";
 import Menu from "./components/Menu";
 import Rebalance from "./pages/Rebalance";
 import PensionForecast from "./pages/PensionForecast";
@@ -64,7 +65,8 @@ type Mode =
   | (typeof orderedTabPlugins)[number]["id"]
   | "pension"
   | "market"
-  | "rebalance";
+  | "rebalance"
+  | "research";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -109,6 +111,8 @@ const initialMode: Mode =
     ? "scenario"
     : path[0] === "pension"
     ? "pension"
+    : path[0] === "research"
+    ? "research"
     : path.length === 0
     ? "group"
     : "movers";
@@ -129,6 +133,9 @@ export default function App({ onLogout }: AppProps) {
   );
   const [selectedGroup, setSelectedGroup] = useState(
     initialMode === "instrument" ? initialSlug : params.get("group") ?? ""
+  );
+  const [researchTicker, setResearchTicker] = useState(
+    initialMode === "research" ? initialSlug : ""
   );
 
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
@@ -223,6 +230,9 @@ export default function App({ onLogout }: AppProps) {
       case "scenario":
         newMode = "scenario";
         break;
+      case "research":
+        newMode = "research";
+        break;
       default:
         newMode = segs.length === 0 ? "group" : "movers";
     }
@@ -244,6 +254,8 @@ export default function App({ onLogout }: AppProps) {
       setSelectedGroup(segs[1] ?? "");
     } else if (newMode === "group") {
       setSelectedGroup(params.get("group") ?? "");
+    } else if (newMode === "research") {
+      setResearchTicker(segs[1] ?? "");
     }
   }, [location.pathname, location.search, tabs, navigate]);
 
@@ -416,6 +428,8 @@ export default function App({ onLogout }: AppProps) {
           {loading ? <p>{t("app.loading")}</p> : <InstrumentTable rows={instruments} />}
         </>
       )}
+
+      {mode === "research" && <InstrumentResearch ticker={researchTicker} />}
 
       {/* PERFORMANCE VIEW */}
       {mode === "performance" && (

--- a/frontend/src/hooks/useRouteMode.ts
+++ b/frontend/src/hooks/useRouteMode.ts
@@ -32,6 +32,7 @@ function deriveInitial() {
     path[0] === "trail" ? "trail" :
     path[0] === "support" ? "support" :
     path[0] === "scenario" ? "scenario" :
+    path[0] === "research" ? "research" :
     path.length === 0 ? "group" : "movers";
   const slug = path[1] ?? "";
   const owner = mode === "owner" ? slug : "";
@@ -129,6 +130,9 @@ export function useRouteMode(): RouteState {
         break;
       case "scenario":
         newMode = "scenario";
+        break;
+      case "research":
+        newMode = "research";
         break;
       default:
         newMode = segs.length === 0 ? "group" : "movers";

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -24,7 +24,6 @@ const VirtualPortfolio = lazy(() => import('./pages/VirtualPortfolio'))
 const Support = lazy(() => import('./pages/Support'))
 const ComplianceWarnings = lazy(() => import('./pages/ComplianceWarnings'))
 const TradeCompliance = lazy(() => import('./pages/TradeCompliance'))
-const InstrumentResearch = lazy(() => import('./pages/InstrumentResearch'))
 const Alerts = lazy(() => import('./pages/Alerts'))
 const Goals = lazy(() => import('./pages/Goals'))
 const Trail = lazy(() => import('./pages/Trail'))
@@ -79,7 +78,6 @@ export function Root() {
           <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
           <Route path="/trade-compliance" element={<TradeCompliance />} />
           <Route path="/trade-compliance/:owner" element={<TradeCompliance />} />
-          <Route path="/research/:ticker" element={<InstrumentResearch />} />
           <Route path="/alerts" element={<Alerts />} />
           <Route path="/alert-settings" element={<AlertSettings />} />
           <Route path="/goals" element={<Goals />} />

--- a/frontend/src/modes.ts
+++ b/frontend/src/modes.ts
@@ -14,7 +14,8 @@ export type Mode =
   | "settings"
   | "trail"
   | "support"
-  | "scenario";
+  | "scenario"
+  | "research";
 
 export const MODES: Mode[] = [
   "group",
@@ -33,4 +34,5 @@ export const MODES: Mode[] = [
   "trail",
   "support",
   "scenario",
+  "research",
 ];

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -36,8 +36,13 @@ function normaliseUppercase(value: unknown) {
   return trimmed || undefined;
 }
 
-export default function InstrumentResearch() {
-  const { ticker } = useParams<{ ticker: string }>();
+interface InstrumentResearchProps {
+  ticker?: string;
+}
+
+export default function InstrumentResearch({ ticker: tickerProp }: InstrumentResearchProps = {}) {
+  const params = useParams<{ ticker: string }>();
+  const ticker = tickerProp ?? params.ticker ?? "";
   const [metrics, setMetrics] = useState<ScreenerResult | null>(null);
   const [days, setDays] = useState(30);
   const [showBollinger, setShowBollinger] = useState(false);


### PR DESCRIPTION
## Summary
- remove the standalone research route from the root router and let the main app handle it
- extend the app mode detection/state to understand research URLs and pass the ticker into InstrumentResearch
- allow the InstrumentResearch page to accept an explicit ticker prop and update shared mode helpers for the new route

## Testing
- npm run test -- --run tests/unit/pages/InstrumentResearch.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d319456b848327b6b41d018119c9b2