### PR TITLE
Improve backend test coverage for data loader, portfolio, risk, and pension routes

### DIFF
--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -7,7 +7,9 @@ import pytest
 from backend.common.data_loader import (
     DATA_BUCKET_ENV,
     ResolvedPaths,
+    _extract_account_names,
     _list_local_plots,
+    _merge_accounts,
     _safe_json_load,
     list_plots,
     load_person_meta,
@@ -41,7 +43,38 @@ def _write_owner(
     for account in accounts:
         (owner_dir / f"{account}.json").write_text("{}")
 
+class TestExtractAccountNames:
+    def test_dedupes_and_filters_metadata(self, tmp_path: Path) -> None:
+        owner_dir = tmp_path / "alice"
+        owner_dir.mkdir()
+        for filename in [
+            "isa.json",
+            "ISA.json",
+            "config.json",
+            "sipp_transactions.json",
+            "GIA.json",
+            "notes.txt",
+        ]:
+            path = owner_dir / filename
+            if path.suffix == ".json":
+                path.write_text("{}")
+            else:
+                path.write_text("")
 
+        result = _extract_account_names(owner_dir)
+
+        assert result == ["GIA", "ISA"]
+
+
+class TestMergeAccounts:
+    def test_merges_unique_accounts_and_full_name(self) -> None:
+        base = {"accounts": ["ISA"]}
+        extra = {"accounts": ["isa", "GIA", 123], "full_name": "Alice Example"}
+
+        _merge_accounts(base, extra)
+
+        assert base["full_name"] == "Alice Example"
+        assert base["accounts"] == ["ISA", "GIA"]
 
 
 class TestSafeJsonLoad:
@@ -275,6 +308,67 @@ class TestListLocalPlots:
         ]
         assert all(entry["owner"] not in {"demo", ".idea"} for entry in result)
 
+
+
+    def test_falls_back_to_repository_when_primary_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo_root = tmp_path / "repo"
+        primary_accounts = repo_root / "accounts"
+        fallback_accounts = tmp_path / "fallback" / "accounts"
+        primary_accounts.mkdir(parents=True, exist_ok=True)
+        fallback_accounts.mkdir(parents=True, exist_ok=True)
+        self._configure(monkeypatch, repo_root, primary_accounts, disable_auth=True)
+
+        _write_owner(fallback_accounts, "eve", ["gia"], viewers=[])
+
+        calls = {"count": 0}
+
+        def fake_resolve_paths(repo_root_value, accounts_root_value):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                return ResolvedPaths(repo_root, primary_accounts, repo_root / "virtual")
+            return ResolvedPaths(Path("fallback-repo"), fallback_accounts, Path("fallback-repo") / "virtual")
+
+        monkeypatch.setattr("backend.common.data_loader.resolve_paths", fake_resolve_paths)
+
+        result = _list_local_plots(current_user=None)
+
+        assert result == [
+            {"owner": "eve", "full_name": "eve", "accounts": ["gia"]},
+        ]
+
+    def test_explicit_root_does_not_merge_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo_root = tmp_path / "repo"
+        primary_accounts = repo_root / "accounts"
+        fallback_accounts = tmp_path / "fallback" / "accounts"
+        primary_accounts.mkdir(parents=True, exist_ok=True)
+        fallback_accounts.mkdir(parents=True, exist_ok=True)
+        self._configure(monkeypatch, repo_root, primary_accounts, disable_auth=True)
+
+        explicit_root = tmp_path / "custom"
+        explicit_root.mkdir()
+        _write_owner(explicit_root, "zoe", ["isa"], viewers=[])
+        _write_owner(fallback_accounts, "eve", ["gia"], viewers=[])
+
+        calls = {"count": 0}
+
+        def fake_resolve_paths(repo_root_value, accounts_root_value):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                return ResolvedPaths(repo_root, primary_accounts, repo_root / "virtual")
+            return ResolvedPaths(Path("fallback-repo"), fallback_accounts, Path("fallback-repo") / "virtual")
+
+        monkeypatch.setattr("backend.common.data_loader.resolve_paths", fake_resolve_paths)
+
+        result = _list_local_plots(data_root=explicit_root, current_user=None)
+
+        assert result == [
+            {"owner": "zoe", "full_name": "zoe", "accounts": ["isa"]},
+        ]
+
     def test_list_plots_with_explicit_root_skips_demo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         repo_root = tmp_path / "repo"
         accounts_root = repo_root / "accounts"
@@ -312,3 +406,57 @@ class TestListLocalPlots:
         assert result == [
             {"owner": "alice", "full_name": "alice", "accounts": ["alpha"]},
         ]
+
+
+def test_list_plots_prefers_aws_results(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = Config()
+    cfg.app_env = "aws"
+    cfg.disable_auth = True
+    cfg.repo_root = tmp_path
+    cfg.accounts_root = tmp_path / "accounts"
+    monkeypatch.setattr("backend.common.data_loader.config", cfg)
+    monkeypatch.delenv(DATA_BUCKET_ENV, raising=False)
+
+    expected = [{"owner": "aws", "full_name": "aws", "accounts": ["isa"]}]
+
+    monkeypatch.setattr(
+        "backend.common.data_loader._list_aws_plots",
+        lambda current_user=None: expected,
+    )
+    # Ensure local discovery would be different to verify the AWS path wins.
+    monkeypatch.setattr(
+        "backend.common.data_loader._list_local_plots",
+        lambda data_root, current_user=None: [{"owner": "local", "full_name": "local", "accounts": []}],
+    )
+
+    result = list_plots(data_root=None, current_user="user@example.com")
+
+    assert result == expected
+
+
+def test_list_plots_aws_falls_back_to_local(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = Config()
+    cfg.app_env = "aws"
+    cfg.disable_auth = True
+    cfg.repo_root = tmp_path
+    cfg.accounts_root = tmp_path / "accounts"
+    monkeypatch.setattr("backend.common.data_loader.config", cfg)
+    monkeypatch.delenv(DATA_BUCKET_ENV, raising=False)
+
+    monkeypatch.setattr(
+        "backend.common.data_loader._list_aws_plots",
+        lambda current_user=None: [],
+    )
+
+    captured: dict[str, tuple[Path | None, object]] = {}
+
+    def fake_local(data_root: Path | None, current_user=None):
+        captured["call"] = (data_root, current_user)
+        return [{"owner": "local", "full_name": "local", "accounts": ["isa"]}]
+
+    monkeypatch.setattr("backend.common.data_loader._list_local_plots", fake_local)
+
+    result = list_plots(data_root=tmp_path, current_user="viewer")
+
+    assert result == [{"owner": "local", "full_name": "local", "accounts": ["isa"]}]
+    assert captured["call"] == (tmp_path, "viewer")

--- a/tests/routes/test_portfolio_helpers.py
+++ b/tests/routes/test_portfolio_helpers.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import pytest
+
+from backend.routes import portfolio
+
+
+def test_collect_account_stems_filters_metadata(tmp_path: Path) -> None:
+    owner_dir = tmp_path / "alice"
+    owner_dir.mkdir()
+    (owner_dir / "isa.json").write_text("{}")
+    (owner_dir / "ISA.json").write_text("{}")
+    (owner_dir / "config.json").write_text("{}")
+    (owner_dir / "alice_transactions.json").write_text("{}")
+    (owner_dir / "notes.txt").write_text("ignored")
+    (owner_dir / "gia.json").write_text("{}")
+
+    stems = portfolio._collect_account_stems(owner_dir)
+
+    assert stems == ["ISA", "gia"]
+
+
+def test_has_transactions_artifact_detects_files_and_directories(tmp_path: Path) -> None:
+    owner_dir = tmp_path / "Alice"
+    owner_dir.mkdir()
+
+    assert portfolio._has_transactions_artifact(owner_dir, "Alice") is False
+
+    (owner_dir / "Alice_transactions.json").write_text("{}")
+    assert portfolio._has_transactions_artifact(owner_dir, "Alice") is True
+
+    (owner_dir / "ALICE_TRANSACTIONS").mkdir()
+    assert portfolio._has_transactions_artifact(owner_dir, "alice") is True
+
+
+@pytest.mark.parametrize(
+    "entry, meta, expected",
+    [
+        ({"full_name": " Alice Example "}, {"display_name": "Ignored"}, "Alice Example"),
+        ({}, {"preferred_name": " Ally "}, "Ally"),
+        ({}, {}, "owner"),
+    ],
+)
+def test_resolve_full_name(entry: dict[str, str], meta: dict[str, str], expected: str) -> None:
+    result = portfolio._resolve_full_name("owner", entry, meta)
+    assert result == expected
+
+
+def test_normalise_owner_entry_combines_accounts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    accounts_root = tmp_path
+    owner_dir = accounts_root / "Alice"
+    owner_dir.mkdir()
+    (owner_dir / "growth.json").write_text("{}")
+    (owner_dir / "person.json").write_text("{}")
+    (owner_dir / "Alice_transactions").mkdir()
+
+    entry = {"owner": "Alice", "accounts": ["ISA", "isa", "custom", " "]}
+
+    result = portfolio._normalise_owner_entry(
+        entry,
+        accounts_root,
+        meta={"display_name": " Ally "},
+    )
+
+    assert result == {
+        "owner": "Alice",
+        "full_name": "Ally",
+        "accounts": [
+            "ISA",
+            "custom",
+            "growth",
+            "brokerage",
+            "savings",
+            "approvals",
+            "settings",
+            "Alice_transactions",
+        ],
+    }
+
+
+def test_normalise_owner_entry_returns_none_for_missing_owner(tmp_path: Path) -> None:
+    result = portfolio._normalise_owner_entry({}, tmp_path)
+    assert result is None

--- a/tests/test_pension_route.py
+++ b/tests/test_pension_route.py
@@ -186,3 +186,77 @@ def test_pension_route_falls_back_to_local_metadata(tmp_path, monkeypatch):
     body = resp.json()
     assert body["dob"] == "1980-01-01"
     assert captured.get("dob") == "1980-01-01"
+
+
+def test_pension_route_returns_400_on_forecast_error(monkeypatch):
+    monkeypatch.setattr(
+        "backend.routes.pension.load_person_meta",
+        lambda owner, root=None: {"dob": "1980-01-01"},
+    )
+    monkeypatch.setattr(
+        "backend.routes.pension.build_owner_portfolio",
+        lambda owner, root=None: {"accounts": []},
+    )
+    monkeypatch.setattr("backend.routes.pension.state_pension_age_uk", lambda dob: 67)
+
+    def boom(**kwargs):  # pragma: no cover - signature passthrough
+        raise ValueError("bad input")
+
+    monkeypatch.setattr("backend.routes.pension.forecast_pension", boom)
+
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get(
+            "/pension/forecast",
+            params={"owner": "erin", "death_age": 90},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "bad input"}
+
+
+def test_pension_route_includes_db_inputs(monkeypatch):
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "backend.routes.pension.load_person_meta",
+        lambda owner, root=None: {"dob": "1975-01-01"},
+    )
+    monkeypatch.setattr(
+        "backend.routes.pension.build_owner_portfolio",
+        lambda owner, root=None: {
+            "accounts": [
+                {"account_type": "SIPP", "value_estimate_gbp": 1000.0},
+                {"account_type": "isa", "value_estimate_gbp": 500.0},
+            ]
+        },
+    )
+    monkeypatch.setattr("backend.routes.pension.state_pension_age_uk", lambda dob: 65)
+
+    def fake_forecast(**kwargs):  # pragma: no cover - signature passthrough
+        captured.update(kwargs)
+        return {"forecast": []}
+
+    monkeypatch.setattr("backend.routes.pension.forecast_pension", fake_forecast)
+
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get(
+            "/pension/forecast",
+            params={
+                "owner": "fred",
+                "death_age": 85,
+                "db_income_annual": 1200,
+                "db_normal_retirement_age": 60,
+                "state_pension_annual": 9000,
+                "desired_income_annual": 30000,
+            },
+        )
+
+    assert resp.status_code == 200
+    assert captured["db_pensions"] == [
+        {"annual_income_gbp": 1200.0, "normal_retirement_age": 60}
+    ]
+    body = resp.json()
+    assert body["pension_pot_gbp"] == 1000.0
+    assert captured["initial_pot"] == 1000.0


### PR DESCRIPTION
## Summary
- add unit tests covering data loader account extraction, fallback discovery, and AWS/list_plots behaviour
- add focused portfolio helper tests to exercise account normalisation utilities
- extend pension route and risk module tests to capture error paths and edge cases

## Testing
- PYTEST_ADDOPTS='' pytest --no-cov tests/test_risk.py tests/backend/common/test_data_loader.py tests/routes/test_portfolio_helpers.py tests/test_pension_route.py

------
https://chatgpt.com/codex/tasks/task_e_68e5094189a48327893e3d9510883076