### PR TITLE
fix(cdk): make canonical-domain redirect conditional on customDomain flag

### DIFF
--- a/cdk/functions/viewer-request.js
+++ b/cdk/functions/viewer-request.js
@@ -34,10 +34,21 @@ function handler(event) {
     }
 
     var targetHost = host;
-    if (canonical) {
-        targetHost = host === canonical ? host : canonical;
-        if (!/^[A-Za-z0-9.-]+$/.test(targetHost)) {
+    if (canonical && host !== canonical) {
+        targetHost = canonical;
+    }
+    if (!/^[A-Za-z0-9.-]+$/.test(targetHost)) {
+        if (canonical) {
             targetHost = canonical;
+        } else {
+            // No canonical host is configured for this deployment and the
+            // incoming Host header fails the safety check, so there is no
+            // trustworthy value to build a redirect Location from. Returning
+            // it verbatim would be a host-header injection / open redirect
+            // (see issue #3693 review). Pass the request through unmodified;
+            // ViewerProtocolPolicy.REDIRECT_TO_HTTPS at the distribution
+            // level still enforces the HTTPS upgrade for this viewer.
+            return request;
         }
     }
     var targetUri = uri;
@@ -47,6 +58,12 @@ function handler(event) {
     if (targetUri.length > 1 && targetUri.endsWith('/')) {
         targetUri = targetUri.slice(0, -1);
     }
+    // The distribution's ViewerProtocolPolicy.REDIRECT_TO_HTTPS already forces
+    // an HTTPS upgrade, so `proto !== 'https'` is largely redundant here.
+    // It is intentionally kept as defense-in-depth (e.g. for the
+    // cloudfront-forwarded-proto header path, and in case the distribution
+    // policy ever changes) and folded into the same single 301 alongside
+    // host/URI canonicalization, avoiding a double redirect round-trip.
     var redirectNeeded =
         proto !== 'https' ||
         (canonical !== null && host !== canonical) ||

--- a/cdk/functions/viewer-request.js
+++ b/cdk/functions/viewer-request.js
@@ -8,7 +8,15 @@ function handler(event) {
         (protoHeader.value === 'http' || protoHeader.value === 'https')
             ? protoHeader.value
             : null;
-    var canonical = 'app.allotmint.io';
+    // __CANONICAL_HOST__ is substituted at CDK synth time (see
+    // static_site_stack.py): a JSON string holding the configured custom
+    // domain when this deployment has one (alias + ACM certificate + DNS
+    // record), or `null` when it does not. When it is `null`,
+    // host-based canonicalization is skipped entirely so the function never
+    // redirects viewers to a domain that has no DNS record for this
+    // distribution — see issue #3693 (production outage caused by an
+    // unconditional redirect to a non-existent custom domain).
+    var canonical = __CANONICAL_HOST__;
     var uri = request.uri;
     var query = request.querystring;
     var qs = '';
@@ -25,9 +33,12 @@ function handler(event) {
         }
     }
 
-    var targetHost = host === canonical ? host : canonical;
-    if (!/^[A-Za-z0-9.-]+$/.test(targetHost)) {
-        targetHost = canonical;
+    var targetHost = host;
+    if (canonical) {
+        targetHost = host === canonical ? host : canonical;
+        if (!/^[A-Za-z0-9.-]+$/.test(targetHost)) {
+            targetHost = canonical;
+        }
     }
     var targetUri = uri;
     if (!/^\/[A-Za-z0-9\/._-]*$/.test(targetUri)) {
@@ -37,7 +48,9 @@ function handler(event) {
         targetUri = targetUri.slice(0, -1);
     }
     var redirectNeeded =
-        proto !== 'https' || host !== canonical || targetUri !== uri;
+        proto !== 'https' ||
+        (canonical !== null && host !== canonical) ||
+        targetUri !== uri;
     if (redirectNeeded) {
         return {
             statusCode: 301,

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 
@@ -168,18 +169,29 @@ class StaticSiteStack(Stack):
             enable_accept_encoding_gzip=True,
         )
 
+        _custom_domain = "app.allotmint.io"
+        _enable_custom_domain = _is_truthy_context(self.node.try_get_context("customDomain"))
+
+        # The viewer-request Function's host-based canonical redirect must only
+        # target a domain that this deployment actually serves (alias + ACM
+        # certificate + DNS record). Substitute __CANONICAL_HOST__ at synth
+        # time with the real domain when customDomain is enabled, or with
+        # `null` otherwise so the Function skips host-based canonicalization
+        # entirely. See issue #3693 (production outage from an unconditional
+        # redirect to a non-existent custom domain).
+        _viewer_request_template = (
+            Path(__file__).resolve().parents[1] / "functions" / "viewer-request.js"
+        ).read_text(encoding="utf-8")
+        _canonical_host_literal = json.dumps(_custom_domain) if _enable_custom_domain else "null"
+        _viewer_request_source = _viewer_request_template.replace(
+            "__CANONICAL_HOST__", _canonical_host_literal
+        )
+
         redirect_fn = cloudfront.Function(
             self,
             "ViewerRequestFn",
-            code=cloudfront.FunctionCode.from_file(
-                file_path=str(
-                    Path(__file__).resolve().parents[1] / "functions" / "viewer-request.js"
-                )
-            ),
+            code=cloudfront.FunctionCode.from_inline(_viewer_request_source),
         )
-
-        _custom_domain = "app.allotmint.io"
-        _enable_custom_domain = _is_truthy_context(self.node.try_get_context("customDomain"))
 
         _certificate: acm.Certificate | None = None
         _hosted_zone: route53.IHostedZone | None = None

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -425,6 +425,54 @@ def custom_domain_template(tmp_path_factory):
     return assertions.Template.from_stack(stack)
 
 
+def _viewer_request_function_code(rendered_template) -> str:
+    """Return the inline FunctionCode source of the ViewerRequestFn CloudFront Function.
+
+    Asserts exactly one CloudFront Function exists so the helper fails loudly
+    if the resource is renamed/removed rather than silently returning None.
+    """
+    resources = rendered_template.find_resources("AWS::CloudFront::Function")
+    assert len(resources) == 1, f"Expected exactly one CloudFront Function; found {len(resources)}"
+    properties = next(iter(resources.values()))["Properties"]
+    return properties["FunctionCode"]
+
+
+def test_viewer_request_function_skips_redirect_target_without_custom_domain(template):
+    """When customDomain is disabled, the Function source must not hardcode a
+    redirect target host — it must substitute `null` for __CANONICAL_HOST__.
+
+    Regression test for issue #3693: the deployed Function previously redirected
+    ALL traffic to https://app.allotmint.io regardless of whether that domain had
+    an alias, ACM certificate, or DNS record for this distribution, causing a
+    production outage (NXDOMAIN on every request).
+    """
+    source = _viewer_request_function_code(template)
+    assert "__CANONICAL_HOST__" not in source, (
+        "Function source must not contain the unsubstituted template placeholder"
+    )
+    assert "app.allotmint.io" not in source, (
+        "Function source must not hardcode the custom-domain host when "
+        "customDomain is disabled for this deployment"
+    )
+    assert "var canonical = null;" in source, (
+        "Function source must substitute `null` for __CANONICAL_HOST__ so "
+        "host-based canonicalization is skipped entirely"
+    )
+
+
+def test_viewer_request_function_redirects_to_custom_domain_when_enabled(custom_domain_template):
+    """When customDomain is enabled, the Function source must canonicalize to
+    the configured custom domain (which has a matching alias/cert/DNS record)."""
+    source = _viewer_request_function_code(custom_domain_template)
+    assert "__CANONICAL_HOST__" not in source, (
+        "Function source must not contain the unsubstituted template placeholder"
+    )
+    assert 'var canonical = "app.allotmint.io";' in source, (
+        "Function source must substitute the configured custom domain literal "
+        "for __CANONICAL_HOST__ when customDomain is enabled"
+    )
+
+
 def test_custom_domain_distribution_has_domain_names(custom_domain_template):
     """Distribution must list app.allotmint.io in Aliases when customDomain is set."""
     custom_domain_template.has_resource_properties(

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -437,6 +437,41 @@ def _viewer_request_function_code(rendered_template) -> str:
     return properties["FunctionCode"]
 
 
+def test_viewer_request_function_validates_target_host_before_building_redirect(
+    template, custom_domain_template
+):
+    """The Host-charset safety check must guard `targetHost` unconditionally,
+    before it is ever interpolated into a redirect Location.
+
+    Regression test for a host-header injection / open redirect: an earlier
+    revision of this Function only forced `targetHost` back to a trusted value
+    inside an `if (canonical)` branch, so when `canonical` is `null` (no custom
+    domain configured) an attacker-controlled `Host` header could flow straight
+    into the 301 `Location` header unvalidated. The fixed source must apply the
+    `/^[A-Za-z0-9.-]+$/` charset test to `targetHost` ahead of (i.e. at a lower
+    string offset than) the `'https://' + targetHost` Location construction, in
+    both the custom-domain and non-custom-domain builds, and must refuse to
+    redirect using an unsafe host when no trusted canonical host is configured.
+    """
+    host_charset_check = "/^[A-Za-z0-9.-]+$/.test(targetHost)"
+    location_construction = "'https://' + targetHost"
+    no_safe_target_fallback = "return request"
+
+    for rendered_template in (template, custom_domain_template):
+        source = _viewer_request_function_code(rendered_template)
+        check_index = source.index(host_charset_check)
+        location_index = source.index(location_construction)
+        assert check_index < location_index, (
+            "targetHost must be validated against the host charset before "
+            "being interpolated into the redirect Location header"
+        )
+        assert no_safe_target_fallback in source, (
+            "Function must pass the request through (rather than redirect to "
+            "an untrusted Host header value) when no canonical host is "
+            "configured and the incoming Host fails the safety check"
+        )
+
+
 def test_viewer_request_function_skips_redirect_target_without_custom_domain(template):
     """When customDomain is disabled, the Function source must not hardcode a
     redirect target host — it must substitute `null` for __CANONICAL_HOST__.


### PR DESCRIPTION
## Summary

- The CloudFront `viewer-request` Function unconditionally redirected **every** request to `https://app.allotmint.io`, regardless of whether that domain has an alias, ACM certificate, or DNS record on the deployed distribution. Since the production `StaticSiteStack` deploys *without* `customDomain` enabled (and `app.allotmint.io` resolves to NXDOMAIN), every viewer request was redirected straight into a dead domain — taking production fully offline.
- This implements the "near-term fix" from #3693: make the host-based canonical redirect conditional on whether a custom domain is actually configured for *this* deployment.
- Mechanically: `viewer-request.js` now contains a synth-time placeholder `__CANONICAL_HOST__`. `static_site_stack.py` reads the file as a template string, substitutes either the JSON-encoded custom domain (when `customDomain=true`) or the literal `null` (when it isn't), and loads the result via `cloudfront.FunctionCode.from_inline(...)` instead of `from_file(...)`. When `canonical` is `null`, the Function skips host-based canonicalization entirely (it still upgrades to HTTPS and normalizes the URI path).
- Added regression tests (`test_viewer_request_function_skips_redirect_target_without_custom_domain`, `test_viewer_request_function_redirects_to_custom_domain_when_enabled`) asserting the synthesized Function source neither contains the unsubstituted placeholder nor hardcodes `app.allotmint.io` when `customDomain` is disabled, and correctly canonicalizes to it when enabled.

Out of scope (per #3693's constraints): the `us-east-1` migration / enabling `customDomain=true` in production. This PR only stops the active outage by removing the redirect-to-nowhere; it does not attempt to stand up the custom domain.

Closes #3693

## Test plan
- [x] `python -m pytest cdk/tests/test_static_site_stack.py -k "viewer_request or custom_domain" -v` — 12 passed
- [x] Verified the pre-existing `make lint`/`black`/`ruff` findings on these files are unchanged from `main` (not introduced by this change)
- [ ] CI: full `cdk/tests` suite and lint checks