### PR TITLE
Fix pension route portfolio root handling

### DIFF
--- a/backend/common/portfolio.py
+++ b/backend/common/portfolio.py
@@ -117,8 +117,11 @@ def build_owner_portfolio(
     owner: str,
     accounts_root: Optional[Path] = None,
     *,
+    root: Optional[Path] = None,
     pricing_date: Optional[dt.date] = None,
 ) -> Dict[str, Any]:
+    if root is not None:
+        accounts_root = root
     calc = PricingDateCalculator(reporting_date=pricing_date)
     today = calc.today
     pricing_date = calc.reporting_date

--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -49,7 +49,7 @@ def pension_forecast(
     forecast_death_age = max(death_age, retirement_age + 1)
 
     try:
-        portfolio = build_owner_portfolio(owner, accounts_root)
+        portfolio = build_owner_portfolio(owner, root=accounts_root)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     pension_pot = 0.0


### PR DESCRIPTION
## Summary
- allow `build_owner_portfolio` to accept a `root` keyword alias for `accounts_root`
- update the pension forecast route to pass the resolved accounts root via keyword

## Testing
- pytest -o addopts='' tests/test_pension_route.py

------
https://chatgpt.com/codex/tasks/task_e_68db065426a883279c96691b14d3b7f1