### PR TITLE
Prefill manual timeseries rows with ticker metadata

### DIFF
--- a/backend/routes/timeseries_edit.py
+++ b/backend/routes/timeseries_edit.py
@@ -89,6 +89,9 @@ async def post_timeseries_edit(
         raise HTTPException(status_code=400, detail=str(exc))
 
     df = _ensure_schema(df)
+    for col in ("Ticker", "Source"):
+        if col in df.columns:
+            df[col] = df[col].replace("", pd.NA)
     if "Ticker" not in df.columns or df["Ticker"].isna().all():
         df["Ticker"] = ticker
     if "Source" not in df.columns or df["Source"].isna().all():

--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -372,7 +372,14 @@ export function TimeseriesEdit() {
       </div>
       <div style={{ marginBottom: "0.5rem" }}>
         <button
-          onClick={() =>
+          onClick={() => {
+            const trimmedTicker = ticker.trim().toUpperCase();
+            const defaultTicker =
+              trimmedTicker && exchange
+                ? trimmedTicker.includes(".")
+                  ? trimmedTicker
+                  : `${trimmedTicker}.${exchange}`
+                : trimmedTicker;
             setRows((rs) => [
               ...rs,
               {
@@ -382,11 +389,11 @@ export function TimeseriesEdit() {
                 Low: null,
                 Close: null,
                 Volume: null,
-                Ticker: "",
-                Source: "",
+                Ticker: defaultTicker,
+                Source: "Manual",
               },
-            ])
-          }
+            ]);
+          }}
         >
           {t("timeseriesEdit.addRow")}
         </button>

--- a/frontend/tests/unit/pages/TimeseriesEdit.test.tsx
+++ b/frontend/tests/unit/pages/TimeseriesEdit.test.tsx
@@ -56,6 +56,10 @@ describe("TimeseriesEdit page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /add row/i }));
     expect(screen.getAllByLabelText("Date")).toHaveLength(2);
+    const tickerInputs = screen.getAllByLabelText("Ticker");
+    expect(tickerInputs[tickerInputs.length - 1]).toHaveValue("ABC.L");
+    const sourceInputs = screen.getAllByLabelText("Source");
+    expect(sourceInputs[sourceInputs.length - 1]).toHaveValue("Manual");
 
     fireEvent.click(screen.getAllByRole("button", { name: /delete/i })[1]);
     expect(screen.getAllByLabelText("Date")).toHaveLength(1);

--- a/tests/routes/test_timeseries_edit.py
+++ b/tests/routes/test_timeseries_edit.py
@@ -50,8 +50,26 @@ def test_post_json_and_get_format(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch)
 
     data = [
-        {"Date": "2024-01-01", "Open": 1.0, "High": 2.0, "Low": 0.5, "Close": 1.5, "Volume": 100},
-        {"Date": "2024-01-02", "Open": 1.1, "High": 2.1, "Low": 0.6, "Close": 1.6, "Volume": 110},
+        {
+            "Date": "2024-01-01",
+            "Open": 1.0,
+            "High": 2.0,
+            "Low": 0.5,
+            "Close": 1.5,
+            "Volume": 100,
+            "Ticker": "",
+            "Source": "",
+        },
+        {
+            "Date": "2024-01-02",
+            "Open": 1.1,
+            "High": 2.1,
+            "Low": 0.6,
+            "Close": 1.6,
+            "Volume": 110,
+            "Ticker": "",
+            "Source": "",
+        },
     ]
     resp = client.post("/timeseries/edit?ticker=ABC&exchange=L", json=data)
     assert resp.status_code == 200
@@ -61,6 +79,7 @@ def test_post_json_and_get_format(tmp_path, monkeypatch):
     df = pd.read_parquet(path)
     assert len(df) == 2
     assert list(df["Ticker"]) == ["ABC", "ABC"]
+    assert list(df["Source"]) == ["Manual", "Manual"]
 
     resp = client.get("/timeseries/edit?ticker=ABC&exchange=L")
     assert resp.status_code == 200
@@ -82,6 +101,8 @@ def test_post_csv_saves_parquet(tmp_path, monkeypatch):
     path = timeseries_edit.meta_timeseries_cache_path("XYZ", "L")
     df = pd.read_parquet(path)
     assert df.loc[0, "Close"] == 1.5
+    assert list(df["Ticker"]) == ["XYZ", "XYZ"]
+    assert list(df["Source"]) == ["Manual", "Manual"]
 
 
 def test_get_missing_file(tmp_path, monkeypatch):

--- a/tests/test_timeseries_edit_route.py
+++ b/tests/test_timeseries_edit_route.py
@@ -41,3 +41,5 @@ def test_timeseries_edit_roundtrip(tmp_path, monkeypatch):
     returned = resp.json()
     assert len(returned) == 2
     assert returned[0]["Open"] == 1.0
+    assert returned[0]["Ticker"] == "ABC"
+    assert returned[0]["Source"] == "Manual"


### PR DESCRIPTION
## Summary
- default new manual timeseries rows to the selected ticker (including exchange) and manual source in the editor
- normalize backend saves by converting blank metadata fields to missing values before applying defaults
- extend frontend and backend regression coverage to ensure ticker/source columns persist when saving

## Testing
- pytest -o addopts='' tests/routes/test_timeseries_edit.py
- pytest -o addopts='' tests/test_timeseries_edit_route.py
- npx vitest run tests/unit/pages/TimeseriesEdit.test.tsx --environment jsdom

------
https://chatgpt.com/codex/tasks/task_e_68d9ba5c3a48832786fe01f987dd7dc8