### PR TITLE
Avoid loading timeseries when VAR metric not requested

### DIFF
--- a/backend/routes/query.py
+++ b/backend/routes/query.py
@@ -144,11 +144,17 @@ async def run_query(q: CustomQuery):
         return {"results": []}
 
     rows = []
+    needs_timeseries = Metric.VAR in q.metrics
     for t in tickers:
         sym, exch = (t.split(".", 1) + ["L"])[:2]
-        df = load_meta_timeseries_range(sym, exch, start_date=q.start, end_date=q.end)
+        if needs_timeseries:
+            df = load_meta_timeseries_range(
+                sym, exch, start_date=q.start, end_date=q.end
+            )
+        else:
+            df = None
         row = {"ticker": t}
-        if Metric.VAR in q.metrics:
+        if needs_timeseries and df is not None:
             row[Metric.VAR.value] = compute_var(df)
         if Metric.META in q.metrics:
             meta = get_security_meta(t) or {}

--- a/tests/routes/test_query.py
+++ b/tests/routes/test_query.py
@@ -190,6 +190,31 @@ def _setup_run_query(monkeypatch):
     monkeypatch.setattr(query, "get_security_meta", lambda t: {"name": "ABC"})
 
 
+def test_run_query_skips_timeseries_when_no_metrics(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_loader(*args, **kwargs):
+        calls["count"] += 1
+        return pd.DataFrame({"close": [1, 2]})
+
+    monkeypatch.setattr(query, "_resolve_tickers", lambda q: ["ABC.L"])
+    monkeypatch.setattr(query, "load_meta_timeseries_range", fake_loader)
+    monkeypatch.setattr(query, "compute_var", lambda df: 1)
+    monkeypatch.setattr(query, "get_security_meta", lambda t: {})
+
+    client = make_client()
+    body = {
+        "start": "2020-01-01",
+        "end": "2020-01-02",
+        "tickers": ["ABC.L"],
+        "metrics": [],
+    }
+    resp = client.post("/custom-query/run", json=body)
+    assert resp.status_code == 200
+    assert resp.json() == {"results": [{"ticker": "ABC.L"}]}
+    assert calls["count"] == 0
+
+
 def test_run_query_json(monkeypatch):
     _setup_run_query(monkeypatch)
     client = make_client()


### PR DESCRIPTION
## Summary
- compute a single needs_timeseries flag before iterating tickers
- skip loading timeseries data and VAR calculations when the metric is not requested
- add a regression test ensuring the timeseries loader is not called for empty metrics

## Testing
- pytest -o addopts= tests/routes/test_query.py

------
https://chatgpt.com/codex/tasks/task_e_68d32aa1a4988327b163d26fbd16693a