### PR TITLE
Ensure scaffolding is created when loading missing owner transactions

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -113,6 +113,7 @@ def load_transactions(
     if not owner_dir.exists():
         if not scaffold_missing:
             raise FileNotFoundError(owner_dir)
+        _ensure_owner_scaffold(owner, owner_dir)
         return []
 
     _ensure_owner_scaffold(owner, owner_dir)


### PR DESCRIPTION
## Summary
- ensure owner scaffolding is created when load_transactions is asked to scaffold missing owners

## Testing
- pytest tests/test_compliance_route.py::test_validate_trade_when_owner_discovery_fails -q --no-cov

------
https://chatgpt.com/codex/tasks/task_e_68d81a9e47e88327a48330141faa5ec3