### PR TITLE
Handle blank Google auth env overrides gracefully

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -316,12 +316,14 @@ def load_config() -> Config:
             )
 
     google_client_id = data.get("google_client_id")
-    env_client_id = os.getenv("GOOGLE_CLIENT_ID")
-    if env_client_id is not None:
-        google_client_id = env_client_id
-
     if isinstance(google_client_id, str):
         google_client_id = google_client_id.strip() or None
+
+    env_client_id = os.getenv("GOOGLE_CLIENT_ID")
+    if env_client_id is not None:
+        env_val = env_client_id.strip()
+        if env_val:
+            google_client_id = env_val
 
     allowed_emails_raw = _parse_str_list(data.get("allowed_emails"))
     allowed_emails = None

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -111,15 +111,14 @@ async def update_config(payload: Dict[str, Any]) -> Dict[str, Any]:
     google_client_id = auth_section.get("google_client_id")
     if isinstance(google_client_id, str):
         google_client_id = google_client_id.strip() or None
+
     env_google_client_id = os.getenv("GOOGLE_CLIENT_ID")
     if env_google_client_id is not None:
         env_val = env_google_client_id.strip()
         if env_val:
             google_client_id = env_val
-        elif google_auth_enabled:
+        elif google_client_id is None and google_auth_enabled:
             raise HTTPException(status_code=400, detail="GOOGLE_CLIENT_ID is empty")
-        else:
-            google_client_id = None
 
     try:
         validate_google_auth(google_auth_enabled, google_client_id)

--- a/tests/routes/test_config.py
+++ b/tests/routes/test_config.py
@@ -74,6 +74,25 @@ def test_update_config_env_requires_client_id(monkeypatch, tmp_path):
     reload_config()
 
 
+def test_update_config_env_uses_existing_client_id(monkeypatch, tmp_path):
+    _setup_config(
+        monkeypatch,
+        tmp_path,
+        "auth:\n  google_auth_enabled: false\n  google_client_id: existing-id\n",
+    )
+    client = TestClient(create_app())
+    monkeypatch.setenv("GOOGLE_AUTH_ENABLED", "true")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "")
+
+    resp = client.put("/config", json={})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["google_auth_enabled"] is True
+    assert data["google_client_id"] == "existing-id"
+
+    monkeypatch.undo()
+    reload_config()
+
 
 def test_update_config_env_valid(monkeypatch, tmp_path):
     _setup_config(monkeypatch, tmp_path)


### PR DESCRIPTION
## Summary
- retain existing Google OAuth client IDs when GOOGLE_CLIENT_ID is set but blank so env overrides do not clear persisted values
- mirror the env override adjustment in the config loader and add regression coverage ensuring PUT /config succeeds with an existing client ID

## Testing
- PYTEST_ADDOPTS="--cov=backend --cov-fail-under=0" pytest tests/routes/test_config.py
- npm run smoke:test -- http://localhost:8000 *(fails later at GET /instrument/intraday -> 404 because demo data is incomplete, but /config checks return 200)*

------
https://chatgpt.com/codex/tasks/task_e_68d99b6046448327acefc4078566d281