### PR TITLE
Allow VaR test portfolio mock to accept pricing date

### DIFF
--- a/tests/test_var_route.py
+++ b/tests/test_var_route.py
@@ -28,7 +28,11 @@ def deterministic_setup(monkeypatch):
             }
         ],
     }
-    monkeypatch.setattr(portfolio_mod, "build_owner_portfolio", lambda owner: portfolio)
+    monkeypatch.setattr(
+        portfolio_mod,
+        "build_owner_portfolio",
+        lambda owner, pricing_date=None: portfolio,
+    )
     monkeypatch.setattr(portfolio_mod, "list_owners", lambda: ["alice"])
 
     # Closing prices for five consecutive days


### PR DESCRIPTION
## Summary
- update the mocked build_owner_portfolio in tests/test_var_route.py to accept an optional pricing_date keyword so the new signature does not raise a TypeError during tests

## Testing
- `pytest -o addopts= tests/test_var_route.py` *(fails: expected VaR of 41.35 but actual result is -10.53; TypeError no longer occurs)*

------
https://chatgpt.com/codex/tasks/task_e_68da7e02f7108327987fc704d5ddcfc3