### PR TITLE
Fix TypeScript build errors breaking deploy CI

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -176,7 +176,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
         Array.isArray(cfg.disabled_tabs) ? cfg.disabled_tabs : [],
       );
       const disableTab = (tab: keyof TabsConfig) => {
-        disabledTabs.add(tab);
+        disabledTabs.add(String(tab));
         tabs[tab] = false;
       };
       const familyMvpEnabled = cfg.enable_family_mvp !== false;

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -1170,7 +1170,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
             const resolvedPrice = resolveDisplayPrice(
               value,
               displayCurrency,
-              detail?.base_currency,
+              detail?.base_currency ?? undefined,
             );
             if (!resolvedPrice) return null;
             return resolvedPrice;
@@ -1248,7 +1248,6 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
           parsedPrices.length > 0 ? parsedPrices[parsedPrices.length - 1] : null;
         const latestPrice = latestPriceEntry?.close ?? null;
         const latestPriceCurrency = latestPriceEntry?.currency ?? displayCurrency;
-        const normalizedLatestCurrency = normaliseUppercase(latestPriceCurrency);
         const normalizedReportingCurrency = normaliseUppercase(detail?.base_currency);
         const formatDisplayPrice = (value: number | null, currency: string) => {
           const normalizedCurrency = normaliseUppercase(currency);

--- a/frontend/src/pages/PerformanceDiagnostics.tsx
+++ b/frontend/src/pages/PerformanceDiagnostics.tsx
@@ -171,8 +171,8 @@ export default function PerformanceDiagnostics() {
     label,
   }: {
     active?: boolean;
-    payload?: Array<{ payload?: PerformancePoint }>;
-    label?: string;
+    payload?: ReadonlyArray<{ payload?: PerformancePoint }>;
+    label?: string | number;
   }) => {
     if (!active || !payload?.length) return null;
     const point = payload[0]?.payload;

--- a/frontend/src/pages/VirtualPortfolio.tsx
+++ b/frontend/src/pages/VirtualPortfolio.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { logAnalyticsEvent } from "@/api";
 
 interface ManualHolding {
@@ -33,7 +33,9 @@ function createId(): string {
     const globalCrypto: Crypto | undefined =
       typeof crypto !== "undefined"
         ? crypto
-        : (typeof window !== "undefined" && (window as unknown as { crypto?: Crypto }).crypto);
+        : typeof window !== "undefined"
+          ? (window as unknown as { crypto?: Crypto }).crypto
+          : undefined;
 
     if (globalCrypto && typeof globalCrypto.getRandomValues === "function") {
       const bytes = new Uint8Array(16);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -39,7 +39,7 @@ export interface Holding {
   forward_7d_change_pct?: number | null;
   forward_30d_change_pct?: number | null;
 
-  days_held?: number;
+  days_held?: number | null;
   sell_eligible?: boolean;
   days_until_eligible?: number | null;
   next_eligible_sell_date?: string | null;


### PR DESCRIPTION
## Summary

Fixes 13 TypeScript errors that caused `npm run build` (`tsc -b && vite build`) to fail in the deploy CI job. The incremental build cache masks these locally (`tsc --noEmit` exits 0), but a clean CI run exposes them all.

Observed in [actions run #25000088031](https://github.com/leonarduk/allotmint/actions/runs/25000088031/job/73207504129).

Closes #2770

## What changed

| File | Fix |
|---|---|
| `frontend/src/types.ts` | `Holding.days_held`: widened from `number \| undefined` to `number \| null \| undefined` — root cause of ~10 cascade errors across 8 files |
| `frontend/src/ConfigContext.tsx` | `disabledTabs.add(String(tab))` — `keyof TabsConfig` includes `number` due to the index signature, so `Set<string>.add` rejected it |
| `frontend/src/pages/InstrumentResearch.tsx` | Coerce `detail?.base_currency` null → undefined before passing to `resolveDisplayPrice`; remove declared-but-never-read `normalizedLatestCurrency` |
| `frontend/src/pages/PerformanceDiagnostics.tsx` | Tooltip function: widen `payload` to `ReadonlyArray` and `label` to `string \| number` to match recharts `ContentType` |
| `frontend/src/pages/VirtualPortfolio.tsx` | `import type FormEvent` (required by `verbatimModuleSyntax`); fix `&&` short-circuit that returned `false \| Crypto \| undefined` instead of `Crypto \| undefined` |

## Verification

```bash
cd frontend && npm ci
./node_modules/.bin/tsc -b --clean && ./node_modules/.bin/tsc -b
# Exit: 0
```

Closes #2770
