### PR TITLE
Configure Playwright smoke tests to start Vite preview server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "test:jsdom": "vitest --environment=jsdom",
-    "smoke:frontend": "playwright install chromium && playwright test tests/smoke.spec.ts",
+    "smoke:frontend": "playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",
     "deploy:aws:linux": "bash scripts/deploy-to-aws.sh -b $S3_BUCKET ${CLOUDFRONT_DISTRIBUTION_ID:+-d $CLOUDFRONT_DISTRIBUTION_ID}"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run preview -- --host 0.0.0.0 --port 5173',
+    url: 'http://localhost:5173',
+    timeout: 2 * 60 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- add a Playwright configuration that launches `npm run preview -- --host 0.0.0.0 --port 5173` before running tests
- update the `smoke:frontend` script to invoke Playwright with the new shared configuration

## Testing
- npm run smoke:frontend *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68d701406dbc8327aab538630aacb51b