### PR TITLE
fix(ci): skip verdict bullet items when extracting follow-up issue titles

### DIFF
--- a/.github/scripts/extract_followups.py
+++ b/.github/scripts/extract_followups.py
@@ -30,10 +30,11 @@ def extract_followups(review_text: str) -> list[str]:
     if verdict_match:
         section_text = section_text[: verdict_match.start()]
 
+    verdict_title_re = re.compile(r'^\*\*(APPROVE|REQUEST CHANGES)\*\*', re.IGNORECASE)
     titles = []
     for m in re.finditer(r'^[-*]\s+(.+)', section_text, re.MULTILINE):
         title = m.group(1).strip()
-        if title:
+        if title and not verdict_title_re.match(title):
             titles.append(title)
     return titles
 

--- a/tests/test_extract_followups.py
+++ b/tests/test_extract_followups.py
@@ -1,0 +1,77 @@
+"""Tests for extract_followups.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".github" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from extract_followups import extract_followups
+
+
+def test_extracts_titles_from_section_5() -> None:
+    review = """\
+## 5. Suggested follow-up issues
+
+- Add unit tests for the new helper
+- Refactor the auth module
+
+**APPROVE**
+"""
+    assert extract_followups(review) == [
+        "Add unit tests for the new helper",
+        "Refactor the auth module",
+    ]
+
+
+def test_verdict_as_bullet_not_extracted() -> None:
+    """Verdict line appearing as a bullet (- **APPROVE**) must not become a title.
+
+    Regression test for https://github.com/leonarduk/allotmint/issues/3376 where
+    the section-5 stop regex only matched **APPROVE** at line-start, so a bullet
+    like '- **APPROVE**' bypassed the guard and was used as an issue title.
+    """
+    review = """\
+## 5. Suggested follow-up issues
+
+- Do some cleanup
+
+- **APPROVE**
+"""
+    titles = extract_followups(review)
+    assert "**APPROVE**" not in titles
+    assert titles == ["Do some cleanup"]
+
+
+def test_request_changes_as_bullet_not_extracted() -> None:
+    review = """\
+## 5. Suggested follow-up issues
+
+- Fix the bug
+
+- **REQUEST CHANGES**
+"""
+    titles = extract_followups(review)
+    assert "**REQUEST CHANGES**" not in titles
+    assert titles == ["Fix the bug"]
+
+
+def test_no_section_5_returns_empty() -> None:
+    review = "## 1. Summary\n\nLooks good.\n\n**APPROVE**\n"
+    assert extract_followups(review) == []
+
+
+def test_verdict_line_stops_section_extraction() -> None:
+    review = """\
+## 5. Suggested follow-up issues
+
+- Valid follow-up
+
+**APPROVE**
+
+- Should not be included
+"""
+    assert extract_followups(review) == ["Valid follow-up"]


### PR DESCRIPTION
## Summary

- Fixes `extract_followups.py` to skip bullet items whose text matches the verdict pattern (`**APPROVE**` / `**REQUEST CHANGES**`), so they are never used as issue titles
- Adds `tests/test_extract_followups.py` with 5 tests covering the regression and related edge cases

## Root cause

The section-5 stop guard used `^\*\*(APPROVE|REQUEST CHANGES)\*\*` (requires `**` at line start). When Claude formats the verdict as a bullet — `- **APPROVE**` — the guard doesn't match, the line passes through, and `**APPROVE**` becomes the captured title, producing a bogus follow-up issue (see [#3376](https://github.com/leonarduk/allotmint/issues/3376)).

## Test plan

- [x] `pytest tests/test_extract_followups.py` — 5 tests, all pass

Closes #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)