### PR TITLE
Fix deploy CI failure: accept AWS_REGION from secret or repository variable

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -59,11 +59,24 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
+      - name: Verify required AWS secrets
+        run: |
+          missing=0
+          if [ -z "${{ secrets.AWS_REGION }}${{ vars.AWS_REGION }}" ]; then
+            echo "AWS_REGION is not configured (set as secret or repository variable)" >&2
+            missing=1
+          fi
+          if [ -z "${{ secrets.AWS_ROLE_TO_ASSUME }}" ]; then
+            echo "AWS_ROLE_TO_ASSUME secret is not configured" >&2
+            missing=1
+          fi
+          if [ "$missing" -eq 1 ]; then exit 1; fi
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
 
       - name: Sync data from S3
         env:
@@ -106,7 +119,7 @@ jobs:
 
       - name: Validate backend and frontend endpoints
         env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_REGION: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
         run: |
           set -euo pipefail
           backend_url="$(aws cloudformation describe-stacks \
@@ -130,7 +143,7 @@ jobs:
 
       - name: Check recent BackendLambda CloudWatch errors
         env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_REGION: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
         run: |
           set -euo pipefail
           backend_fn="$(aws cloudformation list-stack-resources \


### PR DESCRIPTION
## Summary

Fixes the deploy CI failure seen in [run #25000088031](https://github.com/leonarduk/allotmint/actions/runs/25000088031/job/73207504129) and [run #25007420762](https://github.com/leonarduk/allotmint/actions/runs/25007420762/job/73233884979).

The `configure-aws-credentials` action treats `aws-region` as a required input and fails immediately with "Input required and not supplied: aws-region" when `secrets.AWS_REGION` is unset.

## What changed

**`.github/workflows/deploy-lambda.yml`**

- `aws-region` now uses `${{ secrets.AWS_REGION || vars.AWS_REGION }}` — region can be stored as a secret **or** as a repository variable, whichever is configured.
- All three `AWS_REGION` env references in the same job are updated consistently (configure-aws-credentials, Validate endpoints, Check CloudWatch errors).
- Added a **"Verify required AWS secrets"** step _before_ configure-aws-credentials that checks for `AWS_REGION` and `AWS_ROLE_TO_ASSUME` and prints a clear human-readable error for each missing value, rather than letting the action fail with a cryptic message.

Note: Copilot suggested `coalesce(...)` in the expression — that function does not exist in GitHub Actions. The correct syntax is `||`.

## Action required

Even with this change, `AWS_REGION` must be configured somewhere:
- **Recommended**: add it as a repository variable (`Settings → Secrets and variables → Actions → Variables → New repository variable`, name `AWS_REGION`, value e.g. `eu-west-2`)
- **Alternative**: add it as a secret under the same path

`AWS_ROLE_TO_ASSUME` and `DATA_BUCKET` also remain required secrets.

Closes #2770
