### PR TITLE
chore: remove stale xfail markers — trail and query route tests now passing cleanly

### DIFF
--- a/tests/backend/test_custom_query_route.py
+++ b/tests/backend/test_custom_query_route.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
@@ -19,7 +18,6 @@ def temp_queries_dir(tmp_path, monkeypatch):
     return queries_dir
 
 
-@pytest.mark.xfail(reason="Query fallback mechanism needs investigation")
 def test_custom_query_routes_fallback_to_local(monkeypatch):
     monkeypatch.setattr(config, "app_env", "aws")
     monkeypatch.setattr(config, "skip_snapshot_warm", True)

--- a/tests/routes/test_trail_routes.py
+++ b/tests/routes/test_trail_routes.py
@@ -7,7 +7,6 @@ from backend.auth import get_current_user
 from backend.config import config
 
 
-@pytest.mark.xfail(reason="To fix")
 @pytest.mark.parametrize("disable_auth", [True, False])
 def test_trail_routes(tmp_path, monkeypatch, disable_auth):
     monkeypatch.setenv("TRAIL_URI", f"file://{tmp_path/'trail.json'}")


### PR DESCRIPTION
## Summary

Fixes the CI failure in [PR #2822](https://github.com/leonarduk/allotmint/pull/2822) by rebasing the same change onto the latest main.

PR #2822 correctly identified that both tests were xpassing (unexpectedly passing), but its CI run failed because `test_trail_routes[False]` was fragile against a startup lifecycle exception that was not yet protected by a try/except. That exception path was hardened in #2820 (`5d2d0ded`), which merged to main after PR #2822 was created.

This PR makes the same change as #2822 on top of the fixed main:

- **`test_trail_routes[True]` and `test_trail_routes[False]`** (`tests/routes/test_trail_routes.py`): both parametrize variants pass cleanly — blanket `@pytest.mark.xfail` removed.
- **`test_custom_query_routes_fallback_to_local`** (`tests/backend/test_custom_query_route.py`): query fallback now works correctly — `@pytest.mark.xfail` removed.

## Test verification

Both tests pass as normal (no xpassed, no xfailed) on current main.

Closes #2815
Supersedes #2822