### PR TITLE
Bump `yaml` to ^2.8.3 to remediate advisory (fixes #2628)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@capacitor/android": "^5.7.0",
         "@capacitor/core": "^5.7.0",
         "@capacitor/ios": "^5.7.0",
-        "yaml": "^2.8.2"
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@capacitor/cli": "^5.7.0",
@@ -2016,9 +2016,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@capacitor/android": "^5.7.0",
     "@capacitor/core": "^5.7.0",
     "@capacitor/ios": "^5.7.0",
-    "yaml": "^2.8.2"
+    "yaml": "^2.8.3"
   },
   "scripts": {
     "test": "cd frontend && npm test --",


### PR DESCRIPTION
### Motivation
- GitHub Dependabot reported advisory GHSA-48c2-rrv3-qjmp affecting `yaml` versions `<2.8.3` which can trigger uncontrolled recursion / stack overflow for deeply nested YAML inputs.
- The repository declared `yaml@^2.8.2` as a direct dependency in the root `package.json`, so a manual upgrade was required to remove the vulnerable range.
- This change is a low-risk dependency patch intended to remediate the security advisory without touching application code.
Closes #2628 

### Description
- Updated the root dependency `yaml` from `^2.8.2` to `^2.8.3` in `package.json`.
- Regenerated and updated `package-lock.json` so the dependency graph resolves to `node_modules/yaml@2.8.3` with new tarball and integrity metadata.
- No source code or runtime behavior changes were made; this is a dependency-only update.

### Testing
- Ran `npm ls yaml` and it now resolves to `yaml@2.8.3`, confirming the lockfile change.
- Ran `npm audit` and verified the `yaml` advisory is no longer reported (audit shows no `yaml` vulnerability present).
- Executed the frontend unit tests with `npm --prefix frontend run test -- --run` as a regression check; the suite completed but reported existing unrelated failures (5 failing tests and 1 post-teardown error, notably `tests/unit/App.test.tsx` redirect assertions and a `ReferenceError: window is not defined` observed during `HoldingsTable` tests), and none of the failures appear to be caused by the `yaml` version bump.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca30f461cc83279d22fb32381c43d5)