### PR TITLE
Honor exchange argument when metadata conflicts without ticker suffix

### DIFF
--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -230,7 +230,6 @@ def _resolve_cache_exchange(
     provided_exchange = (exchange_arg or "").strip().upper()
 
     if metadata_exchange:
-        cache_exchange = metadata_exchange
         if loader_exchange and loader_exchange != metadata_exchange:
             logger.debug(
                 "Cache exchange mismatch for %s: loader %s vs metadata %s",
@@ -238,6 +237,21 @@ def _resolve_cache_exchange(
                 loader_exchange,
                 metadata_exchange or "<empty>",
             )
+
+        if (
+            provided_exchange
+            and not explicit_exchange
+            and provided_exchange != metadata_exchange
+        ):
+            logger.debug(
+                "Cache exchange override for %s: metadata %s vs argument %s",
+                symbol,
+                metadata_exchange or "<empty>",
+                provided_exchange or "<empty>",
+            )
+            cache_exchange = provided_exchange
+        else:
+            cache_exchange = metadata_exchange
     elif explicit_exchange:
         cache_exchange = explicit_exchange
     elif provided_exchange:


### PR DESCRIPTION
## Summary
- ensure `_resolve_cache_exchange` respects the caller-provided exchange when a ticker lacks a suffix and metadata disagrees
- retain existing mismatch logging while adding diagnostics for argument overrides so metadata-driven tickers remain unaffected

## Testing
- pytest -o addopts='' tests/test_run_all_tickers.py::test_run_all_tickers_accepts_full_tickers
- pytest -o addopts='' tests/timeseries/test_run_all_and_load_timeseries.py::test_run_all_tickers_prefers_metadata_exchange_for_cache tests/timeseries/test_run_all_and_load_timeseries.py::test_load_timeseries_data_prefers_metadata_exchange_for_cache

------
https://chatgpt.com/codex/tasks/task_e_68d837ce8ef8832790300d9532de9c45