### PR TITLE
Ensure cache loaders use metadata exchanges

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -346,8 +346,17 @@ def run_all_tickers(
         sym, ex = _resolve_ticker_exchange(t, exchange)
         logger.debug("run_all_tickers resolved %s -> %s.%s", t, sym, ex)
         loader_exchange = _resolve_loader_exchange(t, exchange, sym, ex)
+        meta_exchange = _resolve_exchange_from_metadata(sym)
+        cache_exchange = meta_exchange or ""
+        if loader_exchange and loader_exchange != cache_exchange:
+            logger.debug(
+                "Cache exchange mismatch for %s: loader %s vs metadata %s",
+                sym,
+                loader_exchange,
+                cache_exchange or "<empty>",
+            )
         try:
-            if not load_meta_timeseries(sym, loader_exchange or "", days).empty:
+            if not load_meta_timeseries(sym, cache_exchange, days).empty:
                 ok.append(t)
         except Exception as exc:
             logger.warning("[WARN] %s: %s", t, exc)
@@ -367,8 +376,17 @@ def load_timeseries_data(
         sym, ex = _resolve_ticker_exchange(t, exchange)
         logger.debug("load_timeseries_data resolved %s -> %s.%s", t, sym, ex)
         loader_exchange = _resolve_loader_exchange(t, exchange, sym, ex)
+        meta_exchange = _resolve_exchange_from_metadata(sym)
+        cache_exchange = meta_exchange or ""
+        if loader_exchange and loader_exchange != cache_exchange:
+            logger.debug(
+                "Cache exchange mismatch for %s: loader %s vs metadata %s",
+                sym,
+                loader_exchange,
+                cache_exchange or "<empty>",
+            )
         try:
-            df = load_meta_timeseries(sym, loader_exchange or "", days)
+            df = load_meta_timeseries(sym, cache_exchange, days)
             if not df.empty:
                 out[t] = df
         except Exception as exc:


### PR DESCRIPTION
## Summary
- make the cache warmup and load helpers use instrument metadata to choose the exchange passed to the parquet cache
- add debug logging when ticker- or argument-derived exchanges differ from the metadata-derived value
- update timeseries cache tests to assert the metadata-preferred behaviour

## Testing
- python -m pytest -o addopts="" tests/timeseries/test_fetch_meta_timeseries.py::test_resolve_exchange_from_metadata tests/timeseries/test_run_all_and_load_timeseries.py::test_run_all_tickers_filters_and_delays tests/timeseries/test_run_all_and_load_timeseries.py::test_load_timeseries_data_filters_and_warnings


------
https://chatgpt.com/codex/tasks/task_e_68d7cebca6f483278e61b339f28754a2