### PR TITLE
Fix Yahoo metadata lookup for US tickers

### DIFF
--- a/backend/tests/test_instruments_autocreate.py
+++ b/backend/tests/test_instruments_autocreate.py
@@ -23,27 +23,29 @@ def test_get_instrument_meta_auto_creates_using_yahoo(tmp_path, monkeypatch):
         "instrument_type": "EQUITY",
     }
 
-    calls: list[str] = []
+    calls: list[tuple[str, str]] = []
 
-    def fake_fetch(full_ticker: str):
-        calls.append(full_ticker)
+    def fake_fetch(symbol: str, exchange: str):
+        calls.append((symbol, exchange))
         return dict(fetched)
 
     monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", fake_fetch)
 
     meta = instruments.get_instrument_meta("aapl.n")
 
-    assert meta["ticker"] == "PFE.N"
+    assert meta["ticker"] == "AAPL.N"
     assert meta["name"] == fetched["name"]
     assert meta["currency"] == fetched["currency"]
-    assert calls == ["PFE.N"]
+    assert meta["sector"] == fetched["sector"]
+    assert calls == [("AAPL", "N")]
 
-    path = tmp_path / "N" / "PFE.json"
+    path = tmp_path / "N" / "AAPL.json"
     assert path.exists()
     saved = json.loads(path.read_text(encoding="utf-8"))
-    assert saved["ticker"] == "PFE.N"
+    assert saved["ticker"] == "AAPL.N"
     assert saved["name"] == fetched["name"]
     assert saved["currency"] == fetched["currency"]
+    assert saved["sector"] == fetched["sector"]
 
 
 def test_auto_create_skips_when_fetch_fails(tmp_path, monkeypatch):
@@ -51,7 +53,7 @@ def test_auto_create_skips_when_fetch_fails(tmp_path, monkeypatch):
 
     calls = 0
 
-    def fake_fetch(full_ticker: str):
+    def fake_fetch(symbol: str, exchange: str):
         nonlocal calls
         calls += 1
         return None
@@ -73,10 +75,10 @@ def test_auto_create_skips_when_fetch_fails(tmp_path, monkeypatch):
 def test_auto_create_requires_exchange(tmp_path, monkeypatch):
     _reset_state(monkeypatch, tmp_path)
 
-    calls: list[str] = []
+    calls: list[tuple[str, str]] = []
 
-    def fake_fetch(full_ticker: str):  # pragma: no cover - should not be called
-        calls.append(full_ticker)
+    def fake_fetch(symbol: str, exchange: str):  # pragma: no cover - should not be called
+        calls.append((symbol, exchange))
         return {"name": "Should not happen"}
 
     monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", fake_fetch)


### PR DESCRIPTION
## Summary
- add a Yahoo suffix helper for instrument metadata fetches so US exchanges omit empty suffixes
- update the auto-create flow and tests to use the helper and ensure currency/sector metadata persists

## Testing
- pytest backend/tests/test_instruments_autocreate.py -q -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d79fe36bfc8327ac6ba705a8f1a9b1