### PR TITLE
Fix compliance smoke path and Windows npm invocation

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -477,11 +477,10 @@ def _list_local_plots(
             if _attach_demo_from(fallback_root):
                 allow_fallback_demo = False
 
+        include_demo = config.disable_auth or include_demo_primary
         if (
-            (config.disable_auth or include_demo_primary)
-            not any(
-            alias in owners_index for alias in demo_lower_aliases
-            )
+            include_demo
+            and not any(alias in owners_index for alias in demo_lower_aliases)
             and not suppress_demo
         ):
             target_root: Optional[Path]


### PR DESCRIPTION
## Summary
- ensure demo compliance data inclusion no longer triggers a syntax error and preserves fallback scaffolding
- make the smoke harness resolve npm on Windows by preferring the CLI script or bundled npm executable

## Testing
- python -m compileall backend/common/data_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68f0a70dd8648327bfb2030c143f6042