### PR TITLE
Prevent demo data from appearing when authentication is disabled

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -228,19 +228,19 @@ def _list_local_plots(
     if "demo" in owners_index:
         _merge_accounts(owners_index["demo"], fallback_demo)
     else:
-        if fallback_demo:
+        if fallback_demo and not config.disable_auth:
             results.append(fallback_demo)
             owners_index["demo"] = fallback_demo
         elif include_demo_primary:
             primary_demo = _load_demo_owner(primary_root)
-            if primary_demo:
+            if primary_demo and not config.disable_auth:
                 results.append(primary_demo)
                 owners_index["demo"] = primary_demo
 
     if same_root:
         return results
 
-    if "demo" not in owners_index:
+    if "demo" not in owners_index and not config.disable_auth:
         primary_demo = _load_demo_owner(primary_root)
         if primary_demo:
             results.append(primary_demo)


### PR DESCRIPTION
## Summary
- avoid appending fallback demo data when authentication is disabled to keep anonymous listings scoped to local owners

## Testing
- pytest -o addopts='' tests/backend/common/test_data_loader.py::TestListLocalPlots::test_authentication_disabled_allows_anonymous_access

------
https://chatgpt.com/codex/tasks/task_e_68d81a52d188832780837b9755d15523