### PR TITLE
Refresh AI-facing contributor docs (AGENTS.md, CLAUDE.md, Copilot guidance)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# GitHub Copilot Instructions for AllotMint
+
+Read `AGENTS.md` for full repository guidance. Use these short rules while generating code or PRs in this repo:
+
+- Backend entrypoint: `backend.app:create_app`; local app: `backend.local_api.main:app`.
+- Primary backend tests live in top-level `tests/`.
+- Use `make format` and `make lint` for Python changes.
+- Use `npm --prefix frontend run lint` and `npm --prefix frontend run test -- --run` for frontend changes.
+- Prefer `bash scripts/bash/run-local-api.sh` for the local backend instead of outdated `uvicorn app:app` examples.
+- Verify command names against actual `package.json`, `Makefile`, and scripts before updating docs.
+- Keep changes out of generated dependency folders such as `node_modules/`.
+- Be careful when changing `data/`, auth defaults, or smoke-test flows; these are tightly coupled to local development and demos.
+- Preserve bash/PowerShell parity when editing shared developer workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,117 @@
-so # Repository Guidelines
+# AllotMint Repository Guidelines for AI Agents
 
-## Project Structure & Module Organization
-Backend FastAPI service lives in `backend/`, arranged by domain (`routes/`, `utils/`, `tasks/`) with data fixtures under `backend/tests/fixtures`. Shared integration suites sit in top-level `tests/`, mirroring backend package names for parity. The React/Vite client is in `frontend/` (`src/` for features, `tests/unit/` for Vitest specs), while IaC and scripts live in `cdk/`, `infra/`, and `scripts/` and deployment docs in `docs/`.
+This repository has a Python/FastAPI backend, a React/Vite frontend, AWS CDK infrastructure, and local/demo data used heavily by tests and smoke checks. If you are taking the project over after time away, read this file first and treat it as the primary operating guide for the whole repo.
 
-## Build, Test, and Development Commands
-Install backend deps with `python -m pip install -r requirements.txt -r requirements-dev.txt` and run `uvicorn backend.app:create_app --factory --reload` for local APIs. Use `make format` before committing and `make lint` (Black, isort, Ruff, pytest) for the full gate. Frontend setup uses `npm install` inside `frontend/`, `npm run dev` for the SPA, `npm run build` for a production bundle, and `npm run deploy:aws` for CDN pushes; repo-level `npm run smoke:test` exercises the integrated smoke harness.
+## 1. Repo map and mental model
 
-## Coding Style & Naming Conventions
-Python code targets 3.12+, 4-space indentation, 120-character lines, and imports grouped by isort's Black profile; keep modules domain-oriented and prefer descriptive function names like `fetch_meta_timeseries`. TypeScript follows Prettier (`tabWidth: 2`, `singleQuote: true`, semicolons enforced) and ESLint; collocate component styles as `.module.css` when styling React views. Name tests `test_<feature>.py` or `<Component>.test.tsx` and keep generated assets out of version control per `.gitignore`.
+- `backend/`: FastAPI application code, domain services, importers, tasks, and Lambda/local entrypoints.
+- `tests/`: primary pytest suite. Prefer adding or updating tests here unless an existing backend-local test sits elsewhere.
+- `frontend/`: React + TypeScript SPA built with Vite, plus Vitest and Playwright coverage.
+- `data/`: local/demo data used for development and many smoke/test scenarios.
+- `scripts/`: local workflow helpers, smoke runners, deployment scripts, and support tooling.
+- `cdk/` and `infra/`: AWS infrastructure definitions and deployment assets.
+- `docs/`: operational docs, smoke test notes, deployment notes, and user-facing setup details.
 
-## Testing Guidelines
-Backend suites rely on pytest with fixtures in `tests/common/`; run targeted checks via `pytest tests/routes/test_accounts_api.py` and capture coverage with `pytest --cov=backend`. Frontend unit tests use Vitest (`npm run test` or `npm run coverage`), while browser flows run Playwright via `npm run smoke:frontend`; review `docs/SMOKE_TESTS.md` for required environment flags. Expect CI to execute backend integration and frontend test workflows, so ensure deterministic outcomes and include data stubs under `tests/data/`.
+## 2. Entrypoints and runtime expectations
 
