### PR TITLE
Align instrument history caching with range selection

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -31,6 +31,8 @@ type Props = {
   onClose?: () => void;
   variant?: Variant;
   hidePositions?: boolean;
+  initialHistoryDays?: number;
+  onHistoryRangeChange?: (days: number) => void;
 };
 
 type Price = {
@@ -192,6 +194,8 @@ export function InstrumentDetail({
   onClose,
   variant = "drawer",
   hidePositions = false,
+  initialHistoryDays,
+  onHistoryRangeChange,
 }: Props) {
   const { t } = useTranslation();
   const { baseCurrency } = useConfig();
@@ -245,8 +249,9 @@ export function InstrumentDetail({
   const [showMA20, setShowMA20] = useState(false);
   const [showMA50, setShowMA50] = useState(false);
   const [showMA200, setShowMA200] = useState(false);
+  const resolvedInitialDays = initialHistoryDays ?? 365;
   const [showRSI, setShowRSI] = useState(false);
-  const [days, setDays] = useState<number>(365);
+  const [days, setDays] = useState<number>(resolvedInitialDays);
   const [priceMode, setPriceMode] = useState<"close" | "intraday">("close");
   const [intradayPrices, setIntradayPrices] = useState<{ timestamp: string; close: number }[]>([]);
   const [intradayLoading, setIntradayLoading] = useState(false);
@@ -271,6 +276,14 @@ export function InstrumentDetail({
       .catch((e: Error) => setErr(e.message))
       .finally(() => setLoading(false));
   }, [ticker, days]);
+
+  useEffect(() => {
+    setDays(resolvedInitialDays);
+  }, [ticker, resolvedInitialDays]);
+
+  useEffect(() => {
+    onHistoryRangeChange?.(days);
+  }, [days, onHistoryRangeChange]);
 
   useEffect(() => {
     setPriceMode("close");

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -113,7 +113,7 @@ function SparklineFromFetch({
   tabIndex,
 }: SparklineFetchProps) {
   const { data, error } = useInstrumentHistory(ticker, days);
-  const cached = getCachedInstrumentHistory(ticker);
+  const cached = getCachedInstrumentHistory(ticker, days);
   const points = (cached ?? data)?.mini?.[String(days)] ?? [];
   const series =
     points

--- a/frontend/tests/unit/components/Sparkline.test.tsx
+++ b/frontend/tests/unit/components/Sparkline.test.tsx
@@ -8,6 +8,7 @@ vi.mock("@/hooks/useInstrumentHistory", () => ({
     error: null,
   })),
   getCachedInstrumentHistory: vi.fn(() => null),
+  updateCachedInstrumentHistory: vi.fn(),
 }));
 import { useInstrumentHistory } from "@/hooks/useInstrumentHistory";
 const mockUseInstrumentHistory = useInstrumentHistory as unknown as vi.Mock;

--- a/frontend/tests/unit/hooks/useInstrumentHistory.test.ts
+++ b/frontend/tests/unit/hooks/useInstrumentHistory.test.ts
@@ -45,6 +45,8 @@ describe('useInstrumentHistory', () => {
     });
 
     expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(2);
+    expect(mockGetInstrumentDetail).toHaveBeenNthCalledWith(1, 'ABC', 7);
+    expect(mockGetInstrumentDetail).toHaveBeenNthCalledWith(2, 'ABC', 7);
     expect(result.current.error).toBeNull();
     expect(result.current.data).not.toBeNull();
   });
@@ -73,12 +75,14 @@ describe('useInstrumentHistory', () => {
       await vi.runAllTimersAsync();
     });
     expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(2);
+    expect(mockGetInstrumentDetail).toHaveBeenNthCalledWith(1, 'ABC', 7);
+    expect(mockGetInstrumentDetail).toHaveBeenNthCalledWith(2, 'ABC', 7);
     expect(result.current.data).not.toBeNull();
 
     randSpy.mockRestore();
   });
 
-  it('caches detail per ticker regardless of day range', async () => {
+  it('caches detail per ticker and day range', async () => {
     mockGetInstrumentDetail.mockResolvedValue({
       mini: { 7: [], 30: [], 180: [], 365: [] },
       positions: [],
@@ -91,9 +95,15 @@ describe('useInstrumentHistory', () => {
 
     await waitFor(() => expect(result.current.data).not.toBeNull());
     expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(1);
+    expect(mockGetInstrumentDetail).toHaveBeenLastCalledWith('ABC', 7);
+
+    rerender({ days: 7 });
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(1);
 
     rerender({ days: 30 });
     await waitFor(() => expect(result.current.data).not.toBeNull());
-    expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(1);
+    expect(mockGetInstrumentDetail).toHaveBeenCalledTimes(2);
+    expect(mockGetInstrumentDetail).toHaveBeenLastCalledWith('ABC', 30);
   });
 });

--- a/frontend/tests/unit/pages/InstrumentResearch.test.tsx
+++ b/frontend/tests/unit/pages/InstrumentResearch.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@/hooks/useInstrumentHistory", () => ({
   useInstrumentHistory: vi.fn(),
   getCachedInstrumentHistory: vi.fn(() => null),
+  updateCachedInstrumentHistory: vi.fn(),
 }));
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";


### PR DESCRIPTION
## Summary
- key instrument history cache entries by ticker and requested range and forward the selected window to the API
- share the overview history range with the timeseries chart so summaries recalculate when the user changes periods
- update helpers and tests to cover the new cache behaviour and range propagation

## Testing
- npm run test -- --run tests/unit/hooks/useInstrumentHistory.test.ts
- npm run test -- --run tests/unit/components/Sparkline.test.tsx
- npm run test -- --run tests/unit/pages/InstrumentResearch.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d4510cdd708327aafde3b290c78c1c