### PR TITLE
Handle config loading and error states in Root

### DIFF
--- a/frontend/tests/unit/rootConfigStates.test.tsx
+++ b/frontend/tests/unit/rootConfigStates.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+describe('Root configuration states', () => {
+  it('shows a loading indicator while configuration is pending', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    const pending = new Promise(() => {})
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn(() => pending),
+        getStoredAuthToken: vi.fn()
+      }
+    })
+
+    document.body.innerHTML = '<div id="root"></div>'
+    const { Root } = await import('@/main')
+
+    render(
+      <BrowserRouter>
+        <Root />
+      </BrowserRouter>,
+    )
+
+    const status = screen.getByRole('status')
+    expect(status).toHaveTextContent(/loading application/i)
+  })
+
+  it('renders an offline message when configuration fails', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    const networkError = new Error('Network unreachable')
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockRejectedValue(networkError),
+        getStoredAuthToken: vi.fn()
+      }
+    })
+
+    document.body.innerHTML = '<div id="root"></div>'
+    const { Root } = await import('@/main')
+
+    render(
+      <BrowserRouter>
+        <Root />
+      </BrowserRouter>,
+    )
+
+    expect(
+      await screen.findByText(/couldn't load the application configuration/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/network unreachable/i)).toBeInTheDocument()
+  })
+})
+


### PR DESCRIPTION
## Summary
- add loading and error state management around the initial configuration fetch in the Root component
- provide visible UI for configuration loading and offline/error cases and cover them with new unit tests

## Testing
- npm run test:jsdom -- rootConfigStates.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d32a8832088327b3fe9103626c1ff0