### PR TITLE
Short-circuit no-op config updates

### DIFF
--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -101,16 +101,20 @@ async def update_config(payload: Dict[str, Any]) -> Dict[str, Any]:
         except Exception as exc:  # pragma: no cover - defensive
             raise HTTPException(500, f"Failed to read config: {exc}")
 
+    existing_data = _normalise_config_structure(stored_data)
+
+    if not payload:
+        return serialise_config(config_module.config)
+
     merged_data = deepcopy(stored_data)
     deep_merge(merged_data, payload)
 
-    existing_data = _normalise_config_structure(stored_data)
     data = _normalise_config_structure(merged_data)
 
-    persisted_data = deepcopy(data)
-    persist_required = persisted_data != existing_data
-    if not persist_required:
+    if data == existing_data:
         return serialise_config(config_module.config)
+
+    persisted_data = deepcopy(data)
 
     auth_section = data.get("auth", {}) if isinstance(data, dict) else {}
     if not isinstance(auth_section, dict):


### PR DESCRIPTION
## Summary
- normalise stored config and return early for empty payloads or no-op updates before applying environment overrides
- keep persisted config snapshots untouched when no effective changes are detected so auth validation only runs for real updates

## Testing
- pytest tests/routes/test_config.py *(fails: repository addopts reference pytest-cov which is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b3590acc832786af09b0378193fc