### PR TITLE
Ensure resolve_accounts_root falls back when cached path disappears

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -30,10 +30,11 @@ def resolve_accounts_root(request: Request) -> Path:
             cached_path = None
             resolved_cached = None
         else:
-            request.app.state.accounts_root = resolved_cached
-            if hasattr(request.app.state, "accounts_root_is_global"):
-                request.app.state.accounts_root_is_global = False
-            return resolved_cached
+            if resolved_cached.exists():
+                request.app.state.accounts_root = resolved_cached
+                if hasattr(request.app.state, "accounts_root_is_global"):
+                    request.app.state.accounts_root_is_global = False
+                return resolved_cached
 
         request.app.state.accounts_root = None
         if hasattr(request.app.state, "accounts_root_is_global"):


### PR DESCRIPTION
## Summary
- verify a cached accounts root still exists before reusing it so stale directories trigger fallback resolution

## Testing
- pytest -o addopts='' tests/routes/test_accounts_root.py

------
https://chatgpt.com/codex/tasks/task_e_68d81a9011e883279cf0d5063c29472f