### PR TITLE
Relax key findings length validation and escalate oversized entries (fix #2614)

### DIFF
--- a/backend/reports.py
+++ b/backend/reports.py
@@ -771,6 +771,10 @@ def _parse_key_findings_text(content: str, *, source_name: str = "key findings")
             numbered = re.match(r"^([1-9][0-9]?)\.\s+(.*)$", value)
             if numbered:
                 value = numbered.group(2).strip()
+        if value in {"-", "*", "\u2022"}:
+            continue
+        if re.match(r"^([1-9][0-9]?)\.$", value):
+            continue
         if not value:
             continue
         if len(value) > max_length:

--- a/docs/REPORT_WORKFLOW.md
+++ b/docs/REPORT_WORKFLOW.md
@@ -80,8 +80,8 @@ EOF2
 Writing guidance:
 - Findings are **not auto-generated**.
 - Use one bullet per finding with concrete numbers.
-- Keep each finding short and specific (recommended 20-240 chars).
-- Invalid lines are skipped with warnings instead of failing report generation.
+- Keep each finding short and specific (maximum 500 chars; no minimum beyond non-empty text).
+- Invalid lines are skipped with error logs instead of failing report generation.
 
 ## 4) Generate and download the PDF
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1087,6 +1087,54 @@ def test_build_key_findings_section_skips_invalid_lines_with_error(tmp_path, mon
     assert "Skipping invalid key finding from key_findings.md because it exceeds 500 characters" in caplog.text
 
 
+def test_build_key_findings_section_accepts_exactly_500_chars(tmp_path, monkeypatch):
+    monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
+    owner_dir = tmp_path / "accounts" / "demo-owner"
+    owner_dir.mkdir(parents=True)
+    exact_limit_finding = "9" * 500
+    (owner_dir / "key_findings.md").write_text(
+        f"- {exact_limit_finding}\n",
+        encoding="utf-8",
+    )
+
+    context = reports.ReportContext("demo-owner", start=None, end=None)
+    schema = reports.ReportSectionSchema(
+        id="key-findings",
+        title="Key Findings",
+        source="portfolio.key_findings",
+        columns=(reports.ReportColumnSchema("finding", "Finding"),),
+    )
+
+    rows = reports._build_key_findings_section(context, schema)
+
+    assert rows == [{"finding": exact_limit_finding}]
+
+
+def test_build_key_findings_section_skips_empty_entries_after_trimming(tmp_path, monkeypatch):
+    monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
+    owner_dir = tmp_path / "accounts" / "demo-owner"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "key_findings.md").write_text(
+        "- \n"
+        "* \n"
+        "2.   \n"
+        "- ok\n",
+        encoding="utf-8",
+    )
+
+    context = reports.ReportContext("demo-owner", start=None, end=None)
+    schema = reports.ReportSectionSchema(
+        id="key-findings",
+        title="Key Findings",
+        source="portfolio.key_findings",
+        columns=(reports.ReportColumnSchema("finding", "Finding"),),
+    )
+
+    rows = reports._build_key_findings_section(context, schema)
+
+    assert rows == [{"finding": "ok"}]
+
+
 def test_build_key_findings_section_reads_txt_fallback(tmp_path, monkeypatch):
     monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
     owner_dir = tmp_path / "accounts" / "demo-owner"


### PR DESCRIPTION
### Motivation
- Key findings parsing previously dropped short lines and silently rejected entries outside an undocumented 20–240 character window. 
- This caused valid short findings to disappear and made long offending entries hard to notice. 
- The change targets clearer, less-surprising behavior when authors provide key findings files.

Closes #2614 

### Description
- Updated `backend/reports.py` to remove the 20-character minimum and enforce a single maximum length via `max_length = 500`. 
- Oversized findings now emit an `ERROR` level log with an explicit message including the maximum and source, instead of a warning. 
- Updated `tests/test_reports.py` to assert that short findings are preserved, a 501-character finding is dropped, and the drop is logged at `ERROR` level. 
- Updated `docs/REPORT_WORKFLOW.md` to document the new constraint (max 500 characters, no minimum beyond non-empty text) and the logging behavior.

### Testing
- Ran the targeted test subset `pytest -q tests/test_reports.py -k key_findings`, which completed successfully with `7 passed, 44 deselected`.
- The modified unit tests validate acceptance of short findings, rejection of findings >500 characters, and the `ERROR`-level log message for dropped items.
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99f1635ec8327a68c8d7a790f930c)