### PR TITLE
Fix AWS deploy script dependency bootstrapping

### DIFF
--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,0 +1,2 @@
+aws-cdk-lib~=2.151.0
+constructs~=10.3.0


### PR DESCRIPTION
## Summary
- allow the deploy-to-AWS PowerShell script to try multiple dependency sources and fall back to installing default CDK packages when aws_cdk is missing
- add a dedicated cdk/requirements.txt so the script can install only the AWS CDK Python prerequisites

## Testing
- Not run (PowerShell script change)


------
https://chatgpt.com/codex/tasks/task_e_68d7ac56ce748327b4d3bfb6ad0ce526