### PR TITLE
Ensure metadata exchange is used when warming tickers

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -289,8 +289,7 @@ def run_all_tickers(
             time.sleep(delay)
         sym, ex = _resolve_ticker_exchange(t, exchange)
         logger.debug("run_all_tickers resolved %s -> %s.%s", t, sym, ex)
-        explicit_exchange = bool(exchange) or bool(re.search(r"[._]", t))
-        loader_exchange = ex if explicit_exchange else ""
+        loader_exchange = ex or ""
         try:
             if not load_meta_timeseries(sym, loader_exchange, days).empty:
                 ok.append(t)

--- a/tests/test_run_all_tickers.py
+++ b/tests/test_run_all_tickers.py
@@ -40,9 +40,11 @@ def test_run_all_tickers_resolves_exchange_from_metadata():
         calls.append((sym, ex, days))
         return pd.DataFrame({"Date": [1], "Close": [2]})
 
-    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
+    with patch("backend.timeseries.fetch_meta_timeseries._resolve_exchange_from_metadata", return_value="L") as meta, \
+         patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load):
         out = run_all_tickers(["GSK"], days=3)
 
     assert out == ["GSK"]
     assert calls == [("GSK", "L", 3)]
+    meta.assert_called_once_with("GSK")
 


### PR DESCRIPTION
## Summary
- ensure `run_all_tickers` always forwards the resolved exchange to the cache loader
- extend the metadata resolution test to assert the metadata resolver is invoked

## Testing
- `pytest tests/test_run_all_tickers.py` *(fails: Coverage failure: total of 24 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68d708e593fc8327b44521ebdd690aa8