### PR TITLE
ci(pre-deploy-check): fail if cdk diff removes an IAM Allow grant for the deploy role

### DIFF
--- a/scripts/bash/pre-deploy-check.sh
+++ b/scripts/bash/pre-deploy-check.sh
@@ -49,11 +49,17 @@ if [[ -z "${AWS_ACCESS_KEY_ID:-}" ]]; then
 elif [[ -z "${GITHUB_DEPLOY_ROLE_ARN:-}" || -z "${JWT_SECRET:-}" || -z "${GOOGLE_CLIENT_ID:-}" || -z "${DATA_BUCKET:-}" ]]; then
     skip "CDK diff (requires GITHUB_DEPLOY_ROLE_ARN, JWT_SECRET, GOOGLE_CLIENT_ID, DATA_BUCKET)"
 else
-    if (cd cdk && npx cdk diff BackendLambdaStack StaticSiteStack -c prod=true --method=changeset); then
-        pass "CDK diff"
-    else
+    cdk_diff_output=$(mktemp)
+    (cd cdk && npx cdk diff BackendLambdaStack StaticSiteStack -c prod=true --method=changeset) | tee "$cdk_diff_output"
+    cdk_diff_exit=${PIPESTATUS[0]}
+    if [[ $cdk_diff_exit -ne 0 ]]; then
         fail "CDK diff"
+    elif ! python3 scripts/check_cdk_diff_iam_removals.py "$cdk_diff_output"; then
+        fail "CDK diff (removes an IAM Allow grant for the deploy role — see #3741)"
+    else
+        pass "CDK diff"
     fi
+    rm -f "$cdk_diff_output"
 fi
 
 # 3. IAM permission simulation

--- a/scripts/check_cdk_diff_iam_removals.py
+++ b/scripts/check_cdk_diff_iam_removals.py
@@ -63,8 +63,10 @@ def find_iam_statement_rows(diff_output: str) -> list[list[str]]:
             continue
         cells = _table_row_cells(line)
         if cells is None:
-            # A non-table line (other than a border) ends this table.
-            if not line.strip().startswith(("┌", "├", "└", "┬", "┼", "┴")):
+            stripped = line.strip()
+            # Blank lines and box-drawing borders don't end the table; any
+            # other non-table line (e.g. the start of the next section) does.
+            if stripped and not stripped.startswith(("┌", "├", "└", "┬", "┼", "┴")):
                 in_table = False
             continue
         if "Effect" in cells and "Action" in cells:

