### PR TITLE
Enable smoke test route without feature flag

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -31,9 +31,7 @@ const PerformanceDiagnostics = lazy(() => import('./pages/PerformanceDiagnostics
 const ReturnComparison = lazy(() => import('./pages/ReturnComparison'))
 const AlertSettings = lazy(() => import('./pages/AlertSettings'))
 const MetricsExplanation = lazy(() => import('./pages/MetricsExplanation'))
-const SmokeTest = import.meta.env.VITE_SMOKE_TEST
-  ? lazy(() => import('./pages/SmokeTest'))
-  : null
+const SmokeTest = lazy(() => import('./pages/SmokeTest'))
 
 export function Root() {
   const [configLoading, setConfigLoading] = useState(true)
@@ -138,9 +136,7 @@ export function Root() {
           <Route path="/alert-settings" element={<AlertSettings />} />
           <Route path="/goals" element={<Goals />} />
           <Route path="/trail" element={<Trail />} />
-          {import.meta.env.VITE_SMOKE_TEST && SmokeTest && (
-            <Route path="/smoke-test" element={<SmokeTest />} />
-          )}
+          <Route path="/smoke-test" element={<SmokeTest />} />
           <Route path="/performance/:owner/diagnostics" element={<PerformanceDiagnostics />} />
           <Route path="/returns/compare" element={<ReturnComparison />} />
           <Route path="/metrics-explained" element={<MetricsExplanation />} />


### PR DESCRIPTION
## Summary
- always lazy-load the SmokeTest page so the route is always registered
- keep the smoke test page rendering its accessibility list

## Testing
- npm --prefix frontend run smoke:frontend *(fails: missing Playwright system dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fd25b3d48327828874fcb1e16486