### PR TITLE
Update saved query tests for structured saved-query responses

### DIFF
--- a/tests/routes/test_query.py
+++ b/tests/routes/test_query.py
@@ -288,7 +288,13 @@ def test_saved_and_load_local(monkeypatch, tmp_path):
     client = make_client()
     resp = client.get("/custom-query/saved")
     assert resp.status_code == 200
-    assert resp.json() == ["sample"]
+    assert resp.json() == [
+        {
+            "id": "sample",
+            "name": "sample",
+            "params": data,
+        }
+    ]
     resp = client.get("/custom-query/sample")
     assert resp.status_code == 200
     assert resp.json() == data
@@ -304,7 +310,21 @@ def test_saved_and_load_aws(monkeypatch, mock_s3):
     client = make_client()
     resp = client.get("/custom-query/saved")
     assert resp.status_code == 200
-    assert resp.json() == ["remote"]
+    expected_params = {
+        "start": "2020-01-01",
+        "end": "2020-01-02",
+        "owners": None,
+        "tickers": ["ABC.L"],
+        "metrics": [],
+        "format": "json",
+    }
+    assert resp.json() == [
+        {
+            "id": "remote",
+            "name": "remote",
+            "params": expected_params,
+        }
+    ]
     resp = client.get("/custom-query/remote")
     assert resp.status_code == 200
     assert resp.json()["tickers"] == ["ABC.L"]

--- a/tests/test_custom_query.py
+++ b/tests/test_custom_query.py
@@ -53,7 +53,19 @@ def test_save_and_load_query(client, tmp_path):
     assert data["tickers"] == BASE_QUERY["tickers"]
 
     resp = client.get("/custom-query/saved")
-    assert slug in resp.json()
+    assert resp.status_code == 200
+    saved = resp.json()
+    entry = next((item for item in saved if item["id"] == slug), None)
+    assert entry is not None
+    expected_params = {
+        "start": BASE_QUERY["start"],
+        "end": BASE_QUERY["end"],
+        "owners": None,
+        "tickers": BASE_QUERY["tickers"],
+        "metrics": [m.value if isinstance(m, Metric) else m for m in BASE_QUERY["metrics"]],
+        "format": "json",
+    }
+    assert entry["params"] == expected_params
 
 
 def test_unknown_metric_rejected(client):

--- a/tests/test_custom_query_aws.py
+++ b/tests/test_custom_query_aws.py
@@ -59,5 +59,17 @@ def test_s3_save_load_and_list(monkeypatch):
     assert resp.json()["tickers"] == BASE_QUERY["tickers"]
 
     resp = client.get("/custom-query/saved")
-    assert slug in resp.json()
+    assert resp.status_code == 200
+    saved = resp.json()
+    entry = next((item for item in saved if item["id"] == slug), None)
+    assert entry is not None
+    expected_params = {
+        "start": BASE_QUERY["start"],
+        "end": BASE_QUERY["end"],
+        "owners": None,
+        "tickers": BASE_QUERY["tickers"],
+        "metrics": [m.value if isinstance(m, qr.Metric) else m for m in BASE_QUERY["metrics"]],
+        "format": "json",
+    }
+    assert entry["params"] == expected_params
 


### PR DESCRIPTION
## Summary
- update the saved query API tests to search for entries by slug and assert the params payload
- align the route tests with the new `{id, name, params}` objects returned by `/custom-query/saved`

## Testing
- pytest --cov-fail-under=0 tests/test_custom_query.py tests/test_custom_query_aws.py tests/routes/test_query.py

------
https://chatgpt.com/codex/tasks/task_e_68d8373adbc08327874bce2508f8a185