### PR TITLE
Route PriceRefresh Lambda invocations through a `live` alias and update deploy workflow to invoke it

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -180,7 +180,7 @@ jobs:
           fi
           response_file="$(mktemp)"
           invoke_meta="$(aws lambda invoke \
-            --function-name "$refresh_fn" \
+            --function-name "${refresh_fn}:live" \
             --cli-binary-format raw-in-base64-out \
             "$response_file")"
           python - "$invoke_meta" "$response_file" <<'PY'
@@ -251,7 +251,7 @@ jobs:
           if [ "$head_exit" -eq 0 ]; then
             echo "Price snapshot prices/latest_prices.json is present in s3://${DATA_BUCKET} — OK"
           elif echo "$head_output" | grep -qi "NoSuchKey\|Not Found\|404"; then
-            echo "::warning::Price snapshot prices/latest_prices.json is NOT present in s3://${DATA_BUCKET}. Portfolio prices will be unavailable until the price-refresh job runs. Trigger it manually: aws lambda invoke --function-name <PriceRefreshLambda-physical-name> /dev/null"
+            echo "::warning::Price snapshot prices/latest_prices.json is NOT present in s3://${DATA_BUCKET}. Portfolio prices will be unavailable until the price-refresh job runs. Trigger it manually: aws lambda invoke --function-name <PriceRefreshLambda-physical-name>:live /dev/null"
           else
             echo "::warning::Could not verify price snapshot — s3api head-object returned exit ${head_exit}: ${head_output}"
           fi

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -407,11 +407,21 @@ class BackendLambdaStack(Stack):
         )
         self._grant_timeseries_cache_access(refresh_fn, bucket=data_bucket, allow_put=True)
 
+        # Route all managed invocations through an explicit alias so Lambda
+        # invoke permissions are qualified and remain compatible with AWS
+        # authorization changes around Qualifier-based invocation.
+        refresh_alias = _lambda.Alias(
+            self,
+            "PriceRefreshLambdaLiveAlias",
+            alias_name="live",
+            version=refresh_fn.current_version,
+        )
+
         events.Rule(
             self,
             "DailyPriceRefresh",
             schedule=events.Schedule.cron(minute="0", hour="0"),
-            targets=[targets.LambdaFunction(refresh_fn)],
+            targets=[targets.LambdaFunction(refresh_alias)],
         )
 
         # Invoke PriceRefreshLambda synchronously after each deployment so


### PR DESCRIPTION
### Motivation
- Ensure managed and CI invocations of the price-refresh Lambda are qualified with an explicit alias to remain compatible with AWS changes around qualifier-based invocation. 
- Make the scheduled EventBridge target and CI invoke calls use a stable, permissioned qualifier so invocation permissions and operator guidance remain correct.

### Description
- Create an `_lambda.Alias` named `PriceRefreshLambdaLiveAlias` with alias name `live` pointing to `refresh_fn.current_version`. 
- Update the daily `events.Rule` target to invoke the new `live` alias instead of the raw function. 
- Modify the GitHub Actions workflow `deploy-lambda.yml` to invoke the price-refresh function with the qualifier `:live` in the warm snapshot step and to include `:live` in the manual-trigger warning message. 

### Testing
- Ran `cdk synth` to validate the stack synthesizes successfully. 
- Ran unit tests with `pytest`; the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e12fafe2083278342a64c73d3d586)