### PR TITLE
docs: add P10-derived code quality invariants to all agent docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,3 +12,13 @@ Read `AGENTS.md` for full repository guidance. Use these short rules while gener
 - Keep changes out of generated dependency folders such as `node_modules/`.
 - Be careful when changing `data/`, auth defaults, or smoke-test flows; these are tightly coupled to local development and demos.
 - Preserve bash/PowerShell parity when editing shared developer workflows.
+
+## Code quality invariants (non-negotiable)
+
+Derived from NASA/JPL Power of Ten — applicable subset only (C-specific rules omitted):
+
+- **Function length**: ~60 lines max. Refactor before adding more to an oversized function.
+- **Zero lint warnings**: `make lint` and `npm --prefix frontend run lint` must pass clean. Rewrite code that triggers false positives rather than suppressing them.
+- **No silent error swallowing**: no bare `except: pass`, no silent `catch` blocks, no unhandled Promise rejections.
+- **No ignored return values**: if you discard a return value intentionally, make it explicit and add a comment explaining why.
+- **Minimum scope**: declare variables as late and as locally as possible; avoid unnecessary module-level mutable state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,26 @@ To support tool-specific agents, keep these files aligned when the repo guidance
 - `.github/copilot-instructions.md` — concise GitHub Copilot coding-agent instructions.
 
 When updating one of these, consider whether the same repo facts or command changes should be mirrored in the others.
+
+## 10. Code quality invariants (non-negotiable)
+
+Derived from the NASA/JPL Power of Ten guidelines — applicable subset only. C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limits, recursion ban) are not applicable to this stack and are intentionally omitted.
+
+### Function length (P10 Rule 4)
+Keep functions to approximately 60 lines or fewer — roughly one screen. If a function exceeds this, refactor it before making further changes. Excessively long functions are a signal of poorly structured code, not a style preference.
+
+### Zero lint warnings (P10 Rule 10)
+`make lint` (Python) and `npm --prefix frontend run lint` (TypeScript) must both pass with zero warnings. If a tool flags something incorrectly, rewrite the code until it no longer triggers — do not suppress or ignore warnings without a documented justification inline. Zero-warning compliance must hold from the first day of work on a branch, not just before merge.
+
+### No silent error swallowing (P10 Rules 5 and 7)
+Every error path must be explicitly handled:
+- No bare `except: pass` or `except Exception: pass` in Python.
+- No `catch` blocks that silently discard exceptions in TypeScript.
+- No unhandled Promise rejections.
+- No `assert False, "unreachable"` used as a substitute for real error handling in production paths.
+
+### No ignored return values (P10 Rule 7)
+Check return values of functions that can signal failure. If you deliberately discard a return value, make it explicit (`_ =` in Python; a `void`-cast comment in TypeScript) and add a brief inline comment explaining why the return value is safe to ignore in that context.
+
+### Minimum scope (P10 Rule 6)
+Declare variables as late as possible and as locally as possible. Avoid module-level or class-level mutable state unless there is a clear, documented reason. Unnecessary broad scope makes fault diagnosis harder and increases the risk of unintended mutation across call sites.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,17 @@ Branch naming convention: `fix/issue-NNNN-short-description` or `feat/issue-NNNN
 4. Run the narrowest useful validation.
 5. Update nearby docs when commands or behavior changed.
 
+## Code quality invariants (non-negotiable)
+
+Derived from the NASA/JPL Power of Ten guidelines — applicable subset only.
+C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limits, recursion ban) are omitted as inapplicable to this stack.
+
+- **Function length**: keep functions to ~60 lines or fewer. If a function no longer fits on one screen, refactor before making further changes.
+- **Zero lint warnings**: `make lint` and `npm --prefix frontend run lint` must pass clean. If a tool flags something incorrectly, rewrite the code until it doesn't — do not suppress warnings without a documented justification inline.
+- **No silent error swallowing**: every error path must be explicitly handled. No bare `except: pass`, no `catch` blocks that discard exceptions silently, no unhandled Promise rejections.
+- **No ignored return values**: check return values of functions that can fail. If you deliberately discard a return value, make it explicit (`_ =` in Python, explicit `void` comment in TS) and add a brief comment explaining why.
+- **Minimum scope**: declare variables as late as possible and as locally as possible. Avoid module-level mutable state unless genuinely necessary.
+
 ## If you touch specific areas
 
 ### Backend


### PR DESCRIPTION
## What changed

Adds a **Code quality invariants** section to all three AI-facing agent docs (`AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`), derived from the NASA/JPL _Power of Ten_ rules for safety-critical code.

## Why

The existing docs stated _what_ to run (lint, tests) but not _what standard_ that output must meet. An AI agent following the old docs would pass lint with warnings or write silent exception handlers without any signal that these are defects. The new section closes that gap.

## Which P10 rules were applied (and which were skipped)

| Rule | Principle | Applied? |
|------|-----------|----------|
| 1 | No goto / recursion | ❌ C-specific, irrelevant |
| 2 | Bounded loops | ❌ C-specific, irrelevant |
| 3 | No dynamic memory allocation | ❌ Meaningless in GC languages |
| 4 | ~60-line function limit | ✅ |
| 5 | Assertion / explicit error handling density | ✅ (as "no silent swallowing") |
| 6 | Minimum variable scope | ✅ |
| 7 | Check all return values | ✅ |
| 8 | Preprocessor restrictions | ❌ C-specific |
| 9 | Pointer restrictions | ❌ C-specific |
| 10 | Zero warnings from day one | ✅ |

## What was validated

Doc-only change; no code modified. Verified content is consistent across all three files and that existing command references are unchanged.

## Follow-up / risk

None. These are agent-guidance docs only — no runtime behaviour is affected.
