### PR TITLE
Stabilize smoke harness coverage

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -59,7 +59,7 @@ const routeMarkerStyle: CSSProperties = {
 
 const renderRouteMarker = (pathname: string, mode: string) => (
   <div
-    data-testid="active-route-marker"
+    data-testid="route-bootstrap-marker"
     data-mode={mode}
     data-pathname={pathname}
     style={routeMarkerStyle}

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -269,7 +269,7 @@ test.describe('config bootstrap', () => {
 
     const navigation = page.goto(target.href);
 
-    const marker = page.getByTestId('active-route-marker');
+    const marker = page.getByTestId('route-bootstrap-marker');
     await expect(marker).toHaveAttribute('data-mode', 'loading');
     await expect(marker).toHaveAttribute('data-pathname', '/portfolio');
 

--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -685,10 +685,10 @@ const SAMPLE_PATH_VALUES: Record<string, string> = {
   email: 'user@example.com',
   source: 'trail',
   id: '1',
-  vp_id: '1',
+  vp_id: 'test',
   quest_id: 'check-in',
   slug: 'demo-slug',
-  name: 'demo',
+  name: 'test',
   exchange: 'NASDAQ',
   ticker: 'PFE',
 };


### PR DESCRIPTION
## Summary
- align backend smoke test path parameters with the resources created during the run
- assign a dedicated test id to the config bootstrap marker so Playwright checks see the active route marker

## Testing
- npm --prefix frontend run test -- tests/unit/configRetrySuccess.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e3bd0f5f088327b96a686aa57b9199