### PR TITLE
Add Lambda integration expected response fixtures and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,26 @@ local-up:
 
 local-down:
 	docker compose -f docker-compose.local.yml --env-file .env.local down --remove-orphans
+
+PYTHON ?= python3
+LAMBDA_INTEGRATION_DIR := tests/integration
+LAMBDA_ACTUAL_DIR := $(LAMBDA_INTEGRATION_DIR)/actual
+
+.PHONY: lambda-test lambda-test-api lambda-test-price-refresh lambda-test-trading-agent
+
+lambda-test: lambda-test-api lambda-test-price-refresh lambda-test-trading-agent
+
+lambda-test-api:
+	mkdir -p $(LAMBDA_ACTUAL_DIR)
+	$(PYTHON) -m tests.integration.invoke_lambda api-http $(LAMBDA_INTEGRATION_DIR)/payloads/api_http_event.json > $(LAMBDA_ACTUAL_DIR)/api_http_response.json
+	jq -e --slurpfile expected $(LAMBDA_INTEGRATION_DIR)/expected/api_http_response.json '.statusCode == $$expected[0].statusCode' $(LAMBDA_ACTUAL_DIR)/api_http_response.json
+
+lambda-test-price-refresh:
+	mkdir -p $(LAMBDA_ACTUAL_DIR)
+	$(PYTHON) -m tests.integration.invoke_lambda price-refresh $(LAMBDA_INTEGRATION_DIR)/payloads/price_refresh_event.json > $(LAMBDA_ACTUAL_DIR)/price_refresh_response.json
+	jq -e --slurpfile expected $(LAMBDA_INTEGRATION_DIR)/expected/price_refresh_response.json '.statusCode == $$expected[0].statusCode' $(LAMBDA_ACTUAL_DIR)/price_refresh_response.json
+
+lambda-test-trading-agent:
+	mkdir -p $(LAMBDA_ACTUAL_DIR)
+	$(PYTHON) -m tests.integration.invoke_lambda trading-agent $(LAMBDA_INTEGRATION_DIR)/payloads/trading_agent_event.json > $(LAMBDA_ACTUAL_DIR)/trading_agent_response.json
+	jq -e --slurpfile expected $(LAMBDA_INTEGRATION_DIR)/expected/trading_agent_response.json '.statusCode == $$expected[0].statusCode' $(LAMBDA_ACTUAL_DIR)/trading_agent_response.json

--- a/Makefile
+++ b/Makefile
@@ -27,18 +27,19 @@ lambda-test: lambda-test-api lambda-test-price-refresh lambda-test-trading-agent
 lambda-test-api:
 	mkdir -p $(LAMBDA_ACTUAL_DIR)
 	$(PYTHON) -m tests.integration.invoke_lambda api-http $(LAMBDA_INTEGRATION_DIR)/payloads/api_http_event.json > $(LAMBDA_ACTUAL_DIR)/api_http_response.json
-	jq -e --slurpfile expected $(LAMBDA_INTEGRATION_DIR)/expected/api_http_response.json '.statusCode == $$expected[0].statusCode' $(LAMBDA_ACTUAL_DIR)/api_http_response.json
+	jq -e --slurpfile expected $(LAMBDA_INTEGRATION_DIR)/expected/api_http_response.json '. == $$expected[0]' $(LAMBDA_ACTUAL_DIR)/api_http_response.json
 
 lambda-test-price-refresh:
 	mkdir -p $(LAMBDA_ACTUAL_DIR)
 	$(PYTHON) -m tests.integration.invoke_lambda price-refresh $(LAMBDA_INTEGRATION_DIR)/payloads/price_refresh_event.json > $(LAMBDA_ACTUAL_DIR)/price_refresh_response.json
-	jq -e --slurpfile expected $(LAMBDA_INTEGRATION_DIR)/expected/price_refresh_response.json '.statusCode == $$expected[0].statusCode' $(LAMBDA_ACTUAL_DIR)/price_refresh_response.json
+	jq -e --slurpfile expected $(LAMBDA_INTEGRATION_DIR)/expected/price_refresh_response.json '. == $$expected[0]' $(LAMBDA_ACTUAL_DIR)/price_refresh_response.json
 
 lambda-test-trading-agent:
 	mkdir -p $(LAMBDA_ACTUAL_DIR)
 	$(PYTHON) -m tests.integration.invoke_lambda trading-agent $(LAMBDA_INTEGRATION_DIR)/payloads/trading_agent_event.json > $(LAMBDA_ACTUAL_DIR)/trading_agent_response.json
