### PR TITLE
Grant Lambda timeseries cache S3 permissions

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -317,10 +317,13 @@ class BackendLambdaStack(Stack):
             log_group=agent_log_group,
         )
 
-        # TradingAgentLambda: read-only for general data keys. The explicit
-        # timeseries cache grant includes GetObject, PutObject, and ListBucket on
-        # timeseries/ so shared parquet cache helpers can use pyarrow S3 safely.
-        # _log_trade() writes to TRADE_LOG_PATH (local filesystem / CloudWatch).
+        # TradingAgentLambda: read-only, no put, no general list.
+        # Audited: trading_agent.py:run() → load_prices_for_tickers()
+        # → load_meta_timeseries_range() reads parquet from S3 by known key.
+        # No S3 writes: _log_trade() writes to TRADE_LOG_PATH (local filesystem / CloudWatch).
+        # The timeseries cache grant adds scoped GetObject and ListBucket so pyarrow
+        # can read cached parquet files under timeseries/. allow_put=False enforces
+        # the read-only invariant on the timeseries prefix.
         self._grant_bucket_access(
             agent_fn,
             bucket=data_bucket,
@@ -329,7 +332,7 @@ class BackendLambdaStack(Stack):
             allow_list=False,
             list_prefix=lambda_list_prefixes["trading_agent"],
         )
-        self._grant_timeseries_cache_access(agent_fn, bucket=data_bucket, allow_put=True)
+        self._grant_timeseries_cache_access(agent_fn, bucket=data_bucket, allow_put=False)
 
         events.Rule(
             self,

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -110,6 +110,33 @@ class BackendLambdaStack(Stack):
                 )
             )
 
+    @staticmethod
+    def _grant_timeseries_cache_access(
+        fn: _lambda.DockerImageFunction,
+        *,
+        bucket: s3.IBucket,
+        allow_put: bool,
+    ) -> None:
+        """Grant S3 permissions required by the Lambda timeseries parquet cache."""
+
+        actions = ["s3:GetObject"]
+        if allow_put:
+            actions.append("s3:PutObject")
+
+        fn.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=actions,
+                resources=[bucket.arn_for_objects("timeseries/*")],
+            )
+        )
+        fn.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["s3:ListBucket"],
+                resources=[bucket.bucket_arn],
+                conditions={"StringLike": {"s3:prefix": ["timeseries", "timeseries/*"]}},
+            )
+        )
+
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
@@ -118,16 +145,13 @@ class BackendLambdaStack(Stack):
         data_repo = os.getenv("DATA_REPO")
         data_branch = os.getenv("DATA_BRANCH", "main")
         budget_limit_usd = float(
-            self.node.try_get_context("monthly_budget_limit_usd")
-            or os.getenv("MONTHLY_BUDGET_LIMIT_USD", "5")
+            self.node.try_get_context("monthly_budget_limit_usd") or os.getenv("MONTHLY_BUDGET_LIMIT_USD", "5")
         )
         noncurrent_expiry_days = int(
             self.node.try_get_context("data_bucket_noncurrent_expiry_days")
             or os.getenv("DATA_BUCKET_NONCURRENT_EXPIRY_DAYS", "30")
         )
-        budget_alert_email = self.node.try_get_context("budget_alert_email") or os.getenv(
-            "BUDGET_ALERT_EMAIL"
-        )
+        budget_alert_email = self.node.try_get_context("budget_alert_email") or os.getenv("BUDGET_ALERT_EMAIL")
         data_bucket = s3.Bucket(
             self,
             "PortfolioDataBucket",
@@ -135,11 +159,7 @@ class BackendLambdaStack(Stack):
             encryption=s3.BucketEncryption.S3_MANAGED,
             enforce_ssl=True,
             versioned=True,
-            lifecycle_rules=[
-                s3.LifecycleRule(
-                    noncurrent_version_expiration=Duration.days(noncurrent_expiry_days)
-                )
-            ],
+            lifecycle_rules=[s3.LifecycleRule(noncurrent_version_expiration=Duration.days(noncurrent_expiry_days))],
         )
 
         bucket_name = data_bucket.bucket_name
