### PR TITLE
Improve instrument research cards for theming

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,6 +15,10 @@
     --drawer-color: rgba(255, 255, 255, 0.87);
     --drawer-border-color: #444;
     --drawer-muted-color: #aaa;
+    --surface-card-bg: #2c2c2c;
+    --surface-card-color: rgba(255, 255, 255, 0.95);
+    --surface-card-border: #3a3a3a;
+    --surface-muted-color: #bbbbbb;
 
     font-synthesis: none;
     text-rendering: optimizeLegibility;
@@ -31,6 +35,10 @@
     --drawer-color: #213547;
     --drawer-border-color: #ccc;
     --drawer-muted-color: #666;
+    --surface-card-bg: #f5f5f5;
+    --surface-card-color: #213547;
+    --surface-card-border: #e0e0e0;
+    --surface-muted-color: #555555;
 }
 
 :root[data-theme='dark'] {
@@ -42,6 +50,10 @@
     --drawer-color: rgba(255, 255, 255, 0.87);
     --drawer-border-color: #444;
     --drawer-muted-color: #aaa;
+    --surface-card-bg: #2c2c2c;
+    --surface-card-color: rgba(255, 255, 255, 0.95);
+    --surface-card-border: #3a3a3a;
+    --surface-muted-color: #bbbbbb;
 }
 
 a {
@@ -103,6 +115,10 @@ button:focus-visible {
         --drawer-color: #213547;
         --drawer-border-color: #ccc;
         --drawer-muted-color: #666;
+        --surface-card-bg: #f5f5f5;
+        --surface-card-color: #213547;
+        --surface-card-border: #e0e0e0;
+        --surface-muted-color: #555555;
     }
 
     :root:not([data-theme]) a:hover {

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -13,6 +13,7 @@ import {
 import type { NewsItem, InstrumentMetadata, ScreenerResult } from "../types";
 import EmptyState from "../components/EmptyState";
 import { useConfig, SUPPORTED_CURRENCIES } from "../ConfigContext";
+import surfaceStyles from "../styles/surface.module.css";
 import { formatDateISO } from "../lib/date";
 import { money, percent } from "../lib/money";
 
@@ -796,16 +797,8 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
               }}
             >
               {summarySections.map((section) => (
-                <div
-                  key={section.title}
-                  style={{
-                    border: "1px solid #e0e0e0",
-                    borderRadius: "8px",
-                    padding: "1rem",
-                    background: "#fafafa",
-                  }}
-                >
-                  <h3 style={{ marginTop: 0 }}>{section.title}</h3>
+                <div key={section.title} className={surfaceStyles.surfaceCard}>
+                  <h3 className={surfaceStyles.surfaceCardTitle}>{section.title}</h3>
                   <dl style={{ margin: 0 }}>
                     {section.items.map((item) => (
                       <div
@@ -819,7 +812,12 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
                           alignItems: "baseline",
                         }}
                       >
-                        <dt style={{ margin: 0, color: "#555" }}>{item.label}</dt>
+                        <dt
+                          className={surfaceStyles.surfaceMuted}
+                          style={{ margin: 0 }}
+                        >
+                          {item.label}
+                        </dt>
                         <dd
                           style={{
                             margin: 0,
@@ -1019,16 +1017,8 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
                   }}
                 >
                   {sections.map((section) => (
-                    <div
-                      key={section.title}
-                      style={{
-                        border: "1px solid #e0e0e0",
-                        borderRadius: "8px",
-                        padding: "1rem",
-                        background: "#fafafa",
-                      }}
-                    >
-                      <h3 style={{ marginTop: 0 }}>{section.title}</h3>
+                    <div key={section.title} className={surfaceStyles.surfaceCard}>
+                      <h3 className={surfaceStyles.surfaceCardTitle}>{section.title}</h3>
                       <table
                         aria-label={`${section.title} fundamentals`}
                         style={{ width: "100%", borderCollapse: "collapse" }}
@@ -1041,9 +1031,9 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
                                 style={{
                                   textAlign: "left",
                                   padding: "0.35rem 0",
-                                  color: "#555",
                                   fontWeight: 500,
                                 }}
+                                className={surfaceStyles.surfaceMuted}
                               >
                                 {row.label}
                               </th>

--- a/frontend/src/styles/surface.module.css
+++ b/frontend/src/styles/surface.module.css
@@ -1,0 +1,16 @@
+.surfaceCard {
+  border: 1px solid var(--surface-card-border);
+  border-radius: 8px;
+  padding: 1rem;
+  background: var(--surface-card-bg);
+  color: var(--surface-card-color);
+}
+
+.surfaceCardTitle {
+  margin-top: 0;
+  color: inherit;
+}
+
+.surfaceMuted {
+  color: var(--surface-muted-color);
+}


### PR DESCRIPTION
## Summary
- add shared surface card styles that pull background and text colors from the active theme
- update instrument research summary and fundamentals cards to reuse the shared styles instead of inline literals
- introduce light and dark theme variables for card surfaces so text remains legible in both modes

## Testing
- `npm run lint` *(fails: pre-existing lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d44b5d66b48327871ec4cf1ec8670e