### PR TITLE
Fix double-space in research page heading

### DIFF
--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -782,7 +782,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
         }
         return (
           <h1 style={{ marginBottom: "1rem" }}>
-            {tkr} {` - ${headingName}`}
+            {`${tkr} - ${headingName}`}
             {displaySector || displayCurrency ? (
               <span
                 style={{


### PR DESCRIPTION
### Motivation
- Address formatting bug on the research page heading that could render an extra space before the dash (Closes #2659 ).

### Description
- Replace adjacent JSX expressions with a single template literal in `frontend/src/pages/InstrumentResearch.tsx` so the heading renders as ```${tkr} - ${headingName}```.

### Testing
- Ran `npm --prefix frontend run lint`, which fails due to unrelated pre-existing repo-wide lint issues, and verified this one-line presentation change did not introduce additional lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae53d7d708327a98350c4a753fcdf)