### PR TITLE
Ensure demo owner is discoverable when auth disabled

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -162,6 +162,9 @@ def _list_local_plots(
         if not isinstance(viewers, list):
             viewers = []
 
+        if config.disable_auth:
+            return True
+
         if config.disable_auth is False and user is None:
             return False
 
@@ -185,11 +188,9 @@ def _list_local_plots(
         if not root.exists():
             return results
 
-        skip_owners = (
-            {owner for owner in _SKIP_OWNERS if owner != "demo"}
-            if include_demo
-            else _SKIP_OWNERS
-        )
+        skip_owners = set(_SKIP_OWNERS)
+        if include_demo or config.disable_auth:
+            skip_owners.discard("demo")
 
         for owner_dir in sorted(root.iterdir()):
             if not owner_dir.is_dir():


### PR DESCRIPTION
## Summary
- allow owner discovery to bypass authorization when global auth is disabled
- include the demo account when scanning owners from a specific accounts root

## Testing
- pytest tests/test_backend_api.py::test_post_transaction_invalid_fields --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d8242a8ba883278f8ae1aa9aa010a6