### PR TITLE
Add opt-in GitHub Actions workflow for smoke tests

### DIFF
--- a/.github/workflows/opt-in-smoke-tests.yml
+++ b/.github/workflows/opt-in-smoke-tests.yml
@@ -17,9 +17,16 @@ on:
         description: Optional deployment URL to test; falls back to the SMOKE_URL repository variable when omitted.
         required: false
         type: string
+      frontend_api_base:
+        description: Optional API base for frontend smoke runs; falls back to smoke_url, then VITE_ALLOTMINT_API_BASE or SMOKE_URL variables.
+        required: false
+        type: string
   pull_request:
     branches: [main]
-    types: [labeled, reopened, synchronize]
+    # Label-triggered smoke runs execute PR code with smoke credentials, so do not
+    # rerun automatically on synchronize. Re-add the label or use manual dispatch
+    # after reviewing follow-up commits.
+    types: [labeled]
 
 permissions:
   contents: read
@@ -36,21 +43,21 @@ jobs:
       (contains(github.event.pull_request.labels.*.name, 'run-smoke') &&
       (github.event.action != 'labeled' || github.event.label.name == 'run-smoke')) }}
     runs-on: ubuntu-latest
+    # Keep the opt-in suite bounded so release checks fail quickly instead of
+    # occupying runners indefinitely when a deployed target is unhealthy.
     timeout-minutes: 35
     env:
       SMOKE_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_target || 'all' }}
       SMOKE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_url || vars.SMOKE_URL }}
-      TEST_ID_TOKEN: ${{ secrets.SMOKE_TEST_ID_TOKEN }}
-      SMOKE_AUTH_TOKEN: ${{ secrets.SMOKE_AUTH_TOKEN }}
       SMOKE_IDENTITY: ${{ vars.SMOKE_IDENTITY }}
