### PR TITLE
Add default metadata placeholders to person scaffold

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -52,6 +52,9 @@ def _ensure_owner_scaffold(owner: str, owner_dir: Path) -> None:
         "settings.json": _default_settings_payload(),
         "approvals.json": {"approvals": []},
         "person.json": {
+            "dob": "",
+            "email": "",
+            "full_name": "",
             "owner": owner,
             "holdings": [],
             "viewers": [],

--- a/backend/tests/test_compliance_scaffold.py
+++ b/backend/tests/test_compliance_scaffold.py
@@ -52,5 +52,8 @@ def test_ensure_owner_scaffold_populates_person_metadata(tmp_path, monkeypatch):
 
     metadata = json.loads(person_path.read_text())
     assert metadata["owner"] == owner
+    assert metadata["full_name"] == ""
+    assert metadata["dob"] == ""
+    assert metadata["email"] == ""
     assert isinstance(metadata.get("holdings"), list)
     assert isinstance(metadata.get("viewers"), list)


### PR DESCRIPTION
## Summary
- populate newly scaffolded person.json with placeholder contact fields
- update compliance scaffolding tests to validate the new default metadata

## Testing
- pytest -o addopts="--cov=backend.common.compliance --cov-fail-under=90" backend/tests/test_compliance_scaffold.py tests/backend/common/test_compliance.py tests/backend/routes/test_compliance.py *(fails: coverage 84 < 90)*

------
https://chatgpt.com/codex/tasks/task_e_68d849700ff08327a40887401662bccc