### PR TITLE
Add compliance menu translations

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -33,8 +33,10 @@
       "taxtools": "Steuer-Tools",
       "trail": "Trail",
       "reports": "Berichte",
-      "alertsettings": "Alert Settings",
-      "support": "Support",
+  "alertsettings": "Alert Settings",
+  "compliance": "Compliance-Warnungen",
+  "trade-compliance": "Handels-Compliance",
+  "support": "Support",
       "scenario": "Szenario-Tester"
     },
     "logs": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -33,8 +33,10 @@
       "taxtools": "Tax Tools",
       "trail": "Trail",
       "reports": "Reports",
-      "alertsettings": "Alert Settings",
-      "support": "Support",
+  "alertsettings": "Alert Settings",
+  "compliance": "Compliance warnings",
+  "trade-compliance": "Trade compliance",
+  "support": "Support",
       "scenario": "Scenario Tester"
     }
   },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -33,8 +33,10 @@
       "taxtools": "Herramientas fiscales",
       "trail": "Trail",
       "reports": "Informes",
-      "alertsettings": "Alert Settings",
-      "support": "Soporte",
+  "alertsettings": "Alert Settings",
+  "compliance": "Alertas de cumplimiento",
+  "trade-compliance": "Cumplimiento de operaciones",
+  "support": "Soporte",
       "scenario": "Probador de Escenarios"
     },
     "logs": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -33,8 +33,10 @@
       "taxtools": "Outils fiscaux",
       "trail": "Trail",
       "reports": "Rapports",
-      "alertsettings": "Alert Settings",
-      "support": "Support",
+  "alertsettings": "Alert Settings",
+  "compliance": "Alertes de conformité",
+  "trade-compliance": "Conformité des transactions",
+  "support": "Support",
       "scenario": "Testeur de Scénario"
     },
     "logs": {

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -33,8 +33,10 @@
       "taxtools": "Strumenti fiscali",
       "trail": "Trail",
       "reports": "Segnalazioni",
-      "alertsettings": "Alert Settings",
-      "support": "Supporto",
+  "alertsettings": "Alert Settings",
+  "compliance": "Avvisi di conformità",
+  "trade-compliance": "Conformità delle operazioni",
+  "support": "Supporto",
       "scenario": "Tester di scenario"
     },
     "logs": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -33,8 +33,10 @@
       "taxtools": "Ferramentas fiscais",
       "trail": "Trail",
       "reports": "Relatórios",
-      "alertsettings": "Alert Settings",
-      "support": "Suporte",
+  "alertsettings": "Alert Settings",
+  "compliance": "Alertas de conformidade",
+  "trade-compliance": "Conformidade de negociações",
+  "support": "Suporte",
       "scenario": "Testador de Cenários"
     },
     "logs": {


### PR DESCRIPTION
## Summary
- add compliance and trade compliance menu labels to all locale files so the navigation shows the proper text across languages

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d451615dc08327b514423e6f5ced63