### PR TITLE
Run dependency-review and super-linter on pull requests to main

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,9 @@
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
 on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
   push:
     branches: [main]
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -7,6 +7,9 @@
 name: Lint Code Base
 
 on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
   push:
     branches: [main]
 jobs:


### PR DESCRIPTION
### Motivation
- Add `pull_request` triggers so `dependency-review` and `super-linter` run on PRs targeting `main` to catch vulnerabilities and lint issues earlier.

### Description
- Added a `pull_request` trigger to `.github/workflows/dependency-review.yml` with `branches: [main]` and `types: [opened, reopened, synchronize]`.
- Added a `pull_request` trigger to `.github/workflows/super-linter.yml` with `branches: [main]` and `types: [opened, reopened, synchronize]`.
- No other workflow steps, permissions, or behavior were modified.

### Testing
- No automated tests were executed as part of this PR; the updated workflows will run on subsequent pull requests to `main`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef93b33148327b31b63ec50847a9b)