### PR TITLE
Fix instrument admin refresh argument

### DIFF
--- a/backend/routes/instrument_admin.py
+++ b/backend/routes/instrument_admin.py
@@ -173,7 +173,7 @@ async def refresh_instrument(
     canonical_ticker = f"{ticker}.{exchange}"
     existing = _load_meta_for_update(exchange, ticker)
 
-    fetched = _fetch_metadata_from_yahoo(canonical_ticker)
+    fetched = _fetch_metadata_from_yahoo(ticker, exchange)
     if not fetched:
         raise HTTPException(status_code=502, detail="Unable to fetch instrument metadata")
 

--- a/backend/tests/test_instrument_admin.py
+++ b/backend/tests/test_instrument_admin.py
@@ -84,8 +84,9 @@ def test_refresh_instrument_preview(monkeypatch):
             "currency": "USD",
         }
 
-    def fake_fetch(full_ticker: str) -> dict[str, Any]:
-        assert full_ticker == "ABC.NYSE"
+    def fake_fetch(ticker: str, exchange: str) -> dict[str, Any]:
+        assert ticker == "ABC"
+        assert exchange == "NYSE"
         return {"name": "Alpha Corp", "currency": "GBP", "instrument_type": "EQUITY"}
 
     monkeypatch.setattr(
@@ -130,7 +131,9 @@ def test_refresh_instrument_confirm(monkeypatch):
     def fake_get_instrument_meta(full_ticker: str) -> dict[str, Any]:
         return {"ticker": full_ticker, "exchange": "NYSE", "name": "Alpha", "currency": "USD"}
 
-    def fake_fetch(full_ticker: str) -> dict[str, Any]:
+    def fake_fetch(ticker: str, exchange: str) -> dict[str, Any]:
+        assert ticker == "ABC"
+        assert exchange == "NYSE"
         return {"name": "Alpha Corp", "currency": "GBP", "instrument_type": "EQUITY"}
 
     def fake_save(ticker: str, exchange: str, payload: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- call the Yahoo metadata fetch helper with separate ticker and exchange inputs
- update the instrument admin route tests to assert the new invocation signature

## Testing
- `pytest backend/tests/test_instrument_admin.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68e50dc47e0c8327b298432ee9e82f49