### PR TITLE
fix: implement haiku issues 3290, 3291, 3294, 3296, 3297, 3303

### DIFF
--- a/.github/scripts/claude_review.py
+++ b/.github/scripts/claude_review.py
@@ -68,7 +68,13 @@ def fetch_claude_review(api_key: str, prompt: str) -> str:
 
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
-            data = json.loads(response.read())
+            status = getattr(response, "status", None)
+            raw = response.read()
+            print(
+                f"INFO: Claude API responded status={status} bytes={len(raw)}",
+                file=sys.stderr,
+            )
+            data = json.loads(raw)
     except urllib.error.HTTPError as exc:
         # Keep the provider response in stderr so maintainers can distinguish auth, quota, and API failures.
         body = exc.read().decode()
@@ -76,6 +82,12 @@ def fetch_claude_review(api_key: str, prompt: str) -> str:
         raise SystemExit(1) from exc
 
     review, stop_reason = extract_claude_review(data)
+    if not review.strip():
+        print(
+            f"WARNING: Claude API returned an empty review body "
+            f"(status={status}, stop_reason={stop_reason})",
+            file=sys.stderr,
+        )
     if stop_reason == "max_tokens":
         review = (
             f"{review}\n\n"

--- a/.github/scripts/gpt_review.py
+++ b/.github/scripts/gpt_review.py
@@ -51,14 +51,26 @@ def fetch_openai_review(api_key: str, prompt: str) -> str:
 
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
-            data = json.loads(response.read())
+            status = getattr(response, "status", None)
+            raw = response.read()
+            print(
+                f"INFO: OpenAI API responded status={status} bytes={len(raw)}",
+                file=sys.stderr,
+            )
+            data = json.loads(raw)
     except urllib.error.HTTPError as exc:
         # Keep the provider response in stderr so maintainers can distinguish auth, quota, and API failures.
         body = exc.read().decode()
         print(f"ERROR: OpenAI API returned {exc.code}: {body}", file=sys.stderr)
         raise SystemExit(1) from exc
 
-    return extract_openai_review(data)
+    review = extract_openai_review(data)
+    if not review.strip():
+        print(
+            f"WARNING: OpenAI API returned an empty review body (status={status})",
+            file=sys.stderr,
+        )
+    return review
 
 
 def main() -> int:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           python3 .github/scripts/claude_review.py > /tmp/claude_review_body.md
 
+          # Guard: `-s` returns true only if the file exists AND has size > 0.
+          # This distinguishes a successful API response (review body written to stdout)
+          # from a failure (empty output, missing file, or API error).
+          # See docs/AI_REVIEW_WORKFLOWS.md for details.
           if [ ! -s /tmp/claude_review_body.md ]; then
             echo "ERROR: Claude review output was empty" >&2
             exit 1
@@ -69,13 +73,17 @@ jobs:
           python3 .github/scripts/extract_verdict.py /tmp/claude_review_body.md Claude
 
       - name: Post Claude review comment
-        if: always() && !cancelled()
+        if: success() || failure()
         continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # Guard: `-s` distinguishes successful API responses from failures.
+          # If the file exists and is non-empty, the API call succeeded;
+          # if missing or empty, the API call failed (this is the fallback path).
+          # See docs/AI_REVIEW_WORKFLOWS.md for detailed explanation.
           if [ -s /tmp/claude_review_body.md ]; then
             # Claude API succeeded — post the full review (APPROVE or REQUEST CHANGES)
             {
@@ -95,4 +103,17 @@ jobs:
             } > /tmp/claude_comment_body.md
           fi
 
-          gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md
+          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md; then
+            echo "::warning title=Claude review comment::Failed to post the Claude review comment to PR #$PR_NUMBER — check the Actions log above for the gh error (rate limit, token scope, or network)."
+            echo "WARNING: failed to post review comment — check the Actions log" >&2
+            exit 0
+          fi
+
+          # Also write review to step summary for visibility in Actions UI
+          if [ -s /tmp/claude_review_body.md ]; then
+            {
+              echo "## Claude AI Code Review"
+              echo ""
+              cat /tmp/claude_review_body.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -103,17 +103,18 @@ jobs:
             } > /tmp/claude_comment_body.md
           fi
 
-          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md; then
-            echo "::warning title=Claude review comment::Failed to post the Claude review comment to PR #$PR_NUMBER — check the Actions log above for the gh error (rate limit, token scope, or network)."
-            echo "WARNING: failed to post review comment — check the Actions log" >&2
-            exit 0
-          fi
-
-          # Also write review to step summary for visibility in Actions UI
+          # Write review to step summary first — before attempting the PR comment — so
+          # it is always recorded in the Actions UI regardless of whether gh pr comment succeeds.
           if [ -s /tmp/claude_review_body.md ]; then
             {
               echo "## Claude AI Code Review"
               echo ""
               cat /tmp/claude_review_body.md
             } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md; then
+            echo "::warning title=Claude review comment::Failed to post the Claude review comment to PR #$PR_NUMBER — check the Actions log above for the gh error (rate limit, token scope, or network)."
+            echo "WARNING: failed to post review comment — check the Actions log" >&2
+            exit 0
           fi

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -102,17 +102,18 @@ jobs:
             } > /tmp/gpt_comment_body.md
           fi
 
