### PR TITLE
Fix owner sanitization to retain demo fallback

### DIFF
--- a/frontend/src/utils/owners.ts
+++ b/frontend/src/utils/owners.ts
@@ -3,7 +3,16 @@ import type { OwnerSummary } from "../types";
 /** Remove any placeholder/system owners that should never appear in the UI. */
 export function sanitizeOwners(owners: OwnerSummary[]): OwnerSummary[] {
   const blockedOwners = new Set(["demo", ".idea"]);
-  return owners.filter((owner) => !blockedOwners.has(owner.owner));
+  const filtered = owners.filter((owner) => !blockedOwners.has(owner.owner));
+
+  if (filtered.length > 0) {
+    return filtered;
+  }
+
+  // When every owner is filtered out we still want to expose demo accounts so that
+  // local/test environments retain at least one selectable owner. System-only
+  // placeholders such as ``.idea`` should continue to be hidden.
+  return owners.filter((owner) => owner.owner !== ".idea");
 }
 
 export function createOwnerDisplayLookup(

--- a/frontend/tests/unit/utils/owners.test.ts
+++ b/frontend/tests/unit/utils/owners.test.ts
@@ -14,9 +14,9 @@ describe('sanitizeOwners', () => {
     expect(sanitizeOwners(owners)).toEqual([makeOwner('alice'), makeOwner('bob')]);
   });
 
-  it('returns empty list when only placeholder owners provided', () => {
+  it('retains demo owner when it is the only available option', () => {
     const owners = [makeOwner('demo'), makeOwner('.idea')];
-    expect(sanitizeOwners(owners)).toEqual([]);
+    expect(sanitizeOwners(owners)).toEqual([makeOwner('demo')]);
   });
 
   it('returns empty list when no owners provided', () => {


### PR DESCRIPTION
## Summary
- ensure sanitizeOwners falls back to demo owners when all entries are filtered
- update the sanitizeOwners unit test to reflect the new fallback

## Testing
- npm run test -- --run tests/unit/utils/owners.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ecf5b31fb88327a70950c3d6d32e30