### PR TITLE
Fix cache exchange fallback for warmup loaders

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -347,7 +347,7 @@ def run_all_tickers(
         logger.debug("run_all_tickers resolved %s -> %s.%s", t, sym, ex)
         loader_exchange = _resolve_loader_exchange(t, exchange, sym, ex)
         meta_exchange = _resolve_exchange_from_metadata(sym)
-        cache_exchange = meta_exchange or ""
+        cache_exchange = meta_exchange or loader_exchange or ""
         if loader_exchange and loader_exchange != cache_exchange:
             logger.debug(
                 "Cache exchange mismatch for %s: loader %s vs metadata %s",
@@ -377,7 +377,7 @@ def load_timeseries_data(
         logger.debug("load_timeseries_data resolved %s -> %s.%s", t, sym, ex)
         loader_exchange = _resolve_loader_exchange(t, exchange, sym, ex)
         meta_exchange = _resolve_exchange_from_metadata(sym)
-        cache_exchange = meta_exchange or ""
+        cache_exchange = meta_exchange or loader_exchange or ""
         if loader_exchange and loader_exchange != cache_exchange:
             logger.debug(
                 "Cache exchange mismatch for %s: loader %s vs metadata %s",

--- a/tests/timeseries/test_run_all_and_load_timeseries.py
+++ b/tests/timeseries/test_run_all_and_load_timeseries.py
@@ -43,11 +43,11 @@ def test_run_all_tickers_prefers_metadata_exchange_for_cache():
         with patch.object(
             fmt,
             "_resolve_exchange_from_metadata",
-            side_effect=["L", ""],
+            side_effect=["L", "L", "", ""],
         ):
             fmt.run_all_tickers(["AAA.N", "BBB"], exchange="Q", days=7)
 
-    assert calls == [("AAA", "L", 7), ("BBB", "", 7)]
+    assert calls == [("AAA", "L", 7), ("BBB", "Q", 7)]
 
 
 def test_load_timeseries_data_filters_and_warnings(monkeypatch, caplog):
@@ -81,8 +81,8 @@ def test_load_timeseries_data_prefers_metadata_exchange_for_cache():
         with patch.object(
             fmt,
             "_resolve_exchange_from_metadata",
-            side_effect=["N", ""],
+            side_effect=["N", "N", "", ""],
         ):
             fmt.load_timeseries_data(["AAA.L", "BBB"], exchange="L", days=3)
 
-    assert calls == [("AAA", "N", 3), ("BBB", "", 3)]
+    assert calls == [("AAA", "N", 3), ("BBB", "L", 3)]


### PR DESCRIPTION
## Summary
- ensure cached meta time series warmup and load functions fall back to loader exchange codes when metadata is absent
- adjust tests to assert the new fallback behaviour and provide sufficient metadata mock responses

## Testing
- pytest --override-ini=addopts="" tests/test_run_all_tickers.py tests/timeseries/test_run_all_and_load_timeseries.py

------
https://chatgpt.com/codex/tasks/task_e_68d81abdb30c83279ab162bcfc2669f0