### PR TITLE
Improve smoke test page accessibility for Playwright checks

### DIFF
--- a/frontend/src/pages/SmokeTest.tsx
+++ b/frontend/src/pages/SmokeTest.tsx
@@ -32,7 +32,7 @@ export default function SmokeTest() {
   return (
     <div style={{ padding: '1rem' }}>
       <h1>Smoke test</h1>
-      <ul>
+      <ul aria-label="Smoke test results">
         {results.map((r) => (
           <li key={r.path} style={{ color: r.ok ? 'green' : 'red' }}>
             {r.path}: {r.ok ? 'ok' : 'failed'}{' '}

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -14,9 +14,13 @@ test.describe('smoke test page', () => {
     }
 
     await page.goto(smokePath);
-    await page.waitForSelector('ul li');
 
-    const items = page.getByRole('listitem');
+    const list = page.getByRole('list', { name: 'Smoke test results' });
+    await expect(list).toBeVisible();
+
+    const items = list.getByRole('listitem');
+    await expect(items.first()).toBeVisible();
+
     const count = await items.count();
     expect(count).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary
- add an accessible label to the smoke test results list
- update the Playwright smoke test to target the labelled list items reliably

## Testing
- not run (Playwright requires system dependencies unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d6f1caeddc8327afff35c3a6afea53