### PR TITLE
Fix InstrumentResearch fetch test isolation

### DIFF
--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -437,7 +437,6 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
         }
       } catch (err) {
         if (cancelled) return;
-        console.error(err);
         const baseMessage = t("instrumentDetail.metadataLoadError");
         const extra = err instanceof Error ? err.message : String(err);
         setMetadataStatus({ kind: "error", text: `${baseMessage} ${extra}` });
@@ -502,7 +501,6 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
       setIsEditingMetadata(true);
       setMetadataStatus(null);
     } catch (err) {
-      console.error(err);
       const message = err instanceof Error ? err.message : String(err);
       setRefreshError(`${t("instrumentDetail.refreshError")} ${message}`);
     } finally {
@@ -553,7 +551,6 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
       }
       setMetadataStatus({ kind: "success", text: t("instrumentDetail.refreshSuccess") });
     } catch (err) {
-      console.error(err);
       const message = err instanceof Error ? err.message : String(err);
       setRefreshError(`${t("instrumentDetail.refreshError")} ${message}`);
     } finally {
@@ -649,7 +646,6 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
       }
       setMetadataStatus({ kind: "success", text: t("instrumentDetail.metadataSaveSuccess") });
     } catch (err) {
-      console.error(err);
       const baseMessage = t("instrumentDetail.metadataSaveError");
       const extra = err instanceof Error ? err.message : String(err);
       setMetadataStatus({ kind: "error", text: `${baseMessage} ${extra}` });
@@ -673,7 +669,6 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
         if (error?.name === "AbortError") {
           return;
         }
-        console.error(err);
         setNews([]);
         setNewsError(err instanceof Error ? err.message : String(err));
       } finally {
@@ -721,7 +716,6 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
       } catch (err) {
         const error = err as { name?: string } | null | undefined;
         if (error?.name === "AbortError") return;
-        console.error(err);
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err);
           setFundamentalsError(`Unable to load fundamentals: ${message}`);

--- a/frontend/tests/unit/pages/InstrumentResearch.test.tsx
+++ b/frontend/tests/unit/pages/InstrumentResearch.test.tsx
@@ -4,6 +4,17 @@ vi.mock("@/hooks/useInstrumentHistory", () => ({
   getCachedInstrumentHistory: vi.fn(() => null),
   updateCachedInstrumentHistory: vi.fn(),
 }));
+
+vi.mock("@/api", () => ({
+  getNews: vi.fn(),
+  listInstrumentMetadata: vi.fn(),
+  updateInstrumentMetadata: vi.fn(),
+  refreshInstrumentMetadata: vi.fn(),
+  confirmInstrumentMetadata: vi.fn(),
+  getScreener: vi.fn(),
+  getInstrumentDetail: vi.fn(),
+  getInstrumentIntraday: vi.fn(),
+}));
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
@@ -13,12 +24,14 @@ import { useInstrumentHistory } from "@/hooks/useInstrumentHistory";
 import * as api from "@/api";
 import { configContext, type ConfigContextValue } from "@/ConfigContext";
 
-const mockGetNews = vi.spyOn(api, "getNews");
-const mockListInstrumentMetadata = vi.spyOn(api, "listInstrumentMetadata");
-const mockUpdateInstrumentMetadata = vi.spyOn(api, "updateInstrumentMetadata");
-const mockRefreshInstrumentMetadata = vi.spyOn(api, "refreshInstrumentMetadata");
-const mockConfirmInstrumentMetadata = vi.spyOn(api, "confirmInstrumentMetadata");
-const mockGetScreener = vi.spyOn(api, "getScreener");
+const mockGetNews = vi.mocked(api.getNews);
+const mockListInstrumentMetadata = vi.mocked(api.listInstrumentMetadata);
+const mockUpdateInstrumentMetadata = vi.mocked(api.updateInstrumentMetadata);
+const mockRefreshInstrumentMetadata = vi.mocked(api.refreshInstrumentMetadata);
+const mockConfirmInstrumentMetadata = vi.mocked(api.confirmInstrumentMetadata);
+const mockGetScreener = vi.mocked(api.getScreener);
+const mockGetInstrumentDetail = vi.mocked(api.getInstrumentDetail);
+const mockGetInstrumentIntraday = vi.mocked(api.getInstrumentIntraday);
 const mockUseInstrumentHistory = vi.mocked(useInstrumentHistory);
 
 const defaultConfig: ConfigContextValue = {
@@ -100,8 +113,19 @@ describe("InstrumentResearch page", () => {
     mockRefreshInstrumentMetadata.mockReset();
     mockConfirmInstrumentMetadata.mockReset();
     mockGetScreener.mockReset();
+    mockGetInstrumentDetail.mockReset();
+    mockGetInstrumentIntraday.mockReset();
     mockGetNews.mockReset();
     mockGetNews.mockResolvedValue([]);
+    mockGetInstrumentDetail.mockResolvedValue({
+      prices: [
+        { date: "2024-01-01", close_gbp: 100 },
+        { date: "2024-01-02", close_gbp: 101 },
+      ],
+      positions: [],
+      currency: "GBP",
+    } as any);
+    mockGetInstrumentIntraday.mockResolvedValue({ prices: [] });
     mockRefreshInstrumentMetadata.mockResolvedValue({
       status: "preview",
       metadata: {


### PR DESCRIPTION
### Motivation
- InstrumentResearch unit tests were brittle and noisy because child components could fall through to real `@/api` helpers (e.g. `getInstrumentDetail`) and handled error paths emitted raw `console.error` output.
- Reduce CI/test noise and make the suite deterministic by fully isolating external fetches and avoiding logging of expected, handled failures.

### Description
- Add a dedicated `vi.mock("@/api", ...)` block in `frontend/tests/unit/pages/InstrumentResearch.test.tsx` supplying mocks for `getNews`, `listInstrumentMetadata`, `updateInstrumentMetadata`, `refreshInstrumentMetadata`, `confirmInstrumentMetadata`, `getScreener`, `getInstrumentDetail`, and `getInstrumentIntraday` so child fetches cannot fall through to real implementations.
- Replace `vi.spyOn(api, ...)` usage with typed `vi.mocked(api.<fn>)` references and reset/default each mocked fetch in `beforeEach`, including deterministic detail/intraday responses used by the page and child components.
- Remove several `console.error(err)` calls from handled error branches in `frontend/src/pages/InstrumentResearch.tsx` to avoid emitting expected error stacks during tests.
- Files changed: `frontend/tests/unit/pages/InstrumentResearch.test.tsx`, `frontend/src/pages/InstrumentResearch.tsx`.

### Testing
- Ran `npm --prefix frontend run test -- --run tests/unit/pages/InstrumentResearch.test.tsx` and the file's tests passed (20/20).
- Ran `npm --prefix frontend run lint` with no lint failures reported.
- Attempted `PYENV_VERSION=3.11.15 python -m pytest tests/ -k "InstrumentResearch"` but the local Python environment is missing the `yaml` package so pytest could not be completed.

Closes #2828

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcce37a0548327a53f9c1605845640)