### PR TITLE
Preserve global accounts root flag when resolving cached path

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -32,7 +32,14 @@ def resolve_accounts_root(request: Request) -> Path:
         else:
             request.app.state.accounts_root = resolved_cached
             if hasattr(request.app.state, "accounts_root_is_global"):
-                request.app.state.accounts_root_is_global = False
+                # Preserve a previously cached "global" flag so callers can
+                # detect that the application is still operating against the
+                # fallback data directory. This is important for routes such
+                # as the transactions endpoints which require an explicitly
+                # configured accounts directory. Only clear the flag when it
+                # is not already marked as global.
+                if getattr(request.app.state, "accounts_root_is_global", None) is not True:
+                    request.app.state.accounts_root_is_global = False
             return resolved_cached
 
         request.app.state.accounts_root = None


### PR DESCRIPTION
## Summary
- preserve the accounts_root_is_global flag when a cached fallback path is reused so endpoints can detect missing configuration

## Testing
- pytest -o addopts= tests/test_transactions_route.py::test_create_transaction_requires_accounts_root

------
https://chatgpt.com/codex/tasks/task_e_68d81ac505a08327b70eef29093163bc