### PR TITLE
Ensure opportunities group auth test respects config flag

### DIFF
--- a/tests/backend/routes/test_opportunities.py
+++ b/tests/backend/routes/test_opportunities.py
@@ -52,7 +52,9 @@ async def test_get_opportunities_rejects_group_and_tickers(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_group_requires_authentication():
+async def test_group_requires_authentication(monkeypatch):
+    monkeypatch.setattr(opportunities_module.config, "disable_auth", False)
+
     with pytest.raises(HTTPException) as exc:
         await opportunities_module.get_opportunities(
             group="growth",


### PR DESCRIPTION
## Summary
- ensure the opportunities group authentication test forces auth to be required by setting config.disable_auth to False

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/backend/routes/test_opportunities.py::test_group_requires_authentication

------
https://chatgpt.com/codex/tasks/task_e_68d981133908832788933abdcb894a7e