### PR TITLE
fix: use data-testid selector for timeseries Load button in smoke test

### DIFF
--- a/frontend/src/pages/TimeseriesEdit.tsx
+++ b/frontend/src/pages/TimeseriesEdit.tsx
@@ -408,7 +408,7 @@ export function TimeseriesEdit() {
             ))}
           </select>
         </label>{" "}
-        <button onClick={handleLoad} disabled={!ticker}>
+        <button data-testid="load-button" onClick={handleLoad} disabled={!ticker}>
           {t("timeseriesEdit.load")}
         </button>
       </div>

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -410,23 +410,9 @@ test.describe('timeseries edit resilience', () => {
 
     await page.goto(target.href);
 
-    const loadButton = page.getByRole('button', { name: 'Load' });
-    // The 'Load' button may not always be rendered as a role=button in preview builds;
-    // try a fallback selector (by text) before failing the test.
-    try {
-      await expect(loadButton).toBeEnabled();
-      await loadButton.click();
-    } catch {
-      const fallback = page.locator("text=Load");
-      if (await fallback.count() > 0) {
-        await expect(fallback.first()).toBeVisible();
-        await fallback.first().click();
-      } else {
-        // If no clickable element is available, proceed to assert that the route marker
-        // remains visible as the main resilience check.
-        console.warn('Load button not found; skipping explicit click and asserting marker state.');
-      }
-    }
+    const loadButton = page.getByTestId('load-button');
+    await expect(loadButton).toBeEnabled();
+    await loadButton.click();
 
     await expect.poll(() => requested).toBeTruthy();
 


### PR DESCRIPTION
## Summary

- Adds `data-testid="load-button"` to the Load `<button>` in `TimeseriesEdit.tsx` so it can be located by a stable, i18n-independent selector
- Replaces the fragile three-layer try/catch/fallback in the `timeseries edit resilience` smoke test with a single `page.getByTestId('load-button')` call
- The click is now always asserted (no more silent skip path), making the test a genuine check rather than a best-effort one

**Root cause:** In CI with `vite preview`, i18n may not be initialized at first render, so `t("timeseriesEdit.load")` returns the key string `"timeseriesEdit.load"` instead of `"Load"`. Both `getByRole('button', { name: 'Load' })` and `text=Load` then miss the button and fall through to `console.warn`.

## Test plan

- [ ] `npm --prefix frontend run test -- --run` — existing unit test for TimeseriesEdit uses `/load/i` regex so still passes
- [ ] `npm run smoke:test` against a `vite preview` build — the `timeseries edit resilience` test should now click the button and assert `requested === true`

Closes #3065

🤖 Generated with [Claude Code](https://claude.com/claude-code)