### PR TITLE
Harden workflow action pinning and update pnpm setup

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -16,7 +16,7 @@ jobs:
       DATA_BUCKET: ${{ secrets.DATA_BUCKET }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
@@ -40,7 +40,7 @@ jobs:
       - name: Configure AWS credentials (optional)
         id: aws-auth
         if: ${{ env.AWS_ROLE_TO_ASSUME != '' }}
-        uses: aws-actions/configure-aws-credentials@v4.3.1
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -23,7 +23,7 @@ jobs:
       SMOKE_TEST_URL: ${{ vars.SMOKE_TEST_URL }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.4.0
@@ -63,7 +63,7 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4.3.1
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -133,7 +133,7 @@ jobs:
       SMOKE_URL: ${{ vars.SMOKE_URL }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.4.0

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -18,7 +18,7 @@ jobs:
         run: python scripts/check_contract_version_sync.py
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2.4.1
+        uses: pnpm/action-setup@v4.1.0
         with:
           version: 8
 


### PR DESCRIPTION
### Motivation
- Reduce supply-chain risk in CI by moving off a stale pnpm action major and replacing mutable action tags with immutable SHA pins for workflows that obtain AWS credentials.
- Keep frontend CI using `pnpm` version 8 while upgrading the setup action to a maintained major.
Closes #2568 
### Description
- Updated `.github/workflows/frontend-tests.yml` to use `pnpm/action-setup@v4.1.0` while retaining `version: 8`.
- Replaced `actions/checkout@v4.3.1` with an immutable commit SHA pin (`34e114876b0b11c390a56381ad16ebd13914f8d5`) in `deploy-lambda.yml` and `backend-integration.yml`, preserving the original tag in a comment.
- Replaced `aws-actions/configure-aws-credentials@v4.3.1` with an immutable commit SHA pin (`7474bc4690e29a8392af63c5b98e7449536d5c3a`) in `deploy-lambda.yml` and `backend-integration.yml`, preserving the original tag in a comment.
- Changes are limited to the three workflow files and do not modify runtime application code.

### Testing
- Verified tag commit SHAs with `git ls-remote https://github.com/actions/checkout refs/tags/v4.3.1` and `git ls-remote https://github.com/aws-actions/configure-aws-credentials refs/tags/v4.3.1`, both of which succeeded.
- Attempted to validate workflow YAML with a Python `yaml.safe_load` check, which failed due to `PyYAML` not being installed in the environment (`ModuleNotFoundError`).
- No GitHub Actions CI run was executed from this environment; full CI will validate end-to-end behavior (especially frontend install/test steps) after the PR is merged or when run on GitHub.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c798f8ecdc83279a4a8d02f64421dc)