### PR TITLE
Require at least one S3 permission in _grant_bucket_access and add unit test

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -34,6 +34,12 @@ class BackendLambdaStack(Stack):
         ``allow_read``/``allow_put`` scope object-level actions to ``/*``.
         """
 
+        if not any((allow_read, allow_put, allow_list)):
+            raise ValueError(
+                "_grant_bucket_access called with no permissions enabled — this is a no-op. "
+                "Pass at least one of allow_read, allow_put, or allow_list as True."
+            )
+
         object_actions: list[str] = []
         if allow_read:
             object_actions.append("s3:GetObject")

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
+import pytest
 from aws_cdk import App
 from aws_cdk.assertions import Template
 
@@ -191,4 +192,23 @@ def test_lambda_roles_do_not_have_s3_delete_permissions() -> None:
         # Also catch wildcard grants which implicitly include delete
         assert "s3:*" not in actions and "*" not in actions, (
             f"Found wildcard grant for {fragment} which implicitly includes delete"
+        )
+
+
+def test_grant_bucket_access_raises_on_no_permissions() -> None:
+    class _MockFn:
+        def add_to_role_policy(self, policy_statement: object) -> None:
+            raise AssertionError(
+                "add_to_role_policy should not be called when no permissions are enabled"
+            )
+
+    mock_fn = _MockFn()
+
+    with pytest.raises(ValueError, match="no permissions enabled"):
+        BackendLambdaStack._grant_bucket_access(
+            mock_fn,
+            bucket_name="test-bucket",
+            allow_read=False,
+            allow_put=False,
+            allow_list=False,
         )


### PR DESCRIPTION
### Motivation
- Ensure callers don't call the helper with no effective permissions which would be a no-op and likely indicate a bug. 
Closes #2587 
### Description
- Added a validation in `BackendLambdaStack._grant_bucket_access` to raise `ValueError` if all of `allow_read`, `allow_put`, and `allow_list` are `False`.
- Preserved existing behavior of scoping object-level actions to `arn:aws:s3:::<bucket>/*` and `s3:ListBucket` to the bucket ARN only.
- Added `test_grant_bucket_access_raises_on_no_permissions` to `cdk/tests/test_backend_lambda_stack_permissions.py` that verifies a `ValueError` is raised and that `add_to_role_policy` is not invoked when no permissions are enabled.

### Testing
- Ran the unit tests in `cdk/tests/test_backend_lambda_stack_permissions.py` with `pytest`, and the suite including the new test `test_grant_bucket_access_raises_on_no_permissions` passed.
- Existing permission-related tests continued to assert correct scoping and absence of delete/wildcard S3 permissions and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94e3b23d083278349218657231570)