### PR TITLE
Prefer base currency on instrument research page

### DIFF
--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -107,7 +107,12 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
     if (!detail) return;
     const name = normaliseOptional(detail.name);
     const sector = normaliseOptional(detail.sector);
-    const currency = normaliseUppercase(detail.currency);
+    const normalizedBaseCurrency =
+      detail && typeof detail.base_currency === "string"
+        ? normaliseUppercase(detail.base_currency)
+        : undefined;
+    const currency =
+      normalizedBaseCurrency ?? normaliseUppercase(detail?.currency ?? undefined);
     setMetadata((prev) => ({
       name: name ?? prev.name,
       sector: sector ?? prev.sector,
@@ -386,7 +391,11 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
   }
 
   const fallbackSector = detail ? normaliseOptional(detail.sector) : undefined;
-  const fallbackCurrency = detail ? normaliseUppercase(detail.currency) : undefined;
+  const fallbackCurrency = detail
+    ? (typeof detail.base_currency === "string"
+        ? normaliseUppercase(detail.base_currency)
+        : undefined) ?? normaliseUppercase(detail.currency)
+    : undefined;
   const displayName = metadata.name || detail?.name || null;
   const displaySector = metadata.sector || fallbackSector || "";
   const displayCurrency = metadata.currency || fallbackCurrency || "";


### PR DESCRIPTION
## Summary
- prefer an instrument's base currency when normalising metadata on the research page
- fall back to the instrument detail's base currency for display when metadata is missing

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d45641c0b083278130a69113fc5777