-## Commit & Pull Request Guidelines
-Follow the existing imperative commit style (`Fix local data discovery issues`, see `git log`) and keep scope focused. Before opening a PR, run `make lint`, `npm run lint`, and the relevant smoke scripts, then attach the command output or coverage deltas in the PR body. Link tracking issues, document config changes in `docs/` when applicable, and include screenshots for UI tweaks; reviewers expect concise summaries and validation steps.
+### Backend
+- App factory: `backend.app:create_app`.
+- Local app module used by scripts: `backend.local_api.main:app`.
+- Lambda handler path: `backend.lambda_api.handler`.
+- Preferred local run path in this repo is the helper script `scripts/bash/run-local-api.sh` or `python -m uvicorn backend.local_api.main:app --reload`.
+- Do **not** assume old docs using `uvicorn app:app` are current without verifying the import path first.
+
+### Frontend
+- Main boot file: `frontend/src/main.tsx`.
+- The SPA expects a backend base URL from `VITE_ALLOTMINT_API_BASE` or falls back to local defaults.
+- The frontend has both unit tests (Vitest) and browser smoke coverage (Playwright).
+
+### Smoke / integrated checks
+- Repo-level smoke commands live in the root `package.json`.
+- Frontend-only smoke commands live in `frontend/package.json`.
+- Many smoke flows assume the backend is reachable and may use demo/local identity settings from config or environment variables.
+
+## 3. Canonical commands
+
+### Install
+- Backend: `python -m pip install -r requirements.txt -r requirements-dev.txt`
+- Frontend: `npm install && npm --prefix frontend install`
+
+### Format and lint
+- Python formatting: `make format`
+- Python gate: `make lint`
+- Frontend lint: `npm --prefix frontend run lint`
+- Frontend tests: `npm --prefix frontend run test -- --run` or `npm --prefix frontend run coverage`
+
+### Run locally
+- Backend: `bash scripts/bash/run-local-api.sh`
+- Frontend: `npm --prefix frontend run dev`
+
+### Smoke checks
+- Backend/API smoke: `npm run smoke:test`
+- Combined smoke orchestration: `npm run smoke:test:all`
+- Frontend smoke: `npm --prefix frontend run smoke:frontend`
+
+## 4. Important repo-specific realities discovered during review
+
+- Python tooling is split across **two config layers**:
+  - root `pyproject.toml` is mainly for pytest/coverage and some general settings;
+  - `backend/pyproject.toml` is the config actually used by `make format` / `make lint` for Black, isort, and Ruff.
+- Root docs may mention Python 3.12, but backend formatting/lint config currently targets Python 3.11. When changing Python-version-sensitive code, verify both the runtime expectation and the active lint config before updating syntax.
+- The backend pytest default in the root `pyproject.toml` sets `testpaths = ["tests"]`, so top-level `tests/` is the primary suite.
+- The repo already contains `node_modules/` folders. Do not edit vendored/generated dependency trees.
+- Many local workflows depend on `data/` fixtures and auth/demo identity fallbacks. Avoid changing default data or auth behavior casually because it can break smoke flows in non-obvious ways.
+- There are PowerShell and bash variants of several scripts. Preserve both when changing cross-platform workflows.
+
+## 5. How to work safely in this codebase
+
+### When modifying backend code
+- Keep business logic in domain-oriented modules under `backend/`; avoid pushing logic directly into route handlers when a helper/service module is more appropriate.
+- Watch for code paths used by both local FastAPI and Lambda entrypoints.
+- Prefer deterministic tests with fixtures under `tests/` or `tests/data/`.
+- Be careful with network-dependent integrations (`yfinance`, Google auth, AWS, etc.); add seams/mocks rather than creating tests that require the public internet.
+
+### When modifying frontend code
+- Use the existing TypeScript + ESLint + Prettier style in `frontend/`.
+- Keep components/pages in the current structure under `frontend/src/` and prefer small, composable changes.
+- If you make a perceptible UI change, capture a screenshot when tooling is available.
+- Keep API assumptions aligned with backend contracts; if you change payload shapes, update both tests and any dependent UI code.
+
+### When modifying scripts/docs/workflows
+- Check whether the same workflow exists in more than one place (`docs/`, `scripts/README.md`, workflow YAML, package scripts, PowerShell helpers).
+- Prefer correcting stale instructions instead of adding another conflicting source of truth.
+- If you update commands, verify them against the actual package scripts/entrypoints in this repo.
+
+## 6. AI-agent handoff checklist
+
+Before making changes:
+1. Read this file.
+2. Check `git status` for uncommitted user work and avoid overwriting it.
+3. Verify whether there are more specific `AGENTS.md` files deeper in the tree for files you plan to touch.
+4. Inspect the command definitions you plan to reference instead of trusting older prose docs.
+
+Before finishing:
+1. Run the smallest relevant automated checks.
+2. If you changed commands/docs, verify the command names still exist.
+3. Update nearby docs when behavior or workflow meaningfully changes.
+4. Summarize any environment limitations clearly.
+
+## 7. Commit and PR expectations
+
+- Use focused, imperative commit messages, e.g. `Refresh AI contributor guidance`.
+- In PR descriptions, include:
+  - what changed,
+  - why it changed,
+  - what you validated,
+  - any known follow-up or risk.
+- If you changed UI behavior, attach screenshots.
+- If you changed operational workflows, mention the exact commands used for validation.
+
+## 8. Additional AI-facing files in this repo
+
+To support tool-specific agents, keep these files aligned when the repo guidance changes:
+- `AGENTS.md` — primary source of truth for agent workflow.
+- `CLAUDE.md` — Claude-oriented handoff and operating notes.
+- `.github/copilot-instructions.md` — concise GitHub Copilot coding-agent instructions.
+
+When updating one of these, consider whether the same repo facts or command changes should be mirrored in the others.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file gives Claude-style coding agents a fast, practical overview for working effectively in AllotMint. For the full repo policy, read `AGENTS.md` first; this file is the concise companion.
+
+## Quick start
+
+- Root guide of record: `AGENTS.md`
+- Backend app factory: `backend.app:create_app`
+- Local backend app: `backend.local_api.main:app`
+- Frontend app entry: `frontend/src/main.tsx`
+- Primary backend tests: top-level `tests/`
+
+## Most useful commands
+
+```bash
+python -m pip install -r requirements.txt -r requirements-dev.txt
+npm install
+npm --prefix frontend install
+make format
+make lint
+npm --prefix frontend run lint
+npm --prefix frontend run test -- --run
+bash scripts/bash/run-local-api.sh
+npm --prefix frontend run dev
+npm run smoke:test
+npm run smoke:test:all
+```
+
+## High-signal warnings
+
+- Do not trust stale prose that references `uvicorn app:app`; verify actual backend entrypoints first.
+- Python config is split: root `pyproject.toml` handles pytest/coverage, while `backend/pyproject.toml` drives Black/isort/Ruff for the backend.
+- Backend lint/format config currently targets Python 3.11 semantics even though some docs mention Python 3.12.
+- Avoid editing generated or vendored folders like `node_modules/`.
+- Be cautious around `data/`, auth toggles, and smoke-test identities; these often affect local demos and automated flows.
+- Preserve cross-platform workflow parity when touching scripts because the repo uses both bash and PowerShell helpers.
+
+## Preferred workflow
+
+1. Inspect `git status` and avoid disturbing user changes.
+2. Read the exact script/package targets you plan to mention or change.
+3. Make the smallest coherent change.
+4. Run the narrowest useful validation.
+5. Update nearby docs when commands or behavior changed.
+
+## If you touch specific areas
+
+### Backend
+- Keep domain logic out of routes when possible.
+- Add/update pytest coverage under `tests/`.
+- Mock external integrations instead of depending on live network access.
+
+### Frontend
+- Follow existing TypeScript/ESLint/Prettier conventions.
+- Add/update Vitest coverage for logic changes.
+- Capture screenshots for visible UI changes when tooling allows.
+
+### Docs / scripts / workflows
+- Look for duplicate instructions in `docs/`, `scripts/README.md`, root scripts, and workflow YAML.
+- Prefer consolidating or correcting instructions rather than introducing a new conflicting variant.


