### PR TITLE
Fix instrument grouping stub and scaling override path

### DIFF
--- a/backend/utils/timeseries_helpers.py
+++ b/backend/utils/timeseries_helpers.py
@@ -37,11 +37,11 @@ def get_scaling_override(ticker: str, exchange: str, requested_scaling: Optional
     if requested_scaling is not None:
         return requested_scaling
 
-    repo_root = (
-        Path(config.repo_root)
-        if config.repo_root and ":" not in str(config.repo_root)
-        else Path(__file__).resolve().parents[2]
-    )
+    repo_root = Path(__file__).resolve().parents[2]
+    if config.repo_root:
+        candidate = str(config.repo_root)
+        if "://" not in candidate:
+            repo_root = Path(config.repo_root)
     path = repo_root / "data" / "scaling_overrides.json"
     try:
         with path.open() as f:

--- a/tests/test_instrument_grouping.py
+++ b/tests/test_instrument_grouping.py
@@ -17,7 +17,11 @@ def client():
 
 
 def _prepare_group_portfolio(monkeypatch, portfolio, meta_map):
-    monkeypatch.setattr(group_portfolio, "build_group_portfolio", lambda slug: portfolio)
+    monkeypatch.setattr(
+        group_portfolio,
+        "build_group_portfolio",
+        lambda slug, *, pricing_date=None: portfolio,
+    )
     monkeypatch.setattr(portfolio_utils, "get_instrument_meta", lambda ticker: meta_map.get(ticker, {}))
     monkeypatch.setattr(portfolio_utils, "get_security_meta", lambda ticker: {})
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {})


### PR DESCRIPTION
## Summary
- allow the grouped instrument test helper to accept the pricing date keyword
- respect the configured repo_root for scaling overrides even when it contains Windows drive letters

## Testing
- PYTEST_ADDOPTS=--no-cov pytest tests/test_instrument_grouping.py::test_grouped_instrument_totals tests/test_timeseries_helpers.py::test_get_scaling_override_reads_override_file


------
https://chatgpt.com/codex/tasks/task_e_68e50d021b5c8327a8aad9e212ada55e