### PR TITLE
Stop fabricating owner accounts

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -74,7 +74,6 @@ _METADATA_STEMS = {
     "notes",
     "settings",
     "approvals",
-    "approval_requests",
 }  # ignore these as accounts
 _SKIP_OWNERS = {".idea", "demo"}
 

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -106,7 +106,6 @@ def _collect_account_stems(owner_dir: Optional[Path]) -> List[str]:
         "notes",
         "settings",
         "approvals",
-        "approval_requests",
     }
 
     try:
@@ -129,25 +128,6 @@ def _collect_account_stems(owner_dir: Optional[Path]) -> List[str]:
         seen.add(lowered)
 
     return stems
-
-
-def _has_transactions_artifact(owner_dir: Optional[Path], owner: str) -> bool:
-    """Return ``True`` when a transactions file or directory exists for ``owner``."""
-
-    if not owner_dir or not owner:
-        return False
-
-    target = f"{owner}{_TRANSACTIONS_SUFFIX}".casefold()
-
-    try:
-        for entry in owner_dir.iterdir():
-            name = entry.stem if entry.is_file() else entry.name
-            if name.casefold() == target:
-                return True
-    except OSError:
-        return False
-
-    return False
 
 
 def _resolve_full_name(
@@ -205,12 +185,6 @@ def _normalise_owner_entry(
             if not stripped:
                 continue
             _append(stripped)
-
-    for extra in _CONVENTIONAL_ACCOUNT_EXTRAS:
-        _append(extra)
-
-    if _has_transactions_artifact(owner_dir, owner):
-        _append(f"{owner}{_TRANSACTIONS_SUFFIX}")
 
     resolved_meta = meta
     if resolved_meta is None:

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -55,7 +55,7 @@ def test_owners_endpoint_matches_sample_data(client):
     assert "demo" in owners
     for owner, accounts in sample_accounts():
         assert owner in owners
-        assert set(accounts).issubset(owners[owner])
+        assert owners[owner] == set(accounts)
 
 
 @pytest.mark.parametrize("owner,accounts", list(sample_accounts()))


### PR DESCRIPTION
## Summary
- stop filtering approval_requests.json from account discovery so real files surface
- prevent the owners endpoint from appending synthetic conventional accounts or transaction files
- update owners endpoint tests to expect only real accounts and flag unexpected extras

## Testing
- pytest -o addopts='' tests/test_accounts_api.py::test_owners_endpoint_matches_sample_data tests/test_main.py::test_owners

------
https://chatgpt.com/codex/tasks/task_e_68d85f4f4ec88327a0fa04f7a3fd7e67