### PR TITLE
Protect production Cognito user pools

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -106,7 +106,7 @@ jobs:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
-        run: npx cdk diff --all
+        run: npx cdk diff --all -c prod=true
         working-directory: cdk
 
       - name: Deploy BackendLambdaStack
@@ -140,7 +140,7 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
         run: >
-          npx cdk deploy StaticSiteStack --require-approval never
+          npx cdk deploy StaticSiteStack --require-approval never -c prod=true
           --parameters StaticSiteStack:BackendApiUrl="$BACKEND_URL"
         working-directory: cdk
 

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -1,17 +1,21 @@
 from pathlib import Path
 
-from aws_cdk import (
-    CfnOutput,
-    CfnParameter,
-    Duration,
-    RemovalPolicy,
-    Stack,
-    aws_cloudfront as cloudfront,
-    aws_cloudfront_origins as origins,
-    aws_s3 as s3,
-    aws_s3_deployment as s3_deployment,
-)
+from aws_cdk import Aws, CfnOutput, CfnParameter, Duration, Fn, RemovalPolicy, Stack
+from aws_cdk import aws_cloudfront as cloudfront
+from aws_cdk import aws_cloudfront_origins as origins
+from aws_cdk import aws_cognito as cognito
+from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_s3_deployment as s3_deployment
 from constructs import Construct
+
+
+def _is_truthy_context(value: object) -> bool:
+    """Return true when a CDK context value explicitly opts into production."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return False
 
 
 class StaticSiteStack(Stack):
@@ -27,6 +31,12 @@ class StaticSiteStack(Stack):
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
+
+        ui_auth_removal_policy = (
+            RemovalPolicy.RETAIN
+            if _is_truthy_context(self.node.try_get_context("prod"))
+            else RemovalPolicy.DESTROY
+        )
 
         # BucketDeployment.Source.json_data() only accepts intra-stack tokens
         # (Ref / Fn::GetAtt / Fn::Select) — Fn::ImportValue is explicitly rejected
@@ -60,9 +70,16 @@ class StaticSiteStack(Stack):
             "SecurityHeaders",
             comment="Security headers for static site",
             security_headers_behavior=cloudfront.ResponseSecurityHeadersBehavior(
-                # Allow Google Identity Services script and iframe
+                # Allow Google Identity Services script and iframe, and Cognito
+                # hosted UI token exchange (amazoncognito.com != amazonaws.com).
                 content_security_policy=cloudfront.ResponseHeadersContentSecurityPolicy(
-                    content_security_policy="default-src 'self'; script-src 'self' https://accounts.google.com/gsi/client; frame-src 'self' https://accounts.google.com/gsi/; frame-ancestors 'none'; object-src 'none'; base-uri 'self'",
+                    content_security_policy=(
+                        "default-src 'self'; "
+                        "script-src 'self' https://accounts.google.com/gsi/client; "
+                        "connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com; "
+                        "frame-src 'self' https://accounts.google.com/gsi/; "
+                        "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
+                    ),
                     override=True,
                 ),
                 strict_transport_security=cloudfront.ResponseHeadersStrictTransportSecurity(
@@ -180,6 +197,11 @@ class StaticSiteStack(Stack):
             price_class=cloudfront.PriceClass.PRICE_CLASS_100,
         )
 
+        ui_auth_pool, ui_auth_client, ui_auth_domain = self._create_ui_auth(
+            distribution=distribution,
+            removal_policy=ui_auth_removal_policy,
+        )
+
         frontend_dir = (
             Path(frontend_dist_path)
             if frontend_dist_path is not None
@@ -217,7 +239,20 @@ class StaticSiteStack(Stack):
         config_deploy = s3_deployment.BucketDeployment(
             self,
             "DeployRuntimeConfig",
-            sources=[s3_deployment.Source.json_data("config.json", {"apiBaseUrl": backend_url_param.value_as_string})],
+            sources=[
+                s3_deployment.Source.json_data(
+                    "config.json",
+                    {
+                        "apiBaseUrl": backend_url_param.value_as_string,
+                        "awsUiAuth": {
+                            "enabled": True,
+                            "domain": ui_auth_domain,
+                            "clientId": ui_auth_client.user_pool_client_id,
+                            "redirectPath": "/",
+                        },
+                    },
+                )
+            ],
             destination_bucket=site_bucket,
             cache_control=[
                 s3_deployment.CacheControl.no_cache(),
@@ -231,3 +266,49 @@ class StaticSiteStack(Stack):
         CfnOutput(self, "SiteBucket", value=site_bucket.bucket_name)
         CfnOutput(self, "DistributionId", value=distribution.distribution_id)
         CfnOutput(self, "DistributionDomain", value=distribution.domain_name)
+        CfnOutput(self, "UiAuthUserPoolId", value=ui_auth_pool.user_pool_id)
+        CfnOutput(self, "UiAuthUserPoolClientId", value=ui_auth_client.user_pool_client_id)
+        CfnOutput(self, "UiAuthDomain", value=ui_auth_domain)
+
+    def _create_ui_auth(
+        self,
+        *,
+        distribution: cloudfront.Distribution,
+        removal_policy: RemovalPolicy,
+    ) -> tuple[cognito.UserPool, cognito.UserPoolClient, str]:
+        ui_auth_pool = cognito.UserPool(
+            self,
+            "UiAuthUserPool",
+            account_recovery=cognito.AccountRecovery.EMAIL_ONLY,
+            self_sign_up_enabled=False,
+            sign_in_aliases=cognito.SignInAliases(email=True),
+            removal_policy=removal_policy,
+        )
+        ui_auth_callback_url = Fn.join("", ["https://", distribution.domain_name, "/"])
+        ui_auth_client = ui_auth_pool.add_client(
+            "UiAuthClient",
+            auth_flows=cognito.AuthFlow(user_password=True, user_srp=True),
+            o_auth=cognito.OAuthSettings(
+                flows=cognito.OAuthFlows(authorization_code_grant=True),
+                scopes=[
+                    cognito.OAuthScope.EMAIL,
+                    cognito.OAuthScope.OPENID,
+                    cognito.OAuthScope.PROFILE,
+                ],
+                callback_urls=[ui_auth_callback_url],
+                logout_urls=[ui_auth_callback_url],
+            ),
+            prevent_user_existence_errors=True,
+        )
+        ui_auth_domain_prefix = Fn.join("-", ["allotmint", Aws.ACCOUNT_ID, Aws.REGION])
+        ui_auth_pool.add_domain(
+            "UiAuthDomain",
+            cognito_domain=cognito.CognitoDomainOptions(
+                domain_prefix=ui_auth_domain_prefix,
+            ),
+        )
+        ui_auth_domain = Fn.join(
+            "",
+            ["https://", ui_auth_domain_prefix, ".auth.", Aws.REGION, ".amazoncognito.com"],
+        )
+        return ui_auth_pool, ui_auth_client, ui_auth_domain

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -4,6 +4,7 @@ Run from the repo root:
     pip install aws-cdk-lib constructs pytest --quiet
     pytest cdk/tests/test_static_site_stack.py -v
 """
