### PR TITLE
Enforce Claude and GPT reviewers must approve on all PRs

### DIFF
--- a/.github/rulesets/default-branch-protection.json
+++ b/.github/rulesets/default-branch-protection.json
@@ -52,6 +52,12 @@
           },
           {
             "context": "CI / Lambda-compat pytest (backend/requirements.txt)"
+          },
+          {
+            "context": "Claude PR Review / Claude AI code review"
+          },
+          {
+            "context": "GPT PR Review / GPT AI code review"
           }
         ]
       }

--- a/.github/scripts/extract_verdict.py
+++ b/.github/scripts/extract_verdict.py
@@ -1,0 +1,71 @@
+"""Extract and validate the AI review verdict from review output."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def extract_verdict(review_text: str) -> str | None:
+    """Extract the verdict from review text.
+
+    Looks for verdict lines in the format:
+    - `**APPROVE**` — ...
+    - `**REQUEST CHANGES**` — ...
+
+    Returns 'APPROVE' or 'REQUEST CHANGES' if found, None otherwise.
+    """
+    # Look for verdict lines that match the expected format
+    match = re.search(r'\*\*(APPROVE|REQUEST CHANGES)\*\*', review_text)
+    if match:
+        return match.group(1)
+    return None
+
+
+def main(review_file: str, provider_name: str) -> int:
+    """Read review file, extract verdict, and exit with appropriate status.
+
+    Args:
+        review_file: Path to the file containing the review text.
+        provider_name: Name of the provider (Claude or GPT) for output messages.
+
+    Returns:
+        0 if verdict is APPROVE, 1 if REQUEST CHANGES or no verdict found.
+    """
+    try:
+        review_text = Path(review_file).read_text()
+    except FileNotFoundError:
+        print(f"ERROR: Review file not found: {review_file}", file=sys.stderr)
+        return 1
+
+    if not review_text.strip():
+        print(f"ERROR: {provider_name} review output was empty", file=sys.stderr)
+        return 1
+
+    verdict = extract_verdict(review_text)
+
+    if verdict == "APPROVE":
+        print(f"✓ {provider_name} review: APPROVED")
+        return 0
+
+    if verdict == "REQUEST CHANGES":
+        print(f"✗ {provider_name} review: CHANGES REQUESTED")
+        return 1
+
+    print(
+        f"ERROR: {provider_name} review did not include a valid verdict. "
+        "Expected '**APPROVE**' or '**REQUEST CHANGES**' in the review.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(
+            f"Usage: {sys.argv[0]} <review_file> <provider_name>",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    raise SystemExit(main(sys.argv[1], sys.argv[2]))

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Check Claude approval
         run: |
-          if grep -q "**APPROVE**" /tmp/claude_review_body.md; then
+          if grep -qF "**APPROVE**" /tmp/claude_review_body.md; then
             echo "✓ Claude review: APPROVED"
           else
             echo "✗ Claude review: CHANGES REQUESTED OR NOT APPROVED"
@@ -91,7 +91,7 @@ jobs:
           gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md
 
       - name: Post Claude failure notice
-        if: failure() && !contains(github.event.pull_request.body, 'Claude review')
+        if: failure()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,7 +8,6 @@ jobs:
   ai-review:
     name: Claude AI code review
     runs-on: ubuntu-latest
-    continue-on-error: true
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       pull-requests: write
@@ -65,6 +64,15 @@ jobs:
             exit 1
           fi
 
+      - name: Check Claude approval
+        run: |
+          if grep -q "**APPROVE**" /tmp/claude_review_body.md; then
+            echo "✓ Claude review: APPROVED"
+          else
+            echo "✗ Claude review: CHANGES REQUESTED OR NOT APPROVED"
+            exit 1
+          fi
+
       - name: Post Claude review comment
         if: success()
         env:
@@ -83,13 +91,13 @@ jobs:
           gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md
 
       - name: Post Claude failure notice
-        if: failure()
+        if: failure() && !contains(github.event.pull_request.body, 'Claude review')
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          printf '## Claude AI Code Review - Skipped\n\nThe Claude review step failed (likely an API key or quota issue). This is advisory only and does not affect CI status.\n\nCheck [Actions](%s) for details.\n' \
+          printf '## Claude AI Code Review - Failed\n\nThe Claude review did not APPROVE this PR. Review the changes and address any concerns raised.\n\nCheck [Actions](%s) for details.\n' \
             "$RUN_URL" > /tmp/claude_fail_notice.md
           gh pr comment "$PR_NUMBER" --body-file /tmp/claude_fail_notice.md

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -66,12 +66,7 @@ jobs:
 
       - name: Check Claude approval
         run: |
-          if grep -qF "**APPROVE**" /tmp/claude_review_body.md; then
-            echo "✓ Claude review: APPROVED"
-          else
-            echo "✗ Claude review: CHANGES REQUESTED OR NOT APPROVED"
-            exit 1
-          fi
+          python3 .github/scripts/extract_verdict.py /tmp/claude_review_body.md Claude
 
       - name: Post Claude review comment
         if: success()

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -8,7 +8,6 @@ jobs:
   gpt-review:
     name: GPT AI code review
     runs-on: ubuntu-latest
-    continue-on-error: true
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       pull-requests: write
@@ -64,6 +63,15 @@ jobs:
             exit 1
           fi
 
+      - name: Check GPT approval
+        run: |
+          if grep -q "**APPROVE**" /tmp/gpt_review_body.md; then
+            echo "✓ GPT review: APPROVED"
+          else
+            echo "✗ GPT review: CHANGES REQUESTED OR NOT APPROVED"
+            exit 1
+          fi
+
       - name: Post GPT review comment
         if: success()
         env:
@@ -82,14 +90,18 @@ jobs:
           gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md
 
       - name: Post GPT failure notice
-        if: failure()
+        if: failure() && !contains(github.event.pull_request.body, 'GPT AI Code Review')
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh pr comment "$PR_NUMBER" --body \
-            "## GPT AI Code Review - Skipped
-
-            The GPT review step failed (likely an API key or quota issue). This is advisory only and does not affect CI status.
-
-            Check [Actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          {
+            echo "## GPT AI Code Review - Failed"
+            echo ""
+            echo "The GPT review did not APPROVE this PR. Review the changes and address any concerns raised."
+            echo ""
+            echo "Check [Actions]($RUN_URL) for details."
+          } > /tmp/gpt_fail_notice.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_fail_notice.md

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -65,12 +65,7 @@ jobs:
 
       - name: Check GPT approval
         run: |
-          if grep -qF "**APPROVE**" /tmp/gpt_review_body.md; then
-            echo "✓ GPT review: APPROVED"
-          else
-            echo "✗ GPT review: CHANGES REQUESTED OR NOT APPROVED"
-            exit 1
-          fi
+          python3 .github/scripts/extract_verdict.py /tmp/gpt_review_body.md GPT
 
       - name: Post GPT review comment
         if: success()

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Check GPT approval
         run: |
-          if grep -q "**APPROVE**" /tmp/gpt_review_body.md; then
+          if grep -qF "**APPROVE**" /tmp/gpt_review_body.md; then
             echo "✓ GPT review: APPROVED"
           else
             echo "✗ GPT review: CHANGES REQUESTED OR NOT APPROVED"
@@ -90,7 +90,7 @@ jobs:
           gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md
 
       - name: Post GPT failure notice
-        if: failure() && !contains(github.event.pull_request.body, 'GPT AI Code Review')
+        if: failure()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -25,8 +25,9 @@ EXPECTED_REQUIRED_CHECKS = {
     "Frontend Tests / frontend-tests",
     "PR Body Issue Reference Check / require-issue-reference",
     "Dependency Review / dependency-review",
+    "Claude PR Review / Claude AI code review",
+    "GPT PR Review / GPT AI code review",
 }
-ADVISORY_CHECK_PREFIXES = ("Claude PR Review /", "GPT PR Review /")
 
 
 def load_ruleset_contexts() -> set[str]:
@@ -86,17 +87,6 @@ def main() -> int:
         errors.append(
             "Required checks do not match workflow/job names: "
             f"{missing_workflows}"
-        )
-
-    advisory_required = sorted(
-        context
-        for context in required_contexts
-        if context.startswith(ADVISORY_CHECK_PREFIXES)
-    )
-    if advisory_required:
-        errors.append(
-            "Advisory AI review checks must not be required: "
-            f"{advisory_required}"
         )
 
     if errors:


### PR DESCRIPTION
## Summary

Enforces that Claude and GPT AI reviewers must approve before a PR can merge. The review workflows now fail if they run but don't include `**APPROVE**` in their verdict, blocking the PR from merging.

## Changes

### Workflows
- **claude-pr-review.yml**: 
  - Removed `continue-on-error: true` to allow workflow failures to block the PR
  - Added approval check that fails if review doesn't contain `**APPROVE**`
  
- **gpt-pr-review.yml**:
  - Removed `continue-on-error: true` to allow workflow failures to block the PR
  - Added approval check that fails if review doesn't contain `**APPROVE**`

### Branch Protection
- Added Claude and GPT review checks to required status checks
- Updated validation script to expect Claude/GPT as required checks (not advisory)

## Behavior

- ✅ **PR merges** if Claude and GPT both approve
- ❌ **PR blocks** if Claude runs but doesn't approve
- ❌ **PR blocks** if GPT runs but doesn't approve  
- ⚠️ **PR blocks** if review fails to run (API issues) — reviewer can manually re-run the check once issue is resolved
- ✅ **PR merges** if only one reviewer approves and the other doesn't run (no API key)

## Related Issue

Closes #3277