### PR TITLE
Make issue #2581 strict-run evidence durable and reviewable

### DIFF
--- a/docs/manual-tests/issue-2581-strict-spec.md
+++ b/docs/manual-tests/issue-2581-strict-spec.md
@@ -51,11 +51,13 @@ Attach these artifacts directly to the issue comment (or link to a durable inter
 - `demo_report.pdf`
 
 The issue closure comment must include links or attachments to these exact artifacts.
+The runner writes these files into `RUN_DIR`; attaching or linking them on GitHub is a required manual closure step.
 
 ### What remains local by default
 
 Keep these under `RUN_DIR` for deeper review, and attach them when requested:
 
+- Step 1 local evidence (`frontend_screenshot.png`, `startup_log.txt`)
 - Raw endpoint payloads (`portfolio_response.json`, `sectors.json`, `regions.json`, `var.json`)
 - Manual external validation input (`broker_snapshot.txt`)
 - Health, timing, and transport logs (`backend_health.json`, `backend_health.timing`, `*.stderr`, `*.status`, `*.check.log`)
@@ -69,6 +71,7 @@ Keep these under `RUN_DIR` for deeper review, and attach them when requested:
 - `evidence_manifest.txt` (explicit evidence inventory)
 
 Use `summary_for_issue.md` as the starting point for the closure comment template.
+`evidence_manifest.txt` is a plain-text inventory grouped into `Required issue attachments` and `Required local durable evidence`.
 
 ## 0) Global rules
 

--- a/docs/manual-tests/templates/issue-2581-closure-comment.md
+++ b/docs/manual-tests/templates/issue-2581-closure-comment.md
@@ -48,6 +48,8 @@
 
 - [ ] backend_health.json
 - [ ] backend_health.timing
+- [ ] frontend_screenshot.png
+- [ ] startup_log.txt
 - [ ] portfolio_response.json
 - [ ] broker_snapshot.txt
 - [ ] sectors.json

--- a/scripts/qa/run_issue_2581_strict.sh
+++ b/scripts/qa/run_issue_2581_strict.sh
@@ -302,6 +302,8 @@ Required issue attachments
 Required local durable evidence
 - backend_health.json
 - backend_health.timing
+- frontend_screenshot.png
+- startup_log.txt
 - portfolio_response.json
 - broker_snapshot.txt
 - sectors.json
@@ -347,6 +349,8 @@ $failure_lines
 ### Local-only (retain in run directory; attach when needed for review)
 - \`backend_health.json\`
 - \`backend_health.timing\`
+- \`frontend_screenshot.png\`
+- \`startup_log.txt\`
 - \`portfolio_response.json\`
 - \`broker_snapshot.txt\`
 - \`sectors.json\`


### PR DESCRIPTION
### Motivation

- Close the process gap where manual strict runs for Issue #2581 could be completed without preserved, reviewable evidence by defining a single durable evidence path and required attachments. 
- Ensure the runner produces paste-ready and attachable artifacts so reviewers and issue-closers have an unambiguous canonical payload to inspect.

Closes #2633 
### Description

- Add a `Durable evidence workflow` section to `docs/manual-tests/issue-2581-strict-spec.md` that specifies the canonical run directory (`artifacts/issue-2581/<timestamp>/`), the exact artifacts that must be attached/linked on the GitHub issue, and which artifacts remain local by default.
- Update `docs/manual-tests/templates/issue-2581-closure-comment.md` to require links/attachments for `summary.json`, `summary_for_issue.md`, `environment_lock.txt`, `evidence_manifest.txt`, and the audit/demo PDFs, and to separate required issue attachments from local durable evidence.
- Enhance `scripts/qa/run_issue_2581_strict.sh` to generate durable review artifacts: add `write_evidence_manifest` to emit `evidence_manifest.txt`, add `write_issue_summary_markdown` to emit `summary_for_issue.md`, introduce `run_verdict` to capture PASS/FAIL, and ensure the evidence artifacts are written regardless of per-step failures; the script still returns non-zero on an overall FAIL so CI/shell callers can detect failure while preserving artifacts.
- Produce a clear artifact inventory and a paste-ready markdown summary intended to be attached or pasted into the closure comment for reproducible, reviewable evidence.

### Testing

- Ran a syntax check with `bash -n scripts/qa/run_issue_2581_strict.sh` which succeeded. 
- Executed a smoke invocation `RUN_DIR=/tmp/issue-2581-smoke OWNER=test-owner GROUP_SLUG=test-group API_BASE=http://127.0.0.1:9 bash scripts/qa/run_issue_2581_strict.sh || true` and verified runner produced `summary.json`, `summary_for_issue.md`, and `evidence_manifest.txt` (artifacts present even when endpoints were unreachable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca654c71608327b81feb09b2e61ee8)