### PR TITLE
Filter demo and .idea owners from plot listings

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -65,6 +65,7 @@ PLOTS_PREFIX = "accounts/"
 # Local discovery
 # ------------------------------------------------------------------
 _METADATA_STEMS = {"person", "config", "notes"}  # ignore these as accounts
+_SKIP_OWNERS = {".idea", "demo"}
 
 
 def _list_local_plots(
@@ -96,21 +97,21 @@ def _list_local_plots(
     for owner_dir in sorted(root.iterdir()):
         if not owner_dir.is_dir():
             continue
+        if owner_dir.name in _SKIP_OWNERS:
+            continue
         # When authentication is enabled (``disable_auth`` is explicitly
-        # ``False``) and no user is authenticated, expose only the "demo"
-        # account.  ``config.disable_auth`` defaults to ``None`` when the
-        # configuration file cannot be loaded, which previously triggered this
-        # condition unintentionally.  Be explicit about the check so that a
-        # missing config behaves the same as auth being disabled.
-        if config.disable_auth is False and user is None and owner_dir.name != "demo":
+        # ``False``) and no user is authenticated, do not expose any accounts.
+        # ``config.disable_auth`` defaults to ``None`` when the configuration
+        # file cannot be loaded, which previously triggered this condition
+        # unintentionally.  Be explicit about the check so that a missing config
+        # behaves the same as auth being disabled.
+        if config.disable_auth is False and user is None:
             continue
 
         owner = owner_dir.name
         meta = load_person_meta(owner, root)
         viewers = meta.get("viewers", [])
-        # Always expose the "demo" owner, even if ``current_user`` is not a
-        # listed viewer. For all other owners, enforce viewer permissions.
-        if owner != "demo" and user and user != owner and user not in viewers:
+        if user and user != owner and user not in viewers:
             continue
 
         acct_names: List[str] = []
@@ -154,8 +155,8 @@ def _list_aws_plots(current_user: Optional[str] = None) -> List[Dict[str, Any]]:
     objects are expected under ``accounts/<owner>/<account>.json``. Metadata
     files like ``person.json`` are ignored and account names are de-duplicated
     case-insensitively. When authentication is enabled and no user is
-    authenticated only the ``demo`` owner is returned, mirroring the behaviour
-    of the local loader.
+    authenticated, no owners are exposed, mirroring the behaviour of the local
+    loader.
     """
 
     bucket = os.getenv(DATA_BUCKET_ENV)
@@ -198,17 +199,19 @@ def _list_aws_plots(current_user: Optional[str] = None) -> List[Dict[str, Any]]:
         else:
             break
 
+    for skip_owner in _SKIP_OWNERS:
+        owners.pop(skip_owner, None)
+
     user = current_user.get(None) if hasattr(current_user, "get") else current_user
     results: List[Dict[str, Any]] = []
     for owner, accounts in sorted(owners.items()):
         # When authentication is enabled (``disable_auth`` explicitly ``False``)
-        # and no user is authenticated, expose only the "demo" account.  If the
+        # and no user is authenticated, do not expose any accounts.  If the
         # configuration failed to load ``disable_auth`` will be ``None``;
         # treating that as "auth disabled" avoids filtering everything.
         if (
             config.disable_auth is False
             and current_user is None
-            and owner != "demo"
         ):
             continue
         if current_user and current_user != owner:

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -146,7 +146,7 @@ class TestListLocalPlots:
         monkeypatch.setattr("backend.common.data_loader.config", cfg)
         monkeypatch.delenv(DATA_BUCKET_ENV, raising=False)
 
-    def test_authentication_required_exposes_only_demo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_authentication_required_skips_special_accounts(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_root = tmp_path / "accounts"
         self._configure(monkeypatch, tmp_path, data_root, disable_auth=False)
 
@@ -155,7 +155,7 @@ class TestListLocalPlots:
 
         result = _list_local_plots(data_root=data_root, current_user=None)
 
-        assert result == [{"owner": "demo", "accounts": ["demo1"]}]
+        assert result == []
 
     def test_enforces_viewer_permissions(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_root = tmp_path / "accounts"
@@ -169,7 +169,6 @@ class TestListLocalPlots:
 
         assert result == [
             {"owner": "alice", "accounts": ["alpha"]},
-            {"owner": "demo", "accounts": ["demo1"]},
         ]
 
     def test_accepts_contextvar_current_user(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -188,7 +187,6 @@ class TestListLocalPlots:
 
         assert result == [
             {"owner": "alice", "accounts": ["alpha"]},
-            {"owner": "demo", "accounts": ["demo1"]},
         ]
 
     def test_authentication_disabled_allows_anonymous_access(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -202,5 +200,4 @@ class TestListLocalPlots:
 
         assert result == [
             {"owner": "carol", "accounts": ["gamma"]},
-            {"owner": "demo", "accounts": ["demo1"]},
         ]

--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -102,9 +102,9 @@ def test_list_aws_plots_filters_without_auth(monkeypatch):
     assert dl._list_aws_plots(current_user="Bob") == expected
 
 
-def test_list_aws_plots_demo_only_when_unauthenticated(monkeypatch):
+def test_list_aws_plots_filters_special_directories(monkeypatch):
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
-    monkeypatch.setattr(dl.config, "disable_auth", False, raising=False)
+    monkeypatch.setattr(dl.config, "disable_auth", True, raising=False)
 
     def fake_client(name):
         assert name == "s3"
@@ -115,6 +115,7 @@ def test_list_aws_plots_demo_only_when_unauthenticated(monkeypatch):
             return {
                 "Contents": [
                     {"Key": "accounts/demo/ISA.json"},
+                    {"Key": "accounts/.idea/ignored.json"},
                     {"Key": "accounts/Real/GIA.json"},
                 ]
             }
@@ -123,7 +124,7 @@ def test_list_aws_plots_demo_only_when_unauthenticated(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
-    expected = [{"owner": "demo", "accounts": ["ISA"]}]
+    expected = [{"owner": "Real", "accounts": ["GIA"]}]
     assert dl._list_aws_plots() == expected
 
 

--- a/tests/test_data_loader_local.py
+++ b/tests/test_data_loader_local.py
@@ -9,19 +9,23 @@ def test_load_account_local(tmp_path):
     assert data == {"balance": 5}
 
 
-def test_list_local_plots_unauthenticated(tmp_path, monkeypatch):
+def test_list_local_plots_filters_special_directories(tmp_path, monkeypatch):
     demo = tmp_path / "demo"
     demo.mkdir()
     (demo / "demo.json").write_text("{}")
+
+    idea = tmp_path / ".idea"
+    idea.mkdir()
+    (idea / "junk.json").write_text("{}")
 
     alice = tmp_path / "alice"
     alice.mkdir()
     (alice / "isa.json").write_text("{}")
 
-    monkeypatch.setattr(dl.config, "disable_auth", False, raising=False)
+    monkeypatch.setattr(dl.config, "disable_auth", True, raising=False)
 
     owners = dl._list_local_plots(data_root=tmp_path, current_user=None)
-    assert owners == [{"owner": "demo", "accounts": ["demo"]}]
+    assert owners == [{"owner": "alice", "accounts": ["isa"]}]
 
 
 def test_list_local_plots_authenticated(tmp_path, monkeypatch):
@@ -52,5 +56,4 @@ def test_list_local_plots_authenticated(tmp_path, monkeypatch):
     assert owners == [
         {"owner": "alice", "accounts": ["isa"]},
         {"owner": "bob", "accounts": ["gia"]},
-        {"owner": "demo", "accounts": ["demo"]},
     ]


### PR DESCRIPTION
## Summary
- skip `.idea` and `demo` owners during local plot discovery and adjust auth handling
- filter the same owners when listing plots from S3 to match the local behaviour
- update data loader unit tests to exercise the new filtering rules

## Testing
- pytest -o addopts='' tests/test_data_loader_local.py tests/test_data_loader_aws.py tests/backend/common/test_data_loader.py


------
https://chatgpt.com/codex/tasks/task_e_68d707b124288327b9646fc5e7a88549