### PR TITLE
Restore slug-only saved query response with optional detail flag

### DIFF
--- a/backend/tests/test_custom_query_route.py
+++ b/backend/tests/test_custom_query_route.py
@@ -1,10 +1,22 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.config import config
+
+
+@pytest.fixture
+def temp_queries_dir(tmp_path, monkeypatch):
+    from backend.routes import query as query_routes
+
+    queries_dir = tmp_path / "queries"
+    queries_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(query_routes, "QUERIES_DIR", queries_dir)
+    return queries_dir
 
 
 def test_custom_query_routes_fallback_to_local(monkeypatch):
@@ -46,3 +58,25 @@ def test_custom_query_routes_fallback_to_local(monkeypatch):
     finally:
         if fallback_path.exists():
             fallback_path.unlink()
+
+
+def test_list_saved_queries_returns_slugs_by_default(monkeypatch, temp_queries_dir):
+    monkeypatch.setattr(config, "app_env", None)
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+
+    (temp_queries_dir / "beta.json").write_text(json.dumps({"name": "Beta"}))
+    (temp_queries_dir / "alpha.json").write_text(json.dumps({"name": "Alpha"}))
+
+    app = create_app()
+
+    with TestClient(app) as client:
+        resp = client.get("/custom-query/saved")
+        assert resp.status_code == 200
+        assert resp.json() == ["alpha", "beta"]
+
+        detailed_resp = client.get("/custom-query/saved?detailed=1")
+        assert detailed_resp.status_code == 200
+        assert detailed_resp.json() == [
+            {"id": "alpha", "name": "Alpha", "params": {}},
+            {"id": "beta", "name": "Beta", "params": {}},
+        ]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1145,8 +1145,15 @@ export const saveCustomQuery = (name: string, params: CustomQuery) =>
   });
 
 /** List saved queries available on the backend. */
-export const listSavedQueries = () =>
-  fetchJson<SavedQuery[]>(`${API_BASE}/custom-query/saved`);
+export function listSavedQueries(opts?: { detailed?: true }): Promise<SavedQuery[]>;
+export function listSavedQueries(opts: { detailed: false }): Promise<string[]>;
+export function listSavedQueries(opts: { detailed?: boolean } = {}) {
+  const detailed = opts.detailed ?? true;
+  if (detailed) {
+    return fetchJson<SavedQuery[]>(`${API_BASE}/custom-query/saved?detailed=1`);
+  }
+  return fetchJson<string[]>(`${API_BASE}/custom-query/saved`);
+}
 /** Fetch Value at Risk metrics for an owner. */
 export const getValueAtRisk = (
   owner: string,

--- a/frontend/src/components/SavedQueries.tsx
+++ b/frontend/src/components/SavedQueries.tsx
@@ -8,7 +8,7 @@ type Props = {
 };
 
 export function SavedQueries({ onLoad }: Props) {
-  const loadQueries = useCallback(() => listSavedQueries(), []);
+  const loadQueries = useCallback(() => listSavedQueries({ detailed: true }), []);
   const { data: queries, loading, error } = useFetch<SavedQuery[]>(
     loadQueries,
     [],
@@ -16,10 +16,23 @@ export function SavedQueries({ onLoad }: Props) {
 
   if (loading) return <p>Loading saved queries…</p>;
   if (error) return <p style={{ color: "red" }}>{error.message}</p>;
+  const validQueries = Array.isArray(queries)
+    ? queries.filter(
+        (q): q is SavedQuery =>
+          q != null &&
+          typeof q === "object" &&
+          "id" in q &&
+          typeof q.id === "string" &&
+          "name" in q &&
+          typeof q.name === "string" &&
+          "params" in q &&
+          typeof q.params === "object",
+      )
+    : [];
   const isTest = (typeof process !== 'undefined' && (process as any)?.env?.NODE_ENV === 'test')
     || Boolean((import.meta as any)?.vitest);
-  const qlist: SavedQuery[] = Array.isArray(queries) && queries.length > 0
-    ? queries
+  const qlist: SavedQuery[] = validQueries.length > 0
+    ? validQueries
     : (isTest ? [{ id: '1', name: 'Saved1', params: {
         start: '2024-01-01', end: '2024-01-31', owners: ['Bob'], tickers: ['BBB'], metrics: ['market_value_gbp']
       } as CustomQuery }] : []);


### PR DESCRIPTION
## Summary
- gate the saved query metadata response behind an explicit detailed flag while keeping the slug list default
- request the detailed response from the saved queries UI and validate the payload shape before rendering
- cover the slug-only default with a regression test to prevent accidental changes

## Testing
- pytest backend/tests/test_custom_query_route.py *(fails the configured 90% coverage threshold when run in isolation, but both tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68d837bf10a0832796580a788a967c9f