### PR TITLE
Forward watermark query param through report routes

### DIFF
--- a/backend/reports.py
+++ b/backend/reports.py
@@ -1455,6 +1455,7 @@ def build_report_document(
     *,
     start: Optional[date] = None,
     end: Optional[date] = None,
+    watermark: Optional[str] = None,
     store: TemplateStore | None = None,
 ) -> ReportDocument:
     template = get_template(template_id, store=store)
@@ -1494,6 +1495,10 @@ def build_report_document(
         params["start"] = start.isoformat()
     if end:
         params["end"] = end.isoformat()
+    if watermark:
+        watermark_text = watermark.strip()
+        if watermark_text:
+            params["watermark"] = watermark_text
 
     return ReportDocument(
         template=template,

--- a/backend/routes/reports.py
+++ b/backend/routes/reports.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import Response
@@ -100,17 +100,20 @@ async def owner_report(
     owner: str,
     start: Optional[str] = None,
     end: Optional[str] = None,
+    watermark: Optional[str] = None,
     format: str = "json",
 ):
     """Return summary report for ``owner``."""
 
     start_d = _parse_date(start)
     end_d = _parse_date(end)
+    watermark_text = watermark.strip() if watermark else None
 
     try:
-        document = build_report_document(
-            DEFAULT_TEMPLATE_ID, owner, start=start_d, end=end_d
-        )
+        build_kwargs: Dict[str, Any] = {"start": start_d, "end": end_d}
+        if watermark_text:
+            build_kwargs["watermark"] = watermark_text
+        document = build_report_document(DEFAULT_TEMPLATE_ID, owner, **build_kwargs)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Owner not found")
     except ValueError as exc:
@@ -139,15 +142,18 @@ async def owner_template_report(
     template_id: str,
     start: Optional[str] = None,
     end: Optional[str] = None,
+    watermark: Optional[str] = None,
     format: str = "json",
 ):
     start_d = _parse_date(start)
     end_d = _parse_date(end)
+    watermark_text = watermark.strip() if watermark else None
 
     try:
-        document = build_report_document(
-            template_id, owner, start=start_d, end=end_d
-        )
+        build_kwargs: Dict[str, Any] = {"start": start_d, "end": end_d}
+        if watermark_text:
+            build_kwargs["watermark"] = watermark_text
+        document = build_report_document(template_id, owner, **build_kwargs)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Owner not found")
     except ValueError as exc:

--- a/docs/REPORT_WORKFLOW.md
+++ b/docs/REPORT_WORKFLOW.md
@@ -89,6 +89,9 @@ Use the report route directly:
 
 ```bash
 curl -sS "http://localhost:8000/reports/demo-owner/audit-report?format=pdf&watermark=SAMPLE" -o demo-owner-audit-report.pdf
+
+# watermark only affects the rendered PDF overlay and is intentionally excluded
+# from the visible title-page parameters list.
 ```
 
 Optional JSON preview of section payloads:

--- a/tests/test_reports_route.py
+++ b/tests/test_reports_route.py
@@ -171,6 +171,64 @@ def test_audit_report_pdf_smoke_returns_pdf_prefix(client, monkeypatch):
     assert resp.content.startswith(b"%PDF")
 
 
+def test_audit_report_pdf_forwards_watermark_query_parameter(client, monkeypatch):
+    captured: Dict[str, object] = {}
+
+    def fake_builder(template_id, owner, start=None, end=None, watermark=None):
+        captured["template_id"] = template_id
+        captured["owner"] = owner
+        captured["watermark"] = watermark
+        document = _build_sample_document()
+        document.parameters["watermark"] = str(watermark)
+        return document
+
+    monkeypatch.setattr(reports_route, "build_report_document", fake_builder)
+
+    def fake_pdf(document: reports.ReportDocument) -> bytes:
+        assert document.parameters["watermark"] == "SAMPLE"
+        return b"%PDF-watermark"
+
+    monkeypatch.setattr(reports_route, "report_to_pdf", fake_pdf)
+
+    resp = client.get("/reports/lucy/audit-report?format=pdf&watermark=SAMPLE")
+    assert resp.status_code == 200
+    assert captured == {
+        "template_id": "audit-report",
+        "owner": "lucy",
+        "watermark": "SAMPLE",
+    }
+    assert resp.content == b"%PDF-watermark"
+
+
+def test_owner_report_pdf_forwards_trimmed_watermark_query_parameter(client, monkeypatch):
+    captured: Dict[str, object] = {}
+
+    def fake_builder(template_id, owner, start=None, end=None, watermark=None):
+        captured["template_id"] = template_id
+        captured["owner"] = owner
+        captured["watermark"] = watermark
+        document = _build_sample_document()
+        document.parameters["watermark"] = str(watermark)
+        return document
+
+    monkeypatch.setattr(reports_route, "build_report_document", fake_builder)
+
+    def fake_pdf(document: reports.ReportDocument) -> bytes:
+        assert document.parameters["watermark"] == "SAMPLE"
+        return b"%PDF-watermark"
+
+    monkeypatch.setattr(reports_route, "report_to_pdf", fake_pdf)
+
+    resp = client.get("/reports/lucy?format=pdf&watermark=%20SAMPLE%20")
+    assert resp.status_code == 200
+    assert captured == {
+        "template_id": reports.DEFAULT_TEMPLATE_ID,
+        "owner": "lucy",
+        "watermark": "SAMPLE",
+    }
+    assert resp.content == b"%PDF-watermark"
+
+
 def test_reports_unknown_owner(client, monkeypatch):
     def fake_builder(template_id, owner, start=None, end=None):
         raise FileNotFoundError


### PR DESCRIPTION
### Motivation
- The PDF renderer already supported a `watermark` overlay but the public report endpoints did not forward the query parameter into the document build step, so route-level PDF requests could not trigger watermark rendering. 
- The change keeps `watermark` as a render-only value that should not leak into the visible title-page parameter list.

Closes #2631 

### Description
- Added an optional `watermark` query parameter to `GET /reports/{owner}` and `GET /reports/{owner}/{template_id}` and trim surrounding whitespace before use. 
- Forward trimmed, non-empty watermark values into `build_report_document(...)` by adding an optional `watermark` argument and populating `ReportDocument.parameters` only when non-empty. 
- Added route-level regression tests (`test_audit_report_pdf_forwards_watermark_query_parameter` and `test_owner_report_pdf_forwards_trimmed_watermark_query_parameter`) to assert forwarding and trimming behavior and updated `docs/REPORT_WORKFLOW.md` to document watermark semantics. 
- Small typing import adjustments to support passing build kwargs (`Dict[str, Any]`).

### Testing
- Ran `pytest -q tests/test_reports_route.py` and observed all route tests succeed (`25 passed`).
- Ran `pytest -q tests/test_reports_route.py -k "watermark or reports_pdf or audit_report_pdf_smoke"` and observed the focused run succeed (`4 passed, 21 deselected`).
- Ran `pytest -q tests/test_reports_additional.py -k "optional_watermark"` and observed the focused test succeed (`1 passed, 34 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6543e68c8327a094ec9aeff0c224)