### PR TITLE
Add scoped `prices/` S3 ListBucket prefixes for price Lambdas

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -145,13 +145,16 @@ class BackendLambdaStack(Stack):
         data_repo = os.getenv("DATA_REPO")
         data_branch = os.getenv("DATA_BRANCH", "main")
         budget_limit_usd = float(
-            self.node.try_get_context("monthly_budget_limit_usd") or os.getenv("MONTHLY_BUDGET_LIMIT_USD", "5")
+            self.node.try_get_context("monthly_budget_limit_usd")
+            or os.getenv("MONTHLY_BUDGET_LIMIT_USD", "5")
         )
         noncurrent_expiry_days = int(
             self.node.try_get_context("data_bucket_noncurrent_expiry_days")
             or os.getenv("DATA_BUCKET_NONCURRENT_EXPIRY_DAYS", "30")
         )
-        budget_alert_email = self.node.try_get_context("budget_alert_email") or os.getenv("BUDGET_ALERT_EMAIL")
+        budget_alert_email = self.node.try_get_context("budget_alert_email") or os.getenv(
+            "BUDGET_ALERT_EMAIL"
+        )
         data_bucket = s3.Bucket(
             self,
             "PortfolioDataBucket",
@@ -159,31 +162,50 @@ class BackendLambdaStack(Stack):
             encryption=s3.BucketEncryption.S3_MANAGED,
             enforce_ssl=True,
             versioned=True,
-            lifecycle_rules=[s3.LifecycleRule(noncurrent_version_expiration=Duration.days(noncurrent_expiry_days))],
+            lifecycle_rules=[
+                s3.LifecycleRule(
+                    noncurrent_version_expiration=Duration.days(noncurrent_expiry_days)
+                )
+            ],
         )
 
         bucket_name = data_bucket.bucket_name
         lambda_list_prefixes = {
             # alerts/ and prices/ are included because S3 returns 403 (not 404) when
             # a key is absent and the caller lacks s3:ListBucket on that prefix, which
-            # prevents the fallback logic in alerts.py and the price-snapshot loader
-            # from distinguishing "missing" from "denied".
-            "backend": ("accounts", "alerts", "prices", "queries", "timeseries/meta", "transactions"),
-            "price_refresh": (),
-            "trading_agent": (),
+            # prevents fallback logic from distinguishing "missing" from "denied".
+            # The price_refresh and trading_agent Lambdas import the same
+            # price-snapshot loader at module import time, so they also need
+            # prices/ list access for fresh buckets without latest_prices.json.
+            "backend": (
+                "accounts",
+                "alerts",
+                "prices",
+                "queries",
+                "timeseries/meta",
+                "transactions",
+            ),
+            "price_refresh": ("prices",),
+            "trading_agent": ("prices",),
         }
 
-        image_code = _lambda.DockerImageCode.from_image_asset(str(project_root), file="backend/Dockerfile.lambda")
+        image_code = _lambda.DockerImageCode.from_image_asset(
+            str(project_root), file="backend/Dockerfile.lambda"
+        )
 
         env = self.node.try_get_context("app_env") or os.getenv("APP_ENV") or "aws"
-        frontend_origin = self.node.try_get_context("frontend_origin") or os.getenv("FRONTEND_ORIGIN")
+        frontend_origin = self.node.try_get_context("frontend_origin") or os.getenv(
+            "FRONTEND_ORIGIN"
+        )
         extra_cors_origins = self.node.try_get_context("cors_origins") or os.getenv("CORS_ORIGINS")
 
         cors_origins = ["http://localhost:3000", "http://localhost:5173"]
         if frontend_origin:
             cors_origins.insert(0, frontend_origin)
         if extra_cors_origins:
-            cors_origins.extend([origin.strip() for origin in extra_cors_origins.split(",") if origin.strip()])
+            cors_origins.extend(
+                [origin.strip() for origin in extra_cors_origins.split(",") if origin.strip()]
+            )
         cors_origins = list(dict.fromkeys(cors_origins))
 
         jwt_secret = os.getenv("JWT_SECRET", "")
@@ -240,7 +262,9 @@ class BackendLambdaStack(Stack):
 
         backend_api = apigwv2.HttpApi(self, "BackendApi")
         self.backend_api_url = backend_api.api_endpoint
-        backend_integration = apigwv2_integrations.HttpLambdaIntegration("BackendLambdaIntegration", backend_fn)
+        backend_integration = apigwv2_integrations.HttpLambdaIntegration(
+            "BackendLambdaIntegration", backend_fn
+        )
         backend_api.add_routes(
             path="/",
             methods=[apigwv2.HttpMethod.ANY],
@@ -276,16 +300,19 @@ class BackendLambdaStack(Stack):
             log_group=refresh_log_group,
         )
 
