### PR TITLE
Centralize frontend page route registration

### DIFF
--- a/docs/frontend-page-manifest.md
+++ b/docs/frontend-page-manifest.md
@@ -1,12 +1,18 @@
 # Frontend page manifest
 
 The frontend route/menu registry now lives in `frontend/src/pageManifest.tsx`.
+That file contains both:
+
+- `PAGE_MANIFEST` for in-app mode ownership and menu metadata.
+- `STANDALONE_PAGE_ROUTES` for top-level lazily loaded routes rendered by
+  `frontend/src/main.tsx`.
 
 ## What belongs in the manifest
 
 Each page entry defines the ownership boundary for:
 
 - the route segment used to derive the active mode,
+- the accepted route patterns for that mode,
 - the canonical path builder used by navigation and redirects,
 - the menu section/category used by the dropdown menu,
 - the display order used when rendering menu items.
@@ -17,18 +23,21 @@ Each page entry defines the ownership boundary for:
 2. Add a manifest entry in `frontend/src/pageManifest.tsx` with:
    - `mode`,
    - `routeSegment` if the page is not the group root route,
+   - `routePatterns`,
    - `path`,
    - `order`,
    - `menu` metadata if it should appear in the menu.
-3. Render the page in the appropriate router/component (`frontend/src/main.tsx` for top-level routes or `frontend/src/App.tsx` for in-app modes).
-4. Update or add tests, especially `frontend/tests/unit/pageManifest.test.tsx`, if the page changes routing or menu behavior.
+3. If the page is a top-level lazy route, add its loader to `STANDALONE_PAGE_ROUTES`.
+4. Render the page in the appropriate router/component (`frontend/src/main.tsx` for top-level routes or `frontend/src/App.tsx` for in-app modes).
+5. Update or add tests, especially `frontend/tests/unit/pageManifest.test.tsx`, if the page changes routing or menu behavior.
 
 ## Retiring a page feature
 
 1. Remove or disable its render path.
-2. Remove the manifest entry.
-3. Remove the mode from `frontend/src/modes.ts` if the mode is no longer used.
-4. Update tests that depend on the route or menu item.
+2. Remove any matching entry from `STANDALONE_PAGE_ROUTES` if it was registered there.
+3. Remove the manifest entry.
+4. Remove the mode from `frontend/src/modes.ts` if the mode is no longer used.
+5. Update tests that depend on the route or menu item.
 
 ## Validation
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -82,23 +82,15 @@ If neither is provided the app falls back to `http://localhost:8000`.
 
 Runtime feature flags and tab visibility come from the backend's `config.yaml`. See the [backend setup instructions](../README.md#local-quick-start) for configuring and running the server.
 
-## Tab plugins
+## Page manifest
 
-Tabs in the navigation bar are driven by a small plugin system. A plugin
-provides the component to render and optional metadata such as a
-`priority` value. Plugins are registered in `src/pluginRegistry.ts`.
+Navigation, route-mode ownership, and standalone lazy route registration
+are defined in `src/pageManifest.tsx`.
 
-```ts
-import { registerTabPlugin } from './pluginRegistry';
-import MyTab from './pages/MyTab';
+- `PAGE_MANIFEST` owns canonical mode metadata such as route segments,
+  route patterns, menu placement, and path builders.
+- `STANDALONE_PAGE_ROUTES` owns the lazily loaded top-level routes that
+  are rendered directly from `src/main.tsx`.
 
-registerTabPlugin({
-  id: 'myTab',
-  Component: MyTab,
-  priority: 50, // higher numbers appear earlier
-});
-```
-
-Plugins with higher priority numbers are displayed before lower ones. A
-plugin can be disabled by setting `isEnabled` to `false` or providing a
-function that returns `false`.
+See `../docs/frontend-page-manifest.md` for the workflow to add or retire
+a page feature safely.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -25,25 +25,12 @@ import { UserProvider, useUser } from './UserContext'
 import ErrorBoundary from './ErrorBoundary'
 import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage'
 import { RouteProvider } from './RouteContext'
