### PR TITLE
fix: grant deploy role s3:GetObject on prices/latest_prices.json; fix cdk diff --all

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -122,7 +122,7 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
-        run: npx cdk diff --all -c prod=true
+        run: npx cdk diff BackendLambdaStack StaticSiteStack -c prod=true
         working-directory: cdk
 
       - name: Deploy StaticSiteStack auth resources

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -584,6 +584,15 @@ class BackendLambdaStack(Stack):
             # run. The grant targets the alias ARN (function:live) to match the qualified
             # invocation in the workflow. See issue #3137.
             refresh_alias.grant_invoke(github_role)
+            # Allow the same step to verify the snapshot landed in S3 via head-object.
+            # HeadObject is authorised by s3:GetObject in IAM (no separate s3:HeadObject
+            # action exists). Scoped to the single key the workflow checks. See issue #3149.
+            github_role.add_to_principal_policy(
+                iam.PolicyStatement(
+                    actions=["s3:GetObject"],
+                    resources=[data_bucket.arn_for_objects("prices/latest_prices.json")],
+                )
+            )
 
         CfnOutput(
             self,

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -594,6 +594,73 @@ def test_no_lambda_invoke_grant_when_github_deploy_role_arn_absent(monkeypatch) 
     )
 
 
+def _s3_getobject_resources_for_role_name(raw_template: dict, role_name: str) -> list[str]:
+    """Return Resource ARNs from s3:GetObject statements for an imported role.
+
+    Follows the same pattern as _lambda_invoke_resources_for_role_name: CDK's
+    add_to_principal_policy on a mutable imported role emits AWS::IAM::Policy with the
+    role name as a plain string in the Roles list.
+    """
+    found: list[str] = []
+    for res in raw_template["Resources"].values():
+        if res.get("Type") != "AWS::IAM::Policy":
+            continue
+        if role_name not in res.get("Properties", {}).get("Roles", []):
+            continue
+        for stmt in res["Properties"]["PolicyDocument"].get("Statement", []):
+            actions = stmt.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+            if "s3:GetObject" not in actions:
+                continue
+            resources = stmt.get("Resource", [])
+            if isinstance(resources, (str, dict)):
+                resources = [resources]
+            for r in resources:
+                found.append(r if isinstance(r, str) else str(r))
+    return found
+
+
+def test_github_deploy_role_can_read_price_snapshot_from_s3(monkeypatch) -> None:
+    """When GITHUB_DEPLOY_ROLE_ARN is set, CDK must grant s3:GetObject on
+    prices/latest_prices.json so the 'Warm price snapshot' step can call head-object
+    to verify the snapshot landed after invoking PriceRefreshLambda. See issue #3149."""
+    role_arn = "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    monkeypatch.setenv("GITHUB_DEPLOY_ROLE_ARN", role_arn)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackS3GetObjectTest")
+    raw = Template.from_stack(stack).to_json()
+
+    resources = _s3_getobject_resources_for_role_name(raw, "allotmint-github-deploy")
+    assert resources, (
+        "Deploy role has no s3:GetObject policy statement; "
+        "add_to_principal_policy(s3:GetObject) must not have been called"
+    )
+    resources_str = str(resources)
+    assert "prices/latest_prices.json" in resources_str, (
+        f"s3:GetObject grant must target prices/latest_prices.json, got: {resources_str}"
+    )
+
+
+def test_no_s3_getobject_grant_when_github_deploy_role_arn_absent(monkeypatch) -> None:
+    """When GITHUB_DEPLOY_ROLE_ARN is unset, no s3:GetObject policy for the deploy role
+    is synthesised (Lambda roles have their own separate grants)."""
+    monkeypatch.delenv("GITHUB_DEPLOY_ROLE_ARN", raising=False)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackNoS3GetObjectTest")
+    resources = _s3_getobject_resources_for_role_name(
+        Template.from_stack(stack).to_json(), "allotmint-github-deploy"
+    )
+    assert not resources, (
+        f"Expected no s3:GetObject for deploy role when GITHUB_DEPLOY_ROLE_ARN is unset; "
+        f"found: {resources}"
+    )
+
+
 def test_grant_bucket_access_raises_on_no_permissions() -> None:
     class _MockFn:
         def add_to_role_policy(self, policy_statement: object) -> None:


### PR DESCRIPTION
## Summary

- Adds `s3:GetObject` on `prices/latest_prices.json` to the GitHub deploy role in the CDK stack so the "Warm price snapshot" step can call `head-object` after invoking PriceRefreshLambda without hitting 403 Forbidden.
- Fixes `cdk diff --all` (unrecognised flag, silently dropped) to `cdk diff BackendLambdaStack StaticSiteStack` so CDK can attempt a changeset-based diff.
- Adds two tests to `test_backend_lambda_stack_permissions.py` covering the new grant.

## Root cause

The "Warm price snapshot" step was added in #3137 with the Lambda invoke grant, but the step also calls `aws s3api head-object` to verify the snapshot — and that call requires `s3:GetObject`, which was never granted to the deploy role. Every deploy since then has failed at step 22 with `403 Forbidden`, preventing smoke tests from running.

```
An error occurred (403) when calling the HeadObject operation: Forbidden
##[error]Process completed with exit code 255.
```

## Test plan

- [ ] `python -m pytest cdk/tests/test_backend_lambda_stack_permissions.py -v` — all existing + 2 new tests pass
- [ ] Deploy pipeline reaches smoke tests on next tagged release

Closes #3149
Relates to #3150