### PR TITLE
ci: replace git merge --abort with git reset --hard HEAD on successful no-conflict dry-run

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -27,5 +27,5 @@ jobs:
             git merge --abort
             exit 1
           fi
-          git merge --abort 2>/dev/null || true
+          git reset --hard HEAD
           echo "No merge conflicts detected."


### PR DESCRIPTION
## Summary
- Replace `git merge --abort` with `git reset --hard HEAD` in the successful cleanup path of conflict-check.yml
- Makes intent clearer: we're unconditionally restoring the working tree after a successful merge dry-run

## Test plan
- Conflict-check workflow still correctly identifies actual merge conflicts
- Cleanup step runs without errors on both conflict and no-conflict scenarios

Closes #3340

🤖 Generated with Claude Code