### PR TITLE
fix: add alerts/ and prices/ to BackendLambda s3:ListBucket scope

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -164,7 +164,11 @@ class BackendLambdaStack(Stack):
 
         bucket_name = data_bucket.bucket_name
         lambda_list_prefixes = {
-            "backend": ("accounts", "queries", "timeseries/meta", "transactions"),
+            # alerts/ and prices/ are included because S3 returns 403 (not 404) when
+            # a key is absent and the caller lacks s3:ListBucket on that prefix, which
+            # prevents the fallback logic in alerts.py and the price-snapshot loader
+            # from distinguishing "missing" from "denied".
+            "backend": ("accounts", "alerts", "prices", "queries", "timeseries/meta", "transactions"),
             "price_refresh": (),
             "trading_agent": (),
         }

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -15,7 +15,7 @@ if str(CDK_DIR) not in sys.path:
 
 from stacks.backend_lambda_stack import BackendLambdaStack
 
-BACKEND_LIST_PREFIXES = ("accounts", "queries", "timeseries/meta", "transactions")
+BACKEND_LIST_PREFIXES = ("accounts", "alerts", "prices", "queries", "timeseries/meta", "transactions")
 
 
 def _stack_template() -> dict:


### PR DESCRIPTION
## Summary

- Adds `alerts` and `prices` to `lambda_list_prefixes["backend"]` in `cdk/stacks/backend_lambda_stack.py`
- Updates the matching `BACKEND_LIST_PREFIXES` constant in `cdk/tests/test_backend_lambda_stack_permissions.py`

## Root cause

On a fresh bucket S3 returns **403 AccessDenied** (not 404) for `GetObject` on a missing key when the caller lacks `s3:ListBucket` on that prefix. The previous policy only scoped `ListBucket` to `accounts/`, `queries/`, `timeseries/meta/`, and `transactions/`, leaving `alerts/` and `prices/` uncovered.

Because `alerts.py` runs `_load_settings()` and `_load_subscriptions()` at **import time**, the 403s block Lambda init and trigger the 30 s invoke timeout seen in the logs.

## Test plan

- [x] `pytest cdk/tests/test_backend_lambda_stack_permissions.py -v` — all 6 tests pass locally
- [ ] CI: CDK diff/synth in the deploy workflow
- [ ] Smoke test after deploy to a fresh or existing stack

## Local testing without CI

```bash
# Verify synthesised IAM policy contains the new prefixes
cd cdk && cdk synth

# Run unit tests (no AWS credentials needed)
pytest cdk/tests/test_backend_lambda_stack_permissions.py -v

# Preview live-stack changes
cdk diff
```

Closes #2889

🤖 Generated with [Claude Code](https://claude.com/claude-code)