### PR TITLE
Allow goals routes to use demo owner when auth disabled

### DIFF
--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import Request
+
+from backend.auth import get_current_user, oauth2_scheme
+from backend.config import config as app_config
+
+
+async def get_active_user(request: Request) -> Optional[str]:
+    """Return the authenticated user or ``None`` when auth is disabled.
+
+    The dependency intentionally skips OAuth processing when authentication
+    has been disabled via configuration so routes can accept anonymous
+    requests in demo environments. When auth remains enabled the helper
+    mirrors :func:`backend.auth.get_current_user` but keeps the dependency
+    signature free from ``Depends`` so callers can reuse it seamlessly.
+    """
+
+    if app_config.disable_auth:
+        return None
+
+    token = await oauth2_scheme(request)
+    return await get_current_user(token)
+
+
+__all__ = ["get_active_user"]


### PR DESCRIPTION
## Summary
- add a reusable get_active_user dependency that bypasses OAuth when auth is disabled
- update goals routes to fall back to the demo owner when the helper returns None
- expand the goals route tests to cover unauthenticated CRUD behaviour

## Testing
- pytest backend/tests/test_goals_route.py --cov=backend --cov-fail-under=0
- SMOKE_URL=http://localhost:8000 npm run smoke:test

------
https://chatgpt.com/codex/tasks/task_e_68d70d1ac2f08327b600a8db28239dbd