### PR TITLE
Gate non‑MVP Movers and Group rendering in Family MVP mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -598,7 +598,7 @@ export default function App({ onLogout }: AppProps) {
         )}
 
         {/* GROUP VIEW */}
-        {mode === 'group' && selectedGroup && (
+        {mode === 'group' && selectedGroup && !familyMvpEnabled && (
           <>
             <ComplianceWarnings owners={selectedGroupSummary?.members ?? []} />
             <GroupPortfolioView slug={selectedGroup} owners={owners} />
@@ -692,7 +692,7 @@ export default function App({ onLogout }: AppProps) {
         {mode === 'allocation' && <AllocationCharts />}
         {mode === 'rebalance' && <Rebalance />}
         {mode === 'market' && <MarketOverview />}
-        {mode === 'movers' && <TopMovers />}
+        {mode === 'movers' && !familyMvpEnabled && <TopMovers />}
         {mode === 'reports' &&
           (isReportCreationRoute ? <ReportTemplateCreator /> : <Reports />)}
         {mode === 'alerts' && <Alerts />}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -598,7 +598,7 @@ export default function App({ onLogout }: AppProps) {
         )}
 
         {/* GROUP VIEW */}
-        {mode === 'group' && selectedGroup && !familyMvpEnabled && (
+        {mode === 'group' && selectedGroup && (!familyMvpEnabled || !familyMvpEntryPath) && (
           <>
             <ComplianceWarnings owners={selectedGroupSummary?.members ?? []} />
             <GroupPortfolioView slug={selectedGroup} owners={owners} />
@@ -692,7 +692,7 @@ export default function App({ onLogout }: AppProps) {
         {mode === 'allocation' && <AllocationCharts />}
         {mode === 'rebalance' && <Rebalance />}
         {mode === 'market' && <MarketOverview />}
-        {mode === 'movers' && !familyMvpEnabled && <TopMovers />}
+        {mode === 'movers' && (!familyMvpEnabled || !familyMvpEntryPath) && <TopMovers />}
         {mode === 'reports' &&
           (isReportCreationRoute ? <ReportTemplateCreator /> : <Reports />)}
         {mode === 'alerts' && <Alerts />}

--- a/frontend/tests/unit/App.familyMvpRedirect.test.tsx
+++ b/frontend/tests/unit/App.familyMvpRedirect.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -43,6 +43,32 @@ const baseConfig = {
   setBaseCurrency: vi.fn(),
 };
 
+async function mockCommonAppDependencies() {
+  vi.doMock("@/api", async () => {
+    const actual = await vi.importActual<typeof import("@/api")>("@/api");
+    return {
+      ...actual,
+      getOwners: vi.fn().mockResolvedValue([]),
+      getGroups: vi.fn().mockResolvedValue([]),
+      getGroupInstruments: vi.fn().mockResolvedValue([]),
+      getPortfolio: vi.fn(),
+      refreshPrices: vi.fn(),
+      getAlerts: vi.fn().mockResolvedValue([]),
+      getNudges: vi.fn().mockResolvedValue([]),
+      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+      getCompliance: vi
+        .fn()
+        .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+      getTimeseries: vi.fn().mockResolvedValue([]),
+      saveTimeseries: vi.fn(),
+      refetchTimeseries: vi.fn(),
+      rebuildTimeseriesCache: vi.fn(),
+      getTradingSignals: vi.fn().mockResolvedValue([]),
+      getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+    };
+  });
+}
+
 describe("App family MVP redirects", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -62,29 +88,7 @@ describe("App family MVP redirects", () => {
       };
     });
 
-    vi.doMock("@/api", async () => {
-      const actual = await vi.importActual<typeof import("@/api")>("@/api");
-      return {
-        ...actual,
-        getOwners: vi.fn().mockResolvedValue([]),
-        getGroups: vi.fn().mockResolvedValue([]),
-        getGroupInstruments: vi.fn().mockResolvedValue([]),
-        getPortfolio: vi.fn(),
-        refreshPrices: vi.fn(),
-        getAlerts: vi.fn().mockResolvedValue([]),
-        getNudges: vi.fn().mockResolvedValue([]),
-        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-        getCompliance: vi
-          .fn()
-          .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
-        getTimeseries: vi.fn().mockResolvedValue([]),
-        saveTimeseries: vi.fn(),
-        refetchTimeseries: vi.fn(),
-        rebuildTimeseriesCache: vi.fn(),
-        getTradingSignals: vi.fn().mockResolvedValue([]),
-        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
-      };
-    });
+    await mockCommonAppDependencies();
 
     const App = (await import("@/App")).default;
     const router = createMemoryRouter(
@@ -95,5 +99,42 @@ describe("App family MVP redirects", () => {
     render(<RouterProvider router={router} />);
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
+  });
+
+  it("does not render the Movers heading on non-MVP aliases in family MVP mode", async () => {
+    vi.doMock("@/ConfigContext", async () => {
+      const actual = await vi.importActual<typeof import("@/ConfigContext")>("@/ConfigContext");
+      return {
+        ...actual,
+        useConfig: () => ({
+          ...baseConfig,
+          configLoaded: true,
+          familyMvpEnabled: true,
+          disabledTabs: [],
+          tabs: {
+            ...baseConfig.tabs,
+            owner: true,
+          },
+        }),
+      };
+    });
+
+    vi.doMock("@/pages/TopMovers", () => ({
+      default: () => <h1>Movers</h1>,
+    }));
+
+    await mockCommonAppDependencies();
+
+    const App = (await import("@/App")).default;
+    const router = createMemoryRouter(
+      [{ path: "*", element: <App /> }],
+      { initialEntries: ["/family"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /movers/i })).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/tests/unit/App.familyMvpRedirect.test.tsx
+++ b/frontend/tests/unit/App.familyMvpRedirect.test.tsx
@@ -49,7 +49,9 @@ async function mockCommonAppDependencies() {
     return {
       ...actual,
       getOwners: vi.fn().mockResolvedValue([]),
-      getGroups: vi.fn().mockResolvedValue([]),
+      getGroups: vi
+        .fn()
+        .mockResolvedValue([{ slug: "kids", name: "Kids", members: [] }]),
       getGroupInstruments: vi.fn().mockResolvedValue([]),
       getPortfolio: vi.fn(),
       refreshPrices: vi.fn(),
@@ -69,6 +71,29 @@ async function mockCommonAppDependencies() {
   });
 }
 
+function mockConfig(overrides: Record<string, unknown>) {
+  vi.doMock("@/ConfigContext", async () => {
+    const actual = await vi.importActual<typeof import("@/ConfigContext")>("@/ConfigContext");
+    return {
+      ...actual,
+      useConfig: () => ({
+        ...baseConfig,
+        ...overrides,
+      }),
+    };
+  });
+}
+
+async function renderAppAt(path: string) {
+  const App = (await import("@/App")).default;
+  const router = createMemoryRouter(
+    [{ path: "*", element: <App /> }],
+    { initialEntries: [path] },
+  );
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
 describe("App family MVP redirects", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -77,46 +102,24 @@ describe("App family MVP redirects", () => {
   it("does not redirect root routes before config finishes loading", async () => {
     window.history.pushState({}, "", "/");
 
-    vi.doMock("@/ConfigContext", async () => {
-      const actual = await vi.importActual<typeof import("@/ConfigContext")>("@/ConfigContext");
-      return {
-        ...actual,
-        useConfig: () => ({
-          ...baseConfig,
-          configLoaded: false,
-        }),
-      };
-    });
+    mockConfig({ configLoaded: false });
 
     await mockCommonAppDependencies();
 
-    const App = (await import("@/App")).default;
-    const router = createMemoryRouter(
-      [{ path: "*", element: <App /> }],
-      { initialEntries: ["/"] },
-    );
-
-    render(<RouterProvider router={router} />);
+    const router = await renderAppAt("/");
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
   });
 
-  it("does not render the Movers heading on non-MVP aliases in family MVP mode", async () => {
-    vi.doMock("@/ConfigContext", async () => {
-      const actual = await vi.importActual<typeof import("@/ConfigContext")>("@/ConfigContext");
-      return {
-        ...actual,
-        useConfig: () => ({
-          ...baseConfig,
-          configLoaded: true,
-          familyMvpEnabled: true,
-          disabledTabs: [],
-          tabs: {
-            ...baseConfig.tabs,
-            owner: true,
-          },
-        }),
-      };
+  it("hides movers page content when family MVP is enabled and an entry route exists", async () => {
+    mockConfig({
+      configLoaded: true,
+      familyMvpEnabled: true,
+      disabledTabs: [],
+      tabs: {
+        ...baseConfig.tabs,
+        owner: true,
+      },
     });
 
     vi.doMock("@/pages/TopMovers", () => ({
@@ -125,16 +128,80 @@ describe("App family MVP redirects", () => {
 
     await mockCommonAppDependencies();
 
-    const App = (await import("@/App")).default;
-    const router = createMemoryRouter(
-      [{ path: "*", element: <App /> }],
-      { initialEntries: ["/family"] },
-    );
-
-    render(<RouterProvider router={router} />);
+    await renderAppAt("/movers");
 
     await waitFor(() => {
       expect(screen.queryByRole("heading", { name: /movers/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders movers page content when family MVP is disabled", async () => {
+    mockConfig({
+      configLoaded: true,
+      familyMvpEnabled: false,
+      disabledTabs: [],
+      tabs: {
+        ...baseConfig.tabs,
+        owner: true,
+      },
+    });
+
+    vi.doMock("@/pages/TopMovers", () => ({
+      default: () => <h1>Movers</h1>,
+    }));
+
+    await mockCommonAppDependencies();
+
+    await renderAppAt("/movers");
+
+    expect(await screen.findByRole("heading", { name: /movers/i })).toBeInTheDocument();
+  });
+
+  it("preserves movers fallback when family MVP has no available entry path", async () => {
+    mockConfig({
+      configLoaded: true,
+      familyMvpEnabled: true,
+      disabledTabs: ["owner", "performance", "transactions"],
+      tabs: {
+        ...baseConfig.tabs,
+        owner: false,
+        performance: false,
+        transactions: false,
+      },
+    });
+
+    vi.doMock("@/pages/TopMovers", () => ({
+      default: () => <h1>Movers</h1>,
+    }));
+
+    await mockCommonAppDependencies();
+
+    await renderAppAt("/movers");
+
+    expect(await screen.findByRole("heading", { name: /movers/i })).toBeInTheDocument();
+  });
+
+  it("hides group view content when family MVP is enabled and an entry route exists", async () => {
+    mockConfig({
+      configLoaded: true,
+      familyMvpEnabled: true,
+      disabledTabs: [],
+      tabs: {
+        ...baseConfig.tabs,
+        owner: true,
+      },
+    });
+
+    vi.doMock("@/components/GroupPortfolioView", () => ({
+      GroupPortfolioView: () => <section>Group Portfolio View</section>,
+    }));
+
+    await mockCommonAppDependencies();
+
+    await renderAppAt("/?group=kids");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Group Portfolio View")).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent flashes of non‑MVP UI when `familyMvpEnabled` is true by ensuring components cannot render at the component level before redirect logic executes.
- Address the specific cases where the Movers heading (root `/` and `/family` aliases) and group view could briefly show non‑MVP content.

Closes #2742 

### Description
- Added component‑level guards in `frontend/src/App.tsx` to avoid rendering group view content when `familyMvpEnabled` is true by changing the group branch to `mode === 'group' && selectedGroup && !familyMvpEnabled`.
- Prevented `TopMovers` from rendering in Family MVP mode by gating the movers branch to `mode === 'movers' && !familyMvpEnabled` in `frontend/src/App.tsx`.
- Extended `frontend/tests/unit/App.familyMvpRedirect.test.tsx` with a shared API mock helper and a regression test that asserts the Movers heading is not present when navigating to a non‑MVP alias (e.g. `/family`) while `familyMvpEnabled` is true.

### Testing
- Ran the targeted frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/App.familyMvpRedirect.test.tsx` and the suite passed (`2 tests` passed).
- Ran the frontend linter with `npm --prefix frontend run lint` which surfaced existing repo lint/parsing issues unrelated to this change and therefore failed; these failures are not introduced by this PR and remain out of scope for this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d16b800798832780e7a508ac8409ff)