### PR TITLE
Add AWS data loader pagination and delegation tests

### DIFF
--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -1,3 +1,4 @@
+import builtins
 import io
 import sys
 from types import SimpleNamespace
@@ -43,6 +44,22 @@ def test_list_aws_plots(monkeypatch):
         {"owner": "Bob", "accounts": ["GIA"]},
     ]
     assert dl._list_aws_plots() == expected
+
+
+def test_list_aws_plots_missing_boto(monkeypatch, cleanup_boto3_module):
+    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
+    monkeypatch.delitem(sys.modules, "boto3", raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "boto3":
+            raise ModuleNotFoundError("No module named 'boto3'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert dl._list_aws_plots() == []
 
 
 def test_list_aws_plots_filters_without_auth(monkeypatch):
@@ -108,6 +125,64 @@ def test_list_aws_plots_demo_only_when_unauthenticated(monkeypatch):
 
     expected = [{"owner": "demo", "accounts": ["ISA"]}]
     assert dl._list_aws_plots() == expected
+
+
+def test_list_aws_plots_pagination(monkeypatch):
+    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
+
+    responses = [
+        {
+            "Contents": [
+                {"Key": "accounts/Alice/ISA.json"},
+                {"Key": "accounts/Alice/person.json"},
+            ],
+            "IsTruncated": True,
+            "NextContinuationToken": "token-1",
+        },
+        {
+            "Contents": [
+                {"Key": "accounts/Alice/isa.json"},
+                {"Key": "accounts/Bob/GIA.json"},
+            ],
+            "IsTruncated": True,
+            "NextContinuationToken": "token-2",
+        },
+        {
+            "Contents": [
+                {"Key": "accounts/Bob/gia.json"},
+                {"Key": "accounts/Carol/401k.json"},
+            ],
+            "IsTruncated": False,
+        },
+    ]
+
+    calls = []
+
+    def fake_client(name):
+        assert name == "s3"
+
+        def list_objects_v2(**kwargs):
+            index = len(calls)
+            calls.append(kwargs)
+            if index == 0:
+                assert "ContinuationToken" not in kwargs
+            else:
+                expected_token = responses[index - 1]["NextContinuationToken"]
+                assert kwargs["ContinuationToken"] == expected_token
+            return responses[index]
+
+        return SimpleNamespace(list_objects_v2=list_objects_v2)
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
+
+    expected = [
+        {"owner": "Alice", "accounts": ["ISA"]},
+        {"owner": "Bob", "accounts": ["GIA"]},
+        {"owner": "Carol", "accounts": ["401k"]},
+    ]
+
+    assert dl._list_aws_plots() == expected
+    assert len(calls) == 3
 
 
 def test_load_account_from_s3(monkeypatch):
@@ -206,3 +281,32 @@ def test_load_person_meta_boto_failure(monkeypatch, cleanup_boto3_module):
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
     assert dl.load_person_meta("Alice") == {}
+
+
+def test_list_plots_delegates_to_aws(monkeypatch):
+    monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
+
+    sentinel = object()
+
+    def fake_aws(current_user=None):
+        assert current_user == "alice"
+        return sentinel
+
+    monkeypatch.setattr(dl, "_list_aws_plots", fake_aws)
+
+    assert dl.list_plots(current_user="alice") is sentinel
+
+
+def test_list_plots_uses_local_when_not_aws(monkeypatch):
+    monkeypatch.setattr(dl.config, "app_env", "local", raising=False)
+
+    sentinel = object()
+
+    def fake_local(data_root=None, current_user=None):
+        assert data_root == "root"
+        assert current_user == "bob"
+        return sentinel
+
+    monkeypatch.setattr(dl, "_list_local_plots", fake_local)
+
+    assert dl.list_plots(data_root="root", current_user="bob") is sentinel


### PR DESCRIPTION
## Summary
- add coverage for `_list_aws_plots` when boto3 is unavailable
- exercise pagination handling and case-insensitive deduplication of S3 results
- verify `list_plots` delegates to the AWS or local implementation based on configuration

## Testing
- pytest --cov=backend.common.data_loader --cov-fail-under=0 tests/test_data_loader_aws.py

------
https://chatgpt.com/codex/tasks/task_e_68d4573e6f408327b28b2c366f2babf0