### PR TITLE
Add coverage-focused auth and risk tests

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,12 +6,30 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from starlette.requests import Request
+from importlib import machinery, util
 
 import backend.auth as auth
 import backend.common.data_loader as dl
 from tests.conftest import _real_verify_google_token
 import tests.conftest as tests_conftest
+
+
+async def _empty_receive() -> dict[str, object]:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _make_request(app: FastAPI) -> Request:
+    scope = {
+        "type": "http",
+        "app": app,
+        "headers": [],
+        "method": "GET",
+        "path": "/",
+        "query_string": b"",
+    }
+    return Request(scope, _empty_receive)
 
 
 def test_allowed_emails_local_filesystem(monkeypatch, tmp_path):
@@ -30,6 +48,62 @@ def test_allowed_emails_local_filesystem(monkeypatch, tmp_path):
     )
     emails = auth._allowed_emails()
     assert emails == {"alice@example.com", "bob@example.com"}
+
+
+def test_allowed_emails_local_relative_root(monkeypatch, tmp_path):
+    repo_root = tmp_path / "repo"
+    accounts = repo_root / "accounts"
+    accounts.mkdir(parents=True)
+    (accounts / "alice").mkdir()
+    (accounts / "carol").mkdir()
+    (accounts / "notes.txt").write_text("ignore")
+
+    monkeypatch.setattr(auth.config, "app_env", "local", raising=False)
+    monkeypatch.setattr(auth.config, "accounts_root", "accounts", raising=False)
+    monkeypatch.setattr(auth.config, "repo_root", repo_root, raising=False)
+
+    monkeypatch.setattr(
+        auth,
+        "resolve_paths",
+        lambda repo_root, _: SimpleNamespace(repo_root=repo_root, accounts_root=repo_root / "default"),
+    )
+    monkeypatch.setattr(
+        auth,
+        "load_person_meta",
+        lambda owner, data_root=None: {"email": f"{owner}@example.com"},
+    )
+
+    emails = auth._allowed_emails()
+
+    assert emails == {"alice@example.com", "carol@example.com"}
+
+
+def test_allowed_emails_local_fallback_handles_errors(monkeypatch, tmp_path):
+    repo_root = tmp_path / "repo"
+    fallback_root = tmp_path / "resolved"
+    (fallback_root / "alice").mkdir(parents=True)
+    (fallback_root / "bob").mkdir()
+
+    monkeypatch.setattr(auth.config, "app_env", "local", raising=False)
+    monkeypatch.setattr(auth.config, "accounts_root", None, raising=False)
+    monkeypatch.setattr(auth.config, "repo_root", repo_root, raising=False)
+
+    monkeypatch.setattr(
+        auth,
+        "resolve_paths",
+        lambda repo_root, _: SimpleNamespace(accounts_root=fallback_root, repo_root=repo_root),
+    )
+
+    def fake_load(owner, data_root=None):
+        if owner == "bob":
+            raise RuntimeError("failed")
+        return {"email": f"{owner}@Example.com"}
+
+    monkeypatch.setattr(auth, "load_person_meta", fake_load)
+
+    emails = auth._allowed_emails()
+
+    assert emails == {"alice@example.com"}
 
 
 def test_allowed_emails_aws_s3_error(monkeypatch, caplog):
@@ -157,6 +231,40 @@ def test_verify_google_token_verification_failure(monkeypatch):
     assert exc.value.status_code == 401
 
 
+def test_verify_google_token_missing_email(monkeypatch):
+    monkeypatch.setattr(auth, "verify_google_token", _real_verify_google_token)
+    monkeypatch.setattr(auth.config, "google_client_id", "client", raising=False)
+
+    def fake_verify(token, request, client_id):
+        return {"email_verified": True}
+
+    monkeypatch.setattr(auth.id_token, "verify_oauth2_token", fake_verify)
+
+    with pytest.raises(HTTPException) as exc:
+        auth.verify_google_token("token")
+
+    assert exc.value.status_code == 401
+    assert "Email missing" in exc.value.detail
+
+
+def test_verify_google_token_no_allowed_emails(monkeypatch, caplog):
+    monkeypatch.setattr(auth, "verify_google_token", _real_verify_google_token)
+    monkeypatch.setattr(auth.config, "google_client_id", "client", raising=False)
+
+    def fake_verify(token, request, client_id):
+        return {"email": "user@example.com", "email_verified": True}
+
+    monkeypatch.setattr(auth.id_token, "verify_oauth2_token", fake_verify)
+    monkeypatch.setattr(auth, "_allowed_emails", lambda: set())
+
+    with caplog.at_level("ERROR", logger=auth.logger.name):
+        with pytest.raises(HTTPException) as exc:
+            auth.verify_google_token("token")
+
+    assert exc.value.status_code == 403
+    assert any("No allowed emails" in record.getMessage() for record in caplog.records)
+
+
 def test_get_current_user_valid_token():
     token = auth.create_access_token("alice@example.com")
     assert asyncio.run(auth.get_current_user(token)) == "alice@example.com"
@@ -165,6 +273,64 @@ def test_get_current_user_valid_token():
 def test_get_current_user_invalid_token():
     with pytest.raises(HTTPException):
         asyncio.run(auth.get_current_user("bad"))
+
+
+@pytest.mark.asyncio
+async def test_get_active_user_auth_enabled(monkeypatch):
+    app = FastAPI()
+    request = _make_request(app)
+
+    token = auth.create_access_token("active@example.com")
+
+    monkeypatch.setattr(auth.config, "disable_auth", False, raising=False)
+
+    captured: dict[str, str | None] = {}
+
+    def fake_user_from_token(raw_token: str | None) -> str:
+        captured["token"] = raw_token
+        return "active@example.com"
+
+    token_var = auth.current_user.set(None)
+    try:
+        monkeypatch.setattr(auth, "_user_from_token", fake_user_from_token)
+        result = await auth.get_active_user(request, token=token)
+    finally:
+        auth.current_user.reset(token_var)
+
+    assert result == "active@example.com"
+    assert captured == {"token": token}
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_returns_local_identity_when_disabled(monkeypatch):
+    monkeypatch.setattr(auth.config, "disable_auth", True, raising=False)
+    monkeypatch.setattr(auth, "local_login_identity", lambda: "local@example.com")
+
+    def fail_user_from_token(token: str | None) -> str:  # pragma: no cover - safety guard
+        raise AssertionError("_user_from_token should not be called when no token is provided")
+
+    monkeypatch.setattr(auth, "_user_from_token", fail_user_from_token)
+
+    assert await auth.get_current_user(token=None) == "local@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_disabled_without_identity(monkeypatch):
+    monkeypatch.setattr(auth.config, "disable_auth", True, raising=False)
+    monkeypatch.setattr(auth, "local_login_identity", lambda: None)
+
+    captured: dict[str, str | None] = {}
+
+    def fake_user_from_token(token: str | None) -> str:
+        captured["token"] = token
+        raise HTTPException(status_code=401, detail="invalid")
+
+    monkeypatch.setattr(auth, "_user_from_token", fake_user_from_token)
+
+    with pytest.raises(HTTPException):
+        await auth.get_current_user(token=None)
+
+    assert captured == {"token": None}
 
 
 def test_missing_secret_key_generates_ephemeral_secret(monkeypatch, caplog):
