### PR TITLE
Fix quest defaults and validation regressions

### DIFF
--- a/backend/quests/trail.py
+++ b/backend/quests/trail.py
@@ -205,6 +205,11 @@ def _build_once_tasks(user: str, user_data: Dict) -> List[TaskDefinition]:
                 commentary="Fine-tune drift alerts so significant moves surface quickly.",
             )
         )
+    elif "set_alert_threshold" not in user_data["once"]:
+        # Ensure users who configured a threshold outside of the quest flow do
+        # not repeatedly see the reminder task.  Recording the completion keeps
+        # the task catalogue stable while reflecting the user's state.
+        user_data["once"].append("set_alert_threshold")
 
     # Push notifications require an explicit subscription – remind the user
     # when none is configured.
@@ -225,6 +230,8 @@ def _build_once_tasks(user: str, user_data: Dict) -> List[TaskDefinition]:
                 commentary="Stay informed about nudges and alerts without opening the app.",
             )
         )
+    elif "enable_push_notifications" not in user_data["once"]:
+        user_data["once"].append("enable_push_notifications")
 
     return tasks
 

--- a/backend/routes/instrument_admin.py
+++ b/backend/routes/instrument_admin.py
@@ -151,7 +151,7 @@ async def delete_instrument(exchange: str, ticker: str) -> dict[str, str]:
     except OSError as exc:
         raise HTTPException(status_code=500, detail="Filesystem error") from exc
     if not exists:
-        return {"status": "missing"}
+        raise HTTPException(status_code=404, detail="Instrument not found")
     delete_instrument_meta(ticker, exchange)
     return {"status": "deleted"}
 

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -289,7 +289,8 @@ def run_all_tickers(
             time.sleep(delay)
         sym, ex = _resolve_ticker_exchange(t, exchange)
         logger.debug("run_all_tickers resolved %s -> %s.%s", t, sym, ex)
-        loader_exchange = ex if ex else ""
+        has_explicit_exchange = bool(exchange) or bool(re.search(r"[._]", t))
+        loader_exchange = ex if has_explicit_exchange else ""
         try:
             if not load_meta_timeseries(sym, loader_exchange, days).empty:
                 ok.append(t)

--- a/backend/timeseries/ticker_validator.py
+++ b/backend/timeseries/ticker_validator.py
@@ -20,7 +20,16 @@ def is_valid_ticker(ticker: str, exchange: str) -> bool:
     ex = exchange.upper()
     full = f"{base}.{ex}"
     meta = get_instrument_meta(full)
-    return bool(meta)
+    if not meta:
+        return False
+    informative_keys = {
+        key
+        for key, value in meta.items()
+        if value not in (None, "")
+    }
+    if informative_keys <= {"ticker", "exchange", "name"}:
+        return False
+    return True
 
 
 def record_skipped_ticker(ticker: str, exchange: str, *, reason: str = "") -> None:


### PR DESCRIPTION
## Summary
- mark quest reminders as completed when users have already configured alerts or push subscriptions outside the quest flow
- treat metadata fallbacks as informational so aggregation keeps “Unknown” buckets and only pass explicit exchanges to the cache warm-up helper
- surface 404s for missing instrument deletions and require richer metadata before accepting tickers

## Testing
- pytest --override-ini=addopts='' tests/quests/test_trail.py tests/routes/test_instrument_admin.py tests/test_backend_api.py tests/test_portfolio_utils_aggregate_by_field.py tests/test_ticker_validation.py tests/timeseries/test_run_all_and_load_timeseries.py
- pytest --override-ini=addopts='' tests/test_portfolio_utils_aggregate_by_field.py

------
https://chatgpt.com/codex/tasks/task_e_68d4e3f998bc83279604d4e7d29c8114