### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -76,7 +76,7 @@ jobs:
           pytest tests/test_backend_api.py::test_health tests/test_accounts_api.py --cov=backend --cov-append --cov-report=xml --cov-report=term --cov-fail-under=80 -q
 
       - name: Upload backend coverage reports to Codecov
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: leonarduk/allotmint

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -18,7 +18,7 @@ jobs:
         run: python scripts/check_contract_version_sync.py
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
         with:
           version: 8
 
@@ -44,7 +44,7 @@ jobs:
         run: pnpm test -- --run --coverage
 
       - name: Upload frontend coverage reports to Codecov
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: leonarduk/allotmint


### PR DESCRIPTION
## Summary

- Pin `pnpm/action-setup` from `v6.0.8` to commit SHA `0e279bb959325dab635dd2c09392533439d90093` in `frontend-tests.yml`
- Pin `codecov/codecov-action` from `v6.0.1` to commit SHA `e79a6962e0d4c0c17b229090214935d2e33f8354` in both `frontend-tests.yml` and `backend-integration.yml`
- Tag names preserved as inline comments for readability

Resolves 3 CodeQL `actions/unpinned-tag` alerts (#219, #220, #221).

Closes #3154

## Test plan

- [ ] Verify CI workflows pass with the pinned SHAs
- [ ] Confirm CodeQL no longer flags these three steps after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)