### PR TITLE
Tighten static site CSP connect-src to limit AWS host patterns

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -13,21 +13,6 @@ from aws_cdk import (
 )
 from constructs import Construct
 
-_STATIC_SITE_CSP = (
-    "; ".join(
-        [
-            "default-src 'self'",
-            "script-src 'self' https://accounts.google.com/gsi/client",
-            "frame-src 'self' https://accounts.google.com/gsi/",
-            "connect-src 'self' https://*.execute-api.*.amazonaws.com https://*.amazoncognito.com",
-            "frame-ancestors 'none'",
-            "object-src 'none'",
-            "base-uri 'self'",
-        ]
-    )
-    + ";"
-)
-
 
 class StaticSiteStack(Stack):
     """CDK stack that provisions S3 + CloudFront for the frontend."""
@@ -60,6 +45,26 @@ class StaticSiteStack(Stack):
             ),
         )
 
+        # CSP connect-src uses the BackendApiUrl parameter directly so that
+        # CloudFormation resolves it to the exact API origin at deploy time.
+        # A static wildcard like *.execute-api.*.amazonaws.com is invalid CSP
+        # syntax (wildcards are only permitted as the leftmost hostname label)
+        # and would be silently ignored by browsers, blocking all API calls.
+        _csp = (
+            "; ".join(
+                [
+                    "default-src 'self'",
+                    "script-src 'self' https://accounts.google.com/gsi/client",
+                    "frame-src 'self' https://accounts.google.com/gsi/",
+                    f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazoncognito.com",
+                    "frame-ancestors 'none'",
+                    "object-src 'none'",
+                    "base-uri 'self'",
+                ]
+            )
+            + ";"
+        )
+
         site_bucket = s3.Bucket(
             self,
             "StaticSiteBucket",
@@ -77,7 +82,7 @@ class StaticSiteStack(Stack):
             security_headers_behavior=cloudfront.ResponseSecurityHeadersBehavior(
                 # Allow Google Identity Services, API Gateway calls, and Cognito token exchange.
                 content_security_policy=cloudfront.ResponseHeadersContentSecurityPolicy(
-                    content_security_policy=_STATIC_SITE_CSP,
+                    content_security_policy=_csp,
                     override=True,
                 ),
                 strict_transport_security=cloudfront.ResponseHeadersStrictTransportSecurity(

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -54,6 +54,11 @@ class StaticSiteStack(Stack):
             "BackendApiUrl",
             type="String",
             default=api_base_url or "",
+            allowed_pattern=r"^$|^https://.+",
+            constraint_description=(
+                "BackendApiUrl must be empty for synth-only workflows or an "
+                "HTTPS URL such as https://abc123.execute-api.us-east-1.amazonaws.com."
+            ),
             description=(
                 "Backend API base URL — override at deploy time with the "
                 "BackendLambdaStack BackendApiUrl output."

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -13,6 +13,21 @@ from aws_cdk import (
 )
 from constructs import Construct
 
+_STATIC_SITE_CSP = (
+    "; ".join(
+        [
+            "default-src 'self'",
+            "script-src 'self' https://accounts.google.com/gsi/client",
+            "frame-src 'self' https://accounts.google.com/gsi/",
+            "connect-src 'self' https://*.execute-api.*.amazonaws.com https://*.amazoncognito.com",
+            "frame-ancestors 'none'",
+            "object-src 'none'",
+            "base-uri 'self'",
+        ]
+    )
+    + ";"
+)
+
 
 class StaticSiteStack(Stack):
     """CDK stack that provisions S3 + CloudFront for the frontend."""
@@ -60,9 +75,9 @@ class StaticSiteStack(Stack):
             "SecurityHeaders",
             comment="Security headers for static site",
             security_headers_behavior=cloudfront.ResponseSecurityHeadersBehavior(
-                # Allow Google Identity Services script and iframe
+                # Allow Google Identity Services, API Gateway calls, and Cognito token exchange.
                 content_security_policy=cloudfront.ResponseHeadersContentSecurityPolicy(
-                    content_security_policy="default-src 'self'; script-src 'self' https://accounts.google.com/gsi/client; frame-src 'self' https://accounts.google.com/gsi/; frame-ancestors 'none'; object-src 'none'; base-uri 'self'",
+                    content_security_policy=_STATIC_SITE_CSP,
                     override=True,
                 ),
                 strict_transport_security=cloudfront.ResponseHeadersStrictTransportSecurity(
@@ -217,7 +232,11 @@ class StaticSiteStack(Stack):
         config_deploy = s3_deployment.BucketDeployment(
             self,
             "DeployRuntimeConfig",
-            sources=[s3_deployment.Source.json_data("config.json", {"apiBaseUrl": backend_url_param.value_as_string})],
+            sources=[
+                s3_deployment.Source.json_data(
+                    "config.json", {"apiBaseUrl": backend_url_param.value_as_string}
+                )
+            ],
             destination_bucket=site_bucket,
             cache_control=[
                 s3_deployment.CacheControl.no_cache(),

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -60,20 +60,17 @@ class StaticSiteStack(Stack):
         # A static wildcard like *.execute-api.*.amazonaws.com is invalid CSP
         # syntax (wildcards are only permitted as the leftmost hostname label)
         # and would be silently ignored by browsers, blocking all API calls.
-        _csp = (
-            "; ".join(
-                [
-                    "default-src 'self'",
-                    "script-src 'self' https://accounts.google.com/gsi/client",
-                    "frame-src 'self' https://accounts.google.com/gsi/",
-                    f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazoncognito.com",
-                    "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
-                    "object-src 'none'",
-                    "base-uri 'self'",              
-                ]
-            )
-            + ";"
-        )
+        _csp = "; ".join(
+            [
+                "default-src 'self'",
+                "script-src 'self' https://accounts.google.com/gsi/client",
+                "frame-src 'self' https://accounts.google.com/gsi/",
+                f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazoncognito.com",
+                "frame-ancestors 'none'",
+                "object-src 'none'",
+                "base-uri 'self'",
+            ]
+        ) + ";"
 
         site_bucket = s3.Bucket(
             self,

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -66,7 +66,7 @@ class StaticSiteStack(Stack):
                     "default-src 'self'",
                     "script-src 'self' https://accounts.google.com/gsi/client",
                     "frame-src 'self' https://accounts.google.com/gsi/",
-                    f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazonaws.com https://*.amazoncognito.com; ",
+                    f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazoncognito.com",
                     "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
                     "object-src 'none'",
                     "base-uri 'self'",              

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -217,6 +217,9 @@ def test_csp_connect_src_uses_backend_url_parameter(template):
         "CSP must not contain any static amazonaws.com wildcard in its string fragments"
     )
     assert "https://*.amazoncognito.com" in static_text
+    assert "base-uri 'self'" in static_text
+    assert static_text.count("object-src 'none'") == 1
+    assert "'self'object-src" not in static_text, "Missing semicolon between base-uri and object-src"
 
 
 # ---------------------------------------------------------------------------

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -125,7 +125,10 @@ def test_backend_api_url_parameter_exists(template):
     """
     template.has_parameter(
         "BackendApiUrl",
-        {"Type": "String"},
+        {
+            "AllowedPattern": "^$|^https://.+",
+            "Type": "String",
+        },
     )
 
 
@@ -157,25 +160,12 @@ def _response_headers_policy_csp(template: assertions.Template) -> object:
     ]["ContentSecurityPolicy"]
 
 
-def test_csp_connect_src_uses_backend_api_url_parameter(template):
-    """CSP connect-src must use the exact API URL parameter, not AWS wildcards."""
-    csp = _response_headers_policy_csp(template)
-
-    assert isinstance(csp, dict)
-    parts = csp["Fn::Join"][1]
-    assert {"Ref": "BackendApiUrl"} in parts
-    rendered_static_parts = "".join(part for part in parts if isinstance(part, str))
-    assert "connect-src 'self' " in rendered_static_parts
-    assert "https://*.amazoncognito.com" in rendered_static_parts
-    assert "*.amazonaws.com" not in rendered_static_parts
-
-
 # ---------------------------------------------------------------------------
 # CloudFront security headers
 # ---------------------------------------------------------------------------
 
 
-def test_csp_connect_src_uses_backend_url_parameter(template):
+def test_csp_connect_src_uses_backend_api_url_parameter(template):
     """CSP connect-src must reference BackendApiUrl directly, not a static wildcard.
 
     API Gateway URLs have the form {api-id}.execute-api.{region}.amazonaws.com.
@@ -216,10 +206,26 @@ def test_csp_connect_src_uses_backend_url_parameter(template):
     assert "amazonaws.com" not in static_text, (
         "CSP must not contain any static amazonaws.com wildcard in its string fragments"
     )
+    assert "connect-src 'self' " in static_text
     assert "https://*.amazoncognito.com" in static_text
-    assert "base-uri 'self'" in static_text
+    assert "script-src 'self' https://accounts.google.com/gsi/client" in static_text
+    assert "frame-src 'self' https://accounts.google.com/gsi/" in static_text
+    assert "frame-ancestors 'none'" in static_text
     assert static_text.count("object-src 'none'") == 1
+    assert static_text.count("base-uri 'self'") == 1
+    assert "; ;" not in static_text
     assert "'self'object-src" not in static_text, "Missing semicolon between base-uri and object-src"
+
+
+def test_csp_header_overrides_origin_csp(template):
+    """CloudFront must emit the managed CSP rather than preserving an origin CSP."""
+    resources = template.find_resources("AWS::CloudFront::ResponseHeadersPolicy")
+    assert len(resources) == 1, f"Expected one response headers policy, found {len(resources)}"
+    policy = next(iter(resources.values()))
+    csp_header = policy["Properties"]["ResponseHeadersPolicyConfig"]["SecurityHeadersConfig"][
+        "ContentSecurityPolicy"
+    ]
+    assert csp_header["Override"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -4,6 +4,7 @@ Run from the repo root:
     pip install aws-cdk-lib constructs pytest --quiet
     pytest cdk/tests/test_static_site_stack.py -v
 """
+
 import sys
 from pathlib import Path
 
@@ -37,6 +38,7 @@ def template(tmp_path_factory):
 # ---------------------------------------------------------------------------
 # SPA error responses
 # ---------------------------------------------------------------------------
+
 
 def test_403_redirects_to_index_html(template):
     """CloudFront must return /index.html for 403 (S3 access-denied) responses."""
@@ -85,6 +87,7 @@ def test_404_redirects_to_index_html(template):
 # ---------------------------------------------------------------------------
 # config.json deployment
 # ---------------------------------------------------------------------------
+
 
 def test_runtime_config_deployment_exists(template):
     """At least one BucketDeployment resource must be present (config.json injection)."""
@@ -144,8 +147,39 @@ def test_static_site_stack_synthesises_without_api_base_url(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# CloudFront security headers
+# ---------------------------------------------------------------------------
+
+
+def test_csp_connect_src_is_limited_to_required_aws_services(template):
+    """CSP connect-src must avoid a broad *.amazonaws.com wildcard."""
+    resources = template.find_resources("AWS::CloudFront::ResponseHeadersPolicy")
+    csp_headers = [
+        security_headers["ContentSecurityPolicy"]["ContentSecurityPolicy"]
+        for resource in resources.values()
+        if (
+            security_headers := resource["Properties"]["ResponseHeadersPolicyConfig"].get(
+                "SecurityHeadersConfig", {}
+            )
+        )
+        if "ContentSecurityPolicy" in security_headers
+    ]
+
+    assert csp_headers == [
+        "default-src 'self'; "
+        "script-src 'self' https://accounts.google.com/gsi/client; "
+        "frame-src 'self' https://accounts.google.com/gsi/; "
+        "connect-src 'self' "
+        "https://*.execute-api.*.amazonaws.com https://*.amazoncognito.com; "
+        "frame-ancestors 'none'; object-src 'none'; base-uri 'self';"
+    ]
+    assert "https://*.amazonaws.com" not in csp_headers[0]
+
+
+# ---------------------------------------------------------------------------
 # CloudFront distribution outputs
 # ---------------------------------------------------------------------------
+
 
 def test_distribution_id_output_exists(template):
     template.has_output("DistributionId", {})
@@ -162,6 +196,7 @@ def test_site_bucket_output_exists(template):
 # ---------------------------------------------------------------------------
 # Site bucket security
 # ---------------------------------------------------------------------------
+
 
 def test_site_bucket_blocks_public_access(template):
     template.has_resource_properties(

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -151,10 +151,17 @@ def test_static_site_stack_synthesises_without_api_base_url(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_csp_connect_src_is_limited_to_required_aws_services(template):
-    """CSP connect-src must avoid a broad *.amazonaws.com wildcard."""
+def test_csp_connect_src_uses_backend_url_parameter(template):
+    """CSP connect-src must reference BackendApiUrl directly, not a static wildcard.
+
+    API Gateway URLs have the form {api-id}.execute-api.{region}.amazonaws.com.
+    No valid static CSP wildcard can match this structure while staying narrower
+    than *.amazonaws.com, so the BackendApiUrl parameter is injected directly,
+    producing a CloudFormation Fn::Join that resolves to the exact origin at
+    deploy time.
+    """
     resources = template.find_resources("AWS::CloudFront::ResponseHeadersPolicy")
-    csp_headers = [
+    csp_values = [
         security_headers["ContentSecurityPolicy"]["ContentSecurityPolicy"]
         for resource in resources.values()
         if (
@@ -165,15 +172,27 @@ def test_csp_connect_src_is_limited_to_required_aws_services(template):
         if "ContentSecurityPolicy" in security_headers
     ]
 
-    assert csp_headers == [
-        "default-src 'self'; "
-        "script-src 'self' https://accounts.google.com/gsi/client; "
-        "frame-src 'self' https://accounts.google.com/gsi/; "
-        "connect-src 'self' "
-        "https://*.execute-api.*.amazonaws.com https://*.amazoncognito.com; "
-        "frame-ancestors 'none'; object-src 'none'; base-uri 'self';"
-    ]
-    assert "https://*.amazonaws.com" not in csp_headers[0]
+    assert len(csp_values) == 1, "Expected exactly one ResponseHeadersPolicy with a CSP"
+    csp = csp_values[0]
+
+    # The CSP value must be a Fn::Join because it contains a parameter reference.
+    assert isinstance(csp, dict) and "Fn::Join" in csp, (
+        "CSP must be a Fn::Join (BackendApiUrl token interpolation); got a plain string, "
+        "which means the connect-src is using a static value instead of the parameter"
+    )
+    join_parts = csp["Fn::Join"][1]
+
+    # The join must include a direct Ref to BackendApiUrl for the narrowest connect-src.
+    assert {"Ref": "BackendApiUrl"} in join_parts, (
+        "CSP Fn::Join must contain a Ref to BackendApiUrl"
+    )
+
+    # No static *.amazonaws.com wildcard should appear in any string fragment.
+    static_text = "".join(p for p in join_parts if isinstance(p, str))
+    assert "amazonaws.com" not in static_text, (
+        "CSP must not contain any static amazonaws.com wildcard in its string fragments"
+    )
+    assert "https://*.amazoncognito.com" in static_text
 
 
 # ---------------------------------------------------------------------------

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -24,6 +24,10 @@ API Gateway URLs include the API ID and the AWS region in different hostname lab
 ```text
 https://{api-id}.execute-api.{region}.amazonaws.com
 ```
+
+The deployed CSP is:
+
+```text
 default-src 'self';
 script-src 'self' https://accounts.google.com/gsi/client;
 frame-src 'self' https://accounts.google.com/gsi/;

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -10,13 +10,17 @@ The deployed CloudFront policy is:
 default-src 'self';
 script-src 'self' https://accounts.google.com/gsi/client;
 frame-src 'self' https://accounts.google.com/gsi/;
-connect-src 'self' https://*.execute-api.*.amazonaws.com https://*.amazoncognito.com;
+connect-src 'self' {BackendApiUrl} https://*.amazoncognito.com;
 frame-ancestors 'none';
 object-src 'none';
 base-uri 'self';
 ```
 
-The `connect-src` directive intentionally permits only API Gateway and Amazon Cognito hosted UI/token exchange endpoints in the AWS namespace. If the frontend adds calls to another AWS service, add the narrowest service-specific host pattern instead of broadening this to `https://*.amazonaws.com`.
+`{BackendApiUrl}` is replaced at deploy time by the CloudFormation `BackendApiUrl` parameter (e.g. `https://abc123.execute-api.eu-west-1.amazonaws.com`). This produces the narrowest possible `connect-src` — pinned to the exact API origin the app uses.
+
+A static wildcard cannot substitute for this parameter. API Gateway URLs have the form `{api-id}.execute-api.{region}.amazonaws.com`. The CSP spec only permits wildcards as the leftmost hostname label, so patterns like `*.execute-api.*.amazonaws.com` are invalid and silently ignored by browsers. The next valid option (`*.amazonaws.com`) is too broad — it covers every AWS service endpoint. Injecting the exact URL avoids both problems.
+
+The `connect-src` directive also permits `https://*.amazoncognito.com` for the Cognito hosted UI and token exchange endpoints.
 
 ### Adding or updating the policy
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -16,45 +16,9 @@ aws cloudformation describe-stacks --stack-name StaticSiteStack \
 
 ## Content Security Policy
 
-AllotMint's frontend is served from S3 behind CloudFront. The static site stack attaches a CloudFront response headers policy that sets a restrictive CSP for production traffic. The policy allows the app itself, Google Identity Services for the existing backend login flow, and AWS endpoints needed for API Gateway and Cognito hosted-UI token exchange.
+AllotMint's frontend is served from S3 behind CloudFront. The static-site CDK stack attaches a CloudFront response headers policy that emits a restrictive Content Security Policy (CSP) for the SPA. The policy allows same-origin resources by default, Google Identity Services for sign-in, the deployed backend API, and Cognito hosted UI/token exchange requests.
 
-The current policy is defined in `cdk/stacks/static_site_stack.py` and includes these main directives:
-
-```text
-default-src 'self';
-script-src 'self' https://accounts.google.com/gsi/client;
-connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com;
-frame-src 'self' https://accounts.google.com/gsi/;
-frame-ancestors 'none';
-object-src 'none';
-base-uri 'self'
-```
-
-Note: `https://*.amazoncognito.com` is required for the PKCE token exchange — the Cognito hosted UI token endpoint (`/oauth2/token`) lives under `amazoncognito.com`, not `amazonaws.com`.
-AllotMint's frontend is served from S3 behind CloudFront. The static-site CDK stack attaches a CloudFront response headers policy that emits a restrictive Content Security Policy (CSP) for the SPA.
-
-The deployed CloudFront policy is:
-
-- same-origin resources by default;
-- the Google Identity Services script and iframe used for sign-in;
-- browser API calls to the deployed AllotMint backend API; and
-- Cognito hosted UI requests on `https://*.amazoncognito.com`.
-
-### Dynamic backend API source
-
-The backend API source in `connect-src` is built from the `BackendApiUrl` CloudFormation parameter in `cdk/stacks/static_site_stack.py`. Deployment workflows pass the Backend Lambda stack's `BackendApiUrl` output to that parameter, and CloudFormation substitutes the exact API Gateway URL into the CloudFront response headers policy at deploy time.
-
-This keeps `connect-src` pinned to the API that the frontend is configured to call rather than permitting broad AWS hostnames.
-
-### Why API Gateway cannot use a wildcard CSP source
-
-API Gateway URLs include the API ID and the AWS region in different hostname labels:
-
-```text
-https://{api-id}.execute-api.{region}.amazonaws.com
-```
-
-The deployed CSP is:
+The deployed CSP is defined in `cdk/stacks/static_site_stack.py` and has this shape:
 
 ```text
 default-src 'self';
@@ -66,19 +30,25 @@ object-src 'none';
 base-uri 'self';
 ```
 
-`{BackendApiUrl}` is replaced at deploy time by the CloudFormation `BackendApiUrl` parameter (e.g. `https://abc123.execute-api.eu-west-1.amazonaws.com`). This produces the narrowest possible `connect-src` — pinned to the exact API origin the app uses.
+`{BackendApiUrl}` is a documentation placeholder for the CloudFormation `BackendApiUrl` parameter. Deployment workflows pass the Backend Lambda stack's `BackendApiUrl` output to that parameter, and CloudFormation substitutes the exact API Gateway URL into the CloudFront response headers policy at deploy time (for example, `https://abc123.execute-api.eu-west-1.amazonaws.com`). The CDK parameter rejects non-empty values that do not start with `https://`, so deploy-time overrides must include the scheme.
 
-A static wildcard cannot substitute for this parameter. API Gateway URLs have the form `{api-id}.execute-api.{region}.amazonaws.com`. The CSP spec only permits wildcards as the leftmost hostname label, so patterns like `*.execute-api.*.amazonaws.com` are invalid and silently ignored by browsers. The next valid option (`*.amazonaws.com`) is too broad — it covers every AWS service endpoint. Injecting the exact URL avoids both problems.
+Note: `https://*.amazoncognito.com` is required for the PKCE token exchange because the Cognito hosted UI token endpoint (`/oauth2/token`) lives under `amazoncognito.com`, not `amazonaws.com`.
 
-The `connect-src` directive also permits `https://*.amazoncognito.com` for the Cognito hosted UI and token exchange endpoints.
+### Why API Gateway cannot use a wildcard CSP source
 
-CSP only allows a wildcard as the leftmost hostname label. As a result:
+API Gateway URLs include the API ID and the AWS region in different hostname labels:
 
-- `https://*.execute-api.*.amazonaws.com` is invalid CSP syntax because the second `*` is in the middle of the hostname, so browsers ignore that source expression;
-- `https://*.execute-api.amazonaws.com` is syntactically valid but does not match regional API Gateway hostnames such as `abc123.execute-api.eu-west-1.amazonaws.com`; and
+```text
+https://{api-id}.execute-api.{region}.amazonaws.com
+```
+
+A static wildcard cannot substitute for the `BackendApiUrl` parameter:
+
+- `https://*.execute-api.*.amazonaws.com` is invalid CSP syntax because CSP only permits wildcards as the leftmost hostname label, so browsers ignore that source expression.
+- `https://*.execute-api.amazonaws.com` is syntactically valid but does not match regional API Gateway hostnames such as `abc123.execute-api.eu-west-1.amazonaws.com`.
 - `https://*.amazonaws.com` is syntactically valid but too broad because it permits any AWS service endpoint under `amazonaws.com`.
 
-Use the dynamic `BackendApiUrl` parameter instead of any `*.amazonaws.com` pattern when adding or updating frontend API connectivity.
+Use the dynamic `BackendApiUrl` parameter instead of any `*.amazonaws.com` pattern when adding or updating frontend API connectivity. This keeps `connect-src` pinned to the exact API origin the frontend is configured to call.
 
 ### Adding or updating the policy
 
@@ -86,10 +56,9 @@ To update the CSP:
 
 1. Edit the CloudFront response headers policy in `cdk/stacks/static_site_stack.py`.
 2. Add the minimum directive needed for the new integration.
-3. Run the CDK static site tests and redeploy:
-2. Keep the backend API entry in `connect-src` tied to the `BackendApiUrl` parameter.
-3. Update `cdk/tests/test_static_site_stack.py` if the expected directives change.
-4. Redeploy the static site stack with the backend URL parameter, for example:
+3. Keep the backend API entry in `connect-src` tied to the `BackendApiUrl` parameter.
+4. Update `cdk/tests/test_static_site_stack.py` if the expected directives change.
+5. Run the CDK static site tests and redeploy with an HTTPS backend URL parameter, for example:
    ```bash
    PYENV_VERSION=3.11.15 pytest cdk/tests/test_static_site_stack.py -v
    cd cdk

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,20 +2,21 @@
 
 ## Content Security Policy
 
-AllotMint's frontend is served from S3 behind CloudFront. Implementing a Content Security Policy (CSP) header limits the sources the browser may load resources from. The stack currently does **not** set a CSP header, so browsers accept resources from any origin.
+AllotMint's frontend is served from S3 behind CloudFront. The static site stack sets a Content Security Policy (CSP) header to limit the sources the browser may load resources from.
 
-A restrictive policy might look like:
+The deployed CloudFront policy is:
 
 ```
 default-src 'self';
-img-src 'self' data:;
-script-src 'self';
-style-src 'self' 'unsafe-inline';
-connect-src 'self' https://www.alphavantage.co;
+script-src 'self' https://accounts.google.com/gsi/client;
+frame-src 'self' https://accounts.google.com/gsi/;
+connect-src 'self' https://*.execute-api.*.amazonaws.com https://*.amazoncognito.com;
 frame-ancestors 'none';
+object-src 'none';
+base-uri 'self';
 ```
 
-This would prevent third‑party scripts or styles from executing unless explicitly whitelisted.
+The `connect-src` directive intentionally permits only API Gateway and Amazon Cognito hosted UI/token exchange endpoints in the AWS namespace. If the frontend adds calls to another AWS service, add the narrowest service-specific host pattern instead of broadening this to `https://*.amazonaws.com`.
 
 ### Adding or updating the policy
 


### PR DESCRIPTION
### Motivation
Closes #2883 
- Reduce the frontend Content Security Policy (CSP) attack surface by avoiding a broad `*.amazonaws.com` wildcard in `connect-src` while preserving required API and Cognito flows. 
- Make the deployed CSP explicit and maintainable by centralising the policy string in the CDK stack.

### Description

- Introduce a reusable `_STATIC_SITE_CSP` constant in `cdk/stacks/static_site_stack.py` and use it for the CloudFront `ResponseHeadersPolicy` `ContentSecurityPolicy` value. 
- Narrow the `connect-src` directive to `https://*.execute-api.*.amazonaws.com` and `https://*.amazoncognito.com` (instead of a broad `https://*.amazonaws.com`).
- Update `docs/SECURITY.md` to document the actual deployed CSP and rationale for avoiding a broad AWS wildcard. 
- Add a CDK assertion test in `cdk/tests/test_static_site_stack.py` that verifies the synthesized `ResponseHeadersPolicy` contains the expected CSP and that `https://*.amazonaws.com` is not present.

### Testing

- Ran `pytest cdk/tests/test_static_site_stack.py -v` and the suite passed (11 tests, including the new CSP assertion). 
- Verified the code compiles with `python -m compileall cdk/stacks/static_site_stack.py cdk/tests/test_static_site_stack.py` and checked `git diff --check` for whitespace/formatting issues. 
- Ran `make lint` which failed due to pre-existing, unrelated lint issues elsewhere in the repository and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe333dbccc83279b406ffaa278f2b3)