### PR TITLE
Fix smoke suite instrument search and automate Playwright install

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "test:jsdom": "vitest --environment=jsdom",
-    "smoke:frontend": "playwright test tests/smoke.spec.ts",
+    "smoke:frontend": "playwright install chromium && playwright test tests/smoke.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",
     "deploy:aws:linux": "bash scripts/deploy-to-aws.sh -b $S3_BUCKET ${CLOUDFRONT_DISTRIBUTION_ID:+-d $CLOUDFRONT_DISTRIBUTION_ID}"

--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -246,7 +246,10 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   },
   {
     "method": "GET",
-    "path": "/instrument/search"
+    "path": "/instrument/search",
+    "query": {
+      "q": "demo"
+    }
   },
   {
     "method": "GET",


### PR DESCRIPTION
## Summary
- include a sample query when calling the instrument search smoke endpoint so it succeeds
- install the Playwright Chromium browser before running the frontend smoke test

## Testing
- npm run smoke:test:all *(fails: backend service not running and container missing Playwright system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f032597c8327aec7a4ea54dc7f31