### PR TITLE
Fix quest auto-completion and restore owner validation fallbacks

### DIFF
--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from backend.common import compliance, data_loader
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
+from backend.routes._accounts import resolve_accounts_root
 
 router = APIRouter(tags=["compliance"])
 logger = logging.getLogger(__name__)
@@ -45,7 +46,7 @@ def _known_owners(accounts_root) -> set[str]:
 @handle_owner_not_found
 async def compliance_for_owner(owner: str, request: Request):
     """Return compliance warnings and status for an owner."""
-    accounts_root = request.app.state.accounts_root
+    accounts_root = resolve_accounts_root(request)
     owners = _known_owners(accounts_root)
     if owners and owner.lower() not in owners:
         raise_owner_not_found()
@@ -71,7 +72,7 @@ async def validate_trade(request: Request):
     trade = await request.json()
     if "owner" not in trade:
         raise HTTPException(status_code=422, detail="owner is required")
-    accounts_root = request.app.state.accounts_root
+    accounts_root = resolve_accounts_root(request)
     owners = _known_owners(accounts_root)
     if owners and trade.get("owner", "").lower() not in owners:
         raise_owner_not_found()

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -146,8 +146,9 @@ async def portfolio(owner: str, request: Request):
     the owner's holdings.
     """
 
+    accounts_root = resolve_accounts_root(request)
     try:
-        return portfolio_mod.build_owner_portfolio(owner, request.app.state.accounts_root)
+        return portfolio_mod.build_owner_portfolio(owner, accounts_root)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Owner not found")
 

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -104,22 +104,16 @@ def _resolve_loader_exchange(
 ) -> str:
     """Return the exchange to use when fetching cached data.
 
-    When the exchange originates solely from instrument metadata (i.e. neither
-    the ticker suffix nor the ``exchange`` argument provided a value) we return
-    an empty string so that the cache loader can apply its own defaults.  This
-    preserves the historical behaviour expected by the warm-up utilities and
-    associated tests.
+    The loader should prefer explicit suffixes or query parameters but fall
+    back to instrument metadata when neither is provided.  Returning the
+    metadata value ensures downstream caches warm using the correct market
+    identifier instead of silently defaulting to an empty exchange.
     """
 
     parts = re.split(r"[._]", ticker, 1)
     suffix = parts[1].upper() if len(parts) == 2 else ""
     provided = (exchange_arg or "").upper()
-    if (
-        resolved_exchange
-        and not suffix
-        and not provided
-        and resolved_exchange == _resolve_exchange_from_metadata(symbol)
-    ):
+    if not resolved_exchange:
         return ""
     return resolved_exchange
 


### PR DESCRIPTION
## Summary
- prevent Trail once-off tasks from auto-completing when only default alert data or incomplete push subscriptions are present
- resolve portfolio and compliance requests against the canonical accounts root before loading data so missing owners return 404s again
- ensure timeseries warm-up passes the metadata exchange to the cache loader instead of dropping it

## Testing
- pytest tests/quests/test_trail.py::test_get_tasks_returns_defaults --override-ini=addopts= -q
- pytest tests/quests/test_trail.py::test_get_tasks_with_completions --override-ini=addopts= -q
- pytest tests/test_backend_api.py::test_invalid_portfolio --override-ini=addopts= -q
- pytest tests/test_backend_api.py::test_compliance_invalid_owner --override-ini=addopts= -q
- pytest tests/test_run_all_tickers.py::test_run_all_tickers_resolves_exchange_from_metadata --override-ini=addopts= -q


------
https://chatgpt.com/codex/tasks/task_e_68d6f1ebad548327bab893f0ed5ca703