### PR TITLE
ci: add tests for review workflow scripts and extract comment-body builder

### DIFF
--- a/.github/scripts/build_review_comment.sh
+++ b/.github/scripts/build_review_comment.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Usage: build_review_comment.sh <body_file> <provider_label> <workflow_file> <run_url>
+# Writes the PR comment markdown to stdout.
+# Extracted from the inline guard previously in claude-pr-review.yml and
+# gpt-pr-review.yml so the logic can be unit-tested without duplicating it.
+set -euo pipefail
+
+body_file="$1"
+provider="$2"
+workflow="$3"
+run_url="$4"
+
+if [ -s "$body_file" ]; then
+    echo "## ${provider} AI Code Review"
+    echo ""
+    cat "$body_file"
+    echo ""
+    echo "---"
+    echo "*Reviewed by ${provider} via [${workflow}](.github/workflows/${workflow}). Advisory only.*"
+else
+    echo "## ${provider} AI Code Review - Failed"
+    echo ""
+    echo "The ${provider} review failed to complete. Check [Actions](${run_url}) for error details."
+fi

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -69,30 +69,18 @@ jobs:
           python3 .github/scripts/extract_verdict.py /tmp/claude_review_body.md Claude
 
       - name: Post Claude review comment
-        if: always()
-        continue-on-error: true
+        if: always() && !cancelled()
+        continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ -s /tmp/claude_review_body.md ]; then
-            # Claude API succeeded — post the full review (APPROVE or REQUEST CHANGES)
-            {
-              echo "## Claude AI Code Review"
-              echo ""
-              cat /tmp/claude_review_body.md
-              echo ""
-              echo "---"
-              echo "*Reviewed by Claude via [claude-pr-review.yml](.github/workflows/claude-pr-review.yml). Advisory only.*"
-            } > /tmp/claude_comment_body.md
-          else
-            # Claude API failed or produced empty output — notify user to check logs
-            {
-              echo "## Claude AI Code Review - Failed"
-              echo ""
-              echo "The Claude review failed to complete. Check [Actions]($RUN_URL) for error details."
-            } > /tmp/claude_comment_body.md
-          fi
+          bash .github/scripts/build_review_comment.sh /tmp/claude_review_body.md \
+            "Claude" "claude-pr-review.yml" "$RUN_URL" > /tmp/claude_comment_body.md
 
           gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md
+
+          # Also write to Actions job summary — same file posted as the PR comment,
+          # so the guard, content, and fallback are identical.
+          cat /tmp/claude_comment_body.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -68,30 +68,18 @@ jobs:
           python3 .github/scripts/extract_verdict.py /tmp/gpt_review_body.md GPT
 
       - name: Post GPT review comment
-        if: always()
-        continue-on-error: true
+        if: always() && !cancelled()
+        continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ -s /tmp/gpt_review_body.md ]; then
-            # GPT API succeeded — post the full review (APPROVE or REQUEST CHANGES)
-            {
-              echo "## GPT AI Code Review"
-              echo ""
-              cat /tmp/gpt_review_body.md
-              echo ""
-              echo "---"
-              echo "*Reviewed by GPT via [gpt-pr-review.yml](.github/workflows/gpt-pr-review.yml). Advisory only.*"
-            } > /tmp/gpt_comment_body.md
-          else
-            # GPT API failed or produced empty output — notify user to check logs
-            {
-              echo "## GPT AI Code Review - Failed"
-              echo ""
-              echo "The GPT review failed to complete. Check [Actions]($RUN_URL) for error details."
-            } > /tmp/gpt_comment_body.md
-          fi
+          bash .github/scripts/build_review_comment.sh /tmp/gpt_review_body.md \
+            "GPT" "gpt-pr-review.yml" "$RUN_URL" > /tmp/gpt_comment_body.md
 
           gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md
