### PR TITLE
Handle smoke tests when backend is offline

### DIFF
--- a/frontend/src/pages/ReturnComparison.tsx
+++ b/frontend/src/pages/ReturnComparison.tsx
@@ -17,11 +17,28 @@ export default function ReturnComparison() {
   const [cashApy, setCashApy] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!owner) return;
-    getReturnComparison(owner, days).then((res) => {
-      setCagr(res.cagr);
-      setCashApy(res.cash_apy);
-    });
+    if (!owner) {
+      setCagr(null);
+      setCashApy(null);
+      return;
+    }
+
+    let cancelled = false;
+    getReturnComparison(owner, days)
+      .then((res) => {
+        if (cancelled) return;
+        setCagr(res.cagr);
+        setCashApy(res.cash_apy);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCagr(null);
+        setCashApy(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [owner, days]);
 
   return (


### PR DESCRIPTION
## Summary
- always render the route marker and fallback UI so smoke navigation checks pass even when the backend is unavailable
- prevent the return comparison page from throwing when API requests fail by resetting state on errors

## Testing
- npm run lint *(fails: existing lint violations across the frontend codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68d822a9f2748327ab8cd9ce949369d7