### PR TITLE
Make Recharts containers explicitly responsive

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -747,7 +747,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
 
       {typeRows.length > 0 && (
         <div style={{ width: "100%", height: 240, margin: "1rem 0" }}>
-          <ResponsiveContainer>
+          <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
                 dataKey="value"
@@ -794,7 +794,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
               Region
             </button>
           </div>
-          <ResponsiveContainer>
+          <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={
                 contribTab === "sector"

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -181,7 +181,7 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
               </p>
             ) : sectorContrib && sectorContrib.length > 0 ? (
               <div className="h-64 w-full">
-                <ResponsiveContainer>
+                <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={sectorContrib}>
                     <XAxis dataKey="sector" interval={0} angle={-35} textAnchor="end" height={70} />
                     <YAxis />

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -208,7 +208,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
       {error && <p className="text-red-500">{error}</p>}
       <div style={{ width: "100%", height: 400 }}>
         {supportsResizeObserver ? (
-          <ResponsiveContainer>
+          <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
                 data={chartData}


### PR DESCRIPTION
### Motivation

- Issue Closes  #2515 reported that some charts overflow their containers on narrow viewports because `ResponsiveContainer` was left without explicit sizing, causing inconsistent fallback sizing. 
- The change ensures Recharts charts inherit parent dimensions reliably so charts resize fluidly at mobile breakpoints.

### Description

- Replaced bare `<ResponsiveContainer>` usages with ` <ResponsiveContainer width="100%" height="100%">` to force charts to fill their parent containers. 
- Updated the following files: `frontend/src/components/GroupPortfolioView.tsx`, `frontend/src/components/PortfolioView.tsx`, and `frontend/src/pages/AllocationCharts.tsx`.
- This is a declarative sizing change only and does not alter chart data, options, or business logic.

### Testing

- Ran targeted ESLint on the modified files with `cd frontend && npx eslint src/components/GroupPortfolioView.tsx src/components/PortfolioView.tsx src/pages/AllocationCharts.tsx --format unix`, which completed without reporting errors for these files. 
- Ran `npm --prefix frontend run lint` which fails due to unrelated pre-existing lint violations in other frontend files and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c467ad15508327b0d218f0cf1f415c)