### PR TITLE
Fix local plot discovery and accounts root handling

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -189,7 +189,7 @@ def _list_local_plots(
             return results
 
         skip_owners = set(_SKIP_OWNERS)
-        if include_demo or config.disable_auth:
+        if include_demo:
             skip_owners.discard("demo")
 
         for owner_dir in sorted(root.iterdir()):
@@ -219,12 +219,8 @@ def _list_local_plots(
             include_demo_primary = primary_root.resolve() == fallback_root.resolve()
         except Exception:
             include_demo_primary = False
-    # When authentication is disabled the demo owner should remain available
-    # even if callers override ``data_root`` (e.g. tests isolating their
-    # working directory). Skipping the demo in that scenario broke the local
-    # API which always exposes the demo account for preview access.
-    if config.disable_auth:
-        include_demo_primary = True
+        if config.disable_auth:
+            include_demo_primary = True
 
     results = _discover(primary_root, include_demo=include_demo_primary)
 
@@ -233,7 +229,7 @@ def _list_local_plots(
     # unit tests (which use temporary roots) isolated from the real repository
     # data and mirrors the expectation that callers passing a custom root only
     # see data from that location.
-    if data_root is not None and not config.disable_auth:
+    if data_root is not None:
         return results
 
     try:

--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -103,7 +103,7 @@ async def validate_trade(request: Request):
     trade = await request.json()
     if "owner" not in trade:
         raise HTTPException(status_code=422, detail="owner is required")
-    accounts_root = resolve_accounts_root(request)
+    accounts_root = resolve_accounts_root(request, allow_missing=True)
     raw_owner = trade.get("owner")
     owner_value = " ".join(str(raw_owner or "").split()).strip()
     if not owner_value:

--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -34,13 +34,12 @@ def pension_forecast(
         raise HTTPException(status_code=400, detail="missing or invalid dob")
 
     retirement_age = state_pension_age_uk(dob)
+    if death_age <= retirement_age:
+        raise HTTPException(status_code=400, detail="death_age must exceed retirement_age")
 
-    # ``forecast_pension`` already handles edge cases where ``death_age`` is
-    # less than the current age by returning an empty forecast. Historically the
-    # API rejected requests where the death age did not exceed the retirement
-    # age which caused the smoke tests to fail when the client provided a value
-    # equal to the retirement age. Clamping the value here keeps the endpoint
-    # permissive while still returning a meaningful projection.
+    # Keep the simulated forecast slightly beyond retirement to align with the
+    # downstream planner assumptions even when the caller supplies a minimal
+    # valid death age.
     forecast_death_age = max(death_age, retirement_age + 1)
 
     try:


### PR DESCRIPTION
## Summary
- avoid including demo data when a custom accounts root is supplied and auth is disabled while still enabling the fallback root when applicable
- let resolve_accounts_root optionally return missing cached paths for scaffolding and use that path in the compliance validation route
- reject pension forecasts where the death age does not exceed the retirement age before resolving portfolios

## Testing
- pytest --override-ini addopts="" tests/backend/common/test_data_loader.py tests/test_data_loader_local.py tests/routes/test_accounts_root.py tests/test_compliance_route.py tests/test_pension_route.py

------
https://chatgpt.com/codex/tasks/task_e_68d82b93bf688327817d68382b320cd0