### PR TITLE
Ensure demo owner is included when auth is disabled

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -226,26 +226,14 @@ def _list_local_plots(
 
     explicit_root = data_root is not None
 
-    include_demo_primary = False
-    if not explicit_root:
-        include_demo_primary = bool(config.disable_auth)
-        if not include_demo_primary:
-            try:
-                include_demo_primary = (
-                    primary_root.resolve() == fallback_root.resolve()
-                )
-            except Exception:
-                include_demo_primary = False
+    include_demo_primary = bool(config.disable_auth)
+    if not explicit_root and not include_demo_primary:
+        try:
+            include_demo_primary = primary_root.resolve() == fallback_root.resolve()
+        except Exception:
+            include_demo_primary = False
 
     results = _discover(primary_root, include_demo=include_demo_primary)
-
-    # When an explicit ``data_root`` is provided treat it as authoritative and
-    # avoid blending in accounts from the repository fallback tree.  This keeps
-    # unit tests (which use temporary roots) isolated from the real repository
-    # data and mirrors the expectation that callers passing a custom root only
-    # see data from that location.
-    if explicit_root:
-        return results
 
     try:
         same_root = fallback_root.resolve() == primary_root.resolve()

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -85,6 +85,12 @@ def test_account_route_adds_missing_account_type(tmp_path):
         json.dumps({"currency": "GBP", "holdings": []})
     )
 
+    demo_dir = tmp_path / "demo"
+    demo_dir.mkdir()
+    (demo_dir / "demo.json").write_text(
+        json.dumps({"currency": "GBP", "holdings": []})
+    )
+
     old_root = config.accounts_root
     config.accounts_root = tmp_path
     reload(app_mod)
@@ -95,4 +101,9 @@ def test_account_route_adds_missing_account_type(tmp_path):
         data = resp.json()
         assert data["account_type"] == acct
         assert "owner" not in data
+        owners_resp = c.get("/owners")
+        assert owners_resp.status_code == 200
+        owners = owners_resp.json()
+        assert any(o.get("owner") == "demo" for o in owners)
     config.accounts_root = old_root
+    reload(app_mod)

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -159,6 +159,26 @@ def test_owners_in_disable_auth_mode(monkeypatch):
     assert any(owner.get("owner") == "demo" for owner in owners)
 
 
+def test_demo_owner_present_with_explicit_root(monkeypatch, tmp_path):
+    """Disable auth with a custom accounts root still exposes the demo owner."""
+
+    demo_dir = tmp_path / "demo"
+    demo_dir.mkdir()
+    (demo_dir / "demo.json").write_text("{}")
+
+    monkeypatch.setattr(config_module.config, "disable_auth", True, raising=False)
+    monkeypatch.setattr(config_module.config, "skip_snapshot_warm", True, raising=False)
+    monkeypatch.setattr(config_module.config, "accounts_root", tmp_path, raising=False)
+
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/owners")
+
+    assert resp.status_code == 200
+    owners = resp.json()
+    assert any(owner.get("owner") == "demo" for owner in owners)
+
+
 def test_health(client):
     resp = client.get("/health")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow the local data loader to keep demo discovery and merging active even for explicit data roots when auth is disabled
- extend the FastAPI test suites to assert that the demo owner remains available with custom accounts roots

## Testing
- pytest -o addopts= tests/test_accounts_api.py::test_account_route_adds_missing_account_type tests/test_backend_api.py::test_demo_owner_present_with_explicit_root

------
https://chatgpt.com/codex/tasks/task_e_68d842664ab4832787149eba86d6bbc7