### PR TITLE
Add coverage for pension and portfolio routes

### DIFF
--- a/tests/routes/test_pension_routes.py
+++ b/tests/routes/test_pension_routes.py
@@ -1,0 +1,136 @@
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from starlette.applications import Starlette
+from starlette.requests import Request
+
+from backend.routes import pension
+
+
+@pytest.fixture
+def request_with_root(tmp_path: Path) -> Request:
+    app = Starlette()
+    app.state.accounts_root = tmp_path
+
+    async def receive() -> dict:
+        return {"type": "http.request"}
+
+    scope = {
+        "type": "http",
+        "app": app,
+        "method": "GET",
+        "path": "/pension/forecast",
+        "headers": [],
+    }
+    return Request(scope, receive)
+
+
+def test_pension_forecast_success(monkeypatch: pytest.MonkeyPatch, request_with_root: Request) -> None:
+    def fake_resolve_accounts_root(request: Request) -> Path:
+        return Path(request.app.state.accounts_root)
+
+    def fake_load_person_meta(owner: str, accounts_root: Path) -> dict:
+        assert owner == "alex"
+        assert accounts_root == Path(request_with_root.app.state.accounts_root)
+        return {"dob": date(1985, 7, 1)}
+
+    def fake_age_from_dob(dob):
+        assert dob == date(1985, 7, 1)
+        return 40
+
+    def fake_state_pension_age_uk(dob):
+        assert dob == date(1985, 7, 1)
+        return 68
+
+    captured_args = {}
+
+    def fake_build_owner_portfolio(owner: str, accounts_root=None, *args, **kwargs):
+        captured_args["args"] = args
+        captured_args["kwargs"] = kwargs
+        captured_args["accounts_root"] = accounts_root
+        return {
+            "accounts": [
+                {"account_type": "SIPP", "value_estimate_gbp": 10_000},
+                {"account_type": "isa", "value_estimate_gbp": 5_000},
+                {"account_type": "kz:sipp", "value_estimate_gbp": 20_000},
+            ]
+        }
+
+    def fake_forecast_pension(**kwargs):
+        assert kwargs["initial_pot"] == 30_000
+        return {"projection": [kwargs]}
+
+    monkeypatch.setattr(pension, "resolve_accounts_root", fake_resolve_accounts_root)
+    monkeypatch.setattr(pension, "load_person_meta", fake_load_person_meta)
+    monkeypatch.setattr(pension, "_age_from_dob", fake_age_from_dob)
+    monkeypatch.setattr(pension, "state_pension_age_uk", fake_state_pension_age_uk)
+    monkeypatch.setattr(pension, "build_owner_portfolio", fake_build_owner_portfolio)
+    monkeypatch.setattr(pension, "forecast_pension", fake_forecast_pension)
+
+    result = pension.pension_forecast(
+        request_with_root,
+        owner="alex",
+        death_age=90,
+        state_pension_annual=8_000,
+        db_income_annual=4_000,
+        db_normal_retirement_age=60,
+        contribution_monthly=500,
+        investment_growth_pct=4.5,
+        desired_income_annual=35_000,
+    )
+
+    assert result["current_age"] == 40
+    assert result["retirement_age"] == 68
+    assert result["pension_pot_gbp"] == 30_000
+    assert "projection" in result
+    assert captured_args["accounts_root"] == Path(request_with_root.app.state.accounts_root)
+
+
+def test_pension_forecast_invalid_death_age(monkeypatch: pytest.MonkeyPatch, request_with_root: Request) -> None:
+    monkeypatch.setattr(pension, "resolve_accounts_root", lambda request: Path("."))
+    monkeypatch.setattr(
+        pension,
+        "load_person_meta",
+        lambda owner, accounts_root: {"dob": date(1990, 1, 1)},
+    )
+    monkeypatch.setattr(pension, "_age_from_dob", lambda dob: 30)
+    monkeypatch.setattr(pension, "state_pension_age_uk", lambda dob: 67)
+
+    with pytest.raises(HTTPException) as exc:
+        pension.pension_forecast(
+            request_with_root,
+            owner="alex",
+            death_age=60,
+            state_pension_annual=None,
+            db_income_annual=None,
+            db_normal_retirement_age=None,
+            contribution_annual=None,
+            investment_growth_pct=5.0,
+            desired_income_annual=None,
+        )
+
+    assert exc.value.status_code == 400
+    assert "death_age" in exc.value.detail
+
+
+def test_pension_forecast_missing_dob(monkeypatch: pytest.MonkeyPatch, request_with_root: Request) -> None:
+    monkeypatch.setattr(pension, "resolve_accounts_root", lambda request: Path("."))
+    monkeypatch.setattr(pension, "load_person_meta", lambda owner, accounts_root: {})
+
+    with pytest.raises(HTTPException) as exc:
+        pension.pension_forecast(
+            request_with_root,
+            owner="alex",
+            death_age=90,
+            state_pension_annual=None,
+            db_income_annual=None,
+            db_normal_retirement_age=None,
+            contribution_annual=None,
+            investment_growth_pct=5.0,
+            desired_income_annual=None,
+        )
+
+    assert exc.value.status_code == 400
+    assert "dob" in exc.value.detail

