### PR TITLE
Improve InstrumentResearch change summary detail

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -403,14 +403,37 @@ export function InstrumentDetail({
 
   const close7 = lookup(7);
   const close30 = lookup(30);
+  const change7dValue =
+    Number.isFinite(latestClose) && Number.isFinite(close7)
+      ? latestClose - close7
+      : NaN;
   const change7dPct =
     Number.isFinite(latestClose) && Number.isFinite(close7)
-      ? ((latestClose / close7 - 1) * 100)
+      ? (latestClose / close7 - 1) * 100
+      : NaN;
+  const change30dValue =
+    Number.isFinite(latestClose) && Number.isFinite(close30)
+      ? latestClose - close30
       : NaN;
   const change30dPct =
     Number.isFinite(latestClose) && Number.isFinite(close30)
-      ? ((latestClose / close30 - 1) * 100)
+      ? (latestClose / close30 - 1) * 100
       : NaN;
+
+  const formatChangeSummary = (absoluteChange: number, percentChange: number) => {
+    const parts: string[] = [];
+
+    if (Number.isFinite(absoluteChange)) {
+      parts.push(money(absoluteChange, baseCurrency));
+    }
+
+    if (Number.isFinite(percentChange)) {
+      const pctText = percent(percentChange, 1);
+      parts.push(parts.length ? `(${pctText})` : pctText);
+    }
+
+    return parts.length ? parts.join(" ") : "—";
+  };
 
   const positions = data?.positions ?? [];
 
@@ -473,7 +496,9 @@ export function InstrumentDetail({
               : undefined,
           }}
         >
-          {t("instrumentDetail.change7d")} {loading ? t("app.loading") : percent(change7dPct, 1)}
+          {t("instrumentDetail.change7d")} {loading
+            ? t("app.loading")
+            : formatChangeSummary(change7dValue, change7dPct)}
         </span>
         {" • "}
         <span
@@ -485,7 +510,9 @@ export function InstrumentDetail({
               : undefined,
           }}
         >
-          {t("instrumentDetail.change30d")} {loading ? t("app.loading") : percent(change30dPct, 1)}
+          {t("instrumentDetail.change30d")} {loading
+            ? t("app.loading")
+            : formatChangeSummary(change30dValue, change30dPct)}
         </span>
       </div>
       {err && <p style={{ color: palette.negative }}>{err}</p>}

--- a/frontend/tests/unit/components/InstrumentDetail.test.tsx
+++ b/frontend/tests/unit/components/InstrumentDetail.test.tsx
@@ -158,12 +158,12 @@ describe("InstrumentDetail", () => {
 
     expect(
       await screen.findByText(
-        `${i18n.t("instrumentDetail.change7d")} 30.0%`,
+        `${i18n.t("instrumentDetail.change7d")} £30.00 (30.0%)`,
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        `${i18n.t("instrumentDetail.change30d")} 30.0%`,
+        `${i18n.t("instrumentDetail.change30d")} £30.00 (30.0%)`,
       ),
     ).toBeInTheDocument();
   });
@@ -191,12 +191,12 @@ describe("InstrumentDetail", () => {
 
     expect(
       await screen.findByText(
-        `${i18n.t("instrumentDetail.change7d")} 30.0%`,
+        `${i18n.t("instrumentDetail.change7d")} £30.00 (30.0%)`,
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        `${i18n.t("instrumentDetail.change30d")} 30.0%`,
+        `${i18n.t("instrumentDetail.change30d")} £30.00 (30.0%)`,
       ),
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- include absolute price deltas alongside percentage changes in the research view summary
- update InstrumentDetail unit tests for the richer change display

## Testing
- npm run test -- --run --environment jsdom tests/unit/components/InstrumentDetail.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ecf0e7276c8327a67e70b65769cd25