### PR TITLE
Keep pension forecast route enabled while config loads

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -207,7 +207,7 @@ export default function App({ onLogout }: AppProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
-  const { tabs } = useConfig();
+  const { tabs, disabledTabs } = useConfig();
   const { lastRefresh } = usePriceRefresh();
 
   const params = new URLSearchParams(location.search);
@@ -334,7 +334,9 @@ export default function App({ onLogout }: AppProps) {
         newMode = segs.length === 0 ? "group" : "movers";
     }
 
-    if (tabs[newMode] === false) {
+    const isDisabled =
+      tabs[newMode] === false || disabledTabs?.includes(newMode);
+    if (isDisabled) {
       setMode("group");
       navigate("/", { replace: true });
       return;
@@ -358,7 +360,7 @@ export default function App({ onLogout }: AppProps) {
     } else if (newMode === "research") {
       setResearchTicker(segs[1] ? decodeURIComponent(segs[1] ?? "") : "");
     }
-  }, [location.pathname, location.search, tabs, navigate]);
+  }, [location.pathname, location.search, tabs, disabledTabs, navigate]);
 
   useEffect(() => {
     if (!ownersReq.data) return;

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -143,15 +143,19 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   const refreshConfig = useCallback(async () => {
     try {
       const cfg = await getConfig<RawConfig>();
-      const tabs = { ...defaultTabs, ...(cfg.tabs ?? {}) } as TabsConfig;
+      const tabs: TabsConfig = { ...defaultTabs };
+      if (cfg.tabs && typeof cfg.tabs === "object") {
+        for (const [tab, value] of Object.entries(cfg.tabs)) {
+          if (typeof value === "boolean") {
+            (tabs as Record<string, boolean>)[tab] = value;
+          }
+        }
+      }
       const disabledTabs = new Set<string>(
         Array.isArray(cfg.disabled_tabs) ? cfg.disabled_tabs : [],
       );
-      for (const [tab, enabled] of Object.entries(tabs) as [
-        string,
-        boolean,
-      ][]) {
-        if (!enabled) disabledTabs.add(String(tab));
+      for (const [tab, enabled] of Object.entries(tabs)) {
+        if (enabled === false) disabledTabs.add(String(tab));
       }
       const theme = isTheme(cfg.theme) ? cfg.theme : "system";
       const stored =

--- a/frontend/src/hooks/useRouteMode.ts
+++ b/frontend/src/hooks/useRouteMode.ts
@@ -151,10 +151,12 @@ export function useRouteMode(): RouteState {
     const params = new URLSearchParams(location.search);
     const newMode = segmentToMode(segs[0], segs.length);
 
-    if (tabs[newMode] !== true || disabledTabs?.includes(newMode)) {
+    const isDisabled =
+      tabs[newMode] === false || disabledTabs?.includes(newMode);
+    if (isDisabled) {
       const firstEnabled = Object.entries(tabs).find(
         ([m, enabled]) =>
-          enabled === true && !disabledTabs?.includes(m as Mode),
+          enabled !== false && !disabledTabs?.includes(m as Mode),
       )?.[0] as Mode | undefined;
 
       if (firstEnabled) {

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -177,6 +177,30 @@ test.describe('pension forecast page', () => {
   });
 });
 
+test.describe('pension forecast routing', () => {
+  test('keeps pension mode when config tab state is indeterminate', async ({ page }) => {
+    await applyAuth(page);
+
+    await page.route('**/config', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          tabs: { pension: null },
+          disabled_tabs: [],
+        }),
+      });
+    });
+
+    await page.goto(pensionForecastPath);
+
+    const marker = page.getByTestId('active-route-marker');
+    await expect(marker).toHaveAttribute('data-mode', 'pension');
+    await expect(marker).toHaveAttribute('data-pathname', '/pension/forecast');
+    await expect(page.getByRole('heading', { name: 'Pension Forecast' })).toBeVisible();
+  });
+});
+
 test.describe('public route smoke coverage', () => {
   for (const route of ROUTES) {
     test(`renders ${route.path}`, async ({ page }) => {


### PR DESCRIPTION
## Summary
- ensure the main app checks both explicit tab disables and disabledTabs before redirecting away from pension
- normalise config tab overrides to only accept booleans so indeterminate values do not disable routes
- update route mode guards and add Playwright coverage for pension forecast when the config tab state is null

## Testing
- npx playwright test tests/smoke.spec.ts --grep "keeps pension mode"
- npx playwright test tests/smoke.spec.ts --grep "pension forecast heading"

------
https://chatgpt.com/codex/tasks/task_e_68d995e708ec832781932244b3db97cc