### PR TITLE
Refine instrument research overview and tests

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -243,6 +243,10 @@ export interface InstrumentDetail {
   name?: string | null;
   sector?: string | null;
   currency?: string | null;
+  rows?: number | null;
+  from?: string | null;
+  to?: string | null;
+  base_currency?: string | null;
 }
 
 export interface Transaction {


### PR DESCRIPTION
## Summary
- add a summary dashboard to the research overview showing key facts, recent performance, and risk metrics while moving the chart into a dedicated Timeseries tab
- extend the instrument detail typing so payload metadata such as coverage, rows, and base currency are available to the UI
- refresh the InstrumentResearch tests to cover the new summary layout, fundamentals placeholder, and news handling

## Testing
- `npx --prefix frontend vitest run tests/unit/pages/InstrumentResearch.test.tsx`
- `npm --prefix frontend run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d324b6f1888327b644d44b48f416a9