### PR TITLE
fix: downgrade instruments fallback log from WARNING to DEBUG

### DIFF
--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -16,7 +16,15 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_instruments_dir() -> Path:
-    """Return the configured instruments directory or fall back to bundled data."""
+    """Return the configured instruments directory or fall back to bundled data.
+
+    On Lambda cold-start ``config.data_root/instruments`` (typically
+    ``/tmp/data/instruments``) is absent until an S3 sync populates it.
+    Falling back to the bundled copy is expected behaviour, so the log is at
+    DEBUG rather than WARNING. Detecting a sustained S3-sync failure requires a
+    dedicated metric alarm — a single log line cannot distinguish a fresh
+    cold-start from a sync that has been broken for days.
+    """
 
     configured_dir = config.data_root / "instruments"
     if configured_dir.is_dir():
@@ -24,10 +32,6 @@ def _resolve_instruments_dir() -> Path:
 
     fallback_dir = Path(__file__).resolve().parents[2] / "data" / "instruments"
     if fallback_dir.is_dir():
-        # DEBUG not WARNING: on Lambda cold-start /tmp/data/instruments is absent until
-        # an S3 sync populates it; falling back to the bundled copy is expected behaviour.
-        # Detecting a *sustained* S3-sync failure requires a dedicated metric alarm —
-        # a single log line cannot distinguish "just cold-started" from "broken for days".
         logger.debug(
             "Configured instruments directory %s missing; falling back to %s", configured_dir, fallback_dir
         )

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -29,6 +29,9 @@ def _resolve_instruments_dir() -> Path:
         logger.debug(
             "Configured instruments directory %s missing; falling back to %s", configured_dir, fallback_dir
         )
