### PR TITLE
feat: generate rich issue bodies for AI-suggested follow-up issues

### DIFF
--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -3,8 +3,75 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+_ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
+_FALLBACK_BODY_TEMPLATE = "Follow-up suggested by Claude AI review of PR #{pr_number}."
+
+
+def _generate_body_via_claude(title: str, pr_number: str, review_text: str) -> str:
+    """Call Claude Haiku to generate a rich issue body. Returns the generated body."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
+
+    prompt = f"""You are writing a GitHub issue for the allotmint repository.
+
+The issue title is: "{title}"
+
+It was suggested as a non-blocking follow-up during an AI code review of PR #{pr_number}.
+The full review text is:
+---
+{review_text}
+---
+
+Write a complete, actionable GitHub issue body in Markdown covering:
+1. **What** — exactly what needs to change and where (file, function, section)
+2. **Why** — the motivation (correctness risk, maintainability, agent confusion, etc.)
+3. **How** — a concrete implementation approach
+4. **Constraints** — what must not break, what is out of scope
+5. **LLM tier** — which model is appropriate: Haiku (simple/mechanical), Sonnet (moderate reasoning), or Opus (complex design/architecture)
+6. **Success looks like** — specific, verifiable criteria
+7. **Failure looks like** — what would indicate the implementation went wrong
+
+Be concise but complete. Do not pad with generic advice.
+End with: _Follow-up from AI review of PR #{pr_number}._"""
+
+    payload = json.dumps({
+        "model": _ANTHROPIC_MODEL,
+        "max_tokens": 1024,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode()
+
+    req = urllib.request.Request(
+        _ANTHROPIC_API_URL,
+        data=payload,
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read())
+        return data["content"][0]["text"].strip()
+    except (urllib.error.HTTPError, urllib.error.URLError, KeyError, IndexError) as exc:
+        print(f"WARNING: failed to generate issue body via Claude API: {exc}", file=sys.stderr)
+        return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
+
+
+def _build_body(title: str, pr_number: str, review_text: str | None) -> str:
+    if review_text:
+        return _generate_body_via_claude(title, pr_number, review_text)
+    return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
 
 
 def issue_exists(title: str) -> bool:
@@ -30,19 +97,22 @@ def issue_exists(title: str) -> bool:
     return any(i.get("title", "").strip() == title.strip() for i in issues)
 
 
-def create_issues(titles: list[str], pr_number: str) -> None:
+def create_issues(
+    titles: list[str], pr_number: str, review_text: str | None = None
+) -> None:
     for title in titles:
-        if not title:
+        if not title.strip():
             continue
         if issue_exists(title):
             print(f"Skipping (already exists): {title}")
             continue
         print(f"Creating issue: {title}")
+        body = _build_body(title, pr_number, review_text)
         subprocess.run(
             [
                 "gh", "issue", "create",
                 "--title", title,
-                "--body", f"Follow-up suggested by Claude AI review of PR #{pr_number}.",
+                "--body", body,
                 "--label", "ai-suggested",
             ],
             check=True,
@@ -50,17 +120,34 @@ def create_issues(titles: list[str], pr_number: str) -> None:
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
-        print(f"Usage: {sys.argv[0]} <followups_json_file> <pr_number>", file=sys.stderr)
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        print(
+            f"Usage: {sys.argv[0]} <followups_json_file> <pr_number> [<review_file>]",
+            file=sys.stderr,
+        )
         return 1
-    followups_file, pr_number = sys.argv[1], sys.argv[2]
+    followups_file = sys.argv[1]
+    pr_number = sys.argv[2]
+    review_file = sys.argv[3] if len(sys.argv) == 4 else None
+
     try:
         with open(followups_file) as f:
             titles = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError) as exc:
         print(f"ERROR reading {followups_file}: {exc}", file=sys.stderr)
         return 1
-    create_issues(titles, pr_number)
+
+    review_text: str | None = None
+    if review_file:
+        try:
+            review_text = Path(review_file).read_text()
+        except FileNotFoundError:
+            print(
+                f"WARNING: review file not found: {review_file} — using fallback body",
+                file=sys.stderr,
+            )
+
+    create_issues(titles, pr_number, review_text)
     return 0
 
 

--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.error
@@ -14,6 +15,16 @@ from pathlib import Path
 _ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
 _FALLBACK_BODY_TEMPLATE = "Follow-up suggested by Claude AI review of PR #{pr_number}."
+
+_LLM_LABEL_MAP = {
+    "haiku": "llm: haiku",
+    "sonnet": "llm: sonnet",
+    "opus": "llm: opus",
+}
+_LLM_TIER_PATTERN = re.compile(
+    r'\*\*LLM\s+tier\*\*[^\n]*\n[^\n]*\*\*(haiku|sonnet|opus)\b',
+    re.IGNORECASE,
+)
 
 
 def _generate_body_via_claude(title: str, pr_number: str, review_text: str) -> str:
@@ -68,6 +79,17 @@ End with: _Follow-up from AI review of PR #{pr_number}._"""
         return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
 
 
+def _extract_llm_label(body: str) -> str | None:
+    """Return the 'llm: <tier>' label name if the body names a tier, else None."""
+    m = _LLM_TIER_PATTERN.search(body)
+    if m:
+        return _LLM_LABEL_MAP.get(m.group(1).lower())
+    for tier, label in _LLM_LABEL_MAP.items():
+        if re.search(rf'\b{tier}\b', body, re.IGNORECASE):
+            return label
+    return None
+
+
 def _build_body(title: str, pr_number: str, review_text: str | None) -> str:
     if review_text:
         return _generate_body_via_claude(title, pr_number, review_text)
@@ -108,13 +130,13 @@ def create_issues(
             continue
         print(f"Creating issue: {title}")
         body = _build_body(title, pr_number, review_text)
+        labels = ["ai-suggested"]
+        llm_label = _extract_llm_label(body)
+        if llm_label:
+            labels.append(llm_label)
+        label_args = [arg for label in labels for arg in ("--label", label)]
         subprocess.run(
-            [
-                "gh", "issue", "create",
-                "--title", title,
-                "--body", body,
-                "--label", "ai-suggested",
-            ],
+            ["gh", "issue", "create", "--title", title, "--body", body, *label_args],
             check=True,
         )
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -103,8 +103,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          # Ensure the ai-suggested label exists before creating issues
+          # Ensure required labels exist before creating issues
           gh label create "ai-suggested" --color "0075ca" --description "Suggested by AI code review" \
+            2>/dev/null || true
+          gh label create "llm: haiku" --color "C5DEF5" --description "Suitable for Claude Haiku (simple/mechanical task)" \
+            2>/dev/null || true
+          gh label create "llm: sonnet" --color "BFD4F2" --description "Suitable for Claude Sonnet (moderate reasoning)" \
+            2>/dev/null || true
+          gh label create "llm: opus" --color "0052CC" --description "Suitable for Claude Opus (complex design/architecture)" \
             2>/dev/null || true
 
           # Extract titles to a file, then create issues via Python subprocess (no shell injection)

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -101,6 +101,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           # Ensure the ai-suggested label exists before creating issues
           gh label create "ai-suggested" --color "0075ca" --description "Suggested by AI code review" \
@@ -109,4 +110,5 @@ jobs:
           # Extract titles to a file, then create issues via Python subprocess (no shell injection)
           python3 .github/scripts/extract_followups.py /tmp/claude_review_body.md \
             > /tmp/followups.json
-          python3 .github/scripts/create_followup_issues.py /tmp/followups.json "${PR_NUMBER}"
+          python3 .github/scripts/create_followup_issues.py \
+            /tmp/followups.json "${PR_NUMBER}" /tmp/claude_review_body.md

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -178,3 +178,57 @@ def test_create_issues_passes_generated_body(
     assert created
     body_idx = created[0].index("--body") + 1
     assert created[0][body_idx] == "Rich body content"
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_label"),
+    [
+        ("**LLM tier**\n**Haiku** — simple task", "llm: haiku"),
+        ("**LLM tier**\n**Sonnet** — moderate reasoning", "llm: sonnet"),
+        ("**LLM tier**\n**Opus** — complex design", "llm: opus"),
+        ("Use Haiku for this", "llm: haiku"),
+        ("Use Sonnet here", "llm: sonnet"),
+        ("Requires Opus", "llm: opus"),
+        ("No model mentioned", None),
+    ],
+)
+def test_extract_llm_label(body: str, expected_label: str | None) -> None:
+    mod = load_module()
+    assert mod._extract_llm_label(body) == expected_label
+
+
+def test_create_issues_applies_llm_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    created: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "issue_exists", lambda title: False)
+    monkeypatch.setattr(
+        mod, "_build_body", lambda *args, **kwargs: "**LLM tier**\n**Sonnet** — moderate"
+    )
+    monkeypatch.setattr(mod.subprocess, "run", lambda cmd, **kwargs: created.append(cmd))
+
+    mod.create_issues(["My title"], "10", "review text")
+    assert created
+    assert "--label" in created[0]
+    assert "llm: sonnet" in created[0]
+    assert "ai-suggested" in created[0]
+
+
+def test_create_issues_no_llm_label_when_not_mentioned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    created: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "issue_exists", lambda title: False)
+    monkeypatch.setattr(mod, "_build_body", lambda *args, **kwargs: "No model info here.")
+    monkeypatch.setattr(mod.subprocess, "run", lambda cmd, **kwargs: created.append(cmd))
+
+    mod.create_issues(["My title"], "10", None)
+    assert created
+    assert "ai-suggested" in created[0]
+    assert "llm: haiku" not in created[0]
+    assert "llm: sonnet" not in created[0]
+    assert "llm: opus" not in created[0]

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -1,0 +1,180 @@
+"""Tests for create_followup_issues.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import urllib.error
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".github" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "create_followup_issues", SCRIPTS_DIR / "create_followup_issues.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._data = json.dumps(payload).encode()
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args) -> None:
+        return None
+
+
+def test_generate_body_returns_fallback_when_no_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    body = mod._build_body("Fix the thing", "42", "Some review text")
+    assert "PR #42" in body
+    assert "Follow-up" in body
+
+
+def test_generate_body_calls_claude_and_returns_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    fake_payload = {"content": [{"text": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}]}
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: FakeResponse(fake_payload),
+    )
+    body = mod._generate_body_via_claude("Fix the thing", "42", "Review text here")
+    assert "Fix the thing" in body
+    assert "Follow-up" in body
+
+
+def test_generate_body_falls_back_on_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mod = load_module()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    def raise_error(*args, **kwargs):
+        raise urllib.error.HTTPError(
+            url="https://example.test", code=500, msg="server error", hdrs=None, fp=None
+        )
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", raise_error)
+    body = mod._generate_body_via_claude("Fix the thing", "42", "Review text here")
+    assert "PR #42" in body
+    assert "failed to generate" in capsys.readouterr().err
+
+
+def test_build_body_uses_fallback_when_no_review_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    body = mod._build_body("Fix the thing", "99", None)
+    assert "PR #99" in body
+
+
+def test_main_missing_review_file_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mod = load_module()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    followups = tmp_path / "followups.json"
+    followups.write_text(json.dumps([]))
+
+    monkeypatch.setattr(
+        sys, "argv", [
+            "create_followup_issues.py",
+            str(followups),
+            "7",
+            "/nonexistent/review.md",
+        ]
+    )
+    result = mod.main()
+    assert result == 0
+    assert "WARNING: review file not found" in capsys.readouterr().err
+
+
+def test_main_wrong_arg_count_prints_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mod = load_module()
+    monkeypatch.setattr(sys, "argv", ["create_followup_issues.py"])
+    assert mod.main() == 1
+    assert "Usage:" in capsys.readouterr().err
+
+
+def test_create_issues_skips_empty_titles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "issue_exists", lambda title: False)
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd),
+    )
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    mod.create_issues(["", "  ", "Real title"], "5", None)
+    assert len(calls) == 1
+    assert "Real title" in calls[0]
+
+
+def test_create_issues_skips_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    calls: list = []
+
+    monkeypatch.setattr(mod, "issue_exists", lambda title: True)
+    monkeypatch.setattr(mod.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd))
+
+    mod.create_issues(["Already exists"], "5", None)
+    assert calls == []
+
+
+def test_create_issues_passes_generated_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    created: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "issue_exists", lambda title: False)
+    monkeypatch.setattr(mod, "_build_body", lambda *args, **kwargs: "Rich body content")
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda cmd, **kwargs: created.append(cmd),
+    )
+
+    mod.create_issues(["My title"], "10", "review text")
+    assert created
+    body_idx = created[0].index("--body") + 1
+    assert created[0][body_idx] == "Rich body content"


### PR DESCRIPTION
## Summary

- Replaces the one-liner `"Follow-up suggested by Claude AI review of PR #N."` body with a structured body generated by calling Claude Haiku once per follow-up title
- The generated body covers: **What / Why / How / Constraints / LLM tier / Success looks like / Failure looks like**
- Falls back gracefully to the one-liner when `ANTHROPIC_API_KEY` is absent or the API call fails — no regression on missing secrets
- Whitespace-only titles are now also filtered (minor correctness fix)

## Files changed

| File | Change |
|---|---|
| `.github/scripts/create_followup_issues.py` | Add `_generate_body_via_claude()`, accept optional `<review_file>` arg, pass generated body to `gh issue create` |
| `.github/workflows/claude-pr-review.yml` | Pass `/tmp/claude_review_body.md` and `ANTHROPIC_API_KEY` to the create-follow-up-issues step |
| `tests/test_create_followup_issues.py` | 9 new unit tests covering API success, API error fallback, missing review file, skip logic, body passthrough |

## Test plan
- [ ] All 9 new tests in `tests/test_create_followup_issues.py` pass
- [ ] Existing `tests/test_ai_review_scripts.py` / `test_extract_verdict.py` still pass
- [ ] CI passes on this branch

Closes #3331