### PR TITLE
Fix resolve_accounts_root fallback for missing cached directory

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -30,10 +30,11 @@ def resolve_accounts_root(request: Request) -> Path:
             cached_path = None
             resolved_cached = None
         else:
-            request.app.state.accounts_root = resolved_cached
-            if hasattr(request.app.state, "accounts_root_is_global"):
-                request.app.state.accounts_root_is_global = False
-            return resolved_cached
+            if cached_path.exists():
+                request.app.state.accounts_root = resolved_cached
+                if hasattr(request.app.state, "accounts_root_is_global"):
+                    request.app.state.accounts_root_is_global = False
+                return resolved_cached
 
         request.app.state.accounts_root = None
         if hasattr(request.app.state, "accounts_root_is_global"):


### PR DESCRIPTION
## Summary
- avoid returning cached account roots when the cached directory has been removed
- ensure the resolver falls back to configured and global paths when cached directories are missing

## Testing
- pytest --override-ini=addopts= tests/routes/test_accounts_root.py

------
https://chatgpt.com/codex/tasks/task_e_68d81a86b1348327b9f64fa3d92d7aaa