-        # PriceRefreshLambda: read + put by known data keys. The explicit timeseries
-        # cache grant also allows ListBucket on timeseries/ because some S3 parquet
-        # clients list the prefix before reading or writing cached parquet files.
-        # See backend/timeseries/cache.py:_rolling_cache() and _save_parquet().
+        # PriceRefreshLambda: read + put by known data keys. It also needs scoped
+        # ListBucket on prices/ so the module-level price snapshot loader can
+        # distinguish a missing latest_prices.json from an access-denied response.
+        # The explicit timeseries cache grant also allows ListBucket on timeseries/
+        # because some S3 parquet clients list the prefix before reading or writing
+        # cached parquet files. See backend/timeseries/cache.py:_rolling_cache()
+        # and _save_parquet().
         self._grant_bucket_access(
             refresh_fn,
             bucket=data_bucket,
             allow_read=True,
             allow_put=True,
-            allow_list=False,
+            allow_list=True,
             list_prefix=lambda_list_prefixes["price_refresh"],
         )
         self._grant_timeseries_cache_access(refresh_fn, bucket=data_bucket, allow_put=True)
@@ -321,8 +348,10 @@ class BackendLambdaStack(Stack):
             log_group=agent_log_group,
         )
 
-        # TradingAgentLambda: read-only, no put, no general list.
-        # Audited: trading_agent.py:run() → load_prices_for_tickers()
+        # TradingAgentLambda: read-only, no put, and only scoped list access.
+        # It needs ListBucket on prices/ so the module-level price snapshot loader
+        # can distinguish a missing latest_prices.json from an access-denied
+        # response. Audited: trading_agent.py:run() → load_prices_for_tickers()
         # → load_meta_timeseries_range() reads parquet from S3 by known key.
         # No S3 writes: _log_trade() writes to TRADE_LOG_PATH (local filesystem / CloudWatch).
         # The timeseries cache grant adds scoped GetObject and ListBucket so pyarrow
@@ -333,7 +362,7 @@ class BackendLambdaStack(Stack):
             bucket=data_bucket,
             allow_read=True,
             allow_put=False,
-            allow_list=False,
+            allow_list=True,
             list_prefix=lambda_list_prefixes["trading_agent"],
         )
         self._grant_timeseries_cache_access(agent_fn, bucket=data_bucket, allow_put=False)
@@ -368,7 +397,9 @@ class BackendLambdaStack(Stack):
                     threshold_type="PERCENTAGE",
                 ),
                 subscribers=[
-                    budgets.CfnBudget.SubscriberProperty(subscription_type="EMAIL", address=budget_alert_email)
+                    budgets.CfnBudget.SubscriberProperty(
+                        subscription_type="EMAIL", address=budget_alert_email
+                    )
                 ],
             )
 

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+from importlib import import_module
 from pathlib import Path
 
 import pytest
@@ -13,9 +14,25 @@ CDK_DIR = Path(__file__).resolve().parents[1]
 if str(CDK_DIR) not in sys.path:
     sys.path.insert(0, str(CDK_DIR))
 
-from stacks.backend_lambda_stack import BackendLambdaStack
+BackendLambdaStack = import_module("stacks.backend_lambda_stack").BackendLambdaStack
 
-BACKEND_LIST_PREFIXES = ("accounts", "alerts", "prices", "queries", "timeseries/meta", "transactions")
+BACKEND_LIST_PREFIXES = (
+    "accounts",
+    "alerts",
+    "prices",
+    "queries",
+    "timeseries/meta",
+    "transactions",
+)
+PRICE_REFRESH_LIST_PREFIXES = ("prices",)
+TRADING_AGENT_LIST_PREFIXES = ("prices",)
+
+
+def _expected_list_prefix_condition(prefixes: tuple[str, ...]) -> dict:
+    expected_prefix_entries: list[str] = []
+    for prefix in prefixes:
+        expected_prefix_entries.extend([prefix, f"{prefix}/*"])
+    return {"StringLike": {"s3:prefix": expected_prefix_entries}}
 
 
 def _stack_template() -> dict:
@@ -58,7 +75,11 @@ def _s3_actions_for_role(template: dict, role_logical_id: str) -> set[str]:
         if resource.get("Type") != "AWS::IAM::Policy":
             continue
         roles = resource.get("Properties", {}).get("Roles", [])
-        role_refs = {role["Ref"] for role in roles if isinstance(role, dict) and isinstance(role.get("Ref"), str)}
+        role_refs = {
+            role["Ref"]
+            for role in roles
+            if isinstance(role, dict) and isinstance(role.get("Ref"), str)
+        }
         if role_logical_id not in role_refs:
             continue
 
