### PR TITLE
Accept pricing_date keyword in portfolio test fakes

### DIFF
--- a/tests/common/test_portfolio_utils_returns.py
+++ b/tests/common/test_portfolio_utils_returns.py
@@ -8,7 +8,9 @@ def test_compute_alpha_and_tracking_error(monkeypatch: pytest.MonkeyPatch) -> No
     dates = pd.date_range("2024-01-01", periods=3, freq="D")
     portfolio_series = pd.Series([100.0, 110.0, 115.0], index=dates.date)
 
-    def fake_portfolio_value_series(name: str, days: int, *, group: bool = False) -> pd.Series:
+    def fake_portfolio_value_series(
+        name: str, days: int, *, group: bool = False, pricing_date=None
+    ) -> pd.Series:
         assert name == "alice"
         assert days == 365
         assert group is False
@@ -35,7 +37,9 @@ def test_compute_metrics_none_when_series_misaligned(monkeypatch: pytest.MonkeyP
     dates = pd.date_range("2024-01-01", periods=3, freq="D")
     portfolio_series = pd.Series([100.0, 110.0, 115.0], index=dates.date)
 
-    def fake_portfolio_value_series(name: str, days: int, *, group: bool = False) -> pd.Series:
+    def fake_portfolio_value_series(
+        name: str, days: int, *, group: bool = False, pricing_date=None
+    ) -> pd.Series:
         return portfolio_series
 
     monkeypatch.setattr(portfolio_utils, "_portfolio_value_series", fake_portfolio_value_series)
@@ -66,7 +70,9 @@ def test_group_metrics_and_max_drawdown(monkeypatch: pytest.MonkeyPatch) -> None
 
     monkeypatch.setattr(portfolio_utils.group_portfolio, "build_group_portfolio", fake_group_portfolio)
 
-    def fake_portfolio_value_series(name: str, days: int, *, group: bool = False) -> pd.Series:
+    def fake_portfolio_value_series(
+        name: str, days: int, *, group: bool = False, pricing_date=None
+    ) -> pd.Series:
         if group:
             # Mirror the real helper by touching the group portfolio builder.
             portfolio_utils.group_portfolio.build_group_portfolio(name)
@@ -91,7 +97,9 @@ def test_group_metrics_and_max_drawdown(monkeypatch: pytest.MonkeyPatch) -> None
     drawdown_dates = pd.date_range("2024-02-01", periods=4, freq="D")
     drawdown_series = pd.Series([100.0, 120.0, 90.0, 110.0], index=drawdown_dates.date)
 
-    def fake_drawdown_series(name: str, days: int, *, group: bool = False) -> pd.Series:
+    def fake_drawdown_series(
+        name: str, days: int, *, group: bool = False, pricing_date=None
+    ) -> pd.Series:
         if group:
             portfolio_utils.group_portfolio.build_group_portfolio(name)
             return drawdown_series


### PR DESCRIPTION
## Summary
- update the test doubles for `_portfolio_value_series` and drawdown helpers to accept the optional `pricing_date` keyword so they match the production signature

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dabcbdb61c8327a8e1a47d21688f9c