### PR TITLE
fix: correct Dockerfile COPY and add Lambda timeout to fix /docs 500

### DIFF
--- a/backend/Dockerfile.lambda
+++ b/backend/Dockerfile.lambda
@@ -5,8 +5,9 @@ FROM public.ecr.aws/lambda/python:3.12
 COPY backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy application code and pre-synced data into the Lambda task root
-COPY backend/ /var/task/
+# Copy the backend package preserving its directory name so that
+# "backend.lambda_api.handler.lambda_handler" is importable from /var/task.
+COPY backend /var/task/backend
 COPY data/ /var/task/data/
 
 WORKDIR /var/task

--- a/backend/routes/support.py
+++ b/backend/routes/support.py
@@ -61,6 +61,8 @@ def _cache_is_fresh(cache: _PortfolioHealthSnapshot, threshold: float) -> bool:
 
 async def _compute_portfolio_health(threshold: float) -> _PortfolioHealthSnapshot:
     try:
+        # Deferred: scripts/ is outside the backend package and not present in the
+        # Lambda Docker image, so a module-level import would block Lambda startup.
         from scripts.check_portfolio_health import run_check  # noqa: PLC0415
         findings = await asyncio.to_thread(run_check, threshold)
     except Exception:  # pragma: no cover - defensive logging

--- a/backend/routes/support.py
+++ b/backend/routes/support.py
@@ -12,7 +12,6 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from backend.utils.telegram_utils import send_message
-from scripts.check_portfolio_health import run_check
 
 router = APIRouter(prefix="/support", tags=["support"])
 
@@ -62,6 +61,7 @@ def _cache_is_fresh(cache: _PortfolioHealthSnapshot, threshold: float) -> bool:
 
 async def _compute_portfolio_health(threshold: float) -> _PortfolioHealthSnapshot:
     try:
+        from scripts.check_portfolio_health import run_check  # noqa: PLC0415
         findings = await asyncio.to_thread(run_check, threshold)
     except Exception:  # pragma: no cover - defensive logging
         logger.exception(

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -184,6 +184,7 @@ class BackendLambdaStack(Stack):
             "BackendLambda",
             code=image_code,
             environment=backend_env,
+            timeout=Duration.seconds(30),
             log_retention=logs.RetentionDays.ONE_WEEK,
         )
         backend_fn.add_environment("APP_ENV", env)

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -237,6 +237,21 @@ def test_backend_lambda_has_jwt_and_google_env_vars(template):
     )
 
 
+def test_backend_lambda_timeout_is_at_least_30s(template):
+    """BackendLambda must have a timeout > the 3 s default to survive cold starts."""
+    functions = template.find_resources("AWS::Lambda::Function")
+    backend_timeouts = [
+        resource["Properties"].get("Timeout", 3)
+        for resource in functions.values()
+        if resource.get("Properties", {}).get("PackageType") == "Image"
+        and "JWT_SECRET" in resource.get("Properties", {}).get("Environment", {}).get("Variables", {})
+    ]
+    assert backend_timeouts, "BackendLambda not found in synthesised template"
+    assert all(t >= 30 for t in backend_timeouts), (
+        f"BackendLambda timeout must be >= 30 s; found {backend_timeouts}"
+    )
+
+
 def test_backend_error_alarm_exists(template):
     template.has_resource_properties(
         "AWS::CloudWatch::Alarm",

--- a/tests/routes/test_support.py
+++ b/tests/routes/test_support.py
@@ -40,7 +40,7 @@ def test_portfolio_health_suggestions(monkeypatch):
             {"message": "all good"},
         ]
 
-    monkeypatch.setattr(support, "run_check", fake_run_check)
+    monkeypatch.setattr("scripts.check_portfolio_health.run_check", fake_run_check)
 
     client = make_client()
     resp = client.post("/support/portfolio-health", json={"threshold": 0.5})
@@ -70,7 +70,7 @@ def test_portfolio_health_handles_run_check_errors(monkeypatch):
             return [{"message": "initial"}]
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(support, "run_check", fake_run_check)
+    monkeypatch.setattr("scripts.check_portfolio_health.run_check", fake_run_check)
 
     client = make_client()
 
@@ -110,7 +110,7 @@ def test_portfolio_health_initial_failure_returns_error(monkeypatch):
     def boom(threshold: float) -> list[dict]:  # pragma: no cover - signature for typing
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(support, "run_check", boom)
+    monkeypatch.setattr("scripts.check_portfolio_health.run_check", boom)
 
     client = make_client()
     resp = client.post("/support/portfolio-health", json={"threshold": 0.1})

--- a/tests/test_support_route.py
+++ b/tests/test_support_route.py
@@ -51,7 +51,7 @@ def test_portfolio_health_empty_cache(monkeypatch):
         calls.append(threshold)
         return [{"type": "owner", "message": "Owner foo max drawdown unavailable"}]
 
-    monkeypatch.setattr("backend.routes.support.run_check", fake_run_check)
+    monkeypatch.setattr("scripts.check_portfolio_health.run_check", fake_run_check)
 
     app = create_app()
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary

- **Root cause**: `COPY backend/ /var/task/` in `Dockerfile.lambda` placed the package *contents* directly into `/var/task/` with no `backend/` subdirectory. The Lambda CMD `backend.lambda_api.handler.lambda_handler` requires `import backend` to succeed, but with no `/var/task/backend/` Python raises `ModuleNotFoundError` — every invocation returned HTTP 500 before the app ever ran.
- **Fix 1 (critical)**: Change to `COPY backend /var/task/backend` so the package is importable and all `from backend.X import Y` imports inside the handler work correctly.
- **Fix 2 (safety)**: Add `timeout=Duration.seconds(30)` to `BackendLambda`; the 3-second default is too short for a Docker Lambda cold start (FastAPI init + potential S3 fallback reads).
- **Fix 3 (guard)**: Add a CDK test asserting `BackendLambda` timeout ≥ 30 s to prevent silent regression.

## Test plan

- [x] All 18 CDK unit tests pass (`pytest cdk/tests/test_backend_lambda_stack.py`)
- [ ] After deploy, `curl --fail .../docs` returns HTTP 200
- [ ] CloudWatch shows no startup errors for BackendLambda

Closes #2842