### PR TITLE
Introduce Family MVP feature flags and gate UI tabs/routes

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -121,6 +121,10 @@ class Config:
     allowed_emails: Optional[List[str]] = None
     local_login_email: Optional[str] = None
     relative_view_enabled: Optional[bool] = None
+    enable_family_mvp: bool = True
+    enable_compliance_workflows: bool = False
+    enable_advanced_analytics: bool = False
+    enable_reporting_extended: bool = False
     theme: Optional[str] = None
     timeseries_cache_base: Optional[str] = None
     fx_proxy_url: Optional[str] = None
@@ -178,6 +182,15 @@ def _env_flag(name: str) -> Optional[bool]:
     if val is None:
         return None
     return val.lower() in {"1", "true", "yes"}
+
+
+def _coerce_bool_with_default(value: Any, *, key: str, default: bool) -> bool:
+    """Return ``default`` for ``None`` and validate non-null boolean values."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    raise ConfigValidationError(f"'{key}' must be a boolean when provided")
 
 
 def _flatten_dict(src: Dict[str, Any], dst: Dict[str, Any]) -> None:
@@ -413,6 +426,26 @@ def load_config() -> Config:
         demo_identity=demo_identity,
         smoke_identity=smoke_identity,
         relative_view_enabled=data.get("relative_view_enabled"),
+        enable_family_mvp=_coerce_bool_with_default(
+            data.get("enable_family_mvp"),
+            key="enable_family_mvp",
+            default=True,
+        ),
+        enable_compliance_workflows=_coerce_bool_with_default(
+            data.get("enable_compliance_workflows"),
+            key="enable_compliance_workflows",
+            default=False,
+        ),
+        enable_advanced_analytics=_coerce_bool_with_default(
+            data.get("enable_advanced_analytics"),
+            key="enable_advanced_analytics",
+            default=False,
+        ),
+        enable_reporting_extended=_coerce_bool_with_default(
+            data.get("enable_reporting_extended"),
+            key="enable_reporting_extended",
+            default=False,
+        ),
         theme=data.get("theme"),
         timeseries_cache_base=timeseries_cache_base,
         fx_proxy_url=data.get("fx_proxy_url"),

--- a/config.yaml
+++ b/config.yaml
@@ -74,6 +74,10 @@ trading:
     min_sharpe: null
     max_volatility: null
 ui:
+  enable_family_mvp: true
+  enable_compliance_workflows: false
+  enable_advanced_analytics: false
+  enable_reporting_extended: false
   relative_view_enabled: false        # Enable relative performance views
   theme: system                       # Default theme: light, dark, or system
   tabs:                               # Toggle availability of frontend tabs
@@ -83,7 +87,7 @@ ui:
     instrument: true
     owner: true
     performance: true
-    transactions: true
+    transactions: false
     screener: true
     trading: true
     timeseries: true
@@ -97,10 +101,10 @@ ui:
     settings: true
     profile: true
     pension: true
-    reports: true
+    reports: false
     scenario: true
     alertsettings: true
-    taxtools: true
-    trail: true
-    trade-compliance: true
+    taxtools: false
+    trail: false
+    trade-compliance: false
     logs: true

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -58,8 +58,17 @@ export interface RawConfig {
   relative_view_enabled?: boolean | null;
   tabs?: Partial<TabsConfig>;
   disabled_tabs?: string[];
+  enable_family_mvp?: boolean | null;
+  enable_compliance_workflows?: boolean | null;
+  enable_advanced_analytics?: boolean | null;
+  enable_reporting_extended?: boolean | null;
   theme?: string | null;
   allowed_emails?: string[] | null;
+}
+
+function readBooleanFlag(value: unknown, defaultValue: boolean): boolean {
+  if (value === undefined || value === null) return defaultValue;
+  return value === true;
 }
 
 const defaultTabs: TabsConfig = {
@@ -68,7 +77,7 @@ const defaultTabs: TabsConfig = {
   owner: true,
   instrument: true,
   performance: true,
-  transactions: true,
+  transactions: false,
   screener: true,
   trading: true,
   timeseries: true,
@@ -85,11 +94,11 @@ const defaultTabs: TabsConfig = {
   profile: false,
   alerts: true,
   pension: true,
-  trail: true,
+  trail: false,
   alertsettings: true,
-  taxtools: true,
-  'trade-compliance': true,
-  reports: true,
+  taxtools: false,
+  'trade-compliance': false,
+  reports: false,
   scenario: true,
 };
 
@@ -157,6 +166,29 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       const disabledTabs = new Set<string>(
         Array.isArray(cfg.disabled_tabs) ? cfg.disabled_tabs : [],
       );
+      const disableTab = (tab: keyof TabsConfig) => {
+        disabledTabs.add(tab);
+        tabs[tab] = false;
+      };
+      const familyMvpEnabled = readBooleanFlag(cfg.enable_family_mvp, true);
+      const complianceEnabled = readBooleanFlag(cfg.enable_compliance_workflows, false);
+      const advancedAnalyticsEnabled = readBooleanFlag(cfg.enable_advanced_analytics, false);
+      const reportingExtendedEnabled = readBooleanFlag(cfg.enable_reporting_extended, false);
+      if (familyMvpEnabled && !complianceEnabled) {
+        disableTab("trade-compliance");
+        disableTab("trail");
+        disableTab("taxtools");
+      }
+      if (familyMvpEnabled && !reportingExtendedEnabled) {
+        disableTab("reports");
+      }
+      if (familyMvpEnabled && !advancedAnalyticsEnabled) {
+        disableTab("scenario");
+      }
+      if (familyMvpEnabled) {
+        // Family MVP excludes transaction history from the default experience.
+        disableTab("transactions");
+      }
       for (const [tab, enabled] of Object.entries(tabs)) {
         if (enabled === false) disabledTabs.add(String(tab));
       }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,11 +12,18 @@ import { createRoot } from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { BrowserRouter, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
+import {
+  BrowserRouter,
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom';
 import './index.css';
 import './styles/responsive.css';
 import './i18n';
-import { ConfigProvider } from './ConfigContext';
+import { ConfigProvider, useConfig } from './ConfigContext';
 import { PriceRefreshProvider } from './PriceRefreshContext';
 import { AuthProvider, useAuth } from './AuthContext';
 import {
@@ -31,7 +38,12 @@ import { UserProvider, useUser } from './UserContext';
 import ErrorBoundary from './ErrorBoundary';
 import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage';
 import { RouteProvider } from './RouteContext';
-import { deriveBootstrapMode, deriveModeFromPathname, standalonePageRoutes } from './pageManifest';
+import {
+  deriveBootstrapMode,
+  deriveModeFromPathname,
+  isModeEnabled,
+  standalonePageRoutes,
+} from './pageManifest';
 
 interface BootstrapConfig {
   google_auth_enabled?: boolean | null;
@@ -51,6 +63,13 @@ const PerformanceDiagnostics = lazy(() => import('./pages/PerformanceDiagnostics
 const ReturnComparison = lazy(() => import('./pages/ReturnComparison'));
 const MetricsExplanation = lazy(() => import('./pages/MetricsExplanation'));
 const SmokeTest = lazy(() => import('./pages/SmokeTest'));
+const FAMILY_MVP_ROUTE_GATES = [
+  { mode: "transactions", path: "/transactions" },
+  { mode: "reports", path: "/reports" },
+  { mode: "taxtools", path: "/tax-tools" },
+  { mode: "trail", path: "/trail" },
+  { mode: "trade-compliance", path: "/trade-compliance" },
+] as const;
 
 const routeMarkerStyle: CSSProperties = {
   position: 'absolute',
@@ -107,6 +126,9 @@ export function Root() {
   const { setProfile } = useUser();
   const navigate = useNavigate();
   const location = useLocation();
+  const { tabs, disabledTabs } = useConfig();
+  const complianceRoutesEnabled = isModeEnabled("trade-compliance", tabs, disabledTabs);
+  const advancedAnalyticsEnabled = isModeEnabled("scenario", tabs, disabledTabs);
   const activeRequest = useRef<AbortController | null>(null);
   const retryTimer = useRef<number | null>(null);
   const isMounted = useRef(true);
@@ -297,10 +319,17 @@ export function Root() {
     <ErrorBoundary key={location.pathname}>
       <Suspense fallback={<div>Loading...</div>}>
         <Routes>
-          <Route path="/compliance" element={<ComplianceWarnings />} />
-          <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
+          {complianceRoutesEnabled ? (
+            <>
+              <Route path="/compliance" element={<ComplianceWarnings />} />
+              <Route path="/compliance/:owner" element={<ComplianceWarnings />} />
+            </>
+          ) : null}
           {standalonePageRoutes.flatMap((route) => {
             if (route.routePath === '/virtual' || !route.lazyComponent) {
+              return [];
+            }
+            if (!isModeEnabled(route.mode, tabs, disabledTabs)) {
               return [];
             }
 
@@ -309,14 +338,23 @@ export function Root() {
               <Route key={route.routePath} path={route.routePath} element={<Component />} />,
             ];
           })}
+          {FAMILY_MVP_ROUTE_GATES.flatMap(({ mode, path }) =>
+            isModeEnabled(mode, tabs, disabledTabs)
+              ? []
+              : [<Route key={`disabled-${path}`} path={path} element={<Navigate to="/" replace />} />],
+          )}
           <Route path="/goals" element={<Goals />} />
           <Route path="/smoke-test" element={<SmokeTest />} />
-          <Route
-            path="/performance/:owner/diagnostics"
-            element={<PerformanceDiagnostics />}
-          />
-          <Route path="/returns/compare" element={<ReturnComparison />} />
-          <Route path="/metrics-explained" element={<MetricsExplanation />} />
+          {advancedAnalyticsEnabled ? (
+            <>
+              <Route
+                path="/performance/:owner/diagnostics"
+                element={<PerformanceDiagnostics />}
+              />
+              <Route path="/returns/compare" element={<ReturnComparison />} />
+              <Route path="/metrics-explained" element={<MetricsExplanation />} />
+            </>
+          ) : null}
           <Route
             path="/*"
             element={

--- a/frontend/tests/unit/ConfigContext.familyMvp.test.tsx
+++ b/frontend/tests/unit/ConfigContext.familyMvp.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConfigProvider, useConfig } from "@/ConfigContext";
+
+vi.mock("@/api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/api")>();
+  return {
+    ...mod,
+    getConfig: vi.fn(),
+  };
+});
+
+function Probe() {
+  const { tabs, disabledTabs } = useConfig();
+  const disabledSet = new Set(disabledTabs ?? []);
+
+  return (
+    <div
+      data-testid="config-probe"
+      data-transactions={String(tabs.transactions)}
+      data-trade-compliance={String(tabs["trade-compliance"])}
+      data-trail={String(tabs.trail)}
+      data-taxtools={String(tabs.taxtools)}
+      data-reports={String(tabs.reports)}
+      data-scenario={String(tabs.scenario)}
+      data-disabled-transactions={String(disabledSet.has("transactions"))}
+      data-disabled-trade-compliance={String(disabledSet.has("trade-compliance"))}
+      data-disabled-reports={String(disabledSet.has("reports"))}
+      data-disabled-scenario={String(disabledSet.has("scenario"))}
+    />
+  );
+}
+
+function expectFlag(probe: HTMLElement, attribute: string, expected: "true" | "false") {
+  expect(probe.getAttribute(attribute)).toBe(expected);
+}
+
+describe("ConfigProvider Family MVP gating", () => {
+  it("disables non-MVP tabs by default when Family MVP mode is enabled", async () => {
+    const { getConfig } = await import("@/api");
+    vi.mocked(getConfig).mockResolvedValue({
+      enable_family_mvp: true,
+      enable_compliance_workflows: false,
+      enable_advanced_analytics: false,
+      enable_reporting_extended: false,
+      tabs: {
+        transactions: true,
+        "trade-compliance": true,
+        trail: true,
+        taxtools: true,
+        reports: true,
+        scenario: true,
+      },
+    });
+
+    render(
+      <ConfigProvider>
+        <Probe />
+      </ConfigProvider>,
+    );
+
+    await waitFor(() => {
+      const probe = screen.getByTestId("config-probe");
+      expectFlag(probe, "data-transactions", "false");
+      expectFlag(probe, "data-trade-compliance", "false");
+      expectFlag(probe, "data-trail", "false");
+      expectFlag(probe, "data-taxtools", "false");
+      expectFlag(probe, "data-reports", "false");
+      expectFlag(probe, "data-scenario", "false");
+      expectFlag(probe, "data-disabled-transactions", "true");
+      expectFlag(probe, "data-disabled-trade-compliance", "true");
+      expectFlag(probe, "data-disabled-reports", "true");
+      expectFlag(probe, "data-disabled-scenario", "true");
+    });
+  });
+
+  it("keeps optional feature tabs enabled when their Family MVP flags are enabled", async () => {
+    const { getConfig } = await import("@/api");
+    vi.mocked(getConfig).mockResolvedValue({
+      enable_family_mvp: true,
+      enable_compliance_workflows: true,
+      enable_advanced_analytics: true,
+      enable_reporting_extended: true,
+      tabs: {
+        transactions: true,
+        "trade-compliance": true,
+        trail: true,
+        taxtools: true,
+        reports: true,
+        scenario: true,
+      },
+    });
+
+    render(
+      <ConfigProvider>
+        <Probe />
+      </ConfigProvider>,
+    );
+
+    await waitFor(() => {
+      const probe = screen.getByTestId("config-probe");
+      expectFlag(probe, "data-transactions", "false");
+      expectFlag(probe, "data-trade-compliance", "true");
+      expectFlag(probe, "data-trail", "true");
+      expectFlag(probe, "data-taxtools", "true");
+      expectFlag(probe, "data-reports", "true");
+      expectFlag(probe, "data-scenario", "true");
+      expectFlag(probe, "data-disabled-transactions", "true");
+      expectFlag(probe, "data-disabled-trade-compliance", "false");
+      expectFlag(probe, "data-disabled-reports", "false");
+      expectFlag(probe, "data-disabled-scenario", "false");
+    });
+  });
+
+  it("does not apply Family MVP forced disables when Family MVP is off", async () => {
+    const { getConfig } = await import("@/api");
+    vi.mocked(getConfig).mockResolvedValue({
+      enable_family_mvp: false,
+      tabs: {
+        transactions: true,
+        "trade-compliance": true,
+        trail: true,
+        taxtools: true,
+        reports: true,
+        scenario: true,
+      },
+    });
+
+    render(
+      <ConfigProvider>
+        <Probe />
+      </ConfigProvider>,
+    );
+
+    await waitFor(() => {
+      const probe = screen.getByTestId("config-probe");
+      expectFlag(probe, "data-transactions", "true");
+      expectFlag(probe, "data-trade-compliance", "true");
+      expectFlag(probe, "data-trail", "true");
+      expectFlag(probe, "data-taxtools", "true");
+      expectFlag(probe, "data-reports", "true");
+      expectFlag(probe, "data-scenario", "true");
+      expectFlag(probe, "data-disabled-transactions", "false");
+      expectFlag(probe, "data-disabled-trade-compliance", "false");
+      expectFlag(probe, "data-disabled-reports", "false");
+      expectFlag(probe, "data-disabled-scenario", "false");
+    });
+  });
+});

--- a/frontend/tests/unit/main.familyMvpRoutes.test.tsx
+++ b/frontend/tests/unit/main.familyMvpRoutes.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function AppShellPath() {
+  const location = useLocation();
+  return <div data-testid="app-shell-path">{location.pathname}</div>;
+}
+
+async function renderRootAt(path: string) {
+  document.body.innerHTML = '<div id="root"></div>';
+  const { Root } = await import("@/main");
+  const { AuthProvider } = await import("@/AuthContext");
+  const { UserProvider } = await import("@/UserContext");
+
+  return render(
+    <AuthProvider>
+      <UserProvider>
+        <MemoryRouter initialEntries={[path]}>
+          <Root />
+        </MemoryRouter>
+      </UserProvider>
+    </AuthProvider>,
+  );
+}
+
+describe("Root Family MVP route gating", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it.each([
+    "/transactions",
+    "/reports",
+    "/trail",
+    "/trade-compliance",
+    "/tax-tools",
+    "/compliance",
+    "/compliance/demo",
+  ])("redirects disabled route %s to a safe fallback", async (path) => {
+    vi.doMock("react-dom/client", () => ({
+      createRoot: () => ({ render: vi.fn() }),
+    }));
+
+    vi.doMock("@/api", async (importOriginal) => {
+      const mod = await importOriginal<typeof import("@/api")>();
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          disable_auth: true,
+          google_auth_enabled: false,
+          local_login_email: "demo@example.com",
+        }),
+        getStoredAuthToken: vi.fn(() => null),
+      };
+    });
+
+    vi.doMock("@/App.tsx", () => ({
+      default: AppShellPath,
+    }));
+
+    await renderRootAt(path);
+    expect(await screen.findByTestId("app-shell-path")).toHaveTextContent("/");
+  });
+});

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,6 +48,84 @@ def test_theme_loaded():
     assert cfg.theme == "system"
 
 
+def test_family_mvp_flags_default_when_missing(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("ui:\n  theme: dark\n")
+    monkeypatch.setattr(sys.modules["backend.config"], "_project_config_path", lambda: config_path)
+    monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
+
+    cfg = reload_config()
+    try:
+        assert cfg.enable_family_mvp is True
+        assert cfg.enable_compliance_workflows is False
+        assert cfg.enable_advanced_analytics is False
+        assert cfg.enable_reporting_extended is False
+    finally:
+        monkeypatch.undo()
+        reload_config()
+
+
+def test_family_mvp_flag_none_falls_back_to_default(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("ui:\n  enable_family_mvp: null\n")
+    monkeypatch.setattr(sys.modules["backend.config"], "_project_config_path", lambda: config_path)
+    monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
+
+    cfg = reload_config()
+    try:
+        assert cfg.enable_family_mvp is True
+    finally:
+        monkeypatch.undo()
+        reload_config()
+
+
+def test_family_mvp_flags_load_from_ui_section(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "ui:\n"
+        "  enable_family_mvp: false\n"
+        "  enable_compliance_workflows: true\n"
+        "  enable_advanced_analytics: true\n"
+        "  enable_reporting_extended: true\n",
+    )
+    monkeypatch.setattr(sys.modules["backend.config"], "_project_config_path", lambda: config_path)
+    monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
+
+    cfg = reload_config()
+    try:
+        assert cfg.enable_family_mvp is False
+        assert cfg.enable_compliance_workflows is True
+        assert cfg.enable_advanced_analytics is True
+        assert cfg.enable_reporting_extended is True
+    finally:
+        monkeypatch.undo()
+        reload_config()
+
+
+def test_family_mvp_flags_reject_non_boolean_values(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("ui:\n  enable_family_mvp: \"true\"\n")
+    monkeypatch.setattr(sys.modules["backend.config"], "_project_config_path", lambda: config_path)
+    monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
+
+    with pytest.raises(ConfigValidationError):
+        reload_config()
+
+    monkeypatch.undo()
+    reload_config()
+
+
+def test_config_endpoint_includes_family_mvp_flags():
+    client = TestClient(create_app())
+    response = client.get("/config")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "enable_family_mvp" in payload
+    assert "enable_compliance_workflows" in payload
+    assert "enable_advanced_analytics" in payload
+    assert "enable_reporting_extended" in payload
+
+
 def test_stooq_timeout_loaded():
     cfg = reload_config()
     assert cfg.stooq_timeout == 10


### PR DESCRIPTION
### Motivation
- Provide configurable feature flags to support a "Family MVP" product mode that selectively hides advanced features and routes from the default UI experience.
- Ensure backend config validation and defaults for the new flags so behaviour is deterministic when settings are missing or null.
- Enforce the flags at the frontend by disabling tabs and guarding routes so users on the Family MVP experience cannot reach non-MVP pages.

### Description
- Added four boolean UI flags to the backend `Config` model: `enable_family_mvp`, `enable_compliance_workflows`, `enable_advanced_analytics`, and `enable_reporting_extended`, with defaults and loading in `load_config`.
- Implemented `_coerce_bool_with_default` to validate boolean inputs and fall back to a default when `null`/missing, and added tests that assert invalid non-boolean values raise `ConfigValidationError`.
- Updated `config.yaml` UI defaults to reflect Family MVP defaults and toggled several tab defaults (e.g. `transactions`, `reports`, `taxtools`, `trail`, `trade-compliance`) to align with the MVP experience.
- Frontend `ConfigContext` now reads the new flags (via `readBooleanFlag`) and applies forced tab disables when Family MVP is enabled; added logic to populate `disabledTabs` accordingly.
- Updated `main.tsx` to import runtime `tabs`/`disabledTabs`, gate standalone routes and compliance/analytics routes via `isModeEnabled`, and add redirect fallbacks so disabled routes navigate to `/`.
- Added unit tests: frontend tests `frontend/tests/unit/ConfigContext.familyMvp.test.tsx` and `frontend/tests/unit/main.familyMvpRoutes.test.tsx` to validate tab disabling and route redirects; backend tests in `tests/test_config.py` to cover defaults, null fallback, loading from `ui` section, and validation rejection of non-boolean values.

### Testing
- Ran backend unit tests with `pytest tests/test_config.py` including `test_family_mvp_flags_default_when_missing`, `test_family_mvp_flag_none_falls_back_to_default`, `test_family_mvp_flags_load_from_ui_section`, and `test_family_mvp_flags_reject_non_boolean_values`, and they passed.
- Ran frontend unit tests with `vitest` for `ConfigContext.familyMvp.test.tsx` and `main.familyMvpRoutes.test.tsx` which validate tab state and route redirects, and they passed.
- Verified existing config-related tests such as `test_tabs_defaults_true` and `test_theme_loaded` continue to pass after changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd9325f8508327be8e02a5ca32643c)