### PR TITLE
Adjust pension smoke test death age parameter

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -305,7 +305,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "path": "/pension/forecast",
     "query": {
       "owner": "demo",
-      "death_age": "0"
+      "death_age": "90"
     }
   },
   {


### PR DESCRIPTION
## Summary
- update the pension forecast smoke test request to use a realistic death_age value so it no longer triggers validation errors

## Testing
- npm run smoke:test:all *(fails: DELETE /instrument/admin/NASDAQ/PFE -> 404 and Playwright dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fd20fd2c83278dcf866408f13baf