### PR TITLE
Fix transactions page filter duplication and missing Amount values

### DIFF
--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -105,43 +105,14 @@ export function TransactionsPage({ owners }: Props) {
     return Array.from(options);
   }, [owner, owners]);
 
-  const newAccountOptions = useMemo(() => {
-    if (!formValues.owner) {
-      return [];
-    }
-    return owners.find((entry) => entry.owner === formValues.owner)?.accounts ?? [];
-  }, [formValues.owner, owners]);
-
   useEffect(() => {
-    if (!formValues.owner && owners.length === 1) {
-      setFormValues((current) => ({ ...current, owner: owners[0].owner }));
-      return;
-    }
-    if (formValues.owner && !owners.some((entry) => entry.owner === formValues.owner)) {
-      setFormValues((current) => ({ ...current, owner: "" }));
-    }
-  }, [owners, formValues.owner]);
-
-  useEffect(() => {
-    if (!formValues.owner) {
-      setFormValues((current) =>
-        current.account ? { ...current, account: "" } : current,
-      );
-      return;
-    }
-    if (newAccountOptions.length === 0) {
-      setFormValues((current) =>
-        current.account ? { ...current, account: "" } : current,
-      );
-      return;
-    }
-    if (!newAccountOptions.includes(formValues.account)) {
-      const nextAccount = newAccountOptions[0] ?? "";
-      setFormValues((current) =>
-        current.account === nextAccount ? current : { ...current, account: nextAccount },
-      );
-    }
-  }, [formValues.owner, formValues.account, newAccountOptions]);
+    setFormValues((current) => {
+      if (current.owner === owner && current.account === account) {
+        return current;
+      }
+      return { ...current, owner, account };
+    });
+  }, [owner, account]);
 
   const handleOwnerChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
     (event) => setOwner(event.target.value),