+
 import sys
 from pathlib import Path
 
@@ -14,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 aws_cdk = pytest.importorskip("aws_cdk", reason="aws-cdk-lib not installed")
 
 from aws_cdk import App, assertions  # noqa: E402
+
 from cdk.stacks.static_site_stack import StaticSiteStack  # noqa: E402
 
 _DUMMY_API_URL = "https://abc123.execute-api.eu-west-1.amazonaws.com"
@@ -37,6 +39,7 @@ def template(tmp_path_factory):
 # ---------------------------------------------------------------------------
 # SPA error responses
 # ---------------------------------------------------------------------------
+
 
 def test_403_redirects_to_index_html(template):
     """CloudFront must return /index.html for 403 (S3 access-denied) responses."""
@@ -86,6 +89,7 @@ def test_404_redirects_to_index_html(template):
 # config.json deployment
 # ---------------------------------------------------------------------------
 
+
 def test_runtime_config_deployment_exists(template):
     """At least one BucketDeployment resource must be present (config.json injection)."""
     # BucketDeployment is backed by Custom::CDKBucketDeployment.
@@ -134,6 +138,7 @@ def test_static_site_stack_synthesises_without_api_base_url(tmp_path):
     deployed from CI.
     """
     from aws_cdk import App  # noqa: PLC0415
+
     from cdk.stacks.static_site_stack import StaticSiteStack  # noqa: PLC0415
 
     (tmp_path / "index.html").write_text("<html></html>")
@@ -146,6 +151,7 @@ def test_static_site_stack_synthesises_without_api_base_url(tmp_path):
 # ---------------------------------------------------------------------------
 # CloudFront distribution outputs
 # ---------------------------------------------------------------------------
+
 
 def test_distribution_id_output_exists(template):
     template.has_output("DistributionId", {})
@@ -163,6 +169,7 @@ def test_site_bucket_output_exists(template):
 # Site bucket security
 # ---------------------------------------------------------------------------
 
+
 def test_site_bucket_blocks_public_access(template):
     template.has_resource_properties(
         "AWS::S3::Bucket",
@@ -175,3 +182,59 @@ def test_site_bucket_blocks_public_access(template):
             }
         },
     )
+
+
+def _template_with_context(tmp_path: Path, context: dict[str, object]) -> assertions.Template:
+    (tmp_path / "index.html").write_text("<html></html>")
+    app = App(context=context)
+    stack = StaticSiteStack(app, "ContextStaticSiteStack", frontend_dist_path=str(tmp_path))
+    return assertions.Template.from_stack(stack)
+
+
+def test_ui_auth_user_pool_created(template):
+    """Static site deploys a Cognito user pool to gate the hosted UI."""
+    template.has_resource_properties(
+        "AWS::Cognito::UserPool",
+        {
+            "AccountRecoverySetting": {
+                "RecoveryMechanisms": assertions.Match.array_with(
+                    [assertions.Match.object_like({"Name": "verified_email", "Priority": 1})]
+                )
+            },
+            "AdminCreateUserConfig": {"AllowAdminCreateUserOnly": True},
+        },
+    )
+
+
+def test_ui_auth_client_uses_authorization_code_flow(template):
+    """Hosted UI auth must use the authorization-code flow for the SPA."""
+    template.has_resource_properties(
+        "AWS::Cognito::UserPoolClient",
+        {
+            "AllowedOAuthFlows": ["code"],
+            "AllowedOAuthScopes": assertions.Match.array_with(["email", "openid", "profile"]),
+            "SupportedIdentityProviders": ["COGNITO"],
+        },
+    )
+
+
+def test_ui_auth_user_pool_is_destroyed_by_default(tmp_path):
+    template = _template_with_context(tmp_path, {})
+    template.has_resource(
+        "AWS::Cognito::UserPool",
+        {"DeletionPolicy": "Delete", "UpdateReplacePolicy": "Delete"},
+    )
+
+
+def test_ui_auth_user_pool_is_retained_for_prod_context(tmp_path):
+    template = _template_with_context(tmp_path, {"prod": "true"})
+    template.has_resource(
+        "AWS::Cognito::UserPool",
+        {"DeletionPolicy": "Retain", "UpdateReplacePolicy": "Retain"},
+    )
+
+
+def test_ui_auth_outputs_exist(template):
+    template.has_output("UiAuthUserPoolId", {})
+    template.has_output("UiAuthUserPoolClientId", {})
+    template.has_output("UiAuthDomain", {})

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -155,13 +155,17 @@ repository root that is ignored by git.
 # Deploy backend and frontend stacks
 ./scripts/deploy-to-AWS.ps1 -Backend -DataBucket my-bucket
 
+# Deploy to a live/production environment; retains the Cognito user pool on destroy
+./scripts/deploy-to-AWS.ps1 -Backend -DataBucket my-bucket -Prod
+
 # Deploy only the frontend stack
 ./scripts/deploy-to-AWS.ps1
 ```
 
 The script changes into the `cdk/` directory, installs the repo-pinned CDK CLI if
 necessary, then deploys `BackendLambdaStack` and `StaticSiteStack` when
-`-Backend` is specified.
+`-Backend` is specified. Pass `-Prod` for any live environment so the Cognito
+user pool uses `RemovalPolicy.RETAIN` and stack deletion does not delete users.
 
 Alternatively, run the commands manually:
 
@@ -169,21 +173,27 @@ Alternatively, run the commands manually:
 cd cdk
 npx cdk bootstrap   # once per account/region
 DEPLOY_BACKEND=false npx cdk deploy StaticSiteStack
+# For live/production frontend deploys, pass -c prod=true so Cognito users are retained:
+DEPLOY_BACKEND=false npx cdk deploy StaticSiteStack -c prod=true
 # or deploy backend and frontend together. Supply the name of your
 # data bucket either via environment variable:
 DATA_BUCKET=my-data-bucket DEPLOY_BACKEND=true npx cdk deploy BackendLambdaStack StaticSiteStack
-# or as a CDK context parameter:
-DEPLOY_BACKEND=true npx cdk deploy BackendLambdaStack StaticSiteStack -c data_bucket=my-data-bucket
-# or deploy every stack managed by app.py:
-npx cdk deploy --all --require-approval never
+# or as CDK context parameters, including prod=true for live environments:
+DEPLOY_BACKEND=true npx cdk deploy BackendLambdaStack StaticSiteStack -c data_bucket=my-data-bucket -c prod=true
+# or deploy every stack managed by app.py for production:
+npx cdk deploy --all --require-approval never -c prod=true
 ```
 
-When manually validating drift before a deploy, always run:
+When manually validating drift before a deploy, always run the diff with the
+same production context you will deploy with:
 
 ```bash
 cd cdk
-npx cdk diff --all
+npx cdk diff --all -c prod=true
 ```
+
+Omit `-c prod=true` only for disposable development stacks where `cdk destroy`
+should remove the demo Cognito user pool.
 
 `BackendLambdaStack` now includes:
 - an S3 data bucket with versioning, SSE-S3 encryption, and non-current object expiry,
@@ -204,8 +214,8 @@ aws cloudfront create-invalidation --distribution-id <DIST_ID> --paths "/*"
 
 If deployment fails or the live environment does not match local behavior:
 
-1. Re-run `npx cdk diff --all` and confirm intended stack changes are present.
-2. Run `npx cdk deploy --all --require-approval never` and capture the exact failing resource from CloudFormation events.
+1. Re-run `npx cdk diff --all -c prod=true` and confirm intended stack changes are present.
+2. Run `npx cdk deploy --all --require-approval never -c prod=true` and capture the exact failing resource from CloudFormation events.
 3. Inspect backend Lambda errors (CloudWatch). Lambda functions in this stack use
    explicit CDK-managed log groups, so read the deployed log group name from the
    stack outputs instead of assuming the `/aws/lambda/<function-name>` convention:

--- a/scripts/deploy-to-AWS.ps1
+++ b/scripts/deploy-to-AWS.ps1
@@ -1,6 +1,7 @@
 Param(
   [switch]$Backend,
-  [string]$DataBucket
+  [string]$DataBucket,
+  [switch]$Prod
 )
 
 $ErrorActionPreference = 'Stop'
@@ -293,7 +294,8 @@ if ($Backend) {
       Write-Host 'DATA_BUCKET is required for backend deployment. Provide via -DataBucket or DATA_BUCKET env var.' -ForegroundColor Red
       exit 1
     }
-    & $cdkCmd.Path deploy BackendLambdaStack StaticSiteStack -c "data_bucket=$effectiveBucket"
+    $prodContext = if ($Prod) { 'true' } else { 'false' }
+    & $cdkCmd.Path deploy BackendLambdaStack StaticSiteStack -c "data_bucket=$effectiveBucket" -c "prod=$prodContext"
   } finally {
     Pop-Location
   }
@@ -309,7 +311,8 @@ if ($Backend) {
     }
     # Provide a context value for data_bucket so the app can instantiate BackendLambdaStack
     $effectiveBucket = if ($env:DATA_BUCKET) { $env:DATA_BUCKET } elseif ($DataBucket) { $DataBucket } else { 'placeholder-bucket' }
-    & $cdkCmd.Path deploy StaticSiteStack -c "data_bucket=$effectiveBucket"
+    $prodContext = if ($Prod) { 'true' } else { 'false' }
+    & $cdkCmd.Path deploy StaticSiteStack -c "data_bucket=$effectiveBucket" -c "prod=$prodContext"
   } finally {
     Pop-Location
   }


### PR DESCRIPTION
### Motivation
Closes #2884 
- Prevent accidental deletion of live Cognito users by making the hosted UI user pool retained in production while allowing disposable dev stacks to be destroyed.
- Provide a first-class Cognito hosted UI integration for the static frontend and surface its settings to the SPA at runtime via `config.json`.
- Ensure CI/CD and local deploy helpers pass an explicit production context so the removal policy is deterministic for live deploys.

### Description

- Add a CDK context helper `_is_truthy_context` and choose `RemovalPolicy.RETAIN` when `prod` is truthy, otherwise `RemovalPolicy.DESTROY`.
- Create Cognito hosted UI resources in `StaticSiteStack` via a new `_create_ui_auth` helper, and emit CloudFormation outputs `UiAuthUserPoolId`, `UiAuthUserPoolClientId`, and `UiAuthDomain`.
- Inject `awsUiAuth` metadata into the runtime `config.json` asset so the frontend can detect and configure the hosted UI client and domain.
- Update CDK assertions (`cdk/tests/test_static_site_stack.py`), GitHub Actions (`.github/workflows/deploy-lambda.yml`), the PowerShell deploy helper (`scripts/deploy-to-AWS.ps1`), and `docs/DEPLOY.md` to pass/document the `prod` context flag and the new `-Prod` helper switch.

### Testing

- Ran formatting and linting with `python -m ruff` (auto-fixed) and `python -m black` and confirmed no remaining lint/format issues.
- Executed the CDK tests with `python -m pytest cdk/tests/test_static_site_stack.py` and received `15 passed` (all assertions for the new Cognito resources and removal-policy behavior passed).
- Verified the stack synth outputs for both default and `prod` contexts to confirm `DeletionPolicy`/`UpdateReplacePolicy` are `Delete` in dev and `Retain` when `prod=true`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe334f5b4c8327a3ae96d1e224198c)