### PR TITLE
Fix PDF percent rendering for *_pct report fields

### DIFF
--- a/backend/reports.py
+++ b/backend/reports.py
@@ -1773,7 +1773,9 @@ def report_to_pdf(document: ReportDocument) -> bytes:
             return _format_gbp(row_value)
         if "pct" in key or "percent" in key:
             return _format_percent(row_value, value_is_ratio=False)
-        if "return" in key or "drawdown" in key or key == "weight":
+        # Keep this block after the *_pct / percent check above so names like
+        # "return_pct" remain percent-point values (not ratio-scaled).
+        if "return" in key or "drawdown" in key or "weight" in key:
             return _format_percent(row_value, value_is_ratio=True)
         if column.type == "number":
             try:

--- a/tests/test_reports_additional.py
+++ b/tests/test_reports_additional.py
@@ -572,12 +572,24 @@ def test_report_to_pdf_formats_values_and_optional_watermark(monkeypatch):
         columns=(
             reports.ReportColumnSchema("amount_gbp", "Amount (GBP)", type="number"),
             reports.ReportColumnSchema("daily_return", "Daily return", type="number"),
+            reports.ReportColumnSchema("drawdown", "Drawdown", type="number"),
+            reports.ReportColumnSchema("portfolio_weight", "Portfolio Weight", type="number"),
+            reports.ReportColumnSchema("return_pct", "Return (%)", type="number"),
             reports.ReportColumnSchema("weight_pct", "Weight (%)", type="number"),
         ),
     )
     section = reports.ReportSectionData(
         schema=schema,
-        rows=({"amount_gbp": 1234.5, "daily_return": 0.125, "weight_pct": 45.32},),
+        rows=(
+            {
+                "amount_gbp": 1234.5,
+                "daily_return": 0.125,
+                "drawdown": -0.05,
+                "portfolio_weight": 0.4532,
+                "return_pct": 45.32,
+                "weight_pct": 45.32,
+            },
+        ),
     )
     document = reports.ReportDocument(
         template=reports.ReportTemplate(
@@ -599,7 +611,9 @@ def test_report_to_pdf_formats_values_and_optional_watermark(monkeypatch):
     drawn_values = [args[2] for name, args, _ in calls if name == "drawString" and len(args) >= 3]
     assert any("£1,234.50" in value for value in drawn_values)
     assert any("12.50%" in value for value in drawn_values)
+    assert any("-5.00%" in value for value in drawn_values)
     assert any("45.32%" in value for value in drawn_values)
+    assert not any("0.4532" in value for value in drawn_values)
     assert not any("4,532.00%" in value for value in drawn_values)
     assert any(
         name == "drawCentredString" and args[-1] == "SAMPLE"


### PR DESCRIPTION
### Motivation
- PDF output was double-scaling percentage-like values (e.g. `weight_pct` values like `45.32` were rendered as `4,532%`) due to inconsistent storage conventions and a blanket multiply-by-100 in the PDF formatter.
- The change establishes a clear rendering convention to avoid customer-facing incorrect percentages.

Closes #2615 
### Description
- Introduced an explicit convention and updated formatter by changing `_format_percent` to accept `value_is_ratio` and document the convention in `backend/reports.py`.
- Updated `_format_cell_value` heuristics to treat keys containing `pct`/`percent` as percent points (0–100) and to treat `return`, `drawdown`, and audit `weight` as ratios (0–1) that should be multiplied by 100 for display.
- Adjusted the PDF formatting test in `tests/test_reports_additional.py` to include a `weight_pct` example and assert that `45.32` renders as `45.32%` and not `4,532.00%`.

### Testing
- Ran `pytest -q tests/test_reports_additional.py -k "report_to_pdf_formats_values_and_optional_watermark"` and the test passed (`1 passed`).
- Ran `pytest -q tests/test_reports.py -k "sectors_weight_pct_sums_to_100 or build_report_document_for_audit_report"` and the selected tests passed (`1 passed`).
- The updated tests validate both GBP, ratio-based returns (e.g. `0.125` -> `12.50%`), and percent-point fields (e.g. `45.32` -> `45.32%`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99f1d614c8327ab28e05114792d25)