### PR TITLE
Adjust instrument admin smoke ordering

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -254,14 +254,20 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "DELETE",
     "path": "/instrument/admin/{exchange}/{ticker}"
   },
-  {
-    "method": "GET",
-    "path": "/instrument/admin/{exchange}/{ticker}"
-  },
+  // Call the POST before any GET that could trigger `_auto_create_instrument_meta`
+  // via the admin endpoint; otherwise the POST would fail with a conflict. Seed
+  // minimal metadata so the subsequent GET reads a non-empty payload.
   {
     "method": "POST",
     "path": "/instrument/admin/{exchange}/{ticker}",
-    "body": {}
+    "body": {
+      "ticker": "PFE.NASDAQ",
+      "exchange": "NASDAQ"
+    }
+  },
+  {
+    "method": "GET",
+    "path": "/instrument/admin/{exchange}/{ticker}"
   },
   {
     "method": "PUT",


### PR DESCRIPTION
## Summary
- run the instrument admin creation POST before any GET to avoid auto-creation conflicts
- seed minimal metadata and document the ordering in the smoke test flow

## Testing
- npm run smoke:test *(fails later at GET /instrument/intraday -> 404 because vendor price data is unavailable in this environment, but the admin POST now returns 200)*

------
https://chatgpt.com/codex/tasks/task_e_68d70d1c50e083279ea1d0fb3050c3b2