### PR TITLE
Add reusable UI behavior manual test plan

### DIFF
--- a/docs/manual-tests/ui-behavior-test-plan.md
+++ b/docs/manual-tests/ui-behavior-test-plan.md
@@ -133,19 +133,19 @@ Severity guide:
 
 Run in order.
 
-| Step ID | Route               | Action          | Expected visible result            | Failure signals         |
-| ------- | ------------------- | --------------- | ---------------------------------- | ----------------------- |
-| 3.1     | `/`                 | open route      | app shell renders, route is stable | blank page, crash loop  |
-| 3.2     | `/portfolio`        | direct-load URL | portfolio/owner view visible       | redirect loop, crash    |
-| 3.3     | `/performance`      | direct-load URL | performance view visible           | chart/runtime exception |
-| 3.4     | `/transactions`     | direct-load URL | transactions view visible          | blank state + errors    |
-| 3.5     | `/trading`          | direct-load URL | trading view visible               | route bounce            |
-| 3.6     | `/reports`          | direct-load URL | reports page visible               | crash/empty shell       |
-| 3.7     | `/reports/new`      | direct-load URL | heading `Create report template`   | missing heading         |
-| 3.8     | `/pension/forecast` | direct-load URL | heading `Pension Forecast`         | wrong route/mode        |
-| 3.9     | `/returns/compare`  | direct-load URL | return comparison heading visible  | render exception        |
-| 3.10    | `/compliance`       | direct-load URL | heading `Compliance warnings`      | missing heading         |
-| 3.11    | `/smoke-test`       | direct-load URL | heading `Smoke test`               | page crash              |
+| Step ID | Route               | Action          | Assertion target (AI/manual)                                                                 | Expected visible result            | Failure signals         |
+| ------- | ------------------- | --------------- | -------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------- |
+| 3.1     | `/`                 | open route      | `[data-route-marker=\"active\"]` has `data-mode=\"group\"`                                   | app shell renders, route is stable | blank page, crash loop  |
+| 3.2     | `/portfolio`        | direct-load URL | `[data-route-marker=\"active\"]` has `data-mode=\"owner\"`                                   | portfolio/owner view visible       | redirect loop, crash    |
+| 3.3     | `/performance`      | direct-load URL | `[data-route-marker=\"active\"]` has `data-mode=\"performance\"`                             | performance view visible           | chart/runtime exception |
+| 3.4     | `/transactions`     | direct-load URL | `[data-route-marker=\"active\"]` has `data-mode=\"transactions\"`                            | transactions view visible          | blank state + errors    |
+| 3.5     | `/trading`          | direct-load URL | `[data-route-marker=\"active\"]` has `data-mode=\"trading\"`                                 | trading view visible               | route bounce            |
+| 3.6     | `/reports`          | direct-load URL | `[data-route-marker=\"active\"]` has `data-mode=\"reports\"`                                 | reports page visible               | crash/empty shell       |
+| 3.7     | `/reports/new`      | direct-load URL | heading text exactly `Create report template`                                                | heading `Create report template`   | missing heading         |
+| 3.8     | `/pension/forecast` | direct-load URL | heading text exactly `Pension Forecast` **and** route marker has `data-pathname` value match | heading `Pension Forecast`         | wrong route/mode        |
+| 3.9     | `/returns/compare`  | direct-load URL | heading text matches `/Return Comparison/`                                                   | return comparison heading visible  | render exception        |
+| 3.10    | `/compliance`       | direct-load URL | heading text exactly `Compliance warnings`                                                   | heading `Compliance warnings`      | missing heading         |
+| 3.11    | `/smoke-test`       | direct-load URL | heading text exactly `Smoke test`                                                            | heading `Smoke test`               | page crash              |
 
 For each step above, also validate:
 
@@ -155,6 +155,12 @@ For each step above, also validate:
 
 Optional extended sweep:
 `/instrument`, `/screener`, `/settings`, `/timeseries`, `/watchlist`, `/market`, `/allocation`, `/rebalance`, `/movers`, `/instrumentadmin`, `/dataadmin`, `/tax-tools`, `/scenario`, `/research/AAA`, `/virtual`, `/support`, `/alerts`, `/alert-settings`, `/goals`, `/trail`, `/metrics-explained`, `/trade-compliance`.
+
+When running this extended sweep with an AI/browser agent, prefer assertion order:
+
+1. route marker (`[data-route-marker="active"]`) when mode-based page,
+2. heading text when standalone page,
+3. explicit `data-testid` marker when present.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Provide a deterministic, reusable UI behavior test plan (manual + AI-executable) to satisfy issue #2642 and make frontend acceptance checks repeatable. 
- Complement existing automated smoke coverage by documenting strict preflight gates, evidence requirements, and a bug-report template to improve triage quality.
Closes #2642 

### Description
- Add `docs/manual-tests/ui-behavior-test-plan.md` containing pre-flight setup, strict execution rules, failure evidence requirements, and a GitHub bug template. 
- Include core navigation checks, an extended route sweep, page-level deterministic checks (portfolio, performance, reports, returns, pension, virtual), and prioritized P1/P2 flows. 
- Provide a recommended run output template, guidance on relation to automated smoke tests, and maintenance instructions for keeping assertions up to date. 

### Testing
- Ran a local verification script using `node -e` to confirm referenced npm scripts exist (`smoke:test:all`, `dev`, `smoke:frontend`) and the check succeeded. 
- Committed the new file and validated the repository status locally; no automated lint/test suites were changed or run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cac6f05150832780fd07ec46146023)