### PR TITLE
Fix S3 timeseries cache invalidation

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -310,6 +310,21 @@ def _s3_object_mtime(cache: str) -> float:
     return float(last_modified.timestamp())
 
 
+def _invalidate_meta_caches_if_stale(ticker: str, exchange: str) -> None:
+    """Clear both meta LRUs when the backing file's mtime has changed."""
+    cache = meta_timeseries_cache_path(ticker, exchange)
+    if cache.startswith("s3://"):
+        mtime = _s3_object_mtime(cache)
+    else:
+        p = Path(cache)
+        mtime = p.stat().st_mtime if p.exists() else 0.0
+    prev = _CACHE_FILE_MTIMES.get(cache)
+    if prev is not None and prev != mtime:
+        _load_meta_timeseries_cached.cache_clear()
+        _memoized_range_cached.cache_clear()
+    _CACHE_FILE_MTIMES[cache] = mtime
+
+
 @lru_cache(maxsize=512)
 def _load_meta_timeseries_cached(ticker: str, exchange: str, days: int) -> pd.DataFrame:
     """LRU-backed loader for Meta timeseries."""
@@ -332,19 +347,10 @@ def load_meta_timeseries(ticker: str, exchange: str, days: int) -> pd.DataFrame:
     if OFFLINE_MODE != config.offline_mode:
         OFFLINE_MODE = config.offline_mode
         _load_meta_timeseries_cached.cache_clear()
+        _memoized_range_cached.cache_clear()
         _CACHE_FILE_MTIMES.clear()
 
-    cache = meta_timeseries_cache_path(ticker, exchange)
-    if cache.startswith("s3://"):
-        mtime = _s3_object_mtime(cache)
-    else:
-        p = Path(cache)
-        mtime = p.stat().st_mtime if p.exists() else 0.0
-    prev = _CACHE_FILE_MTIMES.get(cache)
-    if prev is not None and prev != mtime:
-        _load_meta_timeseries_cached.cache_clear()
-    _CACHE_FILE_MTIMES[cache] = mtime
-
+    _invalidate_meta_caches_if_stale(ticker, exchange)
     return _load_meta_timeseries_cached(ticker, exchange, days).copy()
 
 
@@ -509,6 +515,7 @@ def load_meta_timeseries_range(
     base_currency: str = "GBP",
 ) -> pd.DataFrame:
     global OFFLINE_MODE
+    _invalidate_meta_caches_if_stale(ticker, exchange)
     for offset in range(0, 5):  # try same day, 1-day back, 2-day back...
         s = start_date - timedelta(days=offset)
         e = end_date - timedelta(days=offset)

--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -11,6 +11,7 @@ where the parquet files live, e.g.
 
 from __future__ import annotations
 
+import importlib
 import logging
 import os
 from datetime import date, datetime, timedelta
@@ -286,6 +287,29 @@ def load_stooq_timeseries(ticker: str, exchange: str, days: int) -> pd.DataFrame
 _CACHE_FILE_MTIMES: Dict[str, float] = {}
 
 
+def _s3_object_mtime(cache: str) -> float:
+    """Return the S3 object's LastModified timestamp for cache invalidation."""
+
+    without_scheme = cache[len("s3://") :]
+    bucket, _, key = without_scheme.partition("/")
+    if not bucket or not key:
+        logger.warning("Invalid S3 timeseries cache path: %s", cache)
+        return 0.0
+
+    boto3 = importlib.import_module("boto3")
+    try:
+        resp = boto3.client("s3").head_object(Bucket=bucket, Key=key)
+    except Exception as exc:  # pragma: no cover - defensive AWS path
+        logger.warning("Unable to read S3 cache metadata for %s: %s", cache, exc)
+        return 0.0
+
+    last_modified = resp.get("LastModified")
+    if not hasattr(last_modified, "timestamp"):
+        logger.warning("S3 cache metadata for %s is missing LastModified", cache)
+        return 0.0
+    return float(last_modified.timestamp())
+
+
 @lru_cache(maxsize=512)
 def _load_meta_timeseries_cached(ticker: str, exchange: str, days: int) -> pd.DataFrame:
     """LRU-backed loader for Meta timeseries."""
@@ -312,7 +336,7 @@ def load_meta_timeseries(ticker: str, exchange: str, days: int) -> pd.DataFrame:
 
     cache = meta_timeseries_cache_path(ticker, exchange)
     if cache.startswith("s3://"):
-        mtime = 0.0
+        mtime = _s3_object_mtime(cache)
     else:
         p = Path(cache)
         mtime = p.stat().st_mtime if p.exists() else 0.0
