### PR TITLE
Fix nullish coalescing precedence in InstrumentTable

### DIFF
--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -1006,7 +1006,7 @@ function createGroupedRows(
                 key,
                 raw: trimmed,
                 row,
-              }) ?? trimmed || options.ungroupedLabel;
+              }) ?? (trimmed || options.ungroupedLabel);
       group = {
         key,
         label,


### PR DESCRIPTION
## Summary
- wrap the logical fallback of the grouping label in parentheses to satisfy Babel's parsing rules when mixing nullish coalescing with logical OR

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c2a3fe988327a2f5820ca653e74b