### PR TITLE
feat: add group summary totals for stock and cash

### DIFF
--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -11,6 +11,7 @@ import i18n from '../i18n';
 import { useConfig } from '../ConfigContext';
 import { isSupportedFx } from '../lib/fx';
 import { RelativeViewToggle } from './RelativeViewToggle';
+import { isCashInstrument } from '../lib/instruments';
 import {
   assignInstrumentGroup,
   clearInstrumentGroup,
@@ -60,18 +61,6 @@ const GROUP_SUMMARY_SORT_MAP: Partial<Record<keyof RowWithCost, keyof GroupTotal
   change_30d_pct: 'change30dPct',
   gain_pct: 'gainPct',
 };
-
-export function isCashInstrument(
-  instrument: Pick<InstrumentSummary, 'instrument_type' | 'ticker'>,
-): boolean {
-  const type = instrument.instrument_type?.toLowerCase();
-  if (type === 'cash') {
-    return true;
-  }
-
-  const ticker = instrument.ticker?.toUpperCase();
-  return ticker?.startsWith('CASH') ?? false;
-}
 
 export function InstrumentTable({ rows }: Props) {
   const { t } = useTranslation();

--- a/frontend/src/components/PortfolioSummary.tsx
+++ b/frontend/src/components/PortfolioSummary.tsx
@@ -1,10 +1,14 @@
+import type { ReactNode } from "react";
 import type { Account } from "../types";
 import { money, percent } from "../lib/money";
 import { useConfig } from "../ConfigContext";
-import { PiggyBank, LineChart, BadgeCheck } from "lucide-react";
+import { isCashInstrument } from "../lib/instruments";
+import { LineChart, PiggyBank, TrendingUp, Wallet } from "lucide-react";
 
 export type PortfolioTotals = {
   totalValue: number;
+  totalStockValue: number;
+  totalCash: number;
   totalGain: number;
   totalDayChange: number;
   totalCost: number;
@@ -14,6 +18,8 @@ export type PortfolioTotals = {
 
 export function computePortfolioTotals(accounts: Account[]): PortfolioTotals {
   let totalValue = 0;
+  let totalStockValue = 0;
+  let totalCash = 0;
   let totalGain = 0;
   let totalDayChange = 0;
   let totalCost = 0;
@@ -32,6 +38,15 @@ export function computePortfolioTotals(accounts: Account[]): PortfolioTotals {
           : market - cost;
       const dayChg = h.day_change_gbp ?? 0;
 
+      if (isCashInstrument({
+        instrument_type: h.instrument_type,
+        ticker: h.ticker,
+      })) {
+        totalCash += market;
+      } else {
+        totalStockValue += market;
+      }
+
       totalCost += cost;
       totalGain += gain;
       totalDayChange += dayChg;
@@ -46,6 +61,8 @@ export function computePortfolioTotals(accounts: Account[]): PortfolioTotals {
 
   return {
     totalValue,
+    totalStockValue,
+    totalCash,
     totalGain,
     totalDayChange,
     totalCost,
@@ -61,10 +78,10 @@ type Props = {
 export function PortfolioSummary({ totals }: Props) {
   const {
     totalValue,
-    totalDayChange,
+    totalStockValue,
+    totalCash,
     totalGain,
     totalGainPct,
-    totalDayChangePct,
   } = totals;
   const { baseCurrency } = useConfig();
 
@@ -72,7 +89,8 @@ export function PortfolioSummary({ totals }: Props) {
     <div
       style={{
         display: "flex",
-        gap: "2rem",
+        flexWrap: "wrap",
+        gap: "1.5rem",
         margin: "1rem 0",
         padding: "1rem",
         backgroundColor: "#222",
@@ -80,72 +98,81 @@ export function PortfolioSummary({ totals }: Props) {
         borderRadius: "6px",
       }}
     >
-      <div>
-        <div
-          style={{
-            fontSize: "1rem",
-            color: "#aaa",
-            display: "flex",
-            alignItems: "center",
-            gap: "0.25rem",
-          }}
-        >
-          <PiggyBank size={20} />
-          Total Value
-        </div>
-        <div style={{ fontSize: "2rem", fontWeight: "bold" }}>
-          {money(totalValue, baseCurrency)}
-        </div>
-      </div>
-      <div>
-        <div
-          style={{
-            fontSize: "1rem",
-            color: "#aaa",
-            display: "flex",
-            alignItems: "center",
-            gap: "0.25rem",
-          }}
-        >
-          <LineChart size={20} />
-          Day Change
-        </div>
-        <div
-          style={{
-            fontSize: "2rem",
-            fontWeight: "bold",
-            color: totalDayChange >= 0 ? "lightgreen" : "red",
-          }}
-        >
-          {money(totalDayChange, baseCurrency)} ({percent(totalDayChangePct)})
-        </div>
-      </div>
-      <div>
-        <div
-          style={{
-            fontSize: "1rem",
-            color: "#aaa",
-            display: "flex",
-            alignItems: "center",
-            gap: "0.25rem",
-          }}
-        >
-          <BadgeCheck size={20} />
-          Total Gain
-        </div>
-        <div
-          style={{
-            fontSize: "2rem",
-            fontWeight: "bold",
-            color: totalGain >= 0 ? "lightgreen" : "red",
-          }}
-        >
-          {money(totalGain, baseCurrency)} ({percent(totalGainPct)})
-        </div>
-      </div>
+      <SummaryCard
+        label="Stock value"
+        icon={<LineChart size={20} />}
+        value={money(totalStockValue, baseCurrency)}
+      />
+      <SummaryCard
+        label="Total cash"
+        icon={<Wallet size={20} />}
+        value={money(totalCash, baseCurrency)}
+      />
+      <SummaryCard
+        label="Total value"
+        icon={<PiggyBank size={20} />}
+        value={money(totalValue, baseCurrency)}
+      />
+      <SummaryCard
+        label="Gain/loss"
+        icon={<TrendingUp size={20} />}
+        value={money(totalGain, baseCurrency)}
+        accentColor={totalGain >= 0 ? "lightgreen" : "red"}
+        secondary={`(${percent(totalGainPct)})`}
+      />
     </div>
   );
 }
 
 export default PortfolioSummary;
+
+type SummaryCardProps = {
+  label: string;
+  icon: ReactNode;
+  value: string;
+  secondary?: string;
+  accentColor?: string;
+};
+
+function SummaryCard({ label, icon, value, secondary, accentColor }: SummaryCardProps) {
+  return (
+    <div style={{ minWidth: "12rem", flex: "1 1 12rem" }}>
+      <div
+        style={{
+          fontSize: "1rem",
+          color: "#aaa",
+          display: "flex",
+          alignItems: "center",
+          gap: "0.25rem",
+        }}
+      >
+        {icon}
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: "2rem",
+          fontWeight: "bold",
+          color: accentColor,
+          display: "flex",
+          alignItems: "baseline",
+          gap: "0.5rem",
+        }}
+      >
+        <span>{value}</span>
+        {secondary && (
+          <span
+            style={{
+              fontSize: "1rem",
+              fontWeight: "normal",
+              color: accentColor ?? "#aaa",
+            }}
+          >
+            {secondary}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
 

--- a/frontend/src/lib/instruments.ts
+++ b/frontend/src/lib/instruments.ts
@@ -1,0 +1,19 @@
+import type { InstrumentSummary } from "../types";
+
+export type InstrumentWithIdentity = Pick<
+  InstrumentSummary,
+  "instrument_type" | "ticker"
+>;
+
+export function isCashInstrument({
+  instrument_type,
+  ticker,
+}: InstrumentWithIdentity): boolean {
+  const type = instrument_type?.toLowerCase();
+  if (type === "cash") {
+    return true;
+  }
+
+  const symbol = ticker?.toUpperCase();
+  return symbol?.startsWith("CASH") ?? false;
+}


### PR DESCRIPTION
## Summary
- move the cash-instrument heuristic into a shared helper
- extend portfolio total calculations to capture stock value and cash separately
- render HL-style summary cards for stock value, total cash, total value, and gain/loss in the group portfolio view

## Testing
- npm run lint *(fails: existing lint issues across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d4dd9d50f08327b7714c19fe2c951e