### PR TITLE
Redesign reports page around template catalog

### DIFF
--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -1,37 +1,7 @@
 import { API_BASE, fetchJson } from "@/api";
-import type {
-  ReportTemplate,
-  ReportTemplateInput,
-} from "@/types";
+import type { ReportTemplateMetadata } from "@/types";
 
-const TEMPLATE_BASE = `${API_BASE}/report-templates`;
-
-const jsonHeaders = { "Content-Type": "application/json" } as const;
+const TEMPLATE_BASE = `${API_BASE}/reports/templates`;
 
 export const listReportTemplates = () =>
-  fetchJson<ReportTemplate[]>(TEMPLATE_BASE);
-
-export const createReportTemplate = (payload: ReportTemplateInput) =>
-  fetchJson<ReportTemplate>(TEMPLATE_BASE, {
-    method: "POST",
-    headers: jsonHeaders,
-    body: JSON.stringify(payload),
-  });
-
-export const updateReportTemplate = (
-  id: string,
-  payload: ReportTemplateInput,
-) =>
-  fetchJson<ReportTemplate>(`${TEMPLATE_BASE}/${encodeURIComponent(id)}`, {
-    method: "PUT",
-    headers: jsonHeaders,
-    body: JSON.stringify(payload),
-  });
-
-export const deleteReportTemplate = (id: string) =>
-  fetchJson<void>(`${TEMPLATE_BASE}/${encodeURIComponent(id)}`, {
-    method: "DELETE",
-  });
-
-export const getReportTemplate = (id: string) =>
-  fetchJson<ReportTemplate>(`${TEMPLATE_BASE}/${encodeURIComponent(id)}`);
+  fetchJson<ReportTemplateMetadata[]>(TEMPLATE_BASE);

--- a/frontend/src/hooks/useReportsCatalog.ts
+++ b/frontend/src/hooks/useReportsCatalog.ts
@@ -1,0 +1,37 @@
+import { useCallback, useMemo } from "react";
+
+import { listReportTemplates } from "@/api/reports";
+import type { ReportTemplateMetadata } from "@/types";
+
+import useFetch from "./useFetch";
+
+type ReportsCatalogResult = {
+  templates: ReportTemplateMetadata[];
+  builtin: ReportTemplateMetadata[];
+  custom: ReportTemplateMetadata[];
+  loading: boolean;
+  error: Error | null;
+};
+
+export function useReportsCatalog(): ReportsCatalogResult {
+  const fetchCatalog = useCallback(() => listReportTemplates(), []);
+  const { data, loading, error } = useFetch(fetchCatalog, []);
+
+  const templates = data ?? [];
+
+  const { builtin, custom } = useMemo(() => {
+    const builtinTemplates: ReportTemplateMetadata[] = [];
+    const customTemplates: ReportTemplateMetadata[] = [];
+
+    for (const template of templates) {
+      if (template.builtin) builtinTemplates.push(template);
+      else customTemplates.push(template);
+    }
+
+    return { builtin: builtinTemplates, custom: customTemplates };
+  }, [templates]);
+
+  return { templates, builtin, custom, loading, error };
+}
+
+export default useReportsCatalog;

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -434,7 +434,34 @@
     "csv": "CSV herunterladen",
     "noOwners": "No owners available—check backend connection",
     "pdf": "PDF herunterladen",
