### PR TITLE
Allow null config fields from backend

### DIFF
--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -15,13 +15,13 @@ const tabsSchema = z.record(z.string(), z.boolean());
 export const configContractSchema = z
   .object({
     app_env: z.string(),
-    theme: z.string(),
+    theme: z.string().nullable(),
     tabs: tabsSchema,
-    relative_view_enabled: z.boolean(),
+    relative_view_enabled: z.boolean().nullable(),
     google_auth_enabled: z.boolean().nullable(),
     google_client_id: nullableString,
     disable_auth: z.boolean(),
-    allowed_emails: z.array(z.string()),
+    allowed_emails: z.array(z.string()).nullable(),
     local_login_email: nullableString,
     disabled_tabs: z.array(z.string()).nullable().optional(),
   })

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -161,6 +161,10 @@ export function Root() {
 
           setGoogleLoginEnabled(configAuthEnabled);
           setClientId(configuredClientId);
+          // Backend semantics:
+          // - disable_auth controls whether login is required.
+          // - allowed_emails may be null (no explicit allowlist) without
+          //   changing whether auth is required.
           setNeedsAuth(!disableAuth);
 
           if (disableAuth && localLoginEmail) {

--- a/frontend/tests/unit/apiContracts.test.ts
+++ b/frontend/tests/unit/apiContracts.test.ts
@@ -14,6 +14,42 @@ import {
 } from "@/contracts/apiContracts";
 
 describe("API contract fixtures", () => {
+  it("accepts null config values for optional backend fields", () => {
+    const parsed = configContractSchema.parse({
+      app_env: "local",
+      theme: null,
+      tabs: {},
+      relative_view_enabled: null,
+      google_auth_enabled: false,
+      google_client_id: null,
+      disable_auth: true,
+      allowed_emails: null,
+      local_login_email: null,
+    });
+
+    expect(parsed.theme).toBeNull();
+    expect(parsed.relative_view_enabled).toBeNull();
+    expect(parsed.allowed_emails).toBeNull();
+  });
+
+  it("accepts configured non-null config values", () => {
+    const parsed = configContractSchema.parse({
+      app_env: "local",
+      theme: "system",
+      tabs: { group: true },
+      relative_view_enabled: true,
+      google_auth_enabled: true,
+      google_client_id: "client-id-123",
+      disable_auth: false,
+      allowed_emails: ["user@example.com"],
+      local_login_email: "user@example.com",
+    });
+
+    expect(parsed.theme).toBe("system");
+    expect(parsed.relative_view_enabled).toBe(true);
+    expect(parsed.allowed_emails).toEqual(["user@example.com"]);
+  });
+
   it("validates the config fixture", () => {
     expect(() => configContractSchema.parse(configFixture)).not.toThrow();
   });


### PR DESCRIPTION
### Motivation
- The backend can return `null` for optional config fields which caused the frontend schema to reject `/config` responses and triggered startup parsing failures and retry loops.
Closes #2477

### Description
- Change `frontend/src/contracts/apiContracts.ts` to accept nullable values for `theme`, `relative_view_enabled`, and `allowed_emails` in `configContractSchema`.
- Add a short bootstrap comment in `frontend/src/main.tsx` clarifying that `disable_auth` controls whether login is required and that `allowed_emails` may be `null` without disabling auth.
- Add unit tests in `frontend/tests/unit/apiContracts.test.ts` that verify both `null`-valued optional config fields and fully-configured non-null responses parse correctly.

### Testing
- Ran the focused frontend contract tests with `npm --prefix frontend run test -- tests/unit/apiContracts.test.ts --run` and they passed.
- Ran a combined run with `npm --prefix frontend run test -- tests/unit/apiContracts.test.ts tests/unit/rootBootstrap.test.tsx --run`, where the contract tests passed but one `rootBootstrap` test (`shows Google login on first load when auth is enabled and no token is stored`) timed out in this environment (timeout unrelated to schema change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b8d1ad54832789377a225604972e)