### PR TITLE
feat: add Dependabot pip coverage for backend/ directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,13 @@ updates:
     labels:
       - "dependencies"
       - "chore"
+
+  # Backend Python dependencies: runtime deps in backend/requirements*.txt.
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "chore"


### PR DESCRIPTION
## Summary

- Adds a `pip` entry for `directory: "/backend"` to `.github/dependabot.yml`
- Weekly Monday schedule and `dependencies`/`chore` labels consistent with all existing entries
- Covers `backend/requirements.txt` and `backend/requirements-lambda.txt` (Dependabot scans all `requirements*.txt` in the directory by default)

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid YAML
- [ ] Confirm the new entry follows the same pattern as the existing `pip` entries for `/` and `/cdk`
- [ ] After merge, Dependabot should start opening update PRs for packages in `backend/requirements*.txt`

Closes #2914

🤖 Generated with [Claude Code](https://claude.com/claude-code)