### PR TITLE
Rename group → slug in group portfolio contract and types

### DIFF
--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -104,12 +104,12 @@ export const portfolioContractSchema = z.object({
 });
 
 // GroupPortfolio has a different top-level shape from Portfolio:
-// it identifies itself with `group` + `name` + `members` rather than `owner`,
+// it identifies itself with `slug` + `name` + `members` rather than `owner`,
 // and carries members_summary / subtotals_by_account_type that Portfolio does
 // not have.  Using portfolioContractSchema here would throw at runtime because
 // `owner` is required there but absent in group portfolio responses.
 export const groupPortfolioContractSchema = z.object({
-  group: z.string(),
+  slug: z.string(),
   name: z.string(),
   as_of: z.string(),
   members: z.array(z.string()),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -72,7 +72,7 @@ export type GroupSummary = {
 };
 
 export type GroupPortfolio = {
-  group: string;
+  slug: string;
   name: string;
   as_of: string;
   members: string[];

--- a/frontend/tests/unit/pages/AllocationCharts.test.tsx
+++ b/frontend/tests/unit/pages/AllocationCharts.test.tsx
@@ -8,7 +8,7 @@ vi.mock("@/api");
 const mockGetGroupPortfolio = vi.mocked(api.getGroupPortfolio);
 
 const samplePortfolio: GroupPortfolio = {
-  group: "g",
+  slug: "g",
   name: "Group",
   as_of: "2024-01-01",
   members: [],
@@ -62,4 +62,3 @@ describe("AllocationCharts page", () => {
     expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
   });
 });
-


### PR DESCRIPTION
### Motivation
- The backend `GET /portfolio-group/{slug}` responses use the `slug` key while the frontend `groupPortfolioContractSchema` expected `group`, causing schema parse/typing mismatches.
- Canonicalising the identifier to `slug` in frontend contracts and types prevents runtime parse errors and keeps the API contract aligned with the backend.
- This is a lightweight frontend-only alignment that does not require backend changes.

### Description
- Updated `groupPortfolioContractSchema` to expect `slug: z.string()` (and adjusted the nearby comment) in `frontend/src/contracts/apiContracts.ts`.
- Replaced the `group` field with `slug` on the `GroupPortfolio` TypeScript type in `frontend/src/types.ts`.
- Updated the `AllocationCharts` unit test fixture to use `slug` in `frontend/tests/unit/pages/AllocationCharts.test.tsx` so test data matches the corrected shape.

### Testing
- Ran the targeted unit test command `npm --prefix frontend run test -- --run frontend/tests/unit/pages/AllocationCharts.test.tsx` but it failed to execute in this environment because `vitest` is not installed (`sh: 1: vitest: not found`).
- No other automated tests were run in this environment; please run the full frontend test suite locally or in CI after installing dependencies to verify no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b8d67d8883278653f704a4e4d5dc)