### PR TITLE
fix: replace build-time S3 sync with COPY of pre-synced data in Dockerfile.lambda

### DIFF
--- a/backend/Dockerfile.lambda
+++ b/backend/Dockerfile.lambda
@@ -1,26 +1,15 @@
 FROM public.ecr.aws/lambda/python:3.12
 
-ARG DATA_BUCKET
-ARG DATA_REPO
-ARG DATA_BRANCH
-
-# Install application dependencies and sync prerequisites
+# Install application dependencies
 COPY backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt \
-    && yum install -y git \
-    && pip install awscli
+    && yum install -y git
 
-# Copy application code and sync script into the Lambda task root
+# Copy application code and pre-synced data into the Lambda task root
 COPY backend/ /var/task/
-COPY scripts/bash/sync_data.sh /var/task/scripts/sync_data.sh
+COPY data/ /var/task/data/
 
 WORKDIR /var/task
-RUN chmod +x scripts/sync_data.sh \
-    && if [ -n "$DATA_REPO" ] || [ -n "$DATA_BUCKET" ]; then \
-         DATA_BUCKET=$DATA_BUCKET DATA_REPO=$DATA_REPO DATA_BRANCH=$DATA_BRANCH scripts/sync_data.sh; \
-       else \
-         echo "No build-time data source configured; skipping sync_data.sh"; \
-       fi
 
 # Set the Lambda handler
 CMD ["backend.lambda_api.handler.lambda_handler"]

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -145,20 +145,8 @@ class BackendLambdaStack(Stack):
             "trading_agent": (),
         }
 
-        seed_data_bucket = (
-            self.node.try_get_context("seed_data_bucket")
-            or os.getenv("SEED_DATA_BUCKET")
-            or os.getenv("DATA_BUCKET")
-        )
-        build_args: dict[str, str] = {
-            "DATA_BUCKET": seed_data_bucket or "",
-            "DATA_BRANCH": data_branch,
-        }
-        if data_repo:
-            build_args["DATA_REPO"] = data_repo
-
         image_code = _lambda.DockerImageCode.from_image_asset(
-            str(project_root), file="backend/Dockerfile.lambda", build_args=build_args
+            str(project_root), file="backend/Dockerfile.lambda"
         )
 
         env = self.node.try_get_context("app_env") or os.getenv("APP_ENV") or "aws"
@@ -236,7 +224,6 @@ class BackendLambdaStack(Stack):
             str(project_root),
             file="backend/Dockerfile.lambda",
             cmd=["backend.lambda_api.price_refresh.lambda_handler"],
-            build_args=build_args,
         )
         refresh_env = {
             "APP_ENV": env,
@@ -282,7 +269,6 @@ class BackendLambdaStack(Stack):
             str(project_root),
             file="backend/Dockerfile.lambda",
             cmd=["backend.lambda_api.trading_agent.lambda_handler"],
-            build_args=build_args,
         )
         agent_env = {
             "APP_ENV": env,


### PR DESCRIPTION
## Summary

Closes #2795 
- The `Deploy Infrastructure` workflow was failing because `Dockerfile.lambda` ran `sync_data.sh` during Docker image build, which tried to pull from S3 using `awscli` — but AWS credentials are not available in the Docker build context (only in the runner environment).
- The workflow's **Sync data from S3** step already downloads `data/` to the runner before `cdk deploy` runs, so the Dockerfile can simply `COPY data/ /var/task/data/` instead.
- Removing `pip install awscli` from the Dockerfile also eliminates a `botocore`/`s3transfer` version conflict with `boto3` that appeared as a warning in the build log.
- Removes the `DATA_BUCKET`/`DATA_REPO`/`DATA_BRANCH` build args from `backend_lambda_stack.py` since they were only used to drive the now-removed sync step.

## Root cause

`BackendLambdaStack` passed `DATA_BUCKET` as a Docker build arg → `Dockerfile.lambda` condition `[ -n "$DATA_BUCKET" ]` was true → `sync_data.sh` ran `aws s3 sync` → **fatal error: Unable to locate credentials**.

## Test plan

- [ ] CI `Deploy Infrastructure` workflow completes without the credential error
- [ ] Lambda image contains the expected `data/` directory (same content as before, sourced from the S3 sync step that already runs in the runner)
- [ ] CDK tests (`pytest cdk/`) still pass — no tests reference `build_args`

🤖 Generated with [Claude Code](https://claude.com/claude-code)