### PR TITLE
Refactor InstrumentTable: extract state hook and utilities

### DIFF
--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type Dispatch, type ReactNode, type SetStateAction } from 'react';
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { InstrumentGroupDefinition, InstrumentSummary } from '../types';
 import { useFilterableTable } from '../hooks/useFilterableTable';
@@ -6,12 +6,9 @@ import { money, percent } from '../lib/money';
 import { translateInstrumentType } from '../lib/instrumentType';
 import { formatDateISO } from '../lib/date';
 import tableStyles from '../styles/table.module.css';
-import statusStyles from '../styles/status.module.css';
-import i18n from '../i18n';
 import { useConfig } from '../ConfigContext';
 import { isSupportedFx } from '../lib/fx';
 import { RelativeViewToggle } from './RelativeViewToggle';
-import { isCashInstrument } from '../lib/instruments';
 import {
   assignInstrumentGroup,
   clearInstrumentGroup,
@@ -20,243 +17,54 @@ import {
   listInstrumentGroupingDefinitions,
 } from '../api';
 import { useNavigate } from 'react-router-dom';
+import { useInstrumentTableState } from './instrumentTable/useInstrumentTableState';
+import {
+  cashFirstComparator,
+  createGroups,
+  formatSignedMoney,
+  formatSignedPercent,
+  formatUnits,
+  getStatusPresentation,
+  mergeGroupOptions,
+  sanitizeGroupKey,
+  splitTickerParts,
+  calculateGroupTotals,
+} from './instrumentTable/utils';
+import type { RowWithCost } from './instrumentTable/types';
 
 type Props = {
   rows: InstrumentSummary[];
   showGroupTotals?: boolean;
 };
 
-type RowWithCost = InstrumentSummary & {
-  cost: number;
-  gain_pct: number;
-};
-
-type GroupTotals = {
-  labelValue: string;
-  units: number;
-  cost: number;
-  marketValue: number;
-  gain: number;
-  gainPct: number | null;
-  change7dPct: number | null;
-  change30dPct: number | null;
-};
-
-type GroupedRows = {
-  key: string;
-  label: string;
-  rows: RowWithCost[];
-  totals: GroupTotals;
-};
-
-type GroupingMode = 'group' | 'flat' | 'category';
-
-const UNGROUPED_KEY = '__ungrouped__';
-const GROUP_SUMMARY_SORT_MAP: Partial<Record<keyof RowWithCost, keyof GroupTotals>> = {
-  ticker: 'labelValue',
-  name: 'labelValue',
-  currency: 'labelValue',
-  instrument_type: 'labelValue',
-  units: 'units',
-  cost: 'cost',
-  market_value_gbp: 'marketValue',
-  gain_gbp: 'gain',
-  change_7d_pct: 'change7dPct',
-  change_30d_pct: 'change30dPct',
-  gain_pct: 'gainPct',
-};
-
 export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
   const { t } = useTranslation();
   const { relativeViewEnabled, baseCurrency } = useConfig();
-  const [visibleColumns, setVisibleColumns] = useState({
-    units: true,
-    cost: true,
-    market: true,
-    gain: true,
-    gain_pct: true,
-  });
-  const [groupOptions, setGroupOptions] = useState<string[]>([]);
-  const [groupOverrides, setGroupOverrides] = useState<Record<string, string | null | undefined>>({});
-  const [pendingGroupTicker, setPendingGroupTicker] = useState<string | null>(null);
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set());
   const [groupDefinitions, setGroupDefinitions] = useState<InstrumentGroupDefinition[]>([]);
-  const [groupingMode, setGroupingMode] = useState<GroupingMode>('group');
   const navigate = useNavigate();
