### PR TITLE
Ensure demo owner persists when auth is disabled

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -213,14 +213,12 @@ def _list_local_plots(
 
     fallback_paths = resolve_paths(None, None)
     fallback_root = fallback_paths.accounts_root
-    include_demo_primary = False
-    if data_root is None:
+    include_demo_primary = bool(config.disable_auth)
+    if data_root is None and not include_demo_primary:
         try:
             include_demo_primary = primary_root.resolve() == fallback_root.resolve()
         except Exception:
             include_demo_primary = False
-        if config.disable_auth:
-            include_demo_primary = True
 
     results = _discover(primary_root, include_demo=include_demo_primary)
 

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -13,6 +13,7 @@ from backend.common.data_loader import (
     load_virtual_portfolio,
     resolve_paths,
     save_virtual_portfolio,
+    list_plots,
 )
 from backend.common.virtual_portfolio import VirtualPortfolio
 from backend.config import Config
@@ -210,6 +211,23 @@ class TestListLocalPlots:
 
         assert result == [
             {"owner": "carol", "accounts": ["gamma"]},
+            {"owner": "demo", "accounts": ["demo1"]},
+        ]
+
+    def test_list_plots_with_explicit_root_includes_demo(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        data_root = tmp_path / "accounts"
+        self._configure(monkeypatch, tmp_path, data_root, disable_auth=True)
+
+        _write_owner(data_root, "demo", ["demo1"], viewers=[])
+        _write_owner(data_root, "carol", ["gamma"], viewers=["other"])
+
+        result = list_plots(data_root=data_root, current_user=None)
+
+        assert result == [
+            {"owner": "carol", "accounts": ["gamma"]},
+            {"owner": "demo", "accounts": ["demo1"]},
         ]
 
     def test_allows_access_when_user_matches_owner_email(

--- a/tests/test_data_loader_local.py
+++ b/tests/test_data_loader_local.py
@@ -25,7 +25,10 @@ def test_list_local_plots_filters_special_directories(tmp_path, monkeypatch):
     monkeypatch.setattr(dl.config, "disable_auth", True, raising=False)
 
     owners = dl._list_local_plots(data_root=tmp_path, current_user=None)
-    assert owners == [{"owner": "alice", "accounts": ["isa"]}]
+    assert owners == [
+        {"owner": "alice", "accounts": ["isa"]},
+        {"owner": "demo", "accounts": ["demo"]},
+    ]
 
 
 def test_list_local_plots_authenticated(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure the local discovery path always includes the demo owner whenever auth is disabled, even with an explicit data root
- extend data loader tests to expect the demo owner and add coverage for list_plots with a custom root

## Testing
- PYTEST_ADDOPTS="--cov=backend.common.data_loader --cov-fail-under=0" pytest tests/test_data_loader_local.py tests/backend/common/test_data_loader.py
- PYTEST_ADDOPTS="--cov=backend.common.data_loader --cov-fail-under=0" pytest tests/test_accounts_api.py tests/test_backend_api.py tests/test_portfolio_list_owners.py


------
https://chatgpt.com/codex/tasks/task_e_68d8378d240c8327a6dfb82322252259