### PR TITLE
Fix double-space in research page heading

### DIFF
--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -782,7 +782,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
         }
         return (
           <h1 style={{ marginBottom: "1rem" }}>
-            {tkr} {` - ${headingName}`}
+            {`${tkr} - ${headingName}`}
             {displaySector || displayCurrency ? (
               <span
                 style={{


### PR DESCRIPTION
### Motivation
- The research page heading could render with two spaces before the dash (e.g. `AAA  - AAA.L`) as reported in issue Closes #2656, so the title formatting was corrected to ensure a single space around the dash.

### Description
- Use a single template string to build the heading (``${tkr} - ${headingName}``) in `frontend/src/pages/InstrumentResearch.tsx` to eliminate the accidental double-space introduced by combining JSX spacing with a prefixed string.

### Testing
- Ran the frontend linter with `npm --prefix frontend run lint`, which failed due to pre-existing repository-wide lint issues unrelated to this small, localized change; no new lint errors were introduced by this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae218ebc0832788125bd10ce0553c)