### PR TITLE
Add local Docker app stack with mounted real data

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,6 @@
+# Local Docker environment variables
+DATA_ROOT=/app/data
+API_TOKEN=local-dev-token
+ALPHA_VANTAGE_KEY=demo
+OPENAI_API_KEY=
+DISABLE_AUTH=true

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 build/
 .env*
 !.env.example
+!.env.local.example
 
 # PWA icons (downloaded separately)
 frontend/public/icons/*.png

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY backend ./backend
+COPY config.yaml ./config.yaml
+
+EXPOSE 8000
+
+CMD ["python", "-m", "uvicorn", "backend.local_api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,22 @@
+FROM node:20-slim AS build
+
+WORKDIR /app
+
+COPY frontend/package*.json ./
+RUN npm ci
+
+COPY frontend/ ./
+
+ARG VITE_ALLOTMINT_API_BASE=/api
+ARG VITE_APP_BASE_URL=http://localhost:3000
+ENV VITE_ALLOTMINT_API_BASE=${VITE_ALLOTMINT_API_BASE}
+ENV VITE_APP_BASE_URL=${VITE_APP_BASE_URL}
+
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY docker/nginx/frontend-local.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint
+.PHONY: format lint local-up local-down
 
 format:
 	isort --sp backend/pyproject.toml backend tests
@@ -8,3 +8,10 @@ lint:
 	ruff check --config backend/pyproject.toml backend tests
 	black --check --config backend/pyproject.toml backend tests
 	pytest
+
+
+local-up:
+	docker compose -f docker-compose.local.yml --env-file .env.local up --build
+
+local-down:
+	docker compose -f docker-compose.local.yml --env-file .env.local down --remove-orphans

--- a/README.md
+++ b/README.md
@@ -12,3 +12,40 @@ AllotMint is a family investing platform with a FastAPI backend, React frontend,
 
 GitHub Actions uploads both backend (`coverage.xml`) and frontend (`frontend/coverage/lcov.info`) coverage reports to Codecov on pull requests and pushes to `main`.
 
+
+
+## Local Docker development
+
+Run the full AllotMint stack (backend + frontend) with real local fixture data.
+
+### Prerequisites
+
+- Docker Engine 24+
+- Docker Compose v2 (`docker compose`)
+
+### Quick start
+
+1. Copy local environment defaults:
+
+   ```bash
+   cp .env.local.example .env.local
+   ```
+
+2. Start both services:
+
+   ```bash
+   make local-up
+   ```
+
+3. Open:
+
+   - Frontend UI: http://localhost:3000
+   - Backend OpenAPI docs: http://localhost:8000/docs
+
+The backend bind-mounts `./data` into `/app/data` so portfolio/account fixtures are served live from your local repository checkout.
+
+### Stop services
+
+```bash
+make local-down
+```

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,24 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.app
+    env_file:
+      - .env.local
+    volumes:
+      - ./data:/app/data
+      - ./config.yaml:/app/config.yaml:ro
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+      args:
+        VITE_ALLOTMINT_API_BASE: /api
+        VITE_APP_BASE_URL: http://localhost:3000
+    depends_on:
+      - backend
+    ports:
+      - "3000:80"

--- a/docker/nginx/frontend-local.conf
+++ b/docker/nginx/frontend-local.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://backend:8000/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a reproducible local Docker development stack that boots the full AllotMint app (backend + frontend) and serves real fixtures from `./data` for manual testing and demos as described in issue #2381.
- Keep the existing Jenkins CI compose unchanged while adding a `docker-compose.local.yml` for developer workflows. 

### Description

- Added `Dockerfile.app` to build a lightweight Python image that installs backend dependencies and runs `uvicorn backend.local_api.main:app` on port `8000` with `./data` mounted into `/app/data`.
- Added `Dockerfile.frontend` (multi-stage) to build the Vite React frontend and serve it via `nginx`, plus `docker/nginx/frontend-local.conf` to proxy `/api` → `http://backend:8000` and support SPA routing.
- Added `docker-compose.local.yml` with `backend` and `frontend` services and bind-mounts for `./data` and `./config.yaml`, and added `.env.local.example` with minimal local env vars (`DATA_ROOT`, `API_TOKEN`, `ALPHA_VANTAGE_KEY`, `OPENAI_API_KEY`, `DISABLE_AUTH`).
- Added `make local-up` and `make local-down` targets to the `Makefile`, documented the local Docker flow in `README.md`, and updated `.gitignore` to allow committing `.env.local.example` while still ignoring `.env*`.

### Testing

- Ran `python -m compileall backend/local_api/main.py` which completed successfully. 
- Attempted `docker compose -f docker-compose.local.yml --env-file .env.local.example config` but it could not run in this environment because the `docker` CLI is not available. 
- Ran `ruff check --config backend/pyproject.toml backend tests` which failed with many pre-existing lint issues unrelated to the added Docker files. 
- Ran `pytest -q` which failed in this environment due to missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c380d116a083278d73fd22edf7d596)