### PR TITLE
Require explicit scaffolding when loading compliance data

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -76,17 +76,24 @@ def _parse_date(val: str | None) -> date | None:
         return None
 
 
-def load_transactions(owner: str, accounts_root: Optional[Path] = None) -> List[Dict[str, Any]]:
+def load_transactions(
+    owner: str,
+    accounts_root: Optional[Path] = None,
+    *,
+    scaffold_missing: bool = False,
+) -> List[Dict[str, Any]]:
     """Load all transactions for ``owner`` sorted by date.
 
-    Missing owners are initialised with an empty compliance scaffold, ensuring
-    downstream callers always receive a list (possibly empty) without needing to
-    catch :class:`FileNotFoundError`.
+    By default the function now raises :class:`FileNotFoundError` when the owner
+    directory is absent.  Administrative callers that want to bootstrap a new
+    owner can opt-in to scaffolding by passing ``scaffold_missing=True``.
     """
     paths = resolve_paths(config.repo_root, config.accounts_root)
     root = Path(accounts_root) if accounts_root else paths.accounts_root
     owner_dir = root / owner
     if not owner_dir.exists():
+        if not scaffold_missing:
+            raise FileNotFoundError(f"owner data for '{owner}' not found at {owner_dir}")
         _ensure_owner_scaffold(owner, owner_dir)
 
     results: List[Dict[str, Any]] = []
@@ -224,13 +231,25 @@ def _check_transactions(owner: str, txs: List[Dict[str, Any]], accounts_root: Op
     }
 
 
-def check_owner(owner: str, accounts_root: Optional[Path] = None) -> Dict[str, Any]:
+def check_owner(
+    owner: str,
+    accounts_root: Optional[Path] = None,
+    *,
+    scaffold_missing: bool = False,
+) -> Dict[str, Any]:
     """Return compliance warnings for an owner."""
-    txs = load_transactions(owner, accounts_root)
+    txs = load_transactions(
+        owner, accounts_root, scaffold_missing=scaffold_missing
+    )
     return _check_transactions(owner, txs, accounts_root)
 
 
-def check_trade(trade: Dict[str, Any], accounts_root: Optional[Path] = None) -> Dict[str, Any]:
+def check_trade(
+    trade: Dict[str, Any],
+    accounts_root: Optional[Path] = None,
+    *,
+    scaffold_missing: bool = False,
+) -> Dict[str, Any]:
     """Validate a proposed trade for compliance issues.
 
     The trade is evaluated in the context of the owner's existing transactions.
@@ -239,7 +258,9 @@ def check_trade(trade: Dict[str, Any], accounts_root: Optional[Path] = None) -> 
     owner = trade.get("owner")
     if not owner:
         raise ValueError("owner is required")
-    txs = load_transactions(owner, accounts_root)
+    txs = load_transactions(
+        owner, accounts_root, scaffold_missing=scaffold_missing
+    )
     txs.append(trade)
     return _check_transactions(owner, txs, accounts_root)
 

--- a/tests/backend/common/test_compliance.py
+++ b/tests/backend/common/test_compliance.py
@@ -33,7 +33,9 @@ def stubbed_env(monkeypatch):
     )
 
     monkeypatch.setattr(
-        compliance, "load_transactions", lambda owner, accounts_root=None: []
+        compliance,
+        "load_transactions",
+        lambda owner, accounts_root=None, scaffold_missing=False: [],
     )
     monkeypatch.setattr(compliance, "load_approvals", lambda owner, accounts_root=None: {})
     monkeypatch.setattr(
@@ -59,7 +61,12 @@ def test_load_transactions_bootstraps_missing_owner(tmp_path):
     accounts_root = tmp_path / "accounts"
     owner = "alex"
 
-    records = compliance.load_transactions(owner, accounts_root=accounts_root)
+    with pytest.raises(FileNotFoundError):
+        compliance.load_transactions(owner, accounts_root=accounts_root)
+
+    records = compliance.load_transactions(
+        owner, accounts_root=accounts_root, scaffold_missing=True
+    )
 
     assert records == []
 
@@ -88,7 +95,7 @@ def test_load_transactions_bootstraps_missing_owner(tmp_path):
 def test_check_trade_requires_owner(monkeypatch):
     called = False
 
-    def fake_load_transactions(owner, accounts_root=None):
+    def fake_load_transactions(owner, accounts_root=None, scaffold_missing=False):
         nonlocal called
         called = True
         return []

--- a/tests/test_portfolio_utils_returns.py
+++ b/tests/test_portfolio_utils_returns.py
@@ -24,7 +24,11 @@ def sample_transactions():
 
 def test_compute_time_weighted_return_with_cashflows(monkeypatch, portfolio_series, sample_transactions):
     monkeypatch.setattr(pu, "_portfolio_value_series", lambda owner, days=365: portfolio_series)
-    monkeypatch.setattr(pu, "load_transactions", lambda owner: sample_transactions)
+    monkeypatch.setattr(
+        pu,
+        "load_transactions",
+        lambda owner, *, scaffold_missing=False: sample_transactions,
+    )
 
     result = pu.compute_time_weighted_return("owner")
 
@@ -35,7 +39,9 @@ def test_compute_time_weighted_return_requires_two_points(monkeypatch):
     idx = pd.Index([date(2024, 1, 1)])
     series = pd.Series([1000.0], index=idx)
     monkeypatch.setattr(pu, "_portfolio_value_series", lambda owner, days=365: series)
-    monkeypatch.setattr(pu, "load_transactions", lambda owner: [])
+    monkeypatch.setattr(
+        pu, "load_transactions", lambda owner, *, scaffold_missing=False: []
+    )
 
     assert pu.compute_time_weighted_return("owner") is None
 
@@ -55,7 +61,9 @@ def test_compute_xirr_simple_contribution(monkeypatch, one_year_series):
         {"date": "2023-12-01", "type": "deposit", "amount_minor": 1000},
         {"date": "2025-02-01", "kind": "WITHDRAWAL", "amount_minor": 1000},
     ]
-    monkeypatch.setattr(pu, "load_transactions", lambda owner: transactions)
+    monkeypatch.setattr(
+        pu, "load_transactions", lambda owner, *, scaffold_missing=False: transactions
+    )
 
     result = pu.compute_xirr("owner")
 
@@ -64,7 +72,9 @@ def test_compute_xirr_simple_contribution(monkeypatch, one_year_series):
 
 def test_compute_xirr_requires_cashflows(monkeypatch, one_year_series):
     monkeypatch.setattr(pu, "_portfolio_value_series", lambda owner, days=365: one_year_series)
-    monkeypatch.setattr(pu, "load_transactions", lambda owner: [])
+    monkeypatch.setattr(
+        pu, "load_transactions", lambda owner, *, scaffold_missing=False: []
+    )
 
     assert pu.compute_xirr("owner") is None
 


### PR DESCRIPTION
## Summary
- raise FileNotFoundError from load_transactions unless callers explicitly request scaffolding and propagate the opt-in flag through check_owner/check_trade
- update compliance API and portfolio tests to expect 404s when compliance data is missing and confirm scaffolding works via the new flag
- adjust compliance and portfolio utility tests to match the updated load_transactions signature

## Testing
- pytest -o addopts='' tests/test_backend_api.py::test_invalid_portfolio tests/test_backend_api.py::test_compliance_invalid_owner tests/backend/common/test_compliance.py

------
https://chatgpt.com/codex/tasks/task_e_68d708e266a88327b6371d503a40722a