### PR TITLE
Refine menu section layout

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -244,55 +244,69 @@ export default function Menu({
         <div
           hidden={!open}
           aria-hidden={!open}
-          className={`${open ? 'flex md:flex' : 'hidden'} flex-col gap-2 md:flex-row md:flex-wrap`}
+          className={`${open ? 'flex' : 'hidden'} flex-col gap-6 md:gap-8`}
           style={style}
         >
           {categoriesToRender.map((category) => (
-            <div key={category.id} className="mr-4 flex flex-col">
-              <span className="font-semibold">{t(`app.menuCategories.${category.titleKey}`)}</span>
-              <div className="mt-1 flex flex-col gap-1">
+            <section key={category.id} className="flex flex-col">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-200">
+                {t(`app.menuCategories.${category.titleKey}`)}
+              </h3>
+              <ul className="mt-2 flex flex-col gap-1">
                 {category.tabs.map((tab) => (
-                  <Link
-                    key={tab.id}
-                    to={pathFor(tab.id as string)}
-                    className={`${mode === tab.id ? 'font-bold' : ''} break-words`}
-                    style={{ fontWeight: mode === tab.id ? 'bold' as const : undefined }}
-                    onClick={() => setOpen(false)}
-                  >
-                    {t(`app.modes.${tab.id}`)}
-                  </Link>
+                  <li key={tab.id}>
+                    <Link
+                      to={pathFor(tab.id as string)}
+                      className={`${mode === tab.id ? 'font-bold' : ''} break-words`}
+                      style={{ fontWeight: mode === tab.id ? 'bold' as const : undefined }}
+                      onClick={() => setOpen(false)}
+                    >
+                      {t(`app.modes.${tab.id}`)}
+                    </Link>
+                  </li>
                 ))}
-              </div>
-            </div>
+              </ul>
+            </section>
           ))}
           {supportEnabled && (
-            <Link
-              to={inSupport ? '/' : '/support'}
-              className={`mr-4 ${inSupport ? 'font-bold' : ''} break-words`}
-              onClick={() => setOpen(false)}
-            >
-              {t('app.supportLink')}
-            </Link>
+            <section className="flex flex-col">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-200">
+                {t('app.menuCategories.support')}
+              </h3>
+              <ul className="mt-2 flex flex-col gap-1">
+                <li>
+                  <Link
+                    to={inSupport ? '/' : '/support'}
+                    className={`${inSupport ? 'font-bold' : ''} break-words`}
+                    onClick={() => setOpen(false)}
+                  >
+                    {t('app.supportLink')}
+                  </Link>
+                </li>
+              </ul>
+            </section>
           )}
-          {onLogout && (
+          <div className="flex flex-col gap-2 pt-4 border-t border-slate-200/60 dark:border-slate-700">
+            {onLogout && (
+              <button
+                type="button"
+                onClick={() => {
+                  onLogout();
+                  setOpen(false);
+                }}
+                className="bg-transparent border-0 p-0 text-left cursor-pointer"
+              >
+                {t('app.logout')}
+              </button>
+            )}
             <button
               type="button"
-              onClick={() => {
-                onLogout();
-                setOpen(false);
-              }}
-              className="mr-4 bg-transparent border-0 p-0 cursor-pointer"
+              onClick={() => setFocusMode(true)}
+              className="bg-transparent border-0 p-0 text-left cursor-pointer"
             >
-              {t('app.logout')}
+              {t('app.focusMode')}
             </button>
-          )}
-          <button
-            type="button"
-            onClick={() => setFocusMode(true)}
-            className="mr-4 bg-transparent border-0 p-0 cursor-pointer"
-          >
-            {t('app.focusMode')}
-          </button>
+          </div>
         </div>
       )}
     </nav>

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -17,6 +17,7 @@
       "reporting": "Berichte & Compliance",
       "planning": "Planung & Tools",
       "settings": "Einstellungen",
+      "support": "Support",
       "supportTools": "Support-Tools",
       "other": "Weitere"
     },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -17,6 +17,7 @@
       "reporting": "Reporting & Compliance",
       "planning": "Planning & Tools",
       "settings": "Settings",
+      "support": "Support",
       "supportTools": "Support Tools",
       "other": "Other"
     },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -17,6 +17,7 @@
       "reporting": "Informes y cumplimiento",
       "planning": "Planificación y herramientas",
       "settings": "Configuración",
+      "support": "Soporte",
       "supportTools": "Herramientas de soporte",
       "other": "Otros"
     },

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -17,6 +17,7 @@
       "reporting": "Rapports et conformité",
       "planning": "Planification et outils",
       "settings": "Paramètres",
+      "support": "Support",
       "supportTools": "Outils d'assistance",
       "other": "Autres"
     },

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -17,6 +17,7 @@
       "reporting": "Reportistica e conformità",
       "planning": "Pianificazione e strumenti",
       "settings": "Impostazioni",
+      "support": "Supporto",
       "supportTools": "Strumenti di supporto",
       "other": "Altro"
     },

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -17,6 +17,7 @@
       "reporting": "Relatórios e conformidade",
       "planning": "Planejamento e ferramentas",
       "settings": "Configurações",
+      "support": "Suporte",
       "supportTools": "Ferramentas de suporte",
       "other": "Outros"
     },


### PR DESCRIPTION
## Summary
- render each menu category as its own section with heading and list for child links
- update menu layout styling so categories stack vertically and auxiliary actions are grouped separately
- add translations for the new support menu heading across supported locales

## Testing
- npm --prefix frontend run lint *(fails: pre-existing lint violations in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ea2ccd5c83279f764b5c95cdc0df