### PR TITLE
fix: restore explicit UserProfile | null type on AuthProvider.setUser

### DIFF
--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -2,11 +2,10 @@ import { useState, useCallback, useContext } from 'react';
 import type { ReactNode } from 'react';
 import { loadStoredAuthUser, persistStoredAuthUser } from './authStorage';
 import { AuthContext } from './contexts/auth';
+import type { UserProfile } from './contexts/auth';
 
 export type { UserProfile } from './contexts/auth';
 export { AuthContext } from './contexts/auth';
-
-import type { UserProfile } from './contexts/auth';
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUserState] = useState<UserProfile | null>(() => loadStoredAuthUser());

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -6,9 +6,11 @@ import { AuthContext } from './contexts/auth';
 export type { UserProfile } from './contexts/auth';
 export { AuthContext } from './contexts/auth';
 
+import type { UserProfile } from './contexts/auth';
+
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUserState] = useState(() => loadStoredAuthUser());
-  const setUser = useCallback((u: Parameters<typeof setUserState>[0]) => {
+  const [user, setUserState] = useState<UserProfile | null>(() => loadStoredAuthUser());
+  const setUser = useCallback((u: UserProfile | null) => {
     setUserState(u);
     persistStoredAuthUser(u);
   }, []);


### PR DESCRIPTION
Closes #2776

## Problem

After merging #2774 the deploy workflow fails at `tsc -b`:

```
src/AuthContext.tsx(13,27): error TS2345: Argument of type 'SetStateAction<StoredUserProfile | null>'
is not assignable to parameter of type 'StoredUserProfile | null'.
```

The refactored `AuthContext.tsx` used `Parameters<typeof setUserState>[0]` to type the `setUser` callback. That resolves to `SetStateAction<UserProfile | null>` — a union that includes updater functions `(prev: T) => T`. `AuthContextValue.setUser` is typed as `(u: UserProfile | null) => void`, so TypeScript rejects the incompatible assignment.

## Fix

- Restore `useState<UserProfile | null>` explicit generic
- Restore explicit `(u: UserProfile | null)` parameter type on `setUser`

One-line change; no behaviour difference at runtime.
