### PR TITLE
Add reportlab to root requirements for PDF report support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ pillow~=12.1.1
 platformdirs~=3.10.0
 protobuf~=6.33.5
 pyarrow~=21.0.0
+reportlab~=4.4.3
 pycparser~=2.21
 pyjwt~=2.12.0
 pydantic~=2.11.7


### PR DESCRIPTION
### Motivation
- Ensure PDF report endpoints work for local/backend installs that use the root dependency manifest because PDF generation raises `RuntimeError: reportlab is required for PDF output` when `reportlab` is not present.

### Description
- Added `reportlab~=4.4.3` to the root `requirements.txt` so environments installing from the root file (for example via `scripts/run-backend.ps1`) will have the PDF engine available.

### Testing
- Ran `pytest -q tests/test_reports_pdf.py::test_report_to_pdf_generates_pdf tests/test_reports_route.py::test_owner_template_report_pdf` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc54d2e064832782544894b5e4d553)