### PR TITLE
Clear config retry request handling

### DIFF
--- a/frontend/tests/config-retry.spec.ts
+++ b/frontend/tests/config-retry.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const baseUrl = process.env.SMOKE_URL ?? 'http://localhost:5173';
+const authToken = process.env.SMOKE_AUTH_TOKEN ?? process.env.TEST_ID_TOKEN ?? null;
+
+const applyAuth = async (page: Page) => {
+  if (!authToken) {
+    return;
+  }
+
+  await page.addInitScript((token: string) => {
+    window.localStorage.setItem('authToken', token);
+  }, authToken);
+};
+
+test.describe('config bootstrap regression', () => {
+  test('shows the route marker after retrying config load', async ({ page }) => {
+    await applyAuth(page);
+
+    const rootUrl = new URL('/', baseUrl).toString();
+    let attempt = 0;
+
+    const handler = async (route: Route) => {
+      attempt += 1;
+      if (attempt === 1) {
+        await route.abort('failed');
+        return;
+      }
+
+      await page.unroute('**/config', handler);
+      await route.continue();
+    };
+
+    await page.route('**/config', handler);
+
+    await page.goto(rootUrl);
+
+    await expect.poll(() => attempt).toBeGreaterThan(1);
+
+    const marker = page.getByTestId('active-route-marker');
+    await expect(marker).toHaveAttribute('data-mode', 'group');
+    await expect(marker).toHaveAttribute('data-pathname', '/');
+  });
+});


### PR DESCRIPTION
## Summary
- clear the active config fetch before scheduling retries to avoid continuing aborted routes
- add a focused Playwright regression that forces a retry and asserts the route marker appears

## Testing
- `cd frontend && npx playwright test tests/config-retry.spec.ts` *(fails: missing system libraries in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d980feac10832783d9bb0f172b36a1