### PR TITLE
fix: resolve duplicate FastAPI operationId for refresh_prices

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -925,6 +925,7 @@ async def instrument_detail(slug: str, ticker: str):
 
 
 def _do_refresh_prices() -> dict:
+    # Shared by GET and POST handlers; see issue #2818 to make this non-blocking.
     log.info("Refreshing prices via /prices/refresh")
     result = prices.refresh_prices()
     return {"status": "ok", **result}

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -924,8 +924,17 @@ async def instrument_detail(slug: str, ticker: str):
     return {"prices": prices_list, "mini": series.get("mini", {}), "positions": positions_list}
 
 
-@router.api_route("/prices/refresh", methods=["GET", "POST"])
-async def refresh_prices():
+def _do_refresh_prices() -> dict:
     log.info("Refreshing prices via /prices/refresh")
     result = prices.refresh_prices()
     return {"status": "ok", **result}
+
+
+@router.get("/prices/refresh", operation_id="refresh_prices_get")
+async def refresh_prices_get():
+    return _do_refresh_prices()
+
+
+@router.post("/prices/refresh", operation_id="refresh_prices_post")
+async def refresh_prices_post():
+    return _do_refresh_prices()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -231,6 +231,37 @@ def test_prices_refresh(mock_refresh, client):
     assert response.json() == {"status": "ok", "updated": 5}
 
 
+@patch("backend.common.prices.refresh_prices", return_value={"updated": 3})
+def test_prices_refresh_get(mock_refresh, client):
+    response = client.get("/prices/refresh")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "updated": 3}
+
+
+def test_openapi_no_duplicate_operation_ids():
+    """Regression test: all OpenAPI operation IDs must be unique (issue #2809)."""
+    import warnings
+    from backend.app import create_app
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        local_app = create_app()
+        schema = local_app.openapi()
+
+    duplicate_warnings = [str(w.message) for w in caught if "Duplicate Operation ID" in str(w.message)]
+    assert not duplicate_warnings, f"Duplicate operation IDs found: {duplicate_warnings}"
+
+    operation_ids = []
+    for methods in schema.get("paths", {}).values():
+        for op in methods.values():
+            if isinstance(op, dict) and "operationId" in op:
+                operation_ids.append(op["operationId"])
+
+    refresh_ops = {schema["paths"]["/prices/refresh"][m]["operationId"] for m in ("get", "post")}
+    assert refresh_ops == {"refresh_prices_get", "refresh_prices_post"}
+    assert len(operation_ids) == len(set(operation_ids)), "Found duplicate operationIds in OpenAPI schema"
+
+
 @patch("backend.common.portfolio_utils.aggregate_by_ticker", return_value=[{"ticker": "ABC"}])
 @patch("backend.common.group_portfolio.build_group_portfolio", return_value={"slug": "testslug"})
 @patch("backend.common.group_portfolio.list_groups", return_value=mock_groups)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -6,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.app import create_app
 from backend.common import data_loader
 from backend import config as backend_config
 from backend.local_api.main import app
@@ -225,13 +227,6 @@ def test_get_account_invalid_payload(mock_load_account, client):
 
 
 @patch("backend.common.prices.refresh_prices", return_value={"updated": 5})
-def test_prices_refresh(mock_refresh, client):
-    response = client.post("/prices/refresh")
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok", "updated": 5}
-
-
-@patch("backend.common.prices.refresh_prices", return_value={"updated": 5})
 def test_prices_refresh_get(mock_refresh, client):
     response = client.get("/prices/refresh")
     assert response.status_code == 200
@@ -247,9 +242,6 @@ def test_prices_refresh_post(mock_refresh, client):
 
 def test_openapi_no_duplicate_operation_ids():
     """Regression test: all OpenAPI operation IDs must be unique (issue #2809)."""
-    import warnings
-    from backend.app import create_app
-
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         local_app = create_app()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -231,11 +231,18 @@ def test_prices_refresh(mock_refresh, client):
     assert response.json() == {"status": "ok", "updated": 5}
 
 
-@patch("backend.common.prices.refresh_prices", return_value={"updated": 3})
+@patch("backend.common.prices.refresh_prices", return_value={"updated": 5})
 def test_prices_refresh_get(mock_refresh, client):
     response = client.get("/prices/refresh")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok", "updated": 3}
+    assert response.json() == {"status": "ok", "updated": 5}
+
+
+@patch("backend.common.prices.refresh_prices", return_value={"updated": 5})
+def test_prices_refresh_post(mock_refresh, client):
+    response = client.post("/prices/refresh")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "updated": 5}
 
 
 def test_openapi_no_duplicate_operation_ids():
@@ -257,8 +264,12 @@ def test_openapi_no_duplicate_operation_ids():
             if isinstance(op, dict) and "operationId" in op:
                 operation_ids.append(op["operationId"])
 
-    refresh_ops = {schema["paths"]["/prices/refresh"][m]["operationId"] for m in ("get", "post")}
-    assert refresh_ops == {"refresh_prices_get", "refresh_prices_post"}
+    refresh_path = schema.get("paths", {}).get("/prices/refresh", {})
+    assert refresh_path, "Expected /prices/refresh path in OpenAPI schema"
+    refresh_ops = {m: refresh_path[m].get("operationId") for m in ("get", "post") if m in refresh_path}
+    assert refresh_ops == {"get": "refresh_prices_get", "post": "refresh_prices_post"}, (
+        f"Unexpected refresh_prices operationIds: {refresh_ops}"
+    )
     assert len(operation_ids) == len(set(operation_ids)), "Found duplicate operationIds in OpenAPI schema"
 
 


### PR DESCRIPTION
## Summary

- Replace `@router.api_route("/prices/refresh", methods=["GET", "POST"])` with separate `@router.get` and `@router.post` decorators, each with an explicit `operation_id`
- Extract shared handler logic into `_do_refresh_prices()` to avoid duplication
- Add regression test `test_openapi_no_duplicate_operation_ids` that asserts all OpenAPI operation IDs are unique and confirms the two refresh endpoints carry `refresh_prices_get` / `refresh_prices_post`

## Root cause

FastAPI's `api_route` assigns one `unique_id` to the whole route object. Both the GET and POST operations resolved to `refresh_prices_prices_refresh_get`, producing a `UserWarning` on every schema generation and an invalid OpenAPI spec (likely the root cause of the `/docs` HTTP 500 in production).

## Test plan

- [x] `test_openapi_no_duplicate_operation_ids` — asserts no duplicate `operationId` warnings and verifies distinct IDs for GET and POST
- [x] `test_prices_refresh` — existing POST test continues to pass
- [x] `test_prices_refresh_get` — new GET test passes
- [x] No regressions in `tests/backend/` (pre-existing failures confirmed on main before this branch)

Closes #2809

🤖 Generated with [Claude Code](https://claude.com/claude-code)