### PR TITLE
Expose performance metric breakdowns and enhance metrics explanation UI

### DIFF
--- a/backend/routes/performance.py
+++ b/backend/routes/performance.py
@@ -15,8 +15,8 @@ router = APIRouter(tags=["performance"])
 async def owner_alpha(owner: str, benchmark: str = "VWRL.L", days: int = 365):
     """Return portfolio alpha vs. benchmark for ``owner``."""
     try:
-        val = portfolio_utils.compute_alpha_vs_benchmark(owner, benchmark, days)
-        return {"owner": owner, "benchmark": benchmark, "alpha_vs_benchmark": val}
+        breakdown = portfolio_utils.alpha_vs_benchmark_breakdown(owner, benchmark, days)
+        return {"owner": owner, "benchmark": benchmark, **breakdown}
     except FileNotFoundError:
         raise_owner_not_found()
 
@@ -26,8 +26,8 @@ async def owner_alpha(owner: str, benchmark: str = "VWRL.L", days: int = 365):
 async def owner_tracking_error(owner: str, benchmark: str = "VWRL.L", days: int = 365):
     """Return tracking error vs. benchmark for ``owner``."""
     try:
-        val = portfolio_utils.compute_tracking_error(owner, benchmark, days)
-        return {"owner": owner, "benchmark": benchmark, "tracking_error": val}
+        breakdown = portfolio_utils.tracking_error_breakdown(owner, benchmark, days)
+        return {"owner": owner, "benchmark": benchmark, **breakdown}
     except FileNotFoundError:
         raise_owner_not_found()
 
