### PR TITLE
fix(iam): add CDK lambda:InvokeFunction grant for deploy role on PriceRefreshLambda live alias

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -417,6 +417,18 @@ class BackendLambdaStack(Stack):
             version=refresh_fn.current_version,
         )
 
+        # Grant the CI deploy role permission to invoke the live alias so the
+        # "Warm price snapshot" workflow step can call it after each deploy.
+        # Dual-managed with bootstrap-deploy-role.sh (which bootstraps the role
+        # before the first CDK deploy). This CDK grant re-applies on every
+        # BackendLambdaStack deploy, keeping the permission current. See #3368.
+        github_deploy_role_arn = os.getenv("GITHUB_DEPLOY_ROLE_ARN", "")
+        if github_deploy_role_arn:
+            github_role = iam.Role.from_role_arn(
+                self, "GithubDeployRoleForLambdaInvoke", github_deploy_role_arn, mutable=True
+            )
+            refresh_alias.grant_invoke(github_role)
+
         events.Rule(
             self,
             "DailyPriceRefresh",

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -390,6 +390,58 @@ def test_no_cfn_changeset_grant_in_backend_lambda_stack(monkeypatch) -> None:
     )
 
 
+def _lambda_invoke_actions_for_role_name(raw_template: dict, role_name: str) -> set[str]:
+    """Return lambda:* actions from policies attached to an imported role by name."""
+    actions: set[str] = set()
+    for res in raw_template["Resources"].values():
+        if res.get("Type") != "AWS::IAM::Policy":
+            continue
+        if role_name not in str(res.get("Properties", {}).get("Roles", [])):
+            continue
+        for stmt in res["Properties"]["PolicyDocument"].get("Statement", []):
+            action = stmt.get("Action", [])
+            if isinstance(action, str):
+                action = [action]
+            for a in action:
+                if a.startswith("lambda:") or a == "*":
+                    actions.add(a)
+    return actions
+
+
+def test_deploy_role_gets_lambda_invoke_on_price_refresh_alias(monkeypatch) -> None:
+    """BackendLambdaStack must grant lambda:InvokeFunction to the deploy role on the
+    PriceRefreshLambda live alias so the CI 'Warm price snapshot' step can invoke it.
+    See issue #3368."""
+    role_arn = "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    monkeypatch.setenv("GITHUB_DEPLOY_ROLE_ARN", role_arn)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackLambdaInvokeTest")
+    raw = Template.from_stack(stack).to_json()
+    lambda_actions = _lambda_invoke_actions_for_role_name(raw, "allotmint-github-deploy")
+    assert "lambda:InvokeFunction" in lambda_actions, (
+        "lambda:InvokeFunction must be granted to the deploy role in BackendLambdaStack "
+        "so the CI warm-price-snapshot step can invoke PriceRefreshLambda:live. See #3368."
+    )
+
+
+def test_no_lambda_invoke_grant_when_github_deploy_role_arn_absent(monkeypatch) -> None:
+    """When GITHUB_DEPLOY_ROLE_ARN is unset, BackendLambdaStack must not grant
+    lambda:InvokeFunction to any imported deploy role. See issue #3368."""
+    monkeypatch.delenv("GITHUB_DEPLOY_ROLE_ARN", raising=False)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackNoLambdaInvokeTest")
+    raw = Template.from_stack(stack).to_json()
+    lambda_actions = _lambda_invoke_actions_for_role_name(raw, "allotmint-github-deploy")
+    assert "lambda:InvokeFunction" not in lambda_actions, (
+        "Expected no lambda:InvokeFunction grant for the deploy role in BackendLambdaStack "
+        "when GITHUB_DEPLOY_ROLE_ARN is unset"
+    )
+
+
 def test_grant_bucket_access_raises_on_no_permissions() -> None:
     class _MockFn:
         def add_to_role_policy(self, policy_statement: object) -> None:


### PR DESCRIPTION
## Summary

- Adds `refresh_alias.grant_invoke(github_role)` in `BackendLambdaStack` so CDK manages the `lambda:InvokeFunction` permission for the deploy role on every `cdk deploy BackendLambdaStack`
- Adds two CDK tests asserting the grant is synthesised when `GITHUB_DEPLOY_ROLE_ARN` is set and absent when unset
- Fixes the "Warm price snapshot" deploy step failing with `AccessDeniedException`

## Root cause

`bootstrap-deploy-role.sh` grants `lambda:InvokeFunction` via an inline IAM policy. The CDK stacks never applied this permission, so if the bootstrap script was not run (or its inline policy was overwritten), every deploy fails with:

```
An error occurred (AccessDeniedException) when calling the Invoke operation: ... is not authorized to perform: lambda:InvokeFunction
```

## Test plan

- [ ] CDK tests in `cdk/tests/test_backend_lambda_stack_permissions.py` pass in CI (local failures are a pre-existing Jenkins workspace permission issue unrelated to this change)
- [ ] Re-run [the failing deploy workflow](https://github.com/leonarduk/allotmint/actions/runs/27044289230/job/79826935803) after this PR is merged and the next tag triggers a deploy

## Immediate workaround (if you need to unblock deploy now)

```bash
DEPLOY_ROLE_NAME=allotmint-github-deploy \
DATA_BUCKET=<your-data-bucket-name> \
bash scripts/bash/bootstrap-deploy-role.sh
```

Closes #3368

🤖 Generated with [Claude Code](https://claude.com/claude-code)