### PR TITLE
Ensure transactions use persistent IDs

### DIFF
--- a/backend/tests/test_transactions_route.py
+++ b/backend/tests/test_transactions_route.py
@@ -59,6 +59,8 @@ def test_create_transaction_success(monkeypatch, tmp_path):
     assert file_path.exists()
     saved = json.loads(file_path.read_text())
     assert saved["transactions"][0]["ticker"] == "ABC"
+    stored_id = saved["transactions"][0]["id"]
+    assert transactions._TOKEN_RE.fullmatch(stored_id)
     assert transactions._PORTFOLIO_IMPACT["bob"] == pytest.approx(3.0)
 
 


### PR DESCRIPTION
## Summary
- add UUID-backed transaction tokens and build REST IDs from owner/account/token triples
- update update/delete flows to resolve transactions by stored tokens and persist them when files change
- refresh transaction route tests to assert on the stored identifier format

## Testing
- `pytest -o addopts="" backend/tests/test_transactions_route.py`


------
https://chatgpt.com/codex/tasks/task_e_68d4f3323f688327b9f254885fedbb4a