### PR TITLE
Align #2581 docs and strict runner with current audit-report contract

### DIFF
--- a/docs/REPORT_WORKFLOW.md
+++ b/docs/REPORT_WORKFLOW.md
@@ -97,17 +97,20 @@ Optional JSON preview of section payloads:
 curl -sS "http://localhost:8000/reports/demo-owner/audit-report?format=json" | jq '.sections[].title'
 ```
 
-Expected section order for a complete demo report:
-1. Portfolio Summary
-2. Holdings Breakdown
-3. Sector Allocation
-4. Risk Analysis
-5. Key Findings
+Expected section titles and order for `audit-report`:
+1. Portfolio overview
+2. Sector allocation
+3. Region allocation
+4. Top holdings concentration
+5. Portfolio risk *(present only when VaR inputs are available)*
+6. Key Findings *(present only when `data/accounts/{owner}/key_findings.md` yields valid findings)*
 
 ## 5) Validate report quality before sending
 
 Minimum checks:
-- PDF opens and all five sections render (including Key Findings).
+- PDF opens and renders the four always-on sections (`Portfolio overview`, `Sector allocation`, `Region allocation`, `Top holdings concentration`).
+- `Portfolio risk` appears when VaR data is available; if risk inputs are unavailable, this section is legitimately omitted.
+- `Key Findings` appears only when a valid `key_findings.md` exists for the owner; otherwise it is legitimately omitted.
 - Currency and percentages are formatted for end users (no raw floats/internal IDs).
 - Narrative answers: total value, top risk, and recommended action are clear.
 - Product gate: "Would I confidently send this to a prospect?" must be **yes**.

--- a/docs/manual-tests/issue-2581-strict-spec.md
+++ b/docs/manual-tests/issue-2581-strict-spec.md
@@ -176,12 +176,17 @@ curl -sS "$API_BASE/reports/$OWNER/audit-report?format=pdf" -o "$RUN_DIR/audit_r
 Rules:
 1. Structural hard fail:
    - PDF opens without error
-   - Exactly 5 sections present. The required sections are:
-     1. Portfolio Summary (total value, date, owner)
-     2. Holdings Breakdown (top holdings table)
-     3. Sector Allocation
-     4. Risk Analysis (VaR and Sharpe)
-     5. Key Findings (from `key_findings.md`; omitted only if file is absent per Step 0.3)
+   - Section titles/order match the current built-in `audit-report` contract:
+     1. Portfolio overview
+     2. Sector allocation
+     3. Region allocation
+     4. Top holdings concentration
+     5. Portfolio risk *(optional; omitted when VaR inputs are unavailable)*
+     6. Key Findings *(optional; omitted when `key_findings.md` is absent or yields no valid lines)*
+   - Section-count rule derived from the same contract:
+     - minimum 4 sections (always-on core)
+     - maximum 6 sections (all optional sections present)
+     - `Key Findings`, when present, must be the final section
 2. Data reconciliation hard fail:
    - total value
    - VaR

--- a/scripts/qa/run_issue_2581_strict.sh
+++ b/scripts/qa/run_issue_2581_strict.sh
@@ -202,6 +202,57 @@ if not math.isfinite(value) or value <= 0:
 PY
 }
 
+check_audit_report_sections() {
+  local json_file="$1"
+  python3 - "$json_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+sections = data.get("sections")
+if not isinstance(sections, list):
+    raise ValueError("Report JSON missing 'sections' array")
+
+titles = []
+for section in sections:
+    if not isinstance(section, dict):
+        raise ValueError("Report JSON contains non-object section entry")
+    title = section.get("title")
+    if not isinstance(title, str) or not title.strip():
+        raise ValueError("Report JSON section missing non-empty title")
+    titles.append(title)
+
+required = [
+    "Portfolio overview",
+    "Sector allocation",
+    "Region allocation",
+    "Top holdings concentration",
+]
+for index, expected in enumerate(required):
+    if index >= len(titles) or titles[index] != expected:
+        raise ValueError(
+            f"Section {index + 1} must be '{expected}', got: {titles[index] if index < len(titles) else 'missing'}"
+        )
+
+allowed_optional = {"Portfolio risk", "Key Findings"}
+extras = titles[len(required):]
+for title in extras:
+    if title not in allowed_optional:
+        raise ValueError(f"Unexpected audit-report section title: {title}")
+
+if len(titles) < 4 or len(titles) > 6:
+    raise ValueError(f"Section count must be between 4 and 6 inclusive, got {len(titles)}")
+
+if "Key Findings" in titles and titles[-1] != "Key Findings":
+    raise ValueError("Key Findings must be the last section when present")
+
+if "Portfolio risk" in titles and titles.index("Portfolio risk") != 4:
+    raise ValueError("Portfolio risk must be section 5 when present")
+PY
+}
+
 write_summary() {
   local verdict="PASS"
   if (( failure_count > 0 )); then
@@ -275,6 +326,10 @@ main() {
   echo "$code" >"$RUN_DIR/audit_report.pdf.status"
   if [[ "$code" != "200" ]]; then
     record_failure "P1" "step5" "Audit PDF generation failed with status $code"
+  fi
+  curl_json "$API_BASE/reports/$OWNER/audit-report?format=json" "$RUN_DIR/audit_report.json"
+  if [[ -f "$RUN_DIR/audit_report.json" ]] && ! check_audit_report_sections "$RUN_DIR/audit_report.json" 2>>"$RUN_DIR/audit_report.check.log"; then
+    record_failure "P1" "step5" "Audit report section contract check failed"
   fi
 
   # Step 6


### PR DESCRIPTION
### Motivation
- The `audit-report` built-in template in `backend/reports.py` uses different section titles and optional-section behavior than the #2581 docs and strict-runner, causing confusion and failing strict executions.
- The goal is to make the workflow docs, the strict manual spec, and the strict QA runner agree with the actual template contract so issue #2581 can be executed reproducibly.

Closes #2632 
### Description
- Updated `docs/REPORT_WORKFLOW.md` to document the actual `audit-report` section titles and order (`Portfolio overview`, `Sector allocation`, `Region allocation`, `Top holdings concentration`, with `Portfolio risk` and `Key Findings` treated as optional based on data availability).
- Updated `docs/manual-tests/issue-2581-strict-spec.md` to replace the stale “exactly five sections” rule with the current contract: four always-on core sections and up to two optional sections, with ordering and placement constraints documented.
- Extended `scripts/qa/run_issue_2581_strict.sh` with a new `check_audit_report_sections` function that fetches `format=json` and validates section titles, order, allowed optional sections, section count bounds (4–6), and placement (e.g. `Key Findings` must be last); the runner now records a P1 failure when the JSON contract check fails.
- Committed the changes (branch work, commit short id shown in run) so docs and the strict runner are aligned with the backend template.

### Testing
- Ran a syntax check on the updated runner with `bash -n scripts/qa/run_issue_2581_strict.sh`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca653dbc848327a8633970a5ab662a)