### PR TITLE
Adjust portfolio owner lookup handling

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -148,9 +148,8 @@ async def portfolio(owner: str, request: Request):
 
     accounts_root = resolve_accounts_root(request)
     owner_dir = resolve_owner_directory(accounts_root, owner)
-    if not owner_dir:
-        raise HTTPException(status_code=404, detail="Owner not found")
-    owner = owner_dir.name
+    if owner_dir:
+        owner = owner_dir.name
     try:
         return portfolio_mod.build_owner_portfolio(owner, accounts_root)
     except FileNotFoundError:


### PR DESCRIPTION
## Summary
- normalise portfolio owner names from existing directories while allowing missing owners to reach the builder
- rely on the portfolio builder to signal missing owners and convert FileNotFoundError into a 404 response

## Testing
- pytest --no-cov tests/test_main.py::test_portfolio

------
https://chatgpt.com/codex/tasks/task_e_68d70375410c83278f401740f9b2d0a6