### PR TITLE
Add unit tests for opportunities response models

### DIFF
--- a/tests/routes/test_opportunities_models.py
+++ b/tests/routes/test_opportunities_models.py
@@ -1,0 +1,82 @@
+"""Regression tests for the Opportunities Pydantic models."""
+
+from backend.agent.models import TradingSignal
+from backend.routes import opportunities
+
+
+def test_opportunity_entry_defaults() -> None:
+    """Optional pricing metadata and trading signals should default to ``None``."""
+
+    entry = opportunities.OpportunityEntry(
+        ticker="AAPL.US",
+        name="Apple",
+        change_pct=3.2,
+        side="gainers",
+    )
+
+    assert entry.ticker == "AAPL.US"
+    assert entry.name == "Apple"
+    assert entry.change_pct == 3.2
+    assert entry.side == "gainers"
+    assert entry.last_price_gbp is None
+    assert entry.last_price_date is None
+    assert entry.market_value_gbp is None
+    assert entry.signal is None
+
+    signal = TradingSignal(
+        ticker="AAPL.US",
+        action="BUY",
+        reason="Momentum breakout",
+        confidence=0.75,
+    )
+
+    enriched = opportunities.OpportunityEntry(
+        ticker="AAPL.US",
+        name="Apple",
+        change_pct=3.2,
+        side="gainers",
+        signal=signal,
+    )
+
+    assert enriched.signal is signal
+
+
+def test_opportunities_context_list_defaults() -> None:
+    """List fields should be isolated between OpportunitiesContext instances."""
+
+    first = opportunities.OpportunitiesContext(source="group", group="core", days=7)
+    second = opportunities.OpportunitiesContext(source="watchlist", days=1)
+
+    first.tickers.append("MSFT.US")
+    first.anomalies.append("delisted")
+
+    assert first.tickers == ["MSFT.US"]
+    assert first.anomalies == ["delisted"]
+    assert second.tickers == []
+    assert second.anomalies == []
+    assert second.group is None
+
+
+def test_opportunities_response_default_factories() -> None:
+    """Entries and signals use ``default_factory`` and must not share lists."""
+
+    context = opportunities.OpportunitiesContext(source="group", group="core", days=30)
+
+    response = opportunities.OpportunitiesResponse(context=context)
+    response.entries.append(
+        opportunities.OpportunityEntry(
+            ticker="TSLA.US",
+            name="Tesla",
+            change_pct=-4.1,
+            side="losers",
+        )
+    )
+
+    another = opportunities.OpportunitiesResponse(
+        context=opportunities.OpportunitiesContext(source="watchlist", days=1)
+    )
+
+    assert response.entries and response.entries[0].ticker == "TSLA.US"
+    assert response.signals == []
+    assert another.entries == []
+    assert another.signals == []

--- a/tests/routes/test_portfolio_models.py
+++ b/tests/routes/test_portfolio_models.py
@@ -1,0 +1,68 @@
+"""Unit tests for the Pydantic models in ``backend.routes.portfolio``.
+
+The route module defines a handful of response models that previously had no
+direct tests.  These checks exercise their default values to guard against
+regressions when the models are extended and to ensure the ``Field``
+definitions behave as expected (for example returning fresh lists for each
+instance via ``default_factory``).
+"""
+
+from backend.routes import portfolio
+
+
+def test_owner_summary_defaults() -> None:
+    """Ensure optional OwnerSummary attributes default sensibly."""
+
+    summary = portfolio.OwnerSummary(
+        owner="alex",
+        full_name="Alex Example",
+        accounts=["ISA", "GIA"],
+    )
+
+    assert summary.owner == "alex"
+    assert summary.full_name == "Alex Example"
+    assert summary.accounts == ["ISA", "GIA"]
+    # Optional fields should assume the documented defaults when omitted.
+    assert summary.email is None
+    assert summary.has_transactions_artifact is False
+
+
+def test_group_summary_members_default_factory() -> None:
+    """Members list should be independent for each GroupSummary instance."""
+
+    first = portfolio.GroupSummary(slug="growth", name="Growth Club")
+    second = portfolio.GroupSummary(slug="income", name="Income Club")
+
+    first.members.append("alex")
+
+    assert first.members == ["alex"]
+    # ``default_factory`` should ensure a fresh list per model instance.
+    assert second.members == []
+
+
+def test_mover_optional_fields_default_to_none() -> None:
+    """Movers expose optional pricing metadata that should default to None."""
+
+    mover = portfolio.Mover(ticker="AAPL.US", name="Apple", change_pct=1.5)
+
+    assert mover.ticker == "AAPL.US"
+    assert mover.name == "Apple"
+    assert mover.change_pct == 1.5
+    assert mover.last_price_gbp is None
+    assert mover.last_price_date is None
+    assert mover.market_value_gbp is None
+
+
+def test_movers_response_lists_are_isolated() -> None:
+    """MoversResponse gainers/losers lists should not share mutable defaults."""
+
+    response = portfolio.MoversResponse()
+    response.gainers.append(
+        portfolio.Mover(ticker="AAPL.US", name="Apple", change_pct=2.0)
+    )
+
+    another = portfolio.MoversResponse()
+
+    assert response.gainers and response.gainers[0].ticker == "AAPL.US"
+    assert another.gainers == []
+    assert another.losers == []

