### PR TITLE
Pin CloudFront CSP connect-src to BackendApiUrl (fix #2892)

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -76,7 +76,8 @@ class StaticSiteStack(Stack):
                     content_security_policy=(
                         "default-src 'self'; "
                         "script-src 'self' https://accounts.google.com/gsi/client; "
-                        "connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com; "
+                        f"connect-src 'self' {backend_url_param.value_as_string} "
+                        "https://*.amazoncognito.com; "
                         "frame-src 'self' https://accounts.google.com/gsi/; "
                         "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
                     ),

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -148,6 +148,28 @@ def test_static_site_stack_synthesises_without_api_base_url(tmp_path):
     app.synth()
 
 
+def _response_headers_policy_csp(template: assertions.Template) -> object:
+    resources = template.find_resources("AWS::CloudFront::ResponseHeadersPolicy")
+    assert len(resources) == 1, f"Expected one response headers policy, found {len(resources)}"
+    policy = next(iter(resources.values()))
+    return policy["Properties"]["ResponseHeadersPolicyConfig"]["SecurityHeadersConfig"][
+        "ContentSecurityPolicy"
+    ]["ContentSecurityPolicy"]
+
+
+def test_csp_connect_src_uses_backend_api_url_parameter(template):
+    """CSP connect-src must use the exact API URL parameter, not AWS wildcards."""
+    csp = _response_headers_policy_csp(template)
+
+    assert isinstance(csp, dict)
+    parts = csp["Fn::Join"][1]
+    assert {"Ref": "BackendApiUrl"} in parts
+    rendered_static_parts = "".join(part for part in parts if isinstance(part, str))
+    assert "connect-src 'self' " in rendered_static_parts
+    assert "https://*.amazoncognito.com" in rendered_static_parts
+    assert "*.amazonaws.com" not in rendered_static_parts
+
+
 # ---------------------------------------------------------------------------
 # CloudFront distribution outputs
 # ---------------------------------------------------------------------------

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,32 +2,50 @@
 
 ## Content Security Policy
 
-AllotMint's frontend is served from S3 behind CloudFront. Implementing a Content Security Policy (CSP) header limits the sources the browser may load resources from. The stack currently does **not** set a CSP header, so browsers accept resources from any origin.
+AllotMint's frontend is served from S3 behind CloudFront. The static-site CDK stack attaches a CloudFront response headers policy that emits a restrictive Content Security Policy (CSP) for the SPA.
 
-A restrictive policy might look like:
+The policy allows:
 
+- same-origin resources by default;
+- the Google Identity Services script and iframe used for sign-in;
+- browser API calls to the deployed AllotMint backend API; and
+- Cognito hosted UI requests on `https://*.amazoncognito.com`.
+
+### Dynamic backend API source
+
+The backend API source in `connect-src` is built from the `BackendApiUrl` CloudFormation parameter in `cdk/stacks/static_site_stack.py`. Deployment workflows pass the Backend Lambda stack's `BackendApiUrl` output to that parameter, and CloudFormation substitutes the exact API Gateway URL into the CloudFront response headers policy at deploy time.
+
+This keeps `connect-src` pinned to the API that the frontend is configured to call rather than permitting broad AWS hostnames.
+
+### Why API Gateway cannot use a wildcard CSP source
+
+API Gateway URLs include the API ID and the AWS region in different hostname labels:
+
+```text
+https://{api-id}.execute-api.{region}.amazonaws.com
 ```
-default-src 'self';
-img-src 'self' data:;
-script-src 'self';
-style-src 'self' 'unsafe-inline';
-connect-src 'self' https://www.alphavantage.co;
-frame-ancestors 'none';
-```
 
-This would prevent third‑party scripts or styles from executing unless explicitly whitelisted.
+CSP only allows a wildcard as the leftmost hostname label. As a result:
+
+- `https://*.execute-api.*.amazonaws.com` is invalid CSP syntax because the second `*` is in the middle of the hostname, so browsers ignore that source expression;
+- `https://*.execute-api.amazonaws.com` is syntactically valid but does not match regional API Gateway hostnames such as `abc123.execute-api.eu-west-1.amazonaws.com`; and
+- `https://*.amazonaws.com` is syntactically valid but too broad because it permits any AWS service endpoint under `amazonaws.com`.
+
+Use the dynamic `BackendApiUrl` parameter instead of any `*.amazonaws.com` pattern when adding or updating frontend API connectivity.
 
 ### Adding or updating the policy
 
-To enforce a CSP:
+To update the CSP:
 
-1. Define a CloudFront response headers policy (or function) in `cdk/stacks/static_site_stack.py` that sets the `content-security-policy` header.
-2. Add your directives to the header string.
-3. Associate the policy with the distribution's behavior and redeploy:
+1. Edit the CloudFront response headers policy in `cdk/stacks/static_site_stack.py`.
+2. Keep the backend API entry in `connect-src` tied to the `BackendApiUrl` parameter.
+3. Update `cdk/tests/test_static_site_stack.py` if the expected directives change.
+4. Redeploy the static site stack with the backend URL parameter, for example:
    ```bash
    npm ci
    cd cdk
-   npx cdk deploy StaticSiteStack
+   npx cdk deploy StaticSiteStack \
+     --parameters StaticSiteStack:BackendApiUrl=https://abc123.execute-api.eu-west-1.amazonaws.com
    ```
 
 For temporary local testing you may instead inject a `<meta http-equiv="Content-Security-Policy">` tag in `frontend/index.html`, but prefer the header-based policy in production.


### PR DESCRIPTION
### Motivation

- Prevent overly-broad or invalid CSP `connect-src` values that used an `amazonaws.com` wildcard and could be ignored by browsers for API Gateway hostnames.
- Ensure the SPA's CSP only allows the exact backend API the frontend is configured to call.

### Description

- Updated `cdk/stacks/static_site_stack.py` to build the CloudFront Response Headers Policy `connect-src` directive from the `BackendApiUrl` CloudFormation parameter (`backend_url_param.value_as_string`) instead of a `*.amazonaws.com` wildcard while retaining the Cognito hosted UI `https://*.amazoncognito.com` entry. 
- Added a CDK assertion test in `cdk/tests/test_static_site_stack.py` (`test_csp_connect_src_uses_backend_api_url_parameter`) that verifies the CSP contains a `Ref: BackendApiUrl` token and does not include `*.amazonaws.com`.
- Updated `docs/SECURITY.md` to document the dynamic `BackendApiUrl` usage, explain why API Gateway wildcard CSP sources are invalid or too broad, and show the deploy-time parameter usage.

### Testing

- Ran `PYENV_VERSION=3.11.15 pytest cdk/tests/test_static_site_stack.py -v`, and the test suite passed: `16 passed`.
- The change was validated by synthesising the stack in tests and inspecting the generated `AWS::CloudFront::ResponseHeadersPolicy` to confirm the CSP contains a `Fn::Join` with a `Ref` to `BackendApiUrl` and no `*.amazonaws.com` entries.

Closes #2892

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6463b6788327a84bfd96bdf1cb76)