### PR TITLE
Add instrument directory discovery tests

### DIFF
--- a/tests/timeseries/test_fetch_meta_timeseries.py
+++ b/tests/timeseries/test_fetch_meta_timeseries.py
@@ -1,5 +1,6 @@
 import re
 from datetime import date
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -16,6 +17,72 @@ from backend.timeseries.fetch_meta_timeseries import (
     fetch_meta_timeseries,
 )
 from backend.utils.timeseries_helpers import STANDARD_COLUMNS
+
+
+def _scenario_override_instruments_dir(meta, tmp_path, monkeypatch, _default_dir):
+    data_root_instruments = tmp_path / "data" / "instruments"
+    data_root_instruments.mkdir(parents=True)
+
+    custom_dir = tmp_path / "custom_instruments"
+    custom_dir.mkdir()
+
+    monkeypatch.setattr(meta, "INSTRUMENTS_DIR", custom_dir)
+
+    result = meta._instrument_dirs()
+    assert result == [custom_dir.resolve()]
+
+
+def _scenario_default_and_data_root(meta, tmp_path, monkeypatch, default_dir):
+    data_root_instruments = tmp_path / "data" / "instruments"
+    data_root_instruments.mkdir(parents=True)
+    default_dir.mkdir(parents=True, exist_ok=True)
+
+    result = meta._instrument_dirs()
+    expected = [data_root_instruments.resolve(), default_dir.resolve()]
+    assert result == expected
+
+
+def _scenario_skip_broken_candidate(meta, tmp_path, monkeypatch, default_dir):
+    data_root_instruments = tmp_path / "data" / "instruments"
+    data_root_instruments.mkdir(parents=True)
+    default_dir.mkdir(parents=True, exist_ok=True)
+
+    sentinel = default_dir
+    original_resolve = Path.resolve
+
+    def flaky_resolve(self, *args, **kwargs):
+        if self == sentinel:
+            raise OSError("boom")
+        return original_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", flaky_resolve)
+
+    result = meta._instrument_dirs()
+    assert result == [data_root_instruments.resolve()]
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        pytest.param(_scenario_override_instruments_dir, id="custom_override_only"),
+        pytest.param(_scenario_default_and_data_root, id="default_and_data_root"),
+        pytest.param(_scenario_skip_broken_candidate, id="skip_broken_candidate"),
+    ],
+)
+def test_instrument_dirs_handles_overrides(tmp_path, monkeypatch, scenario):
+    import backend.timeseries.fetch_meta_timeseries as meta
+
+    data_root = tmp_path / "data"
+    monkeypatch.setattr(meta, "config", SimpleNamespace(data_root=data_root))
+
+    default_dir = tmp_path / "default_instruments"
+    default_dir.mkdir(parents=True)
+    monkeypatch.setattr(meta, "_DEFAULT_INSTRUMENTS_DIR", default_dir)
+    monkeypatch.setattr(meta, "INSTRUMENTS_DIR", default_dir)
+
+    meta._resolve_exchange_from_metadata_cached.cache_clear()
+    scenario(meta, tmp_path, monkeypatch, default_dir)
+    meta._resolve_exchange_from_metadata_cached.cache_clear()
 
 
 def test_resolve_exchange_from_metadata(tmp_path):


### PR DESCRIPTION
## Summary
- add parametrized scenarios that validate `_instrument_dirs` behavior with overrides, defaults, and broken candidates
- ensure metadata cache is cleared around the new tests to prevent stale state

## Testing
- pytest --no-cov -q tests/timeseries/test_fetch_meta_timeseries.py::test_instrument_dirs_handles_overrides


------
https://chatgpt.com/codex/tasks/task_e_68d98e85d4a88327869da7aa1997b998