### PR TITLE
Add performance metrics explanation page and link

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -349,58 +349,75 @@ export function GroupPortfolioView({ slug, onSelectMember, onTradeInfo }: Props)
             borderRadius: "6px",
           }}
         >
-          <div>
-            <div
-              style={{
-                fontSize: "0.9rem",
-                color: "#aaa",
-                display: "flex",
-                alignItems: "center",
-                gap: "0.25rem",
-              }}
-            >
-              <BadgeCheck size={16} />
-              Alpha vs Benchmark
-            </div>
-            <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
-              {percentOrNa(safeAlpha)}
-            </div>
-          </div>
-          <div>
-            <div
-              style={{
-                fontSize: "0.9rem",
-                color: "#aaa",
-                display: "flex",
-                alignItems: "center",
-                gap: "0.25rem",
-              }}
-            >
-              <LineChart size={16} />
-              Tracking Error
-            </div>
-            <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
-              {percentOrNa(safeTrackingError)}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.5rem",
+            }}
+          >
+            <BadgeCheck size={16} />
+            <div>
+              <div style={{ fontSize: "0.9rem", color: "#aaa" }}>
+                Alpha vs Benchmark
+              </div>
+              <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
+                {percentOrNa(safeAlpha)}
+              </div>
             </div>
           </div>
-          <div>
-            <div
-              style={{
-                fontSize: "0.9rem",
-                color: "#aaa",
-                display: "flex",
-                alignItems: "center",
-                gap: "0.25rem",
-              }}
-              title={t("dashboard.maxDrawdownHelp")}
-            >
-              <Shield size={16} />
-              <span>{t("dashboard.maxDrawdown")}</span>
-            </div>
-            <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
-              {percentOrNa(safeMaxDrawdown)}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.5rem",
+            }}
+          >
+            <LineChart size={16} />
+            <div>
+              <div style={{ fontSize: "0.9rem", color: "#aaa" }}>
+                Tracking Error
+              </div>
+              <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
+                {percentOrNa(safeTrackingError)}
+              </div>
             </div>
           </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.5rem",
+            }}
+          >
+            <Shield size={16} />
+            <div>
+              <div
+                style={{ fontSize: "0.9rem", color: "#aaa" }}
+                title={t("dashboard.maxDrawdownHelp")}
+              >
+                {t("dashboard.maxDrawdown")}
+              </div>
+              <div style={{ fontSize: "1.2rem", fontWeight: "bold" }}>
+                {percentOrNa(safeMaxDrawdown)}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {isAllPositions && (
+        <div style={{ marginBottom: "1rem" }}>
+          <a
+            href="/metrics-explained"
+            style={{
+              color: "#60a5fa",
+              fontSize: "0.85rem",
+              textDecoration: "underline",
+            }}
+          >
+            {t("dashboard.metricsExplanationLink")}
+          </a>
         </div>
       )}
 

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -255,10 +255,50 @@
     "trackingError": "Tracking Error",
     "maxDrawdown": "Max Drawdown",
     "maxDrawdownHelp": "Der maximale Drawdown ist der größte prozentuale Rückgang vom bisherigen Höchststand des Portfolios bis zum darauffolgenden Tief, berechnet auf Basis der rekonstruierten täglichen Schlusswerte Ihrer Positionen.",
+    "metricsExplanationLink": "Wie werden diese Werte berechnet?",
     "timeWeightedReturn": "Zeitgewichtete Rendite",
     "xirr": "XIRR",
     "portfolioValue": "Portfoliowert",
     "cumulativeReturn": "Kumulierte Rendite"