-	jq -e --slurpfile expected $(LAMBDA_INTEGRATION_DIR)/expected/trading_agent_response.json '.statusCode == $$expected[0].statusCode' $(LAMBDA_ACTUAL_DIR)/trading_agent_response.json
-# ── Local Lambda test harness ──────────────────────────────────────────────
+	jq -e --slurpfile expected $(LAMBDA_INTEGRATION_DIR)/expected/trading_agent_response.json '. == $$expected[0]' $(LAMBDA_ACTUAL_DIR)/trading_agent_response.json
+
+# ── Local Lambda test harness (Docker) ────────────────────────────────────
 # Requires Docker. Copy .env.lambda.example to .env.lambda before first use.
 
 lambda-up:
@@ -46,11 +47,6 @@ lambda-up:
 
 lambda-down:
 	docker compose -f docker-compose.lambda.yml --env-file .env.lambda down --remove-orphans
-
-lambda-test:
-	curl -s -XPOST "http://localhost:9010/2015-03-31/functions/function/invocations" \
-		-H "Content-Type: application/json" \
-		-d @tests/integration/payloads/api_http_event.json | python -m json.tool
 
 lambda-test-price:
 	curl -s -XPOST "http://localhost:9011/2015-03-31/functions/function/invocations" \

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -3,19 +3,20 @@
 This directory contains local fixtures for the Lambda invocation smoke harness.
 The Makefile targets invoke each handler with a representative payload, write the
 actual response under `tests/integration/actual/`, and use `jq` to assert the
-response `statusCode` against the matching expected-response fixture.
+full response against the matching expected-response fixture.
 
 ## Directory layout
 
 - `payloads/api_http_event.json` — API Gateway HTTP API v2 request for `GET /health`.
 - `payloads/price_refresh_event.json` — EventBridge scheduled event for the price-refresh Lambda.
 - `payloads/trading_agent_event.json` — EventBridge scheduled event for the trading-agent Lambda.
+- `payloads/scheduled_event.json` — Generic EventBridge event used by the Docker-based curl targets.
 - `expected/api_http_response.json` — Expected response shape for the HTTP API health check.
 - `expected/price_refresh_response.json` — Expected response shape for the price-refresh scheduled invocation.
 - `expected/trading_agent_response.json` — Expected response shape for the trading-agent scheduled invocation.
 - `invoke_lambda.py` — Deterministic local invocation helper used by `make lambda-test*`.
 
-## Running the checks
+## Running the checks (Python-based, no Docker required)
 
 Run all Lambda fixture checks:
 
@@ -36,6 +37,13 @@ The EventBridge handlers are normalized to a small Lambda-style envelope with a
 price refresh and trading-agent side effects so these checks remain deterministic
 and do not require public network access, AWS, or writable production data.
 
+## Running the checks (Docker-based)
+
+The older `make lambda-test-price` and `make lambda-test-trading` targets invoke
+the handlers via `curl` against locally running Docker containers. Start the harness
+first with `make lambda-up`, then use those targets. These targets do **not** assert
+response shape — they print the raw handler output for manual inspection.
+
 ## Updating expected responses
 
 When a handler intentionally changes its successful response contract:
@@ -44,40 +52,9 @@ When a handler intentionally changes its successful response contract:
    file under `tests/integration/actual/`.
 2. Inspect the generated response and verify the changed shape is intentional.
 3. Copy the actual response over the matching file in `tests/integration/expected/`.
-4. Re-run `make lambda-test` and confirm each `jq` status-code assertion passes.
+4. Re-run `make lambda-test` and confirm each `jq` assertion passes.
 
 Keep the expected files focused on stable response shape. Avoid adding volatile
