### PR TITLE
Merge holdings items into Dashboard dropdown

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -112,11 +112,10 @@ export default function Menu({
   };
 
   const USER_MENU_CATEGORIES: MenuCategory[] = [
-    { id: 'dashboard', titleKey: 'dashboard', tabIds: ['group', 'market', 'movers'] },
     {
-      id: 'holdings',
-      titleKey: 'holdings',
-      tabIds: ['owner', 'performance', 'allocation', 'transactions', 'reports'],
+      id: 'dashboard',
+      titleKey: 'dashboard',
+      tabIds: ['group', 'market', 'movers', 'owner', 'performance', 'allocation', 'transactions', 'reports'],
     },
     {
       id: 'tradeTools',


### PR DESCRIPTION
## Summary
- merge the holdings-related tabs into the Dashboard dropdown while keeping other menu groups intact
- ensure support and logout links remain in the Preferences dropdown for both user and support modes

## Testing
- npx vitest run tests/unit/components/Menu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7a590655c832797ee451f9a48a035