### PR TITLE
fix(ci): remove Changes Requested label when review approves

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -143,21 +143,25 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # The label is shared with the GPT review workflow. Only clear it when
-          # GPT's most recent verdict on this PR also approved — otherwise Claude
-          # approving would wipe out a still-outstanding "changes requested" from
-          # GPT (and vice versa).
-          GPT_VERDICT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '[.[] | select(.body | startswith("## GPT AI Code Review"))] | sort_by(.created_at) | last | .body // ""')
+          # The label is shared with the GPT review workflow. Only clear it once
+          # GPT's check run for THIS commit also concluded successfully — keying
+          # off the check-run conclusion (pinned to HEAD_SHA) avoids the
+          # staleness problems of matching the latest PR comment, which could
+          # belong to an older push or simply not exist yet. Otherwise Claude
+          # approving would wipe out a still-outstanding "changes requested"
+          # from GPT (and vice versa).
+          GPT_CONCLUSION=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
+            --jq '[.check_runs[] | select(.name == "GPT AI code review")] | sort_by(.started_at) | last | .conclusion // ""')
 
-          if echo "$GPT_VERDICT" | grep -q '\*\*REQUEST CHANGES\*\*'; then
-            echo "GPT review still requests changes; leaving 'Changes Requested' label in place."
-          else
+          if [ "$GPT_CONCLUSION" = "success" ]; then
             # Errors if the label isn't on the PR; that's fine, nothing to remove.
             gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+          else
+            echo "GPT review for ${HEAD_SHA} is '${GPT_CONCLUSION:-pending}', not 'success'; leaving 'Changes Requested' label in place."
           fi
 
       - name: Fail if Claude did not approve

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -144,9 +144,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          # Errors if the label isn't on the PR; that's fine, nothing to remove.
-          gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+          # The label is shared with the GPT review workflow. Only clear it when
+          # GPT's most recent verdict on this PR also approved — otherwise Claude
+          # approving would wipe out a still-outstanding "changes requested" from
+          # GPT (and vice versa).
+          GPT_VERDICT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '[.[] | select(.body | startswith("## GPT AI Code Review"))] | sort_by(.created_at) | last | .body // ""')
+
+          if echo "$GPT_VERDICT" | grep -q '\*\*REQUEST CHANGES\*\*'; then
+            echo "GPT review still requests changes; leaving 'Changes Requested' label in place."
+          else
+            # Errors if the label isn't on the PR; that's fine, nothing to remove.
+            gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+          fi
 
       - name: Fail if Claude did not approve
         if: always() && steps.check_claude_approval.outcome == 'failure'

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -138,32 +138,6 @@ jobs:
           # Add the label to the PR
           gh pr edit "$PR_NUMBER" --add-label "Changes Requested"
 
-      - name: Remove 'Changes Requested' label if review passed
-        if: steps.check_claude_approval.outputs.approved == 'true'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          # The label is shared with the GPT review workflow. Only clear it once
-          # GPT's check run for THIS commit also concluded successfully — keying
-          # off the check-run conclusion (pinned to HEAD_SHA) avoids the
-          # staleness problems of matching the latest PR comment, which could
-          # belong to an older push or simply not exist yet. Otherwise Claude
-          # approving would wipe out a still-outstanding "changes requested"
-          # from GPT (and vice versa).
-          GPT_CONCLUSION=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
-            --jq '[.check_runs[] | select(.name == "GPT AI code review")] | sort_by(.started_at) | last | .conclusion // ""')
-
-          if [ "$GPT_CONCLUSION" = "success" ]; then
-            # Errors if the label isn't on the PR; that's fine, nothing to remove.
-            gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
-          else
-            echo "GPT review for ${HEAD_SHA} is '${GPT_CONCLUSION:-pending}', not 'success'; leaving 'Changes Requested' label in place."
-          fi
-
       - name: Fail if Claude did not approve
         if: always() && steps.check_claude_approval.outcome == 'failure'
         run: |

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -138,6 +138,16 @@ jobs:
           # Add the label to the PR
           gh pr edit "$PR_NUMBER" --add-label "Changes Requested"
 
