### PR TITLE
Sanitize owner lists to hide demo accounts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,6 +52,7 @@ import Rebalance from "./pages/Rebalance";
 import PensionForecast from "./pages/PensionForecast";
 import TaxTools from "./pages/TaxTools";
 import RightRail from "./components/RightRail";
+import { sanitizeOwners } from "./utils/owners";
 const PerformanceDashboard = lazyWithDelay(
   () => import("./components/PerformanceDashboard"),
 );
@@ -267,11 +268,13 @@ export default function App({ onLogout }: AppProps) {
   useEffect(() => {
     if (!ownersReq.data) return;
 
-    setOwners(ownersReq.data);
+    const sanitizedOwners = sanitizeOwners(ownersReq.data);
+
+    setOwners(sanitizedOwners);
 
     if (!selectedOwner) return;
 
-    const match = ownersReq.data.find(
+    const match = sanitizedOwners.find(
       (o) => o.owner.toLowerCase() === selectedOwner.toLowerCase(),
     );
 

--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -27,6 +27,7 @@ import InstallPwaPrompt from "./components/InstallPwaPrompt";
 import BackendUnavailableCard from "./components/BackendUnavailableCard";
 import lazyWithDelay from "./utils/lazyWithDelay";
 import PortfolioDashboardSkeleton from "./components/skeletons/PortfolioDashboardSkeleton";
+import { sanitizeOwners } from "./utils/owners";
 
 const ScreenerQuery = lazy(() => import("./pages/ScreenerQuery"));
 const TimeseriesEdit = lazy(() =>
@@ -84,10 +85,11 @@ export default function MainApp() {
 
   useEffect(() => {
     if (ownersReq.data) {
-      setOwners(ownersReq.data);
+      const sanitizedOwners = sanitizeOwners(ownersReq.data);
+      setOwners(sanitizedOwners);
       if (
         selectedOwner &&
-        !ownersReq.data.some((o) => o.owner === selectedOwner)
+        !sanitizedOwners.some((o) => o.owner === selectedOwner)
       ) {
         setSelectedOwner("");
       }

--- a/frontend/src/pages/ComplianceWarnings.tsx
+++ b/frontend/src/pages/ComplianceWarnings.tsx
@@ -4,6 +4,7 @@ import { complianceForOwner, getOwners } from "../api";
 import type { OwnerSummary, ComplianceResult } from "../types";
 import { OwnerSelector } from "../components/OwnerSelector";
 import EmptyState from "../components/EmptyState";
+import { sanitizeOwners } from "../utils/owners";
 
 export default function ComplianceWarnings() {
   const { owner: ownerParam } = useParams<{ owner?: string }>();
@@ -14,7 +15,9 @@ export default function ComplianceWarnings() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    getOwners().then(setOwners).catch(() => setOwners([]));
+    getOwners()
+      .then((os) => setOwners(sanitizeOwners(os)))
+      .catch(() => setOwners([]));
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -17,6 +17,7 @@ import type { OwnerSummary } from "../types";
 import { OwnerSelector } from "../components/OwnerSelector";
 import { useTranslation } from "react-i18next";
 import { useRoute } from "../RouteContext";
+import { sanitizeOwners } from "../utils/owners";
 
 export default function PensionForecast() {
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
@@ -79,7 +80,7 @@ export default function PensionForecast() {
   useEffect(() => {
     getOwners()
       .then((os) => {
-        setOwners(os);
+        setOwners(sanitizeOwners(os));
       })
       .catch(() => setOwners([]));
   }, []);

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { API_BASE, getOwners } from "../api";
 import type { OwnerSummary } from "../types";
 import { OwnerSelector } from "../components/OwnerSelector";
+import { sanitizeOwners } from "../utils/owners";
 
 export default function Reports() {
   const { t } = useTranslation();
@@ -14,7 +15,7 @@ export default function Reports() {
 
   useEffect(() => {
     getOwners()
-      .then(setOwners)
+      .then((os) => setOwners(sanitizeOwners(os)))
       .catch(() => setOwners([]))
       .finally(() => setOwnersLoaded(true));
   }, []);

--- a/frontend/src/pages/ScreenerQuery.tsx
+++ b/frontend/src/pages/ScreenerQuery.tsx
@@ -12,6 +12,7 @@ import { useFetch } from "../hooks/useFetch";
 import { useSortableTable } from "../hooks/useSortableTable";
 import { SavedQueries } from "../components/SavedQueries";
 import { z } from "zod";
+import { sanitizeOwners } from "../utils/owners";
 
 const TICKER_OPTIONS = ["AAA", "BBB", "CCC"];
 const METRIC_OPTIONS = ["market_value_gbp", "gain_gbp"];
@@ -23,8 +24,10 @@ function QuerySection() {
   const { data: owners } = useFetch(fetchOwners, []);
   const isTest = (typeof process !== 'undefined' && (process as any)?.env?.NODE_ENV === 'test')
     || Boolean((import.meta as any)?.vitest);
-  const ownerList = Array.isArray(owners)
-    ? owners
+  const rawOwners = Array.isArray(owners) ? owners : [];
+  const sanitizedOwners = sanitizeOwners(rawOwners);
+  const ownerList = sanitizedOwners.length
+    ? sanitizedOwners
     : (isTest ? [{ owner: 'Alice', accounts: [] }, { owner: 'Bob', accounts: [] }] : []);
   const { t } = useTranslation();
 

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -18,6 +18,7 @@ import SectionCard from "../components/SectionCard";
 import type { OwnerSummary } from "../types";
 import { orderedTabPlugins, type TabPluginId } from "../tabPlugins";
 import { usePriceRefresh } from "../PriceRefreshContext";
+import { sanitizeOwners } from "../utils/owners";
 
 const TAB_KEYS = orderedTabPlugins.map((p) => p.id) as TabPluginId[];
 const EMPTY_TABS = Object.fromEntries(TAB_KEYS.map((k) => [k, false])) as Record<
@@ -58,8 +59,9 @@ export default function Support() {
   useEffect(() => {
     getOwners()
       .then((list) => {
-        setOwners(list);
-        setOwner(list[0]?.owner ?? "");
+        const sanitized = sanitizeOwners(list);
+        setOwners(sanitized);
+        setOwner(sanitized[0]?.owner ?? "");
       })
       .catch(() => setOwners([]));
   }, []);

--- a/frontend/src/pages/TradeCompliance.tsx
+++ b/frontend/src/pages/TradeCompliance.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { getOwners, getTransactionsWithCompliance, requestApproval } from "../api";
 import type { OwnerSummary, TransactionWithCompliance } from "../types";
 import { OwnerSelector } from "../components/OwnerSelector";
+import { sanitizeOwners } from "../utils/owners";
 
 export default function TradeCompliance() {
   const { owner: ownerParam } = useParams<{ owner?: string }>();
@@ -14,7 +15,9 @@ export default function TradeCompliance() {
   const [requested, setRequested] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
-    getOwners().then(setOwners).catch(() => setOwners([]));
+    getOwners()
+      .then((os) => setOwners(sanitizeOwners(os)))
+      .catch(() => setOwners([]));
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/UserConfig.tsx
+++ b/frontend/src/pages/UserConfig.tsx
@@ -11,6 +11,7 @@ import {
 import type { Approval, OwnerSummary, UserConfig } from '../types';
 import { useAuth } from '../AuthContext';
 import { useConfig } from '../ConfigContext';
+import { sanitizeOwners } from '../utils/owners';
 
 export default function UserConfigPage() {
   const { t } = useTranslation();
@@ -30,7 +31,7 @@ export default function UserConfigPage() {
 
   useEffect(() => {
     getOwners()
-      .then(setOwners)
+      .then((os) => setOwners(sanitizeOwners(os)))
       .catch(() => {
         /* ignore */
       });

--- a/frontend/src/pages/VirtualPortfolio.tsx
+++ b/frontend/src/pages/VirtualPortfolio.tsx
@@ -13,6 +13,7 @@ import type {
   VirtualPortfolio as VP,
   OwnerSummary,
 } from "../types";
+import { sanitizeOwners } from "../utils/owners";
 
 export function VirtualPortfolio() {
   const [portfolios, setPortfolios] = useState<VP[]>([]);
@@ -43,7 +44,7 @@ export function VirtualPortfolio() {
         ]);
         if (!cancelled) {
           setPortfolios(ps);
-          setOwners(os);
+          setOwners(sanitizeOwners(os));
         }
       } catch (e) {
         if (!cancelled) {

--- a/frontend/src/utils/owners.ts
+++ b/frontend/src/utils/owners.ts
@@ -1,0 +1,10 @@
+import type { OwnerSummary } from "../types";
+
+/**
+ * Filter out demo owners when real owners exist, but preserve the demo owner when
+ * it is the only option (e.g. demo mode environments).
+ */
+export function sanitizeOwners(owners: OwnerSummary[]): OwnerSummary[] {
+  const nonDemoOwners = owners.filter((owner) => owner.owner !== "demo");
+  return nonDemoOwners.length > 0 ? nonDemoOwners : owners;
+}

--- a/frontend/tests/unit/utils/owners.test.ts
+++ b/frontend/tests/unit/utils/owners.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeOwners } from '@/utils/owners';
+
+const makeOwner = (owner: string) => ({ owner, accounts: [] as string[] });
+
+describe('sanitizeOwners', () => {
+  it('filters demo owner when real owners exist', () => {
+    const owners = [makeOwner('demo'), makeOwner('alice'), makeOwner('bob')];
+    expect(sanitizeOwners(owners)).toEqual([makeOwner('alice'), makeOwner('bob')]);
+  });
+
+  it('keeps demo owner when it is the only option', () => {
+    const owners = [makeOwner('demo')];
+    expect(sanitizeOwners(owners)).toEqual([makeOwner('demo')]);
+  });
+
+  it('returns empty list when no owners provided', () => {
+    expect(sanitizeOwners([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared sanitizeOwners helper that removes demo accounts when real owners exist
- update portfolio navigation, admin, and settings pages to rely on sanitized owner lists instead of demo entries
- add unit coverage for the new sanitizeOwners helper

## Testing
- bun run lint *(fails: existing lint violations in unrelated files)*
- bun run test -- --run *(fails: existing Vitest suite errors across unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68d45c28eab08327bff0449dedd66722