### PR TITLE
Add local auth fallback configuration and UI controls - conflicts

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -116,6 +116,7 @@ class Config:
     google_auth_enabled: Optional[bool] = None
     disable_auth: Optional[bool] = None
     demo_identity: str = "demo"
+    local_auth_email: Optional[str] = None
     google_client_id: Optional[str] = None
     allowed_emails: Optional[List[str]] = None
     relative_view_enabled: Optional[bool] = None
@@ -349,6 +350,15 @@ def load_config() -> Config:
     if not demo_identity:
         demo_identity = "demo"
 
+    local_auth_email = data.get("local_auth_email")
+    if isinstance(local_auth_email, str):
+        local_auth_email = local_auth_email.strip().lower() or None
+
+    env_local_auth = os.getenv("LOCAL_AUTH_EMAIL")
+    if env_local_auth is not None:
+        env_val = env_local_auth.strip().lower()
+        local_auth_email = env_val or None
+
     cfg = Config(
         app_env=data.get("app_env"),
         sns_topic_arn=data.get("sns_topic_arn"),
@@ -372,6 +382,7 @@ def load_config() -> Config:
         google_client_id=google_client_id,
         allowed_emails=allowed_emails,
         demo_identity=demo_identity,
+        local_auth_email=local_auth_email,
         relative_view_enabled=data.get("relative_view_enabled"),
         theme=data.get("theme"),
         timeseries_cache_base=timeseries_cache_base,

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -96,6 +96,7 @@ def _normalise_config_structure(raw: Dict[str, Any]) -> Dict[str, Any]:
         "google_client_id",
         "disable_auth",
         "allowed_emails",
+        "local_auth_email",
     ]:
         if key in data:
             auth_section[key] = data.pop(key)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,6 +13,7 @@ auth:
   google_auth_enabled: false          # Enable Google sign-in (GOOGLE_AUTH_ENABLED)
   disable_auth: true                  # Disable all authentication checks (DISABLE_AUTH) - use only for development
   demo_identity: demo                 # Owner to assume when auth is disabled (ignored when auth is enforced)
+  local_auth_email: user@example.com  # Email issued for local login fallback when auth is disabled (LOCAL_AUTH_EMAIL)
   google_client_id: ""                # OAuth client id for Google auth (GOOGLE_CLIENT_ID)
   allowed_emails:                     # Whitelisted emails (ALLOWED_EMAILS)
     - user@example.com

--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@ auth:
   google_auth_enabled: false          # Enable Google sign-in (GOOGLE_AUTH_ENABLED)
   disable_auth: true                  # Disable all authentication checks (DISABLE_AUTH) - use only for development
   demo_identity: steve                 # Owner to assume when auth is disabled (ignored when auth is enforced)
+  local_auth_email: user@example.com  # Email issued for local login fallback when auth is disabled (LOCAL_AUTH_EMAIL)
   google_client_id: ""                # OAuth client id for Google auth (GOOGLE_CLIENT_ID)
   allowed_emails:                     # Whitelisted emails (ALLOWED_EMAILS)
     - user@example.com

--- a/docs/README.md
+++ b/docs/README.md
@@ -155,6 +155,13 @@ API loads demo data for the owner defined by `auth.demo_identity` (default:
 `demo`). Adjust the value to point at whichever demo account exists under your
 `data/` directory when you want to explore different fixtures.
 
+When authentication is disabled the login endpoints still mint a JWT so the
+frontend can behave as though a user is signed in. The email embedded in that
+token defaults to the first entry in `auth.allowed_emails`, but you can pin a
+specific address via the `auth.local_auth_email` setting (also overridable via
+the `LOCAL_AUTH_EMAIL` environment variable). This is handy when testing roles
+locally without changing the allow list itself.
+
 Production or AWS deployments should flip `auth.disable_auth` to `false` and
 enable Google sign-in. Once authentication is enforced the configured user from
 the incoming token is used instead, so the `demo_identity` value is ignored

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -483,6 +483,13 @@
       "run": "Portfolio-Gesundheitsprüfung ausführen",
       "title": "Portfoliozustand"
     },
+    "auth": {
+      "title": "Authentication",
+      "localUserLabel": "Local login user",
+      "defaultOption": "Automatic (first allowed email)",
+      "description": "Choose which allowed email to use when authentication is disabled. Save the configuration to apply.",
+      "none": "No allowed users configured. Update auth.allowed_emails to enable selection."
+    },
     "notifications": {
       "denied": "Push-Berechtigung verweigert.",
       "disable": "Push-Benachrichtigungen deaktivieren",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -506,6 +506,13 @@
       "refresh": "Refresh logs",
       "title": "Logs"
     },
+    "auth": {
+      "title": "Authentication",
+      "localUserLabel": "Local login user",
+      "defaultOption": "Automatic (first allowed email)",
+      "description": "Choose which allowed email to use when authentication is disabled. Save the configuration to apply.",
+      "none": "No allowed users configured. Update auth.allowed_emails to enable selection."
+    },
     "notifications": {
       "denied": "Push permission denied.",
       "disable": "Disable Push Alerts",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -414,6 +414,13 @@
       "run": "Ejecutar verificación de salud del portafolio",
       "title": "Salud del portafolio"
     },
+    "auth": {
+      "title": "Authentication",
+      "localUserLabel": "Local login user",
+      "defaultOption": "Automatic (first allowed email)",
+      "description": "Choose which allowed email to use when authentication is disabled. Save the configuration to apply.",
+      "none": "No allowed users configured. Update auth.allowed_emails to enable selection."
+    },
     "notifications": {
       "denied": "Permiso de push denegado.",
       "disable": "Desactivar alertas push",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -415,6 +415,13 @@
       "run": "Exécuter la vérification de santé du portefeuille",
       "title": "Santé du portefeuille"
     },
