### PR TITLE
Add portfolio snapshot refresher regression tests

### DIFF
--- a/tests/common/test_portfolio_utils_snapshot.py
+++ b/tests/common/test_portfolio_utils_snapshot.py
@@ -65,6 +65,139 @@ def test_refresh_snapshot_in_memory_from_timeseries_writes_file(tmp_path, monkey
     assert json.loads(prices_path.read_text()) == expected_snapshot
 
 
+def test_refresh_snapshot_scaling_override_rescales_gbp(tmp_path, monkeypatch):
+    tickers = ["GBX.L"]
+    monkeypatch.setattr(pu, "_PRICE_SNAPSHOT", {t: {} for t in tickers})
+    monkeypatch.setattr(pu, "list_all_unique_tickers", lambda: tickers)
+
+    df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-01-03", "2024-01-04"]),
+            "Close_gbp": [55.0, 60.0],
+        }
+    )
+
+    monkeypatch.setattr(
+        pu,
+        "load_meta_timeseries_range",
+        lambda *, ticker, exchange, start_date, end_date: df,
+    )
+
+    monkeypatch.setattr(pu, "get_scaling_override", lambda ticker, exchange, meta: 0.5)
+
+    scale_calls: list[float] = []
+
+    def fake_apply_scaling(frame, scale):
+        scale_calls.append(scale)
+        return frame
+
+    monkeypatch.setattr(pu, "apply_scaling", fake_apply_scaling)
+
+    captured: dict[str, object] = {}
+
+    def fake_refresh_snapshot_in_memory(snapshot, timestamp):
+        captured["snapshot"] = snapshot
+        captured["timestamp"] = timestamp
+
+    monkeypatch.setattr(pu, "refresh_snapshot_in_memory", fake_refresh_snapshot_in_memory)
+
+    prices_path = tmp_path / "latest_prices.json"
+    monkeypatch.setattr(pu, "_PRICES_PATH", prices_path)
+
+    pu.refresh_snapshot_in_memory_from_timeseries(days=2)
+
+    assert scale_calls == [0.5]
+
+    expected_snapshot = {
+        "GBX.L": {"last_price": 30.0, "last_price_date": "2024-01-04"},
+    }
+
+    assert captured["snapshot"] == expected_snapshot
+    assert json.loads(prices_path.read_text()) == expected_snapshot
+
+
+def test_refresh_snapshot_logs_warning_when_timeseries_missing(tmp_path, monkeypatch, caplog):
+    tickers = ["GOOD.L", "BAD.N"]
+    monkeypatch.setattr(pu, "_PRICE_SNAPSHOT", {t: {} for t in tickers})
+    monkeypatch.setattr(pu, "list_all_unique_tickers", lambda: tickers)
+
+    good_df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-02-01", "2024-02-02"]),
+            "Close": [100.0, 101.0],
+        }
+    )
+
+    def fake_load_meta_timeseries_range(*, ticker, exchange, start_date, end_date):
+        if ticker == "GOOD":
+            return good_df
+        raise OSError("boom")
+
+    monkeypatch.setattr(pu, "load_meta_timeseries_range", fake_load_meta_timeseries_range)
+    monkeypatch.setattr(pu, "get_scaling_override", lambda *_, **__: 1)
+
+    refreshed = {}
+
+    def fake_refresh_snapshot_in_memory(snapshot, timestamp):
+        refreshed["snapshot"] = snapshot
+
+    monkeypatch.setattr(pu, "refresh_snapshot_in_memory", fake_refresh_snapshot_in_memory)
+
+    prices_path = tmp_path / "latest_prices.json"
+    monkeypatch.setattr(pu, "_PRICES_PATH", prices_path)
+
+    caplog.set_level("WARNING")
+
+    pu.refresh_snapshot_in_memory_from_timeseries(days=5)
+
+    assert "Could not get timeseries for BAD.N" in "\n".join(caplog.messages)
+
+    expected_snapshot = {
+        "GOOD.L": {"last_price": 101.0, "last_price_date": "2024-02-02"},
+    }
+
+    assert refreshed["snapshot"] == expected_snapshot
+    assert json.loads(prices_path.read_text()) == expected_snapshot
+
+
+def test_refresh_snapshot_skips_write_when_path_missing(monkeypatch, caplog):
+    tickers = ["SKIP.L"]
+    monkeypatch.setattr(pu, "_PRICE_SNAPSHOT", {t: {} for t in tickers})
+    monkeypatch.setattr(pu, "list_all_unique_tickers", lambda: tickers)
+
+    df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-03-10"]),
+            "Close": [12.0],
+        }
+    )
+
+    monkeypatch.setattr(
+        pu,
+        "load_meta_timeseries_range",
+        lambda *, ticker, exchange, start_date, end_date: df,
+    )
+    monkeypatch.setattr(pu, "get_scaling_override", lambda *_, **__: 1)
+
+    recorded = {}
+
+    def fake_refresh_snapshot_in_memory(snapshot, timestamp):
+        recorded["snapshot"] = snapshot
+
+    monkeypatch.setattr(pu, "refresh_snapshot_in_memory", fake_refresh_snapshot_in_memory)
+    monkeypatch.setattr(pu, "_PRICES_PATH", None)
+
+    caplog.set_level("INFO")
+
+    pu.refresh_snapshot_in_memory_from_timeseries(days=1)
+
+    assert recorded["snapshot"] == {
+        "SKIP.L": {"last_price": 12.0, "last_price_date": "2024-03-10"},
+    }
+    assert any(
+        "Price snapshot path not configured; skipping write" in message for message in caplog.messages
+    )
+
 @pytest.mark.anyio("asyncio")
 async def test_refresh_snapshot_async_invokes_to_thread(monkeypatch):
     calls = {}


### PR DESCRIPTION
## Summary
- add regression coverage for GBP scaling overrides when refreshing the price snapshot
- exercise warning handling when a ticker's timeseries fetch raises an `OSError`
- ensure the refresher skips disk writes when the prices path configuration is unset

## Testing
- `pytest tests/common/test_portfolio_utils_snapshot.py` *(fails: coverage fail-under=90 threshold in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d98ffe67b083279a93af39e4143ada