### PR TITLE
Add test for clean_accounts main output directory

### DIFF
--- a/tests/test_clean_accounts.py
+++ b/tests/test_clean_accounts.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from backend.common import clean_accounts
 from backend.common.clean_accounts import simplify_account_file, KEEP_FIELDS
 
 
@@ -48,3 +49,43 @@ def test_simplify_account_file(tmp_path: Path):
 
     # Clean up temporary file
     path.unlink()
+
+
+def test_main_writes_to_simplified_directory(tmp_path: Path, monkeypatch):
+    repo_root = tmp_path
+    accounts_dir = repo_root / "data" / "accounts"
+    owner_dir = accounts_dir / "owner"
+    owner_dir.mkdir(parents=True)
+
+    original_path = owner_dir / "account.json"
+    original_content = {
+        "holdings": [
+            {
+                "ticker": "AAA",
+                "units": 10,
+                "cost_basis_gbp": 100,
+                "acquired_date": "2023-01-01",
+                "extra_field": "remove-me",
+            }
+        ],
+        "notes": "retain top level extras",
+    }
+    original_path.write_text(json.dumps(original_content), encoding="utf-8")
+
+    monkeypatch.setattr(clean_accounts, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(clean_accounts, "ACCOUNTS_DIR", accounts_dir)
+    monkeypatch.setattr(clean_accounts, "OVERWRITE", False)
+
+    clean_accounts.main()
+
+    simplified_path = repo_root / "data" / "accounts_simplified" / "owner" / "account.json"
+    assert simplified_path.exists()
+
+    simplified_data = json.loads(simplified_path.read_text(encoding="utf-8"))
+    assert simplified_data["notes"] == original_content["notes"]
+    assert len(simplified_data["holdings"]) == 1
+    simplified_holding = simplified_data["holdings"][0]
+    assert set(simplified_holding) == KEEP_FIELDS
+
+    original_data = json.loads(original_path.read_text(encoding="utf-8"))
+    assert original_data == original_content


### PR DESCRIPTION
## Summary
- add a regression test ensuring clean_accounts.main writes simplified JSON files into data/accounts_simplified when OVERWRITE is disabled
- verify the simplified file only contains the expected fields while leaving the source file untouched

## Testing
- pytest --no-cov tests/test_clean_accounts.py

------
https://chatgpt.com/codex/tasks/task_e_68d32247fd508327b4d6eb8b539e62a8