### PR TITLE
fix: seed price snapshot and guard against empty overwrites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ data/*
 !data/accounts/**
 !data/instruments/
 !data/instruments/**
+!data/prices/
+!data/prices/**
 !data/scaling_overrides.json
 !data/events.json
 !data/trail.json

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -1981,9 +1981,18 @@ def refresh_snapshot_in_memory_from_timeseries(days: int = 365) -> None:
 
     try:
         if _PRICES_PATH:
-            _PRICES_PATH.parent.mkdir(parents=True, exist_ok=True)
-            _PRICES_PATH.write_text(json.dumps(snapshot, indent=2))
-            logger.info("Wrote %d prices to %s", len(snapshot), _PRICES_PATH)
+            has_valid = any(
+                v.get("last_price") is not None for v in snapshot.values()
+            )
+            if has_valid:
+                _PRICES_PATH.parent.mkdir(parents=True, exist_ok=True)
+                _PRICES_PATH.write_text(json.dumps(snapshot, indent=2))
+                logger.info("Wrote %d prices to %s", len(snapshot), _PRICES_PATH)
+            else:
+                logger.info(
+                    "Skipping price snapshot write — no valid prices fetched"
+                    " (offline mode or no timeseries data)"
+                )
         else:
             logger.info(
                 "Price snapshot path not configured; skipping write (expected when config.prices_json is unset)"

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -1980,23 +1980,24 @@ def refresh_snapshot_in_memory_from_timeseries(days: int = 365) -> None:
     refresh_snapshot_in_memory(snapshot, datetime.now(UTC))
 
     try:
-        if _PRICES_PATH:
-            has_valid = any(
-                v.get("last_price") is not None for v in snapshot.values()
-            )
-            if has_valid:
-                _PRICES_PATH.parent.mkdir(parents=True, exist_ok=True)
-                _PRICES_PATH.write_text(json.dumps(snapshot, indent=2))
-                logger.info("Wrote %d prices to %s", len(snapshot), _PRICES_PATH)
-            else:
-                logger.info(
-                    "Skipping price snapshot write — no valid prices fetched"
-                    " (offline mode or no timeseries data)"
-                )
-        else:
+        if _PRICES_PATH and snapshot:
+            existing: Dict[str, Any] = {}
+            if _PRICES_PATH.exists():
+                try:
+                    existing = json.loads(_PRICES_PATH.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+            merged = {**existing, **snapshot}
+            _PRICES_PATH.parent.mkdir(parents=True, exist_ok=True)
+            _PRICES_PATH.write_text(json.dumps(merged, indent=2))
+            logger.info("Wrote %d prices to %s", len(merged), _PRICES_PATH)
+        elif not _PRICES_PATH:
             logger.info(
-                "Price snapshot path not configured; skipping write (expected when config.prices_json is unset)"
+                "Price snapshot path not configured; skipping write"
+                " (expected when config.prices_json is unset)"
             )
+        else:
+            logger.info("Skipping price snapshot write — no timeseries data found")
     except OSError as e:
         logger.warning("Failed to write latest_prices.json: %s", e)
 

--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -240,17 +240,28 @@ def refresh_prices() -> Dict:
         raise RuntimeError("config.prices_json not configured")
     path = Path(config.prices_json)
     path.parent.mkdir(parents=True, exist_ok=True)
-    # Skip the write when every fetched price is None — this happens in offline
-    # mode or when the market data source is unavailable.  Writing an all-null
-    # snapshot would trash valid seed/cached data without adding any value.
-    has_valid_price = any(
-        v.get("last_price") is not None for v in snapshot.values()
-    )
-    if has_valid_price:
-        path.write_text(json.dumps(snapshot, indent=2))
+
+    # Merge strategy: only write entries where we successfully fetched a price.
+    # This preserves existing seed/cached prices for tickers that returned None
+    # (offline mode, market closed, data-source outage) rather than trashing them.
+    to_persist = {t: v for t, v in snapshot.items() if v.get("last_price") is not None}
+    if to_persist:
+        existing: Dict = {}
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+        merged = {**existing, **to_persist}
+        path.write_text(json.dumps(merged, indent=2))
+    else:
+        logger.info(
+            "Skipping price snapshot write — no valid prices fetched"
+            " (offline mode or data-source unavailable)"
+        )
 
     # ---- persist to S3 (primary store read by all Lambda instances) -------
-    if config.app_env == "aws":
+    if config.app_env == "aws" and to_persist:
         _s3_bucket = os.getenv(DATA_BUCKET_ENV)
         if _s3_bucket:
             try:
@@ -259,7 +270,7 @@ def refresh_prices() -> Dict:
                 boto3.client("s3").put_object(
                     Bucket=_s3_bucket,
                     Key=PRICES_S3_KEY,
-                    Body=json.dumps(snapshot, indent=2).encode("utf-8"),
+                    Body=json.dumps(merged, indent=2).encode("utf-8"),
                     ContentType="application/json",
                 )
                 logger.info(

--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -286,11 +286,14 @@ def refresh_prices() -> Dict:
     # the existing in-memory state intact when no prices were fetched so a
     # null-producing offline refresh does not trash valid cached entries.
     if to_persist:
-        effective = merged
+        # merged = existing (disk) overwritten by to_persist (fresh, non-null).
+        # existing entries come from our own prior writes so are already non-null;
+        # any manually-corrupted null in existing is harmless — it will be
+        # overwritten on the next successful refresh for that ticker.
         _price_cache.clear()
-        for tkr, info in effective.items():
+        for tkr, info in merged.items():
             _price_cache[tkr.upper()] = info["last_price"]
-        refresh_snapshot_in_memory(effective)
+        refresh_snapshot_in_memory(merged)
     check_price_alerts()
 
     logger.debug(f"Snapshot written to {path}")

--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -254,32 +254,32 @@ def refresh_prices() -> Dict:
                 pass
         merged = {**existing, **to_persist}
         path.write_text(json.dumps(merged, indent=2))
+
+        # ---- persist to S3 (primary store read by all Lambda instances) -----
+        if config.app_env == "aws":
+            _s3_bucket = os.getenv(DATA_BUCKET_ENV)
+            if _s3_bucket:
+                try:
+                    import boto3  # type: ignore
+
+                    boto3.client("s3").put_object(
+                        Bucket=_s3_bucket,
+                        Key=PRICES_S3_KEY,
+                        Body=json.dumps(merged, indent=2).encode("utf-8"),
+                        ContentType="application/json",
+                    )
+                    logger.info(
+                        "Uploaded price snapshot to s3://%s/%s", _s3_bucket, PRICES_S3_KEY
+                    )
+                except Exception as exc:
+                    logger.warning("Failed to upload price snapshot to S3: %s", exc)
+            else:
+                logger.warning("DATA_BUCKET not set; skipping S3 upload of price snapshot")
     else:
         logger.info(
             "Skipping price snapshot write — no valid prices fetched"
             " (offline mode or data-source unavailable)"
         )
-
-    # ---- persist to S3 (primary store read by all Lambda instances) -------
-    if config.app_env == "aws" and to_persist:
-        _s3_bucket = os.getenv(DATA_BUCKET_ENV)
-        if _s3_bucket:
-            try:
-                import boto3  # type: ignore
-
-                boto3.client("s3").put_object(
-                    Bucket=_s3_bucket,
-                    Key=PRICES_S3_KEY,
-                    Body=json.dumps(merged, indent=2).encode("utf-8"),
-                    ContentType="application/json",
-                )
-                logger.info(
-                    "Uploaded price snapshot to s3://%s/%s", _s3_bucket, PRICES_S3_KEY
-                )
-            except Exception as exc:
-                logger.warning("Failed to upload price snapshot to S3: %s", exc)
-        else:
-            logger.warning("DATA_BUCKET not set; skipping S3 upload of price snapshot")
 
     # ---- refresh in-memory cache -----------------------------------------
     _price_cache.clear()

--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -240,7 +240,14 @@ def refresh_prices() -> Dict:
         raise RuntimeError("config.prices_json not configured")
     path = Path(config.prices_json)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(snapshot, indent=2))
+    # Skip the write when every fetched price is None — this happens in offline
+    # mode or when the market data source is unavailable.  Writing an all-null
+    # snapshot would trash valid seed/cached data without adding any value.
+    has_valid_price = any(
+        v.get("last_price") is not None for v in snapshot.values()
+    )
+    if has_valid_price:
+        path.write_text(json.dumps(snapshot, indent=2))
 
     # ---- persist to S3 (primary store read by all Lambda instances) -------
     if config.app_env == "aws":

--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -282,12 +282,15 @@ def refresh_prices() -> Dict:
         )
 
     # ---- refresh in-memory cache -----------------------------------------
-    _price_cache.clear()
-    for tkr, info in snapshot.items():
-        _price_cache[tkr.upper()] = info["last_price"]
-
-    # keep portfolio_utils in sync and run alert checks
-    refresh_snapshot_in_memory(snapshot)
+    # Use merged (which includes preserved seed prices) when available; leave
+    # the existing in-memory state intact when no prices were fetched so a
+    # null-producing offline refresh does not trash valid cached entries.
+    if to_persist:
+        effective = merged
+        _price_cache.clear()
+        for tkr, info in effective.items():
+            _price_cache[tkr.upper()] = info["last_price"]
+        refresh_snapshot_in_memory(effective)
     check_price_alerts()
 
     logger.debug(f"Snapshot written to {path}")

--- a/data/instruments/L/COMETF.json
+++ b/data/instruments/L/COMETF.json
@@ -1,6 +1,7 @@
 {
-  "symbol": "COMETF",
+  "name": "Commodity ETF",
+  "ticker": "COMETF.L",
   "exchange": "L",
   "asset_class": "Commodity",
-  "name": "Commodity ETF"
+  "sector": "Commodity"
 }

--- a/data/instruments/L/GSK.json
+++ b/data/instruments/L/GSK.json
@@ -1,1 +1,8 @@
-{}
+{
+  "name": "GSK plc",
+  "ticker": "GSK.L",
+  "exchange": "L",
+  "asset_class": "Equity",
+  "sector": "Healthcare",
+  "currency": "GBP"
+}

--- a/data/instruments/L/HFEL.json
+++ b/data/instruments/L/HFEL.json
@@ -1,6 +1,8 @@
 {
-  "symbol": "HFEL",
+  "name": "Henderson Far East Income",
+  "ticker": "HFEL.L",
   "exchange": "L",
+  "asset_class": "Equity",
   "sector": "Equity",
-  "region": "UK"
+  "region": "Asia Pacific"
 }

--- a/data/instruments/L/HFEL.json
+++ b/data/instruments/L/HFEL.json
@@ -3,6 +3,6 @@
   "ticker": "HFEL.L",
   "exchange": "L",
   "asset_class": "Equity",
-  "sector": "Equity",
+  "sector": "Investment Trust",
   "region": "Asia Pacific"
 }

--- a/data/prices/latest_prices.json
+++ b/data/prices/latest_prices.json
@@ -1,0 +1,1 @@
+{"VWRL.L":{"last_price":97.5,"price_currency":"GBP","last_price_date":"2026-05-16"},"ERNS.L":{"last_price":500.0,"price_currency":"GBP","last_price_date":"2026-05-16"},"PFE.N":{"last_price":22.0,"price_currency":"GBP","last_price_date":"2026-05-16"}}

--- a/data/prices/latest_prices.json
+++ b/data/prices/latest_prices.json
@@ -1,1 +1,17 @@
-{"VWRL.L":{"last_price":97.5,"price_currency":"GBP","last_price_date":"2026-05-16"},"ERNS.L":{"last_price":500.0,"price_currency":"GBP","last_price_date":"2026-05-16"},"PFE.N":{"last_price":22.0,"price_currency":"GBP","last_price_date":"2026-05-16"}}
+{
+  "VWRL.L": {
+    "last_price": 97.5,
+    "price_currency": "GBP",
+    "last_price_date": "2026-05-16"
+  },
+  "ERNS.L": {
+    "last_price": 500.0,
+    "price_currency": "GBP",
+    "last_price_date": "2026-05-16"
+  },
+  "PFE.N": {
+    "last_price": 22.0,
+    "price_currency": "GBP",
+    "last_price_date": "2026-05-16"
+  }
+}

--- a/tests/backend/common/test_prices.py
+++ b/tests/backend/common/test_prices.py
@@ -176,12 +176,15 @@ def test_get_price_snapshot_handles_stale_and_missing_data(monkeypatch: pytest.M
 # ---------------------------------------------------------------------------
 
 
+_STUB_SNAPSHOT = {"STUB.L": {"last_price": 1.0, "price_currency": "GBP", "is_stale": False}}
+
+
 def _stub_refresh_prices(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Wire up minimal mocks so refresh_prices() can run without real data."""
     prices_file = tmp_path / "latest_prices.json"
     monkeypatch.setattr(prices.config, "prices_json", prices_file, raising=False)
-    monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: [])
-    monkeypatch.setattr(prices, "get_price_snapshot", lambda tickers: {})
+    monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: ["STUB.L"])
+    monkeypatch.setattr(prices, "get_price_snapshot", lambda tickers: _STUB_SNAPSHOT)
     monkeypatch.setattr(prices, "refresh_snapshot_in_memory", lambda s: None)
     monkeypatch.setattr(prices, "check_price_alerts", lambda: None)
 

--- a/tests/backend/test_holding_utils.py
+++ b/tests/backend/test_holding_utils.py
@@ -124,4 +124,41 @@ def test_gbx_scaling_defaults_apply_without_override(monkeypatch):
     row = next(r for r in rows if r["ticker"] == full_ticker)
     assert row["last_price_gbp"] == pytest.approx(1.25)
     assert row["market_value_gbp"] == pytest.approx(1.25)
-    assert row["gain_gbp"] == pytest.approx(0.25)
+
+
+def test_enrich_holding_market_value_set_from_price_snapshot(monkeypatch):
+    """market_value_gbp must not be None when a price exists in the snapshot.
+
+    Root cause of issue #2746: holdings with zero cost-basis and no timeseries
+    cache got market_value_gbp=None because the price snapshot was empty on
+    first start.  The seed data/prices/latest_prices.json fixes the snapshot;
+    this test guards the enrichment path.
+    """
+    import backend.common.instrument_api as instrument_api
+    import backend.common.portfolio_utils as pu
+
+    monkeypatch.setattr(instrument_api, "_resolve_full_ticker", lambda *_: ("VWRL", "L"))
+    monkeypatch.setattr(
+        hu,
+        "get_instrument_meta",
+        lambda *_: {"name": "Vanguard FTSE All-World", "currency": "GBP"},
+    )
+    monkeypatch.setattr(pu, "get_security_meta", lambda *_: {})
+    monkeypatch.setattr(
+        pu,
+        "_PRICE_SNAPSHOT",
+        {"VWRL.L": {"last_price": 97.5, "price_currency": "GBP", "is_stale": False}},
+    )
+    # Stub out timeseries access — only the snapshot price should be used.
+    monkeypatch.setattr(hu, "_get_price_for_date_scaled", lambda *args, **kwargs: (None, None))
+    monkeypatch.setattr(hu, "get_effective_cost_basis_gbp", lambda h, cache, price_hint=None: 0.0)
+
+    holding = {TICKER: "VWRL.L", UNITS: 10, COST_BASIS_GBP: 0.0, ACQUIRED_DATE: "2025-01-01"}
+    today = dt.date(2026, 5, 16)
+    result = hu.enrich_holding(holding, today, price_cache={})
+
+    assert result["market_value_gbp"] == pytest.approx(975.0), (
+        "market_value_gbp must not be None when price snapshot has data"
+    )
+    assert result["gain_gbp"] is not None
+    assert result["current_price_gbp"] == pytest.approx(97.5)

--- a/tests/backend/test_holding_utils.py
+++ b/tests/backend/test_holding_utils.py
@@ -124,6 +124,7 @@ def test_gbx_scaling_defaults_apply_without_override(monkeypatch):
     row = next(r for r in rows if r["ticker"] == full_ticker)
     assert row["last_price_gbp"] == pytest.approx(1.25)
     assert row["market_value_gbp"] == pytest.approx(1.25)
+    assert row["gain_gbp"] == pytest.approx(0.25)
 
 
 def test_enrich_holding_market_value_set_from_price_snapshot(monkeypatch):
@@ -134,10 +135,8 @@ def test_enrich_holding_market_value_set_from_price_snapshot(monkeypatch):
     first start.  The seed data/prices/latest_prices.json fixes the snapshot;
     this test guards the enrichment path.
     """
-    import backend.common.instrument_api as instrument_api
     import backend.common.portfolio_utils as pu
 
-    monkeypatch.setattr(instrument_api, "_resolve_full_ticker", lambda *_: ("VWRL", "L"))
     monkeypatch.setattr(
         hu,
         "get_instrument_meta",

--- a/tests/common/test_load_snapshot.py
+++ b/tests/common/test_load_snapshot.py
@@ -335,3 +335,29 @@ def test_load_snapshot_non_aws_missing_local_logs_only_warning(
     assert ts is None
     assert "Price snapshot not found" in caplog.text
     assert "No price data available" not in caplog.text
+
+
+def test_seed_prices_file_loads_demo_holdings(tmp_path, monkeypatch):
+    """data/prices/latest_prices.json seed file must load prices for demo holdings.
+
+    Regression guard for issue #2746: missing seed data caused all non-cash
+    positions to have market_value_gbp=None on a fresh install.
+    """
+    from pathlib import Path
+
+    seed_path = Path(__file__).resolve().parents[2] / "data" / "prices" / "latest_prices.json"
+
+    monkeypatch.setattr(pu.config, "app_env", "local")
+    monkeypatch.setattr(pu.config, "prices_json", seed_path)
+    monkeypatch.setattr(pu, "_PRICES_PATH", seed_path)
+
+    data, ts = pu._load_snapshot()
+
+    assert data, "Seed prices file must not be empty"
+    for ticker in ("VWRL.L", "ERNS.L", "PFE.N"):
+        assert ticker in data, f"Seed prices must include demo holding {ticker}"
+        entry = data[ticker]
+        assert entry.get("last_price") is not None and entry["last_price"] > 0, (
+            f"{ticker} must have a positive last_price"
+        )
+        assert entry.get("price_currency") == "GBP", f"{ticker} price must be in GBP"

--- a/tests/common/test_portfolio_utils_snapshot.py
+++ b/tests/common/test_portfolio_utils_snapshot.py
@@ -231,3 +231,49 @@ async def test_refresh_snapshot_async_invokes_to_thread(monkeypatch):
     assert calls["refresh"] == [3]
     assert calls["to_thread"]["func"] is fake_refresh
     assert calls["to_thread"]["kwargs"] == {"days": 3}
+
+
+def test_refresh_snapshot_merges_with_existing_prices_file(tmp_path, monkeypatch):
+    """Timeseries refresh merges new prices with existing ones — not a full overwrite.
+
+    Tickers not found in the timeseries (no parquet data) keep their existing
+    seed/cached prices.  Only tickers that successfully returned data are updated.
+    """
+    seed = {
+        "OLD.L": {"last_price": 50.0, "price_currency": "GBP", "last_price_date": "2024-01-01"},
+        "NEW.L": {"last_price": 10.0, "price_currency": "GBP", "last_price_date": "2024-01-01"},
+    }
+    prices_path = tmp_path / "latest_prices.json"
+    prices_path.write_text(json.dumps(seed))
+
+    tickers = ["OLD.L", "NEW.L"]
+    monkeypatch.setattr(pu, "_PRICE_SNAPSHOT", {t: {} for t in tickers})
+    monkeypatch.setattr(pu, "list_all_unique_tickers", lambda: tickers)
+
+    new_df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-01-03"]),
+            "Close": [15.0],
+        }
+    )
+
+    def fake_load(*, ticker, exchange, start_date, end_date):
+        if ticker == "NEW":
+            return new_df
+        return pd.DataFrame()
+
+    monkeypatch.setattr(pu, "load_meta_timeseries_range", fake_load)
+    monkeypatch.setattr(pu, "get_scaling_override", lambda *_, **__: 1)
+    monkeypatch.setattr(pu, "apply_scaling", lambda df, scale: df)
+    monkeypatch.setattr(pu, "refresh_snapshot_in_memory", lambda s, ts: None)
+    monkeypatch.setattr(pu, "_PRICES_PATH", prices_path)
+
+    pu.refresh_snapshot_in_memory_from_timeseries(days=7)
+
+    result = json.loads(prices_path.read_text())
+    assert result["NEW.L"]["last_price"] == pytest.approx(15.0), (
+        "Ticker with fresh timeseries data must be updated"
+    )
+    assert result["OLD.L"]["last_price"] == pytest.approx(50.0), (
+        "Ticker with no timeseries data must retain its existing price"
+    )

--- a/tests/common/test_prices.py
+++ b/tests/common/test_prices.py
@@ -366,3 +366,28 @@ def test_refresh_prices_writes_json_and_updates_cache(tmp_path, monkeypatch: pyt
     assert prices._price_cache == {ticker.upper(): snapshot[ticker]["last_price"]}
     refresh_mock.assert_called_once_with(snapshot)
     alerts_mock.assert_called_once_with()
+
+
+def test_refresh_prices_skips_write_when_all_prices_null(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Offline/no-data refresh must not overwrite a valid seed file with all-null prices."""
+    seed = {"VWRL.L": {"last_price": 97.5, "price_currency": "GBP"}}
+    output_path = tmp_path / "prices.json"
+    output_path.write_text(json.dumps(seed))
+
+    null_snapshot = {
+        "VWRL.L": {"last_price": None, "price_currency": None, "is_stale": True}
+    }
+    monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: ["VWRL.L"])
+    monkeypatch.setattr(prices, "get_price_snapshot", lambda _: null_snapshot)
+    monkeypatch.setattr(prices, "refresh_snapshot_in_memory", Mock())
+    monkeypatch.setattr(prices, "check_price_alerts", Mock())
+    monkeypatch.setattr(prices.config, "prices_json", output_path)
+    monkeypatch.setattr(prices, "_price_cache", {})
+
+    prices.refresh_prices()
+
+    assert json.loads(output_path.read_text()) == seed, (
+        "Seed file must not be overwritten when every fetched price is None"
+    )

--- a/tests/common/test_prices.py
+++ b/tests/common/test_prices.py
@@ -408,12 +408,19 @@ def test_refresh_prices_partial_null_preserves_existing_prices(
         "AAA.L": {"last_price": 11.5, "price_currency": "GBP", "is_stale": False},
         "BBB.L": {"last_price": None, "price_currency": None, "is_stale": True},
     }
+    in_memory_calls: list = []
+    price_cache: dict = {}
+
     monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: ["AAA.L", "BBB.L"])
     monkeypatch.setattr(prices, "get_price_snapshot", lambda _: partial_snapshot)
-    monkeypatch.setattr(prices, "refresh_snapshot_in_memory", Mock())
+    monkeypatch.setattr(
+        prices,
+        "refresh_snapshot_in_memory",
+        lambda s: in_memory_calls.append(s),
+    )
     monkeypatch.setattr(prices, "check_price_alerts", Mock())
     monkeypatch.setattr(prices.config, "prices_json", output_path)
-    monkeypatch.setattr(prices, "_price_cache", {})
+    monkeypatch.setattr(prices, "_price_cache", price_cache)
 
     prices.refresh_prices()
 
@@ -423,4 +430,16 @@ def test_refresh_prices_partial_null_preserves_existing_prices(
     )
     assert result["BBB.L"]["last_price"] == pytest.approx(20.0), (
         "Seed price for null-returning ticker must be preserved"
+    )
+
+    assert len(in_memory_calls) == 1, "refresh_snapshot_in_memory must be called once"
+    in_mem = in_memory_calls[0]
+    assert in_mem["AAA.L"]["last_price"] == pytest.approx(11.5), (
+        "In-memory snapshot must contain updated price"
+    )
+    assert in_mem["BBB.L"]["last_price"] == pytest.approx(20.0), (
+        "In-memory snapshot must contain preserved seed price, not None"
+    )
+    assert price_cache.get("BBB.L") == pytest.approx(20.0), (
+        "_price_cache must contain preserved seed price for null-returning ticker"
     )

--- a/tests/common/test_prices.py
+++ b/tests/common/test_prices.py
@@ -391,3 +391,36 @@ def test_refresh_prices_skips_write_when_all_prices_null(
     assert json.loads(output_path.read_text()) == seed, (
         "Seed file must not be overwritten when every fetched price is None"
     )
+
+
+def test_refresh_prices_partial_null_preserves_existing_prices(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Partial-outage refresh updates valid prices and preserves existing ones for null tickers."""
+    seed = {
+        "AAA.L": {"last_price": 10.0, "price_currency": "GBP"},
+        "BBB.L": {"last_price": 20.0, "price_currency": "GBP"},
+    }
+    output_path = tmp_path / "prices.json"
+    output_path.write_text(json.dumps(seed))
+
+    partial_snapshot = {
+        "AAA.L": {"last_price": 11.5, "price_currency": "GBP", "is_stale": False},
+        "BBB.L": {"last_price": None, "price_currency": None, "is_stale": True},
+    }
+    monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: ["AAA.L", "BBB.L"])
+    monkeypatch.setattr(prices, "get_price_snapshot", lambda _: partial_snapshot)
+    monkeypatch.setattr(prices, "refresh_snapshot_in_memory", Mock())
+    monkeypatch.setattr(prices, "check_price_alerts", Mock())
+    monkeypatch.setattr(prices.config, "prices_json", output_path)
+    monkeypatch.setattr(prices, "_price_cache", {})
+
+    prices.refresh_prices()
+
+    result = json.loads(output_path.read_text())
+    assert result["AAA.L"]["last_price"] == pytest.approx(11.5), (
+        "Successfully-fetched price must be updated"
+    )
+    assert result["BBB.L"]["last_price"] == pytest.approx(20.0), (
+        "Seed price for null-returning ticker must be preserved"
+    )


### PR DESCRIPTION
## Summary

- **Root cause of #2746**: `data/prices/latest_prices.json` was missing (gitignored), leaving `_PRICE_SNAPSHOT` empty at startup — all non-cash positions returned `market_value_gbp=None`
- Add seed `data/prices/latest_prices.json` with demo-holding prices (VWRL.L, ERNS.L, PFE.N) and whitelist `data/prices/` in `.gitignore` so it is tracked
- Guard `refresh_prices()` and `refresh_snapshot_in_memory_from_timeseries()` against overwriting a valid snapshot when every freshly-fetched price is `None` (offline/test mode with no timeseries cache)
- Fix malformed/empty instrument metadata for `GSK.L`, `HFEL.L`, and `COMETF.L`

## Test plan

- [x] `test_enrich_holding_market_value_set_from_price_snapshot` — enrichment path uses snapshot price, `market_value_gbp` is non-None
- [x] `test_seed_prices_file_loads_demo_holdings` — seed file loads correctly and contains expected tickers
- [x] `test_refresh_prices_skips_write_when_all_prices_null` — all-null refresh does not overwrite a valid seed file
- [x] `test_refresh_prices_writes_json_and_updates_cache` — normal refresh still writes to disk
- [x] Seed file survives a full test-suite run (`data/prices/latest_prices.json` content unchanged after `pytest`)

Closes #2746

🤖 Generated with [Claude Code](https://claude.com/claude-code)