+  },
+  "metricsExplanation": {
+    "title": "Performancekennzahlen erklärt",
+    "intro": "Diese Kennzahlen fassen zusammen, wie sich das kombinierte Portfolio im Vergleich zu seinem Benchmark entwickelt. Jede Zahl basiert auf denselben täglichen Renditereihen wie die Kacheln im Dashboard.",
+    "backLink": "Zurück zum Portfolio-Dashboard",
+    "calculationHeading": "So berechnen wir das",
+    "notesHeading": "Wissenswertes",
+    "dataHeading": "Datengrundlage",
+    "dataBody": "Wir rekonstruieren tägliche Marktwerte für jede Position mithilfe der neuesten Kursdaten und erfasster Kapitalmaßnahmen. Cashflows, Trades und Benchmark-Stände werden auf UTC-Handelstage normalisiert. Kennzahlen werden aktualisiert, sobald neue Preise vorliegen.",
+    "disclaimer": "Diese Statistiken dienen nur zur Information und können von den Angaben Ihres Brokers abweichen, wenn sich Preisquellen oder Benchmark-Auswahl unterscheiden.",
+    "sections": {
+      "alpha": {
+        "title": "Alpha vs Benchmark",
+        "summary": "Alpha misst die Überrendite des Portfolios gegenüber dem Benchmark im gleichen Zeitraum.",
+        "calculation": "Wir berechnen zeitgewichtete kumulierte Renditen für Portfolio und Benchmark. Alpha ist einfach die Portfoliorendite minus der Benchmark-Rendite in Prozentpunkten.",
+        "notes": [
+          "Positives Alpha bedeutet, dass das Portfolio den Benchmark im betrachteten Zeitraum geschlagen hat.",
+          "Wenn für einen Teil des Zeitraums keine Daten vorliegen, verwenden wir nur die überlappenden Handelstage."
+        ]
+      },
+      "trackingError": {
+        "title": "Tracking Error",
+        "summary": "Der Tracking Error zeigt, wie stark die täglichen Portfoliorenditen vom Benchmark abweichen.",
+        "calculation": "Für jeden Handelstag ziehen wir die Benchmark-Rendite von der Portfoliorendite ab und erhalten so eine Active-Return-Reihe. Der Tracking Error ist die annualisierte Standardabweichung dieser Werte (tägliche Standardabweichung multipliziert mit √252).",
+        "notes": [
+          "Ein höherer Tracking Error deutet auf eine geringere Kopplung an den Benchmark hin.",
+          "Für die Anzeige benötigen wir mindestens 30 überlappende Tagesrenditen."
+        ]
+      },
+      "maxDrawdown": {
+        "title": "Max Drawdown",
+        "summary": "Der maximale Drawdown identifiziert den größten Rückgang vom Höchststand zum Tiefpunkt innerhalb des Beobachtungszeitraums.",
+        "calculation": "Wir verfolgen die zeitgewichtete Renditekurve, merken uns jedes neue Hoch und protokollieren den größten folgenden Rückgang, bevor ein neues Hoch erreicht wird. Der tiefste Verlust in Prozent ist der maximale Drawdown.",
+        "notes": [
+          "Der Drawdown basiert nur auf Portfoliorenditen; der Benchmark fließt hier nicht ein.",
+          "Ein Drawdown von -100 % bedeutet, dass der Portfoliowert nach einem vorherigen Hoch auf null gefallen ist."
+        ]
+      }
+    }
   },
   "support": {
     "title": "Support",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -261,10 +261,50 @@
     "trackingError": "Tracking Error",
     "maxDrawdown": "Max Drawdown",
     "maxDrawdownHelp": "Max drawdown is the largest percentage drop from any portfolio peak to the lowest closing value that follows, calculated from the rebuilt daily totals of your holdings.",
+    "metricsExplanationLink": "How are these calculated?",
     "timeWeightedReturn": "Time-Weighted Return",
     "xirr": "XIRR",
     "portfolioValue": "Portfolio Value",
     "cumulativeReturn": "Cumulative Return"
+  },
+  "metricsExplanation": {
+    "title": "Performance Metrics Explained",
+    "intro": "These metrics summarise how the combined portfolio performs relative to its benchmark. Each value is derived from the same daily return series that powers the dashboard tiles.",
+    "backLink": "Back to portfolio dashboard",
+    "calculationHeading": "How we calculate it",
+    "notesHeading": "Things to know",
+    "dataHeading": "Data inputs",
+    "dataBody": "We rebuild daily market values for every holding using the latest price data and any recorded corporate actions. Cash flows, trades and benchmark levels are normalised to UTC trading days. Metrics refresh whenever new prices are ingested.",
+    "disclaimer": "These statistics are provided for information only and may differ from figures reported by your broker if their pricing or benchmark selection differs.",
+    "sections": {
+      "alpha": {
+        "title": "Alpha vs Benchmark",
+        "summary": "Alpha measures the portfolio's excess return after matching the benchmark over the same date range.",
+        "calculation": "We compute time-weighted cumulative returns for both the portfolio and the configured benchmark. Alpha is simply the portfolio return minus the benchmark return, expressed in percentage points.",
+        "notes": [
+          "Positive alpha means the portfolio outperformed the benchmark over the selected period.",
+          "If either return series is unavailable for the full span we fall back to the overlapping dates only."
+        ]
+      },
+      "trackingError": {
+        "title": "Tracking Error",
+        "summary": "Tracking error captures the variability of active returns—how much the portfolio's daily returns diverge from the benchmark.",
+        "calculation": "For each trading day we take the portfolio return minus the benchmark return, producing an active return series. Tracking error is the annualised standard deviation of those active returns (daily standard deviation multiplied by √252).",
+        "notes": [
+          "Higher tracking error indicates looser alignment with the benchmark.",
+          "We require at least 30 overlapping daily returns to display this metric."
+        ]
+      },
+      "maxDrawdown": {
+        "title": "Max Drawdown",
+        "summary": "Max drawdown identifies the worst peak-to-trough decline in portfolio value over the measurement window.",
+        "calculation": "We scan the time-weighted return curve, track each new peak, and record the largest subsequent drop before a new peak is reached. The deepest percentage loss becomes the max drawdown.",
+        "notes": [
+          "Drawdown is calculated on portfolio returns only; the benchmark is not considered here.",
+          "A -100% drawdown would mean the portfolio value reached zero after a prior peak."
+        ]
+      }
+    }
   },
   "support": {
     "title": "Support",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -31,6 +31,7 @@ const Trail = lazy(() => import('./pages/Trail'))
 const PerformanceDiagnostics = lazy(() => import('./pages/PerformanceDiagnostics'))
 const ReturnComparison = lazy(() => import('./pages/ReturnComparison'))
 const AlertSettings = lazy(() => import('./pages/AlertSettings'))
+const MetricsExplanation = lazy(() => import('./pages/MetricsExplanation'))
 const SmokeTest = import.meta.env.VITE_SMOKE_TEST
   ? lazy(() => import('./pages/SmokeTest'))
   : null
@@ -122,6 +123,7 @@ export function Root() {
           )}
           <Route path="/performance/:owner/diagnostics" element={<PerformanceDiagnostics />} />
           <Route path="/returns/compare" element={<ReturnComparison />} />
