### PR TITLE
Allow compliance routes to respect cached accounts root

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -14,17 +14,20 @@ from backend.config import config
 def resolve_accounts_root(request: Request) -> Path:
     """Determine the accounts root directory for the current request.
 
-    Preference is given to ``request.app.state.accounts_root`` when it points to
-    an existing directory. When missing or invalid the function falls back to
-    the configured repository paths, ultimately defaulting to the standard data
+    Preference is given to ``request.app.state.accounts_root`` when available,
+    even if the directory has not been created yet. When the state is missing
+    or cannot be resolved to a valid path the function falls back to the
+    configured repository paths, ultimately defaulting to the standard data
     directory discovered via :func:`data_loader.resolve_paths`.
     """
 
     accounts_root_value = getattr(request.app.state, "accounts_root", None)
-    if accounts_root_value:
-        candidate = Path(accounts_root_value).expanduser()
-        resolved_candidate = candidate.resolve(strict=False)
-        if resolved_candidate.exists():
+    if accounts_root_value is not None:
+        try:
+            resolved_candidate = Path(accounts_root_value).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError, ValueError, TypeError):
+            resolved_candidate = None
+        if resolved_candidate is not None:
             request.app.state.accounts_root = resolved_candidate
             return resolved_candidate
 
@@ -34,7 +37,7 @@ def resolve_accounts_root(request: Request) -> Path:
         fallback_paths = data_loader.resolve_paths(None, None)
         root = fallback_paths.accounts_root
 
-    resolved_root = Path(root).expanduser().resolve()
+    resolved_root = Path(root).expanduser().resolve(strict=False)
     request.app.state.accounts_root = resolved_root
     return resolved_root
 


### PR DESCRIPTION
## Summary
- allow `resolve_accounts_root` to reuse `app.state.accounts_root` even when the directory is not created yet
- keep canonicalising the resolved path before caching it back on the app state

## Testing
- pytest -o addopts='' tests/test_compliance_route.py::test_validate_trade_when_owner_discovery_fails


------
https://chatgpt.com/codex/tasks/task_e_68d7037132348327a60b168ee9481a5f