### PR TITLE
fix: aider-issue.ps1 robustness - progress output, fail-fast on empty issue, abort if no commits

### DIFF
--- a/scripts/aider-issue.ps1
+++ b/scripts/aider-issue.ps1
@@ -13,6 +13,7 @@ foreach ($cmd in @('gh', 'aider')) {
 # Fetch to ensure remote refs are current before any rev-parse.
 # Warn (don't abort) on failure so offline re-runs still work, but never let a
 # silent fetch failure cause a later reset to operate on a stale ref unnoticed.
+Write-Host "[1/6] Fetching remote refs..."
 git fetch origin 2>$null
 if ($LASTEXITCODE -ne 0) {
     Write-Warning "git fetch origin failed; continuing with possibly stale remote refs."
@@ -24,13 +25,16 @@ if ($remote -match 'github\.com[:/]([^/]+)/([^/]+?)(\.git)?$') {
     $owner = $Matches[1]
     $repo  = $Matches[2]
 } else {
-    Write-Error "Could not parse GitHub owner/repo from git remote: $remote"
+    Write-Error "Could not parse GitHub owner/repo from git remote: ${remote}"
     exit 1
 }
 
 # Derive the repo default branch so --base is never hardcoded
 $defaultBranch = gh repo view "$owner/$repo" --json defaultBranchRef --jq '.defaultBranchRef.name' 2>$null
-if (-not $defaultBranch) { $defaultBranch = 'main' }
+if (-not $defaultBranch) {
+    Write-Warning "Could not detect default branch (gh API call failed); falling back to 'main'."
+    $defaultBranch = 'main'
+}
 
 # Accept either a full URL or a bare issue number
 if ($Issue -match '(\d+)$') {
@@ -40,21 +44,34 @@ if ($Issue -match '(\d+)$') {
     exit 1
 }
 
-# Fetch issue title + body
-$issueData = gh issue view $number --repo "$owner/$repo" --json title,body | ConvertFrom-Json
+# Fetch issue title + body; fail fast if the API call fails so aider never
+# receives an empty prompt and creates a content-free PR.
+Write-Host "[2/6] Fetching issue #$number from $owner/$repo..."
+$issueJson = gh issue view $number --repo "$owner/$repo" --json title,body 2>&1
+if ($LASTEXITCODE -ne 0 -or -not $issueJson) {
+    Write-Error "Failed to fetch issue #$number (exit $LASTEXITCODE). Check network and 'gh auth status'."
+    exit 1
+}
+$issueData = $issueJson | ConvertFrom-Json
 $title     = $issueData.title
 $issueBody = if ($issueData.body) { $issueData.body } else { "" }
+if (-not $title) {
+    Write-Error "Issue #$number has no title or could not be parsed. Raw gh output: $issueJson"
+    exit 1
+}
+Write-Host "    Title: $title"
 
 # Create or reset the issue branch.
 # If it already exists, reset it to origin/$defaultBranch so stale commits from a
 # previous run are not silently included in the PR body or seen by aider.
 $branch = "issue-$number"
+Write-Host "[3/6] Preparing branch $branch..."
 # Reliable existence test: rev-parse sets a non-zero exit code when the ref is
 # absent. (git branch --list returns whitespace-padded output whose truthiness is
 # fragile across Git versions and pager configs.)
 git rev-parse --verify --quiet "refs/heads/$branch" > $null 2>&1
 if ($LASTEXITCODE -eq 0) {
-    Write-Warning "Branch '$branch' already exists — resetting to origin/$defaultBranch to avoid stale commits."
+    Write-Warning "Branch '$branch' already exists - resetting to origin/$defaultBranch to avoid stale commits."
     git checkout $branch
     if ($LASTEXITCODE -ne 0) { exit 1 }
     git reset --hard "origin/$defaultBranch"
@@ -79,11 +96,22 @@ if (-not $baseSha) {
 $promptFile = [System.IO.Path]::GetTempFileName()
 Set-Content -Path $promptFile -Value "GitHub issue #${number}: $title`n`n$issueBody" -Encoding UTF8
 
+Write-Host "[4/6] Running aider on issue #$number..."
 aider --message-file $promptFile
 Remove-Item $promptFile -ErrorAction SilentlyContinue
 if ($LASTEXITCODE -ne 0) { exit 1 }
 
+# Abort if aider made no commits - avoids pushing an empty branch and opening
+# a content-free PR (e.g. when the issue fetch silently returned no data).
+$newCommits = git rev-list "$baseSha..HEAD" --count 2>$null
+if (-not $newCommits -or [int]$newCommits -eq 0) {
+    Write-Error "Aider made no commits. Aborting push and PR creation. Check that the issue prompt was non-empty and that aider connected to the model successfully."
+    exit 1
+}
+Write-Host "    Aider produced $newCommits commit(s)."
+
 # Push the branch
+Write-Host "[5/6] Pushing branch $branch..."
 git push -u origin $branch
 if ($LASTEXITCODE -ne 0) { exit 1 }
 
@@ -114,6 +142,7 @@ $diffStat
 $prTitle = "Fix: " + $title
 
 # Open a draft PR; --head is explicit so fork contributors don't get a cross-repo mismatch
+Write-Host "[6/6] Creating draft PR..."
 gh pr create `
     --title $prTitle `
     --body $prBody `


### PR DESCRIPTION
## Summary

- Add [1/6]..[6/6] step headers so you can see what the script is doing
- Fail hard if gh issue view fails or returns no title - prevents aider receiving an empty prompt and creating a content-free PR
- After aider exits, count new commits; abort push+PR creation if zero commits were made
- Replace mojibake em dash with plain hyphen in Write-Warning (was causing PS 7.2+ parse error via U+201D smart-quote byte)

## Test plan
- Run with a valid issue number and working network - should print each step and create a real PR
- Run with network down - should fail at step 2 with a clear error, not proceed to aider
- Confirm no empty PRs are created when aider makes no commits

Closes #3602

Generated with Claude Code