### PR TITLE
Ignore single-day zero valuations in performance diagnostics

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -508,6 +508,12 @@ export const getPerformance = (
     history: PerformancePoint[];
     reporting_date?: string | null;
     previous_date?: string | null;
+    data_quality_issues?: {
+      date: string;
+      value: number;
+      previous_value: number;
+      next_value: number;
+    }[];
   }>(
     `${API_BASE}/performance/${owner}?${params.toString()}`,
   );
@@ -527,6 +533,13 @@ export const getPerformance = (
     xirr: x.xirr,
     reportingDate: p.reporting_date ?? null,
     previousDate: p.previous_date ?? null,
+    dataQualityIssues:
+      p.data_quality_issues?.map((issue) => ({
+        date: issue.date,
+        value: issue.value,
+        previousValue: issue.previous_value,
+        nextValue: issue.next_value,
+      })) ?? [],
   }));
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -152,12 +152,20 @@ export interface PerformancePoint {
   drawdown?: number | null;
 }
 
+export interface DataQualityIssue {
+  date: string;
+  value: number;
+  previousValue: number;
+  nextValue: number;
+}
+
 export interface PerformanceResponse {
   history: PerformancePoint[];
   time_weighted_return?: number | null;
   xirr?: number | null;
   reportingDate?: string | null;
   previousDate?: string | null;
+  dataQualityIssues?: DataQualityIssue[];
 }
 
 export interface HoldingValue {


### PR DESCRIPTION
## Summary
- ignore isolated single-day price collapses when reconstructing portfolio performance and report them for remediation
- expose the anomaly report via the performance API and display it on the diagnostics screen
- cover the regression with a portfolio-utils unit test

## Testing
- pytest -o addopts= tests/test_portfolio_utils_returns.py

------
https://chatgpt.com/codex/tasks/task_e_68ecf6f37f608327991c1b01a432a098