### PR TITLE
Localize portfolio header summary

### DIFF
--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -55,7 +55,9 @@ export default function MainApp() {
   const [groups, setGroups] = useState<GroupSummary[]>([]);
   const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
   const [instruments, setInstruments] = useState<InstrumentSummary[]>([]);
-  const [tradeInfo, setTradeInfo] = useState<{ tradesThisMonth: number; tradesRemaining: number } | null>(null);
+  const [tradeInfo, setTradeInfo] = useState<
+    { asOf: string; tradesThisMonth: number; tradesRemaining: number } | null
+  >(null);
 
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -164,13 +166,21 @@ export default function MainApp() {
     if (mode === "owner" && selectedOwner) {
       setLoading(true);
       setErr(null);
+      setTradeInfo(null);
       getPortfolio(selectedOwner)
         .then((p) => {
           setPortfolio(p);
-          setTradeInfo({
-            tradesThisMonth: p.trades_this_month,
-            tradesRemaining: p.trades_remaining,
-          });
+          setTradeInfo(
+            p.as_of != null &&
+              p.trades_this_month != null &&
+              p.trades_remaining != null
+              ? {
+                  asOf: p.as_of,
+                  tradesThisMonth: p.trades_this_month,
+                  tradesRemaining: p.trades_remaining,
+                }
+              : null,
+          );
         })
         .catch((e) => setErr(String(e)))
         .finally(() => setLoading(false));
@@ -241,6 +251,7 @@ export default function MainApp() {
       <Menu selectedOwner={selectedOwner} selectedGroup={selectedGroup} />
 
       <Header
+        asOf={tradeInfo?.asOf}
         tradesThisMonth={tradeInfo?.tradesThisMonth}
         tradesRemaining={tradeInfo?.tradesRemaining}
       />
@@ -273,10 +284,14 @@ export default function MainApp() {
             owners={owners}
             onTradeInfo={(info) =>
               setTradeInfo(
-                info
+                info &&
+                  info.as_of != null &&
+                  info.trades_this_month != null &&
+                  info.trades_remaining != null
                   ? {
-                      tradesThisMonth: info.trades_this_month ?? 0,
-                      tradesRemaining: info.trades_remaining ?? 0,
+                      asOf: info.as_of,
+                      tradesThisMonth: info.trades_this_month,
+                      tradesRemaining: info.trades_remaining,
                     }
                   : null,
               )

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -83,7 +83,15 @@ const computeDayChangePct = (value: number, delta: number): number | null => {
 type Props = {
   slug: string;
   owners?: OwnerSummary[];
-  onTradeInfo?: (info: { trades_this_month?: number; trades_remaining?: number } | null) => void;
+  onTradeInfo?: (
+    info:
+      | {
+          as_of?: string | null;
+          trades_this_month?: number | null;
+          trades_remaining?: number | null;
+        }
+      | null,
+  ) => void;
 };
 
 /* ────────────────────────────────────────────────────────────
@@ -268,6 +276,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
       onTradeInfo(
         portfolio
           ? {
+              as_of: portfolio.as_of,
               trades_this_month: portfolio.trades_this_month,
               trades_remaining: portfolio.trades_remaining,
             }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,13 +1,32 @@
+import { useTranslation } from "react-i18next";
+
+import { formatDateISO } from "../lib/date";
+
 interface Props {
+  asOf?: string | null;
   tradesThisMonth?: number | null;
   tradesRemaining?: number | null;
 }
 
-export function Header({ tradesThisMonth, tradesRemaining }: Props) {
-  if (tradesThisMonth == null || tradesRemaining == null) return null;
+export function Header({ asOf, tradesThisMonth, tradesRemaining }: Props) {
+  const { t } = useTranslation();
+
+  if (asOf == null || tradesThisMonth == null || tradesRemaining == null) {
+    return null;
+  }
+
+  const date = new Date(asOf);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
   return (
     <div style={{ marginBottom: "1rem" }}>
-      Trades this month: {tradesThisMonth} / 20 (Remaining: {tradesRemaining})
+      {t("asOf", {
+        date: formatDateISO(date),
+        trades: tradesThisMonth,
+        remaining: tradesRemaining,
+      })}
     </div>
   );
 }

--- a/frontend/tests/unit/components/Header.test.tsx
+++ b/frontend/tests/unit/components/Header.test.tsx
@@ -7,10 +7,14 @@ import { fireEvent } from "@testing-library/react";
 import i18n from "@/i18n";
 
 describe("Header", () => {
-  it("shows trade meter when data present", () => {
-    render(<Header tradesThisMonth={3} tradesRemaining={17} />);
+  it("shows localized as-of summary when data present", () => {
+    render(
+      <Header asOf="2024-07-01" tradesThisMonth={3} tradesRemaining={17} />,
+    );
     expect(
-      screen.getByText(/Trades this month: 3 \/ 20 \(Remaining: 17\)/)
+      screen.getByText(
+        "As of 2024-07-01 • Trades this month: 3 / 20 (Remaining: 17)",
+      ),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- localize the header component so it renders the translated as-of summary with formatted dates and trade counts
- pass portfolio as-of metadata from MainApp and guard against incomplete trade data before displaying the header
- propagate as-of details from group portfolios and update the header unit test to confirm the translated output

## Testing
- npm run test -- Header

------
https://chatgpt.com/codex/tasks/task_e_68d9aa6057b883279186331d7bb9b6a6