-    "title": "Berichte"
+    "title": "Berichte",
+    "templatesTitle": "Berichtsvorlagen",
+    "templatesDescription": "Wählen Sie eine integrierte oder benutzerdefinierte Vorlage, bevor Sie exportieren.",
+    "templatesLoading": "Vorlagen werden geladen…",
+    "templatesError": "Vorlagen konnten nicht geladen werden.",
+    "templatesEmpty": "Keine Vorlagen verfügbar.",
+    "catalog": {
+      "groups": {
+        "builtin": "Integrierte Vorlagen",
+        "custom": "Benutzerdefinierte Vorlagen"
+      },
+      "noFields": "Für diese Vorlage sind keine Felder definiert.",
+      "fieldsLabel_one": "{{count}} Feld: {{fields}}",
+      "fieldsLabel_other": "{{count}} Felder: {{fields}}",
+      "moreFields_one": "+{{count}} weiteres Feld",
+      "moreFields_other": "+{{count}} weitere Felder",
+      "sectionsLabel": "Abschnitte: {{sections}}",
+      "selectLabel": "Vorlage {{name}} auswählen",
+      "badge": {
+        "builtin": "Integriert",
+        "custom": "Benutzerdefiniert"
+      },
+      "selected": "Ausgewählt",
+      "selectedTemplate": "Vorlage: {{name}}"
+    },
+    "downloadsTitle": "Berichte herunterladen",
+    "downloadsDescription": "Erstellen Sie CSV- oder PDF-Exporte mit der ausgewählten Vorlage und dem Datumsbereich.",
+    "downloadsDisabled": "Wählen Sie einen Eigentümer und eine Vorlage, um Downloads zu aktivieren."
   },
   "screener": {
     "loading": "Laden…",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -454,23 +454,33 @@
     "noOwners": "No owners available—check backend connection",
     "pdf": "Download PDF",
     "title": "Reports",
-    "templatesTitle": "Report templates",
-    "templatesDescription": "Save reusable report definitions for your team.",
-    "createTemplateButton": "New template",
-    "templatesLoading": "Loading templates…",
-    "templatesError": "Unable to load templates.",
-    "templatesEmpty": "No templates yet. Create one to get started.",
-    "templatesSaving": "Saving…",
-    "editTemplate": "Edit",
-    "templatesCount": {
-      "metrics_one": "{{count}} metric",
-      "metrics_other": "{{count}} metrics",
-      "columns_one": "{{count}} column",
-      "columns_other": "{{count}} columns",
-      "filters_zero": "No filters",
-      "filters_one": "{{count}} filter",
-      "filters_other": "{{count}} filters"
+  "templatesTitle": "Report templates",
+  "templatesDescription": "Choose a built-in or custom template before exporting.",
+  "templatesLoading": "Loading templates…",
+  "templatesError": "Unable to load templates.",
+  "templatesEmpty": "No templates available yet.",
+  "catalog": {
+    "groups": {
+      "builtin": "Built-in templates",
+      "custom": "Custom templates"
     },
+    "noFields": "No fields defined for this template.",
+    "fieldsLabel_one": "{{count}} field: {{fields}}",
+    "fieldsLabel_other": "{{count}} fields: {{fields}}",
+    "moreFields_one": "+{{count}} more field",
+    "moreFields_other": "+{{count}} more fields",
+    "sectionsLabel": "Sections: {{sections}}",
+    "selectLabel": "Select {{name}} template",
+    "badge": {
+      "builtin": "Built-in",
+      "custom": "Custom"
+    },
+    "selected": "Selected",
+    "selectedTemplate": "Template: {{name}}"
+  },
+  "downloadsTitle": "Download reports",
+  "downloadsDescription": "Generate CSV or PDF exports with the selected template and dates.",
+  "downloadsDisabled": "Select an owner and template to enable downloads.",
     "builder": {
       "headingCreate": "Create report template",
       "headingEdit": "Edit report template",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -365,7 +365,34 @@
     "csv": "Descargar CSV",
     "noOwners": "No owners available—check backend connection",
     "pdf": "Descargar PDF",
-    "title": "Informes"
+    "title": "Informes",
+    "templatesTitle": "Plantillas de informe",
+    "templatesDescription": "Elige una plantilla integrada o personalizada antes de exportar.",
+    "templatesLoading": "Cargando plantillas…",
+    "templatesError": "No se pudieron cargar las plantillas.",
+    "templatesEmpty": "No hay plantillas disponibles.",
+    "catalog": {
+      "groups": {
+        "builtin": "Plantillas integradas",
+        "custom": "Plantillas personalizadas"
+      },
+      "noFields": "Esta plantilla no define campos.",
+      "fieldsLabel_one": "{{count}} campo: {{fields}}",
+      "fieldsLabel_other": "{{count}} campos: {{fields}}",
+      "moreFields_one": "+{{count}} campo adicional",
+      "moreFields_other": "+{{count}} campos adicionales",
+      "sectionsLabel": "Secciones: {{sections}}",
+      "selectLabel": "Seleccionar plantilla {{name}}",
+      "badge": {
+        "builtin": "Integrada",
+        "custom": "Personalizada"
+      },
+      "selected": "Seleccionada",
+      "selectedTemplate": "Plantilla: {{name}}"
+    },
+    "downloadsTitle": "Descargar informes",
+    "downloadsDescription": "Genera exportaciones CSV o PDF con la plantilla y fechas seleccionadas.",
+    "downloadsDisabled": "Selecciona un propietario y una plantilla para habilitar las descargas."
   },
   "screener": {
     "loading": "Cargando…",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -366,7 +366,34 @@
     "csv": "Télécharger CSV",
     "noOwners": "Aucun propriétaire disponible — vérifiez la connexion au backend",
     "pdf": "Télécharger PDF",
-    "title": "Rapports"
+    "title": "Rapports",
+    "templatesTitle": "Modèles de rapport",
+    "templatesDescription": "Choisissez un modèle intégré ou personnalisé avant l'export.",
+    "templatesLoading": "Chargement des modèles…",
+    "templatesError": "Impossible de charger les modèles.",
+    "templatesEmpty": "Aucun modèle disponible.",
+    "catalog": {
+      "groups": {
+        "builtin": "Modèles intégrés",
+        "custom": "Modèles personnalisés"
+      },
+      "noFields": "Ce modèle ne définit aucun champ.",
+      "fieldsLabel_one": "{{count}} champ : {{fields}}",
+      "fieldsLabel_other": "{{count}} champs : {{fields}}",
+      "moreFields_one": "+{{count}} champ supplémentaire",
+      "moreFields_other": "+{{count}} champs supplémentaires",
+      "sectionsLabel": "Sections : {{sections}}",
+      "selectLabel": "Sélectionner le modèle {{name}}",
+      "badge": {
+        "builtin": "Intégré",
+        "custom": "Personnalisé"
+      },
+      "selected": "Sélectionné",
+      "selectedTemplate": "Modèle : {{name}}"
+    },
+    "downloadsTitle": "Télécharger les rapports",
+    "downloadsDescription": "Générez des exports CSV ou PDF avec le modèle et les dates sélectionnés.",
+    "downloadsDisabled": "Sélectionnez un propriétaire et un modèle pour activer les téléchargements."
   },
   "screener": {
     "loading": "Chargement…",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -366,7 +366,34 @@
     "csv": "Scarica CSV",
     "noOwners": "No owners available—check backend connection",
     "pdf": "Scarica PDF",
-    "title": "Segnalazioni"
+    "title": "Segnalazioni",
+    "templatesTitle": "Modelli di report",
+    "templatesDescription": "Scegli un modello integrato o personalizzato prima di esportare.",
+    "templatesLoading": "Caricamento dei modelli…",
+    "templatesError": "Impossibile caricare i modelli.",
+    "templatesEmpty": "Nessun modello disponibile.",
+    "catalog": {
+      "groups": {
+        "builtin": "Modelli integrati",
+        "custom": "Modelli personalizzati"
+      },
+      "noFields": "Questo modello non definisce campi.",
+      "fieldsLabel_one": "{{count}} campo: {{fields}}",
+      "fieldsLabel_other": "{{count}} campi: {{fields}}",
+      "moreFields_one": "+{{count}} campo aggiuntivo",
+      "moreFields_other": "+{{count}} campi aggiuntivi",
+      "sectionsLabel": "Sezioni: {{sections}}",
+      "selectLabel": "Seleziona il modello {{name}}",
+      "badge": {
+        "builtin": "Integrato",
+        "custom": "Personalizzato"
+      },
+      "selected": "Selezionato",
+      "selectedTemplate": "Modello: {{name}}"
+    },
+    "downloadsTitle": "Scarica report",
+    "downloadsDescription": "Genera esportazioni CSV o PDF con il modello e le date selezionate.",
+    "downloadsDisabled": "Seleziona un proprietario e un modello per abilitare i download."
   },
   "screener": {
     "loading": "Caricamento…",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -365,7 +365,34 @@
     "csv": "Baixar CSV",
     "noOwners": "No owners available—check backend connection",
     "pdf": "Baixar PDF",
-    "title": "Relatórios"
+    "title": "Relatórios",
+    "templatesTitle": "Modelos de relatório",
+    "templatesDescription": "Escolha um modelo integrado ou personalizado antes de exportar.",
+    "templatesLoading": "Carregando modelos…",
+    "templatesError": "Não foi possível carregar os modelos.",
+    "templatesEmpty": "Nenhum modelo disponível.",
+    "catalog": {
+      "groups": {
+        "builtin": "Modelos integrados",
+        "custom": "Modelos personalizados"
+      },
+      "noFields": "Este modelo não define campos.",
+      "fieldsLabel_one": "{{count}} campo: {{fields}}",
+      "fieldsLabel_other": "{{count}} campos: {{fields}}",
+      "moreFields_one": "+{{count}} campo adicional",
+      "moreFields_other": "+{{count}} campos adicionais",
+      "sectionsLabel": "Seções: {{sections}}",
+      "selectLabel": "Selecionar modelo {{name}}",
+      "badge": {
+        "builtin": "Integrado",
+        "custom": "Personalizado"
+      },
+      "selected": "Selecionado",
+      "selectedTemplate": "Modelo: {{name}}"
+    },
+    "downloadsTitle": "Baixar relatórios",
+    "downloadsDescription": "Gere exports CSV ou PDF com o modelo e as datas selecionadas.",
+    "downloadsDisabled": "Selecione um proprietário e um modelo para habilitar os downloads."
   },
   "screener": {
     "loading": "Carregando…",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -609,6 +609,28 @@ export interface ReportTemplateFilter {
   value: string;
 }
 
+export interface ReportTemplateColumnMetadata {
+  key: string;
+  label: string;
+  type: string;
+}
+
+export interface ReportTemplateSectionMetadata {
+  id: string;
+  title: string;
+  description?: string | null;
+  source: string;
+  columns: ReportTemplateColumnMetadata[];
+}
+
+export interface ReportTemplateMetadata {
+  template_id: string;
+  name: string;
+  description?: string | null;
+  builtin: boolean;
+  sections: ReportTemplateSectionMetadata[];
+}
+
 export interface ReportTemplate {
   id: string;
   name: string;

--- a/frontend/tests/unit/pages/Reports.test.tsx
+++ b/frontend/tests/unit/pages/Reports.test.tsx
@@ -1,21 +1,16 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { configContext } from "@/ConfigContext";
 
 const mockGetOwners = vi.hoisted(() => vi.fn());
-const mockGetGroups = vi.hoisted(() => vi.fn());
 const mockListTemplates = vi.hoisted(() => vi.fn());
-const mockCreateTemplate = vi.hoisted(() => vi.fn());
-const mockUpdateTemplate = vi.hoisted(() => vi.fn());
-const mockDeleteTemplate = vi.hoisted(() => vi.fn());
-const mockGetTemplate = vi.hoisted(() => vi.fn());
 
 vi.mock("@/api", () => ({
   API_BASE: "http://test",
   getOwners: mockGetOwners,
-  getGroups: mockGetGroups,
+  getGroups: vi.fn(),
   getGroupInstruments: vi.fn().mockResolvedValue([]),
   getPortfolio: vi.fn(),
   refreshPrices: vi.fn(),
@@ -35,10 +30,6 @@ vi.mock("@/api", () => ({
 
 vi.mock("@/api/reports", () => ({
   listReportTemplates: mockListTemplates,
-  createReportTemplate: mockCreateTemplate,
-  updateReportTemplate: mockUpdateTemplate,
-  deleteReportTemplate: mockDeleteTemplate,
-  getReportTemplate: mockGetTemplate,
 }));
 
 const allTabs = {
@@ -65,34 +56,53 @@ const allTabs = {
   scenario: true,
 };
 
+const builtinTemplate = {
+  template_id: "performance-summary",
+  name: "Performance summary",
+  description: "Portfolio performance overview",
+  builtin: true,
+  sections: [
+    {
+      id: "metrics",
+      title: "Performance metrics",
+      description: null,
+      source: "performance.metrics",
+      columns: [
+        { key: "metric", label: "Metric", type: "string" },
+        { key: "value", label: "Value", type: "number" },
+        { key: "units", label: "Units", type: "string" },
+      ],
+    },
+  ],
+} as const;
+
+const customTemplate = {
+  template_id: "custom-holdings",
+  name: "Custom holdings",
+  description: "Snapshot of holdings with status metadata",
+  builtin: false,
+  sections: [
+    {
+      id: "holdings",
+      title: "Holdings",
+      description: null,
+      source: "allocation",
+      columns: [
+        { key: "ticker", label: "Ticker", type: "string" },
+        { key: "name", label: "Name", type: "string" },
+        { key: "value", label: "Value", type: "number" },
+        { key: "currency", label: "Currency", type: "string" },
+        { key: "status", label: "Status", type: "string" },
+      ],
+    },
+  ],
+} as const;
+
 describe("Reports page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
-    mockGetGroups.mockResolvedValue([]);
-    mockListTemplates.mockResolvedValue([]);
-    mockCreateTemplate.mockResolvedValue({
-      id: "new-id",
-      name: "Created template",
-      metrics: ["performance"],
-      columns: ["owner", "ticker"],
-      filters: [],
-    });
-    mockUpdateTemplate.mockResolvedValue({
-      id: "tpl-1",
-      name: "Updated template",
-      metrics: ["performance"],
-      columns: ["owner", "ticker"],
-      filters: [],
-    });
-    mockDeleteTemplate.mockResolvedValue(undefined);
-    mockGetTemplate.mockResolvedValue({
-      id: "tpl-1",
-      name: "Loaded template",
-      metrics: ["performance"],
-      columns: ["owner", "ticker"],
-      filters: [],
-    });
+    mockListTemplates.mockResolvedValue([builtinTemplate, customTemplate]);
   });
 
   async function renderReports(initialEntries: string[] = ["/reports"]) {
@@ -117,97 +127,63 @@ describe("Reports page", () => {
     );
   }
 
-  it("renders owner download links when owner selected", async () => {
+  it("renders the reports catalog with template metadata", async () => {
     await renderReports();
 
-    const select = await screen.findByLabelText(/owner/i);
-    fireEvent.change(select, { target: { value: "alex" } });
+    expect(
+      await screen.findByRole("radio", {
+        name: "Select Performance summary template",
+      }),
+    ).toBeChecked();
 
-    const csv = await screen.findByText(/Download CSV/i);
-    expect(csv).toHaveAttribute("href", expect.stringContaining("/reports/alex"));
+    expect(screen.getByText("Performance summary")).toBeInTheDocument();
+    expect(
+      screen.getByText("3 fields: Metric, Value, Units"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "5 fields: Ticker, Name, Value, Currency +1 more field",
+      ),
+    ).toBeInTheDocument();
   });
 
-  it("creates a report template via the builder route", async () => {
-    mockCreateTemplate.mockResolvedValue({
-      id: "tpl-2",
-      name: "Quarterly Overview",
-      metrics: ["performance"],
-      columns: ["owner", "ticker", "gain_pct"],
-      filters: [],
+  it("switches selection when choosing a different template", async () => {
+    await renderReports();
+
+    const builtinRadio = await screen.findByRole("radio", {
+      name: "Select Performance summary template",
+    });
+    const customRadio = await screen.findByRole("radio", {
+      name: "Select Custom holdings template",
     });
 
-    await renderReports(["/reports/new"]);
-
-    const nameInput = await screen.findByLabelText(/Template name/i);
-    fireEvent.change(nameInput, { target: { value: "Quarterly Overview" } });
-
-    const description = screen.getByLabelText(/Description/);
-    fireEvent.change(description, { target: { value: "All owners" } });
-
-    const createButton = screen.getByRole("button", { name: /Create template/i });
-    fireEvent.click(createButton);
-
-    await waitFor(() => {
-      expect(mockCreateTemplate).toHaveBeenCalledWith({
-        name: "Quarterly Overview",
-        description: "All owners",
-        metrics: expect.any(Array),
-        columns: expect.any(Array),
-        filters: [],
-      });
-    });
-
-    expect(await screen.findByText("Quarterly Overview")).toBeInTheDocument();
+    expect(builtinRadio).toBeChecked();
+    fireEvent.click(customRadio);
+    expect(customRadio).toBeChecked();
+    expect(builtinRadio).not.toBeChecked();
   });
 
-  it("updates an existing template when editing", async () => {
-    mockListTemplates.mockResolvedValue([
-      {
-        id: "tpl-1",
-        name: "Performance pack",
-        metrics: ["performance", "risk"],
-        columns: ["owner", "ticker", "gain_pct"],
-        filters: [],
-      },
-    ]);
+  it("includes the chosen template ID in download links", async () => {
+    await renderReports();
 
-    await renderReports(["/reports/tpl-1/edit"]);
+    const ownerSelect = await screen.findByLabelText(/Owner/i);
+    fireEvent.change(ownerSelect, { target: { value: "alex" } });
 
-    const nameInput = await screen.findByLabelText(/Template name/i);
-    fireEvent.change(nameInput, { target: { value: "Updated template" } });
-
-    const saveButton = screen.getByRole("button", { name: /Save changes/i });
-    fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(mockUpdateTemplate).toHaveBeenCalledWith("tpl-1", {
-        name: "Updated template",
-        description: undefined,
-        metrics: expect.any(Array),
-        columns: expect.any(Array),
-        filters: [],
-      });
+    const customRadio = await screen.findByRole("radio", {
+      name: "Select Custom holdings template",
     });
-  });
+    fireEvent.click(customRadio);
 
-  it("deletes an existing template from the builder", async () => {
-    mockListTemplates.mockResolvedValue([
-      {
-        id: "tpl-1",
-        name: "Performance pack",
-        metrics: ["performance"],
-        columns: ["owner", "ticker"],
-        filters: [],
-      },
-    ]);
+    const csvLink = await screen.findByRole("link", { name: /Download CSV/i });
+    const pdfLink = await screen.findByRole("link", { name: /Download PDF/i });
 
-    await renderReports(["/reports/tpl-1/edit"]);
-
-    const deleteButton = await screen.findByRole("button", { name: /Delete template/i });
-    fireEvent.click(deleteButton);
-
-    await waitFor(() => {
-      expect(mockDeleteTemplate).toHaveBeenCalledWith("tpl-1");
-    });
+    expect(csvLink).toHaveAttribute(
+      "href",
+      "http://test/reports/alex/custom-holdings?format=csv",
+    );
+    expect(pdfLink).toHaveAttribute(
+      "href",
+      "http://test/reports/alex/custom-holdings?format=pdf",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add a useReportsCatalog data hook that fetches the combined /reports/templates catalog and groups templates by type
- rework the reports view to display template metadata, drive selection-aware downloads, and surface the new strings
- refresh locale strings and replace the Vitest suite with coverage for catalog rendering, selection, and download links

## Testing
- npx vitest run tests/unit/pages/Reports.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_690142c214f08327b35d56a2a85e4f84