### PR TITLE
Fix pytest module name collision

### DIFF
--- a/tests/backend/__init__.py
+++ b/tests/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend tests package marker."""

--- a/tests/backend/common/__init__.py
+++ b/tests/backend/common/__init__.py
@@ -1,0 +1,1 @@
+"""Backend common tests package marker."""

--- a/tests/backend/routes/__init__.py
+++ b/tests/backend/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Backend route tests package marker."""


### PR DESCRIPTION
## Summary
- add package markers under `tests/backend` so pytest treats modules as unique packages and no longer confuses compliance tests

## Testing
- `pytest tests/backend/routes/test_compliance.py -q` *(fails: coverage requirement 90% is enforced for full suite and is not met when running the single test module)*

------
https://chatgpt.com/codex/tasks/task_e_68d832a58f388327b38a27968f7f8f5e