### PR TITLE
Add pytest-asyncio to test dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,4 @@ google-auth~=2.36.0
 
 google-auth-oauthlib~=1.2.2
 google-auth-httplib2~=0.2.0
+pytest-asyncio~=0.23


### PR DESCRIPTION
## Summary
- add pytest-asyncio~=0.23 to the test requirements so async pytest fixtures are available in CI

## Testing
- pip install -r requirements.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8372db7fc8327ab8f043d439dcf56