### PR TITLE
feat: allow updating instrument type

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -243,6 +243,7 @@ export interface InstrumentDetail {
   name?: string | null;
   sector?: string | null;
   currency?: string | null;
+  instrument_type?: string | null;
   rows?: number | null;
   from?: string | null;
   to?: string | null;
@@ -312,6 +313,8 @@ export interface InstrumentMetadata {
   sector?: string | null;
   grouping?: string | null;
   currency?: string | null;
+  instrument_type?: string | null;
+  instrumentType?: string | null;
 }
 
 export interface QuoteRow {


### PR DESCRIPTION
## Summary
- allow instrument metadata editing to include instrument type on the research page
- persist and cache the selected instrument type when saving metadata
- extend shared types to cover instrument_type values returned by the API

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d45be310908327bf71cd8efeb8788e