### PR TITLE
Add flat and category grouping modes to instrument table

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -37,6 +37,7 @@ import type {
   RegionContribution,
   UserConfig,
   InstrumentMetadata,
+  InstrumentGroupDefinition,
   ApprovalsResponse,
   NewsItem,
   Nudge,
@@ -698,6 +699,9 @@ export const listInstrumentMetadata = () =>
 
 export const listInstrumentGroups = () =>
   fetchJson<string[]>(`${API_BASE}/instrument/admin/groups`);
+
+export const listInstrumentGroupingDefinitions = () =>
+  fetchJson<InstrumentGroupDefinition[]>(`${API_BASE}/instrument/admin/groupings`);
 
 type InstrumentGroupMutationResponse = {
   status: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -108,6 +108,16 @@ export type InstrumentSummary = {
   change_30d_pct?: number | null;
 };
 
+export interface InstrumentGroupDefinition {
+  id: string;
+  name: string;
+  aliases?: string[] | null;
+  category?: string | null;
+  category_name?: string | null;
+  description?: string | null;
+  [key: string]: unknown;
+}
+
 export type SectorContribution = {
   sector: string;
   market_value_gbp: number;


### PR DESCRIPTION
## Summary
- add a view selector so the instrument table can switch between grouped totals, category summaries, or an ungrouped flat list
- hydrate category groupings from instrument group definition metadata when present and reuse totals logic across the different modes
- expose API helpers and types for instrument group definitions consumed by the table

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b9c2ec3c8327a358be86a00afec3