### PR TITLE
Ensure accounts root cache handles missing directories

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -24,8 +24,9 @@ def resolve_accounts_root(request: Request) -> Path:
     if accounts_root_value:
         candidate = Path(accounts_root_value).expanduser()
         resolved_candidate = candidate.resolve(strict=False)
-        request.app.state.accounts_root = resolved_candidate
-        return resolved_candidate
+        if resolved_candidate.exists():
+            request.app.state.accounts_root = resolved_candidate
+            return resolved_candidate
 
     paths = data_loader.resolve_paths(config.repo_root, config.accounts_root)
     root = paths.accounts_root

--- a/tests/routes/test_accounts_root.py
+++ b/tests/routes/test_accounts_root.py
@@ -44,12 +44,13 @@ def test_resolve_accounts_root_falls_back_to_global_directory(
     from backend.common import data_loader
     from backend.config import config
 
-    missing_from_state = tmp_path / "missing-from-state"
+    cached_path = tmp_path / "cached"
+    cached_path.mkdir()
     missing_from_config = tmp_path / "missing-from-config"
     fallback_root = tmp_path / "fallback"
     fallback_root.mkdir()
 
-    state = SimpleNamespace(accounts_root=missing_from_state)
+    state = SimpleNamespace(accounts_root=cached_path)
     request = _make_request(state)
 
     monkeypatch.setattr(config, "repo_root", Path("/configured/root"))
@@ -67,9 +68,17 @@ def test_resolve_accounts_root_falls_back_to_global_directory(
 
     monkeypatch.setattr(data_loader, "resolve_paths", fake_resolve_paths)
 
+    cached_resolved = resolve_accounts_root(request)
+
+    assert cached_resolved == cached_path.resolve()
+    assert request.app.state.accounts_root == cached_path.resolve()
+    assert calls == []
+
+    cached_path.rmdir()
+
     resolved = resolve_accounts_root(request)
 
-    assert resolved == fallback_root
+    assert resolved == fallback_root.resolve()
     assert request.app.state.accounts_root == fallback_root.resolve()
     assert calls == [
         (config.repo_root, config.accounts_root),


### PR DESCRIPTION
## Summary
- verify that a cached accounts root directory still exists before returning it
- fall back to configured/global paths when the cache is stale and update the request state
- extend the accounts root resolver test to cover disappearing cached directories

## Testing
- pytest --override-ini addopts="" tests/routes/test_accounts_root.py

------
https://chatgpt.com/codex/tasks/task_e_68d6fd3139c08327928b8091a5217613