### PR TITLE
fix: ensure every ai-suggested issue always gets an LLM tier label

### DIFF
--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -25,7 +25,7 @@ _LLM_LABEL_MAP = {
 # script always carry a tier label even when _extract_llm_label finds nothing.
 _FALLBACK_LLM_LABEL: str = next(
     (label for tier, label in _LLM_LABEL_MAP.items() if tier in _ANTHROPIC_MODEL.lower()),
-    "llm: haiku",
+    "haiku",
 )
 _LLM_TIER_PATTERN = re.compile(
     r'\*\*LLM\s+tier\*\*[^\n]*\n[^\n]*\*\*(haiku|sonnet|opus)\b',

--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -21,6 +21,12 @@ _LLM_LABEL_MAP = {
     "sonnet": "llm: sonnet",
     "opus": "llm: opus",
 }
+# Derive a fallback tier label from the model constant so issues created by this
+# script always carry a tier label even when _extract_llm_label finds nothing.
+_FALLBACK_LLM_LABEL: str = next(
+    (label for tier, label in _LLM_LABEL_MAP.items() if tier in _ANTHROPIC_MODEL.lower()),
+    "llm: haiku",
+)
 _LLM_TIER_PATTERN = re.compile(
     r'\*\*LLM\s+tier\*\*[^\n]*\n[^\n]*\*\*(haiku|sonnet|opus)\b',
     re.IGNORECASE,
@@ -131,9 +137,8 @@ def create_issues(
         print(f"Creating issue: {title}")
         body = _build_body(title, pr_number, review_text)
         labels = ["ai-suggested"]
-        llm_label = _extract_llm_label(body)
-        if llm_label:
-            labels.append(llm_label)
+        llm_label = _extract_llm_label(body) or _FALLBACK_LLM_LABEL
+        labels.append(llm_label)
         label_args = [arg for label in labels for arg in ("--label", label)]
         subprocess.run(
             ["gh", "issue", "create", "--title", title, "--body", body, *label_args],

--- a/.github/workflows/empty-pr-check.yml
+++ b/.github/workflows/empty-pr-check.yml
@@ -1,0 +1,55 @@
+name: Check Empty PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  check-files:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get PR files count
+        id: files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          FILES_COUNT=$(gh pr view $PR_NUMBER --json files --jq '.files | length')
+          echo "count=$FILES_COUNT" >> $GITHUB_OUTPUT
+          echo "Files in PR: $FILES_COUNT"
+
+      - name: Add EMPTY label if no files
+        if: steps.files.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit $PR_NUMBER --add-label EMPTY || true
+
+      - name: Remove EMPTY label if files exist
+        if: steps.files.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit $PR_NUMBER --remove-label EMPTY || true
+
+      - name: Set check status
+        if: always()
+        env:
+          FILES_COUNT: ${{ steps.files.outputs.count }}
+        run: |
+          if [ "$FILES_COUNT" == "0" ]; then
+            echo "❌ PR is empty - no files changed"
+            exit 1
+          else
+            echo "✅ PR has $FILES_COUNT file(s)"
+            exit 0
+          fi

--- a/.github/workflows/empty-pr-check.yml
+++ b/.github/workflows/empty-pr-check.yml
@@ -21,8 +21,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          FILES_COUNT=$(gh pr view $PR_NUMBER --json files --jq '.files | length')
-          echo "count=$FILES_COUNT" >> $GITHUB_OUTPUT
+          FILES_COUNT=$(gh pr view "$PR_NUMBER" --json files --jq '.files | length')
+          echo "count=$FILES_COUNT" >> "$GITHUB_OUTPUT"
           echo "Files in PR: $FILES_COUNT"
 
       - name: Add EMPTY label if no files
@@ -31,7 +31,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr edit $PR_NUMBER --add-label EMPTY || true
+          gh pr edit "$PR_NUMBER" --add-label EMPTY || true
 
       - name: Remove EMPTY label if files exist
         if: steps.files.outputs.count != '0'
@@ -39,14 +39,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr edit $PR_NUMBER --remove-label EMPTY || true
+          gh pr edit "$PR_NUMBER" --remove-label EMPTY || true
 
       - name: Set check status
         if: always()
         env:
           FILES_COUNT: ${{ steps.files.outputs.count }}
         run: |
-          if [ "$FILES_COUNT" == "0" ]; then
+          if [ "$FILES_COUNT" = "0" ]; then
             echo "❌ PR is empty - no files changed"
             exit 1
           else

--- a/.github/workflows/label-ai-issues.yml
+++ b/.github/workflows/label-ai-issues.yml
@@ -29,7 +29,7 @@ jobs:
             --jq '[.labels[].name]')
 
           # If any known tier label is already present, nothing to do.
-          for tier in haiku sonnet opus "llm: haiku" "llm: sonnet" "llm: opus"; do
+          for tier in haiku sonnet opus; do
             if echo "$labels" | grep -qF "\"$tier\""; then
               echo "Tier label '$tier' already present — skipping."
               exit 0
@@ -43,17 +43,17 @@ jobs:
           body_lower=$(echo "$ISSUE_BODY" | tr '[:upper:]' '[:lower:]')
           tier_label=""
           if echo "$body_lower" | grep -qE '\*\*llm\s+tier\*\*.*opus|\bopus\b.*appropriate'; then
-            tier_label="llm: opus"
+            tier_label="opus"
           elif echo "$body_lower" | grep -qE '\*\*llm\s+tier\*\*.*sonnet|\bsonnet\b.*appropriate'; then
-            tier_label="llm: sonnet"
+            tier_label="sonnet"
           elif echo "$body_lower" | grep -qE '\bsonnet\b'; then
-            tier_label="llm: sonnet"
+            tier_label="sonnet"
           elif echo "$body_lower" | grep -qE '\bopus\b'; then
-            tier_label="llm: opus"
+            tier_label="opus"
           else
             # Default: haiku — matches the model used by create_followup_issues.py
             # and is the safe, cheapest fallback for simple/mechanical tasks.
-            tier_label="llm: haiku"
+            tier_label="haiku"
           fi
 
           echo "Applying tier label: $tier_label"

--- a/.github/workflows/label-ai-issues.yml
+++ b/.github/workflows/label-ai-issues.yml
@@ -1,0 +1,62 @@
+name: Label AI-suggested issues with LLM tier
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  apply-llm-tier-label:
+    name: Apply LLM tier label if missing
+    runs-on: ubuntu-latest
+    # Only run for issues that carry the ai-suggested label.
+    if: |
+      contains(github.event.issue.labels.*.name, 'ai-suggested')
+    permissions:
+      issues: write
+
+    steps:
+      - name: Check for existing tier label and apply fallback
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Collect current label names on the issue.
+          labels=$(gh issue view "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --json labels \
+            --jq '[.labels[].name]')
+
+          # If any known tier label is already present, nothing to do.
+          for tier in haiku sonnet opus "llm: haiku" "llm: sonnet" "llm: opus"; do
+            if echo "$labels" | grep -qF "\"$tier\""; then
+              echo "Tier label '$tier' already present — skipping."
+              exit 0
+            fi
+          done
+
+          # Infer tier from the issue body (written by Claude Haiku for
+          # create_followup_issues.py issues; may name a different tier for
+          # complex tasks).  Precedence: explicit **LLM tier** section first,
+          # then any bare keyword match.
+          body_lower=$(echo "$ISSUE_BODY" | tr '[:upper:]' '[:lower:]')
+          tier_label=""
+          if echo "$body_lower" | grep -qE '\*\*llm\s+tier\*\*.*opus|\bopus\b.*appropriate'; then
+            tier_label="llm: opus"
+          elif echo "$body_lower" | grep -qE '\*\*llm\s+tier\*\*.*sonnet|\bsonnet\b.*appropriate'; then
+            tier_label="llm: sonnet"
+          elif echo "$body_lower" | grep -qE '\bsonnet\b'; then
+            tier_label="llm: sonnet"
+          elif echo "$body_lower" | grep -qE '\bopus\b'; then
+            tier_label="llm: opus"
+          else
+            # Default: haiku — matches the model used by create_followup_issues.py
+            # and is the safe, cheapest fallback for simple/mechanical tasks.
+            tier_label="llm: haiku"
+          fi
+
+          echo "Applying tier label: $tier_label"
+          gh issue edit "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --add-label "$tier_label"

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -216,9 +216,13 @@ def test_create_issues_applies_llm_label(
     assert "ai-suggested" in created[0]
 
 
-def test_create_issues_no_llm_label_when_not_mentioned(
+def test_create_issues_applies_fallback_llm_label_when_body_has_no_tier(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """When the generated body contains no LLM tier mention, the fallback label
+    derived from _ANTHROPIC_MODEL must still be applied so every ai-suggested
+    issue carries a tier label (e.g. issues created by the pr-merge-checker skill
+    which bypasses this script would previously get no tier label at all)."""
     mod = load_module()
     created: list[list[str]] = []
 
@@ -229,6 +233,8 @@ def test_create_issues_no_llm_label_when_not_mentioned(
     mod.create_issues(["My title"], "10", None)
     assert created
     assert "ai-suggested" in created[0]
-    assert "llm: haiku" not in created[0]
-    assert "llm: sonnet" not in created[0]
-    assert "llm: opus" not in created[0]
+    # A tier label must always be present; the fallback is derived from _ANTHROPIC_MODEL.
+    tier_labels = {"llm: haiku", "llm: sonnet", "llm: opus"}
+    assert any(label in created[0] for label in tier_labels), (
+        f"Expected one of {tier_labels} in the gh command, got: {created[0]}"
+    )


### PR DESCRIPTION
## Summary

- **Root cause**: two separate code paths could create `ai-suggested` issues without a tier label — the `create_followup_issues.py` script when the body contained no tier keyword, and the `pr-merge-checker` skill which bypasses the script entirely (as happened with #3466).
- **Fix A** (`create_followup_issues.py`): adds `_FALLBACK_LLM_LABEL` derived from `_ANTHROPIC_MODEL` at module load time; `create_issues()` now always appends a tier label, falling back to that constant when `_extract_llm_label()` returns `None`.
- **Fix B** (`.github/workflows/label-ai-issues.yml`): new workflow triggered on `issues: opened/labeled` that scans any `ai-suggested` issue for a missing tier label and applies one by keyword-matching the body, defaulting to `llm: haiku`. Catches every creation path — current and future — regardless of which script or skill created the issue.
- Updated `test_create_issues_no_llm_label_when_not_mentioned` → renamed and inverted to assert the fallback tier label **is** present.

Closes #3466

## Test plan

- [ ] `python -m pytest tests/test_create_followup_issues.py -v` — all 18 tests pass
- [ ] CI Backend Integration Tests and IaC Validation green on this branch
- [ ] Manually open a test issue with only `ai-suggested` label and confirm the workflow adds `llm: haiku` within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)