### PR TITLE
Document deterministic branch protection checks

### DIFF
--- a/.github/rulesets/default-branch-protection.json
+++ b/.github/rulesets/default-branch-protection.json
@@ -1,0 +1,54 @@
+{
+  "name": "main deterministic PR gates",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "CI / test"
+          },
+          {
+            "context": "Backend Integration Tests / integration-tests"
+          },
+          {
+            "context": "Frontend Tests / frontend-tests"
+          },
+          {
+            "context": "PR Body Issue Reference Check / require-issue-reference"
+          },
+          {
+            "context": "Dependency Review / dependency-review"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.12'
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt -r requirements-dev.txt
       - run: python scripts/check_branch_protection_required_checks.py
       - uses: actions/setup-node@v6.4.0
         with:
@@ -23,5 +23,4 @@ jobs:
         working-directory: frontend
       - run: npm test -- --run
         working-directory: frontend
-      - run: pip install -r requirements-dev.txt
       - run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - run: python scripts/check_branch_protection_required_checks.py
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: '24'
@@ -18,8 +23,5 @@ jobs:
         working-directory: frontend
       - run: npm test -- --run
         working-directory: frontend
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: '3.12'
-      - run: pip install -r requirements.txt -r requirements-dev.txt
+      - run: pip install -r requirements-dev.txt
       - run: pytest

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,63 @@
+# Branch protection required checks
+
+The default branch (`main`) must be protected by the repository ruleset stored in
+[`.github/rulesets/default-branch-protection.json`](../.github/rulesets/default-branch-protection.json).
+That ruleset is the source of truth for deterministic merge gates and should be
+kept in sync with GitHub repository settings.
+
+## Required deterministic checks
+
+Require these status checks before a pull request can merge into `main`:
+
+- `CI / test`
+- `Backend Integration Tests / integration-tests`
+- `Frontend Tests / frontend-tests`
+- `PR Body Issue Reference Check / require-issue-reference`
+- `Dependency Review / dependency-review`
+
+These names intentionally use the exact `Workflow name / job name` contexts that
+GitHub branch protection expects. If a workflow or job is renamed, update the
+ruleset and this document in the same pull request.
+
+## Applying the ruleset
+
+Repository administrators can apply the checked-in ruleset with the GitHub CLI.
+Create it when it does not exist:
+
+```bash
+gh api --method POST repos/leonarduk/allotmint/rulesets \
+  --input .github/rulesets/default-branch-protection.json
+```
+
+Update it when GitHub already has a ruleset with the same name:
+
+```bash
+RULESET_ID=$(gh api repos/leonarduk/allotmint/rulesets \
+  --jq '.[] | select(.name == "main deterministic PR gates") | .id')
+gh api --method PUT "repos/leonarduk/allotmint/rulesets/${RULESET_ID}" \
+  --input .github/rulesets/default-branch-protection.json
+```
+
+## Advisory checks
+
+AI review jobs are useful review aids, but they depend on external model
+availability and API quotas. Keep these jobs non-blocking and do not add them to
+the required-check ruleset:
+
+- `GPT PR Review / GPT AI code review`
+- `Claude PR Review / Claude AI code review`
+
+## CodeQL
+
+CodeQL should be added to the required-check set only after a CodeQL workflow is
+configured in this repository and its exact check context is known. Until then,
+it is intentionally absent from the ruleset to avoid documenting a required
+check that GitHub cannot evaluate.
+
+## Drift detection
+
+`python scripts/check_branch_protection_required_checks.py` verifies that the
+ruleset contains exactly the deterministic checks above, that those checks match
+current workflow/job names, and that advisory AI review jobs remain non-blocking.
+The `CI / test` job runs this script so workflow renames cannot silently weaken
+branch protection.

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -27,6 +27,7 @@ npm --prefix frontend install
 Notes:
 
 - Python formatting/lint configuration lives in `backend/pyproject.toml`, while pytest and coverage defaults live in the root `pyproject.toml`.
+- Branch protection required-check policy lives in `docs/BRANCH_PROTECTION.md` and is validated by `python scripts/check_branch_protection_required_checks.py`.
 - The frontend already has its own `package.json`; use `npm --prefix frontend ...` from the repo root unless you intentionally `cd frontend`.
 
 ## 3. Environment variables you are most likely to need

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ If you are onboarding, start with:
 - [`DEPLOY.md`](DEPLOY.md) — deployment workflow and operational deployment notes.
 - [`SMOKE_TESTS.md`](SMOKE_TESTS.md) — smoke test commands and expectations.
 - [`SECURITY.md`](SECURITY.md) — security guidance and controls.
+- [`BRANCH_PROTECTION.md`](BRANCH_PROTECTION.md) — required deterministic merge checks and drift detection.
 - [`OBSERVABILITY.md`](OBSERVABILITY.md) — monitoring and diagnostics guidance.
 - [`TECHNICAL_SUPPORT.md`](TECHNICAL_SUPPORT.md) — support/debug runbook.
 

--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -47,7 +47,11 @@ def workflow_check_contexts() -> set[str]:
     contexts: set[str] = set()
 
     for workflow_path in WORKFLOWS_DIR.glob("*.yml"):
-        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        try:
+            workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            print(f"Warning: could not parse {workflow_path.name}: {exc}", file=sys.stderr)
+            continue
         if not isinstance(workflow, dict):
             continue
         workflow_name = workflow.get("name")

--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate required status checks in the default branch ruleset.
+
+This protects the documented branch protection gate from silently drifting away
+from the deterministic GitHub Actions workflows that are expected to block PRs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RULESET_PATH = REPO_ROOT / ".github" / "rulesets" / "default-branch-protection.json"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+EXPECTED_REQUIRED_CHECKS = {
+    "CI / test",
+    "Backend Integration Tests / integration-tests",
+    "Frontend Tests / frontend-tests",
+    "PR Body Issue Reference Check / require-issue-reference",
+    "Dependency Review / dependency-review",
+}
+ADVISORY_CHECK_PREFIXES = ("Claude PR Review /", "GPT PR Review /")
+
+
+def load_ruleset_contexts() -> set[str]:
+    ruleset = json.loads(RULESET_PATH.read_text(encoding="utf-8"))
+    contexts: set[str] = set()
+
+    for rule in ruleset.get("rules", []):
+        if rule.get("type") != "required_status_checks":
+            continue
+        parameters = rule.get("parameters", {})
+        for check in parameters.get("required_status_checks", []):
+            context = check.get("context")
+            if isinstance(context, str):
+                contexts.add(context)
+
+    return contexts
+
+
+def workflow_check_contexts() -> set[str]:
+    contexts: set[str] = set()
+
+    for workflow_path in WORKFLOWS_DIR.glob("*.yml"):
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        if not isinstance(workflow, dict):
+            continue
+        workflow_name = workflow.get("name")
+        jobs = workflow.get("jobs")
+        if not isinstance(workflow_name, str) or not isinstance(jobs, dict):
+            continue
+        for job_id, job in jobs.items():
+            job_name = job.get("name") if isinstance(job, dict) else None
+            display_name = job_name if isinstance(job_name, str) else job_id
+            contexts.add(f"{workflow_name} / {display_name}")
+
+    return contexts
+
+
+def main() -> int:
+    required_contexts = load_ruleset_contexts()
+    available_contexts = workflow_check_contexts()
+    errors: list[str] = []
+
+    if required_contexts != EXPECTED_REQUIRED_CHECKS:
+        missing = sorted(EXPECTED_REQUIRED_CHECKS - required_contexts)
+        unexpected = sorted(required_contexts - EXPECTED_REQUIRED_CHECKS)
+        if missing:
+            errors.append(f"Ruleset is missing required checks: {missing}")
+        if unexpected:
+            errors.append(f"Ruleset has unexpected required checks: {unexpected}")
+
+    missing_workflows = sorted(required_contexts - available_contexts)
+    if missing_workflows:
+        errors.append(
+            "Required checks do not match workflow/job names: "
+            f"{missing_workflows}"
+        )
+
+    advisory_required = sorted(
+        context
+        for context in required_contexts
+        if context.startswith(ADVISORY_CHECK_PREFIXES)
+    )
+    if advisory_required:
+        errors.append(
+            "Advisory AI review checks must not be required: "
+            f"{advisory_required}"
+        )
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("Branch protection required checks match deterministic workflow contexts.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Ensure the `main` branch is protected by a checked-in GitHub ruleset that requires deterministic CI/PR checks and prevents silent drift. 
- Detect when workflow or job names change (which could weaken required-status-checks) and ensure advisory AI review jobs remain non-blocking. 

Closes #2904 
### Description

- Add a repository ruleset at `.github/rulesets/default-branch-protection.json` that enables active protection for `main` and requires the deterministic checks `CI / test`, `Backend Integration Tests / integration-tests`, `Frontend Tests / frontend-tests`, `PR Body Issue Reference Check / require-issue-reference`, and `Dependency Review / dependency-review`. 
- Add a drift-detection script `scripts/check_branch_protection_required_checks.py` which validates the ruleset matches current workflow/job contexts and that advisory AI review jobs are not required. 
- Wire the drift check into the CI job by running `python scripts/check_branch_protection_required_checks.py` early in `.github/workflows/ci.yml`. 
- Add documentation `docs/BRANCH_PROTECTION.md` and link it from `docs/README.md` and `docs/CONTRIBUTOR_RUNBOOK.md` describing the required checks and `gh api` commands to apply/update the ruleset. 

### Testing

- Compiled and ran the checker with `python3 -m py_compile scripts/check_branch_protection_required_checks.py` and `python3 scripts/check_branch_protection_required_checks.py`, which succeeded and printed the expected success message. 
- Verified JSON validity of the checked-in ruleset with `jq . .github/rulesets/default-branch-protection.json >/dev/null` and ran `git diff --check`, both of which passed. 
- Attempted lint/format checks (`ruff` and `black`) in the container but those tools are not installed in this environment, so those steps were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00cdd5aacc832782e7b2b6cc890bce)