### PR TITLE
docs(CLAUDE.md): add guidance on paging gh run list when output is truncated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limi
 - **The Claude PR Review check exit code is meaningful.** Exit 1 from `extract_verdict.py` means one of two things — distinguish them by reading the log:
   - `✗ Claude review: CHANGES REQUESTED` → the AI produced a real review with blocking feedback; read the review body from the PR's top-level comments and address each finding.
   - `ERROR: Claude review output was empty` → the Anthropic API returned nothing; this is genuinely transient and a re-run is appropriate.
+- **`gh run list` defaults to 20 entries and caps at 100 with `--limit`.** On an active branch with many runs (e.g. after repeated force-pushes or rebases), the run for the current HEAD SHA may not appear in the default listing. Pass `--limit 50` as a first step; if the SHA still isn't found, page with the REST API: `gh api "repos/{owner}/{repo}/actions/runs?branch=<branch>&per_page=100&page=2"`. Always match the returned run to the current HEAD SHA before reading the conclusion.
 - **Do not declare a PR "ready to merge" until `gh run list` shows all required checks green on the current HEAD SHA.** "Checks re-running" is not the same as "checks passing".
 
 ### Docs / scripts / workflows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,19 @@ C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limi
 - Add/update Vitest coverage for logic changes.
 - Capture screenshots for visible UI changes when tooling allows.
 
+### GitHub PRs
+- When reviewing PR comments, always call **both** `get_pull_request_comments` (inline review thread comments) and the issue comments endpoint (top-level PR conversation comments) in parallel — they cover different things and GitHub exposes them via separate APIs.
+- Filter comments by `created_at` vs the last commit timestamp so already-addressed threads are not re-processed.
+- If results look sparse (e.g. only stale comments on old code), treat that as a signal to check the other endpoint before assuming you have the full picture.
+
+### CI / GitHub Actions status
+- **`get_pull_request_status` does not cover GitHub Actions.** It calls the legacy Commit Status API and returns `total_count: 0` for repos that use only Actions — which looks like "no CI" but is misleading. Always use `gh run list --repo <owner>/<repo> --branch <head-branch> --limit 10` to get the real Actions run list.
+- **Never assume a failing check is a transient API error without reading the log.** Run `gh run view <run-id> --repo <owner>/<repo> --log-failed` for every failing run and read the actual output before drawing any conclusion.
+- **The Claude PR Review check exit code is meaningful.** Exit 1 from `extract_verdict.py` means one of two things — distinguish them by reading the log:
+  - `✗ Claude review: CHANGES REQUESTED` → the AI produced a real review with blocking feedback; read the review body from the PR's top-level comments and address each finding.
+  - `ERROR: Claude review output was empty` → the Anthropic API returned nothing; this is genuinely transient and a re-run is appropriate.
+- **Do not declare a PR "ready to merge" until `gh run list` shows all required checks green on the current HEAD SHA.** "Checks re-running" is not the same as "checks passing".
+
 ### Docs / scripts / workflows
 - Look for duplicate instructions in `docs/`, `scripts/README.md`, root scripts, and workflow YAML.
 - Prefer consolidating or correcting instructions rather than introducing a new conflicting variant.


### PR DESCRIPTION
## Summary

- Documents that `gh run list` defaults to 20 entries (cap 100 with `--limit`)
- Adds guidance to use `--limit 50` first, then fall back to REST API pagination if the HEAD SHA still isn't found
- Notes that the returned run must always be matched against the current HEAD SHA

On active branches with many runs, the relevant run may not appear in the default `gh run list` output, causing agents to miss results or read stale ones.

**Note:** This branch is based on `docs/claude-md-ci-and-pr-guidance` which adds the `### CI / GitHub Actions status` section. This PR targets `main`; the parent branch should be merged first (or this PR rebased once it lands).

## Test plan
- [ ] Review the new bullet in the `### CI / GitHub Actions status` section of `CLAUDE.md`

Closes #3313