### PR TITLE
Collapse main menu items under Dashboard dropdown

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -8,6 +8,10 @@ import { orderedTabPlugins, SUPPORT_TABS } from '../tabPlugins';
 
 const SUPPORT_ONLY_TABS: TabPluginId[] = [];
 
+const ALL_USER_TAB_IDS: TabPluginId[] = orderedTabPlugins
+  .filter((plugin) => plugin.section === 'user')
+  .map((plugin) => plugin.id);
+
 interface MenuProps {
   selectedOwner?: string;
   selectedGroup?: string;
@@ -112,27 +116,7 @@ export default function Menu({
   };
 
   const USER_MENU_CATEGORIES: MenuCategory[] = [
-    { id: 'dashboard', titleKey: 'dashboard', tabIds: ['group', 'market', 'movers'] },
-    {
-      id: 'holdings',
-      titleKey: 'holdings',
-      tabIds: ['owner', 'performance', 'allocation', 'transactions', 'reports'],
-    },
-    {
-      id: 'tradeTools',
-      titleKey: 'tradeTools',
-      tabIds: [
-        'instrument',
-        'screener',
-        'watchlist',
-        'scenario',
-        'trading',
-        'rebalance',
-        'tradecompliance',
-      ],
-    },
-    { id: 'goals', titleKey: 'goals', tabIds: ['pension', 'taxtools', 'trail'] },
-    { id: 'preferences', titleKey: 'preferences', tabIds: ['alertsettings', 'settings'] },
+    { id: 'dashboard', titleKey: 'dashboard', tabIds: ALL_USER_TAB_IDS },
   ];
 
   const SUPPORT_MENU_CATEGORIES: MenuCategory[] = [
@@ -328,7 +312,9 @@ export default function Menu({
                       </Link>
                     </li>
                   ))}
-                  {category.id === 'preferences' && supportEnabled && (
+                  {((!isSupportMode && category.id === 'dashboard') ||
+                    (isSupportMode && category.id === 'preferences')) &&
+                    supportEnabled && (
                     <li key="support">
                       <Link
                         ref={assignFirstFocusable}
@@ -344,7 +330,9 @@ export default function Menu({
                       </Link>
                     </li>
                   )}
-                  {category.id === 'preferences' && onLogout && (
+                  {((!isSupportMode && category.id === 'dashboard') ||
+                    (isSupportMode && category.id === 'preferences')) &&
+                    onLogout && (
                     <li key="logout">
                       <button
                         ref={(element) => assignFirstFocusable(element)}

--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -12,21 +12,21 @@ describe("Menu", () => {
         <Menu />
       </MemoryRouter>,
     );
-    const settingsToggle = screen.getByRole("button", {
-      name: i18n.t("app.menuCategories.preferences"),
+    const dashboardToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.dashboard"),
     });
-    expect(settingsToggle).toHaveAttribute("aria-expanded", "false");
+    expect(dashboardToggle).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("menuitem", { name: "Support" })).not.toBeInTheDocument();
-    fireEvent.click(settingsToggle);
-    expect(settingsToggle).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(dashboardToggle);
+    expect(dashboardToggle).toHaveAttribute("aria-expanded", "true");
     const supportLink = await screen.findByRole("menuitem", { name: "Support" });
     expect(supportLink).toBeVisible();
     expect(supportLink).toHaveAttribute(
       "href",
       "/support",
     );
-    fireEvent.click(settingsToggle);
-    expect(settingsToggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(dashboardToggle);
+    expect(dashboardToggle).toHaveAttribute("aria-expanded", "false");
     await waitFor(() =>
       expect(screen.queryByRole("menuitem", { name: "Support" })).not.toBeInTheDocument(),
     );
@@ -38,14 +38,14 @@ describe("Menu", () => {
         <Menu />
       </MemoryRouter>,
     );
-    const settingsToggle = screen.getByRole("button", {
-      name: i18n.t("app.menuCategories.preferences"),
+    const dashboardToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.dashboard"),
     });
-    expect(settingsToggle).toHaveAttribute("aria-expanded", "false");
-    fireEvent.click(settingsToggle);
-    expect(settingsToggle).toHaveAttribute("aria-expanded", "true");
-    fireEvent.click(settingsToggle);
-    expect(settingsToggle).toHaveAttribute("aria-expanded", "false");
+    expect(dashboardToggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(dashboardToggle);
+    expect(dashboardToggle).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(dashboardToggle);
+    expect(dashboardToggle).toHaveAttribute("aria-expanded", "false");
   });
 
   it("shows support tabs on support route", async () => {
@@ -54,10 +54,10 @@ describe("Menu", () => {
         <Menu />
       </MemoryRouter>,
     );
-    const settingsToggle = screen.getByRole("button", {
+    const preferencesToggle = screen.getByRole("button", {
       name: i18n.t("app.menuCategories.preferences"),
     });
-    fireEvent.click(settingsToggle);
+    fireEvent.click(preferencesToggle);
     const supportLink = await screen.findByRole("menuitem", { name: "Support" });
     expect(supportLink).toHaveAttribute("href", "/");
   });
@@ -102,10 +102,10 @@ describe("Menu", () => {
         </MemoryRouter>
       </configContext.Provider>,
     );
-    const settingsToggle = screen.getByRole("button", {
-      name: i18n.t("app.menuCategories.preferences"),
+    const dashboardToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.dashboard"),
     });
-    fireEvent.click(settingsToggle);
+    fireEvent.click(dashboardToggle);
     expect(screen.queryByRole("menuitem", { name: "Support" })).toBeNull();
   });
 
@@ -117,10 +117,10 @@ describe("Menu", () => {
         <Menu onLogout={onLogout} />
       </MemoryRouter>,
     );
-    const settingsToggle = screen.getByRole("button", {
-      name: i18n.t("app.menuCategories.preferences"),
+    const dashboardToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.dashboard"),
     });
-    fireEvent.click(settingsToggle);
+    fireEvent.click(dashboardToggle);
     const btn = await screen.findByRole("menuitem", { name: "Déconnexion" });
     fireEvent.click(btn);
     expect(onLogout).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- consolidate all user navigation tabs into a single Dashboard dropdown and keep support/logout actions accessible there
- adjust menu logic to surface support/logout links from the unified dropdown while preserving support-mode behaviour
- update Menu unit tests to reflect the unified navigation experience

## Testing
- npx vitest run tests/unit/components/Menu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7a590655c832797ee451f9a48a035