### PR TITLE
Fix performance route owner selection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -131,7 +131,9 @@ export default function App({ onLogout }: AppProps) {
   const params = new URLSearchParams(location.search);
   const [mode, setMode] = useState<Mode>(initialMode);
   const [selectedOwner, setSelectedOwner] = useState(
-    initialMode === "owner" ? initialSlug : ""
+    initialMode === "owner" || initialMode === "performance"
+      ? initialSlug
+      : "",
   );
   const [selectedGroup, setSelectedGroup] = useState(
     initialMode === "instrument" ? initialSlug : params.get("group") ?? ""
@@ -251,7 +253,7 @@ export default function App({ onLogout }: AppProps) {
       return;
     }
     setMode(newMode);
-    if (newMode === "owner") {
+    if (newMode === "owner" || newMode === "performance") {
       setSelectedOwner(segs[1] ?? "");
     } else if (newMode === "instrument") {
       setSelectedGroup(segs[1] ?? "");

--- a/frontend/src/hooks/useRouteMode.ts
+++ b/frontend/src/hooks/useRouteMode.ts
@@ -34,7 +34,7 @@ function deriveInitial() {
     path[0] === "scenario" ? "scenario" :
     path.length === 0 ? "group" : "movers";
   const slug = path[1] ?? "";
-  const owner = mode === "owner" ? slug : "";
+  const owner = mode === "owner" || mode === "performance" ? slug : "";
   const group =
     mode === "instrument" ? "" : params.get("group") ?? "";
   return { mode, owner, group };
@@ -157,7 +157,7 @@ export function useRouteMode(): RouteState {
       return;
     }
     setMode(newMode);
-    if (newMode === "owner") {
+    if (newMode === "owner" || newMode === "performance") {
       setSelectedOwner(segs[1] ?? "");
     } else if (newMode === "instrument") {
       const slug = segs[1] ?? "";


### PR DESCRIPTION
## Summary
- ensure the performance tab initialises the selected owner from the URL slug in the legacy app shell
- keep the shared route context in sync with performance owner slugs so direct navigation loads real account data

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d453b3f974832799e487b756380b20