### PR TITLE
Fix instrument group smoke test payload

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -204,7 +204,9 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   {
     "method": "POST",
     "path": "/instrument/admin/groups",
-    "body": {}
+    "body": {
+      "name": "SmokeTest"
+    }
   },
   {
     "method": "DELETE",


### PR DESCRIPTION
## Summary
- add a static group name to the smoke test payload for POST /instrument/admin/groups so the endpoint receives a valid request

## Testing
- npm run smoke:test:all *(fails: backend server not running in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d46eaaf97c832785fd7278b040e626