### PR TITLE
fix: pass BACKEND_URL from deploy job to smoke-test as job output

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SMOKE_TEST_URL: ${{ vars.SMOKE_TEST_URL }}
+    outputs:
+      backend_url: ${{ steps.get_backend_url.outputs.backend_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -156,6 +158,7 @@ jobs:
         working-directory: cdk
 
       - name: Get backend API URL
+        id: get_backend_url
         env:
           AWS_REGION: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
         run: |
@@ -169,6 +172,7 @@ jobs:
             exit 1
           fi
           echo "BACKEND_URL=$BACKEND_URL" >> "$GITHUB_ENV"
+          echo "backend_url=$BACKEND_URL" >> "$GITHUB_OUTPUT"
 
       - name: Refresh StaticSiteStack runtime config
         env:
@@ -406,7 +410,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     env:
-      SMOKE_URL: ${{ vars.SMOKE_URL }}
+      SMOKE_URL: ${{ needs.deploy.outputs.backend_url || vars.SMOKE_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- The `smoke-test` job has always failed with `Preflight check failed: could not reach http://localhost:8000/health` because `SMOKE_URL` was empty — the `deploy` job wrote `BACKEND_URL` to `$GITHUB_ENV` (same-job only) but never exposed it as a cross-job output.
- Add `outputs: backend_url` to the `deploy` job backed by a new step `id: get_backend_url`.
- Write `backend_url=$BACKEND_URL` to `$GITHUB_OUTPUT` in the **Get backend API URL** step (the existing `$GITHUB_ENV` write is kept for later steps in the same job).
- Set `SMOKE_URL: ${{ needs.deploy.outputs.backend_url || vars.SMOKE_URL }}` in the `smoke-test` job — uses the freshly-deployed URL when chained from `deploy`, falls back to the repo variable when triggered standalone.

Closes #3016

## Related issues filed from the same log analysis

- [#3017](https://github.com/leonarduk/allotmint/issues/3017) — Lambda cold-start exceeds 10 s init limit (INIT_REPORT timeout)
- [#3018](https://github.com/leonarduk/allotmint/issues/3018) — S3 price snapshot `prices/latest_prices.json` missing (NoSuchKey), portfolio prices unavailable after deploy
- [#3019](https://github.com/leonarduk/allotmint/issues/3019) — Lambda `/tmp/data/instruments` directory missing at runtime, falling back to bundled data

## Test plan

- [ ] Trigger the Deploy Infrastructure workflow on a tag push — the `smoke-test` job should receive a non-empty `SMOKE_URL` from `needs.deploy.outputs.backend_url` and progress past the preflight health check.
- [ ] Verify the `smoke-test` job no longer fails at the preflight step.
- [ ] Confirm the `vars.SMOKE_URL` fallback still works when the `smoke-test` job is triggered in isolation (no `deploy` parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)