### PR TITLE
fix: emit consolidated error when price snapshot missing from S3 and local fallback

### DIFF
--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -250,13 +250,19 @@ def _load_snapshot() -> tuple[Dict[str, Dict], datetime | None]:
                 s3_failed = True
 
     if config.prices_json is None:
-        logger.info("Price snapshot path not configured; skipping load")
+        if s3_failed:
+            logger.error(
+                "No price data available: S3 snapshot unavailable and no local fallback configured. "
+                "Portfolio prices will be unavailable for this request."
+            )
+        else:
+            logger.info("Price snapshot path not configured; skipping load")
         return {}, None
 
     if not _PRICES_PATH or not _PRICES_PATH.exists():
         if s3_failed:
             logger.error(
-                "No price data available: S3 snapshot unreachable and local fallback %s not found. "
+                "No price data available: S3 snapshot unavailable and local fallback %s not found. "
                 "Portfolio prices will be unavailable for this request.",
                 _PRICES_PATH,
             )

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -207,6 +207,7 @@ _PRICES_S3_KEY = "prices/latest_prices.json"
 
 
 def _load_snapshot() -> tuple[Dict[str, Dict], datetime | None]:
+    s3_failed = False
     if config.app_env == "aws":
         bucket = os.getenv(DATA_BUCKET_ENV)
         if not bucket:
@@ -214,6 +215,7 @@ def _load_snapshot() -> tuple[Dict[str, Dict], datetime | None]:
                 "Missing %s env var for AWS price snapshot; falling back to local file",
                 DATA_BUCKET_ENV,
             )
+            s3_failed = True
         else:
             try:
                 import boto3  # type: ignore
@@ -231,6 +233,7 @@ def _load_snapshot() -> tuple[Dict[str, Dict], datetime | None]:
                     _PRICES_S3_KEY,
                     bucket,
                 )
+                s3_failed = True
             except (ClientError, BotoCoreError, json.JSONDecodeError) as exc:
                 logger.error(
                     "Failed to fetch price snapshot %s from bucket %s: %s; falling back to local file",
@@ -238,18 +241,27 @@ def _load_snapshot() -> tuple[Dict[str, Dict], datetime | None]:
                     bucket,
                     exc,
                 )
+                s3_failed = True
             except ImportError as exc:
                 logger.warning(
                     "boto3 not available for S3 price snapshot: %s; falling back to local file",
                     exc,
                 )
+                s3_failed = True
 
     if config.prices_json is None:
         logger.info("Price snapshot path not configured; skipping load")
         return {}, None
 
     if not _PRICES_PATH or not _PRICES_PATH.exists():
-        logger.warning("Price snapshot not found: %s", _PRICES_PATH)
+        if s3_failed:
+            logger.error(
+                "No price data available: S3 snapshot unreachable and local fallback %s not found. "
+                "Portfolio prices will be unavailable for this request.",
+                _PRICES_PATH,
+            )
+        else:
+            logger.warning("Price snapshot not found: %s", _PRICES_PATH)
         return {}, None
     try:
         data = json.loads(_PRICES_PATH.read_text())

--- a/tests/common/test_load_snapshot.py
+++ b/tests/common/test_load_snapshot.py
@@ -88,3 +88,100 @@ def test_load_snapshot_aws_failure_falls_back_to_local(tmp_path, monkeypatch, ca
     assert data == payload
     assert returned_ts == datetime.fromtimestamp(path.stat().st_mtime)
     assert "Failed to fetch price snapshot" in caplog.text
+
+
+def _make_fake_s3_modules(fail: bool):
+    """Return (fake_boto3, fake_botocore_exceptions) that raise or succeed."""
+
+    class ClientError(Exception):
+        pass
+
+    if fail:
+
+        class FakeS3:
+            def get_object(self, Bucket, Key):  # noqa: N802
+                raise ClientError("not found")
+
+    else:
+
+        class FakeS3:  # type: ignore[no-redef]
+            def get_object(self, Bucket, Key):  # noqa: N802
+                import io
+
+                body = io.BytesIO(b'{"OK": {}}')
+                return {"Body": body, "LastModified": None}
+
+    fake_boto3 = types.SimpleNamespace(client=lambda service: FakeS3())
+    fake_exc = types.SimpleNamespace(BotoCoreError=Exception, ClientError=ClientError)
+    return fake_boto3, fake_exc
+
+
+def test_load_snapshot_aws_s3_and_local_both_missing_logs_error(
+    tmp_path, monkeypatch, caplog
+):
+    """ERROR (not WARNING) when S3 fails and local fallback file is also absent."""
+    missing = tmp_path / "missing.json"
+    fake_boto3, fake_exc = _make_fake_s3_modules(fail=True)
+
+    monkeypatch.setattr(pu.config, "app_env", "aws")
+    monkeypatch.setenv(pu.DATA_BUCKET_ENV, "bucket")
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", fake_exc)
+    monkeypatch.setattr(pu.config, "prices_json", missing)
+    monkeypatch.setattr(pu, "_PRICES_PATH", missing)
+
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        data, ts = pu._load_snapshot()
+
+    assert data == {}
+    assert ts is None
+    assert "No price data available" in caplog.text
+    assert "Portfolio prices will be unavailable" in caplog.text
+    assert "Price snapshot not found" not in caplog.text
+
+
+def test_load_snapshot_aws_s3_fails_no_local_path_configured_logs_error(
+    monkeypatch, caplog
+):
+    """ERROR when S3 fails and prices_json is not configured at all."""
+    fake_boto3, fake_exc = _make_fake_s3_modules(fail=True)
+
+    monkeypatch.setattr(pu.config, "app_env", "aws")
+    monkeypatch.setenv(pu.DATA_BUCKET_ENV, "bucket")
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", fake_exc)
+    monkeypatch.setattr(pu.config, "prices_json", None)
+    monkeypatch.setattr(pu, "_PRICES_PATH", None)
+
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        data, ts = pu._load_snapshot()
+
+    assert data == {}
+    assert ts is None
+    assert "No price data available" in caplog.text
+    assert "no local fallback configured" in caplog.text
+
+
+def test_load_snapshot_non_aws_missing_local_logs_only_warning(
+    tmp_path, monkeypatch, caplog
+):
+    """Non-AWS env: missing local file logs WARNING, not ERROR."""
+    missing = tmp_path / "missing.json"
+
+    monkeypatch.setattr(pu.config, "app_env", "local")
+    monkeypatch.setattr(pu.config, "prices_json", missing)
+    monkeypatch.setattr(pu, "_PRICES_PATH", missing)
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        data, ts = pu._load_snapshot()
+
+    assert data == {}
+    assert ts is None
+    assert "Price snapshot not found" in caplog.text
+    assert "No price data available" not in caplog.text


### PR DESCRIPTION
## Summary
- Tracks `s3_failed` across all S3 failure paths in `_load_snapshot()`
- When both S3 and local fallback are missing, emits a single `ERROR` making the operational impact explicit: _"No price data available … Portfolio prices will be unavailable for this request."_
- Non-AWS environments retain the existing `WARNING` (no behaviour change)
- Function always returns `{}, None` gracefully — no fatal error

## Test plan
- [ ] Verify the consolidated ERROR appears in Lambda logs when `prices/latest_prices.json` is absent from S3
- [ ] Verify non-AWS local-only missing snapshot still logs `WARNING` (not ERROR)
- [ ] `make lint` passes; `pytest` passes

Closes #2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)