### PR TITLE
Avoid implicit scaffolding when loading missing transactions

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -113,7 +113,10 @@ def load_transactions(
     if not owner_dir.exists():
         if not scaffold_missing:
             raise FileNotFoundError(owner_dir)
-        _ensure_owner_scaffold(owner, owner_dir)
+        # Callers opting to scaffold missing owners expect the function to
+        # return an empty transaction list without mutating the filesystem.
+        # ``ensure_owner_scaffold`` remains available to explicitly create the
+        # default structure when desired.
         return []
 
     _ensure_owner_scaffold(owner, owner_dir)


### PR DESCRIPTION
## Summary
- return an empty transaction list when scaffold_missing is requested instead of creating files on disk

## Testing
- pytest -o addopts="" tests/backend/common/test_compliance.py::test_load_transactions_missing_owner_raises -q
- pytest -o addopts="" tests/quests/test_trail.py::test_get_tasks_returns_defaults -q

------
https://chatgpt.com/codex/tasks/task_e_68d82440de9c8327a0f4d3b8370fc5f3