### PR TITLE
fix: wrap NaN and Infinity warn assertions in waitFor to fix flaky CI

### DIFF
--- a/frontend/tests/unit/pages/AllocationCharts.test.tsx
+++ b/frontend/tests/unit/pages/AllocationCharts.test.tsx
@@ -195,12 +195,17 @@ describe("AllocationCharts page", () => {
     render(<AllocationCharts />);
     await screen.findByText(/Instrument Types/);
 
-    expect(warnSpy).toHaveBeenCalledWith("Dropped invalid holding value", {
-      ticker: "NAN",
-      originalValue: Number.NaN,
-      coercedValue: 0,
-      originalInvalid: true,
-      dropReason: "invalid-numeric-input",
+    // The chart-data useEffect emits the warning asynchronously after the
+    // loading guard drops (which makes "Instrument Types" visible). Use
+    // waitFor so the assertion retries until the effect has actually run.
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith("Dropped invalid holding value", {
+        ticker: "NAN",
+        originalValue: Number.NaN,
+        coercedValue: 0,
+        originalInvalid: true,
+        dropReason: "invalid-numeric-input",
+      });
     });
   });
 
@@ -217,12 +222,17 @@ describe("AllocationCharts page", () => {
     render(<AllocationCharts />);
     await screen.findByText(/Instrument Types/);
 
-    expect(warnSpy).toHaveBeenCalledWith("Dropped invalid holding value", {
-      ticker: "INF",
-      originalValue: Number.POSITIVE_INFINITY,
-      coercedValue: 0,
-      originalInvalid: true,
-      dropReason: "invalid-numeric-input",
+    // The chart-data useEffect emits the warning asynchronously after the
+    // loading guard drops (which makes "Instrument Types" visible). Use
+    // waitFor so the assertion retries until the effect has actually run.
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith("Dropped invalid holding value", {
+        ticker: "INF",
+        originalValue: Number.POSITIVE_INFINITY,
+        coercedValue: 0,
+        originalInvalid: true,
+        dropReason: "invalid-numeric-input",
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- The `warns in dev for dropped Infinity values` test was failing in CI with 0 `console.warn` calls because the chart-data `useEffect` fires asynchronously — `findByText(/Instrument Types/)` can resolve before the effect runs.
- Wraps the `warnSpy` assertion in `await waitFor(...)` for both the **Infinity** and **NaN** warn tests, matching the pattern established in f22afa58 for the non-numeric test.
- The NaN test was passing by luck; the same fix prevents future flakes.

## Test plan

- [ ] `npm --prefix frontend run test -- --run` passes: all AllocationCharts tests green, including `warns in dev for dropped Infinity values` and `warns in dev for dropped NaN values`
- [ ] No other tests regressed

Closes #3082

🤖 Generated with [Claude Code](https://claude.com/claude-code)