### PR TITLE
Handle default alert threshold in Trail tasks

### DIFF
--- a/backend/quests/trail.py
+++ b/backend/quests/trail.py
@@ -215,15 +215,22 @@ def _has_custom_threshold(user: str) -> bool:
         return False
     if isinstance(raw_threshold, bool):
         return bool(raw_threshold)
-    if isinstance(raw_threshold, (int, float)):
-        return math.isfinite(float(raw_threshold))
-
     try:
         candidate = float(raw_threshold)
     except (TypeError, ValueError):
         return bool(raw_threshold)
 
-    return math.isfinite(candidate)
+    if not math.isfinite(candidate):
+        return False
+
+    default_thresholds = {
+        alerts.DEFAULT_THRESHOLD_PCT,
+        alerts.DEFAULT_THRESHOLD_PCT * 100,
+    }
+    if any(math.isclose(candidate, default, rel_tol=1e-9, abs_tol=1e-9) for default in default_thresholds):
+        return False
+
+    return True
 
 
 _AUTO_ONCE_KEY = "_auto_once"


### PR DESCRIPTION
## Summary
- update Trail task threshold detection to treat default values as incomplete
- ignore default 5% entries whether stored as 0.05 or 5 so seeded defaults no longer mark the task complete

## Testing
- `pytest tests/quests/test_trail.py::test_threshold_once_task_ignores_seeded_default -q`
- `pytest tests/quests/test_trail.py::test_get_tasks_with_completions -q`


------
https://chatgpt.com/codex/tasks/task_e_68d81a6da8b483278af575321c1206be