### PR TITLE
Log missing currency defaults in currency normalization

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -155,6 +155,10 @@ def _normalize_currency_code(currency: str | None) -> str:
 
     raw = (currency or "").strip()
     if not raw:
+        logger.warning(
+            "_normalize_currency_code received empty/missing currency; defaulting to GBP. "
+            "Check instrument metadata."
+        )
         return "GBP"
     if raw == "GBp":
         return "GBX"

--- a/tests/test_portfolio_utils_currency.py
+++ b/tests/test_portfolio_utils_currency.py
@@ -166,3 +166,14 @@ def test_aggregate_by_ticker_sets_grouping(monkeypatch):
     assert by_ticker["AAA.L"]["grouping"] == "Explicit"
     assert by_ticker["BBB.L"]["grouping"] == "Sector B"
     assert by_ticker["CCC.L"]["grouping"] == "Region C"
+
+
+def test_normalize_currency_code_logs_when_missing(caplog):
+    with caplog.at_level("WARNING", logger="portfolio_utils"):
+        normalized = portfolio_utils._normalize_currency_code(None)
+
+    assert normalized == "GBP"
+    assert (
+        "_normalize_currency_code received empty/missing currency; defaulting to GBP."
+        in caplog.text
+    )


### PR DESCRIPTION
### Motivation

- `_normalize_currency_code` silently defaulted empty/missing currency inputs to `GBP`, which can hide incorrect valuations when instrument metadata is missing or malformed (Closes #2511). 
- The intent is to preserve the existing fallback behaviour but make the condition visible in logs so operators can detect and investigate missing metadata.

### Description

- Added a warning log in `backend/common/portfolio_utils.py` inside `_normalize_currency_code` when the input is empty or missing before returning `"GBP"`.
- Added `tests/test_portfolio_utils_currency.py::test_normalize_currency_code_logs_when_missing` to assert that `_normalize_currency_code(None)` returns `"GBP"` and emits the expected warning via `caplog`.

### Testing

- Ran `pytest -q tests/test_portfolio_utils_currency.py`, which exercised the modified behaviour, but the test run could not complete due to a local dependency failure (`ModuleNotFoundError: No module named 'yaml'`).
- No other automated test runs were performed in this environment; the new unit test is in place and should pass in CI where dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c46799b74083278dc4101b29d3aac8)