### PR TITLE
Add owner-aware harvest candidates UI

### DIFF
--- a/frontend/src/pages/TaxTools.tsx
+++ b/frontend/src/pages/TaxTools.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { getAllowances, harvestTax } from "../api";
+import { getAllowances, getPortfolio, harvestTax } from "../api";
 import EmptyState from "../components/EmptyState";
+import { useRoute } from "../RouteContext";
+import type { Account, Holding } from "../types";
 
 type Position = {
   ticker: string;
@@ -11,6 +13,20 @@ type Position = {
 type Trade = {
   ticker: string;
   loss: number;
+};
+
+type HarvestCandidate = {
+  id: string;
+  ticker: string;
+  name: string;
+  account: string;
+  units: number;
+  basisPerUnit: number;
+  price: number;
+  costBasis: number;
+  marketValue: number;
+  loss: number;
+  lossPct: number;
 };
 
 type AllowanceInfo = {
@@ -25,7 +41,6 @@ interface HarvestFormState {
   ticker: string;
   basis: string;
   price: string;
-  threshold: string;
 }
 
 function InputField({
@@ -55,7 +70,6 @@ function useHarvestForm() {
     ticker: "",
     basis: "",
     price: "",
-    threshold: "",
   });
 
   const updateField = useCallback(
@@ -80,34 +94,202 @@ function useHarvestForm() {
     };
   }, [form]);
 
-  const threshold = useMemo(() => {
-    const parsed = parseFloat(form.threshold);
-    return Number.isNaN(parsed) ? null : parsed;
-  }, [form.threshold]);
-
   return {
     form,
     updateField,
     position,
-    threshold,
   } as const;
 }
 
+function coerceNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function getCandidateFromHolding(
+  holding: Holding,
+  account: Account,
+  owner: string,
+  accountIndex: number,
+  holdingIndex: number,
+): HarvestCandidate | null {
+  const units = coerceNumber(holding.units) ?? 0;
+  if (!holding.ticker || units <= 0) return null;
+
+  const basisTotal =
+    coerceNumber(holding.cost_basis_gbp) ??
+    coerceNumber(holding.effective_cost_basis_gbp);
+  if (!basisTotal || basisTotal <= 0) return null;
+
+  const basisPerUnit = basisTotal / units;
+  if (!Number.isFinite(basisPerUnit)) return null;
+
+  const explicitPrice = coerceNumber(holding.current_price_gbp);
+  const marketValue =
+    coerceNumber(holding.market_value_gbp) ??
+    (explicitPrice !== null ? explicitPrice * units : null);
+  if (!marketValue || marketValue <= 0) return null;
+
+  const price = explicitPrice ?? marketValue / units;
+  if (!Number.isFinite(price)) return null;
+
+  const loss = basisTotal - marketValue;
+  if (!(loss > 0)) return null;
+
+  const lossPct = (loss / basisTotal) * 100;
+
+  return {
+    id: `${owner}:${account.account_type}:${holding.ticker}:${accountIndex}:${holdingIndex}`,
+    ticker: holding.ticker,
+    name: holding.name ?? holding.ticker,
+    account: account.account_type,
+    units,
+    basisPerUnit,
+    price,
+    costBasis: basisTotal,
+    marketValue,
+    loss,
+    lossPct,
+  };
+}
+
+function flattenHarvestCandidates(owner: string, accounts: Account[]) {
+  const candidates: HarvestCandidate[] = [];
+  accounts.forEach((account, accountIndex) => {
+    account.holdings.forEach((holding, holdingIndex) => {
+      const candidate = getCandidateFromHolding(
+        holding,
+        account,
+        owner,
+        accountIndex,
+        holdingIndex,
+      );
+      if (candidate) candidates.push(candidate);
+    });
+  });
+
+  return candidates.sort((a, b) => b.loss - a.loss);
+}
+
+function useHarvestCandidates(owner: string | null | undefined) {
+  const [candidates, setCandidates] = useState<HarvestCandidate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    if (!owner) {
+      setCandidates([]);
+      setError(null);
+      setLoading(false);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setLoading(true);
+    getPortfolio(owner)
+      .then((portfolio) => {
+        if (!isMounted) return;
+        setCandidates(flattenHarvestCandidates(owner, portfolio.accounts));
+        setError(null);
+      })
+      .catch((err) => {
+        if (!isMounted) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(msg);
+        setCandidates([]);
+      })
+      .finally(() => {
+        if (!isMounted) return;
+        setLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [owner]);
+
+  return { candidates, loading, error } as const;
+}
+
 function TaxHarvestSection() {
-  const { form, updateField, position, threshold } = useHarvestForm();
+  const { selectedOwner } = useRoute();
+  const { candidates, loading, error: holdingsError } = useHarvestCandidates(
+    selectedOwner,
+  );
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [threshold, setThreshold] = useState(0);
+  const { form, updateField, position } = useHarvestForm();
   const [trades, setTrades] = useState<Trade[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency: "GBP",
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+    [],
+  );
+
+  const percentFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        style: "percent",
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const valid = prev.filter((id) => candidates.some((c) => c.id === id));
+      if (valid.length > 0 || candidates.length === 0) {
+        return valid;
+      }
+      return candidates.slice(0, 1).map((candidate) => candidate.id);
+    });
+  }, [candidates]);
+
+  const selectedPositions = useMemo(() => {
+    const map = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+    return selectedIds
+      .map((id) => map.get(id))
+      .filter((candidate): candidate is HarvestCandidate => Boolean(candidate))
+      .map((candidate) => ({
+        ticker: candidate.ticker,
+        basis: candidate.basisPerUnit,
+        price: candidate.price,
+      }));
+  }, [candidates, selectedIds]);
 
   const handleHarvest = useCallback(async () => {
-    if (!position || threshold === null) {
-      setError("Please fill out all fields with valid values");
+    const payload: Position[] = [...selectedPositions];
+
+    if (position) {
+      payload.push(position);
+    }
+
+    if (payload.length === 0) {
+      setError("Select at least one position or add a manual entry");
       return;
     }
 
     setIsLoading(true);
     try {
-      const response = await harvestTax([position], threshold);
+      const response = await harvestTax(payload, threshold);
       setTrades(response.trades);
       setError(null);
     } catch (err) {
@@ -117,7 +299,9 @@ function TaxHarvestSection() {
     } finally {
       setIsLoading(false);
     }
-  }, [position, threshold]);
+  }, [position, selectedPositions, threshold]);
+
+  const thresholdLabel = useMemo(() => `${threshold}%`, [threshold]);
 
   return (
     <section aria-labelledby="tax-harvest-heading" className="flex flex-col gap-4">
@@ -129,49 +313,175 @@ function TaxHarvestSection() {
           Model potential loss harvesting opportunities from your positions.
         </p>
       </div>
-      <div className="flex flex-col gap-2 max-w-sm">
-        <InputField
-          placeholder="Ticker"
-          value={form.ticker}
-          onChange={updateField("ticker")}
-        />
-        <InputField
-          placeholder="Basis"
-          type="number"
-          value={form.basis}
-          onChange={updateField("basis")}
-        />
-        <InputField
-          placeholder="Price"
-          type="number"
-          value={form.price}
-          onChange={updateField("price")}
-        />
-        <InputField
-          placeholder="Threshold"
-          type="number"
-          value={form.threshold}
-          onChange={updateField("threshold")}
-        />
-      </div>
-      <button
-        type="button"
-        className="w-fit rounded border px-4 py-2"
-        onClick={handleHarvest}
-        disabled={isLoading}
-      >
-        Run Harvest
-      </button>
+
+      {!selectedOwner && (
+        <p className="text-sm text-gray-500">
+          Select an owner to view harvest candidates.
+        </p>
+      )}
+
+      {selectedOwner && (
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <h3 className="text-lg font-semibold">
+              Top loss candidates for {selectedOwner}
+            </h3>
+            {loading && <div>Loading holdings…</div>}
+            {holdingsError && (
+              <p className="text-red-500">Failed to load holdings: {holdingsError}</p>
+            )}
+            {!loading && !holdingsError && candidates.length === 0 && (
+              <p>No qualifying loss positions were found.</p>
+            )}
+            {!loading && !holdingsError && candidates.length > 0 && (
+              <div className="overflow-x-auto">
+                <table
+                  className="min-w-full border-collapse border border-gray-200 text-sm"
+                  data-testid="harvest-candidates"
+                >
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="border px-2 py-1 text-left">Select</th>
+                      <th className="border px-2 py-1 text-left">Ticker</th>
+                      <th className="border px-2 py-1 text-left">Name</th>
+                      <th className="border px-2 py-1 text-left">Account</th>
+                      <th className="border px-2 py-1 text-right">Units</th>
+                      <th className="border px-2 py-1 text-right">Cost</th>
+                      <th className="border px-2 py-1 text-right">Market value</th>
+                      <th className="border px-2 py-1 text-right">Loss (£)</th>
+                      <th className="border px-2 py-1 text-right">Loss (%)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {candidates.map((candidate) => {
+                      const isSelected = selectedIds.includes(candidate.id);
+                      return (
+                        <tr key={candidate.id} className={isSelected ? "bg-blue-50" : undefined}>
+                          <td className="border px-2 py-1 text-center">
+                            <input
+                              type="checkbox"
+                              aria-label={`Select ${candidate.ticker}`}
+                              checked={isSelected}
+                              onChange={(event) => {
+                                setSelectedIds((prev) => {
+                                  if (event.target.checked) {
+                                    if (prev.includes(candidate.id)) {
+                                      return prev;
+                                    }
+                                    return [...prev, candidate.id];
+                                  }
+                                  return prev.filter((id) => id !== candidate.id);
+                                });
+                              }}
+                            />
+                          </td>
+                          <td className="border px-2 py-1 font-mono">{candidate.ticker}</td>
+                          <td className="border px-2 py-1">{candidate.name}</td>
+                          <td className="border px-2 py-1 capitalize">{candidate.account}</td>
+                          <td className="border px-2 py-1 text-right">
+                            {candidate.units.toLocaleString(undefined, {
+                              maximumFractionDigits: 2,
+                            })}
+                          </td>
+                          <td className="border px-2 py-1 text-right">
+                            {currencyFormatter.format(candidate.costBasis)}
+                          </td>
+                          <td className="border px-2 py-1 text-right">
+                            {currencyFormatter.format(candidate.marketValue)}
+                          </td>
+                          <td className="border px-2 py-1 text-right">
+                            {currencyFormatter.format(-candidate.loss)}
+                          </td>
+                          <td className="border px-2 py-1 text-right">
+                            {percentFormatter.format(-candidate.lossPct / 100)}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="harvest-threshold" className="text-sm font-medium">
+              Loss threshold ({thresholdLabel})
+            </label>
+            <input
+              id="harvest-threshold"
+              type="range"
+              min="0"
+              max="50"
+              step="1"
+              value={threshold}
+              onChange={(event) => setThreshold(Number(event.target.value))}
+            />
+            <p className="text-xs text-gray-500">
+              Only trades with losses greater than this percentage of basis will be
+              suggested.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <button
+              type="button"
+              className="w-fit rounded border px-3 py-1 text-sm"
+              onClick={() => setShowAdvanced((prev) => !prev)}
+            >
+              {showAdvanced ? "Hide advanced" : "Advanced"}
+            </button>
+            {showAdvanced && (
+              <div className="flex flex-col gap-2 max-w-sm" data-testid="advanced-form">
+                <InputField
+                  placeholder="Ticker"
+                  value={form.ticker}
+                  onChange={updateField("ticker")}
+                />
+                <InputField
+                  placeholder="Basis per unit"
+                  type="number"
+                  value={form.basis}
+                  onChange={updateField("basis")}
+                />
+                <InputField
+                  placeholder="Price"
+                  type="number"
+                  value={form.price}
+                  onChange={updateField("price")}
+                />
+              </div>
+            )}
+          </div>
+
+          <button
+            type="button"
+            className="w-fit rounded border px-4 py-2"
+            onClick={handleHarvest}
+            disabled={isLoading}
+          >
+            Run Harvest
+          </button>
+        </div>
+      )}
+
       {isLoading && <div data-testid="spinner">Loading...</div>}
       {error && <p className="text-red-500">{error}</p>}
       {trades && trades.length > 0 && (
-        <ul data-testid="harvest-results" className="list-disc pl-5">
-          {trades.map(({ ticker, loss }, index) => (
-            <li key={`${ticker}-${index}`}>
-              {ticker}: {loss}
-            </li>
-          ))}
-        </ul>
+        <div className="flex flex-col gap-2" data-testid="harvest-results">
+          <p className="font-medium">
+            Total realized loss: {currencyFormatter.format(
+              trades.reduce((sum, trade) => sum + (trade.loss ?? 0), 0) * -1,
+            )}
+          </p>
+          <ul className="list-disc pl-5 text-sm">
+            {trades.map(({ ticker, loss }, index) => (
+              <li key={`${ticker}-${index}`}>
+                {ticker}: {currencyFormatter.format(-loss)}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
       {trades && trades.length === 0 && <p>No trades qualify</p>}
     </section>

--- a/frontend/tests/unit/pages/TaxTools.test.tsx
+++ b/frontend/tests/unit/pages/TaxTools.test.tsx
@@ -1,16 +1,57 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import TaxTools from "@/pages/TaxTools";
-import { getAllowances, harvestTax } from "@/api";
+import { getAllowances, getPortfolio, harvestTax } from "@/api";
+import { useRoute } from "@/RouteContext";
 
 vi.mock("@/api", () => ({
   harvestTax: vi.fn(),
   getAllowances: vi.fn(),
+  getPortfolio: vi.fn(),
+}));
+
+vi.mock("@/RouteContext", () => ({
+  useRoute: vi.fn(),
 }));
 
 describe("TaxTools", () => {
   const allowancesMock = getAllowances as unknown as vi.Mock;
   const harvestMock = harvestTax as unknown as vi.Mock;
+  const portfolioMock = getPortfolio as unknown as vi.Mock;
+  const useRouteMock = useRoute as unknown as vi.Mock;
+
+  const basePortfolio = {
+    owner: "demo",
+    as_of: "2024-01-01",
+    trades_this_month: 0,
+    trades_remaining: 10,
+    total_value_estimate_gbp: 15000,
+    accounts: [
+      {
+        account_type: "isa",
+        currency: "GBP",
+        value_estimate_gbp: 15000,
+        holdings: [
+          {
+            ticker: "ABC",
+            name: "ABC Corp",
+            units: 10,
+            cost_basis_gbp: 1000,
+            market_value_gbp: 600,
+            current_price_gbp: 60,
+          },
+          {
+            ticker: "XYZ",
+            name: "XYZ Ltd",
+            units: 5,
+            effective_cost_basis_gbp: 500,
+            market_value_gbp: 250,
+            current_price_gbp: 50,
+          },
+        ],
+      },
+    ],
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -22,34 +63,25 @@ describe("TaxTools", () => {
       },
     });
     harvestMock.mockResolvedValue({ trades: [] });
+    portfolioMock.mockResolvedValue(basePortfolio);
+    useRouteMock.mockReturnValue({
+      mode: "owner",
+      setMode: vi.fn(),
+      selectedOwner: "demo",
+      setSelectedOwner: vi.fn(),
+      selectedGroup: "",
+      setSelectedGroup: vi.fn(),
+    });
   });
 
-  it("calls harvest API and shows results", async () => {
-    harvestMock.mockResolvedValue({ trades: [{ ticker: "ABC", loss: 123 }] });
-
+  it("loads holdings for the active owner", async () => {
     render(<TaxTools />);
 
-    fireEvent.change(screen.getByPlaceholderText(/ticker/i), {
-      target: { value: "ABC" },
-    });
-    fireEvent.change(screen.getByPlaceholderText(/basis/i), {
-      target: { value: "100" },
-    });
-    fireEvent.change(screen.getByPlaceholderText(/price/i), {
-      target: { value: "80" },
-    });
-    fireEvent.change(screen.getByPlaceholderText(/threshold/i), {
-      target: { value: "0" },
-    });
+    await screen.findByTestId("harvest-candidates");
 
-    fireEvent.click(screen.getByRole("button", { name: /run harvest/i }));
-
-    await screen.findByText(/ABC/);
-
-    expect(harvestMock).toHaveBeenCalledWith(
-      [{ ticker: "ABC", basis: 100, price: 80 }],
-      0,
-    );
+    expect(portfolioMock).toHaveBeenCalledWith("demo");
+    expect(screen.getByText("ABC Corp")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Select XYZ/)).toBeInTheDocument();
   });
 
   it("disables button and shows spinner while loading", async () => {
@@ -63,18 +95,7 @@ describe("TaxTools", () => {
 
     render(<TaxTools />);
 
-    fireEvent.change(screen.getByPlaceholderText(/ticker/i), {
-      target: { value: "XYZ" },
-    });
-    fireEvent.change(screen.getByPlaceholderText(/basis/i), {
-      target: { value: "200" },
-    });
-    fireEvent.change(screen.getByPlaceholderText(/price/i), {
-      target: { value: "150" },
-    });
-    fireEvent.change(screen.getByPlaceholderText(/threshold/i), {
-      target: { value: "5" },
-    });
+    await screen.findByTestId("harvest-candidates");
 
     const button = screen.getByRole("button", { name: /run harvest/i });
     fireEvent.click(button);
@@ -82,26 +103,76 @@ describe("TaxTools", () => {
     await screen.findByTestId("spinner");
     expect(button).toBeDisabled();
 
-    resolvePromise!({ trades: [{ ticker: "XYZ", loss: 50 }] });
-    await screen.findByText(/XYZ/);
+    resolvePromise!({ trades: [{ ticker: "ABC", loss: 400 }] });
+    await screen.findByTestId("harvest-results");
+  });
+
+  it("allows selecting candidates and runs harvest", async () => {
+    harvestMock.mockResolvedValue({
+      trades: [
+        { ticker: "ABC", loss: 400 },
+        { ticker: "XYZ", loss: 250 },
+      ],
+    });
+
+    render(<TaxTools />);
+
+    await screen.findByTestId("harvest-candidates");
+
+    fireEvent.click(screen.getByLabelText(/Select XYZ/));
+    const threshold = screen.getByLabelText(/Loss threshold/);
+    fireEvent.change(threshold, { target: { value: "10" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /run harvest/i }));
+
+    await screen.findByText(/Total realized loss/i);
+
+    expect(harvestMock).toHaveBeenCalledWith(
+      [
+        { ticker: "ABC", basis: 100, price: 60 },
+        { ticker: "XYZ", basis: 100, price: 50 },
+      ],
+      10,
+    );
+    expect(screen.getByTestId("harvest-results")).toHaveTextContent("XYZ");
+  });
+
+  it("supports manual advanced entries", async () => {
+    harvestMock.mockResolvedValue({ trades: [{ ticker: "MAN", loss: 150 }] });
+
+    render(<TaxTools />);
+
+    await screen.findByTestId("harvest-candidates");
+
+    fireEvent.click(screen.getByLabelText(/Select ABC/));
+
+    fireEvent.click(screen.getByRole("button", { name: /advanced/i }));
+
+    const advanced = await screen.findByTestId("advanced-form");
+    fireEvent.change(within(advanced).getByPlaceholderText(/ticker/i), {
+      target: { value: "MAN" },
+    });
+    fireEvent.change(within(advanced).getByPlaceholderText(/basis per unit/i), {
+      target: { value: "95" },
+    });
+    fireEvent.change(within(advanced).getByPlaceholderText(/price/i), {
+      target: { value: "80" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /run harvest/i }));
+
+    await screen.findByTestId("harvest-results");
+
+    expect(harvestMock).toHaveBeenCalledWith(
+      [{ ticker: "MAN", basis: 95, price: 80 }],
+      0,
+    );
   });
 
   it("renders allowance data", async () => {
     render(<TaxTools />);
 
-    await screen.findByText(/isa/i);
-    await screen.findByText("19000.00");
-  });
-
-  it("shows validation error when inputs are incomplete", async () => {
-    render(<TaxTools />);
-
-    fireEvent.change(screen.getByPlaceholderText(/ticker/i), {
-      target: { value: "ABC" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /run harvest/i }));
-
-    await screen.findByText(/fill out all fields/i);
-    expect(harvestMock).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getAllByText(/isa/i).length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText("19000.00").length).toBeGreaterThan(0));
   });
 });


### PR DESCRIPTION
## Summary
- load the selected owner’s portfolio and derive loss harvest candidates with basis, price, and loss metrics
- replace the manual harvest form with a candidate picker, threshold slider, and advanced override while summarising modeled results
- extend the TaxTools tests to cover owner loading, candidate selection, and manual entry flows

## Testing
- npm test -- --run TaxTools

------
https://chatgpt.com/codex/tasks/task_e_68d7a084f4d083279d629dcc3bbb8cd0