### PR TITLE
Prevent automatic portfolio redirect when multiple owners exist

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -391,7 +391,12 @@ export default function App({ onLogout }: AppProps) {
     const segs = location.pathname.split("/").filter(Boolean);
     const atPortfolioRoot = segs[0] === "portfolio" && segs.length === 1;
 
-    if (mode === "owner" && !selectedOwner && owners.length && atPortfolioRoot) {
+    if (
+      mode === "owner" &&
+      !selectedOwner &&
+      owners.length === 1 &&
+      atPortfolioRoot
+    ) {
       const owner = owners[0].owner;
       setSelectedOwner(owner);
       navigate(`/portfolio/${owner}`, { replace: true });


### PR DESCRIPTION
## Summary
- guard the portfolio redirect logic so it only auto-navigates when a single owner is available
- add a unit test to confirm /portfolio stays put and renders the owner selector when multiple owners are configured

## Testing
- npm test -- --run tests/unit/App.test.tsx -t "stays on /portfolio when multiple owners are available"


------
https://chatgpt.com/codex/tasks/task_e_68d83137497c8327b54aa927553585db