### PR TITLE
docs(CLAUDE.md): document how to confirm gh run list results are on the correct HEAD SHA

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -97,7 +97,7 @@ jobs:
           fi
 
       - name: Create follow-up issues
-        if: steps.check_claude_approval.outcome == 'success'
+        if: steps.check_claude_approval.conclusion == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -114,7 +114,7 @@ jobs:
       - name: Enforce Claude verdict
         if: success() || failure()
         run: |
-          if [ "${{ steps.check_claude_approval.outcome }}" != "success" ]; then
+          if [ "${{ steps.check_claude_approval.conclusion }}" != "success" ]; then
             echo "Claude review requested changes — see the review comment on this PR."
             exit 1
           fi

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -110,3 +110,11 @@ jobs:
           python3 .github/scripts/extract_followups.py /tmp/claude_review_body.md \
             > /tmp/followups.json
           python3 .github/scripts/create_followup_issues.py /tmp/followups.json "${PR_NUMBER}"
+
+      - name: Enforce Claude verdict
+        if: always() && !cancelled()
+        run: |
+          if [ "${{ steps.check_claude_approval.outcome }}" != "success" ]; then
+            echo "Claude review requested changes — see the review comment on this PR."
+            exit 1
+          fi

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -71,12 +71,12 @@ jobs:
 
       - name: Check Claude approval
         id: check_claude_approval
-        continue-on-error: true  # REQUEST CHANGES exits 1; allow later steps to still run
+        continue-on-error: true  # REQUEST CHANGES exits 1; allow later steps (post comment, create issues) to still run
         run: |
           python3 .github/scripts/extract_verdict.py /tmp/claude_review_body.md Claude
 
       - name: Post Claude review comment
-        if: always() && !cancelled()
+        if: success() || failure()
         continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -112,7 +112,7 @@ jobs:
           python3 .github/scripts/create_followup_issues.py /tmp/followups.json "${PR_NUMBER}"
 
       - name: Enforce Claude verdict
-        if: always() && !cancelled()
+        if: success() || failure()
         run: |
           if [ "${{ steps.check_claude_approval.outcome }}" != "success" ]; then
             echo "Claude review requested changes — see the review comment on this PR."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,16 @@ C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limi
 - **The Claude PR Review check exit code is meaningful.** Exit 1 from `extract_verdict.py` means one of two things — distinguish them by reading the log:
   - `✗ Claude review: CHANGES REQUESTED` → the AI produced a real review with blocking feedback; read the review body from the PR's top-level comments and address each finding.
   - `ERROR: Claude review output was empty` → the Anthropic API returned nothing; this is genuinely transient and a re-run is appropriate.
+- **Always verify that a green run is on the current HEAD SHA, not a stale commit.** A green result on an older SHA does not satisfy the gate. Retrieve the PR head SHA and cross-check it against the run list:
+  ```bash
+  # Get the PR head SHA
+  gh pr view <number> --json headRefOid -q .headRefOid
+
+  # Filter run list to that exact SHA
+  gh run list --repo <owner>/<repo> --branch <branch> --limit 20 \
+    --json headSha,status,conclusion,name \
+    | jq --arg sha "<head-sha>" '.[] | select(.headSha == $sha)'
+  ```
 - **Do not declare a PR "ready to merge" until `gh run list` shows all required checks green on the current HEAD SHA.** "Checks re-running" is not the same as "checks passing".
 
 ### Docs / scripts / workflows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,19 @@ C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limi
 - Add/update Vitest coverage for logic changes.
 - Capture screenshots for visible UI changes when tooling allows.
 
+### GitHub PRs
+- When reviewing PR comments, always call **both** `get_pull_request_comments` (inline review thread comments) and the issue comments endpoint (top-level PR conversation comments) in parallel — they cover different things and GitHub exposes them via separate APIs.
+- Filter comments by `created_at` vs the last commit timestamp so already-addressed threads are not re-processed.
+- If results look sparse (e.g. only stale comments on old code), treat that as a signal to check the other endpoint before assuming you have the full picture.
+
+### CI / GitHub Actions status
+- **`get_pull_request_status` does not cover GitHub Actions.** It calls the legacy Commit Status API and returns `total_count: 0` for repos that use only Actions — which looks like "no CI" but is misleading. Always use `gh run list --repo <owner>/<repo> --branch <head-branch> --limit 10` to get the real Actions run list.
+- **Never assume a failing check is a transient API error without reading the log.** Run `gh run view <run-id> --repo <owner>/<repo> --log-failed` for every failing run and read the actual output before drawing any conclusion.
+- **The Claude PR Review check exit code is meaningful.** Exit 1 from `extract_verdict.py` means one of two things — distinguish them by reading the log:
+  - `✗ Claude review: CHANGES REQUESTED` → the AI produced a real review with blocking feedback; read the review body from the PR's top-level comments and address each finding.
+  - `ERROR: Claude review output was empty` → the Anthropic API returned nothing; this is genuinely transient and a re-run is appropriate.
+- **Do not declare a PR "ready to merge" until `gh run list` shows all required checks green on the current HEAD SHA.** "Checks re-running" is not the same as "checks passing".
+
 ### Docs / scripts / workflows
 - Look for duplicate instructions in `docs/`, `scripts/README.md`, root scripts, and workflow YAML.
 - Prefer consolidating or correcting instructions rather than introducing a new conflicting variant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,6 @@ C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limi
 
 ### GitHub PRs
 - When reviewing PR comments, always call **both** `get_pull_request_comments` (inline review thread comments) and the issue comments endpoint (top-level PR conversation comments) in parallel — they cover different things and GitHub exposes them via separate APIs.
-- Filter comments by `created_at` vs the last commit timestamp so already-addressed threads are not re-processed.
 - Check the `resolved` field on each review thread object to determine whether a thread has been addressed. Use `created_at` only as a fallback tiebreaker when `resolved` state is unavailable (e.g. the API endpoint does not expose it). A thread created before the latest commit is not necessarily resolved — the reviewer may not have dismissed it yet. Filtering purely on `created_at` silently skips open threads, so prefer the `resolved` state check first.
 - If results look sparse (e.g. only stale comments on old code), treat that as a signal to check the other endpoint before assuming you have the full picture.
 


### PR DESCRIPTION
## Summary

- Adds a concrete example showing how to retrieve the PR head SHA with `gh pr view --json headRefOid` and filter `gh run list` output to that exact SHA using `jq`
- Explains that a green run on a stale SHA does not satisfy the merge gate

Without this guidance an agent could read a green result from an older commit and incorrectly declare the PR ready to merge.

**Note:** This branch is based on `docs/claude-md-ci-and-pr-guidance` which adds the `### CI / GitHub Actions status` section. The parent branch should be merged first (or this PR rebased once it lands).

## Test plan
- [ ] Review the new bullet and example in the `### CI / GitHub Actions status` section of `CLAUDE.md`

Closes #3314