### PR TITLE
Migrate Watchlist test to import act from react

### DIFF
--- a/frontend/tests/unit/pages/Watchlist.test.tsx
+++ b/frontend/tests/unit/pages/Watchlist.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/api", () => ({


### PR DESCRIPTION
### Motivation
- Replace the deprecated `act` import from `react-dom/test-utils` with `act` from `react` to eliminate deprecation warnings and follow current React testing guidance.

Closes #2831 

### Description
- Updated `frontend/tests/unit/pages/Watchlist.test.tsx` to use `import { act } from "react";` instead of `import { act } from "react-dom/test-utils";` and this change addresses the issue `Closes #2831`.

### Testing
- Ran `npm --prefix frontend run test -- --run tests/unit/pages/Watchlist.test.tsx` which executed the test file and all 6 tests passed.
- Ran `npm --prefix frontend run lint` which completed with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8261900483278848a2328e6d45db)