### PR TITLE
Fix group portfolio date picker resetting to latest snapshot

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -144,6 +144,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   const [instrumentLoading, setInstrumentLoading] = useState(false);
   const [instrumentError, setInstrumentError] = useState<Error | null>(null);
   const instrumentKeyRef = useRef<string | null>(null);
+  const lastPortfolioAsOfRef = useRef<string | null>(null);
   const [expandedOwners, setExpandedOwners] = useState<Set<string>>(new Set());
 
   const loadGroupInstruments =
@@ -235,9 +236,20 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   }, []);
 
   useEffect(() => {
-    if (!portfolio?.as_of || !asOfOverride) return;
-    const resolved = formatDateISO(new Date(portfolio.as_of));
-    if (resolved !== asOfOverride) {
+    const rawAsOf = portfolio?.as_of ?? null;
+    if (!rawAsOf) {
+      lastPortfolioAsOfRef.current = null;
+      return;
+    }
+
+    const resolved = formatDateISO(new Date(rawAsOf));
+    if (lastPortfolioAsOfRef.current === resolved) {
+      return;
+    }
+
+    lastPortfolioAsOfRef.current = resolved;
+
+    if (asOfOverride && resolved !== asOfOverride) {
       setAsOfOverride(resolved);
     }
   }, [portfolio?.as_of, asOfOverride]);


### PR DESCRIPTION
## Summary
- keep the pricing date override stable until the backend returns a new snapshot
- only resync the override when the response carries a different as_of date

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ecf03f7bd08327b89b0c2630649646