### PR TITLE
ci: fail PR checks when branch has merge conflicts with main

### DIFF
--- a/.github/rulesets/default-branch-protection.json
+++ b/.github/rulesets/default-branch-protection.json
@@ -58,6 +58,9 @@
           },
           {
             "context": "GPT PR Review / GPT AI code review"
+          },
+          {
+            "context": "Merge Conflict Check / Check for merge conflicts with main"
           }
         ]
       }

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -1,0 +1,31 @@
+name: Merge Conflict Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-merge-conflicts:
+    name: Check for merge conflicts with main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Attempt merge with main (dry run)
+        run: |
+          git config user.email "ci@github-actions"
+          git config user.name "GitHub Actions"
+          git fetch origin main
+          if ! git merge --no-commit --no-ff origin/main; then
+            echo "::error::This branch has merge conflicts with main. Resolve them before merging."
+            git merge --abort
+            exit 1
+          fi
+          git merge --abort 2>/dev/null || true
+          echo "No merge conflicts detected."

--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -23,6 +23,7 @@ EXPECTED_REQUIRED_CHECKS = {
     "CI / Lambda-compat pytest (backend/requirements.txt)",
     "Backend Integration Tests / integration-tests",
     "Frontend Tests / frontend-tests",
+    "Merge Conflict Check / Check for merge conflicts with main",
     "PR Body Issue Reference Check / require-issue-reference",
     "Dependency Review / dependency-review",
     "Claude PR Review / Claude AI code review",


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/conflict-check.yml`: runs on every PR targeting `main`, does a dry-run `git merge --no-commit --no-ff origin/main`, and fails if conflicts are detected
- Registers `Merge Conflict Check / Check for merge conflicts with main` as a required status check in `.github/rulesets/default-branch-protection.json`
- Updates `scripts/check_branch_protection_required_checks.py` to include the new check in `EXPECTED_REQUIRED_CHECKS`, keeping CI self-validation in sync

## Test plan

- [ ] Open a PR with known merge conflicts — the new check should show red and block merging
- [ ] Open a clean PR — the check should pass green
- [ ] Confirm `python scripts/check_branch_protection_required_checks.py` passes locally
- [ ] Apply the updated ruleset JSON to the repo via GitHub UI / API so branch protection actually enforces it

Closes #3337

🤖 Generated with [Claude Code](https://claude.com/claude-code)