### PR TITLE
Mock runtime config fetch in frontend tests

### DIFF
--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -8,6 +8,28 @@ import { cleanup } from '@testing-library/react';
 import { toHaveNoViolations } from 'jest-axe';
 expect.extend(toHaveNoViolations);
 
+// Vitest does not serve public/config.json, so intercept only the runtime
+// config asset request and let all API requests continue through the real fetch.
+const nativeFetch = globalThis.fetch.bind(globalThis);
+
+const isRuntimeConfigRequest = (input: RequestInfo | URL) => {
+  if (typeof input === 'string') return input === '/config.json';
+  if (input instanceof URL) return input.pathname === '/config.json';
+
+  return input.url.endsWith('/config.json');
+};
+
+const createRuntimeConfigResponse = () =>
+  new Response(null, { status: 404 });
+
+globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+  if (isRuntimeConfigRequest(input)) {
+    return Promise.resolve(createRuntimeConfigResponse());
+  }
+
+  return nativeFetch(input, init);
+}) as typeof fetch;
+
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return {


### PR DESCRIPTION
### Motivation
- Vitest does not serve `public/config.json`, causing `TypeError: Failed to parse URL from /config.json` when the app bootstrap fetches runtime config during tests, so tests need a small shim to avoid native-fetch URL parsing errors.

### Description
- Add a targeted fetch interceptor in `frontend/src/setupTests.ts` that returns a 404-like `Response` for requests to `/config.json` and delegates all other requests to the real `fetch`, preserving the app's default API-base fallback and test API behavior (Closes #2829).

### Testing
- Ran `npm --prefix frontend run lint` which completed successfully with no lint errors. 
- Ran `npm --prefix frontend run test -- --run` and the Vitest unit suite completed successfully (all unit tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc822c6bac8327afb499a74b15c4e4)