### PR TITLE
Fix compliance, transactions, and timeseries regressions

### DIFF
--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -15,20 +15,29 @@ def _known_owners(accounts_root) -> set[str]:
 
     owners: set[str] = set()
     try:
+        entries = data_loader.list_plots(accounts_root)
+    except Exception:
+        entries = []
+
+    for entry in entries:
+        owner = (entry.get("owner") or "").strip()
+        if owner:
+            owners.add(owner.lower())
+
+    if owners:
+        return owners
+
+    try:
         root_path = Path(accounts_root) if accounts_root else data_loader.resolve_paths(None, None).accounts_root
     except Exception:
-        root_path = None
-    else:
-        if not root_path.exists():
-            root_path = None
+        return owners
 
-    for entry in data_loader.list_plots(accounts_root):
-        owner = (entry.get("owner") or "").strip()
-        if not owner:
-            continue
-        if root_path and not (root_path / owner / "person.json").exists():
-            continue
-        owners.add(owner.lower())
+    if not root_path or not root_path.exists():
+        return owners
+
+    for entry in root_path.iterdir():
+        if entry.is_dir():
+            owners.add(entry.name.lower())
     return owners
 
 

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -310,7 +310,7 @@ async def create_transaction(tx: TransactionCreate) -> dict:
     _rebuild_portfolio(owner, account)
 
     tx_id = _build_transaction_id(owner, account, new_index)
-    return {"owner": owner, "account": account.lower(), "id": tx_id, **tx_data}
+    return {"owner": owner, "account": account, "id": tx_id, **tx_data}
 
 
 @router.put("/transactions/{tx_id}")

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -290,12 +290,12 @@ def run_all_tickers(
         sym, ex = _resolve_ticker_exchange(t, exchange)
         logger.debug("run_all_tickers resolved %s -> %s.%s", t, sym, ex)
         has_explicit_exchange = bool(exchange) or bool(re.search(r"[._]", t))
-        # When the exchange is derived from metadata we still want to hand it to
-        # the loader so cached parquet files are looked up using the fully
-        # qualified symbol.  Previously we only forwarded the exchange when it
-        # was supplied explicitly which caused cache misses for bare symbols
-        # like "GSK" even though metadata contained the correct suffix.
-        loader_exchange = ex if (ex or has_explicit_exchange) else ""
+        # Only forward the exchange to the loader when the caller explicitly
+        # provided one (either via the ``exchange`` argument or within the
+        # ticker itself).  Allowing metadata-derived exchanges to pass through
+        # caused tests relying on the legacy behaviour to fail and introduced
+        # surprising differences between cached and uncached symbols.
+        loader_exchange = ex if has_explicit_exchange else ""
         try:
             if not load_meta_timeseries(sym, loader_exchange, days).empty:
                 ok.append(t)


### PR DESCRIPTION
## Summary
- expand the compliance owner discovery helper to allow owners without metadata while keeping directory fallbacks
- return transaction responses with the original account casing instead of a lower-cased string
- keep metadata-derived exchanges out of run_all_tickers loader calls so behaviour matches legacy expectations

## Testing
- pytest --override-ini="addopts=" tests/quests/test_trail.py::test_get_tasks_returns_defaults -q
- pytest --override-ini="addopts=" tests/test_backend_api.py::test_invalid_portfolio tests/test_backend_api.py::test_compliance_endpoint -q
- pytest --override-ini="addopts=" tests/test_compliance_route.py -q
- pytest --override-ini="addopts=" tests/test_transactions_route.py::test_create_transaction_success -q
- pytest --override-ini="addopts=" tests/timeseries/test_run_all_and_load_timeseries.py::test_run_all_tickers_filters_and_delays -q

------
https://chatgpt.com/codex/tasks/task_e_68d5ba7001f88327ab46ec62179ae826