### PR TITLE
Add owner sector breakdown endpoint and chart

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -473,6 +473,26 @@ async def portfolio(owner: str, request: Request, as_of: str | None = None):
         raise HTTPException(status_code=404, detail="Owner not found")
 
 
+@router.get("/portfolio/{owner}/sectors")
+async def portfolio_sectors(owner: str, request: Request, as_of: str | None = None):
+    """Return return contribution aggregated by sector for an owner."""
+
+    accounts_root = resolve_accounts_root(request)
+    owner_dir = resolve_owner_directory(accounts_root, owner)
+    if owner_dir:
+        owner = owner_dir.name
+    pricing_date = _resolve_pricing_date(as_of)
+
+    try:
+        portfolio_data = portfolio_mod.build_owner_portfolio(
+            owner, accounts_root, pricing_date=pricing_date
+        )
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Owner not found")
+
+    return portfolio_utils.aggregate_by_sector(portfolio_data)
+
+
 @router.get("/var/{owner}")
 async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95, exclude_cash: bool = False):
     """Return historical-simulation VaR for ``owner``.

--- a/backend/tests/test_portfolio_routes.py
+++ b/backend/tests/test_portfolio_routes.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -17,7 +15,7 @@ def test_portfolio_success(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "backend.routes.portfolio.portfolio_mod.build_owner_portfolio",
-        lambda owner, root: {"owner": owner},
+        lambda owner, root, pricing_date=None: {"owner": owner},
     )
     resp = client.get("/portfolio/alice")
     assert resp.status_code == 200
@@ -28,10 +26,47 @@ def test_portfolio_not_found(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "backend.routes.portfolio.portfolio_mod.build_owner_portfolio",
-        lambda owner, root: (_ for _ in ()).throw(FileNotFoundError()),
+        lambda owner, root, pricing_date=None: (_ for _ in ()).throw(FileNotFoundError()),
     )
     resp = client.get("/portfolio/bob")
     assert resp.status_code == 404
+
+
+def test_portfolio_sectors(monkeypatch, tmp_path):
+    client = _client(monkeypatch, tmp_path)
+    sample_portfolio = {
+        "accounts": [
+            {
+                "holdings": [
+                    {
+                        "ticker": "AAA",
+                        "sector": "Tech",
+                        "market_value_gbp": 150,
+                        "cost_gbp": 100,
+                        "gain_gbp": 50,
+                    },
+                    {
+                        "ticker": "BBB",
+                        "sector": "Finance",
+                        "market_value_gbp": 220,
+                        "cost_gbp": 200,
+                        "gain_gbp": 20,
+                    },
+                ]
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        "backend.routes.portfolio.portfolio_mod.build_owner_portfolio",
+        lambda owner, root, pricing_date=None: sample_portfolio,
+    )
+
+    resp = client.get("/portfolio/alice/sectors")
+    assert resp.status_code == 200
+    sectors = {row["sector"]: row for row in resp.json()}
+    assert sectors["Tech"]["market_value_gbp"] == 150
+    assert sectors["Finance"]["gain_gbp"] == 20
 
 
 def test_portfolio_var(monkeypatch, tmp_path):

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -188,6 +188,20 @@ export const getPortfolio = (
   );
 };
 
+/** Retrieve return contribution aggregated by sector for an owner portfolio. */
+export const getOwnerSectorContributions = (
+  owner: string,
+  opts: { asOf?: string | null } = {},
+) => {
+  const params = new URLSearchParams();
+  if (opts.asOf) params.set("as_of", opts.asOf);
+  const qs = params.toString();
+  const url = qs
+    ? `${API_BASE}/portfolio/${owner}/sectors?${qs}`
+    : `${API_BASE}/portfolio/${owner}/sectors`;
+  return fetchJson<SectorContribution[]>(url);
+};
+
 /** List the configured groups (e.g. "adults", "children"). */
 export const getGroups = () =>
   fetchJson<GroupSummary[]>(`${API_BASE}/groups`);

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -3,6 +3,14 @@ import { describe, it, expect, vi } from "vitest";
 import { PortfolioView } from "@/components/PortfolioView";
 import type { Portfolio } from "@/types";
 
+vi.mock("@/api", () => ({
+  complianceForOwner: vi.fn().mockResolvedValue({ warnings: [] }),
+  getOwnerSectorContributions: vi.fn().mockResolvedValue([]),
+  getValueAtRisk: vi.fn().mockResolvedValue({ var: { "1d": 0, "10d": 0 } }),
+  recomputeValueAtRisk: vi.fn().mockResolvedValue(undefined),
+  getVarBreakdown: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("@/components/PerformanceDashboard", () => ({
   __esModule: true,
   default: () => <div data-testid="performance-dashboard" />,

--- a/frontend/tests/unit/components/responsiveRender.test.tsx
+++ b/frontend/tests/unit/components/responsiveRender.test.tsx
@@ -12,6 +12,8 @@ vi.mock("@/components/ValueAtRisk", () => ({
 }));
 vi.mock("@/api", () => ({
   getInstrumentDetail: vi.fn(() => Promise.resolve({ mini: { 7: [], 30: [], 180: [] } })),
+  complianceForOwner: vi.fn().mockResolvedValue({ warnings: [] }),
+  getOwnerSectorContributions: vi.fn().mockResolvedValue([]),
 }));
 
 const defaultConfig: AppConfig = {


### PR DESCRIPTION
## Summary
- add a backend endpoint that aggregates an owner's portfolio by sector and cover it with a regression test
- expose a frontend API helper and render the sector contribution bar chart on the owner portfolio page
- update unit tests to mock the new API surface for portfolio view scenarios

## Testing
- pytest --override-ini addopts="" backend/tests/test_portfolio_routes.py
- npm run test -- --run tests/unit/components/PortfolioView.test.tsx tests/unit/components/responsiveRender.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ecf16d2b308327956436f241136bd4