### PR TITLE
fix: bypass curl's c-ares resolver for CloudFront DNS check

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -279,7 +279,7 @@ jobs:
           dns_ok=0
           frontend_ip=""
           for i in $(seq 1 12); do
-            frontend_ip="$(getent hosts "$frontend_domain" | awk '{print $1; exit}')"
+            frontend_ip="$(getent hosts "$frontend_domain" 2>/dev/null | awk '{print $1; exit}')" || true
             if [ -n "$frontend_ip" ]; then
               echo "DNS resolved to ${frontend_ip} (attempt $i/12)"
               dns_ok=1

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -279,7 +279,9 @@ jobs:
           dns_ok=0
           frontend_ip=""
           for i in $(seq 1 12); do
-            frontend_ip="$(getent hosts "$frontend_domain" 2>/dev/null | awk '{print $1; exit}')" || true
+            # ahostsv4 forces IPv4; avoids bracket-notation requirement for
+            # curl --resolve with IPv6. || true: set -e exits on getent non-zero.
+            frontend_ip="$(getent ahostsv4 "$frontend_domain" 2>/dev/null | awk '{print $1; exit}')" || true
             if [ -n "$frontend_ip" ]; then
               echo "DNS resolved to ${frontend_ip} (attempt $i/12)"
               dns_ok=1

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -271,12 +271,17 @@ jobs:
           # too short; spin here so a fresh deployment doesn't produce exit code 6.
           # Uses getent(1) (libc resolver, always present on Linux) rather than host/nslookup
           # (bind9-dnsutils) to avoid a dependency on a package that may not be installed.
-          # See issue #3000.
+          # getent and curl use different DNS backends on Ubuntu 24.04 (getent → NSS/
+          # systemd-resolved stub; curl → c-ares async resolver). Capturing the IP here
+          # and passing it to curl via --resolve bypasses curl's resolver entirely so the
+          # two backends cannot disagree. See issues #3000 and #3002.
           echo "Waiting for DNS resolution of ${frontend_domain}..."
           dns_ok=0
+          frontend_ip=""
           for i in $(seq 1 12); do
-            if getent hosts "$frontend_domain" >/dev/null 2>&1; then
-              echo "DNS resolved (attempt $i/12)"
+            frontend_ip="$(getent hosts "$frontend_domain" | awk '{print $1; exit}')"
+            if [ -n "$frontend_ip" ]; then
+              echo "DNS resolved to ${frontend_ip} (attempt $i/12)"
               dns_ok=1
               break
             fi
@@ -293,6 +298,7 @@ jobs:
           curl_exit=0
           cf_status=$(curl --location --retry 3 --retry-delay 5 --retry-all-errors \
             --max-time 60 --write-out "%{http_code}" --silent --output /dev/null \
+            --resolve "${frontend_domain}:443:${frontend_ip}" \
             "https://${frontend_domain}") || curl_exit=$?
           if [ "$curl_exit" -ne 0 ]; then
             echo "curl failed (exit ${curl_exit}) checking https://${frontend_domain}" >&2


### PR DESCRIPTION
## Summary

- Capture the IP resolved by `getent` and pass it to `curl` via `--resolve ${frontend_domain}:443:${ip}`, so curl never needs to perform its own DNS lookup for the CloudFront domain check.
- Update the comment to document why `getent` and `curl` can disagree on Ubuntu 24.04.

## Root cause

On Ubuntu 24.04, `getent` queries DNS through the NSS stack (→ `systemd-resolved` stub at `127.0.0.53`), while `curl` is compiled with **c-ares**, an async resolver that issues queries independently and does not share the NSS cache. The DNS wait loop added in #3000 only guarded `getent`; `curl` could still see exit 6 even after the loop reported success, exactly as seen in the `v0.14.12` run:

```
DNS resolved (attempt 1/12)
Checking frontend → https://d32n5ua14kb82t.cloudfront.net
curl failed (exit 6) checking https://d32n5ua14kb82t.cloudfront.net
```

## Test plan

- [ ] CI passes on this PR
- [ ] Next tag deploy reaches `Frontend → 200 OK` without a curl exit 6

Closes #3002