### PR TITLE
Handle legacy group portfolio builder call

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -11,6 +11,7 @@ Owners / groups / portfolio endpoints (shared).
 from __future__ import annotations
 
 import datetime as dt
+import inspect
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -537,7 +538,16 @@ async def group_instruments(
 
     try:
         pricing_date = _resolve_pricing_date(as_of)
-        gp = group_portfolio.build_group_portfolio(slug, pricing_date=pricing_date)
+        builder = group_portfolio.build_group_portfolio
+        try:
+            params = inspect.signature(builder).parameters
+        except (TypeError, ValueError):  # pragma: no cover - non-standard callables
+            params = {}
+
+        if "pricing_date" in params:
+            gp = builder(slug, pricing_date=pricing_date)
+        else:
+            gp = builder(slug)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail="Group not found") from exc
 


### PR DESCRIPTION
## Summary
- guard the portfolio group instruments endpoint against builders without a pricing_date keyword
- add an inspect import to allow runtime signature inspection before invoking the builder

## Testing
- pytest tests/test_group_instruments_changes.py *(fails: coverage fail-under threshold not met in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e50d50cfe08327ac084fadb83a6193