### PR TITLE
Potential fix for code scanning alert no. 60: Partial server-side request forgery

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from datetime import date, datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Callable, Dict
+from urllib.parse import quote
 
 import boto3
 import pandas as pd
@@ -468,7 +470,13 @@ def _convert_to_base_currency(
         return df
 
     def _load_rates(curr: str) -> pd.DataFrame:
-        curr = curr.upper()
+        curr = (curr or "").strip().upper()
+        allowed_currencies = {ccy.upper() for ccy in EXCHANGE_TO_CCY.values()}
+        allowed_currencies.add("GBP")
+        if not re.fullmatch(r"[A-Z]{3}", curr) or curr not in allowed_currencies:
+            logger.warning("Invalid/unsupported FX currency code: %r", curr)
+            return pd.DataFrame(columns=["Date", "Rate"])
+
         if OFFLINE_MODE:
             path = _cache_path("fx", f"{curr}.parquet")
             try:
@@ -480,7 +488,8 @@ def _convert_to_base_currency(
 
             if fx.empty and getattr(config, "fx_proxy_url", None):
                 try:
-                    url = f"{config.fx_proxy_url.rstrip('/')}/{curr}"
+                    safe_curr = quote(curr, safe="")
+                    url = f"{config.fx_proxy_url.rstrip('/')}/{safe_curr}"
                     params = {"start": start.isoformat(), "end": end.isoformat()}
                     resp = requests.get(url, params=params, timeout=5)
                     if resp.ok:

--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -67,6 +67,11 @@ EXCHANGE_TO_CCY = {
 }
 
 
+def _sanitize_for_log(value: object) -> str:
+    """Return a single-line representation safe for plain-text logs."""
+    return str(value).replace("\r", "").replace("\n", "")
+
+
 def _empty_ts() -> pd.DataFrame:
     """Guaranteed-schema empty frame."""
     return pd.DataFrame(columns=EXPECTED_COLS)
@@ -471,10 +476,8 @@ def _convert_to_base_currency(
 
     def _load_rates(curr: str) -> pd.DataFrame:
         curr = (curr or "").strip().upper()
-        allowed_currencies = {ccy.upper() for ccy in EXCHANGE_TO_CCY.values()}
-        allowed_currencies.add("GBP")
-        if not re.fullmatch(r"[A-Z]{3}", curr) or curr not in allowed_currencies:
-            logger.warning("Invalid/unsupported FX currency code: %r", curr)
+        if not re.fullmatch(r"[A-Z]{3}", curr):
+            logger.warning("Invalid/unsupported FX currency code: %s", _sanitize_for_log(curr))
             return pd.DataFrame(columns=["Date", "Rate"])
 
         if OFFLINE_MODE:


### PR DESCRIPTION
Potential fix for [https://github.com/leonarduk/allotmint/security/code-scanning/60](https://github.com/leonarduk/allotmint/security/code-scanning/60)

Best fix: enforce a strict server-side allowlist for FX currency codes before building the proxy URL, and safely join the URL path segment with percent-encoding. This preserves functionality for valid FX lookups while blocking attacker-controlled path/query injection.

In `backend/timeseries/cache.py`, update `_load_rates` inside `_convert_to_base_currency`:
- Validate normalized `curr` against a strict regex (3 uppercase letters).
- Optionally allow only known currencies from existing mapping plus `GBP` to preserve expected behavior and reduce attack surface.
- If invalid, log and return empty dataframe (same graceful failure pattern used elsewhere).
- Build URL using encoded path segment (`urllib.parse.quote`) before `requests.get`.

No behavior change for valid inputs; invalid/unexpected currency values are rejected before outbound HTTP.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