@@ -184,3 +350,32 @@ def test_missing_secret_key_generates_ephemeral_secret(monkeypatch, caplog):
     )
 
     tests_conftest._real_verify_google_token = reloaded.verify_google_token
+
+
+def test_missing_secret_key_in_production_raises(monkeypatch):
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setattr(auth.config, "disable_auth", False, raising=False)
+    monkeypatch.setattr(auth.config, "app_env", "production", raising=False)
+
+    loader = machinery.SourceFileLoader("backend.auth_temp", auth.__file__)
+    spec = util.spec_from_loader(loader.name, loader)
+    module = util.module_from_spec(spec)
+
+    with pytest.raises(RuntimeError):
+        loader.exec_module(module)
+
+    sys.modules.pop("backend.auth_temp", None)
+
+
+def test_authenticate_user_delegates_to_verification(monkeypatch):
+    sentinel = object()
+
+    def fake_verify(token: str) -> object:
+        assert token == "stub"
+        return sentinel
+
+    monkeypatch.setattr(auth, "verify_google_token", fake_verify)
+
+    assert auth.authenticate_user("stub") is sentinel

--- a/tests/test_auth_aws.py
+++ b/tests/test_auth_aws.py
@@ -1,4 +1,5 @@
 import io
+import json
 import sys
 from types import SimpleNamespace
 
@@ -66,3 +67,76 @@ def test_allowed_emails_logs_s3_error(monkeypatch, caplog):
 
     assert emails == set()
     assert any("Failed to list allowed emails from S3" in record.message for record in caplog.records)
+
+
+def test_allowed_emails_s3_handles_pagination(monkeypatch):
+    monkeypatch.setattr(auth.config, "app_env", "aws", raising=False)
+    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
+
+    calls: list[dict[str, object]] = []
+
+    class FakeS3:
+        def list_objects_v2(self, **kwargs):
+            calls.append(kwargs)
+            if "ContinuationToken" in kwargs:
+                return {
+                    "Contents": [
+                        {"Key": f"{dl.PLOTS_PREFIX}Bob/person.json"},
+                    ]
+                }
+            return {
+                "IsTruncated": True,
+                "NextContinuationToken": "token",
+                "Contents": [
+                    {"Key": f"{dl.PLOTS_PREFIX}Alice/person.json"},
+                    {"Key": f"{dl.PLOTS_PREFIX}Ignore.txt"},
+                ],
+            }
+
+        def get_object(self, Bucket, Key):  # noqa: N803 - signature matches boto3
+            email = "alice" if "Alice" in Key else "bob"
+            return {"Body": io.BytesIO(json.dumps({"email": f"{email}@example.com"}).encode("utf-8"))}
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=lambda name: FakeS3()))
+    monkeypatch.setattr(auth, "load_person_meta", lambda owner: {"email": f"{owner}@example.com"})
+
+    emails = auth._allowed_emails()
+
+    assert emails == {"alice@example.com", "bob@example.com"}
+    assert any("ContinuationToken" not in call for call in calls)
+    assert any("ContinuationToken" in call for call in calls)
+
+
+def test_allowed_emails_s3_filters_invalid_entries(monkeypatch):
+    monkeypatch.setattr(auth.config, "app_env", "aws", raising=False)
+    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
+
+    class FakeS3:
+        def list_objects_v2(self, **kwargs):
+            if "ContinuationToken" in kwargs:
+                return {
+                    "Contents": [
+                        {"Key": f"{dl.PLOTS_PREFIX}Bob/person.json"},
+                        {"Key": "wrongprefix/Charlie/person.json"},
+                    ]
+                }
+            return {
+                "IsTruncated": True,
+                "NextContinuationToken": "token",
+                "Contents": [
+                    {"Key": f"{dl.PLOTS_PREFIX}Alice/person.json"},
+                    {"Key": f"{dl.PLOTS_PREFIX}Notes.txt"},
+                ],
+            }
+
+    def fake_load(owner):
+        if owner.lower() == "bob":
+            raise RuntimeError("boom")
+        return {"email": f"{owner}@example.com"}
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=lambda name: FakeS3()))
+    monkeypatch.setattr(auth, "load_person_meta", fake_load)
+
+    emails = auth._allowed_emails()
+
+    assert emails == {"alice@example.com"}

--- a/tests/test_auth_overrides.py
+++ b/tests/test_auth_overrides.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 from types import SimpleNamespace
 
 import pytest
@@ -48,6 +49,60 @@ def test_iter_override_mappings_deduplicates_and_orders():
     assert mappings.count(shared_mapping) == 1
 
 
+def test_iter_override_mappings_handles_missing_app():
+    class KeylessRequest:
+        def __getattr__(self, name: str):
+            if name == "app":
+                raise KeyError(name)
+            raise AttributeError(name)
+
+    request = KeylessRequest()
+
+    mappings = auth._iter_override_mappings(request)  # type: ignore[arg-type]
+
+    assert mappings == []
+
+
+def test_iter_override_mappings_accepts_gettable_objects():
+    class Gettable:
+        def __init__(self, data: dict):
+            self._data = data
+
+        def get(self, key, default=None):
+            return self._data.get(key, default)
+
+        def items(self):
+            return self._data.items()
+
+    request = _make_request(
+        app=SimpleNamespace(
+            router=None,
+            dependency_overrides=Gettable({}),
+            dependency_overrides_provider=SimpleNamespace(
+                dependency_overrides=Gettable({}),
+                dependency_overrides_provider=(SimpleNamespace(dependency_overrides=Gettable({}), dependency_overrides_provider=None),),
+            ),
+        )
+    )
+
+    mappings = auth._iter_override_mappings(request)
+
+    assert len(mappings) >= 2
+    assert all(hasattr(mapping, "get") for mapping in mappings)
+
+
+def test_iter_override_mappings_ignores_non_mapping_candidates():
+    request = _make_request(
+        app=SimpleNamespace(
+            router=None,
+            dependency_overrides=object(),
+            dependency_overrides_provider=None,
+        )
+    )
+
+    assert auth._iter_override_mappings(request) == []
+
+
 @pytest.mark.asyncio
 async def test_invoke_override_injects_token_and_request(monkeypatch):
     monkeypatch.setattr(auth, "Request", FakeRequest)
@@ -77,6 +132,39 @@ async def test_invoke_override_supports_async_callables(monkeypatch):
     assert result == "xyz"
 
 
+@pytest.mark.asyncio
+async def test_invoke_override_handles_request_annotations(monkeypatch):
+    class BaseRequest:
+        pass
+
+    class AnnotatedRequest(BaseRequest):
+        pass
+
+    monkeypatch.setattr(auth, "Request", BaseRequest)
+
+    captured: dict[str, object] = {}
+
+    def override(pos_only="default", /, request=None, *, token, annotated: AnnotatedRequest):
+        captured.update({
+            "pos_only": pos_only,
+            "request": request,
+            "token": token,
+            "annotated": annotated,
+        })
+        return "done"
+
+    request = AnnotatedRequest()
+    result = await auth._invoke_override(override, request=request, token="tok")
+
+    assert result == "done"
+    assert captured == {
+        "pos_only": "default",
+        "request": request,
+        "token": "tok",
+        "annotated": request,
+    }
+
+
 def test_find_override_matches_unwrapped_functions(monkeypatch):
     def dependency():
         return "dependency"
