### PR TITLE
Expose route marker for Playwright config regression test

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, Suspense } from "react";
+import { useCallback, useEffect, useState, Suspense, type CSSProperties } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -130,6 +130,20 @@ const initialSlug = path[1] ?? "";
 
 type InstrumentMetadataWithSymbol = InstrumentMetadata & {
   symbol?: string | null;
+};
+
+const routeMarkerStyle: CSSProperties = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  border: 0,
+  opacity: 0,
+  pointerEvents: "none",
+  clip: "rect(0 0 0 0)",
+  clipPath: "inset(50%)",
+  overflow: "hidden",
 };
 
 function metadataToInstrumentSummary(metadata: InstrumentMetadata): InstrumentSummary {
@@ -629,7 +643,7 @@ export default function App({ onLogout }: AppProps) {
           data-testid="active-route-marker"
           data-mode={mode}
           data-pathname={location.pathname}
-          hidden
+          style={routeMarkerStyle}
         />
         {renderMainContent()}
       </main>

--- a/frontend/tests/config-retry.spec.ts
+++ b/frontend/tests/config-retry.spec.ts
@@ -28,7 +28,13 @@ test.describe('config bootstrap regression', () => {
       }
 
       await page.unroute('**/config', handler);
-      await route.continue();
+      try {
+        await route.continue();
+      } catch (error) {
+        if (!(error instanceof Error) || !/already handled/i.test(error.message)) {
+          throw error;
+        }
+      }
     };
 
     await page.route('**/config', handler);


### PR DESCRIPTION
## Summary
- replace the hidden attribute on the active route marker with a visually-hidden style so Playwright can read its attributes
- harden the config bootstrap Playwright test to ignore benign "route already handled" errors when retrying /config

## Testing
- npx playwright test --reporter=line --config playwright.config.ts tests/config-retry.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9b04294888327be3e75b7db7bcd97