@@ -172,11 +143,12 @@ export function TransactionsPage({ owners }: Props) {
     if (!transaction.id) {
       return;
     }
+    setFilterOwnerAndAccount(transaction.owner, transaction.account ?? "");
     setEditingId(transaction.id);
     setFormValues(createTransactionFormValues(transaction));
     setFormError(null);
     setFormSuccess(null);
-  }, []);
+  }, [setFilterOwnerAndAccount]);
 
   const handleCancelEdit = useCallback(() => {
     setEditingId(null);
@@ -214,6 +186,10 @@ export function TransactionsPage({ owners }: Props) {
   );
 
   const validatePayload = useCallback(() => {
+    if (!formValues.owner || !formValues.account) {
+      setFormError("Select an owner and account in the filters before saving.");
+      return null;
+    }
     const result = buildTransactionPayload(formValues);
     if (result.error) {
       setFormError(result.error);
@@ -372,9 +348,8 @@ export function TransactionsPage({ owners }: Props) {
 
       <TransactionEditorForm
         values={formValues}
-        owners={owners}
-        ownerLookup={ownerLookup}
-        accountOptions={newAccountOptions}
+        activeOwner={owner}
+        activeAccount={account}
         editingId={editingId}
         hasSelection={hasSelection}
         selectedCount={selectedCount}

--- a/frontend/src/components/transactions/TransactionEditorForm.tsx
+++ b/frontend/src/components/transactions/TransactionEditorForm.tsx
@@ -1,14 +1,10 @@
 import type { ChangeEventHandler, FormEventHandler } from "react";
-import type { OwnerSummary } from "@/types";
-import { Selector } from "@/components/Selector";
-import { getOwnerDisplayName } from "@/utils/owners";
 import type { TransactionFormValues } from "./transactionForm";
 
 interface TransactionEditorFormProps {
   values: TransactionFormValues;
-  owners: OwnerSummary[];
-  ownerLookup: Map<string, string>;
-  accountOptions: string[];
+  activeOwner: string;
+  activeAccount: string;
   editingId: string | null;
   hasSelection: boolean;
   selectedCount: number;
@@ -23,9 +19,8 @@ interface TransactionEditorFormProps {
 
 export function TransactionEditorForm({
   values,
-  owners,
-  ownerLookup,
-  accountOptions,
+  activeOwner,
+  activeAccount,
   editingId,
   hasSelection,
   selectedCount,
@@ -35,6 +30,8 @@ export function TransactionEditorForm({
   onCancelEdit,
   onApplyToSelected,
 }: TransactionEditorFormProps) {
+  const ownerAndAccountSelected = Boolean(activeOwner && activeAccount);
+
   return (
     <form
       onSubmit={onSubmit}
@@ -46,27 +43,16 @@ export function TransactionEditorForm({
         marginBottom: "1rem",
       }}
     >
-      <Selector
-        label="Owner"
-        value={values.owner}
-        onChange={onFieldChange("owner")}
-        options={[
-          { value: "", label: "Select" },
-          ...owners.map((entry) => ({
-            value: entry.owner,
-            label: getOwnerDisplayName(ownerLookup, entry.owner, entry.owner),
-          })),
-        ]}
-      />
-      <Selector
-        label="Account"
-        value={values.account}
-        onChange={onFieldChange("account")}
-        options={[
-          { value: "", label: values.owner ? "Select" : "Select owner first" },
-          ...accountOptions.map((option) => ({ value: option, label: option })),
-        ]}
-      />
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.2rem" }}>
+        <strong>Applies to</strong>
+        {ownerAndAccountSelected ? (
+          <span>
+            {activeOwner} / {activeAccount}
+          </span>
+        ) : (
+          <span style={{ opacity: 0.8 }}>Select an owner and account in filters above.</span>
+        )}
+      </div>
       <label style={{ display: "flex", flexDirection: "column" }}>
         Date
         <input type="date" value={values.date} onChange={onFieldChange("date")} required />
@@ -126,7 +112,11 @@ export function TransactionEditorForm({
           placeholder="Optional"
         />
       </label>
-      <button type="submit" disabled={submitting} style={{ height: "2.3rem" }}>
+      <button
+        type="submit"
+        disabled={submitting || !ownerAndAccountSelected}
+        style={{ height: "2.3rem" }}
+      >
         {submitting
           ? editingId
             ? "Updating..."

--- a/frontend/src/components/transactions/transactionTable.ts
+++ b/frontend/src/components/transactions/transactionTable.ts
@@ -57,6 +57,10 @@ export function formatTransactionAmount(
     return money(transaction.price_gbp * transaction.units, baseCurrency);
   }
 
+  if (transaction.price_gbp != null && transaction.shares != null) {
+    return money(transaction.price_gbp * transaction.shares, baseCurrency);
+  }
+
   return "";
 }
 

--- a/frontend/tests/unit/components/transactionTable.test.ts
+++ b/frontend/tests/unit/components/transactionTable.test.ts
@@ -52,5 +52,17 @@ describe("transactionTable helpers", () => {
         "GBP",
       ),
     ).toBe("£37.50");
+
+    expect(
+      formatTransactionAmount(
+        {
+          owner: "alex",
+          account: "isa",
+          price_gbp: 8,
+          shares: 2.5,
+        },
+        "GBP",
+      ),
+    ).toBe("£20.00");
   });
 });


### PR DESCRIPTION
### Motivation
- The Transactions page displayed duplicate Owner/Account controls (filter bar and editor) causing UX confusion and ambiguous target for adds/edits.  
- The Amount column was empty for transactions that provided `shares` instead of `units`, so values were not rendered for some valid records.  
Closes #2542 
### Description
- Remove Owner/Account selectors from the inline editor and make the editor consume the active filters; the editor now shows an “Applies to” indicator derived from the top filter bar.  
- Prevent submit/update when an owner/account is not selected in the top filters by disabling the editor submit button and adding a validation check in `validatePayload`.  
- When editing a row, sync the top filters to that transaction’s owner/account to keep editing context aligned (`setFilterOwnerAndAccount` use).  
- Backfill amount rendering by extending `formatTransactionAmount` to compute `price_gbp * shares` when `amount_minor` and `units` are not available, and add a unit test to cover the `shares`-based fallback.  

### Testing
- Ran the targeted unit test suite with `npm --prefix frontend run test -- --run tests/unit/components/transactionTable.test.ts`, and the tests passed.  
- Ran `npm --prefix frontend run lint`; the linter run reported pre-existing repo-wide issues that are unrelated to these changes (lint run failure is baseline and not caused by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ecdf35748327a1f4fc0212d95c19)