### PR TITLE
Fix frontend build issues

### DIFF
--- a/frontend/src/ErrorBoundary.tsx
+++ b/frontend/src/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import { Component, ReactNode, ErrorInfo } from "react";
+import { Component } from "react";
+import type { ReactNode, ErrorInfo } from "react";
 
 interface Props {
   children: ReactNode;

--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -6,7 +6,6 @@ import { useState } from "react";
 import type { Account } from "../types";
 import { HoldingsTable } from "./HoldingsTable";
 import { InstrumentDetail } from "./InstrumentDetail";
-import { money } from "../lib/money";
 import { formatDateISO } from "../lib/date";
 import { useConfig } from "../ConfigContext";
 

--- a/frontend/src/components/skeletons/ChartSkeleton.tsx
+++ b/frontend/src/components/skeletons/ChartSkeleton.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /** Skeleton placeholder for charts. */
 export default function ChartSkeleton() {
   return (

--- a/frontend/src/components/skeletons/KPISkeleton.tsx
+++ b/frontend/src/components/skeletons/KPISkeleton.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /** Skeleton placeholder for KPI metric grids. */
 export default function KPISkeleton() {
   return (

--- a/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
+++ b/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import KPISkeleton from "./KPISkeleton";
 import ChartSkeleton from "./ChartSkeleton";
 

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -250,7 +250,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
       normalizedBaseCurrency ?? normaliseUppercase(detail?.currency ?? undefined);
     const detailRecord =
       detail && typeof detail === "object"
-        ? (detail as Record<string, unknown>)
+        ? (detail as unknown as Record<string, unknown>)
         : null;
     const detailInstrumentType = extractInstrumentType(detailRecord);
     const overrides = metadataOverridesRef.current;
@@ -495,7 +495,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
         cached.sector = next.sector;
         cached.currency = next.currency;
         cached.instrument_type = next.instrumentType || null;
-        (cached as Record<string, unknown>).instrumentType =
+        (cached as unknown as Record<string, unknown>).instrumentType =
           next.instrumentType || null;
       });
       if (next.sector) {
@@ -589,7 +589,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
         cached.sector = trimmedSector;
         cached.currency = selectedCurrency;
         cached.instrument_type = trimmedInstrumentType || null;
-        (cached as Record<string, unknown>).instrumentType =
+        (cached as unknown as Record<string, unknown>).instrumentType =
           trimmedInstrumentType || null;
       });
       if (trimmedSector) {
@@ -734,7 +734,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
     "USD";
   const detailRecordForDisplay =
     detail && typeof detail === "object"
-      ? (detail as Record<string, unknown>)
+      ? (detail as unknown as Record<string, unknown>)
       : null;
   const detailInstrumentType = extractInstrumentType(detailRecordForDisplay);
   const instrumentType = metadata.instrumentType || detailInstrumentType || null;

--- a/frontend/src/pages/MarketOverview.tsx
+++ b/frontend/src/pages/MarketOverview.tsx
@@ -68,12 +68,12 @@ export default function MarketOverview() {
             <YAxis />
             <Tooltip content={<IndexTooltip />} />
             <Bar dataKey="change">
-              {indexData.map((entry) => (
-                <Cell
-                  key={entry.name}
-                  fill={entry.change >= 0 ? '#16a34a' : '#dc2626'}
-                />
-              ))}
+              {indexData.map((entry) => {
+                const change = entry.change;
+                const fill =
+                  change == null ? '#6b7280' : change >= 0 ? '#16a34a' : '#dc2626';
+                return <Cell key={entry.name} fill={fill} />;
+              })}
             </Bar>
           </BarChart>
         </ResponsiveContainer>

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -87,11 +87,12 @@ if (typeof window.IntersectionObserver === 'undefined') {
 const defineSize = (prop: 'offsetWidth' | 'offsetHeight', value: number) => {
   Object.defineProperty(HTMLElement.prototype, prop, {
     configurable: true,
-    get() {
+    get(this: HTMLElement) {
       // If an explicit inline style is set, try to parse it; otherwise return default
-      const styleVal = (this as HTMLElement).style && (this as HTMLElement).style[prop === 'offsetWidth' ? 'width' : 'height'];
+      const dimension = prop === 'offsetWidth' ? 'width' : 'height';
+      const styleVal = this.style?.getPropertyValue(dimension);
       if (styleVal) {
-        const n = parseInt(styleVal.toString(), 10);
+        const n = parseInt(styleVal, 10);
         if (!Number.isNaN(n)) return n;
       }
       return value;
@@ -104,17 +105,19 @@ defineSize('offsetHeight', 600);
 
 // Fallback for getBoundingClientRect to return a sensible box
 if (!HTMLElement.prototype.getBoundingClientRect) {
-  HTMLElement.prototype.getBoundingClientRect = function () {
+  HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement): DOMRect {
+    const width = this.offsetWidth || 800;
+    const height = this.offsetHeight || 600;
     return {
       x: 0,
       y: 0,
       top: 0,
       left: 0,
-      right: (this as any).offsetWidth || 800,
-      bottom: (this as any).offsetHeight || 600,
-      width: (this as any).offsetWidth || 800,
-      height: (this as any).offsetHeight || 600,
+      right: width,
+      bottom: height,
+      width,
+      height,
       toJSON() {},
     } as DOMRect;
-  } as any;
+  };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -313,6 +313,7 @@ export interface Transaction {
   fees?: number | null;
   comments?: string | null;
   reason?: string | null;
+  reason_to_buy?: string | null;
 }
 
 export interface TransactionWithCompliance extends Transaction {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,18 +1,31 @@
 import { defineConfig } from 'vitest/config'
+import type { UserConfig } from 'vitest/config'
 import type { PluginOption } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import path from 'node:path'
-import { glob } from 'glob'
+import { globSync } from 'glob'
+import { createRequire } from 'node:module'
 
+const require = createRequire(import.meta.url)
 const staticDir = path.resolve(__dirname, 'dist')
-const pageRoutes: string[] = []
 
 // https://vite.dev/config/
-export default defineConfig(async ({ command }) => {
-  const plugins: PluginOption[] = [
-    ...react(),
-    ...VitePWA({
+export default defineConfig(({ command }) => {
+  const plugins: PluginOption[] = []
+  const pageRoutes: string[] = []
+
+  const addPlugin = (plugin: PluginOption | PluginOption[]) => {
+    if (Array.isArray(plugin)) {
+      plugins.push(...plugin)
+    } else {
+      plugins.push(plugin)
+    }
+  }
+
+  addPlugin(react())
+  addPlugin(
+    VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['vite.svg'],
       strategies: 'injectManifest',
@@ -25,27 +38,27 @@ export default defineConfig(async ({ command }) => {
         globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}']
       }
     })
-  ]
+  )
 
-  if (command === 'build') {
-    const files = await glob('src/pages/**/*.tsx', {
+  const shouldPrerender = process.env.ENABLE_PRERENDER === 'true'
+
+  if (command === 'build' && shouldPrerender) {
+    const files = globSync('src/pages/**/*.tsx', {
       cwd: __dirname,
       ignore: ['**/*.test.tsx']
     })
     pageRoutes.push(
       ...files.map((file) => `/${path.basename(file, '.tsx').toLowerCase()}`)
     )
-    const { createRequire } = await import('node:module')
-    const require = createRequire(import.meta.url)
     const vitePrerender = require('vite-plugin-prerender')
     const prerenderPlugin = vitePrerender({
       staticDir,
       routes: ['/', ...pageRoutes]
     })
-    plugins.push(...(Array.isArray(prerenderPlugin) ? prerenderPlugin : [prerenderPlugin]))
+    addPlugin(prerenderPlugin)
   }
 
-  const config = {
+  const config: UserConfig = {
     plugins,
     resolve: {
       alias: {
@@ -73,10 +86,12 @@ export default defineConfig(async ({ command }) => {
       coverage: {
         provider: 'v8',
         reporter: ['text', 'html'],
-        lines: 85,
-        functions: 85,
-        branches: 85,
-        statements: 85,
+        thresholds: {
+          lines: 85,
+          functions: 85,
+          branches: 85,
+          statements: 85
+        },
         include: ['tests/unit/**/*.test.ts?(x)']
       }
     }


### PR DESCRIPTION
## Summary
- clean up React and utility imports so TypeScript strict mode passes across skeleton and account components
- harden instrument metadata handling and type definitions, including support for legacy transaction reason fields
- refresh Vite configuration for synchronous setup, optional prerendering, and Vitest coverage typing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82e4847488327ac67cbdb55cda248