### PR TITLE
Prevent duplicate VirtualPortfolio initial loads in StrictMode

### DIFF
--- a/frontend/tests/unit/pages/VirtualPortfolio.test.tsx
+++ b/frontend/tests/unit/pages/VirtualPortfolio.test.tsx
@@ -223,8 +223,13 @@ describe("VirtualPortfolio page", () => {
       </StrictMode>,
     );
 
+    expect(screen.getByTestId("virtual-portfolio-loader")).toBeInTheDocument();
+
     const option = await screen.findByRole("option", { name: "Slow path demo" });
     expect(option).toBeInTheDocument();
+
+    expect(mockGetVirtualPortfolios).toHaveBeenCalledTimes(1);
+    expect(mockGetOwners).toHaveBeenCalledTimes(1);
 
     await waitFor(() => {
       expect(screen.queryByText(/Loading\.\.\./i)).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- guard the virtual portfolio initial load so StrictMode renders only trigger one fetch and reuse any in-flight promise
- keep spinner visibility tied to the guarded initial load state while normalizing API responses before tracking analytics
- extend the StrictMode regression test to assert the loader remains visible and that duplicate requests are not issued

## Testing
- npm run test -- --run tests/unit/pages/VirtualPortfolio.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9b041a4748327a2153f887112db44