### PR TITLE
Prevent fallback demo owner when explicit local plots exist

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -233,6 +233,10 @@ def _list_local_plots(
         str(entry.get("owner", "")).lower(): entry for entry in results
     }
 
+    allow_fallback_demo = data_root is None or not results
+    if not allow_fallback_demo:
+        return results
+
     fallback_demo = _load_demo_owner(fallback_root)
     fallback_meta = load_person_meta("demo", fallback_root) if fallback_demo else {}
     if "demo" in owners_index:


### PR DESCRIPTION
## Summary
- stop merging fallback demo data when a custom local data root already returns results
- keep demo fallback available when the explicit root has no owners

## Testing
- PYTEST_ADDOPTS="--cov=backend --cov-fail-under=0" pytest tests/backend/common/test_data_loader.py::TestListLocalPlots::test_allows_access_when_user_matches_owner_email -q

------
https://chatgpt.com/codex/tasks/task_e_68d81d43ea4083278fad43d5a0d80036