### PR TITLE
fix: align @capacitor/core and @capacitor/ios to v8 to match android/cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.2",
       "dependencies": {
         "@capacitor/android": "^8.3.3",
-        "@capacitor/core": "^5.7.0",
-        "@capacitor/ios": "^5.7.0",
+        "@capacitor/core": "^8.3.0",
+        "@capacitor/ios": "^8.3.0",
         "yaml": "^2.8.4"
       },
       "devDependencies": {
@@ -64,21 +64,22 @@
       }
     },
     "node_modules/@capacitor/core": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-5.7.8.tgz",
-      "integrity": "sha512-rrZcm/2vJM0WdWRQup1TUidbjQV9PfIadSkV4rAGLD7R6PuzZSMPGT0gmoZzCRlXkqrazrWWDkurei3ozU02FA==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.3.tgz",
+      "integrity": "sha512-xx1FIriZQ5jwqEkZwmWQHfXNEn5a9ZLOtdFoJXslh0ian6T/EU+QJtRmZw3KRsmcUV6p5ufczBrzF1rVP8Nu3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@capacitor/ios": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-5.7.8.tgz",
-      "integrity": "sha512-XhGrziBnlRmCJ97LdPXOJquHPpYTwSJZIxYSXuPl7SDDuAEve8vs2wY76gLdaaFH2Z6ctdugUX+jR6VNu+ds+w==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.3.tgz",
+      "integrity": "sha512-BHlTOxarrvkaqDdlTxKwip+dQmfQSnfctizpheR7SWp/VIlR0HcPpYzWMTiVbHQLq3nLRUdeZO1wSPVGvxzAPA==",
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^5.7.0"
+        "@capacitor/core": "^8.3.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.3.3",
-    "@capacitor/core": "^5.7.0",
-    "@capacitor/ios": "^5.7.0",
+    "@capacitor/core": "^8.3.0",
+    "@capacitor/ios": "^8.3.0",
     "yaml": "^2.8.4"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- `@capacitor/android` and `@capacitor/cli` were already on `^8.3.3` but `@capacitor/core` and `@capacitor/ios` were still pinned to `^5.7.0`
- This caused an `ERESOLVE` peer-dependency conflict that made `npm ci` fail immediately in the deploy CI job, skipping the smoke-test job entirely
- Bumped `@capacitor/core` and `@capacitor/ios` to `^8.3.0` to align all four Capacitor packages on the same major version

## Test plan

- [ ] CI `npm ci` step should now resolve cleanly
- [ ] Deploy job should proceed past the install step
- [ ] Smoke-test job should run after a successful deploy

Closes #2943