### PR TITLE
Add coverage for malformed person meta and virtual portfolio persistence

### DIFF
--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -9,8 +9,12 @@ from backend.common.data_loader import (
     ResolvedPaths,
     _list_local_plots,
     _safe_json_load,
+    load_person_meta,
+    load_virtual_portfolio,
     resolve_paths,
+    save_virtual_portfolio,
 )
+from backend.common.virtual_portfolio import VirtualPortfolio
 from backend.config import Config
 
 
@@ -52,6 +56,22 @@ class TestSafeJsonLoad:
         assert str(exc.value) == f"Empty JSON file: {path}"
 
 
+class TestLoadPersonMeta:
+    def test_malformed_person_json_returns_empty_meta(self, tmp_path: Path) -> None:
+        owner_dir = tmp_path / "alice"
+        owner_dir.mkdir()
+        person_path = owner_dir / "person.json"
+        person_path.write_text("{invalid")
+
+        with pytest.raises(json.JSONDecodeError):
+            _safe_json_load(person_path)
+
+        meta = load_person_meta("alice", data_root=tmp_path)
+
+        assert meta == {}
+        assert meta.get("viewers", []) == []
+
+
 class TestResolvePaths:
     def test_with_relative_accounts_root(self, tmp_path: Path) -> None:
         repo_dir = tmp_path / "repo"
@@ -85,6 +105,35 @@ class TestResolvePaths:
         expected_accounts = Path(windows_accounts).expanduser()
         expected_virtual = expected_accounts.parent / "virtual_portfolios"
         assert result == ResolvedPaths(repo_dir, expected_accounts, expected_virtual)
+
+
+class TestVirtualPortfolioPersistence:
+    def test_save_and_load_round_trip(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo_dir = tmp_path / "repo"
+        accounts_relative = Path("custom") / "accounts"
+        accounts_dir = repo_dir / accounts_relative
+        accounts_dir.mkdir(parents=True, exist_ok=True)
+
+        cfg = Config()
+        cfg.repo_root = repo_dir
+        cfg.accounts_root = accounts_relative
+        cfg.app_env = None
+        monkeypatch.setattr("backend.common.data_loader.config", cfg)
+        monkeypatch.delenv(DATA_BUCKET_ENV, raising=False)
+
+        portfolio = VirtualPortfolio(id="vp-demo", name="demo", holdings=[])
+
+        save_virtual_portfolio(portfolio)
+
+        paths = resolve_paths(cfg.repo_root, cfg.accounts_root)
+        expected_path = paths.virtual_pf_root / "demo.json"
+
+        assert expected_path.exists()
+
+        loaded = load_virtual_portfolio("demo")
+
+        assert loaded is not None
+        assert loaded.model_dump() == portfolio.model_dump()
 
 
 class TestListLocalPlots:


### PR DESCRIPTION
## Summary
- add a regression test that exercises `_safe_json_load` failures on malformed `person.json` and checks `load_person_meta` returns safe defaults
- cover the `save_virtual_portfolio`/`load_virtual_portfolio` round-trip to ensure the data loader resolves the virtual portfolio path correctly

## Testing
- pytest --cov=backend.common.data_loader --cov-fail-under=0 tests/backend/common/test_data_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68d4574669108327ad9dfc1b80c4daea