### PR TITLE
Fix frontend build invocation in AWS deploy script

### DIFF
--- a/scripts/deploy-to-AWS.ps1
+++ b/scripts/deploy-to-AWS.ps1
@@ -201,7 +201,9 @@ if ($pipProcess.ExitCode -ne 0) {
         throw 'bash is required to run frontend/build.sh but was not found in PATH.'
       }
       Write-Host 'Running frontend/build.sh in the frontend workspace...' -ForegroundColor Cyan
-      & $bashCmd.Path $buildScript
+      # Invoke bash with a relative path so path separators are handled consistently across Git Bash and WSL.
+      $bashArgs = @('-c', './build.sh')
+      & $bashCmd.Path @bashArgs
       $buildExitCode = $LASTEXITCODE
     } else {
       $npmCmd = Get-Command npm -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- run frontend/build.sh via a relative path so bash handles separators correctly on Windows and WSL
- document the reasoning for the relative invocation to prevent future regressions

## Testing
- not run (PowerShell/bash deployment script is not executed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3bd35e77c83278c2df4c7b40ab99c