### PR TITLE
fix(aider): rename deprecated `yes` config key and flag to `yes-always`

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,7 +1,7 @@
 model: "ollama/qwen2.5-coder:14b"
 
 auto-commits: true
-yes: true
+yes-always: true
 
 auto-test: true
 test-cmd: "pytest -q --ignore=tests/integration --ignore=tests/live"

--- a/scripts/aider-issue.ps1
+++ b/scripts/aider-issue.ps1
@@ -97,7 +97,7 @@ $promptFile = [System.IO.Path]::GetTempFileName()
 Set-Content -Path $promptFile -Value "GitHub issue #${number}: $title`n`n$issueBody" -Encoding UTF8
 
 Write-Host "[4/6] Running aider on issue #$number..."
-aider --yes --message-file $promptFile
+aider --yes-always --message-file $promptFile
 Remove-Item $promptFile -ErrorAction SilentlyContinue
 if ($LASTEXITCODE -ne 0) { exit 1 }
 


### PR DESCRIPTION
## Summary

`aider` 0.86.x renamed the `yes` config key and the bare `--yes` CLI flag to `yes-always`, and now hard-errors on the old names. The committed `.aider.conf.yml` still uses `yes: true`, so `scripts/aider-issue.ps1` fails at the run step on every invocation with:

```
Configuration error detected.
The file ...\.aider.conf.yml contains a line starting with 'yes:'
Please replace 'yes:' with 'yes-always:' in this file.
```

Because the script does `git reset --hard origin/$defaultBranch` on each run, any local edit to the config is discarded before aider runs - so the fix has to live on the default branch.

Closes #3675

## Changes

- `.aider.conf.yml`: `yes: true` -> `yes-always: true`
- `scripts/aider-issue.ps1`: `aider --yes` -> `aider --yes-always` (the bare `--yes` flag was likewise renamed)

## Validation

`aider --version` (which parses the config before doing anything else) now succeeds:

```
aider 0.86.2
```

Generated with Claude Code