### PR TITLE
Fix GBX native price rendering in research & instrument detail

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { getInstrumentDetail, getInstrumentIntraday } from "../api";
-import { money, percent } from "../lib/money";
+import { money, percent, quotedPrice } from "../lib/money";
 import { translateInstrumentType } from "../lib/instrumentType";
 import tableStyles from "../styles/table.module.css";
 import i18n from "../i18n";
@@ -39,6 +39,7 @@ type Price = {
   date: string;
   close_gbp: number | null | undefined;
   close?: number | null | undefined;
+  close_usd?: number | null | undefined;
 };
 
 type Position = InstrumentPosition & {
@@ -68,6 +69,13 @@ const fixed = (v: unknown, dp = 2): string => {
         maximumFractionDigits: dp,
       }).format(n)
     : "—";
+};
+
+const normaliseCurrency = (value: string | null | undefined): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim().toUpperCase();
+  if (!trimmed) return undefined;
+  return /^[A-Z]{3,5}$/.test(trimmed) ? trimmed : undefined;
 };
 
 export function InstrumentPositionsTable({
@@ -319,40 +327,67 @@ export function InstrumentDetail({
     };
   }, [ticker, priceMode]);
 
-  const displayCurrency = currencyFromData ?? currencyProp ?? "?";
+  const displayCurrency = currencyProp ?? currencyFromData ?? "?";
+  const reportingCurrency = normaliseCurrency(baseCurrency ?? "GBP");
+  const instrumentCurrency = normaliseCurrency(displayCurrency);
 
   const [tickerBase, exch = "L"] = ticker.split(".", 2);
   const editLink = `/timeseries?ticker=${encodeURIComponent(tickerBase)}&exchange=${encodeURIComponent(exch)}`;
 
+  const shouldUseNativeClose =
+    instrumentCurrency != null &&
+    reportingCurrency != null &&
+    instrumentCurrency !== reportingCurrency;
+  const formatDisplayAmount = (amount: number | null | undefined, currency: string) => {
+    const normalized = normaliseCurrency(currency);
+    if (normalized != null && normalized === reportingCurrency) {
+      return money(amount, normalized);
+    }
+    return quotedPrice(amount, normalized ?? currency);
+  };
   const rawPrices = (data?.prices ?? [])
-    .map((p) => ({ date: p.date, close_gbp: toNum(p.close_gbp ?? p.close) }))
-    .filter((p) => Number.isFinite(p.close_gbp));
+    .map((p) => {
+      const nativeClose = toNum(p.close);
+      const reportingClose = toNum(p.close_gbp ?? p.close_usd);
+      const close =
+        shouldUseNativeClose && Number.isFinite(nativeClose)
+          ? nativeClose
+          : Number.isFinite(reportingClose)
+            ? reportingClose
+            : nativeClose;
+      const currency =
+        shouldUseNativeClose && Number.isFinite(nativeClose)
+          ? instrumentCurrency ?? ""
+          : reportingCurrency ?? instrumentCurrency ?? "";
+      return { date: p.date, close, currency };
+    })
+    .filter((p) => Number.isFinite(p.close));
 
   const withChanges = rawPrices.map((p, i) => {
     const prev = rawPrices[i - 1];
-    const change_gbp = prev ? p.close_gbp - prev.close_gbp : NaN;
-    const change_pct = prev ? (change_gbp / prev.close_gbp) * 100 : NaN;
-    return { ...p, change_gbp, change_pct };
+    const change = prev ? p.close - prev.close : NaN;
+    const change_pct = prev ? (change / prev.close) * 100 : NaN;
+    return { ...p, change, change_pct };
   });
 
   const prices = withChanges.map((p, i, arr) => {
     const slice20 = arr.slice(Math.max(0, i - 19), i + 1);
     const mean20 =
-      slice20.reduce((sum, s) => sum + s.close_gbp, 0) / slice20.length;
+      slice20.reduce((sum, s) => sum + s.close, 0) / slice20.length;
     const variance =
-      slice20.reduce((sum, s) => Math.pow(s.close_gbp - mean20, 2) + sum, 0) /
+      slice20.reduce((sum, s) => Math.pow(s.close - mean20, 2) + sum, 0) /
       slice20.length;
     const stdDev = Math.sqrt(variance);
     const has20 = slice20.length === 20;
 
     const slice50 = arr.slice(Math.max(0, i - 49), i + 1);
     const mean50 =
-      slice50.reduce((sum, s) => sum + s.close_gbp, 0) / slice50.length;
+      slice50.reduce((sum, s) => sum + s.close, 0) / slice50.length;
     const has50 = slice50.length === 50;
 
     const slice200 = arr.slice(Math.max(0, i - 199), i + 1);
     const mean200 =
-      slice200.reduce((sum, s) => sum + s.close_gbp, 0) / slice200.length;
+      slice200.reduce((sum, s) => sum + s.close, 0) / slice200.length;
     const has200 = slice200.length === 200;
 
     const rsiSlice = arr.slice(Math.max(0, i - 14), i + 1);
@@ -361,7 +396,7 @@ export function InstrumentDetail({
       let gains = 0;
       let losses = 0;
       for (let j = 1; j < rsiSlice.length; j++) {
-        const diff = rsiSlice[j].close_gbp - rsiSlice[j - 1].close_gbp;
+        const diff = rsiSlice[j].close - rsiSlice[j - 1].close;
         if (diff >= 0) gains += diff;
         else losses -= diff;
       }
@@ -388,7 +423,8 @@ export function InstrumentDetail({
   });
 
   // 7d / 30d change calculations
-  const latestClose = rawPrices[rawPrices.length - 1]?.close_gbp ?? NaN;
+  const latestClose = rawPrices[rawPrices.length - 1]?.close ?? NaN;
+  const latestCurrency = rawPrices[rawPrices.length - 1]?.currency ?? displayCurrency;
 
   const lookup = (days: number): number => {
     if (!rawPrices.length) return NaN;
@@ -396,7 +432,7 @@ export function InstrumentDetail({
     target.setDate(target.getDate() - days);
     for (let i = rawPrices.length - 1; i >= 0; i--) {
       const d = new Date(rawPrices[i].date);
-      if (d <= target) return rawPrices[i].close_gbp;
+      if (d <= target) return rawPrices[i].close;
     }
     return NaN;
   };
@@ -424,7 +460,7 @@ export function InstrumentDetail({
     const parts: string[] = [];
 
     if (Number.isFinite(absoluteChange)) {
-      parts.push(money(absoluteChange, baseCurrency));
+      parts.push(formatDisplayAmount(absoluteChange, latestCurrency));
     }
 
     if (Number.isFinite(percentChange)) {
@@ -707,7 +743,7 @@ export function InstrumentDetail({
                 yAxisId="rsi"
               />
             )}
-            <Line type="monotone" dataKey="close_gbp" dot={false} yAxisId="price" />
+            <Line type="monotone" dataKey="close" dot={false} yAxisId="price" />
           </LineChart>
         </ResponsiveContainer>
       )}
@@ -757,8 +793,8 @@ export function InstrumentDetail({
               .slice(-60)
               .reverse()
               .map((p) => {
-                const colour = Number.isFinite(p.change_gbp)
-                  ? p.change_gbp >= 0
+                const colour = Number.isFinite(p.change)
+                  ? p.change >= 0
                     ? palette.positive
                     : palette.negative
                   : undefined;
@@ -768,13 +804,13 @@ export function InstrumentDetail({
                       {formatDateISO(new Date(p.date))}
                     </td>
                     <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                      {money(p.close_gbp, baseCurrency)}
+                      {formatDisplayAmount(p.close, p.currency)}
                     </td>
                     <td
                       className={`${tableStyles.cell} ${tableStyles.right}`}
                       style={{ color: colour }}
                     >
-                      {money(p.change_gbp, baseCurrency)}
+                      {formatDisplayAmount(p.change, p.currency)}
                     </td>
                     <td
                       className={`${tableStyles.cell} ${tableStyles.right}`}

--- a/frontend/src/lib/money.ts
+++ b/frontend/src/lib/money.ts
@@ -46,6 +46,20 @@ export const money = (
     }).format(v);
 };
 
+export const quotedPrice = (
+    v: number | null | undefined,
+    currency = "",
+    locale: string = i18n.language,
+): string => {
+    if (typeof v !== "number" || !Number.isFinite(v)) return "—";
+    const formatted = new Intl.NumberFormat(locale, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    }).format(v);
+    const normalizedCurrency = currency.trim().toUpperCase();
+    return normalizedCurrency ? `${formatted} ${normalizedCurrency}` : formatted;
+};
+
 export const percent = (
     v: number | null | undefined,
     fractionDigits = 2,

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -18,7 +18,7 @@ import EmptyState from "../components/EmptyState";
 import { useConfig, SUPPORTED_CURRENCIES } from "../ConfigContext";
 import surfaceStyles from "../styles/surface.module.css";
 import { formatDateISO } from "../lib/date";
-import { money, percent } from "../lib/money";
+import { money, percent, quotedPrice } from "../lib/money";
 import { translateInstrumentType } from "../lib/instrumentType";
 
 function normaliseOptional(value: unknown) {
@@ -81,6 +81,45 @@ function addInstrumentTypeOption(options: string[], value: string) {
   return [...options, normalised].sort((a, b) =>
     a.localeCompare(b, undefined, { sensitivity: "base" }),
   );
+}
+
+type DisplayPrice = {
+  close: number;
+  currency: string;
+  date: string | null;
+};
+
+function resolveDisplayPrice(
+  price: Record<string, unknown>,
+  instrumentCurrency: string | undefined,
+  reportingCurrency: string | undefined,
+): DisplayPrice | null {
+  const nativeClose = typeof price.close === "number" && Number.isFinite(price.close)
+    ? price.close
+    : null;
+  const reportingClose =
+    typeof price.close_gbp === "number" && Number.isFinite(price.close_gbp)
+      ? price.close_gbp
+      : typeof price.close_usd === "number" && Number.isFinite(price.close_usd)
+        ? price.close_usd
+        : null;
+  const normalizedInstrumentCurrency = normaliseUppercase(instrumentCurrency);
+  const normalizedReportingCurrency = normaliseUppercase(reportingCurrency);
+  const shouldUseNativeClose =
+    normalizedInstrumentCurrency != null &&
+    normalizedReportingCurrency != null &&
+    normalizedInstrumentCurrency !== normalizedReportingCurrency;
+  const close =
+    shouldUseNativeClose && nativeClose != null
+      ? nativeClose
+      : reportingClose ?? nativeClose;
+  if (close == null) return null;
+  const currency =
+    shouldUseNativeClose && nativeClose != null
+      ? normalizedInstrumentCurrency ?? ""
+      : normalizedReportingCurrency ?? normalizedInstrumentCurrency ?? "";
+  const date = typeof price.date === "string" ? price.date : null;
+  return { close, currency, date };
 }
 
 type InstrumentResearchProps = {
@@ -242,12 +281,12 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
     if (!detail) return;
     const name = normaliseOptional(detail.name);
     const sector = normaliseOptional(detail.sector);
+    const normalizedInstrumentCurrency = normaliseUppercase(detail?.currency ?? undefined);
     const normalizedBaseCurrency =
       detail && typeof detail.base_currency === "string"
         ? normaliseUppercase(detail.base_currency)
         : undefined;
-    const currency =
-      normalizedBaseCurrency ?? normaliseUppercase(detail?.currency ?? undefined);
+    const currency = normalizedInstrumentCurrency ?? normalizedBaseCurrency;
     const detailRecord =
       detail && typeof detail === "object"
         ? (detail as unknown as Record<string, unknown>)
@@ -720,9 +759,10 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
 
   const fallbackSector = detail ? normaliseOptional(detail.sector) : undefined;
   const fallbackCurrency = detail
-    ? (typeof detail.base_currency === "string"
+    ? normaliseUppercase(detail.currency) ??
+      (typeof detail.base_currency === "string"
         ? normaliseUppercase(detail.base_currency)
-        : undefined) ?? normaliseUppercase(detail.currency)
+        : undefined)
     : undefined;
   const displayName = metadata.name || detail?.name || null;
   const displaySector = metadata.sector || fallbackSector || "";
@@ -1117,19 +1157,15 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
           .map((entry) => {
             if (!entry || typeof entry !== "object") return null;
             const value = entry as Record<string, unknown>;
-            const closeCandidates = [
-              value.close_gbp,
-              value.close,
-              value.close_usd,
-            ];
-            const close = closeCandidates.find(
-              (v) => typeof v === "number" && Number.isFinite(v),
-            ) as number | undefined;
-            if (close == null) return null;
-            const date = typeof value.date === "string" ? value.date : null;
-            return { close, date };
+            const resolvedPrice = resolveDisplayPrice(
+              value,
+              displayCurrency,
+              detail?.base_currency,
+            );
+            if (!resolvedPrice) return null;
+            return resolvedPrice;
           })
-          .filter((v): v is { close: number; date: string | null } => v != null);
+          .filter((v): v is DisplayPrice => v != null);
 
         const computeWindowChange = (window: number) => {
           if (parsedPrices.length < 2) return null;
@@ -1201,6 +1237,20 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
         const latestPriceEntry =
           parsedPrices.length > 0 ? parsedPrices[parsedPrices.length - 1] : null;
         const latestPrice = latestPriceEntry?.close ?? null;
+        const latestPriceCurrency = latestPriceEntry?.currency ?? displayCurrency;
+        const normalizedLatestCurrency = normaliseUppercase(latestPriceCurrency);
+        const normalizedReportingCurrency = normaliseUppercase(detail?.base_currency);
+        const formatDisplayPrice = (value: number | null, currency: string) => {
+          const normalizedCurrency = normaliseUppercase(currency);
+          if (
+            normalizedCurrency &&
+            normalizedReportingCurrency &&
+            normalizedCurrency === normalizedReportingCurrency
+          ) {
+            return money(value, normalizedCurrency);
+          }
+          return quotedPrice(value, normalizedCurrency ?? currency);
+        };
         const latestDate = (() => {
           if (!latestPriceEntry?.date) return null;
           const parsed = new Date(latestPriceEntry.date);
@@ -1224,11 +1274,6 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
             ? detail.rows.toLocaleString()
             : "—";
 
-        const priceCurrency =
-          (typeof detail?.base_currency === "string" && detail.base_currency) ||
-          displayCurrency ||
-          baseCurrency;
-
         const percentValue = (ratio: number | null, digits = 2) => {
           if (ratio == null || !Number.isFinite(ratio)) return "—";
           return percent(ratio * 100, digits);
@@ -1248,7 +1293,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
               {
                 label: "Last Close",
                 value: latestPrice != null
-                  ? money(latestPrice, priceCurrency)
+                  ? formatDisplayPrice(latestPrice, latestPriceCurrency)
                   : "—",
               },
               { label: "As of", value: latestDate ?? "—" },

--- a/frontend/tests/unit/components/InstrumentDetail.test.tsx
+++ b/frontend/tests/unit/components/InstrumentDetail.test.tsx
@@ -232,5 +232,24 @@ describe("InstrumentDetail", () => {
     expect(screen.queryByRole('columnheader', { name: /Gain £/ })).toBeNull();
     expect(screen.getByRole('columnheader', { name: /Gain %/ })).toBeInTheDocument();
   });
-});
 
+  it("prefers page currency and renders native GBX prices", async () => {
+    mockGetInstrumentDetail.mockResolvedValue({
+      prices: [
+        { date: "2024-01-01", close: 245, close_gbp: 2.45 },
+        { date: "2024-01-02", close: 250, close_gbp: 2.5 },
+      ],
+      positions: [],
+      currency: "GBP",
+    });
+
+    render(
+      <MemoryRouter>
+        <InstrumentDetail ticker="ABC.L" name="ABC" currency="GBX" onClose={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("250.00 GBX")).toBeInTheDocument();
+    expect(screen.queryByText("£2.50")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/pages/InstrumentResearch.test.tsx
+++ b/frontend/tests/unit/pages/InstrumentResearch.test.tsx
@@ -256,6 +256,43 @@ describe("InstrumentResearch page", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows native GBX close values instead of GBP-normalized close_gbp", async () => {
+    mockListInstrumentMetadata.mockResolvedValueOnce([
+      {
+        ticker: "AAA.L",
+        exchange: "L",
+        name: "Acme Corp",
+        sector: "Tech",
+        currency: "GBX",
+      } as InstrumentMetadata,
+    ]);
+    mockUseInstrumentHistory.mockReturnValue({
+      data: {
+        mini: { "30": [] },
+        positions: [],
+        ticker: "AAA.L",
+        name: "Acme Corp",
+        currency: "GBX",
+        base_currency: "GBP",
+        prices: [
+          { date: "2024-01-01", close: 245, close_gbp: 2.45 },
+          { date: "2024-01-02", close: 250, close_gbp: 2.5 },
+        ],
+        rows: 2,
+        from: "2024-01-01",
+        to: "2024-01-02",
+      },
+      loading: false,
+      error: null,
+    } as any);
+
+    renderPage();
+
+    const lastCloseRow = await screen.findByText("Last Close");
+    expect(lastCloseRow.closest("div")).toHaveTextContent("250.00 GBX");
+    expect(lastCloseRow.closest("div")).not.toHaveTextContent("£2.50");
+  });
+
   it("shows fundamentals error messages", async () => {
     mockGetScreener.mockRejectedValueOnce(new Error("fundamentals fail"));
 


### PR DESCRIPTION
### Motivation
- The research UI was formatting GBP-normalised fields (`close_gbp`) with `money()`, causing native pence quotes like `250` GBX to render as `£2.50` and losing native-quote context.
- The research page sometimes used `base_currency` instead of the instrument/native currency, hiding GBX context and preventing correct native formatting.

### Description
- Add `quotedPrice()` to `frontend/src/lib/money.ts` to format native quoted prices as numeric + currency code (e.g. `250.00 GBX`) without mapping pence codes to GBP symbols.
- Introduce `resolveDisplayPrice()` and related logic in `frontend/src/pages/InstrumentResearch.tsx` to prefer native `close` for non-reporting instruments and fall back to reporting fields (`close_gbp` / `close_usd`) otherwise, and use `quotedPrice()` for native displays.
- Update `frontend/src/components/InstrumentDetail.tsx` to prefer the page-supplied `currency` prop over the API currency, compute chart/table/change values from native quotes when appropriate, and format native vs reporting values consistently using `quotedPrice()` or `money()`.
- Add unit regression tests for the GBX scenario to `frontend/tests/unit/pages/InstrumentResearch.test.tsx` and `frontend/tests/unit/components/InstrumentDetail.test.tsx` covering `close=250`, `close_gbp=2.5`, `currency=GBX`.

### Testing
- Ran the targeted frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/pages/InstrumentResearch.test.tsx tests/unit/components/InstrumentDetail.test.tsx` and iterated until all assertions passed.
- Final test run: `tests/unit/pages/InstrumentResearch.test.tsx` and `tests/unit/components/InstrumentDetail.test.tsx` passed and the suite reported all tests passing (30 tests passed).
- During development there were intermediate failures which were fixed by adjusting currency selection/normalisation logic; final automated tests succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1fc0beac832789a224d653f74043)