-
-  const exchanges = useMemo(() => {
-    const values = new Set<string>();
-    for (const row of rows) {
-      const exchange = row.exchange?.trim();
-      if (exchange) {
-        values.add(exchange);
-      }
-    }
-    return Array.from(values).sort((a, b) => a.localeCompare(b));
-  }, [rows]);
-
-  const [selectedExchanges, setSelectedExchanges] = useState<string[]>(() => [...exchanges]);
-
-  useEffect(() => {
-    setSelectedExchanges((prev) => {
-      const prevSet = new Set(prev);
-      const availableSet = new Set(exchanges);
-      let changed = false;
-      const next: string[] = [];
-
-      for (const value of prev) {
-        if (availableSet.has(value)) {
-          next.push(value);
-        } else {
-          changed = true;
-        }
-      }
-
-      for (const value of exchanges) {
-        if (!prevSet.has(value)) {
-          next.push(value);
-          changed = true;
-        }
-      }
-
-      if (!changed) {
-        return prev;
-      }
-
-      return next;
-    });
-  }, [exchanges]);
-
-  const toggleExchangeSelection = (exchange: string) => {
-    setSelectedExchanges((prev) => {
-      const nextSet = new Set(prev);
-      if (nextSet.has(exchange)) {
-        nextSet.delete(exchange);
-      } else {
-        nextSet.add(exchange);
-      }
-
-      return exchanges.filter((value) => nextSet.has(value));
-    });
-  };
-
-  const toggleColumn = (key: keyof typeof visibleColumns) => {
-    setVisibleColumns((prev) => ({ ...prev, [key]: !prev[key] }));
-  };
-
-  const filteredRows = useMemo(
-    () => {
-      if (!rows.length) {
-        return [];
-      }
-      if (!exchanges.length) {
-        return rows;
-      }
-      if (!selectedExchanges.length) {
-        return [];
-      }
-      const selectedSet = new Set(selectedExchanges);
-      return rows.filter((row) => {
-        const exchange = row.exchange?.trim();
-        if (!exchange) {
-          return true;
-        }
-        return selectedSet.has(exchange);
-      });
-    },
-    [rows, exchanges, selectedExchanges],
-  );
-
-  const rowsWithCost = useMemo<RowWithCost[]>(
-    () =>
-      filteredRows.map((r) => {
-        const cost = r.market_value_gbp - r.gain_gbp;
-        const gain_pct =
-          r.gain_pct !== undefined && r.gain_pct !== null
-            ? r.gain_pct
-            : cost
-              ? (r.gain_gbp / cost) * 100
-              : 0;
-        return { ...r, cost, gain_pct };
-      }),
-    [filteredRows],
-  );
-
-  const categoryLookup = useMemo(
-    () => {
-      const byGroup = new Map<string, { key: string; label: string }>();
-      const categories = new Map<string, string>();
-
-      for (const definition of groupDefinitions) {
-        const rawCategory =
-          typeof definition.category === 'string' ? definition.category.trim() : '';
-        if (!rawCategory) continue;
-        const categoryKey = rawCategory.toLocaleLowerCase();
-        const categoryLabel =
-          typeof definition.category_name === 'string' && definition.category_name.trim()
-            ? definition.category_name.trim()
-            : formatCategoryLabel(rawCategory);
-        if (!categories.has(categoryKey)) {
-          categories.set(categoryKey, categoryLabel);
-        }
-
-        const aliasValues: string[] = [];
-        if (typeof definition.id === 'string') {
-          aliasValues.push(definition.id);
-        }
-        if (typeof definition.name === 'string') {
-          aliasValues.push(definition.name);
-        }
-        if (Array.isArray(definition.aliases)) {
-          for (const alias of definition.aliases) {
-            if (typeof alias === 'string') {
-              aliasValues.push(alias);
-            }
-          }
-        }
-
-        for (const alias of aliasValues) {
-          const trimmed = alias.trim();
-          if (!trimmed) continue;
-          const key = trimmed.toLocaleLowerCase();
-          if (!key) continue;
-          if (!byGroup.has(key)) {
-            byGroup.set(key, { key: categoryKey, label: categoryLabel });
-          }
-        }
-      }
-
-      return { byGroup, categories };
-    },
-    [groupDefinitions],
-  );
-
-  const cashFirstComparator = useCallback(
-    (
-      a: RowWithCost,
-      b: RowWithCost,
-      _sortKey: keyof RowWithCost,
-      _asc: boolean,
-    ) => {
-      const aCash = isCashInstrument(a);
-      const bCash = isCashInstrument(b);
-      if (aCash && !bCash) {
-        return -1;
-      }
-      if (!aCash && bCash) {
-        return 1;
-      }
-      return 0;
-    },
-    [],
-  );
-
-  const { rows: sorted, sortKey, asc, handleSort } = useFilterableTable(
+  const {
+    categoryLookup,
+    exchanges,
+    expandedGroups,
+    groupOptions,
+    groupOverrides,
+    groupingMode,
+    hasCategories,
+    pendingGroupTicker,
     rowsWithCost,
-    'ticker',
-    {},
-    cashFirstComparator,
-  );
+    selectedExchanges,
+    setExpandedGroups,
+    setGroupOptions,
+    setGroupOverrides,
+    setGroupingMode,
+    setPendingGroupTicker,
+    toggleColumn,
+    toggleExchangeSelection,
+    visibleColumns,
+  } = useInstrumentTableState(rows, groupDefinitions);
+
+  const comparator = useCallback((a: RowWithCost, b: RowWithCost) => cashFirstComparator(a, b), []);
+  const { rows: sorted, sortKey, asc, handleSort } = useFilterableTable(rowsWithCost, 'ticker', {}, comparator);
 
   const ungroupedLabel = t('instrumentTable.ungrouped', {
     defaultValue: 'Ungrouped',
@@ -264,44 +72,10 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
   const uncategorisedLabel = t('instrumentTable.uncategorised', {
     defaultValue: 'Uncategorised',
   });
-  const groups = useMemo<ReadonlyArray<GroupedRows>>(() => {
-    if (!sorted.length) {
-      return [];
-    }
-    if (groupingMode === 'flat') {
-      return createGroupedRows(sorted, sortKey, asc, {
-        ungroupedLabel: '',
-        getGroupKey: () => 'all',
-        getGroupLabel: () => '',
-      });
-    }
-    if (groupingMode === 'category') {
-      return createGroupedRows(sorted, sortKey, asc, {
-        ungroupedLabel: uncategorisedLabel,
-        getGroupKey: (row) => {
-          const base = row.grouping?.trim();
-          if (!base) return null;
-          const entry = categoryLookup.byGroup.get(base.toLocaleLowerCase());
-          return entry?.key ?? null;
-        },
-        getGroupLabel: ({ key }) =>
-          categoryLookup.categories.get(key) ?? formatCategoryLabel(key),
-      });
-    }
-    return createGroupedRows(sorted, sortKey, asc, {
-      ungroupedLabel,
-      getGroupKey: (row) => row.grouping ?? null,
-      getGroupLabel: ({ raw }) => raw,
-    });
-  }, [asc, categoryLookup, groupingMode, sorted, sortKey, uncategorisedLabel, ungroupedLabel]);
-
-  const hasCategories = categoryLookup.categories.size > 0;
-
-  useEffect(() => {
-    if (groupingMode === 'category' && !hasCategories) {
-      setGroupingMode('group');
-    }
-  }, [groupingMode, hasCategories]);
+  const groups = createGroups(sorted, sortKey, asc, groupingMode, {
+    ungroupedLabel,
+    uncategorisedLabel,
+  }, categoryLookup);
 
   const handleGroupingModeChange = (value: string) => {
     if (value === 'group' || value === 'flat' || value === 'category') {
@@ -310,11 +84,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
   };
 
   const totalLabel = t('holdingsTable.totalRowLabel');
-
-  const overallTotals = useMemo(
-    () => calculateGroupTotals(rowsWithCost, totalLabel),
-    [rowsWithCost, totalLabel],
-  );
+  const overallTotals = calculateGroupTotals(rowsWithCost, totalLabel);
 
   useEffect(() => {
     let cancelled = false;
@@ -324,13 +94,12 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
         setGroupOptions(mergeGroupOptions([], fetched));
       })
       .catch((err) => {
-        // eslint-disable-next-line no-console
         console.error('Failed to load instrument groups', err);
       });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [setGroupOptions]);
 
   useEffect(() => {
     let cancelled = false;
@@ -340,7 +109,6 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
         setGroupDefinitions(fetched);
       })
       .catch((err) => {
-        // eslint-disable-next-line no-console
         console.error('Failed to load instrument group definitions', err);
       });
     return () => {
@@ -348,31 +116,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
     };
   }, []);
 
