### PR TITLE
Adjust menu categories and settings actions

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -112,15 +112,23 @@ export default function Menu({
   };
 
   const USER_MENU_CATEGORIES: MenuCategory[] = [
-    { id: 'dashboard', titleKey: 'dashboard', tabIds: ['group', 'market', 'movers'] },
     {
-      id: 'holdings',
-      titleKey: 'holdings',
-      tabIds: ['owner', 'performance', 'allocation', 'transactions', 'reports'],
+      id: 'dashboard',
+      titleKey: 'dashboard',
+      tabIds: [
+        'group',
+        'market',
+        'movers',
+        'owner',
+        'performance',
+        'allocation',
+        'transactions',
+        'reports',
+      ],
     },
     {
-      id: 'tradeTools',
-      titleKey: 'tradeTools',
+      id: 'insightts',
+      titleKey: 'insightts',
       tabIds: [
         'instrument',
         'screener',
@@ -131,8 +139,8 @@ export default function Menu({
         'tradecompliance',
       ],
     },
-    { id: 'goals', titleKey: 'goals', tabIds: ['pension', 'taxtools', 'trail'] },
-    { id: 'preferences', titleKey: 'preferences', tabIds: ['alertsettings', 'settings'] },
+    { id: 'requirements', titleKey: 'requirements', tabIds: ['pension', 'taxtools', 'trail'] },
+    { id: 'settings', titleKey: 'settings', tabIds: ['alertsettings', 'settings'] },
   ];
 
   const SUPPORT_MENU_CATEGORIES: MenuCategory[] = [
@@ -312,34 +320,44 @@ export default function Menu({
                       </Link>
                     </li>
                   ))}
+                  {category.id === 'settings' && (supportEnabled || onLogout) && (
+                    <li role="separator" className="my-1 border-t border-gray-200" />
+                  )}
+                  {category.id === 'settings' && supportEnabled && (
+                    <li key="support">
+                      <Link
+                        role="menuitem"
+                        to={inSupport ? '/' : '/support'}
+                        className={`block rounded px-2 py-1 text-sm transition-colors duration-150 focus:outline-none focus-visible:ring ${
+                          inSupport
+                            ? 'font-semibold text-gray-900'
+                            : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                        }`}
+                      >
+                        {t('app.supportLink')}
+                      </Link>
+                    </li>
+                  )}
+                  {category.id === 'settings' && onLogout && (
+                    <li key="logout">
+                      <button
+                        type="button"
+                        role="menuitem"
+                        onClick={() => {
+                          onLogout();
+                        }}
+                        className="block w-full rounded px-2 py-1 text-left text-sm text-gray-600 transition-colors duration-150 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring"
+                      >
+                        {t('app.logout')}
+                      </button>
+                    </li>
+                  )}
                 </ul>
               </div>
             </li>
           );
         })}
       </ul>
-
-      <div className="mt-6 flex flex-col gap-2 border-t border-gray-200 pt-4">
-        {supportEnabled && (
-          <Link
-            to={inSupport ? '/' : '/support'}
-            className={`${inSupport ? 'font-bold' : ''} break-words text-sm text-gray-600 hover:text-gray-900`}
-          >
-            {t('app.supportLink')}
-          </Link>
-        )}
-        {onLogout && (
-          <button
-            type="button"
-            onClick={() => {
-              onLogout();
-            }}
-            className="bg-transparent border-0 p-0 text-left text-sm text-gray-600 hover:text-gray-900 cursor-pointer"
-          >
-            {t('app.logout')}
-          </button>
-        )}
-      </div>
     </nav>
   );
 }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menü",
     "menuCategories": {
       "dashboard": "Dashboard",
-      "holdings": "Bestände",
-      "tradeTools": "Handelstools",
-      "goals": "Ziele",
-      "preferences": "Präferenzen",
+      "insightts": "Insightts",
+      "requirements": "Anforderungen",
+      "settings": "Einstellungen",
       "operations": "Operationen",
       "other": "Weitere"
     },
@@ -40,10 +39,10 @@
       "taxtools": "Steuer-Tools",
       "trail": "Trail",
       "reports": "Berichte",
-  "alertsettings": "Alert Settings",
-  "compliance": "Compliance-Warnungen",
-  "trade-compliance": "Handels-Compliance",
-  "support": "Support",
+      "alertsettings": "Alert Settings",
+      "compliance": "Compliance-Warnungen",
+      "trade-compliance": "Handels-Compliance",
+      "support": "Support",
       "scenario": "Szenario-Tester"
     },
     "logs": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Dashboard",
-      "holdings": "Holdings",
-      "tradeTools": "Trade Tools",
-      "goals": "Goals",
-      "preferences": "Preferences",
+      "insightts": "Insightts",
+      "requirements": "Requirements",
+      "settings": "Settings",
       "operations": "Operations",
       "other": "Other"
     },