@@ -84,17 +172,123 @@ def test_find_override_matches_unwrapped_functions(monkeypatch):
     def override():
         return "override"
 
+    @functools.wraps(dependency)
     def wrapped_dependency():
         return dependency()
-
-    wrapped_dependency.__module__ = dependency.__module__
-    wrapped_dependency.__qualname__ = dependency.__qualname__
 
     mapping = {wrapped_dependency: override}
     monkeypatch.setattr(auth, "_iter_override_mappings", lambda request: [mapping])
 
     result = auth._find_override(SimpleNamespace(), dependency)
     assert result is override
+
+
+def test_find_override_uses_mapping_get(monkeypatch):
+    def dependency():
+        return "dep"
+
+    def override():
+        return "override"
+
+    class MappingWithGet(dict):
+        def get(self, key, default=None):
+            if key is dependency:
+                return override
+            return super().get(key, default)
+
+    monkeypatch.setattr(auth, "_iter_override_mappings", lambda request: [MappingWithGet()])
+
+    result = auth._find_override(SimpleNamespace(), dependency)
+
+    assert result is override
+
+
+def test_find_override_skips_non_callable_items(monkeypatch):
+    class MappingLike(dict):
+        items = []
+
+    mapping = MappingLike()
+    monkeypatch.setattr(auth, "_iter_override_mappings", lambda request: [mapping])
+
+    result = auth._find_override(SimpleNamespace(), lambda: None)
+
+    assert result is None
+
+
+def test_find_override_returns_none_for_missing_identity(monkeypatch):
+    class CallableWithoutIdentity:
+        def __call__(self):  # pragma: no cover - not invoked
+            return None
+
+    dependency = CallableWithoutIdentity()
+    setattr(dependency, "__module__", None)
+    setattr(dependency, "__qualname__", None)
+    monkeypatch.setattr(auth, "_iter_override_mappings", lambda request: [])
+
+    assert auth._find_override(SimpleNamespace(), dependency) is None
+
+
+def test_find_override_matches_direct_dependency(monkeypatch):
+    def dependency():
+        return "dep"
+
+    def override():
+        return "override"
+
+    class MappingNoGet(dict):
+        def get(self, key, default=None):
+            return None
+
+    mapping = MappingNoGet({dependency: override})
+    monkeypatch.setattr(auth, "_iter_override_mappings", lambda request: [mapping])
+
+    assert auth._find_override(SimpleNamespace(), dependency) is override
+
+
+def test_find_override_matches_via_unwrapped_identity(monkeypatch):
+    def dependency():
+        return "dep"
+
+    def override():
+        return "override"
+
+    def alias():
+        return dependency()
+
+    alias.__module__ = dependency.__module__
+    alias.__qualname__ = dependency.__qualname__
+
+    def make_wrapper(target):
+        def wrapper():
+            return target()
+
+        wrapper.__wrapped__ = target
+        return wrapper
+
+    declared_dependency = make_wrapper(alias)
+
+    mapping = {declared_dependency: override}
+    monkeypatch.setattr(auth, "_iter_override_mappings", lambda request: [mapping])
+
+    assert auth._find_override(SimpleNamespace(), dependency) is override
+
+
+def test_find_override_matches_via_unwrap_target(monkeypatch):
+    def dependency():
+        return "dep"
+
+    def override():
+        return "override"
+
+    def wrapper():
+        return dependency()
+
+    wrapper.__wrapped__ = dependency
+
+    mapping = {wrapper: override}
+    monkeypatch.setattr(auth, "_iter_override_mappings", lambda request: [mapping])
+
+    assert auth._find_override(SimpleNamespace(), dependency) is override
 
 
 @pytest.mark.asyncio

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -4,6 +4,10 @@ import sys
 import types
 from datetime import date
 
+import json
+from datetime import date, datetime
+from types import SimpleNamespace
+
 import pytest
 
 import backend.reports as reports
@@ -124,6 +128,13 @@ def test_load_transactions_requires_data_bucket(monkeypatch):
         reports._load_transactions("alice")
 
 