-values unless the harness stubs them to deterministic values.
-# Integration test payloads
-
-Sample event payloads for invoking Lambda handlers via the local Docker test harness.
-
-| File | Handler | Description |
-|---|---|---|
-| `payloads/api_http_event.json` | `lambda-api` (port 9010) | HTTP API Gateway v2 `GET /health` request |
-| `payloads/scheduled_event.json` | `lambda-price-refresh` (port 9011), `lambda-trading-agent` (port 9012) | EventBridge scheduled event |
-
-## Usage
-
-Start the harness first, then use the `make lambda-test*` targets or invoke directly:
-
-```bash
-# Start all services
-make lambda-up
-
-# Invoke via make targets
-make lambda-test           # API handler  -> GET /health
-make lambda-test-price     # price-refresh handler
-make lambda-test-trading   # trading-agent handler
-
-# Or invoke directly with curl
-curl -s -XPOST "http://localhost:9010/2015-03-31/functions/function/invocations" \
-    -H "Content-Type: application/json" \
-    -d @tests/integration/payloads/api_http_event.json | python -m json.tool
-
-# Tear down
-make lambda-down
-```
-
-To add a new payload, drop a `.json` file in `payloads/` and invoke the
-relevant handler port directly with `curl`.
+values unless the harness stubs them to deterministic values. Note that
+`_eventbridge_response` serialises handler results with `sort_keys=True`, so
+expected fixture keys must be in alphabetical order.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,50 @@
+# Lambda integration fixtures
+
+This directory contains local fixtures for the Lambda invocation smoke harness.
+The Makefile targets invoke each handler with a representative payload, write the
+actual response under `tests/integration/actual/`, and use `jq` to assert the
+response `statusCode` against the matching expected-response fixture.
+
+## Directory layout
+
+- `payloads/api_http_event.json` — API Gateway HTTP API v2 request for `GET /health`.
+- `payloads/price_refresh_event.json` — EventBridge scheduled event for the price-refresh Lambda.
+- `payloads/trading_agent_event.json` — EventBridge scheduled event for the trading-agent Lambda.
+- `expected/api_http_response.json` — Expected response shape for the HTTP API health check.
+- `expected/price_refresh_response.json` — Expected response shape for the price-refresh scheduled invocation.
+- `expected/trading_agent_response.json` — Expected response shape for the trading-agent scheduled invocation.
+- `invoke_lambda.py` — Deterministic local invocation helper used by `make lambda-test*`.
+
+## Running the checks
+
+Run all Lambda fixture checks:
+
+```bash
+make lambda-test
+```
+
+Run an individual check:
+
+```bash
+make lambda-test-api
+make lambda-test-price-refresh
+make lambda-test-trading-agent
+```
+
+The EventBridge handlers are normalized to a small Lambda-style envelope with a
+`statusCode`, JSON `body`, and `isBase64Encoded` flag. The harness stubs external
+price refresh and trading-agent side effects so these checks remain deterministic
+and do not require public network access, AWS, or writable production data.
+
+## Updating expected responses
+
+When a handler intentionally changes its successful response contract:
+
+1. Run the relevant `make lambda-test-*` target to regenerate the corresponding
+   file under `tests/integration/actual/`.
+2. Inspect the generated response and verify the changed shape is intentional.
+3. Copy the actual response over the matching file in `tests/integration/expected/`.
+4. Re-run `make lambda-test` and confirm each `jq` status-code assertion passes.
+
+Keep the expected files focused on stable response shape. Avoid adding volatile
+values unless the harness stubs them to deterministic values.

