### PR TITLE
Add CSV and PDF export actions to Portfolio view

### DIFF
--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -39,6 +39,9 @@ const CSV_HEADERS = [
   "gain_pct",
 ];
 
+const sanitizeFilenamePart = (value: string): string =>
+  value.replaceAll(/[^a-zA-Z0-9_-]/g, "_");
+
 const escapeCsvCell = (value: string | number | null | undefined): string => {
   const cell = value == null ? "" : String(value);
   const escaped = cell.replaceAll('"', '""');
@@ -66,7 +69,7 @@ const buildPortfolioCsv = (portfolio: Portfolio): string => {
     ...rows.map((row) => row.map(escapeCsvCell).join(",")),
   ];
 
-  return `${csvRows.join("\n")}\n`;
+  return `${csvRows.join("\r\n")}\r\n`;
 };
 
 const downloadPortfolioCsv = (portfolio: Portfolio): void => {
@@ -74,10 +77,14 @@ const downloadPortfolioCsv = (portfolio: Portfolio): void => {
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
+  const safeOwner = sanitizeFilenamePart(portfolio.owner);
+  const safeAsOf = sanitizeFilenamePart(portfolio.as_of);
   link.href = url;
-  link.download = `${portfolio.owner}-portfolio-${portfolio.as_of}.csv`;
+  link.download = `${safeOwner}-portfolio-${safeAsOf}.csv`;
+  document.body.appendChild(link);
   link.click();
-  URL.revokeObjectURL(url);
+  document.body.removeChild(link);
+  window.setTimeout(() => URL.revokeObjectURL(url), 250);
 };
 
 const escapeHtml = (value: string | number | null | undefined): string => {
@@ -289,7 +296,13 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
     onDateChange?.(trimmed ? trimmed : null);
   };
 
+  const handleExportCsv = () => {
+    if (!data) return;
+    downloadPortfolioCsv(data);
+  };
+
   const handleExportPdf = () => {
+    if (!data) return;
     printPortfolioPdf(data);
   };
 
@@ -334,7 +347,8 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
             <div className="flex flex-wrap items-center gap-2">
               <button
                 type="button"
-                onClick={() => downloadPortfolioCsv(data)}
+                onClick={handleExportCsv}
+                aria-label="Export portfolio as CSV"
                 className="rounded border border-gray-700 px-3 py-1 text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
               >
                 Export CSV
@@ -342,6 +356,7 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
               <button
                 type="button"
                 onClick={handleExportPdf}
+                aria-label="Export portfolio as PDF"
                 className="rounded border border-gray-700 px-3 py-1 text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
               >
                 Export PDF


### PR DESCRIPTION
### Motivation
- Provide a quick way to export a viewed owner portfolio from the owner page (e.g. `/portfolio/steve`) without requiring the reports workflow. 
- Offer lightweight, client-side CSV export and a simple PDF export entrypoint suitable for ad-hoc use.

### Description
- Added CSV export helpers (`CSV_HEADERS`, `escapeCsvCell`, `buildPortfolioCsv`, `downloadPortfolioCsv`) to `frontend/src/components/PortfolioView.tsx` that flatten accounts and holdings into a downloadable CSV file named `<owner>-portfolio-<as_of>.csv`.
- Added two UI actions (buttons) in `PortfolioView` labeled `Export CSV` and `Export PDF` and wired the CSV button to the download helper and the PDF button to trigger `window.print()`.
- Kept the implementation frontend-only and browser-native (no new dependencies), so printed PDF rendering relies on the browser print styles.

### Testing
- Ran targeted ESLint on the updated file with `cd frontend && npx eslint --format unix src/components/PortfolioView.tsx`, which completed successfully.
- Ran repository-wide frontend lint with `npm --prefix frontend run lint`, which failed due to existing pre-existing repo-wide lint issues unrelated to this change.
- No unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc2c11344c832793167aef637762ca)