### PR TITLE
Fix smoke tests for configurable demo owners

### DIFF
--- a/scripts/smoke-all.ts
+++ b/scripts/smoke-all.ts
@@ -54,7 +54,7 @@ const commands: Command[] = [
         label: 'frontend smoke suite',
       }
     : {
-        command: process.platform === 'win32' ? 'npm.cmd' : 'npm',
+        command: 'npm',
         args: ['--prefix', 'frontend', 'run', 'smoke:frontend'],
         label: 'frontend smoke suite',
       },


### PR DESCRIPTION
## Summary
- detect the available demo owner from config/environment when generating smoke test traffic
- reuse the resolved owner in smoke endpoints and pension helpers to avoid 404s when demo data differs
- invoke npm via a platform-neutral command so the frontend smoke suite starts on Windows

## Testing
- Not run (backend services unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ee02f25284832789a8aff6b55b13be