### PR TITLE
Return historical scenario results keyed by day horizon

### DIFF
--- a/backend/routes/scenario.py
+++ b/backend/routes/scenario.py
@@ -109,16 +109,15 @@ def run_historical_scenario(
         horizon_map = {}
         for label, days in label_pairs:
             shocked_pf = (
-                shocked.get(label)
+                shocked.get(days)
+                or shocked.get(label)
                 or shocked.get(str(days))
-                or shocked.get(days)
                 or {}
             )
-            val = (
-                shocked_pf.get("total_value_estimate_gbp")
-                or shocked_pf.get("total_value_gbp")
-            )
-            horizon_map[label] = {
+            val = shocked_pf.get("total_value_estimate_gbp")
+            if val is None:
+                val = shocked_pf.get("total_value_gbp")
+            horizon_map[days] = {
                 "baseline_total_value_gbp": baseline,
                 "shocked_total_value_gbp": val,
             }


### PR DESCRIPTION
## Summary
- ensure historical scenario results use numeric day horizons as keys
- normalise shocked portfolio lookup to support numeric keys while preserving values

## Testing
- pytest --override-ini addopts="" tests/routes/test_scenario.py::test_run_historical_scenario_valid_horizons

------
https://chatgpt.com/codex/tasks/task_e_68d45ce695f08327a178a4994325b966