### PR TITLE
fix: don't re-raise prime_latest_prices failure during ASGI lifespan startup

### DIFF
--- a/backend/bootstrap/startup.py
+++ b/backend/bootstrap/startup.py
@@ -64,8 +64,11 @@ class AppLifecycleService:
         try:
             await asyncio.to_thread(instrument_api.prime_latest_prices)
         except Exception:
+            # Non-fatal: price priming is a startup optimisation. If it fails (e.g.
+            # network unavailable on Lambda cold start) the app should still serve
+            # requests; a re-raise here propagates through the ASGI lifespan and
+            # causes every subsequent request to return 500.
             logger.exception("Failed to prime latest prices from warmed snapshot")
-            raise
 
     @staticmethod
     def _flush_logging() -> None:

--- a/tests/backend/test_app_bootstrap.py
+++ b/tests/backend/test_app_bootstrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 
 import pytest
@@ -139,20 +140,19 @@ async def test_lifecycle_service_startup_survives_prime_latest_prices_failure(
         _fail_prime,
     )
     monkeypatch.setattr("backend.bootstrap.startup.refresh_snapshot_async", lambda days: None)
+    monkeypatch.setattr(config, "skip_snapshot_warm", False, raising=False)
 
-    config.skip_snapshot_warm = False
     service = AppLifecycleService(cfg=config)
     app = app_module.create_app()
-
-    import logging
 
     with caplog.at_level(logging.ERROR):
         # Must not raise — previously the re-raise turned this into a 500 for all requests.
         await service.startup(app)
 
-    assert any("prime" in r.message.lower() for r in caplog.records), (
-        "Expected a log record mentioning 'prime' but got: "
-        + str([r.message for r in caplog.records])
+    assert any(
+        "Failed to prime latest prices" in r.message for r in caplog.records
+    ), "Expected 'Failed to prime latest prices' log but got: " + str(
+        [r.message for r in caplog.records]
     )
 
 

--- a/tests/backend/test_app_bootstrap.py
+++ b/tests/backend/test_app_bootstrap.py
@@ -113,6 +113,7 @@ async def test_lifecycle_service_shutdown_cancels_tasks_and_temp_dirs(
 @pytest.mark.asyncio
 async def test_lifecycle_service_startup_survives_prime_latest_prices_failure(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Startup must not raise when prime_latest_prices fails.
 
@@ -120,6 +121,10 @@ async def test_lifecycle_service_startup_survives_prime_latest_prices_failure(
     request (including /docs) returns 500.  Remove the raise so that Lambda
     cold-start network failures are non-fatal.
     """
+
+    def _fail_prime():
+        raise RuntimeError("simulated network failure")
+
     monkeypatch.setattr("backend.bootstrap.startup._load_snapshot", lambda: ({}, None))
     monkeypatch.setattr(
         "backend.bootstrap.startup.refresh_snapshot_in_memory",
@@ -131,7 +136,7 @@ async def test_lifecycle_service_startup_survives_prime_latest_prices_failure(
     )
     monkeypatch.setattr(
         "backend.common.instrument_api.prime_latest_prices",
-        lambda: (_ for _ in ()).throw(RuntimeError("simulated network failure")),
+        _fail_prime,
     )
     monkeypatch.setattr("backend.bootstrap.startup.refresh_snapshot_async", lambda days: None)
 
@@ -139,8 +144,16 @@ async def test_lifecycle_service_startup_survives_prime_latest_prices_failure(
     service = AppLifecycleService(cfg=config)
     app = app_module.create_app()
 
-    # Must not raise — previously the re-raise turned this into a 500 for all requests.
-    await service.startup(app)
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        # Must not raise — previously the re-raise turned this into a 500 for all requests.
+        await service.startup(app)
+
+    assert any("prime" in r.message.lower() for r in caplog.records), (
+        "Expected a log record mentioning 'prime' but got: "
+        + str([r.message for r in caplog.records])
+    )
 
 
 def test_create_app_skips_snapshot_warm_when_disabled(monkeypatch: pytest.MonkeyPatch):

--- a/tests/backend/test_app_bootstrap.py
+++ b/tests/backend/test_app_bootstrap.py
@@ -110,6 +110,39 @@ async def test_lifecycle_service_shutdown_cancels_tasks_and_temp_dirs(
     assert not temp_dir.exists()
 
 
+@pytest.mark.asyncio
+async def test_lifecycle_service_startup_survives_prime_latest_prices_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Startup must not raise when prime_latest_prices fails.
+
+    If the re-raise is present, the ASGI lifespan aborts and every subsequent
+    request (including /docs) returns 500.  Remove the raise so that Lambda
+    cold-start network failures are non-fatal.
+    """
+    monkeypatch.setattr("backend.bootstrap.startup._load_snapshot", lambda: ({}, None))
+    monkeypatch.setattr(
+        "backend.bootstrap.startup.refresh_snapshot_in_memory",
+        lambda snapshot, ts: None,
+    )
+    monkeypatch.setattr(
+        "backend.common.instrument_api.update_latest_prices_from_snapshot",
+        lambda snapshot: None,
+    )
+    monkeypatch.setattr(
+        "backend.common.instrument_api.prime_latest_prices",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated network failure")),
+    )
+    monkeypatch.setattr("backend.bootstrap.startup.refresh_snapshot_async", lambda days: None)
+
+    config.skip_snapshot_warm = False
+    service = AppLifecycleService(cfg=config)
+    app = app_module.create_app()
+
+    # Must not raise — previously the re-raise turned this into a 500 for all requests.
+    await service.startup(app)
+
+
 def test_create_app_skips_snapshot_warm_when_disabled(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True, raising=False)
 


### PR DESCRIPTION
## Summary

- Removes the `raise` from the `except` block in `AppLifecycleService._warm_snapshot` (`backend/bootstrap/startup.py`).
- Price priming (`prime_latest_prices`) is a startup cache-warmup optimisation. When it fails — e.g. Lambda cold-start can't reach external price APIs (Stooq, Yahoo Finance) — the previous `raise` propagated through the FastAPI lifespan context manager. Mangum treats an ASGI lifespan startup failure as fatal and returns HTTP 500 for **every** subsequent request, including the `/docs` smoke-test curl.
- Adds a regression test asserting that `startup()` completes without raising when `prime_latest_prices` throws a `RuntimeError`.

## Test plan

- [x] `python -m pytest tests/backend/test_app_bootstrap.py` — 5 tests pass (1 new)
- [x] `python -m pytest` — all 31 backend tests pass
- [x] `python -m ruff check` — clean

Closes #2803