### PR TITLE
Refine menu category assignments

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -116,16 +116,25 @@ export default function Menu({
     {
       id: 'portfolio',
       titleKey: 'portfolio',
-      tabIds: ['owner', 'performance', 'transactions', 'trading', 'allocation', 'rebalance', 'trail'],
+      tabIds: [
+        'owner',
+        'performance',
+        'transactions',
+        'trading',
+        'allocation',
+        'rebalance',
+        'trail',
+        'reports',
+        'tradecompliance',
+      ],
     },
     {
       id: 'research',
       titleKey: 'research',
       tabIds: ['instrument', 'screener', 'timeseries', 'watchlist', 'scenario'],
     },
-    { id: 'reporting', titleKey: 'reporting', tabIds: ['reports', 'tradecompliance'] },
     { id: 'planning', titleKey: 'planning', tabIds: ['pension', 'taxtools'] },
-    { id: 'settings', titleKey: 'settings', tabIds: ['settings'] },
+    { id: 'settings', titleKey: 'settings', tabIds: ['alertsettings', 'settings'] },
   ];
 
   const SUPPORT_MENU_CATEGORIES: MenuCategory[] = [

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menü",
     "menuCategories": {
       "overview": "Überblick",
-      "portfolio": "Portfoliomanagement",
-      "research": "Recherche & Analyse",
-      "reporting": "Berichte & Compliance",
-      "planning": "Planung & Tools",
+      "portfolio": "Portfolio",
+      "research": "Research",
+      "planning": "Planning",
       "settings": "Einstellungen",
       "supportTools": "Support-Tools",
       "other": "Weitere"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menu",
     "menuCategories": {
       "overview": "Overview",
-      "portfolio": "Portfolio Management",
-      "research": "Research & Analysis",
-      "reporting": "Reporting & Compliance",
-      "planning": "Planning & Tools",
+      "portfolio": "Portfolio",
+      "research": "Research",
+      "planning": "Planning",
       "settings": "Settings",
       "supportTools": "Support Tools",
       "other": "Other"

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menú",
     "menuCategories": {
       "overview": "Resumen",
-      "portfolio": "Gestión de carteras",
-      "research": "Investigación y análisis",
-      "reporting": "Informes y cumplimiento",
-      "planning": "Planificación y herramientas",
+      "portfolio": "Portfolio",
+      "research": "Research",
+      "planning": "Planning",
       "settings": "Configuración",
       "supportTools": "Herramientas de soporte",
       "other": "Otros"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menu",
     "menuCategories": {
       "overview": "Vue d'ensemble",
-      "portfolio": "Gestion de portefeuille",
-      "research": "Recherche et analyse",
-      "reporting": "Rapports et conformité",
-      "planning": "Planification et outils",
+      "portfolio": "Portfolio",
+      "research": "Research",
+      "planning": "Planning",
       "settings": "Paramètres",
       "supportTools": "Outils d'assistance",
       "other": "Autres"

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menu",
     "menuCategories": {
       "overview": "Panoramica",
-      "portfolio": "Gestione portafoglio",
-      "research": "Ricerca e analisi",
-      "reporting": "Reportistica e conformità",
-      "planning": "Pianificazione e strumenti",
+      "portfolio": "Portfolio",
+      "research": "Research",
+      "planning": "Planning",
       "settings": "Impostazioni",
       "supportTools": "Strumenti di supporto",
       "other": "Altro"

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menu",
     "menuCategories": {
       "overview": "Visão geral",
-      "portfolio": "Gestão de portfólio",
-      "research": "Pesquisa e análise",
-      "reporting": "Relatórios e conformidade",
-      "planning": "Planejamento e ferramentas",
+      "portfolio": "Portfolio",
+      "research": "Research",
+      "planning": "Planning",
       "settings": "Configurações",
       "supportTools": "Ferramentas de suporte",
       "other": "Outros"


### PR DESCRIPTION
## Summary
- align the user navigation categories to the five supported buckets and assign all user tabs explicitly
- refresh each locale's menu category labels to the new "Portfolio", "Research", and "Planning" strings

## Testing
- npm run build *(fails: existing TypeScript errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fd17e188832798d9edf8c0cd5049