### PR TITLE
Normalize value/weight rows: stable labels, weight_pct fallback, deterministic ordering; add tests and manual-test plan

### DIFF
--- a/backend/reports.py
+++ b/backend/reports.py
@@ -890,17 +890,23 @@ def _normalise_value_weight_rows(
     label_key: str,
     value_key: str = "market_value_gbp",
 ) -> List[Dict[str, Any]]:
-    prepared_rows: List[tuple[Any, float | None, float | None]] = []
+    prepared_rows: List[tuple[str, float | None, float | None]] = []
     total_value = 0.0
     for row in rows:
-        label = row.get(label_key)
+        label = str(row.get(label_key) or "Unknown").strip() or "Unknown"
         value = _safe_float(row.get("value"))
         if value is None:
             value = _safe_float(row.get(value_key))
         weight = _safe_float(row.get("weight"))
+        if weight is None:
+            weight_pct = _safe_float(row.get("weight_pct"))
+            if weight_pct is not None:
+                weight = weight_pct / 100.0
         prepared_rows.append((label, value, weight))
         if value is not None:
             total_value += value
+
+    prepared_rows.sort(key=lambda item: item[1] if item[1] is not None else float("-inf"), reverse=True)
 
     normalised: List[Dict[str, Any]] = []
     for label, value, weight in prepared_rows:

--- a/docs/manual-tests/issue-2578-codex-tasks.md
+++ b/docs/manual-tests/issue-2578-codex-tasks.md
@@ -1,0 +1,106 @@
+# Issue #2578 — Codex Implementation Tasks
+
+This checklist turns issue #2578 into execution-ready tasks with explicit validation criteria and AGENTS.md workflow compliance.
+
+## Task 0 — Scope lock and dependency gate
+
+- [ ] Confirm dependency issue/PR #2572 is merged before finalizing VaR behavior.
+- [ ] Confirm scope is limited to report sections 1–4 only (exclude section 5 key findings).
+- [ ] Record whether ETF overlap/scenario outputs are intentionally out of scope for #2578.
+
+**Definition of done**
+- Scope and dependency status are documented in the issue/PR notes.
+
+---
+
+## Task 1 — Build acceptance-criteria traceability matrix
+
+- [ ] Create a matrix with columns: AC item, code location, test case(s), command, pass condition.
+- [ ] Seed matrix with `audit-report` template sections and report route ordering.
+
+**Definition of done**
+- Every acceptance criterion has at least one linked test and pass condition.
+
+---
+
+## Task 2 — Gap audit of current implementation
+
+- [ ] Verify `audit-report` template section order and sources:
+  - `portfolio.overview`
+  - `portfolio.sectors`
+  - `portfolio.regions`
+  - `portfolio.concentration`
+  - `portfolio.var`
+- [ ] Verify builder wiring for all required portfolio report sources.
+- [ ] Mark each AC row as pass/fail before changing code.
+
+**Definition of done**
+- A concise "gaps to fix" checklist exists.
+
+---
+
+## Task 3 — Implement targeted backend changes for failing AC rows
+
+- [ ] Update `backend/reports.py` only where AC failures require changes.
+- [ ] Ensure output rows for overview/sector/region/concentration/var are stable and deterministic for demo fixture inputs.
+- [ ] Keep error handling explicit (no silent swallow patterns).
+
+**Definition of done**
+- All failing AC rows from Task 2 are resolved with minimal, focused diffs.
+
+---
+
+## Task 4 — Add or refine tests for AC completeness
+
+- [ ] Add/update report data tests (`tests/test_reports.py`) for section payload shape and plausible values.
+- [ ] Add/update route tests (`tests/test_reports_route.py`) for JSON section order and PDF response contract.
+- [ ] Add/update PDF/report regression checks (`tests/test_reports_pdf.py` / `tests/test_reports_additional.py`) where needed.
+- [ ] Add explicit checks for:
+  - non-empty or expected-empty behavior,
+  - concentration ordering and summary metrics,
+  - VaR/Sharpe availability fallback behavior,
+  - no regressions to existing built-in templates.
+
+**Definition of done**
+- AC matrix rows are all covered by deterministic tests.
+
+---
+
+## Task 5 — Validation run sequence
+
+- [ ] Run targeted report test commands first:
+  - `pytest tests/test_reports.py tests/test_reports_route.py tests/test_reports_pdf.py`
+- [ ] Run additional related suites if touched:
+  - `pytest tests/test_reports_additional.py tests/test_reports_validation.py`
+- [ ] Run lint gate with zero warnings:
+  - `make lint`
+
+**Definition of done**
+- Commands pass and results are captured in PR notes.
+
+---
+
+## Task 6 — Branch and PR hygiene (AGENTS.md)
+
+- [ ] Work from non-main branch named with issue number (e.g., `feat/issue-2578-audit-report-pipeline`).
+- [ ] Use focused commit messages.
+- [ ] PR description includes:
+  - what changed,
+  - why it changed,
+  - validation performed,
+  - follow-ups/risks.
+
+**Definition of done**
+- Branch and PR satisfy repository branch/PR policy.
+
+---
+
+## Suggested execution order
+
+1. Task 0
+2. Task 1
+3. Task 2
+4. Task 3
+5. Task 4
+6. Task 5
+7. Task 6

