### PR TITLE
Hide demo owner entry when identity is overridden

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -81,7 +81,7 @@ _METADATA_STEMS = {
 def _skip_owners() -> set[str]:
     """Return owner identifiers that should be ignored when listing data."""
 
-    skipped = {".idea"}
+    skipped = {".idea", "demo"}
     identity = get_demo_identity()
     if identity:
         skipped.add(identity.lower())

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import backend.common.data_loader as data_loader
 from backend.common.data_loader import (
     DATA_BUCKET_ENV,
     ResolvedPaths,
@@ -353,6 +354,21 @@ class TestListLocalPlots:
         ]
         assert all("full_name" not in entry for entry in result)
         assert all(entry["owner"] not in {"demo", ".idea"} for entry in result)
+
+    def test_overridden_demo_identity_hides_default_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        data_root = tmp_path / "accounts"
+        self._configure(monkeypatch, tmp_path, data_root, disable_auth=True)
+
+        data_loader.config.demo_identity = "steve"
+
+        _write_owner(data_root, "demo", ["demo1"], viewers=[])
+        _write_owner(data_root, "steve", ["growth"], viewers=[])
+
+        result = _list_local_plots(data_root=data_root, current_user=None)
+
+        assert result == []
 
 
 

--- a/tests/routes/test_portfolio_helpers.py
+++ b/tests/routes/test_portfolio_helpers.py
@@ -93,10 +93,11 @@ def test_normalise_owner_entry_enriches_accounts(tmp_path: Path, monkeypatch: py
 
 
 def test_list_owner_summaries_merges_demo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    demo_dir = tmp_path / "demo"
+    identity = portfolio_routes.demo_identity()
+    demo_dir = tmp_path / identity
     demo_dir.mkdir()
     (demo_dir / "isa.json").write_text("{}", encoding="utf-8")
-    (demo_dir / "demo_transactions.json").write_text("{}", encoding="utf-8")
+    (demo_dir / f"{identity}_transactions.json").write_text("{}", encoding="utf-8")
 
     alex_dir = tmp_path / "alex"
     alex_dir.mkdir()
@@ -111,7 +112,7 @@ def test_list_owner_summaries_merges_demo(tmp_path: Path, monkeypatch: pytest.Mo
         assert accounts_root == tmp_path
         if owner == "alex":
             return {"display_name": "Alex Example"}
-        if owner == "demo":
+        if owner == identity:
             return {"full_name": "Demo Account"}
         return {}
 
@@ -129,11 +130,11 @@ def test_list_owner_summaries_merges_demo(tmp_path: Path, monkeypatch: pytest.Mo
     summaries = portfolio_routes._list_owner_summaries(request)
 
     owners = {summary.owner: summary for summary in summaries}
-    assert set(owners) == {"alex", "demo"}
+    assert set(owners) == {"alex", identity}
     assert owners["alex"].accounts == ["isa"]
     assert owners["alex"].full_name == "Alex Example"
-    assert owners["demo"].full_name == "Demo Account"
-    assert owners["demo"].has_transactions_artifact is True
+    assert owners[identity].full_name == "Demo Account"
+    assert owners[identity].has_transactions_artifact is True
 
 from backend.routes import portfolio
 


### PR DESCRIPTION
## Summary
- always ignore the bundled `demo` owner directory during local account discovery so custom demo identities do not expose it
- update the portfolio helper test to use the configured demo identity when building expectations
- add a regression test that covers the overridden-identity scenario for local data discovery

## Testing
- PYTEST_ADDOPTS="" pytest -c /dev/null tests/backend/common/test_data_loader.py::TestListLocalPlots::test_overridden_demo_identity_hides_default_directory
- PYTEST_ADDOPTS="" pytest -c /dev/null tests/routes/test_portfolio_helpers.py::test_list_owner_summaries_merges_demo


------
https://chatgpt.com/codex/tasks/task_e_68eceee38054832791bb8ffe734e87f5