### PR TITLE
ci: add ready_for_review trigger to conflict-check.yml

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -3,7 +3,7 @@ name: Merge Conflict Check
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `ready_for_review` to the trigger types in conflict-check.yml
- Ensures conflict checks run when draft PRs are marked as ready for review

## Why
Draft PRs can have merge conflicts that aren't checked until the workflow triggers.
Marking a draft as ready should validate conflicts haven't been introduced.

## Test plan
- Create a draft PR with conflicts, mark ready → conflict-check should fail
- Create a clean draft PR, mark ready → conflict-check should pass

Closes #3339

🤖 Generated with Claude Code