### PR TITLE
Add instrument route unit tests

### DIFF
--- a/tests/backend/routes/test_instrument.py
+++ b/tests/backend/routes/test_instrument.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pandas as pd
+import pytest
+from fastapi import HTTPException
+
+from backend.routes import instrument
+
+
+@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
+async def test_search_instruments_validation_and_trim(monkeypatch):
+    monkeypatch.setattr(
+        instrument,
+        "list_instruments",
+        lambda: [
+            {
+                "ticker": "DEV.L",
+                "name": "Dev Plc",
+                "sector": "Tech",
+                "region": "UK",
+            },
+            {
+                "ticker": "IGNORED",
+                "name": "Other",
+                "sector": "Finance",
+                "region": "US",
+            },
+        ],
+    )
+
+    with pytest.raises(HTTPException):
+        await instrument.search_instruments(q="   ")
+    with pytest.raises(HTTPException):
+        await instrument.search_instruments(q="foo", sector="   ", region=None)
+    with pytest.raises(HTTPException):
+        await instrument.search_instruments(q="foo", sector=None, region="   ")
+
+    results = await instrument.search_instruments(
+        q="  dev  ",
+        sector="  TECH  ",
+        region="  uk  ",
+    )
+
+    assert results == [
+        {
+            "ticker": "DEV.L",
+            "name": "Dev Plc",
+            "sector": "Tech",
+            "region": "UK",
+        }
+    ]
+
+
+def test_positions_for_ticker_cost_basis_fallback(monkeypatch):
+    monkeypatch.setattr(
+        instrument,
+        "list_portfolios",
+        lambda: [
+            {
+                "owner": "alex",
+                "accounts": [
+                    {
+                        "account_type": "isa",
+                        "holdings": [
+                            {
+                                "ticker": "ABC",
+                                "units": 10,
+                                "effective_cost_basis_gbp": 900,
+                            }
+                        ],
+                    },
+                    {
+                        "account_type": "sipp",
+                        "holdings": [
+                            {
+                                "ticker": "ABC",
+                                "units": 5,
+                                "cost_basis_gbp": 400,
+                            }
+                        ],
+                    },
+                ],
+            },
+            {
+                "owner": "sam",
+                "accounts": [
+                    {
+                        "account_type": "general",
+                        "holdings": [
+                            {
+                                "ticker": "ABC",
+                                "units": 2,
+                                "cost_basis": "50",
+                            },
+                            {
+                                "ticker": "IGNORED",
+                                "units": 1,
+                            },
+                        ],
+                    }
+                ],
+            },
+        ],
+    )
+
+    positions = instrument._positions_for_ticker("ABC", last_close=100.0)
+
+    assert len(positions) == 3
+    assert positions[0]["market_value_gbp"] == 1000.0
+    assert positions[0]["unrealised_gain_gbp"] == 100.0
+    assert positions[1]["market_value_gbp"] == 500.0
+    assert positions[1]["unrealised_gain_gbp"] == 100.0
+    assert positions[2]["market_value_gbp"] == 200.0
+    assert positions[2]["unrealised_gain_gbp"] == 150.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
+async def test_instrument_empty_template(monkeypatch):
+    monkeypatch.setattr(
+        instrument,
+        "load_meta_timeseries_range",
+        lambda *_, **__: pd.DataFrame(columns=["Date", "Close"]),
+    )
+    monkeypatch.setattr(instrument, "get_security_meta", lambda _ticker: {"name": "Empty"})
+    monkeypatch.setattr(instrument, "list_portfolios", lambda: [])
+
+    response = await instrument.instrument(ticker="NONE.L", days=30, format="html", base_currency=None)
+
+    assert response.status_code == 200
+    assert "No price data" in response.body.decode()
+
+    with pytest.raises(HTTPException) as exc:
+        await instrument.instrument(ticker="NONE.L", days=30, format="json", base_currency=None)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
+async def test_instrument_json_gbx_and_base_currency(monkeypatch):
+    dates = pd.date_range(date(2024, 1, 1), periods=3, freq="D")
+    df = pd.DataFrame({"Date": dates, "Close": [100.0, 110.0, 120.0]})
+
+    monkeypatch.setattr(instrument, "load_meta_timeseries_range", lambda *_, **__: df)
+    monkeypatch.setattr(
+        instrument,
+        "get_security_meta",
+        lambda _ticker: {"name": "GBX Fund", "sector": "Growth", "currency": "GBX"},
+    )
+    monkeypatch.setattr(instrument, "list_portfolios", lambda: [])
+
+    def fake_fetch(from_ccy, to_ccy, start, end):
+        rng = pd.date_range(start, end, freq="D")
+        return pd.DataFrame({"Date": rng, "Rate": [2.0] * len(rng)})
+
+    monkeypatch.setattr(instrument, "fetch_fx_rate_range", fake_fetch)
+    monkeypatch.setattr(instrument, "get_scaling_override", lambda *_, **__: 2.0)
+
+    def fake_apply(df_in, scale):
+        df_scaled = df_in.copy()
+        if "Close" in df_scaled.columns:
+            df_scaled["Close"] = pd.to_numeric(df_scaled["Close"], errors="coerce") * scale
+        return df_scaled
+
+    monkeypatch.setattr(instrument, "apply_scaling", fake_apply)
+    monkeypatch.setattr(instrument.config, "base_currency", "USD")
+
+    response = await instrument.instrument(
+        ticker="GBX.L",
+        days=30,
+        format="json",
+        base_currency="USD",
+    )
+
+    data = json.loads(response.body.decode())
+
+    assert data["currency"] == "GBP"
+    assert data["prices"][-1]["close"] == pytest.approx(240.0)
+    assert data["prices"][-1]["close_gbp"] == pytest.approx(2.4)
+    assert data["prices"][-1]["close_usd"] == pytest.approx(1.2)
+    assert data["fx"] == {"USDGBP": "/timeseries/meta?ticker=USDGBP"}
+    assert set(data["mini"]) == {"7", "30", "180"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
+async def test_instrument_json_foreign_currency_fx(monkeypatch):
+    dates = pd.date_range(date(2024, 2, 1), periods=2, freq="D")
+    df = pd.DataFrame({"Date": dates, "Close": [10.0, 20.0]})
+
+    monkeypatch.setattr(instrument, "load_meta_timeseries_range", lambda *_, **__: df)
+    monkeypatch.setattr(
+        instrument,
+        "get_security_meta",
+        lambda _ticker: {"name": "EUR Fund", "sector": "Value", "currency": "EUR"},
+    )
+    monkeypatch.setattr(instrument, "list_portfolios", lambda: [])
+
+    def fake_fetch(from_ccy, to_ccy, start, end):
+        rng = pd.date_range(start, end, freq="D")
+        rate = 0.8 if from_ccy == "EUR" else 1.25
+        return pd.DataFrame({"Date": rng, "Rate": [rate] * len(rng)})
+
+    monkeypatch.setattr(instrument, "fetch_fx_rate_range", fake_fetch)
+    monkeypatch.setattr(instrument, "get_scaling_override", lambda *_, **__: 1.0)
+    monkeypatch.setattr(instrument, "apply_scaling", lambda df_in, _scale: df_in)
+    monkeypatch.setattr(instrument.config, "base_currency", "GBP")
+
+    response = await instrument.instrument(
+        ticker="EUR.PA",
+        days=180,
+        format="json",
+        base_currency="GBP",
+    )
+
+    data = json.loads(response.body.decode())
+    assert data["currency"] == "GBP"
+    assert data["prices"][0]["close_gbp"] == pytest.approx(8.0)
+    assert data["fx"] == {"EURGBP": "/timeseries/meta?ticker=EURGBP"}
+


### PR DESCRIPTION
## Summary
- add async search validation coverage for the instrument routes
- stub portfolio and timeseries dependencies to test GBX conversion, FX merges, and base currency overrides

## Testing
- pytest tests/backend/routes/test_instrument.py --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d832d5b8f08327a4926898c128227b