### PR TITLE
Add tests for events route and allow path override

### DIFF
--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter
 
 router = APIRouter(tags=["events"])
 
-_events_path = Path(__file__).resolve().parents[2] / "data" / "events.json"
+_events_path = globals().get("_events_path") or Path(__file__).resolve().parents[2] / "data" / "events.json"
 
 try:
     with _events_path.open() as fh:

--- a/tests/routes/test_events.py
+++ b/tests/routes/test_events.py
@@ -1,0 +1,54 @@
+import importlib
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import backend.routes.events as events_module
+
+
+def reload_events_module():
+    global events_module
+    events_module = importlib.reload(events_module)
+    return events_module
+
+
+def create_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(events_module.router)
+    return TestClient(app)
+
+
+def test_list_events_filters_extra_fields(monkeypatch, tmp_path):
+    fixture = tmp_path / "custom.json"
+    fixture.write_text(
+        json.dumps([{"id": "custom", "name": "Custom", "ignored": "value"}])
+    )
+
+    with monkeypatch.context() as patcher:
+        patcher.setattr(events_module, "_events_path", fixture, raising=False)
+        reload_events_module()
+        client = create_client()
+
+        response = client.get("/events")
+
+    assert response.status_code == 200
+    assert response.json() == [{"id": "custom", "name": "Custom"}]
+
+    reload_events_module()
+
+
+def test_list_events_missing_file(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.json"
+
+    with monkeypatch.context() as patcher:
+        patcher.setattr(events_module, "_events_path", missing, raising=False)
+        reload_events_module()
+        client = create_client()
+
+        response = client.get("/events")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+    reload_events_module()


### PR DESCRIPTION
## Summary
- allow the events route to reuse a patched `_events_path` when reloaded
- add coverage for the `/events` endpoint filtering fields and handling missing files

## Testing
- pytest tests/routes/test_events.py --override-ini=addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d448780d1083279986b593612d66dd