### PR TITLE
Add grouping fallback for instrument metadata

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -161,10 +161,20 @@ function metadataToInstrumentSummary(metadata: InstrumentMetadata): InstrumentSu
     typeof metadata.currency === "string" && metadata.currency.trim()
       ? metadata.currency.trim()
       : null;
-  const grouping =
-    typeof metadata.grouping === "string" && metadata.grouping.trim()
-      ? metadata.grouping.trim()
-      : null;
+  const grouping = (() => {
+    const groupingCandidates = [
+      metadata.grouping,
+      metadata.sector,
+      metadata.region,
+      metadata.currency,
+    ];
+    for (const candidate of groupingCandidates) {
+      if (typeof candidate === "string" && candidate.trim()) {
+        return candidate.trim();
+      }
+    }
+    return null;
+  })();
   const instrumentType = (() => {
     if (typeof metadata.instrument_type === "string" && metadata.instrument_type.trim()) {
       return metadata.instrument_type.trim();


### PR DESCRIPTION
## Summary
- ensure the instrument summary helper falls back to sector, region, then currency when grouping metadata is missing
- extend the catalogue instrument test to verify the grouping fallback is populated from sector data

## Testing
- `npm run test -- --run tests/unit/App.test.tsx -t "includes catalogue instruments"`


------
https://chatgpt.com/codex/tasks/task_e_68d85f1a3dd88327bfc7a3ab72d02974