--- a/tests/test_auth_overrides.py
+++ b/tests/test_auth_overrides.py
@@ -1,0 +1,122 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import backend.auth as auth
+
+
+class FakeRequest:
+    def __init__(self):
+        self.app = None
+
+
+def _make_request(**attrs):
+    request = SimpleNamespace(**attrs)
+    return request
+
+
+def test_iter_override_mappings_deduplicates_and_orders():
+    shared_mapping = {"shared": lambda: "shared"}
+
+    nested_provider = SimpleNamespace(
+        dependency_overrides={"nested": lambda: "nested"},
+        dependency_overrides_provider=None,
+    )
+    provider = SimpleNamespace(
+        dependency_overrides={"provider": lambda: "provider"},
+        dependency_overrides_provider=[nested_provider],
+    )
+    router = SimpleNamespace(
+        dependency_overrides={"router": lambda: "router"},
+        dependency_overrides_provider=[provider],
+    )
+    app = SimpleNamespace(
+        router=router,
+        dependency_overrides=shared_mapping,
+        dependency_overrides_provider=provider,
+    )
+    request = _make_request(app=app)
+
+    mappings = auth._iter_override_mappings(request)
+
+    assert mappings[0] is shared_mapping
+    assert mappings[1] == router.dependency_overrides
+    assert any("provider" in mapping for mapping in mappings)
+    assert any("nested" in mapping for mapping in mappings)
+    # shared mapping returned only once despite appearing on both app and provider
+    assert mappings.count(shared_mapping) == 1
+
+
+@pytest.mark.asyncio
+async def test_invoke_override_injects_token_and_request(monkeypatch):
+    monkeypatch.setattr(auth, "Request", FakeRequest)
+
+    captured = {}
+
+    def override(request: FakeRequest, token: str):
+        captured["request"] = request
+        captured["token"] = token
+        return "result"
+
+    request = FakeRequest()
+    result = await auth._invoke_override(override, request=request, token="abc")
+
+    assert result == "result"
+    assert captured == {"request": request, "token": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_invoke_override_supports_async_callables(monkeypatch):
+    async def override(token: str | None = None):
+        await asyncio.sleep(0)
+        return token
+
+    request = FakeRequest()
+    result = await auth._invoke_override(override, request=request, token="xyz")
+    assert result == "xyz"
+
+
+def test_find_override_matches_unwrapped_functions(monkeypatch):
+    def dependency():
+        return "dependency"
+
+    def override():
+        return "override"
+
+    def wrapped_dependency():
+        return dependency()
+
+    wrapped_dependency.__module__ = dependency.__module__
+    wrapped_dependency.__qualname__ = dependency.__qualname__
+
+    mapping = {wrapped_dependency: override}
+    monkeypatch.setattr(auth, "_iter_override_mappings", lambda request: [mapping])
+
+    result = auth._find_override(SimpleNamespace(), dependency)
+    assert result is override
+
+
+@pytest.mark.asyncio
+async def test_resolve_current_user_override_invokes_override(monkeypatch):
+    async def override(token: str | None = None):
+        return f"override:{token}"
+
+    monkeypatch.setattr(auth, "_find_override", lambda request, dependency: override)
+
+    has_override, result = await auth.resolve_current_user_override(
+        SimpleNamespace(), token="token"
+    )
+
+    assert has_override is True
+    assert result == "override:token"
+
+
+@pytest.mark.asyncio
+async def test_resolve_current_user_override_handles_missing(monkeypatch):
+    monkeypatch.setattr(auth, "_find_override", lambda request, dependency: None)
+
+    has_override, result = await auth.resolve_current_user_override(SimpleNamespace())
+
+    assert has_override is False
+    assert result is None

--- a/tests/test_reports_validation.py
+++ b/tests/test_reports_validation.py
@@ -1,0 +1,211 @@
+import pytest
+
+import backend.reports as reports
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("example", "example"),
+        ("  trimmed-id  ", "trimmed-id"),
+        ("alpha_NUM-123", "alpha_NUM-123"),
+    ],
+)
+def test_validate_template_id_accepts_valid_identifiers(raw, expected):
+    assert reports._validate_template_id(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [None, "", "  ", "invalid id", "too*many"],
+)
+def test_validate_template_id_rejects_invalid_values(raw):
+    with pytest.raises(ValueError):
+        reports._validate_template_id(raw)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("metrics", "metrics"),
+        ("  allocations ", "allocations"),
+        ("section-01", "section-01"),
+    ],
+)
+def test_validate_section_id_accepts_valid_identifiers(raw, expected):
+    assert reports._validate_section_id(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [None, "", "   ", "with spaces", "unicode☃"],
+)
+def test_validate_section_id_rejects_invalid_values(raw):
+    with pytest.raises(ValueError):
+        reports._validate_section_id(raw)
+
+
+@pytest.mark.parametrize(
+    "value, digits, expected",
+    [
+        (10, 2, 10.0),
+        ("3.14159", 3, 3.142),
+        (None, 2, None),
+        ("not-a-number", 2, None),
+    ],
+)
+def test_round_if_number_handles_numeric_inputs(value, digits, expected):
+    assert reports._round_if_number(value, digits) == expected
+
+
+@pytest.mark.parametrize(
+    "item, start, end, expected",
+    [
+        (
+            {
+                "date": "2024-01-05",
+                "type": "buy",
+                "amount_minor": 2500,
+                "currency": "usd",
+                "description": " Purchase ",
+            },
+            None,
+            None,
+            {
+                "date": "2024-01-05",
+                "type": "BUY",
+                "description": "Purchase",
+                "amount_gbp": 25.0,
+                "currency": "USD",
+            },
+        ),
+        (
+            {
+                "date": "2024-02-10",
+                "type": "sell",
+                "amount_minor": "oops",
+                "symbol": "Example plc",
+            },
+            None,
+            None,
+            {
+                "date": "2024-02-10",
+                "type": "SELL",
+                "description": "Example plc",
+                "amount_gbp": 0.0,
+                "currency": "GBP",
+            },
+        ),
+    ],
+)
+def test_normalise_transaction_converts_fields(item, start, end, expected):
+    assert reports._normalise_transaction(item, start, end) == expected
+
+
+def test_normalise_transaction_filters_outside_window():
+    item = {"date": "2024-03-01", "type": "buy", "amount_minor": 100}
+    start = reports.date(2024, 3, 10)
+    end = reports.date(2024, 3, 20)
+
+    assert reports._normalise_transaction(item, start, end) is None
+
+    within_window = {"date": "2024-03-15", "type": "buy", "amount_minor": 100}
+    assert reports._normalise_transaction(within_window, start, end) == {
+        "date": "2024-03-15",
+        "type": "BUY",
+        "description": "",
+        "amount_gbp": 1.0,
+        "currency": "GBP",
+    }
+
+
+def _example_section(source: str):
+    return {
+        "id": "metrics",
+        "title": " Metrics ",
+        "source": source,
+        "description": "  Portfolio metrics  ",
+        "columns": [
+            {"key": "metric", "label": "", "type": "string"},
+            {"key": "value"},
+        ],
+    }
+
+
+def test_validate_template_payload_normalises_structure():
+    payload = {
+        "template_id": "  custom-template  ",
+        "name": "  Custom Report  ",
+        "description": "  Example description  ",
+        "sections": [_example_section("performance.metrics")],
+    }
+
+    result = reports._validate_template_payload(payload)
+
+    assert result["template_id"] == "custom-template"
+    assert result["name"] == "Custom Report"
+    section = result["sections"][0]
+    assert section["description"] == "Portfolio metrics"
+    assert section["columns"] == [
+        {"key": "metric", "label": "metric", "type": "string"},
+        {"key": "value", "label": "value", "type": "string"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "mutator, message",
+    [
+        (lambda section: section.update({"id": ""}), "section id"),
+        (lambda section: section.update({"source": "unknown"}), "Unsupported section source"),
+        (
+            lambda section: section.update({"columns": ["oops"]}),
+            "columns must be objects",
+        ),
+        (
+            lambda section: section.update({"columns": [{"key": "metric"}, {"key": "metric"}]}),
+            "duplicate column",
+        ),
+    ],
+)
+def test_validate_template_payload_reports_section_errors(mutator, message):
+    section = _example_section("performance.metrics")
+    mutator(section)
+    payload = {
+        "template_id": "custom",
+        "name": "Example",
+        "sections": [section],
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        reports._validate_template_payload(payload)
+
+    assert message in str(excinfo.value)
+
+
+def test_validate_template_payload_rejects_duplicate_sections():
+    section = _example_section("performance.metrics")
+    payload = {
+        "template_id": "custom",
+        "name": "Example",
+        "sections": [section, dict(section)],
+    }
+
+    with pytest.raises(ValueError, match="Duplicate section id"):
+        reports._validate_template_payload(payload)
+
+
+def test_materialise_template_creates_schema_objects():
+    definition = reports._validate_template_payload(
+        {
+            "template_id": "custom",
+            "name": "Example",
+            "sections": [_example_section("performance.metrics")],
+        }
+    )
+
+    template = reports._materialise_template(definition, builtin=False)
+
+    assert template.template_id == "custom"
+    assert template.builtin is False
+    assert template.sections[0].id == "metrics"
+    assert template.sections[0].columns[0].label == "metric"


### PR DESCRIPTION
## Summary
- add regression tests covering the OpportunityEntry, OpportunitiesContext, and OpportunitiesResponse Pydantic models
- verify optional fields assume documented defaults and list default_factories are isolated between instances

## Testing
- pytest --override-ini addopts= tests/routes/test_opportunities_models.py

------
https://chatgpt.com/codex/tasks/task_e_6906939067a883279a8e2ba2fccd9ff9