### PR TITLE
Ensure compliance scaffold includes person metadata

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -51,6 +51,11 @@ def _ensure_owner_scaffold(owner: str, owner_dir: Path) -> None:
     defaults: Dict[str, Dict[str, Any]] = {
         "settings.json": _default_settings_payload(),
         "approvals.json": {"approvals": []},
+        "person.json": {
+            "owner": owner,
+            "holdings": [],
+            "viewers": [],
+        },
         f"{owner}_transactions.json": {
             "account_type": "brokerage",
             "transactions": [],
@@ -86,8 +91,7 @@ def load_transactions(owner: str, accounts_root: Optional[Path] = None) -> List[
     paths = resolve_paths(config.repo_root, config.accounts_root)
     root = Path(accounts_root) if accounts_root else paths.accounts_root
     owner_dir = root / owner
-    if not owner_dir.exists():
-        _ensure_owner_scaffold(owner, owner_dir)
+    _ensure_owner_scaffold(owner, owner_dir)
 
     results: List[Dict[str, Any]] = []
     for path in owner_dir.glob("*_transactions.json"):

--- a/backend/tests/test_compliance_scaffold.py
+++ b/backend/tests/test_compliance_scaffold.py
@@ -1,0 +1,31 @@
+import json
+
+from backend.common import compliance
+
+
+def test_check_trade_creates_default_person_metadata(tmp_path, monkeypatch):
+    accounts_root = tmp_path / "accounts"
+    trade = {
+        "owner": "newbie",
+        "ticker": "PFE",
+        "type": "buy",
+        "date": "1970-01-01",
+        "shares": 1,
+    }
+
+    monkeypatch.setattr(
+        "backend.common.compliance.get_instrument_meta",
+        lambda ticker: {},
+    )
+
+    result = compliance.check_trade(trade, accounts_root)
+
+    assert result["owner"] == "newbie"
+
+    person_path = accounts_root / "newbie" / "person.json"
+    assert person_path.exists()
+
+    metadata = json.loads(person_path.read_text())
+    assert metadata["owner"] == "newbie"
+    assert isinstance(metadata.get("holdings"), list)
+    assert isinstance(metadata.get("viewers"), list)


### PR DESCRIPTION
## Summary
- ensure compliance scaffolding writes a default person.json alongside other starter files
- always initialise the scaffold when loading transactions so missing metadata is backfilled
- add a regression test that verifies compliance trade validation creates person metadata for new owners

## Testing
- pytest backend/tests/test_compliance_scaffold.py --cov=backend/common/compliance.py --cov-fail-under=0


------
https://chatgpt.com/codex/tasks/task_e_68d5b5b3975c8327a5316257039ddf1e