### PR TITLE
Enable research tab by default

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -27,6 +27,7 @@ export interface TabsConfig {
   instrumentadmin: boolean;
   dataadmin: boolean;
   virtual: boolean;
+  research: boolean;
   support: boolean;
   settings: boolean;
   profile: boolean;
@@ -75,6 +76,7 @@ const defaultTabs: TabsConfig = {
   instrumentadmin: true,
   dataadmin: true,
   virtual: true,
+  research: true,
   support: true,
   settings: true,
   profile: false,


### PR DESCRIPTION
## Summary
- add the research tab to the tabs configuration so it is enabled by default and `/research/:ticker` routes are not redirected away

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d7b5af7e688327bd51bdae414cb066