### PR TITLE
Add opportunities route tests

### DIFF
--- a/tests/backend/routes/test_opportunities.py
+++ b/tests/backend/routes/test_opportunities.py
@@ -1,33 +1,27 @@
-"""Unit tests for the Opportunities FastAPI handler."""
-
-from __future__ import annotations
-
 import pytest
 from fastapi import HTTPException
 
-from backend.routes import opportunities
+from backend.routes import opportunities as opportunities_module
+
+
+@pytest.fixture(autouse=True)
+def stub_weight_calculations(monkeypatch):
+    monkeypatch.setattr(
+        opportunities_module,
+        "_calculate_weights_and_market_values",
+        lambda *args, **kwargs: ([], {}, {}),
+    )
 
 
 @pytest.mark.asyncio
-async def test_get_opportunities_rejects_invalid_days(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The handler should reject unsupported lookback windows."""
-
-    monkeypatch.setattr(opportunities.instrument_api, "top_movers", lambda *_, **__: {})
-    monkeypatch.setattr(opportunities, "_group_opportunities", lambda *_, **__: {})
-    monkeypatch.setattr(
-        opportunities,
-        "_calculate_weights_and_market_values",
-        lambda *_, **__: ([], {}, {}),
-    )
-    monkeypatch.setattr(opportunities.trading_agent, "run", lambda **__: [])
-    monkeypatch.setattr(opportunities, "decode_token", lambda token: {"sub": "user"})
-
+async def test_get_opportunities_rejects_invalid_days():
     with pytest.raises(HTTPException) as exc:
-        await opportunities.get_opportunities(
-            group="growth",
-            tickers=None,
+        await opportunities_module.get_opportunities(
+            tickers="AAA",
             days=999,
-            token="token",
+            limit=5,
+            min_weight=0.0,
+            token=None,
         )
 
     assert exc.value.status_code == 400
@@ -35,203 +29,204 @@ async def test_get_opportunities_rejects_invalid_days(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
-async def test_get_opportunities_rejects_group_and_tickers(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Supplying both a group slug and tickers should fail validation."""
-
-    monkeypatch.setattr(opportunities.instrument_api, "top_movers", lambda *_, **__: {})
-    monkeypatch.setattr(opportunities, "_group_opportunities", lambda *_, **__: {})
+async def test_get_opportunities_rejects_group_and_tickers(monkeypatch):
+    monkeypatch.setattr(opportunities_module.trading_agent, "run", lambda **_: [])
     monkeypatch.setattr(
-        opportunities,
-        "_calculate_weights_and_market_values",
-        lambda *_, **__: ([], {}, {}),
+        opportunities_module.instrument_api,
+        "top_movers",
+        lambda *args, **kwargs: {"gainers": [], "losers": []},
     )
-    monkeypatch.setattr(opportunities.trading_agent, "run", lambda **__: [])
-    monkeypatch.setattr(opportunities, "decode_token", lambda token: {"sub": "user"})
 
     with pytest.raises(HTTPException) as exc:
-        await opportunities.get_opportunities(
+        await opportunities_module.get_opportunities(
             group="growth",
-            tickers="AAA,BBB",
+            tickers="AAA",
             days=1,
+            limit=5,
+            min_weight=0.0,
             token="token",
         )
 
     assert exc.value.status_code == 400
-    assert "Specify either a group or tickers" in exc.value.detail
+    assert exc.value.detail == "Specify either a group or tickers, but not both"
 
 
 @pytest.mark.asyncio
-async def test_get_opportunities_group_flow(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Exercise the group path including authentication and enrichment."""
+async def test_group_requires_authentication():
+    with pytest.raises(HTTPException) as exc:
+        await opportunities_module.get_opportunities(
+            group="growth",
+            tickers=None,
+            days=1,
+            limit=5,
+            min_weight=0.0,
+            token=None,
+        )
 
-    monkeypatch.setattr(opportunities.instrument_api, "top_movers", lambda *_, **__: {})
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Authentication required"
+
+
+@pytest.mark.asyncio
+async def test_group_invalid_token(monkeypatch):
+    monkeypatch.setattr(opportunities_module, "decode_token", lambda token: None)
+    monkeypatch.setattr(opportunities_module.trading_agent, "run", lambda **_: [])
     monkeypatch.setattr(
-        opportunities,
-        "_calculate_weights_and_market_values",
-        lambda *_, **__: ([], {}, {}),
-    )
-    monkeypatch.setattr(
-        opportunities.trading_agent,
-        "run",
-        lambda **__: [
-            {"ticker": "AAA", "action": "BUY", "reason": "Alpha rising"},
-            {"ticker": "BBB", "action": "SELL", "reason": "Beta falling"},
-        ],
+        opportunities_module,
+        "_group_opportunities",
+        lambda *args, **kwargs: {"gainers": [], "losers": [], "anomalies": []},
     )
 
+    with pytest.raises(HTTPException) as exc:
+        await opportunities_module.get_opportunities(
+            group="growth",
+            tickers=None,
+            days=1,
+            limit=5,
+            min_weight=0.0,
+            token="token",
+        )
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Invalid authentication credentials"
+
+
+@pytest.mark.asyncio
+async def test_group_flow_populates_context_and_entries(monkeypatch):
     group_payload = {
         "gainers": [
             {
                 "ticker": "AAA",
                 "name": "Alpha",
-                "change_pct": 2.0,
-                "last_price_gbp": 15.0,
-                "last_price_date": "2024-01-01",
-                "market_value_gbp": 150.0,
+                "change_pct": 1.5,
+                "last_price_gbp": 101.0,
+                "last_price_date": "2024-03-20",
+                "market_value_gbp": 500.0,
             }
         ],
         "losers": [
             {
                 "ticker": "BBB",
                 "name": "Beta",
-                "change_pct": -4.0,
-                "last_price_gbp": 5.0,
-                "last_price_date": "2024-01-02",
-                "market_value_gbp": 50.0,
-            }
+                "change_pct": -0.25,
+                "last_price_gbp": 88.0,
+                "last_price_date": "2024-03-20",
+                "market_value_gbp": 300.0,
+            },
+            {
+                "ticker": "CCC",
+                "name": "Gamma",
+                "change_pct": -3.0,
+                "last_price_gbp": 44.0,
+                "last_price_date": "2024-03-20",
+                "market_value_gbp": 100.0,
+            },
         ],
-        "anomalies": ["BBB data gap"],
+        "anomalies": ["BBB"],
     }
-    monkeypatch.setattr(opportunities, "_group_opportunities", lambda *_, **__: group_payload)
+    monkeypatch.setattr(opportunities_module, "decode_token", lambda token: {"sub": "user"})
+    monkeypatch.setattr(
+        opportunities_module,
+        "_group_opportunities",
+        lambda *args, **kwargs: group_payload,
+    )
+    trading_signals = [
+        {"ticker": "AAA", "action": "BUY", "reason": "Momentum"},
+        {"ticker": "CCC", "action": "SELL", "reason": "Drawdown"},
+    ]
+    monkeypatch.setattr(
+        opportunities_module.trading_agent, "run", lambda **_: trading_signals
+    )
 
-    monkeypatch.setattr(opportunities, "decode_token", lambda token: None)
-    with pytest.raises(HTTPException) as exc_invalid:
-        await opportunities.get_opportunities(
-            group="growth",
-            tickers=None,
-            days=1,
-            token="token",
-        )
-
-    assert exc_invalid.value.status_code == 401
-    assert exc_invalid.value.detail == "Invalid authentication credentials"
-
-    monkeypatch.setattr(opportunities, "decode_token", lambda token: {"sub": "user"})
-    response = await opportunities.get_opportunities(
+    response = await opportunities_module.get_opportunities(
         group="growth",
         tickers=None,
         days=1,
+        limit=5,
+        min_weight=0.0,
         token="token",
     )
 
     assert response.context.source == "group"
     assert response.context.group == "growth"
     assert response.context.days == 1
-    assert response.context.anomalies == ["BBB data gap"]
-
-    tickers = [entry.ticker for entry in response.entries]
-    assert tickers == ["BBB", "AAA"]
-    assert response.entries[0].signal and response.entries[0].signal.action == "SELL"
-    assert response.entries[1].signal and response.entries[1].signal.action == "BUY"
-    assert response.entries[0].market_value_gbp == 50.0
-    assert response.entries[1].last_price_gbp == 15.0
+    assert response.context.anomalies == group_payload["anomalies"]
+    assert [entry.ticker for entry in response.entries] == ["CCC", "AAA", "BBB"]
+    assert response.entries[0].signal is not None
+    assert response.entries[0].signal.ticker == "CCC"
+    assert response.entries[1].signal is not None
+    assert response.entries[1].signal.ticker == "AAA"
+    assert response.entries[2].signal is None
+    assert {signal.ticker for signal in response.signals} == {"AAA", "CCC"}
 
 
 @pytest.mark.asyncio
-async def test_get_opportunities_watchlist_flow(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Watchlist requests should validate inputs and merge trading data."""
+async def test_watchlist_blank_tickers(monkeypatch):
+    monkeypatch.setattr(opportunities_module.trading_agent, "run", lambda **_: [])
 
-    monkeypatch.setattr(
-        opportunities.trading_agent,
-        "run",
-        lambda **__: [
-            {"ticker": "AAA", "action": "BUY", "reason": "Alpha rising"},
-            {"ticker": "BBB", "action": "SELL", "reason": "Beta falling"},
+    with pytest.raises(HTTPException) as exc:
+        await opportunities_module.get_opportunities(
+            group=None,
+            tickers=" ,  , ",
+            days=1,
+            limit=5,
+            min_weight=0.0,
+            token=None,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "No tickers provided"
+
+
+@pytest.mark.asyncio
+async def test_watchlist_flow_sorted_and_enriched(monkeypatch):
+    captured = {}
+    watchlist_payload = {
+        "gainers": [
+            {"ticker": "bbb", "name": "Beta", "change_pct": 2.0},
+            {"ticker": "AAA", "name": "Alpha", "change_pct": 0.5},
         ],
-    )
-    monkeypatch.setattr(opportunities, "_group_opportunities", lambda *_, **__: {})
-    monkeypatch.setattr(
-        opportunities,
-        "_calculate_weights_and_market_values",
-        lambda *_, **__: ([], {}, {}),
-    )
-
-    captured: dict[str, object] = {}
+        "losers": [
+            {"ticker": "CCC", "name": "Gamma", "change_pct": -3.5},
+        ],
+        "anomalies": ["XYZ"],
+    }
 
     def fake_top_movers(tickers, days, limit, **kwargs):
         captured["tickers"] = tickers
         captured["days"] = days
         captured["limit"] = limit
-        return {
-            "gainers": [
-                {
-                    "ticker": "AAA",
-                    "name": "Alpha",
-                    "change_pct": 2.0,
-                    "last_price_gbp": 10.5,
-                    "last_price_date": "2024-01-03",
-                    "market_value_gbp": 100.0,
-                },
-                {
-                    "ticker": "CCC",
-                    "name": "Gamma",
-                    "change_pct": 0.5,
-                    "last_price_gbp": 30.0,
-                    "last_price_date": "2024-01-04",
-                    "market_value_gbp": 300.0,
-                },
-            ],
-            "losers": [
-                {
-                    "ticker": "BBB",
-                    "name": "Beta",
-                    "change_pct": -4.0,
-                    "last_price_gbp": 20.0,
-                    "last_price_date": "2024-01-05",
-                    "market_value_gbp": 200.0,
-                }
-            ],
-            "anomalies": ["BBB flagged"],
-        }
+        return watchlist_payload
 
-    monkeypatch.setattr(opportunities.instrument_api, "top_movers", fake_top_movers)
-    monkeypatch.setattr(opportunities, "decode_token", lambda token: {"sub": "user"})
-
-    with pytest.raises(HTTPException) as exc_blank:
-        await opportunities.get_opportunities(group=None, tickers=" , ", days=1)
-
-    assert exc_blank.value.status_code == 400
-    assert exc_blank.value.detail == "No tickers provided"
-
-    response = await opportunities.get_opportunities(
-        group=None,
-        tickers=" AAA ,BBB , , CCC ",
-        days=7,
-        limit=3,
+    monkeypatch.setattr(
+        opportunities_module.instrument_api,
+        "top_movers",
+        fake_top_movers,
+    )
+    trading_signals = [
+        {"ticker": "BBB", "action": "BUY", "reason": "Watch"},
+        {"ticker": "CCC", "action": "SELL", "reason": "Drop"},
+    ]
+    monkeypatch.setattr(
+        opportunities_module.trading_agent, "run", lambda **_: trading_signals
     )
 
-    assert captured["tickers"] == ["AAA", "BBB", "CCC"]
+    response = await opportunities_module.get_opportunities(
+        group=None,
+        tickers=" AAA ,bbb , CCC ",
+        days=7,
+        limit=4,
+        min_weight=0.0,
+        token=None,
+    )
+
+    assert captured["tickers"] == ["AAA", "bbb", "CCC"]
     assert captured["days"] == 7
-    assert captured["limit"] == 3
-
+    assert captured["limit"] == 4
     assert response.context.source == "watchlist"
-    assert response.context.tickers == ["AAA", "BBB", "CCC"]
-    assert response.context.anomalies == ["BBB flagged"]
-
-    tickers = [entry.ticker for entry in response.entries]
-    assert tickers == ["BBB", "AAA", "CCC"]
-
-    first_entry = response.entries[0]
-    assert first_entry.signal and first_entry.signal.action == "SELL"
-    assert first_entry.last_price_gbp == 20.0
-    assert first_entry.market_value_gbp == 200.0
-
-    second_entry = response.entries[1]
-    assert second_entry.signal and second_entry.signal.action == "BUY"
-    assert second_entry.last_price_date == "2024-01-03"
-
-    third_entry = response.entries[2]
-    assert third_entry.signal is None
-    assert third_entry.market_value_gbp == 300.0
-
-    assert response.signals and len(response.signals) == 2
+    assert response.context.tickers == ["AAA", "bbb", "CCC"]
+    assert response.context.anomalies == watchlist_payload["anomalies"]
+    assert [entry.ticker for entry in response.entries] == ["CCC", "bbb", "AAA"]
+    assert response.entries[0].signal is not None and response.entries[0].signal.ticker == "CCC"
+    assert response.entries[1].signal is not None and response.entries[1].signal.ticker == "BBB"
+    assert response.entries[2].signal is None


### PR DESCRIPTION
## Summary
- add an async pytest module that exercises the `/opportunities` handler validation paths
- stub dependent services to cover authenticated group and watchlist flows with deterministic payloads
- assert response sorting, anomalies propagation, and trading signal enrichment

## Testing
- pytest -o addopts= tests/backend/routes/test_opportunities.py

------
https://chatgpt.com/codex/tasks/task_e_68d8382ffb20832796659eae1fb9919a