### PR TITLE
Fallback to local custom queries without S3

### DIFF
--- a/backend/tests/test_custom_query_route.py
+++ b/backend/tests/test_custom_query_route.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.config import config
+
+
+def test_custom_query_routes_fallback_to_local(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.delenv("DATA_BUCKET", raising=False)
+
+    queries_dir = Path(config.data_root) / "queries"
+    queries_dir.mkdir(parents=True, exist_ok=True)
+
+    fallback_slug = "fallback-slug"
+    fallback_path = queries_dir / f"{fallback_slug}.json"
+    if fallback_path.exists():
+        fallback_path.unlink()
+
+    app = create_app()
+
+    try:
+        with TestClient(app) as client:
+            resp = client.get("/custom-query/demo-slug")
+            assert resp.status_code == 200
+            assert resp.json()["tickers"] == ["AAPL"]
+
+            payload = {
+                "start": "2020-01-01",
+                "end": "2020-01-02",
+                "tickers": ["MSFT"],
+                "metrics": [],
+            }
+
+            save_resp = client.post(f"/custom-query/{fallback_slug}", json=payload)
+            assert save_resp.status_code == 200
+            assert save_resp.json() == {"saved": fallback_slug}
+            assert json.loads(fallback_path.read_text())["tickers"] == ["MSFT"]
+
+            get_resp = client.get(f"/custom-query/{fallback_slug}")
+            assert get_resp.status_code == 200
+            assert get_resp.json()["tickers"] == ["MSFT"]
+    finally:
+        if fallback_path.exists():
+            fallback_path.unlink()


### PR DESCRIPTION
## Summary
- fall back to local query storage for GET/POST when S3 is unavailable in AWS mode
- ensure named query saves from the run endpoint also use the local fallback
- add a regression test covering AWS mode without a DATA_BUCKET

## Testing
- pytest -o addopts='' backend/tests/test_custom_query_route.py

------
https://chatgpt.com/codex/tasks/task_e_68d44f6471b88327be0dbf1cdf5050c0