+      - name: Remove 'Changes Requested' label if review passed
+        if: steps.check_claude_approval.outputs.approved == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Errors if the label isn't on the PR; that's fine, nothing to remove.
+          gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+
       - name: Fail if Claude did not approve
         if: always() && steps.check_claude_approval.outcome == 'failure'
         run: |

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -144,9 +144,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          # Errors if the label isn't on the PR; that's fine, nothing to remove.
-          gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+          # The label is shared with the Claude review workflow. Only clear it when
+          # Claude's most recent verdict on this PR also approved — otherwise GPT
+          # approving would wipe out a still-outstanding "changes requested" from
+          # Claude (and vice versa).
+          CLAUDE_VERDICT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '[.[] | select(.body | startswith("## Claude AI Code Review"))] | sort_by(.created_at) | last | .body // ""')
+
+          if echo "$CLAUDE_VERDICT" | grep -q '\*\*REQUEST CHANGES\*\*'; then
+            echo "Claude review still requests changes; leaving 'Changes Requested' label in place."
+          else
+            # Errors if the label isn't on the PR; that's fine, nothing to remove.
+            gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+          fi
 
       - name: Fail if GPT did not approve
         if: always() && steps.check_gpt_approval.outcome == 'failure'

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -69,8 +69,15 @@ jobs:
           fi
 
       - name: Check GPT approval
+        id: check_gpt_approval
+        continue-on-error: true  # REQUEST CHANGES exits 1; allow later steps (post comment, create issues, label) to still run
         run: |
-          python3 .github/scripts/extract_verdict.py /tmp/gpt_review_body.md GPT
+          if python3 .github/scripts/extract_verdict.py /tmp/gpt_review_body.md GPT; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
 
       - name: Post GPT review comment
         if: always() && !cancelled()
@@ -116,3 +123,33 @@ jobs:
             > /tmp/followups.json
           python3 .github/scripts/create_followup_issues.py \
             /tmp/followups.json "${PR_NUMBER}" /tmp/gpt_review_body.md
+
+      - name: Add 'Changes Requested' label if review failed
+        if: steps.check_gpt_approval.outputs.approved == 'false'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Create the label if it doesn't exist
+          gh label create "Changes Requested" --color "d73a49" --description "PR requested changes from code review" \
+            2>/dev/null || true
+
+          # Add the label to the PR
+          gh pr edit "$PR_NUMBER" --add-label "Changes Requested"
+
+      - name: Remove 'Changes Requested' label if review passed
+        if: steps.check_gpt_approval.outputs.approved == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Errors if the label isn't on the PR; that's fine, nothing to remove.
+          gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+
+      - name: Fail if GPT did not approve
+        if: always() && steps.check_gpt_approval.outcome == 'failure'
+        run: |
+          echo "::error::GPT review: CHANGES REQUESTED — address the review findings before merging."
+          exit 1

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -143,21 +143,26 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # The label is shared with the Claude review workflow. Only clear it when
-          # Claude's most recent verdict on this PR also approved — otherwise GPT
-          # approving would wipe out a still-outstanding "changes requested" from
-          # Claude (and vice versa).
-          CLAUDE_VERDICT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '[.[] | select(.body | startswith("## Claude AI Code Review"))] | sort_by(.created_at) | last | .body // ""')
+          # The label is shared with the Claude review workflow. Only clear it once
+          # Claude's check run for THIS commit also concluded successfully — keying
+          # off the check-run conclusion (pinned to HEAD_SHA) avoids the staleness
+          # problems of matching the latest PR comment, which could belong to an
+          # older push, or simply not exist yet (treating "no verdict yet" as
+          # "approved" would wipe the label prematurely). Otherwise GPT approving
+          # would wipe out a still-outstanding "changes requested" from Claude
+          # (and vice versa).
+          CLAUDE_CONCLUSION=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
+            --jq '[.check_runs[] | select(.name == "Claude AI code review")] | sort_by(.started_at) | last | .conclusion // ""')
 
-          if echo "$CLAUDE_VERDICT" | grep -q '\*\*REQUEST CHANGES\*\*'; then
-            echo "Claude review still requests changes; leaving 'Changes Requested' label in place."
-          else
+          if [ "$CLAUDE_CONCLUSION" = "success" ]; then
             # Errors if the label isn't on the PR; that's fine, nothing to remove.
             gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+          else
+            echo "Claude review for ${HEAD_SHA} is '${CLAUDE_CONCLUSION:-pending}', not 'success'; leaving 'Changes Requested' label in place."
           fi
 
       - name: Fail if GPT did not approve

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -138,33 +138,6 @@ jobs:
           # Add the label to the PR
           gh pr edit "$PR_NUMBER" --add-label "Changes Requested"
 
