### PR TITLE
fix(ci): remove --cli-binary-format flag from lambda invoke — AWS CLI v1 incompatible

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -181,7 +181,6 @@ jobs:
           response_file="$(mktemp)"
           invoke_meta="$(aws lambda invoke \
             --function-name "${refresh_fn}:live" \
-            --cli-binary-format raw-in-base64-out \
             "$response_file")"
           python - "$invoke_meta" "$response_file" <<'PY'
           import json


### PR DESCRIPTION
## Summary

- Removes `--cli-binary-format raw-in-base64-out` from the `aws lambda invoke` call in the "Warm price snapshot" CI step
- This one-line deletion unblocks the entire deploy pipeline and restores smoke-test execution

## Problem

Every deploy since the "Warm price snapshot" step was introduced has been failing at step 21/~30 with:

```
Unknown options: --cli-binary-format, /tmp/tmp.w58bH8jAFY
##[error]Process completed with exit code 255.
```

`--cli-binary-format raw-in-base64-out` is an **AWS CLI v2-only flag**. The `ubuntu-latest` runner ships with AWS CLI v1, which rejects it. No `--payload` argument is passed to this `lambda invoke` call, so the flag was always redundant — it controlled binary encoding of payloads that don't exist here.

## Test plan

- [ ] Verify the "Warm price snapshot" step passes in the next deploy run
- [ ] Confirm the smoke-test job now runs (previously blocked by `success()` evaluating to `false`)
- [ ] Check no regression in the lambda invocation response-validation logic

Closes #3086

🤖 Generated with [Claude Code](https://claude.com/claude-code)