### PR TITLE
Avoid including demo owner for explicit local data roots

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -213,10 +213,11 @@ def _list_local_plots(
     fallback_paths = resolve_paths(None, None)
     fallback_root = fallback_paths.accounts_root
     include_demo_primary = False
-    try:
-        include_demo_primary = primary_root.resolve() == fallback_root.resolve()
-    except Exception:
-        include_demo_primary = False
+    if data_root is None:
+        try:
+            include_demo_primary = primary_root.resolve() == fallback_root.resolve()
+        except Exception:
+            include_demo_primary = False
 
     results = _discover(primary_root, include_demo=include_demo_primary)
 


### PR DESCRIPTION
## Summary
- ensure `_list_local_plots` only evaluates demo inclusion when using the default accounts root
- prevents the demo owner from appearing when callers pass a custom `data_root`

## Testing
- pytest --override-ini "addopts=" tests/test_data_loader_local.py::test_list_local_plots_filters_special_directories -q

------
https://chatgpt.com/codex/tasks/task_e_68d8210679f483278119bfe4c57a3581