### PR TITLE
Fix Recharts -1 dimension warnings on initial chart render

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -747,7 +747,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
 
       {typeRows.length > 0 && (
         <div style={{ width: "100%", height: 240, margin: "1rem 0" }}>
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <PieChart>
               <Pie
                 dataKey="value"
@@ -794,7 +794,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
               Region
             </button>
           </div>
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <BarChart
               data={
                 contribTab === "sector"

--- a/frontend/src/components/InstrumentTile.tsx
+++ b/frontend/src/components/InstrumentTile.tsx
@@ -27,7 +27,7 @@ export function InstrumentTile({ instrument, days = 30 }: Props) {
       <div style={{ fontWeight: 600 }}>{instrument.ticker}</div>
       <div style={{ fontSize: 12, marginBottom: 4 }}>{instrument.name}</div>
       <div style={{ width: "100%", height: 80 }}>
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
           <LineChart data={points}>
             <YAxis domain={["auto", "auto"]} hide />
             <Line type="monotone" dataKey="price" stroke="#8884d8" dot={false} />

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -306,7 +306,7 @@ export function PerformanceDashboard({ owner, asOf }: Props) {
           )}
           {drawdownDetailsAvailable ? (
             <div style={{ height: 220 }}>
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
                 <LineChart data={drawdownSeries}>
                   <XAxis dataKey="date" />
                   <YAxis

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -181,7 +181,7 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
               </p>
             ) : sectorContrib && sectorContrib.length > 0 ? (
               <div className="h-64 w-full">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
                   <BarChart data={sectorContrib}>
                     <XAxis dataKey="sector" interval={0} angle={-35} textAnchor="end" height={70} />
                     <YAxis />

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -242,7 +242,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
       {error && <p className="text-red-500">{error}</p>}
       <div style={{ width: "100%", height: 400 }}>
         {supportsResizeObserver ? (
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <PieChart>
               <Pie
                 data={chartData}

--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -559,7 +559,7 @@ export default function PensionForecast() {
           )}
           {data.length > 0 && (
             <div className="h-72 rounded-2xl bg-white p-4 shadow-sm">
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
                 <LineChart data={data}>
                   <XAxis dataKey="age" />
                   <YAxis />


### PR DESCRIPTION
### Motivation
- Prevent repeated Recharts console warnings (`The width(-1) and height(-1) of chart should be greater than 0`) caused by transient non-positive container dimensions during initial layout for charts that use `height="100%"`.

Closes #2655 

### Description
- Added `minWidth={1}` and `minHeight={1}` to `ResponsiveContainer` instances that use `height="100%"` to ensure resolved dimensions are positive at mount time.
- Updated the following files: `frontend/src/components/GroupPortfolioView.tsx`, `frontend/src/components/PortfolioView.tsx`, `frontend/src/components/PerformanceDashboard.tsx`, `frontend/src/components/InstrumentTile.tsx`, `frontend/src/pages/AllocationCharts.tsx`, and `frontend/src/pages/PensionForecast.tsx`.
- Change is limited to layout props on chart containers and does not alter chart data or rendering logic, keeping risk low.

### Testing
- Ran the targeted frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/pages/AllocationCharts.test.tsx`, and the test suite passed (13 tests passed).
- Ran the frontend linter with `npm --prefix frontend run lint`, which reported pre-existing unrelated lint violations in the repo and did not indicate regressions caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae1c15f6c8327bfafa9658cffc960)