### PR TITLE
Add bootstrap auth integration coverage

### DIFF
--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -214,6 +214,71 @@ test.describe('pension forecast routing', () => {
   });
 });
 
+
+test.describe('bootstrap to portfolio happy path', () => {
+  test('redirects from /portfolio to the only available owner portfolio', async ({ page }) => {
+    await applyAuth(page);
+
+    await page.route('**/config', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          google_auth_enabled: false,
+          google_client_id: '',
+          disable_auth: true,
+          local_login_email: 'demo@example.com',
+          tabs: {},
+          disabled_tabs: [],
+        }),
+      });
+    });
+
+    await page.route('**/owners', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { owner: 'demo-owner', full_name: 'Demo Owner', accounts: ['ISA'] },
+        ]),
+      });
+    });
+
+    await page.route('**/groups', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ slug: 'all', name: 'All portfolios' }]),
+      });
+    });
+
+    await page.route('**/portfolio/demo-owner', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          owner: 'demo-owner',
+          as_of: '2026-03-22',
+          accounts: [
+            {
+              account_type: 'ISA',
+              holdings: [],
+            },
+          ],
+          total_value_estimate_gbp: 1000,
+        }),
+      });
+    });
+
+    await page.goto(new URL('/portfolio', baseUrl).toString());
+
+    await expect(page).toHaveURL(new URL('/portfolio/demo-owner', baseUrl).toString());
+    await expect(getActiveRouteMarker(page)).toHaveAttribute('data-mode', 'owner');
+    await expect(getActiveRouteMarker(page)).toHaveAttribute('data-pathname', '/portfolio/demo-owner');
+    await expect(page.getByTestId('portfolio-owner-selector')).toBeVisible();
+  });
+});
+
 test.describe('public route smoke coverage', () => {
   for (const route of ROUTES) {
     test(`renders ${route.path}`, async ({ page }) => {
@@ -354,7 +419,7 @@ test.describe('timeseries edit resilience', () => {
     try {
       await expect(loadButton).toBeEnabled();
       await loadButton.click();
-    } catch (err) {
+    } catch {
       const fallback = page.locator("text=Load");
       if (await fallback.count() > 0) {
         await expect(fallback.first()).toBeVisible();

--- a/frontend/tests/unit/rootBootstrap.test.tsx
+++ b/frontend/tests/unit/rootBootstrap.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mountRoot = async () => {
+  document.body.innerHTML = '<div id="root"></div>'
+  const { Root } = await import('@/main')
+  const { AuthProvider } = await import('@/AuthContext')
+  const { UserProvider } = await import('@/UserContext')
+  return render(
+    <AuthProvider>
+      <UserProvider>
+        <BrowserRouter>
+          <Root />
+        </BrowserRouter>
+      </UserProvider>
+    </AuthProvider>,
+  )
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetModules()
+  vi.clearAllMocks()
+  localStorage.clear()
+})
+
+describe('Root bootstrap integration coverage', () => {
+  it('shows Google login on first load when auth is enabled and no token is stored', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: true,
+          google_client_id: 'client-123',
+          disable_auth: false
+        }),
+        getStoredAuthToken: vi.fn(() => null)
+      }
+    })
+
+    vi.doMock('@/LoginPage', () => ({
+      default: ({ clientId }: { clientId: string }) => (
+        <div data-testid="login-page">Login ready for {clientId}</div>
+      )
+    }))
+
+    const { container } = await mountRoot()
+
+    expect(await screen.findByTestId('login-page')).toHaveTextContent('client-123')
+    expect(container.querySelector('[data-testid="route-bootstrap-marker"]'))
+      .toHaveAttribute('data-mode', 'group')
+    expect(container.querySelector('[data-testid="route-bootstrap-marker"]'))
+      .toHaveAttribute('data-route-state', 'auth')
+  })
+
+  it('restores local-login identity and renders the app when auth is disabled', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: false,
+          google_client_id: '',
+          disable_auth: true,
+          local_login_email: 'demo@example.com'
+        }),
+        getStoredAuthToken: vi.fn(() => null)
+      }
+    })
+
+    vi.doMock('@/App.tsx', () => ({
+      default: () => <div data-testid="app-shell">App ready</div>
+    }))
+
+    await mountRoot()
+
+    expect(await screen.findByTestId('app-shell')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem('auth.user') ?? '{}')).toMatchObject({
+        email: 'demo@example.com'
+      })
+    )
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem('user.profile') ?? '{}')).toMatchObject({
+        email: 'demo@example.com'
+      })
+    )
+  })
+
+  it('restores stored user context when a token is already present', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    localStorage.setItem('authToken', 'stale-but-present')
+    localStorage.setItem('auth.user', JSON.stringify({ email: 'saved@example.com' }))
+    localStorage.setItem('user.profile', JSON.stringify({ email: 'saved@example.com', name: 'Saved User' }))
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: true,
+          google_client_id: 'client-123',
+          disable_auth: false
+        }),
+        getStoredAuthToken: vi.fn(() => 'stale-but-present')
+      }
+    })
+
+    vi.doMock('@/App.tsx', async () => {
+      const React = await import('react')
+      const { useAuth } = await import('@/AuthContext')
+      const { useUser } = await import('@/UserContext')
+      function RestoredSessionApp() {
+        const { user } = useAuth()
+        const { profile } = useUser()
+        return (
+          <div data-testid="restored-session">
+            {user?.email} / {profile?.name}
+          </div>
+        )
+      }
+
+      return {
+        default: RestoredSessionApp
+      }
+    })
+
+    await mountRoot()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('restored-session')).toHaveTextContent(
+        'saved@example.com / Saved User',
+      )
+    )
+    expect(screen.queryByTestId('login-page')).not.toBeInTheDocument()
+  })
+
+  it('schedules a retry after config failure and cancels it on unmount', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    const getConfig = vi.fn().mockRejectedValue(new Error('network down'))
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig,
+        getStoredAuthToken: vi.fn(() => null)
+      }
+    })
+
+    vi.doMock('@/App.tsx', () => ({
+      default: () => <div data-testid="app-shell">App ready</div>
+    }))
+
+    try {
+      const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+      const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+      const view = await mountRoot()
+
+      await waitFor(() => expect(getConfig).toHaveBeenCalledTimes(1))
+      await waitFor(() =>
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000)
+      )
+
+      view.unmount()
+
+      expect(clearTimeoutSpy).toHaveBeenCalled()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+})