@@ -37,8 +37,8 @@ async def owner_tracking_error(owner: str, benchmark: str = "VWRL.L", days: int 
 async def owner_max_drawdown(owner: str, days: int = 365):
     """Return max drawdown for ``owner``."""
     try:
-        val = portfolio_utils.compute_max_drawdown(owner, days)
-        return {"owner": owner, "max_drawdown": val}
+        breakdown = portfolio_utils.max_drawdown_breakdown(owner, days)
+        return {"owner": owner, **breakdown}
     except FileNotFoundError:
         raise_owner_not_found()
 
@@ -82,8 +82,10 @@ async def owner_holdings(owner: str, date: str):
 async def group_alpha(slug: str, benchmark: str = "VWRL.L", days: int = 365):
     """Return alpha vs. benchmark for a group portfolio."""
     try:
-        val = portfolio_utils.compute_group_alpha_vs_benchmark(slug, benchmark, days)
-        return {"group": slug, "benchmark": benchmark, "alpha_vs_benchmark": val}
+        breakdown = portfolio_utils.group_alpha_vs_benchmark_breakdown(
+            slug, benchmark, days
+        )
+        return {"group": slug, "benchmark": benchmark, **breakdown}
     except (FileNotFoundError, ValueError) as exc:
         raise HTTPException(status_code=404, detail="Group not found") from exc
 
@@ -92,8 +94,10 @@ async def group_alpha(slug: str, benchmark: str = "VWRL.L", days: int = 365):
 async def group_tracking_error(slug: str, benchmark: str = "VWRL.L", days: int = 365):
     """Return tracking error vs. benchmark for a group portfolio."""
     try:
-        val = portfolio_utils.compute_group_tracking_error(slug, benchmark, days)
-        return {"group": slug, "benchmark": benchmark, "tracking_error": val}
+        breakdown = portfolio_utils.group_tracking_error_breakdown(
+            slug, benchmark, days
+        )
+        return {"group": slug, "benchmark": benchmark, **breakdown}
     except (FileNotFoundError, ValueError) as exc:
         raise HTTPException(status_code=404, detail="Group not found") from exc
 
@@ -102,8 +106,8 @@ async def group_tracking_error(slug: str, benchmark: str = "VWRL.L", days: int =
 async def group_max_drawdown(slug: str, days: int = 365):
     """Return max drawdown for a group portfolio."""
     try:
-        val = portfolio_utils.compute_group_max_drawdown(slug, days)
-        return {"group": slug, "max_drawdown": val}
+        breakdown = portfolio_utils.group_max_drawdown_breakdown(slug, days)
+        return {"group": slug, **breakdown}
     except (FileNotFoundError, ValueError) as exc:
         raise HTTPException(status_code=404, detail="Group not found") from exc
 

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -273,6 +273,11 @@
     "title": "Performancekennzahlen erklärt",
     "intro": "Diese Kennzahlen fassen zusammen, wie sich das kombinierte Portfolio im Vergleich zu seinem Benchmark entwickelt. Jede Zahl basiert auf denselben täglichen Renditereihen wie die Kacheln im Dashboard.",
     "backLink": "Zurück zum Portfolio-Dashboard",
+    "context": "Anzeige für {{context}} über die letzten {{days}} Tage.",
+    "loading": "Aktualisierte Kennzahlen werden geladen …",
+    "error": "Die neuesten Daten konnten nicht geladen werden: {{message}}",
+    "groupLabel": "Gruppe „{{group}}“",
+    "ownerLabel": "Portfolio „{{owner}}“",
     "calculationHeading": "So berechnen wir das",
     "notesHeading": "Wissenswertes",
     "dataHeading": "Datengrundlage",
@@ -291,7 +296,7 @@
       "trackingError": {
         "title": "Tracking Error",
         "summary": "Der Tracking Error zeigt, wie stark die täglichen Portfoliorenditen vom Benchmark abweichen.",
-        "calculation": "Für jeden Handelstag ziehen wir die Benchmark-Rendite von der Portfoliorendite ab und erhalten so eine Active-Return-Reihe. Der Tracking Error ist die annualisierte Standardabweichung dieser Werte (tägliche Standardabweichung multipliziert mit √252).",
+        "calculation": "Für jeden Handelstag ziehen wir die Benchmark-Rendite von der Portfoliorendite ab und erhalten so eine Active-Return-Reihe. Der Tracking Error ist die Stichproben-Standardabweichung dieser Werte.",
         "notes": [
           "Ein höherer Tracking Error deutet auf eine geringere Kopplung an den Benchmark hin.",
           "Für die Anzeige benötigen wir mindestens 30 überlappende Tagesrenditen."

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -288,6 +288,11 @@
     "title": "Performance Metrics Explained",
     "intro": "These metrics summarise how the combined portfolio performs relative to its benchmark. Each value is derived from the same daily return series that powers the dashboard tiles.",
     "backLink": "Back to portfolio dashboard",
+    "context": "Showing {{context}} over the past {{days}} days.",
+    "loading": "Loading latest measurements…",
+    "error": "We couldn't load the latest data: {{message}}",
+    "groupLabel": "group \"{{group}}\"",
+    "ownerLabel": "portfolio \"{{owner}}\"",
     "calculationHeading": "How we calculate it",
     "notesHeading": "Things to know",
     "dataHeading": "Data inputs",
@@ -306,7 +311,7 @@
       "trackingError": {
         "title": "Tracking Error",
         "summary": "Tracking error captures the variability of active returns—how much the portfolio's daily returns diverge from the benchmark.",
-        "calculation": "For each trading day we take the portfolio return minus the benchmark return, producing an active return series. Tracking error is the annualised standard deviation of those active returns (daily standard deviation multiplied by √252).",
+        "calculation": "For each trading day we take the portfolio return minus the benchmark return, producing an active return series. Tracking error is the sample standard deviation of those active returns.",
         "notes": [
           "Higher tracking error indicates looser alignment with the benchmark.",
           "We require at least 30 overlapping daily returns to display this metric."

--- a/frontend/src/pages/MetricsExplanation.tsx
+++ b/frontend/src/pages/MetricsExplanation.tsx
@@ -1,8 +1,46 @@
-import { Link } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+
+import {
+  getAlphaVsBenchmark,
+  getGroupAlphaVsBenchmark,
+  getGroupMaxDrawdown,
+  getGroupTrackingError,
+  getMaxDrawdown,
+  getTrackingError,
+} from "../api";
+import { money, percentOrNa } from "../lib/money";
+import type {
+  AlphaBreakdownPoint,
+  AlphaResponse,
+  MaxDrawdownPoint,
+  MaxDrawdownResponse,
+  TrackingErrorPoint,
+  TrackingErrorResponse,
+} from "../types";
 
 export default function MetricsExplanation() {
   const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const group = searchParams.get("group");
+  const owner = searchParams.get("owner");
+  const benchmark = searchParams.get("benchmark") || "VWRL.L";
+  const daysParam = searchParams.get("days");
+  const days = daysParam ? Number(daysParam) : 365;
+  const target = group ?? owner ?? "all";
+  const isGroup = Boolean(group);
+
+  const [alphaData, setAlphaData] = useState<AlphaResponse | null>(null);
+  const [trackingData, setTrackingData] = useState<TrackingErrorResponse | null>(
+    null,
+  );
+  const [drawdownData, setDrawdownData] = useState<MaxDrawdownResponse | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   const alphaNotesRaw = t("metricsExplanation.sections.alpha.notes", {
     returnObjects: true,
   });
@@ -26,13 +64,72 @@ export default function MetricsExplanation() {
     ? (drawdownNotesRaw as string[])
     : [];
 
+  useEffect(() => {
+    if (!target) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const alphaPromise = isGroup
+      ? getGroupAlphaVsBenchmark(target, benchmark, days)
+      : getAlphaVsBenchmark(target, benchmark, days);
+    const trackingPromise = isGroup
+      ? getGroupTrackingError(target, benchmark, days)
+      : getTrackingError(target, benchmark, days);
+    const drawdownPromise = isGroup
+      ? getGroupMaxDrawdown(target, days)
+      : getMaxDrawdown(target, days);
+
+    Promise.all([alphaPromise, trackingPromise, drawdownPromise])
+      .then(([alphaRes, trackingRes, drawdownRes]) => {
+        if (cancelled) return;
+        setAlphaData(alphaRes);
+        setTrackingData(trackingRes);
+        setDrawdownData(drawdownRes);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError(String(err));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [benchmark, days, isGroup, target]);
+
+  const backLink = useMemo(() => {
+    const params = new URLSearchParams();
+    if (group) params.set("group", group);
+    else if (owner) params.set("owner", owner);
+    if (benchmark) params.set("benchmark", benchmark);
+    if (daysParam) params.set("days", daysParam);
+    const suffix = params.toString();
+    return suffix ? `/?${suffix}` : "/?group=all";
+  }, [benchmark, daysParam, group, owner]);
+
+  const alphaBreakdown = (alphaData?.daily_breakdown || []) as AlphaBreakdownPoint[];
+  const trackingBreakdown = (trackingData?.daily_active_returns || []) as TrackingErrorPoint[];
+  const drawdownPath = (drawdownData?.drawdown_path || []) as MaxDrawdownPoint[];
+
+  const latestAlpha = alphaBreakdown[alphaBreakdown.length - 1];
+  const trackingErrorValue =
+    trackingData?.tracking_error ?? trackingData?.standard_deviation ?? null;
+  const contextLabel = isGroup
+    ? t("metricsExplanation.groupLabel", { group: target })
+    : t("metricsExplanation.ownerLabel", { owner: target });
+
   return (
     <main className="container mx-auto max-w-3xl space-y-10 p-4">
       <header className="space-y-2">
-        <Link
-          to="/?group=all"
-          className="inline-block text-blue-500 hover:underline"
-        >
+        <Link to={backLink} className="inline-block text-blue-500 hover:underline">
           {t("metricsExplanation.backLink")}
         </Link>
         <h1 className="text-3xl font-bold">
@@ -41,6 +138,19 @@ export default function MetricsExplanation() {
         <p className="text-lg text-gray-300">
           {t("metricsExplanation.intro")}
         </p>
+        <p className="text-sm text-gray-400">
+          {t("metricsExplanation.context", { context: contextLabel, days })}
+        </p>
+        {loading && (
+          <p className="text-sm text-blue-300">
+            {t("metricsExplanation.loading")}
+          </p>
+        )}
+        {error && (
+          <p className="text-sm text-red-400">
+            {t("metricsExplanation.error", { message: error })}
+          </p>
+        )}
       </header>
 
       <section className="space-y-4">
@@ -52,6 +162,64 @@ export default function MetricsExplanation() {
           {t("metricsExplanation.calculationHeading")}
         </h3>
         <p>{t("metricsExplanation.sections.alpha.calculation")}</p>
+        <p className="rounded-md bg-slate-800 p-3 text-sm text-slate-200">
+          <strong className="font-semibold">Formula:</strong> α = Π<sub>t</sub>(1 +
+          r<sub>p,t</sub>) − 1 − [Π<sub>t</sub>(1 + r<sub>b,t</sub>) − 1]
+        </p>
+        <div className="rounded-md border border-slate-700 p-4">
+          <p className="text-sm text-slate-300">
+            <strong className="font-semibold">Latest alpha:</strong>{" "}
+            {percentOrNa(alphaData?.alpha_vs_benchmark ?? null)} ({
+              alphaData?.benchmark
+            })
+          </p>
+          {latestAlpha && (
+            <ul className="mt-2 space-y-1 text-sm text-slate-300">
+              <li>
+                Portfolio cumulative return: {percentOrNa(latestAlpha.portfolio_cumulative)}
+              </li>
+              <li>
+                Benchmark cumulative return: {percentOrNa(
+                  latestAlpha.benchmark_cumulative,
+                )}
+              </li>
+              <li>Difference (α): {percentOrNa(latestAlpha.alpha)}</li>
+            </ul>
+          )}
+          {alphaBreakdown.length > 0 && (
+            <details className="mt-4">
+              <summary className="cursor-pointer text-sm font-semibold text-blue-300">
+                Daily cumulative path ({alphaBreakdown.length} days)
+              </summary>
+              <div className="mt-2 max-h-72 overflow-auto rounded-md border border-slate-700">
+                <table className="min-w-full divide-y divide-slate-700 text-left text-xs">
+                  <thead className="bg-slate-900 text-slate-200">
+                    <tr>
+                      <th className="px-3 py-2">Date</th>
+                      <th className="px-3 py-2">r<sub>p,t</sub></th>
+                      <th className="px-3 py-2">r<sub>b,t</sub></th>
+                      <th className="px-3 py-2">Π(1 + r<sub>p</sub>) − 1</th>
+                      <th className="px-3 py-2">Π(1 + r<sub>b</sub>) − 1</th>
+                      <th className="px-3 py-2">α</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-800">
+                    {alphaBreakdown.map((row) => (
+                      <tr key={row.date} className="odd:bg-slate-900/40">
+                        <td className="px-3 py-2 font-mono">{row.date}</td>
+                        <td className="px-3 py-2">{percentOrNa(row.portfolio_return)}</td>
+                        <td className="px-3 py-2">{percentOrNa(row.benchmark_return)}</td>
+                        <td className="px-3 py-2">{percentOrNa(row.portfolio_cumulative)}</td>
+                        <td className="px-3 py-2">{percentOrNa(row.benchmark_cumulative)}</td>
+                        <td className="px-3 py-2">{percentOrNa(row.alpha)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          )}
+        </div>
         {alphaNotes.length > 0 && (
           <div>
             <h3 className="text-xl font-semibold">
@@ -75,6 +243,46 @@ export default function MetricsExplanation() {
           {t("metricsExplanation.calculationHeading")}
         </h3>
         <p>{t("metricsExplanation.sections.trackingError.calculation")}</p>
+        <p className="rounded-md bg-slate-800 p-3 text-sm text-slate-200">
+          <strong className="font-semibold">Formula:</strong> Tracking Error =
+          σ(r<sub>p,t</sub> − r<sub>b,t</sub>) using the sample standard deviation of
+          daily active returns.
+        </p>
+        <div className="rounded-md border border-slate-700 p-4">
+          <p className="text-sm text-slate-300">
+            <strong className="font-semibold">Standard deviation:</strong>{" "}
+            {percentOrNa(trackingErrorValue ?? null)} ({trackingData?.benchmark})
+          </p>
+          {trackingBreakdown.length > 0 && (
+            <details className="mt-4">
+              <summary className="cursor-pointer text-sm font-semibold text-blue-300">
+                Daily active returns ({trackingBreakdown.length} days)
+              </summary>
+              <div className="mt-2 max-h-72 overflow-auto rounded-md border border-slate-700">
+                <table className="min-w-full divide-y divide-slate-700 text-left text-xs">
+                  <thead className="bg-slate-900 text-slate-200">
+                    <tr>
+                      <th className="px-3 py-2">Date</th>
+                      <th className="px-3 py-2">r<sub>p,t</sub></th>
+                      <th className="px-3 py-2">r<sub>b,t</sub></th>
+                      <th className="px-3 py-2">Active r<sub>t</sub></th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-800">
+                    {trackingBreakdown.map((row) => (
+                      <tr key={row.date} className="odd:bg-slate-900/40">
+                        <td className="px-3 py-2 font-mono">{row.date}</td>
+                        <td className="px-3 py-2">{percentOrNa(row.portfolio_return)}</td>
+                        <td className="px-3 py-2">{percentOrNa(row.benchmark_return)}</td>
+                        <td className="px-3 py-2">{percentOrNa(row.active_return)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          )}
+        </div>
         {trackingErrorNotes.length > 0 && (
           <div>
             <h3 className="text-xl font-semibold">
@@ -98,6 +306,63 @@ export default function MetricsExplanation() {
           {t("metricsExplanation.calculationHeading")}
         </h3>
         <p>{t("metricsExplanation.sections.maxDrawdown.calculation")}</p>
+        <p className="rounded-md bg-slate-800 p-3 text-sm text-slate-200">
+          <strong className="font-semibold">Formula:</strong> Drawdown<sub>t</sub> =
+          V<sub>t</sub> / max(V<sub>0..t</sub>) − 1. Max drawdown is the minimum drawdown
+          across the window.
+        </p>
+        <div className="rounded-md border border-slate-700 p-4">
+          <p className="text-sm text-slate-300">
+            <strong className="font-semibold">Max drawdown:</strong>{" "}
+            {percentOrNa(drawdownData?.max_drawdown ?? null)}
+          </p>
+          <div className="mt-2 space-y-1 text-sm text-slate-300">
+            {drawdownData?.peak && (
+              <p>
+                Peak: {drawdownData.peak.date} at {money(drawdownData.peak.value)}
+              </p>
+            )}
+            {drawdownData?.trough && (
+              <p>
+                Trough: {drawdownData.trough.date} at {money(drawdownData.trough.value)}
+              </p>
+            )}
+            {drawdownData?.peak && drawdownData?.trough && (
+              <p>
+                Peak → Trough loss: {percentOrNa(drawdownData.max_drawdown ?? null)}
+              </p>
+            )}
+          </div>
+          {drawdownPath.length > 0 && (
+            <details className="mt-4">
+              <summary className="cursor-pointer text-sm font-semibold text-blue-300">
+                Running peaks and drawdowns ({drawdownPath.length} days)
+              </summary>
+              <div className="mt-2 max-h-72 overflow-auto rounded-md border border-slate-700">
+                <table className="min-w-full divide-y divide-slate-700 text-left text-xs">
+                  <thead className="bg-slate-900 text-slate-200">
+                    <tr>
+                      <th className="px-3 py-2">Date</th>
+                      <th className="px-3 py-2">Value</th>
+                      <th className="px-3 py-2">Running peak</th>
+                      <th className="px-3 py-2">Drawdown</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-800">
+                    {drawdownPath.map((row) => (
+                      <tr key={row.date} className="odd:bg-slate-900/40">
+                        <td className="px-3 py-2 font-mono">{row.date}</td>
+                        <td className="px-3 py-2">{money(row.portfolio_value)}</td>
+                        <td className="px-3 py-2">{money(row.running_peak)}</td>
+                        <td className="px-3 py-2">{percentOrNa(row.drawdown)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          )}
+        </div>
         {drawdownNotes.length > 0 && (
           <div>
             <h3 className="text-xl font-semibold">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -185,18 +185,52 @@ export interface ValueAtRiskResponse {
   sharpe_ratio?: number | null;
 }
 
+export interface AlphaBreakdownPoint {
+  date: string;
+  portfolio_return: number;
+  benchmark_return: number;
+  portfolio_cumulative: number;
+  benchmark_cumulative: number;
+  alpha: number;
+}
+
 export interface AlphaResponse {
   alpha_vs_benchmark: number | null;
   benchmark: string;
+  daily_breakdown?: AlphaBreakdownPoint[];
+}
+
+export interface TrackingErrorPoint {
+  date: string;
+  portfolio_return: number;
+  benchmark_return: number;
+  active_return: number;
 }
 
 export interface TrackingErrorResponse {
   tracking_error: number | null;
   benchmark: string;
+  daily_active_returns?: TrackingErrorPoint[];
+  standard_deviation?: number | null;
+}
+
+export interface MaxDrawdownPoint {
+  date: string;
+  portfolio_value: number;
+  running_peak: number;
+  drawdown: number;
+}
+
+export interface DrawdownExtrema {
+  date: string;
+  value: number;
 }
 
 export interface MaxDrawdownResponse {
   max_drawdown: number | null;
+  drawdown_path?: MaxDrawdownPoint[];
+  peak?: DrawdownExtrema | null;
+  trough?: DrawdownExtrema | null;
 }
 
 export interface ReturnComparisonResponse {


### PR DESCRIPTION
## Summary
- add backend helpers that return detailed alpha, tracking error, and drawdown breakdowns and expose them in the existing performance endpoints
- update the metrics explanation page to load group or owner context, fetch the new breakdowns, and present step-by-step tables and formulas
- extend shared types and translation strings so the frontend can render the richer explanations

## Testing
- pytest -o addopts= tests/test_performance_routes.py tests/test_performance_route.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b72aea5883279f4560a61b0c1eb3