### PR TITLE
Allow portfolio health endpoint to run without wait_for timeout

### DIFF
--- a/backend/routes/support.py
+++ b/backend/routes/support.py
@@ -42,11 +42,7 @@ async def post_portfolio_health(req: PortfolioHealthRequest | None = None) -> di
     )
 
     try:
-        findings = await asyncio.wait_for(
-            asyncio.to_thread(run_check, threshold), timeout=10
-        )
-    except asyncio.TimeoutError as exc:  # pragma: no cover - defensive
-        raise HTTPException(status_code=500, detail="health check timed out") from exc
+        findings = await asyncio.to_thread(run_check, threshold)
     except Exception as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail="health check failed") from exc
 


### PR DESCRIPTION
## Summary
- remove the 10 second asyncio.wait_for wrapper around the portfolio health support endpoint so cold cache runs can finish

## Testing
- SMOKE_URL=http://localhost:8000 node node_modules/tsx/dist/cli.mjs <<'TS'
const mod = await import('./scripts/frontend-backend-smoke.ts');
const { smokeEndpoints, fillPath } = mod.default;

const base = process.env.SMOKE_URL?.replace(/\/+$/, '') ?? 'http://localhost:8000';
const target = smokeEndpoints.find((ep: any) => ep.path === '/support/portfolio-health' && ep.method === 'POST');
if (!target) {
  console.error('Target endpoint not found');
  process.exit(1);
}

let url = base + fillPath(target.path);
if (target.query) url += '?' + new URLSearchParams(target.query).toString();
const headers: Record<string, string> = {};
let body: any = undefined;
if (target.body !== undefined) {
  body = JSON.stringify(target.body);
  headers['Content-Type'] = 'application/json';
}

const res = await fetch(url, { method: target.method, headers, body });
console.log(target.method, target.path, res.status);
if (!res.ok) {
  console.error('Response body:', await res.text());
  process.exit(1);
}
TS

------
https://chatgpt.com/codex/tasks/task_e_68d862a508ec83278c68c750f2cf5c26