### PR TITLE
Ensure owner summaries default full name

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -128,6 +128,8 @@ def _build_owner_summary(
                     break
     if display_name:
         summary["full_name"] = display_name
+    else:
+        summary["full_name"] = owner
 
     return summary
 


### PR DESCRIPTION
## Summary
- default owner summaries to the owner slug when metadata does not contain a usable display name

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/backend/common/test_data_loader.py::TestBuildOwnerSummary::test_defaults_to_owner_slug_when_names_missing

------
https://chatgpt.com/codex/tasks/task_e_68d9810c25a083279d92269c98d4de97