### PR TITLE
Rename trade tools menu category to insights

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -12,12 +12,12 @@
     "menu": "Menü",
     "menuCategories": {
       "dashboard": "Dashboard",
-      "holdings": "Bestände",
-      "tradeTools": "Insights",
       "goals": "Anforderungen",
-      "preferences": "Einstellungen",
+      "holdings": "Bestände",
+      "insights": "Insights",
       "operations": "Operationen",
-      "other": "Weitere"
+      "other": "Weitere",
+      "preferences": "Einstellungen"
     },
     "modes": {
       "group": "Gruppe",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -12,12 +12,12 @@
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Dashboard",
-      "holdings": "Holdings",
-      "tradeTools": "Insights",
       "goals": "Requirements",
-      "preferences": "Settings",
+      "holdings": "Holdings",
+      "insights": "Insights",
       "operations": "Operations",
-      "other": "Other"
+      "other": "Other",
+      "preferences": "Settings"
     },
     "modes": {
       "group": "Group",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -12,12 +12,12 @@
     "menu": "Menú",
     "menuCategories": {
       "dashboard": "Panel",
-      "holdings": "Posiciones",
-      "tradeTools": "Insights",
       "goals": "Requisitos",
-      "preferences": "Configuración",
+      "holdings": "Posiciones",
+      "insights": "Insights",
       "operations": "Operaciones",
-      "other": "Otros"
+      "other": "Otros",
+      "preferences": "Configuración"
     },
     "modes": {
       "group": "Grupo",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -12,12 +12,12 @@
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Tableau de bord",
-      "holdings": "Positions",
-      "tradeTools": "Insights",
       "goals": "Exigences",
-      "preferences": "Paramètres",
+      "holdings": "Positions",
+      "insights": "Insights",
       "operations": "Opérations",
-      "other": "Autres"
+      "other": "Autres",
+      "preferences": "Paramètres"
     },
     "modes": {
       "group": "Groupe",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -12,12 +12,12 @@
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Dashboard",
-      "holdings": "Posizioni",
-      "tradeTools": "Insights",
       "goals": "Requisiti",
-      "preferences": "Impostazioni",
+      "holdings": "Posizioni",
+      "insights": "Insights",
       "operations": "Operazioni",
-      "other": "Altro"
+      "other": "Altro",
+      "preferences": "Impostazioni"
     },
     "modes": {
       "group": "Gruppo",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -12,12 +12,12 @@
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Painel",
-      "holdings": "Participações",
-      "tradeTools": "Insights",
       "goals": "Requisitos",
-      "preferences": "Configurações",
+      "holdings": "Participações",
+      "insights": "Insights",
       "operations": "Operações",
-      "other": "Outros"
+      "other": "Outros",
+      "preferences": "Configurações"
     },
     "modes": {
       "group": "Grupo",


### PR DESCRIPTION
## Summary
- rename the trade tools menu category to insights in each localized menu file
- reorder menu category keys alphabetically to ensure consistent rendering

## Testing
- npm test -- Menu

------
https://chatgpt.com/codex/tasks/task_e_68d9894625e8832787d72e3591dc5c70