### PR TITLE
Restore aggregate group totals in portfolio view

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -917,7 +917,7 @@ export function GroupPortfolioView({ slug, onTradeInfo }: Props) {
             width: "100%",
           }}
         >
-          <InstrumentTable rows={instrumentRows} showGroupTotals={false} />
+          <InstrumentTable rows={instrumentRows} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- re-enable group totals in the aggregate portfolio view by rendering the instrument table with its default totals

## Testing
- npm run lint *(fails: pre-existing lint warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f6d2bc3083279d75b3852161835a