### PR TITLE
fix: add Makefile to Claude review diff globs

### DIFF
--- a/.github/scripts/prepare_review_diff.py
+++ b/.github/scripts/prepare_review_diff.py
@@ -8,7 +8,7 @@ import sys
 
 from review_common import MAX_DIFF_CHARS, format_truncation_log, truncate_diff
 
-DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml"]
+DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml", "Makefile", "*.mk"]
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Problem

`prepare_review_diff.py` filters the PR diff to a fixed glob list that did not include `Makefile` or `*.mk`. As a result, the diff sent to Claude never contained Makefile changes — Claude could see the PR description mentioning Makefile targets but had no diff to verify them, causing it to repeatedly flag Makefile concerns on every review even after they had been addressed.

## Fix

Added `Makefile` and `*.mk` to `DEFAULT_GLOBS` in `.github/scripts/prepare_review_diff.py`.

## Testing

The `prepare_review_diff.py` script passes `DEFAULT_GLOBS` straight to `git diff -- <globs>`. Adding `Makefile` there means any PR that touches the Makefile will now have that diff block included (subject to the existing 30k-char truncation budget).
