### PR TITLE
Fix compliance scaffolding, quest persistence, and metadata warm-up

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -92,7 +92,9 @@ def load_transactions(owner: str, accounts_root: Optional[Path] = None) -> List[
     root = Path(accounts_root) if accounts_root else paths.accounts_root
     owner_dir = root / owner
     if not owner_dir.exists():
-        raise FileNotFoundError(f"No compliance data for owner '{owner}'")
+        _ensure_owner_scaffold(owner, owner_dir)
+        # Newly scaffolded owners have no transactions yet.
+        return []
     _ensure_owner_scaffold(owner, owner_dir)
 
     results: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- scaffold missing compliance owners and return an empty transaction list instead of raising
- keep quest "once" task completions persistent for manual actions while tracking auto-complete state separately
- adjust timeseries warm-up helpers to avoid passing metadata-derived exchanges to the cache loader when none was supplied

## Testing
- `pytest --no-cov tests/backend/common/test_compliance.py::test_load_transactions_bootstraps_missing_owner`
- `pytest --no-cov tests/quests/test_trail.py`
- `pytest --no-cov tests/test_backend_api.py::test_invalid_portfolio tests/test_backend_api.py::test_compliance_invalid_owner`
- `pytest --no-cov tests/test_compliance_route.py::test_validate_trade_when_owner_discovery_fails`
- `pytest --no-cov tests/timeseries/test_run_all_and_load_timeseries.py::test_run_all_tickers_filters_and_delays`


------
https://chatgpt.com/codex/tasks/task_e_68d6ee5d554c83279ed85329edc82847