### PR TITLE
fix: grant cloudformation:CreateChangeSet permission to GitHub deploy role

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -527,6 +527,25 @@ class BackendLambdaStack(Stack):
             )
             for log_group in (backend_log_group, refresh_log_group, agent_log_group):
                 log_group.grant(github_role, "logs:FilterLogEvents")
+            # Allow cdk diff --all to create/delete CloudFormation change sets so the diff
+            # shows replacement annotations rather than falling back to template-only diff.
+            # Without these actions the diff step emits:
+            #   "Could not create a change set, will base the diff on template differences"
+            # Both stacks are targeted because deploy-lambda.yml runs `cdk diff --all`.
+            # See issue #3013.
+            github_role.add_to_principal_policy(
+                iam.PolicyStatement(
+                    actions=["cloudformation:CreateChangeSet", "cloudformation:DeleteChangeSet"],
+                    resources=[
+                        self.format_arn(
+                            service="cloudformation",
+                            resource="stack",
+                            resource_name=f"{stack_name}/*",
+                        )
+                        for stack_name in ("BackendLambdaStack", "StaticSiteStack")
+                    ],
+                )
+            )
 
         CfnOutput(
             self,

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -527,22 +527,30 @@ class BackendLambdaStack(Stack):
             )
             for log_group in (backend_log_group, refresh_log_group, agent_log_group):
                 log_group.grant(github_role, "logs:FilterLogEvents")
-            # Allow cdk diff --all to create/delete CloudFormation change sets so the diff
-            # shows replacement annotations rather than falling back to template-only diff.
-            # Without these actions the diff step emits:
+            # Allow cdk diff --all to create/poll/delete CloudFormation change sets so the
+            # diff shows replacement annotations rather than falling back to template-only
+            # diff. Without these actions the diff step emits:
             #   "Could not create a change set, will base the diff on template differences"
-            # Both stacks are targeted because deploy-lambda.yml runs `cdk diff --all`.
-            # See issue #3013.
+            # CDK calls CreateChangeSet → DescribeChangeSet (polls until COMPLETE) →
+            # DeleteChangeSet; all three actions are required for the diff to succeed.
+            # self.stack_name is used for this stack to avoid a hardcoded literal.
+            # StaticSiteStack has no CDK reference here so its name is a string constant —
+            # it must match the ID used in cdk/app.py. Both stacks are targeted because
+            # deploy-lambda.yml runs `cdk diff --all`. See issue #3013.
             github_role.add_to_principal_policy(
                 iam.PolicyStatement(
-                    actions=["cloudformation:CreateChangeSet", "cloudformation:DeleteChangeSet"],
+                    actions=[
+                        "cloudformation:CreateChangeSet",
+                        "cloudformation:DescribeChangeSet",
+                        "cloudformation:DeleteChangeSet",
+                    ],
                     resources=[
                         self.format_arn(
                             service="cloudformation",
                             resource="stack",
                             resource_name=f"{stack_name}/*",
                         )
-                        for stack_name in ("BackendLambdaStack", "StaticSiteStack")
+                        for stack_name in (self.stack_name, "StaticSiteStack")
                     ],
                 )
             )

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -436,10 +436,31 @@ def _cfn_actions_for_role_name(raw_template: dict, role_name: str) -> set[str]:
     return actions
 
 
+def _cfn_changeset_resources(raw_template: dict, role_name: str) -> list[object]:
+    """Return resource entries from all cloudformation:CreateChangeSet statements for role_name."""
+    found: list[object] = []
+    for res in raw_template["Resources"].values():
+        if res.get("Type") != "AWS::IAM::Policy":
+            continue
+        if role_name not in res.get("Properties", {}).get("Roles", []):
+            continue
+        for stmt in res["Properties"]["PolicyDocument"].get("Statement", []):
+            actions = stmt.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+            if "cloudformation:CreateChangeSet" not in actions:
+                continue
+            resources = stmt.get("Resource", [])
+            if isinstance(resources, (str, dict)):
+                resources = [resources]
+            found.extend(resources)
+    return found
+
+
 def test_github_deploy_role_gets_changeset_permissions_on_both_stacks(monkeypatch) -> None:
