### PR TITLE
Fix trade compliance menu label

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -40,10 +40,11 @@
       "taxtools": "Tax Tools",
       "trail": "Trail",
       "reports": "Reports",
-  "alertsettings": "Alert Settings",
-  "compliance": "Compliance warnings",
-  "trade-compliance": "Trade compliance",
-  "support": "Support",
+      "alertsettings": "Alert Settings",
+      "compliance": "Compliance warnings",
+      "tradecompliance": "Trade compliance",
+      "trade-compliance": "Trade compliance",
+      "support": "Support",
       "scenario": "Scenario Tester"
     }
   },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -40,10 +40,11 @@
       "taxtools": "Herramientas fiscales",
       "trail": "Trail",
       "reports": "Informes",
-  "alertsettings": "Alert Settings",
-  "compliance": "Alertas de cumplimiento",
-  "trade-compliance": "Cumplimiento de operaciones",
-  "support": "Soporte",
+      "alertsettings": "Alert Settings",
+      "compliance": "Alertas de cumplimiento",
+      "tradecompliance": "Cumplimiento de operaciones",
+      "trade-compliance": "Cumplimiento de operaciones",
+      "support": "Soporte",
       "scenario": "Probador de Escenarios"
     },
     "logs": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -40,10 +40,11 @@
       "taxtools": "Outils fiscaux",
       "trail": "Trail",
       "reports": "Rapports",
-  "alertsettings": "Alert Settings",
-  "compliance": "Alertes de conformité",
-  "trade-compliance": "Conformité des transactions",
-  "support": "Support",
+      "alertsettings": "Alert Settings",
+      "compliance": "Alertes de conformité",
+      "tradecompliance": "Conformité des transactions",
+      "trade-compliance": "Conformité des transactions",
+      "support": "Support",
       "scenario": "Testeur de Scénario"
     },
     "logs": {

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -40,10 +40,11 @@
       "taxtools": "Strumenti fiscali",
       "trail": "Trail",
       "reports": "Segnalazioni",
-  "alertsettings": "Alert Settings",
-  "compliance": "Avvisi di conformità",
-  "trade-compliance": "Conformità delle operazioni",
-  "support": "Supporto",
+      "alertsettings": "Alert Settings",
+      "compliance": "Avvisi di conformità",
+      "tradecompliance": "Conformità delle operazioni",
+      "trade-compliance": "Conformità delle operazioni",
+      "support": "Supporto",
       "scenario": "Tester di scenario"
     },
     "logs": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -40,10 +40,11 @@
       "taxtools": "Ferramentas fiscais",
       "trail": "Trail",
       "reports": "Relatórios",
-  "alertsettings": "Alert Settings",
-  "compliance": "Alertas de conformidade",
-  "trade-compliance": "Conformidade de negociações",
-  "support": "Suporte",
+      "alertsettings": "Alert Settings",
+      "compliance": "Alertas de conformidade",
+      "tradecompliance": "Conformidade de negociações",
+      "trade-compliance": "Conformidade de negociações",
+      "support": "Suporte",
       "scenario": "Testador de Cenários"
     },
     "logs": {


### PR DESCRIPTION
## Summary
- add missing trade compliance translation keys across locales so the menu shows the friendly label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7aabebc3c8327a57115851c2232e2