### PR TITLE
Add GBX to supported currency options

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -197,12 +197,13 @@ export function useConfig() {
 }
 
 export const SUPPORTED_CURRENCIES = [
-  "GBP",
-  "USD",
-  "EUR",
-  "CHF",
-  "JPY",
   "CAD",
+  "CHF",
+  "EUR",
+  "GBP",
+  "GBX",
+  "JPY",
+  "USD",
 ];
 
 export function BaseCurrencySelector() {


### PR DESCRIPTION
## Summary
- add GBX to the list of supported frontend currencies so base currency selection and validation accept it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9ac0c16f88327929744481d211d7f