### PR TITLE
Add smoke-test importer for holdings endpoint

### DIFF
--- a/backend/importers/__init__.py
+++ b/backend/importers/__init__.py
@@ -18,6 +18,7 @@ class UnknownProvider(Exception):
 _IMPORTER_PATHS: Dict[str, str] = {
     "degiro": "backend.importers.degiro",
     "hargreaves": "backend.importers.hargreaves",
+    "test": "backend.importers.test",
 }
 
 

--- a/backend/importers/test.py
+++ b/backend/importers/test.py
@@ -1,0 +1,19 @@
+"""Utility importer used by smoke tests.
+
+This importer is intentionally minimal: it accepts any payload and produces an
+empty set of holdings.  The smoke tests only validate that the endpoint
+responds successfully, so a stub importer keeps the behaviour predictable
+without depending on provider-specific fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from backend.routes.transactions import Transaction
+
+
+def parse(_data: bytes) -> List[Transaction]:
+    """Return an empty list of transactions for smoke testing purposes."""
+
+    return []


### PR DESCRIPTION
## Summary
- allow the backend smoke test to import holdings by wiring up a stub "test" importer
- document the purpose of the stub importer so smoke tests can succeed without broker data

## Testing
- `pytest backend/tests/test_update_holdings_from_csv.py` *(fails: coverage threshold requires running the full suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d45ec2997083279476121f681bb687