### PR TITLE
Ensure deploy script configures CDK Python interpreter

### DIFF
--- a/scripts/deploy-to-AWS.ps1
+++ b/scripts/deploy-to-AWS.ps1
@@ -30,6 +30,9 @@ if (-not $PYTHON) {
   exit 1
 }
 
+# Hint the CDK CLI to use the discovered interpreter instead of the Microsoft Store shim.
+$env:CDK_PYTHON = $PYTHON
+
 # Determine repository root and key paths
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 $REPO_ROOT  = (Resolve-Path (Join-Path $SCRIPT_DIR '..')).Path


### PR DESCRIPTION
## Summary
- set the CDK_PYTHON environment variable to the detected interpreter to avoid Windows Store shims during deployment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e7c23d7483278c8722c9c21023a7