+
+          # Also write to Actions job summary — same file posted as the PR comment,
+          # so the guard, content, and fallback are identical.
+          cat /tmp/gpt_comment_body.md >> "$GITHUB_STEP_SUMMARY"

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -134,6 +134,52 @@ def test_review_script_prints_review_on_mocked_api_success(
 
 
 @pytest.mark.parametrize(
+    ("module_name", "file_name", "api_env", "payload", "expected_err"),
+    [
+        (
+            "gpt_review_empty_choices",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
+            {"choices": []},
+            "ERROR: OpenAI API returned an empty review",
+        ),
+        (
+            "gpt_review_empty_content",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
+            {"choices": [{"message": {"content": ""}}]},
+            "ERROR: OpenAI API returned an empty review",
+        ),
+        (
+            "claude_review_empty_content",
+            "claude_review.py",
+            "ANTHROPIC_API_KEY",
+            {"content": []},
+            "ERROR: Claude API returned an empty review",
+        ),
+    ],
+)
+def test_review_script_exits_on_empty_api_response(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    module_name: str,
+    file_name: str,
+    api_env: str,
+    payload: dict[str, object],
+    expected_err: str,
+) -> None:
+    module = load_script_module(module_name, file_name)
+    monkeypatch.setenv(api_env, "test-key")
+    monkeypatch.setenv("PR_TITLE", "Add thing")
+    monkeypatch.setenv("ISSUE_BODY", "Do thing")
+    monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
+    monkeypatch.setattr(module.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload))
+
+    assert module.main() == 1
+    assert expected_err in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
     ("module_name", "file_name", "api_env", "expected_message"),
     [
         ("gpt_review_failure", "gpt_review.py", "OPENAI_API_KEY", "ERROR: OpenAI API returned 500: upstream broke"),

--- a/tests/test_extract_verdict.py
+++ b/tests/test_extract_verdict.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".github" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def load_extract_verdict():
+    spec = importlib.util.spec_from_file_location(
+        "extract_verdict_test", SCRIPTS_DIR / "extract_verdict.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return load_extract_verdict()
+
+
+# --- extract_verdict() unit tests ---
+
+
+def test_extract_verdict_approve(mod):
+    assert mod.extract_verdict("blah\n**APPROVE**") == "APPROVE"
+
+
+def test_extract_verdict_request_changes(mod):
+    assert mod.extract_verdict("nope\n**REQUEST CHANGES**") == "REQUEST CHANGES"
+
+
+def test_extract_verdict_none(mod):
+    assert mod.extract_verdict("no verdict here") is None
+
+
+# --- main() integration tests, parametrized over both providers ---
+
+
+@pytest.mark.parametrize("provider", ["Claude", "GPT"])
+def test_main_approve(tmp_path, capsys, mod, provider):
+    f = tmp_path / "review.md"
+    f.write_text("Looks good\n**APPROVE**")
+    assert mod.main(str(f), provider) == 0
+    assert f"✓ {provider} review: APPROVED" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("provider", ["Claude", "GPT"])
+def test_main_request_changes(tmp_path, capsys, mod, provider):
+    f = tmp_path / "review.md"
+    f.write_text("Fix this\n**REQUEST CHANGES**")
+    assert mod.main(str(f), provider) == 1
+    assert f"✗ {provider} review: CHANGES REQUESTED" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("provider", ["Claude", "GPT"])
+def test_main_no_verdict(tmp_path, capsys, mod, provider):
+    f = tmp_path / "review.md"
+    f.write_text("Some review without a verdict line.")
+    assert mod.main(str(f), provider) == 1
+    assert "did not include a valid verdict" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("provider", ["Claude", "GPT"])
+def test_main_empty_file(tmp_path, capsys, mod, provider):
+    f = tmp_path / "review.md"
+    f.write_text("")
+    assert mod.main(str(f), provider) == 1
+    assert f"ERROR: {provider} review output was empty" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("provider", ["Claude", "GPT"])
+def test_main_missing_file(capsys, mod, provider):
+    assert mod.main("/nonexistent/path/review.md", provider) == 1
+    assert "Review file not found" in capsys.readouterr().err

--- a/tests/test_review_comment.py
+++ b/tests/test_review_comment.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "build_review_comment.sh"
+RUN_URL = "https://github.com/example/repo/actions/runs/12345"
+
+
+def _to_bash_path(p: Path | str) -> str:
+    """Convert a Windows path to the form expected by the active bash binary.
+
+    On Linux/macOS the path is returned unchanged. On Windows, Git Bash invoked
+    via subprocess uses WSL-style mounts so C:\\... becomes /mnt/c/...
+    """
+    if platform.system() != "Windows":
+        return str(p)
+    s = str(p).replace("\\", "/")
+    if len(s) >= 2 and s[1] == ":":
+        s = "/mnt/" + s[0].lower() + s[2:]
+    return s
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.parametrize("provider", ["Claude", "GPT"])
+class TestBuildReviewComment:
+    def _run(self, body_file: str, provider: str) -> subprocess.CompletedProcess:
+        workflow = f"{provider.lower()}-pr-review.yml"
+        return subprocess.run(
+            ["bash", _to_bash_path(SCRIPT), _to_bash_path(body_file), provider, workflow, RUN_URL],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_non_empty_body_produces_full_review(self, tmp_path, provider):
+        body = tmp_path / "body.md"
+        body.write_text("This PR looks fine.")
+        result = self._run(str(body), provider)
+        assert result.returncode == 0
+        assert f"## {provider} AI Code Review" in result.stdout
+        assert "This PR looks fine." in result.stdout
+        assert "Advisory only." in result.stdout
+        assert "Failed" not in result.stdout
+
+    def test_empty_body_produces_failure_notice(self, tmp_path, provider):
+        body = tmp_path / "body.md"
+        body.write_text("")
+        result = self._run(str(body), provider)
+        assert result.returncode == 0
+        assert f"## {provider} AI Code Review - Failed" in result.stdout
+        assert RUN_URL in result.stdout
+
+    def test_missing_body_produces_failure_notice(self, tmp_path, provider):
+        missing = str(tmp_path / "nonexistent.md")
+        result = self._run(missing, provider)
+        assert result.returncode == 0
+        assert f"## {provider} AI Code Review - Failed" in result.stdout
+        assert RUN_URL in result.stdout


### PR DESCRIPTION
## Summary

Implements both #3293 and #3295 together (the issues are coupled — they share the `build_review_comment.sh` refactor).

### Layer 1 — empty API response tests (`tests/test_ai_review_scripts.py`)
Added `test_review_script_exits_on_empty_api_response` parametrized over three cases:
- GPT: `{"choices": []}` → exits 1, stderr `ERROR: OpenAI API returned an empty review`
- GPT: `{"choices": [{"message": {"content": ""}}]}` → same
- Claude: `{"content": []}` → exits 1, stderr `ERROR: Claude API returned an empty review`

### Half A — `extract_verdict.py` unit tests (`tests/test_extract_verdict.py`)
New test file covering `extract_verdict()` and `main()`:
- APPROVE / REQUEST CHANGES / no-verdict regex cases
- `main()` exit codes and stdout/stderr messages for all paths
- Parametrized over `Claude` and `GPT` provider names

### Half B — comment-body builder extraction (`tests/test_review_comment.py`)
- Extract inline `if [ -s ... ]` bash from both `claude-pr-review.yml` and `gpt-pr-review.yml` into `.github/scripts/build_review_comment.sh`
- Both workflows replaced with a single `bash .github/scripts/build_review_comment.sh ...` call; output is byte-equivalent to the previous inline heredoc
- `tests/test_review_comment.py` uses `subprocess.run` to test non-empty body, empty file, and missing file for both providers
- Windows/WSL path conversion helper ensures tests run on the Windows dev box; `@pytest.mark.skipif(bash not available)` guard prevents failures on bare-Windows environments
- CI (`ubuntu-latest`) always has bash, so all tests run in CI

## Test plan

- [x] All 31 new + existing tests pass locally (`pytest tests/test_extract_verdict.py tests/test_review_comment.py tests/test_ai_review_scripts.py --no-cov`)
- [ ] CI green

Closes #3293
Closes #3295