### PR TITLE
feat: add tsc -b --noEmit type-check to CI covering all tsconfigs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
         working-directory: frontend
       - run: npm run lint
         working-directory: frontend
-      - name: TypeScript type-check (all tsconfigs)
+      # tsc -b resolves frontend/tsconfig.json, which references
+      # tsconfig.app.json (src/) and tsconfig.node.json (vite.config.ts).
+      # Both are checked in one pass; no Vite build required.
+      - name: TypeScript type-check (tsc -b)
         run: npm run type-check
         working-directory: frontend
       - run: npm test -- --run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         working-directory: frontend
       - run: npm run lint
         working-directory: frontend
+      - name: TypeScript type-check (all tsconfigs)
+        run: npm run type-check
+        working-directory: frontend
       - run: npm test -- --run
         working-directory: frontend
       - run: pytest

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -32,7 +32,10 @@ jobs:
         working-directory: frontend
         run: pnpm install --no-frozen-lockfile
 
-      - name: TypeScript type-check (all tsconfigs)
+      # tsc -b resolves frontend/tsconfig.json, which references
+      # tsconfig.app.json (src/) and tsconfig.node.json (vite.config.ts).
+      # Both are checked in one pass; no Vite build required.
+      - name: TypeScript type-check (tsc -b)
         working-directory: frontend
         run: pnpm run type-check
 

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: frontend
         run: pnpm install --no-frozen-lockfile
 
-      - name: TypeScript type-check (tsconfig.app.json)
+      - name: TypeScript type-check (all tsconfigs)
         working-directory: frontend
         run: pnpm run type-check
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "test:jsdom": "vitest --environment=jsdom",
-    "type-check": "tsc -p tsconfig.app.json --noEmit",
+    "type-check": "tsc -b --noEmit",
     "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "test:jsdom": "vitest --environment=jsdom",
-    "type-check": "tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.app.json --noEmit",
+    "type-check": "tsc -b --noEmit",
     "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "test:jsdom": "vitest --environment=jsdom",
-    "type-check": "tsc -b --noEmit",
+    "type-check": "tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.app.json --noEmit",
     "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,8 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "files": [],
   "references": [
-    {
-      "path": "./tsconfig.app.json"
-    },
-    {
-      "path": "./tsconfig.node.json"
-    }
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
   ]
 }


### PR DESCRIPTION
## Summary

- Widens the `type-check` npm script from `tsc -p tsconfig.app.json --noEmit` to `tsc -b --noEmit`, which processes the root `tsconfig.json` references and checks **both** `tsconfig.app.json` (`src/`) and `tsconfig.node.json` (`vite.config.ts`)
- Adds a TypeScript type-check step to `ci.yml` (after lint, before tests) so every PR and push to `main` catches type errors without a full Vite build
- Updates the step name in `frontend-tests.yml` to reflect the broader coverage (the `pnpm run type-check` call was already present; it now runs the widened script)

## Why

Issues #2947 and #2949 both introduced type errors in `vite.config.ts` that reached `main` undetected because the previous `type-check` script only covered `tsconfig.app.json` (`src/`). `vite.config.ts` is compiled under `tsconfig.node.json`, which was not included. `tsc -b --noEmit` covers all referenced configs and would have blocked both regressions pre-merge.

## Test plan

- [ ] CI passes on this PR with the new type-check step green
- [ ] Confirm a deliberate type error in `vite.config.ts` causes the step to fail (manual verification or a follow-up spike)
- [ ] Deploy workflow is untouched — only `ci.yml` and `frontend-tests.yml` are modified

Closes #2951