### PR TITLE
Handle smoke test exit code

### DIFF
--- a/scripts/run-smoke-tests-all.ps1
+++ b/scripts/run-smoke-tests-all.ps1
@@ -39,6 +39,7 @@ if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
 $repoRoot = Resolve-RepoRoot -ScriptRoot $PSScriptRoot
 
 Push-Location -Path $repoRoot
+$npmExitCode = 0
 try {
     $tsxCliGlob = Join-Path -Path $repoRoot -ChildPath 'node_modules/.bin/tsx*'
     if (-not (Test-Path -Path $tsxCliGlob)) {
@@ -52,7 +53,11 @@ try {
 
     Write-Host 'Running npm run smoke:test:all ...' -ForegroundColor Cyan
     npm run smoke:test:all
+    $npmExitCode = $LASTEXITCODE
 }
 finally {
     Pop-Location
+    if ($npmExitCode -ne 0) {
+        exit $npmExitCode
+    }
 }


### PR DESCRIPTION
## Summary
- capture the npm smoke test exit code so the script can signal failure
- exit with the captured status after restoring the previous location

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79d2c241c8327830d41f4249d7487