### PR TITLE
fix: correct inverted assertion in fallback LLM label test

### DIFF
--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -234,4 +234,4 @@ def test_create_issues_applies_fallback_llm_label_when_body_has_no_tier(
     assert created
     assert "ai-suggested" in created[0]
     label_values = [created[0][i + 1] for i, v in enumerate(created[0][:-1]) if v == "--label"]
-    assert not any(t in label_values for t in ("haiku", "sonnet", "opus"))
+    assert any(t in label_values for t in ("haiku", "sonnet", "opus"))


### PR DESCRIPTION
## Summary
- Fixes the one failing test in CI: `test_create_issues_applies_fallback_llm_label_when_body_has_no_tier`

## Root cause
The assertion in the test was `assert not any(t in label_values for t in ("haiku", "sonnet", "opus"))`, which is the **inverse** of what the test name and docstring specify:

> *"the fallback label derived from `_ANTHROPIC_MODEL` must still be applied so every ai-suggested issue carries a tier label"*

The production code in `create_followup_issues.py` (line 140) correctly does:
```python
llm_label = _extract_llm_label(body) or _FALLBACK_LLM_LABEL
```
where `_FALLBACK_LLM_LABEL = "haiku"` (derived from `_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"`). So when the body has no tier mention, "haiku" is added — which is the correct, intended behaviour. The test assertion was simply backwards.

## Fix
Removed the `not` from the assertion so it matches the documented intent.

🤖 Generated with Claude Code