### PR TITLE
Fix syntax error in compliance module

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -94,16 +94,6 @@ def ensure_owner_scaffold(owner: str, accounts_root: Optional[Path] = None) -> P
     return owner_dir
 
 
-def load_transactions(owner: str, accounts_root: Optional[Path] = None) -> List[Dict[str, Any]]:
-    """Load all transactions for ``owner`` sorted by date.
-
-    Raises
-    ------
-    FileNotFoundError
-        If the owner's accounts directory does not exist. Call
-        :func:`ensure_owner_scaffold` beforehand when deliberate bootstrapping
-        is required.
-
 def load_transactions(
     owner: str,
     accounts_root: Optional[Path] = None,


### PR DESCRIPTION
## Summary
- remove the stray load_transactions stub that left a dangling docstring and broke module imports

## Testing
- python -m py_compile backend/common/compliance.py

------
https://chatgpt.com/codex/tasks/task_e_68d717a063ec83279e3f42f454beaaf2