### PR TITLE
Fix /prices/refresh event loop blocking

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -10,6 +10,7 @@ Owners / groups / portfolio endpoints (shared).
 
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import inspect
 import logging
@@ -924,18 +925,17 @@ async def instrument_detail(slug: str, ticker: str):
     return {"prices": prices_list, "mini": series.get("mini", {}), "positions": positions_list}
 
 
-def _do_refresh_prices() -> dict:
-    # Shared by GET and POST handlers; see issue #2818 to make this non-blocking.
+async def _do_refresh_prices() -> dict:
     log.info("Refreshing prices via /prices/refresh")
-    result = prices.refresh_prices()
+    result = await asyncio.to_thread(prices.refresh_prices)
     return {"status": "ok", **result}
 
 
 @router.get("/prices/refresh", operation_id="refresh_prices_get")
 async def refresh_prices_get():
-    return _do_refresh_prices()
+    return await _do_refresh_prices()
 
 
 @router.post("/prices/refresh", operation_id="refresh_prices_post")
 async def refresh_prices_post():
-    return _do_refresh_prices()
+    return await _do_refresh_prices()

--- a/tests/backend/routes/test_portfolio_helpers.py
+++ b/tests/backend/routes/test_portfolio_helpers.py
@@ -1,3 +1,4 @@
+import asyncio
 import types
 from pathlib import Path
 
@@ -127,3 +128,33 @@ def test_list_owner_summaries_appends_demo_when_missing(monkeypatch: pytest.Monk
 
     second_result = portfolio._list_owner_summaries(request)
     assert [summary.owner for summary in second_result] == ["demo"]
+
+
+@pytest.mark.asyncio
+async def test_do_refresh_prices_uses_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_refresh_prices() -> dict:
+        calls["refresh_called"] = True
+        return {"updated": 5}
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        calls["to_thread"] = {
+            "func": func,
+            "args": args,
+            "kwargs": kwargs,
+        }
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(portfolio.prices, "refresh_prices", fake_refresh_prices)
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    result = await portfolio._do_refresh_prices()
+
+    assert result == {"status": "ok", "updated": 5}
+    assert calls["refresh_called"] is True
+    assert calls["to_thread"] == {
+        "func": fake_refresh_prices,
+        "args": (),
+        "kwargs": {},
+    }


### PR DESCRIPTION
## Summary
- move `/prices/refresh` off the async event loop with `asyncio.to_thread`
- await the shared refresh helper from both GET and POST handlers
- add a regression test proving the route helper uses `asyncio.to_thread`

## Testing
- `../allotmint/.venv/Scripts/python.exe -m pytest -o addopts= tests/backend/routes/test_portfolio_helpers.py -k refresh_prices -q`
- `../allotmint/.venv/Scripts/python.exe -m pytest -o addopts= tests/test_backend_api.py -k 'prices_refresh_get or prices_refresh_post or alerts_endpoint' -q`
- `../allotmint/.venv/Scripts/python.exe -m pytest -o addopts= tests/test_main.py::test_prices_refresh_get tests/test_main.py::test_prices_refresh_post tests/test_main.py::test_openapi_no_duplicate_operation_ids -q`

Closes #2818