### PR TITLE
fix(security): add SSRF protection by validating API base URL

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -65,6 +65,24 @@ const cleanOptionalString = (value: unknown): string | null => {
   return trimmed ? trimmed : null;
 };
 
+const validateApiBase = (url: string): string => {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    throw new Error("API base URL cannot be empty");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Invalid API base URL: ${trimmed}`);
+  }
+  if (!/^https?:$/.test(parsed.protocol)) {
+    throw new Error(`API base URL must use http or https protocol, got: ${parsed.protocol}`);
+  }
+  const cleaned = trimmed.replace(/\/+$/, "");
+  return cleaned;
+};
+
 /* ------------------------------------------------------------------ */
 /* Base URL – can be overridden at runtime via /config.json.          */
 /* ------------------------------------------------------------------ */
@@ -72,14 +90,25 @@ export const DEFAULT_API_BASE =
   import.meta.env.VITE_ALLOTMINT_API_BASE ??
   import.meta.env.VITE_API_URL ??
   "http://localhost:8000";
-export let API_BASE = DEFAULT_API_BASE;
+
+let API_BASE: string;
+try {
+  API_BASE = validateApiBase(DEFAULT_API_BASE);
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  throw new Error(`Failed to initialize API base URL: ${msg}`);
+}
 
 export const getApiBase = () => API_BASE;
 
 export const setApiBase = (value: string | null | undefined) => {
-  const trimmed = value?.trim();
-  if (!trimmed) return;
-  API_BASE = trimmed.replace(/\/+$/, "");
+  if (!value) return;
+  try {
+    API_BASE = validateApiBase(value);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to set API base URL: ${msg}`);
+  }
 };
 
 export type StorageLike = {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -91,13 +91,17 @@ export const DEFAULT_API_BASE =
   import.meta.env.VITE_API_URL ??
   "http://localhost:8000";
 
-let API_BASE: string;
-try {
-  API_BASE = validateApiBase(DEFAULT_API_BASE);
-} catch (err) {
-  const msg = err instanceof Error ? err.message : String(err);
-  throw new Error(`Failed to initialize API base URL: ${msg}`, { cause: err });
-}
+// Validate at startup so a misconfigured URL surfaces immediately (CWE-918 fix).
+// The inner IIFE keeps the try/catch scoped while still producing an exported binding.
+// `let` (not `const`) because setApiBase() may reassign it at runtime.
+export let API_BASE: string = (() => {
+  try {
+    return validateApiBase(DEFAULT_API_BASE);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to initialize API base URL: ${msg}`, { cause: err });
+  }
+})();
 
 export const getApiBase = () => API_BASE;
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -96,7 +96,7 @@ try {
   API_BASE = validateApiBase(DEFAULT_API_BASE);
 } catch (err) {
   const msg = err instanceof Error ? err.message : String(err);
-  throw new Error(`Failed to initialize API base URL: ${msg}`);
+  throw new Error(`Failed to initialize API base URL: ${msg}`, { cause: err });
 }
 
 export const getApiBase = () => API_BASE;
@@ -107,7 +107,7 @@ export const setApiBase = (value: string | null | undefined) => {
     API_BASE = validateApiBase(value);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to set API base URL: ${msg}`);
+    throw new Error(`Failed to set API base URL: ${msg}`, { cause: err });
   }
 };
 

--- a/frontend/tests/unit/api.test.ts
+++ b/frontend/tests/unit/api.test.ts
@@ -267,14 +267,15 @@ describe("client-side request forgery guard (CodeQL #218)", () => {
   });
 
   it("throws a clear error when the configured API base is not a valid absolute URL", async () => {
-    setApiBase("not-a-valid-url");
-    const mockFetch = vi.fn();
-    // @ts-expect-error: replacing global fetch with mock
-    global.fetch = mockFetch;
-    await expect(fetchJson("/health")).rejects.toThrow(
+    // setApiBase() now validates eagerly, so the error is thrown there rather
+    // than deferred to fetchJson().  Test both that setApiBase rejects the bad
+    // value and that createClient with the same bad base also rejects fetchJson.
+    expect(() => setApiBase("not-a-valid-url")).toThrow("Invalid API base URL");
+
+    const { fetchJson: testFetchJson } = createClient("not-a-valid-url");
+    await expect(testFetchJson("/health")).rejects.toThrow(
       "API base is not a valid absolute URL",
     );
-    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("throws a clear error when resolveBase() returns an empty string", async () => {


### PR DESCRIPTION
## Summary

Resolves CodeQL alert `js/client-side-request-forgery` (CWE-918) in `frontend/src/api.ts` by validating the API base URL at startup rather than deferring validation to request time.

## Changes

- Added `validateApiBase()` helper function that:
  - Validates the URL is a valid absolute URL
  - Restricts protocol to `http://` or `https://` only (rejects `file://`, `data://`, `javascript://`, etc.)
  - Trims trailing slashes for consistency
  
- Updated module initialization to validate `DEFAULT_API_BASE` at load time with clear error messaging
- Updated `setApiBase()` to validate any runtime URL changes with error handling

## Security Impact

This prevents client-side request forgery by:
- Ensuring the API base is always a valid http/https URL
- Catching malformed URLs early (at startup or when explicitly set)
- Rejecting protocol injection attempts that could redirect requests to unintended endpoints

## Testing

The fix validates at startup, so invalid configurations surface immediately. Runtime calls to `setApiBase()` with invalid URLs will throw an error instead of silently accepting them.

Closes #3233