### PR TITLE
Add smoke coverage for pension forecast route

### DIFF
--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -1,17 +1,24 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 const baseUrl = process.env.SMOKE_URL ?? 'http://localhost:5173';
 const authToken = process.env.SMOKE_AUTH_TOKEN ?? process.env.TEST_ID_TOKEN ?? null;
 
 const smokePath = new URL('/smoke-test', baseUrl).toString();
+const pensionForecastPath = new URL('/pension/forecast', baseUrl).toString();
+
+const applyAuth = async (page: Page) => {
+  if (!authToken) {
+    return;
+  }
+
+  await page.addInitScript((token: string) => {
+    window.localStorage.setItem('authToken', token);
+  }, authToken);
+};
 
 test.describe('smoke test page', () => {
   test('reports ok for every backend check', async ({ page }) => {
-    if (authToken) {
-      await page.addInitScript((token: string) => {
-        window.localStorage.setItem('authToken', token);
-      }, authToken);
-    }
+    await applyAuth(page);
 
     await page.goto(smokePath);
 
@@ -27,5 +34,21 @@ test.describe('smoke test page', () => {
     for (let index = 0; index < count; index += 1) {
       await expect(items.nth(index)).toContainText('ok');
     }
+  });
+});
+
+test.describe('pension forecast page', () => {
+  test('renders the pension forecast heading without errors', async ({ page }) => {
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => {
+      pageErrors.push(error);
+    });
+
+    await applyAuth(page);
+
+    await page.goto(pensionForecastPath);
+
+    await expect(page.getByRole('heading', { name: 'Pension Forecast' })).toBeVisible();
+    expect(pageErrors).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- extract smoke test auth setup into a helper for reuse
- add a Playwright smoke test that loads the pension forecast page and asserts the main heading renders without page errors

## Testing
- npm run smoke:frontend *(fails: missing system dependencies to run Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68d79d206d848327bf36ccff84516c1a