### PR TITLE
Adjust loader exchange resolution for unsuffixed tickers

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -104,18 +104,17 @@ def _resolve_loader_exchange(
 ) -> str:
     """Return the exchange to use when fetching cached data.
 
-    The loader should prefer explicit suffixes or query parameters but fall
-    back to instrument metadata when neither is provided.  Returning the
-    metadata value ensures downstream caches warm using the correct market
-    identifier instead of silently defaulting to an empty exchange.
+    The loader should prefer explicit suffixes or query parameters. When
+    neither is provided we deliberately ignore metadata-derived exchanges so
+    the cache lookup matches the unsuffixed request that triggered it.
     """
 
     parts = re.split(r"[._]", ticker, 1)
     suffix = parts[1].upper() if len(parts) == 2 else ""
     provided = (exchange_arg or "").upper()
-    if not resolved_exchange:
-        return ""
-    return resolved_exchange
+    if suffix or provided:
+        return resolved_exchange
+    return ""
 
 
 def _merge(sources: List[pd.DataFrame]) -> pd.DataFrame:

--- a/tests/timeseries/test_run_all_and_load_timeseries.py
+++ b/tests/timeseries/test_run_all_and_load_timeseries.py
@@ -32,8 +32,24 @@ def test_run_all_tickers_filters_and_delays(monkeypatch, caplog):
     assert "CCC" in caplog.text
 
 
-def test_load_timeseries_data_filters_and_warnings(monkeypatch, caplog):
+def test_run_all_tickers_uses_suffix_and_argument_exchanges():
+    calls = []
+
     def fake_load(sym, ex, days):
+        calls.append((sym, ex, days))
+        return _df()
+
+    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
+        fmt.run_all_tickers(["AAA.N", "BBB"], exchange="L", days=7)
+
+    assert calls == [("AAA", "N", 7), ("BBB", "L", 7)]
+
+
+def test_load_timeseries_data_filters_and_warnings(monkeypatch, caplog):
+    calls = []
+
+    def fake_load(sym, ex, days):
+        calls.append((sym, ex, days))
         if sym == "AAA":
             return _df()
         if sym == "BBB":
@@ -45,4 +61,18 @@ def test_load_timeseries_data_filters_and_warnings(monkeypatch, caplog):
             out = fmt.load_timeseries_data(["AAA", "BBB", "CCC"], days=5)
 
     assert list(out.keys()) == ["AAA"]
+    assert calls == [("AAA", "", 5), ("BBB", "", 5), ("CCC", "", 5)]
     assert "CCC" in caplog.text
+
+
+def test_load_timeseries_data_uses_suffix_and_argument_exchanges():
+    calls = []
+
+    def fake_load(sym, ex, days):
+        calls.append((sym, ex, days))
+        return _df()
+
+    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
+        fmt.load_timeseries_data(["AAA.N", "BBB"], exchange="L", days=3)
+
+    assert calls == [("AAA", "N", 3), ("BBB", "L", 3)]


### PR DESCRIPTION
## Summary
- ensure `_resolve_loader_exchange` returns an empty exchange for unsuffixed tickers without explicit overrides
- keep batch warm-up and load helpers passing the resolved loader exchange through to the cache
- extend batch loader unit tests to confirm suffix and explicit exchange handling

## Testing
- pytest -o addopts='' tests/timeseries/test_run_all_and_load_timeseries.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f86978508327ac6efcea48bc18fb