### PR TITLE
Update intraday no data test expectation

### DIFF
--- a/tests/backend/routes/test_instrument.py
+++ b/tests/backend/routes/test_instrument.py
@@ -327,5 +327,9 @@ async def test_intraday_no_data(monkeypatch):
         await instrument.intraday("AAA.L")
 
     assert exc.value.status_code == 404
-    assert exc.value.detail == "no intraday data"
+    detail = exc.value.detail
+    assert isinstance(detail, str)
+    lowered = detail.lower()
+    assert "no intraday data" in lowered
+    assert "aaa.l" in lowered
 


### PR DESCRIPTION
## Summary
- allow the intraday no data test to accept the ticker-specific HTTP detail in a case-insensitive fashion

## Testing
- pytest -m asyncio tests/backend/routes/test_instrument.py::test_intraday_no_data -o addopts=
- pytest tests/backend/routes/test_instrument.py::test_intraday_no_data[trio] -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d981123e2c8327a1f0c297f8ec7292