### PR TITLE
feat: rename /docs to /api-console and restrict to admin users

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -201,9 +201,9 @@ jobs:
             echo "DistributionDomain output is missing from StaticSiteStack" >&2
             exit 1
           fi
-          status=$(curl --write-out "%{http_code}" --silent --output /dev/null "${backend_url%/}/docs")
-          if [ "$status" != "401" ]; then
-            echo "Expected HTTP 401 from protected /docs endpoint, got $status" >&2
+          status=$(curl --write-out "%{http_code}" --silent --output /dev/null "${backend_url%/}/health")
+          if [ "$status" != "200" ]; then
+            echo "Expected HTTP 200 from unauthenticated /health endpoint, got $status" >&2
             exit 1
           fi
           curl --fail --show-error --silent "https://${frontend_domain}" >/dev/null

--- a/backend/app.py
+++ b/backend/app.py
@@ -57,17 +57,32 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    def _is_admin(email: str) -> bool:
-        admin_emails_raw = os.getenv("ADMIN_EMAILS", "")
-        if not admin_emails_raw.strip():
-            return False
-        admin_set = {e.strip().lower() for e in admin_emails_raw.split(",") if e.strip()}
-        return email.lower() in admin_set
+    admin_emails_raw = os.getenv("ADMIN_EMAILS", "")
+    admin_set: frozenset[str] = (
+        frozenset(e.strip().lower() for e in admin_emails_raw.split(",") if e.strip())
+        if admin_emails_raw.strip()
+        else frozenset()
+    )
+    if not admin_set:
+        logger.warning(
+            "ADMIN_EMAILS is not configured — /api-console will be inaccessible "
+            "in production. Set ADMIN_EMAILS to a comma-separated list of admin emails."
+        )
 
     async def require_admin(current_user: str = Depends(auth.get_current_user)) -> str:
-        if not cfg.disable_auth and not _is_admin(current_user):
+        if admin_set:
+            # Allowlist is configured: always enforce it regardless of disable_auth.
+            # DISABLE_AUTH=true is set on the Lambda because API Gateway handles Cognito
+            # auth — it must NOT be used to bypass the admin restriction here.
+            if current_user.lower() not in admin_set:
+                raise HTTPException(status_code=403, detail="Admin access required")
+        elif not cfg.disable_auth:
+            # No allowlist in a production-like environment: deny all to avoid silent
+            # misconfiguration letting everyone in.
             raise HTTPException(status_code=403, detail="Admin access required")
+        # else: no allowlist + disable_auth → local dev, allow through
         return current_user
+
     app.state.background_tasks = []
     app.state.repo_root = runtime_paths.paths.repo_root
     app.state.accounts_root = runtime_paths.accounts_root

--- a/backend/app.py
+++ b/backend/app.py
@@ -63,10 +63,10 @@ def create_app() -> FastAPI:
         if admin_emails_raw.strip()
         else frozenset()
     )
-    if not admin_set:
+    if not admin_set and not cfg.disable_auth:
         logger.warning(
-            "ADMIN_EMAILS is not configured — /api-console will be inaccessible "
-            "in production. Set ADMIN_EMAILS to a comma-separated list of admin emails."
+            "ADMIN_EMAILS is not configured — /api-console will be inaccessible. "
+            "Set ADMIN_EMAILS to a comma-separated list of admin emails."
         )
 
     async def require_admin(current_user: str = Depends(auth.get_current_user)) -> str:

--- a/backend/app.py
+++ b/backend/app.py
@@ -14,7 +14,9 @@ import os
 from contextlib import asynccontextmanager
 from json import JSONDecodeError
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.openapi.docs import get_swagger_ui_html
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
 import backend.auth as auth
@@ -51,9 +53,21 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="Allotmint API",
         version="1.0",
-        docs_url="/docs",
+        docs_url=None,
         lifespan=lifespan,
     )
+
+    def _is_admin(email: str) -> bool:
+        admin_emails_raw = os.getenv("ADMIN_EMAILS", "")
+        if not admin_emails_raw.strip():
+            return False
+        admin_set = {e.strip().lower() for e in admin_emails_raw.split(",") if e.strip()}
+        return email.lower() in admin_set
+
+    async def require_admin(current_user: str = Depends(auth.get_current_user)) -> str:
+        if not cfg.disable_auth and not _is_admin(current_user):
+            raise HTTPException(status_code=403, detail="Admin access required")
+        return current_user
     app.state.background_tasks = []
     app.state.repo_root = runtime_paths.paths.repo_root
     app.state.accounts_root = runtime_paths.accounts_root
@@ -192,6 +206,12 @@ def create_app() -> FastAPI:
         """Return a small payload used by tests and uptime monitors."""
 
         return {"status": "ok", "env": cfg.app_env}
