### PR TITLE
fix(deploy): grant deploy role logs:FilterLogEvents and surface AccessDenied

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -549,8 +549,9 @@ jobs:
         # BackendLambdaLogGroupName is exported by BackendLambdaStack at
         # cdk/stacks/backend_lambda_stack.py (CfnOutput "BackendLambdaLogGroupName").
         # The deploy IAM role must have logs:FilterLogEvents on the log group ARN for
-        # this step to produce output; without it filter-log-events errors and
-        # continue-on-error absorbs it.
+        # this step to produce output; see the FilterBackendLambdaLogEvents grant in
+        # cdk/stacks/backend_lambda_stack.py and scripts/bash/fetch-cloudwatch-logs.sh
+        # for how an AccessDeniedException is surfaced as a `::warning::`.
         if: always()
         continue-on-error: true
         env:
@@ -566,18 +567,7 @@ jobs:
             exit 0
           fi
           echo "=== BackendLambda CloudWatch logs (last 10 minutes) ==="
-          # aws logs tail is CLI v2 only; use filter-log-events for CLI v1 compatibility.
-          # Shell arithmetic avoids a python3 dependency on self-hosted runners.
-          # Note: filter-log-events returns at most 10 000 events per call (no pagination);
-          # output of "None" means no events matched (AWS CLI JMESPath null → text "None").
-          start_ms=$(( ($(date +%s) - 600) * 1000 ))
-          aws logs filter-log-events \
-            --log-group-name "$log_group" \
-            --start-time "$start_ms" \
-            --query 'events[].message' \
-            --output text \
-            | grep -v '^None$' \
-            || echo "(no log events found)"
+          bash scripts/bash/fetch-cloudwatch-logs.sh "$log_group" 600
 
       - name: Check recent BackendLambda CloudWatch errors
         if: always()
@@ -780,6 +770,10 @@ jobs:
           if-no-files-found: ignore
 
       - name: Fetch Lambda logs from smoke test
+        # The deploy IAM role must have logs:FilterLogEvents on the log group ARN for
+        # this step to produce output; see the FilterBackendLambdaLogEvents grant in
+        # cdk/stacks/backend_lambda_stack.py and scripts/bash/fetch-cloudwatch-logs.sh
+        # for how an AccessDeniedException is surfaced as a `::warning::`.
         if: always()
         continue-on-error: true
         env:
@@ -795,15 +789,4 @@ jobs:
             exit 0
           fi
           echo "=== BackendLambda CloudWatch logs (last 15 minutes) ==="
-          # aws logs tail is CLI v2 only; use filter-log-events for CLI v1 compatibility.
-          # Shell arithmetic avoids a python3 dependency on self-hosted runners.
-          # Note: filter-log-events returns at most 10 000 events per call (no pagination);
-          # output of "None" means no events matched (AWS CLI JMESPath null → text "None").
-          start_ms=$(( ($(date +%s) - 900) * 1000 ))
-          aws logs filter-log-events \
-            --log-group-name "$log_group" \
-            --start-time "$start_ms" \
-            --query 'events[].message' \
-            --output text \
-            | grep -v '^None$' \
-            || echo "(no log events found)"
+          bash scripts/bash/fetch-cloudwatch-logs.sh "$log_group" 900

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -452,6 +452,21 @@ class BackendLambdaStack(Stack):
                 )
             )
 
