### PR TITLE
Avoid spawning Chromium during prerender readiness probe

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import type { UserConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import path from 'node:path'
-import { spawnSync } from 'node:child_process'
+import { accessSync, constants } from 'node:fs'
 import { createRequire } from 'node:module'
 import fg from 'fast-glob'
 
@@ -54,8 +54,9 @@ export default defineConfig(({ command }) => {
           if (!executable) {
             canPrerender = false
           } else {
-            const probe = spawnSync(executable, ['--version'], { stdio: 'ignore' })
-            if (probe.error || probe.status !== 0) {
+            try {
+              accessSync(executable, constants.X_OK)
+            } catch {
               canPrerender = false
             }
           }


### PR DESCRIPTION
## Summary
- replace the Puppeteer readiness probe with a filesystem access check to avoid starting Chrome during build

## Testing
- `PUPPETEER_EXECUTABLE_PATH=/nonexistent npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d997b2f3348327a72c940070a20a35