### PR TITLE
Normalize owner resolution for VaR endpoints

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -474,7 +474,13 @@ async def portfolio(owner: str, request: Request, as_of: str | None = None):
 
 
 @router.get("/var/{owner}")
-async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95, exclude_cash: bool = False):
+async def portfolio_var(
+    owner: str,
+    request: Request,
+    days: int = 365,
+    confidence: float = 0.95,
+    exclude_cash: bool = False,
+):
     """Return historical-simulation VaR for ``owner``.
 
     Parameters
@@ -494,8 +500,10 @@ async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95, e
     Raises 404 if the owner does not exist and 400 for invalid parameters.
     """
 
-    if owner not in portfolio_mod.list_owners():
-        raise HTTPException(status_code=404, detail="Owner not found")
+    accounts_root = resolve_accounts_root(request)
+    owner_dir = resolve_owner_directory(accounts_root, owner)
+    if owner_dir:
+        owner = owner_dir.name
     try:
         var = risk.compute_portfolio_var(owner, days=days, confidence=confidence, include_cash=not exclude_cash)
         sharpe = risk.compute_sharpe_ratio(owner, days=days)
@@ -513,11 +521,19 @@ async def portfolio_var(owner: str, days: int = 365, confidence: float = 0.95, e
 
 
 @router.get("/var/{owner}/breakdown")
-async def portfolio_var_breakdown(owner: str, days: int = 365, confidence: float = 0.95, exclude_cash: bool = False):
+async def portfolio_var_breakdown(
+    owner: str,
+    request: Request,
+    days: int = 365,
+    confidence: float = 0.95,
+    exclude_cash: bool = False,
+):
     """Return VaR totals with per-ticker contribution breakdown."""
 
-    if owner not in portfolio_mod.list_owners():
-        raise HTTPException(status_code=404, detail="Owner not found")
+    accounts_root = resolve_accounts_root(request)
+    owner_dir = resolve_owner_directory(accounts_root, owner)
+    if owner_dir:
+        owner = owner_dir.name
     try:
         var = risk.compute_portfolio_var(owner, days=days, confidence=confidence, include_cash=not exclude_cash)
         breakdown = risk.compute_portfolio_var_breakdown(owner, days=days, confidence=confidence, include_cash=not exclude_cash)
@@ -535,7 +551,12 @@ async def portfolio_var_breakdown(owner: str, days: int = 365, confidence: float
 
 
 @router.post("/var/{owner}/recompute")
-async def portfolio_var_recompute(owner: str, days: int = 365, confidence: float = 0.95):
+async def portfolio_var_recompute(
+    owner: str,
+    request: Request,
+    days: int = 365,
+    confidence: float = 0.95,
+):
     """Force recomputation of VaR for ``owner``.
 
     This endpoint mirrors :func:`portfolio_var` but is intended to be called
@@ -543,6 +564,10 @@ async def portfolio_var_recompute(owner: str, days: int = 365, confidence: float
     result without additional metadata.
     """
 
+    accounts_root = resolve_accounts_root(request)
+    owner_dir = resolve_owner_directory(accounts_root, owner)
+    if owner_dir:
+        owner = owner_dir.name
     try:
         var = risk.compute_portfolio_var(owner, days=days, confidence=confidence)
     except FileNotFoundError:

--- a/backend/tests/test_portfolio_routes.py
+++ b/backend/tests/test_portfolio_routes.py
@@ -36,7 +36,6 @@ def test_portfolio_not_found(monkeypatch, tmp_path):
 
 def test_portfolio_var(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
-    monkeypatch.setattr("backend.routes.portfolio.portfolio_mod.list_owners", lambda: ["alice"])
     monkeypatch.setattr(
         "backend.routes.portfolio.risk.compute_portfolio_var",
         lambda owner, days, confidence, include_cash: {"1d": 1.0},
@@ -54,14 +53,16 @@ def test_portfolio_var(monkeypatch, tmp_path):
 
 def test_portfolio_var_owner_missing(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
-    monkeypatch.setattr("backend.routes.portfolio.portfolio_mod.list_owners", lambda: [])
+    monkeypatch.setattr(
+        "backend.routes.portfolio.risk.compute_portfolio_var",
+        lambda owner, days=365, confidence=0.95, include_cash=True: (_ for _ in ()).throw(FileNotFoundError()),
+    )
     resp = client.get("/var/alice")
     assert resp.status_code == 404
 
 
 def test_portfolio_var_bad_params(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
-    monkeypatch.setattr("backend.routes.portfolio.portfolio_mod.list_owners", lambda: ["alice"])
 
     def _raise(owner, days, confidence, include_cash):
         raise ValueError("bad")


### PR DESCRIPTION
## Summary
- normalize the portfolio VaR endpoints to resolve owners via the request-scoped accounts root before computing metrics
- refresh the VaR route tests to reflect the new owner resolution behaviour and error handling

## Testing
- pytest backend/tests/test_portfolio_routes.py -k var -q *(fails: coverage failure because the global 90% threshold is enforced even for the focused suite)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf103a9a08327800a1f5b19ed50ec