### PR TITLE
Fix smoke config test request failure wait

### DIFF
--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -242,7 +242,9 @@ test.describe('config bootstrap', () => {
 
     await page.route('**/config', handler);
 
-    const firstFailure = page.waitForRequestFailed('**/config');
+    const firstFailure = page.waitForEvent('requestfailed', (request) =>
+      request.url().endsWith('/config'),
+    );
     const secondResponse = page.waitForResponse((response) =>
       response.url().endsWith('/config') && response.ok(),
     );


### PR DESCRIPTION
## Summary
- update the config bootstrap smoke test to await the requestfailed event for the initial /config retry

## Testing
- npm run smoke:test (fails: could not reach http://localhost:8000/health)


------
https://chatgpt.com/codex/tasks/task_e_68d995eaf9148327bc9406c8ab004c00