### PR TITLE
fix: harden startup lifecycle to prevent 500 on /docs after Lambda cold start

### DIFF
--- a/backend/bootstrap/startup.py
+++ b/backend/bootstrap/startup.py
@@ -60,7 +60,11 @@ class AppLifecycleService:
 
         from backend.common import instrument_api
 
-        instrument_api.update_latest_prices_from_snapshot(snapshot)
+        try:
+            instrument_api.update_latest_prices_from_snapshot(snapshot)
+        except Exception:
+            logger.exception("Failed to update latest prices from snapshot")
+
         try:
             await asyncio.to_thread(instrument_api.prime_latest_prices)
         except Exception:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -64,3 +64,56 @@ def test_create_app_registers_rebalance_route(monkeypatch):
 
     registered_paths = {route.path for route in app.routes}
     assert "/rebalance" in registered_paths
+
+
+def test_docs_endpoint_returns_200(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+    with patch("backend.bootstrap.startup.refresh_snapshot_async"):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/docs")
+    assert resp.status_code == 200
+
+
+def test_docs_returns_200_when_prime_latest_prices_fails(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", False)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+
+    def _fail():
+        raise RuntimeError("simulated network failure on cold start")
+
+    with (
+        patch("backend.bootstrap.startup.refresh_snapshot_async"),
+        patch("backend.bootstrap.startup._load_snapshot", return_value=({}, None)),
+        patch("backend.bootstrap.startup.refresh_snapshot_in_memory"),
+        patch("backend.common.instrument_api.update_latest_prices_from_snapshot"),
+        patch("backend.common.instrument_api.prime_latest_prices", side_effect=_fail),
+    ):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/docs")
+    assert resp.status_code == 200
+
+
+def test_docs_returns_200_when_update_latest_prices_fails(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", False)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+
+    def _fail(_snapshot):
+        raise RuntimeError("simulated update_latest_prices failure")
+
+    with (
+        patch("backend.bootstrap.startup.refresh_snapshot_async"),
+        patch("backend.bootstrap.startup._load_snapshot", return_value=({}, None)),
+        patch("backend.bootstrap.startup.refresh_snapshot_in_memory"),
+        patch(
+            "backend.common.instrument_api.update_latest_prices_from_snapshot",
+            side_effect=_fail,
+        ),
+        patch("backend.common.instrument_api.prime_latest_prices"),
+    ):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/docs")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Closes #2808

The deploy pipeline was failing at the "Validate backend and frontend endpoints" step because the deployed Lambda returned HTTP 500 on `/docs`. This PR addresses two remaining gaps after #2809 fixed the duplicate `refresh_prices` operation ID:

- **Harden `_warm_snapshot`**: `update_latest_prices_from_snapshot` was not wrapped in a try/except. If it raised (e.g. due to a cold-start network error or stale data), the exception propagated through the ASGI lifespan context manager, causing every subsequent request — including `/docs` — to return 500.
- **Add `/docs` integration tests**: Three new tests call `/docs` through the full `TestClient` lifecycle (i.e. they exercise the real ASGI lifespan, not just the service in isolation) to verify the endpoint returns 200 under normal conditions and when startup helpers raise exceptions simulating Lambda cold-start failures.

## Changes

### `backend/bootstrap/startup.py`
- Wrapped `instrument_api.update_latest_prices_from_snapshot(snapshot)` in a `try/except Exception` that logs and continues, matching the existing pattern for `prime_latest_prices`.

### `tests/test_app.py`
- `test_docs_endpoint_returns_200` — verifies `/docs` returns 200 under normal startup.
- `test_docs_returns_200_when_prime_latest_prices_fails` — verifies `/docs` returns 200 when `prime_latest_prices` raises during startup (Lambda cold-start network failure simulation).
- `test_docs_returns_200_when_update_latest_prices_fails` — verifies `/docs` returns 200 when `update_latest_prices_from_snapshot` raises during startup.

## Test plan
- [x] `python -m pytest tests/test_app.py` — 7 passed
- [x] `python -m pytest tests/backend/test_app_bootstrap.py tests/test_lambda_handler.py` — 7 passed
- [x] `python -m ruff check backend/bootstrap/startup.py tests/test_app.py` — clean