### PR TITLE
Wrap trail completion results under tasks

### DIFF
--- a/backend/routes/trail.py
+++ b/backend/routes/trail.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from backend.auth import get_current_user
@@ -21,7 +23,10 @@ if config.disable_auth:
         Returns the updated Trail payload including XP, streak, and daily totals.
         """
         try:
-            return trail.mark_complete("demo", task_id)
+            result = trail.mark_complete("demo", task_id)
+            if isinstance(result, Mapping) and "tasks" in result:
+                return result
+            return {"tasks": result}
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")
 
@@ -39,6 +44,9 @@ else:
         Returns the updated Trail payload including XP, streak, and daily totals.
         """
         try:
-            return trail.mark_complete(current_user, task_id)
+            result = trail.mark_complete(current_user, task_id)
+            if isinstance(result, Mapping) and "tasks" in result:
+                return result
+            return {"tasks": result}
         except KeyError:
             raise HTTPException(status_code=404, detail="Task not found")

--- a/tests/test_trail_route.py
+++ b/tests/test_trail_route.py
@@ -20,3 +20,25 @@ def test_complete_task_authenticated(monkeypatch):
     monkeypatch.setattr(trail_module.trail, "mark_complete", lambda user, tid: ["ok"])
     result = asyncio.run(trail_module.complete_task("t2", current_user="bob"))
     assert result == {"tasks": ["ok"]}
+
+
+def test_complete_task_demo_passthrough(monkeypatch):
+    monkeypatch.setattr(trail_module.config, "disable_auth", True)
+    importlib.reload(trail_module)
+
+    payload = {"tasks": ["already"], "xp": 123}
+    monkeypatch.setattr(trail_module.trail, "mark_complete", lambda user, tid: payload)
+
+    result = asyncio.run(trail_module.complete_task("t3"))
+    assert result is payload
+
+
+def test_complete_task_authenticated_passthrough(monkeypatch):
+    monkeypatch.setattr(trail_module.config, "disable_auth", False)
+    importlib.reload(trail_module)
+
+    payload = {"tasks": ["exists"], "streak": 5}
+    monkeypatch.setattr(trail_module.trail, "mark_complete", lambda user, tid: payload)
+
+    result = asyncio.run(trail_module.complete_task("t4", current_user="alice"))
+    assert result is payload


### PR DESCRIPTION
## Summary
- ensure trail completion endpoints always return a TrailResponse-shaped payload
- add regression tests covering wrapped and passthrough completion results

## Testing
- PYTEST_ADDOPTS='--no-cov' pytest tests/test_trail_route.py

------
https://chatgpt.com/codex/tasks/task_e_68d321403bc8832780181eb2a9b61e64