### PR TITLE
fix: merge pytest config into pytest.ini — restore coverage enforcement and asyncio_mode=auto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,6 @@ test = [
     "pytest-asyncio~=1.3.0",
 ]
 
-[tool.pytest.ini_options]
-addopts = "--cov=backend --cov-fail-under=90"
-testpaths = ["tests"]
-asyncio_mode = "auto"
-markers = ["asyncio: mark tests that require asyncio support"]
-
 [tool.black]
 line-length = 100
 target-version = ["py311"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 pythonpath = . cdk
-addopts = --import-mode=importlib
+addopts = --import-mode=importlib --cov=backend --cov-fail-under=90
+asyncio_mode = auto
 filterwarnings =
     error::pytest.PytestUnhandledThreadExceptionWarning


### PR DESCRIPTION
## Summary

- Adds `--cov=backend --cov-fail-under=90` to `addopts` in `pytest.ini` so coverage is enforced in CI
- Adds `asyncio_mode = auto` to `pytest.ini` so pytest-asyncio runs in AUTO mode (not STRICT)
- Removes the now-redundant `[tool.pytest.ini_options]` block from `pyproject.toml` — pytest silently ignored it whenever `pytest.ini` was present

## Why it was broken

pytest's config resolution: when `pytest.ini` exists at the root it takes **exclusive precedence** — `[tool.pytest.ini_options]` is entirely skipped (CI showed `WARNING: ignoring pytest config in pyproject.toml!`). The coverage threshold and asyncio mode settings in `pyproject.toml` were therefore never active.

## Test plan

- [ ] CI passes with the merged `pytest.ini`
- [ ] CI pytest run shows `asyncio: mode=Mode.AUTO` instead of `Mode.STRICT`
- [ ] CI shows coverage enforced (`--cov-fail-under=90`); if coverage has drifted below 90%, that will surface as a failing step to be addressed separately

Closes #3169