### PR TITLE
Adjust pension forecast smoke test death age

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -298,7 +298,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "path": "/pension/forecast",
     "query": {
       "owner": "demo",
-      "death_age": "0"
+      "death_age": "90"
     }
   },
   {


### PR DESCRIPTION
## Summary
- update the pension forecast smoke test to use a death_age that exceeds the retirement age so the backend request succeeds

## Testing
- `npm run smoke:test:all` *(fails: backend not running in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d70237f2c083278cc9bd47a793b04a