### PR TITLE
Allow owner discovery for authenticated email matches

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -115,7 +115,17 @@ def _list_local_plots(
             owner = owner_dir.name
             meta = load_person_meta(owner, root)
             viewers = meta.get("viewers", [])
-            if user and user != owner and user not in viewers:
+            email = meta.get("email")
+            if isinstance(user, str):
+                allowed_identities = {owner.lower()}
+                if isinstance(email, str) and email:
+                    allowed_identities.add(email.lower())
+                allowed_identities.update(
+                    v.lower() for v in viewers if isinstance(v, str)
+                )
+                if user.lower() not in allowed_identities:
+                    continue
+            elif user and user != owner and user not in viewers:
                 continue
 
             acct_names: List[str] = []


### PR DESCRIPTION
## Summary
- allow the owner discovery helper to treat matching emails as authorised identities
- extend the data loader unit tests to cover email-based access and support email metadata in fixtures

## Testing
- pytest tests/backend/common/test_data_loader.py::TestListLocalPlots::test_allows_access_when_user_matches_owner_email -q -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d7cc76db1483279fca55ab6b58718e