### PR TITLE
Gate virtual portfolio loader on request state

### DIFF
--- a/frontend/src/pages/VirtualPortfolio.tsx
+++ b/frontend/src/pages/VirtualPortfolio.tsx
@@ -71,6 +71,7 @@ export function VirtualPortfolio() {
     const loadId = activeLoadRef.current + 1;
     activeLoadRef.current = loadId;
 
+    setHasLoadedInitialData(false);
     setLoading(true);
     setMessage(null);
     setError(null);
@@ -218,7 +219,7 @@ export function VirtualPortfolio() {
     }
   }
 
-  const isInitialLoading = !hasLoadedInitialData;
+  const isInitialLoading = !hasLoadedInitialData && loading;
 
   return (
     <div className="container mx-auto p-4">

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -91,13 +91,15 @@ const ROUTES: RouteConfig[] = [
       });
     },
     extraAssertions: async (page) => {
-      await expect(page.getByText('Loading...')).toBeVisible();
+      const loader = page.getByText('Loading...');
+      await expect(loader).toBeVisible();
       await expect(
         page.getByRole('heading', { name: 'Virtual Portfolios' }),
       ).toBeVisible();
       await expect(
         page.getByRole('option', { name: 'Slow path demo' }),
       ).toBeVisible();
+      await expect(loader).not.toBeVisible();
     },
   },
   { path: '/support', assertion: { kind: 'heading', name: 'Support' } },


### PR DESCRIPTION
## Summary
- reset the virtual portfolio initial load flag when scheduling a fresh fetch and tie the loader to the active request state
- extend the smoke test to verify the loader appears for slow responses and clears once data arrives

## Testing
- not run (Playwright smoke suite requires a running frontend server)


------
https://chatgpt.com/codex/tasks/task_e_68d99b616f188327a19b43cff72c1418