+            # Grant the CI deploy role read access to BackendLambda's CloudWatch
+            # logs so the "Fetch BackendLambda CloudWatch logs" deploy steps can
+            # surface post-deploy errors instead of silently swallowing
+            # AccessDeniedException. Mirrors the FilterLogEvents statement in
+            # bootstrap-deploy-role.sh; this CDK grant is the source of truth
+            # thereafter and re-applies on every BackendLambdaStack deploy,
+            # preventing drift. See #3742.
+            github_role.add_to_principal_policy(
+                iam.PolicyStatement(
+                    sid="FilterBackendLambdaLogEvents",
+                    actions=["logs:FilterLogEvents"],
+                    resources=[backend_log_group.log_group_arn],
+                )
+            )
+
         events.Rule(
             self,
             "DailyPriceRefresh",

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -568,6 +568,81 @@ def test_no_s3_grant_to_deploy_role_when_github_deploy_role_arn_absent(monkeypat
     )
 
 
+def _logs_statements_for_role_name(raw_template: dict, role_name: str) -> list[dict]:
+    """Return policy statements attached to the named role that grant logs:* actions."""
+    found: list[dict] = []
+    for res in raw_template["Resources"].values():
+        if res.get("Type") != "AWS::IAM::Policy":
+            continue
+        if role_name not in str(res.get("Properties", {}).get("Roles", [])):
+            continue
+        policy_doc = res.get("Properties", {}).get("PolicyDocument", {})
+        for stmt in policy_doc.get("Statement", []):
+            actions = stmt.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+            if any(a.startswith("logs:") for a in actions):
+                found.append(stmt)
+    return found
+
+
+def test_deploy_role_gets_filter_log_events_on_backend_log_group(monkeypatch) -> None:
+    """BackendLambdaStack must grant the deploy role logs:FilterLogEvents scoped to
+    the BackendLambda log group ARN so the 'Fetch BackendLambda CloudWatch logs'
+    deploy steps can read post-deploy logs instead of getting AccessDeniedException.
+    CDK-managed so the grant re-applies on every deploy. See #3742."""
+    role_arn = "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    monkeypatch.setenv("GITHUB_DEPLOY_ROLE_ARN", role_arn)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackDeployRoleLogsTest")
+    raw = Template.from_stack(stack).to_json()
+    statements = _logs_statements_for_role_name(raw, "allotmint-github-deploy")
+
+    filter_log_events_resources: list[str] = []
+    for stmt in statements:
+        actions = stmt.get("Action", [])
+        if isinstance(actions, str):
+            actions = [actions]
+        if "logs:FilterLogEvents" not in actions:
+            continue
+        resources = stmt.get("Resource", [])
+        if isinstance(resources, (str, dict)):
+            resources = [resources]
+        filter_log_events_resources.extend(r if isinstance(r, str) else str(r) for r in resources)
+
+    assert filter_log_events_resources, (
+        "Expected the deploy role to be granted logs:FilterLogEvents in "
+        f"BackendLambdaStack, got statements: {statements}"
+    )
+    for resource in filter_log_events_resources:
+        assert "*" not in resource, (
+            f"Expected logs:FilterLogEvents resource to be scoped to the BackendLambda "
+            f"log group ARN (no wildcard), got: {resource}"
+        )
+        assert "BackendLambdaLogGroup" in resource, (
+            f"Expected logs:FilterLogEvents resource to reference the BackendLambda "
+            f"log group, got: {resource}"
+        )
+
+
+def test_no_logs_grant_to_deploy_role_when_github_deploy_role_arn_absent(monkeypatch) -> None:
+    """When GITHUB_DEPLOY_ROLE_ARN is unset, BackendLambdaStack must not grant
+    any CloudWatch Logs permissions to an imported deploy role."""
+    monkeypatch.delenv("GITHUB_DEPLOY_ROLE_ARN", raising=False)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App()
+    stack = BackendLambdaStack(app, "BackendLambdaStackNoDeployRoleLogsTest")
+    raw = Template.from_stack(stack).to_json()
+    statements = _logs_statements_for_role_name(raw, "allotmint-github-deploy")
+    assert not statements, (
+        "Expected no CloudWatch Logs grants for the deploy role in BackendLambdaStack "
+        f"when GITHUB_DEPLOY_ROLE_ARN is unset, found: {statements}"
+    )
+
+
 def test_grant_bucket_access_raises_on_no_permissions() -> None:
     class _MockFn:
         def add_to_role_policy(self, policy_statement: object) -> None:

