### PR TITLE
Add portfolio loader unit tests

### DIFF
--- a/tests/common/test_portfolio_loader.py
+++ b/tests/common/test_portfolio_loader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from backend.common import portfolio_loader
 from backend.common.portfolio_loader import rebuild_account_holdings
 
 
@@ -46,3 +47,95 @@ def test_rebuild_account_holdings_missing_file(tmp_path: Path, caplog: pytest.Lo
 
     assert result == {}
     assert "Transaction file missing" in caplog.text
+
+
+def test_load_accounts_for_owner_missing_file(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING, logger="portfolio_loader")
+
+    def _raise_missing(owner: str, account: str) -> dict:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(portfolio_loader, "load_account", _raise_missing)
+
+    accounts = portfolio_loader._load_accounts_for_owner("alex", ["isa"])
+
+    assert accounts == []
+    assert "Account file missing: alex/isa.json" in caplog.text
+
+
+def test_load_accounts_for_owner_json_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING, logger="portfolio_loader")
+
+    def _raise_decode_error(owner: str, account: str) -> dict:
+        raise json.JSONDecodeError("bad", "{}", 0)
+
+    monkeypatch.setattr(portfolio_loader, "load_account", _raise_decode_error)
+
+    accounts = portfolio_loader._load_accounts_for_owner("alex", ["isa"])
+
+    assert accounts == []
+    assert "Failed to parse alex/isa.json" in caplog.text
+
+
+@pytest.fixture
+def patched_portfolio_loader(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    owners = [
+        {"owner": "alex", "accounts": ["isa"]},
+        {"owner": "beth", "accounts": ["sipp", "taxable"]},
+    ]
+
+    def _fake_list_plots() -> list[dict[str, object]]:
+        return owners
+
+    def _fake_person(owner: str) -> dict[str, str]:
+        return {"owner": owner, "full_name": owner.title()}
+
+    def _fake_account(owner: str, account: str) -> dict[str, str]:
+        return {
+            "owner": owner,
+            "account": account.upper(),
+            "path": f"{owner}/{account}.json",
+        }
+
+    monkeypatch.setattr(portfolio_loader, "list_plots", _fake_list_plots)
+    monkeypatch.setattr(portfolio_loader, "load_person_meta", _fake_person)
+    monkeypatch.setattr(portfolio_loader, "load_account", _fake_account)
+
+    return owners
+
+
+def test_list_portfolios_aggregates_owners(patched_portfolio_loader: list[dict[str, object]]) -> None:
+    result = portfolio_loader.list_portfolios()
+
+    expected = [
+        {
+            "owner": row["owner"],
+            "person": {"owner": row["owner"], "full_name": row["owner"].title()},
+            "accounts": [
+                {
+                    "owner": row["owner"],
+                    "account": account.upper(),
+                    "path": f"{row['owner']}/{account}.json",
+                }
+                for account in row["accounts"]
+            ],
+        }
+        for row in patched_portfolio_loader
+    ]
+
+    assert result == expected
+
+
+def test_load_portfolio_case_insensitive(
+    patched_portfolio_loader: list[dict[str, object]]
+) -> None:
+    all_portfolios = portfolio_loader.list_portfolios()
+
+    beth_portfolio = portfolio_loader.load_portfolio("BeTh")
+
+    assert beth_portfolio == all_portfolios[1]
+    assert portfolio_loader.load_portfolio("charlie") is None


### PR DESCRIPTION
## Summary
- patch the portfolio loader dependencies in tests to isolate account loading behavior
- add coverage for missing and invalid account files and confirm warnings are emitted
- verify portfolio aggregation, load_portfolio lookups, and missing owner handling

## Testing
- pytest tests/common/test_portfolio_loader.py --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68d3224b4aa483278d48d4c8a76cd42f