### PR TITLE
Fix backend API group portfolio mock signature

### DIFF
--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -42,7 +42,7 @@ def client(mock_google_verify):
 def mock_group_portfolio(monkeypatch):
     """Provide a lightweight group portfolio for known slugs."""
 
-    def _build(slug: str):
+    def _build(slug: str, pricing_date=None):
         if slug == "doesnotexist":
             raise HTTPException(status_code=404, detail="Group not found")
         return {


### PR DESCRIPTION
## Summary
- allow the backend API test group portfolio mock to accept the pricing_date keyword argument used by the route

## Testing
- pytest tests/test_backend_api.py::test_instrument_detail_valid -q --override-ini addopts=''


------
https://chatgpt.com/codex/tasks/task_e_68e50d6efc6483278dfbba6605a34c39