@@ -149,23 +169,17 @@ class BackendLambdaStack(Stack):
             "trading_agent": (),
         }
 
-        image_code = _lambda.DockerImageCode.from_image_asset(
-            str(project_root), file="backend/Dockerfile.lambda"
-        )
+        image_code = _lambda.DockerImageCode.from_image_asset(str(project_root), file="backend/Dockerfile.lambda")
 
         env = self.node.try_get_context("app_env") or os.getenv("APP_ENV") or "aws"
-        frontend_origin = self.node.try_get_context("frontend_origin") or os.getenv(
-            "FRONTEND_ORIGIN"
-        )
+        frontend_origin = self.node.try_get_context("frontend_origin") or os.getenv("FRONTEND_ORIGIN")
         extra_cors_origins = self.node.try_get_context("cors_origins") or os.getenv("CORS_ORIGINS")
 
         cors_origins = ["http://localhost:3000", "http://localhost:5173"]
         if frontend_origin:
             cors_origins.insert(0, frontend_origin)
         if extra_cors_origins:
-            cors_origins.extend(
-                [origin.strip() for origin in extra_cors_origins.split(",") if origin.strip()]
-            )
+            cors_origins.extend([origin.strip() for origin in extra_cors_origins.split(",") if origin.strip()])
         cors_origins = list(dict.fromkeys(cors_origins))
 
         jwt_secret = os.getenv("JWT_SECRET", "")
@@ -202,7 +216,9 @@ class BackendLambdaStack(Stack):
         )
         backend_fn.add_environment("APP_ENV", env)
 
-        # BackendLambda: read + put + list
+        # BackendLambda: read + put + list for API data paths. Add an explicit
+        # timeseries cache grant below so the synthesized IAM policy always covers
+        # pyarrow's S3 parquet read/write/list behavior at timeseries/*.
         # Audited S3 list prefixes used by backend code paths:
         # - accounts/        (auth + portfolio enumeration)
         # - queries/         (saved query listing)
@@ -216,12 +232,11 @@ class BackendLambdaStack(Stack):
             allow_list=True,
             list_prefix=lambda_list_prefixes["backend"],
         )
+        self._grant_timeseries_cache_access(backend_fn, bucket=data_bucket, allow_put=True)
 
         backend_api = apigwv2.HttpApi(self, "BackendApi")
         self.backend_api_url = backend_api.api_endpoint
-        backend_integration = apigwv2_integrations.HttpLambdaIntegration(
-            "BackendLambdaIntegration", backend_fn
-        )
+        backend_integration = apigwv2_integrations.HttpLambdaIntegration("BackendLambdaIntegration", backend_fn)
         backend_api.add_routes(
             path="/",
             methods=[apigwv2.HttpMethod.ANY],
@@ -257,11 +272,9 @@ class BackendLambdaStack(Stack):
             log_group=refresh_log_group,
         )
 
-        # PriceRefreshLambda: read + put, no list
-        # Audited: refresh_prices() calls get_price_snapshot() → load_meta_timeseries_range()
-        # → _rolling_cache() → _save_parquet(), which writes parquet files to S3 by known key
-        # (e.g. s3://bucket/meta/TICKER_EXCHANGE.parquet). All S3 access is by known key —
-        # no bucket enumeration. config.prices_json writes to local filesystem, not S3.
+        # PriceRefreshLambda: read + put by known data keys. The explicit timeseries
+        # cache grant also allows ListBucket on timeseries/ because some S3 parquet
+        # clients list the prefix before reading or writing cached parquet files.
         # See backend/timeseries/cache.py:_rolling_cache() and _save_parquet().
         self._grant_bucket_access(
             refresh_fn,
@@ -271,6 +284,7 @@ class BackendLambdaStack(Stack):
             allow_list=False,
             list_prefix=lambda_list_prefixes["price_refresh"],
         )
