### PR TITLE
Handle blank GOOGLE_AUTH_ENABLED overrides

### DIFF
--- a/tests/backend/routes/test_config.py
+++ b/tests/backend/routes/test_config.py
@@ -228,3 +228,36 @@ async def test_update_config_empty_payload_ignores_google_auth_env_toggle(
     assert loader.cleared is False
     assert result["google_auth_enabled"] is False
     assert result["google_client_id"] is None
+
+
+async def test_update_config_treats_blank_google_auth_env_as_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    base_config = {
+        "auth": {
+            "google_auth_enabled": False,
+            "disable_auth": True,
+            "google_client_id": "",
+            "allowed_emails": ["user@example.com"],
+        },
+        "ui": {
+            "theme": "system",
+            "tabs": {"instrument": True, "market": True},
+        },
+    }
+    _write_config(config_path, base_config)
+    monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
+    loader = _patch_loader(monkeypatch)
+    dummy_config = _DummyConfig(google_auth_enabled=False, google_client_id=None)
+    monkeypatch.setattr(routes_config.config_module, "config", dummy_config)
+    calls = _spy_validate(monkeypatch)
+
+    monkeypatch.setenv("GOOGLE_AUTH_ENABLED", "   ")
+
+    result = await routes_config.update_config({})
+
+    assert calls == []
+    assert loader.cleared is False
+    assert result["google_auth_enabled"] is False
+    assert result["google_client_id"] is None


### PR DESCRIPTION
## Summary
- skip config updates when the merged payload does not change persisted data to avoid unnecessary validation
- treat whitespace-only GOOGLE_AUTH_ENABLED overrides as absent before validation
- add a regression test covering blank GOOGLE_AUTH_ENABLED values during config updates

## Testing
- pytest -o addopts='' tests/backend/routes/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b03e7a8483279825c18cd8028b70