### PR TITLE
Enforce 44px tap targets across dropdown menu items

### DIFF
--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -203,7 +203,7 @@ export default function Menu({
                   }
                 }}
               >
-                <ul className="flex list-none flex-col gap-1">
+                <ul className="flex list-none flex-col gap-2">
                   {category.tabs.map((tab) => (
                     <li key={tab.mode}>
                       <Link
@@ -213,7 +213,7 @@ export default function Menu({
                           owner: selectedOwner,
                           group: selectedGroup,
                         })}
-                        className={`block rounded px-2 py-1 text-sm transition-colors duration-150 focus:outline-none focus-visible:ring ${
+                        className={`block min-h-11 w-full rounded px-3 py-2 text-sm transition-colors duration-150 focus:outline-none focus-visible:ring ${
                           mode === tab.mode
                             ? 'font-semibold text-gray-900'
                             : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
@@ -229,7 +229,7 @@ export default function Menu({
                         ref={assignFirstFocusable}
                         role="menuitem"
                         to={inSupport ? buildPathForMode('group', { group: selectedGroup }) : buildPathForMode('support')}
-                        className={`block rounded px-2 py-1 text-sm transition-colors duration-150 focus:outline-none focus-visible:ring ${
+                        className={`block min-h-11 w-full rounded px-3 py-2 text-sm transition-colors duration-150 focus:outline-none focus-visible:ring ${
                           inSupport
                             ? 'font-semibold text-gray-900'
                             : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
@@ -246,7 +246,7 @@ export default function Menu({
                         type="button"
                         role="menuitem"
                         onClick={onLogout}
-                        className="block min-h-11 w-full rounded px-2 py-1 text-left text-sm text-gray-600 transition-colors duration-150 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring"
+                        className="block min-h-11 w-full rounded px-3 py-2 text-left text-sm text-gray-600 transition-colors duration-150 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring"
                       >
                         {t('app.logout')}
                       </button>

--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -126,4 +126,42 @@ describe("Menu", () => {
     expect(onLogout).toHaveBeenCalled();
     i18n.changeLanguage("en");
   });
+
+  it("applies 44px touch target sizing to dropdown menu items", async () => {
+    const onLogout = vi.fn();
+    render(
+      <MemoryRouter>
+        <Menu onLogout={onLogout} />
+      </MemoryRouter>,
+    );
+
+    const settingsToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.preferences"),
+    });
+    fireEvent.click(settingsToggle);
+
+    const supportLink = await screen.findByRole("menuitem", { name: "Support" });
+    const logoutButton = await screen.findByRole("menuitem", { name: i18n.t("app.logout") });
+
+    expect(supportLink).toHaveClass("min-h-11", "w-full", "px-3", "py-2");
+    expect(logoutButton).toHaveClass("min-h-11", "w-full", "px-3", "py-2");
+  });
+
+  it("uses at least 8px spacing between adjacent dropdown targets", async () => {
+    render(
+      <MemoryRouter>
+        <Menu />
+      </MemoryRouter>,
+    );
+
+    const dashboardToggle = screen.getByRole("button", {
+      name: i18n.t("app.menuCategories.dashboard"),
+    });
+    fireEvent.click(dashboardToggle);
+
+    const firstMenuItem = await screen.findByRole("menuitem", { name: i18n.t("app.modes.group") });
+    const list = firstMenuItem.closest("ul");
+
+    expect(list).toHaveClass("gap-2");
+  });
 });


### PR DESCRIPTION
### Motivation
- Implement WCAG touch-target improvements from issue Closes #2516 so interactive items inside dropdown panels meet a 44×44px target and have at least 8px separation. 
- Reduce touch errors on mobile and improve accessibility for dropdown menu items.

### Description
- Changed dropdown panel list spacing from `gap-1` to `gap-2` in `frontend/src/components/Menu.tsx` to ensure at least 8px separation.
- Applied `min-h-11`, `w-full`, `px-3`, `py-2` classes to dropdown `<Link>` items (including the Support link) and adjusted the logout `<button>` to match the 44px-friendly sizing.
- Updated unit tests in `frontend/tests/unit/components/Menu.test.tsx` to assert the new touch-target classes and `gap-2` spacing, and adjusted a test selector to target the `dashboard` category.

### Testing
- Running `npm --prefix frontend run test -- --run frontend/tests/unit/components/Menu.test.tsx` initially failed to discover tests due to an incorrect path filter. 
- Running `npm --prefix frontend run test -- --run tests/unit/components/Menu.test.tsx` executed the updated spec and reported all tests passing (`7 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c467ba28d88327aa1124731e2b29de)