### PR TITLE
Fix frontend build type errors

### DIFF
--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -283,7 +283,8 @@ export function TransactionsPage({ owners }: Props) {
       );
       setNewFees(tx.fees != null ? String(tx.fees) : "");
       setNewComments(tx.comments ?? "");
-      setNewReason(tx.reason ?? tx.reason_to_buy ?? "");
+      const legacyReason = (tx as { reason_to_buy?: string | null }).reason_to_buy;
+      setNewReason(tx.reason ?? legacyReason ?? "");
       setFormError(null);
       setFormSuccess(null);
     },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config'
 import type { PluginOption } from 'vite'
+import type { UserConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import path from 'node:path'
@@ -79,7 +80,7 @@ export default defineConfig(({ command }) => {
     }
   }
 
-  const config = {
+  const config: UserConfig = {
     plugins,
     resolve: {
       alias: {
@@ -105,13 +106,15 @@ export default defineConfig(({ command }) => {
       setupFiles: './src/setupTests.ts',
       include: ['tests/unit/**/*.test.ts?(x)'],
       coverage: {
-        provider: 'v8' as const,
+        provider: 'v8',
         reporter: ['text', 'html'],
-        lines: 85,
-        functions: 85,
-        branches: 85,
-        statements: 85,
-        include: ['tests/unit/**/*.test.ts?(x)']
+        include: ['tests/unit/**/*.test.ts?(x)'],
+        thresholds: {
+          lines: 85,
+          functions: 85,
+          branches: 85,
+          statements: 85
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- stop referencing legacy transaction fields without a type assertion
- update the Vitest configuration typing and coverage thresholds for Vite 7

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8304faec08327b7f8b6e1bdcc9eec