-          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md; then
-            echo "::warning title=GPT review comment::Failed to post the GPT review comment to PR #$PR_NUMBER — check the Actions log above for the gh error (rate limit, token scope, or network)."
-            echo "WARNING: failed to post review comment — check the Actions log" >&2
-            exit 0
-          fi
-
-          # Also write review to step summary for visibility in Actions UI
+          # Write review to step summary first — before attempting the PR comment — so
+          # it is always recorded in the Actions UI regardless of whether gh pr comment succeeds.
           if [ -s /tmp/gpt_review_body.md ]; then
             {
               echo "## GPT AI Code Review"
               echo ""
               cat /tmp/gpt_review_body.md
             } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md; then
+            echo "::warning title=GPT review comment::Failed to post the GPT review comment to PR #$PR_NUMBER — check the Actions log above for the gh error (rate limit, token scope, or network)."
+            echo "WARNING: failed to post review comment — check the Actions log" >&2
+            exit 0
           fi

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -58,6 +58,10 @@ jobs:
         run: |
           python3 .github/scripts/gpt_review.py > /tmp/gpt_review_body.md
 
+          # Guard: `-s` returns true only if the file exists AND has size > 0.
+          # This distinguishes a successful API response (review body written to stdout)
+          # from a failure (empty output, missing file, or API error).
+          # See docs/AI_REVIEW_WORKFLOWS.md for details.
           if [ ! -s /tmp/gpt_review_body.md ]; then
             echo "ERROR: GPT review output was empty" >&2
             exit 1
@@ -68,13 +72,17 @@ jobs:
           python3 .github/scripts/extract_verdict.py /tmp/gpt_review_body.md GPT
 
       - name: Post GPT review comment
-        if: always() && !cancelled()
+        if: success() || failure()
         continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # Guard: `-s` distinguishes successful API responses from failures.
+          # If the file exists and is non-empty, the API call succeeded;
+          # if missing or empty, the API call failed (this is the fallback path).
+          # See docs/AI_REVIEW_WORKFLOWS.md for detailed explanation.
           if [ -s /tmp/gpt_review_body.md ]; then
             # GPT API succeeded — post the full review (APPROVE or REQUEST CHANGES)
             {
@@ -94,4 +102,17 @@ jobs:
             } > /tmp/gpt_comment_body.md
           fi
 
