### PR TITLE
Allow pension route to pass accounts root alias

### DIFF
--- a/backend/common/portfolio.py
+++ b/backend/common/portfolio.py
@@ -118,7 +118,11 @@ def build_owner_portfolio(
     accounts_root: Optional[Path] = None,
     *,
     pricing_date: Optional[dt.date] = None,
+    root: Optional[Path] = None,
 ) -> Dict[str, Any]:
+    if root is not None:
+        accounts_root = root
+
     calc = PricingDateCalculator(reporting_date=pricing_date)
     today = calc.today
     pricing_date = calc.reporting_date

--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -49,7 +49,7 @@ def pension_forecast(
     forecast_death_age = max(death_age, retirement_age + 1)
 
     try:
-        portfolio = build_owner_portfolio(owner, accounts_root)
+        portfolio = build_owner_portfolio(owner, root=accounts_root)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     pension_pot = 0.0


### PR DESCRIPTION
## Summary
- pass the resolved accounts root to the pension portfolio builder using the new `root` keyword
- allow `build_owner_portfolio` to accept a `root` alias that maps to the existing `accounts_root` parameter

## Testing
- pytest tests/test_pension_route.py --no-cov


------
https://chatgpt.com/codex/tasks/task_e_68db0ee6fe9c83279d266d9264960ca1