### PR TITLE
Fix deploy/docker-compose.yml top-level networks indentation

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -50,6 +50,6 @@ services:
         backend:
           condition: service_healthy
 
-  networks:
-    allotmint:
-      driver: bridge
+networks:
+  allotmint:
+    driver: bridge


### PR DESCRIPTION
### Motivation
- The Jenkins deploy pipeline failed during `docker-compose build` with `yaml: line 52: did not find expected key` because the `networks` block was indented under `services` instead of being a top-level key, so the compose YAML needed to be corrected.

### Description
- Move the `networks` block to the top level in `deploy/docker-compose.yml` and preserve all existing `services` definitions and settings so only YAML structure changed.

### Testing
- Parsed `deploy/docker-compose.yml` with Node's `yaml` parser (succeeded); an attempted Python YAML load failed due to the environment missing the `yaml` module (`PyYAML`); `docker compose config` / `docker-compose config` could not be run because Docker is not available in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c436fdc7548327a81852a41ebf48d0)