### PR TITLE
Handle nullable /config fields in frontend schema and bootstrap

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -54,10 +54,11 @@ export interface AppConfig {
 }
 
 export interface RawConfig {
-  relative_view_enabled?: boolean;
+  relative_view_enabled?: boolean | null;
   tabs?: Partial<TabsConfig>;
   disabled_tabs?: string[];
-  theme?: string;
+  theme?: string | null;
+  allowed_emails?: string[] | null;
 }
 
 const defaultTabs: TabsConfig = {
@@ -237,4 +238,3 @@ function applyTheme(theme: AppConfig["theme"]) {
     root.removeAttribute("data-theme");
   }
 }
-

--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -15,13 +15,13 @@ const tabsSchema = z.record(z.string(), z.boolean());
 export const configContractSchema = z
   .object({
     app_env: z.string(),
-    theme: z.string(),
+    theme: z.string().nullable(),
     tabs: tabsSchema,
-    relative_view_enabled: z.boolean(),
+    relative_view_enabled: z.boolean().nullable(),
     google_auth_enabled: z.boolean().nullable(),
     google_client_id: nullableString,
     disable_auth: z.boolean(),
-    allowed_emails: z.array(z.string()),
+    allowed_emails: z.array(z.string()).nullable(),
     local_login_email: nullableString,
     disabled_tabs: z.array(z.string()).nullable().optional(),
   })

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -27,6 +27,14 @@ import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage';
 import { RouteProvider } from './RouteContext';
 import { deriveBootstrapMode, deriveModeFromPathname, standalonePageRoutes } from './pageManifest';
 
+interface BootstrapConfig {
+  google_auth_enabled?: boolean | null;
+  google_client_id?: string | null;
+  disable_auth?: boolean;
+  local_login_email?: string | null;
+  allowed_emails?: string[] | null;
+}
+
 const storedToken = getStoredAuthToken();
 if (storedToken) setAuthToken(storedToken);
 
@@ -149,15 +157,20 @@ export function Root() {
       let retryDelay = 0;
       let nextAttempt = attempt;
 
-      getConfig<Record<string, unknown>>({ signal: controller.signal })
+      getConfig<BootstrapConfig>({ signal: controller.signal })
         .then((cfg) => {
           if (!isMounted.current || activeRequest.current !== controller) return;
 
-          const configAuthEnabled = Boolean((cfg as { google_auth_enabled?: unknown }).google_auth_enabled);
-          const disableAuth = Boolean((cfg as { disable_auth?: unknown }).disable_auth);
-          const configuredClientId = String((cfg as { google_client_id?: unknown }).google_client_id || '');
-          const localLoginRaw = (cfg as { local_login_email?: unknown }).local_login_email;
-          const localLoginEmail = typeof localLoginRaw === 'string' ? localLoginRaw.trim() : '';
+          const configAuthEnabled = cfg.google_auth_enabled === true;
+          const disableAuth = cfg.disable_auth === true;
+          const configuredClientId = typeof cfg.google_client_id === 'string' ? cfg.google_client_id : '';
+          const localLoginEmail =
+            typeof cfg.local_login_email === 'string' ? cfg.local_login_email.trim() : '';
+          // Backend auth semantics: null/empty allowed_emails means no allowlist
+          // enforcement (allow all users). Keep this normalization explicit to
+          // avoid accidental "deny all" behavior in future bootstrap guards.
+          const allowedEmails = Array.isArray(cfg.allowed_emails) ? cfg.allowed_emails : [];
+          void allowedEmails;
 
           setGoogleLoginEnabled(configAuthEnabled);
           setClientId(configuredClientId);

--- a/frontend/tests/unit/apiContracts.test.ts
+++ b/frontend/tests/unit/apiContracts.test.ts
@@ -14,6 +14,19 @@ import {
 } from "@/contracts/apiContracts";
 
 describe("API contract fixtures", () => {
+  it("accepts null for optional backend-managed config fields", () => {
+    const parsed = configContractSchema.parse({
+      ...configFixture,
+      theme: null,
+      relative_view_enabled: null,
+      allowed_emails: null,
+    });
+
+    expect(parsed.theme).toBeNull();
+    expect(parsed.relative_view_enabled).toBeNull();
+    expect(parsed.allowed_emails).toBeNull();
+  });
+
   it("validates the config fixture", () => {
     expect(() => configContractSchema.parse(configFixture)).not.toThrow();
   });
@@ -38,6 +51,14 @@ describe("API contract fixtures", () => {
     expect(apiContractJsonSchemas.config).toMatchObject({
       type: "object",
       required: expect.arrayContaining(["app_env", "tabs", "theme"]),
+      properties: expect.objectContaining({
+        theme: expect.objectContaining({
+          anyOf: expect.arrayContaining([
+            expect.objectContaining({ type: "string" }),
+            expect.objectContaining({ type: "null" }),
+          ]),
+        }),
+      }),
     });
     expect(apiContractJsonSchemas.owners).toMatchObject({ type: "array" });
     expect(apiContractJsonSchemas.portfolio).toMatchObject({ type: "object" });


### PR DESCRIPTION
### Motivation
- The frontend was rejecting backend `/config` responses that use `null` for optional fields, which could trigger repeated startup retries and break bootstrap flows. 
- Align frontend contracts and bootstrap typing with backend semantics so optional/unconfigured fields (`theme`, `relative_view_enabled`, `allowed_emails`) are accepted as `null`.

### Description
- Updated the Zod API contract so `theme`, `relative_view_enabled`, and `allowed_emails` are nullable in `frontend/src/contracts/apiContracts.ts`.
- Extended `RawConfig` typing in `frontend/src/ConfigContext.tsx` to allow `null` for `theme` and `relative_view_enabled` and added `allowed_emails?: string[] | null`.
- Made bootstrap handling explicit in `frontend/src/main.tsx` by introducing a `BootstrapConfig` interface, parsing nullable fields safely, and normalising `allowed_emails` so `null`/missing means no allowlist enforcement.
- Added a unit test in `frontend/tests/unit/apiContracts.test.ts` that verifies the contract accepts the `null` path and updated the JSON Schema assertion to reflect nullable `theme`.

### Testing
- Ran the targeted frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/apiContracts.test.ts tests/unit/rootBootstrap.test.tsx` and both test files passed.
- Test summary: 2 test files, 12 tests total, all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c0bde1d083279184f806750b1018)