### PR TITLE
Preserve account stem casing after path resolution

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -195,14 +195,20 @@ def _collect_account_stems(owner_dir: Optional[Path]) -> List[str]:
 
     def _resolved_stem(candidate: Path) -> str:
         stem = candidate.stem
+        best_stem = stem
+        best_score = _score_variant(stem)
+
         try:
             resolved = candidate.resolve()
         except OSError:
             resolved = None
         else:
             if resolved.exists():
-                stem = resolved.stem
-        return stem
+                resolved_stem = resolved.stem
+                resolved_score = _score_variant(resolved_stem)
+                if resolved_score > best_score:
+                    best_stem = resolved_stem
+        return best_stem
 
     stems = sorted(
         (_resolved_stem(path) for path in preferred.values()),


### PR DESCRIPTION
## Summary
- retain the higher scoring casing when resolving account JSON stems so Windows does not downcase names like ISA

## Testing
- pytest tests/routes/test_portfolio_helpers.py::test_collect_account_stems_filters_metadata -q *(fails coverage gate: total 22 < 90)*

------
https://chatgpt.com/codex/tasks/task_e_6907b992bab48327bba10aee5a7b0fc7