### PR TITLE
Add tests for nudge snoozing and due user iteration

### DIFF
--- a/tests/test_nudges_frequency.py
+++ b/tests/test_nudges_frequency.py
@@ -13,6 +13,48 @@ def test_frequency_clamped(tmp_path, monkeypatch):
     _setup_tmp_storage(tmp_path, monkeypatch)
     nudge_utils.set_user_nudge("alice", 0)
     assert nudge_utils._SUBSCRIPTIONS["alice"]["frequency"] == 1
+
+    _setup_tmp_storage(tmp_path, monkeypatch)
     nudge_utils.set_user_nudge("alice", 31)
     assert nudge_utils._SUBSCRIPTIONS["alice"]["frequency"] == 30
+
+
+def test_snooze_user_sets_future_timestamp(tmp_path, monkeypatch):
+    _setup_tmp_storage(tmp_path, monkeypatch)
+    nudge_utils.set_user_nudge("bob", 7)
+
+    start = nudge_utils.datetime.now(nudge_utils.UTC)
+    nudge_utils.snooze_user("bob", 3)
+
+    snoozed_until = nudge_utils._SUBSCRIPTIONS["bob"]["snoozed_until"]
+    assert snoozed_until is not None
+
+    until = nudge_utils.datetime.fromisoformat(snoozed_until)
+    assert until >= start + nudge_utils.timedelta(days=3)
+
+
+def test_iter_due_users_respects_snooze(tmp_path, monkeypatch):
+    _setup_tmp_storage(tmp_path, monkeypatch)
+
+    now = nudge_utils.datetime(2024, 1, 10, tzinfo=nudge_utils.UTC)
+    nudge_utils.set_user_nudge("new", 5)
+    nudge_utils.set_user_nudge("due", 2)
+    nudge_utils.set_user_nudge("recent", 5)
+    nudge_utils.set_user_nudge("snoozed", 1)
+
+    nudge_utils._SUBSCRIPTIONS["due"]["last_sent"] = (now - nudge_utils.timedelta(days=3)).isoformat()
+    nudge_utils._SUBSCRIPTIONS["recent"]["last_sent"] = (now - nudge_utils.timedelta(days=1)).isoformat()
+    nudge_utils._SUBSCRIPTIONS["snoozed"]["last_sent"] = (now - nudge_utils.timedelta(days=10)).isoformat()
+    snooze_end = (now + nudge_utils.timedelta(days=1)).isoformat()
+    nudge_utils._SUBSCRIPTIONS["snoozed"]["snoozed_until"] = snooze_end
+    nudge_utils._save_state()
+
+    due_users = set(nudge_utils.iter_due_users(now))
+    assert due_users == {"new", "due"}
+
+    _setup_tmp_storage(tmp_path, monkeypatch)
+
+    later = now + nudge_utils.timedelta(days=2)
+    due_users_later = set(nudge_utils.iter_due_users(later))
+    assert due_users_later == {"new", "due", "snoozed"}
 


### PR DESCRIPTION
## Summary
- reuse the temporary storage helper in additional nudge tests to ensure isolated state
- cover snooze_user by verifying the stored snooze timestamp extends into the future
- verify iter_due_users respects last_sent frequency and snooze windows before and after expiry

## Testing
- pytest tests/test_nudges_frequency.py --cov=backend --cov-fail-under=0


------
https://chatgpt.com/codex/tasks/task_e_68d32255f1788327b72761f71aa38389