### PR TITLE
Add static daily trail tasks and tests

### DIFF
--- a/backend/quests/trail.py
+++ b/backend/quests/trail.py
@@ -58,6 +58,34 @@ class TaskDefinition:
     commentary: str
 
 
+STATIC_DAILY_TASKS: List[TaskDefinition] = [
+    TaskDefinition(
+        id="log_in",
+        title="Log in",
+        type="daily",
+        commentary="Check in to keep your momentum going.",
+    ),
+    TaskDefinition(
+        id="check_overview",
+        title="Check overview",
+        type="daily",
+        commentary="Review your portfolio overview for any changes.",
+    ),
+    TaskDefinition(
+        id="research_new_stock",
+        title="Research a new stock",
+        type="daily",
+        commentary="Explore a new company to stay informed about opportunities.",
+    ),
+    TaskDefinition(
+        id="run_a_report",
+        title="Run a report",
+        type="daily",
+        commentary="Generate a report to track your performance over time.",
+    ),
+]
+
+
 def _owner_directories() -> Iterable[str]:
     """Return the set of owners discovered in the accounts directory."""
 
@@ -303,7 +331,7 @@ def _build_task_definitions(user: str, user_data: Dict) -> List[TaskDefinition]:
     daily_tasks.sort(key=lambda task: task.id)
     once_tasks.sort(key=lambda task: task.id)
 
-    return daily_tasks + once_tasks
+    return list(STATIC_DAILY_TASKS) + daily_tasks + once_tasks
 
 
 def _update_daily_totals(

--- a/tests/quests/test_trail.py
+++ b/tests/quests/test_trail.py
@@ -37,17 +37,16 @@ def _once_ids(response):
 def test_get_tasks_returns_defaults(memory_storage):
     response = trail.get_tasks("demo")
     tasks = response["tasks"]
-    assert [t["id"] for t in tasks] == [
-        "demo_allowance_isa",
-        "demo_allowance_pension",
-        "create_goal",
-        "enable_push_notifications",
-        "set_alert_threshold",
-    ]
+    static_ids = [task.id for task in trail.STATIC_DAILY_TASKS]
+    assert [t["id"] for t in tasks[: len(static_ids)]] == static_ids
     assert all(not t["completed"] for t in tasks)
     assert response["xp"] == 0
     assert response["streak"] == 0
     daily_ids = _daily_ids(response)
+    for static_id in static_ids:
+        assert static_id in daily_ids
+    assert "demo_allowance_isa" in daily_ids
+    assert "demo_allowance_pension" in daily_ids
     assert response["daily_totals"][response["today"]]["completed"] == 0
     assert response["daily_totals"][response["today"]]["total"] == len(daily_ids)
 
@@ -56,6 +55,24 @@ def test_get_tasks_returns_defaults(memory_storage):
     assert stored["streak"] == 0
     assert stored["daily_totals"][response["today"]]["completed"] == 0
     assert stored["daily_totals"][response["today"]]["total"] == len(daily_ids)
+
+    once_ids = _once_ids(response)
+    assert once_ids == [
+        "create_goal",
+        "enable_push_notifications",
+        "set_alert_threshold",
+    ]
+
+
+def test_get_tasks_includes_static_tasks_without_data(memory_storage, monkeypatch):
+    static_ids = [task.id for task in trail.STATIC_DAILY_TASKS]
+    monkeypatch.setattr(trail, "_owners_for_user", lambda user: [])
+
+    response = trail.get_tasks("demo")
+    daily_ids = _daily_ids(response)
+
+    assert daily_ids == static_ids
+    assert response["daily_totals"][response["today"]]["total"] == len(static_ids)
 
 
 def test_get_tasks_upgrades_legacy_records(memory_storage):


### PR DESCRIPTION
## Summary
- define a reusable set of static daily task definitions for the trail quest
- include the static tasks when building the task catalogue alongside allowance and compliance items
- add coverage to ensure the static tasks are always returned, even without allowance/compliance data

## Testing
- pytest --override-ini "addopts=" tests/quests/test_trail.py

------
https://chatgpt.com/codex/tasks/task_e_68d7a07197588327aa8220157e957d33