### PR TITLE
Maintain group action layout in instrument table

### DIFF
--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -634,10 +634,10 @@ export function InstrumentTable({ rows }: Props) {
                           : percent(r.change_30d_pct, 1)}
                       </td>
                       <td className={tableStyles.cell}>
-                        <div className="flex items-center gap-2">
+                        <div className={tableStyles.groupAction}>
                           <span className="shrink-0">{currentGrouping ?? '—'}</span>
                           <select
-                            className="flex-1 min-w-[10rem] max-w-full"
+                            className={tableStyles.groupActionSelect}
                             aria-label={t('instrumentTable.groupActions.ariaLabel', {
                               ticker: r.ticker,
                               defaultValue: `Change group for ${r.ticker}`,

--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -82,6 +82,20 @@
   color: rgba(0, 0, 0, 0.6);
 }
 
+.groupAction {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.groupActionSelect {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+
 @media (max-width: 768px) {
   .cell {
     padding: 2px 4px;


### PR DESCRIPTION
## Summary
- add a CSS module helper that keeps the group label and dropdown aligned without wrapping
- apply the new styles to the instrument table group assignment controls so the select can shrink as needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d708f0af6483278a4d75e7f3dbf70e