### PR TITLE
Expose CDK-managed Lambda log group names and update docs

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -190,12 +190,13 @@ class BackendLambdaStack(Stack):
         if data_repo:
             backend_env["DATA_REPO"] = data_repo
 
+        backend_log_group = self._lambda_log_group(self, "BackendLambdaLogGroup")
         backend_fn = _lambda.DockerImageFunction(
             self,
             "BackendLambda",
             code=image_code,
             environment=backend_env,
-            log_group=self._lambda_log_group(self, "BackendLambdaLogGroup"),
+            log_group=backend_log_group,
             timeout=Duration.seconds(30),
         )
         backend_fn.add_environment("APP_ENV", env)
@@ -245,12 +246,13 @@ class BackendLambdaStack(Stack):
         if data_repo:
             refresh_env["DATA_REPO"] = data_repo
 
+        refresh_log_group = self._lambda_log_group(self, "PriceRefreshLambdaLogGroup")
         refresh_fn = _lambda.DockerImageFunction(
             self,
             "PriceRefreshLambda",
             code=refresh_code,
             environment=refresh_env,
-            log_group=self._lambda_log_group(self, "PriceRefreshLambdaLogGroup"),
+            log_group=refresh_log_group,
         )
 
         # PriceRefreshLambda: read + put, no list
@@ -289,12 +291,13 @@ class BackendLambdaStack(Stack):
         if data_repo:
             agent_env["DATA_REPO"] = data_repo
 
+        agent_log_group = self._lambda_log_group(self, "TradingAgentLambdaLogGroup")
         agent_fn = _lambda.DockerImageFunction(
             self,
             "TradingAgentLambda",
             code=agent_code,
             environment=agent_env,
-            log_group=self._lambda_log_group(self, "TradingAgentLambdaLogGroup"),
+            log_group=agent_log_group,
         )
 
         # TradingAgentLambda: read only, no put, no list
@@ -369,4 +372,7 @@ class BackendLambdaStack(Stack):
             export_name=BACKEND_API_URL_EXPORT,
         )
         CfnOutput(self, "DataBucketName", value=data_bucket.bucket_name)
+        CfnOutput(self, "BackendLambdaLogGroupName", value=backend_log_group.log_group_name)
+        CfnOutput(self, "PriceRefreshLambdaLogGroupName", value=refresh_log_group.log_group_name)
+        CfnOutput(self, "TradingAgentLambdaLogGroupName", value=agent_log_group.log_group_name)
         CfnOutput(self, "BackendLambdaErrorAlarmName", value=backend_error_alarm.alarm_name)

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 aws_cdk = pytest.importorskip("aws_cdk", reason="aws-cdk-lib not installed")
 
 from aws_cdk import App, assertions  # noqa: E402
+
 from cdk.stacks.backend_lambda_stack import BackendLambdaStack  # noqa: E402
 from cdk.stacks.exports import BACKEND_API_URL_EXPORT  # noqa: E402  # stable name guard
 
@@ -268,7 +269,8 @@ def test_backend_lambda_timeout_is_at_least_30s(template):
         resource["Properties"].get("Timeout", 3)
         for resource in functions.values()
         if resource.get("Properties", {}).get("PackageType") == "Image"
