### PR TITLE
Enforce Claude and GPT reviewer approval requirement in PR checks

### DIFF
--- a/.github/rulesets/default-branch-protection.json
+++ b/.github/rulesets/default-branch-protection.json
@@ -52,6 +52,9 @@
           },
           {
             "context": "CI / Lambda-compat pytest (backend/requirements.txt)"
+          },
+          {
+            "context": "Validate AI Reviewer Approval / Validate AI reviewer approval"
           }
         ]
       }

--- a/.github/scripts/validate_ai_reviewer_approval.py
+++ b/.github/scripts/validate_ai_reviewer_approval.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Validate that Claude and GPT reviewers approved if they ran.
+
+This script checks PR comments to determine if Claude and GPT reviews ran.
+If they ran, they must contain an APPROVE verdict; if they didn't run, no approval is required.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import NamedTuple
+
+
+class ReviewStatus(NamedTuple):
+    """Status of a single AI reviewer."""
+
+    ran: bool
+    approved: bool
+
+
+def get_pr_comments(pr_number: int) -> list[dict]:
+    """Fetch all comments on a PR using GitHub CLI."""
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "comments"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+    return data.get("comments", [])
+
+
+def check_claude_review(comments: list[dict]) -> ReviewStatus:
+    """Check if Claude review ran and if it approved."""
+    for comment in comments:
+        body = comment.get("body", "")
+        if "## Claude AI Code Review" in body:
+            approved = "**APPROVE**" in body
+            return ReviewStatus(ran=True, approved=approved)
+    return ReviewStatus(ran=False, approved=False)
+
+
+def check_gpt_review(comments: list[dict]) -> ReviewStatus:
+    """Check if GPT review ran and if it approved."""
+    for comment in comments:
+        body = comment.get("body", "")
+        if "## GPT AI Code Review" in body:
+            approved = "**APPROVE**" in body
+            return ReviewStatus(ran=True, approved=approved)
+    return ReviewStatus(ran=False, approved=False)
+
+
+def main() -> int:
+    """Validate AI reviewer approvals."""
+    try:
+        pr_number = int(json.loads(subprocess.run(
+            ["gh", "pr", "view", "--json", "number"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout).get("number", 0))
+    except (subprocess.CalledProcessError, ValueError, json.JSONDecodeError):
+        print("ERROR: Could not determine PR number", file=sys.stderr)
+        return 1
+
+    try:
+        comments = get_pr_comments(pr_number)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: Failed to fetch PR comments: {exc}", file=sys.stderr)
+        return 1
+
+    claude = check_claude_review(comments)
+    gpt = check_gpt_review(comments)
+
+    errors: list[str] = []
+
+    if claude.ran and not claude.approved:
+        errors.append("Claude review ran but did not APPROVE")
+    if gpt.ran and not gpt.approved:
+        errors.append("GPT review ran but did not APPROVE")
+
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    status_parts = []
+    if claude.ran:
+        status_parts.append(f"Claude: APPROVED")
+    if gpt.ran:
+        status_parts.append(f"GPT: APPROVED")
+    if not status_parts:
+        status_parts.append("No AI reviews ran")
+
+    print(f"✓ AI reviewer approval check passed: {'; '.join(status_parts)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/validate-ai-reviewer-approval.yml
+++ b/.github/workflows/validate-ai-reviewer-approval.yml
@@ -1,0 +1,28 @@
+name: Validate AI Reviewer Approval
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  validate-approval:
+    name: Validate AI reviewer approval
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate Claude and GPT approval
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 .github/scripts/validate_ai_reviewer_approval.py

--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -25,6 +25,7 @@ EXPECTED_REQUIRED_CHECKS = {
     "Frontend Tests / frontend-tests",
     "PR Body Issue Reference Check / require-issue-reference",
     "Dependency Review / dependency-review",
+    "Validate AI Reviewer Approval / Validate AI reviewer approval",
 }
 ADVISORY_CHECK_PREFIXES = ("Claude PR Review /", "GPT PR Review /")
 

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -170,3 +170,75 @@ def test_review_script_reports_mocked_api_failure(
 
     assert exc.value.code == 1
     assert expected_message in capsys.readouterr().err
+
+
+def _mock_subprocess_pr_number(pr_number: int = 123):
+    """Create a mock for subprocess.run that returns PR number."""
+    def mock_run(*args, **kwargs):
+        if isinstance(args[0], list) and "view" in args[0] and "number" in args[0]:
+            result = type("ProcessResult", (), {
+                "stdout": json.dumps({"number": pr_number}),
+                "returncode": 0,
+            })()
+            return result
+        raise RuntimeError(f"Unexpected subprocess call: {args}")
+    return mock_run
+
+
+def test_validate_ai_reviewer_approval_passes_when_both_approved(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_script_module("validate_approval", "validate_ai_reviewer_approval.py")
+    comments = [
+        {"body": "## Claude AI Code Review\n\nLooks good\n**APPROVE**"},
+        {"body": "## GPT AI Code Review\n\nLooks good\n**APPROVE**"},
+    ]
+    monkeypatch.setattr(module, "get_pr_comments", lambda pr_number: comments)
+    monkeypatch.setattr(module.subprocess, "run", _mock_subprocess_pr_number())
+
+    assert module.main() == 0
+    assert "✓ AI reviewer approval check passed" in capsys.readouterr().out
+
+
+def test_validate_ai_reviewer_approval_passes_when_neither_ran(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_script_module("validate_approval_no_reviews", "validate_ai_reviewer_approval.py")
+    comments = []
+    monkeypatch.setattr(module, "get_pr_comments", lambda pr_number: comments)
+    monkeypatch.setattr(module.subprocess, "run", _mock_subprocess_pr_number())
+
+    assert module.main() == 0
+    assert "No AI reviews ran" in capsys.readouterr().out
+
+
+def test_validate_ai_reviewer_approval_fails_when_claude_ran_but_no_approve(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_script_module("validate_approval_claude_fail", "validate_ai_reviewer_approval.py")
+    comments = [
+        {"body": "## Claude AI Code Review\n\nHas concerns\n**REQUEST CHANGES**"},
+    ]
+    monkeypatch.setattr(module, "get_pr_comments", lambda pr_number: comments)
+    monkeypatch.setattr(module.subprocess, "run", _mock_subprocess_pr_number())
+
+    assert module.main() == 1
+    assert "Claude review ran but did not APPROVE" in capsys.readouterr().err
+
+
+def test_validate_ai_reviewer_approval_fails_when_gpt_ran_but_no_approve(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_script_module("validate_approval_gpt_fail", "validate_ai_reviewer_approval.py")
+    comments = [
+        {"body": "## GPT AI Code Review\n\nHas concerns\n**REQUEST CHANGES**"},
+    ]
+    monkeypatch.setattr(module, "get_pr_comments", lambda pr_number: comments)
+    monkeypatch.setattr(module.subprocess, "run", _mock_subprocess_pr_number())
+
+    assert module.main() == 1
+    assert "GPT review ran but did not APPROVE" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Implements validation to ensure Claude and GPT AI reviewers must approve if they run on a PR. This adds a safety gate to prevent PRs from merging when automated reviews complete but don't approve.

## Changes

- **New workflow** `validate-ai-reviewer-approval.yml`: Runs on every PR to check reviewer approvals
- **New validation script** `.github/scripts/validate_ai_reviewer_approval.py`: 
  - Fetches PR comments to detect if Claude/GPT reviews ran
  - Fails if reviewers ran but didn't include `**APPROVE**` verdict
  - Passes if reviewers didn't run (no approval required)
  - Passes if both reviewers ran and approved
- **Updated branch protection rules**: Added new check to required status checks
- **Test coverage**: Comprehensive tests for all approval scenarios

## Behavior

The validation check:
- ✅ **Passes** if both Claude and GPT approved
- ✅ **Passes** if neither reviewer ran (approval optional)
- ❌ **Fails** if Claude ran but didn't approve
- ❌ **Fails** if GPT ran but didn't approve
- ✅ **Passes** if one approved and the other didn't run

## Related Issue

Closes #3277