### PR TITLE
Fix Recharts dimension warnings in GroupPortfolioView tests

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -71,6 +71,8 @@ const DAY_CHANGE_BASELINE_EPSILON = 1e-2;
 // Warn when a single holding represents more than this share of the full portfolio.
 const CONCENTRATION_THRESHOLD_PCT = 20;
 const CASH_DRAG_THRESHOLD_PCT = 5;
+const TYPE_CHART_INITIAL_DIMENSION = { width: 800, height: 240 };
+const CONTRIBUTION_CHART_INITIAL_DIMENSION = { width: 800, height: 300 };
 
 const computeDayChangePct = (value: number, delta: number): number | null => {
   if (!Number.isFinite(value) || !Number.isFinite(delta)) {
@@ -907,7 +909,13 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
 
       {typeRows.length > 0 && (
         <div style={{ width: "100%", height: 240, margin: "1rem 0" }}>
-          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
+          <ResponsiveContainer
+            width="100%"
+            height="100%"
+            minWidth={1}
+            minHeight={1}
+            initialDimension={TYPE_CHART_INITIAL_DIMENSION}
+          >
             <PieChart>
               <Pie
                 dataKey="value"
@@ -954,7 +962,13 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
               Region
             </button>
           </div>
-          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
+          <ResponsiveContainer
+            width="100%"
+            height="100%"
+            minWidth={1}
+            minHeight={1}
+            initialDimension={CONTRIBUTION_CHART_INITIAL_DIMENSION}
+          >
             <BarChart
               data={
                 contribTab === "sector"

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -125,21 +125,28 @@ const defineSize = (prop: 'offsetWidth' | 'offsetHeight', value: number) => {
 defineSize('offsetWidth', 800);
 defineSize('offsetHeight', 600);
 
-// Fallback for getBoundingClientRect to return a sensible box
-if (!HTMLElement.prototype.getBoundingClientRect) {
-  HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
-    const width = this.offsetWidth || 800;
-    const height = this.offsetHeight || 600;
-    return {
-      x: 0,
-      y: 0,
-      top: 0,
-      left: 0,
-      right: width,
-      bottom: height,
-      width,
-      height,
-      toJSON() {},
-    } as DOMRect;
-  };
-}
+// JSDOM provides getBoundingClientRect, but it always reports zero-sized
+// boxes because there is no layout engine. Keep default geometry for most
+// elements, but give Recharts ResponsiveContainer nodes deterministic boxes so
+// chart tests avoid transient 0x0 resize states without affecting virtualized
+// table measurements.
+const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
+  if (!this.classList.contains('recharts-responsive-container')) {
+    return originalGetBoundingClientRect.call(this);
+  }
+
+  const width = this.offsetWidth || 800;
+  const height = this.offsetHeight || 600;
+  return {
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    width,
+    height,
+    toJSON() {},
+  } as DOMRect;
+};


### PR DESCRIPTION
### Motivation
Closes #2844 
- Vitest/JSDOM tests were emitting Recharts warnings because `ResponsiveContainer` could observe transient zero or `-1x-1` sizes, causing noisy test output and occasional test instability. 
- The intent is to provide deterministic chart dimensions in tests without changing application runtime behavior or affecting virtualized table measurements.

### Description
- Add explicit initial dimensions `TYPE_CHART_INITIAL_DIMENSION` and `CONTRIBUTION_CHART_INITIAL_DIMENSION` and pass them to the `ResponsiveContainer` instances in `frontend/src/components/GroupPortfolioView.tsx` so Recharts has a valid initial size. 
- Update the shared test geometry shim in `frontend/src/setupTests.ts` to return deterministic non-zero `getBoundingClientRect()` values only for elements with the `recharts-responsive-container` class so chart tests avoid transient 0x0 states while preserving default geometry for other elements. 
- Keep existing `ResizeObserver` polyfill behavior but improve determinism for chart-related layout in tests. 
- Closes #2844.

### Testing
- Ran the focused tests with `npm --prefix frontend run test -- --run tests/unit/components/GroupPortfolioView.test.tsx tests/unit/components/HoldingsTable.test.tsx` and both test files passed. 
- Ran the full frontend unit suite with `npm --prefix frontend run test -- --run` and the run completed with all unit tests passing (`vitest` run). 
- Ran lint with `npm --prefix frontend run lint` and it completed with no reported warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb585c458c8327a27865153e5962d3)