### PR TITLE
Document clean-checkout workflow for demo audit-report PDF generation

### DIFF
--- a/docs/REPORT_WORKFLOW.md
+++ b/docs/REPORT_WORKFLOW.md
@@ -1,31 +1,92 @@
 # Report Workflow
 
-This workflow explains how to produce a customer report with manually written Key Findings.
+This workflow documents the exact end-to-end path for producing a customer-facing `audit-report` PDF from a clean checkout.
 
-1. **Receive tickers**
-   - Confirm the customer owner identifier and the ticker set that should be reviewed.
+## 1) Start from a clean checkout
 
-2. **Run analysis**
-   - Prepare backend/frontend dependencies when setting up the environment or after dependency changes:
-     - `python -m pip install -r requirements.txt -r requirements-dev.txt`
-     - `npm install && npm --prefix frontend install`
-   - Run backend locally for report-related checks:
-     - `bash scripts/bash/run-local-api.sh`
-   - Use existing smoke checks for confidence when required:
-     - `npm run smoke:test`
+Install dependencies (first run or after dependency changes):
 
-3. **Create the key findings file**
-   - Create this file for the owner:
-     - `data/accounts/{owner}/key_findings.md`
+```bash
+python -m pip install -r requirements.txt -r requirements-dev.txt
+npm install
+npm --prefix frontend install
+```
 
-4. **Write findings manually**
-   - Findings are **NOT auto-generated**.
-   - Write short, specific, numeric findings (one finding per line or bullet).
-   - Recommended format: 20-240 characters, include at least one number, and prefer `- `, `* `, or `1. ` style bullets.
-   - Findings that do not meet the recommended format are skipped with a warning during report generation rather than failing the whole report.
+Bring up the local stack:
 
-5. **Generate report**
-   - Generate the `audit-report` document/PDF using the existing report route or report generation workflow.
+```bash
+make local-up
+```
 
-6. **Send report**
-   - Send the final PDF report to the customer using the normal reporting channel.
+The API is available at `http://localhost:8000` once containers are healthy.
+
+## 2) Confirm the customer scope
+
+Collect:
+- owner identifier (for example, `demo-owner`)
+- ticker/portfolio context to review
+
+## 3) Create or update key findings
+
+`audit-report` expects manually written findings at:
+
+```text
+data/accounts/{owner}/key_findings.md
+```
+
+Example setup for demo generation from a clean checkout:
+
+```bash
+mkdir -p data/accounts/demo-owner
+cat > data/accounts/demo-owner/key_findings.md << 'EOF2'
+- Global equity exposure is 71.4% of portfolio value, above the 65.0% policy target.
+- Largest position concentration is 12.1% in a single issuer versus a 10.0% guardrail.
+- 1-day 95% VaR is £1,240 on a £42,800 portfolio, implying a 2.9% downside move.
+- Cash drag is 9.8% of assets while short-duration bonds yield 4.2%.
+EOF2
+```
+
+Writing guidance:
+- Findings are **not auto-generated**.
+- Use one bullet per finding with concrete numbers.
+- Keep each finding short and specific (recommended 20-240 chars).
+- Invalid lines are skipped with warnings instead of failing report generation.
+
+## 4) Generate and download the PDF
+
+Use the report route directly:
+
+```bash
+curl -sS "http://localhost:8000/reports/demo-owner/audit-report?format=pdf&watermark=SAMPLE" -o demo-owner-audit-report.pdf
+```
+
+Optional JSON preview of section payloads:
+
+```bash
+curl -sS "http://localhost:8000/reports/demo-owner/audit-report?format=json" | jq '.sections[].title'
+```
+
+Expected section order for a complete demo report:
+1. Portfolio Summary
+2. Holdings Breakdown
+3. Sector Allocation
+4. Risk Analysis
+5. Key Findings
+
+## 5) Validate report quality before sending
+
+Minimum checks:
+- PDF opens and all five sections render (including Key Findings).
+- Currency and percentages are formatted for end users (no raw floats/internal IDs).
+- Narrative answers: total value, top risk, and recommended action are clear.
+- Product gate: "Would I confidently send this to a prospect?" must be **yes**.
+
+## 6) Operational handoff
+
+If needed, attach the generated PDF to your normal reporting channel/email flow.
+
+When done with local containers:
+
+```bash
+make local-down
+```


### PR DESCRIPTION
### Motivation

- The existing `docs/REPORT_WORKFLOW.md` was high-level and did not provide the concrete, executable steps needed to produce the demo `audit-report` PDF from a clean checkout.
- The repo needs an explicit, repeatable runbook that shows how to seed `data/accounts/{owner}/key_findings.md`, bring up the local stack, and fetch the PDF for demo validation.

Closes #2617 

### Description

- Rewrote `docs/REPORT_WORKFLOW.md` to include exact commands for dependency installation (`python -m pip install -r requirements.txt -r requirements-dev.txt`, `npm install`, `npm --prefix frontend install`), starting the local stack (`make local-up`), and tearing it down (`make local-down`).
- Added an example `mkdir -p data/accounts/demo-owner` and `cat > data/accounts/demo-owner/key_findings.md << 'EOF' ... EOF` snippet plus the `curl` commands to download PDF and JSON previews for `audit-report` at `http://localhost:8000`.
- This change is documentation-only and does not modify runtime code or behavior.

### Testing

- Verified the demo fixture exists with `test -f data/accounts/demo-owner/key_findings.md` which returned present.
- Ran the targeted route tests with `pytest -q tests/test_reports_route.py -k audit_report --maxfail=1` and they passed (`2 passed, 21 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99f3ab9a48327833ce7372f8efa32)