### PR TITLE
Add pricing date picker to group portfolio view

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -127,6 +127,8 @@
   "group": {
     "atAGlance": "Auf einen Blick",
     "pricingAsOf": "Preisstand vom {{date}}",
+    "pricingDatePickerLabel": "Preisstand ändern",
+    "resetPricingDate": "Auf den neuesten Stand zurücksetzen",
     "select": "Wählen Sie eine Gruppe."
   },
   "holdingsTable": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -121,6 +121,8 @@
   "group": {
     "atAGlance": "At a glance",
     "pricingAsOf": "Pricing as of {{date}}",
+    "pricingDatePickerLabel": "Change pricing date",
+    "resetPricingDate": "Reset to latest",
     "select": "Select a group."
   },
   "holdingsTable": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -127,6 +127,8 @@
   "group": {
     "atAGlance": "De un vistazo",
     "pricingAsOf": "Precios al {{date}}",
+    "pricingDatePickerLabel": "Cambiar fecha de precios",
+    "resetPricingDate": "Restablecer al más reciente",
     "select": "Seleccione un grupo."
   },
   "holdingsTable": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -127,6 +127,8 @@
   "group": {
     "atAGlance": "En un coup d'œil",
     "pricingAsOf": "Tarification au {{date}}",
+    "pricingDatePickerLabel": "Changer la date de tarification",
+    "resetPricingDate": "Réinitialiser sur la plus récente",
     "select": "Sélectionnez un groupe."
   },
   "holdingsTable": {

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -127,6 +127,8 @@
   "group": {
     "atAGlance": "A colpo d'occhio",
     "pricingAsOf": "Prezzi al {{date}}",
+    "pricingDatePickerLabel": "Cambia data dei prezzi",
+    "resetPricingDate": "Reimposta all'ultima disponibile",
     "select": "Seleziona un gruppo."
   },
   "holdingsTable": {

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -127,6 +127,8 @@
   "group": {
     "atAGlance": "Visão geral",
     "pricingAsOf": "Preços em {{date}}",
+    "pricingDatePickerLabel": "Alterar data de preços",
+    "resetPricingDate": "Repor para o mais recente",
     "select": "Selecione um grupo."
   },
   "holdingsTable": {


### PR DESCRIPTION
## Summary
- allow group portfolio endpoints to accept an optional `as_of` query and reuse the new pricing date resolver
- add coverage that group routes forward the requested pricing date to the portfolio builder
- expose a pricing date picker in the group portfolio view and wire the frontend API calls plus translations to honour the selected snapshot

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest backend/tests/test_portfolio_group_instruments_filters.py
- npm run lint *(fails: pre-existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e5068ab468832787468c6ee9acbd17