### PR TITLE
docs: warn about jwt/pyjwt namespace conflict in contributor runbook

### DIFF
--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -26,6 +26,7 @@ npm --prefix frontend install
 
 Notes:
 
+- **JWT namespace conflict**: the `jwt` package (v1.x, from PyPI) and `PyJWT` (listed in `requirements.txt` as `pyjwt`) both install into the `jwt` module namespace. If the standalone `jwt` package is present in your environment it will shadow `PyJWT`, causing `AttributeError: module 'jwt' has no attribute 'encode'` in tests. Fix by running `pip uninstall jwt` before `pip install -r requirements.txt`.
 - Python formatting/lint configuration lives in `backend/pyproject.toml`, while pytest and coverage defaults live in the root `pyproject.toml`.
 - Branch protection required-check policy lives in `docs/BRANCH_PROTECTION.md` and is validated by `python scripts/check_branch_protection_required_checks.py`.
 - The frontend already has its own `package.json`; use `npm --prefix frontend ...` from the repo root unless you intentionally `cd frontend`.


### PR DESCRIPTION
## Summary

- Adds a callout in `docs/CONTRIBUTOR_RUNBOOK.md` explaining the `jwt` vs `pyjwt` namespace conflict and how to resolve it before running `pip install -r requirements.txt`

## Background

The standalone `jwt` 1.x package (PyPI) and `pyjwt` both claim the `jwt` module namespace. When `jwt` 1.x is installed at user level it shadows `pyjwt`, causing `AttributeError: module 'jwt' has no attribute 'encode'` across every test that calls the `/token` endpoint. The code and requirements.txt are already correct — the only missing piece was a contributor-facing warning.

## Test plan

- [ ] `pip uninstall jwt && pip install -r requirements.txt -r requirements-dev.txt`
- [ ] `python -m pytest tests/routes/test_instrument.py tests/backend/routes/test_instrument.py tests/test_instrument_route.py` — all 53 tests pass

Closes #3027

🤖 Generated with [Claude Code](https://claude.com/claude-code)