### PR TITLE
Ensure run_all_tickers respects explicit cache exchanges

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -167,6 +167,11 @@ def _resolve_loader_exchange(
     return resolved
 
 
+def _explicit_exchange_from_ticker(ticker: str) -> str:
+    parts = re.split(r"[._]", ticker, 1)
+    return parts[1].strip().upper() if len(parts) == 2 else ""
+
+
 def _merge(sources: List[pd.DataFrame]) -> pd.DataFrame:
     if not sources:
         return pd.DataFrame(columns=STANDARD_COLUMNS)
@@ -358,7 +363,8 @@ def run_all_tickers(
         sym, ex, meta_exchange = _resolve_symbol_exchange_details(t, exchange)
         logger.debug("run_all_tickers resolved %s -> %s.%s", t, sym, ex)
         loader_exchange = _resolve_loader_exchange(t, exchange, sym, ex)
-        cache_exchange = meta_exchange or loader_exchange or ""
+        explicit_exchange = _explicit_exchange_from_ticker(t)
+        cache_exchange = meta_exchange or explicit_exchange or loader_exchange or ""
         if meta_exchange and loader_exchange and loader_exchange != meta_exchange:
             logger.debug(
                 "Cache exchange mismatch for %s: loader %s vs metadata %s",
@@ -387,7 +393,8 @@ def load_timeseries_data(
         sym, ex, meta_exchange = _resolve_symbol_exchange_details(t, exchange)
         logger.debug("load_timeseries_data resolved %s -> %s.%s", t, sym, ex)
         loader_exchange = _resolve_loader_exchange(t, exchange, sym, ex)
-        cache_exchange = meta_exchange or loader_exchange or ""
+        explicit_exchange = _explicit_exchange_from_ticker(t)
+        cache_exchange = meta_exchange or explicit_exchange or loader_exchange or ""
         if meta_exchange and loader_exchange and loader_exchange != meta_exchange:
             logger.debug(
                 "Cache exchange mismatch for %s: loader %s vs metadata %s",


### PR DESCRIPTION
## Summary
- add a helper that extracts an explicit exchange suffix from tickers
- prefer the explicit suffix when choosing the cache exchange in run_all_tickers and load_timeseries_data

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/test_run_all_tickers.py::test_run_all_tickers_handles_underscore_and_dot -q

------
https://chatgpt.com/codex/tasks/task_e_68d81ebd410c8327a13631f0b2c27a87