### PR TITLE
Improve local data discovery resilience - conflicts

### DIFF
--- a/backend/routes/alert_settings.py
+++ b/backend/routes/alert_settings.py
@@ -11,6 +11,8 @@ from backend.config import demo_identity
 
 router = APIRouter(prefix="/alert-thresholds", tags=["alerts"])
 
+DEMO_IDENTITY = demo_identity()
+
 
 class ThresholdPayload(BaseModel):
     threshold: float


### PR DESCRIPTION
## Summary
- prefer canonical casing for discovered account files even on case-insensitive filesystems
- fall back to the bundled demo owner when the configured identity is missing and hide redundant full names in `list_plots`
- expose the demo identity constant for alert settings to simplify identity resolution

## Testing
- pytest tests/backend/common/test_data_loader.py::TestExtractAccountNames::test_dedupes_and_filters_metadata -q -o addopts=
- pytest tests/backend/common/test_data_loader.py::TestListLocalPlots::test_list_plots_with_explicit_root_skips_demo -q -o addopts=
- pytest tests/backend/common/test_data_loader.py::TestLoadDemoOwner::test_returns_demo_summary_when_available -q -o addopts=
- pytest tests/backend/routes/test_alert_settings.py::test_resolve_identity_defaults_to_demo -q -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68f0a549537083278c2d89fd566fcf8e