### PR TITLE
fix: derive default template selection synchronously to fix checked radio test

### DIFF
--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -149,7 +149,7 @@ export default function Reports() {
   const [owner, setOwner] = useState("");
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");
-  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
+  const [explicitTemplateId, setExplicitTemplateId] = useState<string | null>(
     null,
   );
 
@@ -162,12 +162,14 @@ export default function Reports() {
       .finally(() => setOwnersLoaded(true));
   }, []);
 
-  useEffect(() => {
-    if (templates.length === 0 || selectedTemplateId) return;
-    const preferred =
-      templates.find((template) => template.builtin) ?? templates[0];
-    setSelectedTemplateId(preferred.template_id);
-  }, [templates, selectedTemplateId]);
+  const selectedTemplateId = useMemo(() => {
+    if (explicitTemplateId) return explicitTemplateId;
+    return (
+      templates.find((template) => template.builtin)?.template_id ??
+      templates[0]?.template_id ??
+      null
+    );
+  }, [explicitTemplateId, templates]);
 
   const selectedTemplate = useMemo(
     () =>
@@ -248,14 +250,14 @@ export default function Reports() {
                 title={t("reports.catalog.groups.builtin")}
                 templates={builtin}
                 selectedTemplateId={selectedTemplateId}
-                onSelect={setSelectedTemplateId}
+                onSelect={setExplicitTemplateId}
                 t={t}
               />
               <TemplateGroup
                 title={t("reports.catalog.groups.custom")}
                 templates={custom}
                 selectedTemplateId={selectedTemplateId}
-                onSelect={setSelectedTemplateId}
+                onSelect={setExplicitTemplateId}
                 t={t}
               />
             </>


### PR DESCRIPTION
## Summary

- Replaces the post-render `useEffect` that set `selectedTemplateId` with a `useMemo` that derives the effective selection in the **same render cycle** as templates arriving from the API.
- The old approach caused a render where templates were visible but `selectedTemplateId` was still `null`; `findByRole` resolved at that instant, so `toBeChecked()` failed before the state update landed.
- The new approach never shows templates in an unselected state: if the user hasn't explicitly chosen a template, the memo falls back to the first builtin, then the first template, then `null`.

## Test plan

- [x] `npm --prefix frontend run test -- --run` — 79 files, 434 tests all pass (was 1 failing)
- [x] `npm --prefix frontend run lint` — clean

Closes #2801