--- a/tests/backend/routes/test_config.py
+++ b/tests/backend/routes/test_config.py
@@ -56,6 +56,42 @@ def _spy_validate(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[bool | None, st
 pytestmark = pytest.mark.asyncio
 
 
+async def test_read_config_exposes_auth_enabled_bootstrap_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_config = routes_config.config_module.Config(
+        google_auth_enabled=True,
+        google_client_id="client-123",
+        disable_auth=False,
+        allowed_emails=["user@example.com"],
+        local_login_email=None,
+    )
+    monkeypatch.setattr(routes_config.config_module, "config", dummy_config)
+
+    result = await routes_config.read_config()
+
+    assert result["google_auth_enabled"] is True
+    assert result["google_client_id"] == "client-123"
+    assert result["disable_auth"] is False
+    assert result["allowed_emails"] == ["user@example.com"]
+    assert result["local_login_email"] is None
+
+
+async def test_read_config_exposes_auth_disabled_local_login_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_config = routes_config.config_module.Config(
+        google_auth_enabled=False,
+        google_client_id=None,
+        disable_auth=True,
+        local_login_email="demo@example.com",
+    )
+    monkeypatch.setattr(routes_config.config_module, "config", dummy_config)
+
+    result = await routes_config.read_config()
+
+    assert result["google_auth_enabled"] is False
+    assert result["google_client_id"] is None
+    assert result["disable_auth"] is True
+    assert result["local_login_email"] == "demo@example.com"
+
+
 async def test_update_config_rejects_invalid_google_auth_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     _write_config(config_path)


### PR DESCRIPTION
### Motivation
- Increase test coverage around the frontend bootstrap flow that decides whether to show the Google login gate, restore local-login identity when auth is disabled, or restore a stored session token, as called out in issue Closes #2408.
- Validate that the backend `/config` read surface exposes the specific auth/bootstrap fields consumed by the frontend so regressions in shape/values are caught early.
- Add a focused smoke scenario that verifies redirect/bootstrap behaviour when navigating to `/portfolio` with a single owner available.

### Description
- Added a new frontend unit integration test `frontend/tests/unit/rootBootstrap.test.tsx` that exercises: auth-enabled first load (Google login), auth-disabled local-login restoration, stored-token restoration, and config-retry scheduling/cancellation in `Root`.
- Extended the Playwright smoke suite `frontend/tests/smoke.spec.ts` with a `bootstrap to portfolio happy path` test that intercepts `/config`, `/owners`, `/groups`, and `/portfolio/demo-owner` and asserts navigation to `/portfolio/demo-owner` and presence of the route marker and owner selector.
- Added two backend route tests in `tests/backend/routes/test_config.py` to assert that `read_config()` exposes `google_auth_enabled`, `google_client_id`, `disable_auth`, `allowed_emails`, and `local_login_email` as expected for both auth-enabled and auth-disabled shapes.

### Testing
- Ran the new frontend unit integration test via `npm --prefix frontend run test -- --run tests/unit/rootBootstrap.test.tsx` and all tests in that file passed (4/4 passed).
- Executed direct Python assertions against `backend/routes/config.py` `read_config()` permutations (via a small import-and-run script) and they passed, confirming the backend route returns the expected bootstrap fields.
- Ran `npm --prefix frontend run lint` which surfaced a number of pre-existing frontend lint warnings/errors unrelated to these changes; these were left as-is and did not block this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff5c336ec8327a69715addb8eab33)