### PR DESCRIPTION
### Motivation

- Provide a practical, repo-specific handoff for AI agents returning to or taking over AllotMint. 
- Surface the true backend/frontend entrypoints, canonical install/lint/run/smoke commands, and pitfalls discovered during a repo review. 
- Reduce friction and accidental breakage by documenting command sources, config split, and cross-platform script variants.

### Description

- Rewrote and expanded `AGENTS.md` into a structured AI handoff guide that includes repo topology, precise entrypoints (`backend.app:create_app`, `backend.local_api.main:app`, `frontend/src/main.tsx`), canonical commands, a safety checklist, and repo-specific warnings (Python config layers, `data/` reliance, stale `uvicorn app:app` examples, PowerShell/bash parity). 
- Added `CLAUDE.md` as a concise, tool-oriented companion with quick-start commands, high-signal warnings, and preferred workflows for touching backend/frontend/docs. 
- Added `.github/copilot-instructions.md` to align GitHub Copilot and similar coding agents with the same validated commands and repository safety rules. 
- Changes are documentation-only and confined to the three files above; no application code or runtime behavior was modified.

### Testing

- Ran small automated content checks using short Python assertions that verified the presence of key tokens (e.g. `backend.app:create_app`, `make lint`) in the updated files; these checks passed. 
- Verified `package.json` and `frontend/package.json` contain the referenced scripts (`smoke:test`, `smoke:test:all`, `lint`, `test`) via a small Python verification script; this check passed. 
- Verified `Makefile` contains the referenced targets (`format:`, `lint:`, `pytest`) via a small Python check; this check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1db06c3083278afe472995e45020)