### PR TITLE
Guard Recharts dimension warnings in GroupPortfolioView tests

### DIFF
--- a/frontend/tests/unit/components/GroupPortfolioView.test.tsx
+++ b/frontend/tests/unit/components/GroupPortfolioView.test.tsx
@@ -12,6 +12,16 @@ vi.mock("@/components/TopMoversSummary", () => ({
   TopMoversSummary: () => <div data-testid="top-movers-summary" />,
 }));
 
+const RECHARTS_DIMENSION_WARNING_PATTERN = /width\((?:0|-1)\)|height\((?:0|-1)\)/;
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+const hasRechartsDimensionWarning = (args: unknown[]) =>
+  args.some(
+    (arg) =>
+      typeof arg === "string" && RECHARTS_DIMENSION_WARNING_PATTERN.test(arg),
+  );
+
 beforeEach(() => {
   (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
   vi.unstubAllGlobals();
@@ -20,9 +30,14 @@ beforeEach(() => {
   vi
     .spyOn(api, "getCachedGroupInstruments")
     .mockImplementation((slug, filters) => api.getGroupInstruments(slug, filters));
+  consoleErrorSpy = vi.spyOn(console, "error");
 });
 
 afterEach(async () => {
+  const dimensionWarningCalls = consoleErrorSpy.mock.calls.filter(
+    hasRechartsDimensionWarning,
+  );
+  expect(dimensionWarningCalls).toEqual([]);
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   api.clearGroupInstrumentCache();

--- a/frontend/tests/unit/components/GroupPortfolioView.test.tsx
+++ b/frontend/tests/unit/components/GroupPortfolioView.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/components/TopMoversSummary", () => ({
 const RECHARTS_DIMENSION_WARNING_PATTERN = /width\((?:0|-1)\)|height\((?:0|-1)\)/;
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 
 const hasRechartsDimensionWarning = (args: unknown[]) =>
   args.some(
@@ -31,6 +32,7 @@ beforeEach(() => {
     .spyOn(api, "getCachedGroupInstruments")
     .mockImplementation((slug, filters) => api.getGroupInstruments(slug, filters));
   consoleErrorSpy = vi.spyOn(console, "error");
+  consoleWarnSpy = vi.spyOn(console, "warn");
 });
 
 afterEach(async () => {
@@ -38,6 +40,10 @@ afterEach(async () => {
     hasRechartsDimensionWarning,
   );
   expect(dimensionWarningCalls).toEqual([]);
+  const dimensionWarnCalls = consoleWarnSpy.mock.calls.filter(
+    hasRechartsDimensionWarning,
+  );
+  expect(dimensionWarnCalls).toEqual([]);
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   api.clearGroupInstrumentCache();


### PR DESCRIPTION
### Motivation
- Prevent regressions where Recharts emits console errors about invalid chart dimensions (e.g. `width(0)`, `height(-1)`) during unit tests and ensure those warnings are caught as test failures.
- Make the `GroupPortfolioView` test suite explicitly assert that no Recharts dimension warnings were emitted so CI surfaces layout-related issues early.

### Description
- Added a `RECHARTS_DIMENSION_WARNING_PATTERN` regex and `hasRechartsDimensionWarning` helper to `frontend/tests/unit/components/GroupPortfolioView.test.tsx` to detect known Recharts dimension messages.
- Installed a `console.error` spy (`consoleErrorSpy`) in `beforeEach` and asserted in `afterEach` that no matching Recharts dimension warnings were logged.
- These changes add a small test-safety guard without altering application code and close the linked issue (`Closes #2852`).

### Testing
- Ran `npm --prefix frontend run test -- --run GroupPortfolioView.test.tsx` and the file tests passed (37 tests, all passing). 
- Ran the full frontend test suite with `npm --prefix frontend run test -- --run` and all tests passed (79 files, 434 tests passed).
- Ran `npm --prefix frontend run lint` and the linter completed with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4d2fe03483278b009334aef0a59c)