### PR TITLE
Ensure alert owner validation uses filesystem lookup

### DIFF
--- a/tests/test_push_subscription_route.py
+++ b/tests/test_push_subscription_route.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
+from backend import config as backend_config
 from backend.local_api.main import app
 from backend import alerts as alert_utils
+from backend.common import data_loader
 from backend.common.storage import get_storage
 
 
@@ -16,16 +20,18 @@ def client(tmp_path, monkeypatch):
     alert_utils._PUSH_SUBSCRIPTIONS.clear()
     original_arn = alert_utils.config.sns_topic_arn
     alert_utils.config.sns_topic_arn = None
+    original_disable_auth = backend_config.config.disable_auth
     try:
         yield TestClient(app)
     finally:
         alert_utils.config.sns_topic_arn = original_arn
+        backend_config.config.disable_auth = original_disable_auth
 
 
 def test_push_subscription_owner_validation(client, tmp_path):
-    owners = client.get("/owners").json()
-    assert any(o["owner"] == "demo" for o in owners)
     owner = "demo"
+    accounts_root = data_loader.resolve_paths(None, None).accounts_root
+    assert (Path(accounts_root) / owner).exists()
     payload = {"endpoint": "https://ex", "keys": {"p256dh": "a", "auth": "b"}}
 
     resp = client.post(f"/alerts/push-subscription/{owner}", json=payload)
@@ -54,6 +60,17 @@ def test_push_subscription_falls_back_to_default_dataset(client, tmp_path):
     custom_root = tmp_path / "alt-root"
     custom_root.mkdir()
     client.app.state.accounts_root = custom_root
+
+    resp = client.post(f"/alerts/push-subscription/{owner}", json=payload)
+    assert resp.status_code == 200
+    assert alert_utils.get_user_push_subscription(owner) == payload
+
+
+def test_push_subscription_allows_demo_owner_without_auth(client):
+    owner = "demo"
+    payload = {"endpoint": "https://ex", "keys": {"p256dh": "pub", "auth": "secret"}}
+
+    backend_config.config.disable_auth = False
 
     resp = client.post(f"/alerts/push-subscription/{owner}", json=payload)
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- resolve alert owner validation via resolve_owner_directory instead of listing plots
- retain fallback behaviour when the cached accounts root is missing owners
- expand push subscription tests to cover unauthenticated access and dataset fallbacks

## Testing
- pytest --override-ini="addopts=" tests/test_push_subscription_route.py

------
https://chatgpt.com/codex/tasks/task_e_68d79d2d8ab88327bb6b756cb0343928