### PR TITLE
Add AWS data loader edge case tests

### DIFF
--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -4,6 +4,17 @@ from types import SimpleNamespace
 
 import backend.common.data_loader as dl
 from botocore.exceptions import ClientError
+import pytest
+
+
+@pytest.fixture
+def cleanup_boto3_module():
+    original = sys.modules.get("boto3")
+    yield
+    if original is None:
+        sys.modules.pop("boto3", None)
+    else:
+        sys.modules["boto3"] = original
 
 
 def test_list_aws_plots(monkeypatch):
@@ -118,6 +129,41 @@ def test_load_account_from_s3(monkeypatch):
     assert dl.load_account("Alice", "ISA") == {"balance": 10}
 
 
+def test_load_account_missing_bucket(monkeypatch):
+    monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
+    monkeypatch.delenv(dl.DATA_BUCKET_ENV, raising=False)
+
+    with pytest.raises(FileNotFoundError) as exc:
+        dl.load_account("owner", "acct")
+
+    assert (
+        str(exc.value)
+        == f"Missing {dl.DATA_BUCKET_ENV} env var for AWS account loading"
+    )
+
+
+def test_load_account_empty_payload(monkeypatch, cleanup_boto3_module):
+    monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
+    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
+
+    def fake_client(name):
+        assert name == "s3"
+
+        def get_object(Bucket, Key):
+            assert Bucket == "bucket"
+            assert Key == "accounts/owner/acct.json"
+            return {"Body": io.BytesIO(b"   ")}
+
+        return SimpleNamespace(get_object=get_object)
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
+
+    with pytest.raises(ValueError) as exc:
+        dl.load_account("owner", "acct")
+
+    assert str(exc.value) == "Empty JSON file: s3://bucket/accounts/owner/acct.json"
+
+
 def test_load_person_meta_from_s3(monkeypatch):
     monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
@@ -136,3 +182,27 @@ def test_load_person_meta_from_s3(monkeypatch):
 
     assert dl.load_person_meta("Alice") == {"dob": "1980", "viewers": []}
     assert dl.load_person_meta("Bob") == {}
+
+
+def test_load_person_meta_missing_bucket(monkeypatch, cleanup_boto3_module):
+    monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
+    monkeypatch.delenv(dl.DATA_BUCKET_ENV, raising=False)
+
+    assert dl.load_person_meta("Alice") == {}
+
+
+def test_load_person_meta_boto_failure(monkeypatch, cleanup_boto3_module):
+    monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
+    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
+
+    def fake_client(name):
+        assert name == "s3"
+
+        def get_object(Bucket, Key):
+            raise RuntimeError("boom")
+
+        return SimpleNamespace(get_object=get_object)
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
+
+    assert dl.load_person_meta("Alice") == {}


### PR DESCRIPTION
## Summary
- add a fixture that resets any temporary boto3 module overrides after each test
- cover load_account with missing bucket env and empty payload scenarios
- add load_person_meta tests for missing bucket configuration and boto3 failures

## Testing
- pytest tests/test_data_loader_aws.py --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68d32ac0d22c8327861efde293912e68