-  useEffect(() => {
-    setGroupOverrides({});
-    setGroupOptions((prev) => mergeGroupOptions(prev, rows.map((r) => r.grouping ?? null)));
-  }, [rows]);
 
-  useEffect(() => {
-    if (!groupDefinitions.length) {
-      return;
-    }
-    const names = groupDefinitions
-      .map((definition) => {
-        if (typeof definition.name === 'string' && definition.name.trim()) {
-          return definition.name;
-        }
-        if (typeof definition.id === 'string' && definition.id.trim()) {
-          return definition.id;
-        }
-        return null;
-      })
-      .filter((value): value is string => value !== null);
-    if (!names.length) {
-      return;
-    }
-    setGroupOptions((prev) => mergeGroupOptions(prev, names));
-  }, [groupDefinitions]);
 
   if (!rows.length) {
     return <p>{t('instrumentTable.noInstruments')}</p>;
@@ -631,7 +375,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
                   {!relativeViewEnabled && visibleColumns.units && (
                     <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>
                       {showGroupTotals && Number.isFinite(group.totals.units)
-                        ? new Intl.NumberFormat(i18n.language).format(group.totals.units)
+                        ? formatUnits(group.totals.units)
                         : '—'}
                     </td>
                   )}
@@ -743,7 +487,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
                       </td>
                       {!relativeViewEnabled && visibleColumns.units && (
                         <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                          {new Intl.NumberFormat(i18n.language).format(r.units)}
+                          {formatUnits(r.units)}
                         </td>
                       )}
                       {!relativeViewEnabled && visibleColumns.cost && (
@@ -866,7 +610,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
             {!relativeViewEnabled && visibleColumns.units && (
               <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
                 {Number.isFinite(overallTotals.units)
-                  ? new Intl.NumberFormat(i18n.language).format(overallTotals.units)
+                  ? formatUnits(overallTotals.units)
                   : '—'}
               </td>
             )}
@@ -920,180 +664,6 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
   );
 }
 
-type GroupingOptions = {
-  ungroupedLabel: string;
-  getGroupKey: (row: RowWithCost) => string | null | undefined;
-  getGroupLabel?: (input: { key: string; raw: string; row: RowWithCost }) =>
-    | string
-    | null
-    | undefined;
-};
-
-function createGroupedRows(
-  rows: RowWithCost[],
-  sortKey: keyof RowWithCost,
-  asc: boolean,
-  options: GroupingOptions,
-): GroupedRows[] {
-  if (!rows.length) {
-    return [];
-  }
-
-  const map = new Map<string, { key: string; label: string; rows: RowWithCost[] }>();
-  const ordered: { key: string; label: string; rows: RowWithCost[] }[] = [];
-
-  for (const row of rows) {
-    const rawKey = options.getGroupKey(row);
-    const trimmed = typeof rawKey === 'string' ? rawKey.trim() : '';
-    const key = trimmed ? trimmed.toLocaleLowerCase() : UNGROUPED_KEY;
-    let group = map.get(key);
-    if (!group) {
-      const label =
-        key === UNGROUPED_KEY
-          ? options.ungroupedLabel
-          : options.getGroupLabel?.({
-                key,
-                raw: trimmed,
-                row,
-              }) ?? (trimmed || options.ungroupedLabel);
-      group = {
-        key,
-        label,
-        rows: [],
-      };
-      map.set(key, group);
-      ordered.push(group);
-    }
-    group.rows.push(row);
-  }
-
-  const groups = ordered.map((group) => ({
-    key: group.key,
-    label: group.label,
-    rows: group.rows,
-    totals: calculateGroupTotals(group.rows, group.label),
-  }));
-
-  const totalsKey = GROUP_SUMMARY_SORT_MAP[sortKey];
-  if (totalsKey) {
-    groups.sort((a, b) => {
-      const va = a.totals[totalsKey];
-      const vb = b.totals[totalsKey];
-
-      if (typeof va === 'string' || typeof vb === 'string') {
-        const sa = typeof va === 'string' ? va : '';
-        const sb = typeof vb === 'string' ? vb : '';
-        const cmp = sa.localeCompare(sb);
-        return asc ? cmp : -cmp;
-      }
-
-      const toNumeric = (value: unknown) =>
-        typeof value === 'number' && Number.isFinite(value) ? value : 0;
-
-      const na = toNumeric(va);
-      const nb = toNumeric(vb);
-      if (na === nb) {
-        return 0;
-      }
-      return asc ? na - nb : nb - na;
-    });
-  }
-
-  return groups;
-}
-
-function formatCategoryLabel(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed
-    .split(/[^A-Za-z0-9]+/u)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toLocaleUpperCase() + part.slice(1))
-    .join(' ');
-}
-
-function sanitizeGroupKey(key: string): string {
-  const sanitized = key.replace(/[^a-zA-Z0-9_-]/g, '-');
-  return sanitized || 'group';
-}
-
-function calculateGroupTotals(rows: RowWithCost[], label: string): GroupTotals {
-  const totalUnits = rows.reduce((sum, row) => sum + (row.units ?? 0), 0);
-  const totalMarket = rows.reduce((sum, row) => sum + row.market_value_gbp, 0);
-  const totalGain = rows.reduce((sum, row) => sum + row.gain_gbp, 0);
-  const totalCost = rows.reduce((sum, row) => sum + row.cost, 0);
-
-  const gainPct = Math.abs(totalCost) > 1e-9 ? (totalGain / totalCost) * 100 : null;
-
-  const weightedAverage = (
-    accessor: (row: RowWithCost) => number | null | undefined,
-  ): number | null => {
-    let numerator = 0;
-    let denominator = 0;
-
-    for (const row of rows) {
-      const value = accessor(row);
-      if (value == null || !Number.isFinite(value)) continue;
-      const weight = row.market_value_gbp;
-      if (!Number.isFinite(weight) || weight === 0) continue;
-      numerator += value * weight;
-      denominator += weight;
-    }
-
-    return denominator ? numerator / denominator : null;
-  };
-
-  return {
-    labelValue: label,
-    units: totalUnits,
-    cost: totalCost,
-    marketValue: totalMarket,
-    gain: totalGain,
-    gainPct,
-    change7dPct: weightedAverage((row) => row.change_7d_pct),
-    change30dPct: weightedAverage((row) => row.change_30d_pct),
-  };
-}
-
-type StatusVariant = 'positive' | 'negative' | 'neutral';
-
-const STATUS_CLASS_MAP: Record<StatusVariant, string> = {
-  positive: statusStyles.positive,
-  negative: statusStyles.negative,
-  neutral: statusStyles.neutral,
-};
-
-function classifyStatus(value: number | null | undefined): StatusVariant {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value === 0) {
-    return 'neutral';
-  }
-
-  return value > 0 ? 'positive' : 'negative';
-}
-
-function getStatusPresentation(
-  value: number | null | undefined,
-): { className: string; prefix: string } {
-  const variant = classifyStatus(value);
-  const prefix = variant === 'positive' ? '▲' : variant === 'negative' ? '▼' : '';
-
-  return { className: STATUS_CLASS_MAP[variant], prefix };
-}
-
-function formatSignedMoney(value: number, currency: string): ReactNode {
-  const { className, prefix } = getStatusPresentation(value);
-  const display = money(value, currency);
-  return <span className={className}>{`${prefix}${display}`}</span>;
-}
-
-function formatSignedPercent(value: number | null | undefined): ReactNode {
-  const { className, prefix } = getStatusPresentation(value);
-  const display = percent(value, 1);
-  return <span className={className}>{`${prefix}${display}`}</span>;
-}
-
 type GroupOverridesMap = Record<string, string | null | undefined>;
 
 async function handleGroupSelection(
@@ -1127,7 +697,6 @@ async function handleGroupSelection(
         setOptions((prev) => mergeGroupOptions(prev, [applied]));
       }
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.error('Failed to create group', err);
     } finally {
       setPending(null);
@@ -1141,7 +710,6 @@ async function handleGroupSelection(
       await clearInstrumentGroup(ticker, exchange);
       setOverrides((prev) => ({ ...prev, [fullTicker]: null }));
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.error('Failed to clear group', err);
     } finally {
       setPending(null);
@@ -1160,38 +728,9 @@ async function handleGroupSelection(
       setOptions((prev) => mergeGroupOptions(prev, [applied]));
     }
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error('Failed to assign group', err);
   } finally {
     setPending(null);
   }
 }
 
