### PR TITLE
Register reports router and stop rendering price source metadata in holdings

### DIFF
--- a/backend/bootstrap/routers.py
+++ b/backend/bootstrap/routers.py
@@ -32,6 +32,7 @@ from backend.routes.portfolio import router as portfolio_router
 from backend.routes.query import router as query_router
 from backend.routes.quest_routes import router as quest_router
 from backend.routes.quotes import router as quotes_router
+from backend.routes.reports import router as reports_router
 from backend.routes.scenario import router as scenario_router
 from backend.routes.screener import router as screener_router
 from backend.routes.support import router as support_router
@@ -89,3 +90,4 @@ def register_routers(app: FastAPI, cfg: Config) -> None:
     app.include_router(goals_router, dependencies=protected)
     app.include_router(tax_router)
     app.include_router(pension_router)
+    app.include_router(reports_router, dependencies=protected)

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -540,11 +540,6 @@ export function HoldingsTable({
                       {formatDateISO(new Date(h.last_price_date))}
                     </span>
                   )}
-                  {h.latest_source && (
-                    <span className="ml-1 text-gray">
-                      {t("holdingsTable.source")} {h.latest_source}
-                    </span>
-                  )}
                 </td>
                 {!relativeViewEnabled && visibleColumns.cost && (
                   <td
@@ -695,4 +690,3 @@ export function HoldingsTable({
     </>
   );
 }
-

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -264,9 +264,10 @@ describe("HoldingsTable", () => {
         );
     });
 
-      it("shows price source when available", async () => {
+      it("does not show price metadata source in the price column", async () => {
           render(<HoldingsTable holdings={holdings}/>);
-          expect(await screen.findByText(/Source: Feed/)).toBeInTheDocument();
+          await screen.findByText("AAA");
+          expect(screen.queryByText(/Source: Feed/)).toBeNull();
       });
 
       it("applies sell-eligible quick filter", async () => {


### PR DESCRIPTION
### Motivation
- Fix two regressions reported in issue Closes #2551: the Reports page failing with 404 for `/reports/templates` and the Portfolio Px column leaking price metadata like "Source: snapshot".

### Description
- Register the `reports` router in `backend/bootstrap/routers.py` so the `/reports/templates` and related report endpoints are mounted.
- Remove inline rendering of `latest_source` from the price cell in `frontend/src/components/HoldingsTable.tsx` so the Px column displays only the numeric price (and existing stale/date badges).
- Update the holdings unit test in `frontend/tests/unit/components/HoldingsTable.test.tsx` to assert that source metadata is not shown in the price column.

### Testing
- Ran the frontend unit test file with Vitest: `npm --prefix frontend run test -- --run tests/unit/components/HoldingsTable.test.tsx`, and the test suite passed (17 tests) ✅.
- Attempted to run backend route tests with `pytest -q tests/test_reports_route.py`, but the run was blocked by missing Python dependencies (`jwt`/other packages) and by environment Python version constraints when installing `requirements.txt`, so backend tests could not be completed in this environment ⚠️.
- Installed `pyyaml` successfully as part of triage, but full `pip install -r requirements.txt -r requirements-dev.txt` failed due to a pinned `numpy~=2.3.1` requiring a newer Python, preventing full backend validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6efb221a48327ab0d3d870858e99c)