### PR TITLE
Expose virtual portfolio select once initial data loads

### DIFF
--- a/frontend/src/pages/VirtualPortfolio.tsx
+++ b/frontend/src/pages/VirtualPortfolio.tsx
@@ -131,6 +131,7 @@ export function VirtualPortfolio() {
                 : "You appear to be offline.",
             );
             setLoading(false);
+            setInitialLoadInProgress(false);
             errorToast(err);
             return;
           }
@@ -277,21 +278,24 @@ export function VirtualPortfolio() {
       <div className="mb-4">
         <label>
           Select
-          <select
-            value={selected ?? ""}
-            onChange={(e) => {
-              const id = e.target.value ? Number(e.target.value) : null;
-              if (id) load(id);
-            }}
-            className="ml-2"
-          >
-            <option value="">New…</option>
-            {portfolios.map((p) => (
-              <option key={p.id} value={p.id ?? ""}>
-                {p.name}
-              </option>
-            ))}
-          </select>
+          {!isInitialLoading && (
+            <select
+              value={selected ?? ""}
+              onChange={(e) => {
+                const id = e.target.value ? Number(e.target.value) : null;
+                if (id) load(id);
+              }}
+              className="ml-2"
+              size={Math.min(6, Math.max(1, portfolios.length + 1))}
+            >
+              <option value="">New…</option>
+              {portfolios.map((p) => (
+                <option key={p.id} value={p.id ?? ""}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          )}
         </label>
       </div>
 


### PR DESCRIPTION
## Summary
- ensure the virtual portfolio loader clears the `initialLoadInProgress` flag after the final failed attempt so the retry UI is visible
- hide the virtual portfolio selector while the initial fetch runs and size the list so its options are visible to Playwright once data arrives

## Testing
- npm run smoke:frontend *(fails: backend smoke check remains red and trail/config flows need fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68dabcfa9dec8327a522ff38c45e850a