### PR TITLE
Fix InstrumentPositionsTable config usage

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -77,7 +77,7 @@ export function InstrumentPositionsTable({
   mutedColor = "#888",
 }: PositionsTableProps) {
   const { t } = useTranslation();
-  const { baseCurrency } = useConfig();
+  const { baseCurrency, relativeViewEnabled } = useConfig();
 
   return (
     <table


### PR DESCRIPTION
## Summary
- ensure InstrumentPositionsTable reads both the base currency and relative-view flag from the shared config context

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d324b310f0832799ed8c408b35d064