### PR TITLE
Return 404 for missing cached timeseries metadata

### DIFF
--- a/backend/routes/timeseries_meta.py
+++ b/backend/routes/timeseries_meta.py
@@ -65,33 +65,19 @@ async def get_meta_timeseries(
     end_date = date.today() - timedelta(days=1)
 
     try:
-        df = load_meta_timeseries_range(ticker, exchange, start_date=start_date, end_date=end_date)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        df = load_meta_timeseries_range(
+            ticker, exchange, start_date=start_date, end_date=end_date
+        )
+    except Exception as exc:
+        logger.debug(
+            "Failed to load meta timeseries for %s.%s: %s", ticker, exchange, exc
+        )
+        raise HTTPException(
+            status_code=404, detail="timeseries meta not found"
+        ) from exc
 
-    if df.empty:
-        if format == "json":
-            return JSONResponse(
-                content={
-                    "ticker": f"{ticker}.{exchange}",
-                    "from": start_date.isoformat(),
-                    "to": end_date.isoformat(),
-                    "scaling": scaling,
-                    "prices": [],
-                }
-            )
-        if format == "csv":
-            return PlainTextResponse(content="", media_type="text/csv")
-        empty_html = f"""
-        <html>
-            <head><title>{ticker}.{exchange} Price History</title></head>
-            <body>
-                <h1>{ticker}.{exchange} - {start_date} to {end_date}</h1>
-                <p>No cached data available.</p>
-            </body>
-        </html>
-        """
-        return HTMLResponse(content=empty_html)
+    if df is None or df.empty:
+        raise HTTPException(status_code=404, detail="timeseries meta not found")
 
     df = df.copy()
     df["Date"] = pd.to_datetime(df["Date"])


### PR DESCRIPTION
## Summary
- raise a 404 when loading cached timeseries metadata fails or returns no rows
- remove per-format empty responses so all formats surface the missing data error

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d84df7c1c08327b66dd4a451167dfc