--- a/tests/integration/actual/.gitignore
+++ b/tests/integration/actual/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/integration/expected/api_http_response.json
+++ b/tests/integration/expected/api_http_response.json
@@ -1,0 +1,8 @@
+{
+  "statusCode": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": "{\"status\":\"ok\",\"env\":\"local\"}",
+  "isBase64Encoded": false
+}

--- a/tests/integration/expected/price_refresh_response.json
+++ b/tests/integration/expected/price_refresh_response.json
@@ -1,0 +1,5 @@
+{
+  "statusCode": 200,
+  "body": "{\"snapshot\":{},\"tickers\":[],\"timestamp\":\"2026-05-08T00:00:00Z\"}",
+  "isBase64Encoded": false
+}

--- a/tests/integration/expected/trading_agent_response.json
+++ b/tests/integration/expected/trading_agent_response.json
@@ -1,0 +1,5 @@
+{
+  "statusCode": 200,
+  "body": "{\"status\":\"ok\"}",
+  "isBase64Encoded": false
+}

--- a/tests/integration/invoke_lambda.py
+++ b/tests/integration/invoke_lambda.py
@@ -1,0 +1,90 @@
+"""Local Lambda invocation helpers for Makefile integration checks."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
+
+FIXED_TIMESTAMP = "2026-05-08T00:00:00Z"
+
+
+def _noop() -> None:
+    return None
+
+
+def _load_event(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _eventbridge_response(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "statusCode": 200,
+        "body": json.dumps(result, sort_keys=True, separators=(",", ":")),
+        "isBase64Encoded": False,
+    }
+
+
+def _invoke_api_http(event: dict[str, Any]) -> dict[str, Any]:
+    os.environ.setdefault("APP_ENV", "local")
+    os.environ.setdefault("DISABLE_AUTH", "true")
+    module = importlib.import_module("backend.lambda_api.handler")
+    return module.lambda_handler(event, {})
+
+
+def _invoke_price_refresh(event: dict[str, Any]) -> dict[str, Any]:
+    import backend.common.prices as prices
+
+    def refresh_prices_stub() -> dict[str, Any]:
+        return {
+            "tickers": [],
+            "snapshot": {},
+            "timestamp": FIXED_TIMESTAMP,
+        }
+
+    prices.refresh_prices = refresh_prices_stub
+    os.environ["ALLOTMINT_ENABLE_TRADING_AGENT"] = "false"
+    sys.modules.pop("backend.lambda_api.price_refresh", None)
+    module = importlib.import_module("backend.lambda_api.price_refresh")
+    module.trading_agent = SimpleNamespace(run=_noop)
+    return _eventbridge_response(module.lambda_handler(event, {}))
+
+
+def _invoke_trading_agent(event: dict[str, Any]) -> dict[str, Any]:
+    import backend.agent.trading_agent as trading_agent
+
+    trading_agent.run = _noop
+    sys.modules.pop("backend.lambda_api.trading_agent", None)
+    module = importlib.import_module("backend.lambda_api.trading_agent")
+    return _eventbridge_response(module.lambda_handler(event, {}))
+
+
+def _handler(invocation_name: str) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    handlers = {
+        "api-http": _invoke_api_http,
+        "price-refresh": _invoke_price_refresh,
+        "trading-agent": _invoke_trading_agent,
+    }
+    try:
+        return handlers[invocation_name]
+    except KeyError as exc:
+        known = ", ".join(sorted(handlers))
+        raise SystemExit(f"Unknown invocation '{invocation_name}'. Expected one of: {known}") from exc
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("Usage: python -m tests.integration.invoke_lambda <name> <event.json>")
+
+    event = _load_event(sys.argv[2])
+    response = _handler(sys.argv[1])(event)
+    json.dump(response, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/invoke_lambda.py
+++ b/tests/integration/invoke_lambda.py
@@ -14,7 +14,7 @@ FIXED_TIMESTAMP = "2026-05-08T00:00:00Z"
 
 
 def _noop() -> None:
-    return None
+    pass
 
 
 def _load_event(path: str) -> dict[str, Any]:
@@ -37,6 +37,9 @@ def _invoke_api_http(event: dict[str, Any]) -> dict[str, Any]:
 
 
 def _invoke_price_refresh(event: dict[str, Any]) -> dict[str, Any]:
+    # Patch backend.common.prices before evicting + re-importing the handler so
+    # that the handler's `from backend.common.prices import refresh_prices` picks
+    # up the stub on re-import (the prices module stays cached in sys.modules).
     import backend.common.prices as prices
 
     def refresh_prices_stub() -> dict[str, Any]:
@@ -55,6 +58,8 @@ def _invoke_price_refresh(event: dict[str, Any]) -> dict[str, Any]:
 
 
 def _invoke_trading_agent(event: dict[str, Any]) -> dict[str, Any]:
+    # Patch backend.agent.trading_agent before evicting + re-importing the handler
+    # so the handler's `from backend.agent.trading_agent import run` picks up the stub.
     import backend.agent.trading_agent as trading_agent
 
     trading_agent.run = _noop

--- a/tests/integration/payloads/api_http_event.json
+++ b/tests/integration/payloads/api_http_event.json
@@ -4,9 +4,6 @@
   "rawPath": "/health",
   "rawQueryString": "",
   "headers": {
-    "host": "example.com"
-  },
-  "requestContext": {
     "accept": "*/*",
     "host": "localhost:9010",
     "user-agent": "curl/7.68.0"
@@ -21,8 +18,6 @@
       "path": "/health",
       "protocol": "HTTP/1.1",
       "sourceIp": "127.0.0.1",
-      "userAgent": "make lambda-test"
-    }
       "userAgent": "curl/7.68.0"
     },
     "requestId": "local-test-request-id",

--- a/tests/integration/payloads/api_http_event.json
+++ b/tests/integration/payloads/api_http_event.json
@@ -1,0 +1,19 @@
+{
+  "version": "2.0",
+  "routeKey": "GET /health",
+  "rawPath": "/health",
+  "rawQueryString": "",
+  "headers": {
+    "host": "example.com"
+  },
+  "requestContext": {
+    "http": {
+      "method": "GET",
+      "path": "/health",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "127.0.0.1",
+      "userAgent": "make lambda-test"
+    }
+  },
+  "isBase64Encoded": false
+}

--- a/tests/integration/payloads/price_refresh_event.json
+++ b/tests/integration/payloads/price_refresh_event.json
@@ -1,0 +1,13 @@
+{
+  "version": "0",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "detail-type": "Scheduled Event",
+  "source": "aws.events",
+  "account": "123456789012",
+  "time": "2026-05-08T00:00:00Z",
+  "region": "eu-west-2",
+  "resources": [
+    "arn:aws:events:eu-west-2:123456789012:rule/allotmint-price-refresh"
+  ],
+  "detail": {}
+}

--- a/tests/integration/payloads/trading_agent_event.json
+++ b/tests/integration/payloads/trading_agent_event.json
@@ -1,0 +1,13 @@
+{
+  "version": "0",
+  "id": "11111111-1111-1111-1111-111111111111",
+  "detail-type": "Scheduled Event",
+  "source": "aws.events",
+  "account": "123456789012",
+  "time": "2026-05-08T00:05:00Z",
+  "region": "eu-west-2",
+  "resources": [
+    "arn:aws:events:eu-west-2:123456789012:rule/allotmint-trading-agent"
+  ],
+  "detail": {}
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic, local integration checks for Lambda handlers so regressions in API and scheduled EventBridge responses are caught automatically.
- Ensure price-refresh and trading-agent side effects are stubbed during local checks to avoid network or AWS dependencies.
Closes #2870 


### Description
- Added `tests/integration/invoke_lambda.py` which deterministically invokes the API Gateway (`/health`) and EventBridge handlers and wraps EventBridge results in a stable Lambda-style envelope.
- Added representative payloads under `tests/integration/payloads/` and expected-response fixtures under `tests/integration/expected/` for `api-http`, `price-refresh`, and `trading-agent` invocations.
- Added `Makefile` targets `lambda-test`, `lambda-test-api`, `lambda-test-price-refresh`, and `lambda-test-trading-agent` that run the invocation helper, write actual responses to `tests/integration/actual/`, and assert `statusCode` using `jq`.
- Documented the harness and update process in `tests/integration/README.md` and added an `actual/.gitignore` to keep generated outputs out of commits; this change closes issue `#2870`.

### Testing
- Ran dependency install: `PYENV_VERSION=3.11.15 python -m pip install -r requirements.txt -r requirements-dev.txt` which completed successfully.
- Ran the integration checks: `make PYTHON='PYENV_VERSION=3.11.15 python' lambda-test` and the per-handler checks which executed and returned the expected `statusCode` assertions (`true`).
- Linted and formatted the new helper: `PYENV_VERSION=3.11.15 ruff check --config backend/pyproject.toml tests/integration/invoke_lambda.py` and `PYENV_VERSION=3.11.15 black --check --config backend/pyproject.toml tests/integration/invoke_lambda.py`, both passed.
- Validated JSON fixtures with `jq empty tests/integration/expected/*.json tests/integration/payloads/*.json`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe027799388327bce99a3c9a58f258)