### PR TITLE
Remove duplicate group total rows from instrument table

### DIFF
--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -848,65 +848,6 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
                     </tr>
                   );
                 })}
-              {showGroupTotals && showGroupHeaders && (
-                <tr>
-                  <td
-                    className={`${tableStyles.cell} font-semibold`}
-                    colSpan={4}
-                  >
-                    {totalLabel}
-                    {group.label ? ` — ${group.label}` : ''}
-                  </td>
-                  {!relativeViewEnabled && visibleColumns.units && (
-                    <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                      {Number.isFinite(group.totals.units)
-                        ? new Intl.NumberFormat(i18n.language).format(group.totals.units)
-                        : '—'}
-                    </td>
-                  )}
-                  {!relativeViewEnabled && visibleColumns.cost && (
-                    <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                      {Number.isFinite(group.totals.cost)
-                        ? money(group.totals.cost, baseCurrency)
-                        : '—'}
-                    </td>
-                  )}
-                  {!relativeViewEnabled && visibleColumns.market && (
-                    <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                      {Number.isFinite(group.totals.marketValue)
-                        ? money(group.totals.marketValue, baseCurrency)
-                        : '—'}
-                    </td>
-                  )}
-                  {!relativeViewEnabled && visibleColumns.gain && (
-                    <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                      {Number.isFinite(group.totals.gain)
-                        ? formatSignedMoney(group.totals.gain, baseCurrency)
-                        : '—'}
-                    </td>
-                  )}
-                  {visibleColumns.gain_pct && (
-                    <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                      {formatSignedPercent(group.totals.gainPct)}
-                    </td>
-                  )}
-                  {!relativeViewEnabled && (
-                    <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                      —
-                    </td>
-                  )}
-                  <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                    —
-                  </td>
-                  <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                    {formatSignedPercent(group.totals.change7dPct)}
-                  </td>
-                  <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                    {formatSignedPercent(group.totals.change30dPct)}
-                  </td>
-                  <td className={`${tableStyles.cell} font-semibold`}>—</td>
-                </tr>
-              )}
             </tbody>
           );
         })}

--- a/frontend/tests/unit/components/InstrumentTable.test.tsx
+++ b/frontend/tests/unit/components/InstrumentTable.test.tsx
@@ -242,6 +242,8 @@ describe("InstrumentTable", () => {
         expect(within(groupASummary).getByText("▲0.3%")).toBeInTheDocument();
         expect(within(groupASummary).getByText("▲0.7%")).toBeInTheDocument();
 
+        expect(screen.queryByText(/Total — Group A/i)).toBeNull();
+
         expect(screen.queryByText("ABC")).toBeNull();
 
         openGroup("Group A");


### PR DESCRIPTION
## Summary
- remove the extra per-group total row from the instrument table output
- ensure UI tests expect only the header summary row for each group

## Testing
- `cd frontend && npx vitest run tests/unit/components/InstrumentTable.test.tsx --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68d6fdd3f620832785e875171ac1c6e2