### PR TITLE
Fix CloudFront S3 origin compatibility

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -57,9 +57,17 @@ class StaticSiteStack(Stack):
             ),
         )
 
-        s3_origin = origins.S3BucketOrigin.with_origin_access_identity(
-            site_bucket, origin_access_identity=oai
-        )
+        if hasattr(origins, "S3BucketOrigin") and hasattr(
+            origins.S3BucketOrigin, "with_origin_access_identity"
+        ):
+            s3_origin = origins.S3BucketOrigin.with_origin_access_identity(
+                site_bucket, origin_access_identity=oai
+            )
+        else:
+            # Fallback for older CDK versions where S3BucketOrigin is not available.
+            s3_origin = origins.S3Origin(
+                site_bucket, origin_access_identity=oai
+            )
 
         asset_cache_policy = cloudfront.CachePolicy(
             self,


### PR DESCRIPTION
## Summary
- make the static site stack resilient to AWS CDK installations that do not expose `S3BucketOrigin`
- fall back to the legacy `S3Origin` helper when the newer API is unavailable

## Testing
- pytest *(fails: pytest: error: unrecognized arguments: --cov=backend --cov-fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b42849e883278d96b6acf2dbada3