### PR TITLE
Handle stale accounts root cache

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -22,10 +22,14 @@ def resolve_accounts_root(request: Request) -> Path:
     accounts_root_value = getattr(request.app.state, "accounts_root", None)
     if accounts_root_value:
         candidate = Path(accounts_root_value).expanduser()
-        resolved_candidate = candidate.resolve()
-        if resolved_candidate.exists():
+        if candidate.exists() and candidate.is_dir():
+            resolved_candidate = candidate.resolve()
             request.app.state.accounts_root = resolved_candidate
             return resolved_candidate
+
+        # The cached path is no longer valid; clear it so the fallback logic
+        # can determine a new directory.
+        request.app.state.accounts_root = None
 
     paths = data_loader.resolve_paths(config.repo_root, config.accounts_root)
     root = paths.accounts_root

--- a/tests/routes/test_accounts_root.py
+++ b/tests/routes/test_accounts_root.py
@@ -75,3 +75,54 @@ def test_resolve_accounts_root_falls_back_to_global_directory(
         (config.repo_root, config.accounts_root),
         (None, None),
     ]
+
+
+def test_resolve_accounts_root_handles_deleted_cached_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If a previously cached directory is removed the fallback should run."""
+
+    from backend.common import data_loader
+    from backend.config import config
+
+    cached_root = tmp_path / "cached"
+    cached_root.mkdir()
+    fallback_root = tmp_path / "fallback"
+    fallback_root.mkdir()
+
+    state = SimpleNamespace(accounts_root=cached_root)
+    request = _make_request(state)
+
+    # The first call should resolve and cache the existing directory.
+    initial_resolved = resolve_accounts_root(request)
+    assert initial_resolved == cached_root.resolve()
+    assert request.app.state.accounts_root == cached_root.resolve()
+
+    # Remove the cached directory to force the resolver down the fallback path.
+    cached_root.rmdir()
+
+    monkeypatch.setattr(config, "repo_root", Path("/configured/root"))
+    monkeypatch.setattr(config, "accounts_root", Path("configured-accounts"))
+
+    calls: list[tuple[object, object]] = []
+
+    def fake_resolve_paths(repo_root: object, accounts_root: object):
+        calls.append((repo_root, accounts_root))
+        if repo_root == config.repo_root and accounts_root == config.accounts_root:
+            return SimpleNamespace(accounts_root=tmp_path / "missing-from-config")
+        if repo_root is None and accounts_root is None:
+            return SimpleNamespace(accounts_root=fallback_root)
+        raise AssertionError(
+            f"Unexpected resolve_paths call: {repo_root!r}, {accounts_root!r}"
+        )
+
+    monkeypatch.setattr(data_loader, "resolve_paths", fake_resolve_paths)
+
+    resolved = resolve_accounts_root(request)
+
+    assert resolved == fallback_root.resolve()
+    assert request.app.state.accounts_root == fallback_root.resolve()
+    assert calls == [
+        (config.repo_root, config.accounts_root),
+        (None, None),
+    ]


### PR DESCRIPTION
## Summary
- validate cached accounts_root directories before reusing them and clear stale entries
- ensure fallback resolution uses data_loader and is cached, including when cached directories disappear
- add regression coverage for deleted cached directories when resolving the accounts root

## Testing
- pytest tests/routes/test_accounts_root.py --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d708e08c9c8327a7f50166ce400445