### PR TITLE
Combine portfolio dashboard metrics with holdings view

### DIFF
--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { PortfolioView } from "@/components/PortfolioView";
 import type { Portfolio } from "@/types";
+
+vi.mock("@/components/PerformanceDashboard", () => ({
+  __esModule: true,
+  default: () => <div data-testid="performance-dashboard" />,
+}));
 
 describe("PortfolioView", () => {
     const mockOwner: Portfolio = {


### PR DESCRIPTION
## Summary
- render the performance dashboard alongside the holdings view so owners can see metrics and positions on the same screen
- add lazy loading and card styling around the merged layout to keep the interface organized
- mock the performance dashboard in the portfolio view unit test to keep the test suite isolated

## Testing
- npm --prefix frontend run test -- --run tests/unit/components/PortfolioView.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7970ce3588327b100d782e4c471df