### PR TITLE
Fix loader exchange resolution for metadata fallback

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -112,9 +112,10 @@ def _resolve_loader_exchange(
     parts = re.split(r"[._]", ticker, 1)
     suffix = parts[1].upper() if len(parts) == 2 else ""
     provided = (exchange_arg or "").upper()
-    if suffix or provided:
-        return resolved_exchange
-    return ""
+    # When a suffix or explicit exchange is provided, ``resolved_exchange`` will
+    # already reflect that input. Otherwise it captures any metadata-derived
+    # fallback, which we now want to respect for loader calls as well.
+    return resolved_exchange
 
 
 def _merge(sources: List[pd.DataFrame]) -> pd.DataFrame:

--- a/tests/test_run_all_tickers.py
+++ b/tests/test_run_all_tickers.py
@@ -34,15 +34,11 @@ def test_run_all_tickers_handles_underscore_and_dot():
 
 
 def test_run_all_tickers_resolves_exchange_from_metadata():
-    calls = []
+    with patch("backend.timeseries.cache.load_meta_timeseries") as mock_load:
+        mock_load.return_value = pd.DataFrame({"Date": [1], "Close": [2]})
 
-    def fake_load(sym, ex, days):
-        calls.append((sym, ex, days))
-        return pd.DataFrame({"Date": [1], "Close": [2]})
-
-    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
         out = run_all_tickers(["GSK"], days=3)
 
     assert out == ["GSK"]
-    assert calls == [("GSK", "L", 3)]
+    mock_load.assert_called_once_with("GSK", "L", 3)
 


### PR DESCRIPTION
## Summary
- ensure `_resolve_loader_exchange` returns the resolved exchange even when no suffix or explicit exchange is provided
- update `test_run_all_tickers_resolves_exchange_from_metadata` to assert the loader receives the metadata-derived exchange

## Testing
- pytest tests/test_run_all_tickers.py::test_run_all_tickers_resolves_exchange_from_metadata *(fails: coverage fail-under=90 threshold in project configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fd35c3248327bfe58739d9acc999