+        self._grant_timeseries_cache_access(refresh_fn, bucket=data_bucket, allow_put=True)
 
         events.Rule(
             self,
@@ -303,11 +317,10 @@ class BackendLambdaStack(Stack):
             log_group=agent_log_group,
         )
 
-        # TradingAgentLambda: read only, no put, no list
-        # Audited: backend/agent/trading_agent.py:run() calls load_prices_for_tickers()
-        # → load_meta_timeseries_range() which reads parquet files from S3 by known key.
-        # No S3 writes: _log_trade() writes to TRADE_LOG_PATH (local filesystem / CloudWatch).
-        # No bucket enumeration: all S3 access is by deterministic key.
+        # TradingAgentLambda: read-only for general data keys. The explicit
+        # timeseries cache grant includes GetObject, PutObject, and ListBucket on
+        # timeseries/ so shared parquet cache helpers can use pyarrow S3 safely.
+        # _log_trade() writes to TRADE_LOG_PATH (local filesystem / CloudWatch).
         self._grant_bucket_access(
             agent_fn,
             bucket=data_bucket,
@@ -316,6 +329,7 @@ class BackendLambdaStack(Stack):
             allow_list=False,
             list_prefix=lambda_list_prefixes["trading_agent"],
         )
+        self._grant_timeseries_cache_access(agent_fn, bucket=data_bucket, allow_put=True)
 
         events.Rule(
             self,
@@ -347,9 +361,7 @@ class BackendLambdaStack(Stack):
                     threshold_type="PERCENTAGE",
                 ),
                 subscribers=[
-                    budgets.CfnBudget.SubscriberProperty(
-                        subscription_type="EMAIL", address=budget_alert_email
-                    )
+                    budgets.CfnBudget.SubscriberProperty(subscription_type="EMAIL", address=budget_alert_email)
                 ],
             )
 

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -138,11 +138,12 @@ def _conditions_for_s3_action(template: dict, role_logical_id: str, target_actio
 #   BackendLambda      — full API; reads, writes, and lists portfolio/price data.
 #   PriceRefreshLambda — calls _rolling_cache() → _save_parquet() which writes parquet to S3
 #                        and may need to list the timeseries/ prefix via pyarrow.
-#   TradingAgentLambda — shares the timeseries parquet cache helpers, which need scoped
-#                        GetObject, PutObject, and ListBucket access under timeseries/.
+#   TradingAgentLambda — calls load_prices_for_tickers() → load_meta_timeseries_range() which
+#                        reads parquet from S3 by known key. No writes anywhere in this path.
+#                        Pyarrow may list the timeseries/ prefix before reading cached files.
 BACKEND_MAX_S3 = {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}
 REFRESH_MAX_S3 = {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}
-TRADING_MAX_S3 = {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}
+TRADING_MAX_S3 = {"s3:GetObject", "s3:ListBucket"}
 
 
 def test_s3_permissions_are_scoped_per_lambda() -> None:
@@ -164,7 +165,7 @@ def test_s3_permissions_are_scoped_per_lambda() -> None:
     assert {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}.issubset(
         refresh_actions
     ), f"PriceRefreshLambda missing required S3 actions: {refresh_actions}"
-    assert {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}.issubset(
+    assert {"s3:GetObject", "s3:ListBucket"}.issubset(
         trading_actions
     ), f"TradingAgentLambda missing required S3 actions: {trading_actions}"
 
@@ -178,6 +179,14 @@ def test_s3_permissions_are_scoped_per_lambda() -> None:
     assert (
         trading_actions <= TRADING_MAX_S3
     ), f"TradingAgentLambda has unexpected S3 actions: {trading_actions - TRADING_MAX_S3}"
+
+    # Explicit absence checks (belt-and-suspenders on top of upper-bound)
+    assert "s3:PutObject" not in trading_actions, (
+        "TradingAgentLambda must not have s3:PutObject — read-only S3 access"
+    )
+    assert "s3:ListBucket" not in refresh_actions or all(
+        _conditions_for_s3_action(template, refresh_role, "s3:ListBucket")
+    ), "PriceRefreshLambda s3:ListBucket must always be conditioned (no unrestricted list)"
 
     # s3:ListBucket must be scoped to the bucket ARN (no trailing /*), not the object ARN.
     # Granting ListBucket on /* is both functionally wrong (IAM ignores it) and overly broad.
@@ -204,16 +213,31 @@ def test_all_lambdas_have_scoped_timeseries_cache_permissions() -> None:
     template = _stack_template()
     expected_condition = {"StringLike": {"s3:prefix": ["timeseries", "timeseries/*"]}}
 
+    # All three Lambdas must be able to read from and list the timeseries/ prefix
     for fragment in ("BackendLambda", "PriceRefreshLambda", "TradingAgentLambda"):
         role = _role_logical_id_for_lambda(template, fragment)
-        for action in ("s3:GetObject", "s3:PutObject"):
-            resources = _resources_for_s3_action(template, role, action)
-            assert any(
-                "timeseries/*" in resource for resource in resources
-            ), f"{fragment} missing {action} on the timeseries/* object prefix"
+        resources = _resources_for_s3_action(template, role, "s3:GetObject")
+        assert any(
+            "timeseries/*" in resource for resource in resources
+        ), f"{fragment} missing s3:GetObject on the timeseries/* object prefix"
 
         conditions = _conditions_for_s3_action(template, role, "s3:ListBucket")
         assert expected_condition in conditions, f"{fragment} missing ListBucket scoped to the timeseries/ prefix"
+
+    # Only write-capable Lambdas may put objects under the timeseries/ prefix
+    for fragment in ("BackendLambda", "PriceRefreshLambda"):
+        role = _role_logical_id_for_lambda(template, fragment)
+        resources = _resources_for_s3_action(template, role, "s3:PutObject")
+        assert any(
+            "timeseries/*" in resource for resource in resources
+        ), f"{fragment} missing s3:PutObject on the timeseries/* object prefix"
+
+    # TradingAgentLambda must NOT have PutObject on timeseries/ — read-only cache access
+    trading_role = _role_logical_id_for_lambda(template, "TradingAgentLambda")
+    trading_put_resources = _resources_for_s3_action(template, trading_role, "s3:PutObject")
+    assert not any("timeseries/*" in r for r in trading_put_resources), (
+        "TradingAgentLambda must not have s3:PutObject on timeseries/* — read-only S3 access"
+    )
 
 
 def test_grant_bucket_access_requires_list_prefix_when_allow_list_enabled() -> None:

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -15,7 +15,6 @@ if str(CDK_DIR) not in sys.path:
 
 from stacks.backend_lambda_stack import BackendLambdaStack
 
-
 BACKEND_LIST_PREFIXES = ("accounts", "queries", "timeseries/meta", "transactions")
 
 
@@ -59,11 +58,7 @@ def _s3_actions_for_role(template: dict, role_logical_id: str) -> set[str]:
         if resource.get("Type") != "AWS::IAM::Policy":
             continue
         roles = resource.get("Properties", {}).get("Roles", [])
-        role_refs = {
-            role["Ref"]
-            for role in roles
-            if isinstance(role, dict) and isinstance(role.get("Ref"), str)
-        }
+        role_refs = {role["Ref"] for role in roles if isinstance(role, dict) and isinstance(role.get("Ref"), str)}
         if role_logical_id not in role_refs:
             continue
 
@@ -92,11 +87,7 @@ def _resources_for_s3_action(template: dict, role_logical_id: str, target_action
         if resource.get("Type") != "AWS::IAM::Policy":
             continue
         roles = resource.get("Properties", {}).get("Roles", [])
-        role_refs = {
-            r["Ref"]
-            for r in roles
-            if isinstance(r, dict) and isinstance(r.get("Ref"), str)
-        }
+        role_refs = {r["Ref"] for r in roles if isinstance(r, dict) and isinstance(r.get("Ref"), str)}
         if role_logical_id not in role_refs:
             continue
 
@@ -108,7 +99,7 @@ def _resources_for_s3_action(template: dict, role_logical_id: str, target_action
             if target_action not in actions:
                 continue
             stmt_resources = statement.get("Resource", [])
-            if isinstance(stmt_resources, str):
+            if isinstance(stmt_resources, (str, dict)):
                 stmt_resources = [stmt_resources]
             for r in stmt_resources:
                 found.append(r if isinstance(r, str) else str(r))
@@ -116,9 +107,7 @@ def _resources_for_s3_action(template: dict, role_logical_id: str, target_action
     return found
 
 
-def _conditions_for_s3_action(
-    template: dict, role_logical_id: str, target_action: str
-) -> list[dict]:
+def _conditions_for_s3_action(template: dict, role_logical_id: str, target_action: str) -> list[dict]:
     """Return IAM Condition objects for statements granting target_action."""
     found: list[dict] = []
     resources = template["Resources"]
@@ -126,11 +115,7 @@ def _conditions_for_s3_action(
         if resource.get("Type") != "AWS::IAM::Policy":
             continue
         roles = resource.get("Properties", {}).get("Roles", [])
-        role_refs = {
-            r["Ref"]
-            for r in roles
-            if isinstance(r, dict) and isinstance(r.get("Ref"), str)
-        }
+        role_refs = {r["Ref"] for r in roles if isinstance(r, dict) and isinstance(r.get("Ref"), str)}
         if role_logical_id not in role_refs:
             continue
 
@@ -152,12 +137,12 @@ def _conditions_for_s3_action(
 # Audit evidence:
 #   BackendLambda      — full API; reads, writes, and lists portfolio/price data.
 #   PriceRefreshLambda — calls _rolling_cache() → _save_parquet() which writes parquet to S3
-#                        by known key (backend/timeseries/cache.py). No bucket enumeration.
-#   TradingAgentLambda — calls load_prices_for_tickers() → load_meta_timeseries_range() which
-#                        reads parquet from S3 by known key. No writes, no enumeration.
+#                        and may need to list the timeseries/ prefix via pyarrow.
+#   TradingAgentLambda — shares the timeseries parquet cache helpers, which need scoped
+#                        GetObject, PutObject, and ListBucket access under timeseries/.
 BACKEND_MAX_S3 = {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}
-REFRESH_MAX_S3 = {"s3:GetObject", "s3:PutObject"}
-TRADING_MAX_S3 = {"s3:GetObject"}
+REFRESH_MAX_S3 = {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}
+TRADING_MAX_S3 = {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}
 
 
 def test_s3_permissions_are_scoped_per_lambda() -> None:
@@ -173,37 +158,26 @@ def test_s3_permissions_are_scoped_per_lambda() -> None:
     trading_actions = _s3_actions_for_role(template, trading_role)
 
     # Minimum: required actions must be present
-    assert {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}.issubset(backend_actions), (
-        f"BackendLambda missing required S3 actions: {backend_actions}"
-    )
-    assert {"s3:GetObject", "s3:PutObject"}.issubset(refresh_actions), (
-        f"PriceRefreshLambda missing required S3 actions: {refresh_actions}"
-    )
-    assert {"s3:GetObject"}.issubset(trading_actions), (
-        f"TradingAgentLambda missing required S3 actions: {trading_actions}"
-    )
+    assert {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}.issubset(
+        backend_actions
+    ), f"BackendLambda missing required S3 actions: {backend_actions}"
+    assert {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}.issubset(
+        refresh_actions
+    ), f"PriceRefreshLambda missing required S3 actions: {refresh_actions}"
+    assert {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}.issubset(
+        trading_actions
+    ), f"TradingAgentLambda missing required S3 actions: {trading_actions}"
 
     # Maximum: no role may have S3 actions beyond its audited set (prevents privilege creep)
-    assert backend_actions <= BACKEND_MAX_S3, (
-        f"BackendLambda has unexpected S3 actions: {backend_actions - BACKEND_MAX_S3}"
-    )
-    assert refresh_actions <= REFRESH_MAX_S3, (
-        f"PriceRefreshLambda has unexpected S3 actions: {refresh_actions - REFRESH_MAX_S3}"
-    )
-    assert trading_actions <= TRADING_MAX_S3, (
-        f"TradingAgentLambda has unexpected S3 actions: {trading_actions - TRADING_MAX_S3}"
-    )
-
-    # Explicit absence checks (belt-and-suspenders on top of upper-bound)
-    assert "s3:ListBucket" not in refresh_actions, (
-        "PriceRefreshLambda should not have s3:ListBucket — all S3 access is by known key"
-    )
-    assert "s3:ListBucket" not in trading_actions, (
-        "TradingAgentLambda should not have s3:ListBucket — all S3 access is by known key"
-    )
-    assert "s3:PutObject" not in trading_actions, (
-        "TradingAgentLambda should not have s3:PutObject — read-only S3 access"
-    )
+    assert (
+        backend_actions <= BACKEND_MAX_S3
+    ), f"BackendLambda has unexpected S3 actions: {backend_actions - BACKEND_MAX_S3}"
+    assert (
+        refresh_actions <= REFRESH_MAX_S3
+    ), f"PriceRefreshLambda has unexpected S3 actions: {refresh_actions - REFRESH_MAX_S3}"
+    assert (
+        trading_actions <= TRADING_MAX_S3
+    ), f"TradingAgentLambda has unexpected S3 actions: {trading_actions - TRADING_MAX_S3}"
 
     # s3:ListBucket must be scoped to the bucket ARN (no trailing /*), not the object ARN.
     # Granting ListBucket on /* is both functionally wrong (IAM ignores it) and overly broad.
@@ -216,30 +190,30 @@ def test_s3_permissions_are_scoped_per_lambda() -> None:
         )
 
     list_bucket_conditions = _conditions_for_s3_action(template, backend_role, "s3:ListBucket")
-    assert list_bucket_conditions, (
-        "BackendLambda has s3:ListBucket but no associated IAM Condition"
-    )
+    assert list_bucket_conditions, "BackendLambda has s3:ListBucket but no associated IAM Condition"
     expected_prefix_entries: list[str] = []
     for prefix in BACKEND_LIST_PREFIXES:
         expected_prefix_entries.extend([prefix, f"{prefix}/*"])
     expected_prefix = {"StringLike": {"s3:prefix": expected_prefix_entries}}
-    assert expected_prefix in list_bucket_conditions, (
-        "BackendLambda s3:ListBucket must be conditioned to all audited backend list prefixes"
-    )
+    assert (
+        expected_prefix in list_bucket_conditions
+    ), "BackendLambda s3:ListBucket must be conditioned to all audited backend list prefixes"
 
 
-def test_non_listing_lambdas_do_not_have_listbucket_statement() -> None:
+def test_all_lambdas_have_scoped_timeseries_cache_permissions() -> None:
     template = _stack_template()
+    expected_condition = {"StringLike": {"s3:prefix": ["timeseries", "timeseries/*"]}}
 
-    refresh_role = _role_logical_id_for_lambda(template, "PriceRefreshLambda")
-    trading_role = _role_logical_id_for_lambda(template, "TradingAgentLambda")
+    for fragment in ("BackendLambda", "PriceRefreshLambda", "TradingAgentLambda"):
+        role = _role_logical_id_for_lambda(template, fragment)
+        for action in ("s3:GetObject", "s3:PutObject"):
+            resources = _resources_for_s3_action(template, role, action)
+            assert any(
+                "timeseries/*" in resource for resource in resources
+            ), f"{fragment} missing {action} on the timeseries/* object prefix"
 
-    assert not _conditions_for_s3_action(template, refresh_role, "s3:ListBucket"), (
-        "PriceRefreshLambda should not have a ListBucket statement"
-    )
-    assert not _conditions_for_s3_action(template, trading_role, "s3:ListBucket"), (
-        "TradingAgentLambda should not have a ListBucket statement"
-    )
+        conditions = _conditions_for_s3_action(template, role, "s3:ListBucket")
+        assert expected_condition in conditions, f"{fragment} missing ListBucket scoped to the timeseries/ prefix"
 
 
 def test_grant_bucket_access_requires_list_prefix_when_allow_list_enabled() -> None:
@@ -265,9 +239,7 @@ def test_grant_bucket_access_requires_list_prefix_when_allow_list_enabled() -> N
             )
         except ValueError:
             continue
-        raise AssertionError(
-            f"Expected ValueError for allow_list=True with list_prefix={invalid_prefix!r}"
-        )
+        raise AssertionError(f"Expected ValueError for allow_list=True with list_prefix={invalid_prefix!r}")
 
 
 def test_grant_bucket_access_accepts_multiple_list_prefixes() -> None:
@@ -310,21 +282,17 @@ def test_lambda_roles_do_not_have_s3_delete_permissions() -> None:
     for fragment in role_fragments:
         role = _role_logical_id_for_lambda(template, fragment)
         actions = _s3_actions_for_role(template, role)
-        assert forbidden.isdisjoint(actions), (
-            f"Found forbidden actions for {fragment}: {actions & forbidden}"
-        )
+        assert forbidden.isdisjoint(actions), f"Found forbidden actions for {fragment}: {actions & forbidden}"
         # Also catch wildcard grants which implicitly include delete
-        assert "s3:*" not in actions and "*" not in actions, (
-            f"Found wildcard grant for {fragment} which implicitly includes delete"
-        )
+        assert (
+            "s3:*" not in actions and "*" not in actions
+        ), f"Found wildcard grant for {fragment} which implicitly includes delete"
 
 
 def test_grant_bucket_access_raises_on_no_permissions() -> None:
     class _MockFn:
         def add_to_role_policy(self, policy_statement: object) -> None:
-            raise AssertionError(
-                "add_to_role_policy should not be called when no permissions are enabled"
-            )
+            raise AssertionError("add_to_role_policy should not be called when no permissions are enabled")
 
     mock_fn = _MockFn()
 


### PR DESCRIPTION
### Motivation

- Pyarrow-backed timeseries parquet cache operations require scoped S3 Get/Put/List access under the `timeseries/` prefix, which was not guaranteed by the existing bucket grants and caused runtime access issues (issue #2876).

### Description

- Add a new CDK helper `BackendLambdaStack._grant_timeseries_cache_access()` that grants `s3:GetObject` (always), `s3:PutObject` (optionally), and a `s3:ListBucket` statement conditioned to `timeseries`/`timeseries/*` on the bucket ARN.
- Apply the explicit timeseries cache grant to `BackendLambda`, `PriceRefreshLambda`, and `TradingAgentLambda` so their roles receive scoped `timeseries/*` and `timeseries`-prefixed List permissions.
- Update CDK IAM tests in `cdk/tests/test_backend_lambda_stack_permissions.py` to require the new timeseries-scoped permissions for all three Lambdas and to handle CloudFormation intrinsics when inspecting policy `Resource` entries. Closes #2876.

### Testing

- Ran `PYENV_VERSION=3.11.15 python -m pytest cdk/tests/test_backend_lambda_stack_permissions.py` and the test file passed (`6 passed`).
- Ran `PYENV_VERSION=3.11.15 python -m pytest cdk/tests` and the CDK test suite passed (`36 passed`).
- Ran lint/format checks `python -m ruff` and `python -m black --check` against the changed files and they passed after formatting.
- Validated stack synthesis for the backend with `npx cdk synth BackendLambdaStack` (backend-only synth succeeded and shows the new timeseries-scoped policy statements in the template).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2f0f43f08327b1da4b3c9eae493a)