### PR TITLE
feat(deploy): add IAM permission pre-flight gate before CDK deploy steps

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -90,6 +90,42 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
 
+      - name: Pre-flight IAM permission check
+        env:
+          GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        run: |
+          set -euo pipefail
+          data_bucket="$(aws cloudformation list-stack-resources \
+            --stack-name BackendLambdaStack \
+            --query "StackResourceSummaries[?starts_with(LogicalResourceId,'PortfolioDataBucket')].PhysicalResourceId|[0]" \
+            --output text 2>/dev/null || echo "")"
+          if [ -z "$data_bucket" ] || [ "$data_bucket" = "None" ]; then
+            echo "BackendLambdaStack not yet deployed or PortfolioDataBucket not found; skipping bucket-scoped permission checks."
+            data_bucket="*"
+          fi
+          required_checks=(
+            "cloudformation:CreateChangeSet"
+            "cloudformation:DescribeChangeSet"
+            "cloudformation:DeleteChangeSet"
+            "lambda:InvokeFunction"
+            "s3:GetObject"
+            "s3:ListBucket"
+            "logs:FilterLogEvents"
+          )
+          failed=0
+          for action in "${required_checks[@]}"; do
+            result="$(aws iam simulate-principal-policy \
+              --policy-source-arn "$GITHUB_DEPLOY_ROLE_ARN" \
+              --action-names "$action" \
+              --resource-arns "arn:aws:s3:::${data_bucket}" \
+              --query "EvaluationResults[0].EvalDecision" --output text 2>/dev/null || echo "error")"
+            if [ "$result" != "allowed" ]; then
+              echo "::error::Deploy role is missing $action (got: $result). Fix the CDK grant or base role policy before deploying." >&2
+              failed=1
+            fi
+          done
+          [ "$failed" -eq 0 ] || exit 1
+
       - name: Sync data from S3
         env:
           DATA_BUCKET: ${{ secrets.DATA_BUCKET }}

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -91,8 +91,16 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
 
       - name: Pre-flight IAM permission check
+        # Verifies that the deploy role has every permission needed by this
+        # workflow before spending ~8 minutes on CDK deploy.
+        # Each action is simulated against its correct resource ARN so that
+        # scoped grants (e.g. bucket-level s3:ListBucket vs object-level
+        # s3:GetObject) do not produce false implicitDeny results.
+        # If the role itself lacks iam:SimulatePrincipalPolicy the simulate
+        # call returns an error, which is surfaced as a distinct message so the
+        # operator knows to add that meta-permission to the base role.
         env:
-          GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         run: |
           set -euo pipefail
           data_bucket="$(aws cloudformation list-stack-resources \
@@ -100,27 +108,39 @@ jobs:
             --query "StackResourceSummaries[?starts_with(LogicalResourceId,'PortfolioDataBucket')].PhysicalResourceId|[0]" \
             --output text 2>/dev/null || echo "")"
           if [ -z "$data_bucket" ] || [ "$data_bucket" = "None" ]; then
-            echo "BackendLambdaStack not yet deployed or PortfolioDataBucket not found; skipping bucket-scoped permission checks."
+            echo "::notice::BackendLambdaStack not yet deployed or PortfolioDataBucket not found; using wildcard resource for permission checks."
             data_bucket="*"
           fi
-          required_checks=(
-            "cloudformation:CreateChangeSet"
-            "cloudformation:DescribeChangeSet"
-            "cloudformation:DeleteChangeSet"
-            "lambda:InvokeFunction"
-            "s3:GetObject"
-            "s3:ListBucket"
-            "logs:FilterLogEvents"
+
+          # Map each action to its correct resource ARN.
+          # s3:ListBucket acts on the bucket; s3:GetObject acts on objects.
+          # CloudFormation, Lambda, and logs actions are wildcarded because the
+          # deploy role's grants target multiple stacks/functions/log groups.
+          declare -A action_resource=(
+            ["cloudformation:CreateChangeSet"]="*"
+            ["cloudformation:DescribeChangeSet"]="*"
+            ["cloudformation:DeleteChangeSet"]="*"
+            ["lambda:InvokeFunction"]="*"
+            ["s3:ListBucket"]="arn:aws:s3:::${data_bucket}"
+            ["s3:GetObject"]="arn:aws:s3:::${data_bucket}/*"
+            ["logs:FilterLogEvents"]="*"
           )
+
           failed=0
-          for action in "${required_checks[@]}"; do
-            result="$(aws iam simulate-principal-policy \
-              --policy-source-arn "$GITHUB_DEPLOY_ROLE_ARN" \
+          for action in "${!action_resource[@]}"; do
+            resource="${action_resource[$action]}"
+            raw_result="$(aws iam simulate-principal-policy \
+              --policy-source-arn "$DEPLOY_ROLE_ARN" \
               --action-names "$action" \
-              --resource-arns "arn:aws:s3:::${data_bucket}" \
-              --query "EvaluationResults[0].EvalDecision" --output text 2>/dev/null || echo "error")"
-            if [ "$result" != "allowed" ]; then
-              echo "::error::Deploy role is missing $action (got: $result). Fix the CDK grant or base role policy before deploying." >&2
+              --resource-arns "$resource" \
+              --query "EvaluationResults[0].EvalDecision" --output text 2>&1)" \
+              || raw_result="error"
+            result="$(echo "$raw_result" | tail -1)"
+            if [ "$result" = "error" ] || echo "$result" | grep -qi "AccessDenied\|error"; then
+              echo "::error::simulate-principal-policy failed for $action — verify the deploy role has iam:SimulatePrincipalPolicy, then re-run." >&2
+              failed=1
+            elif [ "$result" != "allowed" ]; then
+              echo "::error::Deploy role is missing $action on $resource (got: $result). Fix the CDK grant or base role policy before deploying." >&2
               failed=1
             fi
           done


### PR DESCRIPTION
## Summary

- Adds a `Pre-flight IAM permission check` step immediately after `Configure AWS credentials` in the deploy workflow
- Uses `aws iam simulate-principal-policy` to verify all 7 permissions the deploy role needs before spending ~8 minutes on Docker build and CDK deploy
- Degrades gracefully on first-time bootstrap: if `BackendLambdaStack` doesn't exist yet, falls back to `arn:aws:s3:::*` and skips bucket-scoped checks with an informational message
- Each denied permission emits a `::error::` annotation with the specific action and a suggested fix

## Permissions checked

`cloudformation:CreateChangeSet`, `cloudformation:DescribeChangeSet`, `cloudformation:DeleteChangeSet`, `lambda:InvokeFunction`, `s3:GetObject`, `s3:ListBucket`, `logs:FilterLogEvents`

## Test plan

- [ ] Confirm step appears after `Configure AWS credentials` and before `Sync data from S3`
- [ ] Trigger a deploy with a role missing `s3:ListBucket` — step should fail immediately with a clear error annotation
- [ ] Trigger a deploy on a fresh account (no `BackendLambdaStack`) — step should log the skip message and pass

## Related

Closes #3199
Related: #3191 (original `s3:ListBucket` incident)
Related: #3196 (local pre-deploy-check script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)