### PR TITLE
Include account directories in compliance owner discovery

### DIFF
--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -25,20 +25,20 @@ def _known_owners(accounts_root) -> set[str]:
         if owner:
             owners.add(owner.lower())
 
-    if owners:
-        return owners
-
     try:
-        root_path = Path(accounts_root) if accounts_root else data_loader.resolve_paths(None, None).accounts_root
+        root_path = (
+            Path(accounts_root)
+            if accounts_root
+            else data_loader.resolve_paths(None, None).accounts_root
+        )
     except Exception:
-        return owners
+        root_path = None
 
-    if not root_path or not root_path.exists():
-        return owners
+    if root_path and root_path.exists():
+        for entry in root_path.iterdir():
+            if entry.is_dir():
+                owners.add(entry.name.lower())
 
-    for entry in root_path.iterdir():
-        if entry.is_dir():
-            owners.add(entry.name.lower())
     return owners
 
 


### PR DESCRIPTION
## Summary
- update compliance owner discovery to union list_plots results with on-disk directories
- add regression test ensuring validate endpoint accepts owners present only on disk

## Testing
- PYTEST_ADDOPTS="--cov=backend --cov-fail-under=0" pytest tests/test_compliance_route.py::test_validate_trade_accepts_owner_directories_even_when_filtered

------
https://chatgpt.com/codex/tasks/task_e_68d7a5a31e408327a205af327a70ae08