### PR TITLE
fix: always post full Claude review regardless of verdict

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -74,14 +74,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          {
-            echo "## Claude AI Code Review"
-            echo ""
-            cat /tmp/claude_review_body.md
-            echo ""
-            echo "---"
-            echo "*Reviewed by Claude via [claude-pr-review.yml](.github/workflows/claude-pr-review.yml). Advisory only.*"
-          } > /tmp/claude_comment_body.md
+          if [ -s /tmp/claude_review_body.md ]; then
+            # Claude API succeeded — post the full review (APPROVE or REQUEST CHANGES)
+            {
+              echo "## Claude AI Code Review"
+              echo ""
+              cat /tmp/claude_review_body.md
+              echo ""
+              echo "---"
+              echo "*Reviewed by Claude via [claude-pr-review.yml](.github/workflows/claude-pr-review.yml). Advisory only.*"
+            } > /tmp/claude_comment_body.md
+          else
+            # Claude API failed or produced empty output — notify user to check logs
+            {
+              echo "## Claude AI Code Review - Failed"
+              echo ""
+              echo "The Claude review failed to complete. Check [Actions]($RUN_URL) for error details."
+            } > /tmp/claude_comment_body.md
+          fi
 
           gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -69,7 +69,8 @@ jobs:
           python3 .github/scripts/extract_verdict.py /tmp/claude_review_body.md Claude
 
       - name: Post Claude review comment
-        if: success()
+        if: always()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -84,15 +85,3 @@ jobs:
           } > /tmp/claude_comment_body.md
 
           gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md
-
-      - name: Post Claude failure notice
-        if: failure()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          printf '## Claude AI Code Review - Failed\n\nThe Claude review did not APPROVE this PR. Review the changes and address any concerns raised.\n\nCheck [Actions](%s) for details.\n' \
-            "$RUN_URL" > /tmp/claude_fail_notice.md
-          gh pr comment "$PR_NUMBER" --body-file /tmp/claude_fail_notice.md

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -68,35 +68,30 @@ jobs:
           python3 .github/scripts/extract_verdict.py /tmp/gpt_review_body.md GPT
 
       - name: Post GPT review comment
-        if: success()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          {
-            echo "## GPT AI Code Review"
-            echo ""
-            cat /tmp/gpt_review_body.md
-            echo ""
-            echo "---"
-            echo "*Reviewed by GPT via [gpt-pr-review.yml](.github/workflows/gpt-pr-review.yml). Advisory only.*"
-          } > /tmp/gpt_comment_body.md
-
-          gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md
-
-      - name: Post GPT failure notice
-        if: failure()
+        if: always()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          {
-            echo "## GPT AI Code Review - Failed"
-            echo ""
-            echo "The GPT review did not APPROVE this PR. Review the changes and address any concerns raised."
-            echo ""
-            echo "Check [Actions]($RUN_URL) for details."
-          } > /tmp/gpt_fail_notice.md
-          gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_fail_notice.md
+          if [ -s /tmp/gpt_review_body.md ]; then
+            # GPT API succeeded — post the full review (APPROVE or REQUEST CHANGES)
+            {
+              echo "## GPT AI Code Review"
+              echo ""
+              cat /tmp/gpt_review_body.md
+              echo ""
+              echo "---"
+              echo "*Reviewed by GPT via [gpt-pr-review.yml](.github/workflows/gpt-pr-review.yml). Advisory only.*"
+            } > /tmp/gpt_comment_body.md
+          else
+            # GPT API failed or produced empty output — notify user to check logs
+            {
+              echo "## GPT AI Code Review - Failed"
+              echo ""
+              echo "The GPT review failed to complete. Check [Actions]($RUN_URL) for error details."
+            } > /tmp/gpt_comment_body.md
+          fi
+
+          gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md


### PR DESCRIPTION
## Summary
When Claude review verdict is REQUEST CHANGES, the full review details are not being posted to the PR. This causes users to only see a generic failure notice without understanding the specific concerns Claude raised.

## Changes
- Modified 'Post Claude review comment' step to use 'if: always()' so the full review is always posted, regardless of verdict
- Removed separate 'Post Claude failure notice' step since we're now always posting the full review

## Impact
Users will now see the complete Claude review with detailed reasoning for any changes requested, making it easier to understand and address the concerns.

Closes #3285