### PR TITLE
Fix trail task defaults and enforce owner validation

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -96,6 +96,8 @@ def _list_local_plots(
     for owner_dir in sorted(root.iterdir()):
         if not owner_dir.is_dir():
             continue
+        if not (owner_dir / "person.json").exists():
+            continue
         # When authentication is enabled (``disable_auth`` is explicitly
         # ``False``) and no user is authenticated, expose only the "demo"
         # account.  ``config.disable_auth`` defaults to ``None`` when the

--- a/backend/quests/trail.py
+++ b/backend/quests/trail.py
@@ -180,7 +180,7 @@ def _build_once_tasks(user: str, user_data: Dict) -> List[TaskDefinition]:
     tasks: List[TaskDefinition] = []
 
     # Encourage the user to model a goal if they have not already done so.
-    if not load_goals(user) or "create_goal" in user_data.get("once", []):
+    if not load_goals(user) and "create_goal" not in user_data.get("once", []):
         tasks.append(
             TaskDefinition(
                 id="create_goal",
@@ -192,7 +192,7 @@ def _build_once_tasks(user: str, user_data: Dict) -> List[TaskDefinition]:
 
     # Configure price-drift alerts to catch meaningful moves.
     thresholds = getattr(alerts, "_USER_THRESHOLDS", {})
-    if user not in thresholds or "set_alert_threshold" in user_data.get("once", []):
+    if user not in thresholds and "set_alert_threshold" not in user_data.get("once", []):
         # ``alerts.get_user_threshold`` falls back to the default without
         # indicating whether the user explicitly configured the value.  The
         # private ``_USER_THRESHOLDS`` cache records explicit overrides, so a
@@ -208,7 +208,10 @@ def _build_once_tasks(user: str, user_data: Dict) -> List[TaskDefinition]:
 
     # Push notifications require an explicit subscription – remind the user
     # when none is configured.
-    if alerts.get_user_push_subscription(user) is None or "enable_push_notifications" in user_data.get("once", []):
+    if (
+        alerts.get_user_push_subscription(user) is None
+        and "enable_push_notifications" not in user_data.get("once", [])
+    ):
         tasks.append(
             TaskDefinition(
                 id="enable_push_notifications",

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -494,7 +494,7 @@ async def get_account(owner: str, account: str, request: Request):
     holdings = data.pop("holdings", data.pop("approvals", [])) or []
 
     data["holdings"] = holdings
-    data.setdefault("account_type", account)
+    data["account_type"] = account
     return data
 
 


### PR DESCRIPTION
## Summary
- require real goal, alert threshold and push notification state before surfacing the once-off Trail tasks
- ensure account responses always report the requested slug as the account_type
- ignore account directories without person metadata so unknown owners continue to return 404s

## Testing
- pytest --override-ini="addopts=" tests/quests/test_trail.py::test_get_tasks_returns_defaults
- pytest --override-ini="addopts=" tests/test_accounts_api.py::test_account_route_returns_data
- pytest --override-ini="addopts=" tests/test_backend_api.py::test_invalid_portfolio tests/test_backend_api.py::test_compliance_invalid_owner

------
https://chatgpt.com/codex/tasks/task_e_68d4628e1b948327bc0712b52fb74fcb