### PR TITLE
Fix smoke bootstrap marker expectations

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -121,12 +121,13 @@ const deriveModeFromPathname = (pathname: string): Mode => {
 
 const renderRouteMarker = (pathname: string, state: 'loading' | 'config-error' | 'auth') => {
   const mode = deriveModeFromPathname(pathname)
+  const bootstrapMode = state === 'loading' ? 'loading' : mode
   return (
     <>
       <div
         data-route-marker="bootstrap"
         data-testid="route-bootstrap-marker"
-        data-mode={mode}
+        data-mode={bootstrapMode}
         data-pathname={pathname}
         data-route-state={state}
         style={routeMarkerStyle}

--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -352,7 +352,9 @@ export const smokeEndpoints: SmokeEndpoint[] = [
   {
     "method": "POST",
     "path": "/instrument/admin/{exchange}/{ticker}/group",
-    "body": {}
+    "body": {
+      "group": smokeIdentity
+    }
   },
   {
     "method": "POST",


### PR DESCRIPTION
## Summary
- ensure the bootstrap route marker reports the loading state so the smoke spec sees the expected data-mode
- seed the instrument-admin group smoke request with a concrete group and keep the YAML parser optional when regenerating the suite

## Testing
- npx playwright test tests/smoke.spec.ts:264 *(fails: Playwright webServer exited early because browser deps are missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6907b9a861048327ab70f3faefdcd2dc