### PR TITLE
Show instrument names on the transactions page

### DIFF
--- a/backend/tests/test_transactions_route.py
+++ b/backend/tests/test_transactions_route.py
@@ -62,6 +62,29 @@ def test_create_transaction_success(monkeypatch, tmp_path):
     assert transactions._PORTFOLIO_IMPACT["bob"] == pytest.approx(3.0)
 
 
+def test_transaction_instrument_name(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    data = {
+        "owner": "bob",
+        "account": "isa",
+        "ticker": "VWRL.L",
+        "date": "2024-01-01",
+        "price_gbp": 1.5,
+        "units": 2,
+        "reason": "why",
+    }
+
+    resp = client.post("/transactions", json=data)
+    assert resp.status_code == 201
+    payload = resp.json()
+    assert payload["instrument_name"] == "Vanguard FTSE All-World UCITS ETF"
+
+    list_resp = client.get("/transactions")
+    assert list_resp.status_code == 200
+    results = list_resp.json()
+    assert results[0]["instrument_name"] == "Vanguard FTSE All-World UCITS ETF"
+
+
 def test_create_transaction_missing_reason(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
     data = {

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -552,6 +552,7 @@ export function TransactionsPage({ owners }: Props) {
                 <th className={tableStyles.cell}>Owner</th>
                 <th className={tableStyles.cell}>Account</th>
                 <th className={tableStyles.cell}>Instrument</th>
+                <th className={tableStyles.cell}>Instrument name</th>
                 <th className={tableStyles.cell}>Type</th>
                 <th className={`${tableStyles.cell} ${tableStyles.right}`}>Amount</th>
                 <th className={`${tableStyles.cell} ${tableStyles.right}`}>Shares</th>
@@ -563,7 +564,7 @@ export function TransactionsPage({ owners }: Props) {
                 <tr>
                   <td
                     className={tableStyles.cell}
-                    colSpan={8}
+                    colSpan={9}
                     style={{ textAlign: "center" }}
                   >
                     No transactions found.
@@ -580,6 +581,7 @@ export function TransactionsPage({ owners }: Props) {
                       <td className={tableStyles.cell}>{t.owner}</td>
                       <td className={tableStyles.cell}>{t.account}</td>
                       <td className={tableStyles.cell}>{t.ticker || t.security_ref || ""}</td>
+                      <td className={tableStyles.cell}>{t.instrument_name || ""}</td>
                       <td className={tableStyles.cell}>{t.type || t.kind}</td>
                       <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                         {t.amount_minor != null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -271,6 +271,7 @@ export interface Transaction {
   currency?: string | null;
   security_ref?: string | null;
   ticker?: string | null;
+  instrument_name?: string | null;
   shares?: number | null;
   units?: number | null;
   price_gbp?: number | null;


### PR DESCRIPTION
## Summary
- populate transaction payloads with instrument names resolved from instrument metadata
- render a non-editable instrument name column on the transactions table
- cover the new metadata enrichment with unit tests

## Testing
- pytest backend/tests/test_transactions_route.py -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d71623d8948327a8fb13c23cfe8457