### PR TITLE
Prevent scaffolding unknown owners when discovery succeeds

### DIFF
--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -119,6 +119,8 @@ async def validate_trade(request: Request):
             raise_owner_not_found()
         trade["owner"] = canonical_owner
     else:
+        if owners:
+            raise_owner_not_found()
         trade["owner"] = owner_value
     try:
         return compliance.check_trade(


### PR DESCRIPTION
## Summary
- stop /compliance/validate from scaffolding a new owner when the owner directory is missing but owner discovery already succeeded
- keep scaffolding behaviour when owner discovery fails entirely

## Testing
- pytest --override-ini addopts='' tests/test_compliance_route.py -k unknown_owner

------
https://chatgpt.com/codex/tasks/task_e_68d81a970ff48327aed9d44e37e7fc4b