### PR TITLE
Alphabetize locale translation keys

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1,14 +1,37 @@
 {
+  "alertSettings": {
+    "description": "Konfigurieren Sie, wann Sie Benachrichtigungen erhalten. Die Alarme erscheinen auf der Alerts-Seite und als Push-Benachrichtigungen.",
+    "push": {
+      "denied": "Push-Berechtigung verweigert.",
+      "disable": "Push-Alerts deaktivieren",
+      "enable": "Push-Alerts aktivieren",
+      "error": "Fehler bei der Verarbeitung der Push-Anmeldung.",
+      "notSupported": "Push wird nicht unterstützt",
+      "title": "Push-Benachrichtigungen"
+    },
+    "save": "Save",
+    "status": {
+      "error": "Error",
+      "saved": "Saved"
+    },
+    "threshold": "Threshold %:",
+    "title": "Alert Settings"
+  },
+  "allocation": {
+    "instrumentTypes": "Instrumenttypen",
+    "region": "Regionen",
+    "sector": "Branchen"
+  },
   "app": {
-    "relativeView": "Relative Ansicht",
-    "refreshPrices": "Preise aktualisieren",
-    "refreshing": "Aktualisierung…",
     "last": "Zuletzt:",
     "loading": "Laden…",
-    "supportLink": "Support",
-    "userLink": "App",
-    "research": "Recherche",
     "logout": "Abmelden",
+    "logs": {
+      "empty": "Keine Protokolle verfügbar.",
+      "error": "Protokolle konnten nicht geladen werden.",
+      "refresh": "Protokolle aktualisieren",
+      "title": "Protokolle"
+    },
     "menu": "Menü",
     "menuCategories": {
       "dashboard": "Dashboard",
@@ -46,498 +69,475 @@
       "transactions": "Transaktionen",
       "watchlist": "Beobachtungsliste"
     },
-    "logs": {
-      "title": "Protokolle",
-      "refresh": "Protokolle aktualisieren",
-      "empty": "Keine Protokolle verfügbar.",
-      "error": "Protokolle konnten nicht geladen werden."
-    }
+    "refreshing": "Aktualisierung…",
+    "refreshPrices": "Preise aktualisieren",
+    "relativeView": "Relative Ansicht",
+    "research": "Recherche",
+    "supportLink": "Support",
+    "userLink": "App"
   },
-  "trail": {
-    "title": "Trail-Fortschritt",
-    "daily": "Täglich",
-    "once": "Einmalig",
-    "progressLabel": "Täglicher Fortschritt: {{completed}} / {{total}} ({{percent}}%)",
-    "xpLabel": "XP: {{xp}}",
-    "streakLabel": "Serie: {{count}} Tag",
-    "streakLabel_plural": "Serie: {{count}} Tage",
-    "dailyComplete": "Tägliche Aufgaben erledigt! Weiter so.",
-    "allDone": "Alle Trail-Aufgaben erledigt – großartig!"
-  },
+  "approxTotal": "Ungefähre Summe: £{{value}}",
+  "asOf": "Stand {{date}} • Trades diesen Monat: {{trades}} / 20 (Verbleibend: {{remaining}})",
   "common": {
+    "action": "Aktion",
     "error": "Fehler",
     "loading": "Laden…",
-    "other": "Andere",
-    "ticker": "Ticker",
     "name": "Name",
-    "action": "Aktion",
+    "other": "Andere",
+    "period": "Zeitraum:",
     "reason": "Grund",
-    "period": "Zeitraum:"
+    "ticker": "Ticker"
   },
-  "instrumentType": {
-    "equity": "Aktie",
-    "bond": "Anleihe",
-    "cash": "Bargeld",
-    "etf": "ETF",
-    "fund": "Fonds",
-    "investmentTrust": "Investmentgesellschaft",
-    "realEstate": "Immobilien",
-    "other": "Andere"
-  },
-  "instrumentTable": {
-    "noInstruments": "Keine Instrumente.",
-    "ungrouped": "Ohne Gruppe",
-    "exchangesLabel": "Börsen:",
-    "groupTotals": {
-      "market": "Marktwert",
-      "gain": "Gewinn",
-      "gainPct": "Gewinn %",
-      "delta7d": "7T %",
-      "delta30d": "30T %"
+  "dashboard": {
+    "alphaVsBenchmark": "Alpha vs Benchmark",
+    "cumulativeReturn": "Kumulierte Rendite",
+    "excludeCash": "Bargeld ausschließen",
+    "maxDrawdown": "Max Drawdown",
+    "maxDrawdownHelp": "Der maximale Drawdown ist der größte prozentuale Rückgang vom bisherigen Höchststand des Portfolios bis zum darauffolgenden Tief, berechnet auf Basis der rekonstruierten täglichen Schlusswerte Ihrer Positionen.",
+    "metricsExplanationLink": "Wie werden diese Werte berechnet?",
+    "portfolioValue": "Portfoliowert",
+    "range": "Zeitraum:",
+    "rangeOptions": {
+      "10y": "10J",
+      "1m": "1M",
+      "1w": "1W",
+      "1y": "1J",
+      "max": "MAX"
     },
+    "selectMember": "Wählen Sie ein Mitglied.",
+    "timeWeightedReturn": "Zeitgewichtete Rendite",
+    "trackingError": "Tracking Error",
+    "xirr": "XIRR"
+  },
+  "goals": {
+    "add": "Ziel hinzufügen",
+    "back": "Zurück zum Portfolio",
+    "currentAmount": "Aktueller Betrag:",
+    "goalLine": "{{name}} – Ziel {{amount}} bis {{date}}",
+    "progress": "Fortschritt: {{progress}}%",
+    "suggestedTrades": "Vorgeschlagene Trades",
+    "targetAmount": "Zielbetrag",
+    "title": "Ziele",
+    "trade": "{{action}} {{amount}} von {{ticker}}",
+    "view": "Ansehen"
+  },
+  "group": {
+    "atAGlance": "Auf einen Blick",
+    "select": "Wählen Sie eine Gruppe."
+  },
+  "holdingsTable": {
+    "actualPurchaseCost": "Tatsächliche Anschaffungskosten",
+    "clearFilters": "Filter löschen",
     "columns": {
-      "ticker": "Ticker",
-      "name": "Name",
+      "acquired": "Erworben",
       "ccy": "Währung",
+      "cost": "Kosten £",
+      "daysHeld": "Tage gehalten",
+      "eligible": "Berechtigt?",
+      "gain": "Gewinn £",
+      "gainPct": "Gewinn %",
+      "market": "Markt £",
+      "name": "Name",
+      "price": "Preis £",
+      "stage": "Stage",
+      "ticker": "Ticker",
+      "trend": "Trend",
       "type": "Typ",
       "units": "Einheiten",
+      "weightPct": "Gewicht %"
+    },
+    "columnsLabel": "Spalten:",
+    "eligible": "Berechtigt",
+    "filters": {
+      "all": "Alle",
+      "gainPct": "Gewinn %",
+      "name": "Name",
+      "no": "Nein",
+      "sellEligible": "Verkaufsberechtigt",
+      "ticker": "Ticker",
+      "type": "Typ",
+      "units": "Einheiten",
+      "yes": "Ja"
+    },
+    "inferredCost": "Abgeleitet vom Preis am Erwerbsdatum",
+    "minimumGainPrompt": "Minimaler Gewinn %",
+    "noHoldings": "Keine Bestände entsprechen den aktuellen Filtern.",
+    "openScreener": "Screener öffnen",
+    "quickFilters": "Schnellfilter:",
+    "quickFiltersGainPct": "Gewinn% > x",
+    "quickFiltersSellEligible": "Verkaufsberechtigt",
+    "range": "Zeitraum:",
+    "rangeOption": "{{count}}T",
+    "source": "Quelle:",
+    "totalRowLabel": "Gesamt",
+    "view": "Ansicht:",
+    "viewPresets": {
+      "all": "Alle"
+    }
+  },
+  "instrumentadmin": {
+    "actions": "Actions",
+    "add": "Add Instrument",
+    "exchange": "Exchange",
+    "grouping": "Gruppierung",
+    "name": "Name",
+    "region": "Region",
+    "save": "Save",
+    "saveError": "Error saving",
+    "saveSuccess": "Saved",
+    "searchPlaceholder": "Filter instruments…",
+    "sector": "Sector",
+    "ticker": "Ticker",
+    "validation": {
+      "grouping": "Grouping is required",
+      "name": "Name is required",
+      "ticker": "Ticker is required"
+    }
+  },
+  "instrumentDetail": {
+    "bollingerBands": "Bollinger-Bänder",
+    "change30d": "30T",
+    "change7d": "7T",
+    "columns": {
+      "account": "Konto",
+      "gain": "Gewinn £",
+      "gainPct": "Gewinn %",
+      "market": "Markt £",
+      "units": "Einheiten"
+    },
+    "edit": "Bearbeiten",
+    "intraday": "Intraday",
+    "intradayUnavailable": "Keine Intraday-Daten",
+    "ma20": "20d MA",
+    "ma200": "200d MA",
+    "ma50": "50d MA",
+    "noPositions": "Keine Positionen",
+    "noPriceData": "Keine Preisdaten",
+    "positions": "Positionen",
+    "priceColumns": {
+      "close": "£ Schluss",
+      "date": "Datum",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "range": "Zeitraum:",
+    "rangeOptions": {
+      "10y": "10J",
+      "1m": "1M",
+      "1w": "1W",
+      "1y": "1J",
+      "max": "MAX"
+    },
+    "recentPrices": "Aktuelle Preise",
+    "rsi": "RSI"
+  },
+  "instrumentTable": {
+    "columns": {
+      "ccy": "Währung",
       "cost": "Kosten £",
-      "market": "Marktwert £",
+      "delta30d": "30T %",
+      "delta7d": "7T %",
       "gain": "Gewinn £",
       "gainPct": "Gewinn %",
       "last": "Letzter £",
       "lastDate": "Letztes Datum",
+      "market": "Marktwert £",
+      "name": "Name",
+      "ticker": "Ticker",
+      "type": "Typ",
+      "units": "Einheiten"
+    },
+    "exchangesLabel": "Börsen:",
+    "groupTotals": {
+      "delta30d": "30T %",
       "delta7d": "7T %",
-      "delta30d": "30T %"
-    }
-  },
-  "holdingsTable": {
-    "range": "Zeitraum:",
-    "rangeOption": "{{count}}T",
-    "view": "Ansicht:",
-    "viewPresets": {
-      "all": "Alle"
-    },
-    "quickFilters": "Schnellfilter:",
-    "quickFiltersSellEligible": "Verkaufsberechtigt",
-    "quickFiltersGainPct": "Gewinn% > x",
-    "minimumGainPrompt": "Minimaler Gewinn %",
-    "columnsLabel": "Spalten:",
-    "columns": {
-      "ticker": "Ticker",
-      "name": "Name",
-      "trend": "Trend",
-      "ccy": "Währung",
-      "type": "Typ",
-      "units": "Einheiten",
-      "price": "Preis £",
-      "cost": "Kosten £",
-      "market": "Markt £",
-      "gain": "Gewinn £",
+      "gain": "Gewinn",
       "gainPct": "Gewinn %",
-      "weightPct": "Gewicht %",
-      "acquired": "Erworben",
-      "daysHeld": "Tage gehalten",
-      "stage": "Stage",
-      "eligible": "Berechtigt?"
+      "market": "Marktwert"
     },
-    "filters": {
-      "ticker": "Ticker",
-      "name": "Name",
-      "type": "Typ",
-      "units": "Einheiten",
-      "gainPct": "Gewinn %",
-      "sellEligible": "Verkaufsberechtigt",
-      "all": "Alle",
-      "yes": "Ja",
-      "no": "Nein"
-    },
-    "noHoldings": "Keine Bestände entsprechen den aktuellen Filtern.",
-    "clearFilters": "Filter löschen",
-    "openScreener": "Screener öffnen",
-    "source": "Quelle:",
-    "actualPurchaseCost": "Tatsächliche Anschaffungskosten",
-    "inferredCost": "Abgeleitet vom Preis am Erwerbsdatum",
-    "eligible": "Berechtigt",
-    "totalRowLabel": "Gesamt"
+    "noInstruments": "Keine Instrumente.",
+    "ungrouped": "Ohne Gruppe"
   },
-  "instrumentDetail": {
-    "edit": "Bearbeiten",
-    "change7d": "7T",
-    "change30d": "30T",
-    "range": "Zeitraum:",
-    "rangeOptions": {
-      "1w": "1W",
-      "1m": "1M",
-      "1y": "1J",
-      "10y": "10J",
-      "max": "MAX"
+  "instrumentType": {
+    "bond": "Anleihe",
+    "cash": "Bargeld",
+    "equity": "Aktie",
+    "etf": "ETF",
+    "fund": "Fonds",
+    "investmentTrust": "Investmentgesellschaft",
+    "other": "Andere",
+    "realEstate": "Immobilien"
+  },
+  "loadingPortfolio": "Portfolio wird geladen…",
+  "market": {
+    "indexLevels": "Indexstände",
+    "latestHeadlines": "Neueste Schlagzeilen",
+    "sectorPerformance": "Sektorentwicklung"
+  },
+  "metricsExplanation": {
+    "activeReturn": "Active Return",
+    "alphaCumulative": "Überrendite",
+    "backLink": "Zurück zum Portfolio-Dashboard",
+    "benchmarkCumulative": "Kumulierte Benchmark-Rendite",
+    "benchmarkReturn": "Benchmark-Rendite",
+    "calculationHeading": "So berechnen wir das",
+    "dataBody": "Wir rekonstruieren tägliche Marktwerte für jede Position mithilfe der neuesten Kursdaten und erfasster Kapitalmaßnahmen. Cashflows, Trades und Benchmark-Stände werden auf UTC-Handelstage normalisiert. Kennzahlen werden aktualisiert, sobald neue Preise vorliegen.",
+    "dataHeading": "Datengrundlage",
+    "dateColumn": "Datum",
+    "disclaimer": "Diese Statistiken dienen nur zur Information und können von den Angaben Ihres Brokers abweichen, wenn sich Preisquellen oder Benchmark-Auswahl unterscheiden.",
+    "drawdownColumn": "Drawdown",
+    "groupContext": "Kennzahlen für die Gruppe {{group}}.",
+    "intro": "Diese Kennzahlen fassen zusammen, wie sich das kombinierte Portfolio im Vergleich zu seinem Benchmark entwickelt. Jede Zahl basiert auf denselben täglichen Renditereihen wie die Kacheln im Dashboard.",
+    "loadError": "Die Kennzahlen konnten nicht geladen werden: {{message}}",
+    "loading": "Kennzahlen werden geladen…",
+    "missingContext": "Es wurde kein Portfolio oder keine Gruppe angegeben. Kehren Sie zum Dashboard zurück und folgen Sie dort dem Link aus dem gewünschten Portfolio.",
+    "noContext": "Öffnen Sie diese Seite aus einem Portfolio oder einer Gruppe, um aktuelle Werte zu sehen.",
+    "notAvailable": "k. A.",
+    "notesHeading": "Wissenswertes",
+    "ownerContext": "Kennzahlen für das Portfolio von {{owner}}.",
+    "parameters": "Benchmark: {{benchmark}} • Zeitraum: {{days}} Tage",
+    "portfolioCumulative": "Kumulierte Portfoliorendite",
+    "portfolioReturn": "Portfoliorendite",
+    "portfolioValue": "Portfoliowert",
+    "runningPeak": "Laufendes Hoch",
+    "sections": {
+      "alpha": {
+        "breakdownHeading": "Kumulierte Renditen im Zeitverlauf",
+        "breakdownIntro": "Die Tabelle zeigt für jeden Handelstag die kumulierten Renditen von Portfolio und Benchmark sowie deren Differenz (Alpha).",
+        "calculation": "Wir berechnen zeitgewichtete kumulierte Renditen für Portfolio und Benchmark. Alpha ist einfach die Portfoliorendite minus der Benchmark-Rendite in Prozentpunkten.",
+        "detail": "Kumulierte Portfoliorendite: {{portfolio}} · Benchmark-Rendite: {{benchmark}} · Alpha: {{alpha}}",
+        "headline": "Alpha gegenüber dem Benchmark",
+        "notes": [
+          "Positives Alpha bedeutet, dass das Portfolio den Benchmark im betrachteten Zeitraum geschlagen hat.",
+          "Wenn für einen Teil des Zeitraums keine Daten vorliegen, verwenden wir nur die überlappenden Handelstage."
+        ],
+        "summary": "Alpha misst die Überrendite des Portfolios gegenüber dem Benchmark im gleichen Zeitraum.",
+        "title": "Alpha vs Benchmark"
+      },
+      "maxDrawdown": {
+        "breakdownHeading": "Tägliche Werte und laufende Hochs",
+        "breakdownIntro": "Wir rekonstruieren die Wertentwicklung des Portfolios, verfolgen laufende Hochs und berechnen daraus den Drawdown. Das Minimum dieser Reihe ist der maximale Drawdown.",
+        "calculation": "Wir verfolgen die zeitgewichtete Renditekurve, merken uns jedes neue Hoch und protokollieren den größten folgenden Rückgang, bevor ein neues Hoch erreicht wird. Der tiefste Verlust in Prozent ist der maximale Drawdown.",
+        "detail": "Max Drawdown: {{drawdown}} · Hoch: {{peakValue}} am {{peakDate}} · Tief: {{troughValue}} am {{troughDate}}",
+        "headline": "Schlimmster Weg vom Hoch zum Tief",
+        "notes": [
+          "Der Drawdown basiert nur auf Portfoliorenditen; der Benchmark fließt hier nicht ein.",
+          "Ein Drawdown von -100 % bedeutet, dass der Portfoliowert nach einem vorherigen Hoch auf null gefallen ist."
+        ],
+        "summary": "Der maximale Drawdown identifiziert den größten Rückgang vom Höchststand zum Tiefpunkt innerhalb des Beobachtungszeitraums.",
+        "title": "Max Drawdown"
+      },
+      "trackingError": {
+        "breakdownHeading": "Tägliche Active Returns",
+        "breakdownIntro": "Hier listen wir die täglichen Differenzen zwischen Portfolio und Benchmark auf. Die Standardabweichung dieser Reihe, multipliziert mit √252, ergibt den oben angegebenen Tracking Error.",
+        "calculation": "Für jeden Handelstag ziehen wir die Benchmark-Rendite von der Portfoliorendite ab und erhalten so eine Active-Return-Reihe. Der Tracking Error ist die annualisierte Standardabweichung dieser Werte (tägliche Standardabweichung multipliziert mit √252).",
+        "detail": "Annualisierter Tracking Error: {{trackingError}} · Tägliche Standardabweichung der Active Returns: {{dailyStd}}",
+        "headline": "Tracking Error und Active Returns",
+        "notes": [
+          "Ein höherer Tracking Error deutet auf eine geringere Kopplung an den Benchmark hin.",
+          "Für die Anzeige benötigen wir mindestens 30 überlappende Tagesrenditen."
+        ],
+        "summary": "Der Tracking Error zeigt, wie stark die täglichen Portfoliorenditen vom Benchmark abweichen.",
+        "title": "Tracking Error"
+      }
     },
-    "bollingerBands": "Bollinger-Bänder",
-    "ma20": "20d MA",
-    "ma50": "50d MA",
-    "ma200": "200d MA",
-    "rsi": "RSI",
-    "positions": "Positionen",
-    "columns": {
-      "account": "Konto",
-      "units": "Einheiten",
-      "market": "Markt £",
-      "gain": "Gewinn £",
-      "gainPct": "Gewinn %"
-    },
-    "noPositions": "Keine Positionen",
-    "recentPrices": "Aktuelle Preise",
-    "priceColumns": {
-      "date": "Datum",
-      "close": "£ Schluss",
-      "delta": "Δ £",
-      "deltaPct": "Δ %"
-    },
-    "noPriceData": "Keine Preisdaten",
-    "intraday": "Intraday",
-    "intradayUnavailable": "Keine Intraday-Daten"
+    "title": "Performancekennzahlen erklärt"
+  },
+  "movers": {
+    "excludeSmall": "Positionen <{{min}}% ausschließen",
+    "loadFailed": "Laden der Movers fehlgeschlagen{{status}}",
+    "loginPrompt": "Bitte melden Sie sich an, um portfolio-basierte Movers zu sehen.",
+    "pctPortfolio": "% des Portfolios",
+    "period": "Zeitraum:",
+    "signal": "Signal",
+    "watchlist": "Beobachtungsliste:"
   },
   "owner": {
     "label": "Besitzer",
     "select": "Wählen Sie einen Besitzer."
   },
   "pensionForecast": {
-    "currentAge": "Aktuelles Alter: {{age}}",
     "birthDate": "Geburtsdatum: {{dob}}",
-    "retirementAge": "Renteneintrittsalter: {{age}}",
-    "pensionPot": "Pensionsvermögen",
+    "currentAge": "Aktuelles Alter: {{age}}",
+    "employerContributionLabel": "Arbeitgeberbeitrag",
     "growthAssumption": "Wachstumsannahme (%):",
-    "monthlyContribution": "Monatlicher Beitrag (£):",
+    "header": {
+      "employeeContribution": "Ihr monatlicher Beitrag",
+      "employerContribution": "Arbeitgeberbeitrag",
+      "heading": "Behalten Sie Ihre Beiträge im Blick",
+      "kicker": "Ihr Rentenüberblick",
+      "linkedPotsHeading": "Verknüpfte Rententöpfe",
+      "noLinkedPots": "Für diese Person sind noch keine Rententöpfe verknüpft.",
+      "notAvailable": "Nicht verfügbar",
+      "pensionPot": "Aktueller Rententopf",
+      "totalContribution": "Gesamte monatliche Beiträge: {{total}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
-      "state": "State pension",
       "definedBenefit": "Defined benefit",
-      "definedContribution": "Defined contribution"
+      "definedContribution": "Defined contribution",
+      "state": "State pension"
     },
     "incomeTable": {
-      "source": "Source",
       "annual": "Annual (£)",
       "monthly": "Monthly (£)",
-      "share": "Share"
+      "share": "Share",
+      "source": "Source"
     },
-    "totalAnnualIncome": "Total annual income",
-    "totalMonthlyIncome": "Total monthly income",
+    "monthlyContribution": "Monatlicher Beitrag (£):",
+    "pensionPot": "Pensionsvermögen",
     "prediction": {
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available.",
       "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
       "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
       "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
-      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
-      "earliest": "Estimated earliest retirement age: {{age}}",
-      "noBreakdown": "No income breakdown available."
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then."
     },
-    "employerContributionLabel": "Arbeitgeberbeitrag",
-    "header": {
-      "kicker": "Ihr Rentenüberblick",
-      "heading": "Behalten Sie Ihre Beiträge im Blick",
-      "pensionPot": "Aktueller Rententopf",
-      "employeeContribution": "Ihr monatlicher Beitrag",
-      "employerContribution": "Arbeitgeberbeitrag",
-      "totalContribution": "Gesamte monatliche Beiträge: {{total}}",
-      "linkedPotsHeading": "Verknüpfte Rententöpfe",
-      "noLinkedPots": "Für diese Person sind noch keine Rententöpfe verknüpft.",
-      "notAvailable": "Nicht verfügbar"
-    }
+    "retirementAge": "Renteneintrittsalter: {{age}}",
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income"
   },
-  "group": {
-    "select": "Wählen Sie eine Gruppe.",
-    "atAGlance": "Auf einen Blick"
-  },
-  "dashboard": {
-    "selectMember": "Wählen Sie ein Mitglied.",
-    "range": "Zeitraum:",
-    "rangeOptions": {
-      "1w": "1W",
-      "1m": "1M",
-      "1y": "1J",
-      "10y": "10J",
-      "max": "MAX"
-    },
-    "excludeCash": "Bargeld ausschließen",
-    "alphaVsBenchmark": "Alpha vs Benchmark",
-    "trackingError": "Tracking Error",
-    "maxDrawdown": "Max Drawdown",
-    "maxDrawdownHelp": "Der maximale Drawdown ist der größte prozentuale Rückgang vom bisherigen Höchststand des Portfolios bis zum darauffolgenden Tief, berechnet auf Basis der rekonstruierten täglichen Schlusswerte Ihrer Positionen.",
-    "metricsExplanationLink": "Wie werden diese Werte berechnet?",
-    "timeWeightedReturn": "Zeitgewichtete Rendite",
-    "xirr": "XIRR",
-    "portfolioValue": "Portfoliowert",
-    "cumulativeReturn": "Kumulierte Rendite"
-  },
-  "metricsExplanation": {
-    "title": "Performancekennzahlen erklärt",
-    "intro": "Diese Kennzahlen fassen zusammen, wie sich das kombinierte Portfolio im Vergleich zu seinem Benchmark entwickelt. Jede Zahl basiert auf denselben täglichen Renditereihen wie die Kacheln im Dashboard.",
-    "backLink": "Zurück zum Portfolio-Dashboard",
-    "groupContext": "Kennzahlen für die Gruppe {{group}}.",
-    "ownerContext": "Kennzahlen für das Portfolio von {{owner}}.",
-    "noContext": "Öffnen Sie diese Seite aus einem Portfolio oder einer Gruppe, um aktuelle Werte zu sehen.",
-    "parameters": "Benchmark: {{benchmark}} • Zeitraum: {{days}} Tage",
-    "missingContext": "Es wurde kein Portfolio oder keine Gruppe angegeben. Kehren Sie zum Dashboard zurück und folgen Sie dort dem Link aus dem gewünschten Portfolio.",
-    "loadError": "Die Kennzahlen konnten nicht geladen werden: {{message}}",
-    "loading": "Kennzahlen werden geladen…",
-    "notAvailable": "k. A.",
-    "dateColumn": "Datum",
-    "portfolioCumulative": "Kumulierte Portfoliorendite",
-    "benchmarkCumulative": "Kumulierte Benchmark-Rendite",
-    "alphaCumulative": "Überrendite",
-    "portfolioReturn": "Portfoliorendite",
-    "benchmarkReturn": "Benchmark-Rendite",
-    "activeReturn": "Active Return",
-    "portfolioValue": "Portfoliowert",
-    "runningPeak": "Laufendes Hoch",
-    "drawdownColumn": "Drawdown",
-    "calculationHeading": "So berechnen wir das",
-    "notesHeading": "Wissenswertes",
-    "dataHeading": "Datengrundlage",
-    "dataBody": "Wir rekonstruieren tägliche Marktwerte für jede Position mithilfe der neuesten Kursdaten und erfasster Kapitalmaßnahmen. Cashflows, Trades und Benchmark-Stände werden auf UTC-Handelstage normalisiert. Kennzahlen werden aktualisiert, sobald neue Preise vorliegen.",
-    "disclaimer": "Diese Statistiken dienen nur zur Information und können von den Angaben Ihres Brokers abweichen, wenn sich Preisquellen oder Benchmark-Auswahl unterscheiden.",
-    "sections": {
-      "alpha": {
-        "title": "Alpha vs Benchmark",
-        "summary": "Alpha misst die Überrendite des Portfolios gegenüber dem Benchmark im gleichen Zeitraum.",
-        "headline": "Alpha gegenüber dem Benchmark",
-        "detail": "Kumulierte Portfoliorendite: {{portfolio}} · Benchmark-Rendite: {{benchmark}} · Alpha: {{alpha}}",
-        "breakdownHeading": "Kumulierte Renditen im Zeitverlauf",
-        "breakdownIntro": "Die Tabelle zeigt für jeden Handelstag die kumulierten Renditen von Portfolio und Benchmark sowie deren Differenz (Alpha).",
-        "calculation": "Wir berechnen zeitgewichtete kumulierte Renditen für Portfolio und Benchmark. Alpha ist einfach die Portfoliorendite minus der Benchmark-Rendite in Prozentpunkten.",
-        "notes": [
-          "Positives Alpha bedeutet, dass das Portfolio den Benchmark im betrachteten Zeitraum geschlagen hat.",
-          "Wenn für einen Teil des Zeitraums keine Daten vorliegen, verwenden wir nur die überlappenden Handelstage."
-        ]
-      },
-      "trackingError": {
-        "title": "Tracking Error",
-        "summary": "Der Tracking Error zeigt, wie stark die täglichen Portfoliorenditen vom Benchmark abweichen.",
-        "headline": "Tracking Error und Active Returns",
-        "detail": "Annualisierter Tracking Error: {{trackingError}} · Tägliche Standardabweichung der Active Returns: {{dailyStd}}",
-        "breakdownHeading": "Tägliche Active Returns",
-        "breakdownIntro": "Hier listen wir die täglichen Differenzen zwischen Portfolio und Benchmark auf. Die Standardabweichung dieser Reihe, multipliziert mit √252, ergibt den oben angegebenen Tracking Error.",
-        "calculation": "Für jeden Handelstag ziehen wir die Benchmark-Rendite von der Portfoliorendite ab und erhalten so eine Active-Return-Reihe. Der Tracking Error ist die annualisierte Standardabweichung dieser Werte (tägliche Standardabweichung multipliziert mit √252).",
-        "notes": [
-          "Ein höherer Tracking Error deutet auf eine geringere Kopplung an den Benchmark hin.",
-          "Für die Anzeige benötigen wir mindestens 30 überlappende Tagesrenditen."
-        ]
-      },
-      "maxDrawdown": {
-        "title": "Max Drawdown",
-        "summary": "Der maximale Drawdown identifiziert den größten Rückgang vom Höchststand zum Tiefpunkt innerhalb des Beobachtungszeitraums.",
-        "headline": "Schlimmster Weg vom Hoch zum Tief",
-        "detail": "Max Drawdown: {{drawdown}} · Hoch: {{peakValue}} am {{peakDate}} · Tief: {{troughValue}} am {{troughDate}}",
-        "breakdownHeading": "Tägliche Werte und laufende Hochs",
-        "breakdownIntro": "Wir rekonstruieren die Wertentwicklung des Portfolios, verfolgen laufende Hochs und berechnen daraus den Drawdown. Das Minimum dieser Reihe ist der maximale Drawdown.",
-        "calculation": "Wir verfolgen die zeitgewichtete Renditekurve, merken uns jedes neue Hoch und protokollieren den größten folgenden Rückgang, bevor ein neues Hoch erreicht wird. Der tiefste Verlust in Prozent ist der maximale Drawdown.",
-        "notes": [
-          "Der Drawdown basiert nur auf Portfoliorenditen; der Benchmark fließt hier nicht ein.",
-          "Ein Drawdown von -100 % bedeutet, dass der Portfoliowert nach einem vorherigen Hoch auf null gefallen ist."
-        ]
-      }
-    }
-  },
-  "support": {
-    "title": "Support",
-    "online": "Online",
-    "onlineYes": "Ja",
-    "onlineNo": "Nein",
-    "environment": "Umgebung",
-    "priceRefresh": "Preisaktualisierung",
-    "telegramMessage": "Telegram-Nachricht",
-    "send": "Senden",
-    "status": {
-      "sent": "Gesendet",
-      "error": "Fehler",
-      "sending": "Wird gesendet...",
-      "saved": "Gespeichert",
-      "saving": "Speichern..."
-    },
-    "health": {
-      "title": "Portfoliozustand",
-      "run": "Portfolio-Gesundheitsprüfung ausführen",
-      "copyReport": "Bericht kopieren",
-      "error": "Fehler beim Ausführen der Gesundheitsprüfung"
-    },
-    "notifications": {
-      "title": "Benachrichtigungen",
-      "notSupported": "Push wird nicht unterstützt",
-      "disable": "Push-Benachrichtigungen deaktivieren",
-      "enable": "Push-Benachrichtigungen aktivieren",
-      "denied": "Push-Berechtigung verweigert.",
-      "error": "Fehler bei der Verarbeitung der Push-Anmeldung."
-    },
-    "config": {
-      "title": "Konfiguration",
-      "tabsEnabled": "Tabs aktiviert",
-      "otherSwitches": "Andere Schalter",
-      "otherParams": "Weitere Parameter",
-      "save": "Speichern"
-    }
-  },
-  "alertSettings": {
-    "title": "Alert Settings",
-    "description": "Konfigurieren Sie, wann Sie Benachrichtigungen erhalten. Die Alarme erscheinen auf der Alerts-Seite und als Push-Benachrichtigungen.",
-    "threshold": "Threshold %:",
-    "save": "Save",
-    "push": {
-      "title": "Push-Benachrichtigungen",
-      "notSupported": "Push wird nicht unterstützt",
-      "enable": "Push-Alerts aktivieren",
-      "disable": "Push-Alerts deaktivieren",
-      "denied": "Push-Berechtigung verweigert.",
-      "error": "Fehler bei der Verarbeitung der Push-Anmeldung."
-    },
-    "status": {
-      "saved": "Saved",
-      "error": "Error"
-    }
+  "portfolio": "Portfolio",
+  "query": {
+    "end": "Ende",
+    "exportCsv": "CSV exportieren",
+    "exportXlsx": "XLSX exportieren",
+    "metrics": "Metriken",
+    "owners": "Eigentümer",
+    "run": "Ausführen",
+    "running": "Wird ausgeführt…",
+    "save": "Speichern",
+    "start": "Start",
+    "tickers": "Ticker"
   },
   "reports": {
-    "title": "Berichte",
     "csv": "CSV herunterladen",
+    "noOwners": "No owners available—check backend connection",
     "pdf": "PDF herunterladen",
-    "noOwners": "No owners available—check backend connection"
+    "title": "Berichte"
   },
-  "loadingPortfolio": "Portfolio wird geladen…",
-  "portfolio": "Portfolio",
-  "asOf": "Stand {{date}} • Trades diesen Monat: {{trades}} / 20 (Verbleibend: {{remaining}})",
-  "approxTotal": "Ungefähre Summe: £{{value}}",
-  "allocation": {
-    "instrumentTypes": "Instrumenttypen",
-    "sector": "Branchen",
-    "region": "Regionen"
+  "screener": {
+    "loading": "Laden…",
+    "max52WeekHigh": "Max 52W High",
+    "max52WeekLow": "Max 52W Low",
+    "maxBeta": "Max Beta",
+    "maxDe": "Max D/E",
+    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
+    "maxLtDe": "Max LT D/E",
+    "maxPe": "Max P/E",
+    "maxPeg": "Max PEG",
+    "min52WeekLow": "Min 52W Low",
+    "minAvgVolume": "Min Avg Volume",
+    "minCurrentRatio": "Min Current Ratio",
+    "minDividendYield": "Min Dividend Yield",
+    "minEbitdaMargin": "Min. EBITDA-Marge",
+    "minEps": "Min EPS",
+    "minFcf": "Min FCF",
+    "minFloatShares": "Min Float Shares",
+    "minGrossMargin": "Min. Bruttomarge",
+    "minInterestCoverage": "Min Interest Coverage",
+    "minMarketCap": "Min Market Cap",
+    "minNetMargin": "Min. Nettomarge",
+    "minOperatingMargin": "Min. operative Marge",
+    "minQuickRatio": "Min Quick Ratio",
+    "minRoa": "Min. ROA",
+    "minRoe": "Min. ROE",
+    "minRoi": "Min. ROI",
+    "minSharesOutstanding": "Min Shares Outstanding",
+    "run": "Ausführen",
+    "tickers": "Ticker",
+    "watchlist": "Beobachtungsliste:"
   },
-  "watchlist": {
-    "refresh": "Aktualisieren"
-  },
-  "trading": {
-    "noPositions": "Keine Positionen.",
-    "noSignals": "Keine Signale."
-  },
-  "movers": {
-    "watchlist": "Beobachtungsliste:",
-    "period": "Zeitraum:",
-    "excludeSmall": "Positionen <{{min}}% ausschließen",
-    "loginPrompt": "Bitte melden Sie sich an, um portfolio-basierte Movers zu sehen.",
-    "loadFailed": "Laden der Movers fehlgeschlagen{{status}}",
-    "signal": "Signal",
-    "pctPortfolio": "% des Portfolios"
+  "support": {
+    "config": {
+      "otherParams": "Weitere Parameter",
+      "otherSwitches": "Andere Schalter",
+      "save": "Speichern",
+      "tabsEnabled": "Tabs aktiviert",
+      "title": "Konfiguration"
+    },
+    "environment": "Umgebung",
+    "health": {
+      "copyReport": "Bericht kopieren",
+      "error": "Fehler beim Ausführen der Gesundheitsprüfung",
+      "run": "Portfolio-Gesundheitsprüfung ausführen",
+      "title": "Portfoliozustand"
+    },
+    "notifications": {
+      "denied": "Push-Berechtigung verweigert.",
+      "disable": "Push-Benachrichtigungen deaktivieren",
+      "enable": "Push-Benachrichtigungen aktivieren",
+      "error": "Fehler bei der Verarbeitung der Push-Anmeldung.",
+      "notSupported": "Push wird nicht unterstützt",
+      "title": "Benachrichtigungen"
+    },
+    "online": "Online",
+    "onlineNo": "Nein",
+    "onlineYes": "Ja",
+    "priceRefresh": "Preisaktualisierung",
+    "send": "Senden",
+    "status": {
+      "error": "Fehler",
+      "saved": "Gespeichert",
+      "saving": "Speichern...",
+      "sending": "Wird gesendet...",
+      "sent": "Gesendet"
+    },
+    "telegramMessage": "Telegram-Nachricht",
+    "title": "Support"
   },
   "timeseries": {
     "loading": "Laden…"
   },
   "timeseriesEdit": {
-    "title": "Zeitreihen-Editor",
-    "ticker": "Ticker",
-    "exchange": "Börse",
-    "load": "Laden",
     "addRow": "Zeile hinzufügen",
-    "save": "Speichern",
-    "delete": "Löschen",
     "columns": {
+      "close": "Schluss",
       "date": "Datum",
-      "open": "Eröffnung",
       "high": "Hoch",
       "low": "Tief",
-      "close": "Schluss",
-      "volume": "Volumen",
+      "open": "Eröffnung",
+      "source": "Quelle",
       "ticker": "Ticker",
-      "source": "Quelle"
+      "volume": "Volumen"
     },
+    "delete": "Löschen",
+    "error": {
+      "noData": "Keine Daten zum Speichern",
+      "unexpectedColumns": "Unerwartete Spalte(n): {{columns}}"
+    },
+    "exchange": "Börse",
+    "load": "Laden",
+    "save": "Speichern",
     "status": {
       "loaded": "Geladen {{count}} Zeilen",
       "saved": "Gespeichert {{count}} Zeilen"
     },
-    "error": {
-      "noData": "Keine Daten zum Speichern",
-      "unexpectedColumns": "Unerwartete Spalte(n): {{columns}}"
-    }
-  },
-  "query": {
-    "start": "Start",
-    "end": "Ende",
-    "owners": "Eigentümer",
-    "tickers": "Ticker",
-    "metrics": "Metriken",
-    "run": "Ausführen",
-    "running": "Wird ausgeführt…",
-    "save": "Speichern",
-    "exportCsv": "CSV exportieren",
-    "exportXlsx": "XLSX exportieren"
-  },
-  "screener": {
-    "watchlist": "Beobachtungsliste:",
-    "tickers": "Ticker",
-    "maxPeg": "Max PEG",
-    "maxPe": "Max P/E",
-    "maxDe": "Max D/E",
-    "maxLtDe": "Max LT D/E",
-    "minInterestCoverage": "Min Interest Coverage",
-    "minCurrentRatio": "Min Current Ratio",
-    "minQuickRatio": "Min Quick Ratio",
-    "minFcf": "Min FCF",
-    "minEps": "Min EPS",
-    "minGrossMargin": "Min. Bruttomarge",
-    "minOperatingMargin": "Min. operative Marge",
-    "minNetMargin": "Min. Nettomarge",
-    "minEbitdaMargin": "Min. EBITDA-Marge",
-    "minRoa": "Min. ROA",
-    "minRoe": "Min. ROE",
-    "minRoi": "Min. ROI",
-    "minDividendYield": "Min Dividend Yield",
-    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
-    "maxBeta": "Max Beta",
-    "minSharesOutstanding": "Min Shares Outstanding",
-    "minFloatShares": "Min Float Shares",
-    "minMarketCap": "Min Market Cap",
-    "max52WeekHigh": "Max 52W High",
-    "max52WeekLow": "Max 52W Low",
-    "min52WeekLow": "Min 52W Low",
-    "minAvgVolume": "Min Avg Volume",
-    "run": "Ausführen",
-    "loading": "Laden…"
-  },
-  "instrumentadmin": {
     "ticker": "Ticker",
-    "exchange": "Exchange",
-    "name": "Name",
-    "region": "Region",
-    "sector": "Sector",
-    "grouping": "Gruppierung",
-    "actions": "Actions",
-    "add": "Add Instrument",
-    "save": "Save",
-    "saveSuccess": "Saved",
-    "saveError": "Error saving",
-    "searchPlaceholder": "Filter instruments…",
-    "validation": {
-      "ticker": "Ticker is required",
-      "name": "Name is required",
-      "grouping": "Grouping is required"
-    }
+    "title": "Zeitreihen-Editor"
+  },
+  "trading": {
+    "noPositions": "Keine Positionen.",
+    "noSignals": "Keine Signale."
+  },
+  "trail": {
+    "allDone": "Alle Trail-Aufgaben erledigt – großartig!",
+    "daily": "Täglich",
+    "dailyComplete": "Tägliche Aufgaben erledigt! Weiter so.",
+    "once": "Einmalig",
+    "progressLabel": "Täglicher Fortschritt: {{completed}} / {{total}} ({{percent}}%)",
+    "streakLabel": "Serie: {{count}} Tag",
+    "streakLabel_plural": "Serie: {{count}} Tage",
+    "title": "Trail-Fortschritt",
+    "xpLabel": "XP: {{xp}}"
   },
   "var": {
-    "title": "Value at Risk",
     "details": "Details zur historischen Simulation",
-    "noData": "Keine VaR-Daten verfügbar."
+    "noData": "Keine VaR-Daten verfügbar.",
+    "title": "Value at Risk"
   },
-  "market": {
-    "indexLevels": "Indexstände",
-    "sectorPerformance": "Sektorentwicklung",
-    "latestHeadlines": "Neueste Schlagzeilen"
-  },
-  "goals": {
-    "title": "Ziele",
-    "targetAmount": "Zielbetrag",
-    "add": "Ziel hinzufügen",
-    "currentAmount": "Aktueller Betrag:",
-    "goalLine": "{{name}} – Ziel {{amount}} bis {{date}}",
-    "view": "Ansehen",
-    "progress": "Fortschritt: {{progress}}%",
-    "suggestedTrades": "Vorgeschlagene Trades",
-    "trade": "{{action}} {{amount}} von {{ticker}}",
-    "back": "Zurück zum Portfolio"
+  "watchlist": {
+    "refresh": "Aktualisieren"
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,13 +1,31 @@
 {
+  "alertSettings": {
+    "description": "Configure when you'll receive alerts. Alerts appear on the Alerts page and in push notifications.",
+    "push": {
+      "denied": "Push permission denied.",
+      "disable": "Disable Push Alerts",
+      "enable": "Enable Push Alerts",
+      "error": "Error handling push subscription.",
+      "notSupported": "Push not supported",
+      "title": "Push Notifications"
+    },
+    "save": "Save",
+    "signInNotice": "Sign in to configure alerts",
+    "status": {
+      "error": "Error",
+      "saved": "Saved"
+    },
+    "threshold": "Threshold %:",
+    "title": "Alert Settings"
+  },
+  "allocation": {
+    "instrumentTypes": "Instrument Types",
+    "region": "Regions",
+    "sector": "Industries"
+  },
   "app": {
-    "relativeView": "Relative view",
-    "refreshPrices": "Refresh Prices",
-    "refreshing": "Refreshing…",
     "last": "Last:",
     "loading": "Loading…",
-    "supportLink": "Support",
-    "userLink": "App",
-    "research": "Research",
     "logout": "Logout",
     "menu": "Menu",
     "menuCategories": {
@@ -45,523 +63,505 @@
       "trail": "Trail",
       "transactions": "Transactions",
       "watchlist": "Watchlist"
-    }
+    },
+    "refreshing": "Refreshing…",
+    "refreshPrices": "Refresh Prices",
+    "relativeView": "Relative view",
+    "research": "Research",
+    "supportLink": "Support",
+    "userLink": "App"
   },
-  "trail": {
-    "title": "Trail progress",
-    "daily": "Daily",
-    "once": "Once",
-    "progressLabel": "Daily progress: {{completed}} / {{total}} ({{percent}}%)",
-    "xpLabel": "XP: {{xp}}",
-    "streakLabel": "Streak: {{count}} day",
-    "streakLabel_plural": "Streak: {{count}} days",
-    "dailyComplete": "Daily tasks complete! Keep the streak going.",
-    "allDone": "All Trail tasks are complete — fantastic work!"
-  },
+  "approxTotal": "Approx Total: £{{value}}",
+  "asOf": "As of {{date}} • Trades this month: {{trades}} / 20 (Remaining: {{remaining}})",
   "common": {
+    "action": "Action",
     "error": "Error",
     "loading": "Loading…",
-    "other": "Other",
-    "ticker": "Ticker",
     "name": "Name",
-    "action": "Action",
+    "other": "Other",
+    "period": "Period:",
     "reason": "Reason",
-    "period": "Period:"
+    "ticker": "Ticker"
   },
-  "instrumentType": {
-    "equity": "Equity",
-    "bond": "Bond",
-    "cash": "Cash",
-    "etf": "ETF",
-    "fund": "Fund",
-    "investmentTrust": "Investment Trust",
-    "realEstate": "Real Estate",
-    "other": "Other"
-  },
-  "instrumentTable": {
-    "noInstruments": "No instruments.",
-    "ungrouped": "Ungrouped",
-    "exchangesLabel": "Exchanges:",
-    "groupTotals": {
-      "market": "Market",
-      "gain": "Gain",
-      "gainPct": "Gain %",
-      "delta7d": "7d %",
-      "delta30d": "30d %"
+  "dashboard": {
+    "alphaVsBenchmark": "Alpha vs Benchmark",
+    "cumulativeReturn": "Cumulative Return",
+    "excludeCash": "Exclude cash",
+    "maxDrawdown": "Max Drawdown",
+    "maxDrawdownHelp": "Max drawdown is the largest percentage drop from any portfolio peak to the lowest closing value that follows, calculated from the rebuilt daily totals of your holdings.",
+    "metricsExplanationLink": "How are these calculated?",
+    "portfolioValue": "Portfolio Value",
+    "range": "Range:",
+    "rangeOptions": {
+      "10y": "10Y",
+      "1m": "1M",
+      "1w": "1W",
+      "1y": "1Y",
+      "max": "MAX"
     },
+    "selectMember": "Select a member.",
+    "timeWeightedReturn": "Time-Weighted Return",
+    "trackingError": "Tracking Error",
+    "xirr": "XIRR"
+  },
+  "goals": {
+    "add": "Add Goal",
+    "back": "Back to Portfolio",
+    "currentAmount": "Current Amount:",
+    "goalLine": "{{name}} – target {{amount}} by {{date}}",
+    "progress": "Progress: {{progress}}%",
+    "suggestedTrades": "Suggested Trades",
+    "targetAmount": "Target Amount",
+    "title": "Goals",
+    "trade": "{{action}} {{amount}} of {{ticker}}",
+    "view": "View"
+  },
+  "group": {
+    "atAGlance": "At a glance",
+    "select": "Select a group."
+  },
+  "holdingsTable": {
+    "actualPurchaseCost": "Actual purchase cost",
+    "clearFilters": "Clear filters",
     "columns": {
-      "ticker": "Ticker",
-      "name": "Name",
+      "acquired": "Acquired",
       "ccy": "CCY",
+      "cost": "Cost £",
+      "daysHeld": "Days Held",
+      "eligible": "Eligible?",
+      "gain": "Gain £",
+      "gainPct": "Gain %",
+      "market": "Mkt £",
+      "name": "Name",
+      "price": "Px £",
+      "stage": "Stage",
+      "ticker": "Ticker",
+      "trend": "Trend",
       "type": "Type",
       "units": "Units",
+      "weightPct": "Weight %"
+    },
+    "columnsLabel": "Columns:",
+    "eligible": "Eligible",
+    "filters": {
+      "all": "All",
+      "gainPct": "Gain %",
+      "name": "Name",
+      "no": "No",
+      "sellEligible": "Sell eligible",
+      "ticker": "Ticker",
+      "type": "Type",
+      "units": "Units",
+      "yes": "Yes"
+    },
+    "inferredCost": "Inferred from price on acquisition date",
+    "minimumGainPrompt": "Min Gain %",
+    "noHoldings": "No holdings match the current filters.",
+    "openScreener": "Open Screener",
+    "quickFilters": "Quick Filters:",
+    "quickFiltersGainPct": "Gain% > x",
+    "quickFiltersSellEligible": "Sell-eligible",
+    "range": "Range:",
+    "rangeOption": "{{count}}d",
+    "source": "Source:",
+    "totalRowLabel": "Total",
+    "view": "View:",
+    "viewPresets": {
+      "all": "All"
+    }
+  },
+  "instrumentadmin": {
+    "actions": "Actions",
+    "add": "Add Instrument",
+    "exchange": "Exchange",
+    "grouping": "Grouping",
+    "name": "Name",
+    "region": "Region",
+    "save": "Save",
+    "saveError": "Error saving",
+    "saveSuccess": "Saved",
+    "searchPlaceholder": "Filter instruments…",
+    "sector": "Sector",
+    "ticker": "Ticker",
+    "validation": {
+      "grouping": "Grouping is required",
+      "name": "Name is required",
+      "ticker": "Ticker is required"
+    }
+  },
+  "instrumentDetail": {
+    "bollingerBands": "Bollinger Bands",
+    "cancel": "Cancel",
+    "change30d": "30d",
+    "change7d": "7d",
+    "columns": {
+      "account": "Account",
+      "gain": "Gain £",
+      "gainPct": "Gain %",
+      "market": "Mkt £",
+      "units": "Units"
+    },
+    "confirm": "Confirm",
+    "currencyLabel": "Currency",
+    "currencyPlaceholder": "Select a currency",
+    "edit": "Edit",
+    "infoHeading": "Instrument info",
+    "intraday": "Intraday",
+    "intradayUnavailable": "Intraday data unavailable",
+    "ma20": "20d MA",
+    "ma200": "200d MA",
+    "ma50": "50d MA",
+    "metadataCurrencyError": "Select a supported currency before saving.",
+    "metadataLoadError": "Unable to load the instrument catalogue.",
+    "metadataMissingExchange": "Instrument exchange is unknown; try reloading.",
+    "metadataSaveError": "Unable to save instrument details.",
+    "metadataSaveSuccess": "Instrument details updated.",
+    "nameLabel": "Name",
+    "noPositions": "No positions",
+    "noPriceData": "No price data",
+    "positions": "Positions",
+    "priceColumns": {
+      "close": "£ Close",
+      "date": "Date",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "range": "Range:",
+    "rangeOptions": {
+      "10y": "10Y",
+      "1m": "1M",
+      "1w": "1W",
+      "1y": "1Y",
+      "max": "MAX"
+    },
+    "recentPrices": "Recent Prices",
+    "refresh": "Refresh",
+    "refreshCancel": "Cancel",
+    "refreshConfirm": "Confirm",
+    "refreshError": "Unable to refresh instrument details.",
+    "refreshNoChanges": "The latest data matches the saved metadata.",
+    "refreshPreviewDescription": "Review the fetched metadata before confirming.",
+    "refreshPreviewTitle": "Proposed updates",
+    "refreshSuccess": "Instrument details refreshed from Yahoo Finance.",
+    "rsi": "RSI",
+    "save": "Save",
+    "sectorLabel": "Sector"
+  },
+  "instrumentTable": {
+    "columns": {
+      "ccy": "CCY",
       "cost": "Cost £",
-      "market": "Market £",
+      "delta30d": "30d %",
+      "delta7d": "7d %",
       "gain": "Gain £",
       "gainPct": "Gain %",
       "last": "Last £",
       "lastDate": "Last Date",
+      "market": "Market £",
+      "name": "Name",
+      "ticker": "Ticker",
+      "type": "Type",
+      "units": "Units"
+    },
+    "exchangesLabel": "Exchanges:",
+    "groupTotals": {
+      "delta30d": "30d %",
       "delta7d": "7d %",
-      "delta30d": "30d %"
-    }
-  },
-  "holdingsTable": {
-    "range": "Range:",
-    "rangeOption": "{{count}}d",
-    "view": "View:",
-    "viewPresets": {
-      "all": "All"
-    },
-    "quickFilters": "Quick Filters:",
-    "quickFiltersSellEligible": "Sell-eligible",
-    "quickFiltersGainPct": "Gain% > x",
-    "minimumGainPrompt": "Min Gain %",
-    "columnsLabel": "Columns:",
-    "columns": {
-      "ticker": "Ticker",
-      "name": "Name",
-      "trend": "Trend",
-      "ccy": "CCY",
-      "type": "Type",
-      "units": "Units",
-      "price": "Px £",
-      "cost": "Cost £",
-      "market": "Mkt £",
-      "gain": "Gain £",
+      "gain": "Gain",
       "gainPct": "Gain %",
-      "weightPct": "Weight %",
-      "acquired": "Acquired",
-      "daysHeld": "Days Held",
-      "stage": "Stage",
-      "eligible": "Eligible?"
+      "market": "Market"
     },
-    "filters": {
-      "ticker": "Ticker",
-      "name": "Name",
-      "type": "Type",
-      "units": "Units",
-      "gainPct": "Gain %",
-      "sellEligible": "Sell eligible",
-      "all": "All",
-      "yes": "Yes",
-      "no": "No"
-    },
-    "noHoldings": "No holdings match the current filters.",
-    "clearFilters": "Clear filters",
-    "openScreener": "Open Screener",
-    "source": "Source:",
-    "actualPurchaseCost": "Actual purchase cost",
-    "inferredCost": "Inferred from price on acquisition date",
-    "eligible": "Eligible",
-    "totalRowLabel": "Total"
+    "noInstruments": "No instruments.",
+    "ungrouped": "Ungrouped"
   },
-  "instrumentDetail": {
-    "edit": "Edit",
-    "save": "Save",
-    "cancel": "Cancel",
-    "confirm": "Confirm",
-    "refresh": "Refresh",
-    "refreshConfirm": "Confirm",
-    "refreshCancel": "Cancel",
-    "refreshPreviewTitle": "Proposed updates",
-    "refreshPreviewDescription": "Review the fetched metadata before confirming.",
-    "refreshNoChanges": "The latest data matches the saved metadata.",
-    "refreshError": "Unable to refresh instrument details.",
-    "refreshSuccess": "Instrument details refreshed from Yahoo Finance.",
-    "infoHeading": "Instrument info",
-    "nameLabel": "Name",
-    "sectorLabel": "Sector",
-    "currencyLabel": "Currency",
-    "currencyPlaceholder": "Select a currency",
-    "metadataSaveSuccess": "Instrument details updated.",
-    "metadataSaveError": "Unable to save instrument details.",
-    "metadataLoadError": "Unable to load the instrument catalogue.",
-    "metadataCurrencyError": "Select a supported currency before saving.",
-    "metadataMissingExchange": "Instrument exchange is unknown; try reloading.",
-    "change7d": "7d",
-    "change30d": "30d",
-    "range": "Range:",
-    "rangeOptions": {
-      "1w": "1W",
-      "1m": "1M",
-      "1y": "1Y",
-      "10y": "10Y",
-      "max": "MAX"
+  "instrumentType": {
+    "bond": "Bond",
+    "cash": "Cash",
+    "equity": "Equity",
+    "etf": "ETF",
+    "fund": "Fund",
+    "investmentTrust": "Investment Trust",
+    "other": "Other",
+    "realEstate": "Real Estate"
+  },
+  "loadingPortfolio": "Loading portfolio…",
+  "market": {
+    "indexLevels": "Index Levels",
+    "latestHeadlines": "Latest Headlines",
+    "sectorPerformance": "Sector Performance"
+  },
+  "metricsExplanation": {
+    "activeReturn": "Active return",
+    "alphaCumulative": "Excess cumulative return",
+    "backLink": "Back to portfolio dashboard",
+    "benchmarkCumulative": "Benchmark cumulative return",
+    "benchmarkReturn": "Benchmark return",
+    "calculationHeading": "How we calculate it",
+    "dataBody": "We rebuild daily market values for every holding using the latest price data and any recorded corporate actions. Cash flows, trades and benchmark levels are normalised to UTC trading days. Metrics refresh whenever new prices are ingested.",
+    "dataHeading": "Data inputs",
+    "dateColumn": "Date",
+    "disclaimer": "These statistics are provided for information only and may differ from figures reported by your broker if their pricing or benchmark selection differs.",
+    "drawdownColumn": "Drawdown",
+    "groupContext": "Showing combined metrics for group {{group}}.",
+    "intro": "These metrics summarise how the combined portfolio performs relative to its benchmark. Each value is derived from the same daily return series that powers the dashboard tiles.",
+    "loadError": "We couldn’t load the latest metrics: {{message}}",
+    "loading": "Loading latest metrics…",
+    "missingContext": "No portfolio or group was specified. Return to the dashboard and follow the metrics explanation link from a specific portfolio.",
+    "noContext": "Open this page from a portfolio or group to see live numbers.",
+    "notAvailable": "n/a",
+    "notesHeading": "Things to know",
+    "ownerContext": "Showing metrics for {{owner}}'s portfolio.",
+    "parameters": "Benchmark: {{benchmark}} • Window: {{days}} days",
+    "portfolioCumulative": "Portfolio cumulative return",
+    "portfolioReturn": "Portfolio return",
+    "portfolioValue": "Portfolio value",
+    "runningPeak": "Running peak",
+    "sections": {
+      "alpha": {
+        "breakdownHeading": "Step-by-step cumulative returns",
+        "breakdownIntro": "Each row shows how the cumulative portfolio and benchmark returns evolve on the same trading days. Their difference is the excess return (alpha).",
+        "calculation": "We compute time-weighted cumulative returns for both the portfolio and the configured benchmark. Alpha is simply the portfolio return minus the benchmark return, expressed in percentage points.",
+        "detail": "Cumulative portfolio return: {{portfolio}} · Benchmark return: {{benchmark}} · Alpha: {{alpha}}",
+        "headline": "Alpha vs benchmark",
+        "notes": [
+          "Positive alpha means the portfolio outperformed the benchmark over the selected period.",
+          "If either return series is unavailable for the full span we fall back to the overlapping dates only."
+        ],
+        "summary": "Alpha measures the portfolio's excess return after matching the benchmark over the same date range.",
+        "title": "Alpha vs Benchmark"
+      },
+      "maxDrawdown": {
+        "breakdownHeading": "Daily values and running peaks",
+        "breakdownIntro": "We rebuild the portfolio value curve, track each rolling peak, and compute the drawdown at every point. The minimum of this series is the max drawdown shown above.",
+        "calculation": "We scan the time-weighted return curve, track each new peak, and record the largest subsequent drop before a new peak is reached. The deepest percentage loss becomes the max drawdown.",
+        "detail": "Max drawdown: {{drawdown}} · Peak: {{peakValue}} on {{peakDate}} · Trough: {{troughValue}} on {{troughDate}}",
+        "headline": "Worst peak-to-trough move",
+        "notes": [
+          "Drawdown is calculated on portfolio returns only; the benchmark is not considered here.",
+          "A -100% drawdown would mean the portfolio value reached zero after a prior peak."
+        ],
+        "summary": "Max drawdown identifies the worst peak-to-trough decline in portfolio value over the measurement window.",
+        "title": "Max Drawdown"
+      },
+      "trackingError": {
+        "breakdownHeading": "Daily active returns",
+        "breakdownIntro": "Daily active returns (portfolio minus benchmark) are listed below. The standard deviation of this series, scaled by √252, produces the tracking error above.",
+        "calculation": "For each trading day we take the portfolio return minus the benchmark return, producing an active return series. Tracking error is the annualised standard deviation of those active returns (daily standard deviation multiplied by √252).",
+        "detail": "Annualised tracking error: {{trackingError}} · Daily active-return standard deviation: {{dailyStd}}",
+        "headline": "Tracking error and daily active returns",
+        "notes": [
+          "Higher tracking error indicates looser alignment with the benchmark.",
+          "We require at least 30 overlapping daily returns to display this metric."
+        ],
+        "summary": "Tracking error captures the variability of active returns—how much the portfolio's daily returns diverge from the benchmark.",
+        "title": "Tracking Error"
+      }
     },
-    "bollingerBands": "Bollinger Bands",
-    "ma20": "20d MA",
-    "ma50": "50d MA",
-    "ma200": "200d MA",
-    "rsi": "RSI",
-    "positions": "Positions",
-    "columns": {
-      "account": "Account",
-      "units": "Units",
-      "market": "Mkt £",
-      "gain": "Gain £",
-      "gainPct": "Gain %"
-    },
-    "noPositions": "No positions",
-    "recentPrices": "Recent Prices",
-    "priceColumns": {
-      "date": "Date",
-      "close": "£ Close",
-      "delta": "Δ £",
-      "deltaPct": "Δ %"
-    },
-    "noPriceData": "No price data",
-    "intraday": "Intraday",
-    "intradayUnavailable": "Intraday data unavailable"
+    "title": "Performance Metrics Explained"
+  },
+  "movers": {
+    "excludeSmall": "Exclude positions <{{min}}%",
+    "loadFailed": "Failed to load movers{{status}}",
+    "loginPrompt": "Please log in to view portfolio-based movers.",
+    "pctPortfolio": "% of portfolio",
+    "period": "Period:",
+    "signal": "Signal",
+    "watchlist": "Watchlist:"
   },
   "owner": {
     "label": "Owner",
     "select": "Select an owner."
   },
   "pensionForecast": {
-    "currentAge": "Current age: {{age}}",
     "birthDate": "Birth date: {{dob}}",
-    "retirementAge": "Retirement age: {{age}}",
-    "pensionPot": "Pension pot",
+    "currentAge": "Current age: {{age}}",
+    "employerContributionLabel": "Employer contribution",
     "growthAssumption": "Growth assumption (%):",
-    "monthlyContribution": "Monthly Contribution (£):",
+    "header": {
+      "employeeContribution": "Your monthly contribution",
+      "employerContribution": "Employer contribution",
+      "heading": "Track your contributions at a glance",
+      "kicker": "Your pension snapshot",
+      "linkedPotsHeading": "Linked pension pots",
+      "noLinkedPots": "No pension pots linked for this owner yet.",
+      "notAvailable": "Not available",
+      "pensionPot": "Current pension pot",
+      "totalContribution": "Total monthly contributions: {{total}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
-      "state": "State pension",
       "definedBenefit": "Defined benefit",
-      "definedContribution": "Defined contribution"
+      "definedContribution": "Defined contribution",
+      "state": "State pension"
     },
     "incomeTable": {
-      "source": "Source",
       "annual": "Annual (£)",
       "monthly": "Monthly (£)",
-      "share": "Share"
+      "share": "Share",
+      "source": "Source"
     },
-    "totalAnnualIncome": "Total annual income",
-    "totalMonthlyIncome": "Total monthly income",
+    "monthlyContribution": "Monthly Contribution (£):",
+    "pensionPot": "Pension pot",
     "prediction": {
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available.",
       "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
       "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
       "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
-      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
-      "earliest": "Estimated earliest retirement age: {{age}}",
-      "noBreakdown": "No income breakdown available."
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then."
     },
-    "employerContributionLabel": "Employer contribution",
-    "header": {
-      "kicker": "Your pension snapshot",
-      "heading": "Track your contributions at a glance",
-      "pensionPot": "Current pension pot",
-      "employeeContribution": "Your monthly contribution",
-      "employerContribution": "Employer contribution",
-      "totalContribution": "Total monthly contributions: {{total}}",
-      "linkedPotsHeading": "Linked pension pots",
-      "noLinkedPots": "No pension pots linked for this owner yet.",
-      "notAvailable": "Not available"
-    }
+    "retirementAge": "Retirement age: {{age}}",
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income"
   },
-  "group": {
-    "select": "Select a group.",
-    "atAGlance": "At a glance"
-  },
-  "dashboard": {
-    "selectMember": "Select a member.",
-    "range": "Range:",
-    "rangeOptions": {
-      "1w": "1W",
-      "1m": "1M",
-      "1y": "1Y",
-      "10y": "10Y",
-      "max": "MAX"
-    },
-    "excludeCash": "Exclude cash",
-    "alphaVsBenchmark": "Alpha vs Benchmark",
-    "trackingError": "Tracking Error",
-    "maxDrawdown": "Max Drawdown",
-    "maxDrawdownHelp": "Max drawdown is the largest percentage drop from any portfolio peak to the lowest closing value that follows, calculated from the rebuilt daily totals of your holdings.",
-    "metricsExplanationLink": "How are these calculated?",
-    "timeWeightedReturn": "Time-Weighted Return",
-    "xirr": "XIRR",
-    "portfolioValue": "Portfolio Value",
-    "cumulativeReturn": "Cumulative Return"
-  },
-  "metricsExplanation": {
-    "title": "Performance Metrics Explained",
-    "intro": "These metrics summarise how the combined portfolio performs relative to its benchmark. Each value is derived from the same daily return series that powers the dashboard tiles.",
-    "backLink": "Back to portfolio dashboard",
-    "groupContext": "Showing combined metrics for group {{group}}.",
-    "ownerContext": "Showing metrics for {{owner}}'s portfolio.",
-    "noContext": "Open this page from a portfolio or group to see live numbers.",
-    "parameters": "Benchmark: {{benchmark}} • Window: {{days}} days",
-    "missingContext": "No portfolio or group was specified. Return to the dashboard and follow the metrics explanation link from a specific portfolio.",
-    "loadError": "We couldn’t load the latest metrics: {{message}}",
-    "loading": "Loading latest metrics…",
-    "notAvailable": "n/a",
-    "dateColumn": "Date",
-    "portfolioCumulative": "Portfolio cumulative return",
-    "benchmarkCumulative": "Benchmark cumulative return",
-    "alphaCumulative": "Excess cumulative return",
-    "portfolioReturn": "Portfolio return",
-    "benchmarkReturn": "Benchmark return",
-    "activeReturn": "Active return",
-    "portfolioValue": "Portfolio value",
-    "runningPeak": "Running peak",
-    "drawdownColumn": "Drawdown",
-    "calculationHeading": "How we calculate it",
-    "notesHeading": "Things to know",
-    "dataHeading": "Data inputs",
-    "dataBody": "We rebuild daily market values for every holding using the latest price data and any recorded corporate actions. Cash flows, trades and benchmark levels are normalised to UTC trading days. Metrics refresh whenever new prices are ingested.",
-    "disclaimer": "These statistics are provided for information only and may differ from figures reported by your broker if their pricing or benchmark selection differs.",
-    "sections": {
-      "alpha": {
-        "title": "Alpha vs Benchmark",
-        "summary": "Alpha measures the portfolio's excess return after matching the benchmark over the same date range.",
-        "headline": "Alpha vs benchmark",
-        "detail": "Cumulative portfolio return: {{portfolio}} · Benchmark return: {{benchmark}} · Alpha: {{alpha}}",
-        "breakdownHeading": "Step-by-step cumulative returns",
-        "breakdownIntro": "Each row shows how the cumulative portfolio and benchmark returns evolve on the same trading days. Their difference is the excess return (alpha).",
-        "calculation": "We compute time-weighted cumulative returns for both the portfolio and the configured benchmark. Alpha is simply the portfolio return minus the benchmark return, expressed in percentage points.",
-        "notes": [
-          "Positive alpha means the portfolio outperformed the benchmark over the selected period.",
-          "If either return series is unavailable for the full span we fall back to the overlapping dates only."
-        ]
-      },
-      "trackingError": {
-        "title": "Tracking Error",
-        "summary": "Tracking error captures the variability of active returns—how much the portfolio's daily returns diverge from the benchmark.",
-        "headline": "Tracking error and daily active returns",
-        "detail": "Annualised tracking error: {{trackingError}} · Daily active-return standard deviation: {{dailyStd}}",
-        "breakdownHeading": "Daily active returns",
-        "breakdownIntro": "Daily active returns (portfolio minus benchmark) are listed below. The standard deviation of this series, scaled by √252, produces the tracking error above.",
-        "calculation": "For each trading day we take the portfolio return minus the benchmark return, producing an active return series. Tracking error is the annualised standard deviation of those active returns (daily standard deviation multiplied by √252).",
-        "notes": [
-          "Higher tracking error indicates looser alignment with the benchmark.",
-          "We require at least 30 overlapping daily returns to display this metric."
-        ]
-      },
-      "maxDrawdown": {
-        "title": "Max Drawdown",
-        "summary": "Max drawdown identifies the worst peak-to-trough decline in portfolio value over the measurement window.",
-        "headline": "Worst peak-to-trough move",
-        "detail": "Max drawdown: {{drawdown}} · Peak: {{peakValue}} on {{peakDate}} · Trough: {{troughValue}} on {{troughDate}}",
-        "breakdownHeading": "Daily values and running peaks",
-        "breakdownIntro": "We rebuild the portfolio value curve, track each rolling peak, and compute the drawdown at every point. The minimum of this series is the max drawdown shown above.",
-        "calculation": "We scan the time-weighted return curve, track each new peak, and record the largest subsequent drop before a new peak is reached. The deepest percentage loss becomes the max drawdown.",
-        "notes": [
-          "Drawdown is calculated on portfolio returns only; the benchmark is not considered here.",
-          "A -100% drawdown would mean the portfolio value reached zero after a prior peak."
-        ]
-      }
-    }
-  },
-  "support": {
-    "title": "Support",
-    "online": "Online",
-    "onlineYes": "Yes",
-    "onlineNo": "No",
-    "environment": "Environment",
-    "priceRefresh": "Price Refresh",
-    "telegramMessage": "Telegram Message",
-    "send": "Send",
-    "status": {
-      "sent": "Sent",
-      "error": "Error",
-      "sending": "Sending...",
-      "saved": "Saved",
-      "saving": "Saving..."
-    },
-    "health": {
-      "title": "Portfolio health",
-      "run": "Run portfolio health check",
-      "copyReport": "Copy report",
-      "error": "Failed to run health check"
-    },
-    "notifications": {
-      "title": "Notifications",
-      "notSupported": "Push not supported",
-      "disable": "Disable Push Alerts",
-      "enable": "Enable Push Alerts",
-      "denied": "Push permission denied.",
-      "error": "Error handling push subscription."
-    },
-    "config": {
-      "title": "Configuration",
-      "tabsEnabled": "Tabs Enabled",
-      "otherSwitches": "Other Switches",
-      "otherParams": "Other parameters",
-      "save": "Save"
-    },
-    "logs": {
-      "title": "Logs",
-      "refresh": "Refresh logs",
-      "empty": "No logs available.",
-      "error": "Failed to load logs."
-    }
-  },
-  "alertSettings": {
-    "title": "Alert Settings",
-    "description": "Configure when you'll receive alerts. Alerts appear on the Alerts page and in push notifications.",
-    "threshold": "Threshold %:",
+  "portfolio": "Portfolio",
+  "query": {
+    "copyLink": "Copy Link",
+    "end": "End",
+    "exportCsv": "Export CSV",
+    "exportXlsx": "Export XLSX",
+    "metrics": "Metrics",
+    "noResults": "No results.",
+    "owners": "Owners",
+    "run": "Run",
+    "running": "Running…",
     "save": "Save",
-    "signInNotice": "Sign in to configure alerts",
-    "push": {
-      "title": "Push Notifications",
-      "notSupported": "Push not supported",
-      "enable": "Enable Push Alerts",
-      "disable": "Disable Push Alerts",
-      "denied": "Push permission denied.",
-      "error": "Error handling push subscription."
-    },
-    "status": {
-      "saved": "Saved",
-      "error": "Error"
-    }
+    "start": "Start",
+    "tickers": "Tickers"
   },
   "reports": {
-    "title": "Reports",
     "csv": "Download CSV",
+    "noOwners": "No owners available—check backend connection",
     "pdf": "Download PDF",
-    "noOwners": "No owners available—check backend connection"
+    "title": "Reports"
   },
-  "loadingPortfolio": "Loading portfolio…",
-  "portfolio": "Portfolio",
-  "asOf": "As of {{date}} • Trades this month: {{trades}} / 20 (Remaining: {{remaining}})",
-  "approxTotal": "Approx Total: £{{value}}",
-  "allocation": {
-    "instrumentTypes": "Instrument Types",
-    "sector": "Industries",
-    "region": "Regions"
+  "screener": {
+    "loading": "Loading…",
+    "max52WeekHigh": "Max 52W High",
+    "max52WeekLow": "Max 52W Low",
+    "maxBeta": "Max Beta",
+    "maxDe": "Max D/E",
+    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
+    "maxLtDe": "Max LT D/E",
+    "maxPe": "Max P/E",
+    "maxPeg": "Max PEG",
+    "min52WeekLow": "Min 52W Low",
+    "minAvgVolume": "Min Avg Volume",
+    "minCurrentRatio": "Min Current Ratio",
+    "minDividendYield": "Min Dividend Yield",
+    "minEbitdaMargin": "Min EBITDA Margin",
+    "minEps": "Min EPS",
+    "minFcf": "Min FCF",
+    "minFloatShares": "Min Float Shares",
+    "minGrossMargin": "Min Gross Margin",
+    "minInterestCoverage": "Min Interest Coverage",
+    "minMarketCap": "Min Market Cap",
+    "minNetMargin": "Min Net Margin",
+    "minOperatingMargin": "Min Operating Margin",
+    "minQuickRatio": "Min Quick Ratio",
+    "minRoa": "Min ROA",
+    "minRoe": "Min ROE",
+    "minRoi": "Min ROI",
+    "minSharesOutstanding": "Min Shares Outstanding",
+    "run": "Run",
+    "tickers": "Tickers",
+    "watchlist": "Watchlist:"
   },
-  "watchlist": {
-    "refresh": "Refresh"
-  },
-  "trading": {
-    "noPositions": "No positions.",
-    "noSignals": "No signals."
-  },
-  "movers": {
-    "watchlist": "Watchlist:",
-    "period": "Period:",
-    "excludeSmall": "Exclude positions <{{min}}%",
-    "loginPrompt": "Please log in to view portfolio-based movers.",
-    "loadFailed": "Failed to load movers{{status}}",
-    "signal": "Signal",
-    "pctPortfolio": "% of portfolio"
+  "support": {
+    "config": {
+      "otherParams": "Other parameters",
+      "otherSwitches": "Other Switches",
+      "save": "Save",
+      "tabsEnabled": "Tabs Enabled",
+      "title": "Configuration"
+    },
+    "environment": "Environment",
+    "health": {
+      "copyReport": "Copy report",
+      "error": "Failed to run health check",
+      "run": "Run portfolio health check",
+      "title": "Portfolio health"
+    },
+    "logs": {
+      "empty": "No logs available.",
+      "error": "Failed to load logs.",
+      "refresh": "Refresh logs",
+      "title": "Logs"
+    },
+    "notifications": {
+      "denied": "Push permission denied.",
+      "disable": "Disable Push Alerts",
+      "enable": "Enable Push Alerts",
+      "error": "Error handling push subscription.",
+      "notSupported": "Push not supported",
+      "title": "Notifications"
+    },
+    "online": "Online",
+    "onlineNo": "No",
+    "onlineYes": "Yes",
+    "priceRefresh": "Price Refresh",
+    "send": "Send",
+    "status": {
+      "error": "Error",
+      "saved": "Saved",
+      "saving": "Saving...",
+      "sending": "Sending...",
+      "sent": "Sent"
+    },
+    "telegramMessage": "Telegram Message",
+    "title": "Support"
   },
   "timeseries": {
     "loading": "Loading…"
   },
   "timeseriesEdit": {
-    "title": "Time Series Editor",
-    "ticker": "Ticker",
-    "exchange": "Exchange",
-    "load": "Load",
     "addRow": "Add Row",
-    "save": "Save",
-    "delete": "Delete",
     "columns": {
+      "close": "Close",
       "date": "Date",
-      "open": "Open",
       "high": "High",
       "low": "Low",
-      "close": "Close",
-      "volume": "Volume",
+      "open": "Open",
+      "source": "Source",
       "ticker": "Ticker",
-      "source": "Source"
+      "volume": "Volume"
     },
+    "delete": "Delete",
+    "error": {
+      "noData": "No data to save",
+      "unexpectedColumns": "Unexpected column(s): {{columns}}"
+    },
+    "exchange": "Exchange",
+    "load": "Load",
+    "save": "Save",
     "status": {
       "loaded": "Loaded {{count}} rows",
       "saved": "Saved {{count}} rows"
     },
-    "error": {
-      "noData": "No data to save",
-      "unexpectedColumns": "Unexpected column(s): {{columns}}"
-    }
-  },
-  "query": {
-    "noResults": "No results.",
-    "start": "Start",
-    "end": "End",
-    "owners": "Owners",
-    "tickers": "Tickers",
-    "metrics": "Metrics",
-    "run": "Run",
-    "running": "Running…",
-    "save": "Save",
-    "copyLink": "Copy Link",
-    "exportCsv": "Export CSV",
-    "exportXlsx": "Export XLSX"
-  },
-  "screener": {
-    "watchlist": "Watchlist:",
-    "tickers": "Tickers",
-    "maxPeg": "Max PEG",
-    "maxPe": "Max P/E",
-    "maxDe": "Max D/E",
-    "maxLtDe": "Max LT D/E",
-    "minInterestCoverage": "Min Interest Coverage",
-    "minCurrentRatio": "Min Current Ratio",
-    "minQuickRatio": "Min Quick Ratio",
-    "minFcf": "Min FCF",
-    "minEps": "Min EPS",
-    "minGrossMargin": "Min Gross Margin",
-    "minOperatingMargin": "Min Operating Margin",
-    "minNetMargin": "Min Net Margin",
-    "minEbitdaMargin": "Min EBITDA Margin",
-    "minRoa": "Min ROA",
-    "minRoe": "Min ROE",
-    "minRoi": "Min ROI",
-    "minDividendYield": "Min Dividend Yield",
-    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
-    "maxBeta": "Max Beta",
-    "minSharesOutstanding": "Min Shares Outstanding",
-    "minFloatShares": "Min Float Shares",
-    "minMarketCap": "Min Market Cap",
-    "max52WeekHigh": "Max 52W High",
-    "max52WeekLow": "Max 52W Low",
-    "min52WeekLow": "Min 52W Low",
-    "minAvgVolume": "Min Avg Volume",
-    "run": "Run",
-    "loading": "Loading…"
-  },
-  "instrumentadmin": {
     "ticker": "Ticker",
-    "exchange": "Exchange",
-    "name": "Name",
-    "region": "Region",
-    "sector": "Sector",
-    "grouping": "Grouping",
-    "actions": "Actions",
-    "add": "Add Instrument",
-    "save": "Save",
-    "saveSuccess": "Saved",
-    "saveError": "Error saving",
-    "searchPlaceholder": "Filter instruments…",
-    "validation": {
-      "ticker": "Ticker is required",
-      "name": "Name is required",
-      "grouping": "Grouping is required"
-    }
+    "title": "Time Series Editor"
+  },
+  "trading": {
+    "noPositions": "No positions.",
+    "noSignals": "No signals."
+  },
+  "trail": {
+    "allDone": "All Trail tasks are complete — fantastic work!",
+    "daily": "Daily",
+    "dailyComplete": "Daily tasks complete! Keep the streak going.",
+    "once": "Once",
+    "progressLabel": "Daily progress: {{completed}} / {{total}} ({{percent}}%)",
+    "streakLabel": "Streak: {{count}} day",
+    "streakLabel_plural": "Streak: {{count}} days",
+    "title": "Trail progress",
+    "xpLabel": "XP: {{xp}}"
   },
   "var": {
-    "title": "Value at Risk",
     "details": "Historical simulation details",
-    "noData": "No VaR data available."
+    "noData": "No VaR data available.",
+    "title": "Value at Risk"
   },
-  "market": {
-    "indexLevels": "Index Levels",
-    "sectorPerformance": "Sector Performance",
-    "latestHeadlines": "Latest Headlines"
-  },
-  "goals": {
-    "title": "Goals",
-    "targetAmount": "Target Amount",
-    "add": "Add Goal",
-    "currentAmount": "Current Amount:",
-    "goalLine": "{{name}} – target {{amount}} by {{date}}",
-    "view": "View",
-    "progress": "Progress: {{progress}}%",
-    "suggestedTrades": "Suggested Trades",
-    "trade": "{{action}} {{amount}} of {{ticker}}",
-    "back": "Back to Portfolio"
+  "watchlist": {
+    "refresh": "Refresh"
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1,14 +1,37 @@
 {
+  "alertSettings": {
+    "description": "Configura cuándo recibirás alertas. Las alertas aparecen en la página de alertas y en las notificaciones push.",
+    "push": {
+      "denied": "Permiso de push denegado.",
+      "disable": "Desactivar alertas push",
+      "enable": "Activar alertas push",
+      "error": "Error al manejar la suscripción push.",
+      "notSupported": "Push no soportado",
+      "title": "Notificaciones push"
+    },
+    "save": "Save",
+    "status": {
+      "error": "Error",
+      "saved": "Saved"
+    },
+    "threshold": "Threshold %:",
+    "title": "Alert Settings"
+  },
+  "allocation": {
+    "instrumentTypes": "Tipos de instrumentos",
+    "region": "Regiones",
+    "sector": "Industrias"
+  },
   "app": {
-    "relativeView": "Vista relativa",
-    "refreshPrices": "Actualizar precios",
-    "refreshing": "Actualizando…",
     "last": "Último:",
     "loading": "Cargando…",
-    "supportLink": "Soporte",
-    "userLink": "App",
-    "research": "Investigación",
     "logout": "Cerrar sesión",
+    "logs": {
+      "empty": "No hay registros disponibles.",
+      "error": "No se pudieron cargar los registros.",
+      "refresh": "Actualizar registros",
+      "title": "Registros"
+    },
     "menu": "Menú",
     "menuCategories": {
       "dashboard": "Panel",
@@ -46,427 +69,404 @@
       "transactions": "Transacciones",
       "watchlist": "Lista de seguimiento"
     },
-    "logs": {
-      "title": "Registros",
-      "refresh": "Actualizar registros",
-      "empty": "No hay registros disponibles.",
-      "error": "No se pudieron cargar los registros."
-    }
+    "refreshing": "Actualizando…",
+    "refreshPrices": "Actualizar precios",
+    "relativeView": "Vista relativa",
+    "research": "Investigación",
+    "supportLink": "Soporte",
+    "userLink": "App"
   },
-  "trail": {
-    "title": "Progreso del Trail",
-    "daily": "Diario",
-    "once": "Única vez",
-    "progressLabel": "Progreso diario: {{completed}} / {{total}} ({{percent}}%)",
-    "xpLabel": "XP: {{xp}}",
-    "streakLabel": "Racha: {{count}} día",
-    "streakLabel_plural": "Racha: {{count}} días",
-    "dailyComplete": "¡Tareas diarias completas! Mantén la racha.",
-    "allDone": "Todas las tareas de Trail están completas — ¡excelente!"
-  },
+  "approxTotal": "Total aproximado: £{{value}}",
+  "asOf": "A fecha de {{date}} • Operaciones este mes: {{trades}} / 20 (Restantes: {{remaining}})",
   "common": {
+    "action": "Acción",
     "error": "Error",
     "loading": "Cargando…",
-    "other": "Otro",
-    "ticker": "Ticker",
     "name": "Nombre",
-    "action": "Acción",
+    "other": "Otro",
+    "period": "Período:",
     "reason": "Motivo",
-    "period": "Período:"
+    "ticker": "Ticker"
   },
-  "instrumentType": {
-    "equity": "Acción",
-    "bond": "Bono",
-    "cash": "Efectivo",
-    "etf": "ETF",
-    "fund": "Fondo",
-    "investmentTrust": "Fideicomiso de inversión",
-    "realEstate": "Bienes raíces",
-    "other": "Otro"
-  },
-  "instrumentTable": {
-    "noInstruments": "Sin instrumentos.",
-    "ungrouped": "Sin grupo",
-    "exchangesLabel": "Bolsas:",
-    "groupTotals": {
-      "market": "Mercado",
-      "gain": "Ganancia",
-      "gainPct": "Ganancia %",
-      "delta7d": "7d %",
-      "delta30d": "30d %"
+  "dashboard": {
+    "alphaVsBenchmark": "Alfa vs Referencia",
+    "cumulativeReturn": "Retorno acumulado",
+    "excludeCash": "Excluir efectivo",
+    "maxDrawdown": "Máxima caída",
+    "portfolioValue": "Valor de la cartera",
+    "range": "Rango:",
+    "rangeOptions": {
+      "10y": "10A",
+      "1m": "1M",
+      "1w": "1S",
+      "1y": "1A",
+      "max": "MÁX"
     },
+    "selectMember": "Seleccione un miembro.",
+    "timeWeightedReturn": "Rentabilidad ponderada en el tiempo",
+    "trackingError": "Error de seguimiento",
+    "xirr": "XIRR"
+  },
+  "goals": {
+    "add": "Agregar objetivo",
+    "back": "Volver al portafolio",
+    "currentAmount": "Monto actual:",
+    "goalLine": "{{name}} – objetivo {{amount}} para {{date}}",
+    "progress": "Progreso: {{progress}}%",
+    "suggestedTrades": "Operaciones sugeridas",
+    "targetAmount": "Monto objetivo",
+    "title": "Objetivos",
+    "trade": "{{action}} {{amount}} de {{ticker}}",
+    "view": "Ver"
+  },
+  "group": {
+    "atAGlance": "De un vistazo",
+    "select": "Seleccione un grupo."
+  },
+  "holdingsTable": {
+    "actualPurchaseCost": "Costo de compra real",
+    "clearFilters": "Limpiar filtros",
     "columns": {
-      "ticker": "Ticker",
-      "name": "Nombre",
+      "acquired": "Adquirido",
       "ccy": "Moneda",
+      "cost": "Coste £",
+      "daysHeld": "Días en posesión",
+      "eligible": "¿Elegible?",
+      "gain": "Ganancia £",
+      "gainPct": "Ganancia %",
+      "market": "Mkt £",
+      "name": "Nombre",
+      "price": "Precio £",
+      "stage": "Stage",
+      "ticker": "Ticker",
+      "trend": "Tendencia",
       "type": "Tipo",
       "units": "Unidades",
+      "weightPct": "Peso %"
+    },
+    "columnsLabel": "Columnas:",
+    "eligible": "Elegible",
+    "filters": {
+      "all": "Todos",
+      "gainPct": "Ganancia %",
+      "name": "Nombre",
+      "no": "No",
+      "sellEligible": "Elegible para venta",
+      "ticker": "Ticker",
+      "type": "Tipo",
+      "units": "Unidades",
+      "yes": "Sí"
+    },
+    "inferredCost": "Inferido del precio en la fecha de adquisición",
+    "minimumGainPrompt": "Ganancia mínima %",
+    "noHoldings": "No hay posiciones que coincidan con los filtros actuales.",
+    "openScreener": "Abrir Screener",
+    "quickFilters": "Filtros rápidos:",
+    "quickFiltersGainPct": "Ganancia% > x",
+    "quickFiltersSellEligible": "Elegible para venta",
+    "range": "Rango:",
+    "rangeOption": "{{count}}d",
+    "source": "Fuente:",
+    "totalRowLabel": "Total",
+    "view": "Vista:",
+    "viewPresets": {
+      "all": "Todos"
+    }
+  },
+  "instrumentadmin": {
+    "actions": "Actions",
+    "add": "Add Instrument",
+    "exchange": "Exchange",
+    "grouping": "Agrupación",
+    "name": "Name",
+    "region": "Region",
+    "save": "Save",
+    "saveError": "Error saving",
+    "saveSuccess": "Saved",
+    "searchPlaceholder": "Filter instruments…",
+    "sector": "Sector",
+    "ticker": "Ticker",
+    "validation": {
+      "grouping": "Grouping is required",
+      "name": "Name is required",
+      "ticker": "Ticker is required"
+    }
+  },
+  "instrumentDetail": {
+    "bollingerBands": "Bandas de Bollinger",
+    "change30d": "30d",
+    "change7d": "7d",
+    "columns": {
+      "account": "Cuenta",
+      "gain": "Ganancia £",
+      "gainPct": "Ganancia %",
+      "market": "Mercado £",
+      "units": "Unidades"
+    },
+    "edit": "Editar",
+    "intraday": "Intradía",
+    "intradayUnavailable": "Datos intradía no disponibles",
+    "ma20": "20d MA",
+    "ma200": "200d MA",
+    "ma50": "50d MA",
+    "noPositions": "Sin posiciones",
+    "noPriceData": "Sin datos de precios",
+    "positions": "Posiciones",
+    "priceColumns": {
+      "close": "£ Cierre",
+      "date": "Fecha",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "range": "Rango:",
+    "rangeOptions": {
+      "10y": "10A",
+      "1m": "1M",
+      "1w": "1S",
+      "1y": "1A",
+      "max": "MÁX"
+    },
+    "recentPrices": "Precios recientes",
+    "rsi": "RSI"
+  },
+  "instrumentTable": {
+    "columns": {
+      "ccy": "Moneda",
       "cost": "Coste £",
-      "market": "Valor de mercado £",
+      "delta30d": "30d %",
+      "delta7d": "7d %",
       "gain": "Ganancia £",
       "gainPct": "Ganancia %",
       "last": "Último £",
       "lastDate": "Última fecha",
+      "market": "Valor de mercado £",
+      "name": "Nombre",
+      "ticker": "Ticker",
+      "type": "Tipo",
+      "units": "Unidades"
+    },
+    "exchangesLabel": "Bolsas:",
+    "groupTotals": {
+      "delta30d": "30d %",
       "delta7d": "7d %",
-      "delta30d": "30d %"
-    }
-  },
-  "holdingsTable": {
-    "range": "Rango:",
-    "rangeOption": "{{count}}d",
-    "view": "Vista:",
-    "viewPresets": {
-      "all": "Todos"
-    },
-    "quickFilters": "Filtros rápidos:",
-    "quickFiltersSellEligible": "Elegible para venta",
-    "quickFiltersGainPct": "Ganancia% > x",
-    "minimumGainPrompt": "Ganancia mínima %",
-    "columnsLabel": "Columnas:",
-    "columns": {
-      "ticker": "Ticker",
-      "name": "Nombre",
-      "trend": "Tendencia",
-      "ccy": "Moneda",
-      "type": "Tipo",
-      "units": "Unidades",
-      "price": "Precio £",
-      "cost": "Coste £",
-      "market": "Mkt £",
-      "gain": "Ganancia £",
+      "gain": "Ganancia",
       "gainPct": "Ganancia %",
-      "weightPct": "Peso %",
-      "acquired": "Adquirido",
-      "daysHeld": "Días en posesión",
-      "stage": "Stage",
-      "eligible": "¿Elegible?"
+      "market": "Mercado"
     },
-    "filters": {
-      "ticker": "Ticker",
-      "name": "Nombre",
-      "type": "Tipo",
-      "units": "Unidades",
-      "gainPct": "Ganancia %",
-      "sellEligible": "Elegible para venta",
-      "all": "Todos",
-      "yes": "Sí",
-      "no": "No"
-    },
-    "noHoldings": "No hay posiciones que coincidan con los filtros actuales.",
-    "clearFilters": "Limpiar filtros",
-    "openScreener": "Abrir Screener",
-    "source": "Fuente:",
-    "actualPurchaseCost": "Costo de compra real",
-    "inferredCost": "Inferido del precio en la fecha de adquisición",
-    "eligible": "Elegible",
-    "totalRowLabel": "Total"
+    "noInstruments": "Sin instrumentos.",
+    "ungrouped": "Sin grupo"
   },
-  "instrumentDetail": {
-    "edit": "Editar",
-    "change7d": "7d",
-    "change30d": "30d",
-    "range": "Rango:",
-    "rangeOptions": {
-      "1w": "1S",
-      "1m": "1M",
-      "1y": "1A",
-      "10y": "10A",
-      "max": "MÁX"
-    },
-    "bollingerBands": "Bandas de Bollinger",
-    "ma20": "20d MA",
-    "ma50": "50d MA",
-    "ma200": "200d MA",
-    "rsi": "RSI",
-    "positions": "Posiciones",
-    "columns": {
-      "account": "Cuenta",
-      "units": "Unidades",
-      "market": "Mercado £",
-      "gain": "Ganancia £",
-      "gainPct": "Ganancia %"
-    },
-    "noPositions": "Sin posiciones",
-    "recentPrices": "Precios recientes",
-    "priceColumns": {
-      "date": "Fecha",
-      "close": "£ Cierre",
-      "delta": "Δ £",
-      "deltaPct": "Δ %"
-    },
-    "noPriceData": "Sin datos de precios",
-    "intraday": "Intradía",
-    "intradayUnavailable": "Datos intradía no disponibles"
+  "instrumentType": {
+    "bond": "Bono",
+    "cash": "Efectivo",
+    "equity": "Acción",
+    "etf": "ETF",
+    "fund": "Fondo",
+    "investmentTrust": "Fideicomiso de inversión",
+    "other": "Otro",
+    "realEstate": "Bienes raíces"
+  },
+  "loadingPortfolio": "Cargando portafolio…",
+  "market": {
+    "indexLevels": "Niveles de índices",
+    "latestHeadlines": "Últimos titulares",
+    "sectorPerformance": "Rendimiento por sector"
+  },
+  "movers": {
+    "excludeSmall": "Excluir posiciones <{{min}}%",
+    "loadFailed": "Error al cargar los movers{{status}}",
+    "loginPrompt": "Inicia sesión para ver los movers basados en el portafolio.",
+    "pctPortfolio": "% del portafolio",
+    "period": "Período:",
+    "signal": "Señal",
+    "watchlist": "Lista de seguimiento:"
   },
   "owner": {
     "label": "Propietario",
     "select": "Seleccione un propietario."
   },
   "pensionForecast": {
-    "currentAge": "Edad actual: {{age}}",
     "birthDate": "Fecha de nacimiento: {{dob}}",
-    "retirementAge": "Edad de jubilación: {{age}}",
-    "pensionPot": "Fondo de pensiones",
+    "currentAge": "Edad actual: {{age}}",
+    "employerContributionLabel": "Aportación del empleador",
     "growthAssumption": "Suposición de crecimiento (%):",
-    "monthlyContribution": "Contribución mensual (£):",
+    "header": {
+      "employeeContribution": "Tu aportación mensual",
+      "employerContribution": "Aportación del empleador",
+      "heading": "Controla tus aportaciones de un vistazo",
+      "kicker": "Resumen de tu pensión",
+      "linkedPotsHeading": "Fondos de pensión vinculados",
+      "noLinkedPots": "Aún no hay fondos de pensión vinculados para este titular.",
+      "notAvailable": "No disponible",
+      "pensionPot": "Fondo de pensión actual",
+      "totalContribution": "Aportaciones mensuales totales: {{total}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
-      "state": "State pension",
       "definedBenefit": "Defined benefit",
-      "definedContribution": "Defined contribution"
+      "definedContribution": "Defined contribution",
+      "state": "State pension"
     },
     "incomeTable": {
-      "source": "Source",
       "annual": "Annual (£)",
       "monthly": "Monthly (£)",
-      "share": "Share"
+      "share": "Share",
+      "source": "Source"
     },
-    "totalAnnualIncome": "Total annual income",
-    "totalMonthlyIncome": "Total monthly income",
+    "monthlyContribution": "Contribución mensual (£):",
+    "pensionPot": "Fondo de pensiones",
     "prediction": {
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available.",
       "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
       "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
       "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
-      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
-      "earliest": "Estimated earliest retirement age: {{age}}",
-      "noBreakdown": "No income breakdown available."
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then."
     },
-    "employerContributionLabel": "Aportación del empleador",
-    "header": {
-      "kicker": "Resumen de tu pensión",
-      "heading": "Controla tus aportaciones de un vistazo",
-      "pensionPot": "Fondo de pensión actual",
-      "employeeContribution": "Tu aportación mensual",
-      "employerContribution": "Aportación del empleador",
-      "totalContribution": "Aportaciones mensuales totales: {{total}}",
-      "linkedPotsHeading": "Fondos de pensión vinculados",
-      "noLinkedPots": "Aún no hay fondos de pensión vinculados para este titular.",
-      "notAvailable": "No disponible"
-    }
+    "retirementAge": "Edad de jubilación: {{age}}",
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income"
   },
-  "group": {
-    "select": "Seleccione un grupo.",
-    "atAGlance": "De un vistazo"
-  },
-  "dashboard": {
-    "selectMember": "Seleccione un miembro.",
-    "range": "Rango:",
-    "rangeOptions": {
-      "1w": "1S",
-      "1m": "1M",
-      "1y": "1A",
-      "10y": "10A",
-      "max": "MÁX"
-    },
-    "excludeCash": "Excluir efectivo",
-    "alphaVsBenchmark": "Alfa vs Referencia",
-    "trackingError": "Error de seguimiento",
-    "maxDrawdown": "Máxima caída",
-    "timeWeightedReturn": "Rentabilidad ponderada en el tiempo",
-    "xirr": "XIRR",
-    "portfolioValue": "Valor de la cartera",
-    "cumulativeReturn": "Retorno acumulado"
-  },
-  "support": {
-    "title": "Soporte",
-    "online": "En línea",
-    "onlineYes": "Sí",
-    "onlineNo": "No",
-    "environment": "Entorno",
-    "priceRefresh": "Actualización de precios",
-    "telegramMessage": "Mensaje de Telegram",
-    "send": "Enviar",
-    "status": {
-      "sent": "Enviado",
-      "error": "Error",
-      "sending": "Enviando...",
-      "saved": "Guardado",
-      "saving": "Guardando..."
-    },
-    "health": {
-      "title": "Salud del portafolio",
-      "run": "Ejecutar verificación de salud del portafolio",
-      "copyReport": "Copiar informe",
-      "error": "No se pudo ejecutar la verificación de salud"
-    },
-    "notifications": {
-      "title": "Notificaciones",
-      "notSupported": "Push no compatible",
-      "disable": "Desactivar alertas push",
-      "enable": "Activar alertas push",
-      "denied": "Permiso de push denegado.",
-      "error": "Error al manejar la suscripción push."
-    },
-    "config": {
-      "title": "Configuración",
-      "tabsEnabled": "Pestañas habilitadas",
-      "otherSwitches": "Otros interruptores",
-      "otherParams": "Otros parámetros",
-      "save": "Guardar"
-    }
-  },
-  "alertSettings": {
-    "title": "Alert Settings",
-    "description": "Configura cuándo recibirás alertas. Las alertas aparecen en la página de alertas y en las notificaciones push.",
-    "threshold": "Threshold %:",
-    "save": "Save",
-    "push": {
-      "title": "Notificaciones push",
-      "notSupported": "Push no soportado",
-      "enable": "Activar alertas push",
-      "disable": "Desactivar alertas push",
-      "denied": "Permiso de push denegado.",
-      "error": "Error al manejar la suscripción push."
-    },
-    "status": {
-      "saved": "Saved",
-      "error": "Error"
-    }
+  "portfolio": "Portafolio",
+  "query": {
+    "end": "Fin",
+    "exportCsv": "Exportar CSV",
+    "exportXlsx": "Exportar XLSX",
+    "metrics": "Métricas",
+    "owners": "Propietarios",
+    "run": "Ejecutar",
+    "running": "Ejecutando…",
+    "save": "Guardar",
+    "start": "Inicio",
+    "tickers": "Tickers"
   },
   "reports": {
-    "title": "Informes",
     "csv": "Descargar CSV",
+    "noOwners": "No owners available—check backend connection",
     "pdf": "Descargar PDF",
-    "noOwners": "No owners available—check backend connection"
+    "title": "Informes"
   },
-  "loadingPortfolio": "Cargando portafolio…",
-  "portfolio": "Portafolio",
-  "asOf": "A fecha de {{date}} • Operaciones este mes: {{trades}} / 20 (Restantes: {{remaining}})",
-  "approxTotal": "Total aproximado: £{{value}}",
-  "allocation": {
-    "instrumentTypes": "Tipos de instrumentos",
-    "sector": "Industrias",
-    "region": "Regiones"
+  "screener": {
+    "loading": "Cargando…",
+    "max52WeekHigh": "Max 52W High",
+    "max52WeekLow": "Max 52W Low",
+    "maxBeta": "Max Beta",
+    "maxDe": "D/E máx",
+    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
+    "maxLtDe": "Max LT D/E",
+    "maxPe": "P/E máx",
+    "maxPeg": "PEG máx",
+    "min52WeekLow": "Min 52W Low",
+    "minAvgVolume": "Min Avg Volume",
+    "minCurrentRatio": "Min Current Ratio",
+    "minDividendYield": "Min Dividend Yield",
+    "minEbitdaMargin": "Margen EBITDA mín",
+    "minEps": "EPS mín",
+    "minFcf": "FCF mín",
+    "minFloatShares": "Min Float Shares",
+    "minGrossMargin": "Margen bruto mín",
+    "minInterestCoverage": "Min Interest Coverage",
+    "minMarketCap": "Min Market Cap",
+    "minNetMargin": "Margen neto mín",
+    "minOperatingMargin": "Margen operativo mín",
+    "minQuickRatio": "Min Quick Ratio",
+    "minRoa": "ROA mín",
+    "minRoe": "ROE mín",
+    "minRoi": "ROI mín",
+    "minSharesOutstanding": "Min Shares Outstanding",
+    "run": "Ejecutar",
+    "tickers": "Tickers",
+    "watchlist": "Lista de seguimiento:"
   },
-  "watchlist": {
-    "refresh": "Actualizar"
-  },
-  "trading": {
-    "noPositions": "Sin posiciones.",
-    "noSignals": "Sin señales."
-  },
-  "movers": {
-    "watchlist": "Lista de seguimiento:",
-    "period": "Período:",
-    "excludeSmall": "Excluir posiciones <{{min}}%",
-    "loginPrompt": "Inicia sesión para ver los movers basados en el portafolio.",
-    "loadFailed": "Error al cargar los movers{{status}}",
-    "signal": "Señal",
-    "pctPortfolio": "% del portafolio"
+  "support": {
+    "config": {
+      "otherParams": "Otros parámetros",
+      "otherSwitches": "Otros interruptores",
+      "save": "Guardar",
+      "tabsEnabled": "Pestañas habilitadas",
+      "title": "Configuración"
+    },
+    "environment": "Entorno",
+    "health": {
+      "copyReport": "Copiar informe",
+      "error": "No se pudo ejecutar la verificación de salud",
+      "run": "Ejecutar verificación de salud del portafolio",
+      "title": "Salud del portafolio"
+    },
+    "notifications": {
+      "denied": "Permiso de push denegado.",
+      "disable": "Desactivar alertas push",
+      "enable": "Activar alertas push",
+      "error": "Error al manejar la suscripción push.",
+      "notSupported": "Push no compatible",
+      "title": "Notificaciones"
+    },
+    "online": "En línea",
+    "onlineNo": "No",
+    "onlineYes": "Sí",
+    "priceRefresh": "Actualización de precios",
+    "send": "Enviar",
+    "status": {
+      "error": "Error",
+      "saved": "Guardado",
+      "saving": "Guardando...",
+      "sending": "Enviando...",
+      "sent": "Enviado"
+    },
+    "telegramMessage": "Mensaje de Telegram",
+    "title": "Soporte"
   },
   "timeseries": {
     "loading": "Cargando…"
   },
   "timeseriesEdit": {
-    "title": "Editor de series temporales",
-    "ticker": "Ticker",
-    "exchange": "Bolsa",
-    "load": "Cargar",
     "addRow": "Añadir fila",
-    "save": "Guardar",
-    "delete": "Eliminar",
     "columns": {
+      "close": "Cierre",
       "date": "Fecha",
-      "open": "Apertura",
       "high": "Máximo",
       "low": "Mínimo",
-      "close": "Cierre",
-      "volume": "Volumen",
+      "open": "Apertura",
+      "source": "Fuente",
       "ticker": "Ticker",
-      "source": "Fuente"
+      "volume": "Volumen"
     },
+    "delete": "Eliminar",
+    "error": {
+      "noData": "No hay datos para guardar",
+      "unexpectedColumns": "Columna(s) inesperada(s): {{columns}}"
+    },
+    "exchange": "Bolsa",
+    "load": "Cargar",
+    "save": "Guardar",
     "status": {
       "loaded": "Cargadas {{count}} filas",
       "saved": "Guardadas {{count}} filas"
     },
-    "error": {
-      "noData": "No hay datos para guardar",
-      "unexpectedColumns": "Columna(s) inesperada(s): {{columns}}"
-    }
-  },
-  "query": {
-    "start": "Inicio",
-    "end": "Fin",
-    "owners": "Propietarios",
-    "tickers": "Tickers",
-    "metrics": "Métricas",
-    "run": "Ejecutar",
-    "running": "Ejecutando…",
-    "save": "Guardar",
-    "exportCsv": "Exportar CSV",
-    "exportXlsx": "Exportar XLSX"
-  },
-  "screener": {
-    "watchlist": "Lista de seguimiento:",
-    "tickers": "Tickers",
-    "maxPeg": "PEG máx",
-    "maxPe": "P/E máx",
-    "maxDe": "D/E máx",
-    "maxLtDe": "Max LT D/E",
-    "minInterestCoverage": "Min Interest Coverage",
-    "minCurrentRatio": "Min Current Ratio",
-    "minQuickRatio": "Min Quick Ratio",
-    "minFcf": "FCF mín",
-    "minEps": "EPS mín",
-    "minGrossMargin": "Margen bruto mín",
-    "minOperatingMargin": "Margen operativo mín",
-    "minNetMargin": "Margen neto mín",
-    "minEbitdaMargin": "Margen EBITDA mín",
-    "minRoa": "ROA mín",
-    "minRoe": "ROE mín",
-    "minRoi": "ROI mín",
-    "minDividendYield": "Min Dividend Yield",
-    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
-    "maxBeta": "Max Beta",
-    "minSharesOutstanding": "Min Shares Outstanding",
-    "minFloatShares": "Min Float Shares",
-    "minMarketCap": "Min Market Cap",
-    "max52WeekHigh": "Max 52W High",
-    "max52WeekLow": "Max 52W Low",
-    "min52WeekLow": "Min 52W Low",
-    "minAvgVolume": "Min Avg Volume",
-    "run": "Ejecutar",
-    "loading": "Cargando…"
-  },
-  "instrumentadmin": {
     "ticker": "Ticker",
-    "exchange": "Exchange",
-    "name": "Name",
-    "region": "Region",
-    "sector": "Sector",
-    "grouping": "Agrupación",
-    "actions": "Actions",
-    "add": "Add Instrument",
-    "save": "Save",
-    "saveSuccess": "Saved",
-    "saveError": "Error saving",
-    "searchPlaceholder": "Filter instruments…",
-    "validation": {
-      "ticker": "Ticker is required",
-      "name": "Name is required",
-      "grouping": "Grouping is required"
-    }
+    "title": "Editor de series temporales"
+  },
+  "trading": {
+    "noPositions": "Sin posiciones.",
+    "noSignals": "Sin señales."
+  },
+  "trail": {
+    "allDone": "Todas las tareas de Trail están completas — ¡excelente!",
+    "daily": "Diario",
+    "dailyComplete": "¡Tareas diarias completas! Mantén la racha.",
+    "once": "Única vez",
+    "progressLabel": "Progreso diario: {{completed}} / {{total}} ({{percent}}%)",
+    "streakLabel": "Racha: {{count}} día",
+    "streakLabel_plural": "Racha: {{count}} días",
+    "title": "Progreso del Trail",
+    "xpLabel": "XP: {{xp}}"
   },
   "var": {
-    "title": "Valor en Riesgo",
     "details": "Detalles de la simulación histórica",
-    "noData": "No hay datos de VaR disponibles."
+    "noData": "No hay datos de VaR disponibles.",
+    "title": "Valor en Riesgo"
   },
-  "market": {
-    "indexLevels": "Niveles de índices",
-    "sectorPerformance": "Rendimiento por sector",
-    "latestHeadlines": "Últimos titulares"
-  },
-  "goals": {
-    "title": "Objetivos",
-    "targetAmount": "Monto objetivo",
-    "add": "Agregar objetivo",
-    "currentAmount": "Monto actual:",
-    "goalLine": "{{name}} – objetivo {{amount}} para {{date}}",
-    "view": "Ver",
-    "progress": "Progreso: {{progress}}%",
-    "suggestedTrades": "Operaciones sugeridas",
-    "trade": "{{action}} {{amount}} de {{ticker}}",
-    "back": "Volver al portafolio"
+  "watchlist": {
+    "refresh": "Actualizar"
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,14 +1,37 @@
 {
+  "alertSettings": {
+    "description": "Configurez quand vous recevrez des alertes. Les alertes apparaissent sur la page des alertes et dans les notifications push.",
+    "push": {
+      "denied": "Permission de push refusée.",
+      "disable": "Désactiver les alertes Push",
+      "enable": "Activer les alertes Push",
+      "error": "Erreur lors de la gestion de l'abonnement push.",
+      "notSupported": "Push non supporté",
+      "title": "Notifications push"
+    },
+    "save": "Save",
+    "status": {
+      "error": "Error",
+      "saved": "Saved"
+    },
+    "threshold": "Threshold %:",
+    "title": "Alert Settings"
+  },
+  "allocation": {
+    "instrumentTypes": "Types d'instruments",
+    "region": "Régions",
+    "sector": "Secteurs"
+  },
   "app": {
-    "relativeView": "Vue relative",
-    "refreshPrices": "Rafraîchir les prix",
-    "refreshing": "Rafraîchissement…",
     "last": "Dernier :",
     "loading": "Chargement…",
-    "supportLink": "Support",
-    "userLink": "App",
-    "research": "Recherche",
     "logout": "Déconnexion",
+    "logs": {
+      "empty": "Aucun journal disponible.",
+      "error": "Impossible de charger les journaux.",
+      "refresh": "Actualiser les journaux",
+      "title": "Journaux"
+    },
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Tableau de bord",
@@ -46,428 +69,405 @@
       "transactions": "Transactions",
       "watchlist": "Liste de suivi"
     },
-    "logs": {
-      "title": "Journaux",
-      "refresh": "Actualiser les journaux",
-      "empty": "Aucun journal disponible.",
-      "error": "Impossible de charger les journaux."
-    }
+    "refreshing": "Rafraîchissement…",
+    "refreshPrices": "Rafraîchir les prix",
+    "relativeView": "Vue relative",
+    "research": "Recherche",
+    "supportLink": "Support",
+    "userLink": "App"
   },
-  "trail": {
-    "title": "Progression du Trail",
-    "daily": "Quotidien",
-    "once": "Une fois",
-    "progressLabel": "Progression du jour : {{completed}} / {{total}} ({{percent}} %)",
-    "xpLabel": "XP : {{xp}}",
-    "streakLabel": "Série : {{count}} jour",
-    "streakLabel_plural": "Série : {{count}} jours",
-    "dailyComplete": "Tâches quotidiennes terminées ! Continuez la série.",
-    "allDone": "Toutes les tâches du Trail sont terminées — formidable !"
-  },
+  "approxTotal": "Total approximatif: £{{value}}",
+  "asOf": "Au {{date}} • Transactions ce mois: {{trades}} / 20 (Restantes: {{remaining}})",
   "common": {
+    "action": "Action",
     "error": "Erreur",
     "loading": "Chargement…",
-    "other": "Autre",
-    "ticker": "Ticker",
     "name": "Nom",
-    "action": "Action",
+    "other": "Autre",
+    "period": "Période:",
     "reason": "Raison",
-    "period": "Période:"
+    "ticker": "Ticker"
   },
-  "instrumentType": {
-    "equity": "Action",
-    "bond": "Obligation",
-    "cash": "Espèces",
-    "etf": "ETF",
-    "fund": "Fonds",
-    "investmentTrust": "Fiducie de placement",
-    "realEstate": "Immobilier",
-    "other": "Autre"
-  },
-  "instrumentTable": {
-    "noInstruments": "Aucun instrument.",
-    "ungrouped": "Non groupé",
-    "exchangesLabel": "Bourses :",
-    "groupTotals": {
-      "market": "Valeur",
-      "gain": "Gain",
-      "gainPct": "Gain %",
-      "delta7d": "7j %",
-      "delta30d": "30j %"
+  "dashboard": {
+    "alphaVsBenchmark": "Alpha vs Indice",
+    "cumulativeReturn": "Rendement cumulatif",
+    "excludeCash": "Exclure la trésorerie",
+    "maxDrawdown": "Drawdown maximal",
+    "portfolioValue": "Valeur du portefeuille",
+    "range": "Plage :",
+    "rangeOptions": {
+      "10y": "10A",
+      "1m": "1M",
+      "1w": "1S",
+      "1y": "1A",
+      "max": "MAX"
     },
+    "selectMember": "Sélectionnez un membre.",
+    "timeWeightedReturn": "Rendement pondéré dans le temps",
+    "trackingError": "Erreur de suivi",
+    "xirr": "XIRR"
+  },
+  "goals": {
+    "add": "Ajouter un objectif",
+    "back": "Retour au portefeuille",
+    "currentAmount": "Montant actuel:",
+    "goalLine": "{{name}} – objectif {{amount}} d'ici {{date}}",
+    "progress": "Progrès: {{progress}}%",
+    "suggestedTrades": "Transactions suggérées",
+    "targetAmount": "Montant cible",
+    "title": "Objectifs",
+    "trade": "{{action}} {{amount}} de {{ticker}}",
+    "view": "Voir"
+  },
+  "group": {
+    "atAGlance": "En un coup d'œil",
+    "select": "Sélectionnez un groupe."
+  },
+  "holdingsTable": {
+    "actualPurchaseCost": "Coût d'achat réel",
+    "clearFilters": "Effacer les filtres",
     "columns": {
-      "ticker": "Ticker",
-      "name": "Nom",
+      "acquired": "Acquis",
       "ccy": "Devise",
+      "cost": "Coût £",
+      "daysHeld": "Jours détenus",
+      "eligible": "Éligible ?",
+      "gain": "Gain £",
+      "gainPct": "Gain %",
+      "market": "Mkt £",
+      "name": "Nom",
+      "price": "Prix £",
+      "stage": "Stage",
+      "ticker": "Ticker",
+      "trend": "Tendance",
       "type": "Type",
       "units": "Unités",
+      "weightPct": "Poids %"
+    },
+    "columnsLabel": "Colonnes :",
+    "eligible": "Éligible",
+    "filters": {
+      "all": "Tous",
+      "gainPct": "Gain %",
+      "name": "Nom",
+      "no": "Non",
+      "sellEligible": "Éligible à la vente",
+      "ticker": "Ticker",
+      "type": "Type",
+      "units": "Unités",
+      "yes": "Oui"
+    },
+    "inferredCost": "Déduit du prix à la date d'acquisition",
+    "minimumGainPrompt": "Gain minimal %",
+    "noHoldings": "Aucune position ne correspond aux filtres actuels.",
+    "openScreener": "Ouvrir le Screener",
+    "quickFilters": "Filtres rapides :",
+    "quickFiltersGainPct": "Gain % > x",
+    "quickFiltersSellEligible": "Éligible à la vente",
+    "range": "Plage :",
+    "rangeOption": "{{count}}j",
+    "source": "Source :",
+    "totalRowLabel": "Total",
+    "view": "Vue :",
+    "viewPresets": {
+      "all": "Tous"
+    }
+  },
+  "instrumentadmin": {
+    "actions": "Actions",
+    "add": "Add Instrument",
+    "exchange": "Exchange",
+    "grouping": "Regroupement",
+    "name": "Name",
+    "region": "Region",
+    "save": "Save",
+    "saveError": "Error saving",
+    "saveSuccess": "Saved",
+    "searchPlaceholder": "Filter instruments…",
+    "sector": "Sector",
+    "ticker": "Ticker",
+    "validation": {
+      "grouping": "Grouping is required",
+      "name": "Name is required",
+      "ticker": "Ticker is required"
+    }
+  },
+  "instrumentDetail": {
+    "bollingerBands": "Bandes de Bollinger",
+    "change30d": "30j",
+    "change7d": "7j",
+    "columns": {
+      "account": "Compte",
+      "gain": "Gain £",
+      "gainPct": "Gain %",
+      "market": "Mkt £",
+      "units": "Unités"
+    },
+    "edit": "Modifier",
+    "intraday": "Intraday",
+    "intradayUnavailable": "Données intraday indisponibles",
+    "ma20": "20d MA",
+    "ma200": "200d MA",
+    "ma50": "50d MA",
+    "noPositions": "Aucune position",
+    "noPriceData": "Pas de données de prix",
+    "positions": "Positions",
+    "priceColumns": {
+      "close": "£ Clôture",
+      "date": "Date",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "range": "Plage :",
+    "rangeOptions": {
+      "10y": "10A",
+      "1m": "1M",
+      "1w": "1S",
+      "1y": "1A",
+      "max": "MAX"
+    },
+    "recentPrices": "Prix récents",
+    "rsi": "RSI"
+  },
+  "instrumentTable": {
+    "columns": {
+      "ccy": "Devise",
       "cost": "Coût £",
-      "market": "Valeur £",
+      "delta30d": "30j %",
+      "delta7d": "7j %",
       "gain": "Gain £",
       "gainPct": "Gain %",
       "last": "Dernier £",
       "lastDate": "Date",
+      "market": "Valeur £",
+      "name": "Nom",
+      "ticker": "Ticker",
+      "type": "Type",
+      "units": "Unités"
+    },
+    "exchangesLabel": "Bourses :",
+    "groupTotals": {
+      "delta30d": "30j %",
       "delta7d": "7j %",
-      "delta30d": "30j %"
-    }
-  },
-  "holdingsTable": {
-    "range": "Plage :",
-    "rangeOption": "{{count}}j",
-    "view": "Vue :",
-    "viewPresets": {
-      "all": "Tous"
-    },
-    "quickFilters": "Filtres rapides :",
-    "quickFiltersSellEligible": "Éligible à la vente",
-    "quickFiltersGainPct": "Gain % > x",
-    "minimumGainPrompt": "Gain minimal %",
-    "columnsLabel": "Colonnes :",
-    "columns": {
-      "ticker": "Ticker",
-      "name": "Nom",
-      "trend": "Tendance",
-      "ccy": "Devise",
-      "type": "Type",
-      "units": "Unités",
-      "price": "Prix £",
-      "cost": "Coût £",
-      "market": "Mkt £",
-      "gain": "Gain £",
+      "gain": "Gain",
       "gainPct": "Gain %",
-      "weightPct": "Poids %",
-      "acquired": "Acquis",
-      "daysHeld": "Jours détenus",
-      "stage": "Stage",
-      "eligible": "Éligible ?"
+      "market": "Valeur"
     },
-    "filters": {
-      "ticker": "Ticker",
-      "name": "Nom",
-      "type": "Type",
-      "units": "Unités",
-      "gainPct": "Gain %",
-      "sellEligible": "Éligible à la vente",
-      "all": "Tous",
-      "yes": "Oui",
-      "no": "Non"
-    },
-    "noHoldings": "Aucune position ne correspond aux filtres actuels.",
-    "clearFilters": "Effacer les filtres",
-    "openScreener": "Ouvrir le Screener",
-    "source": "Source :",
-    "actualPurchaseCost": "Coût d'achat réel",
-    "inferredCost": "Déduit du prix à la date d'acquisition",
-    "eligible": "Éligible",
-    "totalRowLabel": "Total"
+    "noInstruments": "Aucun instrument.",
+    "ungrouped": "Non groupé"
   },
-  "instrumentDetail": {
-    "edit": "Modifier",
-    "change7d": "7j",
-    "change30d": "30j",
-    "range": "Plage :",
-    "rangeOptions": {
-      "1w": "1S",
-      "1m": "1M",
-      "1y": "1A",
-      "10y": "10A",
-      "max": "MAX"
-    },
-    "bollingerBands": "Bandes de Bollinger",
-    "ma20": "20d MA",
-    "ma50": "50d MA",
-    "ma200": "200d MA",
-    "rsi": "RSI",
-    "positions": "Positions",
-    "columns": {
-      "account": "Compte",
-      "units": "Unités",
-      "market": "Mkt £",
-      "gain": "Gain £",
-      "gainPct": "Gain %"
-    },
-    "noPositions": "Aucune position",
-    "recentPrices": "Prix récents",
-    "priceColumns": {
-      "date": "Date",
-      "close": "£ Clôture",
-      "delta": "Δ £",
-      "deltaPct": "Δ %"
-    },
-    "noPriceData": "Pas de données de prix",
-    "intraday": "Intraday",
-    "intradayUnavailable": "Données intraday indisponibles"
+  "instrumentType": {
+    "bond": "Obligation",
+    "cash": "Espèces",
+    "equity": "Action",
+    "etf": "ETF",
+    "fund": "Fonds",
+    "investmentTrust": "Fiducie de placement",
+    "other": "Autre",
+    "realEstate": "Immobilier"
+  },
+  "loadingPortfolio": "Chargement du portefeuille…",
+  "market": {
+    "indexLevels": "Niveaux des indices",
+    "latestHeadlines": "Derniers titres",
+    "sectorPerformance": "Performance des secteurs"
+  },
+  "movers": {
+    "excludeSmall": "Exclure les positions <{{min}} %",
+    "loadFailed": "Échec du chargement des movers{{status}}",
+    "loginPrompt": "Veuillez vous connecter pour afficher les movers basés sur le portefeuille.",
+    "pctPortfolio": "% du portefeuille",
+    "period": "Période :",
+    "signal": "Signal",
+    "watchlist": "Liste de suivi :"
   },
   "owner": {
     "label": "Propriétaire",
     "select": "Sélectionnez un propriétaire."
   },
   "pensionForecast": {
-    "currentAge": "Âge actuel : {{age}}",
     "birthDate": "Date de naissance : {{dob}}",
-    "retirementAge": "Âge de retraite : {{age}}",
-    "pensionPot": "Pot de pension",
+    "currentAge": "Âge actuel : {{age}}",
+    "employerContributionLabel": "Contribution de l'employeur",
     "growthAssumption": "Hypothèse de croissance (%):",
-    "monthlyContribution": "Contribution mensuelle (£):",
+    "header": {
+      "employeeContribution": "Votre cotisation mensuelle",
+      "employerContribution": "Contribution de l'employeur",
+      "heading": "Suivez vos cotisations en un coup d’œil",
+      "kicker": "Aperçu de votre pension",
+      "linkedPotsHeading": "Pots de pension associés",
+      "noLinkedPots": "Aucun pot de pension associé pour ce titulaire pour le moment.",
+      "notAvailable": "Non disponible",
+      "pensionPot": "Épargne retraite actuelle",
+      "totalContribution": "Cotisations mensuelles totales : {{total}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
-      "state": "State pension",
       "definedBenefit": "Defined benefit",
-      "definedContribution": "Defined contribution"
+      "definedContribution": "Defined contribution",
+      "state": "State pension"
     },
     "incomeTable": {
-      "source": "Source",
       "annual": "Annual (£)",
       "monthly": "Monthly (£)",
-      "share": "Share"
+      "share": "Share",
+      "source": "Source"
     },
-    "totalAnnualIncome": "Total annual income",
-    "totalMonthlyIncome": "Total monthly income",
+    "monthlyContribution": "Contribution mensuelle (£):",
+    "pensionPot": "Pot de pension",
     "prediction": {
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available.",
       "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
       "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
       "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
-      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
-      "earliest": "Estimated earliest retirement age: {{age}}",
-      "noBreakdown": "No income breakdown available."
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then."
     },
-    "employerContributionLabel": "Contribution de l'employeur",
-    "header": {
-      "kicker": "Aperçu de votre pension",
-      "heading": "Suivez vos cotisations en un coup d’œil",
-      "pensionPot": "Épargne retraite actuelle",
-      "employeeContribution": "Votre cotisation mensuelle",
-      "employerContribution": "Contribution de l'employeur",
-      "totalContribution": "Cotisations mensuelles totales : {{total}}",
-      "linkedPotsHeading": "Pots de pension associés",
-      "noLinkedPots": "Aucun pot de pension associé pour ce titulaire pour le moment.",
-      "notAvailable": "Non disponible"
-    }
+    "retirementAge": "Âge de retraite : {{age}}",
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income"
   },
-  "group": {
-    "select": "Sélectionnez un groupe.",
-    "atAGlance": "En un coup d'œil"
-  },
-  "dashboard": {
-    "selectMember": "Sélectionnez un membre.",
-    "range": "Plage :",
-    "rangeOptions": {
-      "1w": "1S",
-      "1m": "1M",
-      "1y": "1A",
-      "10y": "10A",
-      "max": "MAX"
-    },
-    "excludeCash": "Exclure la trésorerie",
-    "alphaVsBenchmark": "Alpha vs Indice",
-    "trackingError": "Erreur de suivi",
-    "maxDrawdown": "Drawdown maximal",
-    "timeWeightedReturn": "Rendement pondéré dans le temps",
-    "xirr": "XIRR",
-    "portfolioValue": "Valeur du portefeuille",
-    "cumulativeReturn": "Rendement cumulatif"
-  },
-  "support": {
-    "title": "Support",
-    "online": "En ligne",
-    "onlineYes": "Oui",
-    "onlineNo": "Non",
-    "environment": "Environnement",
-    "priceRefresh": "Actualisation des prix",
-    "telegramMessage": "Message Telegram",
-    "send": "Envoyer",
-    "status": {
-      "sent": "Envoyé",
-      "error": "Erreur",
-      "sending": "Envoi...",
-      "saved": "Enregistré",
-      "saving": "Enregistrement..."
-    },
-    "health": {
-      "title": "Santé du portefeuille",
-      "run": "Exécuter la vérification de santé du portefeuille",
-      "copyReport": "Copier le rapport",
-      "error": "Échec de la vérification de santé"
-    },
-    "notifications": {
-      "title": "Notifications",
-      "notSupported": "Push non supporté",
-      "disable": "Désactiver les alertes Push",
-      "enable": "Activer les alertes Push",
-      "denied": "Permission de push refusée.",
-      "error": "Erreur lors de la gestion de l'abonnement push."
-    },
-    "config": {
-      "title": "Configuration",
-      "tabsEnabled": "Onglets activés",
-      "otherSwitches": "Autres commutateurs",
-      "otherParams": "Autres paramètres",
-      "save": "Enregistrer"
-    }
-  },
-  "alertSettings": {
-    "title": "Alert Settings",
-    "description": "Configurez quand vous recevrez des alertes. Les alertes apparaissent sur la page des alertes et dans les notifications push.",
-    "threshold": "Threshold %:",
-    "save": "Save",
-    "push": {
-      "title": "Notifications push",
-      "notSupported": "Push non supporté",
-      "enable": "Activer les alertes Push",
-      "disable": "Désactiver les alertes Push",
-      "denied": "Permission de push refusée.",
-      "error": "Erreur lors de la gestion de l'abonnement push."
-    },
-    "status": {
-      "saved": "Saved",
-      "error": "Error"
-    }
+  "portfolio": "Portefeuille",
+  "query": {
+    "copyLink": "Copier le lien",
+    "end": "Fin",
+    "exportCsv": "Exporter CSV",
+    "exportXlsx": "Exporter XLSX",
+    "metrics": "Métriques",
+    "owners": "Propriétaires",
+    "run": "Exécuter",
+    "running": "Exécution…",
+    "save": "Enregistrer",
+    "start": "Début",
+    "tickers": "Tickers"
   },
   "reports": {
-    "title": "Rapports",
     "csv": "Télécharger CSV",
+    "noOwners": "No owners available—check backend connection",
     "pdf": "Télécharger PDF",
-    "noOwners": "No owners available—check backend connection"
+    "title": "Rapports"
   },
-  "loadingPortfolio": "Chargement du portefeuille…",
-  "portfolio": "Portefeuille",
-  "asOf": "Au {{date}} • Transactions ce mois: {{trades}} / 20 (Restantes: {{remaining}})",
-  "approxTotal": "Total approximatif: £{{value}}",
-  "allocation": {
-    "instrumentTypes": "Types d'instruments",
-    "sector": "Secteurs",
-    "region": "Régions"
+  "screener": {
+    "loading": "Chargement…",
+    "max52WeekHigh": "Max 52W High",
+    "max52WeekLow": "Max 52W Low",
+    "maxBeta": "Max Beta",
+    "maxDe": "D/E max",
+    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
+    "maxLtDe": "Max LT D/E",
+    "maxPe": "P/E max",
+    "maxPeg": "PEG max",
+    "min52WeekLow": "Min 52W Low",
+    "minAvgVolume": "Min Avg Volume",
+    "minCurrentRatio": "Min Current Ratio",
+    "minDividendYield": "Min Dividend Yield",
+    "minEbitdaMargin": "Marge EBITDA min",
+    "minEps": "BPA min",
+    "minFcf": "FCF min",
+    "minFloatShares": "Min Float Shares",
+    "minGrossMargin": "Marge brute min",
+    "minInterestCoverage": "Min Interest Coverage",
+    "minMarketCap": "Min Market Cap",
+    "minNetMargin": "Marge nette min",
+    "minOperatingMargin": "Marge opérationnelle min",
+    "minQuickRatio": "Min Quick Ratio",
+    "minRoa": "ROA min",
+    "minRoe": "ROE min",
+    "minRoi": "ROI min",
+    "minSharesOutstanding": "Min Shares Outstanding",
+    "run": "Exécuter",
+    "tickers": "Tickers",
+    "watchlist": "Liste de suivi:"
   },
-  "watchlist": {
-    "refresh": "Actualiser"
-  },
-  "trading": {
-    "noPositions": "Aucune position.",
-    "noSignals": "Aucun signal."
-  },
-  "movers": {
-    "watchlist": "Liste de suivi :",
-    "period": "Période :",
-    "excludeSmall": "Exclure les positions <{{min}} %",
-    "loginPrompt": "Veuillez vous connecter pour afficher les movers basés sur le portefeuille.",
-    "loadFailed": "Échec du chargement des movers{{status}}",
-    "signal": "Signal",
-    "pctPortfolio": "% du portefeuille"
+  "support": {
+    "config": {
+      "otherParams": "Autres paramètres",
+      "otherSwitches": "Autres commutateurs",
+      "save": "Enregistrer",
+      "tabsEnabled": "Onglets activés",
+      "title": "Configuration"
+    },
+    "environment": "Environnement",
+    "health": {
+      "copyReport": "Copier le rapport",
+      "error": "Échec de la vérification de santé",
+      "run": "Exécuter la vérification de santé du portefeuille",
+      "title": "Santé du portefeuille"
+    },
+    "notifications": {
+      "denied": "Permission de push refusée.",
+      "disable": "Désactiver les alertes Push",
+      "enable": "Activer les alertes Push",
+      "error": "Erreur lors de la gestion de l'abonnement push.",
+      "notSupported": "Push non supporté",
+      "title": "Notifications"
+    },
+    "online": "En ligne",
+    "onlineNo": "Non",
+    "onlineYes": "Oui",
+    "priceRefresh": "Actualisation des prix",
+    "send": "Envoyer",
+    "status": {
+      "error": "Erreur",
+      "saved": "Enregistré",
+      "saving": "Enregistrement...",
+      "sending": "Envoi...",
+      "sent": "Envoyé"
+    },
+    "telegramMessage": "Message Telegram",
+    "title": "Support"
   },
   "timeseries": {
     "loading": "Chargement…"
   },
   "timeseriesEdit": {
-    "title": "Éditeur de séries temporelles",
-    "ticker": "Ticker",
-    "exchange": "Bourse",
-    "load": "Charger",
     "addRow": "Ajouter une ligne",
-    "save": "Enregistrer",
-    "delete": "Supprimer",
     "columns": {
+      "close": "Clôture",
       "date": "Date",
-      "open": "Ouverture",
       "high": "Haut",
       "low": "Bas",
-      "close": "Clôture",
-      "volume": "Volume",
+      "open": "Ouverture",
+      "source": "Source",
       "ticker": "Ticker",
-      "source": "Source"
+      "volume": "Volume"
     },
+    "delete": "Supprimer",
+    "error": {
+      "noData": "Pas de données à enregistrer",
+      "unexpectedColumns": "Colonne(s) inattendue(s) : {{columns}}"
+    },
+    "exchange": "Bourse",
+    "load": "Charger",
+    "save": "Enregistrer",
     "status": {
       "loaded": "Chargé {{count}} lignes",
       "saved": "Enregistré {{count}} lignes"
     },
-    "error": {
-      "noData": "Pas de données à enregistrer",
-      "unexpectedColumns": "Colonne(s) inattendue(s) : {{columns}}"
-    }
-  },
-  "query": {
-    "start": "Début",
-    "end": "Fin",
-    "owners": "Propriétaires",
-    "tickers": "Tickers",
-    "metrics": "Métriques",
-    "run": "Exécuter",
-    "running": "Exécution…",
-    "save": "Enregistrer",
-    "copyLink": "Copier le lien",
-    "exportCsv": "Exporter CSV",
-    "exportXlsx": "Exporter XLSX"
-  },
-  "screener": {
-    "watchlist": "Liste de suivi:",
-    "tickers": "Tickers",
-    "maxPeg": "PEG max",
-    "maxPe": "P/E max",
-    "maxDe": "D/E max",
-    "maxLtDe": "Max LT D/E",
-    "minInterestCoverage": "Min Interest Coverage",
-    "minCurrentRatio": "Min Current Ratio",
-    "minQuickRatio": "Min Quick Ratio",
-    "minFcf": "FCF min",
-    "minEps": "BPA min",
-    "minGrossMargin": "Marge brute min",
-    "minOperatingMargin": "Marge opérationnelle min",
-    "minNetMargin": "Marge nette min",
-    "minEbitdaMargin": "Marge EBITDA min",
-    "minRoa": "ROA min",
-    "minRoe": "ROE min",
-    "minRoi": "ROI min",
-    "minDividendYield": "Min Dividend Yield",
-    "maxDividendPayoutRatio": "Max Dividend Payout Ratio",
-    "maxBeta": "Max Beta",
-    "minSharesOutstanding": "Min Shares Outstanding",
-    "minFloatShares": "Min Float Shares",
-    "minMarketCap": "Min Market Cap",
-    "max52WeekHigh": "Max 52W High",
-    "max52WeekLow": "Max 52W Low",
-    "min52WeekLow": "Min 52W Low",
-    "minAvgVolume": "Min Avg Volume",
-    "run": "Exécuter",
-    "loading": "Chargement…"
-  },
-  "instrumentadmin": {
     "ticker": "Ticker",
-    "exchange": "Exchange",
-    "name": "Name",
-    "region": "Region",
-    "sector": "Sector",
-    "grouping": "Regroupement",
-    "actions": "Actions",
-    "add": "Add Instrument",
-    "save": "Save",
-    "saveSuccess": "Saved",
-    "saveError": "Error saving",
-    "searchPlaceholder": "Filter instruments…",
-    "validation": {
-      "ticker": "Ticker is required",
-      "name": "Name is required",
-      "grouping": "Grouping is required"
-    }
+    "title": "Éditeur de séries temporelles"
+  },
+  "trading": {
+    "noPositions": "Aucune position.",
+    "noSignals": "Aucun signal."
+  },
+  "trail": {
+    "allDone": "Toutes les tâches du Trail sont terminées — formidable !",
+    "daily": "Quotidien",
+    "dailyComplete": "Tâches quotidiennes terminées ! Continuez la série.",
+    "once": "Une fois",
+    "progressLabel": "Progression du jour : {{completed}} / {{total}} ({{percent}} %)",
+    "streakLabel": "Série : {{count}} jour",
+    "streakLabel_plural": "Série : {{count}} jours",
+    "title": "Progression du Trail",
+    "xpLabel": "XP : {{xp}}"
   },
   "var": {
-    "title": "Valeur à risque",
     "details": "Détails de la simulation historique",
-    "noData": "Pas de données VaR disponibles."
+    "noData": "Pas de données VaR disponibles.",
+    "title": "Valeur à risque"
   },
-  "market": {
-    "indexLevels": "Niveaux des indices",
-    "sectorPerformance": "Performance des secteurs",
-    "latestHeadlines": "Derniers titres"
-  },
-  "goals": {
-    "title": "Objectifs",
-    "targetAmount": "Montant cible",
-    "add": "Ajouter un objectif",
-    "currentAmount": "Montant actuel:",
-    "goalLine": "{{name}} – objectif {{amount}} d'ici {{date}}",
-    "view": "Voir",
-    "progress": "Progrès: {{progress}}%",
-    "suggestedTrades": "Transactions suggérées",
-    "trade": "{{action}} {{amount}} de {{ticker}}",
-    "back": "Retour au portefeuille"
+  "watchlist": {
+    "refresh": "Actualiser"
   }
 }

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -1,14 +1,37 @@
 {
+  "alertSettings": {
+    "description": "Configura quando riceverai avvisi. Gli avvisi compaiono nella pagina degli avvisi e nelle notifiche push.",
+    "push": {
+      "denied": "Autorizzazione push negata.",
+      "disable": "Disattiva avvisi push",
+      "enable": "Attiva avvisi push",
+      "error": "Errore nella gestione dell'iscrizione push.",
+      "notSupported": "Push non supportato",
+      "title": "Notifiche push"
+    },
+    "save": "Save",
+    "status": {
+      "error": "Error",
+      "saved": "Saved"
+    },
+    "threshold": "Threshold %:",
+    "title": "Alert Settings"
+  },
+  "allocation": {
+    "instrumentTypes": "Tipi di strumenti",
+    "region": "Regioni",
+    "sector": "Industrie"
+  },
   "app": {
-    "relativeView": "Vista relativa",
-    "refreshPrices": "Aggiorna i prezzi",
-    "refreshing": "Rinfrescante…",
     "last": "Scorso:",
     "loading": "Caricamento…",
-    "supportLink": "Supporto",
-    "userLink": "App",
-    "research": "Ricerca",
     "logout": "Logout",
+    "logs": {
+      "empty": "Nessun log disponibile.",
+      "error": "Impossibile caricare i log.",
+      "refresh": "Aggiorna log",
+      "title": "Log"
+    },
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Dashboard",
@@ -46,428 +69,405 @@
       "transactions": "Transazioni",
       "watchlist": "Elenco di guardia"
     },
-    "logs": {
-      "title": "Log",
-      "refresh": "Aggiorna log",
-      "empty": "Nessun log disponibile.",
-      "error": "Impossibile caricare i log."
-    }
+    "refreshing": "Rinfrescante…",
+    "refreshPrices": "Aggiorna i prezzi",
+    "relativeView": "Vista relativa",
+    "research": "Ricerca",
+    "supportLink": "Supporto",
+    "userLink": "App"
   },
-  "trail": {
-    "title": "Progressi Trail",
-    "daily": "Quotidiano",
-    "once": "Una volta",
-    "progressLabel": "Avanzamento giornaliero: {{completed}} / {{total}} ({{percent}}%)",
-    "xpLabel": "XP: {{xp}}",
-    "streakLabel": "Serie: {{count}} giorno",
-    "streakLabel_plural": "Serie: {{count}} giorni",
-    "dailyComplete": "Attività giornaliere completate! Continua la serie.",
-    "allDone": "Tutte le attività Trail sono completate — ottimo lavoro!"
-  },
+  "approxTotal": "Circa totale: £ {{value}}",
+  "asOf": "A partire da {{date}} • scambia questo mese: {{scambi}} / 20 (rimanente: {{rimanente}})",
   "common": {
+    "action": "Azione",
     "error": "Errore",
     "loading": "Caricamento…",
-    "other": "Altro",
-    "ticker": "Ticker",
     "name": "Nome",
-    "action": "Azione",
+    "other": "Altro",
+    "period": "Periodo:",
     "reason": "Motivo",
-    "period": "Periodo:"
+    "ticker": "Ticker"
   },
-  "instrumentType": {
-    "equity": "Equità",
-    "bond": "Legame",
-    "cash": "Contanti",
-    "etf": "ETF",
-    "fund": "Finanziare",
-    "investmentTrust": "Fiducia degli investimenti",
-    "realEstate": "Immobiliare",
-    "other": "Altro"
-  },
-  "instrumentTable": {
-    "noInstruments": "Nessun strumento.",
-    "ungrouped": "Senza gruppo",
-    "exchangesLabel": "Borse:",
-    "groupTotals": {
-      "market": "Mercato",
-      "gain": "Guadagno",
-      "gainPct": "Guadagno %",
-      "delta7d": "7d %",
-      "delta30d": "30d %"
+  "dashboard": {
+    "alphaVsBenchmark": "Alpha vs benchmark",
+    "cumulativeReturn": "Ritorno cumulativo",
+    "excludeCash": "Escludere contanti",
+    "maxDrawdown": "Drawdown massimo",
+    "portfolioValue": "Valore del portafoglio",
+    "range": "Allineare:",
+    "rangeOptions": {
+      "10y": "10y",
+      "1m": "1 m",
+      "1w": "1W",
+      "1y": "1y",
+      "max": "Max"
     },
+    "selectMember": "Seleziona un membro.",
+    "timeWeightedReturn": "Rendimento ponderato nel tempo",
+    "trackingError": "Errore di tracciamento",
+    "xirr": "XIRR"
+  },
+  "goals": {
+    "add": "Aggiungi obiettivo",
+    "back": "Torna al portafoglio",
+    "currentAmount": "Importo attuale:",
+    "goalLine": "{{name}} – obiettivo {{amount}} entro {{date}}",
+    "progress": "Progresso: {{progress}}%",
+    "suggestedTrades": "Operazioni suggerite",
+    "targetAmount": "Importo obiettivo",
+    "title": "Obiettivi",
+    "trade": "{{action}} {{amount}} di {{ticker}}",
+    "view": "Visualizza"
+  },
+  "group": {
+    "atAGlance": "A colpo d'occhio",
+    "select": "Seleziona un gruppo."
+  },
+  "holdingsTable": {
+    "actualPurchaseCost": "Costo di acquisto effettivo",
+    "clearFilters": "Cancella filtri",
     "columns": {
-      "ticker": "Ticker",
-      "name": "Nome",
+      "acquired": "Acquisito",
       "ccy": "CCY",
+      "cost": "Costo £",
+      "daysHeld": "Giorni tenuti",
+      "eligible": "Idoneo?",
+      "gain": "Guadagna £",
+      "gainPct": "Guadagno %",
+      "market": "Mkt £",
+      "name": "Nome",
+      "price": "Px £",
+      "stage": "Stage",
+      "ticker": "Ticker",
+      "trend": "Tendenza",
       "type": "Tipo",
       "units": "Unità",
+      "weightPct": "Peso %"
+    },
+    "columnsLabel": "Colonne:",
+    "eligible": "Idoneo",
+    "filters": {
+      "all": "Tutto",
+      "gainPct": "Guadagno %",
+      "name": "Nome",
+      "no": "NO",
+      "sellEligible": "Vendi idonei",
+      "ticker": "Ticker",
+      "type": "Tipo",
+      "units": "Unità",
+      "yes": "SÌ"
+    },
+    "inferredCost": "Dedotto dal prezzo alla data di acquisizione",
+    "minimumGainPrompt": "Min guadagno %",
+    "noHoldings": "Nessuna partecipazione corrisponde ai filtri attuali.",
+    "openScreener": "Apri Screener",
+    "quickFilters": "Filtri veloci:",
+    "quickFiltersGainPct": "Guadagnare%> x",
+    "quickFiltersSellEligible": "Idoneo alla vendita",
+    "range": "Allineare:",
+    "rangeOption": "{{Count}} d",
+    "source": "Fonte:",
+    "totalRowLabel": "Totale",
+    "view": "Visualizzazione:",
+    "viewPresets": {
+      "all": "Tutto"
+    }
+  },
+  "instrumentadmin": {
+    "actions": "Azioni",
+    "add": "Aggiungi strumento",
+    "exchange": "Scambio",
+    "grouping": "Raggruppamento",
+    "name": "Nome",
+    "region": "Regione",
+    "save": "Salva",
+    "saveError": "Risparmio di errore",
+    "saveSuccess": "Salvato",
+    "searchPlaceholder": "Filtro Strumenti ...",
+    "sector": "Settore",
+    "ticker": "Ticker",
+    "validation": {
+      "grouping": "È richiesto il raggruppamento",
+      "name": "È richiesto il nome",
+      "ticker": "È richiesto il ticker"
+    }
+  },
+  "instrumentDetail": {
+    "bollingerBands": "Bande Bollinger",
+    "change30d": "30D",
+    "change7d": "7d",
+    "columns": {
+      "account": "Account",
+      "gain": "Guadagna £",
+      "gainPct": "Guadagno %",
+      "market": "Mkt £",
+      "units": "Unità"
+    },
+    "edit": "Modificare",
+    "intraday": "Intraday",
+    "intradayUnavailable": "Dati intraday non disponibili",
+    "ma20": "20d MA",
+    "ma200": "200d MA",
+    "ma50": "50d MA",
+    "noPositions": "Nessuna posizione",
+    "noPriceData": "Nessun dati sui prezzi",
+    "positions": "Posizioni",
+    "priceColumns": {
+      "close": "£ Close",
+      "date": "Data",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "range": "Allineare:",
+    "rangeOptions": {
+      "10y": "10y",
+      "1m": "1 m",
+      "1w": "1W",
+      "1y": "1y",
+      "max": "Max"
+    },
+    "recentPrices": "Prezzi recenti",
+    "rsi": "RSI"
+  },
+  "instrumentTable": {
+    "columns": {
+      "ccy": "CCY",
       "cost": "Costo £",
-      "market": "MERCATO £",
+      "delta30d": "30d %",
+      "delta7d": "7d %",
       "gain": "Guadagna £",
       "gainPct": "Guadagno %",
       "last": "Ultimo £",
       "lastDate": "Ultimo appuntamento",
+      "market": "MERCATO £",
+      "name": "Nome",
+      "ticker": "Ticker",
+      "type": "Tipo",
+      "units": "Unità"
+    },
+    "exchangesLabel": "Borse:",
+    "groupTotals": {
+      "delta30d": "30d %",
       "delta7d": "7d %",
-      "delta30d": "30d %"
-    }
-  },
-  "holdingsTable": {
-    "range": "Allineare:",
-    "rangeOption": "{{Count}} d",
-    "view": "Visualizzazione:",
-    "viewPresets": {
-      "all": "Tutto"
-    },
-    "quickFilters": "Filtri veloci:",
-    "quickFiltersSellEligible": "Idoneo alla vendita",
-    "quickFiltersGainPct": "Guadagnare%> x",
-    "minimumGainPrompt": "Min guadagno %",
-    "columnsLabel": "Colonne:",
-    "columns": {
-      "ticker": "Ticker",
-      "name": "Nome",
-      "trend": "Tendenza",
-      "ccy": "CCY",
-      "type": "Tipo",
-      "units": "Unità",
-      "price": "Px £",
-      "cost": "Costo £",
-      "market": "Mkt £",
-      "gain": "Guadagna £",
+      "gain": "Guadagno",
       "gainPct": "Guadagno %",
-      "weightPct": "Peso %",
-      "acquired": "Acquisito",
-      "daysHeld": "Giorni tenuti",
-      "stage": "Stage",
-      "eligible": "Idoneo?"
+      "market": "Mercato"
     },
-    "filters": {
-      "ticker": "Ticker",
-      "name": "Nome",
-      "type": "Tipo",
-      "units": "Unità",
-      "gainPct": "Guadagno %",
-      "sellEligible": "Vendi idonei",
-      "all": "Tutto",
-      "yes": "SÌ",
-      "no": "NO"
-    },
-    "noHoldings": "Nessuna partecipazione corrisponde ai filtri attuali.",
-    "clearFilters": "Cancella filtri",
-    "openScreener": "Apri Screener",
-    "source": "Fonte:",
-    "actualPurchaseCost": "Costo di acquisto effettivo",
-    "inferredCost": "Dedotto dal prezzo alla data di acquisizione",
-    "eligible": "Idoneo",
-    "totalRowLabel": "Totale"
+    "noInstruments": "Nessun strumento.",
+    "ungrouped": "Senza gruppo"
   },
-  "instrumentDetail": {
-    "edit": "Modificare",
-    "change7d": "7d",
-    "change30d": "30D",
-    "range": "Allineare:",
-    "rangeOptions": {
-      "1w": "1W",
-      "1m": "1 m",
-      "1y": "1y",
-      "10y": "10y",
-      "max": "Max"
-    },
-    "bollingerBands": "Bande Bollinger",
-    "ma20": "20d MA",
-    "ma50": "50d MA",
-    "ma200": "200d MA",
-    "rsi": "RSI",
-    "positions": "Posizioni",
-    "columns": {
-      "account": "Account",
-      "units": "Unità",
-      "market": "Mkt £",
-      "gain": "Guadagna £",
-      "gainPct": "Guadagno %"
-    },
-    "noPositions": "Nessuna posizione",
-    "recentPrices": "Prezzi recenti",
-    "priceColumns": {
-      "date": "Data",
-      "close": "£ Close",
-      "delta": "Δ £",
-      "deltaPct": "Δ %"
-    },
-    "noPriceData": "Nessun dati sui prezzi",
-    "intraday": "Intraday",
-    "intradayUnavailable": "Dati intraday non disponibili"
+  "instrumentType": {
+    "bond": "Legame",
+    "cash": "Contanti",
+    "equity": "Equità",
+    "etf": "ETF",
+    "fund": "Finanziare",
+    "investmentTrust": "Fiducia degli investimenti",
+    "other": "Altro",
+    "realEstate": "Immobiliare"
+  },
+  "loadingPortfolio": "Caricamento del portafoglio ...",
+  "market": {
+    "indexLevels": "Livelli degli indici",
+    "latestHeadlines": "Ultime notizie",
+    "sectorPerformance": "Rendimento dei settori"
+  },
+  "movers": {
+    "excludeSmall": "Escludere le posizioni <{{min}}%",
+    "loadFailed": "Impossibile caricare i motori {{status}}",
+    "loginPrompt": "Accedi per visualizzare i traslochi basati sul portafoglio.",
+    "pctPortfolio": "% del portafoglio",
+    "period": "Periodo:",
+    "signal": "Segnale",
+    "watchlist": "Watchlist:"
   },
   "owner": {
     "label": "Proprietario",
     "select": "Seleziona un proprietario."
   },
   "pensionForecast": {
-    "currentAge": "Età attuale: {{age}}",
     "birthDate": "Data di nascita: {{dob}}",
-    "retirementAge": "Età pensionistica: {{age}}",
-    "pensionPot": "Fondo pensione",
+    "currentAge": "Età attuale: {{age}}",
+    "employerContributionLabel": "Contributo del datore di lavoro",
     "growthAssumption": "Ipotesi di crescita (%):",
-    "monthlyContribution": "Contributo mensile (£):",
+    "header": {
+      "employeeContribution": "Il tuo contributo mensile",
+      "employerContribution": "Contributo del datore di lavoro",
+      "heading": "Tieni traccia dei contributi a colpo d’occhio",
+      "kicker": "Panoramica della tua pensione",
+      "linkedPotsHeading": "Fondi pensione collegati",
+      "noLinkedPots": "Nessun fondo pensione collegato per questo titolare.",
+      "notAvailable": "Non disponibile",
+      "pensionPot": "Montante pensionistico attuale",
+      "totalContribution": "Contributi mensili totali: {{total}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
-      "state": "State pension",
       "definedBenefit": "Defined benefit",
-      "definedContribution": "Defined contribution"
+      "definedContribution": "Defined contribution",
+      "state": "State pension"
     },
     "incomeTable": {
-      "source": "Source",
       "annual": "Annual (£)",
       "monthly": "Monthly (£)",
-      "share": "Share"
+      "share": "Share",
+      "source": "Source"
     },
-    "totalAnnualIncome": "Total annual income",
-    "totalMonthlyIncome": "Total monthly income",
+    "monthlyContribution": "Contributo mensile (£):",
+    "pensionPot": "Fondo pensione",
     "prediction": {
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available.",
       "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
       "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
       "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
-      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
-      "earliest": "Estimated earliest retirement age: {{age}}",
-      "noBreakdown": "No income breakdown available."
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then."
     },
-    "employerContributionLabel": "Contributo del datore di lavoro",
-    "header": {
-      "kicker": "Panoramica della tua pensione",
-      "heading": "Tieni traccia dei contributi a colpo d’occhio",
-      "pensionPot": "Montante pensionistico attuale",
-      "employeeContribution": "Il tuo contributo mensile",
-      "employerContribution": "Contributo del datore di lavoro",
-      "totalContribution": "Contributi mensili totali: {{total}}",
-      "linkedPotsHeading": "Fondi pensione collegati",
-      "noLinkedPots": "Nessun fondo pensione collegato per questo titolare.",
-      "notAvailable": "Non disponibile"
-    }
+    "retirementAge": "Età pensionistica: {{age}}",
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income"
   },
-  "group": {
-    "select": "Seleziona un gruppo.",
-    "atAGlance": "A colpo d'occhio"
-  },
-  "dashboard": {
-    "selectMember": "Seleziona un membro.",
-    "range": "Allineare:",
-    "rangeOptions": {
-      "1w": "1W",
-      "1m": "1 m",
-      "1y": "1y",
-      "10y": "10y",
-      "max": "Max"
-    },
-    "excludeCash": "Escludere contanti",
-    "alphaVsBenchmark": "Alpha vs benchmark",
-    "trackingError": "Errore di tracciamento",
-    "maxDrawdown": "Drawdown massimo",
-    "timeWeightedReturn": "Rendimento ponderato nel tempo",
-    "xirr": "XIRR",
-    "portfolioValue": "Valore del portafoglio",
-    "cumulativeReturn": "Ritorno cumulativo"
-  },
-  "support": {
-    "title": "Supporto",
-    "online": "Online",
-    "onlineYes": "SÌ",
-    "onlineNo": "NO",
-    "environment": "Ambiente",
-    "priceRefresh": "Aggiornamento dei prezzi",
-    "telegramMessage": "Messaggio del telegramma",
-    "send": "Inviare",
-    "status": {
-      "sent": "Inviato",
-      "error": "Errore",
-      "sending": "Invio ...",
-      "saved": "Salvato",
-      "saving": "Salvataggio..."
-    },
-    "health": {
-      "title": "Salute del portafoglio",
-      "run": "Esegui controllo salute portafoglio",
-      "copyReport": "Copia rapporto",
-      "error": "Impossibile eseguire il controllo della salute"
-    },
-    "notifications": {
-      "title": "Notifiche",
-      "notSupported": "Push non supportato",
-      "disable": "Disattiva avvisi Push",
-      "enable": "Abilita avvisi Push",
-      "denied": "Permesso push negato.",
-      "error": "Errore nella gestione dell'iscrizione push."
-    },
-    "config": {
-      "title": "Configurazione",
-      "tabsEnabled": "Schede abilitate",
-      "otherSwitches": "Altri interruttori",
-      "otherParams": "Altri parametri",
-      "save": "Salva"
-    }
-  },
-  "alertSettings": {
-    "title": "Alert Settings",
-    "description": "Configura quando riceverai avvisi. Gli avvisi compaiono nella pagina degli avvisi e nelle notifiche push.",
-    "threshold": "Threshold %:",
-    "save": "Save",
-    "push": {
-      "title": "Notifiche push",
-      "notSupported": "Push non supportato",
-      "enable": "Attiva avvisi push",
-      "disable": "Disattiva avvisi push",
-      "denied": "Autorizzazione push negata.",
-      "error": "Errore nella gestione dell'iscrizione push."
-    },
-    "status": {
-      "saved": "Saved",
-      "error": "Error"
-    }
+  "portfolio": "Portfolio",
+  "query": {
+    "end": "FINE",
+    "exportCsv": "Esportazione CSV",
+    "exportXlsx": "Esporta XLSX",
+    "metrics": "Metrica",
+    "noResults": "Nessun risultato.",
+    "owners": "Proprietari",
+    "run": "Correre",
+    "running": "Corsa…",
+    "save": "Salva",
+    "start": "Inizio",
+    "tickers": "Ticker"
   },
   "reports": {
-    "title": "Segnalazioni",
     "csv": "Scarica CSV",
+    "noOwners": "No owners available—check backend connection",
     "pdf": "Scarica PDF",
-    "noOwners": "No owners available—check backend connection"
+    "title": "Segnalazioni"
   },
-  "loadingPortfolio": "Caricamento del portafoglio ...",
-  "portfolio": "Portfolio",
-  "asOf": "A partire da {{date}} • scambia questo mese: {{scambi}} / 20 (rimanente: {{rimanente}})",
-  "approxTotal": "Circa totale: £ {{value}}",
-  "allocation": {
-    "instrumentTypes": "Tipi di strumenti",
-    "sector": "Industrie",
-    "region": "Regioni"
+  "screener": {
+    "loading": "Caricamento…",
+    "max52WeekHigh": "Massimo 52W di altezza",
+    "max52WeekLow": "MAX 52W BASSO",
+    "maxBeta": "Max beta",
+    "maxDe": "Max d/e",
+    "maxDividendPayoutRatio": "Rapporto di pagamento di dividendi massimo",
+    "maxLtDe": "Max lt d/e",
+    "maxPe": "Max p/e",
+    "maxPeg": "Max Peg",
+    "min52WeekLow": "Minimo 52W",
+    "minAvgVolume": "Volume Min Avg",
+    "minCurrentRatio": "Rapporto di corrente min",
+    "minDividendYield": "Min Desidend Resa",
+    "minEbitdaMargin": "Min Margin EBITDA",
+    "minEps": "Min eps",
+    "minFcf": "Min fcf",
+    "minFloatShares": "Min Float azioni",
+    "minGrossMargin": "Margine lordo min",
+    "minInterestCoverage": "Copertura di interesse min",
+    "minMarketCap": "Min Market Chap",
+    "minNetMargin": "Margine netto min",
+    "minOperatingMargin": "Margine operativo min",
+    "minQuickRatio": "Min Rapporto rapido",
+    "minRoa": "Min roa",
+    "minRoe": "Min Roe",
+    "minRoi": "Min Roi",
+    "minSharesOutstanding": "Min condivide in circolazione",
+    "run": "Correre",
+    "tickers": "Ticker",
+    "watchlist": "Watchlist:"
   },
-  "watchlist": {
-    "refresh": "Rinfrescare"
-  },
-  "trading": {
-    "noPositions": "Nessuna posizione.",
-    "noSignals": "Nessun segnali."
-  },
-  "movers": {
-    "watchlist": "Watchlist:",
-    "period": "Periodo:",
-    "excludeSmall": "Escludere le posizioni <{{min}}%",
-    "loginPrompt": "Accedi per visualizzare i traslochi basati sul portafoglio.",
-    "loadFailed": "Impossibile caricare i motori {{status}}",
-    "signal": "Segnale",
-    "pctPortfolio": "% del portafoglio"
+  "support": {
+    "config": {
+      "otherParams": "Altri parametri",
+      "otherSwitches": "Altri interruttori",
+      "save": "Salva",
+      "tabsEnabled": "Schede abilitate",
+      "title": "Configurazione"
+    },
+    "environment": "Ambiente",
+    "health": {
+      "copyReport": "Copia rapporto",
+      "error": "Impossibile eseguire il controllo della salute",
+      "run": "Esegui controllo salute portafoglio",
+      "title": "Salute del portafoglio"
+    },
+    "notifications": {
+      "denied": "Permesso push negato.",
+      "disable": "Disattiva avvisi Push",
+      "enable": "Abilita avvisi Push",
+      "error": "Errore nella gestione dell'iscrizione push.",
+      "notSupported": "Push non supportato",
+      "title": "Notifiche"
+    },
+    "online": "Online",
+    "onlineNo": "NO",
+    "onlineYes": "SÌ",
+    "priceRefresh": "Aggiornamento dei prezzi",
+    "send": "Inviare",
+    "status": {
+      "error": "Errore",
+      "saved": "Salvato",
+      "saving": "Salvataggio...",
+      "sending": "Invio ...",
+      "sent": "Inviato"
+    },
+    "telegramMessage": "Messaggio del telegramma",
+    "title": "Supporto"
   },
   "timeseries": {
     "loading": "Caricamento…"
   },
   "timeseriesEdit": {
-    "title": "Editor serie temporali",
-    "ticker": "Ticker",
-    "exchange": "Scambio",
-    "load": "Carico",
     "addRow": "Aggiungi riga",
-    "save": "Salva",
-    "delete": "Eliminare",
     "columns": {
+      "close": "Vicino",
       "date": "Data",
-      "open": "Aprire",
       "high": "Alto",
       "low": "Basso",
-      "close": "Vicino",
-      "volume": "Volume",
+      "open": "Aprire",
+      "source": "Fonte",
       "ticker": "Ticker",
-      "source": "Fonte"
+      "volume": "Volume"
     },
+    "delete": "Eliminare",
+    "error": {
+      "noData": "Nessun dato da salvare",
+      "unexpectedColumns": "Colonna (s) imprevisto: {{colonne}}"
+    },
+    "exchange": "Scambio",
+    "load": "Carico",
+    "save": "Salva",
     "status": {
       "loaded": "Caricato {{Count}} ROWS",
       "saved": "Saved {{count}} righe"
     },
-    "error": {
-      "noData": "Nessun dato da salvare",
-      "unexpectedColumns": "Colonna (s) imprevisto: {{colonne}}"
-    }
-  },
-  "query": {
-    "noResults": "Nessun risultato.",
-    "start": "Inizio",
-    "end": "FINE",
-    "owners": "Proprietari",
-    "tickers": "Ticker",
-    "metrics": "Metrica",
-    "run": "Correre",
-    "running": "Corsa…",
-    "save": "Salva",
-    "exportCsv": "Esportazione CSV",
-    "exportXlsx": "Esporta XLSX"
-  },
-  "screener": {
-    "watchlist": "Watchlist:",
-    "tickers": "Ticker",
-    "maxPeg": "Max Peg",
-    "maxPe": "Max p/e",
-    "maxDe": "Max d/e",
-    "maxLtDe": "Max lt d/e",
-    "minInterestCoverage": "Copertura di interesse min",
-    "minCurrentRatio": "Rapporto di corrente min",
-    "minQuickRatio": "Min Rapporto rapido",
-    "minFcf": "Min fcf",
-    "minEps": "Min eps",
-    "minGrossMargin": "Margine lordo min",
-    "minOperatingMargin": "Margine operativo min",
-    "minNetMargin": "Margine netto min",
-    "minEbitdaMargin": "Min Margin EBITDA",
-    "minRoa": "Min roa",
-    "minRoe": "Min Roe",
-    "minRoi": "Min Roi",
-    "minDividendYield": "Min Desidend Resa",
-    "maxDividendPayoutRatio": "Rapporto di pagamento di dividendi massimo",
-    "maxBeta": "Max beta",
-    "minSharesOutstanding": "Min condivide in circolazione",
-    "minFloatShares": "Min Float azioni",
-    "minMarketCap": "Min Market Chap",
-    "max52WeekHigh": "Massimo 52W di altezza",
-    "max52WeekLow": "MAX 52W BASSO",
-    "min52WeekLow": "Minimo 52W",
-    "minAvgVolume": "Volume Min Avg",
-    "run": "Correre",
-    "loading": "Caricamento…"
-  },
-  "instrumentadmin": {
     "ticker": "Ticker",
-    "exchange": "Scambio",
-    "name": "Nome",
-    "region": "Regione",
-    "sector": "Settore",
-    "grouping": "Raggruppamento",
-    "actions": "Azioni",
-    "add": "Aggiungi strumento",
-    "save": "Salva",
-    "saveSuccess": "Salvato",
-    "saveError": "Risparmio di errore",
-    "searchPlaceholder": "Filtro Strumenti ...",
-    "validation": {
-      "ticker": "È richiesto il ticker",
-      "name": "È richiesto il nome",
-      "grouping": "È richiesto il raggruppamento"
-    }
+    "title": "Editor serie temporali"
+  },
+  "trading": {
+    "noPositions": "Nessuna posizione.",
+    "noSignals": "Nessun segnali."
+  },
+  "trail": {
+    "allDone": "Tutte le attività Trail sono completate — ottimo lavoro!",
+    "daily": "Quotidiano",
+    "dailyComplete": "Attività giornaliere completate! Continua la serie.",
+    "once": "Una volta",
+    "progressLabel": "Avanzamento giornaliero: {{completed}} / {{total}} ({{percent}}%)",
+    "streakLabel": "Serie: {{count}} giorno",
+    "streakLabel_plural": "Serie: {{count}} giorni",
+    "title": "Progressi Trail",
+    "xpLabel": "XP: {{xp}}"
   },
   "var": {
-    "title": "Valore a rischio",
     "details": "Dettagli di simulazione storica",
-    "noData": "Nessun dati VAR disponibile."
+    "noData": "Nessun dati VAR disponibile.",
+    "title": "Valore a rischio"
   },
-  "market": {
-    "indexLevels": "Livelli degli indici",
-    "sectorPerformance": "Rendimento dei settori",
-    "latestHeadlines": "Ultime notizie"
-  },
-  "goals": {
-    "title": "Obiettivi",
-    "targetAmount": "Importo obiettivo",
-    "add": "Aggiungi obiettivo",
-    "currentAmount": "Importo attuale:",
-    "goalLine": "{{name}} – obiettivo {{amount}} entro {{date}}",
-    "view": "Visualizza",
-    "progress": "Progresso: {{progress}}%",
-    "suggestedTrades": "Operazioni suggerite",
-    "trade": "{{action}} {{amount}} di {{ticker}}",
-    "back": "Torna al portafoglio"
+  "watchlist": {
+    "refresh": "Rinfrescare"
   }
 }

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -1,14 +1,37 @@
 {
+  "alertSettings": {
+    "description": "Configure quando receber alertas. Os alertas aparecem na página de alertas e nas notificações push.",
+    "push": {
+      "denied": "Permissão de push negada.",
+      "disable": "Desativar alertas push",
+      "enable": "Ativar alertas push",
+      "error": "Erro ao lidar com a assinatura de push.",
+      "notSupported": "Push não suportado",
+      "title": "Notificações push"
+    },
+    "save": "Save",
+    "status": {
+      "error": "Error",
+      "saved": "Saved"
+    },
+    "threshold": "Threshold %:",
+    "title": "Alert Settings"
+  },
+  "allocation": {
+    "instrumentTypes": "Tipos de instrumentos",
+    "region": "Regiões",
+    "sector": "Indústrias"
+  },
   "app": {
-    "relativeView": "Visão relativa",
-    "refreshPrices": "Atualizar preços",
-    "refreshing": "Atualizando…",
     "last": "Último:",
     "loading": "Carregando…",
-    "supportLink": "Suporte",
-    "userLink": "App",
-    "research": "Pesquisa",
     "logout": "Sair",
+    "logs": {
+      "empty": "Nenhum registro disponível.",
+      "error": "Não foi possível carregar os registros.",
+      "refresh": "Atualizar registros",
+      "title": "Registros"
+    },
     "menu": "Menu",
     "menuCategories": {
       "dashboard": "Painel",
@@ -46,427 +69,404 @@
       "transactions": "Transações",
       "watchlist": "Lista de observação"
     },
-    "logs": {
-      "title": "Registros",
-      "refresh": "Atualizar registros",
-      "empty": "Nenhum registro disponível.",
-      "error": "Não foi possível carregar os registros."
-    }
+    "refreshing": "Atualizando…",
+    "refreshPrices": "Atualizar preços",
+    "relativeView": "Visão relativa",
+    "research": "Pesquisa",
+    "supportLink": "Suporte",
+    "userLink": "App"
   },
-  "trail": {
-    "title": "Progresso do Trail",
-    "daily": "Diário",
-    "once": "Única vez",
-    "progressLabel": "Progresso diário: {{completed}} / {{total}} ({{percent}}%)",
-    "xpLabel": "XP: {{xp}}",
-    "streakLabel": "Sequência: {{count}} dia",
-    "streakLabel_plural": "Sequência: {{count}} dias",
-    "dailyComplete": "Tarefas diárias concluídas! Continue a sequência.",
-    "allDone": "Todas as tarefas do Trail estão concluídas — trabalho incrível!"
-  },
+  "approxTotal": "Total aproximado: £{{value}}",
+  "asOf": "Em {{date}} • Negociações este mês: {{trades}} / 20 (Restantes: {{remaining}})",
   "common": {
+    "action": "Ação",
     "error": "Erro",
     "loading": "Carregando…",
-    "other": "Outro",
-    "ticker": "Ticker",
     "name": "Nome",
-    "action": "Ação",
+    "other": "Outro",
+    "period": "Período:",
     "reason": "Motivo",
-    "period": "Período:"
+    "ticker": "Ticker"
   },
-  "instrumentType": {
-    "equity": "Ação",
-    "bond": "Título",
-    "cash": "Dinheiro",
-    "etf": "ETF",
-    "fund": "Fundo",
-    "investmentTrust": "Trust de investimento",
-    "realEstate": "Imóveis",
-    "other": "Outro"
-  },
-  "instrumentTable": {
-    "noInstruments": "Sem instrumentos.",
-    "ungrouped": "Sem grupo",
-    "exchangesLabel": "Bolsas:",
-    "groupTotals": {
-      "market": "Mercado",
-      "gain": "Ganho",
-      "gainPct": "Ganho %",
-      "delta7d": "7d %",
-      "delta30d": "30d %"
+  "dashboard": {
+    "alphaVsBenchmark": "Alfa vs Referência",
+    "cumulativeReturn": "Retorno acumulado",
+    "excludeCash": "Excluir caixa",
+    "maxDrawdown": "Máxima queda",
+    "portfolioValue": "Valor da carteira",
+    "range": "Intervalo:",
+    "rangeOptions": {
+      "10y": "10A",
+      "1m": "1M",
+      "1w": "1S",
+      "1y": "1A",
+      "max": "MÁX"
     },
+    "selectMember": "Selecione um membro.",
+    "timeWeightedReturn": "Retorno ponderado no tempo",
+    "trackingError": "Erro de acompanhamento",
+    "xirr": "XIRR"
+  },
+  "goals": {
+    "add": "Adicionar meta",
+    "back": "Voltar ao portfólio",
+    "currentAmount": "Valor atual:",
+    "goalLine": "{{name}} – alvo {{amount}} até {{date}}",
+    "progress": "Progresso: {{progress}}%",
+    "suggestedTrades": "Negociações sugeridas",
+    "targetAmount": "Valor alvo",
+    "title": "Metas",
+    "trade": "{{action}} {{amount}} de {{ticker}}",
+    "view": "Ver"
+  },
+  "group": {
+    "atAGlance": "Visão geral",
+    "select": "Selecione um grupo."
+  },
+  "holdingsTable": {
+    "actualPurchaseCost": "Custo de compra real",
+    "clearFilters": "Limpar filtros",
     "columns": {
-      "ticker": "Ticker",
-      "name": "Nome",
+      "acquired": "Adquirido",
       "ccy": "Moeda",
+      "cost": "Custo £",
+      "daysHeld": "Dias mantidos",
+      "eligible": "Elegível?",
+      "gain": "Ganho £",
+      "gainPct": "Ganho %",
+      "market": "Mkt £",
+      "name": "Nome",
+      "price": "Preço £",
+      "stage": "Stage",
+      "ticker": "Ticker",
+      "trend": "Tendência",
       "type": "Tipo",
       "units": "Unidades",
+      "weightPct": "Peso %"
+    },
+    "columnsLabel": "Colunas:",
+    "eligible": "Elegível",
+    "filters": {
+      "all": "Todos",
+      "gainPct": "Ganho %",
+      "name": "Nome",
+      "no": "Não",
+      "sellEligible": "Elegível para venda",
+      "ticker": "Ticker",
+      "type": "Tipo",
+      "units": "Unidades",
+      "yes": "Sim"
+    },
+    "inferredCost": "Inferido do preço na data de aquisição",
+    "minimumGainPrompt": "Ganho mínimo %",
+    "noHoldings": "Nenhuma posição corresponde aos filtros atuais.",
+    "openScreener": "Abrir Screener",
+    "quickFilters": "Filtros rápidos:",
+    "quickFiltersGainPct": "Ganho% > x",
+    "quickFiltersSellEligible": "Elegível para venda",
+    "range": "Intervalo:",
+    "rangeOption": "{{count}}d",
+    "source": "Fonte:",
+    "totalRowLabel": "Total",
+    "view": "Visão:",
+    "viewPresets": {
+      "all": "Todos"
+    }
+  },
+  "instrumentadmin": {
+    "actions": "Ações",
+    "add": "Adicionar instrumento",
+    "exchange": "Exchange",
+    "grouping": "Agrupamento",
+    "name": "Nome",
+    "region": "Região",
+    "save": "Salvar",
+    "saveError": "Erro ao salvar",
+    "saveSuccess": "Salvo",
+    "searchPlaceholder": "Filtrar instrumentos…",
+    "sector": "Setor",
+    "ticker": "Ticker",
+    "validation": {
+      "grouping": "Agrupamento é obrigatório",
+      "name": "Nome é obrigatório",
+      "ticker": "Ticker é obrigatório"
+    }
+  },
+  "instrumentDetail": {
+    "bollingerBands": "Bandas de Bollinger",
+    "change30d": "30d",
+    "change7d": "7d",
+    "columns": {
+      "account": "Conta",
+      "gain": "Ganho £",
+      "gainPct": "Ganho %",
+      "market": "Mercado £",
+      "units": "Unidades"
+    },
+    "edit": "Editar",
+    "intraday": "Intraday",
+    "intradayUnavailable": "Dados intraday indisponíveis",
+    "ma20": "20d MA",
+    "ma200": "200d MA",
+    "ma50": "50d MA",
+    "noPositions": "Sem posições",
+    "noPriceData": "Sem dados de preços",
+    "positions": "Posições",
+    "priceColumns": {
+      "close": "£ Fechamento",
+      "date": "Data",
+      "delta": "Δ £",
+      "deltaPct": "Δ %"
+    },
+    "range": "Intervalo:",
+    "rangeOptions": {
+      "10y": "10A",
+      "1m": "1M",
+      "1w": "1S",
+      "1y": "1A",
+      "max": "MÁX"
+    },
+    "recentPrices": "Preços recentes",
+    "rsi": "RSI"
+  },
+  "instrumentTable": {
+    "columns": {
+      "ccy": "Moeda",
       "cost": "Custo £",
-      "market": "Valor de mercado £",
+      "delta30d": "30d %",
+      "delta7d": "7d %",
       "gain": "Ganho £",
       "gainPct": "Ganho %",
       "last": "Último £",
       "lastDate": "Última data",
+      "market": "Valor de mercado £",
+      "name": "Nome",
+      "ticker": "Ticker",
+      "type": "Tipo",
+      "units": "Unidades"
+    },
+    "exchangesLabel": "Bolsas:",
+    "groupTotals": {
+      "delta30d": "30d %",
       "delta7d": "7d %",
-      "delta30d": "30d %"
-    }
-  },
-  "holdingsTable": {
-    "range": "Intervalo:",
-    "rangeOption": "{{count}}d",
-    "view": "Visão:",
-    "viewPresets": {
-      "all": "Todos"
-    },
-    "quickFilters": "Filtros rápidos:",
-    "quickFiltersSellEligible": "Elegível para venda",
-    "quickFiltersGainPct": "Ganho% > x",
-    "minimumGainPrompt": "Ganho mínimo %",
-    "columnsLabel": "Colunas:",
-    "columns": {
-      "ticker": "Ticker",
-      "name": "Nome",
-      "trend": "Tendência",
-      "ccy": "Moeda",
-      "type": "Tipo",
-      "units": "Unidades",
-      "price": "Preço £",
-      "cost": "Custo £",
-      "market": "Mkt £",
-      "gain": "Ganho £",
+      "gain": "Ganho",
       "gainPct": "Ganho %",
-      "weightPct": "Peso %",
-      "acquired": "Adquirido",
-      "daysHeld": "Dias mantidos",
-      "stage": "Stage",
-      "eligible": "Elegível?"
+      "market": "Mercado"
     },
-    "filters": {
-      "ticker": "Ticker",
-      "name": "Nome",
-      "type": "Tipo",
-      "units": "Unidades",
-      "gainPct": "Ganho %",
-      "sellEligible": "Elegível para venda",
-      "all": "Todos",
-      "yes": "Sim",
-      "no": "Não"
-    },
-    "noHoldings": "Nenhuma posição corresponde aos filtros atuais.",
-    "clearFilters": "Limpar filtros",
-    "openScreener": "Abrir Screener",
-    "source": "Fonte:",
-    "actualPurchaseCost": "Custo de compra real",
-    "inferredCost": "Inferido do preço na data de aquisição",
-    "eligible": "Elegível",
-    "totalRowLabel": "Total"
+    "noInstruments": "Sem instrumentos.",
+    "ungrouped": "Sem grupo"
   },
-  "instrumentDetail": {
-    "edit": "Editar",
-    "change7d": "7d",
-    "change30d": "30d",
-    "range": "Intervalo:",
-    "rangeOptions": {
-      "1w": "1S",
-      "1m": "1M",
-      "1y": "1A",
-      "10y": "10A",
-      "max": "MÁX"
-    },
-    "bollingerBands": "Bandas de Bollinger",
-    "ma20": "20d MA",
-    "ma50": "50d MA",
-    "ma200": "200d MA",
-    "rsi": "RSI",
-    "positions": "Posições",
-    "columns": {
-      "account": "Conta",
-      "units": "Unidades",
-      "market": "Mercado £",
-      "gain": "Ganho £",
-      "gainPct": "Ganho %"
-    },
-    "noPositions": "Sem posições",
-    "recentPrices": "Preços recentes",
-    "priceColumns": {
-      "date": "Data",
-      "close": "£ Fechamento",
-      "delta": "Δ £",
-      "deltaPct": "Δ %"
-    },
-    "noPriceData": "Sem dados de preços",
-    "intraday": "Intraday",
-    "intradayUnavailable": "Dados intraday indisponíveis"
+  "instrumentType": {
+    "bond": "Título",
+    "cash": "Dinheiro",
+    "equity": "Ação",
+    "etf": "ETF",
+    "fund": "Fundo",
+    "investmentTrust": "Trust de investimento",
+    "other": "Outro",
+    "realEstate": "Imóveis"
+  },
+  "loadingPortfolio": "Carregando portfólio…",
+  "market": {
+    "indexLevels": "Níveis dos índices",
+    "latestHeadlines": "Últimas manchetes",
+    "sectorPerformance": "Desempenho por setor"
+  },
+  "movers": {
+    "excludeSmall": "Excluir posições <{{min}}%",
+    "loadFailed": "Falha ao carregar os movers{{status}}",
+    "loginPrompt": "Faça login para ver os movers baseados no portfólio.",
+    "pctPortfolio": "% do portfólio",
+    "period": "Período:",
+    "signal": "Sinal",
+    "watchlist": "Lista de observação:"
   },
   "owner": {
     "label": "Proprietário",
     "select": "Selecione um proprietário."
   },
   "pensionForecast": {
-    "currentAge": "Idade atual: {{age}}",
     "birthDate": "Data de nascimento: {{dob}}",
-    "retirementAge": "Idade de aposentadoria: {{age}}",
-    "pensionPot": "Fundo de pensão",
+    "currentAge": "Idade atual: {{age}}",
+    "employerContributionLabel": "Contribuição do empregador",
     "growthAssumption": "Suposição de crescimento (%):",
-    "monthlyContribution": "Contribuição mensal (£):",
+    "header": {
+      "employeeContribution": "Sua contribuição mensal",
+      "employerContribution": "Contribuição do empregador",
+      "heading": "Acompanhe suas contribuições de relance",
+      "kicker": "Visão geral da sua aposentadoria",
+      "linkedPotsHeading": "Fundos de pensão vinculados",
+      "noLinkedPots": "Ainda não há fundos de pensão vinculados para este titular.",
+      "notAvailable": "Não disponível",
+      "pensionPot": "Fundo de aposentadoria atual",
+      "totalContribution": "Contribuições mensais totais: {{total}}"
+    },
     "incomeBreakdownHeading": "Retirement income breakdown",
     "incomeSources": {
-      "state": "State pension",
       "definedBenefit": "Defined benefit",
-      "definedContribution": "Defined contribution"
+      "definedContribution": "Defined contribution",
+      "state": "State pension"
     },
     "incomeTable": {
-      "source": "Source",
       "annual": "Annual (£)",
       "monthly": "Monthly (£)",
-      "share": "Share"
+      "share": "Share",
+      "source": "Source"
     },
-    "totalAnnualIncome": "Total annual income",
-    "totalMonthlyIncome": "Total monthly income",
+    "monthlyContribution": "Contribuição mensal (£):",
+    "pensionPot": "Fundo de pensão",
     "prediction": {
+      "earliest": "Estimated earliest retirement age: {{age}}",
+      "noBreakdown": "No income breakdown available.",
       "onTrack": "You're on track: projected annual income of {{total}} meets your desired {{desired}}.",
       "onTrackWithAge": "You're on track: projected income of {{total}} meets your desired {{desired}} from age {{age}}.",
       "shortfall": "Projected income leaves a shortfall of {{shortfallAnnual}} per year ({{shortfallMonthly}} per month) against your desired {{desired}}.",
-      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then.",
-      "earliest": "Estimated earliest retirement age: {{age}}",
-      "noBreakdown": "No income breakdown available."
+      "shortfallWithAge": "You'll reach your desired {{desired}} around age {{age}}, leaving a shortfall of {{shortfallAnnual}} per year until then."
     },
-    "employerContributionLabel": "Contribuição do empregador",
-    "header": {
-      "kicker": "Visão geral da sua aposentadoria",
-      "heading": "Acompanhe suas contribuições de relance",
-      "pensionPot": "Fundo de aposentadoria atual",
-      "employeeContribution": "Sua contribuição mensal",
-      "employerContribution": "Contribuição do empregador",
-      "totalContribution": "Contribuições mensais totais: {{total}}",
-      "linkedPotsHeading": "Fundos de pensão vinculados",
-      "noLinkedPots": "Ainda não há fundos de pensão vinculados para este titular.",
-      "notAvailable": "Não disponível"
-    }
+    "retirementAge": "Idade de aposentadoria: {{age}}",
+    "totalAnnualIncome": "Total annual income",
+    "totalMonthlyIncome": "Total monthly income"
   },
-  "group": {
-    "select": "Selecione um grupo.",
-    "atAGlance": "Visão geral"
-  },
-  "dashboard": {
-    "selectMember": "Selecione um membro.",
-    "range": "Intervalo:",
-    "rangeOptions": {
-      "1w": "1S",
-      "1m": "1M",
-      "1y": "1A",
-      "10y": "10A",
-      "max": "MÁX"
-    },
-    "excludeCash": "Excluir caixa",
-    "alphaVsBenchmark": "Alfa vs Referência",
-    "trackingError": "Erro de acompanhamento",
-    "maxDrawdown": "Máxima queda",
-    "timeWeightedReturn": "Retorno ponderado no tempo",
-    "xirr": "XIRR",
-    "portfolioValue": "Valor da carteira",
-    "cumulativeReturn": "Retorno acumulado"
-  },
-  "support": {
-    "title": "Suporte",
-    "online": "Online",
-    "onlineYes": "Sim",
-    "onlineNo": "Não",
-    "environment": "Ambiente",
-    "priceRefresh": "Atualização de preços",
-    "telegramMessage": "Mensagem do Telegram",
-    "send": "Enviar",
-    "status": {
-      "sent": "Enviado",
-      "error": "Erro",
-      "sending": "Enviando...",
-      "saved": "Salvo",
-      "saving": "Salvando..."
-    },
-    "health": {
-      "title": "Saúde do portfólio",
-      "run": "Executar verificação de saúde do portfólio",
-      "copyReport": "Copiar relatório",
-      "error": "Falha ao executar verificação de saúde"
-    },
-    "notifications": {
-      "title": "Notificações",
-      "notSupported": "Push não suportado",
-      "disable": "Desativar alertas Push",
-      "enable": "Ativar alertas Push",
-      "denied": "Permissão de push negada.",
-      "error": "Erro ao lidar com a assinatura de push."
-    },
-    "config": {
-      "title": "Configuração",
-      "tabsEnabled": "Abas ativadas",
-      "otherSwitches": "Outros interruptores",
-      "otherParams": "Outros parâmetros",
-      "save": "Salvar"
-    }
-  },
-  "alertSettings": {
-    "title": "Alert Settings",
-    "description": "Configure quando receber alertas. Os alertas aparecem na página de alertas e nas notificações push.",
-    "threshold": "Threshold %:",
-    "save": "Save",
-    "push": {
-      "title": "Notificações push",
-      "notSupported": "Push não suportado",
-      "enable": "Ativar alertas push",
-      "disable": "Desativar alertas push",
-      "denied": "Permissão de push negada.",
-      "error": "Erro ao lidar com a assinatura de push."
-    },
-    "status": {
-      "saved": "Saved",
-      "error": "Error"
-    }
+  "portfolio": "Portfólio",
+  "query": {
+    "end": "Fim",
+    "exportCsv": "Exportar CSV",
+    "exportXlsx": "Exportar XLSX",
+    "metrics": "Métricas",
+    "owners": "Proprietários",
+    "run": "Executar",
+    "running": "Executando…",
+    "save": "Salvar",
+    "start": "Início",
+    "tickers": "Tickers"
   },
   "reports": {
-    "title": "Relatórios",
     "csv": "Baixar CSV",
+    "noOwners": "No owners available—check backend connection",
     "pdf": "Baixar PDF",
-    "noOwners": "No owners available—check backend connection"
+    "title": "Relatórios"
   },
-  "loadingPortfolio": "Carregando portfólio…",
-  "portfolio": "Portfólio",
-  "asOf": "Em {{date}} • Negociações este mês: {{trades}} / 20 (Restantes: {{remaining}})",
-  "approxTotal": "Total aproximado: £{{value}}",
-  "allocation": {
-    "instrumentTypes": "Tipos de instrumentos",
-    "sector": "Indústrias",
-    "region": "Regiões"
+  "screener": {
+    "loading": "Carregando…",
+    "max52WeekHigh": "Alta 52S máx",
+    "max52WeekLow": "Baixa 52S máx",
+    "maxBeta": "Beta máx",
+    "maxDe": "D/E máx",
+    "maxDividendPayoutRatio": "Rácio de pagamento de dividendos máx",
+    "maxLtDe": "D/E LP máx",
+    "maxPe": "P/E máx",
+    "maxPeg": "PEG máx",
+    "min52WeekLow": "Baixa 52S mín",
+    "minAvgVolume": "Volume médio mín",
+    "minCurrentRatio": "Liquidez corrente mín",
+    "minDividendYield": "Rendimento de dividendos mín",
+    "minEbitdaMargin": "Margem EBITDA mín",
+    "minEps": "EPS mín",
+    "minFcf": "FCF mín",
+    "minFloatShares": "Ações flutuantes mín",
+    "minGrossMargin": "Margem bruta mín",
+    "minInterestCoverage": "Cobertura de juros mín",
+    "minMarketCap": "Capitalização de mercado mín",
+    "minNetMargin": "Margem líquida mín",
+    "minOperatingMargin": "Margem operacional mín",
+    "minQuickRatio": "Liquidez imediata mín",
+    "minRoa": "ROA mín",
+    "minRoe": "ROE mín",
+    "minRoi": "ROI mín",
+    "minSharesOutstanding": "Ações em circulação mín",
+    "run": "Executar",
+    "tickers": "Tickers",
+    "watchlist": "Lista de observação:"
   },
-  "watchlist": {
-    "refresh": "Atualizar"
-  },
-  "trading": {
-    "noPositions": "Sem posições.",
-    "noSignals": "Sem sinais."
-  },
-  "movers": {
-    "watchlist": "Lista de observação:",
-    "period": "Período:",
-    "excludeSmall": "Excluir posições <{{min}}%",
-    "loginPrompt": "Faça login para ver os movers baseados no portfólio.",
-    "loadFailed": "Falha ao carregar os movers{{status}}",
-    "signal": "Sinal",
-    "pctPortfolio": "% do portfólio"
+  "support": {
+    "config": {
+      "otherParams": "Outros parâmetros",
+      "otherSwitches": "Outros interruptores",
+      "save": "Salvar",
+      "tabsEnabled": "Abas ativadas",
+      "title": "Configuração"
+    },
+    "environment": "Ambiente",
+    "health": {
+      "copyReport": "Copiar relatório",
+      "error": "Falha ao executar verificação de saúde",
+      "run": "Executar verificação de saúde do portfólio",
+      "title": "Saúde do portfólio"
+    },
+    "notifications": {
+      "denied": "Permissão de push negada.",
+      "disable": "Desativar alertas Push",
+      "enable": "Ativar alertas Push",
+      "error": "Erro ao lidar com a assinatura de push.",
+      "notSupported": "Push não suportado",
+      "title": "Notificações"
+    },
+    "online": "Online",
+    "onlineNo": "Não",
+    "onlineYes": "Sim",
+    "priceRefresh": "Atualização de preços",
+    "send": "Enviar",
+    "status": {
+      "error": "Erro",
+      "saved": "Salvo",
+      "saving": "Salvando...",
+      "sending": "Enviando...",
+      "sent": "Enviado"
+    },
+    "telegramMessage": "Mensagem do Telegram",
+    "title": "Suporte"
   },
   "timeseries": {
     "loading": "Carregando…"
   },
   "timeseriesEdit": {
-    "title": "Editor de séries temporais",
-    "ticker": "Ticker",
-    "exchange": "Bolsa",
-    "load": "Carregar",
     "addRow": "Adicionar linha",
-    "save": "Salvar",
-    "delete": "Excluir",
     "columns": {
+      "close": "Fechamento",
       "date": "Data",
-      "open": "Abertura",
       "high": "Máxima",
       "low": "Mínima",
-      "close": "Fechamento",
-      "volume": "Volume",
+      "open": "Abertura",
+      "source": "Fonte",
       "ticker": "Ticker",
-      "source": "Fonte"
+      "volume": "Volume"
     },
+    "delete": "Excluir",
+    "error": {
+      "noData": "Sem dados para salvar",
+      "unexpectedColumns": "Coluna(s) inesperada(s): {{columns}}"
+    },
+    "exchange": "Bolsa",
+    "load": "Carregar",
+    "save": "Salvar",
     "status": {
       "loaded": "Carregadas {{count}} linhas",
       "saved": "Salvas {{count}} linhas"
     },
-    "error": {
-      "noData": "Sem dados para salvar",
-      "unexpectedColumns": "Coluna(s) inesperada(s): {{columns}}"
-    }
-  },
-  "query": {
-    "start": "Início",
-    "end": "Fim",
-    "owners": "Proprietários",
-    "tickers": "Tickers",
-    "metrics": "Métricas",
-    "run": "Executar",
-    "running": "Executando…",
-    "save": "Salvar",
-    "exportCsv": "Exportar CSV",
-    "exportXlsx": "Exportar XLSX"
-  },
-  "screener": {
-    "watchlist": "Lista de observação:",
-    "tickers": "Tickers",
-    "maxPeg": "PEG máx",
-    "maxPe": "P/E máx",
-    "maxDe": "D/E máx",
-    "maxLtDe": "D/E LP máx",
-    "minInterestCoverage": "Cobertura de juros mín",
-    "minCurrentRatio": "Liquidez corrente mín",
-    "minQuickRatio": "Liquidez imediata mín",
-    "minFcf": "FCF mín",
-    "minEps": "EPS mín",
-    "minGrossMargin": "Margem bruta mín",
-    "minOperatingMargin": "Margem operacional mín",
-    "minNetMargin": "Margem líquida mín",
-    "minEbitdaMargin": "Margem EBITDA mín",
-    "minRoa": "ROA mín",
-    "minRoe": "ROE mín",
-    "minRoi": "ROI mín",
-    "minDividendYield": "Rendimento de dividendos mín",
-    "maxDividendPayoutRatio": "Rácio de pagamento de dividendos máx",
-    "maxBeta": "Beta máx",
-    "minSharesOutstanding": "Ações em circulação mín",
-    "minFloatShares": "Ações flutuantes mín",
-    "minMarketCap": "Capitalização de mercado mín",
-    "max52WeekHigh": "Alta 52S máx",
-    "max52WeekLow": "Baixa 52S máx",
-    "min52WeekLow": "Baixa 52S mín",
-    "minAvgVolume": "Volume médio mín",
-    "run": "Executar",
-    "loading": "Carregando…"
-  },
-  "instrumentadmin": {
     "ticker": "Ticker",
-    "exchange": "Exchange",
-    "name": "Nome",
-    "region": "Região",
-    "sector": "Setor",
-    "grouping": "Agrupamento",
-    "actions": "Ações",
-    "add": "Adicionar instrumento",
-    "save": "Salvar",
-    "saveSuccess": "Salvo",
-    "saveError": "Erro ao salvar",
-    "searchPlaceholder": "Filtrar instrumentos…",
-    "validation": {
-      "ticker": "Ticker é obrigatório",
-      "name": "Nome é obrigatório",
-      "grouping": "Agrupamento é obrigatório"
-    }
+    "title": "Editor de séries temporais"
+  },
+  "trading": {
+    "noPositions": "Sem posições.",
+    "noSignals": "Sem sinais."
+  },
+  "trail": {
+    "allDone": "Todas as tarefas do Trail estão concluídas — trabalho incrível!",
+    "daily": "Diário",
+    "dailyComplete": "Tarefas diárias concluídas! Continue a sequência.",
+    "once": "Única vez",
+    "progressLabel": "Progresso diário: {{completed}} / {{total}} ({{percent}}%)",
+    "streakLabel": "Sequência: {{count}} dia",
+    "streakLabel_plural": "Sequência: {{count}} dias",
+    "title": "Progresso do Trail",
+    "xpLabel": "XP: {{xp}}"
   },
   "var": {
-    "title": "Valor em Risco",
     "details": "Detalhes da simulação histórica",
-    "noData": "Nenhum dado de VaR disponível."
+    "noData": "Nenhum dado de VaR disponível.",
+    "title": "Valor em Risco"
   },
-  "market": {
-    "indexLevels": "Níveis dos índices",
-    "sectorPerformance": "Desempenho por setor",
-    "latestHeadlines": "Últimas manchetes"
-  },
-  "goals": {
-    "title": "Metas",
-    "targetAmount": "Valor alvo",
-    "add": "Adicionar meta",
-    "currentAmount": "Valor atual:",
-    "goalLine": "{{name}} – alvo {{amount}} até {{date}}",
-    "view": "Ver",
-    "progress": "Progresso: {{progress}}%",
-    "suggestedTrades": "Negociações sugeridas",
-    "trade": "{{action}} {{amount}} de {{ticker}}",
-    "back": "Voltar ao portfólio"
+  "watchlist": {
+    "refresh": "Atualizar"
   }
 }


### PR DESCRIPTION
## Summary
- alphabetized all locale translation keys across en, fr, de, it, es, and pt files to ensure consistent ordering

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d98fd3710483279eabf8fac5aecd9c