### PR TITLE
Move trade compliance tab to requirements menu

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -127,10 +127,9 @@ export default function Menu({
         'scenario',
         'trading',
         'rebalance',
-        'tradecompliance',
       ],
     },
-    { id: 'goals', titleKey: 'goals', tabIds: ['pension', 'taxtools', 'trail'] },
+    { id: 'goals', titleKey: 'goals', tabIds: ['pension', 'taxtools', 'trail', 'tradecompliance'] },
     { id: 'preferences', titleKey: 'preferences', tabIds: ['alertsettings', 'settings'] },
   ];
 


### PR DESCRIPTION
## Summary
- move the Trade Compliance tab from the Insights menu group to the Requirements group

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7aea9768c83279db7118cc1051cb2