### PR TITLE
Rename GroupPortfolio 'group' field to 'slug'

### DIFF
--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -104,12 +104,12 @@ export const portfolioContractSchema = z.object({
 });
 
 // GroupPortfolio has a different top-level shape from Portfolio:
-// it identifies itself with `group` + `name` + `members` rather than `owner`,
+// it identifies itself with `slug` + `name` + `members` rather than `owner`,
 // and carries members_summary / subtotals_by_account_type that Portfolio does
 // not have.  Using portfolioContractSchema here would throw at runtime because
 // `owner` is required there but absent in group portfolio responses.
 export const groupPortfolioContractSchema = z.object({
-  group: z.string(),
+  slug: z.string(),
   name: z.string(),
   as_of: z.string(),
   members: z.array(z.string()),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -72,7 +72,7 @@ export type GroupSummary = {
 };
 
 export type GroupPortfolio = {
-  group: string;
+  slug: string;
   name: string;
   as_of: string;
   members: string[];

--- a/frontend/tests/unit/pages/AllocationCharts.test.tsx
+++ b/frontend/tests/unit/pages/AllocationCharts.test.tsx
@@ -8,7 +8,7 @@ vi.mock("@/api");
 const mockGetGroupPortfolio = vi.mocked(api.getGroupPortfolio);
 
 const samplePortfolio: GroupPortfolio = {
-  group: "g",
+  slug: "g",
   name: "Group",
   as_of: "2024-01-01",
   members: [],
@@ -62,4 +62,3 @@ describe("AllocationCharts page", () => {
     expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
   });
 });
-


### PR DESCRIPTION
### Motivation
- The backend `GET /portfolio-group/{slug}` response uses `slug` as the top-level identifier, while the frontend contract/type expected `group`, causing schema parse/type mismatches.
- Aligning the frontend contract and types with the backend prevents runtime parse errors when validating group portfolio payloads.
- The change surfaces existing test fixtures that were partial and relied on the old shape, so the contract must be strict and consistent.

### Description
- Updated `groupPortfolioContractSchema` in `frontend/src/contracts/apiContracts.ts` to use `slug` instead of `group` as the top-level identifier.
- Updated the `GroupPortfolio` TypeScript type in `frontend/src/types.ts` to replace `group: string` with `slug: string`.
- Updated the typed fixture in `frontend/tests/unit/pages/AllocationCharts.test.tsx` to use `slug` so the test remains consistent with the new contract.

### Testing
- Ran `npm --prefix frontend run test -- --run tests/unit/pages/AllocationCharts.test.tsx` and the `AllocationCharts` tests passed.
- Ran `npm --prefix frontend run test -- --run tests/unit/pages/AllocationCharts.test.tsx tests/unit/components/GroupPortfolioView.test.tsx` and the `GroupPortfolioView` suite failed because many of its fixtures are partial payloads that do not satisfy the stricter group portfolio contract (missing `slug`, `members_summary`, `subtotals_by_account_type`, etc.).
- Ran `npm --prefix frontend run lint` which failed due to pre-existing lint issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c0c515b88327a583454990a2998e)