-    """When GITHUB_DEPLOY_ROLE_ARN is set, CDK must grant cloudformation:CreateChangeSet and
-    cloudformation:DeleteChangeSet on BackendLambdaStack and StaticSiteStack so that
-    `cdk diff --all` can create change sets and show replacement annotations. See #3013."""
+    """When GITHUB_DEPLOY_ROLE_ARN is set, CDK must grant CreateChangeSet,
+    DescribeChangeSet, and DeleteChangeSet on BackendLambdaStack and StaticSiteStack
+    so `cdk diff --all` can compute an accurate diff. See #3013."""
     role_arn = "arn:aws:iam::123456789012:role/allotmint-github-deploy"
     monkeypatch.setenv("GITHUB_DEPLOY_ROLE_ARN", role_arn)
     monkeypatch.setenv("JWT_SECRET", "test-secret")
@@ -450,37 +471,28 @@ def test_github_deploy_role_gets_changeset_permissions_on_both_stacks(monkeypatc
     raw = template.to_json()
 
     cfn_actions = _cfn_actions_for_role_name(raw, "allotmint-github-deploy")
-    assert "cloudformation:CreateChangeSet" in cfn_actions, (
-        f"Deploy role missing cloudformation:CreateChangeSet; got: {cfn_actions}"
-    )
-    assert "cloudformation:DeleteChangeSet" in cfn_actions, (
-        f"Deploy role missing cloudformation:DeleteChangeSet; got: {cfn_actions}"
-    )
+    for required_action in (
+        "cloudformation:CreateChangeSet",
+        "cloudformation:DescribeChangeSet",
+        "cloudformation:DeleteChangeSet",
+    ):
+        assert required_action in cfn_actions, (
+            f"Deploy role missing {required_action}; got: {cfn_actions}"
+        )
 
-    # Verify both stack names appear in the policy resource ARNs.
-    target_stacks = {"BackendLambdaStack", "StaticSiteStack"}
-    for res in raw["Resources"].values():
-        if res.get("Type") != "AWS::IAM::Policy":
-            continue
-        if "allotmint-github-deploy" not in res.get("Properties", {}).get("Roles", []):
-            continue
-        for stmt in res["Properties"]["PolicyDocument"].get("Statement", []):
-            actions = stmt.get("Action", [])
-            if isinstance(actions, str):
-                actions = [actions]
-            if "cloudformation:CreateChangeSet" not in actions:
-                continue
-            resources = stmt.get("Resource", [])
-            if isinstance(resources, dict):
-                resources = [resources]
-            stmt_str = str(resources)
-            for stack_name in list(target_stacks):
-                if stack_name in stmt_str:
-                    target_stacks.discard(stack_name)
-
-    assert not target_stacks, (
-        f"cloudformation:CreateChangeSet is not scoped to these stacks: {target_stacks}"
+    # Verify resource ARNs include the wildcard suffix (/*) and cover both stack names.
+    # Resources are CloudFormation intrinsics (Fn::Join) since the region/account are
+    # tokens at synth time; stringify for pattern matching.
+    resources = _cfn_changeset_resources(raw, "allotmint-github-deploy")
+    assert resources, "cloudformation:CreateChangeSet statement has no resource ARNs"
+    resources_str = str(resources)
+    assert "/*" in resources_str, (
+        f"Change set resource ARNs should end with /* (wildcard stack ID); got: {resources_str}"
     )
+    for stack_name in ("BackendLambdaStackCfnGrantTest", "StaticSiteStack"):
+        assert stack_name in resources_str, (
+            f"cloudformation:CreateChangeSet not scoped to {stack_name}; got: {resources_str}"
+        )
 
 
 def test_no_cfn_changeset_grant_when_github_deploy_role_arn_absent(monkeypatch) -> None:

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -418,6 +418,86 @@ def test_no_log_grant_when_github_deploy_role_arn_absent(monkeypatch) -> None:
     )
 
 
+def _cfn_actions_for_role_name(raw_template: dict, role_name: str) -> set[str]:
+    """Return cloudformation:* actions from policies attached to an imported role by name."""
+    actions: set[str] = set()
+    for res in raw_template["Resources"].values():
+        if res.get("Type") != "AWS::IAM::Policy":
+            continue
+        if role_name not in res.get("Properties", {}).get("Roles", []):
+            continue
+        for stmt in res["Properties"]["PolicyDocument"].get("Statement", []):
+            action = stmt.get("Action", [])
+            if isinstance(action, str):
+                action = [action]
+            for a in action:
+                if a.startswith("cloudformation:") or a == "*":
+                    actions.add(a)
+    return actions
+
+
+def test_github_deploy_role_gets_changeset_permissions_on_both_stacks(monkeypatch) -> None:
+    """When GITHUB_DEPLOY_ROLE_ARN is set, CDK must grant cloudformation:CreateChangeSet and
+    cloudformation:DeleteChangeSet on BackendLambdaStack and StaticSiteStack so that
+    `cdk diff --all` can create change sets and show replacement annotations. See #3013."""
+    role_arn = "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    monkeypatch.setenv("GITHUB_DEPLOY_ROLE_ARN", role_arn)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackCfnGrantTest")
+    template = Template.from_stack(stack)
+    raw = template.to_json()
+
+    cfn_actions = _cfn_actions_for_role_name(raw, "allotmint-github-deploy")
+    assert "cloudformation:CreateChangeSet" in cfn_actions, (
+        f"Deploy role missing cloudformation:CreateChangeSet; got: {cfn_actions}"
+    )
+    assert "cloudformation:DeleteChangeSet" in cfn_actions, (
+        f"Deploy role missing cloudformation:DeleteChangeSet; got: {cfn_actions}"
+    )
+
+    # Verify both stack names appear in the policy resource ARNs.
+    target_stacks = {"BackendLambdaStack", "StaticSiteStack"}
+    for res in raw["Resources"].values():
+        if res.get("Type") != "AWS::IAM::Policy":
+            continue
+        if "allotmint-github-deploy" not in res.get("Properties", {}).get("Roles", []):
+            continue
+        for stmt in res["Properties"]["PolicyDocument"].get("Statement", []):
+            actions = stmt.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+            if "cloudformation:CreateChangeSet" not in actions:
+                continue
+            resources = stmt.get("Resource", [])
+            if isinstance(resources, dict):
+                resources = [resources]
+            stmt_str = str(resources)
+            for stack_name in list(target_stacks):
+                if stack_name in stmt_str:
+                    target_stacks.discard(stack_name)
+
+    assert not target_stacks, (
+        f"cloudformation:CreateChangeSet is not scoped to these stacks: {target_stacks}"
+    )
+
+
+def test_no_cfn_changeset_grant_when_github_deploy_role_arn_absent(monkeypatch) -> None:
+    """When GITHUB_DEPLOY_ROLE_ARN is unset, no cloudformation change set policy is synthesised."""
+    monkeypatch.delenv("GITHUB_DEPLOY_ROLE_ARN", raising=False)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackNoCfnGrantTest")
+    cfn_actions = _cfn_actions_for_role_name(
+        Template.from_stack(stack).to_json(), "allotmint-github-deploy"
+    )
+    assert "cloudformation:CreateChangeSet" not in cfn_actions, (
+        "Expected no cloudformation:CreateChangeSet when GITHUB_DEPLOY_ROLE_ARN is unset"
+    )
+
+
 def test_grant_bucket_access_raises_on_no_permissions() -> None:
     class _MockFn:
         def add_to_role_policy(self, policy_statement: object) -> None:


### PR DESCRIPTION
## Summary

- Adds `cloudformation:CreateChangeSet` and `cloudformation:DeleteChangeSet` to the GitHub Actions deploy role policy (synthesised by CDK into `BackendLambdaStack`)
- Both `BackendLambdaStack` and `StaticSiteStack` ARNs are targeted since `cdk diff --all` runs against both stacks
- Permissions are only synthesised when `GITHUB_DEPLOY_ROLE_ARN` env var is set (same guard as the existing `logs:FilterLogEvents` grant)

## Test plan

- [x] `pytest cdk/tests/test_backend_lambda_stack_permissions.py` — all 10 tests pass, including 2 new tests:
  - `test_github_deploy_role_gets_changeset_permissions_on_both_stacks` — verifies both actions and both stack names appear in the synthesised policy
  - `test_no_cfn_changeset_grant_when_github_deploy_role_arn_absent` — verifies no policy is synthesised when the env var is unset

Closes #3013

🤖 Generated with [Claude Code](https://claude.com/claude-code)