### PR TITLE
fix(cdk): grant deploy role CDK-managed S3 read access to price snapshot

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -429,6 +429,29 @@ class BackendLambdaStack(Stack):
             )
             refresh_alias.grant_invoke(github_role)
 
+            # Grant the CI deploy role read access to the warmed price snapshot
+            # so the "Warm price snapshot" workflow step's head-object check
+            # succeeds. Mirrors the ReadPriceSnapshot/ListPricesPrefix
+            # statements in bootstrap-deploy-role.sh (used only to bootstrap
+            # the role before the first CDK deploy); this CDK grant is the
+            # source of truth thereafter and re-applies on every
+            # BackendLambdaStack deploy, preventing drift. See #3191, #3639.
+            github_role.add_to_principal_policy(
+                iam.PolicyStatement(
+                    sid="ReadPriceSnapshot",
+                    actions=["s3:GetObject"],
+                    resources=[data_bucket.arn_for_objects("prices/latest_prices.json")],
+                )
+            )
+            github_role.add_to_principal_policy(
+                iam.PolicyStatement(
+                    sid="ListPricesPrefix",
+                    actions=["s3:ListBucket"],
+                    resources=[data_bucket.bucket_arn],
+                    conditions={"StringLike": {"s3:prefix": ["prices", "prices/*"]}},
+                )
+            )
+
         events.Rule(
             self,
             "DailyPriceRefresh",

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -488,6 +488,86 @@ def test_lambda_invoke_grant_scoped_to_alias_arn(monkeypatch) -> None:
         )
 
 
+def _s3_statements_for_role_name(raw_template: dict, role_name: str) -> list[dict]:
+    """Return policy statements attached to the named role that grant S3 actions."""
+    found: list[dict] = []
+    for res in raw_template["Resources"].values():
+        if res.get("Type") != "AWS::IAM::Policy":
+            continue
+        if role_name not in str(res.get("Properties", {}).get("Roles", [])):
+            continue
+        policy_doc = res.get("Properties", {}).get("PolicyDocument", {})
+        for stmt in policy_doc.get("Statement", []):
+            actions = stmt.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+            if any(a.startswith("s3:") for a in actions):
+                found.append(stmt)
+    return found
+
+
+def test_deploy_role_gets_read_access_to_price_snapshot(monkeypatch) -> None:
+    """BackendLambdaStack must grant the deploy role s3:GetObject on
+    prices/latest_prices.json and a prefix-scoped s3:ListBucket so the CI
+    'Warm price snapshot' step's head-object check succeeds without a 403.
+    CDK-managed so the grant re-applies on every deploy and cannot drift out
+    of sync with the manually-run bootstrap script. See #3191, #3639."""
+    role_arn = "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    monkeypatch.setenv("GITHUB_DEPLOY_ROLE_ARN", role_arn)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackDeployRoleS3ReadTest")
+    raw = Template.from_stack(stack).to_json()
+    statements = _s3_statements_for_role_name(raw, "allotmint-github-deploy")
+
+    get_object_resources: list[str] = []
+    list_bucket_statements: list[dict] = []
+    for stmt in statements:
+        actions = stmt.get("Action", [])
+        if isinstance(actions, str):
+            actions = [actions]
+        resources = stmt.get("Resource", [])
+        if isinstance(resources, (str, dict)):
+            resources = [resources]
+        if "s3:GetObject" in actions:
+            get_object_resources.extend(r if isinstance(r, str) else str(r) for r in resources)
+        if "s3:ListBucket" in actions:
+            list_bucket_statements.append(stmt)
+
+    assert any("prices/latest_prices.json" in r for r in get_object_resources), (
+        "Expected the deploy role to be granted s3:GetObject on prices/latest_prices.json "
+        f"in BackendLambdaStack, got resources: {get_object_resources}"
+    )
+    assert list_bucket_statements, (
+        "Expected the deploy role to be granted a prefix-scoped s3:ListBucket in "
+        "BackendLambdaStack so the 'Warm price snapshot' head-object check can succeed"
+    )
+    assert any(
+        stmt.get("Condition", {}).get("StringLike", {}).get("s3:prefix") == ["prices", "prices/*"]
+        for stmt in list_bucket_statements
+    ), (
+        "Expected the deploy role's s3:ListBucket grant to be scoped to the 'prices' "
+        f"prefix, got statements: {list_bucket_statements}"
+    )
+
+
+def test_no_s3_grant_to_deploy_role_when_github_deploy_role_arn_absent(monkeypatch) -> None:
+    """When GITHUB_DEPLOY_ROLE_ARN is unset, BackendLambdaStack must not grant
+    any S3 permissions to an imported deploy role."""
+    monkeypatch.delenv("GITHUB_DEPLOY_ROLE_ARN", raising=False)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackNoDeployRoleS3Test")
+    raw = Template.from_stack(stack).to_json()
+    statements = _s3_statements_for_role_name(raw, "allotmint-github-deploy")
+    assert not statements, (
+        "Expected no S3 grants for the deploy role in BackendLambdaStack when "
+        f"GITHUB_DEPLOY_ROLE_ARN is unset, found: {statements}"
+    )
+
+
 def test_grant_bucket_access_raises_on_no_permissions() -> None:
     class _MockFn:
         def add_to_role_policy(self, policy_statement: object) -> None:


### PR DESCRIPTION
## Summary
- The "Warm price snapshot" deploy step (`deploy-lambda.yml`) fails with `An error occurred (403) when calling the HeadObject operation: Forbidden` on `prices/latest_prices.json` — see [run 72762363992](https://github.com/leonarduk/allotmint/actions/runs/72762363992), step 20.
- `scripts/bash/bootstrap-deploy-role.sh` already contains the needed `ReadPriceSnapshot` (`s3:GetObject` on `prices/latest_prices.json`) and `ListPricesPrefix` (`s3:ListBucket` scoped to the `prices` prefix) statements, but **CDK never grants these to `github_role`** — only the manually-run bootstrap script does, so the live role policy drifts out of sync (exactly what #3191 was supposed to prevent).
- This mirrors the existing `lambda:InvokeFunction` grant pattern for the deploy role (#3368): add the S3 grants via `github_role.add_to_principal_policy(...)` in `BackendLambdaStack` so they re-apply on every deploy and can't drift.

## Test plan
- [x] `python -m pytest cdk/tests/test_backend_lambda_stack_permissions.py -q` — 12 passed, including 2 new tests:
  - `test_deploy_role_gets_read_access_to_price_snapshot` asserts the synthesized template grants `s3:GetObject` on `prices/latest_prices.json` and a prefix-scoped `s3:ListBucket` (`["prices", "prices/*"]`) to the deploy role.
  - `test_no_s3_grant_to_deploy_role_when_github_deploy_role_arn_absent` asserts no S3 grant is added when `GITHUB_DEPLOY_ROLE_ARN` is unset.

Closes #3639