### PR TITLE
Fix instrument default group navigation for smoke tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -412,7 +412,9 @@ export default function App({ onLogout }: AppProps) {
     if (mode === "instrument" && !selectedGroup && groups.length) {
       const slug = groups[0].slug;
       setSelectedGroup(slug);
-      navigate(`/instrument/${slug}`, { replace: true });
+      if (slug && slug !== "all") {
+        navigate(`/instrument/${slug}`, { replace: true });
+      }
     }
     if (mode === "group" && groups.length) {
       const hasSelection = groups.some((g) => g.slug === selectedGroup);

--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -131,7 +131,9 @@ export default function MainApp() {
     if (mode === "instrument" && !selectedGroup && groups.length) {
       const slug = groups[0].slug;
       setSelectedGroup(slug);
-      navigate(`/instrument/${slug}`, { replace: true });
+      if (slug && slug !== "all") {
+        navigate(`/instrument/${slug}`, { replace: true });
+      }
     }
     if (mode === "group" && groups.length) {
       const hasSelection = groups.some((g) => g.slug === selectedGroup);


### PR DESCRIPTION
## Summary
- avoid redirecting /instrument to /instrument/all when the default group is 'all'
- apply the same guard in both the shell and main app to keep smoke tests stable

## Testing
- npm --prefix frontend run smoke:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d8450514948327ab1721a7a085c9f3