### PR TITLE
Detect owner transaction artifacts

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2,6 +2,7 @@ export type OwnerSummary = {
   owner: string;
   accounts: string[];
   full_name?: string | null;
+  has_transactions_artifact?: boolean;
 };
 
 export interface Holding {

--- a/tests/backend/routes/test_portfolio_helpers.py
+++ b/tests/backend/routes/test_portfolio_helpers.py
@@ -70,6 +70,7 @@ def test_build_demo_summary_upgrades_default_name(monkeypatch: pytest.MonkeyPatc
     assert summary["owner"] == "demo"
     assert summary["full_name"] == "Demo"
     assert "demo" in {account.casefold() for account in summary["accounts"]}
+    assert summary["has_transactions_artifact"] is False
 
     def raising_meta(owner: str, root: Path) -> dict:
         raise RuntimeError("boom")
@@ -80,6 +81,7 @@ def test_build_demo_summary_upgrades_default_name(monkeypatch: pytest.MonkeyPatc
     assert fallback["owner"] == "demo"
     assert fallback["full_name"] == "Demo"
     assert "demo" in {account.casefold() for account in fallback["accounts"]}
+    assert fallback["has_transactions_artifact"] is False
 
 
 def test_list_owner_summaries_appends_demo_when_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a helper that detects owner transaction exports stored as either JSON files or directories
- expose a `has_transactions_artifact` flag on owner summaries, including the demo fallback path
- align the frontend OwnerSummary type and backend tests with the new metadata

## Testing
- pytest tests/backend/routes/test_portfolio_helpers.py::test_has_transactions_artifact_detects_file_and_directory --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d9810e1cd08327a893211f1341e39e