### PR TITLE
Require authentication helper for quest routes

### DIFF
--- a/backend/routes/quest_routes.py
+++ b/backend/routes/quest_routes.py
@@ -1,19 +1,32 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from backend.auth import get_current_user
+from backend.auth import get_active_user, oauth2_scheme
 from backend import quests
 
 router = APIRouter(prefix="/quests", tags=["quests"])
 
 
+async def require_active_user(
+    request: Request, token: str | None = Depends(oauth2_scheme)
+) -> str:
+    """Resolve the authenticated user or raise ``401`` when missing."""
+
+    user = await get_active_user(request, token)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+        )
+    return user
+
+
 @router.get("/today")
-async def today(current_user: str = Depends(get_current_user)):
+async def today(current_user: str = Depends(require_active_user)):
     """Return today's quests for the authenticated user."""
     return quests.get_quests(current_user)
 
 
 @router.post("/{quest_id}/complete")
-async def complete(quest_id: str, current_user: str = Depends(get_current_user)):
+async def complete(quest_id: str, current_user: str = Depends(require_active_user)):
     """Mark ``quest_id`` complete for the authenticated user."""
     try:
         return quests.mark_complete(current_user, quest_id)


### PR DESCRIPTION
## Summary
- add a `require_active_user` dependency that validates the resolved quest user
- update quest routes to depend on the helper so dependency overrides continue to work
- expand quest route tests to cover authenticated overrides and unauthorized responses

## Testing
- `pytest --override-ini addopts="" tests/test_quests_route.py`


------
https://chatgpt.com/codex/tasks/task_e_68d99ebd7a2883279a54173c0d9e6a24