### PR TITLE
fix(scripts): pass PR body via --body-file in aider-issue.ps1

### DIFF
--- a/scripts/aider-issue.ps1
+++ b/scripts/aider-issue.ps1
@@ -151,7 +151,11 @@ $prTitle = "Fix: " + $title
 # quote all values that have spaces". A file sidesteps command-line quoting
 # entirely (the same approach already used for the aider prompt above).
 $bodyFile = [System.IO.Path]::GetTempFileName()
-Set-Content -Path $bodyFile -Value $prBody -Encoding UTF8
+# Write BOM-free UTF-8: Set-Content -Encoding UTF8 emits a BOM on Windows
+# PowerShell 5.x, and [System.Text.Encoding]::UTF8 also carries a 3-byte
+# preamble, either of which gh would copy verbatim into the PR body. A
+# UTF8Encoding constructed with $false omits the BOM on both 5.x and 7.x.
+[System.IO.File]::WriteAllText($bodyFile, $prBody, (New-Object System.Text.UTF8Encoding($false)))
 
 # Open a draft PR; --head is explicit so fork contributors don't get a cross-repo mismatch
 Write-Host "[6/6] Creating draft PR..."

--- a/scripts/aider-issue.ps1
+++ b/scripts/aider-issue.ps1
@@ -143,12 +143,28 @@ $diffStat
 # Build the PR title with + to avoid re-evaluating backticks or $(...) in $title
 $prTitle = "Fix: " + $title
 
+# Write the PR body to a temp file and pass it via --body-file. Passing the
+# multi-line body straight through --body is unreliable under Windows
+# PowerShell: its native-argument quoting splits the string on the embedded
+# spaces, double quotes, and backticks that issue bodies routinely contain, so
+# gh sees dozens of stray tokens and aborts with "unknown arguments ...; please
+# quote all values that have spaces". A file sidesteps command-line quoting
+# entirely (the same approach already used for the aider prompt above).
+$bodyFile = [System.IO.Path]::GetTempFileName()
+Set-Content -Path $bodyFile -Value $prBody -Encoding UTF8
+
 # Open a draft PR; --head is explicit so fork contributors don't get a cross-repo mismatch
 Write-Host "[6/6] Creating draft PR..."
 gh pr create `
     --title $prTitle `
-    --body $prBody `
+    --body-file $bodyFile `
     --draft `
     --head $branch `
     --base $defaultBranch `
     --repo "$owner/$repo"
+$prExit = $LASTEXITCODE
+Remove-Item $bodyFile -ErrorAction SilentlyContinue
+if ($prExit -ne 0) {
+    Write-Error "gh pr create failed (exit $prExit). The branch was pushed; create the PR manually or re-run after fixing the error above."
+    exit 1
+}


### PR DESCRIPTION
## Summary

`scripts/aider-issue.ps1` step 6 (`gh pr create`) passed the multi-line PR body straight through `--body $prBody`. Under Windows PowerShell, native-argument quoting splits such a string on the embedded spaces, double quotes, and backticks that GitHub issue bodies routinely contain, so `gh` receives dozens of stray tokens and aborts:

```
unknown arguments [...]; please quote all values that have spaces
```

The branch gets pushed but **no PR is created** — exactly the failure observed running `aider-issue.ps1 3677`.

## Fix

- Write `$prBody` to a temp file and pass it via `--body-file` instead of `--body`. This sidesteps command-line quoting entirely — the same file-based approach the script already uses for the aider prompt (`--message-file`).
- Capture and check `gh pr create`'s exit code (previously ignored), and clean up the temp file, so a PR-creation failure is reported rather than silently swallowed.

## Testing

- `scripts/aider-issue.ps1` parses cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`).
- The `--message-file` path in the same script already proves the file-based pattern works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
