### PR TITLE
Fix config bootstrap route handling

### DIFF
--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -263,8 +263,8 @@ test.describe('config bootstrap', () => {
         await route.abort('failed');
         return;
       }
-      await page.unroute('**/config', handler);
       await route.continue();
+      await page.unroute('**/config', handler);
     };
 
     await page.route('**/config', handler);


### PR DESCRIPTION
## Summary
- ensure the config bootstrap Playwright handler continues the request before removing the route so it is only processed once

## Testing
- npm run smoke:frontend *(fails: Playwright could not launch Chromium because required system libraries like libX11-xcb are missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9aace7a008327a4eed62e8eb19a50