### PR TITLE
Fix goals smoke test ordering

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -185,10 +185,6 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     }
   },
   {
-    "method": "DELETE",
-    "path": "/goals/{name}"
-  },
-  {
     "method": "GET",
     "path": "/goals/{name}",
     "query": {
@@ -203,6 +199,10 @@ export const smokeEndpoints: SmokeEndpoint[] = [
       "target_amount": 0,
       "target_date": "1970-01-01"
     }
+  },
+  {
+    "method": "DELETE",
+    "path": "/goals/{name}"
   },
   {
     "method": "GET",
@@ -656,7 +656,7 @@ const SAMPLE_PATH_VALUES: Record<string, string> = {
   vp_id: '1',
   quest_id: 'check-in',
   slug: 'demo-slug',
-  name: 'demo',
+  name: 'test',
   exchange: 'NASDAQ',
   ticker: 'PFE',
 };


### PR DESCRIPTION
## Summary
- reorder the goals smoke endpoints so retrieval and updates occur before cleanup
- align the sample path name with the goal created during the smoke test sequence

## Testing
- npm run smoke:test:all *(fails: backend service not running in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7147e9ed883279f60f39a3292d459