### PR TITLE
Handle S3 failures when loading person metadata

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -337,6 +337,8 @@ def load_person_meta(owner: str, data_root: Optional[Path] = None) -> Dict[str, 
                 exc,
                 exc_info=True,
             )
+            if config.app_env == "aws" and data_root is None:
+                return {}
     paths = resolve_paths(config.repo_root, config.accounts_root)
     root = data_root or paths.accounts_root
     path = root / owner / "person.json"


### PR DESCRIPTION
## Summary
- return an empty metadata dict when S3 access fails in AWS environments
- keep the existing local fallback behaviour for non-AWS or explicitly provided roots

## Testing
- pytest tests/test_data_loader_aws.py::test_load_person_meta_boto_failure tests/common/test_data_loader.py::test_load_person_meta_falls_back_to_local --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d7124233ec8327b19674f443ab7e87