### PR TITLE
fix: remove non-ASCII em dashes from StaticSiteStack to fix silent cdk diff omission

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -44,7 +44,7 @@ class StaticSiteStack(Stack):
         ui_auth_removal_policy = _ui_auth_removal_policy(self)
 
         # BucketDeployment.Source.json_data() only accepts intra-stack tokens
-        # (Ref / Fn::GetAtt / Fn::Select) — Fn::ImportValue is explicitly rejected
+        # (Ref / Fn::GetAtt / Fn::Select) - Fn::ImportValue is explicitly rejected
         # by CDK's renderData validator. A CfnParameter produces a Ref token and
         # therefore works. The real URL is supplied at deploy time via
         # `--parameters StaticSiteStack:BackendApiUrl=<url>`.
@@ -60,7 +60,7 @@ class StaticSiteStack(Stack):
                 "HTTPS URL such as https://abc123.execute-api.us-east-1.amazonaws.com."
             ),
             description=(
-                "Backend API base URL — override at deploy time with the "
+                "Backend API base URL - override at deploy time with the "
                 "BackendLambdaStack BackendApiUrl output."
             ),
         )
@@ -117,7 +117,7 @@ class StaticSiteStack(Stack):
         )
 
         # Origin selection: prefer OAC (CDK >= 2.116), fall back to OAI,
-        # then to legacy S3Origin — each path grants CloudFront bucket read.
+        # then to legacy S3Origin - each path grants CloudFront bucket read.
         if hasattr(origins, "S3BucketOrigin") and hasattr(
             origins.S3BucketOrigin, "with_origin_access_control"
         ):


### PR DESCRIPTION
## Summary

- Replaces three UTF-8 em dashes (U+2014 `—`) with ASCII hyphens (`-`) in `cdk/stacks/static_site_stack.py`
- The critical one is in the `CfnParameter` `description=` string, which CDK embeds directly in the synthesised CloudFormation template — that caused `cdk diff` to silently skip one entry with the warning `Omitted 1 changes because they are likely mangled non-ASCII characters`
- The other two were in Python comments and cleaned up for consistency

## Test plan

- [x] All 20 existing CDK assertion tests pass (`pytest cdk/tests/test_static_site_stack.py -v`)
- [ ] Run `npx cdk diff StaticSiteStack --all -c prod=true` after deploy and confirm the "Omitted N changes" warning no longer appears

Closes #3014

🤖 Generated with [Claude Code](https://claude.com/claude-code)