### PR TITLE
Adjust AWS plot listing delegation

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -425,16 +425,10 @@ def list_plots(
     """
 
     if config.app_env == "aws":
-        bucket = os.getenv(DATA_BUCKET_ENV)
-        if bucket:
-            aws_results = _list_aws_plots(current_user)
-            if aws_results or not data_root:
-                return aws_results
-        if data_root is None:
-            # Fall back to the configured repository data when no explicit root
-            # is supplied. This mirrors the non-AWS behaviour and keeps unit
-            # tests using temporary roots isolated from global data.
-            return _list_local_plots(None, current_user)
+        aws_results = _list_aws_plots(current_user)
+        if data_root is None or aws_results:
+            return aws_results
+        return _list_local_plots(data_root, current_user)
     return _list_local_plots(data_root, current_user)
 
 


### PR DESCRIPTION
## Summary
- always call the AWS plot discovery helper when running in the AWS environment
- keep the local data_root fallback available when the AWS helper yields no results

## Testing
- pytest --override-ini=addopts= tests/test_data_loader_aws.py::test_list_plots_delegates_to_aws

------
https://chatgpt.com/codex/tasks/task_e_68d837cd2b7c8327a1eea810deacca5d