### PR TITLE
Avoid shadowing inspect signature helper

### DIFF
--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -1,4 +1,3 @@
-from inspect import signature
 import inspect
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -51,7 +50,7 @@ def pension_forecast(
     # valid death age.
     forecast_death_age = max(death_age, retirement_age + 1)
 
-    builder_params = signature(build_owner_portfolio).parameters
+    builder_params = inspect.signature(build_owner_portfolio).parameters
     portfolio_kwargs = {}
     portfolio_args = ()
     if "accounts_root" in builder_params:
@@ -62,13 +61,13 @@ def pension_forecast(
         portfolio_args = (accounts_root,)
 
     try:
-        signature = inspect.signature(build_owner_portfolio)
+        builder_signature = inspect.signature(build_owner_portfolio)
     except (TypeError, ValueError):
-        signature = None
+        builder_signature = None
 
-    if signature and "root" in signature.parameters:
+    if builder_signature and "root" in builder_signature.parameters:
         kwargs: dict[str, object] = {"root": accounts_root}
-    elif signature and "accounts_root" in signature.parameters:
+    elif builder_signature and "accounts_root" in builder_signature.parameters:
         kwargs = {"accounts_root": accounts_root}
     else:
         kwargs = {"root": accounts_root}


### PR DESCRIPTION
## Summary
- replace the pension route's shadowed inspect import by using inspect.signature directly
- rename the local introspection helper to builder_signature so subsequent checks are clearer

## Testing
- PYTEST_ADDOPTS="--cov=backend --cov-fail-under=0" pytest tests/test_pension_route.py::test_pension_route_prefers_monthly_over_annual tests/test_pension_route.py::test_pension_route_propagates_missing_portfolio

------
https://chatgpt.com/codex/tasks/task_e_68dbcde3559c83279d933b6762dc2d6d