+          <Route path="/metrics-explained" element={<MetricsExplanation />} />
           <Route path="/*" element={<App onLogout={logout} />} />
         </Routes>
       </Suspense>

--- a/frontend/src/pages/MetricsExplanation.tsx
+++ b/frontend/src/pages/MetricsExplanation.tsx
@@ -1,0 +1,126 @@
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+export default function MetricsExplanation() {
+  const { t } = useTranslation();
+  const alphaNotesRaw = t("metricsExplanation.sections.alpha.notes", {
+    returnObjects: true,
+  });
+  const trackingErrorNotesRaw = t(
+    "metricsExplanation.sections.trackingError.notes",
+    { returnObjects: true },
+  );
+  const drawdownNotesRaw = t(
+    "metricsExplanation.sections.maxDrawdown.notes",
+    {
+      returnObjects: true,
+    },
+  );
+  const alphaNotes = Array.isArray(alphaNotesRaw)
+    ? (alphaNotesRaw as string[])
+    : [];
+  const trackingErrorNotes = Array.isArray(trackingErrorNotesRaw)
+    ? (trackingErrorNotesRaw as string[])
+    : [];
+  const drawdownNotes = Array.isArray(drawdownNotesRaw)
+    ? (drawdownNotesRaw as string[])
+    : [];
+
+  return (
+    <main className="container mx-auto max-w-3xl space-y-10 p-4">
+      <header className="space-y-2">
+        <Link
+          to="/?group=all"
+          className="inline-block text-blue-500 hover:underline"
+        >
+          {t("metricsExplanation.backLink")}
+        </Link>
+        <h1 className="text-3xl font-bold">
+          {t("metricsExplanation.title")}
+        </h1>
+        <p className="text-lg text-gray-300">
+          {t("metricsExplanation.intro")}
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">
+          {t("metricsExplanation.sections.alpha.title")}
+        </h2>
+        <p>{t("metricsExplanation.sections.alpha.summary")}</p>
+        <h3 className="text-xl font-semibold">
+          {t("metricsExplanation.calculationHeading")}
+        </h3>
+        <p>{t("metricsExplanation.sections.alpha.calculation")}</p>
+        {alphaNotes.length > 0 && (
+          <div>
+            <h3 className="text-xl font-semibold">
+              {t("metricsExplanation.notesHeading")}
+            </h3>
+            <ul className="list-disc space-y-1 pl-6">
+              {alphaNotes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">
+          {t("metricsExplanation.sections.trackingError.title")}
+        </h2>
+        <p>{t("metricsExplanation.sections.trackingError.summary")}</p>
+        <h3 className="text-xl font-semibold">
+          {t("metricsExplanation.calculationHeading")}
+        </h3>
+        <p>{t("metricsExplanation.sections.trackingError.calculation")}</p>
+        {trackingErrorNotes.length > 0 && (
+          <div>
+            <h3 className="text-xl font-semibold">
+              {t("metricsExplanation.notesHeading")}
+            </h3>
+            <ul className="list-disc space-y-1 pl-6">
+              {trackingErrorNotes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">
+          {t("metricsExplanation.sections.maxDrawdown.title")}
+        </h2>
+        <p>{t("metricsExplanation.sections.maxDrawdown.summary")}</p>
+        <h3 className="text-xl font-semibold">
+          {t("metricsExplanation.calculationHeading")}
+        </h3>
+        <p>{t("metricsExplanation.sections.maxDrawdown.calculation")}</p>
+        {drawdownNotes.length > 0 && (
+          <div>
+            <h3 className="text-xl font-semibold">
+              {t("metricsExplanation.notesHeading")}
+            </h3>
+            <ul className="list-disc space-y-1 pl-6">
+              {drawdownNotes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-2xl font-semibold">
+          {t("metricsExplanation.dataHeading")}
+        </h2>
+        <p>{t("metricsExplanation.dataBody")}</p>
+        <p className="text-sm text-gray-400">
+          {t("metricsExplanation.disclaimer")}
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated MetricsExplanation page that details how alpha vs benchmark, tracking error, and max drawdown are calculated
- register the new page in the router and provide English and German translations for its content and for the dashboard link text
- surface a help link from the group portfolio metrics card so users can reach the explanation page

## Testing
- npm run test -- --run tests/unit/components/GroupPortfolioView.test.tsx *(fails: existing test `GroupPortfolioView > switches instrument rows across owner and account tabs` expected mocked fetch to include `account=isa`)*

------
https://chatgpt.com/codex/tasks/task_e_68d4db86749083278daf4ce278cc740a