### PR TITLE
Skip defaulting owner display names to slugs

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -120,18 +120,15 @@ def _build_owner_summary(
     summary: Dict[str, Any] = {"owner": owner, "accounts": accounts}
 
     display_name: Optional[str] = None
-    if meta:
+    if isinstance(meta, dict):
         for key in ("full_name", "display_name", "preferred_name", "owner", "name"):
-            value = meta.get(key) if isinstance(meta, dict) else None
+            value = meta.get(key)
             if isinstance(value, str) and value.strip():
                 display_name = value.strip()
                 if key == "full_name":
                     break
-        if display_name:
-            summary["full_name"] = display_name
-
-    if "full_name" not in summary:
-        summary["full_name"] = owner
+    if display_name:
+        summary["full_name"] = display_name
 
     return summary
 

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -192,8 +192,9 @@ class TestListLocalPlots:
         result = _list_local_plots(data_root=data_root, current_user="viewer")
 
         assert result == [
-            {"owner": "alice", "full_name": "alice", "accounts": ["alpha"]},
+            {"owner": "alice", "accounts": ["alpha"]},
         ]
+        assert all("full_name" not in entry for entry in result)
 
     def test_accepts_contextvar_current_user(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_root = tmp_path / "accounts"
@@ -210,8 +211,9 @@ class TestListLocalPlots:
             user_var.reset(token)
 
         assert result == [
-            {"owner": "alice", "full_name": "alice", "accounts": ["alpha"]},
+            {"owner": "alice", "accounts": ["alpha"]},
         ]
+        assert all("full_name" not in entry for entry in result)
 
     def test_includes_full_name_from_metadata(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_root = tmp_path / "accounts"
@@ -256,10 +258,10 @@ class TestListLocalPlots:
         assert result == [
             {
                 "owner": "charlie",
-                "full_name": "charlie",
                 "accounts": ["brokerage", "isa"],
             },
         ]
+        assert all("full_name" not in entry for entry in result)
 
     def test_authentication_disabled_allows_anonymous_access(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_root = tmp_path / "accounts"
@@ -271,8 +273,9 @@ class TestListLocalPlots:
         result = _list_local_plots(data_root=data_root, current_user=None)
 
         assert result == [
-            {"owner": "carol", "full_name": "carol", "accounts": ["gamma"]},
+            {"owner": "carol", "accounts": ["gamma"]},
         ]
+        assert all("full_name" not in entry for entry in result)
         assert all(entry["owner"] not in {"demo", ".idea"} for entry in result)
 
     def test_list_plots_with_explicit_root_skips_demo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -288,8 +291,9 @@ class TestListLocalPlots:
         result = list_plots(data_root=explicit_root, current_user=None)
 
         assert result == [
-            {"owner": "carol", "full_name": "carol", "accounts": ["gamma"]},
+            {"owner": "carol", "accounts": ["gamma"]},
         ]
+        assert all("full_name" not in entry for entry in result)
         assert all(entry["owner"] not in {"demo", ".idea"} for entry in result)
 
     def test_allows_access_when_user_matches_owner_email(
@@ -310,5 +314,6 @@ class TestListLocalPlots:
         result = _list_local_plots(data_root=data_root, current_user="alice@example.com")
 
         assert result == [
-            {"owner": "alice", "full_name": "alice", "accounts": ["alpha"]},
+            {"owner": "alice", "accounts": ["alpha"]},
         ]
+        assert all("full_name" not in entry for entry in result)

--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -43,7 +43,9 @@ def test_list_aws_plots(monkeypatch):
         {"owner": "Alice", "accounts": ["ISA"]},
         {"owner": "Bob", "accounts": ["GIA"]},
     ]
-    assert dl._list_aws_plots() == expected
+    owners = dl._list_aws_plots()
+    assert owners == expected
+    assert all("full_name" not in entry for entry in owners)
 
 
 def test_list_aws_plots_missing_boto(monkeypatch, cleanup_boto3_module):
@@ -99,7 +101,9 @@ def test_list_aws_plots_filters_without_auth(monkeypatch):
         {"owner": "Alice", "accounts": ["ISA"]},
         {"owner": "Bob", "accounts": ["GIA"]},
     ]
-    assert dl._list_aws_plots(current_user="Bob") == expected
+    owners = dl._list_aws_plots(current_user="Bob")
+    assert owners == expected
+    assert all("full_name" not in entry for entry in owners)
 
 
 def test_list_aws_plots_filters_special_directories(monkeypatch):
@@ -125,7 +129,9 @@ def test_list_aws_plots_filters_special_directories(monkeypatch):
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
     expected = [{"owner": "Real", "accounts": ["GIA"]}]
-    assert dl._list_aws_plots() == expected
+    owners = dl._list_aws_plots()
+    assert owners == expected
+    assert all("full_name" not in entry for entry in owners)
 
 
 def test_list_aws_plots_pagination(monkeypatch):
@@ -182,7 +188,9 @@ def test_list_aws_plots_pagination(monkeypatch):
         {"owner": "Carol", "accounts": ["401k"]},
     ]
 
-    assert dl._list_aws_plots() == expected
+    owners = dl._list_aws_plots()
+    assert owners == expected
+    assert all("full_name" not in entry for entry in owners)
     assert len(calls) == 3
 
 

--- a/tests/test_data_loader_local.py
+++ b/tests/test_data_loader_local.py
@@ -28,6 +28,7 @@ def test_list_local_plots_filters_special_directories(tmp_path, monkeypatch):
     assert owners == [
         {"owner": "alice", "accounts": ["isa"]},
     ]
+    assert all("full_name" not in entry for entry in owners)
     assert all(entry["owner"] not in {"demo", ".idea"} for entry in owners)
 
 
@@ -60,3 +61,4 @@ def test_list_local_plots_authenticated(tmp_path, monkeypatch):
         {"owner": "alice", "accounts": ["isa"]},
         {"owner": "bob", "accounts": ["gia"]},
     ]
+    assert all("full_name" not in entry for entry in owners)


### PR DESCRIPTION
## Summary
- avoid adding a fallback full_name in `_build_owner_summary` when metadata lacks a display value
- update local and AWS data loader expectations to assert that entries omit full_name unless metadata provides one
- refresh the comprehensive data loader test suite to handle the leaner payload

## Testing
- pytest --no-cov tests/test_data_loader_local.py tests/test_data_loader_aws.py tests/backend/common/test_data_loader.py


------
https://chatgpt.com/codex/tasks/task_e_68d85f5042048327abe29125260d3e48