### PR TITLE
Improve offline uvicorn installation attempt

### DIFF
--- a/scripts/run-backend.ps1
+++ b/scripts/run-backend.ps1
@@ -325,8 +325,19 @@ try {
 } catch {}
 if (-not $uvicornAvailable) {
   if ($offline) {
-    Write-Host 'uvicorn is not installed and Offline mode is enabled. Install dependencies (pip install -r requirements.txt) or run without -Offline.' -ForegroundColor Red
-    exit 1
+    Write-Host 'uvicorn not found; attempting to install using existing pip cache...' -ForegroundColor Yellow
+    try {
+      & $PYTHON -m pip install -r .\requirements.txt
+      if ($LASTEXITCODE -eq 0) {
+        & $PYTHON -c "import uvicorn" 2>$null
+        if ($LASTEXITCODE -eq 0) { $uvicornAvailable = $true }
+      }
+    } catch {}
+
+    if (-not $uvicornAvailable) {
+      Write-Host 'uvicorn is not installed and Offline mode is enabled. Install dependencies (pip install -r requirements.txt) or run without -Offline.' -ForegroundColor Red
+      exit 1
+    }
   } else {
     Write-Host 'Installing uvicorn...' -ForegroundColor Yellow
     & $PYTHON -m pip install uvicorn


### PR DESCRIPTION
## Summary
- attempt to install backend requirements even when offline if uvicorn is missing
- fall back to existing pip cache before failing with offline mode guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6eddea9ec8327945bea97e62e6ca8