### PR TITLE
[codex] fix lambda docker build dependency conflict

### DIFF
--- a/backend/Dockerfile.lambda
+++ b/backend/Dockerfile.lambda
@@ -1,10 +1,9 @@
 FROM public.ecr.aws/lambda/python:3.12
 
-# Install application dependencies
+# Install application dependencies. Build-time data sync happens before the
+# image build, so the Lambda image does not need git or awscli.
 COPY backend/requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt \
-    && dnf install -y git \
-    && pip install awscli
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code and pre-synced data into the Lambda task root
 COPY backend/ /var/task/

--- a/tests/test_lambda_dockerfile.py
+++ b/tests/test_lambda_dockerfile.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import unittest
+
+
+DOCKERFILE = Path(__file__).resolve().parents[1] / "backend" / "Dockerfile.lambda"
+
+
+class LambdaDockerfileTests(unittest.TestCase):
+    def test_lambda_dockerfile_avoids_build_only_sync_tools(self) -> None:
+        text = DOCKERFILE.read_text(encoding="utf-8")
+
+        self.assertNotIn(
+            "pip install awscli",
+            text,
+            "Lambda Dockerfile should not install awscli into the application "
+            "Python environment because it can pull in incompatible botocore "
+            "and s3transfer versions.",
+        )
+        self.assertNotIn(
+            "dnf install -y git",
+            text,
+            "Lambda Dockerfile should not install git for build-time data sync "
+            "because deployment pre-syncs data before the image build.",
+        )
+        self.assertIn(
+            "COPY data/ /var/task/data/",
+            text,
+            "Lambda Dockerfile is expected to copy pre-synced data into the "
+            "image rather than fetching it during the build.",
+        )


### PR DESCRIPTION
## Summary
- remove unused `git` and `awscli` installation from `backend/Dockerfile.lambda`
- keep Lambda builds focused on app dependencies because deployment pre-syncs and copies `data/` into the image
- add a regression test to prevent reintroducing build-only sync tooling into the Lambda image

## Why
The Lambda image build was installing `awscli` with `pip` into the same Python environment as the application dependencies. That can pull in incompatible `botocore` and `s3transfer` versions relative to the pinned `boto3` requirement and cause noisy or risky Lambda builds.

## Validation
- `python3 -m unittest -q tests.test_lambda_dockerfile`

Closes #2810
