### PR TITLE
fix: avoid logging env-var-derived path in smoke test (CodeQL #32)

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -96,7 +96,7 @@ function computeSmokeDeathAge(identity: string): string {
       return String(retirementAge + 20);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.warn(`Unable to derive smoke pension death age from ${personPath}: ${message}`);
+      console.warn(`Unable to derive smoke pension death age for identity '${slug}': ${message}`);
     }
   }
 

--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -94,8 +94,9 @@ function computeSmokeDeathAge(identity: string): string {
       }
       const retirementAge = statePensionAgeUk(dob);
       return String(retirementAge + 20);
-    } catch {
-      console.warn(`Unable to derive smoke pension death age for identity '${slug}': person.json missing or unreadable`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Unable to derive smoke pension death age for identity '${slug}': ${message}`);
     }
   }
 

--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -94,9 +94,8 @@ function computeSmokeDeathAge(identity: string): string {
       }
       const retirementAge = statePensionAgeUk(dob);
       return String(retirementAge + 20);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`Unable to derive smoke pension death age for identity '${slug}': ${message}`);
+    } catch {
+      console.warn(`Unable to derive smoke pension death age for identity '${slug}': person.json missing or unreadable`);
     }
   }
 


### PR DESCRIPTION
## Summary

- Replace `${personPath}` (tainted by `process.env.ACCOUNTS_ROOT`) in the `console.warn` call at `scripts/frontend-backend-smoke.ts:99` with the safe identity `${slug}`, eliminating the CodeQL `js/clear-text-logging` taint flow.

## Details

CodeQL alert [#32](https://github.com/leonarduk/allotmint/security/code-scanning/32) traced a taint path from `process.env.ACCOUNTS_ROOT` → `accountsRoot` → `personPath` → `console.warn(...)`. The logged path contained the raw env-var value in plain text.

The fix logs the `slug` (the identity string, e.g. `"demo"`) instead of the full derived filesystem path, which is both safer and equally useful for debugging.

## Test plan

- [ ] Confirm `npm --prefix frontend run lint` passes (TypeScript/ESLint)
- [ ] Confirm CodeQL re-scan no longer flags `scripts/frontend-backend-smoke.ts:99`

Closes #3157