### PR TITLE
Handle config load timeouts on frontend

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1004,8 +1004,8 @@ export const deleteVirtualPortfolio = (id: number | string) =>
   });
 
 /** Retrieve backend configuration. */
-export const getConfig = <T = Record<string, unknown>>() =>
-  fetchJson<T>(`${API_BASE}/config`);
+export const getConfig = <T = Record<string, unknown>>(init?: RequestInit) =>
+  fetchJson<T>(`${API_BASE}/config`, init);
 
 /** Persist configuration changes. */
 export const updateConfig = (cfg: Record<string, unknown>) =>


### PR DESCRIPTION
## Summary
- allow passing request options to the `getConfig` API helper
- abort the initial configuration fetch after a timeout and surface a friendly error
- add a regression test covering timeout handling in the Root component

## Testing
- npm test -- --run tests/unit/rootConfigStates.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6f2cdbcc08327a0591e01e2842fbd