### PR TITLE
Fix accounts root fallback after cached directory deletion

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -24,13 +25,13 @@ def resolve_accounts_root(request: Request) -> Path:
     accounts_root_value = getattr(request.app.state, "accounts_root", None)
     if accounts_root_value is not None:
         try:
-            cached_path = Path(accounts_root_value).expanduser()
+            cached_path = Path(os.fspath(accounts_root_value)).expanduser()
             resolved_cached = cached_path.resolve(strict=False)
         except (TypeError, ValueError, OSError):
             cached_path = None
             resolved_cached = None
         else:
-            if cached_path.exists():
+            if cached_path.exists() and cached_path.is_dir():
                 request.app.state.accounts_root = resolved_cached
                 if hasattr(request.app.state, "accounts_root_is_global"):
                     request.app.state.accounts_root_is_global = False


### PR DESCRIPTION
## Summary
- ensure cached request state paths are re-evaluated using os.fspath before checking the filesystem
- require cached paths to still point to directories before reusing them, allowing fallback resolution when directories are removed

## Testing
- pytest -o addopts="" tests/routes/test_accounts_root.py::test_resolve_accounts_root_handles_deleted_cached_directory -q

------
https://chatgpt.com/codex/tasks/task_e_68d81c3031e083278e1cd97dcf4a53bd