+    "auth": {
+      "title": "Authentication",
+      "localUserLabel": "Local login user",
+      "defaultOption": "Automatic (first allowed email)",
+      "description": "Choose which allowed email to use when authentication is disabled. Save the configuration to apply.",
+      "none": "No allowed users configured. Update auth.allowed_emails to enable selection."
+    },
     "notifications": {
       "denied": "Permission de push refusée.",
       "disable": "Désactiver les alertes Push",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -415,6 +415,13 @@
       "run": "Esegui controllo salute portafoglio",
       "title": "Salute del portafoglio"
     },
+    "auth": {
+      "title": "Authentication",
+      "localUserLabel": "Local login user",
+      "defaultOption": "Automatic (first allowed email)",
+      "description": "Choose which allowed email to use when authentication is disabled. Save the configuration to apply.",
+      "none": "No allowed users configured. Update auth.allowed_emails to enable selection."
+    },
     "notifications": {
       "denied": "Permesso push negato.",
       "disable": "Disattiva avvisi Push",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -414,6 +414,13 @@
       "run": "Executar verificação de saúde do portfólio",
       "title": "Saúde do portfólio"
     },
+    "auth": {
+      "title": "Authentication",
+      "localUserLabel": "Local login user",
+      "defaultOption": "Automatic (first allowed email)",
+      "description": "Choose which allowed email to use when authentication is disabled. Save the configuration to apply.",
+      "none": "No allowed users configured. Update auth.allowed_emails to enable selection."
+    },
     "notifications": {
       "denied": "Permissão de push negada.",
       "disable": "Desativar alertas Push",

--- a/frontend/tests/unit/pages/Support.test.tsx
+++ b/frontend/tests/unit/pages/Support.test.tsx
@@ -57,6 +57,8 @@ beforeEach(() => {
       rebalance: false,
       pension: true,
     },
+    allowed_emails: ["user@example.com", "demo@example.com"],
+    local_auth_email: "user@example.com",
   });
   mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
 });
@@ -83,6 +85,15 @@ describe("Support page", () => {
     expect(
       await screen.findByLabelText(new RegExp(en.owner.label))
     ).toBeInTheDocument();
+  });
+
+  it("allows selecting a local auth user", async () => {
+    render(<Support />, { wrapper: MemoryRouter });
+    await expandSection(en.support.auth.title);
+    const select = await screen.findByLabelText(en.support.auth.localUserLabel);
+    expect((select as HTMLSelectElement).value).toBe("user@example.com");
+    await userEvent.selectOptions(select, "demo@example.com");
+    expect((select as HTMLSelectElement).value).toBe("demo@example.com");
   });
 
   it("handles owner fetch failure gracefully", async () => {
@@ -124,6 +135,8 @@ describe("Support page", () => {
       rebalance: false,
       pension: true,
     },
+    allowed_emails: ["user@example.com"],
+    local_auth_email: "user@example.com",
   });
   mockGetConfig.mockResolvedValueOnce({
     flag: false,
@@ -142,6 +155,8 @@ describe("Support page", () => {
       rebalance: false,
       pension: true,
     },
+    allowed_emails: ["user@example.com", "demo@example.com"],
+    local_auth_email: "demo@example.com",
   });
     mockUpdateConfig.mockResolvedValue(undefined);
 
@@ -202,14 +217,17 @@ describe("Support page", () => {
         group: true,
         owner: true,
         instrument: true,
-      trading: true,
-      support: true,
-      reports: true,
-      market: true,
+        trading: true,
+        support: true,
+        reports: true,
+        market: true,
         allocation: true,
         rebalance: true,
         pension: true,
+        scenario: true,
       },
+      allowed_emails: ["user@example.com"],
+      local_auth_email: "user@example.com",
     });
     mockGetConfig.mockResolvedValueOnce({
       flag: true,
@@ -218,14 +236,17 @@ describe("Support page", () => {
         group: true,
         owner: true,
         instrument: false,
-      trading: true,
-      support: true,
-      reports: true,
-      market: true,
+        trading: true,
+        support: true,
+        reports: true,
+        market: true,
         allocation: true,
         rebalance: true,
         pension: true,
+        scenario: true,
       },
+      allowed_emails: ["user@example.com", "demo@example.com"],
+      local_auth_email: "demo@example.com",
     });
     mockUpdateConfig.mockResolvedValue(undefined);
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,6 +93,17 @@ def test_demo_identity_override(monkeypatch, tmp_path):
         reload_config()
 
 
+def test_local_auth_email_defaults(monkeypatch):
+    cfg = reload_config()
+    assert cfg.local_auth_email == "user@example.com"
+
+    monkeypatch.setenv("LOCAL_AUTH_EMAIL", "ADMIN@Example.com")
+    cfg = reload_config()
+    assert cfg.local_auth_email == "admin@example.com"
+    monkeypatch.delenv("LOCAL_AUTH_EMAIL")
+    reload_config()
+
+
 def test_allowed_emails_loaded_lowercase():
     cfg = reload_config()
     assert cfg.allowed_emails == ["user@example.com"]


### PR DESCRIPTION
## Summary
- add a configurable `local_auth_email` setting with environment overrides and persist it through config routes
- issue local development tokens using the configured email (or the first allowed email) and document the behaviour
- surface a Support page selector backed by translations/tests so operators can switch the fallback user without editing raw JSON

## Testing
- pytest --override-ini addopts='' tests/test_config.py tests/test_google_auth.py
- npm run test -- --run tests/unit/pages/Support.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68f0a33ca0308327925d04a337189f19