### PR TITLE
Rename group portfolio field to slug

### DIFF
--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -104,12 +104,12 @@ export const portfolioContractSchema = z.object({
 });
 
 // GroupPortfolio has a different top-level shape from Portfolio:
-// it identifies itself with `group` + `name` + `members` rather than `owner`,
+// it identifies itself with `slug` + `name` + `members` rather than `owner`,
 // and carries members_summary / subtotals_by_account_type that Portfolio does
 // not have.  Using portfolioContractSchema here would throw at runtime because
 // `owner` is required there but absent in group portfolio responses.
 export const groupPortfolioContractSchema = z.object({
-  group: z.string(),
+  slug: z.string(),
   name: z.string(),
   as_of: z.string(),
   members: z.array(z.string()),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -72,7 +72,7 @@ export type GroupSummary = {
 };
 
 export type GroupPortfolio = {
-  group: string;
+  slug: string;
   name: string;
   as_of: string;
   members: string[];

--- a/frontend/tests/unit/pages/AllocationCharts.test.tsx
+++ b/frontend/tests/unit/pages/AllocationCharts.test.tsx
@@ -8,7 +8,7 @@ vi.mock("@/api");
 const mockGetGroupPortfolio = vi.mocked(api.getGroupPortfolio);
 
 const samplePortfolio: GroupPortfolio = {
-  group: "g",
+  slug: "g",
   name: "Group",
   as_of: "2024-01-01",
   members: [],
@@ -62,4 +62,3 @@ describe("AllocationCharts page", () => {
     expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
   });
 });
-


### PR DESCRIPTION
### Motivation

- Frontend validation and types expected the group identifier as `group` while backend group portfolio payloads use `slug`, causing a schema mismatch at runtime.
- Aligning the frontend contracts and types with the backend prevents zod validation errors and keeps type definitions consistent across the app.
Closes #2481 

### Description

- Updated the group portfolio contract to use `slug` instead of `group` in `frontend/src/contracts/apiContracts.ts` and clarified the comment accordingly.
- Updated the `GroupPortfolio` TypeScript type to replace the `group` field with `slug` in `frontend/src/types.ts`.
- Updated the `AllocationCharts` unit test fixture in `frontend/tests/unit/pages/AllocationCharts.test.tsx` to use `slug` and keep tests consistent with the new contract.

### Testing

- Running the incorrect filtered command `npm --prefix frontend run test -- --run frontend/tests/unit/pages/AllocationCharts.test.tsx` returned "No test files found" due to the Vitest include pattern, which failed to run tests.
- Running the targeted frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/pages/AllocationCharts.test.tsx` executed successfully and `2` tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c5f1df748327b01a08e884f2a8f5)