### PR TITLE
Honor request-scoped accounts root even when missing

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -22,10 +22,9 @@ def resolve_accounts_root(request: Request) -> Path:
     accounts_root_value = getattr(request.app.state, "accounts_root", None)
     if accounts_root_value:
         candidate = Path(accounts_root_value).expanduser()
-        resolved_candidate = candidate.resolve()
-        if resolved_candidate.exists():
-            request.app.state.accounts_root = resolved_candidate
-            return resolved_candidate
+        resolved_candidate = candidate.resolve(strict=False)
+        request.app.state.accounts_root = resolved_candidate
+        return resolved_candidate
 
     paths = data_loader.resolve_paths(config.repo_root, config.accounts_root)
     root = paths.accounts_root


### PR DESCRIPTION
## Summary
- resolve request-scoped account roots even when they do not yet exist
- retain fallback behaviour when no request-scoped override is provided

## Testing
- pytest -o addopts='' tests/test_compliance_route.py::test_validate_trade_when_owner_discovery_fails

------
https://chatgpt.com/codex/tasks/task_e_68d6f863ddec8327b2964a1914df8cf9