### PR TITLE
fix(viewer-request): default proto to 'https' when cloudfront-forwarded-proto absent

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -519,11 +519,16 @@ jobs:
           fi
           echo "/api-console → $auth_status (auth required) OK"
           # Check CloudFront distribution domain directly (not the canonical custom domain).
-          # viewer-request.js (cdk/functions/viewer-request.js) returns 301 for any request
-          # whose Host header is not app.allotmint.io — so a 301 here confirms the
-          # distribution is live and the CloudFront Function is executing correctly.
-          # Accepting 200 OR 301 avoids a hard dependency on external DNS for app.allotmint.io
-          # which is not yet configured in the CDK stack (see issue #3011 and #3012).
+          # Expected response depends on the deployment's customDomain context flag:
+          #   customDomain=false (default): viewer-request.js passes the request through →
+          #     200 from the SPA index (or appropriate HTML response).
+          #   customDomain=true (when alias/cert/DNS are configured): viewer-request.js
+          #     redirects non-canonical hosts to https://app.allotmint.io → 301.
+          # Accepting 200 OR 301 handles both cases.  A 301 from a customDomain=false
+          # deployment indicates a bug in viewer-request.js (likely the infinite proto
+          # self-redirect fixed in issue #3763); that class of fault is caught by
+          # Lighthouse CI (step "Run Lighthouse CI") which Chrome would fail with
+          # ERR_TOO_MANY_REDIRECTS / CHROME_INTERSTITIAL_ERROR.
           # Use --output /dev/null (not >/dev/null) to avoid curl exit 23 on HTTP/2 streams.
           echo "Checking CloudFront → https://${frontend_domain}"
           curl_exit=0

--- a/cdk/functions/viewer-request.js
+++ b/cdk/functions/viewer-request.js
@@ -3,11 +3,16 @@ function handler(event) {
     var headers = request.headers;
     var host = headers.host.value;
     var protoHeader = headers['cloudfront-forwarded-proto'];
-    var proto =
-        protoHeader &&
-        (protoHeader.value === 'http' || protoHeader.value === 'https')
-            ? protoHeader.value
-            : null;
+    // 'cloudfront-forwarded-proto' is added by CloudFront for origin-request
+    // events; it may be absent on viewer-request events.  The distribution's
+    // ViewerProtocolPolicy.REDIRECT_TO_HTTPS guarantees that every request
+    // reaching this function is already HTTPS, so treat a missing or
+    // unrecognised value as 'https'.  Defaulting to null instead caused an
+    // infinite self-redirect loop (proto !== 'https' → 301 to the same HTTPS
+    // URL → proto still absent → 301 again) when no custom domain was
+    // configured, resulting in ERR_TOO_MANY_REDIRECTS for Chrome users.
+    // See issue #3763.
+    var proto = protoHeader && protoHeader.value === 'http' ? 'http' : 'https';
     // __CANONICAL_HOST__ is substituted at CDK synth time (see
     // static_site_stack.py): a JSON string holding the configured custom
     // domain when this deployment has one (alias + ACM certificate + DNS

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -495,6 +495,32 @@ def test_viewer_request_function_skips_redirect_target_without_custom_domain(tem
     )
 
 
+def test_viewer_request_function_defaults_proto_to_https_when_header_absent(
+    template, custom_domain_template
+):
+    """The Function must default proto to 'https' when cloudfront-forwarded-proto
+    is absent, not null.
+
+    Regression test for issue #3763: defaulting to null caused proto !== 'https'
+    to always be true when the header was missing (common in viewer-request
+    events), triggering an infinite self-redirect loop (301 → same HTTPS URL →
+    301 again) and ERR_TOO_MANY_REDIRECTS / CHROME_INTERSTITIAL_ERROR in both
+    Lighthouse CI and real browsers when customDomain is disabled.
+    """
+    safe_fallback = "? 'http' : 'https'"
+    avoid_null_fallback = ": null"
+
+    for rendered_template in (template, custom_domain_template):
+        source = _viewer_request_function_code(rendered_template)
+        assert safe_fallback in source, (
+            "cloudfront-forwarded-proto absent/unrecognised must default to "
+            "'https', not null — null causes an infinite self-redirect loop"
+        )
+        assert avoid_null_fallback not in source, (
+            "proto must never default to null; use 'https' as the safe fallback"
+        )
+
+
 def test_viewer_request_function_redirects_to_custom_domain_when_enabled(custom_domain_template):
     """When customDomain is enabled, the Function source must canonicalize to
     the configured custom domain (which has a matching alias/cert/DNS record)."""


### PR DESCRIPTION
## Summary

- **Root cause of Lighthouse CI failure (#3763):** `viewer-request.js` was defaulting `proto` to `null` when the `cloudfront-forwarded-proto` header was absent. Because `cloudfront-forwarded-proto` is an *origin-request* header that CloudFront adds for downstream processing, it is routinely missing on *viewer-request* events. With `proto = null`, the condition `proto !== 'https'` was always `true`, producing a `301` redirect back to the **same** HTTPS URL — an infinite self-redirect loop (`ERR_TOO_MANY_REDIRECTS`).
- `curl` (used in the endpoint-validation step) never follows redirects by default, so it silently reported the 301 as healthy. Lighthouse CI runs headless Chrome, which *does* follow redirects, and hit `CHROME_INTERSTITIAL_ERROR` on every deploy.
- **Fix:** treat a missing or unrecognised `cloudfront-forwarded-proto` as `'https'`. This is correct because `ViewerProtocolPolicy.REDIRECT_TO_HTTPS` guarantees the viewer is already on HTTPS before the CloudFront Function fires. An explicit `'http'` value still triggers an upgrade redirect (defence-in-depth).

## Changes

| File | Change |
|---|---|
| `cdk/functions/viewer-request.js` | `proto` fallback changed from `null` → `'https'`; added inline comment explaining why |
| `cdk/tests/test_static_site_stack.py` | New regression test `test_viewer_request_function_defaults_proto_to_https_when_header_absent` asserting `? 'http' : 'https'` pattern is present in both customDomain builds and `': null'` is absent |
| `.github/workflows/deploy-lambda.yml` | Corrected misleading comment in CloudFront health-check step that incorrectly stated "a 301 confirms the function is working correctly" |

## Test plan

- [x] `python -m pytest cdk/tests/test_static_site_stack.py -x -q` — 43 passed (includes new regression test)
- [ ] Deploy to staging/production and verify Lighthouse CI step completes without `CHROME_INTERSTITIAL_ERROR`
- [ ] Step 26 (validate endpoints) still accepts 200 or 301 — no change required there

Closes #3763

🤖 Generated with [Claude Code](https://claude.com/claude-code)