### PR TITLE
Respect viewer permissions with auth disabled

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -202,7 +202,12 @@ def _list_local_plots(
             viewers = []
 
         if config.disable_auth:
-            return True
+            if user is None:
+                return True
+            # Fall back to the identity checks below when a caller supplies a
+            # specific user.  This allows local "disable_auth" environments to
+            # emulate logged-in views and still respect per-account viewer
+            # permissions.
 
         if config.disable_auth is False and user is None:
             return False

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -272,6 +272,22 @@ class TestListLocalPlots:
         ]
         assert all("full_name" not in entry for entry in result)
 
+    def test_respects_viewers_when_auth_disabled_and_user_provided(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        data_root = tmp_path / "accounts"
+        self._configure(monkeypatch, tmp_path, data_root, disable_auth=True)
+
+        _write_owner(data_root, "alice", ["alpha"], viewers=["viewer"])
+        _write_owner(data_root, "demo", ["demo1"], viewers=[])
+
+        result = _list_local_plots(data_root=data_root, current_user="viewer")
+
+        assert result == [
+            {"owner": "alice", "accounts": ["alpha"]},
+        ]
+        assert all("full_name" not in entry for entry in result)
+
     def test_accepts_contextvar_current_user(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_root = tmp_path / "accounts"
         self._configure(monkeypatch, tmp_path, data_root, disable_auth=False)


### PR DESCRIPTION
## Summary
- ensure local portfolio discovery honours viewer restrictions when a specific user is supplied, even if auth is disabled
- add a regression test covering the disabled-auth viewer scenario

## Testing
- pytest -o addopts='' tests/backend/common/test_data_loader.py::TestListLocalPlots::test_respects_viewers_when_auth_disabled_and_user_provided

------
https://chatgpt.com/codex/tasks/task_e_68ecb0f3425c83279722fdcce452c60b