### PR TITLE
Stop defaulting owner summary full name

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -129,8 +129,6 @@ def _build_owner_summary(
                     break
     if display_name:
         summary["full_name"] = display_name
-    else:
-        summary["full_name"] = owner
 
     return summary
 

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -99,7 +99,6 @@ class TestBuildOwnerSummary:
         assert result == {
             "owner": "alex",
             "accounts": accounts,
-            "full_name": "alex",
         }
 
 


### PR DESCRIPTION
## Summary
- avoid populating owner summaries with a fallback full_name when metadata lacks a display value
- align the owner summary test to expect omission of the full_name key when no display name exists

## Testing
- pytest --override-ini=addopts= tests/backend/common/test_data_loader.py tests/test_data_loader_local.py tests/test_data_loader_aws.py

------
https://chatgpt.com/codex/tasks/task_e_68d985fcbcdc8327b258034dd4be1f31