### PR TITLE
Add Cognito auth gate for AWS UI

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -203,21 +203,13 @@ class StaticSiteStack(Stack):
             price_class=cloudfront.PriceClass.PRICE_CLASS_100,
         )
 
-        # Retain the UserPool (and all user accounts) when the CDK context key
-        # "retainUserPool" is set to "true" — required for production deployments.
-        # Default (no context key) is DESTROY for convenience in ephemeral/dev
-        # environments.  Set it at deploy time:
-        #   cdk deploy --context retainUserPool=true
-        _retain_user_pool = (
-            str(self.node.try_get_context("retainUserPool") or "").lower() == "true"
-        )
         ui_auth_pool = cognito.UserPool(
             self,
             "UiAuthUserPool",
             account_recovery=cognito.AccountRecovery.EMAIL_ONLY,
             self_sign_up_enabled=False,
             sign_in_aliases=cognito.SignInAliases(email=True),
-            removal_policy=RemovalPolicy.RETAIN if _retain_user_pool else RemovalPolicy.DESTROY,
+            removal_policy=ui_auth_removal_policy,
         )
         ui_auth_callback_url = Fn.join("", ["https://", distribution.domain_name, "/"])
         ui_auth_client = ui_auth_pool.add_client(

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -32,12 +32,6 @@ class StaticSiteStack(Stack):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        ui_auth_removal_policy = (
-            RemovalPolicy.RETAIN
-            if _is_truthy_context(self.node.try_get_context("prod"))
-            else RemovalPolicy.DESTROY
-        )
-
         # BucketDeployment.Source.json_data() only accepts intra-stack tokens
         # (Ref / Fn::GetAtt / Fn::Select) — Fn::ImportValue is explicitly rejected
         # by CDK's renderData validator. A CfnParameter produces a Ref token and
@@ -243,9 +237,6 @@ class StaticSiteStack(Stack):
         ui_auth_domain = Fn.join(
             "",
             ["https://", ui_auth_domain_prefix, ".auth.", Aws.REGION, ".amazoncognito.com"],
-        ui_auth_pool, ui_auth_client, ui_auth_domain = self._create_ui_auth(
-            distribution=distribution,
-            removal_policy=ui_auth_removal_policy,
         )
 
         frontend_dir = (
@@ -315,46 +306,3 @@ class StaticSiteStack(Stack):
         CfnOutput(self, "UiAuthUserPoolId", value=ui_auth_pool.user_pool_id)
         CfnOutput(self, "UiAuthUserPoolClientId", value=ui_auth_client.user_pool_client_id)
         CfnOutput(self, "UiAuthDomain", value=ui_auth_domain)
-
-    def _create_ui_auth(
-        self,
-        *,
-        distribution: cloudfront.Distribution,
-        removal_policy: RemovalPolicy,
-    ) -> tuple[cognito.UserPool, cognito.UserPoolClient, str]:
-        ui_auth_pool = cognito.UserPool(
-            self,
-            "UiAuthUserPool",
-            account_recovery=cognito.AccountRecovery.EMAIL_ONLY,
-            self_sign_up_enabled=False,
-            sign_in_aliases=cognito.SignInAliases(email=True),
-            removal_policy=removal_policy,
-        )
-        ui_auth_callback_url = Fn.join("", ["https://", distribution.domain_name, "/"])
-        ui_auth_client = ui_auth_pool.add_client(
-            "UiAuthClient",
-            auth_flows=cognito.AuthFlow(user_password=True, user_srp=True),
-            o_auth=cognito.OAuthSettings(
-                flows=cognito.OAuthFlows(authorization_code_grant=True),
-                scopes=[
-                    cognito.OAuthScope.EMAIL,
-                    cognito.OAuthScope.OPENID,
-                    cognito.OAuthScope.PROFILE,
-                ],
-                callback_urls=[ui_auth_callback_url],
-                logout_urls=[ui_auth_callback_url],
-            ),
-            prevent_user_existence_errors=True,
-        )
-        ui_auth_domain_prefix = Fn.join("-", ["allotmint", Aws.ACCOUNT_ID, Aws.REGION])
-        ui_auth_pool.add_domain(
-            "UiAuthDomain",
-            cognito_domain=cognito.CognitoDomainOptions(
-                domain_prefix=ui_auth_domain_prefix,
-            ),
-        )
-        ui_auth_domain = Fn.join(
-            "",
-            ["https://", ui_auth_domain_prefix, ".auth.", Aws.REGION, ".amazoncognito.com"],
-        )
-        return ui_auth_pool, ui_auth_client, ui_auth_domain

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -55,12 +55,13 @@ class StaticSiteStack(Stack):
             "SecurityHeaders",
             comment="Security headers for static site",
             security_headers_behavior=cloudfront.ResponseSecurityHeadersBehavior(
-                # Allow Google Identity Services script and iframe
+                # Allow Google Identity Services script and iframe, and Cognito
+                # hosted UI token exchange (amazoncognito.com != amazonaws.com).
                 content_security_policy=cloudfront.ResponseHeadersContentSecurityPolicy(
                     content_security_policy=(
                         "default-src 'self'; "
                         "script-src 'self' https://accounts.google.com/gsi/client; "
-                        "connect-src 'self' https://*.amazonaws.com; "
+                        "connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com; "
                         "frame-src 'self' https://accounts.google.com/gsi/; "
                         "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
                     ),

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -1,16 +1,11 @@
 from pathlib import Path
 
-from aws_cdk import (
-    CfnOutput,
-    CfnParameter,
-    Duration,
-    RemovalPolicy,
-    Stack,
-    aws_cloudfront as cloudfront,
-    aws_cloudfront_origins as origins,
-    aws_s3 as s3,
-    aws_s3_deployment as s3_deployment,
-)
+from aws_cdk import Aws, CfnOutput, CfnParameter, Duration, Fn, RemovalPolicy, Stack
+from aws_cdk import aws_cloudfront as cloudfront
+from aws_cdk import aws_cloudfront_origins as origins
+from aws_cdk import aws_cognito as cognito
+from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_s3_deployment as s3_deployment
 from constructs import Construct
 
 
@@ -62,7 +57,13 @@ class StaticSiteStack(Stack):
             security_headers_behavior=cloudfront.ResponseSecurityHeadersBehavior(
                 # Allow Google Identity Services script and iframe
                 content_security_policy=cloudfront.ResponseHeadersContentSecurityPolicy(
-                    content_security_policy="default-src 'self'; script-src 'self' https://accounts.google.com/gsi/client; frame-src 'self' https://accounts.google.com/gsi/; frame-ancestors 'none'; object-src 'none'; base-uri 'self'",
+                    content_security_policy=(
+                        "default-src 'self'; "
+                        "script-src 'self' https://accounts.google.com/gsi/client; "
+                        "connect-src 'self' https://*.amazonaws.com; "
+                        "frame-src 'self' https://accounts.google.com/gsi/; "
+                        "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
+                    ),
                     override=True,
                 ),
                 strict_transport_security=cloudfront.ResponseHeadersStrictTransportSecurity(
@@ -180,6 +181,42 @@ class StaticSiteStack(Stack):
             price_class=cloudfront.PriceClass.PRICE_CLASS_100,
         )
 
+        ui_auth_pool = cognito.UserPool(
+            self,
+            "UiAuthUserPool",
+            account_recovery=cognito.AccountRecovery.EMAIL_ONLY,
+            self_sign_up_enabled=False,
+            sign_in_aliases=cognito.SignInAliases(email=True),
+            removal_policy=RemovalPolicy.DESTROY,
+        )
+        ui_auth_callback_url = Fn.join("", ["https://", distribution.domain_name, "/"])
+        ui_auth_client = ui_auth_pool.add_client(
+            "UiAuthClient",
+            auth_flows=cognito.AuthFlow(user_password=True, user_srp=True),
+            o_auth=cognito.OAuthSettings(
+                flows=cognito.OAuthFlows(authorization_code_grant=True),
+                scopes=[
+                    cognito.OAuthScope.EMAIL,
+                    cognito.OAuthScope.OPENID,
+                    cognito.OAuthScope.PROFILE,
+                ],
+                callback_urls=[ui_auth_callback_url],
+                logout_urls=[ui_auth_callback_url],
+            ),
+            prevent_user_existence_errors=True,
+        )
+        ui_auth_domain_prefix = Fn.join("-", ["allotmint", Aws.ACCOUNT_ID, Aws.REGION])
+        ui_auth_pool.add_domain(
+            "UiAuthDomain",
+            cognito_domain=cognito.CognitoDomainOptions(
+                domain_prefix=ui_auth_domain_prefix,
+            ),
+        )
+        ui_auth_domain = Fn.join(
+            "",
+            ["https://", ui_auth_domain_prefix, ".auth.", Aws.REGION, ".amazoncognito.com"],
+        )
+
         frontend_dir = (
             Path(frontend_dist_path)
             if frontend_dist_path is not None
@@ -217,7 +254,20 @@ class StaticSiteStack(Stack):
         config_deploy = s3_deployment.BucketDeployment(
             self,
             "DeployRuntimeConfig",
-            sources=[s3_deployment.Source.json_data("config.json", {"apiBaseUrl": backend_url_param.value_as_string})],
+            sources=[
+                s3_deployment.Source.json_data(
+                    "config.json",
+                    {
+                        "apiBaseUrl": backend_url_param.value_as_string,
+                        "awsUiAuth": {
+                            "enabled": True,
+                            "domain": ui_auth_domain,
+                            "clientId": ui_auth_client.user_pool_client_id,
+                            "redirectPath": "/",
+                        },
+                    },
+                )
+            ],
             destination_bucket=site_bucket,
             cache_control=[
                 s3_deployment.CacheControl.no_cache(),
@@ -231,3 +281,6 @@ class StaticSiteStack(Stack):
         CfnOutput(self, "SiteBucket", value=site_bucket.bucket_name)
         CfnOutput(self, "DistributionId", value=distribution.distribution_id)
         CfnOutput(self, "DistributionDomain", value=distribution.domain_name)
+        CfnOutput(self, "UiAuthUserPoolId", value=ui_auth_pool.user_pool_id)
+        CfnOutput(self, "UiAuthUserPoolClientId", value=ui_auth_client.user_pool_client_id)
+        CfnOutput(self, "UiAuthDomain", value=ui_auth_domain)

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -195,8 +195,10 @@ class StaticSiteStack(Stack):
         ui_auth_callback_url = Fn.join("", ["https://", distribution.domain_name, "/"])
         ui_auth_client = ui_auth_pool.add_client(
             "UiAuthClient",
-            # user_srp=True is sufficient for the hosted UI + PKCE authorization-code flow.
-            # user_password=True would also enable ALLOW_USER_PASSWORD_AUTH which is weaker.
+            # auth_flows gates the direct Cognito API auth endpoints (USER_SRP_AUTH,
+            # USER_PASSWORD_AUTH). The hosted UI uses browser redirects and does not
+            # go through these API flows. user_srp=True is kept to avoid enabling the
+            # weaker ALLOW_USER_PASSWORD_AUTH endpoint on this public client.
             auth_flows=cognito.AuthFlow(user_srp=True),
             o_auth=cognito.OAuthSettings(
                 flows=cognito.OAuthFlows(authorization_code_grant=True),

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -182,15 +182,21 @@ class StaticSiteStack(Stack):
             price_class=cloudfront.PriceClass.PRICE_CLASS_100,
         )
 
-        # WARNING: DESTROY removes the UserPool and all users on stack deletion.
-        # Change to RemovalPolicy.RETAIN before deploying to production.
+        # Retain the UserPool (and all user accounts) when the CDK context key
+        # "retainUserPool" is set to "true" — required for production deployments.
+        # Default (no context key) is DESTROY for convenience in ephemeral/dev
+        # environments.  Set it at deploy time:
+        #   cdk deploy --context retainUserPool=true
+        _retain_user_pool = (
+            str(self.node.try_get_context("retainUserPool") or "").lower() == "true"
+        )
         ui_auth_pool = cognito.UserPool(
             self,
             "UiAuthUserPool",
             account_recovery=cognito.AccountRecovery.EMAIL_ONLY,
             self_sign_up_enabled=False,
             sign_in_aliases=cognito.SignInAliases(email=True),
-            removal_policy=RemovalPolicy.DESTROY,
+            removal_policy=RemovalPolicy.RETAIN if _retain_user_pool else RemovalPolicy.DESTROY,
         )
         ui_auth_callback_url = Fn.join("", ["https://", distribution.domain_name, "/"])
         ui_auth_client = ui_auth_pool.add_client(

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -182,6 +182,8 @@ class StaticSiteStack(Stack):
             price_class=cloudfront.PriceClass.PRICE_CLASS_100,
         )
 
+        # WARNING: DESTROY removes the UserPool and all users on stack deletion.
+        # Change to RemovalPolicy.RETAIN before deploying to production.
         ui_auth_pool = cognito.UserPool(
             self,
             "UiAuthUserPool",
@@ -193,7 +195,9 @@ class StaticSiteStack(Stack):
         ui_auth_callback_url = Fn.join("", ["https://", distribution.domain_name, "/"])
         ui_auth_client = ui_auth_pool.add_client(
             "UiAuthClient",
-            auth_flows=cognito.AuthFlow(user_password=True, user_srp=True),
+            # user_srp=True is sufficient for the hosted UI + PKCE authorization-code flow.
+            # user_password=True would also enable ALLOW_USER_PASSWORD_AUTH which is weaker.
+            auth_flows=cognito.AuthFlow(user_srp=True),
             o_auth=cognito.OAuthSettings(
                 flows=cognito.OAuthFlows(authorization_code_grant=True),
                 scopes=[

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -4,6 +4,7 @@ Run from the repo root:
     pip install aws-cdk-lib constructs pytest --quiet
     pytest cdk/tests/test_static_site_stack.py -v
 """
+
 import sys
 from pathlib import Path
 
@@ -14,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 aws_cdk = pytest.importorskip("aws_cdk", reason="aws-cdk-lib not installed")
 
 from aws_cdk import App, assertions  # noqa: E402
+
 from cdk.stacks.static_site_stack import StaticSiteStack  # noqa: E402
 
 _DUMMY_API_URL = "https://abc123.execute-api.eu-west-1.amazonaws.com"
@@ -37,6 +39,7 @@ def template(tmp_path_factory):
 # ---------------------------------------------------------------------------
 # SPA error responses
 # ---------------------------------------------------------------------------
+
 
 def test_403_redirects_to_index_html(template):
     """CloudFront must return /index.html for 403 (S3 access-denied) responses."""
@@ -86,6 +89,7 @@ def test_404_redirects_to_index_html(template):
 # config.json deployment
 # ---------------------------------------------------------------------------
 
+
 def test_runtime_config_deployment_exists(template):
     """At least one BucketDeployment resource must be present (config.json injection)."""
     # BucketDeployment is backed by Custom::CDKBucketDeployment.
@@ -134,6 +138,7 @@ def test_static_site_stack_synthesises_without_api_base_url(tmp_path):
     deployed from CI.
     """
     from aws_cdk import App  # noqa: PLC0415
+
     from cdk.stacks.static_site_stack import StaticSiteStack  # noqa: PLC0415
 
     (tmp_path / "index.html").write_text("<html></html>")
@@ -146,6 +151,7 @@ def test_static_site_stack_synthesises_without_api_base_url(tmp_path):
 # ---------------------------------------------------------------------------
 # CloudFront distribution outputs
 # ---------------------------------------------------------------------------
+
 
 def test_distribution_id_output_exists(template):
     template.has_output("DistributionId", {})
@@ -163,6 +169,7 @@ def test_site_bucket_output_exists(template):
 # Site bucket security
 # ---------------------------------------------------------------------------
 
+
 def test_site_bucket_blocks_public_access(template):
     template.has_resource_properties(
         "AWS::S3::Bucket",
@@ -175,3 +182,36 @@ def test_site_bucket_blocks_public_access(template):
             }
         },
     )
+
+
+def test_ui_auth_user_pool_created(template):
+    """Static site deploys a Cognito user pool to gate the hosted UI."""
+    template.has_resource_properties(
+        "AWS::Cognito::UserPool",
+        {
+            "AccountRecoverySetting": {
+                "RecoveryMechanisms": assertions.Match.array_with(
+                    [assertions.Match.object_like({"Name": "verified_email", "Priority": 1})]
+                )
+            },
+            "AdminCreateUserConfig": {"AllowAdminCreateUserOnly": True},
+        },
+    )
+
+
+def test_ui_auth_client_uses_authorization_code_flow(template):
+    """Hosted UI auth must use the authorization-code flow for the SPA."""
+    template.has_resource_properties(
+        "AWS::Cognito::UserPoolClient",
+        {
+            "AllowedOAuthFlows": ["code"],
+            "AllowedOAuthScopes": assertions.Match.array_with(["email", "openid", "profile"]),
+            "SupportedIdentityProviders": ["COGNITO"],
+        },
+    )
+
+
+def test_ui_auth_outputs_exist(template):
+    template.has_output("UiAuthUserPoolId", {})
+    template.has_output("UiAuthUserPoolClientId", {})
+    template.has_output("UiAuthDomain", {})

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -215,3 +215,30 @@ def test_ui_auth_outputs_exist(template):
     template.has_output("UiAuthUserPoolId", {})
     template.has_output("UiAuthUserPoolClientId", {})
     template.has_output("UiAuthDomain", {})
+
+
+def test_ui_auth_user_pool_destroy_by_default(template):
+    """Without the retainUserPool context key the UserPool uses DeletionPolicy: Delete."""
+    pools = template.find_resources(
+        "AWS::Cognito::UserPool",
+        {"DeletionPolicy": "Delete"},
+    )
+    assert len(pools) >= 1, "Expected UserPool DeletionPolicy to be Delete in default (dev) mode"
+
+
+def test_ui_auth_user_pool_retain_when_context_set(tmp_path):
+    """Setting retainUserPool=true context switches the UserPool to DeletionPolicy: Retain."""
+    (tmp_path / "index.html").write_text("<html></html>")
+    app = App(context={"retainUserPool": "true"})
+    stack = StaticSiteStack(
+        app,
+        "RetainStack",
+        api_base_url=_DUMMY_API_URL,
+        frontend_dist_path=str(tmp_path),
+    )
+    t = assertions.Template.from_stack(stack)
+    pools = t.find_resources(
+        "AWS::Cognito::UserPool",
+        {"DeletionPolicy": "Retain"},
+    )
+    assert len(pools) >= 1, "Expected UserPool DeletionPolicy to be Retain when retainUserPool=true"

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -227,12 +227,19 @@ If deployment fails or the live environment does not match local behavior:
    curl -fsSL "<BackendApiUrl>/docs" >/dev/null
    ```
 
-5. Validate static frontend output with `DistributionDomain`:
+5. Validate static frontend output and the Cognito UI gate outputs:
 
    ```bash
    aws cloudformation describe-stacks --stack-name StaticSiteStack \
      --query "Stacks[0].Outputs[?OutputKey=='DistributionDomain'].OutputValue" --output text
-   curl -fsSL "https://<DistributionDomain>" >/dev/null
+   aws cloudformation describe-stacks --stack-name StaticSiteStack \
+     --query "Stacks[0].Outputs[?starts_with(OutputKey, 'UiAuth')].[OutputKey,OutputValue]" \
+     --output table
    ```
+
+   Create or invite at least one administrator-approved user in the emitted
+   Cognito user pool before sharing the CloudFront URL; self sign-up is disabled.
+   Browser validation should now redirect unauthenticated visitors to Cognito
+   instead of returning a bare HTTP 200 for the dashboard.
 
 6. If the frontend is stale after a successful deploy, run CloudFront invalidation (`/*`).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -23,12 +23,14 @@ The current policy is defined in `cdk/stacks/static_site_stack.py` and includes 
 ```text
 default-src 'self';
 script-src 'self' https://accounts.google.com/gsi/client;
-connect-src 'self' https://*.amazonaws.com;
+connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com;
 frame-src 'self' https://accounts.google.com/gsi/;
 frame-ancestors 'none';
 object-src 'none';
 base-uri 'self'
 ```
+
+Note: `https://*.amazoncognito.com` is required for the PKCE token exchange — the Cognito hosted UI token endpoint (`/oauth2/token`) lives under `amazoncognito.com`, not `amazonaws.com`.
 
 ### Adding or updating the policy
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,31 +1,44 @@
 # Security
 
+## AWS-hosted UI authentication
+
+The AWS static site stack protects the hosted frontend with an Amazon Cognito user pool and hosted UI. `StaticSiteStack` creates the user pool, a public SPA client that uses the OAuth 2.0 authorization-code flow with PKCE, and a Cognito domain. The deployed `/config.json` includes the Cognito domain and client ID so the React app redirects unauthenticated visitors before rendering the portfolio dashboard.
+
+After deploying `StaticSiteStack`, create or invite users in the `UiAuthUserPoolId` output before sharing the CloudFront URL. Self sign-up is disabled, so only administrator-created Cognito users can pass the UI gate.
+
+Useful outputs:
+
+```bash
+aws cloudformation describe-stacks --stack-name StaticSiteStack \
+  --query "Stacks[0].Outputs[?starts_with(OutputKey, 'UiAuth')].[OutputKey,OutputValue]" \
+  --output table
+```
+
 ## Content Security Policy
 
-AllotMint's frontend is served from S3 behind CloudFront. Implementing a Content Security Policy (CSP) header limits the sources the browser may load resources from. The stack currently does **not** set a CSP header, so browsers accept resources from any origin.
+AllotMint's frontend is served from S3 behind CloudFront. The static site stack attaches a CloudFront response headers policy that sets a restrictive CSP for production traffic. The policy allows the app itself, Google Identity Services for the existing backend login flow, and AWS endpoints needed for API Gateway and Cognito hosted-UI token exchange.
 
-A restrictive policy might look like:
+The current policy is defined in `cdk/stacks/static_site_stack.py` and includes these main directives:
 
-```
+```text
 default-src 'self';
-img-src 'self' data:;
-script-src 'self';
-style-src 'self' 'unsafe-inline';
-connect-src 'self' https://www.alphavantage.co;
+script-src 'self' https://accounts.google.com/gsi/client;
+connect-src 'self' https://*.amazonaws.com;
+frame-src 'self' https://accounts.google.com/gsi/;
 frame-ancestors 'none';
+object-src 'none';
+base-uri 'self'
 ```
-
-This would prevent third‑party scripts or styles from executing unless explicitly whitelisted.
 
 ### Adding or updating the policy
 
-To enforce a CSP:
+To update the CSP:
 
-1. Define a CloudFront response headers policy (or function) in `cdk/stacks/static_site_stack.py` that sets the `content-security-policy` header.
-2. Add your directives to the header string.
-3. Associate the policy with the distribution's behavior and redeploy:
+1. Edit the CloudFront response headers policy in `cdk/stacks/static_site_stack.py`.
+2. Add the minimum directive needed for the new integration.
+3. Run the CDK static site tests and redeploy:
    ```bash
-   npm ci
+   PYENV_VERSION=3.11.15 pytest cdk/tests/test_static_site_stack.py -v
    cd cdk
    npx cdk deploy StaticSiteStack
    ```

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -49,7 +49,8 @@ const redirectUri = (redirectPath?: string) => {
 };
 
 const loadSession = (): StoredSession | null => {
-  const raw = window.localStorage.getItem(SESSION_KEY);
+  // sessionStorage is cleared on tab close, limiting token exposure window.
+  const raw = window.sessionStorage.getItem(SESSION_KEY);
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as Partial<StoredSession>;
@@ -62,7 +63,7 @@ const loadSession = (): StoredSession | null => {
     return parsed as StoredSession;
   } catch (error) {
     console.warn('Discarding unreadable AWS UI auth session', error);
-    window.localStorage.removeItem(SESSION_KEY);
+    window.sessionStorage.removeItem(SESSION_KEY);
     return null;
   }
 };
@@ -78,7 +79,8 @@ const storeSession = (payload: {
     accessToken: payload.access_token,
     expiresAt: Date.now() + expiresInSeconds * 1000,
   };
-  window.localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  // sessionStorage scopes the token to this tab/session only.
+  window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
 };
 
 const hasValidSession = () => {

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -101,7 +101,9 @@ const exchangeCode = async (config: AuthConfig) => {
   const state = params.get('state');
   const errorParam = params.get('error');
 
-  // Cognito returns ?error=access_denied (etc.) on cancellation or policy denial.
+  // access_denied = user clicked Cancel on the Cognito hosted UI — redirect
+  // back so they get another login opportunity rather than an error screen.
+  if (errorParam === 'access_denied') return false;
   if (errorParam) throw new Error(`Cognito auth error: ${errorParam}`);
   if (!code || !state) return false;
 

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -11,6 +11,12 @@ interface StoredSession {
   expiresAt: number;
 }
 
+interface AuthConfig {
+  domain: string;
+  clientId: string;
+  redirectPath: string;
+}
+
 const SESSION_KEY = 'awsUiAuthSession';
 const STATE_KEY = 'awsUiAuthState';
 const VERIFIER_KEY = 'awsUiAuthCodeVerifier';
@@ -89,27 +95,32 @@ const hasValidSession = () => {
   return true;
 };
 
-const exchangeCode = async (
-  config: Required<Pick<AwsUiAuthConfig, 'domain' | 'clientId'>>
-) => {
+const exchangeCode = async (config: AuthConfig) => {
   const params = new URLSearchParams(window.location.search);
   const code = params.get('code');
   const state = params.get('state');
+  const errorParam = params.get('error');
+
+  // Cognito returns ?error=access_denied (etc.) on cancellation or policy denial.
+  if (errorParam) throw new Error(`Cognito auth error: ${errorParam}`);
   if (!code || !state) return false;
 
   const expectedState = window.sessionStorage.getItem(STATE_KEY);
   const verifier = window.sessionStorage.getItem(VERIFIER_KEY);
-  window.sessionStorage.removeItem(STATE_KEY);
-  window.sessionStorage.removeItem(VERIFIER_KEY);
   if (!expectedState || !verifier || state !== expectedState) {
+    window.sessionStorage.removeItem(STATE_KEY);
+    window.sessionStorage.removeItem(VERIFIER_KEY);
     throw new Error('Invalid AWS UI authentication callback state');
   }
+  // State matched — consume the one-time PKCE credentials before the fetch.
+  window.sessionStorage.removeItem(STATE_KEY);
+  window.sessionStorage.removeItem(VERIFIER_KEY);
 
   const tokenParams = new URLSearchParams({
     grant_type: 'authorization_code',
     client_id: config.clientId,
     code,
-    redirect_uri: redirectUri(),
+    redirect_uri: redirectUri(config.redirectPath),
     code_verifier: verifier,
   });
   const response = await fetch(`${config.domain}/oauth2/token`, {
@@ -134,9 +145,7 @@ const exchangeCode = async (
   return true;
 };
 
-const redirectToHostedUi = async (
-  config: Required<Pick<AwsUiAuthConfig, 'domain' | 'clientId'>>
-) => {
+const redirectToHostedUi = async (config: AuthConfig) => {
   const verifier = randomString(64);
   const state = randomString(32);
   window.sessionStorage.setItem(STATE_KEY, state);
@@ -144,7 +153,7 @@ const redirectToHostedUi = async (
   const params = new URLSearchParams({
     response_type: 'code',
     client_id: config.clientId,
-    redirect_uri: redirectUri(),
+    redirect_uri: redirectUri(config.redirectPath),
     scope: SCOPE,
     state,
     code_challenge: await sha256Base64Url(verifier),
@@ -167,7 +176,8 @@ export const ensureAwsUiAuth = async (config?: AwsUiAuthConfig | null) => {
   if (!domain || !clientId)
     throw new Error('AWS UI authentication is enabled but not configured');
 
-  const authConfig = { domain, clientId };
+  const redirectPath = authConfigInput.redirectPath ?? DEFAULT_REDIRECT_PATH;
+  const authConfig: AuthConfig = { domain, clientId, redirectPath };
   if (await exchangeCode(authConfig)) return true;
   if (hasValidSession()) return true;
   await redirectToHostedUi(authConfig);

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -193,8 +193,11 @@ export const ensureAwsUiAuth = async (config?: AwsUiAuthConfig | null) => {
 
   const redirectPath = authConfigInput.redirectPath ?? DEFAULT_REDIRECT_PATH;
   const authConfig: AuthConfig = { domain, clientId, redirectPath };
-  if (await exchangeCode(authConfig)) return true;
+  // Session check before code exchange: if the user already has a valid session,
+  // skip exchangeCode entirely to avoid a state-mismatch error when ?code= params
+  // are present in the URL from a previous (already-consumed) callback.
   if (hasValidSession()) return true;
+  if (await exchangeCode(authConfig)) return true;
   await redirectToHostedUi(authConfig);
   return false;
 };

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -1,0 +1,173 @@
+export interface AwsUiAuthConfig {
+  enabled?: boolean | string;
+  domain?: string;
+  clientId?: string;
+  redirectPath?: string;
+}
+
+interface StoredSession {
+  idToken: string;
+  accessToken?: string;
+  expiresAt: number;
+}
+
+const SESSION_KEY = 'awsUiAuthSession';
+const STATE_KEY = 'awsUiAuthState';
+const VERIFIER_KEY = 'awsUiAuthCodeVerifier';
+const DEFAULT_REDIRECT_PATH = '/';
+const SCOPE = 'openid email profile';
+
+const base64UrlEncode = (bytes: Uint8Array) =>
+  btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+const randomString = (bytes = 32) => {
+  const values = new Uint8Array(bytes);
+  crypto.getRandomValues(values);
+  return base64UrlEncode(values);
+};
+
+const sha256Base64Url = async (value: string) => {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return base64UrlEncode(new Uint8Array(digest));
+};
+
+const normaliseDomain = (domain: string) => {
+  const trimmed = domain.trim().replace(/\/+$/, '');
+  if (!trimmed) return '';
+  return trimmed.startsWith('https://') ? trimmed : `https://${trimmed}`;
+};
+
+const redirectUri = (redirectPath?: string) => {
+  const path = redirectPath?.startsWith('/')
+    ? redirectPath
+    : DEFAULT_REDIRECT_PATH;
+  return `${window.location.origin}${path}`;
+};
+
+const loadSession = (): StoredSession | null => {
+  const raw = window.localStorage.getItem(SESSION_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredSession>;
+    if (
+      typeof parsed.idToken !== 'string' ||
+      typeof parsed.expiresAt !== 'number'
+    ) {
+      return null;
+    }
+    return parsed as StoredSession;
+  } catch (error) {
+    console.warn('Discarding unreadable AWS UI auth session', error);
+    window.localStorage.removeItem(SESSION_KEY);
+    return null;
+  }
+};
+
+const storeSession = (payload: {
+  id_token: string;
+  access_token?: string;
+  expires_in?: number;
+}) => {
+  const expiresInSeconds = Math.max(60, payload.expires_in ?? 3600);
+  const session: StoredSession = {
+    idToken: payload.id_token,
+    accessToken: payload.access_token,
+    expiresAt: Date.now() + expiresInSeconds * 1000,
+  };
+  window.localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+};
+
+const hasValidSession = () => {
+  const session = loadSession();
+  if (!session || session.expiresAt <= Date.now() + 60000) return false;
+  return true;
+};
+
+const exchangeCode = async (
+  config: Required<Pick<AwsUiAuthConfig, 'domain' | 'clientId'>>
+) => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code');
+  const state = params.get('state');
+  if (!code || !state) return false;
+
+  const expectedState = window.sessionStorage.getItem(STATE_KEY);
+  const verifier = window.sessionStorage.getItem(VERIFIER_KEY);
+  window.sessionStorage.removeItem(STATE_KEY);
+  window.sessionStorage.removeItem(VERIFIER_KEY);
+  if (!expectedState || !verifier || state !== expectedState) {
+    throw new Error('Invalid AWS UI authentication callback state');
+  }
+
+  const tokenParams = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: config.clientId,
+    code,
+    redirect_uri: redirectUri(),
+    code_verifier: verifier,
+  });
+  const response = await fetch(`${config.domain}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: tokenParams.toString(),
+  });
+  if (!response.ok)
+    throw new Error('AWS UI authentication token exchange failed');
+  storeSession(
+    (await response.json()) as {
+      id_token: string;
+      access_token?: string;
+      expires_in?: number;
+    }
+  );
+  window.history.replaceState(
+    {},
+    document.title,
+    window.location.pathname + window.location.hash
+  );
+  return true;
+};
+
+const redirectToHostedUi = async (
+  config: Required<Pick<AwsUiAuthConfig, 'domain' | 'clientId'>>
+) => {
+  const verifier = randomString(64);
+  const state = randomString(32);
+  window.sessionStorage.setItem(STATE_KEY, state);
+  window.sessionStorage.setItem(VERIFIER_KEY, verifier);
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: config.clientId,
+    redirect_uri: redirectUri(),
+    scope: SCOPE,
+    state,
+    code_challenge: await sha256Base64Url(verifier),
+    code_challenge_method: 'S256',
+  });
+  window.location.assign(
+    `${config.domain}/oauth2/authorize?${params.toString()}`
+  );
+};
+
+const isEnabled = (value: AwsUiAuthConfig['enabled']) =>
+  value === true ||
+  (typeof value === 'string' && value.toLowerCase() === 'true');
+
+export const ensureAwsUiAuth = async (config?: AwsUiAuthConfig | null) => {
+  if (!isEnabled(config?.enabled)) return true;
+  const authConfigInput = config ?? {};
+  const domain = normaliseDomain(authConfigInput.domain ?? '');
+  const clientId = authConfigInput.clientId?.trim() ?? '';
+  if (!domain || !clientId)
+    throw new Error('AWS UI authentication is enabled but not configured');
+
+  const authConfig = { domain, clientId };
+  if (await exchangeCode(authConfig)) return true;
+  if (hasValidSession()) return true;
+  await redirectToHostedUi(authConfig);
+  return false;
+};

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -1,3 +1,10 @@
+export class UserCancelledError extends Error {
+  constructor() {
+    super('User cancelled Cognito login');
+    this.name = 'UserCancelledError';
+  }
+}
+
 export interface AwsUiAuthConfig {
   enabled?: boolean | string;
   domain?: string;
@@ -101,9 +108,15 @@ const exchangeCode = async (config: AuthConfig) => {
   const state = params.get('state');
   const errorParam = params.get('error');
 
-  // access_denied = user clicked Cancel on the Cognito hosted UI — redirect
-  // back so they get another login opportunity rather than an error screen.
-  if (errorParam === 'access_denied') return false;
+  // access_denied = user clicked Cancel on the Cognito hosted UI.
+  // Clean up PKCE state and URL, then throw so the caller renders a retry UI
+  // instead of falling through to redirectToHostedUi and looping indefinitely.
+  if (errorParam === 'access_denied') {
+    window.sessionStorage.removeItem(STATE_KEY);
+    window.sessionStorage.removeItem(VERIFIER_KEY);
+    window.history.replaceState({}, document.title, window.location.pathname);
+    throw new UserCancelledError();
+  }
   if (errorParam) throw new Error(`Cognito auth error: ${errorParam}`);
   if (!code || !state) return false;
 

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -125,6 +125,7 @@ const exchangeCode = async (config: AuthConfig) => {
   if (!expectedState || !verifier || state !== expectedState) {
     window.sessionStorage.removeItem(STATE_KEY);
     window.sessionStorage.removeItem(VERIFIER_KEY);
+    window.history.replaceState({}, document.title, window.location.pathname);
     throw new Error('Invalid AWS UI authentication callback state');
   }
   // State matched — consume the one-time PKCE credentials before the fetch.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -38,7 +38,7 @@ import { UserProvider, useUser } from './UserContext';
 import ErrorBoundary from './ErrorBoundary';
 import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage';
 import { RouteProvider } from './RouteContext';
-import { ensureAwsUiAuth, type AwsUiAuthConfig } from './awsUiAuth';
+import { ensureAwsUiAuth, UserCancelledError, type AwsUiAuthConfig } from './awsUiAuth';
 import {
   deriveBootstrapMode,
   deriveModeFromPathname,
@@ -462,9 +462,20 @@ void bootstrapRuntimeConfig()
   })
   .catch((error) => {
     console.error('AWS UI authentication bootstrap failed', error);
-    createRoot(rootEl).render(
-      <div role="alert" className="app-offline">
-        Authentication is unavailable. Please contact your administrator.
-      </div>
-    );
+    if (error instanceof UserCancelledError) {
+      createRoot(rootEl).render(
+        <div role="alert" className="app-offline">
+          <p>Login cancelled.</p>
+          <button type="button" onClick={() => window.location.reload()}>
+            Sign in
+          </button>
+        </div>
+      );
+    } else {
+      createRoot(rootEl).render(
+        <div role="alert" className="app-offline">
+          Authentication is unavailable. Please contact your administrator.
+        </div>
+      );
+    }
   });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -38,6 +38,7 @@ import { UserProvider, useUser } from './UserContext';
 import ErrorBoundary from './ErrorBoundary';
 import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage';
 import { RouteProvider } from './RouteContext';
+import { ensureAwsUiAuth, type AwsUiAuthConfig } from './awsUiAuth';
 import {
   deriveBootstrapMode,
   deriveModeFromPathname,
@@ -415,38 +416,56 @@ const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('Root element not found');
 
 const bootstrapRuntimeConfig = async () => {
+  let payload: { apiBaseUrl?: unknown; awsUiAuth?: AwsUiAuthConfig } | null =
+    null;
   try {
     const response = await fetch('/config.json', { cache: 'no-store' });
-    if (!response.ok) return;
-    const payload = (await response.json()) as { apiBaseUrl?: unknown };
-    if (typeof payload.apiBaseUrl === 'string') {
-      setApiBase(payload.apiBaseUrl);
-    }
+    if (!response.ok) return true;
+    payload = (await response.json()) as {
+      apiBaseUrl?: unknown;
+      awsUiAuth?: AwsUiAuthConfig;
+    };
   } catch (error) {
     console.warn(
       'Runtime config not loaded, using default API base URL',
       error
     );
+    return true;
   }
+
+  if (typeof payload.apiBaseUrl === 'string') {
+    setApiBase(payload.apiBaseUrl);
+  }
+  return ensureAwsUiAuth(payload.awsUiAuth);
 };
 
-void bootstrapRuntimeConfig().finally(() => {
-  createRoot(rootEl).render(
-    <StrictMode>
-      <HelmetProvider>
-        <ConfigProvider>
-          <PriceRefreshProvider>
-            <AuthProvider>
-              <UserProvider>
-                <BrowserRouter>
-                  <Root />
-                </BrowserRouter>
-                <ToastContainer autoClose={5000} />
-              </UserProvider>
-            </AuthProvider>
-          </PriceRefreshProvider>
-        </ConfigProvider>
-      </HelmetProvider>
-    </StrictMode>
-  );
-});
+void bootstrapRuntimeConfig()
+  .then((shouldRender) => {
+    if (!shouldRender) return;
+    createRoot(rootEl).render(
+      <StrictMode>
+        <HelmetProvider>
+          <ConfigProvider>
+            <PriceRefreshProvider>
+              <AuthProvider>
+                <UserProvider>
+                  <BrowserRouter>
+                    <Root />
+                  </BrowserRouter>
+                  <ToastContainer autoClose={5000} />
+                </UserProvider>
+              </AuthProvider>
+            </PriceRefreshProvider>
+          </ConfigProvider>
+        </HelmetProvider>
+      </StrictMode>
+    );
+  })
+  .catch((error) => {
+    console.error('AWS UI authentication bootstrap failed', error);
+    createRoot(rootEl).render(
+      <div role="alert" className="app-offline">
+        Authentication is unavailable. Please contact your administrator.
+      </div>
+    );
+  });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -416,8 +416,7 @@ const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('Root element not found');
 
 const bootstrapRuntimeConfig = async () => {
-  let payload: { apiBaseUrl?: unknown; awsUiAuth?: AwsUiAuthConfig } | null =
-    null;
+  let payload: { apiBaseUrl?: unknown; awsUiAuth?: AwsUiAuthConfig } = {};
   try {
     const response = await fetch('/config.json', { cache: 'no-store' });
     if (!response.ok) return true;

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -3,30 +3,65 @@ import { ensureAwsUiAuth } from '@/awsUiAuth';
 
 const assignMock = vi.fn();
 
-beforeEach(() => {
-  window.localStorage.clear();
-  window.sessionStorage.clear();
-  assignMock.mockClear();
+const AUTH_CONFIG = {
+  enabled: true as const,
+  domain: 'auth.example.test',
+  clientId: 'client123',
+};
+
+const setLocation = (search = '') => {
   Object.defineProperty(window, 'location', {
     configurable: true,
     value: {
       origin: 'https://app.example.test',
       pathname: '/',
-      search: '',
+      search,
       hash: '',
       assign: assignMock,
     },
   });
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  assignMock.mockClear();
+  setLocation();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('ensureAwsUiAuth', () => {
   it('allows rendering when AWS UI auth is disabled', async () => {
     await expect(ensureAwsUiAuth({ enabled: false })).resolves.toBe(true);
     expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it('allows rendering when enabled is the string "true"', async () => {
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+      (array as Uint8Array).fill(1);
+      return array;
+    });
+    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
+
+    const result = await ensureAwsUiAuth({ ...AUTH_CONFIG, enabled: 'true' });
+    expect(result).toBe(false);
+    expect(assignMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when enabled but domain is missing', async () => {
+    await expect(
+      ensureAwsUiAuth({ enabled: true, clientId: 'client123' })
+    ).rejects.toThrow('AWS UI authentication is enabled but not configured');
+  });
+
+  it('throws when enabled but clientId is missing', async () => {
+    await expect(
+      ensureAwsUiAuth({ enabled: true, domain: 'auth.example.test' })
+    ).rejects.toThrow('AWS UI authentication is enabled but not configured');
   });
 
   it('redirects enabled unauthenticated users to the Cognito hosted UI', async () => {
@@ -39,13 +74,7 @@ describe('ensureAwsUiAuth', () => {
       new Uint8Array(32).buffer
     );
 
-    await expect(
-      ensureAwsUiAuth({
-        enabled: true,
-        domain: 'auth.example.test',
-        clientId: 'client123',
-      })
-    ).resolves.toBe(false);
+    await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(false);
 
     expect(assignMock).toHaveBeenCalledTimes(1);
     const target = new URL(assignMock.mock.calls[0][0]);
@@ -57,5 +86,82 @@ describe('ensureAwsUiAuth', () => {
       'https://app.example.test/'
     );
     expect(target.searchParams.get('scope')).toBe('openid email profile');
+  });
+
+  it('skips redirect when a valid session is already stored', async () => {
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({ idToken: 'tok', expiresAt: Date.now() + 3600 * 1000 })
+    );
+
+    await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(true);
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  describe('token exchange (OAuth callback path)', () => {
+    const STORED_STATE = 'test-state-abc';
+    const STORED_VERIFIER = 'test-verifier-xyz';
+
+    beforeEach(() => {
+      setLocation(`?code=auth-code-123&state=${STORED_STATE}`);
+      window.sessionStorage.setItem('awsUiAuthState', STORED_STATE);
+      window.sessionStorage.setItem('awsUiAuthCodeVerifier', STORED_VERIFIER);
+      vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    });
+
+    it('completes token exchange and returns true on success', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              id_token: 'id-tok',
+              access_token: 'access-tok',
+              expires_in: 3600,
+            }),
+        })
+      );
+
+      await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(true);
+      expect(assignMock).not.toHaveBeenCalled();
+
+      const storedRaw = window.sessionStorage.getItem('awsUiAuthSession');
+      expect(storedRaw).not.toBeNull();
+      const stored = JSON.parse(storedRaw!);
+      expect(stored.idToken).toBe('id-tok');
+      expect(stored.accessToken).toBe('access-tok');
+    });
+
+    it('clears the code and state from the URL after exchange', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ id_token: 'tok', expires_in: 3600 }),
+        })
+      );
+      const replaceState = vi.spyOn(window.history, 'replaceState');
+
+      await ensureAwsUiAuth(AUTH_CONFIG);
+
+      expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
+    });
+
+    it('throws on state mismatch', async () => {
+      window.sessionStorage.setItem('awsUiAuthState', 'different-state');
+
+      await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
+        'Invalid AWS UI authentication callback state'
+      );
+    });
+
+    it('throws when token endpoint returns an error response', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+
+      await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
+        'AWS UI authentication token exchange failed'
+      );
+    });
   });
 });

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -40,7 +40,7 @@ describe('ensureAwsUiAuth', () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
-  it('allows rendering when enabled is the string "true"', async () => {
+  it('redirects to Cognito when enabled is the string "true"', async () => {
     vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
       (array as Uint8Array).fill(1);
       return array;
@@ -88,6 +88,21 @@ describe('ensureAwsUiAuth', () => {
     expect(target.searchParams.get('scope')).toBe('openid email profile');
   });
 
+  it('uses a configured redirectPath in the hosted UI redirect URL', async () => {
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+      (array as Uint8Array).fill(1);
+      return array;
+    });
+    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
+
+    await ensureAwsUiAuth({ ...AUTH_CONFIG, redirectPath: '/callback' });
+
+    const target = new URL(assignMock.mock.calls[0][0]);
+    expect(target.searchParams.get('redirect_uri')).toBe(
+      'https://app.example.test/callback'
+    );
+  });
+
   it('skips redirect when a valid session is already stored', async () => {
     window.sessionStorage.setItem(
       'awsUiAuthSession',
@@ -95,6 +110,15 @@ describe('ensureAwsUiAuth', () => {
     );
 
     await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(true);
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when Cognito returns an error query param', async () => {
+    setLocation('?error=access_denied');
+
+    await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
+      'Cognito auth error: access_denied'
+    );
     expect(assignMock).not.toHaveBeenCalled();
   });
 
@@ -131,6 +155,22 @@ describe('ensureAwsUiAuth', () => {
       const stored = JSON.parse(storedRaw!);
       expect(stored.idToken).toBe('id-tok');
       expect(stored.accessToken).toBe('access-tok');
+    });
+
+    it('uses configured redirectPath in the token exchange request', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ id_token: 'tok', expires_in: 3600 }),
+        })
+      );
+
+      await ensureAwsUiAuth({ ...AUTH_CONFIG, redirectPath: '/callback' });
+
+      const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body = new URLSearchParams(fetchCall[1].body as string);
+      expect(body.get('redirect_uri')).toBe('https://app.example.test/callback');
     });
 
     it('clears the code and state from the URL after exchange', async () => {

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ensureAwsUiAuth } from '@/awsUiAuth';
+import { ensureAwsUiAuth, UserCancelledError } from '@/awsUiAuth';
 
 const assignMock = vi.fn();
 
@@ -130,18 +130,15 @@ describe('ensureAwsUiAuth', () => {
     expect(assignMock).toHaveBeenCalledTimes(1);
   });
 
-  it('redirects back to Cognito when user cancels (access_denied)', async () => {
-    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
-      (array as Uint8Array).fill(1);
-      return array;
-    });
-    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
-
+  it('throws UserCancelledError and cleans up URL when user cancels (access_denied)', async () => {
+    const replaceState = vi.spyOn(window.history, 'replaceState');
     setLocation('?error=access_denied');
 
-    const result = await ensureAwsUiAuth(AUTH_CONFIG);
-    expect(result).toBe(false);
-    expect(assignMock).toHaveBeenCalledTimes(1);
+    await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toBeInstanceOf(UserCancelledError);
+    expect(assignMock).not.toHaveBeenCalled();
+    expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
+    expect(window.sessionStorage.getItem('awsUiAuthState')).toBeNull();
+    expect(window.sessionStorage.getItem('awsUiAuthCodeVerifier')).toBeNull();
   });
 
   it('throws when Cognito returns a non-cancellation error', async () => {

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -113,11 +113,42 @@ describe('ensureAwsUiAuth', () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
-  it('throws when Cognito returns an error query param', async () => {
+  it('redirects back to Cognito when session is expired', async () => {
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+      (array as Uint8Array).fill(1);
+      return array;
+    });
+    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
+
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({ idToken: 'tok', expiresAt: Date.now() - 1000 })
+    );
+
+    const result = await ensureAwsUiAuth(AUTH_CONFIG);
+    expect(result).toBe(false);
+    expect(assignMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects back to Cognito when user cancels (access_denied)', async () => {
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+      (array as Uint8Array).fill(1);
+      return array;
+    });
+    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
+
     setLocation('?error=access_denied');
 
+    const result = await ensureAwsUiAuth(AUTH_CONFIG);
+    expect(result).toBe(false);
+    expect(assignMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when Cognito returns a non-cancellation error', async () => {
+    setLocation('?error=server_error');
+
     await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
-      'Cognito auth error: access_denied'
+      'Cognito auth error: server_error'
     );
     expect(assignMock).not.toHaveBeenCalled();
   });

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensureAwsUiAuth } from '@/awsUiAuth';
+
+const assignMock = vi.fn();
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  assignMock.mockClear();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      origin: 'https://app.example.test',
+      pathname: '/',
+      search: '',
+      hash: '',
+      assign: assignMock,
+    },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ensureAwsUiAuth', () => {
+  it('allows rendering when AWS UI auth is disabled', async () => {
+    await expect(ensureAwsUiAuth({ enabled: false })).resolves.toBe(true);
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects enabled unauthenticated users to the Cognito hosted UI', async () => {
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+      const bytes = array as Uint8Array;
+      bytes.fill(1);
+      return array;
+    });
+    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(
+      new Uint8Array(32).buffer
+    );
+
+    await expect(
+      ensureAwsUiAuth({
+        enabled: true,
+        domain: 'auth.example.test',
+        clientId: 'client123',
+      })
+    ).resolves.toBe(false);
+
+    expect(assignMock).toHaveBeenCalledTimes(1);
+    const target = new URL(assignMock.mock.calls[0][0]);
+    expect(target.origin).toBe('https://auth.example.test');
+    expect(target.pathname).toBe('/oauth2/authorize');
+    expect(target.searchParams.get('response_type')).toBe('code');
+    expect(target.searchParams.get('client_id')).toBe('client123');
+    expect(target.searchParams.get('redirect_uri')).toBe(
+      'https://app.example.test/'
+    );
+    expect(target.searchParams.get('scope')).toBe('openid email profile');
+  });
+});

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -229,12 +229,16 @@ describe('ensureAwsUiAuth', () => {
       expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
     });
 
-    it('throws on state mismatch', async () => {
+    it('throws on state mismatch and cleans up URL', async () => {
+      const replaceState = vi.spyOn(window.history, 'replaceState');
       window.sessionStorage.setItem('awsUiAuthState', 'different-state');
 
       await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
         'Invalid AWS UI authentication callback state'
       );
+      expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
+      expect(window.sessionStorage.getItem('awsUiAuthState')).toBeNull();
+      expect(window.sessionStorage.getItem('awsUiAuthCodeVerifier')).toBeNull();
     });
 
     it('throws when token endpoint returns an error response', async () => {

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -113,6 +113,19 @@ describe('ensureAwsUiAuth', () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
+  it('skips code exchange when a valid session exists despite stale ?code= in URL', async () => {
+    // A stale ?code= with no PKCE verifier in sessionStorage would throw
+    // 'Invalid AWS UI authentication callback state' if exchangeCode ran first.
+    setLocation('?code=stale-code&state=stale-state');
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({ idToken: 'tok', expiresAt: Date.now() + 3600 * 1000 })
+    );
+
+    await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(true);
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
   it('redirects back to Cognito when session is expired', async () => {
     vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
       (array as Uint8Array).fill(1);


### PR DESCRIPTION
### Motivation

- Prevent the AWS-hosted frontend from being publicly accessible by gating the static site behind a managed Cognito hosted UI and enforcing authentication before the SPA renders. 

Closes #2748 
### Description

- CDK: extend `StaticSiteStack` to create a Cognito `UserPool`, a SPA `UserPoolClient` configured for the authorization-code flow, a Cognito domain, and CloudFormation outputs (`UiAuthUserPoolId`, `UiAuthUserPoolClientId`, `UiAuthDomain`), and inject `awsUiAuth` settings into the deployed `/config.json` at runtime. 
- Security/CSP: update the CloudFront response headers policy to include `connect-src` entries required for AWS endpoints while preserving a restrictive policy for other directives. 
- Frontend: add `frontend/src/awsUiAuth.ts` with PKCE/authorization-code bootstrap logic that exchanges callback codes, stores session info, redirects unauthenticated visitors to the Cognito hosted UI, and exposes `ensureAwsUiAuth` used by `frontend/src/main.tsx` to block rendering until bootstrap completes. 
- Tests & docs: add CDK assertions in `cdk/tests/test_static_site_stack.py` and a Vitest unit test `frontend/tests/unit/awsUiAuth.test.ts`; update `docs/SECURITY.md` and `docs/DEPLOY.md` with Cognito setup and CSP guidance. 

### Testing

- Ran the CDK unit/assertion tests with `PYENV_VERSION=3.11.15 pytest cdk/tests/test_static_site_stack.py` and they passed. 
- Ran frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/awsUiAuth.test.ts` and they passed. 
- Performed static checks and linting including `PYENV_VERSION=3.11.15 python -m ruff check cdk/stacks/static_site_stack.py cdk/tests/test_static_site_stack.py`, `npm --prefix frontend run type-check`, and `npm --prefix frontend run lint`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2b09dc9c8327aeec6e28e45e0dc9)