### PR TITLE
Potential fix for code scanning alert no. 31: Reflected server-side cross-site scripting

### DIFF
--- a/backend/routes/timeseries_meta.py
+++ b/backend/routes/timeseries_meta.py
@@ -1,3 +1,4 @@
+import html
 import logging
 from datetime import date
 
@@ -109,12 +110,15 @@ async def get_meta_timeseries(
 
     # ── HTML output (default) ─────────────────────────────────
     html_table = df.to_html(index=False)
+    safe_symbol = html.escape(f"{ticker}.{exchange}")
+    safe_date_range = html.escape(f"{start_date} to {end_date}")
+    safe_scaling = html.escape(str(scaling))
     html_doc = f"""
     <html>
-        <head><title>{ticker}.{exchange} Price History</title></head>
+        <head><title>{safe_symbol} Price History</title></head>
         <body>
-            <h1>{ticker}.{exchange} - {start_date} to {end_date}</h1>
-            <p><strong>Scaling:</strong> {scaling}x</p>
+            <h1>{safe_symbol} - {safe_date_range}</h1>
+            <p><strong>Scaling:</strong> {safe_scaling}x</p>
             {html_table}
         </body>
     </html>


### PR DESCRIPTION
Potential fix for [https://github.com/leonarduk/allotmint/security/code-scanning/31](https://github.com/leonarduk/allotmint/security/code-scanning/31)

The correct fix is to HTML-escape all user-influenced values before inserting them into `html_doc`. In this file, the best minimal change is to use `html.escape` from Python’s standard library and apply it to:
- the combined ticker/exchange label used in `<title>` and `<h1>`
- rendered date strings used in `<h1>` (defensive consistency)
- the scaling display value used in `<p>`

Keep JSON/CSV behavior unchanged and avoid altering endpoint functionality.  
Concretely in `backend/routes/timeseries_meta.py`:
1. Add `import html` near existing imports.
2. In the HTML output block, create escaped display variables (`safe_symbol`, `safe_date_range`, `safe_scaling`) and use them in the f-string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
