### PR TITLE
Relax error handling for coverage test run

### DIFF
--- a/scripts/test-with-coverage.ps1
+++ b/scripts/test-with-coverage.ps1
@@ -57,8 +57,18 @@ catch {
 Write-Host '# Running tests with coverage (backend scope via .coveragerc) ...' -ForegroundColor Cyan
 
 & $PYTHON -m coverage erase | Out-Null
-& $PYTHON -m coverage run -m pytest -o addopts='' -p no:cov @PytestArgs 2>&1 | Tee-Object -Variable testOutput
-$exitCode = $LASTEXITCODE
+
+$exitCode = 1
+$previousErrorActionPreference = $ErrorActionPreference
+try {
+  $ErrorActionPreference = 'Continue'
+  & $PYTHON -m coverage run -m pytest -o addopts='' -p no:cov @PytestArgs 2>&1 |
+    Tee-Object -Variable testOutput
+  $exitCode = $LASTEXITCODE
+}
+finally {
+  $ErrorActionPreference = $previousErrorActionPreference
+}
 
 & $PYTHON -m coverage html
 & $PYTHON -m coverage report


### PR DESCRIPTION
## Summary
- temporarily relax PowerShell error handling when invoking coverage+pytest so stderr warnings do not trigger termination
- preserve the original `$ErrorActionPreference` and exit-code reporting so genuine test failures still stop the script

## Testing
- not run (PowerShell script requires Windows environment)


------
https://chatgpt.com/codex/tasks/task_e_68d858c6799c8327815c7fb5e4c8e611