### PR TITLE
fix: resolve TypeScript errors in vite.config.ts that broke deploy

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vitest/config'
 import type { PluginOption } from 'vite'
-import type { UserConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
 
@@ -13,7 +12,7 @@ export default defineConfig(() => {
   // Prerender/PWA plugins were intentionally removed because this app now ships
   // as a standard SPA and infrastructure does not consume prerendered artifacts.
 
-  const config: UserConfig = {
+  const config = {
     plugins,
     resolve: {
       alias: {
@@ -25,7 +24,7 @@ export default defineConfig(() => {
         '/api': {
           target: 'http://backend:8000', // Docker internal hostname
           changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api/, '') // Optional: strip /api prefix
+          rewrite: (p: string) => p.replace(/^\/api/, '')
         }
       }
     },


### PR DESCRIPTION
## Summary

- Remove `UserConfig` import from `vitest/config` — no longer exported in the current version; `defineConfig` infers the config type automatically.
- Rename the proxy `rewrite` callback parameter from `path` to `p: string` to avoid shadowing the `path` module import and eliminate the implicit-any error.

## Test plan

- [ ] `npm --prefix frontend run lint` passes clean
- [ ] `npm --prefix frontend run build` (`tsc -b && vite build`) completes without TypeScript errors
- [ ] Deploy CI pipeline passes the "Build frontend" step

Closes #2947

🤖 Generated with [Claude Code](https://claude.com/claude-code)