### PR TITLE
Fix frontend build issues and make config resilient

### DIFF
--- a/frontend/src/ErrorBoundary.tsx
+++ b/frontend/src/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import { Component, ReactNode, ErrorInfo } from "react";
+import { Component } from "react";
+import type { ReactNode, ErrorInfo } from "react";
 
 interface Props {
   children: ReactNode;

--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -6,7 +6,6 @@ import { useState } from "react";
 import type { Account } from "../types";
 import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
-import { money } from "../lib/money";
 import { formatDateISO } from "../lib/date";
 import { useConfig } from "../ConfigContext";
 
@@ -85,7 +84,7 @@ export function AccountBlock({
       )}
     </div>
   );
-  }
+}
 
 /* Export default as convenience for `lazy()` / Storybook */
 export default AccountBlock;

--- a/frontend/src/components/skeletons/ChartSkeleton.tsx
+++ b/frontend/src/components/skeletons/ChartSkeleton.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /** Skeleton placeholder for charts. */
 export default function ChartSkeleton() {
   return (

--- a/frontend/src/components/skeletons/KPISkeleton.tsx
+++ b/frontend/src/components/skeletons/KPISkeleton.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /** Skeleton placeholder for KPI metric grids. */
 export default function KPISkeleton() {
   return (

--- a/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
+++ b/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import KPISkeleton from "./KPISkeleton";
 import ChartSkeleton from "./ChartSkeleton";
 

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -250,7 +250,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
       normalizedBaseCurrency ?? normaliseUppercase(detail?.currency ?? undefined);
     const detailRecord =
       detail && typeof detail === "object"
-        ? (detail as Record<string, unknown>)
+        ? (detail as unknown as Record<string, unknown>)
         : null;
     const detailInstrumentType = extractInstrumentType(detailRecord);
     const overrides = metadataOverridesRef.current;
@@ -495,7 +495,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
         cached.sector = next.sector;
         cached.currency = next.currency;
         cached.instrument_type = next.instrumentType || null;
-        (cached as Record<string, unknown>).instrumentType =
+        (cached as unknown as Record<string, unknown>).instrumentType =
           next.instrumentType || null;
       });
       if (next.sector) {
@@ -589,7 +589,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
         cached.sector = trimmedSector;
         cached.currency = selectedCurrency;
         cached.instrument_type = trimmedInstrumentType || null;
-        (cached as Record<string, unknown>).instrumentType =
+        (cached as unknown as Record<string, unknown>).instrumentType =
           trimmedInstrumentType || null;
       });
       if (trimmedSector) {
@@ -734,7 +734,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
     "USD";
   const detailRecordForDisplay =
     detail && typeof detail === "object"
-      ? (detail as Record<string, unknown>)
+      ? (detail as unknown as Record<string, unknown>)
       : null;
   const detailInstrumentType = extractInstrumentType(detailRecordForDisplay);
   const instrumentType = metadata.instrumentType || detailInstrumentType || null;

--- a/frontend/src/pages/MarketOverview.tsx
+++ b/frontend/src/pages/MarketOverview.tsx
@@ -68,12 +68,15 @@ export default function MarketOverview() {
             <YAxis />
             <Tooltip content={<IndexTooltip />} />
             <Bar dataKey="change">
-              {indexData.map((entry) => (
-                <Cell
-                  key={entry.name}
-                  fill={entry.change >= 0 ? '#16a34a' : '#dc2626'}
-                />
-              ))}
+              {indexData.map((entry) => {
+                const changeValue = entry.change ?? 0;
+                return (
+                  <Cell
+                    key={entry.name}
+                    fill={changeValue >= 0 ? '#16a34a' : '#dc2626'}
+                  />
+                );
+              })}
             </Bar>
           </BarChart>
         </ResponsiveContainer>

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -104,17 +104,19 @@ defineSize('offsetHeight', 600);
 
 // Fallback for getBoundingClientRect to return a sensible box
 if (!HTMLElement.prototype.getBoundingClientRect) {
-  HTMLElement.prototype.getBoundingClientRect = function () {
+  HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
+    const width = this.offsetWidth || 800;
+    const height = this.offsetHeight || 600;
     return {
       x: 0,
       y: 0,
       top: 0,
       left: 0,
-      right: (this as any).offsetWidth || 800,
-      bottom: (this as any).offsetHeight || 600,
-      width: (this as any).offsetWidth || 800,
-      height: (this as any).offsetHeight || 600,
+      right: width,
+      bottom: height,
+      width,
+      height,
       toJSON() {},
     } as DOMRect;
-  } as any;
+  };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -313,6 +313,7 @@ export interface Transaction {
   fees?: number | null;
   comments?: string | null;
   reason?: string | null;
+  reason_to_buy?: string | null;
 }
 
 export interface TransactionWithCompliance extends Transaction {


### PR DESCRIPTION
## Summary
- remove unused imports and update transaction typings to satisfy the TypeScript build
- harden component utilities and setup mocks for stricter compiler options
- simplify Vite configuration while gating prerendering when Puppeteer is unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82c93c3888327a28e53c9235a4b88