### PR TITLE
Fix run_all_tickers cache exchange precedence

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -102,8 +102,11 @@ def _resolve_exchange_from_metadata(symbol: str) -> str:
     return ""
 
 
-def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> Tuple[str, str]:
-    """Resolve base symbol and exchange from inputs and metadata."""
+def _resolve_symbol_exchange_details(
+    ticker: str, exchange: str | None
+) -> Tuple[str, str, str]:
+    """Return symbol, resolved exchange and metadata exchange."""
+
     sym, suffix = (re.split(r"[._]", ticker, 1) + [""])[:2]
     provided = (exchange or "").upper()
     suffix = suffix.upper()
@@ -111,9 +114,10 @@ def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> Tuple[str, st
         logger.debug(
             "Exchange mismatch for %s: suffix %s vs argument %s", ticker, suffix, provided
         )
-    ex = suffix or provided
+    resolved = suffix or provided
 
-    meta_ex = _resolve_exchange_from_metadata(sym)
+    meta_ex = _resolve_exchange_from_metadata(sym).upper()
+    ex = resolved
     if not ex and meta_ex:
         ex = meta_ex
         logger.debug("Resolved exchange for %s via metadata: %s", sym, ex)
@@ -126,7 +130,15 @@ def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> Tuple[str, st
         )
     elif not ex:
         logger.debug("No exchange information for %s; continuing without exchange", sym)
-    return sym.upper(), ex.upper()
+
+    return sym.upper(), (ex or "").upper(), meta_ex
+
+
+def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> Tuple[str, str]:
+    """Resolve base symbol and exchange from inputs and metadata."""
+
+    sym, ex, _ = _resolve_symbol_exchange_details(ticker, exchange)
+    return sym, ex
 
 
 def _resolve_loader_exchange(
@@ -343,17 +355,16 @@ def run_all_tickers(
     for idx, t in enumerate(tickers):
         if delay and idx:
             time.sleep(delay)
-        sym, ex = _resolve_ticker_exchange(t, exchange)
+        sym, ex, meta_exchange = _resolve_symbol_exchange_details(t, exchange)
         logger.debug("run_all_tickers resolved %s -> %s.%s", t, sym, ex)
         loader_exchange = _resolve_loader_exchange(t, exchange, sym, ex)
-        meta_exchange = _resolve_exchange_from_metadata(sym)
-        cache_exchange = meta_exchange or ""
-        if loader_exchange and loader_exchange != cache_exchange:
+        cache_exchange = meta_exchange or loader_exchange or ""
+        if meta_exchange and loader_exchange and loader_exchange != meta_exchange:
             logger.debug(
                 "Cache exchange mismatch for %s: loader %s vs metadata %s",
                 sym,
                 loader_exchange,
-                cache_exchange or "<empty>",
+                meta_exchange or "<empty>",
             )
         try:
             if not load_meta_timeseries(sym, cache_exchange, days).empty:
@@ -373,17 +384,16 @@ def load_timeseries_data(
     from backend.timeseries.cache import load_meta_timeseries
     out: dict[str, pd.DataFrame] = {}
     for t in tickers:
-        sym, ex = _resolve_ticker_exchange(t, exchange)
+        sym, ex, meta_exchange = _resolve_symbol_exchange_details(t, exchange)
         logger.debug("load_timeseries_data resolved %s -> %s.%s", t, sym, ex)
         loader_exchange = _resolve_loader_exchange(t, exchange, sym, ex)
-        meta_exchange = _resolve_exchange_from_metadata(sym)
-        cache_exchange = meta_exchange or ""
-        if loader_exchange and loader_exchange != cache_exchange:
+        cache_exchange = meta_exchange or loader_exchange or ""
+        if meta_exchange and loader_exchange and loader_exchange != meta_exchange:
             logger.debug(
                 "Cache exchange mismatch for %s: loader %s vs metadata %s",
                 sym,
                 loader_exchange,
-                cache_exchange or "<empty>",
+                meta_exchange or "<empty>",
             )
         try:
             df = load_meta_timeseries(sym, cache_exchange, days)

--- a/tests/timeseries/test_run_all_and_load_timeseries.py
+++ b/tests/timeseries/test_run_all_and_load_timeseries.py
@@ -47,7 +47,7 @@ def test_run_all_tickers_prefers_metadata_exchange_for_cache():
         ):
             fmt.run_all_tickers(["AAA.N", "BBB"], exchange="Q", days=7)
 
-    assert calls == [("AAA", "L", 7), ("BBB", "", 7)]
+    assert calls == [("AAA", "L", 7), ("BBB", "Q", 7)]
 
 
 def test_load_timeseries_data_filters_and_warnings(monkeypatch, caplog):
@@ -85,4 +85,4 @@ def test_load_timeseries_data_prefers_metadata_exchange_for_cache():
         ):
             fmt.load_timeseries_data(["AAA.L", "BBB"], exchange="L", days=3)
 
-    assert calls == [("AAA", "N", 3), ("BBB", "", 3)]
+    assert calls == [("AAA", "N", 3), ("BBB", "L", 3)]


### PR DESCRIPTION
## Summary
- add a helper that returns both resolved and metadata exchanges for a symbol
- prefer explicit suffixes or provided defaults when metadata is missing while retaining metadata precedence when present
- update tests to cover the adjusted cache exchange behaviour

## Testing
- pytest --override-ini="addopts=" tests/test_run_all_tickers.py -q
- pytest --override-ini="addopts=" tests/timeseries/test_run_all_and_load_timeseries.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d81ab581f483278a209f54ecbe0d6d