### PR TITLE
Annotate JSDOM chart dimension workarounds

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -71,6 +71,7 @@ const DAY_CHANGE_BASELINE_EPSILON = 1e-2;
 // Warn when a single holding represents more than this share of the full portfolio.
 const CONCENTRATION_THRESHOLD_PCT = 20;
 const CASH_DRAG_THRESHOLD_PCT = 5;
+// JSDOM has no layout engine; these give Recharts a non-zero initial size in tests.
 const TYPE_CHART_INITIAL_DIMENSION = { width: 800, height: 240 };
 const CONTRIBUTION_CHART_INITIAL_DIMENSION = { width: 800, height: 300 };
 


### PR DESCRIPTION
### Motivation
- Clarify that the hardcoded Recharts initial sizes in `GroupPortfolioView.tsx` are test/JSDOM workarounds rather than business-logic values.
Closes #2853 

### Description
- Add an inline comment above `TYPE_CHART_INITIAL_DIMENSION` in `frontend/src/components/GroupPortfolioView.tsx` explaining that JSDOM has no layout engine and these fixed dimensions give Recharts a non-zero initial size for tests.

### Testing
- Ran `npm --prefix frontend run lint` and `npm --prefix frontend run test -- --run`; the lint step and the frontend unit test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd92c7d648327a407ae91b23b149d)