### PR TITLE
Update saved query tests for structured listings

### DIFF
--- a/tests/routes/test_query.py
+++ b/tests/routes/test_query.py
@@ -286,7 +286,7 @@ def test_saved_and_load_local(monkeypatch, tmp_path):
     }
     (tmp_path / "sample.json").write_text(json.dumps(data))
     client = make_client()
-    resp = client.get("/custom-query/saved")
+    resp = client.get("/custom-query/saved", params={"detailed": "true"})
     assert resp.status_code == 200
     saved_entries = resp.json()
     assert any(
@@ -308,7 +308,7 @@ def test_saved_and_load_aws(monkeypatch, mock_s3):
     )
     query._save_query_s3("remote", q)
     client = make_client()
-    resp = client.get("/custom-query/saved")
+    resp = client.get("/custom-query/saved", params={"detailed": "true"})
     assert resp.status_code == 200
     saved_entries = resp.json()
     expected_params = q.model_dump(mode="json")

--- a/tests/test_custom_query.py
+++ b/tests/test_custom_query.py
@@ -52,9 +52,15 @@ def test_save_and_load_query(client, tmp_path):
     data = resp.json()
     assert data["tickers"] == BASE_QUERY["tickers"]
 
-    resp = client.get("/custom-query/saved")
+    expected_params = dict(data)
+    expected_params.pop("name", None)
+
+    resp = client.get("/custom-query/saved", params={"detailed": "true"})
     saved_entries = resp.json()
-    assert any(entry["id"] == slug and entry["name"] == slug for entry in saved_entries)
+    matching_entry = next((entry for entry in saved_entries if entry["id"] == slug), None)
+    assert matching_entry is not None
+    assert matching_entry["name"] == slug
+    assert matching_entry["params"] == expected_params
 
 
 def test_unknown_metric_rejected(client):

--- a/tests/test_custom_query_aws.py
+++ b/tests/test_custom_query_aws.py
@@ -56,9 +56,16 @@ def test_s3_save_load_and_list(monkeypatch):
 
     resp = client.get(f"/custom-query/{slug}")
     assert resp.status_code == 200
-    assert resp.json()["tickers"] == BASE_QUERY["tickers"]
+    data = resp.json()
+    assert data["tickers"] == BASE_QUERY["tickers"]
 
-    resp = client.get("/custom-query/saved")
+    expected_params = dict(data)
+    expected_params.pop("name", None)
+
+    resp = client.get("/custom-query/saved", params={"detailed": "true"})
     saved_entries = resp.json()
-    assert any(entry["id"] == slug and entry["name"] == slug for entry in saved_entries)
+    matching_entry = next((entry for entry in saved_entries if entry["id"] == slug), None)
+    assert matching_entry is not None
+    assert matching_entry["name"] == slug
+    assert matching_entry["params"] == expected_params
 


### PR DESCRIPTION
## Summary
- update custom query API tests to locate saved entries by slug and validate their parameter payloads
- request detailed saved-query listings in route-level tests to assert the new id/name/params structure

## Testing
- pytest --override-ini addopts='' tests/test_custom_query.py tests/test_custom_query_aws.py tests/routes/test_query.py

------
https://chatgpt.com/codex/tasks/task_e_68d839dad6bc83278f3be586b3027550