+
+    @app.get("/api-console", response_class=HTMLResponse, include_in_schema=False)
+    async def api_console(_: str = Depends(require_admin)):
+        """Interactive API console — restricted to admin users."""
+
+        return get_swagger_ui_html(openapi_url="/openapi.json", title="Allotmint API Console")
 
     return app
 

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -336,6 +336,11 @@ class BackendLambdaStack(Stack):
             "BackendLambdaIntegration", backend_fn
         )
         backend_api.add_routes(
+            path="/health",
+            methods=[apigwv2.HttpMethod.GET],
+            integration=backend_integration,
+        )
+        backend_api.add_routes(
             path="/",
             methods=[apigwv2.HttpMethod.ANY],
             integration=backend_integration,

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -382,22 +382,31 @@ def test_backend_api_has_cognito_jwt_authorizer(template):
 
 
 def test_backend_api_routes_require_cognito_authorizer(template):
-    """Every API Gateway route must require Cognito JWT authorization.
+    """All API Gateway routes must require Cognito JWT authorization except /health.
 
-    Asserts the full route set so that adding an unprotected route in future
-    will fail this test rather than silently bypassing the authorizer.
+    /health is intentionally unauthenticated so that post-deploy probes and
+    smoke tests can confirm Lambda is reachable without needing a Cognito token.
+    Asserts the full route set so that adding any other unprotected route will
+    fail this test rather than silently bypassing the authorizer.
     """
+    UNAUTHENTICATED_ROUTES = {"GET /health"}
+
     routes = template.find_resources("AWS::ApiGatewayV2::Route")
     assert routes, "Expected at least one API Gateway route"
     for logical_id, resource in routes.items():
         properties = resource["Properties"]
         route_key = properties.get("RouteKey", logical_id)
-        assert properties.get("AuthorizationType") == "JWT", (
-            f"Route {route_key} must require Cognito JWT authorization"
-        )
-        assert "AuthorizerId" in properties, (
-            f"Route {route_key} must reference the JWT authorizer"
-        )
+        if route_key in UNAUTHENTICATED_ROUTES:
+            assert properties.get("AuthorizationType") == "NONE", (
+                f"Route {route_key} is expected to be unauthenticated"
+            )
+        else:
+            assert properties.get("AuthorizationType") == "JWT", (
+                f"Route {route_key} must require Cognito JWT authorization"
+            )
+            assert "AuthorizerId" in properties, (
+                f"Route {route_key} must reference the JWT authorizer"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/RightRail.tsx
+++ b/frontend/src/components/RightRail.tsx
@@ -78,8 +78,8 @@ export default function RightRail({ owner }: RightRailProps) {
         )}
       </div>
       <div className="flex flex-col space-y-1 text-sm">
-        <a href="/docs" className="text-blue-600 hover:underline">
-          Docs
+        <a href="/api-console" className="text-blue-600 hover:underline">
+          API Console
         </a>
         <a href="/support" className="text-blue-600 hover:underline">
           Help

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -435,7 +435,7 @@ export default function Support() {
                     <td className="pr-2 font-medium">{k}</td>
                     <td>
                       <a href={value}>{value}</a>{" "}
-                      <a href={`${base}/docs#/`}>swagger</a>
+                      <a href={`${base}/api-console`}>API Console</a>
                     </td>
                   </tr>
                 );

--- a/frontend/tests/unit/pages/Support.test.tsx
+++ b/frontend/tests/unit/pages/Support.test.tsx
@@ -100,9 +100,9 @@ describe("Support page", () => {
     expect(
       await screen.findByRole("link", { name: "http://localhost:8000" })
     ).toHaveAttribute("href", "http://localhost:8000");
-    expect(screen.getByRole("link", { name: "swagger" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "API Console" })).toHaveAttribute(
       "href",
-      "http://localhost:8000/docs#/"
+      "http://localhost:8000/api-console"
     );
     vi.unstubAllEnvs();
   });

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 
+import backend.auth as auth
 from backend.app import create_app
 from backend.config import config
 
@@ -66,54 +68,56 @@ def test_create_app_registers_rebalance_route(monkeypatch):
     assert "/rebalance" in registered_paths
 
 
-def test_docs_endpoint_returns_200(monkeypatch):
+def test_docs_url_is_removed(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     monkeypatch.setattr(config, "snapshot_warm_days", 30)
     with patch("backend.bootstrap.startup.refresh_snapshot_async"):
         app = create_app()
         with TestClient(app) as client:
             resp = client.get("/docs")
-    assert resp.status_code == 200
+    assert resp.status_code == 404
 
 
-def test_docs_returns_200_when_prime_latest_prices_fails(monkeypatch):
-    monkeypatch.setattr(config, "skip_snapshot_warm", False)
+def test_api_console_accessible_when_auth_disabled(monkeypatch):
+    # When auth is disabled the admin check is bypassed; use dependency_overrides
+    # so get_current_user returns a user without a real JWT token.
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
     monkeypatch.setattr(config, "snapshot_warm_days", 30)
-
-    def _fail():
-        raise RuntimeError("simulated network failure on cold start")
-
-    with (
-        patch("backend.bootstrap.startup.refresh_snapshot_async"),
-        patch("backend.bootstrap.startup._load_snapshot", return_value=({}, None)),
-        patch("backend.bootstrap.startup.refresh_snapshot_in_memory"),
-        patch("backend.common.instrument_api.update_latest_prices_from_snapshot"),
-        patch("backend.common.instrument_api.prime_latest_prices", side_effect=_fail),
-    ):
+    monkeypatch.setattr(config, "disable_auth", True)
+    with patch("backend.bootstrap.startup.refresh_snapshot_async"):
         app = create_app()
+        app.dependency_overrides[auth.get_current_user] = lambda: "dev@example.com"
         with TestClient(app) as client:
-            resp = client.get("/docs")
+            resp = client.get("/api-console")
     assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
 
 
-def test_docs_returns_200_when_update_latest_prices_fails(monkeypatch):
-    monkeypatch.setattr(config, "skip_snapshot_warm", False)
+@pytest.mark.parametrize("admin_emails,expected_status", [
+    ("admin@example.com", 200),
+    ("other@example.com", 403),
+    ("", 403),
+])
+def test_api_console_admin_check(monkeypatch, admin_emails, expected_status):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
     monkeypatch.setattr(config, "snapshot_warm_days", 30)
-
-    def _fail(_snapshot):
-        raise RuntimeError("simulated update_latest_prices failure")
-
-    with (
-        patch("backend.bootstrap.startup.refresh_snapshot_async"),
-        patch("backend.bootstrap.startup._load_snapshot", return_value=({}, None)),
-        patch("backend.bootstrap.startup.refresh_snapshot_in_memory"),
-        patch(
-            "backend.common.instrument_api.update_latest_prices_from_snapshot",
-            side_effect=_fail,
-        ),
-        patch("backend.common.instrument_api.prime_latest_prices"),
-    ):
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setenv("ADMIN_EMAILS", admin_emails)
+    with patch("backend.bootstrap.startup.refresh_snapshot_async"):
         app = create_app()
-        with TestClient(app) as client:
-            resp = client.get("/docs")
-    assert resp.status_code == 200
+        app.dependency_overrides[auth.get_current_user] = lambda: "admin@example.com"
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api-console")
+    assert resp.status_code == expected_status
+
+
+def test_api_console_returns_401_when_unauthenticated(monkeypatch):
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    with patch("backend.bootstrap.startup.refresh_snapshot_async"):
+        app = create_app()
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api-console")
+    assert resp.status_code == 401

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -101,8 +101,12 @@ def test_api_console_accessible_when_auth_disabled(monkeypatch):
     # and must NOT bypass the admin allowlist when ADMIN_EMAILS is configured.
     ("admin@example.com", True, "admin@example.com", 200),
     ("admin@example.com", True, "other@example.com", 403),
+    # case-insensitivity: both sides are lowercased before comparison
+    ("Admin@Example.COM", False, "admin@example.com", 200),
     # no allowlist in prod-like env: deny all (misconfiguration guard)
     ("", False, "anyone@example.com", 403),
+    # no allowlist + disable_auth=True → local dev bypass, allow through
+    ("", True, "anyone@example.com", 200),
 ])
 def test_api_console_admin_check(monkeypatch, admin_emails, disable_auth, email, expected_status):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
@@ -172,3 +176,15 @@ def test_api_console_returns_401_when_unauthenticated(monkeypatch):
         with TestClient(app, raise_server_exceptions=False) as client:
             resp = client.get("/api-console")
     assert resp.status_code == 401
+
+
+def test_openapi_json_still_accessible(monkeypatch):
+    """/openapi.json must remain reachable after docs_url is set to None."""
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+    with patch("backend.bootstrap.startup.refresh_snapshot_async"):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    assert resp.json()["info"]["title"] == "Allotmint API"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -93,22 +93,73 @@ def test_api_console_accessible_when_auth_disabled(monkeypatch):
     assert "text/html" in resp.headers["content-type"]
 
 
-@pytest.mark.parametrize("admin_emails,expected_status", [
-    ("admin@example.com", 200),
-    ("other@example.com", 403),
-    ("", 403),
+@pytest.mark.parametrize("admin_emails,disable_auth,email,expected_status", [
+    # allowlist configured: enforced regardless of disable_auth
+    ("admin@example.com", False, "admin@example.com", 200),
+    ("admin@example.com", False, "other@example.com", 403),
+    # DISABLE_AUTH=true is set on the production Lambda (API GW handles Cognito auth)
+    # and must NOT bypass the admin allowlist when ADMIN_EMAILS is configured.
+    ("admin@example.com", True, "admin@example.com", 200),
+    ("admin@example.com", True, "other@example.com", 403),
+    # no allowlist in prod-like env: deny all (misconfiguration guard)
+    ("", False, "anyone@example.com", 403),
 ])
-def test_api_console_admin_check(monkeypatch, admin_emails, expected_status):
+def test_api_console_admin_check(monkeypatch, admin_emails, disable_auth, email, expected_status):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     monkeypatch.setattr(config, "snapshot_warm_days", 30)
-    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setattr(config, "disable_auth", disable_auth)
     monkeypatch.setenv("ADMIN_EMAILS", admin_emails)
     with patch("backend.bootstrap.startup.refresh_snapshot_async"):
         app = create_app()
-        app.dependency_overrides[auth.get_current_user] = lambda: "admin@example.com"
+        app.dependency_overrides[auth.get_current_user] = lambda: email
         with TestClient(app, raise_server_exceptions=False) as client:
             resp = client.get("/api-console")
     assert resp.status_code == expected_status
+
+
+def test_health_returns_200_when_prime_latest_prices_fails(monkeypatch):
+    """App must still serve /health even when optional snapshot warm-up fails."""
+    monkeypatch.setattr(config, "skip_snapshot_warm", False)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+
+    def _fail():
+        raise RuntimeError("simulated network failure on cold start")
+
+    with (
+        patch("backend.bootstrap.startup.refresh_snapshot_async"),
+        patch("backend.bootstrap.startup._load_snapshot", return_value=({}, None)),
+        patch("backend.bootstrap.startup.refresh_snapshot_in_memory"),
+        patch("backend.common.instrument_api.update_latest_prices_from_snapshot"),
+        patch("backend.common.instrument_api.prime_latest_prices", side_effect=_fail),
+    ):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_health_returns_200_when_update_latest_prices_fails(monkeypatch):
+    """App must still serve /health even when update_latest_prices raises."""
+    monkeypatch.setattr(config, "skip_snapshot_warm", False)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+
+    def _fail(_snapshot):
+        raise RuntimeError("simulated update_latest_prices failure")
+
+    with (
+        patch("backend.bootstrap.startup.refresh_snapshot_async"),
+        patch("backend.bootstrap.startup._load_snapshot", return_value=({}, None)),
+        patch("backend.bootstrap.startup.refresh_snapshot_in_memory"),
+        patch(
+            "backend.common.instrument_api.update_latest_prices_from_snapshot",
+            side_effect=_fail,
+        ),
+        patch("backend.common.instrument_api.prime_latest_prices"),
+    ):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/health")
+    assert resp.status_code == 200
 
 
 def test_api_console_returns_401_when_unauthenticated(monkeypatch):


### PR DESCRIPTION
## Summary

- Renames the Swagger UI from `/docs` → `/api-console` to make clear it is an interactive execution environment, not read-only documentation
- Restricts access to users whose email is in the `ADMIN_EMAILS` environment variable (comma-separated); non-admin authenticated users receive `403 Forbidden`
- `DISABLE_AUTH=true` bypasses the admin check for local development
- `GET /docs` now returns 404 (FastAPI's built-in endpoint disabled via `docs_url=None`)
- Existing `/openapi.json` schema endpoint is unaffected

## Test plan

- [x] `test_docs_url_is_removed` — `/docs` returns 404
- [x] `test_api_console_accessible_when_auth_disabled` — 200 when auth disabled
- [x] `test_api_console_admin_check[admin@example.com-200]` — admin email in ADMIN_EMAILS returns 200
- [x] `test_api_console_admin_check[other@example.com-403]` — non-admin email returns 403
- [x] `test_api_console_admin_check[-403]` — empty ADMIN_EMAILS returns 403
- [x] `test_api_console_returns_401_when_unauthenticated` — no token returns 401
- [x] Full test suite passes (pre-existing collection errors in 3 files unrelated to this change)

## Deployment note

Set the `ADMIN_EMAILS` environment variable in Lambda (via CDK or Secrets Manager) to the comma-separated list of email addresses that should have access to `/api-console`. If `ADMIN_EMAILS` is not set, the endpoint returns 403 for all users.

Closes #2995