### PR TITLE
Add single MVP portfolio insight banner with concentration/duplication/cash-drag fallbacks

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -70,7 +70,7 @@ const PIE_COLORS = [
 const DAY_CHANGE_BASELINE_EPSILON = 1e-2;
 // Warn when a single holding represents more than this share of the full portfolio.
 const CONCENTRATION_THRESHOLD_PCT = 20;
-const CASH_DRAG_THRESHOLD_PCT = 1;
+const CASH_DRAG_THRESHOLD_PCT = 5;
 
 const computeDayChangePct = (value: number, delta: number): number | null => {
   if (!Number.isFinite(value) || !Number.isFinite(delta)) {
@@ -141,10 +141,19 @@ const computeDuplicationInsight = (accounts: GroupPortfolio["accounts"]): Portfo
   >();
 
   for (const [accountIndex, account] of accounts.entries()) {
+    // Treat separate account rows as distinct even when owner/type labels match.
     const accountKey = `${account.owner ?? "unknown"}::${account.account_type ?? "unknown"}::${accountIndex}`;
     for (const holding of account.holdings ?? []) {
       const ticker = holding.ticker?.trim();
-      if (!ticker) continue;
+      if (
+        !ticker ||
+        isCashInstrument({
+          instrument_type: holding.instrument_type,
+          ticker: holding.ticker,
+        })
+      ) {
+        continue;
+      }
 
       const entry =
         tickerAccounts.get(ticker) ?? { accounts: new Set<string>(), totalMarketValue: 0 };
@@ -664,6 +673,8 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   const isAllPositions = activeOwner === null;
   const hasFilteredAccounts = filteredAccounts.length > 0;
   const portfolioInsight = useMemo<PortfolioInsight>(() => {
+    // Filtered owner/account slices can look spuriously concentrated, so only surface the
+    // plain-language insight for the full group view.
     if (!isAllPositions || !portfolio) return null;
     return (
       computeConcentrationInsight(portfolio.accounts ?? []) ??

--- a/frontend/tests/unit/components/GroupPortfolioView.test.tsx
+++ b/frontend/tests/unit/components/GroupPortfolioView.test.tsx
@@ -804,7 +804,7 @@ describe("GroupPortfolioView", () => {
     expect(screen.queryByText("10.00% of your portfolio is in cash")).toBeNull();
   });
 
-  it("suppresses tiny cash balances as an insight", async () => {
+  it("suppresses cash balances below the cash-drag threshold", async () => {
     mockAllFetches({
       name: "At a glance",
       accounts: [
@@ -813,12 +813,12 @@ describe("GroupPortfolioView", () => {
           account_type: "isa",
           value_estimate_gbp: 100,
           holdings: [
-            { ticker: "AAA", units: 1, market_value_gbp: 19.8, instrument_type: "equity" },
-            { ticker: "BBB", units: 1, market_value_gbp: 19.8, instrument_type: "equity" },
-            { ticker: "CCC", units: 1, market_value_gbp: 19.8, instrument_type: "equity" },
-            { ticker: "DDD", units: 1, market_value_gbp: 19.8, instrument_type: "equity" },
-            { ticker: "EEE", units: 1, market_value_gbp: 19.8, instrument_type: "equity" },
-            { ticker: "CASH.GBP", units: 1, market_value_gbp: 1, instrument_type: "cash" },
+            { ticker: "AAA", units: 1, market_value_gbp: 19.2, instrument_type: "equity" },
+            { ticker: "BBB", units: 1, market_value_gbp: 19.2, instrument_type: "equity" },
+            { ticker: "CCC", units: 1, market_value_gbp: 19.2, instrument_type: "equity" },
+            { ticker: "DDD", units: 1, market_value_gbp: 19.2, instrument_type: "equity" },
+            { ticker: "EEE", units: 1, market_value_gbp: 19.2, instrument_type: "equity" },
+            { ticker: "CASH.GBP", units: 4, market_value_gbp: 4, instrument_type: "cash" },
           ],
         },
       ],
@@ -844,6 +844,41 @@ describe("GroupPortfolioView", () => {
             { ticker: "CCC", units: 1, market_value_gbp: 20, instrument_type: "equity" },
             { ticker: "DDD", units: 1, market_value_gbp: 20, instrument_type: "equity" },
             { ticker: "EEE", units: 1, market_value_gbp: 20, instrument_type: "equity" },
+          ],
+        },
+      ],
+    });
+
+    renderWithConfig(<GroupPortfolioView slug="all" owners={ownerFixtures} />);
+
+    await screen.findByText("At a glance");
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+  });
+
+  it("ignores duplicated cash tickers when choosing the duplication insight", async () => {
+    mockAllFetches({
+      name: "At a glance",
+      accounts: [
+        {
+          owner: "alice",
+          account_type: "isa",
+          value_estimate_gbp: 50,
+          holdings: [
+            { ticker: "AAA", units: 1, market_value_gbp: 16, instrument_type: "equity" },
+            { ticker: "BBB", units: 1, market_value_gbp: 16, instrument_type: "equity" },
+            { ticker: "CCC", units: 1, market_value_gbp: 16, instrument_type: "equity" },
+            { ticker: "CASH.GBP", units: 2, market_value_gbp: 2, instrument_type: "cash" },
+          ],
+        },
+        {
+          owner: "bob",
+          account_type: "sipp",
+          value_estimate_gbp: 50,
+          holdings: [
+            { ticker: "DDD", units: 1, market_value_gbp: 16, instrument_type: "equity" },
+            { ticker: "EEE", units: 1, market_value_gbp: 16, instrument_type: "equity" },
+            { ticker: "FFF", units: 1, market_value_gbp: 16, instrument_type: "equity" },
+            { ticker: "CASH.GBP", units: 2, market_value_gbp: 2, instrument_type: "cash" },
           ],
         },
       ],


### PR DESCRIPTION
### Motivation
- The Family MVP requires exactly one plain-language insight on the portfolio view (concentration preferred, then duplication, then cash drag) and none were being surfaced. This implements that client-side so no backend changes are required.

Closes #2717 

### Description
- Added a `PortfolioInsight` type and three client-side insight calculators: `computeConcentrationInsight`, `computeDuplicationInsight`, and `computeCashDragInsight` in `GroupPortfolioView` to select a single prioritized insight.
- Replaced the prior concentration-only display with a single banner that shows the chosen insight message (concentration message now includes the ticker: `Top holding [TICKER] is X% of your portfolio`).
- Integrated the insight selection with `useMemo` so the banner is only shown in the full group view and not for filtered owner slices, and kept existing instrument table rendering.
- Updated/added unit tests in `frontend/tests/unit/components/GroupPortfolioView.test.tsx` to cover concentration, duplication fallback, and cash-drag fallback scenarios.

### Testing
- Ran the focused unit test suite with `npm --prefix frontend run test -- --run tests/unit/components/GroupPortfolioView.test.tsx`, and all tests in that file passed successfully (31 tests).
- Ran frontend lint with `npm --prefix frontend run lint`; lint reported pre-existing repository issues unrelated to this change (lint did not pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cece3d0f94832789e87a6051d773d9)