### PR TITLE
Document exact Codex Playwright MCP registration steps

### DIFF
--- a/docs/CODEX_PLAYWRIGHT_MCP.md
+++ b/docs/CODEX_PLAYWRIGHT_MCP.md
@@ -1,0 +1,54 @@
+# Codex Playwright MCP setup
+
+This guide provides exact, copy/paste-ready registration steps for enabling a Playwright MCP server with Codex.
+
+## 1) Prerequisite
+
+Install Node.js (18+) so `npx` is available.
+
+## 2) Codex + MCP registration (exact steps)
+
+### Option A (recommended): Codex CLI config file
+
+1. Create the Codex config directory and file:
+
+```bash
+mkdir -p ~/.codex
+cat > ~/.codex/config.toml <<'TOML'
+[mcp_servers.playwright]
+command = "npx"
+args = ["-y", "@playwright/mcp@latest"]
+TOML
+```
+
+2. Save the file at this exact location:
+   - macOS/Linux: `~/.codex/config.toml`
+   - Windows (PowerShell): `$HOME/.codex/config.toml`
+
+This location is where Codex CLI reads MCP server registrations.
+
+### Option B: Codex app MCP settings UI
+
+If you are using the Codex app UI instead of the CLI config file:
+
+1. Open **Settings**.
+2. Open **MCP Settings** (or **Tools → MCP Servers**, depending on app version).
+3. Add a custom server with:
+   - Name: `playwright`
+   - Command: `npx`
+   - Args: `-y @playwright/mcp@latest`
+4. Save and restart the Codex session for the workspace.
+
+## 3) Verify registration
+
+Run this command and confirm `playwright` appears in the output:
+
+```bash
+codex mcp list
+```
+
+If `playwright` is not listed, re-check the config path and restart Codex.
+
+## 4) Workspace note
+
+If your environment uses per-workspace MCP policies, ensure the `playwright` server is enabled for this repository after registration.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ If you are onboarding, start with:
 
 ### Core contributor and operations docs
 - [`CONTRIBUTOR_RUNBOOK.md`](CONTRIBUTOR_RUNBOOK.md) — contributor onboarding and day-to-day development flow.
+- [`CODEX_PLAYWRIGHT_MCP.md`](CODEX_PLAYWRIGHT_MCP.md) — exact Playwright MCP registration steps for Codex.
 - [`DEPLOY.md`](DEPLOY.md) — deployment workflow and operational deployment notes.
 - [`SMOKE_TESTS.md`](SMOKE_TESTS.md) — smoke test commands and expectations.
 - [`SECURITY.md`](SECURITY.md) — security guidance and controls.


### PR DESCRIPTION
### Motivation
- Provide exact, copy/paste-ready steps (including config placement and a verification command) to register a Playwright MCP server with Codex as requested in issue Closes #2743.

### Description
- Added `docs/CODEX_PLAYWRIGHT_MCP.md` containing a concrete `~/.codex/config.toml` example, CLI and Codex app UI registration steps, and the verification command `codex mcp list`, and updated `docs/README.md` to include the new guide.

### Testing
- Ran `git diff --check`, which returned no issues, and committed the documentation-only changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0367532b08327a28f5e88afa387e7)