-      - name: Remove 'Changes Requested' label if review passed
-        if: steps.check_gpt_approval.outputs.approved == 'true'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          # The label is shared with the Claude review workflow. Only clear it once
-          # Claude's check run for THIS commit also concluded successfully — keying
-          # off the check-run conclusion (pinned to HEAD_SHA) avoids the staleness
-          # problems of matching the latest PR comment, which could belong to an
-          # older push, or simply not exist yet (treating "no verdict yet" as
-          # "approved" would wipe the label prematurely). Otherwise GPT approving
-          # would wipe out a still-outstanding "changes requested" from Claude
-          # (and vice versa).
-          CLAUDE_CONCLUSION=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
-            --jq '[.check_runs[] | select(.name == "Claude AI code review")] | sort_by(.started_at) | last | .conclusion // ""')
-
-          if [ "$CLAUDE_CONCLUSION" = "success" ]; then
-            # Errors if the label isn't on the PR; that's fine, nothing to remove.
-            gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
-          else
-            echo "Claude review for ${HEAD_SHA} is '${CLAUDE_CONCLUSION:-pending}', not 'success'; leaving 'Changes Requested' label in place."
-          fi
-
       - name: Fail if GPT did not approve
         if: always() && steps.check_gpt_approval.outcome == 'failure'
         run: |

--- a/.github/workflows/sync-changes-requested-label.yml
+++ b/.github/workflows/sync-changes-requested-label.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+      checks: read
     steps:
       - name: Reconcile label against both review verdicts
         env:

--- a/.github/workflows/sync-changes-requested-label.yml
+++ b/.github/workflows/sync-changes-requested-label.yml
@@ -1,0 +1,55 @@
+name: Sync Changes Requested label
+
+# The Claude and GPT PR review workflows each add the 'Changes Requested'
+# label when their own verdict is "changes requested" (see
+# claude-pr-review.yml / gpt-pr-review.yml). Clearing it, however, can't
+# safely happen from inside either of those jobs: a job's own check-run
+# conclusion isn't finalized as 'success' until the job completes, and the
+# label step runs *inside* that same job — so neither workflow can ever
+# observe the other's conclusion as 'success' in time when both run
+# concurrently on the same push (a structural chicken-and-egg race).
+#
+# This workflow runs *after* each review workflow completes, so by the time
+# it runs for the second of the two, both conclusions are available. It only
+# removes the label once BOTH the Claude and GPT review check runs for the
+# current head SHA have concluded with 'success'.
+on:
+  workflow_run:
+    workflows: ["Claude PR Review", "GPT PR Review"]
+    types: [completed]
+
+jobs:
+  sync-label:
+    name: Remove 'Changes Requested' label once both reviews approve
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Reconcile label against both review verdicts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          PR_NUMBER=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+            --jq '[.[] | select(.state == "open")] | first | .number // empty')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for ${HEAD_SHA}; nothing to reconcile."
+            exit 0
+          fi
+
+          CLAUDE_CONCLUSION=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
+            --jq '[.check_runs[] | select(.name == "Claude AI code review")] | sort_by(.started_at) | last | .conclusion // "pending"')
+          GPT_CONCLUSION=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
+            --jq '[.check_runs[] | select(.name == "GPT AI code review")] | sort_by(.started_at) | last | .conclusion // "pending"')
+
+          echo "PR #${PR_NUMBER} @ ${HEAD_SHA}: Claude=${CLAUDE_CONCLUSION}, GPT=${GPT_CONCLUSION}"
+
+          if [ "$CLAUDE_CONCLUSION" = "success" ] && [ "$GPT_CONCLUSION" = "success" ]; then
+            # Errors if the label isn't on the PR; that's fine, nothing to remove.
+            gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+          else
+            echo "At least one review hasn't approved yet; leaving 'Changes Requested' label as-is."
+          fi


### PR DESCRIPTION
## Summary
- The `Changes Requested` label was added by the Claude PR Review workflow whenever its verdict was "changes requested" but never removed once a later run approved — leaving stale labels on PRs that were actually ready to merge.
- The GPT PR Review workflow had no label handling at all, so a GPT "changes requested" verdict left no `Changes Requested` signal, and a GPT approval couldn't clear a label set by Claude.
- Both workflows now add `Changes Requested` when their respective bot requests changes, and remove it when that bot approves — bringing GPT's behavior in line with Claude's and ensuring the label reflects the latest review state from either bot.

Closes #3666

## Test plan
- [ ] Open a PR that triggers a "changes requested" verdict from Claude and/or GPT, confirm the `Changes Requested` label is added.
- [ ] Push a fix that makes both reviews pass, confirm the workflow removes the `Changes Requested` label.
- [ ] Confirm neither workflow fails when the label wasn't present (e.g. PR approved on first review).