### PR TITLE
Auto create missing instruments using Yahoo metadata

### DIFF
--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -8,7 +8,7 @@ import re
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from backend.config import config
 
@@ -40,6 +40,8 @@ _VALID_RE = re.compile(r"^[A-Z0-9-]+$")
 
 METADATA_BUCKET_ENV = "METADATA_BUCKET"
 METADATA_PREFIX_ENV = "METADATA_PREFIX"
+
+_AUTO_CREATE_FAILURES: set[str] = set()
 
 
 @lru_cache(maxsize=1)
@@ -148,7 +150,8 @@ def get_instrument_meta(ticker: str) -> Dict[str, Any]:
         with path.open("r", encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
-        return {}
+        created = _auto_create_instrument_meta(ticker)
+        return created or {}
     except json.JSONDecodeError as exc:
         logger.warning("Invalid instrument JSON %s: %s", path, exc)
         return {}
@@ -222,6 +225,137 @@ def save_instrument_meta(
 
     get_instrument_meta.cache_clear()
     return path
+
+
+def _clean_str(value: Any, *, upper: bool = False) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+    else:
+        text = str(value).strip()
+    if not text:
+        return None
+    return text.upper() if upper else text
+
+
+def _asset_class_from_quote_type(quote_type: Optional[str]) -> Optional[str]:
+    if not quote_type:
+        return None
+    mapping = {
+        "EQUITY": "Equity",
+        "ETF": "Fund",
+        "MUTUALFUND": "Fund",
+        "INDEX": "Index",
+        "CURRENCY": "Currency",
+        "CRYPTOCURRENCY": "Crypto",
+        "FUTURE": "Derivative",
+        "OPTION": "Derivative",
+        "BOND": "Bond",
+        "MONEYMARKET": "Cash",
+    }
+    key = quote_type.upper()
+    if key in mapping:
+        return mapping[key]
+    return quote_type.replace("_", " ").title()
+
+
+def _fetch_metadata_from_yahoo(full_ticker: str) -> Optional[Dict[str, Any]]:
+    try:
+        import yfinance as yf  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency missing
+        logger.debug("yfinance unavailable; cannot fetch metadata for %s: %s", full_ticker, exc)
+        return None
+
+    try:
+        stock = yf.Ticker(full_ticker)
+    except Exception as exc:  # pragma: no cover - network/IO errors
+        logger.warning("Failed to initialise yfinance for %s: %s", full_ticker, exc)
+        return None
+
+    info: Dict[str, Any] = {}
+    try:
+        fetched = stock.get_info()
+        if isinstance(fetched, dict):
+            info = fetched
+    except Exception as exc:  # pragma: no cover - best effort fallback
+        logger.debug("yfinance get_info failed for %s: %s", full_ticker, exc)
+        try:
+            fetched_attr = getattr(stock, "info", None)
+            if isinstance(fetched_attr, dict):
+                info = fetched_attr
+        except Exception as exc_attr:  # pragma: no cover - best effort fallback
+            logger.debug("yfinance info attribute failed for %s: %s", full_ticker, exc_attr)
+
+    name = _clean_str(
+        info.get("shortName")
+        or info.get("longName")
+        or info.get("displayName")
+        or info.get("name")
+        or full_ticker,
+    )
+
+    currency = _clean_str(info.get("currency"), upper=True)
+    if not currency:
+        try:
+            fast = getattr(stock, "fast_info", None)
+            if fast is not None:
+                if isinstance(fast, dict):
+                    currency = _clean_str(fast.get("currency"), upper=True)
+                else:
+                    currency = _clean_str(getattr(fast, "currency", None), upper=True)
+        except Exception:  # pragma: no cover - best effort fallback
+            currency = None
+
+    sector = _clean_str(info.get("sector") or info.get("category"))
+    industry = _clean_str(info.get("industry") or info.get("industryDisp"))
+    region = _clean_str(info.get("region") or info.get("country") or info.get("market"))
+    quote_type = _clean_str(info.get("quoteType"), upper=True)
+    asset_class = _asset_class_from_quote_type(quote_type) if quote_type else None
+
+    metadata: Dict[str, Any] = {
+        "name": name or full_ticker,
+        "currency": currency,
+        "sector": sector,
+        "region": region,
+        "asset_class": asset_class,
+        "industry": industry,
+    }
+    if quote_type:
+        metadata["instrument_type"] = quote_type
+
+    return {k: v for k, v in metadata.items() if v is not None}
+
+
+def _auto_create_instrument_meta(ticker: str) -> Optional[Dict[str, Any]]:
+    canonical = (ticker or "").strip().upper()
+    if not canonical or canonical in _AUTO_CREATE_FAILURES:
+        return None
+
+    sym, exch = (canonical.split(".", 1) + [None])[:2]
+    if not exch or not sym or sym == "CASH":
+        return None
+
+    full = f"{sym}.{exch}"
+    fetched = _fetch_metadata_from_yahoo(full)
+    if not fetched:
+        _AUTO_CREATE_FAILURES.add(full)
+        return None
+
+    payload: Dict[str, Any] = {
+        "ticker": full,
+        "exchange": exch,
+        **fetched,
+    }
+
+    try:
+        save_instrument_meta(sym, exch, payload)
+    except Exception as exc:  # pragma: no cover - filesystem errors are rare
+        logger.warning("Failed to persist auto-created metadata for %s: %s", full, exc)
+    else:
+        logger.info("Auto-created instrument metadata for %s from Yahoo Finance", full)
+
+    return payload
 
 
 def delete_instrument_meta(ticker: str, exchange: str) -> None:

--- a/backend/tests/test_instruments_autocreate.py
+++ b/backend/tests/test_instruments_autocreate.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+
+from backend.common import instruments
+
+
+def _reset_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", tmp_path)
+    monkeypatch.setattr(instruments, "_AUTO_CREATE_FAILURES", set())
+    instruments.get_instrument_meta.cache_clear()
+
+
+def test_get_instrument_meta_auto_creates_using_yahoo(tmp_path, monkeypatch):
+    _reset_state(monkeypatch, tmp_path)
+
+    fetched = {
+        "name": "Apple Inc.",
+        "currency": "USD",
+        "sector": "Technology",
+        "region": "United States",
+        "asset_class": "Equity",
+        "instrument_type": "EQUITY",
+    }
+
+    calls: list[str] = []
+
+    def fake_fetch(full_ticker: str):
+        calls.append(full_ticker)
+        return dict(fetched)
+
+    monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", fake_fetch)
+
+    meta = instruments.get_instrument_meta("aapl.n")
+
+    assert meta["ticker"] == "AAPL.N"
+    assert meta["name"] == fetched["name"]
+    assert meta["currency"] == fetched["currency"]
+    assert calls == ["AAPL.N"]
+
+    path = tmp_path / "N" / "AAPL.json"
+    assert path.exists()
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved["ticker"] == "AAPL.N"
+    assert saved["name"] == fetched["name"]
+    assert saved["currency"] == fetched["currency"]
+
+
+def test_auto_create_skips_when_fetch_fails(tmp_path, monkeypatch):
+    _reset_state(monkeypatch, tmp_path)
+
+    calls = 0
+
+    def fake_fetch(full_ticker: str):
+        nonlocal calls
+        calls += 1
+        return None
+
+    monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", fake_fetch)
+
+    meta = instruments.get_instrument_meta("MISS.N")
+    assert meta == {}
+    assert "MISS.N" in instruments._AUTO_CREATE_FAILURES
+    assert calls == 1
+    assert not list(tmp_path.rglob("*.json"))
+
+    instruments.get_instrument_meta.cache_clear()
+    meta_again = instruments.get_instrument_meta("MISS.N")
+    assert meta_again == {}
+    assert calls == 1  # failure cached, no retry
+
+
+def test_auto_create_requires_exchange(tmp_path, monkeypatch):
+    _reset_state(monkeypatch, tmp_path)
+
+    calls: list[str] = []
+
+    def fake_fetch(full_ticker: str):  # pragma: no cover - should not be called
+        calls.append(full_ticker)
+        return {"name": "Should not happen"}
+
+    monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", fake_fetch)
+
+    meta = instruments.get_instrument_meta("AAPL")
+    assert meta == {}
+    assert calls == []
+    assert not list(tmp_path.rglob("*.json"))


### PR DESCRIPTION
## Summary
- add a Yahoo Finance-backed fallback in `get_instrument_meta` that persists metadata for unknown tickers
- normalise fetched metadata before saving and memoise failed lookups to avoid repeated network calls
- cover the auto-create behaviour with new tests for success, failure and unsupported tickers

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0 --cov=backend/common/instruments.py" pytest backend/tests/test_instruments_autocreate.py

------
https://chatgpt.com/codex/tasks/task_e_68d4649d52748327bd18c22c335220b2