### PR TITLE
Add Dependabot update coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+# Dependabot version updates for the dependency ecosystems used by AllotMint.
+#
+# Dependency Review still protects pull requests that modify manifests; this file
+# adds proactive scheduled update PRs. To extend coverage, add another entry under
+# `updates` with a supported `package-ecosystem`, the manifest `directory`, and a
+# `schedule` block.
+version: 2
+updates:
+  # GitHub Actions: scans workflows under .github/workflows from the repo root.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "chore"
+
+  # Root npm workspace: package.json and package-lock.json in the repo root.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "chore"
+
+  # Frontend npm workspace: React/Vite app dependencies in frontend/.
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "chore"
+
+  # Root Python dependencies: requirements.txt plus requirements-dev.txt.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "chore"
+
+  # CDK Python dependencies: infrastructure requirements in cdk/.
+  - package-ecosystem: "pip"
+    directory: "/cdk"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "chore"


### PR DESCRIPTION
### Motivation
- Make dependency updates proactive by adding scheduled Dependabot version-update configuration rather than relying solely on post-change Dependency Review checks.  
- Ensure the main dependency manifests and GitHub Actions workflows are covered so routine updates surface as PRs for review.

Closes #2906 
### Description
- Add `.github/dependabot.yml` with `version: 2` and `updates` entries for `github-actions` at `/` and `npm` at both `/` and `/frontend`.  
- Add `pip` entries for the root Python manifests at `/` and the CDK manifests at `/cdk`.  
- Set each update to run on a `weekly` schedule (Monday) and apply the labels `dependencies` and `chore` to Dependabot PRs.

### Testing
- Parsed and validated `.github/dependabot.yml` with a small Node.js script using the `yaml` package that asserts the expected ecosystems, directories, weekly schedules, and labels and reported success.  
- Verified formatting with `npm exec -- prettier --check .github/dependabot.yml`, which reported that the file matches Prettier style.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00cdc93db88327bd5762013d85380d)