### PR TITLE
security: add explicit permissions blocks to CI workflows

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   frontend-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -12,6 +12,11 @@ on:
     types: [opened, reopened, synchronize]
   push:
     branches: [main]
+
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   run-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves CodeQL alerts **#58** and **#59** (`actions/missing-workflow-permissions`) by adding explicit `permissions` blocks to both affected workflows, following the principle of least privilege.

## Changes

| Workflow | Permissions added | Reason |
|----------|-------------------|--------|
| `frontend-tests.yml` | `contents: read` | All steps are read-only; Codecov upload uses its own `CODECOV_TOKEN`, not `GITHUB_TOKEN` |
| `super-linter.yml` | `contents: read` + `statuses: write` | Super-linter posts commit status results via `GITHUB_TOKEN` |

## References

- CodeQL alert [#58](https://github.com/leonarduk/allotmint/security/code-scanning/58) — `frontend-tests.yml`
- CodeQL alert [#59](https://github.com/leonarduk/allotmint/security/code-scanning/59) — `super-linter.yml`
- GitHub Docs: [Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs)

Closes #3159