### PR TITLE
Add Codex + Playwright MCP plan and POC smoke command (issue #2734)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,7 @@ Read `AGENTS.md` for full repository guidance. Use these short rules while gener
 - Keep changes out of generated dependency folders such as `node_modules/`.
 - Be careful when changing `data/`, auth defaults, or smoke-test flows; these are tightly coupled to local development and demos.
 - Preserve bash/PowerShell parity when editing shared developer workflows.
+- For Codex browser-testing setup and POC commands, see `docs/CODEX_PLAYWRIGHT_MCP.md`.
 
 ## Code quality invariants (non-negotiable)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ This repository has a Python/FastAPI backend, a React/Vite frontend, AWS CDK inf
 - Backend/API smoke: `npm run smoke:test`
 - Combined smoke orchestration: `npm run smoke:test:all`
 - Frontend smoke: `npm --prefix frontend run smoke:frontend`
+- Codex browser POC smoke: `npm run smoke:test:codex:poc`
 
 ## 4. Important repo-specific realities discovered during review
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ bash scripts/bash/run-local-api.sh
 npm --prefix frontend run dev
 npm run smoke:test
 npm run smoke:test:all
+npm run smoke:test:codex:poc
 ```
 
 ## High-signal warnings

--- a/docs/CODEX_PLAYWRIGHT_MCP.md
+++ b/docs/CODEX_PLAYWRIGHT_MCP.md
@@ -1,0 +1,155 @@
+# Codex + Playwright MCP browser-testing plan
+
+This document captures the recommended setup for AI-driven browser testing in AllotMint, plus a minimal proof-of-concept (POC) path that can be validated today.
+
+## 1. Recommendation (default approach)
+
+Use **both** of these paths, with clear roles:
+
+1. **Deterministic regression checks (default for CI and repeatable local validation):**
+   - Keep using repository-owned Playwright tests under `frontend/tests/`.
+   - Run these with standard `npm` scripts.
+2. **Exploratory AI-driven browser control (default for interactive debugging and discovery):**
+   - Use Codex with a Playwright MCP server so the agent can drive a real browser session.
+   - Treat this as an interactive development aid, not a replacement for deterministic tests.
+
+Why this split works best here:
+
+- deterministic tests are versioned, reviewable, and CI-friendly;
+- MCP-driven sessions are stronger for ad-hoc exploration, triage, and reproducing UX regressions quickly;
+- both modes can share the same local app startup and smoke URL assumptions.
+
+## 2. Local setup
+
+### Prerequisites
+
+- Python + backend dependencies installed.
+- Node dependencies installed at root and `frontend/`.
+- Chromium installable through Playwright (`playwright install chromium`).
+- A running backend + frontend stack, or at least frontend preview for isolated route checks.
+
+### Install commands
+
+From repo root:
+
+```bash
+python -m pip install -r requirements.txt -r requirements-dev.txt
+npm install
+npm --prefix frontend install
+```
+
+Install Playwright browser runtime:
+
+```bash
+npm --prefix frontend exec playwright install chromium
+```
+
+### Codex + MCP registration (what to configure)
+
+Use a Playwright MCP server configuration in your Codex environment (for example Microsoft `playwright-mcp`) and enable it for this workspace.
+
+Minimum config expectations:
+
+- MCP server is registered and visible to Codex.
+- Server can launch a browser in your local environment.
+- Codex has access to your local app URL (typically `http://localhost:5173`).
+
+### Verify Codex browser control works
+
+1. Start backend:
+
+   ```bash
+   bash scripts/bash/run-local-api.sh
+   ```
+
+2. Start frontend dev server (separate shell):
+
+   ```bash
+   npm --prefix frontend run dev
+   ```
+
+3. In Codex with Playwright MCP enabled, ask Codex to:
+   - open `http://localhost:5173/smoke-test`,
+   - verify the `Smoke test` heading,
+   - navigate to `/portfolio`,
+   - verify the route marker indicates owner mode.
+
+Success evidence: Codex returns successful browser actions/assertions and no browser-launch errors from MCP.
+
+## 3. Repo integration (implemented)
+
+### Files and scripts
+
+- Added `frontend` script `smoke:codex:poc` for a minimal deterministic browser POC.
+- Added root script alias `smoke:test:codex:poc` so contributors can run it from repo root.
+- Added this document as the canonical Codex+MCP plan.
+
+### Scope boundaries
+
+- No broad new test framework was introduced.
+- No CI workflow was changed in this issue.
+- No speculative infrastructure was added.
+
+## 4. Minimal proof of concept
+
+The implemented POC flow uses an existing deterministic Playwright scenario (`bootstrap to portfolio happy path`) from `frontend/tests/smoke.spec.ts`:
+
+1. Build preview frontend.
+2. Launch Playwright against preview server.
+3. Navigate to `/portfolio`.
+4. Assert route and mode markers.
+5. Verify owner selector is visible (meaningful UI interaction surface is present and loaded).
+
+This gives a small but real browser-based end-to-end check while preserving existing smoke-test patterns.
+
+## 5. Validation commands
+
+### Deterministic automated POC
+
+From repo root:
+
+```bash
+npm run smoke:test:codex:poc
+```
+
+Equivalent frontend-only command:
+
+```bash
+npm --prefix frontend run smoke:codex:poc
+```
+
+Expected success evidence:
+
+- Playwright exits with success.
+- The `bootstrap to portfolio happy path` test passes.
+- No preview server startup failures.
+
+### Exploratory AI-driven browser control
+
+- Start local stack (`run-local-api.sh` + `frontend dev`).
+- Run Codex with Playwright MCP.
+- Ask Codex to execute the same navigation/assertion steps interactively.
+
+Expected success evidence:
+
+- Browser starts via MCP.
+- Codex can navigate and report assertions.
+- Failures are actionable (selector mismatch, route marker mismatch, or network/auth errors).
+
+## 6. Risks, limitations, and deferrals
+
+### Real risks
+
+- **Flaky UI automation:** dynamic loading and network timing can make selectors intermittently unavailable.
+- **Auth/session mismatch:** local auth-disabled mode and protected deployment mode can behave differently.
+- **MCP/browser startup issues:** local sandboxing, missing browser binaries, or server registration errors can block exploratory mode.
+- **CI limitations for MCP mode:** interactive agent-driven workflows are not directly CI-native.
+- **Slower exploratory loops:** agentic interaction is slower than direct deterministic Playwright runs for regression gating.
+
+### Explicit deferrals
+
+- No CI integration for MCP exploratory runs yet.
+- No broad test-suite restructure.
+- No new auth harness solely for MCP scenarios.
+
+Use deterministic Playwright tests for regression confidence, and MCP-driven Codex sessions for exploratory diagnosis.

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -326,6 +326,14 @@ npm run smoke:test:all
 npm --prefix frontend run smoke:frontend
 ```
 
+### Codex browser-testing proof of concept
+
+```bash
+npm run smoke:test:codex:poc
+```
+
+For setup and exploratory Codex+MCP usage, see [docs/CODEX_PLAYWRIGHT_MCP.md](CODEX_PLAYWRIGHT_MCP.md).
+
 ### Deployment-oriented entrypoints
 
 ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",
-    "deploy:aws:linux": "bash scripts/deploy-to-aws.sh -b $S3_BUCKET ${CLOUDFRONT_DISTRIBUTION_ID:+-d $CLOUDFRONT_DISTRIBUTION_ID}"
+    "deploy:aws:linux": "bash scripts/deploy-to-aws.sh -b $S3_BUCKET ${CLOUDFRONT_DISTRIBUTION_ID:+-d $CLOUDFRONT_DISTRIBUTION_ID}",
+    "smoke:codex:poc": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts --grep \"bootstrap to portfolio happy path\" tests/smoke.spec.ts"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "deploy:local:backend:ps": "powershell -ExecutionPolicy Bypass -File scripts/deploy-local.ps1 -Target backend",
     "deploy:local:both:ps": "powershell -ExecutionPolicy Bypass -File scripts/deploy-local.ps1 -Target both",
     "smoke:test": "node node_modules/tsx/dist/cli.mjs scripts/frontend-backend-smoke.ts",
-    "smoke:test:all": "node node_modules/tsx/dist/cli.mjs scripts/smoke-all.ts"
+    "smoke:test:all": "node node_modules/tsx/dist/cli.mjs scripts/smoke-all.ts",
+    "smoke:test:codex:poc": "npm --prefix frontend run smoke:codex:poc"
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a practical, documented path to enable Codex-driven browser testing using a Playwright MCP server so exploratory agent-driven runs are feasible. 
- Keep scope small by reusing existing deterministic Playwright tests for a minimal proof-of-concept rather than introducing a new test framework. 
- Surface the new workflow in repo guidance so contributors can discover and run the POC easily.

Closes #2734 

### Description
- Add `docs/CODEX_PLAYWRIGHT_MCP.md` with the recommended architecture, setup steps, POC flow, validation commands, and risks/deferrals. 
- Add `smoke:codex:poc` to `frontend/package.json` to run a focused Playwright scenario (the "bootstrap to portfolio happy path"). 
- Add root alias `smoke:test:codex:poc` to `package.json` so the POC can be executed from the repository root. 
- Update documentation and agent-facing guidance files (`AGENTS.md`, `docs/CONTRIBUTOR_RUNBOOK.md`, `CLAUDE.md`, and `.github/copilot-instructions.md`) to reference the new doc and commands.

### Testing
- Ran `npm run smoke:test:codex:poc` and observed `vite build` succeed but Playwright failed to download the Chromium binary in this environment due to CDN access returning `403 Domain forbidden`, so the full end-to-end run could not complete here. 
- Verified the new scripts are registered by running `npm --prefix frontend run | rg "smoke:codex:poc"` and `npm run | rg "smoke:test:codex:poc"`, both of which returned the new commands. 
- No backend code or unit tests were modified in this change, so standard test suites were not altered by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceece6673c83279310e1f664c7fa7a)