### PR TITLE
Handle missing boto3 dependency in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,15 @@ import inspect
 import os
 from pathlib import Path
 
-import boto3
+try:
+    import boto3
+except ImportError:  # pragma: no cover - fallback for environments without boto3
+    import types
+
+    # Provide a minimal ``boto3`` stub so tests that monkeypatch ``resource`` can
+    # still run in environments where the real dependency isn't installed.
+    boto3 = types.SimpleNamespace(resource=lambda *args, **kwargs: None)
+
 import pytest
 
 os.environ.setdefault("TESTING", "1")


### PR DESCRIPTION
## Summary
- guard the boto3 import in tests with a fallback stub so the suite runs without the dependency
- document why the fallback exists for future contributors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d853e90c34832795fd31010dc855fa