### PR TITLE
docs: document why continue-on-error is used on review posting steps

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Post Claude review comment
         if: always()
-        continue-on-error: true
+        continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Post GPT review comment
         if: always()
-        continue-on-error: true
+        continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Add inline comments explaining that continue-on-error allows the workflow to proceed even if the gh pr comment call fails (e.g. due to API rate limits or network issues), since the review is also written to the Actions job summary as a fallback for visibility.

Applies to both Claude and GPT review workflows.

Closes #3292