### PR TITLE
Allow unauthenticated demo access to alert thresholds

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -52,7 +52,7 @@ if not SECRET_KEY:
         raise RuntimeError("JWT_SECRET environment variable is required")
 ALGORITHM = "HS256"
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token", auto_error=False)
 
 # Context variable storing the username of the authenticated user.
 # This allows downstream helpers to detect whether a request is
@@ -181,7 +181,12 @@ def decode_token(token: str) -> Optional[str]:
         return None
 
 
-async def get_current_user(token: str = Depends(oauth2_scheme)) -> str:
+def _user_from_token(token: str | None) -> str:
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+        )
     email = decode_token(token)
     if not email:
         raise HTTPException(
@@ -189,6 +194,29 @@ async def get_current_user(token: str = Depends(oauth2_scheme)) -> str:
             detail="Invalid authentication credentials",
         )
     return email
+
+
+async def get_current_user(token: str | None = Depends(oauth2_scheme)) -> str:
+    """Return the authenticated user extracted from the bearer token."""
+
+    return _user_from_token(token)
+
+
+async def get_active_user(token: str | None = Depends(oauth2_scheme)) -> str | None:
+    """Return the active user when authentication is enabled.
+
+    When ``config.disable_auth`` is truthy the API allows unauthenticated
+    access and this helper returns ``None`` so callers can fall back to a
+    shared demo identity.  If a token is supplied while auth is disabled it is
+    still validated to support mixed environments where some requests provide
+    credentials.
+    """
+
+    if config.disable_auth:
+        if token:
+            return _user_from_token(token)
+        return None
+    return _user_from_token(token)
 
 
 def verify_google_token(token: str) -> str:

--- a/backend/routes/alert_settings.py
+++ b/backend/routes/alert_settings.py
@@ -2,7 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
 from backend import alerts as alert_utils
-from backend.auth import get_current_user
+from backend.auth import get_active_user
+
+DEMO_IDENTITY = "demo"
 
 router = APIRouter(prefix="/alert-thresholds", tags=["alerts"])
 
@@ -20,20 +22,22 @@ def _validate_owner(user: str, current_user: str) -> None:
 
 
 @router.get("/{user}")
-async def get_threshold(user: str, current_user: str = Depends(get_current_user)):
+async def get_threshold(user: str, current_user: str | None = Depends(get_active_user)):
     """Return the alert threshold configured for ``user``."""
-    _validate_owner(user, current_user)
-    return {"threshold": alert_utils.get_user_threshold(user)}
+    identity = current_user or DEMO_IDENTITY
+    _validate_owner(user, identity)
+    return {"threshold": alert_utils.get_user_threshold(identity)}
 
 
 @router.post("/{user}")
 async def set_threshold(
     user: str,
     payload: ThresholdPayload,
-    current_user: str = Depends(get_current_user),
+    current_user: str | None = Depends(get_active_user),
 ):
     """Update the alert threshold for ``user``."""
-    _validate_owner(user, current_user)
-    alert_utils.set_user_threshold(user, payload.threshold)
+    identity = current_user or DEMO_IDENTITY
+    _validate_owner(user, identity)
+    alert_utils.set_user_threshold(identity, payload.threshold)
     return {"threshold": payload.threshold}
 

--- a/backend/tests/test_alert_settings.py
+++ b/backend/tests/test_alert_settings.py
@@ -1,14 +1,15 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from backend.auth import get_current_user
+from backend.auth import get_active_user
+from backend.config import load_config, config
 from backend.routes import alert_settings
 
 
 def _app_for(user: str) -> TestClient:
     app = FastAPI()
     app.include_router(alert_settings.router)
-    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_active_user] = lambda: user
     return TestClient(app)
 
 
@@ -48,3 +49,31 @@ def test_set_alert_threshold_invalid_payload(monkeypatch):
     client = _app_for("alice")
     resp = client.post("/alert-thresholds/alice", json={})
     assert resp.status_code == 422
+
+
+def test_alert_thresholds_auth_disabled(monkeypatch):
+    monkeypatch.setattr("backend.alerts.get_user_threshold", lambda user: 0.3)
+
+    recorded: dict[str, tuple[str, float]] = {}
+
+    def set_threshold(user, threshold):
+        recorded["args"] = (user, threshold)
+
+    monkeypatch.setattr("backend.alerts.set_user_threshold", set_threshold)
+
+    # Ensure configuration reflects auth being disabled.
+    load_config.cache_clear()
+    monkeypatch.setattr(config, "disable_auth", True, raising=False)
+
+    app = FastAPI()
+    app.include_router(alert_settings.router)
+    client = TestClient(app)
+
+    resp = client.get("/alert-thresholds/demo")
+    assert resp.status_code == 200
+    assert resp.json()["threshold"] == 0.3
+
+    resp = client.post("/alert-thresholds/demo", json={"threshold": 0.5})
+    assert resp.status_code == 200
+    assert resp.json()["threshold"] == 0.5
+    assert recorded["args"] == ("demo", 0.5)


### PR DESCRIPTION
## Summary
- add an auth helper that returns the demo identity when authentication is disabled
- update the alert settings routes to use the helper and fall back to the demo owner
- extend alert settings tests to cover disabled-auth flows

## Testing
- pytest -o addopts='' backend/tests/test_alert_settings.py
- npm run smoke:test

------
https://chatgpt.com/codex/tasks/task_e_68d70d199120832796cc4f8b57d34e34