@@ -87,7 +108,9 @@ def _resources_for_s3_action(template: dict, role_logical_id: str, target_action
         if resource.get("Type") != "AWS::IAM::Policy":
             continue
         roles = resource.get("Properties", {}).get("Roles", [])
-        role_refs = {r["Ref"] for r in roles if isinstance(r, dict) and isinstance(r.get("Ref"), str)}
+        role_refs = {
+            r["Ref"] for r in roles if isinstance(r, dict) and isinstance(r.get("Ref"), str)
+        }
         if role_logical_id not in role_refs:
             continue
 
@@ -107,7 +130,9 @@ def _resources_for_s3_action(template: dict, role_logical_id: str, target_action
     return found
 
 
-def _conditions_for_s3_action(template: dict, role_logical_id: str, target_action: str) -> list[dict]:
+def _conditions_for_s3_action(
+    template: dict, role_logical_id: str, target_action: str
+) -> list[dict]:
     """Return IAM Condition objects for statements granting target_action."""
     found: list[dict] = []
     resources = template["Resources"]
@@ -115,7 +140,9 @@ def _conditions_for_s3_action(template: dict, role_logical_id: str, target_actio
         if resource.get("Type") != "AWS::IAM::Policy":
             continue
         roles = resource.get("Properties", {}).get("Roles", [])
-        role_refs = {r["Ref"] for r in roles if isinstance(r, dict) and isinstance(r.get("Ref"), str)}
+        role_refs = {
+            r["Ref"] for r in roles if isinstance(r, dict) and isinstance(r.get("Ref"), str)
+        }
         if role_logical_id not in role_refs:
             continue
 
@@ -181,9 +208,9 @@ def test_s3_permissions_are_scoped_per_lambda() -> None:
     ), f"TradingAgentLambda has unexpected S3 actions: {trading_actions - TRADING_MAX_S3}"
 
     # Explicit absence checks (belt-and-suspenders on top of upper-bound)
-    assert "s3:PutObject" not in trading_actions, (
-        "TradingAgentLambda must not have s3:PutObject — read-only S3 access"
-    )
+    assert (
+        "s3:PutObject" not in trading_actions
+    ), "TradingAgentLambda must not have s3:PutObject — read-only S3 access"
     assert "s3:ListBucket" not in refresh_actions or all(
         _conditions_for_s3_action(template, refresh_role, "s3:ListBucket")
     ), "PriceRefreshLambda s3:ListBucket must always be conditioned (no unrestricted list)"
@@ -200,13 +227,19 @@ def test_s3_permissions_are_scoped_per_lambda() -> None:
 
     list_bucket_conditions = _conditions_for_s3_action(template, backend_role, "s3:ListBucket")
     assert list_bucket_conditions, "BackendLambda has s3:ListBucket but no associated IAM Condition"
-    expected_prefix_entries: list[str] = []
-    for prefix in BACKEND_LIST_PREFIXES:
-        expected_prefix_entries.extend([prefix, f"{prefix}/*"])
-    expected_prefix = {"StringLike": {"s3:prefix": expected_prefix_entries}}
     assert (
-        expected_prefix in list_bucket_conditions
+        _expected_list_prefix_condition(BACKEND_LIST_PREFIXES) in list_bucket_conditions
     ), "BackendLambda s3:ListBucket must be conditioned to all audited backend list prefixes"
+
+    refresh_list_conditions = _conditions_for_s3_action(template, refresh_role, "s3:ListBucket")
+    assert (
+        _expected_list_prefix_condition(PRICE_REFRESH_LIST_PREFIXES) in refresh_list_conditions
+    ), "PriceRefreshLambda s3:ListBucket must include prices/ for the price snapshot loader"
+
+    trading_list_conditions = _conditions_for_s3_action(template, trading_role, "s3:ListBucket")
+    assert (
+        _expected_list_prefix_condition(TRADING_AGENT_LIST_PREFIXES) in trading_list_conditions
+    ), "TradingAgentLambda s3:ListBucket must include prices/ for the price snapshot loader"
 
 
 def test_all_lambdas_have_scoped_timeseries_cache_permissions() -> None:
@@ -222,7 +255,9 @@ def test_all_lambdas_have_scoped_timeseries_cache_permissions() -> None:
         ), f"{fragment} missing s3:GetObject on the timeseries/* object prefix"
 
         conditions = _conditions_for_s3_action(template, role, "s3:ListBucket")
-        assert expected_condition in conditions, f"{fragment} missing ListBucket scoped to the timeseries/ prefix"
+        assert (
+            expected_condition in conditions
+        ), f"{fragment} missing ListBucket scoped to the timeseries/ prefix"
 
     # Only write-capable Lambdas may put objects under the timeseries/ prefix
     for fragment in ("BackendLambda", "PriceRefreshLambda"):
@@ -235,9 +270,9 @@ def test_all_lambdas_have_scoped_timeseries_cache_permissions() -> None:
     # TradingAgentLambda must NOT have PutObject on timeseries/ — read-only cache access
     trading_role = _role_logical_id_for_lambda(template, "TradingAgentLambda")
     trading_put_resources = _resources_for_s3_action(template, trading_role, "s3:PutObject")
-    assert not any("timeseries/*" in r for r in trading_put_resources), (
-        "TradingAgentLambda must not have s3:PutObject on timeseries/* — read-only S3 access"
-    )
+    assert not any(
+        "timeseries/*" in r for r in trading_put_resources
+    ), "TradingAgentLambda must not have s3:PutObject on timeseries/* — read-only S3 access"
 
 
 def test_grant_bucket_access_requires_list_prefix_when_allow_list_enabled() -> None:
@@ -263,7 +298,9 @@ def test_grant_bucket_access_requires_list_prefix_when_allow_list_enabled() -> N
             )
         except ValueError:
             continue
