### PR TITLE
Ensure compliance demo owner is recognized under testing datasets

### DIFF
--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -15,6 +15,29 @@ def _known_owners(accounts_root) -> set[str]:
     """Return a lower-cased set of known owners for the configured root."""
 
     owners: set[str] = set()
+
+    def _ensure_demo_owner(owner_set: set[str]) -> None:
+        """Ensure the bundled demo owner remains discoverable."""
+
+        if not owner_set or "demo" in owner_set:
+            return
+
+        try:
+            fallback_root = data_loader.resolve_paths(None, None).accounts_root
+        except Exception:
+            return
+
+        try:
+            demo_dir = fallback_root / "demo"
+        except TypeError:
+            return
+
+        try:
+            if demo_dir.exists() and demo_dir.is_dir():
+                owner_set.add("demo")
+        except Exception:
+            return
+
     try:
         entries = data_loader.list_plots(accounts_root)
     except Exception:
@@ -24,6 +47,8 @@ def _known_owners(accounts_root) -> set[str]:
         owner = (entry.get("owner") or "").strip()
         if owner:
             owners.add(owner.lower())
+
+    _ensure_demo_owner(owners)
 
     if owners:
         return owners
@@ -39,6 +64,8 @@ def _known_owners(accounts_root) -> set[str]:
     for entry in root_path.iterdir():
         if entry.is_dir():
             owners.add(entry.name.lower())
+
+    _ensure_demo_owner(owners)
     return owners
 
 

--- a/backend/tests/test_compliance_route.py
+++ b/backend/tests/test_compliance_route.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes import compliance
+
+
+def test_validate_demo_owner_available_with_testing(monkeypatch, tmp_path):
+    clone_root = tmp_path / "clone" / "accounts"
+    (clone_root / "demo").mkdir(parents=True)
+    (clone_root / "alice").mkdir(parents=True)
+    (clone_root / "alice" / "portfolio.json").write_text("{}")
+    (clone_root / "demo" / "portfolio.json").write_text("{}")
+
+    monkeypatch.setenv("TESTING", "1")
+
+    app = FastAPI()
+    app.state.accounts_root = clone_root
+    app.include_router(compliance.router)
+
+    monkeypatch.setattr(
+        "backend.common.compliance.check_trade",
+        lambda trade, root: {"owner": trade["owner"]},
+    )
+
+    with TestClient(app) as client:
+        resp = client.post("/compliance/validate", json={"owner": "demo"})
+
+    assert resp.status_code != 404
+    assert resp.status_code == 200
+    assert resp.json()["owner"] == "demo"


### PR DESCRIPTION
## Summary
- ensure `_known_owners` preserves the bundled demo owner by checking the fallback dataset
- add a regression test confirming demo validation succeeds when TESTING=1 and the accounts root points to a cloned dataset

## Testing
- pytest -o addopts='' backend/tests/test_compliance_route.py
- node node_modules/tsx/dist/cli.mjs scripts/frontend-backend-smoke.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7d038fd108327890fed86c093b7c5