### PR TITLE
fix: supply familyMvpEnabled and trail tab config in failing unit tests

### DIFF
--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -38,6 +38,12 @@ const configWithTransactions: ConfigContextValue = {
   setBaseCurrency: () => {},
 };
 
+/** Config that enables Family MVP mode — hides non-MVP categories like insights/goals. */
+const familyMvpConfig: ConfigContextValue = {
+  ...configWithTransactions,
+  familyMvpEnabled: true,
+};
+
 describe('Menu', () => {
   it('hides links by default and shows them after toggle', async () => {
     render(
@@ -231,10 +237,14 @@ describe('Menu', () => {
   });
 
   it('does not render non-MVP menu categories', () => {
+    // familyMvpEnabled: true is required — the context default is false ("fail open")
+    // so an explicit provider is needed for the MVP-gating assertion to hold.
     render(
-      <MemoryRouter>
-        <Menu />
-      </MemoryRouter>
+      <configContext.Provider value={familyMvpConfig}>
+        <MemoryRouter>
+          <Menu />
+        </MemoryRouter>
+      </configContext.Provider>
     );
 
     expect(

--- a/frontend/tests/unit/hooks/useRouteMode.test.tsx
+++ b/frontend/tests/unit/hooks/useRouteMode.test.tsx
@@ -9,6 +9,15 @@ import {
 import { useRouteMode } from "@/hooks/useRouteMode";
 import { type ReactNode } from "react";
 
+/** Minimal config with all tabs enabled including trail. */
+const allTabsConfig: ConfigContextValue = {
+  ...configContext._currentValue,
+  tabs: {
+    ...configContext._currentValue.tabs,
+    trail: true,
+  },
+};
+
 describe("useRouteMode", () => {
   it("defaults to group mode on root path", async () => {
     window.history.pushState({}, "", "/");
@@ -29,8 +38,12 @@ describe("useRouteMode", () => {
   it("recognizes trail mode", async () => {
     window.history.pushState({}, "", "/trail");
 
+    // trail is disabled in defaultTabs — supply a config that enables it so the
+    // hook does not redirect away from /trail to the first enabled tab.
     const wrapper = ({ children }: { children: ReactNode }) => (
-      <MemoryRouter initialEntries={["/trail"]}>{children}</MemoryRouter>
+      <configContext.Provider value={allTabsConfig}>
+        <MemoryRouter initialEntries={["/trail"]}>{children}</MemoryRouter>
+      </configContext.Provider>
     );
 
     const { result } = renderHook(


### PR DESCRIPTION
Closes #2783

## What

Fixes two unit test failures on `main` after #2782 merged. No production source files are changed.

### Menu.test.tsx — "does not render non-MVP menu categories"

The test rendered `<Menu />` with no `configContext.Provider` and asserted that the `insights` category button is absent. That assertion only holds when `familyMvpEnabled: true`. The context default is intentionally `false` ("fail open" — see comment in `ConfigContext.tsx`).

Fix: wrap the test in `<configContext.Provider value={familyMvpConfig}>` where `familyMvpConfig` has `familyMvpEnabled: true`. A `familyMvpConfig` constant is extracted at the top of the file for reuse.

### useRouteMode.test.tsx — "recognizes trail mode"

The test mounted at `/trail` and expected `mode === 'trail'`. The hook's `useEffect` checks `tabs['trail']` from config. `defaultTabs.trail` is `false`, so the hook treats `/trail` as a disabled route and redirects to `'group'`.

Fix: wrap the test in `<configContext.Provider value={allTabsConfig}>` where `allTabsConfig` spreads the context default with `trail: true`. An `allTabsConfig` constant is extracted at the top of the file.

## Not changed

- `Menu.tsx`, `ConfigContext.tsx`, `useRouteMode.ts`, `registry.ts` — no production code modified
- The `familyMvpEnabled: false` default in `ConfigContext.tsx` is intentional and preserved
- The `trail: false` default in `defaultTabs` is intentional and preserved
