### PR TITLE
Ensure API tests start without stray owner directories

### DIFF
--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import shutil
 
 import pytest
 from fastapi import HTTPException
@@ -22,6 +23,13 @@ def client(mock_google_verify):
 
     # allow alerts to operate without SNS configuration
     alerts.config.sns_topic_arn = None
+
+    # Some tests rely on the absence of an owner directory to verify 404
+    # responses. Ensure the fixture starts from a clean slate in case a
+    # previous test run or developer environment left behind the scaffold.
+    missing_owner = Path(client.app.state.accounts_root) / "noone"
+    if missing_owner.exists():
+        shutil.rmtree(missing_owner)
     try:
         yield client
     finally:


### PR DESCRIPTION
## Summary
- remove any stray `noone` owner directory before running backend API tests to keep missing-owner assertions reliable

## Testing
- pytest tests/test_backend_api.py::test_invalid_portfolio

------
https://chatgpt.com/codex/tasks/task_e_68d71202d04483278baae14e8ba82efb