### PR TITLE
Match reporting date typography with metric headings

### DIFF
--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -119,8 +119,8 @@ export function PerformanceDashboard({ owner }: Props) {
           display: "flex",
           gap: "1rem",
           flexWrap: "wrap",
-          fontSize: "0.85rem",
-          color: "#666",
+          fontSize: "0.9rem",
+          color: "#aaa",
           marginBottom: "0.75rem",
         }}
       >


### PR DESCRIPTION
## Summary
- align the reporting and previous date summary typography with the surrounding metric headings for consistent styling

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d99efd06c4832780dbc7737871531b