### PR TITLE
Fix owner scaffolding and ticker exchange resolution

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -250,33 +250,30 @@ def _list_local_plots(
     }
 
     allow_fallback_demo = data_root is None or not results
-    if not allow_fallback_demo:
-        return results
 
-    fallback_demo = _load_demo_owner(fallback_root)
-    fallback_meta = load_person_meta("demo", fallback_root) if fallback_demo else {}
+    def _attach_demo_from(root: Optional[Path]) -> bool:
+        if not root:
+            return False
+        demo_entry = _load_demo_owner(root)
+        if not demo_entry:
+            return False
+        meta = load_person_meta("demo", root)
+        if not _is_authorized("demo", meta):
+            return False
+        results.append(demo_entry)
+        owners_index["demo"] = demo_entry
+        return True
+
     if "demo" in owners_index:
-        _merge_accounts(owners_index["demo"], fallback_demo)
+        if allow_fallback_demo:
+            fallback_demo = _load_demo_owner(fallback_root)
+            _merge_accounts(owners_index["demo"], fallback_demo)
     else:
-        if (
-            fallback_demo
-            and config.disable_auth
-            and _is_authorized("demo", fallback_meta)
-        ):
-            results.append(fallback_demo)
-            owners_index["demo"] = fallback_demo
-        elif include_demo_primary:
-            primary_demo = _load_demo_owner(primary_root)
-            primary_meta = (
-                load_person_meta("demo", primary_root) if primary_demo else {}
-            )
-            if (
-                primary_demo
-                and config.disable_auth
-                and _is_authorized("demo", primary_meta)
-            ):
-                results.append(primary_demo)
-                owners_index["demo"] = primary_demo
+        if allow_fallback_demo and config.disable_auth:
+            if _attach_demo_from(fallback_root):
+                allow_fallback_demo = False
+        if (config.disable_auth or include_demo_primary) and "demo" not in owners_index:
+            _attach_demo_from(primary_root if include_demo_primary else fallback_root)
 
     def _lookup_meta(owner: str) -> Dict[str, Any]:
         """Load metadata for ``owner`` from known search roots."""

--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -123,7 +123,7 @@ async def validate_trade(request: Request):
             raise_owner_not_found()
         trade["owner"] = owner_value
     try:
-        return compliance.check_trade(
+        result = compliance.check_trade(
             trade,
             accounts_root,
             scaffold_missing=scaffold_missing,
@@ -132,3 +132,11 @@ async def validate_trade(request: Request):
         raise_owner_not_found()
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    if scaffold_missing:
+        try:
+            compliance.ensure_owner_scaffold(trade["owner"], accounts_root)
+        except Exception:
+            logger.warning("failed to scaffold compliance data for %s", trade.get("owner"))
+
+    return result

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -191,25 +191,23 @@ def _resolve_cache_exchange(
 ) -> str:
     """Return the exchange code to use when reading from the cache."""
 
-    loader_exchange = _resolve_loader_exchange(ticker, exchange_arg, symbol, resolved_exchange)
+    loader_exchange = _resolve_loader_exchange(
+        ticker, exchange_arg, symbol, resolved_exchange
+    )
     explicit_exchange = _explicit_exchange_from_ticker(ticker)
-    cache_exchange = ""
+    provided_exchange = (exchange_arg or "").strip().upper()
 
-    # When the ticker explicitly encodes an exchange (either as ``.L`` or
-    # ``_L``) prefer the instrument metadata. This mirrors how the parquet
-    # cache is organised – metadata derived from the instruments directory is
-    # authoritative for full tickers. Conversely, if callers only provide an
-    # exchange via the ``exchange`` argument we should respect that override so
-    # tests can exercise scenarios where metadata is absent. Fall back to the
-    # loader exchange when nothing else is available.
-    if metadata_exchange and explicit_exchange:
-        cache_exchange = metadata_exchange
-    elif metadata_exchange and not loader_exchange:
-        cache_exchange = metadata_exchange
-    elif explicit_exchange:
+    if explicit_exchange:
         cache_exchange = explicit_exchange
+    elif provided_exchange:
+        cache_exchange = provided_exchange
     elif loader_exchange:
         cache_exchange = loader_exchange
+    elif metadata_exchange:
+        cache_exchange = metadata_exchange
+    else:
+        cache_exchange = ""
+
     if metadata_exchange and loader_exchange and loader_exchange != metadata_exchange:
         logger.debug(
             "Cache exchange mismatch for %s: loader %s vs metadata %s",


### PR DESCRIPTION
## Summary
- ensure compliance validation scaffolds new owner data when discovery misses
- keep the bundled demo owner visible in owner listings when auth is disabled
- respect explicit ticker suffixes ahead of overrides when resolving cache exchanges

## Testing
- `PYTEST_ADDOPTS="--override-ini=addopts=" pytest tests/backend/common/test_compliance.py::test_load_transactions_missing_owner_raises -q`
- `PYTEST_ADDOPTS="--override-ini=addopts=" pytest tests/quests/test_trail.py::test_get_tasks_returns_defaults tests/quests/test_trail.py::test_get_tasks_with_completions -q`
- `PYTEST_ADDOPTS="--override-ini=addopts=" pytest tests/test_accounts_api.py::test_owners_endpoint_matches_sample_data -q`
- `PYTEST_ADDOPTS="--override-ini=addopts=" pytest tests/test_backend_api.py::test_owners tests/test_backend_api.py::test_post_transaction_persists_and_updates_portfolio tests/test_backend_api.py::test_post_transaction_invalid_fields[date-not-a-date] tests/test_backend_api.py::test_post_transaction_invalid_fields[units--5] tests/test_backend_api.py::test_post_transaction_missing_reason tests/test_backend_api.py::test_compliance_endpoint -q`
- `PYTEST_ADDOPTS="--override-ini=addopts=" pytest tests/test_compliance_route.py::test_validate_trade_when_owner_discovery_fails -q`
- `PYTEST_ADDOPTS="--override-ini=addopts=" pytest tests/test_run_all_tickers.py -q`
- `PYTEST_ADDOPTS="--override-ini=addopts=" pytest tests/timeseries/test_run_all_and_load_timeseries.py::test_run_all_tickers_filters_and_delays tests/timeseries/test_run_all_and_load_timeseries.py::test_load_timeseries_data_filters_and_warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68d826da26dc8327814d75ffd7b09f9f