### PR TITLE
Enforce filter-driven transaction editor state and harden amount formatting

### DIFF
--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -46,11 +46,7 @@ export function TransactionsPage({ owners }: Props) {
   const ownerLookup = useMemo(() => createOwnerDisplayLookup(owners), [owners]);
 
   const resetForm = useCallback(() => {
-    setFormValues((current) => ({
-      ...EMPTY_TRANSACTION_FORM_VALUES,
-      owner: current.owner,
-      account: current.account,
-    }));
+    setFormValues({ ...EMPTY_TRANSACTION_FORM_VALUES });
   }, []);
 
   const fetchTransactions = useCallback(
@@ -104,15 +100,6 @@ export function TransactionsPage({ owners }: Props) {
     owners.forEach((entry) => entry.accounts.forEach((value) => options.add(value)));
     return Array.from(options);
   }, [owner, owners]);
-
-  useEffect(() => {
-    setFormValues((current) => {
-      if (current.owner === owner && current.account === account) {
-        return current;
-      }
-      return { ...current, owner, account };
-    });
-  }, [owner, account]);
 
   const handleOwnerChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
     (event) => setOwner(event.target.value),
@@ -186,17 +173,17 @@ export function TransactionsPage({ owners }: Props) {
   );
 
   const validatePayload = useCallback(() => {
-    if (!formValues.owner || !formValues.account) {
+    if (!owner || !account) {
       setFormError("Select an owner and account in the filters before saving.");
       return null;
     }
-    const result = buildTransactionPayload(formValues);
+    const result = buildTransactionPayload(formValues, owner, account);
     if (result.error) {
       setFormError(result.error);
       return null;
     }
     return result.payload;
-  }, [formValues]);
+  }, [account, formValues, owner]);
 
   const handleBulkDelete = useCallback(async () => {
     if (!hasSelection) {

--- a/frontend/src/components/transactions/transactionForm.ts
+++ b/frontend/src/components/transactions/transactionForm.ts
@@ -1,8 +1,6 @@
 import type { Transaction } from "@/types";
 
 export type TransactionFormValues = {
-  owner: string;
-  account: string;
   date: string;
   ticker: string;
   price: string;
@@ -13,8 +11,6 @@ export type TransactionFormValues = {
 };
 
 export const EMPTY_TRANSACTION_FORM_VALUES: TransactionFormValues = {
-  owner: "",
-  account: "",
   date: "",
   ticker: "",
   price: "",
@@ -63,8 +59,6 @@ export function createTransactionFormValues(
   const legacyReason = (transaction as { reason_to_buy?: string | null }).reason_to_buy;
 
   return {
-    owner: transaction.owner,
-    account: transaction.account,
     date: transaction.date ? transaction.date.slice(0, 10) : "",
     ticker: tickerValue,
     price:
@@ -94,6 +88,8 @@ export type BuildTransactionPayloadResult =
 
 export function buildTransactionPayload(
   values: TransactionFormValues,
+  owner: string,
+  account: string,
 ): BuildTransactionPayloadResult {
   const price = Number.parseFloat(values.price);
   const units = Number.parseFloat(values.units);
@@ -105,7 +101,7 @@ export function buildTransactionPayload(
   const reason = values.reason.trim();
   const comments = values.comments.trim();
 
-  if (!values.owner || !values.account || !values.date || !ticker || !reason) {
+  if (!owner || !account || !values.date || !ticker || !reason) {
     return {
       payload: null,
       error: "Please complete all required fields.",
@@ -130,8 +126,8 @@ export function buildTransactionPayload(
 
   return {
     payload: {
-      owner: values.owner,
-      account: values.account,
+      owner,
+      account,
       date: values.date,
       ticker,
       price_gbp: price,

--- a/frontend/src/components/transactions/transactionTable.ts
+++ b/frontend/src/components/transactions/transactionTable.ts
@@ -47,18 +47,43 @@ export function formatTransactionAmount(
   transaction: Transaction,
   baseCurrency: string,
 ): string {
+  const price =
+    typeof transaction.price_gbp === "number" && Number.isFinite(transaction.price_gbp)
+      ? transaction.price_gbp
+      : null;
+  const units =
+    typeof transaction.units === "number" && Number.isFinite(transaction.units)
+      ? transaction.units
+      : null;
+  const shares =
+    typeof transaction.shares === "number" && Number.isFinite(transaction.shares)
+      ? transaction.shares
+      : null;
+
   if (transaction.amount_minor != null) {
     // Use || rather than ?? so that an empty string currency also falls back
     // to baseCurrency (the backend should never send "", but guard defensively).
     return money(transaction.amount_minor / 100, transaction.currency || baseCurrency);
   }
 
-  if (transaction.price_gbp != null && transaction.units != null) {
-    return money(transaction.price_gbp * transaction.units, baseCurrency);
+  if (price == null) {
+    return "";
   }
 
-  if (transaction.price_gbp != null && transaction.shares != null) {
-    return money(transaction.price_gbp * transaction.shares, baseCurrency);
+  if (units != null && shares != null) {
+    console.warn(
+      "Transaction contains both units and shares; using units for amount display.",
+      transaction,
+    );
+    return money(price * units, baseCurrency);
+  }
+
+  if (units != null) {
+    return money(price * units, baseCurrency);
+  }
+
+  if (shares != null) {
+    return money(price * shares, baseCurrency);
   }
 
   return "";

--- a/frontend/tests/unit/components/TransactionsPage.test.tsx
+++ b/frontend/tests/unit/components/TransactionsPage.test.tsx
@@ -1,11 +1,12 @@
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TransactionsPage } from "@/components/TransactionsPage";
 
-vi.mock("@/api", () => ({
-  getTransactions: vi.fn(() =>
+const { getTransactionsMock, createTransactionMock } = vi.hoisted(() => ({
+  getTransactionsMock: vi.fn(() =>
     Promise.resolve([
       {
+        id: "alex:isa:0",
         owner: "alex",
         account: "isa",
         ticker: "PFE",
@@ -14,20 +15,88 @@ vi.mock("@/api", () => ({
         currency: "GBP",
         shares: 5,
         date: "2024-01-01",
+        reason: "Initial",
       },
-    ])
+      {
+        id: "sam:sipp:1",
+        owner: "sam",
+        account: "sipp",
+        ticker: "MSFT",
+        type: "BUY",
+        amount_minor: 20000,
+        currency: "GBP",
+        units: 10,
+        date: "2024-01-02",
+        reason: "Growth",
+      },
+    ]),
   ),
+  createTransactionMock: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock("@/api", () => ({
+  getTransactions: getTransactionsMock,
+  createTransaction: createTransactionMock,
+  updateTransaction: vi.fn(() => Promise.resolve({})),
+  deleteTransaction: vi.fn(() => Promise.resolve({})),
 }));
 
 describe("TransactionsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("displays instrument ticker", async () => {
     render(
       <TransactionsPage
-        owners={[{ owner: "alex", full_name: "Alex Example", accounts: ["isa"] }]}
+        owners={[
+          { owner: "alex", full_name: "Alex Example", accounts: ["isa"] },
+          { owner: "sam", full_name: "Sam Example", accounts: ["sipp"] },
+        ]}
       />,
     );
     expect(await screen.findByText("PFE")).toBeInTheDocument();
     expect((await screen.findAllByText("Alex Example")).at(-1)).toBeInTheDocument();
   });
-});
 
+  it("syncs filter owner/account when editing and reflects it in the editor context", async () => {
+    render(
+      <TransactionsPage
+        owners={[
+          { owner: "alex", full_name: "Alex Example", accounts: ["isa"] },
+          { owner: "sam", full_name: "Sam Example", accounts: ["sipp"] },
+        ]}
+      />,
+    );
+
+    await screen.findByText("MSFT");
+    const [ownerFilter, accountFilter] = screen.getAllByRole("combobox");
+
+    expect(ownerFilter).toHaveValue("");
+    expect(accountFilter).toHaveValue("");
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[1]!);
+
+    expect(ownerFilter).toHaveValue("sam");
+    expect(accountFilter).toHaveValue("sipp");
+    expect(screen.getByText("sam / sipp")).toBeInTheDocument();
+  });
+
+  it("guards validation when submitting without filter owner/account context", async () => {
+    render(<TransactionsPage owners={[{ owner: "alex", full_name: "Alex Example", accounts: ["isa"] }]} />);
+    await screen.findByText("PFE");
+
+    fireEvent.change(screen.getByLabelText("Date"), { target: { value: "2024-03-01" } });
+    fireEvent.change(screen.getByLabelText("Ticker"), { target: { value: "VUSA" } });
+    fireEvent.change(screen.getByLabelText("Price (GBP)"), { target: { value: "10" } });
+    fireEvent.change(screen.getByLabelText("Units"), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText("Reason"), { target: { value: "test reason" } });
+
+    fireEvent.submit(screen.getByRole("button", { name: "Add transaction" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Select an owner and account in the filters before saving.")).toBeInTheDocument();
+    });
+    expect(createTransactionMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/components/transactionForm.test.ts
+++ b/frontend/tests/unit/components/transactionForm.test.ts
@@ -19,8 +19,6 @@ describe("transactionForm helpers", () => {
         date: "2024-02-01T10:00:00Z",
       }),
     ).toEqual({
-      owner: "alex",
-      account: "isa",
       ticker: "VUSA",
       price: "5.25",
       units: "2",
@@ -46,8 +44,6 @@ describe("transactionForm helpers", () => {
   it("builds a valid transaction payload", () => {
     expect(
       buildTransactionPayload({
-        owner: "alex",
-        account: "isa",
         date: "2024-02-01",
         ticker: " vusa ",
         price: "12.50",
@@ -55,7 +51,7 @@ describe("transactionForm helpers", () => {
         fees: "1.25",
         comments: " add more ",
         reason: " rebalance ",
-      }),
+      }, "alex", "isa"),
     ).toEqual({
       error: null,
       payload: {
@@ -75,8 +71,6 @@ describe("transactionForm helpers", () => {
   it("returns a validation error for invalid fees", () => {
     expect(
       buildTransactionPayload({
-        owner: "alex",
-        account: "isa",
         date: "2024-02-01",
         ticker: "VUSA",
         price: "12.50",
@@ -84,7 +78,7 @@ describe("transactionForm helpers", () => {
         fees: "abc",
         comments: "",
         reason: "rebalance",
-      }),
+      }, "alex", "isa"),
     ).toEqual({
       payload: null,
       error: "Enter a valid fee or leave it blank.",
@@ -96,8 +90,6 @@ describe("transactionForm helpers", () => {
     // correctly rejects it.
     expect(
       buildTransactionPayload({
-        owner: "alex",
-        account: "isa",
         date: "2024-02-01",
         ticker: "VUSA",
         price: "12.50",
@@ -105,7 +97,7 @@ describe("transactionForm helpers", () => {
         fees: "1.5abc",
         comments: "",
         reason: "rebalance",
-      }),
+      }, "alex", "isa"),
     ).toEqual({
       payload: null,
       error: "Enter a valid fee or leave it blank.",
@@ -115,8 +107,6 @@ describe("transactionForm helpers", () => {
   it("returns a validation error for negative fees", () => {
     expect(
       buildTransactionPayload({
-        owner: "alex",
-        account: "isa",
         date: "2024-02-01",
         ticker: "VUSA",
         price: "12.50",
@@ -124,7 +114,7 @@ describe("transactionForm helpers", () => {
         fees: "-1",
         comments: "",
         reason: "rebalance",
-      }),
+      }, "alex", "isa"),
     ).toEqual({
       payload: null,
       error: "Fees cannot be negative.",

--- a/frontend/tests/unit/components/transactionTable.test.ts
+++ b/frontend/tests/unit/components/transactionTable.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildBulkDeletionOrder,
   formatTransactionAmount,
@@ -64,5 +64,48 @@ describe("transactionTable helpers", () => {
         "GBP",
       ),
     ).toBe("£20.00");
+  });
+
+  it("uses units precedence and warns when units and shares both exist", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(
+      formatTransactionAmount(
+        {
+          owner: "alex",
+          account: "isa",
+          price_gbp: 10,
+          units: 3,
+          shares: 9,
+        },
+        "GBP",
+      ),
+    ).toBe("£30.00");
+    expect(warnSpy).toHaveBeenCalledOnce();
+    warnSpy.mockRestore();
+  });
+
+  it("returns blank when price is missing or non-numeric", () => {
+    expect(
+      formatTransactionAmount(
+        {
+          owner: "alex",
+          account: "isa",
+          units: 3,
+        },
+        "GBP",
+      ),
+    ).toBe("");
+
+    expect(
+      formatTransactionAmount(
+        {
+          owner: "alex",
+          account: "isa",
+          price_gbp: Number.NaN,
+          units: 3,
+        },
+        "GBP",
+      ),
+    ).toBe("");
   });
 });


### PR DESCRIPTION
### Motivation

- Remove the dual source-of-truth for `owner`/`account` between filters and the transaction form to eliminate race/overwrite bugs in the edit flow.  
- Make transaction amount derivation explicit and safe against missing or non-numeric `price_gbp` and ambiguous `units`/`shares` data.  
- Ensure payload construction uses the UI filter context as the authoritative owner/account for create/update operations.  

Closes #2542 

### Description

- Removed `owner` and `account` from the form model by updating `TransactionFormValues` and `EMPTY_TRANSACTION_FORM_VALUES` and ensured form values no longer carry duplicate ownership state in `frontend/src/components/transactions/transactionForm.ts`.  
- Updated `TransactionsPage` to stop mirroring filter fields into the form and to use filter state as the source of truth, including passing `owner`/`account` into `buildTransactionPayload(formValues, owner, account)` and simplifying `resetForm` in `frontend/src/components/TransactionsPage.tsx`.  
- Hardened `formatTransactionAmount` in `frontend/src/components/transactions/transactionTable.ts` by validating numeric `price_gbp`, `units`, and `shares`, returning an empty string if price is missing/invalid, and logging + preferring `units` if both `units` and `shares` appear.  
- Kept `Transaction` typing as-is after verifying `shares?: number | null` is already declared in `frontend/src/types.ts`, so no type file changes were required.  
- Updated and added unit tests to cover the edit→filter sync, payload validation guard (requires filter owner/account), and amount fallback/precedence cases in the frontend test files under `frontend/tests/unit/components/`.

### Testing

- Ran unit tests for the changed areas with `npm --prefix frontend run test -- --run tests/unit/components/transactionForm.test.ts tests/unit/components/transactionTable.test.ts tests/unit/components/TransactionsPage.test.tsx`, and all targeted tests passed (the three modified/added test files passed).  
- Added/updated tests: `TransactionsPage.test.tsx` (edit→filter sync + filter validation guard), `transactionTable.test.ts` (units/shares precedence and missing/non-numeric price cases), and `transactionForm.test.ts` (payload builder changes).  
- Ran frontend lint with `npm --prefix frontend run lint`; lint reported pre-existing repo-wide issues unrelated to this change and did not block this PR (reported failures are outside the modified files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f1d13da48327868b9eeaf8b479bb)