### PR TITLE
Add owner display names to API owner summaries

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -49,6 +49,7 @@ KEY_LOSERS = "losers"
 # ──────────────────────────────────────────────────────────────
 class OwnerSummary(BaseModel):
     owner: str
+    full_name: str
     accounts: List[str]
 
 
@@ -82,8 +83,8 @@ if config.disable_auth:
         """
         Returns
             [
-              {"owner": "alex",  "accounts": ["isa", "sipp"]},
-              {"owner": "joe",   "accounts": ["isa", "sipp"]},
+              {"owner": "alex",  "full_name": "Alex Example", "accounts": ["isa", "sipp"]},
+              {"owner": "joe",   "full_name": "Joe Example",  "accounts": ["isa", "sipp"]},
               ...
             ]
         """
@@ -98,8 +99,8 @@ else:
         """
         Returns
             [
-              {"owner": "alex",  "accounts": ["isa", "sipp"]},
-              {"owner": "joe",   "accounts": ["isa", "sipp"]},
+              {"owner": "alex",  "full_name": "Alex Example", "accounts": ["isa", "sipp"]},
+              {"owner": "joe",   "full_name": "Joe Example",  "accounts": ["isa", "sipp"]},
               ...
             ]
         """

--- a/tests/routes/test_scenario.py
+++ b/tests/routes/test_scenario.py
@@ -6,10 +6,10 @@ from backend.routes import scenario
 
 def test_run_scenario_multiple_owners_and_missing_data(monkeypatch):
     plots = [
-        {"owner": "alice", "accounts": [{"id": 1}]},
-        {"owner": "bob", "accounts": [{"id": 2}]},
-        {"owner": "carol", "accounts": []},
-        {"owner": "dave"},
+        {"owner": "alice", "full_name": "Alice Example", "accounts": [{"id": 1}]},
+        {"owner": "bob", "full_name": "Bob Example", "accounts": [{"id": 2}]},
+        {"owner": "carol", "full_name": "Carol Example", "accounts": []},
+        {"owner": "dave", "full_name": "Dave Example"},
     ]
 
     monkeypatch.setattr(scenario, "list_plots", lambda: plots)
@@ -60,7 +60,7 @@ def test_run_historical_scenario_valid_horizons(monkeypatch):
     monkeypatch.setattr(
         scenario,
         "list_plots",
-        lambda: [{"owner": "alice", "accounts": [{"id": 1}]}],
+        lambda: [{"owner": "alice", "full_name": "Alice Example", "accounts": [{"id": 1}]}],
     )
 
     def fake_build_owner_portfolio(owner):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,11 +18,15 @@ def client():
 
 # Shared mock data
 mock_owners = [
-    {"owner": "demo", "accounts": ["isa"]},
-    {"owner": "alex", "accounts": ["isa", "sipp"]},
-    {"owner": "joe", "accounts": ["isa", "sipp"]},
-    {"owner": "lucy", "accounts": ["isa", "pension-forecast"]},
-    {"owner": "steve", "accounts": ["isa", "jpm", "sipp"]},
+    {"owner": "demo", "full_name": "Demo", "accounts": ["isa"]},
+    {"owner": "alex", "full_name": "Alex Example", "accounts": ["isa", "sipp"]},
+    {"owner": "joe", "full_name": "Joe Example", "accounts": ["isa", "sipp"]},
+    {
+        "owner": "lucy",
+        "full_name": "Lucy Example",
+        "accounts": ["isa", "pension-forecast"],
+    },
+    {"owner": "steve", "full_name": "Steve Example", "accounts": ["isa", "jpm", "sipp"]},
 ]
 
 mock_groups = [

--- a/tests/test_scenario_route.py
+++ b/tests/test_scenario_route.py
@@ -18,7 +18,7 @@ def test_scenario_route(monkeypatch):
     monkeypatch.setattr(
         scenario_route,
         "list_plots",
-        lambda: [{"owner": "alice", "accounts": [{}]}],
+        lambda: [{"owner": "alice", "full_name": "Alice Example", "accounts": [{}]}],
     )
     monkeypatch.setattr(
         scenario_route,
@@ -58,7 +58,7 @@ def test_historical_scenario_route(monkeypatch):
     monkeypatch.setattr(
         scenario_route,
         "list_plots",
-        lambda: [{"owner": "alice", "accounts": [{}]}],
+        lambda: [{"owner": "alice", "full_name": "Alice Example", "accounts": [{}]}],
     )
     monkeypatch.setattr(
         scenario_route,


### PR DESCRIPTION
## Summary
- include owner display names when reading person metadata
- expose the new `full_name` field from the `/owners` endpoint
- update related tests and fixtures for the expanded owner summary schema

## Testing
- `pytest -o addopts= tests/backend/common/test_data_loader.py`
- `pytest -o addopts= tests/test_main.py`
- `pytest -o addopts= tests/test_scenario_route.py`
- `pytest -o addopts= tests/backend/routes/test_compliance.py`


------
https://chatgpt.com/codex/tasks/task_e_68d8496ee5e88327b93ce714e85edf7d