--- a/tests/test_reports_additional.py
+++ b/tests/test_reports_additional.py
@@ -832,11 +832,11 @@ def test_audit_concentration_hhi_uses_full_holding_set(monkeypatch):
     assert all(row["hhi"] == pytest.approx(expected_hhi) for row in concentration)
 
 
-def test_normalise_value_weight_rows_prefers_value_consistently():
+def test_normalise_value_weight_rows_prefers_value_and_sorts_descending():
     rows = reports._normalise_value_weight_rows(
         [
-            {"sector": "Technology", "value": 70.0, "market_value_gbp": 700.0},
             {"sector": "Healthcare", "value": 30.0, "market_value_gbp": 300.0},
+            {"sector": "Technology", "value": 70.0, "market_value_gbp": 700.0},
         ],
         label_key="sector",
     )
@@ -844,6 +844,21 @@ def test_normalise_value_weight_rows_prefers_value_consistently():
     assert rows == [
         {"sector": "Technology", "value": 70.0, "weight": 0.7},
         {"sector": "Healthcare", "value": 30.0, "weight": 0.3},
+    ]
+
+
+def test_normalise_value_weight_rows_uses_weight_pct_and_unknown_label():
+    rows = reports._normalise_value_weight_rows(
+        [
+            {"sector": "", "market_value_gbp": 1000.0, "weight_pct": 75.0},
+            {"market_value_gbp": 333.0, "weight_pct": 25.0},
+        ],
+        label_key="sector",
+    )
+
+    assert rows == [
+        {"sector": "Unknown", "value": 1000.0, "weight": 0.75},
+        {"sector": "Unknown", "value": 333.0, "weight": 0.25},
     ]
 
 


### PR DESCRIPTION
### Motivation

- Ensure portfolio report sections produce stable, deterministic rows and sensible defaults for missing label/weight data.
- Make downstream report rendering and tests less brittle by normalizing labels and using alternative weight fields when present.
- Provide a manual-tests checklist for issue Closes #2578 to document scope, acceptance criteria, and validation steps.

### Description

- Updated `backend/reports.py` in `_normalise_value_weight_rows` to coerce empty labels to a trimmed string and default to `"Unknown"`, and updated type hints to reflect label strings. 
- Added fallback logic to use `weight_pct` (divided by 100) when `weight` is missing, and made rows sort deterministically by numeric `value` in descending order before normalization. 
- Added `docs/manual-tests/issue-2578-codex-tasks.md` with a step-by-step checklist for scope, acceptance criteria, gap audit, targeted changes, tests, and validation commands. 
- Updated `tests/test_reports_additional.py` to rename an existing test for clarity and add a new test that verifies `weight_pct` usage and `Unknown` label behavior.

### Testing

- Ran targeted unit tests in `tests/test_reports_additional.py` using `pytest tests/test_reports_additional.py`, and the updated/added tests passed. 
- Existing report-related tests exercising `_build_portfolio_concentration_section` and `_build_portfolio_var_section` continued to pass under the updated normalization behavior. 
- No lint or CI failures were observed for the modified files in local test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94e1829a0832795c35cb9b4f01c65)