### PR TITLE
Group menu items into categories

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -10,6 +10,16 @@
     "research": "Recherche",
     "logout": "Abmelden",
     "menu": "Menü",
+    "menuCategories": {
+      "overview": "Überblick",
+      "portfolio": "Portfoliomanagement",
+      "research": "Recherche & Analyse",
+      "reporting": "Berichte & Compliance",
+      "planning": "Planung & Tools",
+      "settings": "Einstellungen",
+      "supportTools": "Support-Tools",
+      "other": "Weitere"
+    },
     "focusMode": "Fokusmodus",
     "exitFocusMode": "Fokusmodus verlassen",
     "modes": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -10,6 +10,16 @@
     "research": "Research",
     "logout": "Logout",
     "menu": "Menu",
+    "menuCategories": {
+      "overview": "Overview",
+      "portfolio": "Portfolio Management",
+      "research": "Research & Analysis",
+      "reporting": "Reporting & Compliance",
+      "planning": "Planning & Tools",
+      "settings": "Settings",
+      "supportTools": "Support Tools",
+      "other": "Other"
+    },
     "focusMode": "Focus Mode",
     "exitFocusMode": "Exit Focus Mode",
     "modes": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -10,6 +10,16 @@
     "research": "Investigación",
     "logout": "Cerrar sesión",
     "menu": "Menú",
+    "menuCategories": {
+      "overview": "Resumen",
+      "portfolio": "Gestión de carteras",
+      "research": "Investigación y análisis",
+      "reporting": "Informes y cumplimiento",
+      "planning": "Planificación y herramientas",
+      "settings": "Configuración",
+      "supportTools": "Herramientas de soporte",
+      "other": "Otros"
+    },
     "focusMode": "Modo de enfoque",
     "exitFocusMode": "Salir del modo de enfoque",
     "modes": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -10,6 +10,16 @@
     "research": "Recherche",
     "logout": "Déconnexion",
     "menu": "Menu",
+    "menuCategories": {
+      "overview": "Vue d'ensemble",
+      "portfolio": "Gestion de portefeuille",
+      "research": "Recherche et analyse",
+      "reporting": "Rapports et conformité",
+      "planning": "Planification et outils",
+      "settings": "Paramètres",
+      "supportTools": "Outils d'assistance",
+      "other": "Autres"
+    },
     "focusMode": "Mode concentration",
     "exitFocusMode": "Quitter le mode concentration",
     "modes": {

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -10,6 +10,16 @@
     "research": "Ricerca",
     "logout": "Logout",
     "menu": "Menu",
+    "menuCategories": {
+      "overview": "Panoramica",
+      "portfolio": "Gestione portafoglio",
+      "research": "Ricerca e analisi",
+      "reporting": "Reportistica e conformità",
+      "planning": "Pianificazione e strumenti",
+      "settings": "Impostazioni",
+      "supportTools": "Strumenti di supporto",
+      "other": "Altro"
+    },
     "focusMode": "Modalità concentrazione",
     "exitFocusMode": "Esci dalla modalità concentrazione",
     "modes": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -10,6 +10,16 @@
     "research": "Pesquisa",
     "logout": "Sair",
     "menu": "Menu",
+    "menuCategories": {
+      "overview": "Visão geral",
+      "portfolio": "Gestão de portfólio",
+      "research": "Pesquisa e análise",
+      "reporting": "Relatórios e conformidade",
+      "planning": "Planejamento e ferramentas",
+      "settings": "Configurações",
+      "supportTools": "Ferramentas de suporte",
+      "other": "Outros"
+    },
     "focusMode": "Modo de foco",
     "exitFocusMode": "Sair do modo de foco",
     "modes": {


### PR DESCRIPTION
## Summary
- organize the application menu into localized category groupings for user and support tabs
- add translations for the new category labels across supported locales

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm run test *(cancelled after initial run)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ba44888883278c8f9865a828f408