### PR TITLE
Allow compliance validation to scaffold new owners

### DIFF
--- a/tests/test_compliance_route.py
+++ b/tests/test_compliance_route.py
@@ -120,7 +120,19 @@ def test_validate_trade_when_owner_discovery_fails(tmp_path):
     app.state.accounts_root = missing_root
 
     with TestClient(app) as client:
-        resp = client.post("/compliance/validate", json={"owner": "demo"})
+        resp = client.post(
+            "/compliance/validate",
+            json={
+                "owner": " demo ",
+                "account": "brokerage",
+                "date": "2024-03-01",
+                "type": "buy",
+                "ticker": "XYZ",
+            },
+        )
         assert resp.status_code == 200
+        data = resp.json()
+        assert data["owner"] == "demo"
+        assert data["warnings"] == []
         scaffold = missing_root / "demo" / "demo_transactions.json"
         assert scaffold.exists()


### PR DESCRIPTION
## Summary
- update the compliance validation route to look up known owners before resolving directories
- allow trades to proceed when no known owners exist so scaffolding can be created, while still canonicalising existing owners
- extend the compliance route tests to cover the scaffolding fallback path

## Testing
- pytest --override-ini=addopts= tests/test_compliance_route.py

------
https://chatgpt.com/codex/tasks/task_e_68d6fd346df8832785b99c3794560a04