### PR TITLE
Enhance Issue #2581 strict QA runner: artifact capture, broker JSON, and PDF reconciliation

### DIFF
--- a/docs/manual-tests/issue-2581-strict-spec.md
+++ b/docs/manual-tests/issue-2581-strict-spec.md
@@ -166,6 +166,7 @@ Required external input:
   - portfolio-level numeric total, resolved in this precedence order: `total_value` → `portfolio_value` → `total`
   - holdings list entries with symbol (`ticker`/`symbol`) and numeric value resolved in this precedence order: `market_value` → `value` → `position_value` → `current_value` → `amount`
 - If a non-JSON broker snapshot is provided, the runner records a P2 and skips automated Step 2 reconciliation (manual review required).
+- Legacy compatibility: if `BROKER_SNAPSHOT_PATH` is unset and `$RUN_DIR/broker_snapshot.txt` exists, the runner copies it to `broker_snapshot.json` and records a P2 migration warning.
 
 Rules:
 1. Holdings integrity (hard fail/P1)

--- a/scripts/qa/run_issue_2581_strict.sh
+++ b/scripts/qa/run_issue_2581_strict.sh
@@ -175,6 +175,11 @@ capture_broker_snapshot() {
     if [[ -f "$BROKER_SNAPSHOT_RUN_PATH" ]]; then
       return
     fi
+    if [[ -f "$RUN_DIR/broker_snapshot.txt" ]]; then
+      cp "$RUN_DIR/broker_snapshot.txt" "$BROKER_SNAPSHOT_RUN_PATH"
+      record_failure "P2" "step2" "Using legacy broker_snapshot.txt fallback; migrate to broker_snapshot.json"
+      return
+    fi
     record_failure "P1" "step2" "BROKER_SNAPSHOT_PATH is required unless RUN_DIR/broker_snapshot.json already exists"
     : >"$BROKER_SNAPSHOT_RUN_PATH.missing"
     return


### PR DESCRIPTION
### Motivation
- Make the strict runbook fully reproducible by requiring and capturing concrete frontline evidence artifacts for Step 1 and a structured broker snapshot for Step 2. 
- Automate reconciliation of generated audit PDFs against endpoint payloads to remove a manual verification gap and produce explicit check logs. 
- Enforce an explicit product gate attestation for the demo report so closure criteria remain unambiguous.

Closes #2641 
### Description
- Documentation: updated `docs/manual-tests/issue-2581-strict-spec.md` to add `FRONTEND_SCREENSHOT_PATH`, `STARTUP_LOG_PATH`, `BROKER_SNAPSHOT_PATH`, and `DEMO_PRODUCT_GATE_RESULT` inputs and to switch `broker_snapshot.txt` references to `broker_snapshot.json`.
- Script changes: extended `scripts/qa/run_issue_2581_strict.sh` to capture Step 1 artifacts (`frontend_screenshot.png`, `startup_log.txt`) and record P1 failures when missing or containing crash signatures.
- Broker snapshot handling: added `capture_broker_snapshot` plus JSON validation and an automated top-10 holdings and total-value reconciliation (`check_portfolio_vs_broker_snapshot`) that enforces the documented thresholds and emits `portfolio_vs_broker.check.log`.
- Audit/report reconciliation: added checks that reconcile `audit_report.json` with endpoint payloads via `check_pdf_total_and_var_reconciliation` and `check_pdf_sector_region_reconciliation`, and emit `audit_reconciliation.check.log` on failure.
- Demo gate and watermark: added `check_demo_watermark` to ensure the `SAMPLE` watermark and `check_demo_product_gate` to require `DEMO_PRODUCT_GATE_RESULT=YES` or record a P1 failure.
- Outputs: `summary.json`, `evidence_manifest.txt`, and `summary_for_issue.md` updated to reference `broker_snapshot.json` and the new artifacts; new `.check.log` files are produced for reconciliation failures.

### Testing
- No automated unit tests were added for these changes.
- The QA runner script changes are self-contained and write explicit check logs (`*.check.log`) when reconciliation or artifact validation fails.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cac6d9abb0832793a81412a05f6ce0)