### PR TITLE
Route research through App shell

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,6 +55,9 @@ import RightRail from "./components/RightRail";
 const PerformanceDashboard = lazyWithDelay(
   () => import("./components/PerformanceDashboard"),
 );
+const InstrumentResearch = lazyWithDelay(
+  () => import("./pages/InstrumentResearch"),
+);
 
 interface AppProps {
   onLogout?: () => void;
@@ -64,7 +67,8 @@ type Mode =
   | (typeof orderedTabPlugins)[number]["id"]
   | "pension"
   | "market"
-  | "rebalance";
+  | "rebalance"
+  | "research";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -107,6 +111,8 @@ const initialMode: Mode =
     ? "reports"
     : path[0] === "scenario"
     ? "scenario"
+    : path[0] === "research"
+    ? "research"
     : path[0] === "pension"
     ? "pension"
     : path.length === 0
@@ -129,6 +135,10 @@ export default function App({ onLogout }: AppProps) {
   );
   const [selectedGroup, setSelectedGroup] = useState(
     initialMode === "instrument" ? initialSlug : params.get("group") ?? ""
+  );
+
+  const [researchTicker, setResearchTicker] = useState(
+    initialMode === "research" ? decodeURIComponent(initialSlug) : ""
   );
 
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
@@ -208,6 +218,9 @@ export default function App({ onLogout }: AppProps) {
       case "support":
         newMode = "support";
         break;
+      case "research":
+        newMode = "research";
+        break;
       case "pension":
         newMode = "pension";
         break;
@@ -244,6 +257,8 @@ export default function App({ onLogout }: AppProps) {
       setSelectedGroup(segs[1] ?? "");
     } else if (newMode === "group") {
       setSelectedGroup(params.get("group") ?? "");
+    } else if (newMode === "research") {
+      setResearchTicker(segs[1] ? decodeURIComponent(segs[1] ?? "") : "");
     }
   }, [location.pathname, location.search, tabs, navigate]);
 
@@ -449,6 +464,11 @@ export default function App({ onLogout }: AppProps) {
       {mode === "support" && <Support />}
       {mode === "settings" && <UserConfigPage />}
       {mode === "scenario" && <ScenarioTester />}
+      {mode === "research" && (
+        <Suspense fallback={<p>{t("app.loading")}</p>}>
+          <InstrumentResearch ticker={researchTicker} />
+        </Suspense>
+      )}
       {mode === "pension" && <PensionForecast />}
       </main>
       <Defer>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -24,7 +24,6 @@ const VirtualPortfolio = lazy(() => import('./pages/VirtualPortfolio'))
 const Support = lazy(() => import('./pages/Support'))
 const ComplianceWarnings = lazy(() => import('./pages/ComplianceWarnings'))
 const TradeCompliance = lazy(() => import('./pages/TradeCompliance'))
-const InstrumentResearch = lazy(() => import('./pages/InstrumentResearch'))
 const Alerts = lazy(() => import('./pages/Alerts'))
 const Goals = lazy(() => import('./pages/Goals'))
 const Trail = lazy(() => import('./pages/Trail'))
@@ -79,7 +78,6 @@ export function Root() {
           <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
           <Route path="/trade-compliance" element={<TradeCompliance />} />
           <Route path="/trade-compliance/:owner" element={<TradeCompliance />} />
-          <Route path="/research/:ticker" element={<InstrumentResearch />} />
           <Route path="/alerts" element={<Alerts />} />
           <Route path="/alert-settings" element={<AlertSettings />} />
           <Route path="/goals" element={<Goals />} />

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -22,10 +22,19 @@ function normaliseUppercase(value: unknown) {
   return trimmed || undefined;
 }
 
-export default function InstrumentResearch() {
-  const { ticker } = useParams<{ ticker: string }>();
+type InstrumentResearchProps = {
+  ticker?: string;
+};
+
+export default function InstrumentResearch({ ticker }: InstrumentResearchProps) {
+  const { ticker: routeTicker } = useParams<{ ticker: string }>();
   const { t } = useTranslation();
-  const tkr = ticker && /^[A-Za-z0-9.-]{1,10}$/.test(ticker) ? ticker : "";
+  const resolvedTicker =
+    typeof ticker === "string" && ticker ? ticker : routeTicker ?? "";
+  const tkr =
+    resolvedTicker && /^[A-Za-z0-9.-]{1,10}$/.test(resolvedTicker)
+      ? resolvedTicker
+      : "";
   const tickerParts = tkr.split(".", 2);
   const baseTicker = tickerParts[0] ?? "";
   const initialExchange = tickerParts.length > 1 ? tickerParts[1] ?? "" : "";


### PR DESCRIPTION
## Summary
- route /research navigation through the main App shell instead of a standalone route
- add research mode detection/state and render InstrumentResearch within the shared layout
- allow InstrumentResearch to receive a ticker prop while still falling back to the URL param

## Testing
- npm --prefix frontend run lint *(fails: pre-existing lint errors across multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68d31f30740083279c6f9691e4065dfe