### PR TITLE
Fix demo owner availability in owner discovery

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -196,18 +196,30 @@ def create_app() -> FastAPI:
 
     configured_root = getattr(cfg, "accounts_root", None)
     fallback_used = False
+    configured_path_missing = False
     try:
         if configured_root:
             configured_path = Path(configured_root).expanduser()
             if not configured_path.exists():
                 fallback_used = True
+                configured_path_missing = True
         else:
             fallback_used = True
     except (TypeError, ValueError, OSError):
         fallback_used = True
+        configured_path_missing = True
 
     paths = resolve_paths(cfg.repo_root, cfg.accounts_root)
     accounts_root = paths.accounts_root
+
+    if configured_path_missing:
+        fallback_paths = resolve_paths(None, None)
+        accounts_root = fallback_paths.accounts_root
+        try:
+            cfg.accounts_root = accounts_root
+        except Exception:
+            cfg.accounts_root = fallback_paths.accounts_root
+
     original_accounts_root = accounts_root
 
     try:


### PR DESCRIPTION
## Summary
- fall back to the bundled accounts directory when the configured accounts root is missing
- ensure the demo owner is exposed when an explicit accounts root already contains the demo data

## Testing
- pytest --override-ini=addopts= -q tests/quests/test_trail.py::test_get_tasks_with_completions tests/test_accounts_api.py::test_owners_endpoint_matches_sample_data tests/test_backend_api.py::test_owners

------
https://chatgpt.com/codex/tasks/task_e_68d824377c948327851f52941496b9bb