### PR TITLE
Follow-up: Restore demo owner fallbacks -conflicts

### DIFF
--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -43,7 +43,7 @@ def _known_owners(accounts_root) -> KnownOwnerSet:
                 continue
             lower_candidate = candidate.lower()
             if lower_candidate in owner_set:
-                return
+                continue
             candidate_pairs.append((candidate, lower_candidate))
 
         try:


### PR DESCRIPTION
## Summary
- expose the configured demo identity constant within the alert settings routes
- allow compliance owner discovery to include the default demo directory when present
- ensure the default demo owner is still considered when the configured identity already exists

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/backend/routes/test_compliance.py

------
https://chatgpt.com/codex/tasks/task_e_68f73e01d31c83278c1ba6c5ba8761a7