### PR TITLE
Ensure loader exchange falls back to metadata

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -104,25 +104,25 @@ def _resolve_loader_exchange(
 ) -> str:
     """Return the exchange to use when fetching cached data.
 
-    The loader should prefer explicit suffixes or query parameters. When
-    neither is provided we deliberately ignore metadata-derived exchanges so
-    the cache lookup matches the unsuffixed request that triggered it.
+    Explicit suffixes and ``exchange`` arguments take priority, otherwise fall
+    back to the previously resolved exchange (which may come from metadata).
     """
 
     parts = re.split(r"[._]", ticker, 1)
     suffix = parts[1].strip().upper() if len(parts) == 2 else ""
-    provided = (exchange_arg or "").strip()
+    provided = (exchange_arg or "").strip().upper()
+    resolved = (resolved_exchange or "").strip().upper()
 
     if provided:
         # ``resolved_exchange`` already respects explicit overrides, but we
         # normalise again defensively in case the caller passed a lowercase
         # string and resolution fell back to metadata.
-        return (resolved_exchange or provided.upper()).upper()
+        return resolved or provided
 
     if suffix:
-        return (resolved_exchange or suffix).upper()
+        return resolved or suffix
 
-    return ""
+    return resolved
 
 
 def _merge(sources: List[pd.DataFrame]) -> pd.DataFrame:

--- a/tests/test_run_all_tickers.py
+++ b/tests/test_run_all_tickers.py
@@ -34,11 +34,18 @@ def test_run_all_tickers_handles_underscore_and_dot():
 
 
 def test_run_all_tickers_resolves_exchange_from_metadata():
-    with patch("backend.timeseries.cache.load_meta_timeseries") as mock_load:
-        mock_load.return_value = pd.DataFrame({"Date": [1], "Close": [2]})
+    calls = []
 
+    def fake_load(sym, ex, days):
+        calls.append((sym, ex, days))
+        return pd.DataFrame({"Date": [1], "Close": [2]})
+
+    with patch(
+        "backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load
+    ) as mock_load:
         out = run_all_tickers(["GSK"], days=3)
 
     assert out == ["GSK"]
-    mock_load.assert_called_once_with("GSK", "L", 3)
+    assert calls == [("GSK", "L", 3)]
+    mock_load.assert_called_once()
 


### PR DESCRIPTION
## Summary
- update loader exchange resolution so metadata-derived exchanges are used when no suffix or explicit argument is provided
- extend the run_all_tickers metadata test to assert the cache loader receives the resolved exchange

## Testing
- pytest --cov=backend --cov-fail-under=0 tests/test_run_all_tickers.py::test_run_all_tickers_resolves_exchange_from_metadata


------
https://chatgpt.com/codex/tasks/task_e_68d70f99cec48327a33946cb03a7845c