### PR TITLE
Fix GBX close_gbp double scaling on instrument route

### DIFF
--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -292,8 +292,6 @@ async def instrument(
     scale = get_scaling_override(tkr, exch, None)
     if scale != 1.0:
         df = apply_scaling(df, scale)
-        if "Close_gbp" in df.columns:
-            df["Close_gbp"] = pd.to_numeric(df["Close_gbp"], errors="coerce") * scale
 
     df = df[pd.notnull(df["Close"])]
 

--- a/tests/test_instrument_route.py
+++ b/tests/test_instrument_route.py
@@ -482,6 +482,37 @@ def test_gbx_prices_scaled_and_cost_basis_fallback(monkeypatch):
     assert position["gain_pct"] == pytest.approx(20.0)
 
 
+def test_gbx_with_scaling_override_does_not_double_scale_close_gbp(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    app = create_app()
+    df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-01", periods=1, freq="D"),
+            "Close": [300.0],
+        }
+    )
+
+    monkeypatch.setattr(
+        "backend.routes.instrument.load_meta_timeseries_range", lambda *args, **kwargs: df
+    )
+    monkeypatch.setattr(
+        "backend.routes.instrument.get_security_meta", lambda ticker: {"currency": "GBX"}
+    )
+    monkeypatch.setattr(
+        "backend.routes.instrument.get_scaling_override", lambda *_args, **_kwargs: 0.01
+    )
+    monkeypatch.setattr("backend.routes.instrument.list_portfolios", lambda: [])
+
+    client = _auth_client(app)
+    resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
+    assert resp.status_code == 200
+    payload = resp.json()
+    prices = payload["prices"]
+
+    assert prices[-1]["close"] == pytest.approx(3.0)
+    assert prices[-1]["close_gbp"] == pytest.approx(3.0)
+
+
 def test_base_currency_fetch_failure_is_resilient(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()


### PR DESCRIPTION
### Motivation
- GBX-denominated instruments with a non-unity scaling override produced GBP values 100× too small because `Close` was scaled once but `Close_gbp` was being multiplied by the scale again.
- The intent is to ensure instrument timeseries expose correct GBP values when both GBX→GBP conversion and scaling overrides are present.

### Description
- Removed the extra post-scaling multiplication of `Close_gbp` in `backend/routes/instrument.py` so `apply_scaling(...)` is the single source of truth for numeric scaling.
- Added a regression test `test_gbx_with_scaling_override_does_not_double_scale_close_gbp` in `tests/test_instrument_route.py` that simulates a GBX time series with a `0.01` scaling override and asserts `close` and `close_gbp` are correctly reported.
- Kept existing GBX-related behavior and the other GBX test (`test_gbx_prices_scaled_and_cost_basis_fallback`) unchanged.

### Testing
- Ran `pytest -q tests/test_instrument_route.py -k "gbx"` and observed `2 passed` for the GBX-focused tests.
- No other automated test suites were run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf7c5ade083279d78ef7a23501c44)