### PR TITLE
Ensure transactions endpoint requires configured accounts root

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -138,7 +138,7 @@ def _require_accounts_root(request: Request) -> Path:
     except FileNotFoundError as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=400, detail="Accounts root not configured") from exc
 
-    if getattr(request.app.state, "accounts_root_is_global", False):
+    if state_is_global or getattr(request.app.state, "accounts_root_is_global", False):
         raise HTTPException(status_code=400, detail="Accounts root not configured")
 
     if not resolved.exists():


### PR DESCRIPTION
## Summary
- ensure the transactions route notices when the application is using the fallback accounts root
- return a 400 response when the accounts root has not been configured instead of silently accepting requests

## Testing
- pytest -q tests/test_transactions_route.py::test_create_transaction_requires_accounts_root *(fails: coverage threshold is unmet when running a single test)*

------
https://chatgpt.com/codex/tasks/task_e_68d81f112ba083279cf3e290a5cf8183