### PR TITLE
fix(tests): eliminate act() warnings and guard fetch in InstrumentResearch tests

### DIFF
--- a/frontend/tests/unit/pages/InstrumentResearch.test.tsx
+++ b/frontend/tests/unit/pages/InstrumentResearch.test.tsx
@@ -89,18 +89,22 @@ function renderPage(config?: Partial<ConfigContextValue>) {
 }
 
 describe("InstrumentResearch page", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   beforeEach(() => {
+    // Safety net: return an empty-array JSON response for any fetch call that
+    // escapes the @/api mocks (e.g. in CI environments). All intentional API
+    // calls go through the vi.mock("@/api") module above and never reach the
+    // global fetch. Using mockImplementation (not mockResolvedValue) so that
+    // each intercepted call receives its own fresh Response instance — a
+    // single Response body can only be consumed once.
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(
-        new Response(JSON.stringify([]), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
       ),
     );
 
@@ -212,6 +216,10 @@ describe("InstrumentResearch page", () => {
     ];
     mockListInstrumentMetadata.mockResolvedValue(catalogue);
     mockUpdateInstrumentMetadata.mockResolvedValue({} as any);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders overview summary and defers chart to timeseries tab", async () => {

--- a/frontend/tests/unit/pages/InstrumentResearch.test.tsx
+++ b/frontend/tests/unit/pages/InstrumentResearch.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 vi.mock("@/hooks/useInstrumentHistory", () => ({
   useInstrumentHistory: vi.fn(),
   getCachedInstrumentHistory: vi.fn(() => null),
@@ -89,7 +89,21 @@ function renderPage(config?: Partial<ConfigContextValue>) {
 }
 
 describe("InstrumentResearch page", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
     mockUseInstrumentHistory.mockReset();
     mockUseInstrumentHistory.mockReturnValue({
       data: {
@@ -411,11 +425,13 @@ describe("InstrumentResearch page", () => {
     expect(await screen.findByText("Watchlist Page")).toBeInTheDocument();
   });
 
-  it("hides navigation links when corresponding tab is disabled", () => {
+  it("hides navigation links when corresponding tab is disabled", async () => {
     renderPage({
       tabs: { screener: false, watchlist: false },
       disabledTabs: ["screener", "watchlist"],
     });
+    // Await catalogue load so async state updates settle before assertions
+    await screen.findByRole("heading", { level: 1 });
     expect(
       screen.queryByRole("link", { name: /View Screener/i }),
     ).not.toBeInTheDocument();

--- a/frontend/tests/unit/pages/InstrumentResearch.test.tsx
+++ b/frontend/tests/unit/pages/InstrumentResearch.test.tsx
@@ -430,8 +430,11 @@ describe("InstrumentResearch page", () => {
       tabs: { screener: false, watchlist: false },
       disabledTabs: ["screener", "watchlist"],
     });
-    // Await catalogue load so async state updates settle before assertions
-    await screen.findByRole("heading", { level: 1 });
+    // Wait for the h1 that contains the catalogue name: this element is absent
+    // on initial render (displayName is null until listInstrumentMetadata
+    // resolves) and only appears once the async state update has flushed,
+    // making it a reliable post-fetch sentinel.
+    await screen.findByRole("heading", { level: 1, name: /Acme Corp/ });
     expect(
       screen.queryByRole("link", { name: /View Screener/i }),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Converts the only synchronous test (`"hides navigation links when corresponding tab is disabled"`) to async and awaits the page heading after render, so `listInstrumentMetadata` and `getNews` mock promises fully settle before the test exits — eliminating all `act()` warnings.
- Adds `vi.stubGlobal('fetch', ...)` in `beforeEach` (restored in `afterEach` via `vi.unstubAllGlobals()`) so any fetch call that escapes the `@/api` mocks in CI returns a clean empty response instead of `TypeError: fetch failed`.
- All 20 tests continue to pass.

## Test plan

- [ ] `npm --prefix frontend run test -- --run tests/unit/pages/InstrumentResearch.test.tsx` passes with 20/20 tests and no `act()` warnings in stderr
- [ ] No regressions: `npm --prefix frontend run test -- --run` passes across the full suite

Closes #3087

🤖 Generated with [Claude Code](https://claude.com/claude-code)