### PR TITLE
ci: fix deploy-lambda IAM race and StaticSiteStack prod-context asymmetry

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -131,7 +131,7 @@ jobs:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
-        run: npx cdk deploy StaticSiteStack --require-approval never
+        run: npx cdk deploy StaticSiteStack --require-approval never -c prod=true
         working-directory: cdk
 
       - name: Get Cognito UI auth outputs

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -219,11 +219,11 @@ jobs:
             if aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null 2>&1; then
               break
             fi
+            echo "head-object attempt $attempt/3 failed (IAM propagation delay); retrying in 20s..." >&2
+            sleep 20
             if [ "$attempt" -eq 3 ]; then
               aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null
             fi
-            echo "head-object attempt $attempt/3 failed (IAM propagation delay); retrying in 20s..." >&2
-            sleep 20
           done
 
       - name: Get backend API URL

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -219,11 +219,14 @@ jobs:
             if aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null 2>&1; then
               break
             fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "head-object failed on attempt 3/3; waiting 20s for IAM propagation before final check..." >&2
+              sleep 20
+              aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null
+              break
+            fi
             echo "head-object attempt $attempt/3 failed (IAM propagation delay); retrying in 20s..." >&2
             sleep 20
-            if [ "$attempt" -eq 3 ]; then
-              aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null
-            fi
           done
 
       - name: Get backend API URL

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -211,7 +211,20 @@ jobs:
           if not isinstance(payload, dict) or "snapshot" not in payload or "timestamp" not in payload:
               raise SystemExit(f"Unexpected PriceRefreshLambda response: {payload!r}")
           PY
-          aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null
+          # Retry with backoff: IAM policy changes are eventually consistent (~60s).
+          # On the first deploy after s3:GetObject is newly granted to the deploy role
+          # the role may get 403 for up to a minute even though CloudFormation has
+          # already reported UPDATE_COMPLETE. See issue #3166.
+          for attempt in 1 2 3; do
+            if aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null
+            fi
+            echo "head-object attempt $attempt/3 failed (IAM propagation delay); retrying in 20s..." >&2
+            sleep 20
+          done
 
       - name: Get backend API URL
         id: get_backend_url


### PR DESCRIPTION
## Summary

- **Fix #3166** — adds a retry loop (3 attempts, 20 s apart) around `aws s3api head-object` in the "Warm price snapshot" CI step, tolerating the IAM eventual-consistency window that caused the deploy to fail with `403 Forbidden`
- **Fix #3168** — adds `-c prod=true` to the step 19 `npx cdk deploy StaticSiteStack` call so it matches steps 18 (CDK diff) and 33 (final StaticSiteStack deploy); without it, step 19 synthesises `RemovalPolicy.DESTROY` for the Cognito UserPool and would revert the DeletionPolicy to `Delete` on the next deploy after step 33 first applies `Retain`

## Root cause — #3166 (IAM propagation race)

On the failing run, the CDK diff showed `s3:GetObject` being **added for the first time** to the GitHub deploy role. CloudFormation reported `UPDATE_COMPLETE` for `GithubDeployRole/Policy` at ~22:49:41; the `head-object` call ran 34 seconds later and received 403. IAM policy changes can take up to ~60 s to propagate, so the window was hit.

All other steps passed: 2284 backend tests, 463 frontend tests, CDK deploy itself, and the Lambda invocation inside the same step all succeeded.

## Root cause — #3168 (missing `-c prod=true`)

`npx cdk diff` (step 18) already uses `-c prod=true`. Step 33 also has it. Only step 19 was missing the flag, so it synthesised `RemovalPolicy.DESTROY` for the UserPool. On a normal deploy the deployed stack already has `DESTROY`, so no CloudFormation update is sent and the omission is invisible — until step 33 successfully applies `RETAIN`, at which point the *next* deploy's step 19 would synthesise `DESTROY` again and downgrade the protection.

## Test plan

- [ ] Confirm `deploy-lambda.yml` lints cleanly (no YAML errors)
- [ ] On next deploy, verify "Warm price snapshot" passes — on a normal deploy where the permission is already propagated the first attempt succeeds and exits immediately
- [ ] Verify CDK diff for StaticSiteStack shows no DeletionPolicy change on subsequent deploys

Closes #3166
Closes #3168
