### PR TITLE
Validate cached accounts root paths before reuse

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -27,9 +27,10 @@ def resolve_accounts_root(request: Request) -> Path:
             resolved_candidate = Path(accounts_root_value).expanduser().resolve(strict=False)
         except (OSError, RuntimeError, ValueError, TypeError):
             resolved_candidate = None
-        if resolved_candidate is not None:
-            request.app.state.accounts_root = resolved_candidate
-            return resolved_candidate
+        else:
+            if resolved_candidate.exists():
+                request.app.state.accounts_root = resolved_candidate
+                return resolved_candidate
 
     paths = data_loader.resolve_paths(config.repo_root, config.accounts_root)
     root = paths.accounts_root

--- a/tests/routes/test_accounts_root.py
+++ b/tests/routes/test_accounts_root.py
@@ -50,7 +50,8 @@ def test_resolve_accounts_root_falls_back_to_global_directory(
     fallback_root = tmp_path / "fallback"
     fallback_root.mkdir()
 
-    state = SimpleNamespace(accounts_root=cached_path)
+    # Store the cached path as a string to mirror common serialization behaviour.
+    state = SimpleNamespace(accounts_root=str(cached_path))
     request = _make_request(state)
 
     monkeypatch.setattr(config, "repo_root", Path("/configured/root"))


### PR DESCRIPTION
## Summary
- ensure cached account root paths are only reused when they still exist
- fall back to resolving the accounts root when the cached location has been removed
- adjust the accounts root tests to cover the deleted-cache fallback scenario

## Testing
- pytest tests/routes/test_accounts_root.py --override-ini="addopts="

------
https://chatgpt.com/codex/tasks/task_e_68d70f9834b88327bb537231c28a1c63