+def test_load_transactions_skips_missing_owner_directory(monkeypatch, tmp_path):
+    monkeypatch.setattr(reports.config, "app_env", "local", raising=False)
+    monkeypatch.setattr(reports, "_transaction_roots", lambda: [tmp_path.as_posix()])
+
+    assert reports._load_transactions("alice") == []
+
+
 def test_build_report_document_uses_context(monkeypatch):
     history = [
         {"date": "2024-01-01", "value": 100.0, "daily_return": 0.1, "weekly_return": 0.2, "cumulative_return": 0.3, "drawdown": 0.0},
@@ -162,6 +173,7 @@ def test_build_report_document_uses_context(monkeypatch):
 
 
 def test_list_template_metadata_merges_user_templates(tmp_path):
+    reports.get_template_store.cache_clear()
     store = reports.FileTemplateStore(tmp_path)
     definition = {
         "template_id": "custom",
@@ -220,3 +232,354 @@ def test_create_update_delete_user_template(tmp_path):
 
     reports.delete_user_template("custom", store=store)
     assert store.get_template("custom") is None
+
+
+def test_get_template_returns_user_definition(tmp_path, monkeypatch):
+    original_get_store = reports.get_template_store
+    original_get_store.cache_clear()
+    store = reports.FileTemplateStore(tmp_path)
+    definition = {
+        "template_id": "custom",
+        "name": "Custom",
+        "description": "",
+        "sections": [
+            {
+                "id": "metrics",
+                "title": "Metrics",
+                "source": "performance.metrics",
+                "columns": [{"key": "metric", "label": "Metric", "type": "string"}],
+            }
+        ],
+    }
+    store.create_template(definition)
+    monkeypatch.setattr(reports, "get_template_store", lambda: store)
+
+    template = reports.get_template("custom")
+
+    assert template is not None
+    assert template.template_id == "custom"
+    original_get_store.cache_clear()
+
+
+def test_get_template_returns_none_for_missing(monkeypatch):
+    original_get_store = reports.get_template_store
+    original_get_store.cache_clear()
+    monkeypatch.setattr(
+        reports,
+        "get_template_store",
+        lambda: SimpleNamespace(get_template=lambda template_id: None),
+    )
+
+    assert reports.get_template("missing") is None
+
+    original_get_store.cache_clear()
+
+
+def test_file_template_store_filters_invalid_definitions(tmp_path, caplog):
+    store = reports.FileTemplateStore(tmp_path)
+    valid = {
+        "template_id": "valid",
+        "name": "Valid",
+        "description": "",
+        "sections": [
+            {
+                "id": "metrics",
+                "title": "Metrics",
+                "source": "performance.metrics",
+                "columns": [
+                    {"key": "metric", "label": "Metric", "type": "string"},
+                ],
+            }
+        ],
+    }
+    store.create_template(valid)
+
+    # Corrupt JSON file should be skipped with a warning
+    (tmp_path / "broken.json").write_text("{not json")
+
+    # Invalid schema (missing name) should also be skipped
+    (tmp_path / "invalid.json").write_text(
+        json.dumps({
+            "template_id": "invalid",
+            "sections": [],
+        })
+    )
+
+    with caplog.at_level("WARNING", logger=reports.logger.name):
+        templates = store.list_templates()
+
+    assert [t["template_id"] for t in templates] == ["valid"]
+    assert "failed to load report template" in caplog.text
+    assert "invalid template definition" in caplog.text
+
+
+def test_file_template_store_get_template_handles_invalid_json(tmp_path, caplog):
+    store = reports.FileTemplateStore(tmp_path)
+    (tmp_path / "example.json").write_text("{not json")
+
+    with caplog.at_level("WARNING", logger=reports.logger.name):
+        template = store.get_template("example")
+
+    assert template is None
+    assert "failed to load report template" in caplog.text
+
+
+def test_get_template_store_requires_aws_configuration(monkeypatch):
+    reports.get_template_store.cache_clear()
+    monkeypatch.setattr(reports.config, "app_env", "aws", raising=False)
+    monkeypatch.delenv("REPORT_TEMPLATES_TABLE", raising=False)
+
+    with pytest.raises(RuntimeError, match="REPORT_TEMPLATES_TABLE"):
+        reports.get_template_store()
+
+
+def test_get_template_store_local_returns_file_store(monkeypatch, tmp_path):
+    reports.get_template_store.cache_clear()
+    monkeypatch.setattr(reports.config, "app_env", "local", raising=False)
+    monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
+
+    store = reports.get_template_store()
+
+    assert isinstance(store, reports.FileTemplateStore)
+    assert store.root == tmp_path / "reports"
+
+
+def test_report_context_transactions_filters_and_sorts(monkeypatch):
+    raw = [
+        {"date": "2024-01-02", "type": "sell", "amount_minor": 200},
+        {"date": "invalid", "type": "buy", "amount_minor": 100},
+        {"date": "2024-01-01", "type": "buy", "amount_minor": 100},
+    ]
+
+    monkeypatch.setattr(reports, "_load_transactions", lambda owner: raw)
+    monkeypatch.setattr(
+        reports, "_compile_summary", lambda owner, start, end: (
+            reports.ReportData(
+                owner=owner,
+                start=None,
+                end=None,
+                realized_gains_gbp=0.0,
+                income_gbp=0.0,
+                cumulative_return=None,
+                max_drawdown=None,
+            ),
+            {},
+        )
+    )
+
+    context = reports.ReportContext("alice", start=date(2024, 1, 1), end=None)
+    rows = context.transactions()
+
+    assert [row["date"] for row in rows] == ["2024-01-01", "2024-01-02", "invalid"]
+
+
+def test_report_context_allocation_handles_errors(monkeypatch):
+    summary = reports.ReportData(
+        owner="alice",
+        start=None,
+        end=None,
+        realized_gains_gbp=0.0,
+        income_gbp=0.0,
+        cumulative_return=None,
+        max_drawdown=None,
+    )
+    monkeypatch.setattr(reports, "_compile_summary", lambda owner, start, end: (summary, {}))
+    monkeypatch.setattr(
+        reports.portfolio_utils,
+        "portfolio_value_breakdown",
+        lambda owner, date: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+
+    context = reports.ReportContext("alice", start=None, end=None)
+    assert context.allocation() == []
+
+
+def test_report_context_allocation_rounds_and_sorts(monkeypatch):
+    summary = reports.ReportData(
+        owner="alice",
+        start=None,
+        end=date(2024, 1, 1),
+        realized_gains_gbp=0.0,
+        income_gbp=0.0,
+        cumulative_return=None,
+        max_drawdown=None,
+    )
+    perf = {"reporting_date": "2024-01-01"}
+
+    monkeypatch.setattr(reports, "_compile_summary", lambda owner, start, end: (summary, perf))
+
+    rows = [
+        {"ticker": "XYZ.L", "exchange": "L", "units": 1.23456, "price": 9.8765, "value": 123.4567},
+        {"ticker": "ABC.N", "exchange": "N", "units": None, "price": None, "value": None},
+    ]
+
+    def fake_breakdown(owner, date):
+        assert date == "2024-01-01"
+        return rows
+
+    monkeypatch.setattr(reports.portfolio_utils, "portfolio_value_breakdown", fake_breakdown)
+
+    context = reports.ReportContext("alice", start=None, end=date(2024, 1, 1))
+    allocation = context.allocation()
+
+    assert allocation[0] == {
+        "ticker": "XYZ.L",
+        "exchange": "L",
+        "units": 1.2346,
+        "price": 9.8765,
+        "value": 123.46,
+    }
+    assert allocation[1]["ticker"] == "ABC.N"
+
+
+def test_build_report_document_warns_on_missing_builder(monkeypatch, caplog):
+    template = reports.ReportTemplate(
+        template_id="custom",
+        name="Custom",
+        description="",
+        sections=(
+            reports.ReportSectionSchema(
+                id="mystery",
+                title="Mystery",
+                source="unknown.section",
+                columns=(),
+            ),
+        ),
+        builtin=False,
+    )
+
+    monkeypatch.setattr(reports, "get_template", lambda template_id, store=None: template)
+    monkeypatch.setattr(
+        reports, "ReportContext", lambda owner, start=None, end=None: SimpleNamespace(
+            summary=lambda: reports.ReportData(
+                owner=owner,
+                start=None,
+                end=None,
+                realized_gains_gbp=0.0,
+                income_gbp=0.0,
+                cumulative_return=None,
+                max_drawdown=None,
+            ),
+        )
+    )
+
+    with caplog.at_level("WARNING", logger=reports.logger.name):
+        document = reports.build_report_document("custom", "alice")
+
+    assert document.sections[0].rows == ()
+    assert "No builder registered" in caplog.text
+
+
+def test_section_to_dataframe_includes_missing_columns():
+    schema = reports.ReportSectionSchema(
+        id="metrics",
+        title="Metrics",
+        source="performance.metrics",
+        columns=(
+            reports.ReportColumnSchema("metric", "Metric"),
+            reports.ReportColumnSchema("value", "Value"),
+            reports.ReportColumnSchema("units", "Units"),
+        ),
+    )
+    section = reports.ReportSectionData(
+        schema=schema,
+        rows=({"metric": "Owner", "value": "alice"},),
+    )
+
+    df = reports._section_to_dataframe(section)
+
+    assert list(df.columns) == ["Metric", "Value", "Units"]
+    assert df.iloc[0].to_dict() == {"Metric": "Owner", "Value": "alice", "Units": None}
+
+
+def test_section_to_dataframe_empty_creates_headers():
+    schema = reports.ReportSectionSchema(
+        id="metrics",
+        title="Metrics",
+        source="performance.metrics",
+        columns=(
+            reports.ReportColumnSchema("metric", "Metric"),
+            reports.ReportColumnSchema("value", "Value"),
+        ),
+    )
+    section = reports.ReportSectionData(schema=schema, rows=())
+
+    df = reports._section_to_dataframe(section)
+
+    assert df.empty
+    assert list(df.columns) == ["Metric", "Value"]
+
+
+def test_report_to_csv_includes_metadata(tmp_path):
+    schema = reports.ReportSectionSchema(
+        id="metrics",
+        title="Metrics",
+        source="performance.metrics",
+        columns=(
+            reports.ReportColumnSchema("metric", "Metric"),
+            reports.ReportColumnSchema("value", "Value"),
+        ),
+    )
+    template = reports.ReportTemplate(
+        template_id="example",
+        name="Example",
+        description="",
+        sections=(schema,),
+        builtin=True,
+    )
+    section = reports.ReportSectionData(
+        schema=schema,
+        rows=(
+            {"metric": "Owner", "value": "alice"},
+            {"metric": "Transactions", "value": 2},
+        ),
+    )
+    document = reports.ReportDocument(
+        template=template,
+        owner="alice",
+        generated_at=datetime.now(tz=reports.UTC),
+        parameters={"start": "2024-01-01"},
+        sections=(section,),
+    )
+
+    csv_bytes = reports.report_to_csv(document)
+    content = csv_bytes.decode("utf-8")
+
+    assert "Template: Example" in content
+    assert "start: 2024-01-01" in content
+    assert "Metric,Value" in content
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("2024-01-01", date(2024, 1, 1)),
+        ("invalid", None),
+        (None, None),
+    ],
+)
+def test_parse_date_handles_invalid_values(value, expected):
+    assert reports._parse_date(value) == expected
+
+
+def test_transaction_roots_local(monkeypatch, tmp_path):
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    transactions_dir = data_root / "transactions"
+    transactions_dir.mkdir()
+
+    output_root = tmp_path / "output"
+    output_root.mkdir()
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+
+    monkeypatch.setattr(reports.config, "app_env", "local", raising=False)
+    monkeypatch.setattr(reports.config, "transactions_output_root", output_root, raising=False)
+    monkeypatch.setattr(reports.config, "accounts_root", accounts_root, raising=False)
+    monkeypatch.setattr(reports.config, "data_root", data_root, raising=False)
+
+    roots = list(reports._transaction_roots())
+
+    assert output_root.as_posix() in roots
+    assert accounts_root.as_posix() in roots
+    assert transactions_dir.as_posix() in roots

--- a/tests/test_reports_additional.py
+++ b/tests/test_reports_additional.py
@@ -1,0 +1,545 @@
+import json
+import sys
+from datetime import UTC, date, datetime
+from types import SimpleNamespace
+import pytest
+
+import backend.reports as reports
+
+
+def test_report_dataclasses_to_dict():
+    section_schema = reports.ReportSectionSchema(
+        id="metrics",
+        title="Metrics",
+        source="performance.metrics",
+        columns=(reports.ReportColumnSchema("metric", "Metric"),),
+    )
+    section = reports.ReportSectionData(schema=section_schema, rows=({"metric": "Owner"},))
+    document = reports.ReportDocument(
+        template=reports.PERFORMANCE_SUMMARY_TEMPLATE,
+        owner="alice",
+        generated_at=datetime(2024, 1, 1, tzinfo=UTC),
+        parameters={"start": "2024-01-01"},
+        sections=(section,),
+    )
+    payload = document.to_dict()
+
+    assert payload["owner"] == "alice"
+    assert payload["sections"][0]["rows"] == [{"metric": "Owner"}]
+
+    data = reports.ReportData(
+        owner="alice",
+        start=date(2024, 1, 1),
+        end=date(2024, 1, 31),
+        realized_gains_gbp=10.123,
+        income_gbp=5.678,
+        cumulative_return=0.1234,
+        max_drawdown=-0.25,
+        history=[{"date": "2024-01-01"}],
+    )
+    summary = data.to_dict()
+
+    assert summary["realized_gains_gbp"] == 10.12
+    assert summary["history"] == [{"date": "2024-01-01"}]
+
+
+def test_template_store_methods_raise_not_implemented():
+    store = reports.TemplateStore()
+    with pytest.raises(NotImplementedError):
+        store.list_templates()
+    with pytest.raises(NotImplementedError):
+        store.get_template("example")
+    with pytest.raises(NotImplementedError):
+        store.create_template({})
+    with pytest.raises(NotImplementedError):
+        store.update_template({})
+    with pytest.raises(NotImplementedError):
+        store.delete_template("example")
+
+
+def test_file_template_store_error_paths(tmp_path, caplog):
+    store = reports.FileTemplateStore(tmp_path)
+    definition = {
+        "template_id": "example",
+        "name": "Example",
+        "description": "",
+        "sections": [
+            {
+                "id": "metrics",
+                "title": "Metrics",
+                "source": "performance.metrics",
+                "columns": [{"key": "metric", "label": "Metric"}],
+            }
+        ],
+    }
+    store.create_template(definition)
+
+    with pytest.raises(FileExistsError):
+        store.create_template(definition)
+
+    missing = store.root / "missing.json"
+    missing.write_text(json.dumps({"template_id": "missing", "sections": []}))
+    with caplog.at_level("WARNING", logger=reports.logger.name):
+        assert store.get_template("missing") is None
+    assert "invalid template definition" in caplog.text
+
+    with pytest.raises(FileNotFoundError):
+        store.update_template({"template_id": "absent"})
+
+    with pytest.raises(FileNotFoundError):
+        store.delete_template("absent")
+
+
+def _install_fake_boto_modules(monkeypatch, table):
+    exceptions_mod = SimpleNamespace(ClientError=type("ClientError", (Exception,), {}))
+    boto3_mod = SimpleNamespace(
+        resource=lambda name: SimpleNamespace(Table=lambda table_name: table),
+    )
+    monkeypatch.setitem(sys.modules, "boto3", boto3_mod)
+    monkeypatch.setitem(sys.modules, "botocore", SimpleNamespace(exceptions=exceptions_mod))
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", exceptions_mod)
+
+
+def test_dynamo_template_store_list_and_get(monkeypatch, caplog):
+    class FakeTable:
+        def __init__(self):
+            self.scan_calls: list[dict[str, object]] = []
+            self.put_requests: list[dict[str, object]] = []
+            self.delete_requests: list[dict[str, object]] = []
+
+        def scan(self, **params):
+            self.scan_calls.append(params)
+            if not params:
+                return {
+                    "Items": [
+                        {"definition": json.dumps({"template_id": "custom", "name": "Custom", "description": "", "sections": [
+                            {
+                                "id": "metrics",
+                                "title": "Metrics",
+                                "source": "performance.metrics",
+                                "columns": [{"key": "metric", "label": "Metric"}],
+                            }
+                        ]})},
+                        {"definition": "not json"},
+                        {"definition": json.dumps({"template_id": "invalid", "name": "", "sections": []})},
+                    ],
+                    "LastEvaluatedKey": {"token": "1"},
+                }
+            return {
+                "Items": [
+                    {"definition": json.dumps({"template_id": "other", "name": "Other", "description": "", "sections": [
+                        {
+                            "id": "metrics",
+                            "title": "Metrics",
+                            "source": "performance.metrics",
+                            "columns": [{"key": "metric", "label": "Metric"}],
+                        }
+                    ]})}
+                ]
+            }
+
+        def get_item(self, Key):
+            if Key["template_id"] == "missing":
+                return {}
+            if Key["template_id"] == "invalid":
+                return {"Item": {"definition": "not json"}}
+            if Key["template_id"] == "baddef":
+                return {"Item": {"definition": json.dumps({"template_id": "baddef", "name": "", "sections": []})}}
+            return {
+                "Item": {
+                    "definition": json.dumps({
+                        "template_id": Key["template_id"],
+                        "name": "Loaded",
+                        "description": "",
+                        "sections": [
+                            {
+                                "id": "metrics",
+                                "title": "Metrics",
+                                "source": "performance.metrics",
+                                "columns": [{"key": "metric", "label": "Metric"}],
+                            }
+                        ],
+                    })
+                }
+            }
+
+        def put_item(self, **kwargs):
+            self.put_requests.append(kwargs)
+
+        def delete_item(self, **kwargs):
+            self.delete_requests.append(kwargs)
+
+    table = FakeTable()
+    _install_fake_boto_modules(monkeypatch, table)
+
+    store = reports.DynamoTemplateStore("reports-table")
+
+    with caplog.at_level("WARNING", logger=reports.logger.name):
+        templates = store.list_templates()
+
+    assert sorted(t["template_id"] for t in templates) == ["custom", "other"]
+    assert "Invalid JSON" in caplog.text
+    assert "invalid template definition in Dynamo" in caplog.text
+
+    assert store.get_template("missing") is None
+    assert store.get_template("invalid") is None
+    assert store.get_template("baddef") is None
+
+    template = store.get_template("custom")
+    assert template["template_id"] == "custom"
+
+    store.create_template(template)
+    store.update_template(template)
+    store.delete_template("custom")
+
+    assert table.put_requests[0]["ConditionExpression"] == "attribute_not_exists(template_id)"
+    assert table.put_requests[1]["ConditionExpression"] == "attribute_exists(template_id)"
+    assert table.delete_requests[0]["ConditionExpression"] == "attribute_exists(template_id)"
+
+
+def test_list_templates_handles_conflicts(monkeypatch, caplog):
+    class FakeStore(reports.TemplateStore):
+        def list_templates(self):
+            return [
+                {
+                    "template_id": "performance-summary",
+                    "name": "Duplicate",
+                    "description": "",
+                    "sections": [
+                        {
+                            "id": "metrics",
+                            "title": "Metrics",
+                            "source": "performance.metrics",
+                            "columns": [{"key": "metric", "label": "Metric"}],
+                        }
+                    ],
+                }
+            ]
+
+    store = FakeStore()
+    monkeypatch.setattr(reports, "get_template_store", lambda: store)
+
+    with caplog.at_level("WARNING", logger=reports.logger.name):
+        templates = reports.list_templates()
+
+    assert any(t.template_id == "performance-summary" for t in templates)
+    assert "clashes with a built-in" in caplog.text
+
+
+def test_list_templates_handles_store_errors(monkeypatch, caplog):
+    class FailingStore(reports.TemplateStore):
+        def list_templates(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(reports, "get_template_store", lambda: FailingStore())
+
+    with caplog.at_level("WARNING", logger=reports.logger.name):
+        reports.list_templates()
+
+    assert "Failed to list user templates" in caplog.text
+
+
+def test_user_template_management_errors(monkeypatch):
+    store = SimpleNamespace(
+        get_template=lambda template_id: None,
+        create_template=lambda payload: None,
+        update_template=lambda payload: None,
+        delete_template=lambda template_id: None,
+    )
+    monkeypatch.setattr(reports, "get_template_store", lambda: store)
+
+    with pytest.raises(ValueError):
+        reports.create_user_template({"template_id": reports.DEFAULT_TEMPLATE_ID, "name": "Built-in", "sections": [
+            {"id": "metrics", "title": "Metrics", "source": "performance.metrics", "columns": [{"key": "metric"}]}
+        ]})
+
+    store.get_template = lambda template_id: {"template_id": template_id}
+    with pytest.raises(ValueError):
+        reports.create_user_template({"template_id": "custom", "name": "Custom", "sections": [
+            {"id": "metrics", "title": "Metrics", "source": "performance.metrics", "columns": [{"key": "metric"}]}
+        ]})
+
+    store.get_template = lambda template_id: None
+    with pytest.raises(ValueError):
+        reports.update_user_template(reports.DEFAULT_TEMPLATE_ID, {"name": "Built-in", "sections": [
+            {"id": "metrics", "title": "Metrics", "source": "performance.metrics", "columns": [{"key": "metric"}]}
+        ]})
+
+    with pytest.raises(FileNotFoundError):
+        reports.update_user_template("missing", {"name": "Custom", "sections": [
+            {"id": "metrics", "title": "Metrics", "source": "performance.metrics", "columns": [{"key": "metric"}]}
+        ]})
+
+    store.get_template = lambda template_id: None
+    with pytest.raises(ValueError):
+        reports.delete_user_template(reports.DEFAULT_TEMPLATE_ID)
+
+    with pytest.raises(FileNotFoundError):
+        reports.delete_user_template("missing")
+
+
+def test_build_report_document_requires_known_template(monkeypatch):
+    monkeypatch.setattr(reports, "get_template", lambda template_id, store=None: None)
+
+    with pytest.raises(ValueError):
+        reports.build_report_document("unknown", "alice")
+
+
+def test_transaction_roots_aws(monkeypatch):
+    monkeypatch.setattr(reports.config, "app_env", "aws", raising=False)
+    assert list(reports._transaction_roots()) == ["transactions"]
+
+
+def test_load_transactions_s3_pagination_errors(monkeypatch, caplog):
+    monkeypatch.setattr(reports.config, "app_env", "aws", raising=False)
+    monkeypatch.setenv("DATA_BUCKET", "bucket")
+
+    class FakeBotoCoreError(Exception):
+        pass
+
+    class FakeClientError(Exception):
+        pass
+
+    class FakePaginator:
+        def paginate(self, **kwargs):
+            raise FakeBotoCoreError()
+
+    class FakeS3:
+        def get_paginator(self, name):
+            return FakePaginator()
+
+    def fake_client(name):
+        return FakeS3()
+
+    boto3_mod = SimpleNamespace(client=fake_client)
+    exceptions_mod = SimpleNamespace(BotoCoreError=FakeBotoCoreError, ClientError=FakeClientError)
+    monkeypatch.setitem(sys.modules, "boto3", boto3_mod)
+    monkeypatch.setitem(sys.modules, "botocore", SimpleNamespace(exceptions=exceptions_mod))
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", exceptions_mod)
+
+    with caplog.at_level("WARNING", logger=reports.logger.name):
+        assert reports._load_transactions("alice") == []
+
+    assert "failed to paginate S3 objects" in caplog.text
+
+
+def test_get_template_store_returns_dynamo(monkeypatch):
+    class EmptyTable:
+        def scan(self, **kwargs):
+            return {}
+
+        def get_item(self, **kwargs):
+            return {}
+
+        def put_item(self, **kwargs):
+            return {}
+
+        def delete_item(self, **kwargs):
+            return {}
+
+    reports.get_template_store.cache_clear()
+    monkeypatch.setattr(reports.config, "app_env", "aws", raising=False)
+    monkeypatch.setenv("REPORT_TEMPLATES_TABLE", "reports-table")
+    _install_fake_boto_modules(monkeypatch, EmptyTable())
+
+    store = reports.get_template_store()
+
+    assert isinstance(store, reports.DynamoTemplateStore)
+
+    reports.get_template_store.cache_clear()
+
+
+def test_compile_summary_filters_history(monkeypatch):
+    monkeypatch.setattr(reports, "_load_transactions", lambda owner: [
+        {"date": "2024-01-01", "type": "SELL", "amount_minor": 1000},
+        {"date": "invalid", "type": "DIVIDEND", "amount_minor": 200},
+    ])
+
+    performance = {
+        "history": [
+            {"date": "2024-01-01", "cumulative_return": 0.1},
+            {"date": "2024-01-05", "cumulative_return": 0.2},
+            {"date": "invalid"},
+        ],
+        "max_drawdown": -0.2,
+    }
+    monkeypatch.setattr(reports.portfolio_utils, "compute_owner_performance", lambda owner: performance)
+
+    summary, perf = reports._compile_summary("alice", start=date(2024, 1, 2), end=date(2024, 1, 6))
+
+    assert summary.realized_gains_gbp == 0.0
+    assert summary.income_gbp == 2.0
+    assert summary.history == [{"date": "2024-01-05", "cumulative_return": 0.2}]
+    assert perf is performance
+
+
+def test_report_to_csv_multiple_sections():
+    schema = reports.ReportSectionSchema(
+        id="metrics",
+        title="Metrics",
+        source="performance.metrics",
+        columns=(reports.ReportColumnSchema("metric", "Metric"),),
+    )
+    section = reports.ReportSectionData(schema=schema, rows=({"metric": "Owner"},))
+    template = reports.ReportTemplate(
+        template_id="example",
+        name="Example",
+        description="",
+        sections=(schema, schema),
+        builtin=False,
+    )
+    document = reports.ReportDocument(
+        template=template,
+        owner="alice",
+        generated_at=datetime.now(tz=UTC),
+        parameters={},
+        sections=(section, section),
+    )
+
+    csv_data = reports.report_to_csv(document).decode()
+    assert csv_data.count("# Section: Metrics") == 2
+
+
+def test_report_to_pdf_generates_output(monkeypatch):
+    class FakeCanvas:
+        def __init__(self, buffer, pagesize):
+            self.buffer = buffer
+            self.pagesize = pagesize
+            self.calls: list[str] = []
+
+        def setFont(self, *args, **kwargs):
+            self.calls.append("setFont")
+
+        def drawString(self, *args, **kwargs):
+            self.calls.append("drawString")
+
+        def showPage(self):
+            self.calls.append("showPage")
+
+        def save(self):
+            self.calls.append("save")
+
+    fake_canvas_mod = SimpleNamespace(Canvas=FakeCanvas)
+    monkeypatch.setattr(reports, "canvas", fake_canvas_mod)
+    monkeypatch.setattr(reports, "letter", (200, 150))
+
+    schema = reports.ReportSectionSchema(
+        id="metrics",
+        title="Metrics",
+        source="performance.metrics",
+        description="Portfolio metrics",
+        columns=(
+            reports.ReportColumnSchema("metric", "Metric"),
+            reports.ReportColumnSchema("value", "Value"),
+        ),
+    )
+    section = reports.ReportSectionData(
+        schema=schema,
+        rows=(
+            {"metric": "Owner", "value": 1.2345},
+            {"metric": "Empty", "value": None},
+        ),
+    )
+    document = reports.ReportDocument(
+        template=reports.ReportTemplate(
+            template_id="pdf",
+            name="PDF",
+            description="",
+            sections=(schema,),
+            builtin=False,
+        ),
+        owner="alice",
+        generated_at=datetime.now(tz=UTC),
+        parameters={"start": "2024-01-01"},
+        sections=(section,),
+    )
+
+    output = reports.report_to_pdf(document)
+    assert isinstance(output, bytes)
+
+
+def test_report_to_pdf_requires_canvas(monkeypatch):
+    monkeypatch.setattr(reports, "canvas", None)
+    schema = reports.ALLOCATION_BREAKDOWN_TEMPLATE.sections[0]
+    document = reports.ReportDocument(
+        template=reports.ALLOCATION_BREAKDOWN_TEMPLATE,
+        owner="alice",
+        generated_at=datetime.now(tz=UTC),
+        parameters={},
+        sections=(reports.ReportSectionData(schema=schema, rows=()),),
+    )
+
+    with pytest.raises(RuntimeError, match="reportlab is required"):
+        reports.report_to_pdf(document)
+
+
+def test_section_builders_use_context():
+    summary = reports.ReportData(
+        owner="alice",
+        start=date(2024, 1, 1),
+        end=date(2024, 1, 31),
+        realized_gains_gbp=12.5,
+        income_gbp=7.25,
+        cumulative_return=0.15,
+        max_drawdown=-0.05,
+        history=[
+            {
+                "date": "2024-01-01",
+                "value": 100.0,
+                "daily_return": 0.01,
+                "weekly_return": 0.02,
+                "cumulative_return": 0.05,
+                "drawdown": 0.0,
+            }
+        ],
+    )
+
+    context = SimpleNamespace(
+        summary=lambda: summary,
+        transactions=lambda: [{"metric": "Owner"}],
+        allocation=lambda: [{"ticker": "ABC", "value": 10.0}],
+    )
+
+    metrics_schema = reports.PERFORMANCE_SUMMARY_TEMPLATE.sections[0]
+    history_schema = reports.PERFORMANCE_SUMMARY_TEMPLATE.sections[1]
+    tx_schema = reports.TRANSACTIONS_TEMPLATE.sections[0]
+    alloc_schema = reports.ALLOCATION_BREAKDOWN_TEMPLATE.sections[0]
+
+    metrics_rows = reports._build_metrics_section(context, metrics_schema)
+    history_rows = reports._build_history_section(context, history_schema)
+    tx_rows = reports._build_transactions_section(context, tx_schema)
+    alloc_rows = reports._build_allocation_section(context, alloc_schema)
+
+    assert metrics_rows[0]["metric"] == "Owner"
+    assert history_rows[0]["date"] == "2024-01-01"
+    assert tx_rows == [{"metric": "Owner"}]
+    assert alloc_rows == [{"ticker": "ABC", "value": 10.0}]
+
+
+def test_build_report_document_includes_parameters(monkeypatch):
+    summary = reports.ReportData(
+        owner="alice",
+        start=date(2024, 1, 1),
+        end=date(2024, 1, 31),
+        realized_gains_gbp=0.0,
+        income_gbp=0.0,
+        cumulative_return=None,
+        max_drawdown=None,
+        history=[],
+    )
+
+    context = SimpleNamespace(
+        summary=lambda: summary,
+        transactions=lambda: [],
+        allocation=lambda: [],
+    )
+
+    monkeypatch.setattr(reports, "ReportContext", lambda owner, start=None, end=None: context)
+    monkeypatch.setattr(reports, "get_template", lambda template_id, store=None: reports.PERFORMANCE_SUMMARY_TEMPLATE)
+
+    start = date(2024, 1, 1)
+    end = date(2024, 1, 2)
+    document = reports.build_report_document("performance-summary", "alice", start=start, end=end)
+
+    assert document.parameters == {"start": "2024-01-01", "end": "2024-01-02"}
+

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -130,6 +130,19 @@ def test_compute_portfolio_var_breakdown_invalid_days():
         risk.compute_portfolio_var_breakdown("owner", days=0)
 
 
+def test_compute_portfolio_var_breakdown_accepts_percentage(monkeypatch):
+    monkeypatch.setattr(
+        risk.portfolio_mod,
+        "build_owner_portfolio",
+        lambda owner: {"owner": owner},
+    )
+    monkeypatch.setattr(risk.portfolio_utils, "aggregate_by_ticker", lambda portfolio: [])
+
+    result = risk.compute_portfolio_var_breakdown("owner", confidence=95)
+
+    assert result == []
+
+
 def test_compute_portfolio_var_invalid_days():
     with pytest.raises(ValueError):
         risk.compute_portfolio_var("owner", days=0)
@@ -173,3 +186,146 @@ def test_compute_portfolio_var_handles_empty_returns(monkeypatch):
     result = risk.compute_portfolio_var("owner")
 
     assert result == {"window_days": 365, "confidence": 0.95, "1d": None, "10d": None}
+
+
+def test_compute_portfolio_var_handles_nan_quantiles(monkeypatch):
+    history = []
+    for idx in range(11):
+        daily_return = 1e308 if idx < 10 else -1e308
+        history.append({"value": 100.0 + idx, "daily_return": daily_return})
+
+    monkeypatch.setattr(
+        risk.portfolio_utils,
+        "compute_owner_performance",
+        lambda owner, days=365, include_flagged=False, include_cash=True: {"history": history},
+    )
+
+    result = risk.compute_portfolio_var("owner", days=10)
+
+    assert result["1d"] is None
+    assert result["10d"] is None
+
+
+def test_compute_portfolio_var_produces_values(monkeypatch):
+    returns = [0.01, -0.015, 0.02, -0.005, 0.012, -0.01, 0.018, -0.007, 0.009, -0.012, 0.011]
+    values = list(np.linspace(100, 110, num=len(returns) + 1))
+    history = []
+    for idx, ret in enumerate(returns, start=1):
+        history.append(
+            {
+                "date": f"2024-01-{idx:02d}",
+                "value": values[idx],
+                "daily_return": ret,
+            }
+        )
+
+    monkeypatch.setattr(
+        risk.portfolio_utils,
+        "compute_owner_performance",
+        lambda owner, days=11, include_flagged=False, include_cash=True: {"history": history},
+    )
+
+    result = risk.compute_portfolio_var("owner", days=10, confidence=0.9)
+
+    df = pd.DataFrame(history[-11:])
+    returns_series = df["daily_return"].dropna()
+    if len(returns_series) > 10:
+        returns_series = returns_series.iloc[-10:]
+    expected_1d = max(-(returns_series.quantile(0.1)), 0.0) * float(df["value"].iloc[-1])
+    ten_day = returns_series.add(1).rolling(10).apply(np.prod) - 1
+    expected_10d = max(-(ten_day.dropna().quantile(0.1)), 0.0) * float(df["value"].iloc[-1])
+
+    assert result["window_days"] == 10
+    assert result["confidence"] == 0.9
+    assert result["1d"] == round(expected_1d, 2)
+    assert result["10d"] == round(expected_10d, 2)
+
+
+def test_compute_portfolio_var_handles_nan_quantiles(monkeypatch):
+    history = [
+        {"value": 100.0, "daily_return": 0.01},
+        {"value": 101.0, "daily_return": -0.02},
+    ]
+
+    def fake_perf(owner, days=365, include_flagged=False, include_cash=True):
+        return {"history": history}
+
+    monkeypatch.setattr(risk.portfolio_utils, "compute_owner_performance", fake_perf)
+
+    def always_nan(self, q):
+        return float("nan")
+
+    monkeypatch.setattr(pd.Series, "quantile", always_nan)
+
+    result = risk.compute_portfolio_var("owner", days=1)
+
+    assert result["1d"] is None
+    assert result["10d"] is None
+
+
+def test_compute_portfolio_var_breakdown_skip_conditions(monkeypatch):
+    holdings = [
+        {"ticker": None},
+        {"ticker": "CASH.GBP"},
+        {"ticker": "ABC.L"},
+        {"ticker": "DEF.L"},
+        {"ticker": "GHI.L"},
+        {"ticker": "JKL.L"},
+        {"ticker": "MNO.L", "market_value_gbp": 0.0, "currency": "USD"},
+        {"ticker": "PQR.L", "market_value_gbp": 100.0},
+    ]
+
+    monkeypatch.setattr(risk.portfolio_mod, "build_owner_portfolio", lambda owner: {})
+    monkeypatch.setattr(risk.portfolio_utils, "aggregate_by_ticker", lambda portfolio: holdings)
+
+    def fake_load_meta_timeseries(symbol, exchange, days):
+        key = f"{symbol}.{exchange}"
+        if key == "ABC.L":
+            return None
+        if key == "DEF.L":
+            return pd.DataFrame({})
+        if key == "GHI.L":
+            return pd.DataFrame({"Close": [float("nan")]})
+        if key == "JKL.L":
+            return pd.DataFrame({"Close": [0.0]})
+        if key == "MNO.L":
+            return pd.DataFrame({"Close": [1.0]})
+        return pd.DataFrame({"Close": [10.0, 11.0]})
+
+    def fake_compute_var(ts, confidence):
+        if ts is None:
+            return None
+        return 5.0
+
+    monkeypatch.setattr(risk.portfolio_utils, "load_meta_timeseries", fake_load_meta_timeseries)
+    monkeypatch.setattr(risk.portfolio_utils, "compute_var", fake_compute_var)
+
+    result = risk.compute_portfolio_var_breakdown("owner", include_cash=False)
+
+    assert result == [
+        {"ticker": "PQR.L", "contribution": pytest.approx(45.45, rel=1e-2)}
+    ]
+
+
+def test_compute_sharpe_ratio_invalid_days():
+    with pytest.raises(ValueError):
+        risk.compute_sharpe_ratio("owner", days=0)
+
+
+def test_compute_sharpe_ratio_handles_dict_payload(monkeypatch):
+    perf = {"history": [{"daily_return": 0.01}]}
+    monkeypatch.setattr(risk.portfolio_utils, "compute_owner_performance", lambda owner, days=1: perf)
+
+    assert risk.compute_sharpe_ratio("owner", days=1) is None
+
+
+def test_compute_sharpe_ratio_returns_none_when_std_zero(monkeypatch):
+    history = [
+        {"daily_return": 0.01},
+        {"daily_return": 0.01},
+        {"daily_return": 0.01},
+    ]
+    monkeypatch.setattr(risk.portfolio_utils, "compute_owner_performance", lambda owner, days=3: history)
+    monkeypatch.setattr(risk.config, "risk_free_rate", 0.0, raising=False)
+
+    assert risk.compute_sharpe_ratio("owner", days=3) is None


### PR DESCRIPTION
## Summary
- expand auth tests to cover allowed email resolution, Google token failures, and auth-enabled get_current_user paths
- exercise FastAPI override plumbing with new override mapping tests
- extend risk tests to trigger 10-day VaR NaN handling while retaining existing report coverage suites

## Testing
- `pytest tests/test_auth.py tests/test_auth_aws.py tests/test_auth_get_active_user.py tests/test_auth_overrides.py tests/test_risk.py --cov=backend.auth --cov=backend.common.risk --cov-report=term-missing -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_6907b9f280d88327b140509bed5592ba