### PR TITLE
Update saved custom query tests to expect structured payload

### DIFF
--- a/tests/routes/test_query.py
+++ b/tests/routes/test_query.py
@@ -288,7 +288,13 @@ def test_saved_and_load_local(monkeypatch, tmp_path):
     client = make_client()
     resp = client.get("/custom-query/saved")
     assert resp.status_code == 200
-    assert resp.json() == ["sample"]
+    saved_entries = resp.json()
+    assert any(
+        entry.get("id") == "sample"
+        and entry.get("name") == "sample"
+        and entry.get("params") == data
+        for entry in saved_entries
+    )
     resp = client.get("/custom-query/sample")
     assert resp.status_code == 200
     assert resp.json() == data
@@ -304,7 +310,15 @@ def test_saved_and_load_aws(monkeypatch, mock_s3):
     client = make_client()
     resp = client.get("/custom-query/saved")
     assert resp.status_code == 200
-    assert resp.json() == ["remote"]
+    saved_entries = resp.json()
+    expected_params = q.model_dump(mode="json")
+    expected_params.pop("name", None)
+    assert any(
+        entry.get("id") == "remote"
+        and entry.get("name") == "remote"
+        and entry.get("params") == expected_params
+        for entry in saved_entries
+    )
     resp = client.get("/custom-query/remote")
     assert resp.status_code == 200
     assert resp.json()["tickers"] == ["ABC.L"]

--- a/tests/test_custom_query.py
+++ b/tests/test_custom_query.py
@@ -53,7 +53,8 @@ def test_save_and_load_query(client, tmp_path):
     assert data["tickers"] == BASE_QUERY["tickers"]
 
     resp = client.get("/custom-query/saved")
-    assert slug in resp.json()
+    saved_entries = resp.json()
+    assert any(entry["id"] == slug and entry["name"] == slug for entry in saved_entries)
 
 
 def test_unknown_metric_rejected(client):

--- a/tests/test_custom_query_aws.py
+++ b/tests/test_custom_query_aws.py
@@ -59,5 +59,6 @@ def test_s3_save_load_and_list(monkeypatch):
     assert resp.json()["tickers"] == BASE_QUERY["tickers"]
 
     resp = client.get("/custom-query/saved")
-    assert slug in resp.json()
+    saved_entries = resp.json()
+    assert any(entry["id"] == slug and entry["name"] == slug for entry in saved_entries)
 


### PR DESCRIPTION
## Summary
- update saved query route tests to validate id, name, and params in the API response
- adjust custom query integration tests to expect the object-based saved query payload

## Testing
- pytest -o addopts='' tests/routes/test_query.py tests/test_custom_query.py tests/test_custom_query_aws.py

------
https://chatgpt.com/codex/tasks/task_e_68d83789ae2083279b7a0d2d2dc55a6e