### PR TITLE
fix: replace raw CSV test upload data with content

### DIFF
--- a/tests/routes/test_timeseries_edit.py
+++ b/tests/routes/test_timeseries_edit.py
@@ -95,7 +95,7 @@ def test_post_csv_saves_parquet(tmp_path, monkeypatch):
     headers = {"Content-Type": "text/csv"}
     resp = client.post(
         "/timeseries/edit?ticker=XYZ&exchange=L",
-        data=csv_data,
+        content=csv_data,
         headers=headers,
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- replace the raw CSV upload in `tests/routes/test_timeseries_edit.py` to use `content=` instead of `data=`
- keep the test behavior unchanged while removing the deprecated httpx upload path

## Testing
- `/mnt/c/Users/steph/workspace/GitHub/allotmint/.venv/Scripts/python.exe -m pytest -q tests/routes/test_timeseries_edit.py -W default`

Closes #2812