-        raise AssertionError(f"Expected ValueError for allow_list=True with list_prefix={invalid_prefix!r}")
+        raise AssertionError(
+            f"Expected ValueError for allow_list=True with list_prefix={invalid_prefix!r}"
+        )
 
 
 def test_grant_bucket_access_accepts_multiple_list_prefixes() -> None:
@@ -291,10 +328,7 @@ def test_grant_bucket_access_accepts_multiple_list_prefixes() -> None:
     conditions = _conditions_for_s3_action(template, role_logical_id, "s3:ListBucket")
     assert len(conditions) == 1, "Expected exactly one ListBucket statement"
 
-    expected_prefix_entries: list[str] = []
-    for prefix in BACKEND_LIST_PREFIXES:
-        expected_prefix_entries.extend([prefix, f"{prefix}/*"])
-    assert conditions[0] == {"StringLike": {"s3:prefix": expected_prefix_entries}}
+    assert conditions[0] == _expected_list_prefix_condition(BACKEND_LIST_PREFIXES)
 
 
 def test_lambda_roles_do_not_have_s3_delete_permissions() -> None:
@@ -306,7 +340,9 @@ def test_lambda_roles_do_not_have_s3_delete_permissions() -> None:
     for fragment in role_fragments:
         role = _role_logical_id_for_lambda(template, fragment)
         actions = _s3_actions_for_role(template, role)
-        assert forbidden.isdisjoint(actions), f"Found forbidden actions for {fragment}: {actions & forbidden}"
+        assert forbidden.isdisjoint(
+            actions
+        ), f"Found forbidden actions for {fragment}: {actions & forbidden}"
         # Also catch wildcard grants which implicitly include delete
         assert (
             "s3:*" not in actions and "*" not in actions
@@ -316,7 +352,9 @@ def test_lambda_roles_do_not_have_s3_delete_permissions() -> None:
 def test_grant_bucket_access_raises_on_no_permissions() -> None:
     class _MockFn:
         def add_to_role_policy(self, policy_statement: object) -> None:
-            raise AssertionError("add_to_role_policy should not be called when no permissions are enabled")
+            raise AssertionError(
+                "add_to_role_policy should not be called when no permissions are enabled"
+            )
 
     mock_fn = _MockFn()
 


### PR DESCRIPTION
### Motivation
- Fix a cold-start access issue where the shared price snapshot loader cannot distinguish a missing `prices/latest_prices.json` (404) from an access-denied (403) response, which breaks fresh-bucket flows.
- Ensure the `PriceRefreshLambda` and `TradingAgentLambda` have the minimal scoped `s3:ListBucket` permission needed by module-level loaders without widening other S3 privileges.

### Description
- Updated `cdk/stacks/backend_lambda_stack.py` to include `"prices"` in `lambda_list_prefixes` for the `price_refresh` and `trading_agent` roles and enabled scoped `allow_list=True` for those grants while preserving read/write object semantics.
- Kept the `timeseries` cache grants unchanged and still scope object-level `GetObject`/`PutObject` and `ListBucket` conditions to `timeseries` entries.
- Updated `cdk/tests/test_backend_lambda_stack_permissions.py` to add `PRICE_REFRESH_LIST_PREFIXES` and `TRADING_AGENT_LIST_PREFIXES`, introduced `_expected_list_prefix_condition()` helper, and added assertions that both price-related Lambda roles include the `prices/` list-prefix condition.
- Ran formatting and lint fixes on the touched files to keep style consistent with the project tooling.
- Closes #2891

### Testing
- Ran lint/format checks with `ruff` and `black` and fixed issues, and both checks report clean for the modified files.
- Ran the unit tests with `pytest cdk/tests/test_backend_lambda_stack_permissions.py -v` and all tests passed (`6 passed`).
- Also installed CDK test deps (`pip install -r cdk/requirements.txt`) as part of the test run to synthesize and assert IAM policy conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6457a150832785da836ee6b0a584)