### PR TITLE
Robust parsing for key findings: skip markdown headings and separator lines

### DIFF
--- a/backend/reports.py
+++ b/backend/reports.py
@@ -750,9 +750,29 @@ def _normalise_transaction(
 def _parse_key_findings_text(content: str, *, source_name: str = "key findings") -> List[Dict[str, str]]:
     max_length = 500
     findings: List[Dict[str, str]] = []
-    for line in content.splitlines():
-        value = line.strip()
+    lines = content.splitlines()
+    index = 0
+    # Maintain index manually because setext heading preambles consume two lines.
+    while index < len(lines):
+        value = lines[index].strip()
         if not value:
+            index += 1
+            continue
+        # Treat separator-only markdown lines as structure, not findings.
+        if re.match(r"^(=|-){3,}$", value):
+            index += 1
+            continue
+        next_value = lines[index + 1].strip() if index + 1 < len(lines) else ""
+        if next_value and re.match(r"^(=|-){3,}$", next_value):
+            is_numbered = re.match(r"^([1-9][0-9]?)\.\s+", value)
+            if not value.startswith(("- ", "* ", "\u2022 ")) and not is_numbered:
+                index += 2
+                continue
+        if re.match(r"^#{1,6}(?:\s|$)", value):
+            index += 1
+            continue
+        if re.match(r"^key findings:?$", value, flags=re.IGNORECASE):
+            index += 1
             continue
         if value.startswith(("- ", "* ", "\u2022 ")):
             value = value[2:].strip()
@@ -761,10 +781,13 @@ def _parse_key_findings_text(content: str, *, source_name: str = "key findings")
             if numbered:
                 value = numbered.group(2).strip()
         if value in {"-", "*", "\u2022"}:
+            index += 1
             continue
         if re.match(r"^([1-9][0-9]?)\.$", value):
+            index += 1
             continue
         if not value:
+            index += 1
             continue
         if len(value) > max_length:
             logger.error(
@@ -773,8 +796,10 @@ def _parse_key_findings_text(content: str, *, source_name: str = "key findings")
                 max_length,
                 value,
             )
+            index += 1
             continue
         findings.append({"finding": value})
+        index += 1
     return findings
 
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1054,6 +1054,149 @@ def test_build_key_findings_section_parses_valid_file(tmp_path, monkeypatch):
     ]
 
 
