### PR TITLE
fix: restore negative assertion in fallback LLM label test

### DIFF
--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -234,4 +234,4 @@ def test_create_issues_applies_fallback_llm_label_when_body_has_no_tier(
     assert created
     assert "ai-suggested" in created[0]
     label_values = [created[0][i + 1] for i, v in enumerate(created[0][:-1]) if v == "--label"]
-    assert any(t in label_values for t in ("haiku", "sonnet", "opus"))
+    assert not any(t in label_values for t in ("haiku", "sonnet", "opus"))


### PR DESCRIPTION
## Summary
- Reverts the assertion in `test_create_issues_applies_fallback_llm_label_when_body_has_no_tier` (tests/test_create_followup_issues.py:237) from `assert any(...)` back to `assert not any(...)`.
- [#3553](https://github.com/leonarduk/allotmint/pull/3553) (commit 5cc4aeb0) inverted this assertion based on a since-removed `_FALLBACK_LLM_LABEL` code path. [#3417](https://github.com/leonarduk/allotmint/pull/3417) subsequently removed `_FALLBACK_LLM_LABEL` from `create_followup_issues.py` and updated the test's docstring to describe the correct (negative) contract — but left the assertion itself in the inverted state, so the test now contradicts both its own docstring and the production code.
- Production behavior (`create_followup_issues.py:133-136`): when `_extract_llm_label(body)` returns `None`, only the `ai-suggested` label is applied — there is no fallback to a model-derived tier label. The negative assertion is the correct check.

## Test plan
- [x] `python -m pytest tests/test_create_followup_issues.py -k fallback -v` — was 1 failed, now passes
- [x] `python -m pytest tests/test_create_followup_issues.py -v` — all 18 tests pass