### PR TITLE
Use accounts resolver for pension forecast

### DIFF
--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -7,6 +7,7 @@ from backend.common.pension import (
     state_pension_age_uk,
 )
 from backend.common.portfolio import build_owner_portfolio
+from backend.routes._accounts import resolve_accounts_root
 
 router = APIRouter(tags=["pension"])
 
@@ -24,7 +25,9 @@ def pension_forecast(
     investment_growth_pct: float = Query(5.0),
     desired_income_annual: float | None = Query(None, ge=0),
 ):
-    meta = load_person_meta(owner, request.app.state.accounts_root)
+    accounts_root = resolve_accounts_root(request)
+
+    meta = load_person_meta(owner, accounts_root)
     dob = meta.get("dob")
     current_age = _age_from_dob(dob)
     if current_age is None:
@@ -37,7 +40,7 @@ def pension_forecast(
         )
 
     try:
-        portfolio = build_owner_portfolio(owner, request.app.state.accounts_root)
+        portfolio = build_owner_portfolio(owner, accounts_root)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     pension_pot = sum(

--- a/backend/tests/test_pension_route.py
+++ b/backend/tests/test_pension_route.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.config import reload_config
+
+
+def test_pension_forecast_demo_owner_returns_ok() -> None:
+    """The pension forecast endpoint should succeed with default settings."""
+
+    reload_config()
+    app = create_app()
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/pension/forecast",
+            params={
+                "owner": "demo",
+                "death_age": 90,
+            },
+        )
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- resolve the pension forecast accounts directory via the shared helper to keep FastAPI state aligned
- ensure the pension forecast endpoint can serve the demo owner by adding a regression test

## Testing
- pytest backend/tests/test_pension_route.py --cov=backend --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68d7113f9c688327a86ebc2416cd4263