### PR TITLE
fix(ci): re-check open PRs for merge conflicts when main advances

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -4,17 +4,23 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
 
 permissions:
   contents: read
+  statuses: write
+  pull-requests: read
 
 jobs:
   check-merge-conflicts:
+    if: github.event_name == 'pull_request'
     name: Check for merge conflicts with main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Attempt merge with main (dry run)
@@ -29,3 +35,61 @@ jobs:
           fi
           git reset --hard HEAD
           echo "No merge conflicts detected."
+
+  recheck-open-prs:
+    if: github.event_name == 'push'
+    name: Re-check open PRs against new main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Re-run merge dry-run for each open PR targeting main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          git config user.email "ci@github-actions"
+          git config user.name "GitHub Actions"
+
+          prs=$(gh pr list --repo "$REPO" --base main --state open --json number,headRefOid,headRefName -q '.[] | "\(.number) \(.headRefOid) \(.headRefName)"')
+
+          if [ -z "$prs" ]; then
+            echo "No open PRs targeting main."
+            exit 0
+          fi
+
+          any_conflict=0
+
+          while IFS=' ' read -r number sha branch; do
+            echo "::group::PR #$number ($branch @ $sha)"
+            git checkout --quiet --force "$sha"
+            git reset --hard --quiet "$sha"
+
+            if git merge --no-commit --no-ff origin/main; then
+              git merge --abort 2>/dev/null || git reset --hard --quiet "$sha"
+              state="success"
+              description="No merge conflicts detected with the latest main."
+              echo "PR #$number: no merge conflicts with main."
+            else
+              git merge --abort
+              state="failure"
+              description="PR #$number has merge conflicts with the latest main."
+              echo "::error::PR #$number ($branch) now has merge conflicts with main."
+              any_conflict=1
+            fi
+
+            gh api "repos/$REPO/statuses/$sha" \
+              -f state="$state" \
+              -f context="Merge Conflict Check / recheck-against-main" \
+              -f description="$description" \
+              --silent || true
+
+            echo "::endgroup::"
+          done <<< "$prs"
+
+          if [ "$any_conflict" -ne 0 ]; then
+            exit 1
+          fi

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -7,16 +7,13 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: read
-  statuses: write
-  pull-requests: read
-
 jobs:
   check-merge-conflicts:
     if: github.event_name == 'pull_request'
     name: Check for merge conflicts with main
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -40,15 +37,21 @@ jobs:
     if: github.event_name == 'push'
     name: Re-check open PRs against new main
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Re-run merge dry-run for each open PR targeting main
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          MAIN_SHA: ${{ github.sha }}
         run: |
           set -e
           git config user.email "ci@github-actions"
@@ -69,8 +72,12 @@ jobs:
             # point at (it is not reachable from main).
             git fetch --quiet origin "$sha"
             git checkout --quiet --force "$sha"
+            git clean -fd --quiet
 
-            if git merge --no-commit --no-ff origin/main; then
+            # Merge against the exact commit that triggered this run, not the
+            # origin/main remote-tracking ref -- another push could move that
+            # ref between checkout and the merge attempt.
+            if git merge --no-commit --no-ff "$MAIN_SHA"; then
               state="success"
               description="No merge conflicts detected with the latest main."
               echo "PR #$number: no merge conflicts with main."
@@ -81,9 +88,10 @@ jobs:
             fi
 
             # Always return to a clean state before the next iteration,
-            # regardless of whether a merge is in progress.
-            git merge --abort 2>/dev/null
-            git reset --hard --quiet "$sha"
+            # regardless of whether a merge is in progress or merely staged.
+            git merge --abort 2>/dev/null || true
+            git checkout --quiet --force "$sha"
+            git clean -fd --quiet
 
             if ! gh api "repos/$REPO/statuses/$sha" \
               -f state="$state" \

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -61,35 +61,36 @@ jobs:
             exit 0
           fi
 
-          any_conflict=0
-
           while IFS=' ' read -r number sha branch; do
             echo "::group::PR #$number ($branch @ $sha)"
+
+            # The clone only has main's history by default; fetch this PR's
+            # head commit explicitly so the checkout below has an object to
+            # point at (it is not reachable from main).
+            git fetch --quiet origin "$sha"
             git checkout --quiet --force "$sha"
-            git reset --hard --quiet "$sha"
 
             if git merge --no-commit --no-ff origin/main; then
-              git merge --abort 2>/dev/null || git reset --hard --quiet "$sha"
               state="success"
               description="No merge conflicts detected with the latest main."
               echo "PR #$number: no merge conflicts with main."
             else
-              git merge --abort
               state="failure"
               description="PR #$number has merge conflicts with the latest main."
               echo "::error::PR #$number ($branch) now has merge conflicts with main."
-              any_conflict=1
             fi
 
-            gh api "repos/$REPO/statuses/$sha" \
+            # Always return to a clean state before the next iteration,
+            # regardless of whether a merge is in progress.
+            git merge --abort 2>/dev/null
+            git reset --hard --quiet "$sha"
+
+            if ! gh api "repos/$REPO/statuses/$sha" \
               -f state="$state" \
               -f context="Merge Conflict Check / recheck-against-main" \
-              -f description="$description" \
-              --silent || true
+              -f description="$description"; then
+              echo "::warning::Failed to post commit status for PR #$number ($sha)"
+            fi
 
             echo "::endgroup::"
           done <<< "$prs"
-
-          if [ "$any_conflict" -ne 0 ]; then
-            exit 1
-          fi


### PR DESCRIPTION
## Summary
- The Merge Conflict Check only triggered on `pull_request: [opened, synchronize, reopened, ready_for_review]`, so a PR that merged cleanly with `main` at sync time stays green even after `main` advances and a real conflict appears (this happened on [#3711](https://github.com/leonarduk/allotmint/pull/3711) — its check passed at sync time but GitHub now reports `mergeable: CONFLICTING` / `mergeStateStatus: DIRTY` after later commits to `main` touched the same files).
- Add a `push: branches: [main]` job that lists all open PRs targeting `main`, re-runs the dry-run merge against the new `main` tip for each, and posts a commit status (`Merge Conflict Check / recheck-against-main`) reflecting the live result.
- Also check out the PR's actual head SHA (`github.event.pull_request.head.sha`) in the existing per-PR job rather than the cached `refs/pull/<N>/merge` ref, since that ref can itself be stale relative to the current `main` tip.

Closes #3723

## Test plan
- [ ] Confirm the `pull_request`-triggered job still runs and passes/fails correctly on PR sync events
- [ ] Confirm the new `push`-triggered job runs on a push to `main`, lists open PRs, and posts commit statuses
- [ ] Manually verify against #3711 (a known-conflicting PR) that the recheck job reports `failure` for it