### PR TITLE
Extend get_active_user override lookup

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -229,9 +229,17 @@ async def get_active_user(
 
     override = request.app.dependency_overrides.get(get_current_user)
     if not override:
-        provider = getattr(request.app, "dependency_overrides_provider", None)
-        overrides = getattr(provider, "dependency_overrides", {}) if provider else {}
-        override = overrides.get(get_current_user)
+        providers = [
+            getattr(request.app, "dependency_overrides_provider", None),
+            getattr(getattr(request.app, "router", None), "dependency_overrides_provider", None),
+        ]
+        for provider in providers:
+            if not provider:
+                continue
+            overrides = getattr(provider, "dependency_overrides", {})
+            override = overrides.get(get_current_user)
+            if override:
+                break
     if override:
         return await _invoke_override(override)
 


### PR DESCRIPTION
## Summary
- allow get_active_user to resolve dependency overrides from the app or router provider
- cover sync and async provider overrides for get_active_user in dedicated tests

## Testing
- pytest -o addopts='' tests/test_auth_get_active_user.py


------
https://chatgpt.com/codex/tasks/task_e_68d9a82814288327825976e3b1b88b5c