+        # INFO so CloudWatch dashboards/alarms can detect prolonged bundled-source usage
+        # (e.g. if the S3 sync is silently broken) without requiring DEBUG logging enabled.
+        logger.info("instruments_source=bundled dir=%s", fallback_dir)
         return fallback_dir
 
     logger.warning(

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -24,7 +24,9 @@ def _resolve_instruments_dir() -> Path:
 
     fallback_dir = Path(__file__).resolve().parents[2] / "data" / "instruments"
     if fallback_dir.is_dir():
-        logger.warning(
+        # DEBUG not WARNING: on Lambda cold-start /tmp/data/instruments is absent until
+        # an S3 sync populates it; falling back to the bundled copy is expected behaviour.
+        logger.debug(
             "Configured instruments directory %s missing; falling back to %s", configured_dir, fallback_dir
         )
         return fallback_dir

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -26,13 +26,11 @@ def _resolve_instruments_dir() -> Path:
     if fallback_dir.is_dir():
         # DEBUG not WARNING: on Lambda cold-start /tmp/data/instruments is absent until
         # an S3 sync populates it; falling back to the bundled copy is expected behaviour.
+        # Detecting a *sustained* S3-sync failure requires a dedicated metric alarm —
+        # a single log line cannot distinguish "just cold-started" from "broken for days".
         logger.debug(
             "Configured instruments directory %s missing; falling back to %s", configured_dir, fallback_dir
         )
-        # Emitted on every cold-start fallback. Useful as a CloudWatch breadcrumb
-        # (filter for instruments_source=bundled) but does not distinguish a single
-        # cold start from a sustained S3 sync failure — use metric alarms for that.
-        logger.info("instruments_source=bundled dir=%s", fallback_dir)
         return fallback_dir
 
     logger.warning(

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -29,8 +29,9 @@ def _resolve_instruments_dir() -> Path:
         logger.debug(
             "Configured instruments directory %s missing; falling back to %s", configured_dir, fallback_dir
         )
-        # INFO so CloudWatch dashboards/alarms can detect prolonged bundled-source usage
-        # (e.g. if the S3 sync is silently broken) without requiring DEBUG logging enabled.
+        # Emitted on every cold-start fallback. Useful as a CloudWatch breadcrumb
+        # (filter for instruments_source=bundled) but does not distinguish a single
+        # cold start from a sustained S3 sync failure — use metric alarms for that.
         logger.info("instruments_source=bundled dir=%s", fallback_dir)
         return fallback_dir
 

--- a/config.lambda.yaml
+++ b/config.lambda.yaml
@@ -6,7 +6,9 @@
 
 paths:
   repo_root: /var/task
-  data_root: /tmp/data              # writable; populated at runtime from S3
+  data_root: /tmp/data              # writable; populated at runtime from S3 when available.
+                                    # On cold-start /tmp is empty so instrument lookups fall
+                                    # back to the bundled /var/task/data copy (logged at DEBUG).
   accounts_root: accounts           # → /tmp/data/accounts
   prices_json: prices/latest_prices.json  # → /tmp/data/prices/latest_prices.json
   timeseries_cache_base: timeseries # → /tmp/data/timeseries

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -253,7 +253,7 @@ def test_instruments_dir_resolution(
 
     def reload_module() -> object:
         caplog.clear()
-        with caplog.at_level("WARNING"):
+        with caplog.at_level("DEBUG"):
             if patch_module_path:
                 def fake_resolve(self, *args, **kwargs):  # type: ignore[override]
                     resolved = original_resolve(self, *args, **kwargs)

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -281,6 +281,13 @@ def test_instruments_dir_resolution(
                 warning_fragment in record.getMessage() and record.levelname == expected_level
                 for record in caplog.records
             )
+            if expected_source == "fallback":
+                # Bundled-source usage is also logged at INFO so CloudWatch alarms can
+                # detect prolonged fallback without DEBUG logging enabled.
+                assert any(
+                    "instruments_source=bundled" in record.getMessage() and record.levelname == "INFO"
+                    for record in caplog.records
+                )
     finally:
         if module is not None:
             module.get_instrument_meta.cache_clear()

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -208,11 +208,12 @@ def test_list_group_definitions_returns_empty_when_missing(monkeypatch, tmp_path
         "fallback_exists",
         "expected_source",
         "warning_fragment",
+        "expected_level",
     ),
     [
-        (True, False, False, "configured", None),
-        (False, True, True, "fallback", "falling back to"),
-        (False, True, False, "configured", "not found"),
+        (True, False, False, "configured", None, None),
+        (False, True, True, "fallback", "falling back to", "DEBUG"),
+        (False, True, False, "configured", "not found", "WARNING"),
     ],
     ids=[
         "configured-directory",
@@ -229,6 +230,7 @@ def test_instruments_dir_resolution(
     fallback_exists: bool,
     expected_source: str,
     warning_fragment: str | None,
+    expected_level: str | None,
 ) -> None:
     original_data_root = instruments.config.data_root
     module_path = Path(instruments.__file__).resolve()
@@ -275,8 +277,10 @@ def test_instruments_dir_resolution(
         if warning_fragment is None:
             assert not caplog.records
         else:
-            messages = [record.getMessage() for record in caplog.records]
-            assert any(warning_fragment in message for message in messages)
+            assert any(
+                warning_fragment in record.getMessage() and record.levelname == expected_level
+                for record in caplog.records
+            )
     finally:
         if module is not None:
             module.get_instrument_meta.cache_clear()

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -209,12 +209,11 @@ def test_list_group_definitions_returns_empty_when_missing(monkeypatch, tmp_path
         "expected_source",
         "warning_fragment",
         "expected_level",
-        "expect_bundled_info",
     ),
     [
-        (True, False, False, "configured", None, None, False),
-        (False, True, True, "fallback", "falling back to", "DEBUG", True),
-        (False, True, False, "configured", "not found", "WARNING", False),
+        (True, False, False, "configured", None, None),
+        (False, True, True, "fallback", "falling back to", "DEBUG"),
+        (False, True, False, "configured", "not found", "WARNING"),
     ],
     ids=[
         "configured-directory",
@@ -232,7 +231,6 @@ def test_instruments_dir_resolution(
     expected_source: str,
     warning_fragment: str | None,
     expected_level: str | None,
-    expect_bundled_info: bool,
 ) -> None:
     original_data_root = instruments.config.data_root
     module_path = Path(instruments.__file__).resolve()
@@ -283,9 +281,11 @@ def test_instruments_dir_resolution(
                 warning_fragment in record.getMessage() and record.levelname == expected_level
                 for record in caplog.records
             )
-            if expect_bundled_info:
-                assert any(
-                    "instruments_source=bundled" in record.getMessage() and record.levelname == "INFO"
+            if expected_source == "fallback":
+                # Regression guard: the bundled-fallback path must not emit WARNING
+                # (the log was intentionally downgraded to DEBUG in this fix).
+                assert not any(
+                    "falling back to" in record.getMessage() and record.levelname == "WARNING"
                     for record in caplog.records
                 )
     finally:

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -209,11 +209,12 @@ def test_list_group_definitions_returns_empty_when_missing(monkeypatch, tmp_path
         "expected_source",
         "warning_fragment",
         "expected_level",
+        "expect_bundled_info",
     ),
     [
-        (True, False, False, "configured", None, None),
-        (False, True, True, "fallback", "falling back to", "DEBUG"),
-        (False, True, False, "configured", "not found", "WARNING"),
+        (True, False, False, "configured", None, None, False),
+        (False, True, True, "fallback", "falling back to", "DEBUG", True),
+        (False, True, False, "configured", "not found", "WARNING", False),
     ],
     ids=[
         "configured-directory",
@@ -231,6 +232,7 @@ def test_instruments_dir_resolution(
     expected_source: str,
     warning_fragment: str | None,
     expected_level: str | None,
+    expect_bundled_info: bool,
 ) -> None:
     original_data_root = instruments.config.data_root
     module_path = Path(instruments.__file__).resolve()
@@ -281,9 +283,7 @@ def test_instruments_dir_resolution(
                 warning_fragment in record.getMessage() and record.levelname == expected_level
                 for record in caplog.records
             )
-            if expected_source == "fallback":
-                # Bundled-source usage is also logged at INFO so CloudWatch alarms can
-                # detect prolonged fallback without DEBUG logging enabled.
+            if expect_bundled_info:
                 assert any(
                     "instruments_source=bundled" in record.getMessage() and record.levelname == "INFO"
                     for record in caplog.records


### PR DESCRIPTION
## Summary

- `_resolve_instruments_dir()` in `backend/common/instruments.py` logged a `WARNING` whenever the configured directory (`/tmp/data/instruments`) was absent and the code fell back to the bundled copy at `/var/task/data/instruments`.
- On Lambda cold-start `/tmp` is always empty (no S3 sync has populated it yet), so this warning fired on every cold start, adding noise to CloudWatch logs with no actionable signal.
- Downgrade the log from `WARNING` to `DEBUG` since the fallback is intentional and non-fatal.
- Update the test (`test_instruments_dir_resolution`) to capture at `DEBUG` level so the packaged-fallback case still asserts the message is present.
- Add a clarifying comment to `config.lambda.yaml` documenting the expected cold-start behaviour.

## Test plan

- [x] `pytest tests/backend/common/test_instruments.py::test_instruments_dir_resolution` — all 3 parametrised cases pass
- [x] `make lint` / `ruff` clean (no new suppressions added)

Closes #3019

🤖 Generated with [Claude Code](https://claude.com/claude-code)