### PR TITLE
Prevent fallback demo data when using custom roots

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -220,6 +220,14 @@ def _list_local_plots(
 
     results = _discover(primary_root, include_demo=include_demo_primary)
 
+    # When an explicit ``data_root`` is provided treat it as authoritative and
+    # avoid blending in accounts from the repository fallback tree.  This keeps
+    # unit tests (which use temporary roots) isolated from the real repository
+    # data and mirrors the expectation that callers passing a custom root only
+    # see data from that location.
+    if data_root is not None:
+        return results
+
     try:
         same_root = fallback_root.resolve() == primary_root.resolve()
     except OSError:


### PR DESCRIPTION
## Summary
- stop `_list_local_plots` from merging fallback demo accounts when a custom `data_root` is provided
- document the intent so temporary data roots remain isolated from repository fixtures

## Testing
- pytest tests/test_data_loader_local.py::test_list_local_plots_authenticated -q --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68d81e6065748327be974fe19c320deb