### PR TITLE
Add semantic headings to /instrument, /market, and /movers routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -568,6 +568,9 @@ export default function App({ onLogout }: AppProps) {
         {/* INSTRUMENT VIEW */}
         {mode === "instrument" && groups.length > 0 && (
           <>
+            <h1 className="mb-4 text-2xl">
+              {t("app.modes.instrument", { defaultValue: "Instruments" })}
+            </h1>
             {err && <p style={{ color: "red" }}>{err}</p>}
             {loading ? (
               <p>{t("app.loading")}</p>

--- a/frontend/src/pages/MarketOverview.tsx
+++ b/frontend/src/pages/MarketOverview.tsx
@@ -41,9 +41,30 @@ export default function MarketOverview() {
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading) return <p>{t('common.loading')}</p>;
-  if (error) return <p className="text-red-500">{error}</p>;
-  if (!data) return null;
+  const pageHeading = t('app.modes.market', { defaultValue: 'Market Overview' });
+  if (loading) {
+    return (
+      <div className="container mx-auto p-4">
+        <h1 className="mb-4 text-2xl">{pageHeading}</h1>
+        <p>{t('common.loading')}</p>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="container mx-auto p-4">
+        <h1 className="mb-4 text-2xl">{pageHeading}</h1>
+        <p className="text-red-500">{error}</p>
+      </div>
+    );
+  }
+  if (!data) {
+    return (
+      <div className="container mx-auto p-4">
+        <h1 className="mb-4 text-2xl">{pageHeading}</h1>
+      </div>
+    );
+  }
 
   const indexData = Object.entries(data.indexes).map(
     ([name, { value, change }]) => ({
@@ -55,9 +76,7 @@ export default function MarketOverview() {
 
   return (
     <div className="container mx-auto p-4">
-      <h1 className="mb-4 text-2xl">
-        {t('app.modes.market', { defaultValue: 'Market Overview' })}
-      </h1>
+      <h1 className="mb-4 text-2xl">{pageHeading}</h1>
 
       <div className="mb-8">
         <h2 className="mb-2 text-xl">

--- a/frontend/src/pages/TopMovers.tsx
+++ b/frontend/src/pages/TopMovers.tsx
@@ -1,8 +1,14 @@
 import { TopMoversPage } from "../components/TopMoversPage";
+import { useTranslation } from "react-i18next";
 
 export default function TopMovers() {
+  const { t } = useTranslation();
+
   return (
     <div className="container mx-auto p-4">
+      <h1 className="mb-4 text-2xl">
+        {t("app.modes.movers", { defaultValue: "Top Movers" })}
+      </h1>
       <TopMoversPage />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Fix missing semantic headings on the instrument, market, and movers pages reported in issue #2654 to improve accessibility and make heading-based UI assertions reliable. 
- Ensure the primary page title is provided as an `<h1>` for each route so screen readers and automated tests have a stable heading to target.

Closes #2654 

### Description
- Added a semantic `<h1>` header for the instrument catalogue view rendered in `App` when `mode === "instrument"`, using the `t("app.modes.instrument")` i18n key. 
- Added a semantic `<h1>` header to the `/movers` wrapper page in `frontend/src/pages/TopMovers.tsx`, using the `t("app.modes.movers")` i18n key. 
- Refactored `frontend/src/pages/MarketOverview.tsx` so the page heading is rendered consistently across loading, error, empty, and success states by introducing a `pageHeading` variable and including the `<h1>` in all early returns and the final render.

### Testing
- Ran the MarketOverview unit tests with `npm --prefix frontend run test -- --run tests/unit/pages/MarketOverview.test.tsx`, which passed. 
- Ran the app-level unit tests `npm --prefix frontend run test -- --run tests/unit/pages/MarketOverview.test.tsx tests/unit/App.test.tsx`, which failed due to pre-existing test environment/mocking and network-related issues unrelated to these markup changes. 
- Ran the frontend linter with `npm --prefix frontend run lint`, which reported pre-existing lint warnings/errors in the repository and is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae1ae2e6c83279b02e13869384705)