### PR TITLE
Prevent menu tabs from wrapping on medium screens

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -179,7 +179,7 @@ export default function Menu({
         <div
           hidden={!open}
           aria-hidden={!open}
-          className={`${open ? 'flex md:flex' : 'hidden'} flex-col gap-2 md:flex-row md:flex-wrap`}
+          className={`${open ? 'flex md:flex' : 'hidden'} flex-col gap-2 md:flex-row md:flex-nowrap overflow-x-auto`}
           style={style}
         >
           {orderedTabPlugins


### PR DESCRIPTION
## Summary
- prevent the navigation menu from wrapping at medium breakpoints by using a non-wrapping flex layout
- enable horizontal scrolling when needed so desktop tabs remain on a single row

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7057fee6483279097874d8e22ad34