### PR TITLE
Refine pension forecast panels and tests

### DIFF
--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import {
   LineChart,
   Line,
@@ -275,37 +276,25 @@ export default function PensionForecast() {
           </button>
         </div>
         <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <div className="rounded-2xl bg-white/10 p-4">
-            <dt className="text-sm font-medium text-blue-100">
-              {t("pensionForecast.header.pensionPot")}
-            </dt>
-            <dd className="mt-2 text-2xl font-semibold">
-              {pensionPot != null
+          <SnapshotStat
+            label={t("pensionForecast.header.pensionPot")}
+            value={
+              pensionPot != null
                 ? currencyFormatter.format(pensionPot)
-                : t("pensionForecast.header.notAvailable")}
-            </dd>
-          </div>
-          <div className="rounded-2xl bg-white/10 p-4">
-            <dt className="text-sm font-medium text-blue-100">
-              {t("pensionForecast.header.employeeContribution")}
-            </dt>
-            <dd className="mt-2 text-2xl font-semibold">
-              {currencyFormatter.format(monthlySavings)}
-            </dd>
-          </div>
-          <div className="rounded-2xl bg-white/10 p-4">
-            <dt className="text-sm font-medium text-blue-100">
-              {t("pensionForecast.header.employerContribution")}
-            </dt>
-            <dd className="mt-2 text-2xl font-semibold">
-              {currencyFormatter.format(employerContributionMonthly)}
-            </dd>
-            <p className="mt-1 text-xs text-blue-100">
-              {t("pensionForecast.header.totalContribution", {
-                total: currencyFormatter.format(totalMonthlyContribution),
-              })}
-            </p>
-          </div>
+                : t("pensionForecast.header.notAvailable")
+            }
+          />
+          <SnapshotStat
+            label={t("pensionForecast.header.employeeContribution")}
+            value={currencyFormatter.format(monthlySavings)}
+          />
+          <SnapshotStat
+            label={t("pensionForecast.header.employerContribution")}
+            value={currencyFormatter.format(employerContributionMonthly)}
+            helper={t("pensionForecast.header.totalContribution", {
+              total: currencyFormatter.format(totalMonthlyContribution),
+            })}
+          />
         </dl>
       </section>
       <div className="grid gap-6 md:grid-cols-2">
@@ -456,13 +445,13 @@ export default function PensionForecast() {
             {pensionPot !== null && (
               <InfoLine
                 label={t("pensionForecast.pensionPot")}
-                value={`£${pensionPot.toFixed(2)}`}
+                value={currencyFormatter.format(pensionPot)}
               />
             )}
             {projectedPot !== null && retirementAge !== null && (
               <InfoLine
                 label={`Projected pot at ${retirementAge}`}
-                value={`£${projectedPot.toFixed(2)}`}
+                value={currencyFormatter.format(projectedPot)}
               />
             )}
           </div>
@@ -554,6 +543,24 @@ type SliderControlProps = {
   helper?: string;
 };
 
+function SnapshotStat({
+  label,
+  value,
+  helper,
+}: {
+  label: string;
+  value: string;
+  helper?: string;
+}) {
+  return (
+    <div className="rounded-2xl bg-white/10 p-4">
+      <dt className="text-sm font-medium text-blue-100">{label}</dt>
+      <dd className="mt-2 text-2xl font-semibold">{value}</dd>
+      {helper && <p className="mt-1 text-xs text-blue-100">{helper}</p>}
+    </div>
+  );
+}
+
 function SliderControl({
   id,
   label,
@@ -605,7 +612,13 @@ function SliderControl({
   );
 }
 
-function InfoLine({ label, value }: { label: string; value?: string }) {
+function InfoLine({
+  label,
+  value,
+}: {
+  label: string;
+  value?: ReactNode;
+}) {
   return (
     <div className="rounded-xl bg-white p-3 shadow-sm">
       <p className="text-sm font-medium text-slate-900">{label}</p>

--- a/frontend/tests/unit/pages/PensionForecast.test.tsx
+++ b/frontend/tests/unit/pages/PensionForecast.test.tsx
@@ -94,14 +94,22 @@ describe("PensionForecast page", () => {
     const ownerSelect = await within(form).findByLabelText(/owner/i);
     await userEvent.selectOptions(ownerSelect, "beth");
 
-    const careerPath = within(form).getByLabelText(/career path/i);
+    const nowPanel = screen.getByRole("region", {
+      name: /adjust the plan to match your life today/i,
+    });
+    const nowWithin = within(nowPanel);
+    const careerPath = nowWithin.getByLabelText(/career path/i) as HTMLInputElement;
+    expect(careerPath).toHaveAttribute("aria-valuetext", "Balanced pace");
     fireEvent.change(careerPath, { target: { value: "2" } });
+    expect(careerPath).toHaveAttribute("aria-valuetext", "Accelerated path");
 
     fireEvent.change(ownerSelect, { target: { value: "beth" } });
-    const monthlySavings = within(form).getByLabelText(/monthly savings/i);
+    const monthlySavings = nowWithin.getByLabelText(/monthly savings/i);
     fireEvent.change(monthlySavings, { target: { value: "100" } });
 
-    const monthlySpending = within(form).getByLabelText(/monthly spending in retirement/i);
+    const monthlySpending = nowWithin.getByLabelText(
+      /monthly spending in retirement/i,
+    );
     fireEvent.change(monthlySpending, { target: { value: "3000" } });
 
     const btn = screen.getByRole("button", { name: /forecast/i });


### PR DESCRIPTION
## Summary
- extract snapshot stat card helper and use consistent currency formatting across the pension forecast panels
- allow info lines to render richer content while keeping the cards accessible
- expand the pension forecast unit test to exercise the panel layout and slider aria-valuetext updates

## Testing
- npx vitest run --environment=jsdom tests/unit/pages/PensionForecast.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d31fa242e8832797ac74bd1363c619