### PR TITLE
Display pricing date in group portfolio header

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -38,6 +38,7 @@ import { getGroupDisplayName } from "../utils/groups";
 import { RelativeViewToggle } from "./RelativeViewToggle";
 import { preloadInstrumentHistory } from "../hooks/useInstrumentHistory";
 import { isCashInstrument } from "../lib/instruments";
+import { formatDateISO } from "../lib/date";
 import { createOwnerDisplayLookup, getOwnerDisplayName } from "../utils/owners";
 import {
   PieChart,
@@ -490,16 +491,34 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   const hasFilteredAccounts = filteredAccounts.length > 0;
 
   /* ── render ────────────────────────────────────────────── */
+  const pricingDate = portfolio.as_of
+    ? formatDateISO(new Date(portfolio.as_of))
+    : null;
+
   return (
     <div style={{ marginTop: "1rem" }}>
       <div
         style={{
           display: "flex",
           justifyContent: "space-between",
-          alignItems: "center",
+          alignItems: "flex-end",
+          gap: "1rem",
         }}
       >
-        <h2>{getGroupDisplayName(slug, portfolio.name, t)}</h2>
+        <div>
+          <h2>{getGroupDisplayName(slug, portfolio.name, t)}</h2>
+          {pricingDate && (
+            <div
+              style={{
+                marginTop: "0.25rem",
+                fontSize: "0.85rem",
+                color: "#aaa",
+              }}
+            >
+              {t("group.pricingAsOf", { date: pricingDate })}
+            </div>
+          )}
+        </div>
         <RelativeViewToggle />
       </div>
 

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -126,6 +126,7 @@
   },
   "group": {
     "atAGlance": "Auf einen Blick",
+    "pricingAsOf": "Preisstand vom {{date}}",
     "select": "Wählen Sie eine Gruppe."
   },
   "holdingsTable": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -120,6 +120,7 @@
   },
   "group": {
     "atAGlance": "At a glance",
+    "pricingAsOf": "Pricing as of {{date}}",
     "select": "Select a group."
   },
   "holdingsTable": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -126,6 +126,7 @@
   },
   "group": {
     "atAGlance": "De un vistazo",
+    "pricingAsOf": "Precios al {{date}}",
     "select": "Seleccione un grupo."
   },
   "holdingsTable": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -126,6 +126,7 @@
   },
   "group": {
     "atAGlance": "En un coup d'œil",
+    "pricingAsOf": "Tarification au {{date}}",
     "select": "Sélectionnez un groupe."
   },
   "holdingsTable": {

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -126,6 +126,7 @@
   },
   "group": {
     "atAGlance": "A colpo d'occhio",
+    "pricingAsOf": "Prezzi al {{date}}",
     "select": "Seleziona un gruppo."
   },
   "holdingsTable": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -126,6 +126,7 @@
   },
   "group": {
     "atAGlance": "Visão geral",
+    "pricingAsOf": "Preços em {{date}}",
     "select": "Selecione um grupo."
   },
   "holdingsTable": {

--- a/frontend/tests/unit/components/GroupPortfolioView.test.tsx
+++ b/frontend/tests/unit/components/GroupPortfolioView.test.tsx
@@ -257,6 +257,24 @@ describe("GroupPortfolioView", () => {
     expect(screen.queryByText("Total Value")).toBeNull();
   });
 
+  it("renders the pricing as-of date", async () => {
+    const mockPortfolio = {
+      name: "At a glance",
+      as_of: "2024-04-01T12:00:00Z",
+      accounts: [],
+    };
+
+    mockAllFetches(mockPortfolio);
+
+    renderWithConfig(<GroupPortfolioView slug="all" owners={ownerFixtures} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Pricing as of 2024-04-01", { exact: false }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("suppresses day change percentage when the baseline is nearly zero", async () => {
     const mockPortfolio = {
       name: "Tiny balances",


### PR DESCRIPTION
## Summary
- render the group portfolio pricing date using the shared ISO formatter
- add locale strings for the pricing date caption across supported languages
- cover the pricing date display with a dedicated unit test

## Testing
- npm --prefix frontend run test -- --run tests/unit/components/GroupPortfolioView.test.tsx --t "renders the pricing as-of date"


------
https://chatgpt.com/codex/tasks/task_e_68d9ba8165148327837285c7ce0fc1b0