### PR TITLE
Grant Lambda timeseries cache HeadObject access

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -119,7 +119,7 @@ class BackendLambdaStack(Stack):
     ) -> None:
         """Grant S3 permissions required by the Lambda timeseries parquet cache."""
 
-        actions = ["s3:GetObject"]
+        actions = ["s3:GetObject", "s3:HeadObject"]
         if allow_put:
             actions.append("s3:PutObject")
 

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -141,9 +141,9 @@ def _conditions_for_s3_action(template: dict, role_logical_id: str, target_actio
 #   TradingAgentLambda — calls load_prices_for_tickers() → load_meta_timeseries_range() which
 #                        reads parquet from S3 by known key. No writes anywhere in this path.
 #                        Pyarrow may list the timeseries/ prefix before reading cached files.
-BACKEND_MAX_S3 = {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}
-REFRESH_MAX_S3 = {"s3:GetObject", "s3:PutObject", "s3:ListBucket"}
-TRADING_MAX_S3 = {"s3:GetObject", "s3:ListBucket"}
+BACKEND_MAX_S3 = {"s3:GetObject", "s3:HeadObject", "s3:PutObject", "s3:ListBucket"}
+REFRESH_MAX_S3 = {"s3:GetObject", "s3:HeadObject", "s3:PutObject", "s3:ListBucket"}
+TRADING_MAX_S3 = {"s3:GetObject", "s3:HeadObject", "s3:ListBucket"}
 
 
 def test_s3_permissions_are_scoped_per_lambda() -> None:
@@ -213,13 +213,14 @@ def test_all_lambdas_have_scoped_timeseries_cache_permissions() -> None:
     template = _stack_template()
     expected_condition = {"StringLike": {"s3:prefix": ["timeseries", "timeseries/*"]}}
 
-    # All three Lambdas must be able to read from and list the timeseries/ prefix
+    # All three Lambdas must be able to read, head, and list the timeseries/ prefix
     for fragment in ("BackendLambda", "PriceRefreshLambda", "TradingAgentLambda"):
         role = _role_logical_id_for_lambda(template, fragment)
-        resources = _resources_for_s3_action(template, role, "s3:GetObject")
-        assert any(
-            "timeseries/*" in resource for resource in resources
-        ), f"{fragment} missing s3:GetObject on the timeseries/* object prefix"
+        for action in ("s3:GetObject", "s3:HeadObject"):
+            resources = _resources_for_s3_action(template, role, action)
+            assert any(
+                "timeseries/*" in resource for resource in resources
+            ), f"{fragment} missing {action} on the timeseries/* object prefix"
 
         conditions = _conditions_for_s3_action(template, role, "s3:ListBucket")
         assert expected_condition in conditions, f"{fragment} missing ListBucket scoped to the timeseries/ prefix"


### PR DESCRIPTION
### Motivation
- The timeseries parquet cache uses S3 object metadata checks (head-object) to detect mtime changes, so Lambda roles need `s3:HeadObject` in addition to reads/writes for correct cache invalidation.

### Description
- Added `s3:HeadObject` to the timeseries cache IAM grant in `_grant_timeseries_cache_access` so Lambdas may call HeadObject on `timeseries/*` objects.
- Updated CDK permission tests to include `s3:HeadObject` in the audited S3 action upper bounds for Backend, PriceRefresh, and TradingAgent roles and to assert both `s3:GetObject` and `s3:HeadObject` are scoped to `timeseries/*`.
- Closes #2894.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest cdk/tests/test_backend_lambda_stack_permissions.py` and all tests passed (`6 passed`).
- Built the frontend with `npm --prefix frontend run build` which completed successfully.
- Synthesised the CDK app with `JWT_SECRET=test-secret GOOGLE_CLIENT_ID=test-client-id PYENV_VERSION=3.11.15 npx cdk synth --app "python3 app.py"` and synthesis succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff35028d8c83279aa5204bb68d31e0)