### PR TITLE
Handle config loading states in Root

### DIFF
--- a/frontend/tests/unit/rootConfigStates.test.tsx
+++ b/frontend/tests/unit/rootConfigStates.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  localStorage.clear()
+})
+
+describe('Root config states', () => {
+  it('shows a loading indicator while configuration is pending', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    const pending = new Promise(() => {})
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn(() => pending),
+        getStoredAuthToken: vi.fn()
+      }
+    })
+
+    document.body.innerHTML = '<div id="root"></div>'
+    const { Root } = await import('@/main')
+
+    const { unmount } = render(
+      <BrowserRouter>
+        <Root />
+      </BrowserRouter>,
+    )
+
+    expect(screen.getByText(/loading configuration/i)).toBeInTheDocument()
+    unmount()
+  })
+
+  it('shows an offline message when configuration fails to load', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockRejectedValue(new Error('network error')),
+        getStoredAuthToken: vi.fn()
+      }
+    })
+
+    document.body.innerHTML = '<div id="root"></div>'
+    const { Root } = await import('@/main')
+
+    try {
+      render(
+        <BrowserRouter>
+          <Root />
+        </BrowserRouter>,
+      )
+
+      expect(
+        await screen.findByText(/unable to load configuration/i),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(/please check your connection and try again/i),
+      ).toBeInTheDocument()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit loading and error states to the Root component so configuration fetch feedback is visible
- show an offline message when configuration retrieval fails instead of rendering nothing
- cover the new UI behaviour with unit tests for the loading and error flows

## Testing
- npx vitest --environment=jsdom run --reporter verbose tests/unit/rootConfigStates.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d38293391c8327b76e45d676a42c2b