### PR TITLE
feat(frontend): allow creating transactions from UI

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -776,6 +776,25 @@ export const getTransactions = (params: {
   return fetchJson<Transaction[]>(`${API_BASE}/transactions${qs ? `?${qs}` : ""}`);
 };
 
+export interface CreateTransactionPayload {
+  owner: string;
+  account: string;
+  ticker: string;
+  date: string;
+  price_gbp: number;
+  units: number;
+  reason: string;
+  fees?: number;
+  comments?: string;
+}
+
+export const createTransaction = (payload: CreateTransactionPayload) =>
+  fetchJson<Transaction>(`${API_BASE}/transactions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
 export const getDividends = (params?: {
   owner?: string;
   account?: string;

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState, useCallback } from "react";
-import type { ChangeEventHandler } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
+import type { ChangeEventHandler, FormEvent } from "react";
 import type { OwnerSummary, Transaction } from "../types";
-import { getTransactions } from "../api";
+import { createTransaction, getTransactions } from "../api";
 import { Selector } from "./Selector";
 import { useFetch } from "../hooks/useFetch";
 import tableStyles from "../styles/table.module.css";
@@ -19,6 +19,19 @@ export function TransactionsPage({ owners }: Props) {
   const [account, setAccount] = useState("");
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [newOwner, setNewOwner] = useState("");
+  const [newAccount, setNewAccount] = useState("");
+  const [newDate, setNewDate] = useState("");
+  const [newTicker, setNewTicker] = useState("");
+  const [newPrice, setNewPrice] = useState("");
+  const [newUnits, setNewUnits] = useState("");
+  const [newFees, setNewFees] = useState("");
+  const [newComments, setNewComments] = useState("");
+  const [newReason, setNewReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formSuccess, setFormSuccess] = useState<string | null>(null);
   const { t } = useTranslation();
   const { baseCurrency } = useConfig();
   const fetchTransactions = useCallback(
@@ -29,11 +42,11 @@ export function TransactionsPage({ owners }: Props) {
         start: start || undefined,
         end: end || undefined,
       }),
-    [owner, account, start, end]
+    [owner, account, start, end, refreshKey]
   );
   const { data: transactions, loading, error } = useFetch<Transaction[]>(
     fetchTransactions,
-    [owner, account, start, end]
+    [owner, account, start, end, refreshKey]
   );
 
   const accountOptions = useMemo(() => {
@@ -45,6 +58,43 @@ export function TransactionsPage({ owners }: Props) {
     return Array.from(set);
   }, [owner, owners]);
 
+  const newAccountOptions = useMemo(() => {
+    if (!newOwner) {
+      return [];
+    }
+    return owners.find((o) => o.owner === newOwner)?.accounts ?? [];
+  }, [newOwner, owners]);
+
+  useEffect(() => {
+    if (!newOwner && owners.length === 1) {
+      setNewOwner(owners[0].owner);
+    }
+    if (newOwner && !owners.some((o) => o.owner === newOwner)) {
+      setNewOwner("");
+    }
+  }, [owners, newOwner]);
+
+  useEffect(() => {
+    if (!newOwner) {
+      if (newAccount) {
+        setNewAccount("");
+      }
+      return;
+    }
+    if (newAccountOptions.length === 0) {
+      if (newAccount) {
+        setNewAccount("");
+      }
+      return;
+    }
+    if (!newAccountOptions.includes(newAccount)) {
+      const nextAccount = newAccountOptions[0] ?? "";
+      if (nextAccount !== newAccount) {
+        setNewAccount(nextAccount);
+      }
+    }
+  }, [newOwner, newAccountOptions, newAccount]);
+
   const handleOwnerChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
     (e) => setOwner(e.target.value),
     [],
@@ -53,6 +103,93 @@ export function TransactionsPage({ owners }: Props) {
   const handleAccountChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
     (e) => setAccount(e.target.value),
     [],
+  );
+
+  const setFilterOwnerAndAccount = useCallback(
+    (nextOwner: string, nextAccount: string) => {
+      setOwner(nextOwner);
+      setAccount(nextAccount);
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setFormError(null);
+      setFormSuccess(null);
+
+      const price = Number.parseFloat(newPrice);
+      const units = Number.parseFloat(newUnits);
+      const fees = newFees ? Number.parseFloat(newFees) : undefined;
+      const ticker = newTicker.trim().toUpperCase();
+      const reason = newReason.trim();
+      const comments = newComments.trim();
+
+      if (!newOwner || !newAccount || !newDate || !ticker || !reason) {
+        setFormError("Please complete all required fields.");
+        return;
+      }
+      if (!Number.isFinite(price) || price <= 0) {
+        setFormError("Enter a valid price.");
+        return;
+      }
+      if (!Number.isFinite(units) || units <= 0) {
+        setFormError("Enter a valid number of units.");
+        return;
+      }
+      if (newFees && (fees == null || Number.isNaN(fees))) {
+        setFormError("Enter a valid fee or leave it blank.");
+        return;
+      }
+      if (fees != null && fees < 0) {
+        setFormError("Fees cannot be negative.");
+        return;
+      }
+
+      setSubmitting(true);
+      try {
+        await createTransaction({
+          owner: newOwner,
+          account: newAccount,
+          date: newDate,
+          ticker,
+          price_gbp: price,
+          units,
+          reason,
+          fees,
+          comments: comments || undefined,
+        });
+        setFormSuccess("Transaction created successfully.");
+        setFilterOwnerAndAccount(newOwner, newAccount);
+        setNewTicker("");
+        setNewPrice("");
+        setNewUnits("");
+        setNewFees("");
+        setNewComments("");
+        setNewReason("");
+        setNewDate("");
+        setRefreshKey((key) => key + 1);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to create transaction.";
+        setFormError(message);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [
+      newOwner,
+      newAccount,
+      newDate,
+      newTicker,
+      newPrice,
+      newUnits,
+      newReason,
+      newFees,
+      newComments,
+      setFilterOwnerAndAccount,
+    ],
   );
 
   return (
@@ -84,6 +221,111 @@ export function TransactionsPage({ owners }: Props) {
         </label>
       </div>
 
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "0.75rem",
+          alignItems: "flex-end",
+          marginBottom: "1rem",
+        }}
+      >
+        <Selector
+          label="Owner"
+          value={newOwner}
+          onChange={(e) => setNewOwner(e.target.value)}
+          options={[
+            { value: "", label: "Select" },
+            ...owners.map((o) => ({ value: o.owner, label: o.owner })),
+          ]}
+        />
+        <Selector
+          label="Account"
+          value={newAccount}
+          onChange={(e) => setNewAccount(e.target.value)}
+          options={[
+            { value: "", label: newOwner ? "Select" : "Select owner first" },
+            ...newAccountOptions.map((a) => ({ value: a, label: a })),
+          ]}
+        />
+        <label style={{ display: "flex", flexDirection: "column" }}>
+          Date
+          <input
+            type="date"
+            value={newDate}
+            onChange={(e) => setNewDate(e.target.value)}
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column" }}>
+          Ticker
+          <input
+            type="text"
+            value={newTicker}
+            onChange={(e) => setNewTicker(e.target.value.toUpperCase())}
+            placeholder="e.g. VUSA"
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column" }}>
+          Price (GBP)
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            value={newPrice}
+            onChange={(e) => setNewPrice(e.target.value)}
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column" }}>
+          Units
+          <input
+            type="number"
+            step="0.0001"
+            min="0"
+            value={newUnits}
+            onChange={(e) => setNewUnits(e.target.value)}
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column" }}>
+          Fees (GBP)
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            value={newFees}
+            onChange={(e) => setNewFees(e.target.value)}
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", minWidth: "180px" }}>
+          Reason
+          <input
+            type="text"
+            value={newReason}
+            onChange={(e) => setNewReason(e.target.value)}
+            required
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", minWidth: "180px" }}>
+          Comments
+          <input
+            type="text"
+            value={newComments}
+            onChange={(e) => setNewComments(e.target.value)}
+            placeholder="Optional"
+          />
+        </label>
+        <button type="submit" disabled={submitting} style={{ height: "2.3rem" }}>
+          {submitting ? "Saving..." : "Add transaction"}
+        </button>
+      </form>
+
+      {formError && <p style={{ color: "red" }}>{formError}</p>}
+      {formSuccess && <p style={{ color: "limegreen" }}>{formSuccess}</p>}
+
       {error && <p style={{ color: "red" }}>{error.message}</p>}
       {loading ? (
         <p>{t("common.loading")}</p>
@@ -113,9 +355,13 @@ export function TransactionsPage({ owners }: Props) {
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                   {t.amount_minor != null
                     ? money(t.amount_minor / 100, t.currency ?? baseCurrency)
+                    : t.price_gbp != null && t.units != null
+                    ? money(t.price_gbp * t.units, baseCurrency)
                     : ""}
                 </td>
-                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{t.shares ?? ""}</td>
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                  {t.shares ?? t.units ?? ""}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -261,6 +261,11 @@ export interface Transaction {
   security_ref?: string | null;
   ticker?: string | null;
   shares?: number | null;
+  units?: number | null;
+  price_gbp?: number | null;
+  fees?: number | null;
+  comments?: string | null;
+  reason?: string | null;
 }
 
 export interface TransactionWithCompliance extends Transaction {


### PR DESCRIPTION
## Summary
- add API helper for posting new transactions
- extend transaction types to expose manual entry fields
- build a creation form on the transactions page with validation and automatic refresh

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d464d118388327978836f0a9719a54