### PR TITLE
Align instrument group selector inline

### DIFF
--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -634,9 +634,10 @@ export function InstrumentTable({ rows }: Props) {
                           : percent(r.change_30d_pct, 1)}
                       </td>
                       <td className={tableStyles.cell}>
-                        <div className="flex flex-col gap-1">
-                          <span>{currentGrouping ?? '—'}</span>
+                        <div className="flex items-center gap-2">
+                          <span className="shrink-0">{currentGrouping ?? '—'}</span>
                           <select
+                            className="flex-1 min-w-[10rem] max-w-full"
                             aria-label={t('instrumentTable.groupActions.ariaLabel', {
                               ticker: r.ticker,
                               defaultValue: `Change group for ${r.ticker}`,


### PR DESCRIPTION
## Summary
- display the instrument group label and change dropdown on a single row
- allow the selector to grow within the cell while keeping the label visible

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d703d3e32483279c40bf1a13040cb8