### PR TITLE
fix: replace short JWT test key to suppress InsecureKeyLengthWarning

### DIFF
--- a/tests/backend/test_auth_module.py
+++ b/tests/backend/test_auth_module.py
@@ -175,5 +175,5 @@ def test_missing_jwt_secret_raises_error(monkeypatch):
     monkeypatch.setattr(auth.config, "disable_auth", False)
     with pytest.raises(RuntimeError):
         importlib.reload(auth)
-    monkeypatch.setenv("JWT_SECRET", "restored")
+    monkeypatch.setenv("JWT_SECRET", "a-restored-test-secret-that-is-at-least-32-bytes")
     importlib.reload(auth)


### PR DESCRIPTION
## Summary

- Replaces the 8-byte `"restored"` string used in `tests/backend/test_auth_module.py` with a 48-char string that meets PyJWT's 32-byte minimum for HS256 (RFC 7518 §3.2)
- Eliminates `InsecureKeyLengthWarning` emitted on every test run when the module is reloaded after the missing-secret error path test

## Test plan

- [ ] Run `pytest tests/backend/test_auth_module.py` — no `InsecureKeyLengthWarning` warnings
- [ ] Run full `pytest` suite — all tests pass

Closes #2811