### PR TITLE
fix: resolve SMOKE_URL from CloudFormation in smoke-test job

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -437,6 +437,29 @@ jobs:
         run: npx playwright install --with-deps
         working-directory: frontend
 
+      - name: Resolve backend URL for smoke tests
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
+        run: |
+          set -euo pipefail
+          # Resolve directly from CloudFormation rather than relying on the cross-job
+          # output from the deploy job. Cross-job outputs containing masked secret
+          # substrings (AWS_REGION appears in the API Gateway URL) arrive empty in
+          # the downstream job, causing the smoke script to fall back to localhost.
+          if [ -n "${SMOKE_URL:-}" ]; then
+            echo "SMOKE_URL already set via vars.SMOKE_URL; skipping CloudFormation lookup."
+            exit 0
+          fi
+          BACKEND_URL="$(aws cloudformation describe-stacks \
+            --stack-name BackendLambdaStack \
+            --query "Stacks[0].Outputs[?OutputKey=='BackendApiUrl'].OutputValue" \
+            --output text)"
+          if [ -z "$BACKEND_URL" ] || [ "$BACKEND_URL" = "None" ]; then
+            echo "BackendApiUrl output is missing from BackendLambdaStack" >&2
+            exit 1
+          fi
+          echo "SMOKE_URL=$BACKEND_URL" >> "$GITHUB_ENV"
+
       - name: Run backend smoke tests
         run: npm run smoke:test
 


### PR DESCRIPTION
## Summary

- The `smoke-test` job was setting `SMOKE_URL` from `needs.deploy.outputs.backend_url`, but that cross-job output arrives **empty** because the API Gateway URL contains the masked `AWS_REGION` secret substring — GitHub Actions redacts the value when passing it between jobs
- This caused the smoke script to fall back to `http://localhost:8000`, fail the preflight health check, and skip every endpoint test
- Fix: add a **Resolve backend URL for smoke tests** step that queries `BackendLambdaStack` directly via `aws cloudformation describe-stacks` (same pattern as the deploy job's validate step). The `vars.SMOKE_URL` manual-override path is preserved

## Test plan

- [ ] Trigger a tag-based deploy and confirm the `smoke-test` job's **Resolve backend URL** step prints a non-empty `SMOKE_URL` pointing to the API Gateway URL
- [ ] Confirm `Run backend smoke tests` (`npm run smoke:test`) reaches the deployed API and does not error with `could not reach http://localhost:8000/health`
- [ ] Confirm the `vars.SMOKE_URL` short-circuit (`if [ -n "${SMOKE_URL:-}" ]`) works when the repo variable is set

Closes #3053

🤖 Generated with [Claude Code](https://claude.com/claude-code)