### PR TITLE
Add tests for first nonempty string helpers

### DIFF
--- a/tests/common/test_portfolio_utils.py
+++ b/tests/common/test_portfolio_utils.py
@@ -52,6 +52,28 @@ def test_first_nonempty_str_skips_blank_candidates():
     assert result == "ticker"
 
 
+def test_first_nonempty_str_with_source_returns_trimmed_value():
+    result = pu._first_nonempty_str_with_source(
+        ("yahoo", "  value  "),
+        ("manual", ""),
+        ("fallback", None),
+    )
+
+    assert result == ("value", "yahoo")
+
+
+def test_first_nonempty_str_with_source_returns_none_when_missing():
+    result = pu._first_nonempty_str_with_source(
+        ("primary", "  "),
+        ("secondary", None),
+        ("tertiary", 0),
+        ("quaternary", []),
+        ("quinary", "\n"),
+    )
+
+    assert result == (None, None)
+
+
 def test_fx_to_base_uses_cache_for_currency_and_base(monkeypatch):
     rates = {"JPY": 0.005, "USD": 0.8}
     calls: list[tuple[str, str]] = []


### PR DESCRIPTION
## Summary
- add coverage for `_first_nonempty_str_with_source` returning trimmed values and labels
- assert the helper ignores blank, `None`, and non-string values by returning `(None, None)`

## Testing
- pytest --override-ini addopts='' tests/common/test_portfolio_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d90a70ce608327a5ccb6c51271f745