### PR TITLE
Fix demo owner visibility and allow scaffolding when accounts root is missing

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -218,6 +218,12 @@ def _list_local_plots(
             include_demo_primary = primary_root.resolve() == fallback_root.resolve()
         except Exception:
             include_demo_primary = False
+    # When authentication is disabled the demo owner should remain available
+    # even if callers override ``data_root`` (e.g. tests isolating their
+    # working directory). Skipping the demo in that scenario broke the local
+    # API which always exposes the demo account for preview access.
+    if config.disable_auth:
+        include_demo_primary = True
 
     results = _discover(primary_root, include_demo=include_demo_primary)
 

--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -31,7 +31,10 @@ def resolve_accounts_root(request: Request) -> Path:
             cached_path = None
             resolved_cached = None
         else:
-            if cached_path.exists() and cached_path.is_dir():
+            if cached_path.exists() and not cached_path.is_dir():
+                cached_path = None
+                resolved_cached = None
+            elif resolved_cached is not None:
                 request.app.state.accounts_root = resolved_cached
                 if hasattr(request.app.state, "accounts_root_is_global"):
                     request.app.state.accounts_root_is_global = False


### PR DESCRIPTION
## Summary
- ensure the demo owner remains visible when authentication is disabled even if a custom data root is provided
- reuse configured accounts roots for scaffolding instead of falling back when the directory does not exist yet

## Testing
- pytest tests/test_backend_api.py::test_post_transaction_missing_reason tests/test_backend_api.py::test_compliance_endpoint tests/test_compliance_route.py::test_validate_trade_when_owner_discovery_fails -q -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68d824200e6883278d5adb17740ae24b