### PR TITLE
Expand Playwright smoke test route coverage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -361,6 +361,12 @@ export default function App({ onLogout }: AppProps) {
   return (
     <div className="xl:flex xl:justify-center">
       <main style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
+        <div
+          data-testid="active-route-marker"
+          data-mode={mode}
+          data-pathname={location.pathname}
+          hidden
+        />
       <div
         style={{
           display: "flex",

--- a/frontend/src/pages/Alerts.tsx
+++ b/frontend/src/pages/Alerts.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import * as api from "../api";
 import type { Alert } from "../types";
 import EmptyState from "../components/EmptyState";
@@ -59,45 +59,61 @@ export default function Alerts() {
     ? virtualRows
     : alerts.map((_, index) => ({ index, start: index * 32, end: (index + 1) * 32 }));
 
+  const marker = <span data-testid="alerts-page-marker" hidden />;
+
   if (loading) {
     return (
-      <div role="status" aria-live="polite">
-        Loading...
-      </div>
+      <Fragment>
+        {marker}
+        <div role="status" aria-live="polite">
+          Loading...
+        </div>
+      </Fragment>
     );
   }
 
   if (error) {
     return (
-      <div role="alert" aria-live="assertive">
-        {error}
-      </div>
+      <Fragment>
+        {marker}
+        <div role="alert" aria-live="assertive">
+          {error}
+        </div>
+      </Fragment>
     );
   }
 
   if (alerts.length === 0) {
-    return <EmptyState message="No alerts." role="status" aria-live="polite" />;
+    return (
+      <Fragment>
+        {marker}
+        <EmptyState message="No alerts." role="status" aria-live="polite" />
+      </Fragment>
+    );
   }
 
   return (
-    <div
-      ref={parentRef}
-      style={{ maxHeight: "60vh", overflowY: "auto", overflowX: "hidden" }}
-      aria-live="polite"
-    >
-      <ul style={{ margin: 0, paddingLeft: "1.2rem" }}>
-        {paddingTop > 0 && <li style={{ height: paddingTop }} />}
-        {items.map((virtualRow) => {
-          const a = alerts[virtualRow.index];
-          const key = (a as any)?.id ?? `${a.ticker}-${virtualRow.index}`;
-          return (
-            <li key={key} style={{ height: 32, display: "flex", alignItems: "center" }}>
-              <strong>{a.ticker}</strong>: {a.message}
-            </li>
-          );
-        })}
-        {paddingBottom > 0 && <li style={{ height: paddingBottom }} />}
-      </ul>
-    </div>
+    <Fragment>
+      {marker}
+      <div
+        ref={parentRef}
+        style={{ maxHeight: "60vh", overflowY: "auto", overflowX: "hidden" }}
+        aria-live="polite"
+      >
+        <ul style={{ margin: 0, paddingLeft: "1.2rem" }}>
+          {paddingTop > 0 && <li style={{ height: paddingTop }} />}
+          {items.map((virtualRow) => {
+            const a = alerts[virtualRow.index];
+            const key = (a as any)?.id ?? `${a.ticker}-${virtualRow.index}`;
+            return (
+              <li key={key} style={{ height: 32, display: "flex", alignItems: "center" }}>
+                <strong>{a.ticker}</strong>: {a.message}
+              </li>
+            );
+          })}
+          {paddingBottom > 0 && <li style={{ height: paddingBottom }} />}
+        </ul>
+      </div>
+    </Fragment>
   );
 }

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -16,6 +16,90 @@ const applyAuth = async (page: Page) => {
   }, authToken);
 };
 
+type ModeAssertion = { kind: 'mode'; mode: string };
+type HeadingAssertion = {
+  kind: 'heading';
+  name: string | RegExp;
+  level?: number;
+};
+type TextAssertion = { kind: 'text'; value: string };
+type TestIdAssertion = { kind: 'testId'; value: string };
+
+type RouteConfig = {
+  path: string;
+  assertion: ModeAssertion | HeadingAssertion | TextAssertion | TestIdAssertion;
+};
+
+const ROUTES: RouteConfig[] = [
+  { path: '/', assertion: { kind: 'mode', mode: 'group' } },
+  { path: '/portfolio', assertion: { kind: 'mode', mode: 'owner' } },
+  { path: '/portfolio/demo-owner', assertion: { kind: 'mode', mode: 'owner' } },
+  { path: '/performance', assertion: { kind: 'mode', mode: 'performance' } },
+  {
+    path: '/performance/demo-owner',
+    assertion: { kind: 'mode', mode: 'performance' },
+  },
+  { path: '/instrument', assertion: { kind: 'mode', mode: 'instrument' } },
+  { path: '/transactions', assertion: { kind: 'mode', mode: 'transactions' } },
+  { path: '/trading', assertion: { kind: 'mode', mode: 'trading' } },
+  { path: '/screener', assertion: { kind: 'mode', mode: 'screener' } },
+  { path: '/timeseries', assertion: { kind: 'mode', mode: 'timeseries' } },
+  { path: '/watchlist', assertion: { kind: 'mode', mode: 'watchlist' } },
+  { path: '/market', assertion: { kind: 'mode', mode: 'market' } },
+  { path: '/allocation', assertion: { kind: 'mode', mode: 'allocation' } },
+  { path: '/rebalance', assertion: { kind: 'mode', mode: 'rebalance' } },
+  { path: '/movers', assertion: { kind: 'mode', mode: 'movers' } },
+  {
+    path: '/instrumentadmin',
+    assertion: { kind: 'mode', mode: 'instrumentadmin' },
+  },
+  { path: '/dataadmin', assertion: { kind: 'mode', mode: 'dataadmin' } },
+  { path: '/reports', assertion: { kind: 'mode', mode: 'reports' } },
+  { path: '/tax-tools', assertion: { kind: 'mode', mode: 'taxtools' } },
+  { path: '/scenario', assertion: { kind: 'mode', mode: 'scenario' } },
+  { path: '/pension/forecast', assertion: { kind: 'mode', mode: 'pension' } },
+  { path: '/research/AAA', assertion: { kind: 'mode', mode: 'research' } },
+  { path: '/virtual', assertion: { kind: 'heading', name: 'Virtual Portfolios' } },
+  { path: '/support', assertion: { kind: 'heading', name: 'Support' } },
+  { path: '/alerts', assertion: { kind: 'testId', value: 'alerts-page-marker' } },
+  { path: '/alert-settings', assertion: { kind: 'heading', name: 'Alert Settings' } },
+  { path: '/goals', assertion: { kind: 'heading', name: 'Goals' } },
+  { path: '/trail', assertion: { kind: 'heading', name: 'Trail progress' } },
+  { path: '/smoke-test', assertion: { kind: 'heading', name: 'Smoke test' } },
+  {
+    path: '/metrics-explained',
+    assertion: { kind: 'heading', name: 'Performance Metrics Explained' },
+  },
+  {
+    path: '/returns/compare',
+    assertion: { kind: 'heading', name: /Return Comparison/ },
+  },
+  {
+    path: '/returns/compare?owner=demo-owner',
+    assertion: { kind: 'heading', name: 'Return Comparison – demo-owner' },
+  },
+  {
+    path: '/performance/demo-owner/diagnostics',
+    assertion: { kind: 'heading', name: 'Performance Diagnostics – demo-owner' },
+  },
+  {
+    path: '/trade-compliance',
+    assertion: { kind: 'heading', name: 'Trade compliance' },
+  },
+  {
+    path: '/trade-compliance/demo-owner',
+    assertion: { kind: 'heading', name: 'Trade compliance' },
+  },
+  {
+    path: '/compliance',
+    assertion: { kind: 'heading', name: 'Compliance warnings' },
+  },
+  {
+    path: '/compliance/demo-owner',
+    assertion: { kind: 'heading', name: 'Compliance warnings' },
+  },
+];
+
 test.describe('smoke test page', () => {
   test('reports ok for every backend check', async ({ page }) => {
     await applyAuth(page);
@@ -51,4 +135,42 @@ test.describe('pension forecast page', () => {
     await expect(page.getByRole('heading', { name: 'Pension Forecast' })).toBeVisible();
     expect(pageErrors).toHaveLength(0);
   });
+});
+
+test.describe('public route smoke coverage', () => {
+  for (const route of ROUTES) {
+    test(`renders ${route.path}`, async ({ page }) => {
+      const target = new URL(route.path, baseUrl);
+      const pageErrors: Error[] = [];
+      page.on('pageerror', (error) => {
+        pageErrors.push(error);
+      });
+
+      await applyAuth(page);
+
+      await page.goto(target);
+      await expect(page).toHaveURL(target.href);
+
+      if (route.assertion.kind === 'mode') {
+        const marker = page.getByTestId('active-route-marker');
+        await expect(marker).toHaveAttribute('data-mode', route.assertion.mode);
+        await expect(marker).toHaveAttribute('data-pathname', target.pathname);
+      } else if (route.assertion.kind === 'heading') {
+        await expect(
+          page.getByRole('heading', {
+            name: route.assertion.name,
+            level: route.assertion.level ?? 1,
+          }),
+        ).toBeVisible();
+      } else if (route.assertion.kind === 'testId') {
+        await expect(page.getByTestId(route.assertion.value)).toHaveCount(1);
+      } else {
+        await expect(
+          page.getByText(route.assertion.value, { exact: true }),
+        ).toBeVisible();
+      }
+
+      expect(pageErrors).toHaveLength(0);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add a hidden active-route marker to the main app shell for smoke assertions
- expose a persistent marker on the alerts page to stabilise navigation checks
- iterate the public and tab routes in the smoke Playwright spec and verify each renders without errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a593e780832785563ad8ab2f1841