### PR TITLE
Fix CDK diff method argument typo: changeset → change-set

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -224,7 +224,7 @@ jobs:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
-        run: npx cdk diff BackendLambdaStack StaticSiteStack --method=changeset -c prod=true
+        run: npx cdk diff BackendLambdaStack StaticSiteStack --method=change-set -c prod=true
         working-directory: cdk
 
       - name: Deploy StaticSiteStack auth resources


### PR DESCRIPTION
## Summary

Fixes a typo in the CDK diff step of the deploy workflow that was causing deploy failures.

The CDK command requires  (with hyphen), not .

Error message from failed workflow:
```
Error: Invalid values: Argument: method, Given: "changeset", Choices: "auto", "change-set", "template"
```

Closes #3242