### PR TITLE
Improve trading signals explanations

### DIFF
--- a/backend/agent/models.py
+++ b/backend/agent/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Pydantic models used by the trading agent."""
 
 from pydantic import BaseModel, ConfigDict
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 
 class TradingSignal(BaseModel):
@@ -15,6 +15,8 @@ class TradingSignal(BaseModel):
         reason: Human readable description of why the signal was generated.
         confidence: Optional confidence score between 0 and 1.
         rationale: Optional detailed explanation of the signal.
+        factors: Optional list of plain-English statements describing the
+            indicators that support the recommendation.
     """
 
     ticker: str
@@ -22,5 +24,6 @@ class TradingSignal(BaseModel):
     reason: str
     confidence: Optional[float] = None
     rationale: Optional[str] = None
+    factors: Optional[List[str]] = None
 
     model_config = ConfigDict(extra="ignore")

--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -7,10 +7,11 @@ import json
 import logging
 import math
 import os
+from collections import defaultdict
 from dataclasses import asdict
 from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 import pandas as pd
 
@@ -107,6 +108,28 @@ def _price_column(df: pd.DataFrame) -> Optional[str]:
     return None
 
 
+def _join_with_and(items: Sequence[str]) -> str:
+    """Return a human friendly phrase that joins ``items`` with commas and ``and``."""
+
+    items = [item for item in items if item]
+    if not items:
+        return ""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return ", ".join(items[:-1]) + f", and {items[-1]}"
+
+
+def _average_confidence(entries: Sequence[Dict[str, Any]]) -> Optional[float]:
+    """Return the arithmetic mean of the ``confidence`` values in ``entries``."""
+
+    values = [entry.get("confidence") for entry in entries if entry.get("confidence") is not None]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
 def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
     """Create trade signals from a price snapshot.
 
@@ -134,173 +157,208 @@ def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
         ):
             continue
 
+        action_details: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+
+        def add_reason(
+            action: str,
+            indicator: str,
+            summary: str,
+            detail: str,
+            confidence: float,
+        ) -> None:
+            action_details[action].append(
+                {
+                    "indicator": indicator,
+                    "summary": summary,
+                    "detail": detail,
+                    "confidence": confidence,
+                }
+            )
+
         # price momentum
         change = info.get("change_7d_pct")
         if change is not None:
             if change <= PRICE_DROP_THRESHOLD:
                 confidence = min(1.0, abs(change) / abs(PRICE_DROP_THRESHOLD))
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "SELL",
-                        "reason": f"Price dropped {change:.2f}% in last 7d",
-                        "confidence": confidence,
-                        "rationale": (
-                            f"7-day price change of {change:.2f}% is below the"
-                            f" threshold of {PRICE_DROP_THRESHOLD}%, indicating"
-                            " bearish momentum."
-                        ),
-                    }
+                add_reason(
+                    "SELL",
+                    "7-day price momentum",
+                    "Price has fallen sharply over the last week.",
+                    (
+                        f"The price dropped {abs(change):.2f}% in the last 7 days,"
+                        f" breaching the {abs(PRICE_DROP_THRESHOLD):.0f}% downside"
+                        " momentum threshold."
+                    ),
+                    confidence,
                 )
-                continue
-            if change >= PRICE_GAIN_THRESHOLD:
+            elif change >= PRICE_GAIN_THRESHOLD:
                 confidence = min(1.0, abs(change) / PRICE_GAIN_THRESHOLD)
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "BUY",
-                        "reason": f"Price gained {change:.2f}% in last 7d",
-                        "confidence": confidence,
-                        "rationale": (
-                            f"7-day price change of {change:.2f}% exceeds"
-                            f" the threshold of {PRICE_GAIN_THRESHOLD}% and"
-                            " suggests upward momentum."
-                        ),
-                    }
+                add_reason(
+                    "BUY",
+                    "7-day price momentum",
+                    "Price has gained strongly over the last week.",
+                    (
+                        f"The price gained {change:.2f}% in the last 7 days,"
+                        f" exceeding the {PRICE_GAIN_THRESHOLD:.0f}% momentum"
+                        " trigger."
+                    ),
+                    confidence,
                 )
-                continue
 
         rsi = info.get("rsi")
         ma_short = info.get("ma_short")
         ma_long = info.get("ma_long")
 
         if rsi is not None:
+            indicator_name = f"{cfg.rsi_window}-day RSI"
             if cfg.rsi_buy is not None and rsi <= cfg.rsi_buy:
                 diff = cfg.rsi_buy - rsi
                 confidence = min(1.0, diff / 10)  # 10 point diff -> max confidence
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "BUY",
-                        "reason": f"RSI {rsi:.2f} <= {cfg.rsi_buy}",
-                        "confidence": confidence,
-                        "rationale": (
-                            f"RSI of {rsi:.2f} is below the buy threshold"
-                            f" of {cfg.rsi_buy}, signalling potential"
-                            " oversold conditions."
-                        ),
-                    }
+                add_reason(
+                    "BUY",
+                    indicator_name,
+                    "RSI suggests the instrument is oversold.",
+                    (
+                        f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, below"
+                        f" the buy threshold of {cfg.rsi_buy:.0f}."
+                    ),
+                    confidence,
                 )
-                continue
-            if cfg.rsi_sell is not None and rsi >= cfg.rsi_sell:
+            elif cfg.rsi_sell is not None and rsi >= cfg.rsi_sell:
                 diff = rsi - cfg.rsi_sell
                 confidence = min(1.0, diff / 10)
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "SELL",
-                        "reason": f"RSI {rsi:.2f} >= {cfg.rsi_sell}",
-                        "confidence": confidence,
-                        "rationale": (
-                            f"RSI of {rsi:.2f} is above the sell threshold"
-                            f" of {cfg.rsi_sell}, suggesting overbought"
-                            " conditions."
-                        ),
-                    }
+                add_reason(
+                    "SELL",
+                    indicator_name,
+                    "RSI points to overbought conditions.",
+                    (
+                        f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, above"
+                        f" the sell threshold of {cfg.rsi_sell:.0f}."
+                    ),
+                    confidence,
                 )
-                continue
-        if rsi is not None:
-            if rsi > 70:
-                confidence = min(1.0, (rsi - 70) / 10)
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "SELL",
-                        "reason": f"RSI {rsi:.2f} above 70",
-                        "confidence": confidence,
-                        "rationale": (
-                            f"RSI reading of {rsi:.2f} exceeds the typical"
-                            " overbought level of 70."
-                        ),
-                    }
-                )
-                continue
-            if rsi < 30:
+            elif rsi < 30:
                 confidence = min(1.0, (30 - rsi) / 10)
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "BUY",
-                        "reason": f"RSI {rsi:.2f} below 30",
-                        "confidence": confidence,
-                        "rationale": (
-                            f"RSI reading of {rsi:.2f} is below the"
-                            " commonly used oversold level of 30."
-                        ),
-                    }
+                add_reason(
+                    "BUY",
+                    indicator_name,
+                    "RSI indicates the price may be oversold.",
+                    (
+                        f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, below"
+                        " the commonly used oversold level of 30."
+                    ),
+                    confidence,
                 )
-                continue
+            elif rsi > 70:
+                confidence = min(1.0, (rsi - 70) / 10)
+                add_reason(
+                    "SELL",
+                    indicator_name,
+                    "RSI indicates the price may be overbought.",
+                    (
+                        f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, above"
+                        " the typical overbought level of 70."
+                    ),
+                    confidence,
+                )
 
         if ma_short is not None and ma_long is not None:
+            indicator_name = (
+                f"{cfg.ma_short_window}- vs {cfg.ma_long_window}-day moving averages"
+            )
             if ma_short > ma_long:
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "BUY",
-                        "reason": f"MA{cfg.ma_short_window}>{cfg.ma_long_window}",
-                        "confidence": 0.6,
-                        "rationale": (
-                            f"Short moving average {ma_short:.2f} is above"
-                            f" long moving average {ma_long:.2f},"
-                            " indicating bullish momentum."
-                        ),
-                    }
+                add_reason(
+                    "BUY",
+                    indicator_name,
+                    "Short-term trend is above the longer-term trend.",
+                    (
+                        f"The {cfg.ma_short_window}-day moving average {ma_short:.2f}"
+                        f" is above the {cfg.ma_long_window}-day average"
+                        f" {ma_long:.2f}, signalling bullish momentum."
+                    ),
+                    0.6,
                 )
             elif ma_short < ma_long:
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "SELL",
-                        "reason": f"MA{cfg.ma_short_window}<{cfg.ma_long_window}",
-                        "confidence": 0.6,
-                        "rationale": (
-                            f"Short moving average {ma_short:.2f} is below"
-                            f" long moving average {ma_long:.2f},"
-                            " signalling bearish momentum."
-                        ),
-                    }
+                add_reason(
+                    "SELL",
+                    indicator_name,
+                    "Short-term trend is below the longer-term trend.",
+                    (
+                        f"The {cfg.ma_short_window}-day moving average {ma_short:.2f}"
+                        f" is below the {cfg.ma_long_window}-day average"
+                        f" {ma_long:.2f}, signalling bearish momentum."
+                    ),
+                    0.6,
                 )
+
         short_ma = info.get("sma_50")
         long_ma = info.get("sma_200")
         if short_ma is not None and long_ma is not None:
+            indicator_name = "50-day vs 200-day moving averages"
             if short_ma > long_ma:
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "BUY",
-                        "reason": f"50d MA {short_ma:.2f} above 200d MA {long_ma:.2f}",
-                        "confidence": 0.6,
-                        "rationale": (
-                            f"50-day moving average {short_ma:.2f} is above"
-                            f" the 200-day moving average {long_ma:.2f},"
-                            " a traditional bullish indicator."
-                        ),
-                    }
+                add_reason(
+                    "BUY",
+                    indicator_name,
+                    "Medium-term trend is bullish.",
+                    (
+                        f"The 50-day moving average {short_ma:.2f} is above"
+                        f" the 200-day moving average {long_ma:.2f},"
+                        " a classic bullish signal."
+                    ),
+                    0.6,
                 )
             elif short_ma < long_ma:
-                signals.append(
-                    {
-                        "ticker": ticker,
-                        "action": "SELL",
-                        "reason": f"50d MA {short_ma:.2f} below 200d MA {long_ma:.2f}",
-                        "confidence": 0.6,
-                        "rationale": (
-                            f"50-day moving average {short_ma:.2f} is below"
-                            f" the 200-day moving average {long_ma:.2f},"
-                            " suggesting a bearish trend."
-                        ),
-                    }
+                add_reason(
+                    "SELL",
+                    indicator_name,
+                    "Medium-term trend is bearish.",
+                    (
+                        f"The 50-day moving average {short_ma:.2f} is below"
+                        f" the 200-day moving average {long_ma:.2f},"
+                        " suggesting a bearish trend."
+                    ),
+                    0.6,
                 )
+
+        best_action: Optional[str] = None
+        best_reasons: List[Dict[str, Any]] = []
+        best_score: tuple[int, float] = (0, 0.0)
+        best_confidence: Optional[float] = None
+
+        for action, reasons in action_details.items():
+            if len(reasons) < 2:
+                continue
+            avg_conf = _average_confidence(reasons)
+            score = (len(reasons), avg_conf or 0.0)
+            if score > best_score:
+                best_action = action
+                best_reasons = reasons
+                best_score = score
+                best_confidence = avg_conf
+
+        if not best_action or not best_reasons:
+            continue
+
+        indicator_names = [reason.get("indicator", "") for reason in best_reasons]
+        indicator_phrase = _join_with_and(indicator_names)
+        reason_text = (
+            f"{len(best_reasons)} indicators ({indicator_phrase}) support a"
+            f" {best_action.lower()} opportunity."
+        )
+        factor_details = [reason["detail"] for reason in best_reasons]
+        rationale_text = " ".join(factor_details)
+
+        signals.append(
+            {
+                "ticker": ticker,
+                "action": best_action,
+                "reason": reason_text,
+                "confidence": best_confidence,
+                "rationale": rationale_text,
+                "factors": factor_details,
+            }
+        )
+
     return signals
 
 

--- a/backend/tests/test_trading_agent_signals.py
+++ b/backend/tests/test_trading_agent_signals.py
@@ -1,0 +1,67 @@
+from backend.agent import trading_agent
+from backend.config import TradingAgentConfig
+
+
+def _base_config() -> TradingAgentConfig:
+    cfg = TradingAgentConfig()
+    cfg.min_sharpe = None
+    cfg.max_volatility = None
+    return cfg
+
+
+def test_generate_signals_combines_multiple_indicators(monkeypatch):
+    monkeypatch.setattr(
+        trading_agent,
+        "load_strategy_config",
+        lambda: _base_config(),
+    )
+
+    snapshot = {
+        "AAA": {
+            "change_7d_pct": 6.0,
+            "rsi": 28.0,
+            "ma_short": None,
+            "ma_long": None,
+            "sma_50": None,
+            "sma_200": None,
+            "volatility": None,
+            "sharpe": None,
+        }
+    }
+
+    signals = trading_agent.generate_signals(snapshot)
+
+    assert len(signals) == 1
+    signal = signals[0]
+    assert signal["action"] == "BUY"
+    assert "2 indicators" in signal["reason"]
+    assert signal["confidence"] is not None
+    assert signal["factors"] and len(signal["factors"]) == 2
+    # ensure both RSI and price momentum contribute to the rationale
+    assert any("RSI" in factor for factor in signal["factors"])
+    assert any("price" in factor.lower() for factor in signal["factors"])
+
+
+def test_generate_signals_requires_multiple_factors(monkeypatch):
+    monkeypatch.setattr(
+        trading_agent,
+        "load_strategy_config",
+        lambda: _base_config(),
+    )
+
+    snapshot = {
+        "BBB": {
+            "change_7d_pct": 6.0,
+            "rsi": None,
+            "ma_short": None,
+            "ma_long": None,
+            "sma_50": None,
+            "sma_200": None,
+            "volatility": None,
+            "sharpe": None,
+        }
+    }
+
+    signals = trading_agent.generate_signals(snapshot)
+
+    assert signals == []

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -425,9 +425,25 @@ export function InstrumentDetail({
         <div style={{ marginBottom: "0.5rem" }}>
           <strong>{signal.action.toUpperCase()}</strong> – {signal.reason}
           {signal.confidence != null && (
-            <div>Confidence: {(signal.confidence * 100).toFixed(0)}%</div>
+            <div>
+              Signal strength:{" "}
+              {signal.confidence >= 0.75
+                ? "Strong"
+                : signal.confidence >= 0.5
+                  ? "Moderate"
+                  : "Weak"}
+              {` (${Math.round(signal.confidence * 100)}%)`}
+            </div>
           )}
-          {signal.rationale && <div>{signal.rationale}</div>}
+          {signal.factors && signal.factors.length ? (
+            <ul style={{ margin: "0.25rem 0 0 1.1rem" }}>
+              {signal.factors.map((factor, idx) => (
+                <li key={idx}>{factor}</li>
+              ))}
+            </ul>
+          ) : (
+            signal.rationale && <div>{signal.rationale}</div>
+          )}
         </div>
       )}
       <div

--- a/frontend/src/pages/Trading.tsx
+++ b/frontend/src/pages/Trading.tsx
@@ -25,6 +25,46 @@ export default function Trading() {
     return <p>{t('trading.noSignals')}</p>;
   }
 
+  const formatAction = (action: string) => {
+    if (!action) {
+      return action;
+    }
+    const lower = action.toLowerCase();
+    return lower.charAt(0).toUpperCase() + lower.slice(1);
+  };
+
+  const renderStrength = (confidence?: number | null) => {
+    if (confidence == null) {
+      return '—';
+    }
+
+    const percent = Math.round(confidence * 100);
+    let label = 'Weak';
+    if (confidence >= 0.75) {
+      label = 'Strong';
+    } else if (confidence >= 0.5) {
+      label = 'Moderate';
+    }
+
+    return `${label} (${percent}%)`;
+  };
+
+  const renderFactors = (factors?: string[], fallback?: string) => {
+    if (factors && factors.length) {
+      return (
+        <ul style={{ margin: 0, paddingLeft: '1.1rem' }}>
+          {factors.map((factor, idx) => (
+            <li key={idx}>{factor}</li>
+          ))}
+        </ul>
+      );
+    }
+    if (fallback) {
+      return <span>{fallback}</span>;
+    }
+    return '—';
+  };
+
   return (
     <>
       <table className={tableStyles.table}>
@@ -33,7 +73,9 @@ export default function Trading() {
           <tr>
             <th className={tableStyles.cell}>Ticker</th>
             <th className={tableStyles.cell}>Action</th>
-            <th className={tableStyles.cell}>Reason</th>
+            <th className={tableStyles.cell}>Strength</th>
+            <th className={tableStyles.cell}>Summary</th>
+            <th className={tableStyles.cell}>Why</th>
           </tr>
         </thead>
         <tbody>
@@ -48,8 +90,10 @@ export default function Trading() {
                   {s.ticker}
                 </button>
               </td>
-              <td className={tableStyles.cell}>{s.action}</td>
+              <td className={tableStyles.cell}>{formatAction(s.action)}</td>
+              <td className={tableStyles.cell}>{renderStrength(s.confidence)}</td>
               <td className={tableStyles.cell}>{s.reason}</td>
+              <td className={tableStyles.cell}>{renderFactors(s.factors, s.rationale)}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -425,12 +425,13 @@ export interface VirtualPortfolio {
 export interface TradingSignal {
   ticker: string;
   name: string;
-  action: 'buy' | 'sell';
+  action: 'buy' | 'sell' | 'BUY' | 'SELL';
   reason: string;
   confidence?: number;
   rationale?: string;
   currency?: string | null;
   instrument_type?: string | null;
+  factors?: string[];
 }
 
 export interface CustomQuery {


### PR DESCRIPTION
## Summary
- require multiple confirming indicators before issuing a trading signal and aggregate the plain-English rationale
- extend the trading signal model with supporting factors and surface them in the UI
- refresh the trading page and instrument detail with signal strength, summaries, and new backend tests

## Testing
- pytest --override-ini="addopts=" backend/tests/test_trading_agent_signals.py

------
https://chatgpt.com/codex/tasks/task_e_68d466eae0608327836d62dc3f2d8bec