### PR TITLE
fix(deploy): use cdk diff --method=template to fix recurring CDK diff failure (#3287)

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -218,34 +218,24 @@ jobs:
             exit 1
           fi
 
-      - name: Check stacks exist for CDK diff
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
-        run: |
-          set -euo pipefail
-          # Use --method=change-set only when both stacks already exist.
-          # BackendLambdaStack must exist so CloudFormation can reuse its
-          # stored UiAuthUserPoolId/UiAuthUserPoolClientId parameter values
-          # (cdk diff has no --parameters flag; values come from the live stack).
-          # StaticSiteStack must exist as the upstream source of those values;
-          # gating on both avoids a gap in partial-deploy states where
-          # StaticSiteStack has not yet been provisioned.
-          if aws cloudformation describe-stacks --stack-name BackendLambdaStack > /dev/null 2>&1 \
-             && aws cloudformation describe-stacks --stack-name StaticSiteStack > /dev/null 2>&1; then
-            echo CDK_DIFF_METHOD=change-set >> "$GITHUB_ENV"
-            echo 'Both stacks exist: using --method=change-set (CloudFormation reuses existing parameter values)'
-          else
-            echo CDK_DIFF_METHOD=auto >> "$GITHUB_ENV"
-            echo 'One or more stacks not yet deployed: falling back to --method=auto'
-          fi
-
       - name: CDK diff
+        # Use --method=template: a direct template comparison that creates no
+        # CloudFormation change set. BackendLambdaStack declares UiAuthUserPoolId
+        # and UiAuthUserPoolClientId as required parameters with no default
+        # (backend_lambda_stack.py); their values are produced by StaticSiteStack
+        # and only fetched in the "Get Cognito UI auth outputs" step *below*, so
+        # they are unavailable at diff time. The "change-set"/"auto" methods try
+        # to create a change set, which fails here because cdk diff has no
+        # --parameters flag and does not send UsePreviousValue, so CloudFormation
+        # reports UiAuthUserPoolId/UiAuthUserPoolClientId as missing a value
+        # (see issue #3287). The diff is informational only; the real cdk deploy
+        # steps below still pass the actual parameter values.
         env:
           DATA_BUCKET: ${{ secrets.DATA_BUCKET }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
-        run: npx cdk diff BackendLambdaStack StaticSiteStack --method="$CDK_DIFF_METHOD" -c prod=true
+        run: npx cdk diff BackendLambdaStack StaticSiteStack --method=template -c prod=true
         working-directory: cdk
 
       - name: Deploy StaticSiteStack auth resources


### PR DESCRIPTION
## What

Pins the **CDK diff** step in `.github/workflows/deploy-lambda.yml` to `--method=template` and removes the dead `Check stacks exist for CDK diff` gate.

Closes #3287

## Why

The deploy workflow failed **every** run at the *CDK diff* step:

```
Could not create a change set, and '--method=change-set' was specified.
The following CloudFormation Parameters are missing a value: UiAuthUserPoolId, UiAuthUserPoolClientId
```

`BackendLambdaStack` declares `UiAuthUserPoolId` / `UiAuthUserPoolClientId` as **required** `CfnParameter`s with no default (`cdk/stacks/backend_lambda_stack.py:299-321`). Their values come from `StaticSiteStack`'s Cognito outputs, which the workflow only fetches in the *Get Cognito UI auth outputs* step that runs **after** the diff.

The previous gate assumed a `change-set` diff would reuse the live stack's stored parameter values — but `cdk diff` has **no `--parameters` flag** and does not send `UsePreviousValue`, so CloudFormation reports the parameters as missing and change-set creation fails. `change-set`/`auto` can therefore never succeed for `BackendLambdaStack` in this ordering. This is why successive fixes (`--method=changeset` → `change-set`, the stack-existence gate, IAM preflight tweaks) never resolved it.

## Fix

`--method=template` (valid choices in CDK 2.1119.0 are `auto` / `change-set` / `template`) compares the synthesized template directly without creating a change set, so it needs neither the unavailable parameter values nor `cloudformation:CreateChangeSet`. The diff is informational only; the real `cdk deploy` steps still pass the actual parameter values via `--parameters`.

## Verification

- `cdk diff --help` (CDK 2.1119.0) confirms `template` is a valid `--method` choice; `template-only` is **not** (an earlier draft of the issue used that invalid token).
- `cdk synth BackendLambdaStack StaticSiteStack -c prod=true` constructs both stacks and both `CfnParameter`s successfully (stops only at the `frontend/dist` asset, which the workflow's `npm run build` step produces earlier).
- Workflow YAML re-validated; no remaining references to the removed `CDK_DIFF_METHOD` env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)