### PR TITLE
Check S3 meta timeseries cache existence using boto3 head_object

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -18,8 +18,10 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Callable, Dict
 
+import boto3
 import pandas as pd
 import requests
+from botocore.exceptions import ClientError
 
 from backend.common.instruments import get_instrument_meta
 from backend.config import config
@@ -446,7 +448,6 @@ def _convert_to_base_currency(
                 return pd.DataFrame()
             fx["Date"] = pd.to_datetime(fx["Date"])
 
-
         fx["Rate"] = pd.to_numeric(fx["Rate"], errors="coerce")
         return fx
 
@@ -520,10 +521,28 @@ def load_meta_timeseries_range(
     return _empty_ts()
 
 
+def _s3_cache_object_exists(cache: str) -> bool:
+    without_scheme = cache.removeprefix("s3://")
+    bucket, _, key = without_scheme.partition("/")
+    if not bucket or not key:
+        logger.warning("Invalid S3 timeseries cache path: %s", cache)
+        return False
+
+    try:
+        boto3.client("s3").head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        error_code = exc.response.get("Error", {}).get("Code")
+        if error_code in {"404", "NoSuchKey", "NotFound"}:
+            return False
+        logger.warning("Unable to check S3 timeseries cache object %s: %s", cache, exc)
+        return False
+    return True
+
+
 def has_cached_meta_timeseries(ticker: str, exchange: str) -> bool:
     cache = meta_timeseries_cache_path(ticker, exchange)
     if cache.startswith("s3://"):
-        return True  # S3 presence is checked lazily on read
+        return _s3_cache_object_exists(cache)
     p = Path(cache)
     return p.exists() and p.stat().st_size > 0
 

--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -11,7 +11,6 @@ where the parquet files live, e.g.
 
 from __future__ import annotations
 
-import importlib
 import logging
 import os
 from datetime import date, datetime, timedelta
@@ -289,19 +288,32 @@ def load_stooq_timeseries(ticker: str, exchange: str, days: int) -> pd.DataFrame
 _CACHE_FILE_MTIMES: Dict[str, float] = {}
 
 
-def _s3_object_mtime(cache: str) -> float:
-    """Return the S3 object's LastModified timestamp for cache invalidation."""
+@lru_cache(maxsize=1)
+def _s3_client():
+    """Return the shared boto3 S3 client used by cache metadata checks."""
+    return boto3.client("s3")
 
+
+def _split_s3_cache_uri(cache: str) -> tuple[str, str] | None:
     without_scheme = cache[len("s3://") :]
     bucket, _, key = without_scheme.partition("/")
     if not bucket or not key:
         logger.warning("Invalid S3 timeseries cache path: %s", cache)
-        return 0.0
+        return None
+    return bucket, key
 
-    boto3 = importlib.import_module("boto3")
+
+def _s3_object_mtime(cache: str) -> float:
+    """Return the S3 object's LastModified timestamp for cache invalidation."""
+
+    parsed = _split_s3_cache_uri(cache)
+    if parsed is None:
+        return 0.0
+    bucket, key = parsed
+
     try:
-        resp = boto3.client("s3").head_object(Bucket=bucket, Key=key)
-    except Exception as exc:  # pragma: no cover - defensive AWS path
+        resp = _s3_client().head_object(Bucket=bucket, Key=key)
+    except (BotoCoreError, ClientError) as exc:  # pragma: no cover - defensive AWS path
         logger.warning("Unable to read S3 cache metadata for %s: %s", cache, exc)
         return 0.0
 
@@ -553,14 +565,19 @@ def load_meta_timeseries_range(
 
 
 def _s3_cache_object_exists(cache: str) -> bool:
-    without_scheme = cache.removeprefix("s3://")
-    bucket, _, key = without_scheme.partition("/")
-    if not bucket or not key:
-        logger.warning("Invalid S3 timeseries cache path: %s", cache)
+    """Return whether an S3 cache object exists using a shared boto3 client.
+
+    Non-404 AWS errors are treated as cache misses after error logging so local
+    fallback paths can continue when credentials, networking, or IAM are broken.
+    """
+
+    parsed = _split_s3_cache_uri(cache)
+    if parsed is None:
         return False
+    bucket, key = parsed
 
     try:
-        boto3.client("s3").head_object(Bucket=bucket, Key=key)
+        _s3_client().head_object(Bucket=bucket, Key=key)
     except ClientError as exc:
         error_code = exc.response.get("Error", {}).get("Code")
         if error_code in {"404", "NoSuchKey", "NotFound"}:

--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -21,7 +21,7 @@ from typing import Callable, Dict
 import boto3
 import pandas as pd
 import requests
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 
 from backend.common.instruments import get_instrument_meta
 from backend.config import config
@@ -534,7 +534,10 @@ def _s3_cache_object_exists(cache: str) -> bool:
         error_code = exc.response.get("Error", {}).get("Code")
         if error_code in {"404", "NoSuchKey", "NotFound"}:
             return False
-        logger.warning("Unable to check S3 timeseries cache object %s: %s", cache, exc)
+        logger.error("Unable to check S3 timeseries cache object %s: %s", cache, exc)
+        return False
+    except BotoCoreError as exc:
+        logger.error("AWS client error checking S3 timeseries cache object %s: %s", cache, exc)
         return False
     return True
 

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -119,8 +119,10 @@ class BackendLambdaStack(Stack):
     ) -> None:
         """Grant S3 permissions required by the Lambda timeseries parquet cache.
 
-        S3 HeadObject authorization is covered by s3:GetObject, so the read
-        grant below supports both parquet reads and cache-existence checks.
+        In AWS IAM, HeadObject is authorized by the s3:GetObject action (there
+        is no separate s3:HeadObject action in the S3 IAM namespace), so a
+        single s3:GetObject grant covers both parquet reads and cache-existence
+        checks via boto3 head_object.
         """
 
         actions = ["s3:GetObject"]

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -117,7 +117,11 @@ class BackendLambdaStack(Stack):
         bucket: s3.IBucket,
         allow_put: bool,
     ) -> None:
-        """Grant S3 permissions required by the Lambda timeseries parquet cache."""
+        """Grant S3 permissions required by the Lambda timeseries parquet cache.
+
+        S3 HeadObject authorization is covered by s3:GetObject, so the read
+        grant below supports both parquet reads and cache-existence checks.
+        """
 
         actions = ["s3:GetObject"]
         if allow_put:

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -39,3 +39,49 @@ def test_cache_base_from_config(monkeypatch, tmp_path):
     cache = import_cache()
     assert cache._cache_path("baz") == str(tmp_path / "baz")
 
+
+def test_has_cached_meta_timeseries_returns_true_for_existing_s3_object(monkeypatch):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+    calls = []
+
+    class FakeS3Client:
+        def head_object(self, Bucket, Key):  # noqa: N803 - boto3 API parameter names
+            calls.append((Bucket, Key))
+            return {"ContentLength": 10}
+
+    monkeypatch.setattr(cache.boto3, "client", lambda service: FakeS3Client())
+
+    assert cache.has_cached_meta_timeseries("aapl", "us") is True
+    assert calls == [("bucket", "timeseries/meta/AAPL_US.parquet")]
+
+
+def test_has_cached_meta_timeseries_returns_false_for_missing_s3_object(monkeypatch):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+
+    class FakeS3Client:
+        def head_object(self, Bucket, Key):  # noqa: N803 - boto3 API parameter names
+            raise cache.ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadObject",
+            )
+
+    monkeypatch.setattr(cache.boto3, "client", lambda service: FakeS3Client())
+
+    assert cache.has_cached_meta_timeseries("missing", "l") is False
+
+
+def test_has_cached_meta_timeseries_keeps_local_path_behaviour(monkeypatch, tmp_path):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
+    cache = import_cache()
+
+    assert cache.has_cached_meta_timeseries("empty", "l") is False
+
+    path = tmp_path / "meta" / "EMPTY_L.parquet"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"")
+    assert cache.has_cached_meta_timeseries("empty", "l") is False
+
+    path.write_bytes(b"cached")
+    assert cache.has_cached_meta_timeseries("empty", "l") is True

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -69,7 +69,7 @@ def test_has_cached_meta_timeseries_returns_false_for_missing_s3_object(monkeypa
 
     monkeypatch.setattr(cache.boto3, "client", lambda service: FakeS3Client())
 
-    assert cache.has_cached_meta_timeseries("missing", "l") is False
+    assert cache.has_cached_meta_timeseries("missing", "us") is False
 
 
 def test_has_cached_meta_timeseries_keeps_local_path_behaviour(monkeypatch, tmp_path):
@@ -85,3 +85,40 @@ def test_has_cached_meta_timeseries_keeps_local_path_behaviour(monkeypatch, tmp_
 
     path.write_bytes(b"cached")
     assert cache.has_cached_meta_timeseries("empty", "l") is True
+
+
+def test_has_cached_meta_timeseries_returns_false_for_non_404_client_error(monkeypatch):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+
+    class FakeS3Client:
+        def head_object(self, Bucket, Key):  # noqa: N803 - boto3 API parameter names
+            raise cache.ClientError(
+                {"Error": {"Code": "403", "Message": "Forbidden"}},
+                "HeadObject",
+            )
+
+    monkeypatch.setattr(cache.boto3, "client", lambda service: FakeS3Client())
+
+    assert cache.has_cached_meta_timeseries("restricted", "us") is False
+
+
+def test_has_cached_meta_timeseries_returns_false_for_botocore_error(monkeypatch):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+
+    class FakeS3Client:
+        def head_object(self, Bucket, Key):  # noqa: N803 - boto3 API parameter names
+            raise cache.BotoCoreError()
+
+    monkeypatch.setattr(cache.boto3, "client", lambda service: FakeS3Client())
+
+    assert cache.has_cached_meta_timeseries("any", "us") is False
+
+
+def test_s3_cache_object_exists_returns_false_for_invalid_path(monkeypatch):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+
+    assert cache._s3_cache_object_exists("s3://") is False
+    assert cache._s3_cache_object_exists("s3:///nokey") is False

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -136,6 +136,7 @@ def test_has_cached_meta_timeseries_returns_false_when_s3_client_creation_fails(
         created_clients.append(service)
         raise cache.BotoCoreError()
 
+    cache._s3_client.cache_clear()
     monkeypatch.setattr(cache.boto3, "client", fake_client)
 
     assert cache.has_cached_meta_timeseries("any", "us") is False

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -23,6 +23,7 @@ def patch_s3_client(monkeypatch, cache, client):
         created_clients.append(service)
         return client
 
+    cache._s3_client.cache_clear()
     monkeypatch.setattr(cache.boto3, "client", fake_client)
     return created_clients
 

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -2,7 +2,6 @@ import importlib
 import os
 import sys
 from datetime import datetime, timezone
-from types import SimpleNamespace
 
 import pandas as pd
 import pytest
@@ -14,6 +13,18 @@ def import_cache():
     """Import ``backend.timeseries.cache`` after clearing any previous copy."""
     sys.modules.pop("backend.timeseries.cache", None)
     return importlib.import_module("backend.timeseries.cache")
+
+
+def patch_s3_client(monkeypatch, cache, client):
+    created_clients = []
+
+    def fake_client(service):
+        assert service == "s3"
+        created_clients.append(service)
+        return client
+
+    monkeypatch.setattr(cache.boto3, "client", fake_client)
+    return created_clients
 
 
 def test_missing_cache_base_raises(monkeypatch):
@@ -54,10 +65,15 @@ def test_has_cached_meta_timeseries_returns_true_for_existing_s3_object(monkeypa
             calls.append((Bucket, Key))
             return {"ContentLength": 10}
 
-    monkeypatch.setattr(cache.boto3, "client", lambda service: FakeS3Client())
+    created_clients = patch_s3_client(monkeypatch, cache, FakeS3Client())
 
     assert cache.has_cached_meta_timeseries("aapl", "us") is True
-    assert calls == [("bucket", "timeseries/meta/AAPL_US.parquet")]
+    assert cache.has_cached_meta_timeseries("aapl", "us") is True
+    assert calls == [
+        ("bucket", "timeseries/meta/AAPL_US.parquet"),
+        ("bucket", "timeseries/meta/AAPL_US.parquet"),
+    ]
+    assert created_clients == ["s3"]
 
 
 def test_has_cached_meta_timeseries_returns_false_for_missing_s3_object(monkeypatch):
@@ -71,9 +87,10 @@ def test_has_cached_meta_timeseries_returns_false_for_missing_s3_object(monkeypa
                 "HeadObject",
             )
 
-    monkeypatch.setattr(cache.boto3, "client", lambda service: FakeS3Client())
+    created_clients = patch_s3_client(monkeypatch, cache, FakeS3Client())
 
     assert cache.has_cached_meta_timeseries("missing", "us") is False
+    assert created_clients == ["s3"]
 
 
 def test_has_cached_meta_timeseries_keeps_local_path_behaviour(monkeypatch, tmp_path):
@@ -102,22 +119,26 @@ def test_has_cached_meta_timeseries_returns_false_for_non_404_client_error(monke
                 "HeadObject",
             )
 
-    monkeypatch.setattr(cache.boto3, "client", lambda service: FakeS3Client())
+    created_clients = patch_s3_client(monkeypatch, cache, FakeS3Client())
 
     assert cache.has_cached_meta_timeseries("restricted", "us") is False
+    assert created_clients == ["s3"]
 
 
-def test_has_cached_meta_timeseries_returns_false_for_botocore_error(monkeypatch):
+def test_has_cached_meta_timeseries_returns_false_when_s3_client_creation_fails(monkeypatch):
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
     cache = import_cache()
+    created_clients = []
 
-    class FakeS3Client:
-        def head_object(self, Bucket, Key):  # noqa: N803 - boto3 API parameter names
-            raise cache.BotoCoreError()
+    def fake_client(service):
+        assert service == "s3"
+        created_clients.append(service)
+        raise cache.BotoCoreError()
 
-    monkeypatch.setattr(cache.boto3, "client", lambda service: FakeS3Client())
+    monkeypatch.setattr(cache.boto3, "client", fake_client)
 
     assert cache.has_cached_meta_timeseries("any", "us") is False
+    assert created_clients == ["s3"]
 
 
 def test_s3_cache_object_exists_returns_false_for_invalid_path(monkeypatch):
@@ -126,6 +147,9 @@ def test_s3_cache_object_exists_returns_false_for_invalid_path(monkeypatch):
 
     assert cache._s3_cache_object_exists("s3://") is False
     assert cache._s3_cache_object_exists("s3:///nokey") is False
+    assert cache._s3_cache_object_exists("s3://bucket") is False
+
+
 def _frame(close: float) -> pd.DataFrame:
     return pd.DataFrame(
         {
@@ -153,7 +177,7 @@ def test_s3_meta_cache_invalidates_when_last_modified_changes(monkeypatch):
             assert Key == "timeseries/meta/ABC_L.parquet"
             return {"LastModified": last_modified}
 
-    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=lambda _service: FakeS3()))
+    patch_s3_client(monkeypatch, cache, FakeS3())
 
     loads = []
 
@@ -213,7 +237,7 @@ def test_s3_range_cache_invalidates_when_last_modified_changes(monkeypatch):
         def head_object(self, *, Bucket, Key):
             return {"LastModified": last_modified}
 
-    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=lambda _service: FakeS3()))
+    patch_s3_client(monkeypatch, cache, FakeS3())
 
     loads = []
 


### PR DESCRIPTION
### Motivation
- The existing `has_cached_meta_timeseries` returned `True` for any `s3://` cache path which caused callers to attempt parquet reads for S3 objects that might not exist.
- Implement an explicit S3 existence check so the cache layer can avoid unnecessary reads and behave consistently with local-path checks.

### Description
- Added `boto3` import and `from botocore.exceptions import ClientError` and implemented `_s3_cache_object_exists(cache: str) -> bool` which parses `s3://` URIs and calls `boto3.client('s3').head_object(...)` to verify existence, returning `False` on 404/NoSuchKey/NotFound and logging other errors.
- Updated `has_cached_meta_timeseries` to call `_s3_cache_object_exists` for `s3://` paths and preserved the existing local `Path(...).exists()` and `stat().st_size` behavior.
- Added unit tests in `tests/test_timeseries_cache_base.py` to cover an existing S3 key, a missing S3 key (404), and unchanged local-file behavior.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/test_timeseries_cache_base.py` and the test file passed (`6 passed`).
- Ran `PYENV_VERSION=3.11.15 ruff check --config backend/pyproject.toml backend/timeseries/cache.py tests/test_timeseries_cache_base.py` and the targeted checks passed.
- Ran `PYENV_VERSION=3.11.15 black --config backend/pyproject.toml` to format the changed files and then re-checked with `--check`, which passed for the modified files.
- `make lint` reported repo-wide lint failures and a local `pyenv` version mismatch that are pre-existing and outside the scope of this change (these did not block the targeted file checks or the new tests).

Closes #2874

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2fcf57288327a2d9aef2a26b5242)