### PR TITLE
Annualise tracking error metric

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -1043,7 +1043,8 @@ def _tracking_error(name: str, benchmark: str, days: int = 365, *, group: bool =
     std = diff.std()
     if not math.isfinite(std):
         return None
-    return float(std)
+    annualised = std * math.sqrt(252)
+    return float(annualised)
 
 
 def _max_drawdown(name: str, days: int = 365, *, group: bool = False) -> float | None:

--- a/tests/common/test_portfolio_utils_returns.py
+++ b/tests/common/test_portfolio_utils_returns.py
@@ -28,7 +28,7 @@ def test_compute_alpha_and_tracking_error(monkeypatch: pytest.MonkeyPatch) -> No
     assert alpha == pytest.approx(0.03, rel=1e-4)
 
     tracking_error = portfolio_utils.compute_tracking_error("alice", "SPY.L", days=365)
-    assert tracking_error == pytest.approx(0.008190058, rel=1e-4)
+    assert tracking_error == pytest.approx(0.13001314, rel=1e-4)
 
 
 def test_compute_metrics_none_when_series_misaligned(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -84,7 +84,7 @@ def test_group_metrics_and_max_drawdown(monkeypatch: pytest.MonkeyPatch) -> None
     assert alpha == pytest.approx(0.03, rel=1e-4)
 
     tracking_error = portfolio_utils.compute_group_tracking_error("demo-group", "SPY.L", days=365)
-    assert tracking_error == pytest.approx(0.008190058, rel=1e-4)
+    assert tracking_error == pytest.approx(0.13001314, rel=1e-4)
 
     assert group_calls == ["demo-group", "demo-group"]
 


### PR DESCRIPTION
## Summary
- annualise the tracking error calculation so the backend returns an annualised value
- update the tracking error unit tests to match the new scaling

## Testing
- PYTEST_ADDOPTS="--cov=backend/common/portfolio_utils.py --cov-fail-under=0" pytest tests/common/test_portfolio_utils_returns.py


------
https://chatgpt.com/codex/tasks/task_e_68d7b72f3abc83279350cc11cecaa161