-function mergeGroupOptions(
-  base: Iterable<string>,
-  extras: Iterable<string | null | undefined>,
-): string[] {
-  const map = new Map<string, string>();
-  for (const value of base) {
-    if (typeof value !== 'string') continue;
-    const trimmed = value.trim();
-    if (!trimmed) continue;
-    const key = trimmed.toLocaleLowerCase();
-    if (!map.has(key)) map.set(key, trimmed);
-  }
-  for (const value of extras) {
-    if (typeof value !== 'string') continue;
-    const trimmed = value.trim();
-    if (!trimmed) continue;
-    const key = trimmed.toLocaleLowerCase();
-    if (!map.has(key)) map.set(key, trimmed);
-  }
-  return Array.from(map.values()).sort((a, b) => a.localeCompare(b));
-}
-
-function splitTickerParts(value: string): { ticker: string; exchange: string } {
-  const [sym, exch] = value.split('.', 2);
-  const ticker = sym?.trim() ?? '';
-  const exchange = (exch?.trim() ?? 'L') || 'L';
-  return { ticker, exchange };
-}

--- a/frontend/src/components/instrumentTable/types.ts
+++ b/frontend/src/components/instrumentTable/types.ts
@@ -1,0 +1,34 @@
+import type { InstrumentSummary } from '@/types';
+
+export type RowWithCost = InstrumentSummary & {
+  cost: number;
+  gain_pct: number;
+};
+
+export type GroupTotals = {
+  labelValue: string;
+  units: number;
+  cost: number;
+  marketValue: number;
+  gain: number;
+  gainPct: number | null;
+  change7dPct: number | null;
+  change30dPct: number | null;
+};
+
+export type GroupedRows = {
+  key: string;
+  label: string;
+  rows: RowWithCost[];
+  totals: GroupTotals;
+};
+
+export type GroupingMode = 'group' | 'flat' | 'category';
+
+export type VisibleColumns = {
+  units: boolean;
+  cost: boolean;
+  market: boolean;
+  gain: boolean;
+  gain_pct: boolean;
+};

