### PR TITLE
fix(deploy): add s3:ListBucket to deploy role and distinguish 403 from 404 in snapshot verify

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -225,8 +225,7 @@ jobs:
             if [ "$attempt" -eq 5 ]; then
               echo "head-object failed on attempt 5/5; giving up." >&2
               echo "$head_out" >&2
-              aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null
-              break
+              exit 1
             fi
             echo "head-object attempt $attempt/5 failed (key not yet written); retrying in 20s..." >&2
             sleep 20

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -211,21 +211,24 @@ jobs:
           if not isinstance(payload, dict) or "snapshot" not in payload or "timestamp" not in payload:
               raise SystemExit(f"Unexpected PriceRefreshLambda response: {payload!r}")
           PY
-          # Retry with backoff: IAM policy changes are eventually consistent (~60s).
-          # On the first deploy after s3:GetObject is newly granted to the deploy role
-          # the role may get 403 for up to a minute even though CloudFormation has
-          # already reported UPDATE_COMPLETE. See issue #3166.
-          for attempt in 1 2 3; do
-            if aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null 2>&1; then
-              break
+          # Retry with backoff: the Lambda write may lag the invocation response.
+          # With s3:ListBucket now granted to the deploy role (issue #3191), a
+          # missing key returns 404 (retryable) instead of 403 (hard failure).
+          # 403 means a genuine permission problem — retrying will never help.
+          for attempt in 1 2 3 4 5; do
+            head_out="$(aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json 2>&1)" && break
+            if echo "$head_out" | grep -q "(403)"; then
+              echo "head-object returned 403 Forbidden — deploy role lacks s3:GetObject or s3:ListBucket on the data bucket. Check CDK grants for GITHUB_DEPLOY_ROLE_ARN. See issue #3191." >&2
+              echo "$head_out" >&2
+              exit 1
             fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "head-object failed on attempt 3/3; waiting 20s for IAM propagation before final check..." >&2
-              sleep 20
+            if [ "$attempt" -eq 5 ]; then
+              echo "head-object failed on attempt 5/5; giving up." >&2
+              echo "$head_out" >&2
               aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json >/dev/null
               break
             fi
-            echo "head-object attempt $attempt/3 failed (IAM propagation delay); retrying in 20s..." >&2
+            echo "head-object attempt $attempt/5 failed (key not yet written); retrying in 20s..." >&2
             sleep 20
           done
 

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -593,6 +593,17 @@ class BackendLambdaStack(Stack):
                     resources=[data_bucket.arn_for_objects("prices/latest_prices.json")],
                 )
             )
+            # Without s3:ListBucket a missing key returns HTTP 403 instead of 404,
+            # which makes it impossible to distinguish "no permission" from "file not
+            # written yet" in the retry loop. Scoped to the prices/ prefix only.
+            # See issue #3191.
+            github_role.add_to_principal_policy(
+                iam.PolicyStatement(
+                    actions=["s3:ListBucket"],
+                    resources=[data_bucket.bucket_arn],
+                    conditions={"StringLike": {"s3:prefix": ["prices", "prices/*"]}},
+                )
+            )
 
         CfnOutput(
             self,

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -644,6 +644,43 @@ def test_github_deploy_role_can_read_price_snapshot_from_s3(monkeypatch) -> None
     )
 
 
+def test_github_deploy_role_has_s3_listbucket_on_prices_prefix(monkeypatch) -> None:
+    """Deploy role must have s3:ListBucket conditioned on the prices/ prefix so that a
+    missing key returns 404 (not 403). Without ListBucket, AWS returns 403 for any
+    missing key, making it impossible to distinguish permission errors from write lag.
+    See issue #3191."""
+    role_arn = "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    monkeypatch.setenv("GITHUB_DEPLOY_ROLE_ARN", role_arn)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackListBucketTest")
+    raw = Template.from_stack(stack).to_json()
+
+    list_stmts = []
+    for res in raw["Resources"].values():
+        if res.get("Type") != "AWS::IAM::Policy":
+            continue
+        if "allotmint-github-deploy" not in res.get("Properties", {}).get("Roles", []):
+            continue
+        for stmt in res["Properties"]["PolicyDocument"].get("Statement", []):
+            actions = stmt.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+            if "s3:ListBucket" in actions:
+                list_stmts.append(stmt)
+
+    assert list_stmts, (
+        "Deploy role has no s3:ListBucket statement; "
+        "the CDK grant is missing — missing keys will return 403 instead of 404"
+    )
+    conditions = list_stmts[0].get("Condition", {})
+    prefixes = str(conditions)
+    assert "prices" in prefixes, (
+        f"s3:ListBucket must be conditioned on the prices/ prefix; got conditions: {conditions}"
+    )
+
+
 def test_no_s3_getobject_grant_when_github_deploy_role_arn_absent(monkeypatch) -> None:
     """When GITHUB_DEPLOY_ROLE_ARN is unset, no s3:GetObject policy for the deploy role
     is synthesised (Lambda roles have their own separate grants)."""


### PR DESCRIPTION
## Summary

- **CDK**: adds `s3:ListBucket` (conditioned on `prices/` prefix) to the GitHub deploy role alongside the existing `s3:GetObject` grant — without this, a missing key returns HTTP 403 instead of 404, making permission errors and write-lag indistinguishable
- **Workflow**: rewrites the `head-object` retry loop to fail immediately on 403 (permission error; retrying will never help) and retry on 404 (key not yet written); increases retry count from 3 to 5
- **Tests**: adds `test_github_deploy_role_has_s3_listbucket_on_prices_prefix` to cover the new CDK grant

## Root cause of the deploy failure

From log `logs_71561779839` (v0.16 tag deploy):
```
head-object attempt 1/3 failed (IAM propagation delay); retrying in 20s...
head-object attempt 2/3 failed (IAM propagation delay); retrying in 20s...
head-object failed on attempt 3/3; waiting 20s for IAM propagation before final check...
An error occurred (403) when calling the HeadObject operation: Forbidden
##[error]Process completed with exit code 255.
```

The existing grant (`s3:GetObject` on `prices/latest_prices.json`) is correct, but without `s3:ListBucket` AWS returns 403 for any key the caller cannot enumerate — whether that key exists or not. The retry loop treated every non-zero exit as an IAM-propagation transient, so it spun through all retries on what may have been a missing key or a genuine permission gap, always ending in 255.

## Test plan

- [ ] CDK unit tests pass: `cd cdk && python -m pytest tests/test_backend_lambda_stack_permissions.py -x -q`
- [ ] `cdk diff BackendLambdaStack` (with GITHUB_DEPLOY_ROLE_ARN set) shows the new `s3:ListBucket` policy statement in the diff
- [ ] Trigger a deploy: the `head-object` step should exit 0 on success, or print a clear `403 Forbidden — deploy role lacks permission` message and fail immediately on a real permission error

Closes #3191

🤖 Generated with [Claude Code](https://claude.com/claude-code)