### PR TITLE
chore: remove stale xfail markers — 2 tests now passing cleanly

### DIFF
--- a/tests/backend/test_custom_query_route.py
+++ b/tests/backend/test_custom_query_route.py
@@ -19,7 +19,6 @@ def temp_queries_dir(tmp_path, monkeypatch):
     return queries_dir
 
 
-@pytest.mark.xfail(reason="Query fallback mechanism needs investigation")
 def test_custom_query_routes_fallback_to_local(monkeypatch):
     monkeypatch.setattr(config, "app_env", "aws")
     monkeypatch.setattr(config, "skip_snapshot_warm", True)

--- a/tests/routes/test_trail_routes.py
+++ b/tests/routes/test_trail_routes.py
@@ -7,7 +7,6 @@ from backend.auth import get_current_user
 from backend.config import config
 
 
-@pytest.mark.xfail(reason="To fix")
 @pytest.mark.parametrize("disable_auth", [True, False])
 def test_trail_routes(tmp_path, monkeypatch, disable_auth):
     monkeypatch.setenv("TRAIL_URI", f"file://{tmp_path/'trail.json'}")


### PR DESCRIPTION
## Summary

Removes stale `@pytest.mark.xfail` markers from 2 tests that are now unexpectedly passing (xpassed), as identified in issue #2815.

- **`test_custom_query_routes_fallback_to_local`** (`tests/backend/test_custom_query_route.py`): the query fallback mechanism now works correctly — xfail reason was "Query fallback mechanism needs investigation".
- **`test_trail_routes[True]` and `test_trail_routes[False]`** (`tests/routes/test_trail_routes.py`): both parametrize variants pass cleanly — the blanket `@pytest.mark.xfail` decorator was removed entirely.

## Test verification

Before: `2 xpassed` in the suite  
After: `0 xpassed` — both tests run as normal passing tests

## Notes

The issue log cited 10 xpassed tests from a previous CI run; at the time of this fix the suite shows 2 xpassed (the rest were likely fixed in intervening PRs). This PR clears the remaining stale markers.

Closes #2815