### PR TITLE
Update tests for group portfolio pricing date argument

### DIFF
--- a/tests/common/test_instrument_api_core.py
+++ b/tests/common/test_instrument_api_core.py
@@ -106,7 +106,7 @@ def test_positions_for_ticker_matches(monkeypatch):
             }
         ]
     }
-    monkeypatch.setattr(ia, "build_group_portfolio", lambda slug: gp)
+    monkeypatch.setattr(ia, "build_group_portfolio", lambda slug, **_: gp)
     rows = ia.positions_for_ticker("grp", "ABC")
     assert rows == [
         {
@@ -158,7 +158,7 @@ def test_instrument_summaries_populate_grouping(monkeypatch):
         "CCC.L": {"region": "Region C"},
     }
 
-    monkeypatch.setattr(ia, "build_group_portfolio", lambda slug: portfolio)
+    monkeypatch.setattr(ia, "build_group_portfolio", lambda slug, **_: portfolio)
     monkeypatch.setattr(ia, "get_security_meta", lambda t: meta.get(t, {}))
 
     def fake_price_and_changes(ticker: str) -> dict:

--- a/tests/routes/test_portfolio_group.py
+++ b/tests/routes/test_portfolio_group.py
@@ -48,7 +48,7 @@ def test_group_instruments_filters_accounts(monkeypatch):
         {"id": 3, "owner": "bob", "account_type": "isa"},
     ]
 
-    def fake_group(slug: str):
+    def fake_group(slug: str, *, pricing_date=None):
         assert slug == "demo"
         return {"slug": slug, "accounts": accounts}
 

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import shutil
 
 import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from backend.common.instruments import get_instrument_meta
@@ -42,9 +41,9 @@ def client(mock_google_verify):
 def mock_group_portfolio(monkeypatch):
     """Provide a lightweight group portfolio for known slugs."""
 
-    def _build(slug: str):
+    def _build(slug: str, *, pricing_date=None):
         if slug == "doesnotexist":
-            raise HTTPException(status_code=404, detail="Group not found")
+            raise ValueError("Group not found")
         return {
             "slug": slug,
             "accounts": [

--- a/tests/test_group_instruments_changes.py
+++ b/tests/test_group_instruments_changes.py
@@ -25,7 +25,9 @@ def test_group_instruments_populates_change_fields(monkeypatch, client):
             }
         ]
     }
-    monkeypatch.setattr(group_portfolio, "build_group_portfolio", lambda slug: portfolio)
+    monkeypatch.setattr(
+        group_portfolio, "build_group_portfolio", lambda slug, **_: portfolio
+    )
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {"AAA.L": {"last_price": 100.0}})
     monkeypatch.setattr(
         instrument_api,

--- a/tests/test_instrument_grouping.py
+++ b/tests/test_instrument_grouping.py
@@ -17,7 +17,9 @@ def client():
 
 
 def _prepare_group_portfolio(monkeypatch, portfolio, meta_map):
-    monkeypatch.setattr(group_portfolio, "build_group_portfolio", lambda slug: portfolio)
+    monkeypatch.setattr(
+        group_portfolio, "build_group_portfolio", lambda slug, **_: portfolio
+    )
     monkeypatch.setattr(portfolio_utils, "get_instrument_meta", lambda ticker: meta_map.get(ticker, {}))
     monkeypatch.setattr(portfolio_utils, "get_security_meta", lambda ticker: {})
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {})


### PR DESCRIPTION
## Summary
- update portfolio group-related test doubles to accept the new pricing_date parameter
- align the backend API test fixture with the production ValueError signalling

## Testing
- pytest --override-ini=addopts= tests/routes/test_portfolio_group.py tests/test_backend_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e50d9e63348327a4dca166e4a32a4f