### PR TITLE
Add concentration insight warning to GroupPortfolioView

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -68,6 +68,7 @@ const PIE_COLORS = [
 ];
 
 const DAY_CHANGE_BASELINE_EPSILON = 1e-2;
+// Warn when a single holding represents more than this share of the full portfolio.
 const CONCENTRATION_THRESHOLD_PCT = 20;
 
 const computeDayChangePct = (value: number, delta: number): number | null => {
@@ -570,7 +571,11 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   const isAllPositions = activeOwner === null;
   const hasFilteredAccounts = filteredAccounts.length > 0;
   const topHoldingSharePct = computeTopHoldingSharePct(instrumentRows);
+  // Only show the concentration warning in the full group view; per-owner
+  // filtered slices can look spuriously concentrated even when the group
+  // as a whole is well-diversified.
   const showConcentrationWarning =
+    isAllPositions &&
     topHoldingSharePct != null &&
     topHoldingSharePct > CONCENTRATION_THRESHOLD_PCT;
 
@@ -1131,7 +1136,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
         >
           {showConcentrationWarning && (
             <div
-              role="status"
+              role="alert"
               style={{
                 marginBottom: "0.75rem",
                 padding: "0.5rem 0.75rem",

--- a/frontend/tests/unit/components/GroupPortfolioView.test.tsx
+++ b/frontend/tests/unit/components/GroupPortfolioView.test.tsx
@@ -583,6 +583,57 @@ describe("GroupPortfolioView", () => {
     );
   });
 
+  it("does not show concentration warning when filtered to a single owner", async () => {
+    // In the full group view AAA is 70% — warning would show.
+    // When filtered to alice (single-holding sub-portfolio), the warning must
+    // be suppressed because it only reflects a filtered slice, not real exposure.
+    const mockPortfolio = {
+      name: "At a glance",
+      accounts: [
+        {
+          owner: "alice",
+          account_type: "isa",
+          value_estimate_gbp: 300,
+          holdings: [],
+        },
+        {
+          owner: "bob",
+          account_type: "isa",
+          value_estimate_gbp: 100,
+          holdings: [],
+        },
+      ],
+    };
+
+    mockAllFetches(mockPortfolio, {
+      instruments: {
+        [instrumentKey()]: [
+          { ticker: "AAA", name: "Alpha", market_value_gbp: 210, gain_gbp: 0 },
+          { ticker: "BBB", name: "Beta", market_value_gbp: 90, gain_gbp: 0 },
+        ],
+        // Alice's filtered view has only one holding — looks 100% concentrated
+        [instrumentKey("alice")]: [
+          { ticker: "AAA", name: "Alpha", market_value_gbp: 210, gain_gbp: 0 },
+        ],
+      },
+    });
+
+    renderWithConfig(<GroupPortfolioView slug="all" owners={ownerFixtures} />);
+
+    // Wait for full group view to load and show the warning
+    expect(
+      await screen.findByText("Top holding is 70.00% of your portfolio"),
+    ).toBeInTheDocument();
+
+    // Switch to alice's filtered view
+    await userEvent.click(screen.getByRole("tab", { name: "Alice Example" }));
+
+    // Warning must disappear — we are in a filtered (non-isAllPositions) view
+    await waitFor(() =>
+      expect(screen.queryByText(/Top holding is .* of your portfolio/i)).toBeNull(),
+    );
+  });
+
   const locales = ["en", "fr", "de", "es", "pt", "it"] as const;
 
   it.each(locales)("renders select group message in %s", async (lng) => {


### PR DESCRIPTION
### Motivation

- Implement the Family MVP concentration insight from issue Closes #2700 by surfacing a simple, plain-language warning when a single holding is an outsized share of a portfolio. 
- Keep the change scoped to concentration only and avoid introducing new rules engines or additional insight types.

### Description

- Added a 20% concentration threshold (`CONCENTRATION_THRESHOLD_PCT`) and a helper `computeTopHoldingSharePct(rows)` that computes the top holding share from aggregated instrument rows using `market_value_gbp`.
- Render a plain-language warning above the aggregated instrument table when the top holding share exceeds the threshold using the existing `percent` formatter: `Top holding is X% of your portfolio`.
- Added unit tests to `GroupPortfolioView.test.tsx` that assert the warning appears when the top holding > 20% and that it does not appear when no holding exceeds 20%.
- Modified files: `frontend/src/components/GroupPortfolioView.tsx` and `frontend/tests/unit/components/GroupPortfolioView.test.tsx`.

### Testing

- Ran unit tests for the modified component with `npm --prefix frontend run test -- --run tests/unit/components/GroupPortfolioView.test.tsx`, and the test run passed (28 tests).
- An initial mis-invoked test command (`npm --prefix frontend run test -- --run frontend/tests/unit/components/GroupPortfolioView.test.tsx`) matched no files and produced no tests, so the correct test command above was used to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cebed03cdc8327867c2098674dfe9a)