### PR TITLE
Ensure demo owner fallback and compliance scaffolding

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -25,13 +25,16 @@ def resolve_accounts_root(request: Request) -> Path:
     if accounts_root_value is not None:
         try:
             cached_path = Path(accounts_root_value).expanduser()
+            resolved_cached = cached_path.resolve(strict=False)
         except (TypeError, ValueError, OSError):
             cached_path = None
+            resolved_cached = None
         else:
-            if cached_path.exists():
-                resolved_cached = cached_path.resolve()
-                request.app.state.accounts_root = resolved_cached
-                return resolved_cached
+            request.app.state.accounts_root = resolved_cached
+            if hasattr(request.app.state, "accounts_root_is_global"):
+                request.app.state.accounts_root_is_global = False
+            return resolved_cached
+
         request.app.state.accounts_root = None
         if hasattr(request.app.state, "accounts_root_is_global"):
             request.app.state.accounts_root_is_global = False


### PR DESCRIPTION
## Summary
- always merge the bundled demo dataset into owner discovery, even when using request-level account roots
- treat per-request account roots as optional overrides while keeping default fallbacks available
- relax compliance validation to normalise owner slugs and allow scaffold-less checks with default approvals/configuration
- skip directory creation when loading transactions in scaffold mode so missing owners stay untouched

## Testing
- pytest -o addopts='' tests/test_accounts_api.py::test_owners_endpoint_matches_sample_data
- pytest -o addopts='' tests/test_backend_api.py::test_owners tests/test_backend_api.py::test_groups
- pytest -o addopts='' tests/backend/common/test_compliance.py::test_load_transactions_missing_owner_raises
- pytest -o addopts='' tests/test_compliance_route.py::test_validate_trade_when_owner_discovery_fails *(fails: existing test still expects scaffold files to be created)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ce8bf58c8327ad9cf7379acb0886