--- a/frontend/src/components/instrumentTable/useInstrumentTableState.ts
+++ b/frontend/src/components/instrumentTable/useInstrumentTableState.ts
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { InstrumentGroupDefinition, InstrumentSummary } from '@/types';
+import {
+  buildCategoryLookup,
+  collectExchanges,
+  createRowsWithCost,
+  filterRowsByExchange,
+  mergeGroupOptions,
+} from './utils';
+import type { GroupingMode, VisibleColumns } from './types';
+
+const DEFAULT_VISIBLE_COLUMNS: VisibleColumns = {
+  units: true,
+  cost: true,
+  market: true,
+  gain: true,
+  gain_pct: true,
+};
+
+export function useInstrumentTableState(
+  rows: InstrumentSummary[],
+  groupDefinitions: InstrumentGroupDefinition[],
+) {
+  const [visibleColumns, setVisibleColumns] = useState<VisibleColumns>(DEFAULT_VISIBLE_COLUMNS);
+  const [groupOptions, setGroupOptions] = useState<string[]>([]);
+  const [groupOverrides, setGroupOverrides] = useState<Record<string, string | null | undefined>>({});
+  const [pendingGroupTicker, setPendingGroupTicker] = useState<string | null>(null);
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set());
+  const [groupingMode, setGroupingMode] = useState<GroupingMode>('group');
+
+  const exchanges = useMemo(() => collectExchanges(rows), [rows]);
+  const [selectedExchanges, setSelectedExchanges] = useState<string[]>(() => [...exchanges]);
+
+  useEffect(() => {
+    setSelectedExchanges((prev) => {
+      const prevSet = new Set(prev);
+      const availableSet = new Set(exchanges);
+      let changed = false;
+      const next: string[] = [];
+
+      for (const value of prev) {
+        if (availableSet.has(value)) {
+          next.push(value);
+        } else {
+          changed = true;
+        }
+      }
+
+      for (const value of exchanges) {
+        if (!prevSet.has(value)) {
+          next.push(value);
+          changed = true;
+        }
+      }
+
+      return changed ? next : prev;
+    });
+  }, [exchanges]);
+
+  useEffect(() => {
+    setGroupOverrides({});
+    setGroupOptions((prev) => mergeGroupOptions(prev, rows.map((row) => row.grouping ?? null)));
+  }, [rows]);
+
+  useEffect(() => {
+    if (!groupDefinitions.length) return;
+    const names = groupDefinitions
+      .map((definition) => {
+        if (typeof definition.name === 'string' && definition.name.trim()) return definition.name;
+        if (typeof definition.id === 'string' && definition.id.trim()) return definition.id;
+        return null;
+      })
+      .filter((value): value is string => value !== null);
+    if (!names.length) return;
+    setGroupOptions((prev) => mergeGroupOptions(prev, names));
+  }, [groupDefinitions]);
+
+  const filteredRows = useMemo(
+    () => filterRowsByExchange(rows, exchanges, selectedExchanges),
+    [rows, exchanges, selectedExchanges],
+  );
+  const rowsWithCost = useMemo(() => createRowsWithCost(filteredRows), [filteredRows]);
+  const categoryLookup = useMemo(() => buildCategoryLookup(groupDefinitions), [groupDefinitions]);
+  const hasCategories = categoryLookup.categories.size > 0;
+
+  useEffect(() => {
+    if (groupingMode === 'category' && !hasCategories) {
+      setGroupingMode('group');
+    }
+  }, [groupingMode, hasCategories]);
+
+  const toggleExchangeSelection = (exchange: string) => {
+    setSelectedExchanges((prev) => {
+      const nextSet = new Set(prev);
+      if (nextSet.has(exchange)) nextSet.delete(exchange);
+      else nextSet.add(exchange);
+      return exchanges.filter((value) => nextSet.has(value));
+    });
+  };
+
+  const toggleColumn = (key: keyof VisibleColumns) => {
+    setVisibleColumns((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  return {
+    categoryLookup,
+    exchanges,
+    expandedGroups,
+    filteredRows,
+    groupOptions,
+    groupOverrides,
+    groupingMode,
+    hasCategories,
+    pendingGroupTicker,
+    rowsWithCost,
+    selectedExchanges,
+    setExpandedGroups,
+    setGroupOptions,
+    setGroupOverrides,
+    setGroupingMode,
+    setPendingGroupTicker,
+    toggleColumn,
+    toggleExchangeSelection,
+    visibleColumns,
+  };
+}

--- a/frontend/src/components/instrumentTable/utils.tsx
+++ b/frontend/src/components/instrumentTable/utils.tsx
@@ -1,0 +1,308 @@
+import type { ReactNode } from 'react';
+import { money, percent } from '@/lib/money';
+import { isCashInstrument } from '@/lib/instruments';
+import i18n from '@/i18n';
+import statusStyles from '@/styles/status.module.css';
+import type { InstrumentGroupDefinition, InstrumentSummary } from '@/types';
+import type { GroupedRows, GroupingMode, GroupTotals, RowWithCost } from './types';
+
+const UNGROUPED_KEY = '__ungrouped__';
+
+const GROUP_SUMMARY_SORT_MAP: Partial<Record<keyof RowWithCost, keyof GroupTotals>> = {
+  ticker: 'labelValue',
+  name: 'labelValue',
+  currency: 'labelValue',
+  instrument_type: 'labelValue',
+  units: 'units',
+  cost: 'cost',
+  market_value_gbp: 'marketValue',
+  gain_gbp: 'gain',
+  change_7d_pct: 'change7dPct',
+  change_30d_pct: 'change30dPct',
+  gain_pct: 'gainPct',
+};
+
+export function collectExchanges(rows: InstrumentSummary[]): string[] {
+  const values = new Set<string>();
+  for (const row of rows) {
+    const exchange = row.exchange?.trim();
+    if (exchange) {
+      values.add(exchange);
+    }
+  }
+  return Array.from(values).sort((a, b) => a.localeCompare(b));
+}
+
+export function filterRowsByExchange(
+  rows: InstrumentSummary[],
+  exchanges: string[],
+  selectedExchanges: string[],
+): InstrumentSummary[] {
+  if (!rows.length) return [];
+  if (!exchanges.length) return rows;
+  if (!selectedExchanges.length) return [];
+  const selectedSet = new Set(selectedExchanges);
+  return rows.filter((row) => {
+    const exchange = row.exchange?.trim();
+    if (!exchange) return true;
+    return selectedSet.has(exchange);
+  });
+}
+
+export function createRowsWithCost(rows: InstrumentSummary[]): RowWithCost[] {
+  return rows.map((row) => {
+    const cost = row.market_value_gbp - row.gain_gbp;
+    const gain_pct =
+      row.gain_pct !== undefined && row.gain_pct !== null
+        ? row.gain_pct
+        : cost
+          ? (row.gain_gbp / cost) * 100
+          : 0;
+    return { ...row, cost, gain_pct };
+  });
+}
+
+export function buildCategoryLookup(groupDefinitions: InstrumentGroupDefinition[]) {
+  const byGroup = new Map<string, { key: string; label: string }>();
+  const categories = new Map<string, string>();
+
+  for (const definition of groupDefinitions) {
+    const rawCategory = typeof definition.category === 'string' ? definition.category.trim() : '';
+    if (!rawCategory) continue;
+
+    const categoryKey = rawCategory.toLocaleLowerCase();
+    const categoryLabel =
+      typeof definition.category_name === 'string' && definition.category_name.trim()
+        ? definition.category_name.trim()
+        : formatCategoryLabel(rawCategory);
+    if (!categories.has(categoryKey)) {
+      categories.set(categoryKey, categoryLabel);
+    }
+
+    const aliasValues: string[] = [];
+    if (typeof definition.id === 'string') aliasValues.push(definition.id);
+    if (typeof definition.name === 'string') aliasValues.push(definition.name);
+    if (Array.isArray(definition.aliases)) {
+      for (const alias of definition.aliases) {
+        if (typeof alias === 'string') aliasValues.push(alias);
+      }
+    }
+
+    for (const alias of aliasValues) {
+      const trimmed = alias.trim();
+      if (!trimmed) continue;
+      const key = trimmed.toLocaleLowerCase();
+      if (!byGroup.has(key)) {
+        byGroup.set(key, { key: categoryKey, label: categoryLabel });
+      }
+    }
+  }
+
+  return { byGroup, categories };
+}
+
+type GroupingOptions = {
+  ungroupedLabel: string;
+  getGroupKey: (row: RowWithCost) => string | null | undefined;
+  getGroupLabel?: (input: { key: string; raw: string; row: RowWithCost }) => string | null | undefined;
+};
+
+export function createGroups(
+  rows: RowWithCost[],
+  sortKey: keyof RowWithCost,
+  asc: boolean,
+  groupingMode: GroupingMode,
+  labels: { ungroupedLabel: string; uncategorisedLabel: string },
+  categoryLookup: ReturnType<typeof buildCategoryLookup>,
+): ReadonlyArray<GroupedRows> {
+  if (!rows.length) return [];
+
+  if (groupingMode === 'flat') {
+    return createGroupedRows(rows, sortKey, asc, {
+      ungroupedLabel: '',
+      getGroupKey: () => 'all',
+      getGroupLabel: () => '',
+    });
+  }
+
+  if (groupingMode === 'category') {
+    return createGroupedRows(rows, sortKey, asc, {
+      ungroupedLabel: labels.uncategorisedLabel,
+      getGroupKey: (row) => {
+        const base = row.grouping?.trim();
+        if (!base) return null;
+        const entry = categoryLookup.byGroup.get(base.toLocaleLowerCase());
+        return entry?.key ?? null;
+      },
+      getGroupLabel: ({ key }) => categoryLookup.categories.get(key) ?? formatCategoryLabel(key),
+    });
+  }
+
+  return createGroupedRows(rows, sortKey, asc, {
+    ungroupedLabel: labels.ungroupedLabel,
+    getGroupKey: (row) => row.grouping ?? null,
+    getGroupLabel: ({ raw }) => raw,
+  });
+}
+
+function createGroupedRows(
+  rows: RowWithCost[],
+  sortKey: keyof RowWithCost,
+  asc: boolean,
+  options: GroupingOptions,
+): GroupedRows[] {
+  const map = new Map<string, { key: string; label: string; rows: RowWithCost[] }>();
+  const ordered: { key: string; label: string; rows: RowWithCost[] }[] = [];
+
+  for (const row of rows) {
+    const rawKey = options.getGroupKey(row);
+    const trimmed = typeof rawKey === 'string' ? rawKey.trim() : '';
+    const key = trimmed ? trimmed.toLocaleLowerCase() : UNGROUPED_KEY;
+    let group = map.get(key);
+    if (!group) {
+      const label =
+        key === UNGROUPED_KEY
+          ? options.ungroupedLabel
+          : options.getGroupLabel?.({ key, raw: trimmed, row }) ?? (trimmed || options.ungroupedLabel);
+      group = { key, label, rows: [] };
+      map.set(key, group);
+      ordered.push(group);
+    }
+    group.rows.push(row);
+  }
+
+  const groups = ordered.map((group) => ({
+    key: group.key,
+    label: group.label,
+    rows: group.rows,
+    totals: calculateGroupTotals(group.rows, group.label),
+  }));
+
+  const totalsKey = GROUP_SUMMARY_SORT_MAP[sortKey];
+  if (totalsKey) {
+    groups.sort((a, b) => {
+      const va = a.totals[totalsKey];
+      const vb = b.totals[totalsKey];
+      if (typeof va === 'string' || typeof vb === 'string') {
+        const cmp = String(va ?? '').localeCompare(String(vb ?? ''));
+        return asc ? cmp : -cmp;
+      }
+      const na = typeof va === 'number' && Number.isFinite(va) ? va : 0;
+      const nb = typeof vb === 'number' && Number.isFinite(vb) ? vb : 0;
+      if (na === nb) return 0;
+      return asc ? na - nb : nb - na;
+    });
+  }
+
+  return groups;
+}
+
+export function formatCategoryLabel(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  return trimmed
+    .split(/[^A-Za-z0-9]+/u)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toLocaleUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function sanitizeGroupKey(key: string): string {
+  const sanitized = key.replace(/[^a-zA-Z0-9_-]/g, '-');
+  return sanitized || 'group';
+}
+
+export function calculateGroupTotals(rows: RowWithCost[], label: string): GroupTotals {
+  const totalUnits = rows.reduce((sum, row) => sum + (row.units ?? 0), 0);
+  const totalMarket = rows.reduce((sum, row) => sum + row.market_value_gbp, 0);
+  const totalGain = rows.reduce((sum, row) => sum + row.gain_gbp, 0);
+  const totalCost = rows.reduce((sum, row) => sum + row.cost, 0);
+  const gainPct = Math.abs(totalCost) > 1e-9 ? (totalGain / totalCost) * 100 : null;
+
+  const weightedAverage = (accessor: (row: RowWithCost) => number | null | undefined): number | null => {
+    let numerator = 0;
+    let denominator = 0;
+    for (const row of rows) {
+      const value = accessor(row);
+      if (value == null || !Number.isFinite(value)) continue;
+      const weight = row.market_value_gbp;
+      if (!Number.isFinite(weight) || weight === 0) continue;
+      numerator += value * weight;
+      denominator += weight;
+    }
+    return denominator ? numerator / denominator : null;
+  };
+
+  return {
+    labelValue: label,
+    units: totalUnits,
+    cost: totalCost,
+    marketValue: totalMarket,
+    gain: totalGain,
+    gainPct,
+    change7dPct: weightedAverage((row) => row.change_7d_pct),
+    change30dPct: weightedAverage((row) => row.change_30d_pct),
+  };
+}
+
+type StatusVariant = 'positive' | 'negative' | 'neutral';
+
+const STATUS_CLASS_MAP: Record<StatusVariant, string> = {
+  positive: statusStyles.positive,
+  negative: statusStyles.negative,
+  neutral: statusStyles.neutral,
+};
+
+export function cashFirstComparator(a: RowWithCost, b: RowWithCost): number {
+  const aCash = isCashInstrument(a);
+  const bCash = isCashInstrument(b);
+  if (aCash && !bCash) return -1;
+  if (!aCash && bCash) return 1;
+  return 0;
+}
+
+function classifyStatus(value: number | null | undefined): StatusVariant {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value === 0) {
+    return 'neutral';
+  }
+  return value > 0 ? 'positive' : 'negative';
+}
+
+export function getStatusPresentation(value: number | null | undefined): { className: string; prefix: string } {
+  const variant = classifyStatus(value);
+  const prefix = variant === 'positive' ? '▲' : variant === 'negative' ? '▼' : '';
+  return { className: STATUS_CLASS_MAP[variant], prefix };
+}
+
+export function formatSignedMoney(value: number, currency: string): ReactNode {
+  const { className, prefix } = getStatusPresentation(value);
+  return <span className={className}>{`${prefix}${money(value, currency)}`}</span>;
+}
+
+export function formatSignedPercent(value: number | null | undefined): ReactNode {
+  const { className, prefix } = getStatusPresentation(value);
+  return <span className={className}>{`${prefix}${percent(value, 1)}`}</span>;
+}
+
+export function mergeGroupOptions(base: Iterable<string>, extras: Iterable<string | null | undefined>): string[] {
+  const map = new Map<string, string>();
+  for (const value of [...base, ...extras]) {
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLocaleLowerCase();
+    if (!map.has(key)) map.set(key, trimmed);
+  }
+  return Array.from(map.values()).sort((a, b) => a.localeCompare(b));
+}
+
+export function splitTickerParts(value: string): { ticker: string; exchange: string } {
+  const [sym, exch] = value.split('.', 2);
+  const ticker = sym?.trim() ?? '';
+  const exchange = (exch?.trim() ?? 'L') || 'L';
+  return { ticker, exchange };
+}
+
+export function formatUnits(value: number): string {
+  return new Intl.NumberFormat(i18n.language).format(value);
+}

--- a/frontend/tests/unit/components/instrumentTable/useInstrumentTableState.test.tsx
+++ b/frontend/tests/unit/components/instrumentTable/useInstrumentTableState.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { InstrumentGroupDefinition, InstrumentSummary } from '@/types';
+import { useInstrumentTableState } from '@/components/instrumentTable/useInstrumentTableState';
+
+const rows: InstrumentSummary[] = [
+  {
+    ticker: 'AAA',
+    name: 'Alpha',
+    grouping: 'Dividend Growth',
+    exchange: 'L',
+    currency: 'GBP',
+    units: 10,
+    market_value_gbp: 1000,
+    gain_gbp: 100,
+  },
+  {
+    ticker: 'BBB',
+    name: 'Beta',
+    grouping: 'Global Tech',
+    exchange: 'N',
+    currency: 'USD',
+    units: 5,
+    market_value_gbp: 500,
+    gain_gbp: -50,
+  },
+];
+
+const definitions: InstrumentGroupDefinition[] = [
+  { id: 'income', name: 'Dividend Growth', category: 'income' },
+];
+
+describe('useInstrumentTableState', () => {
+  it('derives exchanges, group options, and filters rows', () => {
+    const { result } = renderHook(() => useInstrumentTableState(rows, definitions));
+
+    expect(result.current.exchanges).toEqual(['L', 'N']);
+    expect(result.current.groupOptions).toEqual(['Dividend Growth', 'Global Tech']);
+    expect(result.current.hasCategories).toBe(true);
+
+    act(() => {
+      result.current.toggleExchangeSelection('L');
+    });
+
+    expect(result.current.selectedExchanges).toEqual(['N']);
+    expect(result.current.rowsWithCost.map((row) => row.ticker)).toEqual(['BBB']);
+  });
+
+  it('falls back from category mode when categories disappear', () => {
+    const { result, rerender } = renderHook(
+      ({ activeDefinitions }) => useInstrumentTableState(rows, activeDefinitions),
+      { initialProps: { activeDefinitions: definitions } },
+    );
+
+    act(() => {
+      result.current.setGroupingMode('category');
+    });
+    expect(result.current.groupingMode).toBe('category');
+
+    rerender({ activeDefinitions: [] });
+    expect(result.current.groupingMode).toBe('group');
+  });
+});

--- a/frontend/tests/unit/components/instrumentTable/utils.test.tsx
+++ b/frontend/tests/unit/components/instrumentTable/utils.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { InstrumentGroupDefinition, InstrumentSummary } from '@/types';
+import {
+  buildCategoryLookup,
+  createGroups,
+  createRowsWithCost,
+  filterRowsByExchange,
+  mergeGroupOptions,
+  splitTickerParts,
+} from '@/components/instrumentTable/utils';
+
+const rows: InstrumentSummary[] = [
+  {
+    ticker: 'AAA',
+    name: 'Alpha',
+    grouping: 'Dividend Growth',
+    exchange: 'L',
+    currency: 'GBP',
+    units: 10,
+    market_value_gbp: 1000,
+    gain_gbp: 100,
+    change_7d_pct: 1,
+  },
+  {
+    ticker: 'BBB',
+    name: 'Beta',
+    grouping: 'Global Tech',
+    exchange: 'N',
+    currency: 'USD',
+    units: 5,
+    market_value_gbp: 500,
+    gain_gbp: -50,
+    change_7d_pct: -2,
+  },
+];
+
+describe('instrumentTable utils', () => {
+  it('filters exchanges and preserves exchange-less rows', () => {
+    const result = filterRowsByExchange(
+      [...rows, { ...rows[0], ticker: 'CASH', exchange: null }],
+      ['L', 'N'],
+      ['N'],
+    );
+
+    expect(result.map((row) => row.ticker)).toEqual(['BBB', 'CASH']);
+  });
+
+  it('groups rows by category aliases and calculates totals', () => {
+    const definitions: InstrumentGroupDefinition[] = [
+      {
+        id: 'dividend-growth',
+        name: 'Dividend Growth',
+        aliases: ['Dividend Growth'],
+        category: 'income-strategies',
+        category_name: 'Income Strategies',
+      },
+    ];
+
+    const lookup = buildCategoryLookup(definitions);
+    const grouped = createGroups(createRowsWithCost(rows), 'ticker', true, 'category', {
+      ungroupedLabel: 'Ungrouped',
+      uncategorisedLabel: 'Uncategorised',
+    }, lookup);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0]).toMatchObject({ label: 'Income Strategies' });
+    expect(grouped[0]?.totals.marketValue).toBe(1000);
+    expect(grouped[1]).toMatchObject({ label: 'Uncategorised' });
+  });
+
+  it('deduplicates group options and parses ticker parts', () => {
+    expect(mergeGroupOptions([' Income '], ['income', 'Growth', null])).toEqual([
+      'Growth',
+      'Income',
+    ]);
+    expect(splitTickerParts('VUSA')).toEqual({ ticker: 'VUSA', exchange: 'L' });
+    expect(splitTickerParts('VUSA.N')).toEqual({ ticker: 'VUSA', exchange: 'N' });
+  });
+});


