### PR TITLE
docs(bootstrap): annotate bootstrap-deploy-role.sh inline policy as redundant post-#3368

### DIFF
--- a/scripts/bash/bootstrap-deploy-role.sh
+++ b/scripts/bash/bootstrap-deploy-role.sh
@@ -35,6 +35,13 @@ echo "  Account : ${AWS_ACCOUNT_ID}"
 echo "  Region  : ${AWS_REGION}"
 echo "  Bucket  : ${DATA_BUCKET}"
 
+# NOTE: The InvokePriceRefreshLambdaLiveAlias statement is redundant post-#3368.
+# As of PR #3368, the BackendLambdaStack grants lambda:InvokeFunction
+# permission to this role via CDK's grant_invoke() on the price_refresh
+# Lambda alias. This inline policy is retained ONLY for first-deploy
+# bootstrapping, when the CDK stack cannot yet attach the grant.
+# Post-bootstrap, CDK grants are the source of truth.
+
 policy_document="$(cat <<EOF
 {
   "Version": "2012-10-17",


### PR DESCRIPTION
## Summary
- Add comment to `bootstrap-deploy-role.sh` explaining the `InvokePriceRefreshLambdaLiveAlias` permission is now redundant
- Clarifies why the permission is retained despite CDK handling it via `grant_invoke()`
- Documents the bootstrap-only rationale to prevent premature removal

## Context
PR #3368 introduced CDK's `grant_invoke()` for the price refresh Lambda, making this inline policy 
functionally redundant for normal operations. However, the policy is essential for first-deploy 
scenarios where CDK cannot yet grant permissions. The annotation prevents confusion about 
duplicate permission management.

Closes #3380

🤖 Generated with Claude Code