### PR TITLE
fix(tests): prevent StopIteration in background thread from test_sends_messages_after_ttl

### DIFF
--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -106,8 +106,19 @@ def test_sends_messages_after_ttl(monkeypatch):
     monkeypatch.setattr(telegram_utils.config.config, "telegram_bot_token", "T")
     monkeypatch.setattr(telegram_utils.config.config, "telegram_chat_id", "C")
 
-    times = iter([1000.0] * 3 + [1000.0 + telegram_utils.MESSAGE_TTL_SECONDS + 1] * 3)
-    monkeypatch.setattr(telegram_utils.time, "time", lambda: next(times))
+    # Use a state-based function rather than an exhaustible iterator so that
+    # background threads from the `limits` library (which also call time.time
+    # via the same global patch) cannot raise StopIteration in a daemon thread
+    # and corrupt a later test's result.
+    call_count = [0]
+
+    def fake_time() -> float:
+        call_count[0] += 1
+        if call_count[0] <= 3:
+            return 1000.0
+        return 1000.0 + telegram_utils.MESSAGE_TTL_SECONDS + 1
+
+    monkeypatch.setattr(telegram_utils.time, "time", fake_time)
     monkeypatch.setattr(telegram_utils.time, "sleep", lambda s: None)
 
     calls = []


### PR DESCRIPTION
## Summary

- Replaces the exhaustible `iter([...])` lambda in `test_sends_messages_after_ttl` with a stateful `fake_time()` function that never raises `StopIteration`
- No change to test logic or assertions — the observable behaviour (first call within TTL is deduplicated, second call after TTL goes through) is identical

## Root cause

`monkeypatch.setattr(telegram_utils.time, "time", lambda: next(times))` patches the global `time` module, so the `limits` library's background expiry thread (in `limits/storage/memory.py`) also calls the patched function. With only 6 iterator values the thread exhausts the iterator and raises `StopIteration` in a daemon thread. pytest captures this as an unhandled thread exception and reports it on the *next* test (`test_timeseries_api.py::test_timeseries_json`), masking the true source.

## Fix

```python
# before
times = iter([1000.0] * 3 + [1000.0 + telegram_utils.MESSAGE_TTL_SECONDS + 1] * 3)
monkeypatch.setattr(telegram_utils.time, "time", lambda: next(times))

# after
call_count = [0]
def fake_time() -> float:
    call_count[0] += 1
    if call_count[0] <= 3:
        return 1000.0
    return 1000.0 + telegram_utils.MESSAGE_TTL_SECONDS + 1
monkeypatch.setattr(telegram_utils.time, "time", fake_time)
```

Closes #3094