### PR TITLE
Stabilize smoke tests for goals and markers

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -697,6 +697,7 @@ export default function App({ onLogout }: AppProps) {
     <div className="xl:flex xl:justify-center">
       <main style={{ maxWidth: 900, margin: "0 auto", padding: "1rem" }}>
         <div
+          data-route-marker="active"
           data-testid="active-route-marker"
           data-mode={mode}
           data-pathname={location.pathname}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -59,6 +59,7 @@ const routeMarkerStyle: CSSProperties = {
 
 const renderRouteMarker = (pathname: string, mode: string) => (
   <div
+    data-route-marker="bootstrap"
     data-testid="route-bootstrap-marker"
     data-mode={mode}
     data-pathname={pathname}

--- a/frontend/tests/config-retry.spec.ts
+++ b/frontend/tests/config-retry.spec.ts
@@ -43,7 +43,9 @@ test.describe('config bootstrap regression', () => {
 
     await expect.poll(() => attempt).toBeGreaterThan(1);
 
-    const marker = page.getByTestId('active-route-marker');
+    const marker = page.locator(
+      '[data-route-marker="active"], [data-testid="active-route-marker"]',
+    );
     await expect(marker).toHaveAttribute('data-mode', 'group');
     await expect(marker).toHaveAttribute('data-pathname', '/');
   });

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -16,6 +16,12 @@ const applyAuth = async (page: Page) => {
   }, authToken);
 };
 
+const getActiveRouteMarker = (page: Page) =>
+  page.locator('[data-route-marker="active"], [data-testid="active-route-marker"]');
+
+const getBootstrapMarker = (page: Page) =>
+  page.locator('[data-route-marker="bootstrap"], [data-testid="route-bootstrap-marker"]');
+
 type ModeAssertion = { kind: 'mode'; mode: string };
 type HeadingAssertion = {
   kind: 'heading';
@@ -197,7 +203,7 @@ test.describe('pension forecast routing', () => {
 
     await page.goto(pensionForecastPath);
 
-    const marker = page.getByTestId('active-route-marker');
+    const marker = getActiveRouteMarker(page);
     await expect(marker).toHaveAttribute('data-mode', 'pension');
     await expect(marker).toHaveAttribute('data-pathname', '/pension/forecast');
     await expect(page.getByRole('heading', { name: 'Pension Forecast' })).toBeVisible();
@@ -223,7 +229,7 @@ test.describe('public route smoke coverage', () => {
       await expect(page).toHaveURL(target.href);
 
       if (route.assertion.kind === 'mode') {
-        const marker = page.getByTestId('active-route-marker');
+        const marker = getActiveRouteMarker(page);
         await expect(marker).toHaveAttribute('data-mode', route.assertion.mode);
         await expect(marker).toHaveAttribute('data-pathname', target.pathname);
       } else if (route.assertion.kind === 'heading') {
@@ -269,7 +275,7 @@ test.describe('config bootstrap', () => {
 
     const navigation = page.goto(target.href);
 
-    const marker = page.getByTestId('route-bootstrap-marker');
+    const marker = getBootstrapMarker(page);
     await expect(marker).toHaveAttribute('data-mode', 'loading');
     await expect(marker).toHaveAttribute('data-pathname', '/portfolio');
 
@@ -311,7 +317,7 @@ test.describe('config bootstrap', () => {
 
     await expect.poll(() => attempt).toBeGreaterThan(1);
 
-    const marker = page.getByTestId('active-route-marker');
+    const marker = getActiveRouteMarker(page);
     await expect(marker).toBeVisible();
     await expect(marker).toHaveAttribute('data-mode', 'group');
     await expect(marker).toHaveAttribute('data-pathname', '/');
@@ -344,7 +350,7 @@ test.describe('timeseries edit resilience', () => {
 
     await expect.poll(() => requested).toBeTruthy();
 
-    const marker = page.getByTestId('active-route-marker');
+    const marker = getActiveRouteMarker(page);
     await expect(marker).toHaveAttribute('data-mode', 'timeseries');
     await expect(marker).toHaveAttribute('data-pathname', '/timeseries');
   });

--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -197,10 +197,6 @@ export const smokeEndpoints: SmokeEndpoint[] = [
     }
   },
   {
-    "method": "DELETE",
-    "path": "/goals/{name}"
-  },
-  {
     "method": "GET",
     "path": "/goals/{name}",
     "query": {
@@ -215,6 +211,10 @@ export const smokeEndpoints: SmokeEndpoint[] = [
       "target_amount": 0,
       "target_date": "1970-01-01"
     }
+  },
+  {
+    "method": "DELETE",
+    "path": "/goals/{name}"
   },
   {
     "method": "GET",


### PR DESCRIPTION
## Summary
- reorder the autogenerated goals smoke endpoints so the detail check runs before the delete call
- add explicit route marker attributes in the app and reuse them in Playwright smoke/config specs to keep assertions resilient in production builds

## Testing
- `curl -s -o /tmp/get_goals.json -w "%{http_code}\n" http://localhost:8000/goals/`
- `curl -s -o /tmp/post_goal.json -w "%{http_code}\n" -X POST http://localhost:8000/goals/ -H "Content-Type: application/json" -d '{"name":"smoke","target_amount":123,"target_date":"1970-01-01"}'`
- `curl -s -o /tmp/get_goal.json -w "%{http_code}\n" "http://localhost:8000/goals/smoke?current_amount=0"`
- `curl -s -o /tmp/put_goal.json -w "%{http_code}\n" -X PUT http://localhost:8000/goals/smoke -H "Content-Type: application/json" -d '{"name":"smoke","target_amount":456,"target_date":"1970-01-01"}'`
- `curl -s -o /tmp/delete_goal.json -w "%{http_code}\n" -X DELETE http://localhost:8000/goals/smoke`


------
https://chatgpt.com/codex/tasks/task_e_68e50583fdf88327b5611f57e012efe6