### PR TITLE
Normalise holding eligibility to weekdays

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -442,11 +442,13 @@ def enrich_holding(
         days = (pricing_date - acq).days
         out["days_held"] = days
         hold_days = ucfg.hold_days_min or 0
-        eligible = days >= hold_days
-        next_date = acq + dt.timedelta(days=hold_days)
+        next_date_candidate = acq + dt.timedelta(days=hold_days)
+        next_date = calc.resolve_weekday(next_date_candidate, forward=True)
+        anchor = calc.today
+        eligible = anchor >= next_date
         out["eligible_on"] = next_date.isoformat()
         out["next_eligible_sell_date"] = next_date.isoformat()
-        out["days_until_eligible"] = max(0, hold_days - days)
+        out["days_until_eligible"] = max(0, (next_date - anchor).days)
     else:
         out["days_held"] = None
         eligible = False


### PR DESCRIPTION
## Summary
- normalise holding eligibility dates using PricingDateCalculator weekday resolution
- add regression coverage for weekend hold anniversaries in trade approval enrichment

## Testing
- pytest -o addopts='' tests/test_trade_approvals.py


------
https://chatgpt.com/codex/tasks/task_e_68da7a83cfc08327a3af02b4cfb66dd7