### PR TITLE
fix: remove CDK add_dependency that caused circular deploy failure (#2989)

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -18,8 +18,12 @@ backend_stack = BackendLambdaStack(app, "BackendLambdaStack")
 #   cdk deploy StaticSiteStack --parameters StaticSiteStack:BackendApiUrl=<url>
 # See deploy-lambda.yml for how the URL is extracted from BackendLambdaStack.
 static_stack = StaticSiteStack(app, "StaticSiteStack")
-# Guarantee BackendLambdaStack is deployed before StaticSiteStack so the
-# BackendApiUrl output is available when the workflow reads it.
-static_stack.add_dependency(backend_stack)
+# Deployment order is managed explicitly by deploy-lambda.yml:
+# 1. StaticSiteStack → creates Cognito User Pool, exposes UiAuthUserPoolId / UiAuthUserPoolClientId
+# 2. BackendLambdaStack → uses those IDs as CfnParameters, exposes BackendApiUrl
+# 3. StaticSiteStack (redeploy) → injects BackendApiUrl into the runtime config
+# A CDK add_dependency here would force BackendLambdaStack to deploy before
+# StaticSiteStack, which is the opposite of the required order and causes the
+# CfnParameters to have no value on the first run.
 
 app.synth()


### PR DESCRIPTION
## Summary

- Removes `static_stack.add_dependency(backend_stack)` from `cdk/app.py`
- Replaces it with a comment explaining the explicit two-phase deployment order in `deploy-lambda.yml`

## Root cause

The deploy workflow fails at "Deploy StaticSiteStack auth resources" with:

```
The following CloudFormation Parameters are missing a value: UiAuthUserPoolId, UiAuthUserPoolClientId
```

`BackendLambdaStack` now requires `UiAuthUserPoolId` and `UiAuthUserPoolClientId` as CfnParameters (Cognito IDs from StaticSiteStack). The `add_dependency` call forced CDK to deploy `BackendLambdaStack` before `StaticSiteStack`, so those parameters had no value on the first run.

The deploy workflow already handles the correct ordering explicitly — the CDK-level dependency was redundant and actively caused this failure.

## Test plan

- [x] `pytest cdk/tests/` — 50 tests pass
- [ ] Deploy pipeline re-run should complete step 18 and proceed through the remaining deploy steps

Closes #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)