### PR TITLE
Fix duplicate allowed_emails argument in config builder

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -379,7 +379,6 @@ def load_config() -> Config:
         approval_valid_days=data.get("approval_valid_days"),
         approval_exempt_types=approval_exempt_types,
         approval_exempt_tickers=approval_exempt_tickers,
-        allowed_emails=allowed_emails,
         tabs=tabs,
         trading_agent=trading_agent,
         cors_origins=cors_origins,


### PR DESCRIPTION
## Summary
- remove the duplicate `allowed_emails` keyword when instantiating `Config`

## Testing
- uvicorn backend.local_api.main:app --host 0.0.0.0 --port 8000 *(fails: existing FastAPI response model error)*

------
https://chatgpt.com/codex/tasks/task_e_68d8531e48948327b1e1c971ca44bb9d