### PR TITLE
Ensure trail tests reset alert caches

### DIFF
--- a/tests/quests/test_trail.py
+++ b/tests/quests/test_trail.py
@@ -13,6 +13,9 @@ def memory_storage(monkeypatch):
     data = {}
     storage = get_storage("file://trail.json")
 
+    monkeypatch.setattr(alerts, "_USER_THRESHOLDS", {})
+    monkeypatch.setattr(alerts, "_PUSH_SUBSCRIPTIONS", {})
+
     def load():
         return data
 


### PR DESCRIPTION
## Summary
- clear the alerts threshold and push subscription caches in the trail test fixture to avoid leakage from prior tests

## Testing
- PYTEST_ADDOPTS='--no-cov' pytest tests/quests/test_trail.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d81d8d3c188327a5f16295847c2569