### PR TITLE
fix: remap Docker backend host port to 8001 to avoid local port clash

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -14,7 +14,9 @@ services:
         # Mount config file
         - ../config.yaml:/workspace/backend/config.yaml:rw
       ports:
-        - "8000:8000"
+        # Host port 8001 avoids clashing with a local uvicorn dev server on 8000.
+        # Internal Docker networking still uses 8000, so VITE_API_URL is unaffected.
+        - "8001:8000"
       environment:
         - DISABLE_AUTH=false
         - ACCOUNTS_ROOT=/workspace/backend/data


### PR DESCRIPTION
## Summary
- Docker backend was mapping host port `8000 → container 8000`, clashing with a local uvicorn dev server also on `8000`
- Changed Docker backend host port to `8001` (container-internal port stays `8000`)
- Docker frontend already uses host port `3000` (no clash with local Vite on `5173`)
- `VITE_API_URL=http://backend:8000` in docker-compose is unaffected — that is the Docker-internal network address
Closes #2496 

## Port map after this change
| Mode | Backend | Frontend |
|------|---------|----------|
| Local dev | `localhost:8000` | `localhost:5173` |
| Docker | `localhost:8001` | `localhost:3000` |

## Test plan
- [ ] Start Docker: `docker compose -f deploy/docker-compose.yml up` — backend should be reachable at `http://localhost:8001`
- [ ] Start local backend: `scripts/run-backend.ps1` — should bind `localhost:8000` without conflict
- [ ] Both can run simultaneously without an "address already in use" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)