### PR TITLE
Update navigation categories to new tab mapping

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -112,33 +112,35 @@ export default function Menu({
   };
 
   const USER_MENU_CATEGORIES: MenuCategory[] = [
-    { id: 'overview', titleKey: 'overview', tabIds: ['group', 'market', 'movers'] },
+    { id: 'dashboard', titleKey: 'dashboard', tabIds: ['group', 'market', 'movers'] },
     {
-      id: 'portfolio',
-      titleKey: 'portfolio',
+      id: 'holdings',
+      titleKey: 'holdings',
+      tabIds: ['owner', 'performance', 'allocation', 'transactions', 'reports'],
+    },
+    {
+      id: 'tradeTools',
+      titleKey: 'tradeTools',
       tabIds: [
-        'owner',
-        'performance',
-        'transactions',
+        'instrument',
+        'screener',
+        'watchlist',
+        'scenario',
         'trading',
-        'allocation',
         'rebalance',
-        'trail',
-        'reports',
         'tradecompliance',
       ],
     },
-    {
-      id: 'research',
-      titleKey: 'research',
-      tabIds: ['instrument', 'screener', 'timeseries', 'watchlist', 'scenario'],
-    },
-    { id: 'planning', titleKey: 'planning', tabIds: ['pension', 'taxtools'] },
-    { id: 'settings', titleKey: 'settings', tabIds: ['alertsettings', 'settings'] },
+    { id: 'goals', titleKey: 'goals', tabIds: ['pension', 'taxtools', 'trail'] },
+    { id: 'preferences', titleKey: 'preferences', tabIds: ['alertsettings', 'settings'] },
   ];
 
   const SUPPORT_MENU_CATEGORIES: MenuCategory[] = [
-    { id: 'supportTools', titleKey: 'supportTools', tabIds: ['instrumentadmin', 'dataadmin'] },
+    {
+      id: 'operations',
+      titleKey: 'operations',
+      tabIds: ['instrumentadmin', 'dataadmin', 'timeseries', 'support'],
+    },
   ];
 
   const availableTabs = useMemo(

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -11,12 +11,12 @@
     "logout": "Abmelden",
     "menu": "Menü",
     "menuCategories": {
-      "overview": "Überblick",
-      "portfolio": "Portfolio",
-      "research": "Research",
-      "planning": "Planning",
-      "settings": "Einstellungen",
-      "supportTools": "Support-Tools",
+      "dashboard": "Dashboard",
+      "holdings": "Bestände",
+      "tradeTools": "Handelstools",
+      "goals": "Ziele",
+      "preferences": "Präferenzen",
+      "operations": "Operationen",
       "other": "Weitere"
     },
     "modes": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -11,12 +11,12 @@
     "logout": "Logout",
     "menu": "Menu",
     "menuCategories": {
-      "overview": "Overview",
-      "portfolio": "Portfolio",
-      "research": "Research",
-      "planning": "Planning",
-      "settings": "Settings",
-      "supportTools": "Support Tools",
+      "dashboard": "Dashboard",
+      "holdings": "Holdings",
+      "tradeTools": "Trade Tools",
+      "goals": "Goals",
+      "preferences": "Preferences",
+      "operations": "Operations",
       "other": "Other"
     },
     "modes": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -11,12 +11,12 @@
     "logout": "Cerrar sesión",
     "menu": "Menú",
     "menuCategories": {
-      "overview": "Resumen",
-      "portfolio": "Portfolio",
-      "research": "Research",
-      "planning": "Planning",
-      "settings": "Configuración",
-      "supportTools": "Herramientas de soporte",
+      "dashboard": "Panel",
+      "holdings": "Posiciones",
+      "tradeTools": "Herramientas de trading",
+      "goals": "Objetivos",
+      "preferences": "Preferencias",
+      "operations": "Operaciones",
       "other": "Otros"
     },
     "modes": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -11,12 +11,12 @@
     "logout": "Déconnexion",
     "menu": "Menu",
     "menuCategories": {
-      "overview": "Vue d'ensemble",
-      "portfolio": "Portfolio",
-      "research": "Research",
-      "planning": "Planning",
-      "settings": "Paramètres",
-      "supportTools": "Outils d'assistance",
+      "dashboard": "Tableau de bord",
+      "holdings": "Positions",
+      "tradeTools": "Outils de trading",
+      "goals": "Objectifs",
+      "preferences": "Préférences",
+      "operations": "Opérations",
       "other": "Autres"
     },
     "modes": {

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -11,12 +11,12 @@
     "logout": "Logout",
     "menu": "Menu",
     "menuCategories": {
-      "overview": "Panoramica",
-      "portfolio": "Portfolio",
-      "research": "Research",
-      "planning": "Planning",
-      "settings": "Impostazioni",
-      "supportTools": "Strumenti di supporto",
+      "dashboard": "Dashboard",
+      "holdings": "Posizioni",
+      "tradeTools": "Strumenti di trading",
+      "goals": "Obiettivi",
+      "preferences": "Preferenze",
+      "operations": "Operazioni",
       "other": "Altro"
     },
     "modes": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -11,12 +11,12 @@
     "logout": "Sair",
     "menu": "Menu",
     "menuCategories": {
-      "overview": "Visão geral",
-      "portfolio": "Portfolio",
-      "research": "Research",
-      "planning": "Planning",
-      "settings": "Configurações",
-      "supportTools": "Ferramentas de suporte",
+      "dashboard": "Painel",
+      "holdings": "Participações",
+      "tradeTools": "Ferramentas de negociação",
+      "goals": "Objetivos",
+      "preferences": "Preferências",
+      "operations": "Operações",
       "other": "Outros"
     },
     "modes": {

--- a/frontend/src/tabPlugins.ts
+++ b/frontend/src/tabPlugins.ts
@@ -36,7 +36,7 @@ export const orderedTabPlugins = [
   { id: "transactions", priority: 50, section: "user" },
   { id: "trading", priority: 55, section: "user" },
   { id: "screener", priority: 60, section: "user" },
-  { id: "timeseries", priority: 70, section: "user" },
+  { id: "timeseries", priority: 70, section: "support" },
   { id: "watchlist", priority: 80, section: "user" },
   { id: "allocation", priority: 85, section: "user" },
   { id: "rebalance", priority: 86, section: "user" },


### PR DESCRIPTION
## Summary
- align the app menu with the new Dashboard, Holdings, Trade Tools, Goals, and Preferences categories
- move the operations section under support to include timeseries and support tabs
- update all locale files with the new menu category labels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d70d922fa08327b8f511a9636f6dc0