### PR TITLE
Adjust menu settings and translations

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -13,9 +13,9 @@
     "menuCategories": {
       "dashboard": "Dashboard",
       "holdings": "Bestände",
-      "tradeTools": "Handelstools",
-      "goals": "Ziele",
-      "preferences": "Präferenzen",
+      "tradeTools": "Insightts",
+      "goals": "Anforderungen",
+      "preferences": "Einstellungen",
       "operations": "Operationen",
       "other": "Weitere"
     },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -13,9 +13,9 @@
     "menuCategories": {
       "dashboard": "Dashboard",
       "holdings": "Holdings",
-      "tradeTools": "Trade Tools",
-      "goals": "Goals",
-      "preferences": "Preferences",
+      "tradeTools": "Insightts",
+      "goals": "Requirements",
+      "preferences": "Settings",
       "operations": "Operations",
       "other": "Other"
     },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -13,9 +13,9 @@
     "menuCategories": {
       "dashboard": "Panel",
       "holdings": "Posiciones",
-      "tradeTools": "Herramientas de trading",
-      "goals": "Objetivos",
-      "preferences": "Preferencias",
+      "tradeTools": "Insightts",
+      "goals": "Requisitos",
+      "preferences": "Configuración",
       "operations": "Operaciones",
       "other": "Otros"
     },

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -13,9 +13,9 @@
     "menuCategories": {
       "dashboard": "Tableau de bord",
       "holdings": "Positions",
-      "tradeTools": "Outils de trading",
-      "goals": "Objectifs",
-      "preferences": "Préférences",
+      "tradeTools": "Insightts",
+      "goals": "Exigences",
+      "preferences": "Paramètres",
       "operations": "Opérations",
       "other": "Autres"
     },

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -13,9 +13,9 @@
     "menuCategories": {
       "dashboard": "Dashboard",
       "holdings": "Posizioni",
-      "tradeTools": "Strumenti di trading",
-      "goals": "Obiettivi",
-      "preferences": "Preferenze",
+      "tradeTools": "Insightts",
+      "goals": "Requisiti",
+      "preferences": "Impostazioni",
       "operations": "Operazioni",
       "other": "Altro"
     },

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -13,9 +13,9 @@
     "menuCategories": {
       "dashboard": "Painel",
       "holdings": "Participações",
-      "tradeTools": "Ferramentas de negociação",
-      "goals": "Objetivos",
-      "preferences": "Preferências",
+      "tradeTools": "Insightts",
+      "goals": "Requisitos",
+      "preferences": "Configurações",
       "operations": "Operações",
       "other": "Outros"
     },

