### PR TITLE
Align goals route authentication with config flag

### DIFF
--- a/backend/routes/goals.py
+++ b/backend/routes/goals.py
@@ -6,7 +6,8 @@ from pydantic import BaseModel
 
 from backend.common.goals import Goal, add_goal, delete_goal, load_goals, save_goals
 from backend.common.rebalance import suggest_trades
-from backend.routes import get_active_user
+from backend.auth import get_current_user
+from backend.config import config
 
 router = APIRouter(prefix="/goals", tags=["goals"])
 
@@ -24,31 +25,18 @@ class GoalResponse(GoalPayload):
     trades: List[dict] | None = None
 
 
-@router.get("/")
-async def list_goals(current_user: str | None = Depends(get_active_user)) -> List[GoalPayload]:
-    owner = current_user or DEMO_OWNER
+def _list_goals(owner: str) -> List[GoalPayload]:
     goals = load_goals(owner)
     return [GoalPayload(**g.to_dict()) for g in goals]
 
 
-@router.post("/")
-async def create_goal(
-    payload: GoalPayload,
-    current_user: str | None = Depends(get_active_user),
-) -> GoalPayload:
-    owner = current_user or DEMO_OWNER
+def _create_goal(owner: str, payload: GoalPayload) -> GoalPayload:
     goal = Goal(payload.name, payload.target_amount, payload.target_date)
     add_goal(owner, goal)
     return GoalPayload(**goal.to_dict())
 
 
-@router.get("/{name}")
-async def get_goal(
-    name: str,
-    current_amount: float,
-    current_user: str | None = Depends(get_active_user),
-) -> GoalResponse:
-    owner = current_user or DEMO_OWNER
+def _get_goal(owner: str, name: str, current_amount: float) -> GoalResponse:
     goals = load_goals(owner)
     for g in goals:
         if g.name == name:
@@ -59,31 +47,70 @@ async def get_goal(
     raise HTTPException(status_code=404, detail="Goal not found")
 
 
-@router.put("/{name}")
-async def update_goal(
-    name: str,
-    payload: GoalPayload,
-    current_user: str | None = Depends(get_active_user),
-) -> GoalPayload:
-    owner = current_user or DEMO_OWNER
+def _update_goal(owner: str, name: str, payload: GoalPayload) -> GoalPayload:
     goals = load_goals(owner)
-    found = False
     for idx, g in enumerate(goals):
         if g.name == name:
             goals[idx] = Goal(payload.name, payload.target_amount, payload.target_date)
-            found = True
-            break
-    if not found:
-        raise HTTPException(status_code=404, detail="Goal not found")
-    save_goals(owner, goals)
-    return GoalPayload(**payload.model_dump())
+            save_goals(owner, goals)
+            return GoalPayload(**payload.model_dump())
+    raise HTTPException(status_code=404, detail="Goal not found")
 
 
-@router.delete("/{name}")
-async def remove_goal(name: str, current_user: str | None = Depends(get_active_user)) -> dict:
-    owner = current_user or DEMO_OWNER
+def _remove_goal(owner: str, name: str) -> dict:
     goals = load_goals(owner)
     if not any(g.name == name for g in goals):
         raise HTTPException(status_code=404, detail="Goal not found")
     delete_goal(owner, name)
     return {"status": "deleted"}
+
+
+if config.disable_auth:
+
+    @router.get("/")
+    async def list_goals() -> List[GoalPayload]:
+        return _list_goals(DEMO_OWNER)
+
+    @router.post("/")
+    async def create_goal(payload: GoalPayload) -> GoalPayload:
+        return _create_goal(DEMO_OWNER, payload)
+
+    @router.get("/{name}")
+    async def get_goal(name: str, current_amount: float) -> GoalResponse:
+        return _get_goal(DEMO_OWNER, name, current_amount)
+
+    @router.put("/{name}")
+    async def update_goal(name: str, payload: GoalPayload) -> GoalPayload:
+        return _update_goal(DEMO_OWNER, name, payload)
+
+    @router.delete("/{name}")
+    async def remove_goal(name: str) -> dict:
+        return _remove_goal(DEMO_OWNER, name)
+
+else:
+
+    @router.get("/")
+    async def list_goals(current_user: str = Depends(get_current_user)) -> List[GoalPayload]:
+        return _list_goals(current_user)
+
+    @router.post("/")
+    async def create_goal(
+        payload: GoalPayload, current_user: str = Depends(get_current_user)
+    ) -> GoalPayload:
+        return _create_goal(current_user, payload)
+
+    @router.get("/{name}")
+    async def get_goal(
+        name: str, current_amount: float, current_user: str = Depends(get_current_user)
+    ) -> GoalResponse:
+        return _get_goal(current_user, name, current_amount)
+
+    @router.put("/{name}")
+    async def update_goal(
+        name: str, payload: GoalPayload, current_user: str = Depends(get_current_user)
+    ) -> GoalPayload:
+        return _update_goal(current_user, name, payload)
+
+    @router.delete("/{name}")
+    async def remove_goal(name: str, current_user: str = Depends(get_current_user)) -> dict:
+        return _remove_goal(current_user, name)


### PR DESCRIPTION
## Summary
- mirror the goals route auth handling after the trail route, routing demo requests when auth is disabled
- refactor helpers to share goal CRUD logic across authenticated and demo paths
- extend the goals route tests to cover the unauthenticated flow when auth is disabled

## Testing
- pytest backend/tests/test_goals_route.py -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d7113a6748832798cd3dae13490216