### PR TITLE
docs: add AWS architecture SVG diagram and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ AllotMint is a family investing platform with a FastAPI backend, React frontend,
 - Local setup and contributor workflow: [docs/CONTRIBUTOR_RUNBOOK.md](docs/CONTRIBUTOR_RUNBOOK.md)
 - User-oriented setup/readme: [docs/USER_README.md](docs/USER_README.md)
 
+## AWS architecture
+
+![AWS architecture](docs/aws-architecture.svg)
+
+> StaticSiteStack (CloudFront, S3, Cognito) and BackendLambdaStack (API Gateway, Lambda, EventBridge, S3 data bucket, CloudWatch, Budgets, ECR).
+
 ## Coverage reporting
 
 GitHub Actions uploads both backend (`coverage.xml`) and frontend (`frontend/coverage/lcov.info`) coverage reports to Codecov on pull requests and pushes to `main`.
-
-
 
 ## Local Docker development
 

--- a/docs/aws-architecture.svg
+++ b/docs/aws-architecture.svg
@@ -1,0 +1,196 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="860" viewBox="0 0 860 960" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">
+
+  <!-- ─── Background ─────────────────────────────────────────── -->
+  <rect width="860" height="960" fill="#f8f9fa" rx="12"/>
+
+  <!-- ─── Title ────────────────────────────────────────────────── -->
+  <text x="430" y="36" text-anchor="middle" font-size="17" font-weight="600" fill="#1a1a2e">AllotMint — AWS deployed architecture</text>
+  <text x="430" y="54" text-anchor="middle" font-size="11" fill="#6c757d">StaticSiteStack · BackendLambdaStack</text>
+
+  <!-- ═══════════════════════════════════════════════════════════ -->
+  <!-- INTERNET / USER -->
+  <!-- ═══════════════════════════════════════════════════════════ -->
+  <rect x="358" y="70" width="144" height="38" rx="8" fill="#e9ecef" stroke="#adb5bd" stroke-width="1"/>
+  <text x="430" y="93" text-anchor="middle" font-weight="600" fill="#343a40">Browser / user</text>
+
+  <!-- ═══════════════════════════════════════════════════════════ -->
+  <!-- StaticSiteStack container -->
+  <!-- ═══════════════════════════════════════════════════════════ -->
+  <rect x="20" y="128" width="820" height="230" rx="14" fill="#e7f3ff" stroke="#4a90d9" stroke-width="1.5" stroke-dasharray="6 3"/>
+  <text x="34" y="148" font-size="12" font-weight="600" fill="#1a5fa8">StaticSiteStack</text>
+
+  <!-- Route 53 -->
+  <rect x="36" y="158" width="148" height="52" rx="8" fill="#d0e8ff" stroke="#4a90d9" stroke-width="1"/>
+  <text x="110" y="180" text-anchor="middle" font-weight="600" fill="#0d3f7a">Route 53</text>
+  <text x="110" y="198" text-anchor="middle" font-size="11" fill="#1a5fa8">app.allotmint.io (opt)</text>
+
+  <!-- ACM cert -->
+  <rect x="204" y="158" width="148" height="52" rx="8" fill="#d0e8ff" stroke="#4a90d9" stroke-width="1"/>
+  <text x="278" y="180" text-anchor="middle" font-weight="600" fill="#0d3f7a">ACM certificate</text>
+  <text x="278" y="198" text-anchor="middle" font-size="11" fill="#1a5fa8">us-east-1, optional</text>
+
+  <!-- CloudFront -->
+  <rect x="372" y="158" width="168" height="52" rx="8" fill="#d0e8ff" stroke="#4a90d9" stroke-width="1.5"/>
+  <text x="456" y="178" text-anchor="middle" font-weight="600" fill="#0d3f7a">CloudFront distribution</text>
+  <text x="456" y="196" text-anchor="middle" font-size="11" fill="#1a5fa8">Viewer-request fn · CSP · SPA routing</text>
+
+  <!-- S3 site bucket -->
+  <rect x="560" y="158" width="156" height="52" rx="8" fill="#d0e8ff" stroke="#4a90d9" stroke-width="1"/>
+  <text x="638" y="178" text-anchor="middle" font-weight="600" fill="#0d3f7a">S3 — site bucket</text>
+  <text x="638" y="196" text-anchor="middle" font-size="11" fill="#1a5fa8">HTML · assets · config.json</text>
+
+  <!-- Cognito user pool -->
+  <rect x="36" y="232" width="168" height="52" rx="8" fill="#ece0ff" stroke="#7b5ea7" stroke-width="1"/>
+  <text x="120" y="252" text-anchor="middle" font-weight="600" fill="#3b1f7a">Cognito user pool</text>
+  <text x="120" y="270" text-anchor="middle" font-size="11" fill="#5e3d9e">Auth-code · SRP · hosted UI</text>
+
+  <!-- Cognito app client -->
+  <rect x="224" y="232" width="160" height="52" rx="8" fill="#ece0ff" stroke="#7b5ea7" stroke-width="1"/>
+  <text x="304" y="252" text-anchor="middle" font-weight="600" fill="#3b1f7a">Cognito app client</text>
+  <text x="304" y="270" text-anchor="middle" font-size="11" fill="#5e3d9e">email · openid · profile</text>
+
+  <!-- Cognito hosted domain -->
+  <rect x="404" y="232" width="164" height="52" rx="8" fill="#ece0ff" stroke="#7b5ea7" stroke-width="1"/>
+  <text x="486" y="252" text-anchor="middle" font-weight="600" fill="#3b1f7a">Cognito hosted domain</text>
+  <text x="486" y="270" text-anchor="middle" font-size="11" fill="#5e3d9e">allotmint-{acct}-{region}</text>
+
+  <!-- ═══════════════════════════════════════════════════════════ -->
+  <!-- BackendLambdaStack container -->
+  <!-- ═══════════════════════════════════════════════════════════ -->
+  <rect x="20" y="378" width="820" height="556" rx="14" fill="#fff4ec" stroke="#d4622a" stroke-width="1.5" stroke-dasharray="6 3"/>
+  <text x="34" y="398" font-size="12" font-weight="600" fill="#8b3a14">BackendLambdaStack</text>
+
+  <!-- API Gateway -->
+  <rect x="270" y="410" width="320" height="52" rx="8" fill="#ffd8c0" stroke="#d4622a" stroke-width="1.5"/>
+  <text x="430" y="430" text-anchor="middle" font-weight="600" fill="#5c1f00">API Gateway — HTTP API</text>
+  <text x="430" y="450" text-anchor="middle" font-size="11" fill="#8b3a14">Cognito JWT authorizer · CORS · /health open</text>
+
+  <!-- BackendLambda -->
+  <rect x="270" y="486" width="320" height="52" rx="8" fill="#ffd8c0" stroke="#d4622a" stroke-width="1.5"/>
+  <text x="430" y="506" text-anchor="middle" font-weight="600" fill="#5c1f00">BackendLambda</text>
+  <text x="430" y="524" text-anchor="middle" font-size="11" fill="#8b3a14">FastAPI · Docker · 512 MB · 30 s timeout</text>
+
+  <!-- S3 data bucket -->
+  <rect x="36" y="486" width="210" height="72" rx="8" fill="#fff0c0" stroke="#c07a00" stroke-width="1"/>
+  <text x="141" y="508" text-anchor="middle" font-weight="600" fill="#5c3a00">S3 — data bucket</text>
+  <text x="141" y="526" text-anchor="middle" font-size="11" fill="#7a4f00">accounts · alerts · prices</text>
+  <text x="141" y="542" text-anchor="middle" font-size="11" fill="#7a4f00">transactions · timeseries (parquet)</text>
+
+  <!-- CloudWatch log groups -->
+  <rect x="614" y="486" width="210" height="72" rx="8" fill="#e8e8e8" stroke="#888" stroke-width="1"/>
+  <text x="719" y="508" text-anchor="middle" font-weight="600" fill="#2c2c2c">CloudWatch logs</text>
+  <text x="719" y="526" text-anchor="middle" font-size="11" fill="#444">Backend · PriceRefresh</text>
+  <text x="719" y="542" text-anchor="middle" font-size="11" fill="#444">TradingAgent · 1-week TTL</text>
+
+  <!-- EventBridge label -->
+  <text x="36" y="588" font-size="11" font-style="italic" fill="#8b3a14">EventBridge schedules</text>
+
+  <!-- PriceRefreshLambda -->
+  <rect x="36" y="600" width="230" height="68" rx="8" fill="#ffd8c0" stroke="#d4622a" stroke-width="1"/>
+  <text x="151" y="622" text-anchor="middle" font-weight="600" fill="#5c1f00">PriceRefreshLambda</text>
+  <text x="151" y="640" text-anchor="middle" font-size="11" fill="#8b3a14">Daily 00:00 · 512 MB · 10 min</text>
+  <text x="151" y="656" text-anchor="middle" font-size="11" fill="#8b3a14">+ CDK post-deploy Trigger</text>
+
+  <!-- TradingAgentLambda -->
+  <rect x="286" y="600" width="228" height="68" rx="8" fill="#ffd8c0" stroke="#d4622a" stroke-width="1"/>
+  <text x="400" y="622" text-anchor="middle" font-weight="600" fill="#5c1f00">TradingAgentLambda</text>
+  <text x="400" y="640" text-anchor="middle" font-size="11" fill="#8b3a14">Daily 01:00 · read-only S3</text>
+  <text x="400" y="656" text-anchor="middle" font-size="11" fill="#8b3a14">prices + timeseries</text>
+
+  <!-- IAM roles -->
+  <rect x="534" y="600" width="290" height="68" rx="8" fill="#e8e8e8" stroke="#888" stroke-width="1"/>
+  <text x="679" y="622" text-anchor="middle" font-weight="600" fill="#2c2c2c">IAM roles (per-Lambda)</text>
+  <text x="679" y="640" text-anchor="middle" font-size="11" fill="#444">Scoped s3:Get/Put/List per prefix</text>
+  <text x="679" y="656" text-anchor="middle" font-size="11" fill="#444">+ logs:FilterLogEvents for CI</text>
+
+  <!-- CW alarm -->
+  <rect x="36" y="700" width="230" height="52" rx="8" fill="#e8e8e8" stroke="#888" stroke-width="1"/>
+  <text x="151" y="722" text-anchor="middle" font-weight="600" fill="#2c2c2c">CloudWatch alarm</text>
+  <text x="151" y="740" text-anchor="middle" font-size="11" fill="#444">BackendLambda error rate ≥1</text>
+
+  <!-- AWS Budgets -->
+  <rect x="286" y="700" width="228" height="52" rx="8" fill="#fff0c0" stroke="#c07a00" stroke-width="1"/>
+  <text x="400" y="722" text-anchor="middle" font-weight="600" fill="#5c3a00">AWS Budgets</text>
+  <text x="400" y="740" text-anchor="middle" font-size="11" fill="#7a4f00">Monthly cost · 80 % alert email</text>
+
+  <!-- GitHub Actions -->
+  <rect x="534" y="700" width="290" height="52" rx="8" fill="#e8e8e8" stroke="#888" stroke-width="1"/>
+  <text x="679" y="722" text-anchor="middle" font-weight="600" fill="#2c2c2c">GitHub Actions (CI/CD)</text>
+  <text x="679" y="740" text-anchor="middle" font-size="11" fill="#444">cdk deploy · smoke tests · log-dump</text>
+
+  <!-- ECR -->  
+  <rect x="36" y="784" width="788" height="42" rx="8" fill="#e8e8e8" stroke="#888" stroke-width="1"/>
+  <text x="430" y="808" text-anchor="middle" font-weight="600" fill="#2c2c2c">ECR — Docker image (shared by Backend / PriceRefresh / TradingAgent, differentiated by cmd override)</text>
+
+  <!-- ─── Legend ─────────────────────────────────────────────── -->
+  <rect x="36" y="846" width="788" height="90" rx="8" fill="#ffffff" stroke="#dee2e6" stroke-width="1"/>
+  <text x="54" y="866" font-size="11" font-weight="600" fill="#343a40">Legend</text>
+  <rect x="54" y="874" width="14" height="14" rx="3" fill="#d0e8ff" stroke="#4a90d9" stroke-width="1"/>
+  <text x="74" y="885" font-size="11" fill="#343a40">StaticSiteStack (frontend infra)</text>
+  <rect x="54" y="896" width="14" height="14" rx="3" fill="#ece0ff" stroke="#7b5ea7" stroke-width="1"/>
+  <text x="74" y="907" font-size="11" fill="#343a40">Cognito (auth)</text>
+  <rect x="260" y="874" width="14" height="14" rx="3" fill="#ffd8c0" stroke="#d4622a" stroke-width="1"/>
+  <text x="280" y="885" font-size="11" fill="#343a40">BackendLambdaStack (backend infra)</text>
+  <rect x="260" y="896" width="14" height="14" rx="3" fill="#fff0c0" stroke="#c07a00" stroke-width="1"/>
+  <text x="280" y="907" font-size="11" fill="#343a40">S3 / Budgets (data &amp; cost)</text>
+  <rect x="500" y="874" width="14" height="14" rx="3" fill="#e8e8e8" stroke="#888" stroke-width="1"/>
+  <text x="520" y="885" font-size="11" fill="#343a40">Shared / IAM / observability</text>
+  <text x="520" y="907" font-size="11" fill="#6c757d">--- dashed border = CDK stack boundary</text>
+
+  <!-- ─── Arrows ─────────────────────────────────────────────── -->
+  <defs>
+    <marker id="ah" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#6c757d" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <!-- User → CloudFront -->
+  <line x1="430" y1="108" x2="456" y2="158" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- Route53 → CloudFront -->
+  <line x1="184" y1="184" x2="372" y2="184" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- ACM → CloudFront -->
+  <line x1="352" y1="184" x2="372" y2="184" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- CloudFront → S3 site -->
+  <line x1="540" y1="184" x2="560" y2="184" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- CloudFront → Cognito domain (auth redirect) -->
+  <path d="M456 210 Q486 220 486 232" fill="none" stroke="#7b5ea7" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#ah)"/>
+
+  <!-- Cross-stack: Cognito pool/client IDs -->
+  <line x1="430" y1="358" x2="430" y2="410" stroke="#4a90d9" stroke-width="1" stroke-dasharray="5 3" marker-end="url(#ah)"/>
+  <text x="438" y="388" font-size="10" fill="#1a5fa8">Cognito pool/client IDs (CfnParameter)</text>
+
+  <!-- User → API GW (browser API calls) -->
+  <path d="M502 108 Q700 108 700 350 Q700 395 590 420" fill="none" stroke="#d4622a" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#ah)"/>
+
+  <!-- API GW → BackendLambda -->
+  <line x1="430" y1="462" x2="430" y2="486" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- BackendLambda → S3 data bucket -->
+  <line x1="270" y1="510" x2="246" y2="510" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- BackendLambda → CW logs -->
+  <line x1="590" y1="510" x2="614" y2="510" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- PriceRefreshLambda → S3 data bucket -->
+  <line x1="151" y1="600" x2="141" y2="558" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- TradingAgentLambda → S3 data bucket -->
+  <path d="M340 600 Q280 574 200 558" fill="none" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- PriceRefreshLambda → CW logs -->
+  <path d="M266 618 Q500 590 614 530" fill="none" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- TradingAgentLambda → CW logs -->
+  <line x1="514" y1="620" x2="614" y2="540" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- GitHub Actions → IAM (deploy role) -->
+  <line x1="679" y1="700" x2="679" y2="668" stroke="#6c757d" stroke-width="1" marker-end="url(#ah)"/>
+
+  <!-- CW alarm → BackendLambda (monitors) -->
+  <path d="M151 700 Q220 680 300 538" fill="none" stroke="#888" stroke-width="1" stroke-dasharray="3 3" marker-end="url(#ah)"/>
+
+</svg>


### PR DESCRIPTION
Closes #3059

## Changes
- `docs/aws-architecture.svg` — self-contained SVG (hardcoded colours, no CSS variables or external dependencies) covering both CDK stacks. GitHub renders it natively.
- `README.md` — adds `## AWS architecture` section with `![AWS architecture](docs/aws-architecture.svg)` immediately below the intro links.

## Diagram covers
StaticSiteStack: CloudFront · S3 site bucket · Route 53 (optional) · ACM (optional) · Cognito user pool / app client / hosted domain

BackendLambdaStack: API Gateway HTTP API · BackendLambda · PriceRefreshLambda · TradingAgentLambda · S3 data bucket · EventBridge schedules · CloudWatch log groups · CloudWatch alarm · IAM roles · AWS Budgets · ECR (shared Docker image)

## Notes
- SVG uses only inline `fill`/`stroke` attributes — GitHub's sanitiser strips `<style>` blocks and CSS variables, so this is necessary for reliable rendering.
- No CI impact — doc-only change.