### PR TITLE
Improve instrument metadata lookup for timeseries exchange resolution

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -55,20 +55,50 @@ _TICKER_RE = re.compile(r"^[A-Za-z0-9]{1,12}(?:[-\.][A-Z]{1,3})?$")
 INSTRUMENTS_DIR = Path(__file__).resolve().parents[2] / "data" / "instruments"
 
 
+def _instrument_dirs() -> list[Path]:
+    """Return candidate directories that may contain instrument metadata."""
+
+    candidates: list[Path] = []
+    data_root = getattr(config, "data_root", None)
+    if data_root:
+        candidates.append(Path(data_root) / "instruments")
+    candidates.append(INSTRUMENTS_DIR)
+
+    seen: set[Path] = set()
+    resolved: list[Path] = []
+    for candidate in candidates:
+        try:
+            resolved_path = Path(candidate).expanduser().resolve()
+        except OSError:
+            continue
+        if resolved_path in seen:
+            continue
+        seen.add(resolved_path)
+        try:
+            if resolved_path.is_dir():
+                resolved.append(resolved_path)
+        except OSError:
+            continue
+    return resolved
+
+
 @lru_cache(maxsize=2048)
 def _resolve_exchange_from_metadata(symbol: str) -> str:
     """Return exchange code for *symbol* using instrument metadata if possible."""
+
     sym = symbol.upper()
-    if not INSTRUMENTS_DIR.exists():
-        return ""
-    try:
-        for ex_dir in INSTRUMENTS_DIR.iterdir():
-            if not ex_dir.is_dir() or ex_dir.name.lower() == "cash":
-                continue
-            if (ex_dir / f"{sym}.json").exists():
-                return ex_dir.name.upper()
-    except OSError:
-        return ""
+    for root in _instrument_dirs():
+        try:
+            for ex_dir in root.iterdir():
+                if not ex_dir.is_dir() or ex_dir.name.lower() == "cash":
+                    continue
+                try:
+                    if (ex_dir / f"{sym}.json").is_file():
+                        return ex_dir.name.upper()
+                except OSError:
+                    continue
+        except OSError:
+            continue
     return ""
 
 


### PR DESCRIPTION
## Summary
- search both the configured data directory and bundled fixtures when resolving instrument metadata
- keep run_all_tickers exchange resolution working even if the default instruments path is unavailable

## Testing
- pytest -o addopts="" tests/test_run_all_tickers.py -vv
- pytest -o addopts="" tests/test_data_loader_aws.py::test_load_person_meta_boto_failure -vv
- pytest -o addopts="" tests/timeseries/test_fetch_meta_timeseries.py::test_resolve_exchange_from_metadata -vv


------
https://chatgpt.com/codex/tasks/task_e_68d71259b2348327b9e0848d67a4cc72