### PR TITLE
fix(deploy): preserve AWS error message in preflight IAM check

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -164,12 +164,15 @@ jobs:
           simulate_unavailable=0
           for action in "${!action_resource[@]}"; do
             resource="${action_resource[$action]}"
+            # || true prevents set -e from aborting; 2>&1 already captures the real
+            # AWS error into raw_result. Using || raw_result="error" would overwrite
+            # the actual message and break the AccessDenied/SimulatePrincipalPolicy
+            # detection below. See issue #3226.
             raw_result="$(aws iam simulate-principal-policy \
               --policy-source-arn "$DEPLOY_ROLE_ARN" \
               --action-names "$action" \
               --resource-arns "$resource" \
-              --query "EvaluationResults[0].EvalDecision" --output text 2>&1)" \
-              || raw_result="error"
+              --query "EvaluationResults[0].EvalDecision" --output text 2>&1)" || true
             result="$(echo "$raw_result" | tail -1)"
             # Distinguish three cases:
             # 1. AccessDenied specifically for iam:SimulatePrincipalPolicy itself —
@@ -186,7 +189,7 @@ jobs:
               echo "::warning::simulate-principal-policy unavailable for $action — deploy role lacks iam:SimulatePrincipalPolicy. Run scripts/bash/bootstrap-deploy-role.sh to fix. See issue #3208." >&2
               echo "  Raw AWS response: $raw_result" >&2
               simulate_unavailable=1
-            elif [ "$result" = "error" ] || echo "$raw_result" | grep -qi "exception\|error\|AccessDenied"; then
+            elif echo "$raw_result" | grep -qi "exception\|error\|AccessDenied"; then
               # Use $raw_result (full response) not $result (last line only) to catch
               # multi-line AWS error payloads where the error type is on line 1.
               echo "::error::simulate-principal-policy call failed unexpectedly for $action. Raw response: $raw_result" >&2


### PR DESCRIPTION
## Summary

- Replaces `|| raw_result="error"` with `|| true` in the preflight `simulate-principal-policy` loop so `raw_result` retains the real AWS CLI output (captured by `2>&1`).
- Removes the now-dead `elif [ "$result" = "error" ]` arm; the broader `grep -qi "exception|error|AccessDenied"` check covers all non-allowed error cases.

## Root cause (from v0.16.2 deploy failure)

The `|| raw_result="error"` sentinel fired on any non-zero AWS CLI exit, **overwriting** the actual error message in `raw_result` with the literal string `"error"`. The graceful-degradation path (added for issue #3208) greps `raw_result` for `"AccessDenied"` and `"SimulatePrincipalPolicy"` — but those greps always failed against the literal string `"error"`, so every action fell through to the hard-fail branch. Result: all 7 preflight checks emitted `::error::` and the deploy job exited 1 before CDK even ran.

## Test plan

- [ ] Verify a role without `iam:SimulatePrincipalPolicy` now emits `::warning::` (not `::error::`) and the deploy proceeds to CDK.
- [ ] Verify a role with a genuine permission gap still emits `::error::` and blocks the deploy.

Closes #3226
Related to #3209