### PR TITLE
Capture git metadata in frontend build scripts

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,3 +3,6 @@ VITE_ALLOTMINT_API_BASE=http://localhost:8000
 VITE_APP_BASE_URL=https://app.allotmint.io
 # VITE_API_TOKEN enables authenticated requests and must match the backend API_TOKEN
 VITE_API_TOKEN=
+# Optional git metadata surfaced on the Support page
+VITE_GIT_COMMIT=
+VITE_GIT_BRANCH=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -70,6 +70,7 @@ Set one of the following environment variables to tell the UI where the backend 
 * `VITE_ALLOTMINT_API_BASE` – full base URL to the backend.
 * `VITE_API_URL` – legacy fallback used when `VITE_ALLOTMINT_API_BASE` is unset.
 * `VITE_API_TOKEN` – optional token sent as `X-API-Token` with every request.
+* `VITE_GIT_COMMIT` / `VITE_GIT_BRANCH` – optional git metadata shown on the Support page for build provenance (set them manually or rely on `build.sh` / `scripts/deploy-to-aws.sh`).
 
 To provide the token, add it to your environment or a `.env` file in `frontend`:
 

--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -4,15 +4,30 @@ set -euo pipefail
 # Ensure the script runs from the frontend directory
 cd "$(dirname "$0")"
 
+# Populate git metadata for build provenance if available
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  VITE_GIT_COMMIT_DEFAULT="$(git rev-parse HEAD)"
+  VITE_GIT_BRANCH_DEFAULT="$(git rev-parse --abbrev-ref HEAD)"
+  : "${VITE_GIT_COMMIT:=$VITE_GIT_COMMIT_DEFAULT}"
+  : "${VITE_GIT_BRANCH:=$VITE_GIT_BRANCH_DEFAULT}"
+fi
+
+export VITE_GIT_COMMIT="${VITE_GIT_COMMIT:-}"
+export VITE_GIT_BRANCH="${VITE_GIT_BRANCH:-}"
+
 # Ensure environment variables are populated
 if [ ! -f .env ]; then
   cp .env.example .env
 fi
 
 # Override .env values with any provided environment variables
-for var in VITE_ALLOTMINT_API_BASE VITE_APP_BASE_URL VITE_API_TOKEN; do
+for var in VITE_ALLOTMINT_API_BASE VITE_APP_BASE_URL VITE_API_TOKEN VITE_GIT_COMMIT VITE_GIT_BRANCH; do
   if [ -n "${!var:-}" ]; then
-    sed -i "s|^${var}=.*|${var}=${!var}|" .env
+    if grep -q "^${var}=" .env; then
+      sed -i "s|^${var}=.*|${var}=${!var}|" .env
+    else
+      printf '%s=%s\n' "$var" "${!var}" >> .env
+    fi
   fi
 done
 

--- a/frontend/scripts/deploy-to-aws.sh
+++ b/frontend/scripts/deploy-to-aws.sh
@@ -68,6 +68,17 @@ if ! command -v aws >/dev/null 2>&1; then
 fi
 
 echo "\n=== Building frontend ==="
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  VITE_GIT_COMMIT_DEFAULT="$(git rev-parse HEAD)"
+  VITE_GIT_BRANCH_DEFAULT="$(git rev-parse --abbrev-ref HEAD)"
+  : "${VITE_GIT_COMMIT:=$VITE_GIT_COMMIT_DEFAULT}"
+  : "${VITE_GIT_BRANCH:=$VITE_GIT_BRANCH_DEFAULT}"
+fi
+
+export VITE_GIT_COMMIT="${VITE_GIT_COMMIT:-}"
+export VITE_GIT_BRANCH="${VITE_GIT_BRANCH:-}"
+
 npm run build
 
 if [[ ! -d dist ]]; then


### PR DESCRIPTION
## Summary
- add VITE_GIT_COMMIT and VITE_GIT_BRANCH placeholders to the example environment file and configuration docs
- export git metadata during build/deploy scripts and write the values into .env before running the Vite build

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d055ea548327b4d37eb0c1fe0354