### PR TITLE
Remove dead getBoundingClientRect size fallbacks

### DIFF
--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -136,8 +136,8 @@ HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
     return originalGetBoundingClientRect.call(this);
   }
 
-  const width = this.offsetWidth || 800;
-  const height = this.offsetHeight || 600;
+  const width = this.offsetWidth;
+  const height = this.offsetHeight;
   return {
     x: 0,
     y: 0,


### PR DESCRIPTION
### Motivation
- Remove the unreachable `|| 800` / `|| 600` fallbacks from the Recharts `getBoundingClientRect` test shim because `defineSize` already stamps deterministic `offsetWidth`/`offsetHeight` values.

### Description
- Replace `const width = this.offsetWidth || 800; const height = this.offsetHeight || 600;` with `const width = this.offsetWidth; const height = this.offsetHeight;` in `frontend/src/setupTests.ts`, preserving behavior and closing the issue (Closes #2851).

### Testing
- Ran frontend unit tests with `npm --prefix frontend run test -- --run`, which completed successfully with 79 files / 434 tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcce6c2a7c8327a370fde3869e6d85)