### PR TITLE
Replace Lambda logRetention with explicit CloudWatch LogGroups

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -2,7 +2,7 @@ import os
 from collections.abc import Sequence
 from pathlib import Path
 
-from aws_cdk import CfnOutput, Duration, Stack
+from aws_cdk import CfnOutput, Duration, RemovalPolicy, Stack
 from aws_cdk import aws_apigatewayv2 as apigwv2
 from aws_cdk import aws_apigatewayv2_integrations as apigwv2_integrations
 from aws_cdk import aws_budgets as budgets
@@ -20,6 +20,17 @@ from stacks.exports import BACKEND_API_URL_EXPORT
 
 class BackendLambdaStack(Stack):
     """CDK stack that builds and deploys the backend Lambda."""
+
+    @staticmethod
+    def _lambda_log_group(scope: Construct, construct_id: str) -> logs.LogGroup:
+        """Create the Lambda log group with the stack's standard retention policy."""
+
+        return logs.LogGroup(
+            scope,
+            construct_id,
+            retention=logs.RetentionDays.ONE_WEEK,
+            removal_policy=RemovalPolicy.DESTROY,
+        )
 
     @staticmethod
     def _grant_bucket_access(
@@ -184,7 +195,7 @@ class BackendLambdaStack(Stack):
             "BackendLambda",
             code=image_code,
             environment=backend_env,
-            log_retention=logs.RetentionDays.ONE_WEEK,
+            log_group=self._lambda_log_group(self, "BackendLambdaLogGroup"),
         )
         backend_fn.add_environment("APP_ENV", env)
 
@@ -238,7 +249,7 @@ class BackendLambdaStack(Stack):
             "PriceRefreshLambda",
             code=refresh_code,
             environment=refresh_env,
-            log_retention=logs.RetentionDays.ONE_WEEK,
+            log_group=self._lambda_log_group(self, "PriceRefreshLambdaLogGroup"),
         )
 
         # PriceRefreshLambda: read + put, no list
@@ -282,7 +293,7 @@ class BackendLambdaStack(Stack):
             "TradingAgentLambda",
             code=agent_code,
             environment=agent_env,
-            log_retention=logs.RetentionDays.ONE_WEEK,
+            log_group=self._lambda_log_group(self, "TradingAgentLambdaLogGroup"),
         )
 
         # TradingAgentLambda: read only, no put, no list

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -210,12 +210,36 @@ def test_all_lambda_functions_have_data_bucket_env_var(template):
 # Observability, secrets, and cost guardrails
 # ---------------------------------------------------------------------------
 
-def test_all_lambda_functions_have_one_week_log_retention(template):
-    resources = template.find_resources("Custom::LogRetention")
-    # one log retention custom resource per Lambda function
-    assert len(resources) >= 3, (
-        "Expected Custom::LogRetention resources for backend, refresh, and agent Lambdas"
-    )
+def test_all_lambda_functions_have_one_week_log_groups(template):
+    resources = template.find_resources("AWS::Logs::LogGroup")
+    lambda_log_groups = {
+        logical_id: resource
+        for logical_id, resource in resources.items()
+        if logical_id.startswith(
+            ("BackendLambdaLogGroup", "PriceRefreshLambdaLogGroup", "TradingAgentLambdaLogGroup")
+        )
+    }
+
+    assert len(lambda_log_groups) == 3
+    for logical_id, resource in lambda_log_groups.items():
+        assert resource["Properties"]["RetentionInDays"] == 7, (
+            f"Lambda log group {logical_id} must retain logs for one week"
+        )
+        assert resource["DeletionPolicy"] == "Delete", (
+            f"Lambda log group {logical_id} must be destroyed with the stack"
+        )
+
+    lambda_functions = template.find_resources("AWS::Lambda::Function")
+    image_functions = {
+        logical_id: resource
+        for logical_id, resource in lambda_functions.items()
+        if resource.get("Properties", {}).get("PackageType") == "Image"
+    }
+    for logical_id, resource in image_functions.items():
+        assert "LogGroup" in resource["Properties"].get("LoggingConfig", {}), (
+            f"Lambda function {logical_id} must use an explicit log group"
+        )
+    assert template.find_resources("Custom::LogRetention") == {}
 
 
 def test_backend_lambda_has_jwt_and_google_env_vars(template):


### PR DESCRIPTION
### Motivation

Closes #2832 
- Replace the implicit `log_retention` / `Custom::LogRetention` flow with explicit `AWS::Logs::LogGroup` resources to avoid deprecation warnings and to control removal policy and retention directly.

### Description
- Add a reusable `BackendLambdaStack._lambda_log_group(scope, construct_id)` helper that creates a `logs.LogGroup` with `retention=logs.RetentionDays.ONE_WEEK` and `removal_policy=RemovalPolicy.DESTROY`.
- Replace `log_retention=logs.RetentionDays.ONE_WEEK` with `log_group=self._lambda_log_group(self, "<Name>LogGroup")` for the `BackendLambda`, `PriceRefreshLambda`, and `TradingAgentLambda` `DockerImageFunction` constructs.
- Update CDK assertions in `cdk/tests/test_backend_lambda_stack.py` to assert three `AWS::Logs::LogGroup` resources exist, each with `RetentionInDays == 7` and `DeletionPolicy == "Delete"`, verify Lambda `LoggingConfig.LogGroup` references for image functions, and assert no `Custom::LogRetention` resources are synthesized.
- Apply formatting changes to the modified test file so it follows the repository style.

### Testing
- Ran `pytest cdk/tests -q`, which passed (33 passed). 
- Synthesised the backend stack with `cdk synth` (using `JWT_SECRET=test-secret GOOGLE_CLIENT_ID=test-client-id`) to validate the template contains the explicit `AWS::Logs::LogGroup` resources and Lambda `LoggingConfig` references, which succeeded. 
- Attempted `make lint`; it failed due to unrelated, pre-existing Ruff/formatting issues elsewhere in `backend/` and `tests/` that were not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5b161c688327ac8366d1d7650a5b)