-import { deriveModeFromPathname } from './pageManifest'
+import { deriveModeFromPathname, STANDALONE_PAGE_ROUTES } from './pageManifest'
 
 const storedToken = getStoredAuthToken()
 if (storedToken) setAuthToken(storedToken)
 
 const App = lazy(() => import('./App.tsx'))
-const VirtualPortfolio = lazy(() => import('./pages/VirtualPortfolio'))
-const Support = lazy(() => import('./pages/Support'))
-const ComplianceWarnings = lazy(() => import('./pages/ComplianceWarnings'))
-const TradeCompliance = lazy(() => import('./pages/TradeCompliance'))
-const Alerts = lazy(() => import('./pages/Alerts'))
-const Goals = lazy(() => import('./pages/Goals'))
-const Trail = lazy(() => import('./pages/Trail'))
-const PerformanceDiagnostics = lazy(() => import('./pages/PerformanceDiagnostics'))
-const ReturnComparison = lazy(() => import('./pages/ReturnComparison'))
-const AlertSettings = lazy(() => import('./pages/AlertSettings'))
-const MetricsExplanation = lazy(() => import('./pages/MetricsExplanation'))
-const SmokeTest = lazy(() => import('./pages/SmokeTest'))
-
 const routeMarkerStyle: CSSProperties = {
   position: 'absolute',
   width: 1,
@@ -268,20 +255,10 @@ export function Root() {
     <ErrorBoundary key={location.pathname}>
       <Suspense fallback={<div>Loading...</div>}>
         <Routes>
-          <Route path="/support" element={<Support />} />
-          <Route path="/virtual" element={<VirtualPortfolio />} />
-          <Route path="/compliance" element={<ComplianceWarnings />} />
-          <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
-          <Route path="/trade-compliance" element={<TradeCompliance />} />
-          <Route path="/trade-compliance/:owner" element={<TradeCompliance />} />
-          <Route path="/alerts" element={<Alerts />} />
-          <Route path="/alert-settings" element={<AlertSettings />} />
-          <Route path="/goals" element={<Goals />} />
-          <Route path="/trail" element={<Trail />} />
-          <Route path="/smoke-test" element={<SmokeTest />} />
-          <Route path="/performance/:owner/diagnostics" element={<PerformanceDiagnostics />} />
-          <Route path="/returns/compare" element={<ReturnComparison />} />
-          <Route path="/metrics-explained" element={<MetricsExplanation />} />
+          {STANDALONE_PAGE_ROUTES.map((route) => {
+            const Component = route.component
+            return <Route key={route.path} path={route.path} element={<Component />} />
+          })}
           <Route
             path="/*"
             element={

--- a/frontend/src/pageManifest.tsx
+++ b/frontend/src/pageManifest.tsx
@@ -1,3 +1,4 @@
+import { lazy } from "react";
 import type { TabsConfig } from "./ConfigContext";
 import type { Mode } from "./modes";
 import { isDefaultGroupSlug } from "./utils/groups";
@@ -18,6 +19,7 @@ export interface PagePathContext {
 export interface PageManifestEntry {
   mode: Mode;
   routeSegment?: string;
+  routePatterns: readonly string[];
   order: number;
   menu?: {
     section: MenuSection;
@@ -29,6 +31,7 @@ export interface PageManifestEntry {
 export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "group",
+    routePatterns: ["/"],
     order: 0,
     menu: { section: "user", category: "dashboard" },
     path: ({ group }) =>
@@ -37,6 +40,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "market",
     routeSegment: "market",
+    routePatterns: ["/market"],
     order: 5,
     menu: { section: "user", category: "dashboard" },
     path: () => "/market",
@@ -44,6 +48,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "movers",
     routeSegment: "movers",
+    routePatterns: ["/movers"],
     order: 10,
     menu: { section: "user", category: "dashboard" },
     path: () => "/movers",
@@ -51,6 +56,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "instrument",
     routeSegment: "instrument",
+    routePatterns: ["/instrument", "/instrument/:group"],
     order: 20,
     menu: { section: "user", category: "insights" },
     path: ({ group }) => (group ? `/instrument/${group}` : "/instrument"),
@@ -58,6 +64,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "owner",
     routeSegment: "portfolio",
+    routePatterns: ["/portfolio", "/portfolio/:owner"],
     order: 30,
     menu: { section: "user", category: "dashboard" },
     path: ({ owner }) => (owner ? `/portfolio/${owner}` : "/portfolio"),
@@ -65,6 +72,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "performance",
     routeSegment: "performance",
+    routePatterns: ["/performance", "/performance/:owner"],
     order: 40,
     menu: { section: "user", category: "dashboard" },
     path: ({ owner }) => (owner ? `/performance/${owner}` : "/performance"),
@@ -72,6 +80,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "transactions",
     routeSegment: "transactions",
+    routePatterns: ["/transactions"],
     order: 50,
     menu: { section: "user", category: "dashboard" },
     path: () => "/transactions",
@@ -79,6 +88,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "trading",
     routeSegment: "trading",
+    routePatterns: ["/trading"],
     order: 55,
     menu: { section: "user", category: "insights" },
     path: () => "/trading",
@@ -86,6 +96,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "screener",
     routeSegment: "screener",
+    routePatterns: ["/screener"],
     order: 60,
     menu: { section: "user", category: "insights" },
     path: () => "/screener",
@@ -93,6 +104,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "timeseries",
     routeSegment: "timeseries",
+    routePatterns: ["/timeseries"],
     order: 70,
     menu: { section: "support", category: "operations" },
     path: () => "/timeseries",
@@ -100,6 +112,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "watchlist",
     routeSegment: "watchlist",
+    routePatterns: ["/watchlist"],
     order: 80,
     menu: { section: "user", category: "insights" },
     path: () => "/watchlist",
@@ -107,6 +120,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "allocation",
     routeSegment: "allocation",
+    routePatterns: ["/allocation"],
     order: 85,
     menu: { section: "user", category: "dashboard" },
     path: () => "/allocation",
@@ -114,6 +128,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "instrumentadmin",
     routeSegment: "instrumentadmin",
+    routePatterns: ["/instrumentadmin"],
     order: 85,
     menu: { section: "support", category: "operations" },
     path: () => "/instrumentadmin",
@@ -121,6 +136,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "rebalance",
     routeSegment: "rebalance",
+    routePatterns: ["/rebalance"],
     order: 86,
     menu: { section: "user", category: "insights" },
     path: () => "/rebalance",
@@ -128,6 +144,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "dataadmin",
     routeSegment: "dataadmin",
+    routePatterns: ["/dataadmin"],
     order: 90,
     menu: { section: "support", category: "operations" },
     path: () => "/dataadmin",
@@ -135,6 +152,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "reports",
     routeSegment: "reports",
+    routePatterns: ["/reports", "/reports/new", "/reports/new/:templateId"],
     order: 100,
     menu: { section: "user", category: "dashboard" },
     path: () => "/reports",
@@ -142,6 +160,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "trail",
     routeSegment: "trail",
+    routePatterns: ["/trail"],
     order: 102,
     menu: { section: "user", category: "goals" },
     path: () => "/trail",
@@ -149,6 +168,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "alertsettings",
     routeSegment: "alert-settings",
+    routePatterns: ["/alert-settings"],
     order: 104,
     menu: { section: "user", category: "preferences" },
     path: () => "/alert-settings",
@@ -156,6 +176,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "settings",
     routeSegment: "settings",
+    routePatterns: ["/settings"],
     order: 105,
     menu: { section: "user", category: "preferences" },
     path: () => "/settings",
@@ -163,6 +184,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "pension",
     routeSegment: "pension",
+    routePatterns: ["/pension", "/pension/forecast"],
     order: 107,
     menu: { section: "user", category: "goals" },
     path: () => "/pension/forecast",
@@ -170,6 +192,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "taxtools",
     routeSegment: "tax-tools",
+    routePatterns: ["/tax-tools"],
     order: 108,
     menu: { section: "user", category: "goals" },
     path: () => "/tax-tools",
@@ -177,6 +200,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "trade-compliance",
     routeSegment: "trade-compliance",
+    routePatterns: ["/trade-compliance", "/trade-compliance/:owner"],
     order: 110,
     menu: { section: "user", category: "goals" },
     path: () => "/trade-compliance",
@@ -184,6 +208,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "support",
     routeSegment: "support",
+    routePatterns: ["/support"],
     order: 110,
     menu: { section: "support", category: "preferences" },
     path: () => "/support",
@@ -191,6 +216,7 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "scenario",
     routeSegment: "scenario",
+    routePatterns: ["/scenario"],
     order: 120,
     menu: { section: "user", category: "insights" },
     path: () => "/scenario",
@@ -198,14 +224,95 @@ export const PAGE_MANIFEST: readonly PageManifestEntry[] = [
   {
     mode: "virtual",
     routeSegment: "virtual",
+    routePatterns: ["/virtual"],
     order: 130,
     path: () => "/virtual",
   },
   {
     mode: "research",
     routeSegment: "research",
+    routePatterns: ["/research", "/research/:ticker"],
     order: 140,
     path: () => "/research",
+  },
+] as const;
+
+export interface StandalonePageRoute {
+  path: string;
+  mode: Mode | "loading";
+  component: ReturnType<typeof lazy>;
+}
+
+export const STANDALONE_PAGE_ROUTES: readonly StandalonePageRoute[] = [
+  {
+    path: "/support",
+    mode: "support",
+    component: lazy(() => import("./pages/Support")),
+  },
+  {
+    path: "/virtual",
+    mode: "virtual",
+    component: lazy(() => import("./pages/VirtualPortfolio")),
+  },
+  {
+    path: "/trade-compliance",
+    mode: "trade-compliance",
+    component: lazy(() => import("./pages/TradeCompliance")),
+  },
+  {
+    path: "/trade-compliance/:owner",
+    mode: "trade-compliance",
+    component: lazy(() => import("./pages/TradeCompliance")),
+  },
+  {
+    path: "/alert-settings",
+    mode: "alertsettings",
+    component: lazy(() => import("./pages/AlertSettings")),
+  },
+  {
+    path: "/trail",
+    mode: "trail",
+    component: lazy(() => import("./pages/Trail")),
+  },
+  {
+    path: "/compliance",
+    mode: "loading",
+    component: lazy(() => import("./pages/ComplianceWarnings")),
+  },
+  {
+    path: "/compliance/:owner",
+    mode: "loading",
+    component: lazy(() => import("./pages/ComplianceWarnings")),
+  },
+  {
+    path: "/alerts",
+    mode: "loading",
+    component: lazy(() => import("./pages/Alerts")),
+  },
+  {
+    path: "/goals",
+    mode: "loading",
+    component: lazy(() => import("./pages/Goals")),
+  },
+  {
+    path: "/smoke-test",
+    mode: "loading",
+    component: lazy(() => import("./pages/SmokeTest")),
+  },
+  {
+    path: "/performance/:owner/diagnostics",
+    mode: "loading",
+    component: lazy(() => import("./pages/PerformanceDiagnostics")),
+  },
+  {
+    path: "/returns/compare",
+    mode: "loading",
+    component: lazy(() => import("./pages/ReturnComparison")),
+  },
+  {
+    path: "/metrics-explained",
+    mode: "loading",
+    component: lazy(() => import("./pages/MetricsExplanation")),
   },
 ] as const;
 
@@ -252,8 +359,10 @@ export function getMenuEntries(section: MenuSection): PageManifestEntry[] {
 export function validatePageManifest() {
   const duplicateModes = new Set<string>();
   const duplicateSegments = new Set<string>();
+  const duplicateRoutes = new Set<string>();
   const seenModes = new Set<string>();
   const seenSegments = new Set<string>();
+  const seenRoutes = new Set<string>();
 
   for (const entry of PAGE_MANIFEST) {
     if (seenModes.has(entry.mode)) {
@@ -267,10 +376,18 @@ export function validatePageManifest() {
       }
       seenSegments.add(entry.routeSegment);
     }
+
+    for (const routePattern of entry.routePatterns) {
+      if (seenRoutes.has(routePattern)) {
+        duplicateRoutes.add(routePattern);
+      }
+      seenRoutes.add(routePattern);
+    }
   }
 
   return {
-    duplicateModes: Array.from(duplicateModes),
-    duplicateSegments: Array.from(duplicateSegments),
+    duplicateModes: Array.from(duplicateModes).sort(),
+    duplicateSegments: Array.from(duplicateSegments).sort(),
+    duplicateRoutes: Array.from(duplicateRoutes).sort(),
   };
 }

--- a/frontend/tests/unit/pageManifest.test.tsx
+++ b/frontend/tests/unit/pageManifest.test.tsx
@@ -6,6 +6,7 @@ import {
   getMenuEntries,
   MENU_CATEGORY_ORDER,
   PAGE_MANIFEST,
+  STANDALONE_PAGE_ROUTES,
   validatePageManifest,
 } from "@/pageManifest";
 
@@ -15,6 +16,7 @@ describe("pageManifest", () => {
 
     expect(validation.duplicateModes).toEqual([]);
     expect(validation.duplicateSegments).toEqual([]);
+    expect(validation.duplicateRoutes).toEqual([]);
     expect(PAGE_MANIFEST.map((entry) => entry.mode).sort()).toEqual([...MODES].sort());
   });
 
@@ -37,5 +39,19 @@ describe("pageManifest", () => {
     expect(buildPathForMode("group", { group: "kids" })).toBe("/?group=kids");
     expect(buildPathForMode("owner", { owner: "alex" })).toBe("/portfolio/alex");
     expect(buildPathForMode("pension")).toBe("/pension/forecast");
+  });
+
+  it("keeps standalone lazy routes aligned with canonical page routes", () => {
+    const standalonePaths = STANDALONE_PAGE_ROUTES.map((route) => route.path);
+
+    expect(standalonePaths).toContain("/support");
+    expect(standalonePaths).toContain("/virtual");
+    expect(standalonePaths).toContain("/trade-compliance");
+    expect(standalonePaths).toContain("/alert-settings");
+
+    for (const entry of PAGE_MANIFEST) {
+      if (!entry.menu && entry.mode !== "virtual") continue;
+      expect(entry.routePatterns.length).toBeGreaterThan(0);
+    }
   });
 });


### PR DESCRIPTION
### Motivation

- Reduce duplication and make route ownership explicit by consolidating route metadata, menu placement and top-level lazy-route registration in a single manifest.
- Provide safer validation and a clearer workflow for adding/retiring pages as requested in issue closes #2414.

### Description

- Added a `routePatterns` field to each `PAGE_MANIFEST` entry to list accepted route patterns for a mode and added duplicate-route validation in `validatePageManifest`.
- Introduced `STANDALONE_PAGE_ROUTES` (with lazy-loaded components) in `frontend/src/pageManifest.tsx` to register top-level routes alongside the canonical manifest metadata.
- Updated `frontend/src/main.tsx` to render top-level routes by iterating `STANDALONE_PAGE_ROUTES` instead of using hard-coded `<Route>` entries.
- Updated tests and docs: expanded `frontend/tests/unit/pageManifest.test.tsx` to cover duplicate route detection and standalone route alignment, and refreshed `frontend/README.md` and `docs/frontend-page-manifest.md` to document the manifest workflow.

### Testing

- Ran the targeted frontend unit tests with `npm run test -- --run tests/unit/pageManifest.test.tsx tests/unit/components/Menu.test.tsx tests/unit/hooks/useRouteMode.test.tsx`, and all included tests passed (3 files, 13 tests total).
- Ran `npm run lint` in `frontend`, which produced existing repository lint failures unrelated to this change and therefore did not pass; these are pre-existing issues across many frontend files and are out of scope for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1052241c8327bc79968b0d601269)