+def test_build_key_findings_section_skips_markdown_heading_preamble(tmp_path, monkeypatch):
+    monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
+    owner_dir = tmp_path / "accounts" / "demo-owner"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "key_findings.md").write_text(
+        "## Key Findings\n"
+        "Key Findings:\n"
+        "-----\n"
+        "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
+        encoding="utf-8",
+    )
+
+    context = reports.ReportContext("demo-owner", start=None, end=None)
+    schema = reports.ReportSectionSchema(
+        id="key-findings",
+        title="Key Findings",
+        source="portfolio.key_findings",
+        columns=(reports.ReportColumnSchema("finding", "Finding"),),
+    )
+
+    rows = reports._build_key_findings_section(context, schema)
+
+    assert rows == [{"finding": "Portfolio is well-diversified across 4 regions and 8 sectors."}]
+
+
+def test_build_key_findings_section_skips_standalone_separator_line(tmp_path, monkeypatch):
+    monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
+    owner_dir = tmp_path / "accounts" / "demo-owner"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "key_findings.md").write_text(
+        "---\n"
+        "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
+        encoding="utf-8",
+    )
+
+    context = reports.ReportContext("demo-owner", start=None, end=None)
+    schema = reports.ReportSectionSchema(
+        id="key-findings",
+        title="Key Findings",
+        source="portfolio.key_findings",
+        columns=(reports.ReportColumnSchema("finding", "Finding"),),
+    )
+
+    rows = reports._build_key_findings_section(context, schema)
+
+    assert rows == [{"finding": "Portfolio is well-diversified across 4 regions and 8 sectors."}]
+
+
+def test_build_key_findings_section_skips_setext_heading_preamble(tmp_path, monkeypatch):
+    monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
+    owner_dir = tmp_path / "accounts" / "demo-owner"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "key_findings.md").write_text(
+        "Summary\n"
+        "-------\n"
+        "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
+        encoding="utf-8",
+    )
+
+    context = reports.ReportContext("demo-owner", start=None, end=None)
+    schema = reports.ReportSectionSchema(
+        id="key-findings",
+        title="Key Findings",
+        source="portfolio.key_findings",
+        columns=(reports.ReportColumnSchema("finding", "Finding"),),
+    )
+
+    rows = reports._build_key_findings_section(context, schema)
+
+    assert rows == [{"finding": "Portfolio is well-diversified across 4 regions and 8 sectors."}]
+
+
+def test_build_key_findings_section_keeps_numbered_finding_before_separator(tmp_path, monkeypatch):
+    monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
+    owner_dir = tmp_path / "accounts" / "demo-owner"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "key_findings.md").write_text(
+        "1. Cash drag is elevated versus target corridor.\n"
+        "----------------\n",
+        encoding="utf-8",
+    )
+
+    context = reports.ReportContext("demo-owner", start=None, end=None)
+    schema = reports.ReportSectionSchema(
+        id="key-findings",
+        title="Key Findings",
+        source="portfolio.key_findings",
+        columns=(reports.ReportColumnSchema("finding", "Finding"),),
+    )
+
+    rows = reports._build_key_findings_section(context, schema)
+
+    assert rows == [{"finding": "Cash drag is elevated versus target corridor."}]
+
+
+def test_build_key_findings_section_skips_setext_heading_with_equals(tmp_path, monkeypatch):
+    monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
+    owner_dir = tmp_path / "accounts" / "demo-owner"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "key_findings.md").write_text(
+        "Summary\n"
+        "=======\n"
+        "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
+        encoding="utf-8",
+    )
+
+    context = reports.ReportContext("demo-owner", start=None, end=None)
+    schema = reports.ReportSectionSchema(
+        id="key-findings",
+        title="Key Findings",
+        source="portfolio.key_findings",
+        columns=(reports.ReportColumnSchema("finding", "Finding"),),
+    )
+
+    rows = reports._build_key_findings_section(context, schema)
+
+    assert rows == [{"finding": "Portfolio is well-diversified across 4 regions and 8 sectors."}]
+
+
+def test_build_key_findings_section_allows_findings_after_interleaved_heading(tmp_path, monkeypatch):
+    monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
+    owner_dir = tmp_path / "accounts" / "demo-owner"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "key_findings.md").write_text(
+        "- Finding one.\n"
+        "## Sub-section\n"
+        "- Finding two.\n",
+        encoding="utf-8",
+    )
+
+    context = reports.ReportContext("demo-owner", start=None, end=None)
+    schema = reports.ReportSectionSchema(
+        id="key-findings",
+        title="Key Findings",
+        source="portfolio.key_findings",
+        columns=(reports.ReportColumnSchema("finding", "Finding"),),
+    )
+
+    rows = reports._build_key_findings_section(context, schema)
+
+    assert rows == [{"finding": "Finding one."}, {"finding": "Finding two."}]
+
+
 def test_build_key_findings_section_returns_empty_when_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
 


### PR DESCRIPTION
### Motivation

- Key findings parsing needed to ignore Markdown structural lines (ATX headings, setext underlines, and separator rules) so only actual findings are extracted.
- The parser should also preserve numbered list items that precede setext separators while treating separator-only lines as structural noise.

### Description

- Rewrote `_parse_key_findings_text` to iterate with a manual index and handle multi-line setext heading preambles and separator-only lines. 
- Added logic to skip ATX headings (`^#{1,6}`), setext underlines (`^(-|=){3,}$`), and standalone separator lines while preserving numbered list items when appropriate. 
- Normalizes bullet markers and numbered items, enforces the `max_length` check with logging, and continues scanning correctly after skipped lines. 
- Added multiple tests in `tests/test_reports.py` covering heading preambles, standalone separators, setext headings (both `-` and `=`), numbered items before separators, and interleaved headings keeping adjacent findings.

### Testing

- Ran the test suite including the new tests in `tests/test_reports.py` that exercise `._build_key_findings_section` and `._parse_key_findings_text`. 
- All new and existing automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cac6cc0a248327afc582e52f293b14)