### PR TITLE
Ensure load_latest_prices returns GBP-normalised values and add regression tests

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -57,8 +57,11 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
     - Output values are always GBP-normalised regardless of source columns.
     - If ``Close_gbp``/``close_gbp`` exists, use it directly (already in GBP).
     - Otherwise use native close (``Close``/``close``/``Adj Close``) and convert
-      to GBP using instrument currency metadata and FX rates:
-      - Pence-denominated instruments (GBX, GBXP) are divided by 100.
+      to GBP using instrument currency metadata and scaling:
+      - If ``get_scaling_override`` returned a non-unity scale, ``apply_scaling``
+        has already performed the pence-to-pounds conversion; no further action.
+      - If scale == 1 and the currency is pence-denominated (GBX, GBXP, GBp),
+        divide by 100 (pence → pounds is arithmetic, not FX).
       - All other non-GBP currencies are converted via ``_fx_to_base``.
 
     Additional behaviour:
@@ -99,7 +102,7 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
                 # no data -> don't write a zero; just continue
                 continue
 
-            # apply instrument-specific scaling (e.g., GBX -> GBP)
+            # apply instrument-specific scaling (e.g., GBX -> GBP via 0.01 factor)
             scale = get_scaling_override(ticker, exchange, None)
             df = apply_scaling(df, scale)
             if scale != 1 and "Close_gbp" in df.columns:
@@ -127,15 +130,21 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
             if close_gbp_col is None:
                 full_ticker = f"{ticker}.{exchange}"
                 meta = get_instrument_meta(full_ticker) or {}
-                # Preserve the raw metadata currency string for pence detection
-                # before normalising to uppercase, since GBX/GBp are pence.
+                # Preserve the raw metadata string for mixed-case pence detection
+                # (e.g. Yahoo Finance emits "GBp") before uppercasing.
                 raw_currency = str(meta.get("currency") or "GBP").strip()
                 currency = raw_currency.upper()
 
-                # Pence-denominated instruments: divide by 100, do not apply FX.
-                # Recognised pence codes: GBX (Bloomberg/Yahoo), GBXP, GBp (raw).
-                if currency in {"GBX", "GBXP"} or raw_currency == "GBp":
-                    val /= 100.0
+                is_pence = currency in {"GBX", "GBXP"} or raw_currency == "GBp"
+
+                if is_pence:
+                    # Pence → pounds is arithmetic (/100), not an FX operation.
+                    # Only apply when scale == 1: a non-unity scale means
+                    # apply_scaling already performed this conversion via the
+                    # instrument's scaling override (e.g. 0.01 for GBX).
+                    if scale == 1:
+                        val /= 100.0
+                    # else: apply_scaling already converted pence to pounds
                 elif currency != "GBP":
                     val *= _fx_to_base(currency, "GBP", fx_cache)
 

--- a/tests/common/test_holding_utils.py
+++ b/tests/common/test_holding_utils.py
@@ -101,10 +101,10 @@ def test_load_latest_prices_does_not_double_convert_close_gbp(monkeypatch):
 
 
 @pytest.mark.parametrize("raw_currency", ["GBX", "GBXP", "GBp"])
-def test_load_latest_prices_gbx_pence_instrument(monkeypatch, raw_currency):
-    """Pence-denominated instruments (GBX / GBp) must be divided by 100.
+def test_load_latest_prices_gbx_pence_no_scaling_override(monkeypatch, raw_currency):
+    """When scale==1 (no scaling override), pence instruments must be divided by 100.
 
-    A native close of 10_000 pence should yield 100.0 pounds.
+    A native close of 10_000 pence with scale=1.0 should yield 100.0 pounds.
     FX conversion must NOT be called — pence->pounds is arithmetic, not FX.
     """
     from backend.common import instrument_api
@@ -117,6 +117,7 @@ def test_load_latest_prices_gbx_pence_instrument(monkeypatch, raw_currency):
             {"Date": [dt.date(2024, 1, 1)], "Close": [10_000.0]}
         ),
     )
+    # scale=1.0: no scaling override present, so our code must divide by 100
     monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 1.0)
     monkeypatch.setattr(
         holding_utils, "get_instrument_meta", lambda *_: {"currency": raw_currency}
@@ -131,6 +132,40 @@ def test_load_latest_prices_gbx_pence_instrument(monkeypatch, raw_currency):
 
     prices = holding_utils.load_latest_prices(["HFEL.L"])
 
+    assert prices == {"HFEL.L": pytest.approx(100.0)}
+
+
+def test_load_latest_prices_gbx_pence_with_scaling_override(monkeypatch):
+    """When scale==0.01 (the standard GBX override), apply_scaling already converted
+    pence to pounds. Our code must NOT divide by 100 again.
+
+    Native close 10_000p * scale 0.01 = 100.0 GBP via apply_scaling.
+    Dividing by 100 again would give 1.0 — wrong.
+    """
+    from backend.common import instrument_api
+
+    monkeypatch.setattr(instrument_api, "_resolve_full_ticker", lambda f, r: ("HFEL", "L"))
+    monkeypatch.setattr(
+        holding_utils,
+        "load_meta_timeseries_range",
+        lambda *args, **kwargs: pd.DataFrame(
+            {"Date": [dt.date(2024, 1, 1)], "Close": [10_000.0]}
+        ),
+    )
+    # scale=0.01: standard GBX override — apply_scaling handles pence->pounds
+    monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 0.01)
+    monkeypatch.setattr(
+        holding_utils, "get_instrument_meta", lambda *_: {"currency": "GBX"}
+    )
+
+    def _boom_fx(*args, **kwargs):
+        raise AssertionError("_fx_to_base must not be called for GBX")
+
+    monkeypatch.setattr(portfolio_utils, "_fx_to_base", _boom_fx)
+
+    prices = holding_utils.load_latest_prices(["HFEL.L"])
+
+    # apply_scaling multiplied 10_000 * 0.01 = 100.0; no further conversion
     assert prices == {"HFEL.L": pytest.approx(100.0)}
 
 


### PR DESCRIPTION
### Motivation
- Fix ambiguous output-currency behaviour in the last-close fallback to avoid mixed/misinterpreted currencies and potential double FX conversion as reported in issue Closes #2506. 
- Make the contract for `load_latest_prices` explicit so downstream aggregation and snapshots always operate on GBP values. 

### Description
- Update `backend/common/holding_utils.py` `load_latest_prices` to prefer `close_gbp`/`close_gbp` when present and otherwise use native close (`Close`/`close`/`Adj Close`) then convert that native value to GBP using instrument metadata + `_fx_to_base` before returning. 
- Add a lower-case name mapping and explicit selection (`close_gbp_col` vs `close_native_col`) to make the column selection robust and case-insensitive. 
- Add regression tests in `tests/common/test_holding_utils.py` that assert native USD `Close` values are converted to GBP and that `Close_gbp` is not double-converted by FX logic. 

### Testing
- Ran `python -m compileall backend/common/holding_utils.py tests/common/test_holding_utils.py` which completed successfully. 
- Attempted targeted pytest run `pytest -q tests/common/test_holding_utils.py tests/test_load_latest_prices.py tests/common/test_prices.py` but the run was blocked in this environment by missing runtime test dependencies such as `fastapi` (after installing `pyyaml` and `pyjwt` the suite still requires the full test environment). 
- New tests were added and compiled; a full pytest run should be executed in a fully provisioned dev environment with `pip install -r requirements.txt -r requirements-dev.txt` to validate end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c391b43f348327bf528076ca5f927e)