### PR TITLE
fix: ensure frontend smoke tests run even when backend smoke fails

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -441,7 +441,28 @@ jobs:
         run: npm run smoke:test
 
       - name: Run frontend smoke tests
+        # Run even if the backend smoke step failed so frontend results are
+        # always visible in CI logs (fixes issue #3055).  SMOKE_URL at job
+        # level is the backend API URL; override it to localhost so Playwright
+        # navigates to the local preview server, and expose the backend URL via
+        # VITE_ALLOTMINT_API_BASE so the built app calls the real deployed API.
+        if: success() || failure()
         run: npm --prefix frontend run smoke:frontend
+        env:
+          VITE_ALLOTMINT_API_BASE: ${{ env.SMOKE_URL }}
+          SMOKE_URL: 'http://localhost:5173'
+          TEST_ID_TOKEN: ${{ secrets.SMOKE_TEST_ID_TOKEN }}
+          SMOKE_AUTH_TOKEN: ${{ secrets.SMOKE_AUTH_TOKEN }}
+
+      - name: Upload Playwright deploy-smoke artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-deploy-smoke-artifacts
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          if-no-files-found: ignore
 
       - name: Fetch Lambda logs from smoke test
         if: always()

--- a/.github/workflows/opt-in-smoke-tests.yml
+++ b/.github/workflows/opt-in-smoke-tests.yml
@@ -100,9 +100,12 @@ jobs:
         # (success() || failure()) ensures this step runs even when the backend
         # smoke step failed, so frontend results are always visible in CI logs
         # regardless of backend health (fixes issue #3055).
+        # Note: the if: field evaluates as an expression context already;
+        # ${{ }} wrappers are intentionally omitted here so that the
+        # status-check functions (success, failure) are resolved correctly.
         if: >-
-          ${{ (success() || failure()) &&
-          (env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'frontend') }}
+          (success() || failure()) &&
+          (env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'frontend')
         run: npm --prefix frontend run smoke:frontend
         env:
           TEST_ID_TOKEN: ${{ secrets.SMOKE_TEST_ID_TOKEN }}

--- a/.github/workflows/opt-in-smoke-tests.yml
+++ b/.github/workflows/opt-in-smoke-tests.yml
@@ -97,7 +97,12 @@ jobs:
           TEST_ID_TOKEN: ${{ secrets.SMOKE_TEST_ID_TOKEN }}
 
       - name: Run frontend Playwright smoke tests
-        if: ${{ env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'frontend' }}
+        # (success() || failure()) ensures this step runs even when the backend
+        # smoke step failed, so frontend results are always visible in CI logs
+        # regardless of backend health (fixes issue #3055).
+        if: >-
+          ${{ (success() || failure()) &&
+          (env.SMOKE_TARGET == 'all' || env.SMOKE_TARGET == 'frontend') }}
         run: npm --prefix frontend run smoke:frontend
         env:
           TEST_ID_TOKEN: ${{ secrets.SMOKE_TEST_ID_TOKEN }}


### PR DESCRIPTION
## Summary

- **`deploy-lambda.yml`**: The `smoke-test` job's frontend step now has `if: success() || failure()` so it always runs after deployment, even if the backend smoke step fails. `SMOKE_URL` is overridden to `http://localhost:5173` at step level (so Playwright targets the local Vite preview server, not the backend API), and `VITE_ALLOTMINT_API_BASE` is set to the backend URL so the built frontend app calls the real deployed API. Auth secrets (`SMOKE_TEST_ID_TOKEN`, `SMOKE_AUTH_TOKEN`) and a Playwright artifact upload step are added.
- **`opt-in-smoke-tests.yml`**: The frontend step condition is prefixed with `(success() || failure()) &&` so it runs when `SMOKE_TARGET=all` regardless of backend smoke outcome.

## Root cause

`SMOKE_URL` in the `smoke-test` job was the *backend* API URL (from `needs.deploy.outputs.backend_url`), but `smoke.spec.ts` uses `SMOKE_URL` as the *frontend* base URL. The two scripts use the variable for different purposes. The frontend step also had no `if:` guard, so any backend failure silently skipped it.

## Test plan

- [ ] Trigger a tag deploy and confirm "Run frontend smoke tests" appears in the CI log after the backend smoke step (pass or fail)
- [ ] Trigger `opt-in-smoke-tests` workflow with `smoke_target=all` on a branch where the backend smoke URL is unset; confirm the frontend step still runs

Closes #3055

🤖 Generated with [Claude Code](https://claude.com/claude-code)