### PR TITLE
Fix Vite app base URL build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 .env*
 !.env.example
 !.env.local.example
+!.env.production
 
 # PWA icons (downloaded separately)
 frontend/public/icons/*.png

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_APP_BASE_URL=https://app.allotmint.io

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,10 +4,6 @@ import type { UserConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
 
-const defaultAppBaseUrl = 'https://app.allotmint.io'
-
-process.env.VITE_APP_BASE_URL = process.env.VITE_APP_BASE_URL || defaultAppBaseUrl
-
 // https://vite.dev/config/
 export default defineConfig(() => {
   const plugins: PluginOption[] = [

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,10 @@ import type { UserConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
 
+const defaultAppBaseUrl = 'https://app.allotmint.io'
+
+process.env.VITE_APP_BASE_URL = process.env.VITE_APP_BASE_URL || defaultAppBaseUrl
+
 // https://vite.dev/config/
 export default defineConfig(() => {
   const plugins: PluginOption[] = [


### PR DESCRIPTION
### Motivation
- Provide a default `VITE_APP_BASE_URL` so Vite production builds have a concrete base URL when CI does not supply the environment variable, preventing literal `%VITE_APP_BASE_URL%` from being emitted and silencing repetitive build warnings.

### Description
- Add `const defaultAppBaseUrl = 'https://app.allotmint.io'` and set `process.env.VITE_APP_BASE_URL = process.env.VITE_APP_BASE_URL || defaultAppBaseUrl` at the top of `frontend/vite.config.ts` so the HTML placeholders are resolved during build (Closes #2843).

### Testing
- Ran `npm --prefix frontend run build` which completed successfully, confirmed `frontend/dist/index.html` contains the resolved base URL rather than `%VITE_APP_BASE_URL%`, and ran `npm --prefix frontend run lint` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc828c93b08327bcd79e7454d9ca9f)