### PR TITLE
Prevent owner lookups from scaffolding missing directories

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 from fastapi import Request
 
@@ -36,3 +37,33 @@ def resolve_accounts_root(request: Request) -> Path:
     resolved_root = Path(root).expanduser().resolve()
     request.app.state.accounts_root = resolved_root
     return resolved_root
+
+
+def resolve_owner_directory(accounts_root: Optional[Path], owner: str) -> Optional[Path]:
+    """Return the directory for ``owner`` if it exists under ``accounts_root``.
+
+    The lookup is case-insensitive: the first matching directory name is
+    returned even if the provided ``owner`` casing differs from the on-disk
+    representation.
+    """
+
+    if not accounts_root or not owner:
+        return None
+
+    root = Path(accounts_root)
+    if not root.exists():
+        return None
+
+    direct = root / owner
+    if direct.exists():
+        return direct
+
+    owner_casefold = owner.casefold()
+    try:
+        for candidate in root.iterdir():
+            if candidate.is_dir() and candidate.name.casefold() == owner_casefold:
+                return candidate
+    except OSError:
+        return None
+
+    return None

--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from backend.common import compliance, data_loader
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
-from backend.routes._accounts import resolve_accounts_root
+from backend.routes._accounts import resolve_accounts_root, resolve_owner_directory
 
 router = APIRouter(tags=["compliance"])
 logger = logging.getLogger(__name__)
@@ -47,6 +47,10 @@ def _known_owners(accounts_root) -> set[str]:
 async def compliance_for_owner(owner: str, request: Request):
     """Return compliance warnings and status for an owner."""
     accounts_root = resolve_accounts_root(request)
+    owner_dir = resolve_owner_directory(accounts_root, owner)
+    if not owner_dir:
+        raise_owner_not_found()
+    owner = owner_dir.name
     owners = _known_owners(accounts_root)
     if owners and owner.lower() not in owners:
         raise_owner_not_found()
@@ -73,10 +77,15 @@ async def validate_trade(request: Request):
     if "owner" not in trade:
         raise HTTPException(status_code=422, detail="owner is required")
     accounts_root = resolve_accounts_root(request)
+    owner_value = (trade.get("owner") or "").strip()
+    owner_dir = resolve_owner_directory(accounts_root, owner_value)
+    if not owner_dir:
+        raise_owner_not_found()
     owners = _known_owners(accounts_root)
-    if owners and trade.get("owner", "").lower() not in owners:
+    if owners and owner_dir.name.lower() not in owners:
         raise_owner_not_found()
     try:
+        trade["owner"] = owner_dir.name
         return compliance.check_trade(trade, accounts_root)
     except FileNotFoundError:
         raise_owner_not_found()

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -30,7 +30,7 @@ from backend.common import (
 )
 from backend.common import portfolio as portfolio_mod
 from backend.config import config
-from backend.routes._accounts import resolve_accounts_root
+from backend.routes._accounts import resolve_accounts_root, resolve_owner_directory
 
 log = logging.getLogger("routes.portfolio")
 router = APIRouter(tags=["portfolio"])
@@ -147,6 +147,10 @@ async def portfolio(owner: str, request: Request):
     """
 
     accounts_root = resolve_accounts_root(request)
+    owner_dir = resolve_owner_directory(accounts_root, owner)
+    if not owner_dir:
+        raise HTTPException(status_code=404, detail="Owner not found")
+    owner = owner_dir.name
     try:
         return portfolio_mod.build_owner_portfolio(owner, accounts_root)
     except FileNotFoundError:

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
@@ -182,8 +184,13 @@ def test_valid_portfolio(client):
 
 
 def test_invalid_portfolio(client):
-    resp = client.get("/portfolio/noone")
+    missing_owner = "noone"
+    accounts_root = Path(client.app.state.accounts_root)
+    missing_dir = accounts_root / missing_owner
+    assert not missing_dir.exists()
+    resp = client.get(f"/portfolio/{missing_owner}")
     assert resp.status_code == 404
+    assert not missing_dir.exists()
 
 
 def test_valid_account(client):
@@ -314,8 +321,13 @@ def test_compliance_endpoint(client):
 
 
 def test_compliance_invalid_owner(client):
-    resp = client.get("/compliance/noone")
+    missing_owner = "noone"
+    accounts_root = Path(client.app.state.accounts_root)
+    missing_dir = accounts_root / missing_owner
+    assert not missing_dir.exists()
+    resp = client.get(f"/compliance/{missing_owner}")
     assert resp.status_code == 404
+    assert not missing_dir.exists()
 
 
 def test_instrument_detail_valid(client):


### PR DESCRIPTION
## Summary
- add a shared helper that locates an owner's directory case-insensitively without creating new folders
- update the compliance and portfolio routes to reject requests when the owner directory is missing before running additional logic
- extend backend API tests to assert missing owners return 404 and no directories are created

## Testing
- pytest --no-cov tests/test_backend_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f864f6fc8327985c3350dd940f30