### PR TITLE
Handle empty intraday data with 404

### DIFF
--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -471,7 +471,7 @@ async def intraday(
     except Exception as exc:  # pragma: no cover - network/IO errors
         raise HTTPException(502, str(exc))
     if df.empty:
-        return {"ticker": ticker, "prices": []}
+        raise HTTPException(status_code=404, detail="no intraday data")
 
     df = df.reset_index()
     prices = [


### PR DESCRIPTION
## Summary
- raise a 404 error when intraday price history contains no data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d84df55d288327a03aa86aa5b9e299