-          gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md
+          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md; then
+            echo "::warning title=GPT review comment::Failed to post the GPT review comment to PR #$PR_NUMBER — check the Actions log above for the gh error (rate limit, token scope, or network)."
+            echo "WARNING: failed to post review comment — check the Actions log" >&2
+            exit 0
+          fi
+
+          # Also write review to step summary for visibility in Actions UI
+          if [ -s /tmp/gpt_review_body.md ]; then
+            {
+              echo "## GPT AI Code Review"
+              echo ""
+              cat /tmp/gpt_review_body.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/AI_REVIEW_WORKFLOWS.md
+++ b/docs/AI_REVIEW_WORKFLOWS.md
@@ -1,0 +1,66 @@
+# AI Review Workflows
+
+This document describes how the Claude and GPT AI review workflows handle review generation, posting, and failure scenarios.
+
+## Overview
+
+Two GitHub Actions workflows provide automated code reviews on pull requests:
+
+- **claude-pr-review.yml**: Runs Claude AI review via the Anthropic API
+- **gpt-pr-review.yml**: Runs GPT review via the OpenAI API
+
+Both workflows follow the same pattern: generate a review, extract a verdict (APPROVE or REQUEST CHANGES), and post the full review to the PR regardless of verdict.
+
+## Review Posting Behavior
+
+### Successful Review
+
+When the AI API successfully generates a review, the full review content is posted to the PR as a comment, including the verdict (APPROVE or REQUEST CHANGES) and detailed reasoning. Users always see the complete rationale for any feedback, enabling them to understand and address concerns.
+
+### Failed Review
+
+If the AI API call fails before producing a non-empty review file (e.g., missing credentials, HTTP error, empty response), a fallback notice is posted instead. The exact text posted is generated in the `else` branch of the `-s` guard in each workflow's "Post review comment" step:
+
+```
+## Claude AI Code Review - Failed
+
+The Claude review failed to complete. Check [Actions](<run URL>) for error details.
+```
+
+(`<run URL>` is replaced at runtime with the Actions run URL via `$RUN_URL`.) This ensures users are aware that a review was attempted and directs them to the Actions logs for debugging.
+
+### File-Existence Guard
+
+Both workflows use the POSIX test `[ -s /tmp/<reviewer>_review_body.md ]` to distinguish between:
+
+1. **File exists and non-empty** (`-s` returns true): API call succeeded → post full review
+2. **File missing or empty** (`-s` returns false): API call failed → post fallback notice
+
+This guard is robust to cancellations, timeouts, and partial failures.
+
+## Fallback Mechanisms
+
+### PR Comment
+
+The primary posting mechanism is `gh pr comment`, which posts the review as a comment visible to all PR viewers. If this call fails (e.g., due to GitHub API rate limits or token issues), a warning is logged in the Actions run.
+
+### Step Summary
+
+As a secondary fallback for visibility, the review body is also written to `$GITHUB_STEP_SUMMARY` so it appears in the GitHub Actions run UI. If the `gh pr comment` call fails, the review content is still accessible here.
+
+## Workflow Step Configuration
+
+- **`if: success() || failure()`**: The "Post review comment" step runs even if the verdict is REQUEST CHANGES (which exits the preceding step with a non-zero exit code), so the full review is always visible. The condition excludes cancelled runs to avoid spurious failure notices when a run is superseded by a new push.
+- **`continue-on-error: true`**: Set on the "Post review comment" step in both `claude-pr-review.yml` and `gpt-pr-review.yml`. If the `gh pr comment` call fails, the job does not fail. The failure is recorded in the workflow logs but does not block the overall workflow.
+
+## Debugging
+
+When a review fails to post, check the Actions logs for:
+
+1. **API authentication errors**: Verify `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` secrets are configured
+2. **Empty responses**: Check the workflow logs for API response status and size; look for `WARNING: ... empty review body`
+3. **Network/rate limit errors**: Review the workflow logs for the run; structured logging shows the API status code
+4. **GitHub token issues**: Verify `GH_TOKEN` and PR comment posting permissions are correct
+5. **PR comment posting failures**: Look for `::warning title=...` annotations in the Actions summary
+
+For more information, see the workflow files in `.github/workflows/`.

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -4,6 +4,10 @@ This is the opinionated setup path for contributors who want to run AllotMint lo
 
 For the broader product overview, see [docs/README.md](README.md). For repo-wide agent guidance, see [AGENTS.md](../AGENTS.md).
 
+## 0. Automated code reviews
+
+Before pushing, be aware that pull requests trigger automated AI code reviews via Claude and GPT workflows. These reviews are advisory and posted as PR comments. For details on how these workflows operate, failure handling, and debugging tips, see [docs/AI_REVIEW_WORKFLOWS.md](AI_REVIEW_WORKFLOWS.md).
+
 ## 1. Supported run modes at a glance
 
 | Mode | When to use it | Backend entrypoint | Frontend entrypoint | Auth expectation | Data expectation |


### PR DESCRIPTION
Implement all six haiku-labeled issues for CI/workflow improvements:

## Changes

### #3290: Write Claude/GPT review to $GITHUB_STEP_SUMMARY
- Add review body output to step summary in both workflows
- Provides durable fallback record if PR comment posting fails

### #3291: Log failures when posting Claude/GPT review comments
- Wrap gh pr comment in error check with ::warning annotations  
- Emit diagnostic message in Actions logs for troubleshooting

### #3294: Add structured logging for Claude/GPT API responses
- Log HTTP status and response size in stderr after API calls
- Log warning if review body is empty for faster diagnosis
- Applied to both claude_review.py and gpt_review.py

### #3296: Document review-body guard and fallback behaviour
- Add inline comments explaining -s guard in both workflows
- Create docs/AI_REVIEW_WORKFLOWS.md with comprehensive guide
- Update docs to describe verdict posting and failure handling

### #3297: Suppress spurious "review failed" comments on cancelled workflow runs
- Change condition from `if: always() && !cancelled()` to `if: success() || failure()`
- Prevents spurious failure notices when runs are superseded by new pushes

### #3303: Link AI_REVIEW_WORKFLOWS.md from CONTRIBUTOR_RUNBOOK.md
- Add section 0 with reference to new AI review workflows documentation
- Makes the guide discoverable from the main contributor runbook

## Testing

- All existing tests pass: `pytest tests/test_ai_review_scripts.py`
- No test changes needed (mock compatibility preserved with getattr() guard)
- Workflows are well-commented and self-documenting

Closes #3290 #3291 #3294 #3296 #3297 #3303