### PR TITLE
Align smoke test owner fixtures

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -20,7 +20,7 @@ function statePensionAgeUk(dob: string): number {
 
 function computeDemoDeathAge(): string {
   const accountsRoot = process.env.ACCOUNTS_ROOT ?? path.resolve(__dirname, '../data/accounts');
-  const personPath = path.join(accountsRoot, 'demo', 'person.json');
+  const personPath = path.join(accountsRoot, 'demo-owner', 'person.json');
 
   try {
     const meta = JSON.parse(fs.readFileSync(personPath, 'utf8')) as { dob?: unknown };
@@ -123,7 +123,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "POST",
     "path": "/compliance/validate",
     "body": {
-      "owner": "demo"
+      "owner": "demo-owner"
     }
   },
   {
@@ -217,7 +217,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "path": "/holdings/import",
     "body": {
       "__form__": {
-        "owner": "demo",
+        "owner": "demo-owner",
         "account": "isa",
         "provider": "test",
         "file": "__file__"
@@ -352,7 +352,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/pension/forecast",
     "query": {
-      "owner": "demo",
+      "owner": "demo-owner",
       "death_age": demoPensionDeathAge
     }
   },
@@ -447,7 +447,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/returns/compare",
     "query": {
-      "owner": "demo"
+      "owner": "demo-owner"
     }
   },
   {
@@ -587,7 +587,7 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     "method": "GET",
     "path": "/transactions/compliance",
     "query": {
-      "owner": "demo"
+      "owner": "demo-owner"
     }
   },
   {
@@ -651,9 +651,9 @@ export const smokeEndpoints: SmokeEndpoint[] = [
 // Values are chosen based on common parameter names. Unknown names default to
 // `1` which parses as an integer or string.
 const SAMPLE_PATH_VALUES: Record<string, string> = {
-  owner: 'demo',
+  owner: 'demo-owner',
   account: 'isa',
-  user: 'demo',
+  user: 'demo-owner',
   email: 'user@example.com',
   id: '1',
   vp_id: 'test',


### PR DESCRIPTION
## Summary
- point the smoke script at the demo-owner fixture for pension and compliance endpoints
- update owner placeholders to demo-owner so generated paths hit canonical data

## Testing
- npm run smoke:test *(fails: backend not running in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d84faee7988327a8597900690ed804