### PR TITLE
Fix frontend act warnings in Goals and Watchlist tests

### DIFF
--- a/frontend/tests/unit/pages/Goals.test.tsx
+++ b/frontend/tests/unit/pages/Goals.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import i18n from "@/i18n";
@@ -19,21 +19,26 @@ vi.mock("@/api", async () => {
 });
 
 beforeEach(() => {
-  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
   vi.clearAllMocks();
   mockGetGoals.mockResolvedValue([]);
 });
 
 describe("Goals page", () => {
   it("renders translated strings", async () => {
-    i18n.changeLanguage("fr");
-    render(<Goals />, { wrapper: MemoryRouter });
+    await act(async () => {
+      await i18n.changeLanguage("fr");
+    });
+    const { unmount } = render(<Goals />, { wrapper: MemoryRouter });
     expect(
       await screen.findByRole("heading", { name: "Objectifs" })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Ajouter un objectif" })
     ).toBeInTheDocument();
-    i18n.changeLanguage("en");
+    await waitFor(() => expect(mockGetGoals).toHaveBeenCalledTimes(1));
+    unmount();
+    await act(async () => {
+      await i18n.changeLanguage("en");
+    });
   });
 });

--- a/frontend/tests/unit/pages/Watchlist.test.tsx
+++ b/frontend/tests/unit/pages/Watchlist.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/api", () => ({


### PR DESCRIPTION
### Motivation
- Remove spurious React `act()` warnings observed in unit tests (issue #2830) by making async test interactions explicit and using the recommended `act` API.

### Description
- Updated `frontend/tests/unit/pages/Goals.test.tsx` to wrap i18n locale changes in `act()`, wait for the `getGoals` effect to settle with `waitFor()`, and unmount before restoring the locale to avoid pending async updates.
- Replaced the deprecated `react-dom/test-utils` `act` import in `frontend/tests/unit/pages/Watchlist.test.tsx` with the `act` export from `react`.
- Changes are limited to test files and make no runtime code changes (tests only). Closes #2830.

### Testing
- Ran frontend linter with `npm --prefix frontend run lint` which completed successfully.
- Ran targeted tests with `npm --prefix frontend run test -- --run tests/unit/pages/Goals.test.tsx tests/unit/pages/Watchlist.test.tsx` which passed.
- Ran the full frontend unit suite with `npm --prefix frontend run test -- --run` and observed all tests passing (`79` test files, `434` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc823d7e8c8327a5ea542d9ed5637f)