### PR TITLE
fix(security): log injection in compliance modules

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -13,6 +13,7 @@ from backend.common.instruments import get_instrument_meta
 from backend.common.path_utils import safe_join
 from backend.common.user_config import UserConfig, load_user_config
 from backend.config import config
+from backend.logging_setup import sanitise_log_value
 
 logger = logging.getLogger("compliance")
 
@@ -190,8 +191,8 @@ def _check_transactions(owner: str, txs: List[Dict[str, Any]], accounts_root: Op
             logger.info(
                 "%s MAX_TRADES_PER_MONTH %s %s",
                 datetime.now(UTC).isoformat(),
-                owner,
-                month,
+                sanitise_log_value(owner),
+                sanitise_log_value(month),
             )
 
     # holding period rule
@@ -223,8 +224,8 @@ def _check_transactions(owner: str, txs: List[Dict[str, Any]], accounts_root: Op
                 logger.info(
                     "%s HOLD_DAYS_MIN %s %s",
                     datetime.now(UTC).isoformat(),
-                    owner,
-                    ticker,
+                    sanitise_log_value(owner),
+                    sanitise_log_value(ticker),
                 )
 
             meta = get_instrument_meta(ticker)
@@ -252,8 +253,8 @@ def _check_transactions(owner: str, txs: List[Dict[str, Any]], accounts_root: Op
                     logger.info(
                         "%s APPROVAL_REQUIRED %s %s",
                         datetime.now(UTC).isoformat(),
-                        owner,
-                        ticker,
+                        sanitise_log_value(owner),
+                        sanitise_log_value(ticker),
                     )
             if positions.get(ticker, 0) <= 0:
                 positions.pop(ticker, None)

--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -145,7 +145,7 @@ async def compliance_for_owner(owner: str, request: Request):
         # forwarded directly to the client.
         return compliance.check_owner(owner, accounts_root)
     except FileNotFoundError as exc:
-        logger.warning("accounts for %s not found: %s", sanitise_log_value(owner), exc)
+        logger.warning("accounts for %s not found: %s", sanitise_log_value(owner), sanitise_log_value(exc))
         raise_owner_not_found()
 
 

--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -5,8 +5,9 @@ from fastapi import APIRouter, HTTPException, Request
 
 from backend.common import compliance, data_loader
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
-from backend.routes._accounts import resolve_accounts_root, resolve_owner_directory
 from backend.config import demo_identity
+from backend.logging_setup import sanitise_log_value
+from backend.routes._accounts import resolve_accounts_root, resolve_owner_directory
 
 router = APIRouter(tags=["compliance"])
 logger = logging.getLogger(__name__)
@@ -144,7 +145,7 @@ async def compliance_for_owner(owner: str, request: Request):
         # forwarded directly to the client.
         return compliance.check_owner(owner, accounts_root)
     except FileNotFoundError as exc:
-        logger.warning("accounts for %s not found: %s", owner, exc)
+        logger.warning("accounts for %s not found: %s", sanitise_log_value(owner), exc)
         raise_owner_not_found()
 
 
@@ -197,6 +198,6 @@ async def validate_trade(request: Request):
         try:
             compliance.ensure_owner_scaffold(trade["owner"], accounts_root)
         except Exception:
-            logger.warning("failed to scaffold compliance data for %s", trade.get("owner"))
+            logger.warning("failed to scaffold compliance data for %s", sanitise_log_value(trade.get("owner")))
 
     return result


### PR DESCRIPTION
## Summary

- Import `sanitise_log_value` from `backend.logging_setup` in `backend/common/compliance.py` and `backend/routes/compliance.py`
- Wrap all user-controlled values (`owner`, `ticker`, `month`) passed to `logger.info`/`logger.warning` calls with `sanitise_log_value()`
- Reuses the shared helper introduced in #3228 — no new utility code needed

Addresses CodeQL `py/log-injection` alerts #83, #86, #87, #88, #89, #90, #91, #92 (CWE-117).

Closes #3229

## Test plan

- [x] `python -m pytest tests/backend/ -q --no-cov` — 605 tests pass
- [x] `python -m ruff check backend/common/compliance.py backend/routes/compliance.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)