### PR TITLE
Filter placeholder owners from owner selectors

### DIFF
--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -93,7 +93,7 @@ export default function PensionForecast() {
       return;
     }
 
-    const fallbackOwner = owners.find((o) => o.owner !== "demo") ?? owners[0];
+    const fallbackOwner = owners[0];
     if (!fallbackOwner) return;
 
     setOwner(fallbackOwner.owner);

--- a/frontend/src/utils/owners.ts
+++ b/frontend/src/utils/owners.ts
@@ -1,10 +1,7 @@
 import type { OwnerSummary } from "../types";
 
-/**
- * Filter out demo owners when real owners exist, but preserve the demo owner when
- * it is the only option (e.g. demo mode environments).
- */
+/** Remove any placeholder/system owners that should never appear in the UI. */
 export function sanitizeOwners(owners: OwnerSummary[]): OwnerSummary[] {
-  const nonDemoOwners = owners.filter((owner) => owner.owner !== "demo");
-  return nonDemoOwners.length > 0 ? nonDemoOwners : owners;
+  const blockedOwners = new Set(["demo", ".idea"]);
+  return owners.filter((owner) => !blockedOwners.has(owner.owner));
 }

--- a/frontend/tests/unit/pages/PensionForecast.test.tsx
+++ b/frontend/tests/unit/pages/PensionForecast.test.tsx
@@ -236,7 +236,7 @@ describe("PensionForecast page", () => {
     expect(routeState.setSelectedOwner).not.toHaveBeenCalled();
   });
 
-  it("defaults to first non-demo owner when no active selection", async () => {
+  it("defaults to first available owner when no active selection", async () => {
     routeState.selectedOwner = "";
     mockGetOwners.mockResolvedValue([
       { owner: "demo", accounts: [] },

--- a/frontend/tests/unit/utils/owners.test.ts
+++ b/frontend/tests/unit/utils/owners.test.ts
@@ -4,14 +4,19 @@ import { sanitizeOwners } from '@/utils/owners';
 const makeOwner = (owner: string) => ({ owner, accounts: [] as string[] });
 
 describe('sanitizeOwners', () => {
-  it('filters demo owner when real owners exist', () => {
-    const owners = [makeOwner('demo'), makeOwner('alice'), makeOwner('bob')];
+  it('filters placeholder owners', () => {
+    const owners = [
+      makeOwner('demo'),
+      makeOwner('.idea'),
+      makeOwner('alice'),
+      makeOwner('bob'),
+    ];
     expect(sanitizeOwners(owners)).toEqual([makeOwner('alice'), makeOwner('bob')]);
   });
 
-  it('keeps demo owner when it is the only option', () => {
-    const owners = [makeOwner('demo')];
-    expect(sanitizeOwners(owners)).toEqual([makeOwner('demo')]);
+  it('returns empty list when only placeholder owners provided', () => {
+    const owners = [makeOwner('demo'), makeOwner('.idea')];
+    expect(sanitizeOwners(owners)).toEqual([]);
   });
 
   it('returns empty list when no owners provided', () => {


### PR DESCRIPTION
## Summary
- update owner sanitization to always drop demo and .idea placeholder entries
- adjust PensionForecast fallback logic to work with the sanitized list
- refresh related unit tests for the new filtering rules

## Testing
- npm run test -- tests/unit/utils/owners.test.ts tests/unit/pages/PensionForecast.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d707b232188327b24ccc22705e87be