### PR TITLE
fix(deploy): remove v1-incompatible --no-cli-pager from head-object check

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -425,8 +425,7 @@ jobs:
           fi
           head_output="$(aws s3api head-object \
               --bucket "$DATA_BUCKET" \
-              --key "prices/latest_prices.json" \
-              --no-cli-pager 2>&1)" && head_exit=0 || head_exit=$?
+              --key "prices/latest_prices.json" 2>&1)" && head_exit=0 || head_exit=$?
           if [ "$head_exit" -eq 0 ]; then
             echo "Price snapshot prices/latest_prices.json is present in s3://${DATA_BUCKET} — OK"
           elif echo "$head_output" | grep -qi "NoSuchKey\|Not Found\|404"; then


### PR DESCRIPTION
## Summary
- The "Verify price snapshot seeded in S3" step calls `aws s3api head-object --no-cli-pager`, but `--no-cli-pager` is unknown to the AWS CLI v1 binary on the runner, causing the command to exit 255 with `Unknown options: --no-cli-pager`.
- The step has `continue-on-error: true` and treats any non-`NoSuchKey` failure as a generic warning, so this has been silently masking the snapshot check on every recent deploy (confirmed in run 27240567116, branch `v0.19.2`).
- Fix: drop `--no-cli-pager`. A non-interactive CI shell never opens a pager regardless of CLI version, so the flag served no purpose.

Closes #3743

## Test plan
- [x] `git diff` reviewed — single-line removal, no other behavior changed
- [ ] Next deploy run on `main` should show either "Price snapshot ... is present ... — OK" or the `NoSuchKey` warning, not the "Could not verify ... exit 255: Unknown options" message