-        and "JWT_SECRET" in resource.get("Properties", {}).get("Environment", {}).get("Variables", {})
+        and "JWT_SECRET"
+        in resource.get("Properties", {}).get("Environment", {}).get("Variables", {})
     ]
     assert backend_timeouts, "BackendLambda not found in synthesised template"
     assert all(t >= 30 for t in backend_timeouts), (
@@ -324,6 +326,15 @@ def test_backend_api_url_output_has_stable_export_name(template):
 
 def test_data_bucket_name_output_exists(template):
     template.has_output("DataBucketName", {})
+
+
+def test_lambda_log_group_name_outputs_exist(template):
+    for output_name in (
+        "BackendLambdaLogGroupName",
+        "PriceRefreshLambdaLogGroupName",
+        "TradingAgentLambdaLogGroupName",
+    ):
+        template.has_output(output_name, {})
 
 
 def test_backend_lambda_error_alarm_output_exists(template):

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -206,13 +206,18 @@ If deployment fails or the live environment does not match local behavior:
 
 1. Re-run `npx cdk diff --all` and confirm intended stack changes are present.
 2. Run `npx cdk deploy --all --require-approval never` and capture the exact failing resource from CloudFormation events.
-3. Inspect backend Lambda errors (CloudWatch):
+3. Inspect backend Lambda errors (CloudWatch). Lambda functions in this stack use
+   explicit CDK-managed log groups, so read the deployed log group name from the
+   stack outputs instead of assuming the `/aws/lambda/<function-name>` convention:
 
    ```bash
-   aws cloudformation list-stack-resources --stack-name BackendLambdaStack \
-     --query "StackResourceSummaries[?ResourceType=='AWS::Lambda::Function' && starts_with(LogicalResourceId, 'BackendLambda')].PhysicalResourceId | [0]" --output text
-   aws logs tail /aws/lambda/<BackendLambdaPhysicalName> --since 30m --follow
+   BACKEND_LOG_GROUP=$(aws cloudformation describe-stacks --stack-name BackendLambdaStack \
+     --query "Stacks[0].Outputs[?OutputKey=='BackendLambdaLogGroupName'].OutputValue" --output text)
+   aws logs tail "$BACKEND_LOG_GROUP" --since 30m --follow
    ```
+
+   The scheduled Lambdas expose the same discoverability outputs as
+   `PriceRefreshLambdaLogGroupName` and `TradingAgentLambdaLogGroupName`.
 
 4. Validate API Gateway connectivity with the `BackendApiUrl` output:
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -4,7 +4,10 @@
 
 - Backend uses Python's `logging` module. The main configuration lives in `backend/logging.ini`.
 - A minimal top-level `logging.ini` only overrides noisy third-party loggers such as `yfinance`.
-- When deployed on AWS Lambda, logs are available in CloudWatch log groups named `/aws/lambda/<FunctionName>`.
+- When deployed on AWS Lambda, logs are written to explicit CDK-managed CloudWatch log groups.
+  Discover the deployed names from the `BackendLambdaStack` outputs:
+  `BackendLambdaLogGroupName`, `PriceRefreshLambdaLogGroupName`, and
+  `TradingAgentLambdaLogGroupName`.
 - Local runs print logs to the console.
 
 ## Dashboards


### PR DESCRIPTION
### Motivation
- Operators cannot reliably assume the `/aws/lambda/<FunctionName>` CloudWatch naming convention because this stack creates explicit CDK-managed log groups, so the deployed log group names must be discoverable.
Closes #2850 
### Description
- Create and reuse explicit log group constructs for `BackendLambda`, `PriceRefreshLambda`, and `TradingAgentLambda` and pass them into each `DockerImageFunction` instead of recreating them inline.
- Emit three new CloudFormation stack outputs: `BackendLambdaLogGroupName`, `PriceRefreshLambdaLogGroupName`, and `TradingAgentLambdaLogGroupName` so operators can discover the deployed log group names.
- Update `docs/DEPLOY.md` and `docs/OBSERVABILITY.md` to document reading the log group names from stack outputs and tailing logs with `aws logs tail` rather than assuming `/aws/lambda/<function-name>`.
- Add a CDK assertion test `test_lambda_log_group_name_outputs_exist` to `cdk/tests/test_backend_lambda_stack.py` that verifies the three new outputs exist.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest cdk/tests/test_backend_lambda_stack.py -q`, which succeeded with `19 passed`.
- Ran formatting and lint checks including `python -m black` and `python -m ruff check`, with no remaining issues after fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcce5045048327acda15cfd7998d2a)