### PR TITLE
Honor retainUserPool context when deciding Cognito user pool RemovalPolicy

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -18,6 +18,15 @@ def _is_truthy_context(value: object) -> bool:
     return False
 
 
+def _ui_auth_removal_policy(scope: Construct) -> RemovalPolicy:
+    """Retain the Cognito user pool when production retention is requested."""
+    retain_user_pool = _is_truthy_context(scope.node.try_get_context("retainUserPool"))
+    prod = _is_truthy_context(scope.node.try_get_context("prod"))
+    if retain_user_pool or prod:
+        return RemovalPolicy.RETAIN
+    return RemovalPolicy.DESTROY
+
+
 class StaticSiteStack(Stack):
     """CDK stack that provisions S3 + CloudFront for the frontend."""
 
@@ -32,11 +41,7 @@ class StaticSiteStack(Stack):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        ui_auth_removal_policy = (
-            RemovalPolicy.RETAIN
-            if _is_truthy_context(self.node.try_get_context("prod"))
-            else RemovalPolicy.DESTROY
-        )
+        ui_auth_removal_policy = _ui_auth_removal_policy(self)
 
         # BucketDeployment.Source.json_data() only accepts intra-stack tokens
         # (Ref / Fn::GetAtt / Fn::Select) — Fn::ImportValue is explicitly rejected

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -234,6 +234,14 @@ def test_ui_auth_user_pool_is_retained_for_prod_context(tmp_path):
     )
 
 
+def test_ui_auth_user_pool_is_retained_for_retain_user_pool_context(tmp_path):
+    template = _template_with_context(tmp_path, {"retainUserPool": "true"})
+    template.has_resource(
+        "AWS::Cognito::UserPool",
+        {"DeletionPolicy": "Retain", "UpdateReplacePolicy": "Retain"},
+    )
+
+
 def test_ui_auth_outputs_exist(template):
     template.has_output("UiAuthUserPoolId", {})
     template.has_output("UiAuthUserPoolClientId", {})


### PR DESCRIPTION
### Motivation
- CDK synthesis and assertions expected the Cognito UI user pool to be retained in production, but there was no explicit context key to request retention outside `prod`, causing mismatches in some workflows and CI tests.
- Provide a clear, low-risk opt-in (`retainUserPool`) so operators can preserve the user pool without switching full `prod` behaviour.

### Description
- Add a helper `_ui_auth_removal_policy(scope: Construct) -> RemovalPolicy` that returns `RemovalPolicy.RETAIN` when either the `prod` or `retainUserPool` CDK context key is truthy, otherwise returns `RemovalPolicy.DESTROY`.
- Replace the inline `prod`-only removal policy with a call to `_ui_auth_removal_policy(self)` in `StaticSiteStack`.
- Add a CDK assertion test `test_ui_auth_user_pool_is_retained_for_retain_user_pool_context` to verify the `retainUserPool=true` path synthesises `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain`.
- Apply small formatting adjustments so linters (`black`, `ruff`) are happy with the updated files.

### Testing
- Ran formatting check with `python -m black --check cdk/stacks/static_site_stack.py cdk/tests/test_static_site_stack.py` and it succeeded.
- Ran static analysis with `python -m ruff check cdk/stacks/static_site_stack.py cdk/tests/test_static_site_stack.py` and it succeeded.
- Ran the stack assertion tests with `python -m pytest cdk/tests/test_static_site_stack.py -q` which resulted in all tests passing (16 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff67fe3ca883278c4eaffd49b0dce6)