### PR TITLE
Fix Jenkins CI failures: missing jsonschema and TypeScript errors

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -766,7 +766,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
                 ))}
               </Pie>
               <Tooltip
-                formatter={(v: number, n: string) => [
+                formatter={(v: number | undefined, n: string) => [
                   money(v, baseCurrency),
                   n,
                 ]}
@@ -804,7 +804,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
             >
               <XAxis dataKey={contribTab === "sector" ? "sector" : "region"} />
               <YAxis />
-              <Tooltip formatter={(v: number) => money(v, baseCurrency)} />
+              <Tooltip formatter={(v: number | undefined) => money(v, baseCurrency)} />
               <Bar dataKey="gain_gbp">
                 {(contribTab === "sector" ? sectorContrib : regionContrib)?.map(
                   (row, idx) => (

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -313,8 +313,8 @@ export function PerformanceDashboard({ owner, asOf }: Props) {
                     tickFormatter={(v) => percent(v * 100, 1, i18n.language)}
                   />
                   <Tooltip
-                    formatter={(value: number) =>
-                      percent(value * 100, 2, i18n.language)
+                    formatter={(value: number | undefined) =>
+                      percent((value ?? 0) * 100, 2, i18n.language)
                     }
                   />
                   {drawdownPeak && drawdownTrough && (
@@ -394,7 +394,7 @@ export function PerformanceDashboard({ owner, asOf }: Props) {
         <LineChart data={data}>
           <XAxis dataKey="date" />
           <YAxis tickFormatter={(v) => percent(v * 100, 2, i18n.language)} />
-          <Tooltip formatter={(v: number) => percent(v * 100, 2, i18n.language)} />
+          <Tooltip formatter={(v: number | undefined) => percent((v ?? 0) * 100, 2, i18n.language)} />
           <Line
             type="monotone"
             dataKey="cumulative_return"

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -185,7 +185,7 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
                   <BarChart data={sectorContrib}>
                     <XAxis dataKey="sector" interval={0} angle={-35} textAnchor="end" height={70} />
                     <YAxis />
-                    <Tooltip formatter={(v: number) => money(v, baseCurrency)} />
+                    <Tooltip formatter={(v: number | undefined) => money(v, baseCurrency)} />
                     <Bar dataKey="gain_gbp">
                       {sectorContrib.map((row, idx) => (
                         <Cell

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -242,7 +242,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
                 ))}
               </Pie>
               <Tooltip
-                formatter={(v: number, _n: string, item: any) =>
+                formatter={(v: number | undefined, _n: string, item: any) =>
                   relativeViewEnabled
                     ? `${
                         total

--- a/frontend/src/pages/PerformanceDiagnostics.tsx
+++ b/frontend/src/pages/PerformanceDiagnostics.tsx
@@ -70,7 +70,7 @@ export default function PerformanceDiagnostics() {
 
     let current: ActiveEvent = null;
 
-    history.forEach((point) => {
+    for (const point of history) {
       const drawdownValue =
         typeof point.drawdown === "number" && Number.isFinite(point.drawdown)
           ? point.drawdown
@@ -107,7 +107,7 @@ export default function PerformanceDiagnostics() {
         });
         current = null;
       }
-    });
+    }
 
     if (current) {
       const lastDate = current.lastDate || history[history.length - 1].date;
@@ -241,7 +241,7 @@ export default function PerformanceDiagnostics() {
                 >
                   <XAxis dataKey="date" />
                   <YAxis tickFormatter={(v) => percent(v * 100)} />
-                  <Tooltip formatter={(v: number) => percent(v * 100)} />
+                  <Tooltip formatter={(v: number | undefined) => percent((v ?? 0) * 100)} />
                   <Line
                     type="monotone"
                     dataKey="drawdown"

--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -114,7 +114,7 @@ function PortfolioDashboard({
         <LineChart data={data}>
           <XAxis dataKey="date" />
           <YAxis tickFormatter={(v) => percent(v * 100)} />
-          <Tooltip formatter={(v: number) => percent(v * 100)} />
+          <Tooltip formatter={(v: number | undefined) => percent((v ?? 0) * 100)} />
           <Line
             type="monotone"
             dataKey="cumulative_return"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -81,14 +81,14 @@ export type GroupPortfolio = {
   trades_this_month?: number;
   trades_remaining?: number;
   accounts: Account[];
-  members_summary: {
+  members_summary?: {
     owner: string;
     total_value_estimate_gbp: number;
     total_value_estimate_currency?: string | null;
     trades_this_month: number;
     trades_remaining: number;
   }[];
-  subtotals_by_account_type: Record<string, number>;
+  subtotals_by_account_type?: Record<string, number>;
 };
 
 export type InstrumentSummary = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,5 +64,6 @@ google-auth~=2.36.0
 google-auth-oauthlib~=1.2.2
 google-auth-httplib2~=0.2.0
 pytest-asyncio~=0.23
+jsonschema~=4.23.0
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 pyasn1>=0.6.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary

- Add `jsonschema~=4.23.0` to `requirements.txt` — was missing, causing collection error in `tests/contracts/test_api_response_contracts.py`
- Make `GroupPortfolio.members_summary` and `subtotals_by_account_type` optional in `types.ts` to match the Zod schema (already `.optional()`) and actual API response shape
- Fix Recharts `Formatter` callbacks to accept `number | undefined` across 6 components — required by the library's type signature in TypeScript 5.8
- Switch `forEach` to `for...of` in `PerformanceDiagnostics` drawdown loop — TypeScript 5.8 doesn't track variable mutations through closure callbacks, causing `current` to be narrowed to `never`

Closes #2499

## Test plan

- [ ] Python CI: `pytest tests` should now collect and run without import errors
- [ ] Frontend CI: `tsc -b && vite build` should complete without type errors
- [ ] No runtime behaviour changes — `money`/`percent` already handle `undefined`, and `for...of` is semantically identical to `forEach` here

🤖 Generated with [Claude Code](https://claude.com/claude-code)