### PR TITLE
Localize default group view and clean group routing

### DIFF
--- a/backend/common/group_portfolio.py
+++ b/backend/common/group_portfolio.py
@@ -39,7 +39,7 @@ def list_groups() -> List[Dict[str, Any]]:
     return [
         {
             "slug": "all",
-            "name": "All owners combined",
+            "name": "At a glance",
             "members": owners,
         },
         {

--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, lazy, Suspense } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { getGroupInstruments, getGroups, getOwners, getPortfolio } from "./api";
 import type {
@@ -28,6 +28,7 @@ import BackendUnavailableCard from "./components/BackendUnavailableCard";
 import lazyWithDelay from "./utils/lazyWithDelay";
 import PortfolioDashboardSkeleton from "./components/skeletons/PortfolioDashboardSkeleton";
 import { sanitizeOwners } from "./utils/owners";
+import { isDefaultGroupSlug } from "./utils/groups";
 
 const ScreenerQuery = lazy(() => import("./pages/ScreenerQuery"));
 const TimeseriesEdit = lazy(() =>
@@ -46,6 +47,7 @@ const PerformanceDashboard = lazyWithDelay(
 
 export default function MainApp() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation();
   const { mode, setMode, selectedOwner, setSelectedOwner, selectedGroup, setSelectedGroup } = useRoute();
 
@@ -131,12 +133,29 @@ export default function MainApp() {
       setSelectedGroup(slug);
       navigate(`/instrument/${slug}`, { replace: true });
     }
-    if (mode === "group" && !selectedGroup && groups.length) {
-      const slug = groups[0].slug;
-      setSelectedGroup(slug);
-      navigate(`/?group=${slug}`, { replace: true });
+    if (mode === "group" && groups.length) {
+      const hasSelection = groups.some((g) => g.slug === selectedGroup);
+      if (!hasSelection) {
+        const slug = groups[0].slug;
+        setSelectedGroup(slug);
+        if (isDefaultGroupSlug(slug)) {
+          if (location.search) navigate("/", { replace: true });
+        } else {
+          navigate(`/?group=${slug}`, { replace: true });
+        }
+      }
     }
-  }, [mode, selectedOwner, selectedGroup, owners, groups, navigate, setSelectedOwner, setSelectedGroup]);
+  }, [
+    mode,
+    selectedOwner,
+    selectedGroup,
+    owners,
+    groups,
+    navigate,
+    setSelectedOwner,
+    setSelectedGroup,
+    location.search,
+  ]);
 
   // data fetching based on route
   useEffect(() => {

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -33,6 +33,7 @@ import { useFetch } from "../hooks/useFetch";
 import tableStyles from "../styles/table.module.css";
 import { useTranslation } from "react-i18next";
 import { useConfig } from "../ConfigContext";
+import { getGroupDisplayName } from "../utils/groups";
 import { RelativeViewToggle } from "./RelativeViewToggle";
 import { preloadInstrumentHistory } from "../hooks/useInstrumentHistory";
 import { isCashInstrument } from "../lib/instruments";
@@ -463,7 +464,7 @@ export function GroupPortfolioView({ slug, onTradeInfo }: Props) {
           alignItems: "center",
         }}
       >
-        <h2>{portfolio.name}</h2>
+        <h2>{getGroupDisplayName(slug, portfolio.name, t)}</h2>
         <RelativeViewToggle />
       </div>
 

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -3,6 +3,7 @@ import { useMemo, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useConfig } from '../ConfigContext';
+import { isDefaultGroupSlug } from '../utils/groups';
 import type { TabPluginId } from '../tabPlugins';
 import { orderedTabPlugins, SUPPORT_TABS } from '../tabPlugins';
 
@@ -211,7 +212,9 @@ export default function Menu({
   function pathFor(m: any) {
     switch (m) {
       case 'group':
-        return selectedGroup ? `/?group=${selectedGroup}` : '/';
+        return selectedGroup && !isDefaultGroupSlug(selectedGroup)
+          ? `/?group=${selectedGroup}`
+          : '/';
       case 'instrument':
         return selectedGroup ? `/instrument/${selectedGroup}` : '/instrument';
       case 'owner':

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -246,7 +246,8 @@
     }
   },
   "group": {
-    "select": "Wählen Sie eine Gruppe."
+    "select": "Wählen Sie eine Gruppe.",
+    "atAGlance": "Auf einen Blick"
   },
   "dashboard": {
     "selectMember": "Wählen Sie ein Mitglied.",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -261,7 +261,8 @@
     }
   },
   "group": {
-    "select": "Select a group."
+    "select": "Select a group.",
+    "atAGlance": "At a glance"
   },
   "dashboard": {
     "selectMember": "Select a member.",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -246,7 +246,8 @@
     }
   },
   "group": {
-    "select": "Seleccione un grupo."
+    "select": "Seleccione un grupo.",
+    "atAGlance": "De un vistazo"
   },
   "dashboard": {
     "selectMember": "Seleccione un miembro.",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -246,7 +246,8 @@
     }
   },
   "group": {
-    "select": "Sélectionnez un groupe."
+    "select": "Sélectionnez un groupe.",
+    "atAGlance": "En un coup d'œil"
   },
   "dashboard": {
     "selectMember": "Sélectionnez un membre.",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -246,7 +246,8 @@
     }
   },
   "group": {
-    "select": "Seleziona un gruppo."
+    "select": "Seleziona un gruppo.",
+    "atAGlance": "A colpo d'occhio"
   },
   "dashboard": {
     "selectMember": "Seleziona un membro.",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -246,7 +246,8 @@
     }
   },
   "group": {
-    "select": "Selecione um grupo."
+    "select": "Selecione um grupo.",
+    "atAGlance": "Visão geral"
   },
   "dashboard": {
     "selectMember": "Selecione um membro.",

--- a/frontend/src/pages/MetricsExplanation.tsx
+++ b/frontend/src/pages/MetricsExplanation.tsx
@@ -29,10 +29,7 @@ export default function MetricsExplanation() {
   return (
     <main className="container mx-auto max-w-3xl space-y-10 p-4">
       <header className="space-y-2">
-        <Link
-          to="/?group=all"
-          className="inline-block text-blue-500 hover:underline"
-        >
+        <Link to="/" className="inline-block text-blue-500 hover:underline">
           {t("metricsExplanation.backLink")}
         </Link>
         <h1 className="text-3xl font-bold">

--- a/frontend/src/plugins/group.ts
+++ b/frontend/src/plugins/group.ts
@@ -1,6 +1,7 @@
 import { GroupPortfolioView } from "../components/GroupPortfolioView";
 import type { ComponentProps } from "react";
 import type { TabPlugin } from "./TabPlugin";
+import { isDefaultGroupSlug } from "../utils/groups";
 
 type Props = ComponentProps<typeof GroupPortfolioView>;
 
@@ -8,7 +9,8 @@ const plugin: TabPlugin<Props> = {
   id: "group",
   component: GroupPortfolioView,
   priority: 10,
-  path: ({ group }) => (group ? `/?group=${group}` : "/"),
+  path: ({ group }) =>
+    group && !isDefaultGroupSlug(group) ? `/?group=${group}` : "/",
 };
 
 export default plugin;

--- a/frontend/src/plugins/movers.ts
+++ b/frontend/src/plugins/movers.ts
@@ -1,11 +1,13 @@
 import TopMovers from "../pages/TopMovers";
 import type { TabPlugin } from "./TabPlugin";
+import { isDefaultGroupSlug } from "../utils/groups";
 
 const plugin: TabPlugin = {
   id: "movers",
   component: TopMovers,
   priority: 0,
-  path: ({ group }) => (group ? `/movers?group=${group}` : "/movers"),
+  path: ({ group }) =>
+    group && !isDefaultGroupSlug(group) ? `/movers?group=${group}` : "/movers",
 };
 
 export default plugin;

--- a/frontend/src/utils/groups.ts
+++ b/frontend/src/utils/groups.ts
@@ -1,0 +1,19 @@
+import type { TFunction } from "i18next";
+
+export const DEFAULT_GROUP_SLUG = "all" as const;
+
+export function isDefaultGroupSlug(slug?: string | null): boolean {
+  return !slug || slug === DEFAULT_GROUP_SLUG;
+}
+
+export function normaliseGroupSlug(slug?: string | null): string {
+  return !slug || slug === DEFAULT_GROUP_SLUG ? DEFAULT_GROUP_SLUG : slug;
+}
+
+export function getGroupDisplayName(
+  slug: string | null | undefined,
+  fallbackName: string,
+  t: TFunction,
+): string {
+  return isDefaultGroupSlug(slug) ? t("group.atAGlance") : fallbackName;
+}

--- a/frontend/tests/unit/components/GroupPortfolioView.test.tsx
+++ b/frontend/tests/unit/components/GroupPortfolioView.test.tsx
@@ -191,7 +191,7 @@ const mockAllFetches = (
 describe("GroupPortfolioView", () => {
   it("shows per-owner totals with percentages in relative view", async () => {
     const mockPortfolio = {
-      name: "All owners combined",
+      name: "At a glance",
       accounts: [
         {
           owner: "alice",
@@ -245,7 +245,7 @@ describe("GroupPortfolioView", () => {
 
   it("renders instrument type pie chart", async () => {
     const mockPortfolio = {
-      name: "All owners combined",
+      name: "At a glance",
       accounts: [
         {
           owner: "alice",
@@ -290,7 +290,7 @@ describe("GroupPortfolioView", () => {
 
   it("switches instrument rows across owner and account tabs", async () => {
     const mockPortfolio = {
-      name: "All owners combined",
+      name: "At a glance",
       accounts: [
         {
           owner: "alice",
@@ -401,7 +401,7 @@ describe("GroupPortfolioView", () => {
 
   it("calls onSelectMember when owner name clicked", async () => {
     const mockPortfolio = {
-      name: "All owners combined",
+      name: "At a glance",
       accounts: [
         {
           owner: "alice",
@@ -465,7 +465,7 @@ describe("GroupPortfolioView", () => {
 
   it("renders metrics error message", async () => {
     const mockPortfolio = {
-      name: "All owners combined",
+      name: "At a glance",
       accounts: [],
     };
 
@@ -494,7 +494,7 @@ describe("GroupPortfolioView", () => {
   });
 
   it("shows N/A for invalid performance metrics", async () => {
-    const mockPortfolio = { name: "All owners combined", accounts: [] };
+    const mockPortfolio = { name: "At a glance", accounts: [] };
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     mockAllFetches(mockPortfolio, {

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -335,7 +335,7 @@ describe("HoldingsTable", () => {
 
       it("opens InstrumentDetail without altering search params", async () => {
         const portfolio = {
-          name: "All owners combined",
+          name: "At a glance",
           accounts: [
             {
               owner: "alice",

--- a/tests/common/test_group_portfolio.py
+++ b/tests/common/test_group_portfolio.py
@@ -17,7 +17,7 @@ def test_list_groups_returns_expected_defaults():
     assert groups == [
         {
             "slug": "all",
-            "name": "All owners combined",
+            "name": "At a glance",
             "members": ["Alex", "Joe", "Lucy", "Steve"],
         },
         {"slug": "adults", "name": "Adults", "members": ["Lucy", "Steve"]},


### PR DESCRIPTION
## Summary
- add group utilities to recognise the default "all" slug, translate its display name to the new "At a glance" label, and update navigation to avoid leaking the redundant `group=all` parameter
- adjust portfolio, menu, hook, and plugin routing so the overview loads at `/`, including the metrics explanation link and new group label translations across locales
- rename the backend default group to "At a glance" and refresh related frontend/backend tests and fixtures

## Testing
- npm run test -- --run --environment jsdom tests/unit/components/GroupPortfolioView.test.tsx tests/unit/components/HoldingsTable.test.tsx *(fails: Vitest mocks missing cached instrument helpers in current test setup)*
- pytest tests/common/test_group_portfolio.py *(fails: repo-wide pytest configuration requires coverage plugin unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b62378b483278a43a56b6086a74a