--- a/scripts/bash/fetch-cloudwatch-logs.sh
+++ b/scripts/bash/fetch-cloudwatch-logs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Fetch recent CloudWatch log events for a log group, distinguishing a genuine
+# "no events" result from an API error (e.g. AccessDeniedException) so deploy
+# steps don't silently swallow IAM permission regressions. See #3742.
+#
+# Usage: fetch-cloudwatch-logs.sh <log-group-name> <lookback-seconds>
+#
+# aws logs tail is CLI v2 only; filter-log-events is used for CLI v1
+# compatibility. filter-log-events returns at most 10 000 events per call (no
+# pagination); an empty/"None" result over --output text means no events
+# matched (AWS CLI JMESPath null -> text "None").
+#
+# Always exits 0 (log fetching is diagnostic, not load-bearing); on error it
+# emits a `::warning::` GitHub Actions annotation instead of failing or
+# silently printing "(no log events found)".
+
+set -uo pipefail
+
+log_group="${1:?log group name required}"
+lookback_seconds="${2:?lookback window in seconds required}"
+
+start_ms=$(( ($(date +%s) - lookback_seconds) * 1000 ))
+
+output="$(aws logs filter-log-events \
+    --log-group-name "$log_group" \
+    --start-time "$start_ms" \
+    --query 'events[].message' \
+    --output text 2>&1)"
+exit_code=$?
+
+if [ "$exit_code" -ne 0 ]; then
+    if printf '%s' "$output" | grep -q "AccessDeniedException"; then
+        echo "::warning::logs:FilterLogEvents denied for $log_group; CloudWatch logs not available (see #3742)"
+    else
+        echo "::warning::Failed to fetch CloudWatch logs for $log_group: $output"
+    fi
+    exit 0
+fi
+
+filtered="$(printf '%s' "$output" | grep -v '^None$' || true)"
+if [ -z "$filtered" ]; then
+    echo "(no log events found)"
+else
+    printf '%s\n' "$filtered"
+fi


### PR DESCRIPTION
## Summary
- Adds a CDK-managed `logs:FilterLogEvents` grant on the GitHub deploy role, scoped to the `BackendLambda` CloudWatch log group ARN (`cdk/stacks/backend_lambda_stack.py`), following the existing "CDK is the source of truth" pattern used for the other deploy-role grants in this file.
- Extracts the post-deploy CloudWatch log fetch into `scripts/bash/fetch-cloudwatch-logs.sh`, used by both the "Fetch BackendLambda CloudWatch logs (deploy)" and "Fetch Lambda logs from smoke test" steps in `deploy-lambda.yml`. It distinguishes a genuine empty result from an `aws logs filter-log-events` API error: on `AccessDeniedException` (or any other error) it emits `::warning::` instead of silently printing `(no log events found)`. Always exits 0 (diagnostic only).
- Adds CDK permission tests asserting the new grant exists, is scoped to the BackendLambda log group ARN (no wildcard), and is absent when `GITHUB_DEPLOY_ROLE_ARN` is unset.

## Notes vs. the original issue
While implementing, I found a couple of inaccuracies in #3742's "How" section (posted as a comment on the issue with details):
- The deploy role's CDK block currently grants no `logs:FilterLogEvents` at all, so there's no "removal" in a CDK diff — it was simply never re-added after commit `3e39b997` moved grants out of CDK.
- `bootstrap-deploy-role.sh` already has a correctly-scoped `logs:FilterLogEvents` statement, but it's a manual one-time bootstrap script.
- A second, identical occurrence of the same swallow-on-error pattern existed in the "Fetch Lambda logs from smoke test" step and is fixed alongside step 27.

Closes #3742

## Test plan
- [x] `python -m pytest cdk/tests/test_backend_lambda_stack_permissions.py -q` — 14 passed (2 new tests for the FilterLogEvents grant)
- [x] `python -m black --check` / `python -m ruff check` on changed CDK files
- [x] `bash -n scripts/bash/fetch-cloudwatch-logs.sh`
- [x] `actionlint .github/workflows/deploy-lambda.yml`
- [ ] Live deploy run against AWS (requires credentials not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)