### PR TITLE
fix: resolve price snapshot bucket from CloudFormation, not DATA_BUCKET secret

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -157,6 +157,49 @@ jobs:
           --parameters BackendLambdaStack:UiAuthUserPoolClientId="$UI_AUTH_USER_POOL_CLIENT_ID"
         working-directory: cdk
 
+      - name: Warm price snapshot
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
+        run: |
+          set -euo pipefail
+          refresh_fn="$(aws cloudformation list-stack-resources \
+            --stack-name BackendLambdaStack \
+            --query "StackResourceSummaries[?ResourceType=='AWS::Lambda::Function' && starts_with(LogicalResourceId, 'PriceRefreshLambda')].PhysicalResourceId | [0]" \
+            --output text)"
+          if [ -z "$refresh_fn" ] || [ "$refresh_fn" = "None" ]; then
+            echo "Unable to resolve PriceRefreshLambda physical function name from BackendLambdaStack resources" >&2
+            exit 1
+          fi
+          data_bucket="$(aws cloudformation list-stack-resources \
+            --stack-name BackendLambdaStack \
+            --query "StackResourceSummaries[?ResourceType=='AWS::S3::Bucket' && starts_with(LogicalResourceId, 'PortfolioDataBucket')].PhysicalResourceId | [0]" \
+            --output text)"
+          if [ -z "$data_bucket" ] || [ "$data_bucket" = "None" ]; then
+            echo "Unable to resolve PortfolioDataBucket physical bucket name from BackendLambdaStack resources" >&2
+            exit 1
+          fi
+          response_file="$(mktemp)"
+          invoke_meta="$(aws lambda invoke \
+            --function-name "$refresh_fn" \
+            --cli-binary-format raw-in-base64-out \
+            "$response_file")"
+          python - "$invoke_meta" "$response_file" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          meta = json.loads(sys.argv[1])
+          payload_text = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8").strip()
+          if meta.get("FunctionError"):
+              raise SystemExit(
+                  f"PriceRefreshLambda returned {meta['FunctionError']}: {payload_text or '<empty>'}"
+              )
+          payload = json.loads(payload_text or "{}")
+          if not isinstance(payload, dict) or "snapshot" not in payload or "timestamp" not in payload:
+              raise SystemExit(f"Unexpected PriceRefreshLambda response: {payload!r}")
+          PY
+          aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null
+
       - name: Get backend API URL
         id: get_backend_url
         env:

--- a/tests/scripts/test_deploy_lambda_workflow.py
+++ b/tests/scripts/test_deploy_lambda_workflow.py
@@ -1,0 +1,45 @@
+"""Regression tests for the production deploy workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy-lambda.yml"
+
+
+def test_deploy_workflow_warms_price_snapshot() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    deploy_job = workflow["jobs"]["deploy"]
+    steps = deploy_job["steps"]
+    step_names = [s.get("name", "") for s in steps]
+
+    warm_step = next(
+        step for step in steps if step.get("name") == "Warm price snapshot"
+    )
+
+    run_script = warm_step["run"]
+
+    assert "aws lambda invoke" in run_script
+    assert "PriceRefreshLambda" in run_script
+    assert "aws s3api head-object" in run_script
+    assert "prices/latest_prices.json" in run_script
+
+    # Bucket must be resolved from CloudFormation, not from the $DATA_BUCKET secret
+    # (empty/masked secrets cause exit 255 from the AWS CLI).
+    assert "PortfolioDataBucket" in run_script, (
+        "head-object bucket must be derived from CloudFormation, not $DATA_BUCKET secret"
+    )
+    assert '--bucket "$DATA_BUCKET"' not in run_script, (
+        "head-object must not use $DATA_BUCKET directly — secret may be masked or empty"
+    )
+
+    # Step must run after the CDK deploy that creates the bucket.
+    deploy_idx = next(
+        i for i, name in enumerate(step_names) if "Deploy BackendLambdaStack" in name
+    )
+    warm_idx = step_names.index("Warm price snapshot")
+    assert warm_idx > deploy_idx, "Warm price snapshot must run after Deploy BackendLambdaStack"


### PR DESCRIPTION
## Summary

- Adds a "Warm price snapshot" step to `deploy-lambda.yml` that invokes `PriceRefreshLambda` and verifies the snapshot key exists in S3.
- Resolves both the Lambda function name and S3 bucket name from CloudFormation stack resources at runtime — the same pattern already used to fix `backend_url` masking. This avoids the exit 255 failure caused by passing an empty/masked `$DATA_BUCKET` secret as `--bucket`.
- Adds `tests/scripts/test_deploy_lambda_workflow.py` with a regression test that asserts the step invokes the lambda, checks the snapshot key, derives the bucket from CloudFormation (not the secret), and runs after `Deploy BackendLambdaStack`.

## Test plan

- [x] `pytest tests/scripts/test_deploy_lambda_workflow.py` passes locally
- [x] `PortfolioDataBucket` CloudFormation lookup present in the step
- [x] `--bucket "$DATA_BUCKET"` absent from the step

Closes #3074

🤖 Generated with [Claude Code](https://claude.com/claude-code)