-      VITE_ALLOTMINT_API_BASE: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_url || vars.SMOKE_URL }}
+      VITE_ALLOTMINT_API_BASE: ${{ github.event_name == 'workflow_dispatch' && (inputs.frontend_api_base || inputs.smoke_url) || (vars.VITE_ALLOTMINT_API_BASE || vars.SMOKE_URL) }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: npm
@@ -86,11 +93,29 @@ jobs:
       - name: Run backend API smoke tests
         if: ${{ env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'backend' }}
         run: npm run smoke:test
+        env:
+          TEST_ID_TOKEN: ${{ secrets.SMOKE_TEST_ID_TOKEN }}
 
       - name: Run frontend Playwright smoke tests
         if: ${{ env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'frontend' }}
         run: npm --prefix frontend run smoke:frontend
+        env:
+          TEST_ID_TOKEN: ${{ secrets.SMOKE_TEST_ID_TOKEN }}
+          SMOKE_AUTH_TOKEN: ${{ secrets.SMOKE_AUTH_TOKEN }}
 
       - name: Run Codex browser POC smoke test
         if: ${{ env.SMOKE_TARGET == 'codex-poc' }}
         run: npm run smoke:test:codex:poc
+        env:
+          TEST_ID_TOKEN: ${{ secrets.SMOKE_TEST_ID_TOKEN }}
+          SMOKE_AUTH_TOKEN: ${{ secrets.SMOKE_AUTH_TOKEN }}
+
+      - name: Upload Playwright artifacts
+        if: ${{ failure() && (env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'frontend' || env.SMOKE_TARGET == 'codex-poc') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-artifacts
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/opt-in-smoke-tests.yml
+++ b/.github/workflows/opt-in-smoke-tests.yml
@@ -1,0 +1,96 @@
+name: Opt-in Smoke Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      smoke_target:
+        description: Smoke suite to run.
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - backend
+          - frontend
+          - codex-poc
+      smoke_url:
+        description: Optional deployment URL to test; falls back to the SMOKE_URL repository variable when omitted.
+        required: false
+        type: string
+  pull_request:
+    branches: [main]
+    types: [labeled, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: opt-in-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Run opt-in smoke suite
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.pull_request.labels.*.name, 'run-smoke') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'run-smoke')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      SMOKE_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_target || 'all' }}
+      SMOKE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_url || vars.SMOKE_URL }}
+      TEST_ID_TOKEN: ${{ secrets.SMOKE_TEST_ID_TOKEN }}
+      SMOKE_AUTH_TOKEN: ${{ secrets.SMOKE_AUTH_TOKEN }}
+      SMOKE_IDENTITY: ${{ vars.SMOKE_IDENTITY }}
+      VITE_ALLOTMINT_API_BASE: ${{ github.event_name == 'workflow_dispatch' && inputs.smoke_url || vars.SMOKE_URL }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Install Playwright browsers
+        if: ${{ env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'frontend' || env.SMOKE_TARGET == 'codex-poc' }}
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: Summarize smoke target
+        run: |
+          echo "### Opt-in smoke test run" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Target: \`$SMOKE_TARGET\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${SMOKE_URL:-}" ]; then
+            echo "- Smoke URL: \`$SMOKE_URL\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Smoke URL: not set; suites will use their local defaults." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -n "${SMOKE_IDENTITY:-}" ]; then
+            echo "- Smoke identity: \`$SMOKE_IDENTITY\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Run backend API smoke tests
+        if: ${{ env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'backend' }}
+        run: npm run smoke:test
+
+      - name: Run frontend Playwright smoke tests
+        if: ${{ env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'frontend' }}
+        run: npm --prefix frontend run smoke:frontend
+
+      - name: Run Codex browser POC smoke test
+        if: ${{ env.SMOKE_TARGET == 'codex-poc' }}
+        run: npm run smoke:test:codex:poc

--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -19,6 +19,30 @@ Preflight check failed: could not reach http://localhost:8000/health (fetch fail
 
 Start the backend locally or point `SMOKE_URL` at an accessible deployment, then re-run the smoke tests.
 
+## Opt-in GitHub Actions workflow
+
+High-risk PRs can run the smoke suites in GitHub Actions without making them
+part of the default required PR checks. The `.github/workflows/opt-in-smoke-tests.yml`
+workflow has two opt-in triggers:
+
+- **Manual dispatch**: run **Opt-in Smoke Tests** from the Actions tab and choose
+  `all`, `backend`, `frontend`, or `codex-poc`. The optional `smoke_url` input
+  points the suites at a deployed target; if omitted, the workflow falls back to
+  the repository `SMOKE_URL` variable.
+- **PR label**: add the `run-smoke` label to a PR. The workflow reruns on new
+  commits while the label is present and executes the combined `all` target.
+
+Use this workflow for release-bound or higher-risk changes such as auth,
+deployment, API routing, smoke-test infrastructure, or broad `frontend/` updates.
+It intentionally does not run for every PR by default, so the deterministic CI
+checks remain the fast required gate.
+
+The workflow forwards the same environment variables described above. Configure
+`SMOKE_URL` and `SMOKE_IDENTITY` as repository variables when a stable deployment
+or identity should be used by label-triggered runs. Configure `SMOKE_TEST_ID_TOKEN`
+and `SMOKE_AUTH_TOKEN` as repository secrets when the target requires
+authenticated smoke coverage.
+
 ## Usage
 
 Run the backend and frontend suites together with a single command:

--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -27,10 +27,16 @@ workflow has two opt-in triggers:
 
 - **Manual dispatch**: run **Opt-in Smoke Tests** from the Actions tab and choose
   `all`, `backend`, `frontend`, or `codex-poc`. The optional `smoke_url` input
-  points the suites at a deployed target; if omitted, the workflow falls back to
-  the repository `SMOKE_URL` variable.
-- **PR label**: add the `run-smoke` label to a PR. The workflow reruns on new
-  commits while the label is present and executes the combined `all` target.
+  points the backend and default frontend API base at a deployed target; if
+  omitted, the workflow falls back to the repository `SMOKE_URL` variable. When
+  frontend smoke tests need a different API base, set `frontend_api_base`; it
+  falls back to `smoke_url`, then the `VITE_ALLOTMINT_API_BASE` repository
+  variable, and finally `SMOKE_URL`.
+- **PR label**: add the `run-smoke` label to a PR. Label-triggered runs execute
+  the combined `all` target only; the `codex-poc` target is manual-dispatch
+  only. To protect smoke credentials, label-triggered runs do not rerun
+  automatically on new commits. Remove and re-add the label, or use manual
+  dispatch, after reviewing follow-up commits.
 
 Use this workflow for release-bound or higher-risk changes such as auth,
 deployment, API routing, smoke-test infrastructure, or broad `frontend/` updates.
@@ -38,10 +44,12 @@ It intentionally does not run for every PR by default, so the deterministic CI
 checks remain the fast required gate.
 
 The workflow forwards the same environment variables described above. Configure
-`SMOKE_URL` and `SMOKE_IDENTITY` as repository variables when a stable deployment
-or identity should be used by label-triggered runs. Configure `SMOKE_TEST_ID_TOKEN`
-and `SMOKE_AUTH_TOKEN` as repository secrets when the target requires
-authenticated smoke coverage.
+`SMOKE_URL`, `SMOKE_IDENTITY`, and optionally `VITE_ALLOTMINT_API_BASE` as
+repository variables when a stable deployment, identity, or separate frontend API
+base should be used by label-triggered runs. Configure `SMOKE_TEST_ID_TOKEN` and
+`SMOKE_AUTH_TOKEN` as repository secrets when the target requires authenticated
+smoke coverage. Those secrets are scoped to the smoke-test execution steps rather
+than dependency installation or summary steps.
 
 ## Usage
 


### PR DESCRIPTION
### Motivation

- Provide an opt-in path to run the slower/flakier backend and frontend smoke suites for release-bound or higher-risk PRs without making them required for every PR.
- Allow maintainers to target a specific deployed URL or run a minimal Codex POC browser smoke run when needed.

Closes #2907 
### Description

- Add `.github/workflows/opt-in-smoke-tests.yml` implementing a workflow with `workflow_dispatch` inputs (`smoke_target`, `smoke_url`) and PR label gating (`run-smoke`) so maintainers can manually dispatch or label PRs to trigger smoke runs.
- The workflow installs root and frontend dependencies, conditionally installs Playwright browsers, summarizes the run to `$GITHUB_STEP_SUMMARY`, and runs the requested target(s) (`all`, `backend`, `frontend`, `codex-poc`).
- Forward the repository variables/secrets used by the smoke suites (`SMOKE_URL`, `SMOKE_IDENTITY`, `TEST_ID_TOKEN`, `SMOKE_AUTH_TOKEN`) and set `VITE_ALLOTMINT_API_BASE` for frontend runs when a `smoke_url` is provided.
- Update `docs/SMOKE_TESTS.md` to document the opt-in workflow, its triggers, usage guidance, and which variables/secrets it forwards.

### Testing

- Parsed the new workflow YAML with `python3.12`/PyYAML and confirmed expected triggers and fields, which succeeded.
- Linted the workflow using `actionlint` (installed via `go install github.com/rhysd/actionlint/cmd/actionlint@latest`) and received no errors.
- Ran `git diff --check` to validate there are no trivial diff errors, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00cdb992e883279cb9c589f4e21b5b)