### PR TITLE
chore(cdk): export GITHUB_DEPLOY_ROLE_ARN before cdk deploy BackendLambdaStack

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -276,6 +276,7 @@ jobs:
           DATA_BUCKET: ${{ secrets.DATA_BUCKET }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
         run: >
           npx cdk deploy BackendLambdaStack --require-approval never

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -272,6 +272,14 @@ jobs:
           echo "UI_AUTH_USER_POOL_CLIENT_ID=$UI_AUTH_USER_POOL_CLIENT_ID" >> "$GITHUB_ENV"
 
       - name: Deploy BackendLambdaStack
+        # GITHUB_DEPLOY_ROLE_ARN must be set here so CDK can read it during synthesis.
+        # backend_lambda_stack.py calls os.getenv("GITHUB_DEPLOY_ROLE_ARN") at synth time
+        # (not at deploy time) to grant lambda:InvokeFunction on the PriceRefreshLambda live
+        # alias (PR #3368). If the variable is absent during synthesis, the grant is silently
+        # omitted from the CloudFormation template and the "Warm price snapshot" step will fail.
+        # AWS_ROLE_TO_ASSUME is this workflow's GitHub Actions deploy role ARN — the same
+        # principal that invokes the Lambda in the "Warm price snapshot" step below, so it is
+        # the correct ARN to grant invoke permission to.
         env:
           DATA_BUCKET: ${{ secrets.DATA_BUCKET }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}


### PR DESCRIPTION
## Summary
- Add `GITHUB_DEPLOY_ROLE_ARN` environment variable to the Deploy BackendLambdaStack step
- Set to `AWS_ROLE_TO_ASSUME` (the GitHub Actions deploy role ARN)
- Ensures CDK stack synthesis has access to the role for granting lambda:InvokeFunction permission

## Why this matters
`backend_lambda_stack.py` reads `GITHUB_DEPLOY_ROLE_ARN` during synthesis (line 425) to grant
the GitHub Actions deploy role lambda:InvokeFunction permission on the PriceRefreshLambda live alias
(PR #3368). Without this variable set before `cdk deploy`, the grant is skipped silently and
the "Warm price snapshot" step cannot invoke the Lambda.

## Context
The CDK stack grant keeps permissions current across deploys and is dual-managed with the bootstrap
script (which grants permissions for first-deploy bootstrapping). Both need to work together for
the Lambda invoke permission to be present.

Fixes #3377

🤖 Generated with Claude Code