@@ -40,10 +39,10 @@
       "taxtools": "Tax Tools",
       "trail": "Trail",
       "reports": "Reports",
-  "alertsettings": "Alert Settings",
-  "compliance": "Compliance warnings",
-  "trade-compliance": "Trade compliance",
-  "support": "Support",
+      "alertsettings": "Alert Settings",
+      "compliance": "Compliance warnings",
+      "trade-compliance": "Trade compliance",
+      "support": "Support",
       "scenario": "Scenario Tester"
     }
   },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menú",
     "menuCategories": {
       "dashboard": "Panel",
-      "holdings": "Posiciones",
-      "tradeTools": "Herramientas de trading",
-      "goals": "Objetivos",
-      "preferences": "Preferencias",
+      "insightts": "Insightts",
+      "requirements": "Requisitos",
+      "settings": "Configuración",
       "operations": "Operaciones",
       "other": "Otros"
     },
@@ -40,10 +39,10 @@
       "taxtools": "Herramientas fiscales",
       "trail": "Trail",
       "reports": "Informes",
-  "alertsettings": "Alert Settings",
-  "compliance": "Alertas de cumplimiento",
-  "trade-compliance": "Cumplimiento de operaciones",
-  "support": "Soporte",
+      "alertsettings": "Alert Settings",
+      "compliance": "Alertas de cumplimiento",
+      "trade-compliance": "Cumplimiento de operaciones",
+      "support": "Soporte",
       "scenario": "Probador de Escenarios"
     },
     "logs": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Tableau de bord",
-      "holdings": "Positions",
-      "tradeTools": "Outils de trading",
-      "goals": "Objectifs",
-      "preferences": "Préférences",
+      "insightts": "Insightts",
+      "requirements": "Exigences",
+      "settings": "Paramètres",
       "operations": "Opérations",
       "other": "Autres"
     },
@@ -40,10 +39,10 @@
       "taxtools": "Outils fiscaux",
       "trail": "Trail",
       "reports": "Rapports",
-  "alertsettings": "Alert Settings",
-  "compliance": "Alertes de conformité",
-  "trade-compliance": "Conformité des transactions",
-  "support": "Support",
+      "alertsettings": "Alert Settings",
+      "compliance": "Alertes de conformité",
+      "trade-compliance": "Conformité des transactions",
+      "support": "Support",
       "scenario": "Testeur de Scénario"
     },
     "logs": {

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Dashboard",
-      "holdings": "Posizioni",
-      "tradeTools": "Strumenti di trading",
-      "goals": "Obiettivi",
-      "preferences": "Preferenze",
+      "insightts": "Insightts",
+      "requirements": "Requisiti",
+      "settings": "Impostazioni",
       "operations": "Operazioni",
       "other": "Altro"
     },
@@ -40,10 +39,10 @@
       "taxtools": "Strumenti fiscali",
       "trail": "Trail",
       "reports": "Segnalazioni",
-  "alertsettings": "Alert Settings",
-  "compliance": "Avvisi di conformità",
-  "trade-compliance": "Conformità delle operazioni",
-  "support": "Supporto",
+      "alertsettings": "Alert Settings",
+      "compliance": "Avvisi di conformità",
+      "trade-compliance": "Conformità delle operazioni",
+      "support": "Supporto",
       "scenario": "Tester di scenario"
     },
     "logs": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -12,10 +12,9 @@
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Painel",
-      "holdings": "Participações",
-      "tradeTools": "Ferramentas de negociação",
-      "goals": "Objetivos",
-      "preferences": "Preferências",
+      "insightts": "Insightts",
+      "requirements": "Requisitos",
+      "settings": "Configurações",
       "operations": "Operações",
       "other": "Outros"
     },
@@ -40,10 +39,10 @@
       "taxtools": "Ferramentas fiscais",
       "trail": "Trail",
       "reports": "Relatórios",
-  "alertsettings": "Alert Settings",
-  "compliance": "Alertas de conformidade",
-  "trade-compliance": "Conformidade de negociações",
-  "support": "Suporte",
+      "alertsettings": "Alert Settings",
+      "compliance": "Alertas de conformidade",
+      "trade-compliance": "Conformidade de negociações",
+      "support": "Suporte",
       "scenario": "Testador de Cenários"
     },
     "logs": {


### PR DESCRIPTION
## Summary
- rename user menu categories, consolidating holdings tabs under dashboard and introducing the new insightts, requirements, and settings group names
- add support and logout entries directly inside the settings dropdown while removing the redundant footer links
- update all locale translation files so menu category labels align with the renamed structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a0657c0c83278af9845b060802d2