### PR TITLE
[codex] Remove stale xfail markers from passing backend tests

### DIFF
--- a/tests/backend/test_custom_query_route.py
+++ b/tests/backend/test_custom_query_route.py
@@ -19,7 +19,6 @@ def temp_queries_dir(tmp_path, monkeypatch):
     return queries_dir
 
 
-@pytest.mark.xfail(reason="Query fallback mechanism needs investigation")
 def test_custom_query_routes_fallback_to_local(monkeypatch):
     monkeypatch.setattr(config, "app_env", "aws")
     monkeypatch.setattr(config, "skip_snapshot_warm", True)

--- a/tests/routes/test_instrument.py
+++ b/tests/routes/test_instrument.py
@@ -137,7 +137,6 @@ def test_render_html_contains_tables():
 # /instrument route
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(reason="To fix")
 def test_instrument_route_json_html_and_base_currency(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
@@ -181,7 +180,6 @@ def test_instrument_route_json_html_and_base_currency(monkeypatch):
     assert "<table" in resp_html.text
 
 
-@pytest.mark.xfail(reason="To fix")
 def test_instrument_route_close_only_prices_populates_positions(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()

--- a/tests/routes/test_portfolio_group.py
+++ b/tests/routes/test_portfolio_group.py
@@ -41,7 +41,6 @@ class TestAccountMatchesFilters:
         assert portfolio_module._account_matches_filters(account, filters) is False
 
 
-@pytest.mark.xfail(reason="To fix")
 def test_group_instruments_filters_accounts(monkeypatch):
     captured_portfolio = {}
     accounts = [

--- a/tests/routes/test_query.py
+++ b/tests/routes/test_query.py
@@ -253,7 +253,6 @@ def test_run_query_csv(monkeypatch):
     assert "ABC.L" in lines[1]
 
 
-@pytest.mark.xfail(reason="To fix")
 def test_run_query_xlsx(monkeypatch):
     _setup_run_query(monkeypatch)
     client = make_client()

--- a/tests/routes/test_trading_agent.py
+++ b/tests/routes/test_trading_agent.py
@@ -13,7 +13,6 @@ def make_client() -> TestClient:
     return client
 
 
-@pytest.mark.xfail(reason="To fix")
 def test_basic_response_model_validation(monkeypatch):
     fake_signals = [
         {
@@ -41,7 +40,6 @@ def test_basic_response_model_validation(monkeypatch):
     ]
 
 
-@pytest.mark.xfail(reason="To fix")
 def test_notify_email(monkeypatch):
     fake_signals = [
         {
@@ -75,7 +73,6 @@ def test_notify_email(monkeypatch):
     assert pushed["message"] == "BUY AAA: r"
 
 
-@pytest.mark.xfail(reason="To fix")
 def test_notify_telegram_env_gating(monkeypatch):
     fake_signals = [
         {
@@ -111,7 +108,6 @@ def test_notify_telegram_env_gating(monkeypatch):
     assert sent["text"] == "BUY AAA: r"
 
 
-@pytest.mark.xfail(reason="To fix")
 def test_no_signals(monkeypatch):
     monkeypatch.setattr("backend.agent.trading_agent.run", lambda **_: [])
 

--- a/tests/routes/test_trail_routes.py
+++ b/tests/routes/test_trail_routes.py
@@ -3,11 +3,9 @@ import importlib
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.auth import get_current_user
 from backend.config import config
 
 
-@pytest.mark.xfail(reason="To fix")
 @pytest.mark.parametrize("disable_auth", [True, False])
 def test_trail_routes(tmp_path, monkeypatch, disable_auth):
     monkeypatch.setenv("TRAIL_URI", f"file://{tmp_path/'trail.json'}")
@@ -20,10 +18,11 @@ def test_trail_routes(tmp_path, monkeypatch, disable_auth):
     importlib.reload(trail_route_module)
     importlib.reload(app_mod)
     app = app_mod.create_app()
-    if not disable_auth:
-        app.dependency_overrides[get_current_user] = lambda: "demo"
 
     with TestClient(app) as client:
+        if not disable_auth:
+            token = client.post("/token", json={"id_token": "good"}).json()["access_token"]
+            client.headers.update({"Authorization": f"Bearer {token}"})
         resp = client.get("/trail")
         assert resp.status_code == 200
         payload = resp.json()


### PR DESCRIPTION
## Summary
- remove stale `xfail` markers from 10 backend tests that now pass cleanly
- switch the authenticated `trail` route test to token-based auth so it stays stable in full-suite runs
- leave the remaining expected `xfail` coverage unchanged

## Why
The backend suite was reporting these tests as `XPASS`, which meant the underlying behavior was already fixed but the suite was still treating the cases as expected failures.

## Validation
- `C:\Users\steph\workspace\GitHub\allotmint-2815\.venv-test\Scripts\python.exe -m pytest tests/routes/test_trail_routes.py tests/routes/test_trading_agent.py tests/routes/test_instrument.py tests/routes/test_portfolio_group.py tests/routes/test_query.py tests/backend/test_custom_query_route.py -q`
- `C:\Users\steph\workspace\GitHub\allotmint-2815\.venv-test\Scripts\python.exe -m pytest tests --tb=no -q`
  - `2077 passed, 5 skipped, 22 xfailed`

Closes #2815
