### PR TITLE
Fix smoke test navigation URLs

### DIFF
--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -148,7 +148,7 @@ test.describe('public route smoke coverage', () => {
 
       await applyAuth(page);
 
-      await page.goto(target);
+      await page.goto(target.href);
       await expect(page).toHaveURL(target.href);
 
       if (route.assertion.kind === 'mode') {


### PR DESCRIPTION
## Summary
- ensure the smoke test navigates using the target URL string rather than the URL object

## Testing
- npm --prefix frontend run smoke:frontend *(fails: Playwright browser dependencies missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d03a3d508327bc42a011f94beaff