### PR TITLE
Fix instrument group smoke payload

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -233,7 +233,9 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   {
     "method": "POST",
     "path": "/instrument/admin/{exchange}/{ticker}/group",
-    "body": {}
+    "body": {
+      "group": "demo"
+    }
   },
   {
     "method": "GET",


### PR DESCRIPTION
## Summary
- ensure the instrument admin group assignment smoke test sends a valid grouping value

## Testing
- not run (smoke tests require running services that are not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5c458c120832798ecb9852489e1a8