### PR TITLE
Handle virtual mode in route parsing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,6 +72,9 @@ const PerformanceDashboard = lazyWithDelay(
 const InstrumentResearch = lazyWithDelay(
   () => import("./pages/InstrumentResearch"),
 );
+const VirtualPortfolio = lazyWithDelay(
+  () => import("./pages/VirtualPortfolio"),
+);
 
 interface AppProps {
   onLogout?: () => void;
@@ -674,6 +677,11 @@ export default function App({ onLogout }: AppProps) {
 
         {mode === "screener" && <ScreenerQuery />}
         {mode === "timeseries" && <TimeseriesEdit />}
+        {mode === "virtual" && (
+          <Suspense fallback={<p>{t("app.loading")}</p>}>
+            <VirtualPortfolio />
+          </Suspense>
+        )}
         {mode === "instrumentadmin" && <InstrumentAdmin />}
         {mode === "dataadmin" && <DataAdmin />}
         {mode === "watchlist" && <Watchlist />}


### PR DESCRIPTION
## Summary
- ensure the virtual route initializes the application in virtual mode
- add explicit virtual mode handling to the route switch logic

## Testing
- ENABLE_PRERENDER=false npm --prefix frontend run build
- npm --prefix frontend run smoke:frontend *(fails: Chromium dependencies missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da77bfb44483278ceb87e0ff9b21f5