### PR TITLE
Fix holdings list key warning in performance diagnostics

### DIFF
--- a/frontend/src/pages/PerformanceDiagnostics.tsx
+++ b/frontend/src/pages/PerformanceDiagnostics.tsx
@@ -113,8 +113,8 @@ export default function PerformanceDiagnostics() {
             <div style={{ marginTop: "1rem" }}>
               <h2>Holdings on {selected}</h2>
               <ul>
-                {holdings.map((h) => (
-                  <li key={`${h.ticker}.${h.exchange}`}>
+                {holdings.map((h, index) => (
+                  <li key={`${h.ticker}.${h.exchange}.${index}`}>
                     <a
                       href={`/timeseries?ticker=${encodeURIComponent(
                         h.ticker,


### PR DESCRIPTION
## Summary
- ensure holdings list items include a stable unique key when rendering holdings

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ecf685e8d88327b4a279a8c4f2f45e