### PR TITLE
Stop auto-scaffolding for unknown owners

### DIFF
--- a/backend/tests/test_compliance_scaffold.py
+++ b/backend/tests/test_compliance_scaffold.py
@@ -1,9 +1,11 @@
 import json
 
+import pytest
+
 from backend.common import compliance
 
 
-def test_check_trade_creates_default_person_metadata(tmp_path, monkeypatch):
+def test_check_trade_missing_owner_raises_without_scaffold(tmp_path, monkeypatch):
     accounts_root = tmp_path / "accounts"
     trade = {
         "owner": "newbie",
@@ -18,14 +20,37 @@ def test_check_trade_creates_default_person_metadata(tmp_path, monkeypatch):
         lambda ticker: {},
     )
 
+    with pytest.raises(FileNotFoundError):
+        compliance.check_trade(trade, accounts_root)
+
+    assert not (accounts_root / "newbie").exists()
+
+
+def test_ensure_owner_scaffold_populates_person_metadata(tmp_path, monkeypatch):
+    accounts_root = tmp_path / "accounts"
+    owner = "newbie"
+    trade = {
+        "owner": owner,
+        "ticker": "PFE",
+        "type": "buy",
+        "date": "1970-01-01",
+        "shares": 1,
+    }
+
+    monkeypatch.setattr(
+        "backend.common.compliance.get_instrument_meta",
+        lambda ticker: {},
+    )
+
+    owner_dir = compliance.ensure_owner_scaffold(owner, accounts_root)
     result = compliance.check_trade(trade, accounts_root)
 
-    assert result["owner"] == "newbie"
+    assert result["owner"] == owner
 
-    person_path = accounts_root / "newbie" / "person.json"
+    person_path = owner_dir / "person.json"
     assert person_path.exists()
 
     metadata = json.loads(person_path.read_text())
-    assert metadata["owner"] == "newbie"
+    assert metadata["owner"] == owner
     assert isinstance(metadata.get("holdings"), list)
     assert isinstance(metadata.get("viewers"), list)

--- a/tests/backend/common/test_compliance.py
+++ b/tests/backend/common/test_compliance.py
@@ -55,15 +55,23 @@ def stubbed_env(monkeypatch):
     monkeypatch.setattr(compliance, "datetime", FixedDateTime)
 
 
-def test_load_transactions_bootstraps_missing_owner(tmp_path):
+def test_load_transactions_missing_owner_raises(tmp_path):
     accounts_root = tmp_path / "accounts"
     owner = "alex"
 
-    records = compliance.load_transactions(owner, accounts_root=accounts_root)
+    with pytest.raises(FileNotFoundError):
+        compliance.load_transactions(owner, accounts_root=accounts_root)
 
-    assert records == []
+    assert not (accounts_root / owner).exists()
 
-    owner_dir = accounts_root / owner
+
+def test_ensure_owner_scaffold_creates_defaults(tmp_path):
+    accounts_root = tmp_path / "accounts"
+    owner = "alex"
+
+    owner_dir = compliance.ensure_owner_scaffold(owner, accounts_root=accounts_root)
+
+    assert owner_dir == accounts_root / owner
     assert owner_dir.is_dir()
 
     settings_path = owner_dir / "settings.json"

--- a/tests/test_compliance_route.py
+++ b/tests/test_compliance_route.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date
+
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
@@ -111,11 +112,8 @@ def test_validate_trade_missing_owner(tmp_path):
         assert resp.status_code == 422
 
 
-def test_validate_trade_when_owner_discovery_fails(tmp_path):
+def test_validate_trade_unknown_owner_returns_404_without_scaffold(tmp_path):
     app = _setup_app(tmp_path)
-    # Point the app to a non-existent accounts directory so owner discovery
-    # yields an empty set. The endpoint should still accept the request and
-    # fall back to scaffolding the owner on demand instead of returning a 404.
     missing_root = tmp_path / "missing"
     app.state.accounts_root = missing_root
 
@@ -130,9 +128,17 @@ def test_validate_trade_when_owner_discovery_fails(tmp_path):
                 "ticker": "XYZ",
             },
         )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["owner"] == "demo"
-        assert data["warnings"] == []
-        scaffold = missing_root / "demo" / "demo_transactions.json"
-        assert scaffold.exists()
+        assert resp.status_code == 404
+    assert not any(missing_root.rglob("demo"))
+
+
+def test_compliance_unknown_owner_does_not_create_directory(tmp_path):
+    app = create_app()
+    accounts_root = tmp_path / "accounts"
+    app.state.accounts_root = accounts_root
+
+    with TestClient(app) as client:
+        resp = client.get("/compliance/missing")
+        assert resp.status_code == 404
+
+    assert not (accounts_root / "missing").exists()

--- a/tests/test_portfolio_route_regression.py
+++ b/tests/test_portfolio_route_regression.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+
+
+def test_portfolio_unknown_owner_does_not_create_directory(tmp_path):
+    app = create_app()
+    accounts_root = tmp_path / "accounts"
+    missing_owner = accounts_root / "ghost"
+    app.state.accounts_root = accounts_root
+
+    with TestClient(app) as client:
+        resp = client.get("/portfolio/ghost")
+        assert resp.status_code == 404
+
+    assert not missing_owner.exists()


### PR DESCRIPTION
## Summary
- prevent compliance transaction loader from creating new owner directories implicitly
- expose an explicit ensure_owner_scaffold helper and update tests to use it
- add regression tests verifying compliance and portfolio routes do not create directories for unknown owners

## Testing
- python -m pytest -o addopts='' tests/backend/common/test_compliance.py backend/tests/test_compliance_scaffold.py tests/test_compliance_route.py tests/test_portfolio_route_regression.py

------
https://chatgpt.com/codex/tasks/task_e_68d70f9aa4e88327a1116a6802c3d68c