### PR TITLE
Fix local account casing and alert demo identity fallback

### DIFF
--- a/backend/routes/alert_settings.py
+++ b/backend/routes/alert_settings.py
@@ -14,9 +14,6 @@ router = APIRouter(prefix="/alert-thresholds", tags=["alerts"])
 DEMO_IDENTITY = demo_identity()
 
 
-DEMO_IDENTITY = demo_identity()
-
-
 class ThresholdPayload(BaseModel):
     threshold: float
 


### PR DESCRIPTION
## Summary
- normalise known account names while keeping local listings in lowercase and fixing demo alias handling
- ensure default full names only populate when requested during local discovery
- expose the demo identity constant in alert settings with the required imports

## Testing
- pytest --no-cov tests/backend/common/test_data_loader.py::TestExtractAccountNames::test_dedupes_and_filters_metadata
- pytest --no-cov tests/backend/common/test_data_loader.py::TestListLocalPlots::test_list_plots_with_explicit_root_skips_demo
- pytest --no-cov tests/backend/common/test_data_loader.py::TestLoadDemoOwner::test_returns_demo_summary_when_available
- pytest --no-cov tests/backend/routes/test_alert_settings.py::test_resolve_identity_defaults_to_demo


------
https://chatgpt.com/codex/tasks/task_e_68f77b57f7408327829d5442dff1cb62