### PR TITLE
Make deleting instruments idempotent

### DIFF
--- a/backend/routes/instrument_admin.py
+++ b/backend/routes/instrument_admin.py
@@ -151,7 +151,7 @@ async def delete_instrument(exchange: str, ticker: str) -> dict[str, str]:
     except OSError as exc:
         raise HTTPException(status_code=500, detail="Filesystem error") from exc
     if not exists:
-        raise HTTPException(status_code=404, detail="Instrument not found")
+        return {"status": "missing"}
     delete_instrument_meta(ticker, exchange)
     return {"status": "deleted"}
 


### PR DESCRIPTION
## Summary
- treat DELETE /instrument/admin/{exchange}/{ticker} as idempotent by returning a success payload when metadata is absent

## Testing
- PYTEST_ADDOPTS="" pytest backend/tests/test_instrument_admin.py

------
https://chatgpt.com/codex/tasks/task_e_68d46fc7380c8327bf1d010ab807cac6