### PR TITLE
Gate owner/group analytics panels when advanced analytics is disabled

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -52,6 +52,7 @@ export interface AppConfig {
   tabs: TabsConfig;
   theme: "dark" | "light" | "system";
   baseCurrency: string;
+  enableAdvancedAnalytics?: boolean;
 }
 
 export interface RawConfig {
@@ -109,6 +110,7 @@ export const configContext = createContext<ConfigContextValue>({
   tabs: defaultTabs,
   theme: "system",
   baseCurrency: "GBP",
+  enableAdvancedAnalytics: true,
   refreshConfig: async () => {},
   setRelativeViewEnabled: () => {},
   setBaseCurrency: () => {},
@@ -130,6 +132,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       tabs: defaultTabs,
       theme: "system",
       baseCurrency: storedCurrency || "GBP",
+      enableAdvancedAnalytics: true,
     };
   });
 
@@ -197,6 +200,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
         tabs,
         theme,
         baseCurrency: config.baseCurrency,
+        enableAdvancedAnalytics: cfg.enable_advanced_analytics !== false,
       });
       applyTheme(theme);
     } catch {

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -123,7 +123,11 @@ type Props = {
  * ────────────────────────────────────────────────────────── */
 export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   const { t } = useTranslation();
-  const { relativeViewEnabled, baseCurrency } = useConfig();
+  const {
+    relativeViewEnabled,
+    baseCurrency,
+    enableAdvancedAnalytics = true,
+  } = useConfig();
   const [asOfOverride, setAsOfOverride] = useState<string | null>(null);
 
   const fetchPortfolio = useCallback(
@@ -146,13 +150,13 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   );
   const { data: sectorContrib } = useFetch<SectorContribution[]>(
     fetchSector,
-    [slug, asOfOverride],
-    !!slug,
+    [slug, asOfOverride, enableAdvancedAnalytics],
+    !!slug && enableAdvancedAnalytics,
   );
   const { data: regionContrib } = useFetch<RegionContribution[]>(
     fetchRegion,
-    [slug, asOfOverride],
-    !!slug,
+    [slug, asOfOverride, enableAdvancedAnalytics],
+    !!slug && enableAdvancedAnalytics,
   );
   const [alpha, setAlpha] = useState<number | null>(null);
   const [trackingError, setTrackingError] = useState<number | null>(null);
@@ -336,7 +340,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   }, [portfolio]);
 
   useEffect(() => {
-    if (!slug) return;
+    if (!slug || !enableAdvancedAnalytics) return;
     setError(null);
     Promise.all([
       getGroupAlphaVsBenchmark(slug, "VWRL.L"),
@@ -351,7 +355,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
       .catch((e) =>
         setError(e instanceof Error ? e : new Error(String(e)))
       );
-  }, [slug]);
+  }, [slug, enableAdvancedAnalytics]);
 
   useEffect(() => {
     if (onTradeInfo) {
@@ -684,7 +688,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
         <PortfolioSummary totals={totals} />
       )}
 
-      {isAllPositions && (
+      {isAllPositions && enableAdvancedAnalytics && (
         <div
           style={{
             display: "flex",
@@ -753,7 +757,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
         </div>
       )}
 
-      {isAllPositions && (
+      {isAllPositions && enableAdvancedAnalytics && (
         <div style={{ marginBottom: "1rem" }}>
           <a
             href="/metrics-explained"
@@ -768,7 +772,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
         </div>
       )}
 
-      {isAllPositions && error && (
+      {isAllPositions && enableAdvancedAnalytics && error && (
         <p style={{ color: "red" }}>
           {t("common.error")}: {error.message}
         </p>
@@ -806,7 +810,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
         </div>
       )}
 
-      {isAllPositions && (sectorContrib?.length || regionContrib?.length) && (
+      {isAllPositions && enableAdvancedAnalytics && (sectorContrib?.length || regionContrib?.length) && (
         <div style={{ width: "100%", height: 300, margin: "1rem 0" }}>
           <div style={{ marginBottom: "0.5rem" }}>
             <button
@@ -849,7 +853,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
         </div>
       )}
 
-      {isAllPositions && <TopMoversSummary slug={slug} />}
+      {isAllPositions && enableAdvancedAnalytics && <TopMoversSummary slug={slug} />}
 
       {ownerRows.length > 0 && (
         <table className={tableStyles.table} style={{ marginBottom: "1rem" }}>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -219,7 +219,7 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
   const [hasWarnings, setHasWarnings] = useState(false);
   const [pendingDate, setPendingDate] = useState<string>("");
-  const { baseCurrency } = useConfig();
+  const { baseCurrency, enableAdvancedAnalytics = true } = useConfig();
 
   const accountKey = (acct: Account, idx: number) => `${acct.account_type}-${idx}`;
 
@@ -235,15 +235,19 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
   const asOf = data?.as_of ?? null;
 
   const fetchSectorContribution = useCallback(() => {
-    if (!owner) return Promise.resolve([] as SectorContribution[]);
+    if (!owner || !enableAdvancedAnalytics) return Promise.resolve([] as SectorContribution[]);
     return getOwnerSectorContributions(owner, { asOf: asOf ?? undefined });
-  }, [owner, asOf]);
+  }, [owner, asOf, enableAdvancedAnalytics]);
 
   const {
     data: sectorContrib,
     loading: sectorLoading,
     error: sectorError,
-  } = useFetch<SectorContribution[]>(fetchSectorContribution, [], Boolean(owner));
+  } = useFetch<SectorContribution[]>(
+    fetchSectorContribution,
+    [owner, asOf, enableAdvancedAnalytics],
+    Boolean(owner && enableAdvancedAnalytics),
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -373,41 +377,45 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
               </Link>
             </div>
           )}
-          <div className="mb-6 rounded-lg border border-gray-800 bg-black/30 p-4">
-            <ValueAtRisk owner={data.owner} onDateChange={onDateChange} />
-          </div>
-          <div className="mb-6 rounded-lg border border-gray-800 bg-black/30 p-4">
-            <h3 className="mb-3 text-base font-semibold text-white">
-              Sector contribution
-            </h3>
-            {sectorLoading ? (
-              <p className="text-sm text-gray-400">Loading sector data…</p>
-            ) : sectorError ? (
-              <p className="text-sm text-red-500">
-                Failed to load sector contribution
-              </p>
-            ) : sectorContrib && sectorContrib.length > 0 ? (
-              <div className="h-64 w-full">
-                <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
-                  <BarChart data={sectorContrib}>
-                    <XAxis dataKey="sector" interval={0} angle={-35} textAnchor="end" height={70} />
-                    <YAxis />
-                    <Tooltip formatter={(v: number | undefined) => money(v, baseCurrency)} />
-                    <Bar dataKey="gain_gbp">
-                      {sectorContrib.map((row, idx) => (
-                        <Cell
-                          key={`${row.sector}-${idx}`}
-                          fill={row.gain_gbp >= 0 ? "#22c55e" : "#ef4444"}
-                        />
-                      ))}
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
+          {enableAdvancedAnalytics && (
+            <>
+              <div className="mb-6 rounded-lg border border-gray-800 bg-black/30 p-4">
+                <ValueAtRisk owner={data.owner} onDateChange={onDateChange} />
               </div>
-            ) : (
-              <p className="text-sm text-gray-400">No sector data available.</p>
-            )}
-          </div>
+              <div className="mb-6 rounded-lg border border-gray-800 bg-black/30 p-4">
+                <h3 className="mb-3 text-base font-semibold text-white">
+                  Sector contribution
+                </h3>
+                {sectorLoading ? (
+                  <p className="text-sm text-gray-400">Loading sector data…</p>
+                ) : sectorError ? (
+                  <p className="text-sm text-red-500">
+                    Failed to load sector contribution
+                  </p>
+                ) : sectorContrib && sectorContrib.length > 0 ? (
+                  <div className="h-64 w-full">
+                    <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
+                      <BarChart data={sectorContrib}>
+                        <XAxis dataKey="sector" interval={0} angle={-35} textAnchor="end" height={70} />
+                        <YAxis />
+                        <Tooltip formatter={(v: number | undefined) => money(v, baseCurrency)} />
+                        <Bar dataKey="gain_gbp">
+                          {sectorContrib.map((row, idx) => (
+                            <Cell
+                              key={`${row.sector}-${idx}`}
+                              fill={row.gain_gbp >= 0 ? "#22c55e" : "#ef4444"}
+                            />
+                          ))}
+                        </Bar>
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-400">No sector data available.</p>
+                )}
+              </div>
+            </>
+          )}
           <div className="space-y-4">
             {data.accounts.map((acct, idx) => {
               const key = accountKey(acct, idx);
@@ -448,9 +456,11 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
           </div>
         </section>
         <section className="rounded-lg border border-gray-800 bg-gray-900/70 p-4 md:p-6">
-          <Suspense fallback={<PortfolioDashboardSkeleton />}>
-            <PerformanceDashboard owner={data.owner} asOf={data.as_of} />
-          </Suspense>
+          {enableAdvancedAnalytics && (
+            <Suspense fallback={<PortfolioDashboardSkeleton />}>
+              <PerformanceDashboard owner={data.owner} asOf={data.as_of} />
+            </Suspense>
+          )}
         </section>
       </div>
     </div>

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { PortfolioView } from "@/components/PortfolioView";
 import type { Portfolio } from "@/types";
+import { configContext } from "@/ConfigContext";
 
 vi.mock("@/api", () => ({
   complianceForOwner: vi.fn().mockResolvedValue({ warnings: [] }),
@@ -68,5 +69,57 @@ describe("PortfolioView", () => {
         fireEvent.click(sippCheckbox);
 
         expect(total).toHaveTextContent("£0.00");
+    });
+
+    it("hides advanced analytics panels when feature flag is disabled", () => {
+        render(
+            <configContext.Provider
+                value={{
+                    relativeViewEnabled: false,
+                    tabs: {
+                        group: true,
+                        market: true,
+                        owner: true,
+                        instrument: true,
+                        performance: true,
+                        transactions: true,
+                        screener: true,
+                        trading: true,
+                        timeseries: true,
+                        watchlist: true,
+                        allocation: true,
+                        rebalance: true,
+                        movers: true,
+                        instrumentadmin: true,
+                        dataadmin: true,
+                        virtual: true,
+                        research: true,
+                        support: true,
+                        settings: true,
+                        profile: false,
+                        alerts: true,
+                        pension: true,
+                        trail: false,
+                        alertsettings: true,
+                        taxtools: false,
+                        "trade-compliance": false,
+                        reports: false,
+                        scenario: false,
+                    },
+                    theme: "system",
+                    baseCurrency: "GBP",
+                    enableAdvancedAnalytics: false,
+                    disabledTabs: [],
+                    refreshConfig: async () => {},
+                    setRelativeViewEnabled: () => {},
+                    setBaseCurrency: () => {},
+                }}
+            >
+                <PortfolioView data={mockOwner} />
+            </configContext.Provider>,
+        );
+
+        expect(screen.queryByText(/Sector contribution/i)).not.toBeInTheDocument();
+        expect(screen.queryByTestId("performance-dashboard")).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
### Motivation
- Fix issue where advanced analytics (VaR, TWR, Alpha, Tracking Error, XIRR, etc.) remained visible in portfolio/group views even when the backend config `enable_advanced_analytics` is `false`, which violates the Family MVP requirement to gate these features.
Closes #2714 


### Description
- Add `enableAdvancedAnalytics` to the frontend `ConfigContext` and populate it from the backend `/config` value `enable_advanced_analytics`, defaulting to enabled when omitted (`frontend/src/ConfigContext.tsx`).
- Gate owner-level analytics in `PortfolioView` behind the flag by skipping sector-contribution fetches and hiding the Value-at-Risk panel, Sector contribution block, and `PerformanceDashboard` when disabled (`frontend/src/components/PortfolioView.tsx`).
- Gate group-level analytics in `GroupPortfolioView` by skipping metrics fetches and hiding alpha/tracking/max-drawdown cards, metrics explanation link, sector/region contribution chart, and TopMovers when disabled (`frontend/src/components/GroupPortfolioView.tsx`).
- Add a unit test asserting the analytics panels are not rendered when `enableAdvancedAnalytics` is `false` (`frontend/tests/unit/components/PortfolioView.test.tsx`).

### Testing
- Ran targeted frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/components/PortfolioView.test.tsx tests/unit/components/GroupPortfolioView.test.tsx`, and the test run succeeded (2 test files, 32 tests passed).
- Ran frontend lint with `npm --prefix frontend run lint`; this command surfaced pre-existing repository-wide lint issues unrelated to these changes (lint did not pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cecb2331dc8327b29b10661df32ea6)