### PR TITLE
Ignore approval request metadata files

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -74,6 +74,7 @@ _METADATA_STEMS = {
     "notes",
     "settings",
     "approvals",
+    "approval_requests",
 }  # ignore these as accounts
 _SKIP_OWNERS = {".idea", "demo"}
 

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -106,6 +106,7 @@ def _collect_account_stems(owner_dir: Optional[Path]) -> List[str]:
         "notes",
         "settings",
         "approvals",
+        "approval_requests",
     }
 
     try:


### PR DESCRIPTION
## Summary
- treat approval request exports as metadata in local data discovery
- ensure portfolio account stem collection skips approval request files

## Testing
- `PYTEST_ADDOPTS="--cov=backend --cov-fail-under=0" pytest tests/backend/common/test_data_loader.py::TestListLocalPlots::test_skips_metadata_and_transaction_exports tests/backend/routes/test_portfolio_helpers.py::test_collect_account_stems_filters_metadata_and_transactions`


------
https://chatgpt.com/codex/tasks/task_e_68d9810d2adc832793a6957e37d449ec