### PR TITLE
Potential fix for code scanning alert no. 153: Log Injection

### DIFF
--- a/backend/utils/fx_rates.py
+++ b/backend/utils/fx_rates.py
@@ -7,6 +7,15 @@ import yfinance as yf
 
 logger = logging.getLogger(__name__)
 
+
+def _safe_for_log(value: object) -> str:
+    """Return a single-line, printable representation safe for plain-text logs."""
+
+    text = str(value)
+    text = text.replace("\r", "").replace("\n", "")
+    return "".join(ch if ch.isprintable() else "?" for ch in text)
+
+
 # Map of base -> quote -> ticker used by yfinance.  When a pair is missing we
 # fall back to the generic "BASEQUOTE=X" symbol which Yahoo Finance supports for
 # most combinations.
@@ -58,7 +67,12 @@ def fetch_fx_rate_range(base: str, quote: str, start_date: date, end_date: date)
             df["Date"] = pd.to_datetime(df["Date"]).dt.date
             return df[["Date", "Close"]].rename(columns={"Close": "Rate"}).copy()
     except Exception as exc:
-        logger.info("FX fetch failed for %s/%s: %s", base, quote, exc)
+        logger.info(
+            "FX fetch failed for %s/%s: %s",
+            _safe_for_log(base),
+            _safe_for_log(quote),
+            _safe_for_log(exc),
+        )
 
     dates = pd.bdate_range(start_date, end_date).date
     const = FALLBACK_RATES.get((base, quote))

--- a/tests/utils/test_fx_rates.py
+++ b/tests/utils/test_fx_rates.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 import yfinance as yf
 
-from backend.utils.fx_rates import fetch_fx_rate_range
+from backend.utils.fx_rates import _safe_for_log, fetch_fx_rate_range
 
 
 def _fake_df(start, end):
@@ -83,3 +83,20 @@ def test_fetch_fx_rate_same_currency():
     fetch_fx_rate_range.cache_clear()
     df = fetch_fx_rate_range("USD", "USD", start, end)
     assert list(df["Rate"]) == [1.0, 1.0, 1.0]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("USD", "USD"),
+        ("USD\nGBP", "USDGBP"),
+        ("USD\rGBP", "USDGBP"),
+        ("USD\r\nGBP", "USDGBP"),
+        ("abc\x00def", "abc?def"),
+        ("\x1b[31mred\x1b[0m", "?[31mred?[0m"),
+        (RuntimeError("boom\nboom"), "boomboom"),
+        (123, "123"),
+    ],
+)
+def test_safe_for_log(value, expected):
+    assert _safe_for_log(value) == expected


### PR DESCRIPTION
Closes #3146

Potential fix for [https://github.com/leonarduk/allotmint/security/code-scanning/153](https://github.com/leonarduk/allotmint/security/code-scanning/153)

The best fix is to normalize log-bound dynamic values by removing CR/LF and other non-printable/control characters before passing them to the logger. This preserves functionality while preventing log-forging via newline injection.

In `backend/utils/fx_rates.py`, add a small helper (e.g. `_safe_for_log`) and use it in the `except` block at line 61 for `base`, `quote`, and `exc`. This is the minimal, targeted fix that addresses all alert variants converging on this sink without changing business logic or API behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
