### PR TITLE
docs: add DEPLOY.md note about dummy env variable format for CDK dry-run

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -59,10 +59,11 @@ logic in `backend_lambda_stack.py` (e.g., checking secret length, format, or tru
 ensure dummy values still pass. Empty or falsy values will cause `cdk synth` to fail in
 CI and block deployment.
 
-Example: ✅ `if not jwt_secret:` passes ("dummy" is truthy so this check does not fire);
-❌ `if len(jwt_secret) < 32:` breaks CI ("dummy" is only 5 characters, so this condition
-fires and would cause a synth failure — use a longer placeholder or avoid minimum-length
-guards against these secrets).
+For example, `if not jwt_secret:` is safe with the current placeholder — `"dummy"` is truthy
+so this guard does not fire. By contrast, `if len(jwt_secret) < 32:` breaks the dry-run
+immediately: `"dummy"` is only 5 characters, so that condition is true and `cdk synth` fails.
+Any new validation guard that the current placeholder cannot satisfy will break the CI
+dry-run gate.
 
 The advisory AI review workflows run on pull request `opened`, `reopened`, and `synchronize`
 events. They require `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` to be configured as GitHub

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -47,6 +47,20 @@ and the `allotmint/app` Secrets Manager secret are no longer used. Remove
 `APP_SECRET_NAME` from any existing GitHub Actions secrets or local `.env`
 files and add `JWT_SECRET` and `GOOGLE_CLIENT_ID` directly instead.
 
+### Dummy environment variable format for CDK dry-run CI
+
+The CI dry-run workflow (`.github/workflows/cdk-dry-run.yml`) validates `cdk synth`
+using placeholder values for secrets:
+- `JWT_SECRET=dummy`
+- `GOOGLE_CLIENT_ID=dummy`
+
+These placeholders **must remain non-empty strings**. If you add or modify validation
+logic in `backend_lambda_stack.py` (e.g., checking secret length, format, or truthiness),
+ensure dummy values still pass. Empty or falsy values will cause `cdk synth` to fail in
+CI and block deployment.
+
+Example: ❌ `if not jwt_secret:` will fail; ✅ `if len(jwt_secret) < 32:` passes (dummy is non-empty).
+
 The advisory AI review workflows run on pull request `opened`, `reopened`, and `synchronize`
 events. They require `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` to be configured as GitHub
 repository secrets if you want review comments to be posted, but they remain advisory-only and

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -59,7 +59,10 @@ logic in `backend_lambda_stack.py` (e.g., checking secret length, format, or tru
 ensure dummy values still pass. Empty or falsy values will cause `cdk synth` to fail in
 CI and block deployment.
 
-Example: ❌ `if not jwt_secret:` will fail; ✅ `if len(jwt_secret) < 32:` passes (dummy is non-empty).
+Example: ✅ `if not jwt_secret:` passes ("dummy" is truthy so this check does not fire);
+❌ `if len(jwt_secret) < 32:` breaks CI ("dummy" is only 5 characters, so this condition
+fires and would cause a synth failure — use a longer placeholder or avoid minimum-length
+guards against these secrets).
 
 The advisory AI review workflows run on pull request `opened`, `reopened`, and `synchronize`
 events. They require `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` to be configured as GitHub


### PR DESCRIPTION
## Summary
- Add documentation section to `DEPLOY.md` explaining dummy env variable format requirement
- Clarifies that `JWT_SECRET` and `GOOGLE_CLIENT_ID` placeholders must remain non-empty
- Prevents future maintainers from breaking CI with stricter validation logic

## Context
The CDK dry-run CI workflow uses `JWT_SECRET=dummy` and `GOOGLE_CLIENT_ID=dummy` for synth validation. 
If validation logic is tightened (e.g., length checks), these placeholders could become invalid and 
break the CI gate without clear explanation.

## Test plan
- Read the documentation and confirm the requirement is clear
- Verify the examples illustrate the difference between failing and passing validation patterns

Closes #3350

🤖 Generated with Claude Code