### PR TITLE
Fix config contract nullability coverage and schema artifacts

### DIFF
--- a/frontend/src/contracts/fixtures/groupPortfolio.v1.json
+++ b/frontend/src/contracts/fixtures/groupPortfolio.v1.json
@@ -1,8 +1,10 @@
 {
-  "group": "all",
   "name": "At a glance",
   "as_of": "2026-03-23",
-  "members": ["alice", "bob"],
+  "members": [
+    "alice",
+    "bob"
+  ],
   "total_value_estimate_gbp": 12345.67,
   "accounts": [
     {
@@ -32,5 +34,6 @@
   ],
   "subtotals_by_account_type": {
     "ISA": 12345.67
-  }
+  },
+  "slug": "all"
 }

--- a/frontend/src/contracts/generated/api-contract-schemas.v1.json
+++ b/frontend/src/contracts/generated/api-contract-schemas.v1.json
@@ -11,7 +11,14 @@
             "type": "string"
           },
           "theme": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "tabs": {
             "type": "object",
@@ -23,7 +30,14 @@
             }
           },
           "relative_view_enabled": {
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "google_auth_enabled": {
             "anyOf": [
@@ -49,10 +63,17 @@
             "type": "boolean"
           },
           "allowed_emails": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "local_login_email": {
             "anyOf": [

--- a/frontend/tests/unit/apiContracts.test.ts
+++ b/frontend/tests/unit/apiContracts.test.ts
@@ -16,17 +16,6 @@ import {
 } from "@/contracts/apiContracts";
 
 describe("API contract fixtures", () => {
-  it("accepts null config values for optional backend fields", () => {
-    const parsed = configContractSchema.parse({
-      app_env: "local",
-      theme: null,
-      tabs: {},
-      relative_view_enabled: null,
-      google_auth_enabled: false,
-      google_client_id: null,
-      disable_auth: true,
-      allowed_emails: null,
-      local_login_email: null,
   it("accepts null for optional backend-managed config fields", () => {
     const parsed = configContractSchema.parse({
       ...configFixture,
@@ -76,6 +65,8 @@ describe("API contract fixtures", () => {
 
   it("validates the group portfolio fixture", () => {
     expect(() => groupPortfolioContractSchema.parse(groupPortfolioFixture)).not.toThrow();
+  });
+
   it("validates a group portfolio response shape", () => {
     const groupFixture = {
       group: "children",


### PR DESCRIPTION
### Motivation

- The SPA failed to load when the backend returned `null` for optional config fields (`theme`, `relative_view_enabled`, `allowed_emails`), causing repeated Zod parse errors and a retry loop.
- Tests and the checked-in JSON Schema artifact did not consistently reflect the backend's nullable semantics, increasing risk of regressions.
Closes #2477 

### Description

- Repaired and simplified `frontend/tests/unit/apiContracts.test.ts` to safely compile and validate both `null` and non-null shapes for `theme`, `relative_view_enabled`, and `allowed_emails` using `configContractSchema.parse()`.
- Updated the generated API JSON schema artifact at `frontend/src/contracts/generated/api-contract-schemas.v1.json` to mark the three config fields as nullable so the artifact matches runtime behaviour.
- Fixed the group portfolio fixture shape in `frontend/src/contracts/fixtures/groupPortfolio.v1.json` to use `slug` (instead of legacy `group`) and adjusted formatting so the fixture validates against `groupPortfolioContractSchema`.

### Testing

- Ran targeted frontend unit tests with `npm --prefix frontend run test -- tests/unit/apiContracts.test.ts tests/unit/rootBootstrap.test.tsx tests/unit/configRetrySuccess.test.tsx --run` and verified all tests passed.
- Confirmed the modified test suite (`tests/unit/apiContracts.test.ts`) runs cleanly and asserts both null and non-null parsing for the affected config fields.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e7d572b483278135fb6c4a3a3e39)