### PR TITLE
docs(CLAUDE.md): add jq SHA cross-check example with matching/non-matching output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,52 @@ C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limi
 - Add/update Vitest coverage for logic changes.
 - Capture screenshots for visible UI changes when tooling allows.
 
+### GitHub PRs
+- When reviewing PR comments, always call **both** `get_pull_request_comments` (inline review thread comments) and the issue comments endpoint (top-level PR conversation comments) in parallel — they cover different things and GitHub exposes them via separate APIs.
+- Filter comments by `created_at` vs the last commit timestamp so already-addressed threads are not re-processed.
+- If results look sparse (e.g. only stale comments on old code), treat that as a signal to check the other endpoint before assuming you have the full picture.
+
+### CI / GitHub Actions status
+- **`get_pull_request_status` does not cover GitHub Actions.** It calls the legacy Commit Status API and returns `total_count: 0` for repos that use only Actions — which looks like "no CI" but is misleading. Always use `gh run list --repo <owner>/<repo> --branch <head-branch> --limit 10` to get the real Actions run list.
+- **Never assume a failing check is a transient API error without reading the log.** Run `gh run view <run-id> --repo <owner>/<repo> --log-failed` for every failing run and read the actual output before drawing any conclusion.
+- **The Claude PR Review check exit code is meaningful.** Exit 1 from `extract_verdict.py` means one of two things — distinguish them by reading the log:
+  - `✗ Claude review: CHANGES REQUESTED` → the AI produced a real review with blocking feedback; read the review body from the PR's top-level comments and address each finding.
+  - `ERROR: Claude review output was empty` → the Anthropic API returned nothing; this is genuinely transient and a re-run is appropriate.
+- **Do not declare a PR "ready to merge" until `gh run list` shows all required checks green on the current HEAD SHA.** "Checks re-running" is not the same as "checks passing".
+
+  To confirm a run is on the right SHA, retrieve the HEAD SHA and filter with `jq`:
+
+  ```bash
+  # bash
+  HEAD_SHA=$(gh pr view <PR_NUMBER> --repo <owner>/<repo> --json headRefOid -q '.headRefOid')
+  gh run list --repo <owner>/<repo> --branch <head-branch> --limit 10 \
+    --json headSha,status,conclusion,name \
+    | jq --arg sha "$HEAD_SHA" '.[] | select(.headSha == $sha)'
+  ```
+
+  ```powershell
+  # PowerShell
+  $HEAD_SHA = gh pr view <PR_NUMBER> --repo <owner>/<repo> --json headRefOid -q '.headRefOid'
+  gh run list --repo <owner>/<repo> --branch <head-branch> --limit 10 `
+    --json headSha,status,conclusion,name `
+    | jq --arg sha $HEAD_SHA '.[] | select(.headSha == $sha)'
+  ```
+
+  **Matching (run is on the current HEAD — merge gate can be satisfied):**
+  ```json
+  {
+    "headSha": "e1eb5106a29dbe3340f19068db79b834fcaa2fd4",
+    "status": "completed",
+    "conclusion": "success",
+    "name": "CI"
+  }
+  ```
+
+  **Non-matching (no output — all runs are on a stale SHA; do not declare ready to merge):**
+  ```
+  (no output)
+  ```
+
 ### Docs / scripts / workflows
 - Look for duplicate instructions in `docs/`, `scripts/README.md`, root scripts, and workflow YAML.
 - Prefer consolidating or correcting instructions rather than introducing a new conflicting variant.


### PR DESCRIPTION
## Summary

- Adds `### GitHub PRs` and `### CI / GitHub Actions status` sections to `CLAUDE.md` (these existed on the unmerged `docs/issue-3314-gh-run-list-head-sha` branch but not yet on `main`)
- Adds a concrete `jq` + `gh` command pair (bash and PowerShell variants) showing how to filter `gh run list` output to the current HEAD SHA
- Shows both the **matching** case (JSON object returned — merge gate can be satisfied) and the **non-matching/stale** case (no output — do not declare ready to merge)

Without this example an agent can read a green run on a stale SHA and incorrectly declare a PR ready to merge.

## Test plan
- [ ] Read the `### CI / GitHub Actions status` section and confirm both code blocks and both output examples are present
- [ ] `make lint` passes (docs-only change, no Python/TS touched)

Closes #3329