### PR TITLE
Default Vite base URL during scripted deployments

### DIFF
--- a/scripts/build-and-deploy.ps1
+++ b/scripts/build-and-deploy.ps1
@@ -17,6 +17,11 @@ if (-not (Test-Path $frontendDir)) {
 
 Push-Location $frontendDir
 try {
+  if ([string]::IsNullOrWhiteSpace($env:VITE_APP_BASE_URL)) {
+    $defaultBaseUrl = 'https://app.allotmint.io'
+    Write-Host "VITE_APP_BASE_URL is not set. Defaulting to $defaultBaseUrl. Set VITE_APP_BASE_URL to override." -ForegroundColor Yellow
+    $env:VITE_APP_BASE_URL = $defaultBaseUrl
+  }
   Write-Host 'Running `npm run build` in the frontend workspace...' -ForegroundColor Cyan
   npm run build
   if ($LASTEXITCODE -ne 0) {

--- a/scripts/deploy-to-AWS.ps1
+++ b/scripts/deploy-to-AWS.ps1
@@ -8,6 +8,12 @@ $ErrorActionPreference = 'Stop'
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 $REPO_ROOT  = (Resolve-Path (Join-Path $SCRIPT_DIR '..')).Path
 $CDK_DIR    = Join-Path $REPO_ROOT 'cdk'
+
+if ([string]::IsNullOrWhiteSpace($env:VITE_APP_BASE_URL)) {
+  $defaultBaseUrl = 'https://app.allotmint.io'
+  Write-Host "VITE_APP_BASE_URL is not set. Defaulting to $defaultBaseUrl. Set VITE_APP_BASE_URL to override." -ForegroundColor Yellow
+  $env:VITE_APP_BASE_URL = $defaultBaseUrl
+}
 $requirementsFile = Join-Path $CDK_DIR 'requirements.txt'
 $requirementsSources = @()
 if (Test-Path $requirementsFile) {


### PR DESCRIPTION
## Summary
- ensure scripts/build-and-deploy.ps1 defaults VITE_APP_BASE_URL to https://app.allotmint.io when not provided and logs how to override it
- add the same defaulting logic to scripts/deploy-to-AWS.ps1 so every deployment entry point yields a fully qualified base URL

## Testing
- pwsh -File scripts/build-and-deploy.ps1 *(fails: AWS CDK CLI not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d84f7194c08327bf2204c687154cb8