### PR TITLE
Use python3 for CDK app command

### DIFF
--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,4 +1,4 @@
 {
-  "app": "python app.py",
+  "app": "python3 app.py",
   "output": "../../.cdk.out"
 }


### PR DESCRIPTION
## Summary
- update the CDK app command to call python3 so deployments work when `python` is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6edf70aa08327a5bb28d66582cf73