--- a/frontend/tests/unit/components/Header.test.tsx
+++ b/frontend/tests/unit/components/Header.test.tsx
@@ -19,14 +19,16 @@ describe("Header", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("toggles menu drawer", () => {
+  it("toggles menu drawer", async () => {
     render(
       <MemoryRouter>
         <Menu />
       </MemoryRouter>
     );
-    const toggle = screen.getByLabelText(i18n.t("app.menu"));
-    fireEvent.click(toggle);
-    expect(screen.getByRole("link", { name: "Support" })).toBeInTheDocument();
+    const settingsToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.preferences"),
+    });
+    fireEvent.click(settingsToggle);
+    expect(await screen.findByRole("menuitem", { name: "Support" })).toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "@/i18n";
@@ -6,26 +6,30 @@ import Menu from "@/components/Menu";
 import { configContext, type ConfigContextValue } from "@/ConfigContext";
 
 describe("Menu", () => {
-  it("hides links by default and shows them after toggle", () => {
+  it("hides links by default and shows them after toggle", async () => {
     render(
       <MemoryRouter>
         <Menu />
       </MemoryRouter>,
     );
-    const toggle = screen.getByRole("button", { name: i18n.t("app.menu") });
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByRole("link", { name: "Support" })).not.toBeInTheDocument();
-    fireEvent.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
-    const supportLink = screen.getByRole("link", { name: "Support" });
+    const settingsToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.preferences"),
+    });
+    expect(settingsToggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("menuitem", { name: "Support" })).not.toBeInTheDocument();
+    fireEvent.click(settingsToggle);
+    expect(settingsToggle).toHaveAttribute("aria-expanded", "true");
+    const supportLink = await screen.findByRole("menuitem", { name: "Support" });
     expect(supportLink).toBeVisible();
     expect(supportLink).toHaveAttribute(
       "href",
       "/support",
     );
-    fireEvent.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByRole("link", { name: "Support" })).not.toBeInTheDocument();
+    fireEvent.click(settingsToggle);
+    expect(settingsToggle).toHaveAttribute("aria-expanded", "false");
+    await waitFor(() =>
+      expect(screen.queryByRole("menuitem", { name: "Support" })).not.toBeInTheDocument(),
+    );
   });
 
   it("updates aria-expanded attribute when toggled", () => {
@@ -34,25 +38,28 @@ describe("Menu", () => {
         <Menu />
       </MemoryRouter>,
     );
-    const toggle = screen.getByRole("button", { name: i18n.t("app.menu") });
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
-    fireEvent.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
-    fireEvent.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    const settingsToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.preferences"),
+    });
+    expect(settingsToggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(settingsToggle);
+    expect(settingsToggle).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(settingsToggle);
+    expect(settingsToggle).toHaveAttribute("aria-expanded", "false");
   });
 
-  it("shows support tabs on support route", () => {
+  it("shows support tabs on support route", async () => {
     render(
       <MemoryRouter initialEntries={["/support"]}>
         <Menu />
       </MemoryRouter>,
     );
-    fireEvent.click(screen.getByLabelText(i18n.t("app.menu")));
-    expect(screen.getByRole("link", { name: "Support" })).toHaveAttribute(
-      "href",
-      "/",
-    );
+    const settingsToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.preferences"),
+    });
+    fireEvent.click(settingsToggle);
+    const supportLink = await screen.findByRole("menuitem", { name: "Support" });
+    expect(supportLink).toHaveAttribute("href", "/");
   });
 
   it("hides support toggle when support tab disabled", () => {
@@ -95,11 +102,14 @@ describe("Menu", () => {
         </MemoryRouter>
       </configContext.Provider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: i18n.t("app.menu") }));
-    expect(screen.queryByRole("link", { name: "Support" })).toBeNull();
+    const settingsToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.preferences"),
+    });
+    fireEvent.click(settingsToggle);
+    expect(screen.queryByRole("menuitem", { name: "Support" })).toBeNull();
   });
 
-  it("renders logout button when callback provided", () => {
+  it("renders logout button when callback provided", async () => {
     const onLogout = vi.fn();
     i18n.changeLanguage("fr");
     render(
@@ -107,9 +117,11 @@ describe("Menu", () => {
         <Menu onLogout={onLogout} />
       </MemoryRouter>,
     );
-    const toggle = screen.getByRole("button", { name: i18n.t("app.menu") });
-    fireEvent.click(toggle);
-    const btn = screen.getByRole("button", { name: "Déconnexion" });
+    const settingsToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.preferences"),
+    });
+    fireEvent.click(settingsToggle);
+    const btn = await screen.findByRole("menuitem", { name: "Déconnexion" });
     fireEvent.click(btn);
     expect(onLogout).toHaveBeenCalled();
     i18n.changeLanguage("en");

--- a/frontend/tests/unit/pages/AlertSettings.test.tsx
+++ b/frontend/tests/unit/pages/AlertSettings.test.tsx
@@ -21,10 +21,11 @@ describe("AlertSettings navigation", () => {
         </Routes>
       </MemoryRouter>,
     );
-    fireEvent.click(screen.getByRole("button", { name: i18n.t("app.menu") }));
-    fireEvent.click(
-      screen.getByRole("link", { name: i18n.t("app.modes.alertsettings") }),
-    );
+    fireEvent.click(screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.preferences"),
+    }));
+    const alertSettingsLink = await screen.findByRole("menuitem", { name: i18n.t("app.modes.alertsettings") });
+    fireEvent.click(alertSettingsLink);
     expect(
       await screen.findByRole("heading", { name: en.alertSettings.title }),
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- move the Support and Logout actions into the Settings dropdown while keeping support navigation available in support mode
- rename the Trade Tools, Goals, and Preferences menu category labels across all locales
- update navigation tests to open the Settings menu and assert on the new menuitem roles

## Testing
- npm test -- --run tests/unit/components/Menu.test.tsx tests/unit/components/Header.test.tsx tests/unit/pages/AlertSettings.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d799d77d4483279c36022c3441232a