### PR TITLE
Add settings page to smoke coverage

### DIFF
--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -45,6 +45,7 @@ const ROUTES: RouteConfig[] = [
   { path: '/transactions', assertion: { kind: 'mode', mode: 'transactions' } },
   { path: '/trading', assertion: { kind: 'mode', mode: 'trading' } },
   { path: '/screener', assertion: { kind: 'mode', mode: 'screener' } },
+  { path: '/settings', assertion: { kind: 'mode', mode: 'settings' } },
   { path: '/timeseries', assertion: { kind: 'mode', mode: 'timeseries' } },
   { path: '/watchlist', assertion: { kind: 'mode', mode: 'watchlist' } },
   { path: '/market', assertion: { kind: 'mode', mode: 'market' } },


### PR DESCRIPTION
## Summary
- include the settings route in the smoke test route list so the page is covered by mode assertions

## Testing
- npm --prefix frontend run smoke:frontend *(fails: expected backend smoke check endpoints to return ok in this environment and several optional flows such as /virtual and /trail to load)*

------
https://chatgpt.com/codex/tasks/task_e_68d99eb03608832782f6999c3b1c7fc5