### PR TITLE
Handle virtual mode in route parsing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,7 +82,8 @@ type Mode =
   | "pension"
   | "market"
   | "rebalance"
-  | "research";
+  | "research"
+  | "virtual";
 
 // derive initial mode + id from path
 const path = window.location.pathname.split("/").filter(Boolean);
@@ -111,6 +112,8 @@ const initialMode: Mode =
     ? "market"
     : path[0] === "movers"
     ? "movers"
+    : path[0] === "virtual"
+    ? "virtual"
     : path[0] === "instrumentadmin"
     ? "instrumentadmin"
     : path[0] === "dataadmin"
@@ -340,6 +343,9 @@ export default function App({ onLogout }: AppProps) {
         break;
       case "movers":
         newMode = "movers";
+        break;
+      case "virtual":
+        newMode = "virtual";
         break;
       case "instrumentadmin":
         newMode = "instrumentadmin";


### PR DESCRIPTION
## Summary
- ensure the virtual route initializes the application in virtual mode
- add explicit virtual mode handling to the route switch logic

## Testing
- ENABLE_PRERENDER=false npm --prefix frontend run build
- npm --prefix frontend run smoke:frontend *(fails: Chromium dependencies missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da77bfb44483278ceb87e0ff9b21f5