--- a/scripts/check_cdk_diff_iam_removals.py
+++ b/scripts/check_cdk_diff_iam_removals.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Fail if a `cdk diff --method=changeset` run removes an IAM Allow statement
+for the GitHub deploy role (or other watched resources) without an equivalent
+replacement.
+
+`cdk diff` exits 0 even when its "IAM Statement Changes" table shows an
+``Allow`` statement being removed, so a removed grant for the deploy role
+(e.g. `lambda:InvokeFunction` on `PriceRefreshLambdaLiveAlias`, or `s3:GetObject`
+on `PortfolioDataBucket`) would otherwise pass `pre-deploy-check` silently. See #3741.
+
+Usage:
+    python scripts/check_cdk_diff_iam_removals.py [diff_output_file]
+
+Reads the diff output from the given file, or from stdin if no file is given.
+Exits 1 and prints the offending rows if an unmatched removal is found.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+IAM_TABLE_HEADER = "IAM Statement Changes"
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# Substrings (matched case-insensitively against a removed row's cells) that
+# identify a statement as belonging to the GitHub deploy role's grants.
+DEFAULT_WATCH_PATTERNS = (
+    "github-deploy",
+    "GithubDeployRole",
+    "PriceRefreshLambda",
+    "PortfolioDataBucket",
+)
+
+
+def _table_row_cells(line: str) -> list[str] | None:
+    """Split a `│ a │ b │ c │`-style table row into trimmed cells.
+
+    Returns None for lines that aren't a `│`-delimited row (borders, blank
+    lines, or text outside the table).
+    """
+    stripped = line.strip()
+    if not stripped.startswith("│") or not stripped.endswith("│"):
+        return None
+    return [cell.strip() for cell in stripped.strip("│").split("│")]
+
+
+def find_iam_statement_rows(diff_output: str) -> list[list[str]]:
+    """Return data rows from any "IAM Statement Changes" table in `diff_output`.
+
+    Each row is `[marker, resource, effect, action, principal, condition]`
+    where `marker` is `+`, `-`, or empty. The column-header row itself is
+    skipped.
+    """
+    rows: list[list[str]] = []
+    in_table = False
+    for raw_line in diff_output.splitlines():
+        line = ANSI_ESCAPE_RE.sub("", raw_line)
+        if IAM_TABLE_HEADER in line:
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        cells = _table_row_cells(line)
+        if cells is None:
+            # A non-table line (other than a border) ends this table.
+            if not line.strip().startswith(("┌", "├", "└", "┬", "┼", "┴")):
+                in_table = False
+            continue
+        if "Effect" in cells and "Action" in cells:
+            continue  # column-header row
+        rows.append(cells)
+    return rows
+
+
+def find_unmatched_allow_removals(
+    diff_output: str, watch_patterns: tuple[str, ...] = DEFAULT_WATCH_PATTERNS
+) -> list[list[str]]:
+    """Return removed `Allow` statement rows matching `watch_patterns` that
+    have no identical addition elsewhere in the diff (i.e. a net removal,
+    not a destroy+create replacement that nets out unchanged)."""
+    rows = find_iam_statement_rows(diff_output)
+    removed = [r for r in rows if r and r[0] == "-"]
+    added = [r for r in rows if r and r[0] == "+"]
+    added_signatures = {tuple(r[1:]) for r in added}
+
+    unmatched: list[list[str]] = []
+    for row in removed:
+        if tuple(row[1:]) in added_signatures:
+            continue
+        effect = row[2] if len(row) > 2 else ""
+        if effect.lower() != "allow":
+            continue
+        row_text = " ".join(row)
+        if any(re.search(pat, row_text, re.IGNORECASE) for pat in watch_patterns):
+            unmatched.append(row)
+    return unmatched
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 1:
+        diff_output = open(argv[1], encoding="utf-8", errors="replace").read()
+    else:
+        diff_output = sys.stdin.read()
+
+    unmatched = find_unmatched_allow_removals(diff_output)
+    if not unmatched:
+        return 0
+
+    print(
+        "ERROR: cdk diff removes the following IAM 'Allow' statement(s) for the "
+        "GitHub deploy role (or other watched resources) with no matching "
+        "addition elsewhere in the diff:",
+        file=sys.stderr,
+    )
+    for row in unmatched:
+        print(f"  - {row}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/powershell/pre-deploy-check.ps1
+++ b/scripts/powershell/pre-deploy-check.ps1
@@ -65,10 +65,27 @@ if (-not $env:AWS_ACCESS_KEY_ID) {
     try {
         Push-Location cdk -ErrorAction Stop
         # Use & to invoke npx as an external executable so arguments are passed correctly.
-        & npx cdk diff BackendLambdaStack StaticSiteStack -c prod=true --method=changeset
-        if ($LASTEXITCODE -eq 0) { Write-Pass "CDK diff" } else { Write-Fail "CDK diff" }
+        $cdkDiffOutput = & npx cdk diff BackendLambdaStack StaticSiteStack -c prod=true --method=changeset 2>&1
+        $cdkDiffExit = $LASTEXITCODE
     } finally {
         Pop-Location
+    }
+    $cdkDiffOutput | ForEach-Object { Write-Host $_ }
+    if ($cdkDiffExit -ne 0) {
+        Write-Fail "CDK diff"
+    } else {
+        $tmpFile = New-TemporaryFile
+        try {
+            $cdkDiffOutput | Out-String | Set-Content -Path $tmpFile -Encoding utf8
+            python scripts/check_cdk_diff_iam_removals.py $tmpFile
+            if ($LASTEXITCODE -eq 0) {
+                Write-Pass "CDK diff"
+            } else {
+                Write-Fail "CDK diff (removes an IAM Allow grant for the deploy role — see #3741)"
+            }
+        } finally {
+            Remove-Item $tmpFile -Force
+        }
     }
 }
 

--- a/tests/scripts/test_check_cdk_diff_iam_removals.py
+++ b/tests/scripts/test_check_cdk_diff_iam_removals.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 from pathlib import Path
 
 _SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_cdk_diff_iam_removals.py"
@@ -63,6 +64,46 @@ IAM Statement Changes
 └───┴──────────────────────┴────────┴───────────────────────┴──────────────────────────┘
 """
 
+REMOVED_S3_GRANT_DIFF = """
+Stack BackendLambdaStack
+IAM Statement Changes
+┌───┬──────────────────────┬────────┬───────────────────────┬──────────────────────────┐
+│   │ Resource              │ Effect │ Action                │ Principal                 │
+├───┼──────────────────────┼────────┼───────────────────────┼──────────────────────────┤
+│ - │ ${PortfolioDataBucket}│ Allow  │ s3:GetObject          │ AWS:${github-deploy.Arn} │
+└───┴──────────────────────┴────────┴───────────────────────┴──────────────────────────┘
+"""
+
+# A blank line inside the table block, as can occur when a wide table wraps
+# in CI logs. The removal row appears after the blank line and must still
+# be picked up.
+BLANK_LINE_MID_TABLE_DIFF = """
+Stack BackendLambdaStack
+IAM Statement Changes
+┌───┬──────────────────────┬────────┬───────────────────────┬──────────────────────────┐
+│   │ Resource              │ Effect │ Action                │ Principal                 │
+
+│ - │ ${PriceRefreshAlias}  │ Allow  │ lambda:InvokeFunction │ AWS:${github-deploy.Arn} │
+└───┴──────────────────────┴────────┴───────────────────────┴──────────────────────────┘
+"""
+
+# Same removal as REMOVED_DEPLOY_ROLE_GRANT_DIFF but with ANSI colour escape
+# codes wrapping each line, as `cdk diff` can emit when run in CI.
+ANSI_COLORED_REMOVAL_DIFF = (
+    "\x1b[0mStack BackendLambdaStack\x1b[0m\n"
+    "\x1b[1mIAM Statement Changes\x1b[0m\n"
+    "\x1b[90m┌───┬──────────────────────┬────────┬───────────────────────┬─────"
+    "─────────────────────┐\x1b[0m\n"
+    "\x1b[90m│   │ Resource              │ Effect │ Action                │ Princ"
+    "ipal                 │\x1b[0m\n"
+    "\x1b[90m├───┼──────────────────────┼────────┼───────────────────────┼─────"
+    "─────────────────────┤\x1b[0m\n"
+    "\x1b[31m│ - │ ${PriceRefreshAlias}  │ Allow  │ lambda:InvokeFunction │ AWS:"
+    "${github-deploy.Arn} │\x1b[0m\n"
+    "\x1b[90m└───┴──────────────────────┴────────┴───────────────────────┴─────"
+    "─────────────────────┘\x1b[0m\n"
+)
+
 
 def test_no_iam_table_means_no_removals() -> None:
     assert find_unmatched_allow_removals(NO_IAM_CHANGES_DIFF) == []
@@ -96,3 +137,26 @@ def test_main_returns_one_for_removed_grant(tmp_path) -> None:
     diff_file = tmp_path / "diff.txt"
     diff_file.write_text(REMOVED_DEPLOY_ROLE_GRANT_DIFF, encoding="utf-8")
     assert main(["check_cdk_diff_iam_removals.py", str(diff_file)]) == 1
+
+
+def test_flags_removed_s3_grant_for_portfolio_data_bucket() -> None:
+    unmatched = find_unmatched_allow_removals(REMOVED_S3_GRANT_DIFF)
+    assert len(unmatched) == 1
+    assert "s3:GetObject" in unmatched[0]
+
+
+def test_flags_removal_after_blank_line_mid_table() -> None:
+    unmatched = find_unmatched_allow_removals(BLANK_LINE_MID_TABLE_DIFF)
+    assert len(unmatched) == 1
+    assert "lambda:InvokeFunction" in unmatched[0]
+
+
+def test_flags_removal_in_ansi_colored_diff() -> None:
+    unmatched = find_unmatched_allow_removals(ANSI_COLORED_REMOVAL_DIFF)
+    assert len(unmatched) == 1
+    assert "lambda:InvokeFunction" in unmatched[0]
+
+
+def test_main_reads_from_stdin(monkeypatch) -> None:
+    monkeypatch.setattr(_mod.sys, "stdin", io.StringIO(REMOVED_DEPLOY_ROLE_GRANT_DIFF))
+    assert main(["check_cdk_diff_iam_removals.py"]) == 1

--- a/tests/scripts/test_check_cdk_diff_iam_removals.py
+++ b/tests/scripts/test_check_cdk_diff_iam_removals.py
@@ -1,0 +1,98 @@
+"""Unit tests for scripts/check_cdk_diff_iam_removals.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_cdk_diff_iam_removals.py"
+spec = importlib.util.spec_from_file_location("check_cdk_diff_iam_removals", _SCRIPT)
+_mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+find_unmatched_allow_removals = _mod.find_unmatched_allow_removals
+main = _mod.main
+
+NO_IAM_CHANGES_DIFF = """
+Stack BackendLambdaStack
+Resources
+[~] AWS::Lambda::Function PriceRefreshLambda
+ └─ [~] Code
+"""
+
+REMOVED_DEPLOY_ROLE_GRANT_DIFF = """
+Stack BackendLambdaStack
+IAM Statement Changes
+┌───┬──────────────────────┬────────┬───────────────────────┬──────────────────────────┐
+│   │ Resource              │ Effect │ Action                │ Principal                 │
+├───┼──────────────────────┼────────┼───────────────────────┼──────────────────────────┤
+│ - │ ${PriceRefreshAlias}  │ Allow  │ lambda:InvokeFunction │ AWS:${github-deploy.Arn} │
+└───┴──────────────────────┴────────┴───────────────────────┴──────────────────────────┘
+
+Resources
+[-] AWS::IAM::Policy GithubDeployRoleForLambdaInvokePolicy80453C0D destroy
+"""
+
+REPLACED_DEPLOY_ROLE_GRANT_DIFF = """
+Stack BackendLambdaStack
+IAM Statement Changes
+┌───┬──────────────────────┬────────┬───────────────────────┬──────────────────────────┐
+│   │ Resource              │ Effect │ Action                │ Principal                 │
+├───┼──────────────────────┼────────┼───────────────────────┼──────────────────────────┤
+│ - │ ${PriceRefreshAlias}  │ Allow  │ lambda:InvokeFunction │ AWS:${github-deploy.Arn} │
+│ + │ ${PriceRefreshAlias}  │ Allow  │ lambda:InvokeFunction │ AWS:${github-deploy.Arn} │
+└───┴──────────────────────┴────────┴───────────────────────┴──────────────────────────┘
+"""
+
+REMOVED_UNRELATED_GRANT_DIFF = """
+Stack BackendLambdaStack
+IAM Statement Changes
+┌───┬──────────────────────┬────────┬───────────────────────┬──────────────────────────┐
+│   │ Resource              │ Effect │ Action                │ Principal                 │
+├───┼──────────────────────┼────────┼───────────────────────┼──────────────────────────┤
+│ - │ ${SomeOtherBucket}    │ Allow  │ s3:GetObject          │ AWS:${SomeOtherRole.Arn} │
+└───┴──────────────────────┴────────┴───────────────────────┴──────────────────────────┘
+"""
+
+REMOVED_DENY_DIFF = """
+Stack BackendLambdaStack
+IAM Statement Changes
+┌───┬──────────────────────┬────────┬───────────────────────┬──────────────────────────┐
+│   │ Resource              │ Effect │ Action                │ Principal                 │
+├───┼──────────────────────┼────────┼───────────────────────┼──────────────────────────┤
+│ - │ ${PortfolioDataBucket}│ Deny   │ s3:DeleteObject       │ AWS:${github-deploy.Arn} │
+└───┴──────────────────────┴────────┴───────────────────────┴──────────────────────────┘
+"""
+
+
+def test_no_iam_table_means_no_removals() -> None:
+    assert find_unmatched_allow_removals(NO_IAM_CHANGES_DIFF) == []
+
+
+def test_flags_removed_allow_grant_for_deploy_role() -> None:
+    unmatched = find_unmatched_allow_removals(REMOVED_DEPLOY_ROLE_GRANT_DIFF)
+    assert len(unmatched) == 1
+    assert "lambda:InvokeFunction" in unmatched[0]
+
+
+def test_replace_pair_is_not_flagged() -> None:
+    assert find_unmatched_allow_removals(REPLACED_DEPLOY_ROLE_GRANT_DIFF) == []
+
+
+def test_removed_grant_for_unrelated_role_is_not_flagged() -> None:
+    assert find_unmatched_allow_removals(REMOVED_UNRELATED_GRANT_DIFF) == []
+
+
+def test_removed_deny_statement_is_not_flagged() -> None:
+    assert find_unmatched_allow_removals(REMOVED_DENY_DIFF) == []
+
+
+def test_main_returns_zero_for_clean_diff(tmp_path) -> None:
+    diff_file = tmp_path / "diff.txt"
+    diff_file.write_text(REPLACED_DEPLOY_ROLE_GRANT_DIFF, encoding="utf-8")
+    assert main(["check_cdk_diff_iam_removals.py", str(diff_file)]) == 0
+
+
+def test_main_returns_one_for_removed_grant(tmp_path) -> None:
+    diff_file = tmp_path / "diff.txt"
+    diff_file.write_text(REMOVED_DEPLOY_ROLE_GRANT_DIFF, encoding="utf-8")
+    assert main(["check_cdk_diff_iam_removals.py", str(diff_file)]) == 1


### PR DESCRIPTION
## Summary
- `pre-deploy-check`'s CDK diff step only checked `cdk diff`'s exit code, which is 0 even when the diff's "IAM Statement Changes" table shows an `Allow` statement being removed for the `allotmint-github-deploy` role.
- Adds `scripts/check_cdk_diff_iam_removals.py`, which parses that table and fails if any removed `Allow` row referencing the deploy role (or `PriceRefreshLambda`/`PortfolioDataBucket`) has no matching addition elsewhere in the diff (so destroy+create replacement pairs that net out unchanged are not flagged).
- Wires this into both `scripts/bash/pre-deploy-check.sh` and `scripts/powershell/pre-deploy-check.ps1` step 2.

Closes #3741

## Test plan
- [x] `python -m pytest tests/scripts/test_check_cdk_diff_iam_removals.py -q` — 7 new tests covering: no IAM table, removed grant flagged, replace-pair not flagged, removal for unrelated role not flagged, removed `Deny` not flagged, and `main()` exit codes.
- [x] `python -m ruff check` / `black --check` pass on the new files.
- [x] `bash -n scripts/bash/pre-deploy-check.sh` and PowerShell tokenizer check pass.
- [ ] Live `cdk diff` run against AWS (requires credentials not available in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)