--- a/tests/routes/test_portfolio_helpers.py
+++ b/tests/routes/test_portfolio_helpers.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+
+from backend.routes import portfolio as portfolio_routes
+
+
+@pytest.fixture
+def tmp_owner_dir(tmp_path: Path) -> Path:
+    owner_dir = tmp_path / "alex"
+    owner_dir.mkdir()
+    return owner_dir
+
+
+async def _empty_receive() -> dict:
+    return {"type": "http.request"}
+
+
+def _make_request_with_root(root: Path) -> Request:
+    app = Starlette()
+    app.state.accounts_root = root
+    scope = {
+        "type": "http",
+        "app": app,
+        "method": "GET",
+        "path": "/owners",
+        "headers": [],
+    }
+    return Request(scope, _empty_receive)
+
+
+def test_collect_account_stems_filters_noise(tmp_owner_dir: Path) -> None:
+    (tmp_owner_dir / "ISA.json").write_text("{}", encoding="utf-8")
+    (tmp_owner_dir / "isa.json").write_text("{}", encoding="utf-8")
+    (tmp_owner_dir / "GIA.JSON").write_text("{}", encoding="utf-8")
+    (tmp_owner_dir / "person.json").write_text("{}", encoding="utf-8")
+    (tmp_owner_dir / "notes.txt").write_text("notes", encoding="utf-8")
+    (tmp_owner_dir / "isa_transactions.json").write_text("{}", encoding="utf-8")
+    (tmp_owner_dir / "notes").mkdir()
+
+    stems = portfolio_routes._collect_account_stems(tmp_owner_dir)
+
+    assert stems == ["GIA", "ISA"]
+
+
+@pytest.mark.parametrize(
+    "artifact_name",
+    ["alex_transactions.json", "alex_transactions"],
+)
+def test_has_transactions_artifact_detects_matches(
+    tmp_owner_dir: Path, artifact_name: str
+) -> None:
+    target = tmp_owner_dir / artifact_name
+    if target.suffix:
+        target.write_text("{}", encoding="utf-8")
+    else:
+        target.mkdir()
+
+    assert portfolio_routes._has_transactions_artifact(tmp_owner_dir, "Alex") is True
+
+
+def test_normalise_owner_entry_enriches_accounts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    owner_dir = tmp_path / "alex"
+    owner_dir.mkdir()
+    (owner_dir / "isa.json").write_text("{}", encoding="utf-8")
+    (owner_dir / "sipp.json").write_text("{}", encoding="utf-8")
+    (owner_dir / "alex_transactions.json").write_text("{}", encoding="utf-8")
+
+    def fake_load_person_meta(owner: str, accounts_root: Path):
+        assert owner == "Alex"
+        assert accounts_root == tmp_path
+        return {"preferred_name": "Alexandra"}
+
+    monkeypatch.setattr(
+        portfolio_routes.data_loader,
+        "load_person_meta",
+        fake_load_person_meta,
+    )
+
+    result = portfolio_routes._normalise_owner_entry(
+        {"owner": "  Alex  ", "accounts": [" isa", "GIA", "ISA"]},
+        tmp_path,
+    )
+
+    assert result == {
+        "owner": "Alex",
+        "full_name": "Alexandra",
+        "accounts": ["isa", "GIA", "sipp"],
+        "has_transactions_artifact": True,
+    }
+
+
+def test_list_owner_summaries_merges_demo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    demo_dir = tmp_path / "demo"
+    demo_dir.mkdir()
+    (demo_dir / "isa.json").write_text("{}", encoding="utf-8")
+    (demo_dir / "demo_transactions.json").write_text("{}", encoding="utf-8")
+
+    alex_dir = tmp_path / "alex"
+    alex_dir.mkdir()
+    (alex_dir / "isa.json").write_text("{}", encoding="utf-8")
+
+    def fake_list_plots(accounts_root: Path, current_user: str | None):
+        assert accounts_root == tmp_path
+        assert current_user is None
+        return [{"owner": "alex", "accounts": ["isa", ""]}]
+
+    def fake_load_person_meta(owner: str, accounts_root: Path):
+        assert accounts_root == tmp_path
+        if owner == "alex":
+            return {"display_name": "Alex Example"}
+        if owner == "demo":
+            return {"full_name": "Demo Account"}
+        return {}
+
+    monkeypatch.setattr(
+        portfolio_routes.data_loader, "list_plots", fake_list_plots
+    )
+    monkeypatch.setattr(
+        portfolio_routes.data_loader,
+        "load_person_meta",
+        fake_load_person_meta,
+    )
+
+    request = _make_request_with_root(tmp_path)
+
+    summaries = portfolio_routes._list_owner_summaries(request)
+
+    owners = {summary.owner: summary for summary in summaries}
+    assert set(owners) == {"alex", "demo"}
+    assert owners["alex"].accounts == ["isa"]
+    assert owners["alex"].full_name == "Alex Example"
+    assert owners["demo"].full_name == "Demo Account"
+    assert owners["demo"].has_transactions_artifact is True


### PR DESCRIPTION
## Summary
- add FastAPI unit tests for the pension forecast route covering happy-path and validation branches
- exercise portfolio helper utilities to validate account discovery, metadata enrichment, and demo fallbacks

## Testing
- pytest tests/routes/test_portfolio_helpers.py tests/routes/test_pension_routes.py -p no:cov -o addopts=

------
https://chatgpt.com/codex/tasks/task_e_68e505b89b28832781c7cf258688da72