### PR TITLE
Add shared navigation menu to performance diagnostics route

### DIFF
--- a/frontend/src/pages/PerformanceDiagnostics.tsx
+++ b/frontend/src/pages/PerformanceDiagnostics.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
 } from "recharts";
 import { getPerformance, getPortfolioHoldings } from "../api";
+import Menu from "../components/Menu";
 import type {
   PerformancePoint,
   HoldingValue,
@@ -222,6 +223,9 @@ export default function PerformanceDiagnostics() {
 
   return (
     <div style={{ padding: "1rem" }}>
+      <div style={{ marginBottom: "1rem" }}>
+        <Menu selectedOwner={owner} />
+      </div>
       <h1>Performance Diagnostics – {owner}</h1>
       {err ? (
         <div role="alert" aria-live="assertive" style={{ marginTop: "1rem" }}>

--- a/frontend/tests/unit/pages/PerformanceDiagnostics.test.tsx
+++ b/frontend/tests/unit/pages/PerformanceDiagnostics.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PerformanceDiagnostics from "@/pages/PerformanceDiagnostics";
+
+const mockGetPerformance = vi.hoisted(() => vi.fn());
+const mockGetPortfolioHoldings = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api", async () => {
+  const actual = await vi.importActual<typeof import("@/api")>("@/api");
+  return {
+    ...actual,
+    getPerformance: mockGetPerformance,
+    getPortfolioHoldings: mockGetPortfolioHoldings,
+  };
+});
+
+vi.mock("@/components/Menu", () => ({
+  default: ({ selectedOwner }: { selectedOwner?: string }) => (
+    <nav data-testid="diagnostics-menu">Menu for {selectedOwner}</nav>
+  ),
+}));
+
+describe("PerformanceDiagnostics page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPerformance.mockResolvedValue({
+      history: [{ date: "2026-01-01", drawdown: 0 }],
+      dataQualityIssues: [],
+    });
+    mockGetPortfolioHoldings.mockResolvedValue({ holdings: [] });
+  });
+
+  it("renders the shared menu with owner context", async () => {
+    render(
+      <MemoryRouter initialEntries={["/performance/alex/diagnostics"]}>
+        <Routes>
+          <Route
+            path="/performance/:owner/diagnostics"
+            element={<PerformanceDiagnostics />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mockGetPerformance).toHaveBeenCalledWith("alex");
+    });
+
+    expect(screen.getByTestId("diagnostics-menu")).toHaveTextContent(
+      "Menu for alex",
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- The performance diagnostics route rendered without the app's standard navigation, making it harder to move to other sections and causing inconsistent UI behavior (Closes #2695). 

### Description
- Import and render the existing `Menu` component at the top of `PerformanceDiagnostics` and pass the route `owner` as `selectedOwner` so menu links remain owner-aware.
- Add a focused unit test `tests/unit/pages/PerformanceDiagnostics.test.tsx` which mocks `@/components/Menu` and `@/api` and asserts the diagnostics page renders the shared menu for the `/performance/:owner/diagnostics` route.

### Testing
- Ran the focused unit test with `npm --prefix frontend run test -- --run tests/unit/pages/PerformanceDiagnostics.test.tsx`, which passed.
- Ran `npm --prefix frontend run lint`, which surfaced pre-existing lint errors in other files unrelated to this change and therefore did not pass (these lint issues are part of the repo baseline and should be addressed separately).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd8387d6688327ac3809265af579ef)