### PR TITLE
fix(lint): resolve no-useless-assignment errors introduced by eslint/js 10

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -455,7 +455,7 @@ const exchangeCognitoForBackendToken = async (
 };
 
 const bootstrapRuntimeConfig = async () => {
-  let payload: { apiBaseUrl?: unknown; awsUiAuth?: AwsUiAuthConfig } = {};
+  let payload: { apiBaseUrl?: unknown; awsUiAuth?: AwsUiAuthConfig } | undefined;
   try {
     const response = await fetch('/config.json', { cache: 'no-store' });
     if (!response.ok) return true;
@@ -470,6 +470,8 @@ const bootstrapRuntimeConfig = async () => {
     );
     return true;
   }
+
+  if (!payload) return true;
 
   if (typeof payload.apiBaseUrl === 'string') {
     setApiBase(payload.apiBaseUrl);

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -23,7 +23,7 @@ export function Portfolio() {
   const { owner: ownerParam } = useParams<{ owner?: string }>();
   const ownerSlug = ownerParam?.trim() ?? "";
 
-  let routeContext: ReturnType<typeof useRoute> | null = null;
+  let routeContext: ReturnType<typeof useRoute> | null;
   try {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     routeContext = useRoute();

--- a/frontend/tests/unit/rootBootstrap.test.tsx
+++ b/frontend/tests/unit/rootBootstrap.test.tsx
@@ -150,7 +150,6 @@ describe('Root bootstrap integration coverage', () => {
     })
 
     vi.doMock('@/App.tsx', async () => {
-      const React = await import('react')
       const { useAuth } = await import('@/AuthContext')
       const { useUser } = await import('@/UserContext')
       function RestoredSessionApp() {


### PR DESCRIPTION
## Summary

ESLint 10 (landed via dependabot [PR #3134](https://github.com/leonarduk/allotmint/pull/3134)) ships a stricter `no-useless-assignment` rule that flags three places where an initial variable assignment is always overwritten before being read.

## Changes

| File | Problem | Fix |
|------|---------|-----|
| `frontend/src/main.tsx:458` | `payload` initialised to `{}` but always reassigned inside the `try` before being read; all other paths `return true` | Declare as `\| undefined`; add a narrow-to-defined guard after the `try`-catch |
| `frontend/src/pages/Portfolio.tsx:26` | `routeContext` initialised to `null` but both `try` and `catch` branches always reassign it | Remove the useless initialiser; TypeScript CFA keeps it definitely-assigned |
| `frontend/tests/unit/rootBootstrap.test.tsx:153` | `React` imported via dynamic `import('react')` but never referenced — automatic JSX transform handles it | Remove the unused import |

## Verification

```
npm --prefix frontend run lint
```
→ exits 0, no warnings.

Closes #3139

🤖 Generated with [Claude Code](https://claude.com/claude-code)