### PR TITLE
Return detailed saved query data by default

### DIFF
--- a/backend/routes/query.py
+++ b/backend/routes/query.py
@@ -219,10 +219,11 @@ def _format_saved_query(slug: str, payload: dict) -> dict:
 
 
 @router.get("/saved")
-async def list_saved_queries(detailed: bool = Query(False)):
+async def list_saved_queries(detailed: bool | None = Query(None)):
+    wants_detailed = True if detailed is None else detailed
     if config.app_env == "aws":
         slugs = _list_queries_s3()
-        if not detailed:
+        if not wants_detailed:
             return slugs
 
         entries = []
@@ -240,7 +241,7 @@ async def list_saved_queries(detailed: bool = Query(False)):
         return []
 
     slugs = [path.stem for path in sorted(QUERIES_DIR.glob("*.json"))]
-    if not detailed:
+    if not wants_detailed:
         return slugs
 
     entries = []

--- a/tests/routes/test_query.py
+++ b/tests/routes/test_query.py
@@ -286,7 +286,7 @@ def test_saved_and_load_local(monkeypatch, tmp_path):
     }
     (tmp_path / "sample.json").write_text(json.dumps(data))
     client = make_client()
-    resp = client.get("/custom-query/saved", params={"detailed": "true"})
+    resp = client.get("/custom-query/saved")
     assert resp.status_code == 200
     saved_entries = resp.json()
     assert any(
@@ -295,6 +295,9 @@ def test_saved_and_load_local(monkeypatch, tmp_path):
         and entry.get("params") == data
         for entry in saved_entries
     )
+    resp = client.get("/custom-query/saved", params={"detailed": "0"})
+    assert resp.status_code == 200
+    assert resp.json() == ["sample"]
     resp = client.get("/custom-query/sample")
     assert resp.status_code == 200
     assert resp.json() == data
@@ -308,7 +311,7 @@ def test_saved_and_load_aws(monkeypatch, mock_s3):
     )
     query._save_query_s3("remote", q)
     client = make_client()
-    resp = client.get("/custom-query/saved", params={"detailed": "true"})
+    resp = client.get("/custom-query/saved")
     assert resp.status_code == 200
     saved_entries = resp.json()
     expected_params = q.model_dump(mode="json")
@@ -319,6 +322,9 @@ def test_saved_and_load_aws(monkeypatch, mock_s3):
         and entry.get("params") == expected_params
         for entry in saved_entries
     )
+    resp = client.get("/custom-query/saved", params={"detailed": "0"})
+    assert resp.status_code == 200
+    assert resp.json() == ["remote"]
     resp = client.get("/custom-query/remote")
     assert resp.status_code == 200
     assert resp.json()["tickers"] == ["ABC.L"]

--- a/tests/test_custom_query.py
+++ b/tests/test_custom_query.py
@@ -55,7 +55,7 @@ def test_save_and_load_query(client, tmp_path):
     expected_params = dict(data)
     expected_params.pop("name", None)
 
-    resp = client.get("/custom-query/saved", params={"detailed": "true"})
+    resp = client.get("/custom-query/saved")
     saved_entries = resp.json()
     matching_entry = next((entry for entry in saved_entries if entry["id"] == slug), None)
     assert matching_entry is not None

--- a/tests/test_custom_query_aws.py
+++ b/tests/test_custom_query_aws.py
@@ -62,10 +62,13 @@ def test_s3_save_load_and_list(monkeypatch):
     expected_params = dict(data)
     expected_params.pop("name", None)
 
-    resp = client.get("/custom-query/saved", params={"detailed": "true"})
+    resp = client.get("/custom-query/saved")
     saved_entries = resp.json()
     matching_entry = next((entry for entry in saved_entries if entry["id"] == slug), None)
     assert matching_entry is not None
     assert matching_entry["name"] == slug
     assert matching_entry["params"] == expected_params
+    resp = client.get("/custom-query/saved", params={"detailed": "0"})
+    assert resp.status_code == 200
+    assert resp.json() == [slug]
 


### PR DESCRIPTION
## Summary
- return formatted saved query entries by default when listing
- keep an opt-in flag to fetch lightweight slug lists
- update tests for both detailed and lightweight modes across environments

## Testing
- pytest tests/routes/test_query.py tests/test_custom_query.py tests/test_custom_query_aws.py

------
https://chatgpt.com/codex/tasks/task_e_68d83d835df08327930ed367565a6c0d