### PR TITLE
Ignore metadata and transaction exports during account discovery

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -68,7 +68,14 @@ PLOTS_PREFIX = "accounts/"
 # ------------------------------------------------------------------
 # Local discovery
 # ------------------------------------------------------------------
-_METADATA_STEMS = {"person", "config", "notes"}  # ignore these as accounts
+_METADATA_STEMS = {
+    "person",
+    "config",
+    "notes",
+    "settings",
+    "approvals",
+    "approval_requests",
+}  # ignore these as accounts
 _SKIP_OWNERS = {".idea", "demo"}
 
 
@@ -85,7 +92,10 @@ def _extract_account_names(owner_dir: Path) -> List[str]:
         if not path.is_file() or path.suffix.lower() != ".json":
             continue
         stem = path.stem
-        if stem.lower() in _METADATA_STEMS:
+        lowered = stem.lower()
+        if lowered in _METADATA_STEMS:
+            continue
+        if lowered.endswith("_transactions"):
             continue
         acct_names.append(stem)
 

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -200,6 +200,32 @@ class TestListLocalPlots:
             {"owner": "alice", "accounts": ["alpha"]},
         ]
 
+    def test_skips_metadata_and_transaction_exports(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        data_root = tmp_path / "accounts"
+        self._configure(monkeypatch, tmp_path, data_root, disable_auth=True)
+
+        _write_owner(data_root, "charlie", ["isa", "brokerage"])
+        owner_dir = data_root / "charlie"
+        for filename in [
+            "person.json",
+            "config.json",
+            "notes.json",
+            "settings.json",
+            "approvals.json",
+            "approval_requests.json",
+            "isa_transactions.json",
+            "BROKERAGE_TRANSACTIONS.json",
+        ]:
+            (owner_dir / filename).write_text("{}")
+
+        result = _list_local_plots(data_root=data_root, current_user=None)
+
+        assert result == [
+            {"owner": "charlie", "accounts": ["brokerage", "isa"]},
+        ]
+
     def test_authentication_disabled_allows_anonymous_access(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_root = tmp_path / "accounts"
         self._configure(monkeypatch, tmp_path, data_root, disable_auth=True)


### PR DESCRIPTION
## Summary
- treat settings, approvals, and other metadata JSON files as non-account data during discovery
- skip files whose stem ends with `_transactions` so exports do not appear as accounts
- add a regression test covering owners with real accounts plus metadata/transaction exports

## Testing
- pytest --cov-fail-under=0 tests/backend/common/test_data_loader.py -k metadata

------
https://chatgpt.com/codex/tasks/task_e_68d83ee827d88327945c91141e5285f6