### PR TITLE
Fix owner scaffolding and exchange resolution

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -113,7 +113,8 @@ def load_transactions(
     if not owner_dir.exists():
         if not scaffold_missing:
             raise FileNotFoundError(owner_dir)
-        _ensure_owner_scaffold(owner, owner_dir)
+        if owner_dir.parent.exists():
+            _ensure_owner_scaffold(owner, owner_dir)
         return []
 
     _ensure_owner_scaffold(owner, owner_dir)

--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -31,7 +31,7 @@ def resolve_accounts_root(request: Request) -> Path:
             cached_path = None
             resolved_cached = None
         else:
-            if cached_path.exists() and cached_path.is_dir():
+            if resolved_cached is not None:
                 request.app.state.accounts_root = resolved_cached
                 if hasattr(request.app.state, "accounts_root_is_global"):
                     request.app.state.accounts_root_is_global = False

--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -119,9 +119,15 @@ async def validate_trade(request: Request):
             raise_owner_not_found()
         trade["owner"] = canonical_owner
     else:
-        if owners:
+        if owners and owner_value.lower() not in owners:
             raise_owner_not_found()
         trade["owner"] = owner_value
+    if scaffold_missing and accounts_root:
+        try:
+            Path(accounts_root).mkdir(parents=True, exist_ok=True)
+        except Exception:
+            logger.warning("Failed to create accounts root %s", accounts_root)
+
     try:
         return compliance.check_trade(
             trade,

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -193,7 +193,12 @@ def _resolve_cache_exchange(
 
     loader_exchange = _resolve_loader_exchange(ticker, exchange_arg, symbol, resolved_exchange)
     explicit_exchange = _explicit_exchange_from_ticker(ticker)
-    cache_exchange = metadata_exchange or explicit_exchange or loader_exchange or ""
+    cache_exchange = (
+        explicit_exchange
+        or loader_exchange
+        or metadata_exchange
+        or ""
+    )
 
     if metadata_exchange and loader_exchange and loader_exchange != metadata_exchange:
         logger.debug(


### PR DESCRIPTION
## Summary
- prevent compliance transaction loading from creating owner directories when the accounts root is absent
- allow compliance validation to scaffold owners under custom roots and keep the demo owner visible in owners listings
- prefer explicit or requested exchanges when resolving cached timeseries lookups

## Testing
- pytest --override-ini addopts="" tests/backend/common/test_compliance.py::test_load_transactions_missing_owner_raises -q
- pytest --override-ini addopts="" tests/test_compliance_route.py::test_validate_trade_when_owner_discovery_fails -q
- pytest --override-ini addopts="" tests/test_accounts_api.py::test_owners_endpoint_matches_sample_data -q
- pytest --override-ini addopts="" tests/test_backend_api.py::test_owners -q
- pytest --override-ini addopts="" tests/test_backend_api.py::test_post_transaction_persists_and_updates_portfolio -q
- pytest --override-ini addopts="" tests/test_run_all_tickers.py::test_run_all_tickers_accepts_full_tickers -q
- pytest --override-ini addopts="" tests/timeseries/test_run_all_and_load_timeseries.py::test_run_all_tickers_filters_and_delays -q
- pytest --override-ini addopts="" tests/timeseries/test_run_all_and_load_timeseries.py::test_load_timeseries_data_filters_and_warnings -q

------
https://chatgpt.com/codex/tasks/task_e_68d823b0c3208327a7627586fdf3bf6b