### PR TITLE
Standardize 'Alpha vs Benchmark' capitalization in en locale

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -342,7 +342,7 @@
         "breakdownIntro": "Each row shows how the cumulative portfolio and benchmark returns evolve on the same trading days. Their difference is the excess return (alpha).",
         "calculation": "We compute time-weighted cumulative returns for both the portfolio and the configured benchmark. Alpha is simply the portfolio return minus the benchmark return, expressed in percentage points.",
         "detail": "Cumulative portfolio return: {{portfolio}} · Benchmark return: {{benchmark}} · Alpha: {{alpha}}",
-        "headline": "Alpha vs benchmark",
+        "headline": "Alpha vs Benchmark",
         "notes": [
           "Positive alpha means the portfolio outperformed the benchmark over the selected period.",
           "If either return series is unavailable for the full span we fall back to the overlapping dates only."


### PR DESCRIPTION
### Motivation
- Fix inconsistent capitalization on the `/metrics-explained` page where the alpha sub-heading used "Alpha vs benchmark" instead of title case, as reported in issue Closes #2657.

### Description
- Update `frontend/src/locales/en/translation.json` to change `sections.alpha.headline` from `"Alpha vs benchmark"` to `"Alpha vs Benchmark"` to match the section title and other UI labels.

### Testing
- Ran `python -m json.tool frontend/src/locales/en/translation.json` to validate JSON (succeeds) and ran `npm --prefix frontend run lint` which failed due to pre-existing repository lint violations unrelated to this copy-only locale change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae2c632e48327b21f4b11efa9f2e5)