### PR TITLE
Align portfolio builder test enrich mock signature

### DIFF
--- a/tests/backend/common/test_portfolio_builder.py
+++ b/tests/backend/common/test_portfolio_builder.py
@@ -54,7 +54,9 @@ def fixture_portfolio_stubs(monkeypatch, today):
             "holdings": list(base_holdings),
         }
 
-    def fake_enrich_holding(holding, as_of, price_cache, approvals, ucfg):  # noqa: ARG001
+    def fake_enrich_holding(
+        holding, as_of, price_cache, approvals, ucfg, *, calc=None
+    ):  # noqa: ARG001
         return {
             **holding,
             "market_value_gbp": holding["base_value"],


### PR DESCRIPTION
## Summary
- allow the `fake_enrich_holding` test helper to accept the optional calculation kwarg expected by `enrich_holding`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dabcbdb8b48327ba6e385b6194463c