### PR TITLE
fix: add as const to coverage.provider to satisfy vitest literal type

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -47,7 +47,7 @@ export default defineConfig(() => {
       setupFiles: './src/setupTests.ts',
       include: ['tests/unit/**/*.test.ts?(x)'],
       coverage: {
-        provider: 'v8' as const,
+        provider: 'v8' as const, // literal required by CoverageV8Options — widened to string without explicit annotation
         reporter: ['text', 'html'],
         include: ['tests/unit/**/*.test.ts?(x)'],
         thresholds: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -47,7 +47,7 @@ export default defineConfig(() => {
       setupFiles: './src/setupTests.ts',
       include: ['tests/unit/**/*.test.ts?(x)'],
       coverage: {
-        provider: 'v8',
+        provider: 'v8' as const,
         reporter: ['text', 'html'],
         include: ['tests/unit/**/*.test.ts?(x)'],
         thresholds: {


### PR DESCRIPTION
## Summary

After #2948 removed the explicit `UserConfig` annotation, TypeScript widened `coverage.provider: 'v8'` from the string literal `'v8'` to the broad `string` type. `defineConfig` from `vitest/config` requires `"v8" | "istanbul" | "custom"`, so the build broke again.

Single-character fix: add `as const` so TypeScript keeps the narrow literal type.

```diff
- provider: 'v8',
+ provider: 'v8' as const,
```

## Test plan

- [ ] `npm --prefix frontend run build` (`tsc -b && vite build`) completes without errors
- [ ] Deploy CI "Build frontend" step passes

Closes #2949

🤖 Generated with [Claude Code](https://claude.com/claude-code)