### PR TITLE
fix(types): update recharts Tooltip formatter signatures for 3.8.1 compatibility

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -935,9 +935,9 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
                 ))}
               </Pie>
               <Tooltip
-                formatter={(v: number | undefined, n?: string) => [
-                  money(v, baseCurrency),
-                  n ?? "",
+                formatter={(v, n) => [
+                  money(v as number | undefined, baseCurrency),
+                  (n as string | undefined) ?? "",
                 ]}
               />
               <Legend />
@@ -972,14 +972,14 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
           >
             <BarChart
               data={
-                contribTab === "sector"
+                (contribTab === "sector"
                   ? sectorContrib || []
-                  : regionContrib || []
+                  : regionContrib || []) as (SectorContribution | RegionContribution)[]
               }
             >
               <XAxis dataKey={contribTab === "sector" ? "sector" : "region"} />
               <YAxis />
-              <Tooltip formatter={(v: number | undefined) => money(v, baseCurrency)} />
+              <Tooltip formatter={(v) => money(v as number | undefined, baseCurrency)} />
               <Bar dataKey="gain_gbp">
                 {(contribTab === "sector" ? sectorContrib : regionContrib)?.map(
                   (row, idx) => (

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -313,8 +313,8 @@ export function PerformanceDashboard({ owner, asOf }: Props) {
                     tickFormatter={(v) => percent(v * 100, 1, i18n.language)}
                   />
                   <Tooltip
-                    formatter={(value: number | undefined) =>
-                      percent((value ?? 0) * 100, 2, i18n.language)
+                    formatter={(value) =>
+                      percent(((value as number | undefined) ?? 0) * 100, 2, i18n.language)
                     }
                   />
                   {drawdownPeak && drawdownTrough && (
@@ -394,7 +394,7 @@ export function PerformanceDashboard({ owner, asOf }: Props) {
         <LineChart data={data}>
           <XAxis dataKey="date" />
           <YAxis tickFormatter={(v) => percent(v * 100, 2, i18n.language)} />
-          <Tooltip formatter={(v: number | undefined) => percent((v ?? 0) * 100, 2, i18n.language)} />
+          <Tooltip formatter={(v) => percent(((v as number | undefined) ?? 0) * 100, 2, i18n.language)} />
           <Line
             type="monotone"
             dataKey="cumulative_return"

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -403,7 +403,7 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
                         <BarChart data={sectorContrib}>
                           <XAxis dataKey="sector" interval={0} angle={-35} textAnchor="end" height={70} />
                           <YAxis />
-                          <Tooltip formatter={(v: number | undefined) => money(v, baseCurrency)} />
+                          <Tooltip formatter={(v) => money(v as number | undefined, baseCurrency)} />
                           <Bar dataKey="gain_gbp">
                             {sectorContrib.map((row, idx) => (
                               <Cell

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -276,14 +276,14 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
                 ))}
               </Pie>
               <Tooltip
-                formatter={(v: number | undefined, _n?: string, item?: any) =>
+                formatter={(v, _n, item) =>
                   relativeViewEnabled
                     ? `${
                         total
-                          ? ((item?.payload?.value / total) * 100).toFixed(2)
+                          ? (((item as any)?.payload?.value / total) * 100).toFixed(2)
                           : "0.00"
                       }%`
-                    : money(v, baseCurrency)
+                    : money(v as number | undefined, baseCurrency)
                 }
               />
               <Legend

--- a/frontend/src/pages/PortfolioDashboard.tsx
+++ b/frontend/src/pages/PortfolioDashboard.tsx
@@ -114,7 +114,7 @@ function PortfolioDashboard({
         <LineChart data={data}>
           <XAxis dataKey="date" />
           <YAxis tickFormatter={(v) => percent(v * 100)} />
-          <Tooltip formatter={(v: number | undefined) => percent((v ?? 0) * 100)} />
+          <Tooltip formatter={(v) => percent(((v as number | undefined) ?? 0) * 100)} />
           <Line
             type="monotone"
             dataKey="cumulative_return"


### PR DESCRIPTION
## Summary

Closes #3091

- In recharts 3.8.1 the `Formatter<ValueType, NameType>` type broadened `value` from `number` to `ValueType` (`string | number | (string | number)[]`). This broke the `type-check` step in CI on the dependabot recharts bump PR #3044.
- Removes explicit `number | undefined` parameter annotations from `Tooltip formatter` callbacks in 5 files and casts internally (`v as number | undefined`) so the signatures satisfy the updated constraint while remaining backward-compatible with recharts 3.6.x.
- Also casts the `BarChart` `data` union (`SectorContribution[] | RegionContribution[]`) to `(SectorContribution | RegionContribution)[]` to fix the stricter `ChartData<T>` inference added in 3.8.1.

## Files changed

- `frontend/src/components/GroupPortfolioView.tsx` — 3 formatters + BarChart data cast
- `frontend/src/components/PerformanceDashboard.tsx` — 2 formatters
- `frontend/src/components/PortfolioView.tsx` — 1 formatter
- `frontend/src/pages/AllocationCharts.tsx` — 1 formatter
- `frontend/src/pages/PortfolioDashboard.tsx` — 1 formatter

## Test plan

- [x] `npm --prefix frontend run type-check` passes clean with recharts 3.8.1
- [x] `npm --prefix frontend run type-check` passes clean with recharts 3.6.0 (no regression)
- [ ] Merge this PR first, then merge/rebase the dependabot recharts PR #3044 — CI should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)