@@ -445,7 +469,6 @@ def _convert_to_base_currency(
             if fx.empty:
                 return pd.DataFrame()
             fx["Date"] = pd.to_datetime(fx["Date"])
-
 
         fx["Rate"] = pd.to_numeric(fx["Rate"], errors="coerce")
         return fx

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -119,3 +119,36 @@ def test_local_meta_cache_still_invalidates_when_file_mtime_changes(monkeypatch,
     assert second["Close"].iloc[0] == 1.0
     assert third["Close"].iloc[0] == 2.0
     assert len(loads) == 2
+
+
+def test_s3_range_cache_invalidates_when_last_modified_changes(monkeypatch):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+
+    last_modified = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+
+    class FakeS3:
+        def head_object(self, *, Bucket, Key):
+            return {"LastModified": last_modified}
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=lambda _service: FakeS3()))
+
+    loads = []
+
+    def fake_rolling_cache(*_args, **_kwargs):
+        loads.append(last_modified)
+        return _frame(float(len(loads)))
+
+    monkeypatch.setattr(cache, "_rolling_cache", fake_rolling_cache)
+
+    target = pd.Timestamp("2026-05-08").date()
+    first = cache.load_meta_timeseries_range("ABC", "L", target, target)
+    second = cache.load_meta_timeseries_range("ABC", "L", target, target)
+
+    last_modified = datetime(2026, 5, 8, 12, 5, tzinfo=timezone.utc)
+    third = cache.load_meta_timeseries_range("ABC", "L", target, target)
+
+    assert first["Close"].iloc[0] == 1.0
+    assert second["Close"].iloc[0] == 1.0
+    assert third["Close"].iloc[0] == 2.0
+    assert len(loads) == 2

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -1,6 +1,10 @@
 import importlib
+import os
 import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 
 from backend.config import reload_config
@@ -39,3 +43,79 @@ def test_cache_base_from_config(monkeypatch, tmp_path):
     cache = import_cache()
     assert cache._cache_path("baz") == str(tmp_path / "baz")
 
+
+def _frame(close: float) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2026-05-08")],
+            "Open": [close],
+            "High": [close],
+            "Low": [close],
+            "Close": [close],
+            "Volume": [100],
+            "Ticker": ["ABC"],
+            "Source": ["TEST"],
+        }
+    )
+
+
+def test_s3_meta_cache_invalidates_when_last_modified_changes(monkeypatch):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+
+    last_modified = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+
+    class FakeS3:
+        def head_object(self, *, Bucket, Key):
+            assert Bucket == "bucket"
+            assert Key == "timeseries/meta/ABC_L.parquet"
+            return {"LastModified": last_modified}
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=lambda _service: FakeS3()))
+
+    loads = []
+
+    def fake_rolling_cache(*_args, **_kwargs):
+        loads.append(last_modified)
+        return _frame(float(len(loads)))
+
+    monkeypatch.setattr(cache, "_rolling_cache", fake_rolling_cache)
+
+    first = cache.load_meta_timeseries("ABC", "L", 5)
+    second = cache.load_meta_timeseries("ABC", "L", 5)
+
+    last_modified = datetime(2026, 5, 8, 12, 5, tzinfo=timezone.utc)
+    third = cache.load_meta_timeseries("ABC", "L", 5)
+
+    assert first["Close"].iloc[0] == 1.0
+    assert second["Close"].iloc[0] == 1.0
+    assert third["Close"].iloc[0] == 2.0
+    assert len(loads) == 2
+
+
+def test_local_meta_cache_still_invalidates_when_file_mtime_changes(monkeypatch, tmp_path):
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
+    cache = import_cache()
+    cache_file = tmp_path / "meta" / "ABC_L.parquet"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_text("old", encoding="utf-8")
+
+    loads = []
+
+    def fake_rolling_cache(*_args, **_kwargs):
+        loads.append(cache_file.stat().st_mtime)
+        return _frame(float(len(loads)))
+
+    monkeypatch.setattr(cache, "_rolling_cache", fake_rolling_cache)
+
+    first = cache.load_meta_timeseries("ABC", "L", 5)
+    second = cache.load_meta_timeseries("ABC", "L", 5)
+
+    changed_mtime = cache_file.stat().st_mtime + 10
+    os.utime(cache_file, (changed_mtime, changed_mtime))
+    third = cache.load_meta_timeseries("ABC", "L", 5)
+
+    assert first["Close"].iloc[0] == 1.0
+    assert second["Close"].iloc[0] == 1.0
+    assert third["Close"].iloc[0] == 2.0
+    assert len(loads) == 2


### PR DESCRIPTION
### Motivation
- Warm Lambda / long-running processes were serving stale Meta timeseries from an in-memory LRU because S3-updated parquet files did not change the cached mtime used to invalidate the LRU.

### Description
- Added `_s3_object_mtime(cache: str) -> float` which uses `boto3.client('s3').head_object(...)["LastModified"]` to obtain an S3 object's timestamp for cache invalidation and logs/wraps failures defensively.
- Use `_s3_object_mtime` in `load_meta_timeseries` so that S3-backed `meta` parquet files trigger in-process LRU invalidation when their `LastModified` changes, while local files continue to use filesystem `stat().st_mtime`.
- Import `boto3` lazily via `importlib.import_module` and fall back to a `0.0` mtime on errors to preserve previous best-effort behavior.
- Added unit tests to `tests/test_timeseries_cache_base.py` that mock S3 `head_object` metadata changing and assert the LRU is cleared, and a test that verifies local file mtime invalidation remains unchanged.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/test_timeseries_cache_base.py` and the new/updated tests passed (`5 passed`).
- Ran `isort` / `black` / `ruff` on the touched files and formatting/lint checks for the changed files passed. 
- Attempted full `make lint`; it failed due to existing repository-wide lint issues unrelated to these changes, so only the focused checks and unit tests for this change were used for validation.

Closes #2875

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2f92bc308327b6c0b0943392a115)