### PR DESCRIPTION
### Motivation
- Decompose the large `InstrumentTable.tsx` component to make grouping, filtering and derived row logic easier to test and maintain, in line with issue Closes #2409. 
- Move pure logic out of the render-heavy component so UI code focuses on presentation and orchestration.

### Description
- Extracted table state and derived data into a hook `useInstrumentTableState` at `frontend/src/components/instrumentTable/useInstrumentTableState.ts`. 
- Moved grouping, exchange collection/filtering, cost enrichment, totals, formatting and related helpers into `frontend/src/components/instrumentTable/utils.tsx` and shared types into `frontend/src/components/instrumentTable/types.ts`. 
- Updated `InstrumentTable` to use the `useInstrumentTableState` hook and the new utilities, reducing the component's responsibilities and file size. 
- Added unit tests for the pure utilities and the extracted hook in `frontend/tests/unit/components/instrumentTable/utils.test.tsx` and `frontend/tests/unit/components/instrumentTable/useInstrumentTableState.test.tsx` to validate behavior in isolation.

### Testing
- Ran the frontend unit tests with `npm run test -- --run tests/unit/components/InstrumentTable.test.tsx tests/unit/components/instrumentTable/utils.test.tsx tests/unit/components/instrumentTable/useInstrumentTableState.test.tsx`, resulting in all tests passing: 3 test files, 18 tests passed. 
- Executed lint checks with `npx eslint --format unix src/components/InstrumentTable.tsx src/components/instrumentTable/utils.tsx src/components/instrumentTable/useInstrumentTableState.ts tests/unit/components/instrumentTable/utils.test.tsx tests/unit/components/instrumentTable/useInstrumentTableState.test.tsx`, with no blocking errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c42f6b248327a797839809ede715)