### PR TITLE
feat(frontend): add max drawdown help tooltip

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -392,9 +392,10 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
                 alignItems: "center",
                 gap: "0.25rem",
               }}
+              title={t("dashboard.maxDrawdownHelp")}
             >
               <Shield size={16} />
-              Max Drawdown
+              <span>{t("dashboard.maxDrawdown")}</span>
             </div>
             <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
               {percentOrNa(safeMaxDrawdown)}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -254,6 +254,7 @@
     "alphaVsBenchmark": "Alpha vs Benchmark",
     "trackingError": "Tracking Error",
     "maxDrawdown": "Max Drawdown",
+    "maxDrawdownHelp": "Der maximale Drawdown ist der größte prozentuale Rückgang vom bisherigen Höchststand des Portfolios bis zum darauffolgenden Tief, berechnet auf Basis der rekonstruierten täglichen Schlusswerte Ihrer Positionen.",
     "timeWeightedReturn": "Zeitgewichtete Rendite",
     "xirr": "XIRR",
     "portfolioValue": "Portfoliowert",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -260,6 +260,7 @@
     "alphaVsBenchmark": "Alpha vs Benchmark",
     "trackingError": "Tracking Error",
     "maxDrawdown": "Max Drawdown",
+    "maxDrawdownHelp": "Max drawdown is the largest percentage drop from any portfolio peak to the lowest closing value that follows, calculated from the rebuilt daily totals of your holdings.",
     "timeWeightedReturn": "Time-Weighted Return",
     "xirr": "XIRR",
     "portfolioValue": "Portfolio Value",


### PR DESCRIPTION
## Summary
- add a tooltip to the Max Drawdown stat tile so users can see how the value is computed
- provide localized helper copy in English and German for the new tooltip

## Testing
- npm --prefix frontend run test -- run tests/unit/components/GroupPortfolioView.test.tsx *(fails: GroupPortfolioView tests require a router context when run in isolation)*
- npm --prefix frontend run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d15ffd1d208327975a56b6a406560e