### PR TITLE
fix(prices): always upload price snapshot to S3, even with no fresh prices

### DIFF
--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -246,41 +246,49 @@ def refresh_prices() -> Dict:
     # This preserves existing seed/cached prices for tickers that returned None
     # (offline mode, market closed, data-source outage) rather than trashing them.
     to_persist = {t: v for t, v in snapshot.items() if v.get("last_price") is not None}
+    existing: Dict = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
     if to_persist:
-        existing: Dict = {}
-        if path.exists():
-            try:
-                existing = json.loads(path.read_text())
-            except (json.JSONDecodeError, OSError):
-                pass
         merged = {**existing, **to_persist}
         path.write_text(json.dumps(merged, indent=2))
-
-        # ---- persist to S3 (primary store read by all Lambda instances) -----
-        if config.app_env == "aws":
-            _s3_bucket = os.getenv(DATA_BUCKET_ENV)
-            if _s3_bucket:
-                try:
-                    import boto3  # type: ignore
-
-                    boto3.client("s3").put_object(
-                        Bucket=_s3_bucket,
-                        Key=PRICES_S3_KEY,
-                        Body=json.dumps(merged, indent=2).encode("utf-8"),
-                        ContentType="application/json",
-                    )
-                    logger.info(
-                        "Uploaded price snapshot to s3://%s/%s", _s3_bucket, PRICES_S3_KEY
-                    )
-                except Exception as exc:
-                    logger.warning("Failed to upload price snapshot to S3: %s", exc)
-            else:
-                logger.warning("DATA_BUCKET not set; skipping S3 upload of price snapshot")
     else:
+        merged = existing
         logger.info(
-            "Skipping price snapshot write — no valid prices fetched"
+            "Skipping local snapshot write — no valid prices fetched"
             " (offline mode or data-source unavailable)"
         )
+
+    # ---- persist to S3 (primary store read by all Lambda instances) ---------
+    # Always upload — even when no fresh prices were fetched — so that the
+    # snapshot key always exists in S3. Without this, a refresh that runs
+    # during market-closed/offline windows (e.g. a CI deploy invocation)
+    # silently returns success without ever creating the key, and downstream
+    # consumers (and the deploy workflow's post-deploy snapshot check) wait
+    # indefinitely for a file that is never written. See issue #3685.
+    if config.app_env == "aws":
+        _s3_bucket = os.getenv(DATA_BUCKET_ENV)
+        if _s3_bucket:
+            try:
+                import boto3  # type: ignore
+
+                boto3.client("s3").put_object(
+                    Bucket=_s3_bucket,
+                    Key=PRICES_S3_KEY,
+                    Body=json.dumps(merged, indent=2).encode("utf-8"),
+                    ContentType="application/json",
+                )
+                logger.info(
+                    "Uploaded price snapshot to s3://%s/%s", _s3_bucket, PRICES_S3_KEY
+                )
+            except Exception as exc:
+                logger.warning("Failed to upload price snapshot to S3: %s", exc)
+        else:
+            logger.warning("DATA_BUCKET not set; skipping S3 upload of price snapshot")
 
     # ---- refresh in-memory cache -----------------------------------------
     # Use merged (which includes preserved seed prices) when available; leave

--- a/tests/common/test_prices.py
+++ b/tests/common/test_prices.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import UTC, date, datetime, timedelta
+from types import SimpleNamespace
 from typing import Dict, List
 
 import pandas as pd
@@ -391,6 +393,49 @@ def test_refresh_prices_skips_write_when_all_prices_null(
     assert json.loads(output_path.read_text()) == seed, (
         "Seed file must not be overwritten when every fetched price is None"
     )
+
+
+def test_refresh_prices_uploads_existing_snapshot_to_s3_when_all_prices_null(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even when no fresh prices are fetched, the S3 key must always be (re)written.
+
+    Otherwise a refresh that runs during a market-closed/offline window never
+    creates ``prices/latest_prices.json`` in S3, and consumers that wait for
+    that key (e.g. the deploy workflow's post-deploy snapshot check) hang
+    indefinitely. See issue #3685.
+    """
+    seed = {"VWRL.L": {"last_price": 97.5, "price_currency": "GBP"}}
+    output_path = tmp_path / "prices.json"
+    output_path.write_text(json.dumps(seed))
+
+    null_snapshot = {
+        "VWRL.L": {"last_price": None, "price_currency": None, "is_stale": True}
+    }
+    monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: ["VWRL.L"])
+    monkeypatch.setattr(prices, "get_price_snapshot", lambda _: null_snapshot)
+    monkeypatch.setattr(prices, "refresh_snapshot_in_memory", Mock())
+    monkeypatch.setattr(prices, "check_price_alerts", Mock())
+    monkeypatch.setattr(prices.config, "prices_json", output_path)
+    monkeypatch.setattr(prices, "_price_cache", {})
+    monkeypatch.setattr(prices.config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+
+    put_calls = []
+
+    class _FakeS3:
+        def put_object(self, **kwargs):
+            put_calls.append(kwargs)
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=lambda svc: _FakeS3()))
+
+    prices.refresh_prices()
+
+    assert len(put_calls) == 1
+    assert put_calls[0]["Bucket"] == "test-bucket"
+    assert put_calls[0]["Key"] == prices.PRICES_S3_KEY
+    assert json.loads(put_calls[0]["Body"]) == seed
+    assert put_calls[0]["ContentType"] == "application/json"
 
 
 def test_refresh_prices_partial_null_preserves_existing_prices(


### PR DESCRIPTION
## Summary
- Root-causes the recurring deploy failure at the "Warm price snapshot" step (e.g. [run 27090029974](https://github.com/leonarduk/allotmint/actions/runs/27090029974/job/79952147862), [run 27102712082](https://github.com/leonarduk/allotmint/actions/runs/27102712082/job/79987500988), [run 27061876922](https://github.com/leonarduk/allotmint/actions/runs/27061876922/job/79878620549)). It is **not** the IAM permission issue from #3191/#3640 — that grant works (the final error is a 404 Not Found, not 403 Forbidden, which is only possible once `s3:ListBucket` is correctly granted).
- The real cause: `backend/common/prices.py::refresh_prices()` skips the S3 write entirely when every fetched ticker returns `last_price=None` (markets closed, data-source outage, etc.) yet still returns a "successful"-looking payload. `lambda_handler` only seeds a stub snapshot on a *raised* exception, so this silent path leaves `prices/latest_prices.json` never created in S3 — and the deploy workflow then polls `head-object` for ~100s before giving up with a 404.
- Fix: `refresh_prices()` now always uploads the merged snapshot (existing data, or `{}` if none exists) to S3, guaranteeing the key exists after every invocation, while preserving existing local-disk write semantics (never clobber a good seed file with all-null prices).

Closes #3685

## Test plan
- [x] `pytest tests/common/test_prices.py -k refresh_prices` — 4 passed, including a new test `test_refresh_prices_uploads_existing_snapshot_to_s3_when_all_prices_null` that asserts the existing snapshot is re-uploaded to S3 when no fresh prices are fetched
- [x] `pytest tests/test_price_refresh_lambda.py tests/common/test_prices.py` — 22 passed
- [x] `ruff check --config backend/pyproject.toml backend/common/prices.py` — clean