### PR TITLE
Filter demo listings when real owners exist

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -75,6 +75,8 @@ _METADATA_STEMS = {
     "settings",
     "approvals",
     "approval_requests",
+    "pension-forecast",
+    "pension_forecast",
 }  # ignore these as accounts
 
 
@@ -336,9 +338,16 @@ def _list_local_plots(
 
     results = _discover(
         primary_root,
-        include_demo=include_demo_primary,
+        include_demo=False,
         default_full_name=default_primary_full_name,
     )
+
+    if include_demo_primary and not results:
+        results = _discover(
+            primary_root,
+            include_demo=True,
+            default_full_name=default_primary_full_name,
+        )
 
     try:
         same_root = fallback_root.resolve() == primary_root.resolve()
@@ -353,9 +362,15 @@ def _list_local_plots(
     if not explicit_root and not results:
         fallback_results = _discover(
             fallback_root,
-            include_demo=True,
+            include_demo=False,
             default_full_name=True,
         )
+        if config.disable_auth and not fallback_results:
+            fallback_results = _discover(
+                fallback_root,
+                include_demo=True,
+                default_full_name=True,
+            )
         results.extend(fallback_results)
 
     owners_index = {

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -391,12 +391,7 @@ def _list_owner_summaries(
         if normalised:
             summaries.append(normalised)
 
-    demo_owner = demo_identity().casefold()
-    demo_present = any(summary["owner"].casefold() == demo_owner for summary in summaries)
-
-    if summaries and not demo_present:
-        summaries.append(_build_demo_summary(accounts_root))
-    elif not summaries:
+    if not summaries:
         summaries.append(_build_demo_summary(accounts_root))
 
     return [OwnerSummary(**summary) for summary in summaries]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,7 +24,7 @@ mock_owners = [
     {
         "owner": "lucy",
         "full_name": "Lucy Example",
-        "accounts": ["isa", "pension-forecast"],
+        "accounts": ["isa"],
     },
     {"owner": "steve", "full_name": "Steve Example", "accounts": ["isa", "jpm", "sipp"]},
 ]


### PR DESCRIPTION
## Summary
- filter pension forecast JSON from owner account discovery and only surface the configured demo owner when no other data exists
- stop automatically appending the demo summary in the owners endpoint so the UI reflects the filtered list
- align the API and local UI tests with the new filtering rules and updated Lucy fixtures

## Testing
- PYTEST_ADDOPTS="--cov=backend --cov-fail-under=0" pytest tests/test_accounts_api.py tests/test_backend_api.py tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68ecef6025e48327b9265c445a4f5bb8