### PR TITLE
docs(CLAUDE.md): audit and improve CI guidance; fix create_followup_issues tier-label logic

### DIFF
--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -21,12 +21,6 @@ _LLM_LABEL_MAP = {
     "sonnet": "sonnet",
     "opus": "opus",
 }
-# Derive a fallback tier label from the model constant so issues created by this
-# script always carry a tier label even when _extract_llm_label finds nothing.
-_FALLBACK_LLM_LABEL: str = next(
-    (label for tier, label in _LLM_LABEL_MAP.items() if tier in _ANTHROPIC_MODEL.lower()),
-    "haiku",
-)
 _LLM_TIER_PATTERN = re.compile(
     r'\*\*LLM\s+tier\*\*[^\n]*\n[^\n]*\*\*(haiku|sonnet|opus)\b',
     re.IGNORECASE,
@@ -137,8 +131,9 @@ def create_issues(
         print(f"Creating issue: {title}")
         body = _build_body(title, pr_number, review_text)
         labels = ["ai-suggested"]
-        llm_label = _extract_llm_label(body) or _FALLBACK_LLM_LABEL
-        labels.append(llm_label)
+        llm_label = _extract_llm_label(body)
+        if llm_label:
+            labels.append(llm_label)
         label_args = [arg for label in labels for arg in ("--label", label)]
         subprocess.run(
             ["gh", "issue", "create", "--title", title, "--body", body, *label_args],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,18 +101,24 @@ C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limi
 - **The Claude PR Review check exit code is meaningful.** Exit 1 from `extract_verdict.py` means one of two things — distinguish them by reading the log:
   - `✗ Claude review: CHANGES REQUESTED` → the AI produced a real review with blocking feedback; read the review body from the PR's top-level comments and address each finding.
   - `ERROR: Claude review output was empty` → the Anthropic API returned nothing; this is genuinely transient and a re-run is appropriate.
-- **Always verify that a green run is on the current HEAD SHA, not a stale commit.** A green result on an older SHA does not satisfy the gate. Retrieve the PR head SHA and cross-check it against the run list:
+- **Always verify that a green run is on the current HEAD SHA, not a stale commit — and do not declare a PR "ready to merge" until all required checks are green on that SHA.** "Checks re-running" is not the same as "checks passing". A green result on an older SHA does not satisfy the gate. Retrieve the PR head SHA and cross-check it against the run list:
   ```bash
   # Get the PR head SHA
   gh pr view <number> --json headRefOid -q .headRefOid
 
-  # Filter run list to that exact SHA (in PowerShell, use "$sha" instead of '$sha')
+  # Filter run list to that exact SHA (bash)
   gh run list --repo <owner>/<repo> --branch <branch> --limit 50 \
     --json headSha,status,conclusion,name \
     | jq --arg sha "<head-sha>" '[.[] | select(.headSha == $sha)]'
   ```
-  If the `jq` filter returns an empty array (`[]`), the run hasn't started yet or isn't in the 50-result window. Wait and retry; don't assume "no CI."
-- **Do not declare a PR "ready to merge" until `gh run list` shows all required checks green on the current HEAD SHA.** "Checks re-running" is not the same as "checks passing". Concurrent runs on other branches can push your target SHA outside the limit; SHA-matching is the safety net.
+  ```powershell
+  # PowerShell: use double-quoted "$headSha" so the shell expands the variable before jq sees it
+  $headSha = gh pr view <number> --json headRefOid -q .headRefOid
+  gh run list --repo <owner>/<repo> --branch <branch> --limit 50 `
+    --json headSha,status,conclusion,name `
+    | jq --arg sha "$headSha" '[.[] | select(.headSha == $sha)]'
+  ```
+  If the `jq` filter returns an empty array (`[]`), first verify the branch name is correct, then wait and retry; don't assume "no CI." Concurrent runs on other branches can push your target SHA outside the limit; SHA-matching is the safety net.
 
 ### Docs / scripts / workflows
 - Look for duplicate instructions in `docs/`, `scripts/README.md`, root scripts, and workflow YAML.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limi
 
 ### GitHub PRs
 - When reviewing PR comments, always call **both** `get_pull_request_comments` (inline review thread comments) and the issue comments endpoint (top-level PR conversation comments) in parallel — they cover different things and GitHub exposes them via separate APIs.
-- Check the `resolved` field on each review thread object to determine whether a thread has been addressed. Use `created_at` only as a fallback tiebreaker when `resolved` state is unavailable (e.g. the API endpoint does not expose it). A thread created before the latest commit is not necessarily resolved — the reviewer may not have dismissed it yet. Filtering purely on `created_at` silently skips open threads, so prefer the `resolved` state check first.
+- Check the `resolved` field on each review thread object to determine whether a thread has been addressed. **Note:** `resolved` is only available via GraphQL; the REST API exposes `dismissed` as a proxy. Use `created_at` only as a fallback tiebreaker when `resolved` state is unavailable. A thread created before the latest commit is not necessarily resolved — the reviewer may not have dismissed it yet. Filtering purely on `created_at` silently skips open threads, so prefer the `resolved`/`dismissed` state check first.
 - If results look sparse (e.g. only stale comments on old code), treat that as a signal to check the other endpoint before assuming you have the full picture.
 
 ### CI / GitHub Actions status
@@ -106,12 +106,13 @@ C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limi
   # Get the PR head SHA
   gh pr view <number> --json headRefOid -q .headRefOid
 
-  # Filter run list to that exact SHA
-  gh run list --repo <owner>/<repo> --branch <branch> --limit 20 \
+  # Filter run list to that exact SHA (in PowerShell, use "$sha" instead of '$sha')
+  gh run list --repo <owner>/<repo> --branch <branch> --limit 50 \
     --json headSha,status,conclusion,name \
-    | jq --arg sha "<head-sha>" '.[] | select(.headSha == $sha)'
+    | jq --arg sha "<head-sha>" '[.[] | select(.headSha == $sha)]'
   ```
-- **Do not declare a PR "ready to merge" until `gh run list` shows all required checks green on the current HEAD SHA.** "Checks re-running" is not the same as "checks passing".
+  If the `jq` filter returns an empty array (`[]`), the run hasn't started yet or isn't in the 50-result window. Wait and retry; don't assume "no CI."
+- **Do not declare a PR "ready to merge" until `gh run list` shows all required checks green on the current HEAD SHA.** "Checks re-running" is not the same as "checks passing". Concurrent runs on other branches can push your target SHA outside the limit; SHA-matching is the safety net.
 
 ### Docs / scripts / workflows
 - Look for duplicate instructions in `docs/`, `scripts/README.md`, root scripts, and workflow YAML.

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -234,4 +234,4 @@ def test_create_issues_applies_fallback_llm_label_when_body_has_no_tier(
     assert created
     assert "ai-suggested" in created[0]
     label_values = [created[0][i + 1] for i, v in enumerate(created[0][:-1]) if v == "--label"]
-    assert not any(t in label_values for t in ("haiku", "sonnet", "opus"))
+    assert any(t in label_values for t in ("haiku", "sonnet", "opus"))

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -219,10 +219,10 @@ def test_create_issues_applies_llm_label(
 def test_create_issues_applies_fallback_llm_label_when_body_has_no_tier(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When the generated body contains no LLM tier mention, the fallback label
-    derived from _ANTHROPIC_MODEL must still be applied so every ai-suggested
-    issue carries a tier label (e.g. issues created by the pr-merge-checker skill
-    which bypasses this script would previously get no tier label at all)."""
+    """When the generated body contains no LLM tier mention, create_issues()
+    should apply only the generic 'ai-suggested' label and no model-tier label
+    (haiku/sonnet/opus). The tier label is derived from body content only;
+    there is no automatic fallback to a model-name-derived tier."""
     mod = load_module()
     created: list[list[str]] = []
 
@@ -234,4 +234,4 @@ def test_create_issues_applies_fallback_llm_label_when_body_has_no_tier(
     assert created
     assert "ai-suggested" in created[0]
     label_values = [created[0][i + 1] for i, v in enumerate(created[0][:-1]) if v == "--label"]
-    assert any(t in label_values for t in ("haiku", "sonnet", "opus"))
+    assert not any(t in label_values for t in ("haiku", "sonnet", "opus"))


### PR DESCRIPTION
## Summary

- Consolidate and clarify GitHub Actions status guidance in CLAUDE.md
- Wrap jq select in array brackets for valid JSON output
- Document PowerShell variable quoting in jq examples with a concrete PowerShell code block
- Add guidance for zero-result case (run not yet started / branch name mismatch)
- Explain why concurrent runs can push target SHA out of limit
- Document GraphQL vs REST differences for resolved/dismissed field
- Merge duplicate 'current HEAD SHA' bullets into one consolidated block
- **Fix `create_followup_issues.py`: remove unconditional `_FALLBACK_LLM_LABEL`** — tier label is now derived from the issue body only; if the body names no tier, only `ai-suggested` is applied (no implicit haiku fallback). Test and docstring updated to match.

## Changes

### CLAUDE.md (documentation)
- **jq select formatting:** `'.[] | select(...)'` → `'[.[] | select(...)]'` for valid JSON
- **PowerShell example:** Added standalone PowerShell code block showing `"$headSha"` expansion
- **Zero-result guidance:** If jq returns `[]`, verify branch name first, then wait and retry
- **Concurrency note:** Clarify that SHA-matching is the safety net when concurrent runs push target outside limit
- **GraphQL/REST:** Document that `resolved` is GraphQL-only; REST uses `dismissed` as proxy
- **Duplicate bullet removed:** Two 'current HEAD SHA' bullets merged into one

### .github/scripts/create_followup_issues.py (behaviour change — not docs-only)
- Removed `_FALLBACK_LLM_LABEL` constant and its automatic application when `_extract_llm_label()` returns `None`
- Issues whose generated body contains no tier keyword now receive only `["ai-suggested"]` — no implicit model-derived tier label
- This corrects a silent misrepresentation: the old code always tagged issues as `haiku` when the body matched no tier, regardless of actual complexity

### tests/test_create_followup_issues.py
- Updated `test_create_issues_applies_fallback_llm_label_when_body_has_no_tier` docstring and assertion to reflect the new contract

Closes #3393

🤖 Generated with Claude Code