### PR TITLE
Guard header date until portfolio metadata ready

### DIFF
--- a/frontend/tests/unit/components/Header.test.tsx
+++ b/frontend/tests/unit/components/Header.test.tsx
@@ -5,21 +5,29 @@ import Menu from "@/components/Menu";
 import { MemoryRouter } from "react-router-dom";
 import { fireEvent } from "@testing-library/react";
 import i18n from "@/i18n";
+import { I18nextProvider } from "react-i18next";
+import { formatDateISO } from "@/lib/date";
 
 describe("Header", () => {
   it("shows localized as-of summary when data present", () => {
     render(
-      <Header asOf="2024-07-01" tradesThisMonth={3} tradesRemaining={17} />,
+      <I18nextProvider i18n={i18n}>
+        <Header asOf="2024-07-01" tradesThisMonth={3} tradesRemaining={17} />
+      </I18nextProvider>,
     );
     expect(
       screen.getByText(
-        "As of 2024-07-01 • Trades this month: 3 / 20 (Remaining: 17)",
+        `As of ${formatDateISO(new Date("2024-07-01"))} • Trades this month: 3 / 20 (Remaining: 17)`,
       ),
     ).toBeInTheDocument();
   });
 
   it("renders nothing without data", () => {
-    const { container } = render(<Header />);
+    const { container } = render(
+      <I18nextProvider i18n={i18n}>
+        <Header />
+      </I18nextProvider>,
+    );
     expect(container).toBeEmptyDOMElement();
   });
 


### PR DESCRIPTION
## Summary
- reset the dashboard header while owner/group data loads and source the as-of date from portfolio responses
- wrap the header unit test with the i18n provider to assert the localized summary text

## Testing
- npm --prefix frontend run test -- Header

------
https://chatgpt.com/codex/tasks/task_e_68d9ad6bde248327a7ec5efceb593457