### PR TITLE
Fix GBX prices being 100x too small when Close_gbp is present

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -134,8 +134,6 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
 
             selected_col = close_gbp_col or close_native_col
             val = float(last[selected_col])
-            if selected_col == close_gbp_col and scale not in (None, 1):
-                val *= scale
 
             if not (val == val and val != float("inf") and val != float("-inf")):
                 continue

--- a/tests/common/test_holding_utils.py
+++ b/tests/common/test_holding_utils.py
@@ -63,7 +63,7 @@ def test_load_latest_prices_resolution_scaling_and_missing(monkeypatch):
     monkeypatch.setattr(holding_utils, "_fx_to_base", lambda from_ccy, to_ccy, cache: 0.8)
 
     prices = holding_utils.load_latest_prices(["ABC", "USD", "XYZ"])
-    assert prices == {"ABC.L": 10.0, "USD.L": 80.0}
+    assert prices == {"ABC.L": 20.0, "USD.L": 80.0}
 
 
 def test_load_latest_prices_converts_native_close_to_gbp(monkeypatch):
@@ -106,6 +106,25 @@ def test_load_latest_prices_does_not_double_convert_close_gbp(monkeypatch):
     prices = holding_utils.load_latest_prices(["VUSA.L"])
 
     assert prices == {"VUSA.L": pytest.approx(79.0)}
+
+
+def test_load_latest_prices_close_gbp_not_rescaled(monkeypatch):
+    from backend.common import instrument_api
+
+    monkeypatch.setattr(instrument_api, "_resolve_full_ticker", lambda f, r: ("SBRY", "L"))
+    monkeypatch.setattr(
+        holding_utils,
+        "load_meta_timeseries_range",
+        lambda *args, **kwargs: pd.DataFrame(
+            {"Date": [dt.date(2024, 1, 1)], "Close": [283.4], "Close_gbp": [2.834]}
+        ),
+    )
+    monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 0.01)
+    monkeypatch.setattr(holding_utils, "get_instrument_meta", lambda *_: {"currency": "GBX"})
+
+    prices = holding_utils.load_latest_prices(["SBRY.L"])
+
+    assert prices == {"SBRY.L": pytest.approx(2.834)}
 
 
 @pytest.mark.parametrize("raw_currency", ["GBX", "GBXP", "GBp"])


### PR DESCRIPTION
### Motivation
- Prices for LSE/GBX instruments were sometimes ~100x too small because `Close_gbp` values were being scaled again when a scaling override existed. 
- `Close_gbp` is already GBP-normalized and must not be multiplied by the exchange `scale` a second time.

### Description
- Stop re-applying `scale` to `Close_gbp` values in `load_latest_prices` by removing the extra multiplication in `backend/common/holding_utils.py`.
- Preserve existing behavior for native `Close` values (they still get `apply_scaling` and FX conversion as appropriate).
- Update the expected output in `tests/common/test_holding_utils.py` to reflect that `Close_gbp` is preserved rather than rescaled.
- Add a regression test `test_load_latest_prices_close_gbp_not_rescaled` in `tests/common/test_holding_utils.py` that verifies a GBX instrument with `Close_gbp` (example `SBRY.L`) is returned unchanged.

### Testing
- Ran the targeted unit test file with `pytest -q tests/common/test_holding_utils.py` and all tests passed: `20 passed`.
- The new regression test and the adjusted existing tests executed successfully and validate the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf49f31548327845537b067e1bfa1)