### PR TITLE
fix(deploy): self-heal UiAuthClient OAuth config drift on every deploy

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -477,25 +477,31 @@ jobs:
             --query "UserPoolClient.ClientName" --output text)"
           CALLBACK_URL="https://${FRONTEND_DOMAIN}/"
           UPDATE_FILE="$(mktemp)"
-          cat > "$UPDATE_FILE" <<JSON
-          {
-            "UserPoolId": "${USER_POOL_ID}",
-            "ClientId": "${CLIENT_ID}",
-            "ClientName": "${CLIENT_NAME}",
-            "RefreshTokenValidity": 30,
-            "ExplicitAuthFlows": ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
-            "SupportedIdentityProviders": ["COGNITO"],
-            "CallbackURLs": ["${CALLBACK_URL}"],
-            "LogoutURLs": ["${CALLBACK_URL}"],
-            "AllowedOAuthFlows": ["code"],
-            "AllowedOAuthScopes": ["email", "openid", "profile"],
-            "AllowedOAuthFlowsUserPoolClient": true,
-            "PreventUserExistenceErrors": "ENABLED",
-            "EnableTokenRevocation": true,
-            "EnablePropagateAdditionalUserContextData": false,
-            "AuthSessionValidity": 3
-          }
-          JSON
+          # Build the payload with jq (not a heredoc) so CLIENT_NAME is JSON-escaped;
+          # a client name containing a quote or backslash would otherwise produce
+          # malformed --cli-input-json.
+          jq -n \
+            --arg userPoolId "$USER_POOL_ID" \
+            --arg clientId "$CLIENT_ID" \
+            --arg clientName "$CLIENT_NAME" \
+            --arg callbackUrl "$CALLBACK_URL" \
+            '{
+              UserPoolId: $userPoolId,
+              ClientId: $clientId,
+              ClientName: $clientName,
+              RefreshTokenValidity: 30,
+              ExplicitAuthFlows: ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+              SupportedIdentityProviders: ["COGNITO"],
+              CallbackURLs: [$callbackUrl],
+              LogoutURLs: [$callbackUrl],
+              AllowedOAuthFlows: ["code"],
+              AllowedOAuthScopes: ["email", "openid", "profile"],
+              AllowedOAuthFlowsUserPoolClient: true,
+              PreventUserExistenceErrors: "ENABLED",
+              EnableTokenRevocation: true,
+              EnablePropagateAdditionalUserContextData: false,
+              AuthSessionValidity: 3
+            }' > "$UPDATE_FILE"
           aws cognito-idp update-user-pool-client --cli-input-json "file://${UPDATE_FILE}" >/dev/null
           rm -f "$UPDATE_FILE"
           echo "UiAuthClient ($CLIENT_ID) OAuth configuration reconciled to ${CALLBACK_URL}"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -435,6 +435,70 @@ jobs:
             exit 1
           fi
           echo "LIGHTHOUSE_URL=https://${FRONTEND_DOMAIN}" >> "$GITHUB_ENV"
+          echo "FRONTEND_DOMAIN=${FRONTEND_DOMAIN}" >> "$GITHUB_ENV"
+
+      - name: Reconcile UiAuthClient OAuth configuration
+        # cognito-idp:UpdateUserPoolClient replaces ALL writable client attributes in
+        # one call (no partial update). If the live UiAuthClient is ever edited
+        # out-of-band (console, manual CLI call) without setting every OAuth field,
+        # CallbackURLs/LogoutURLs/AllowedOAuthFlows/AllowedOAuthScopes/
+        # SupportedIdentityProviders silently get wiped to empty/false. Because the
+        # CDK template itself hasn't changed, `cdk deploy` does not detect or correct
+        # this drift, and the Cognito Hosted UI then rejects every login with
+        # redirect_mismatch (400) — which is exactly what broke Lighthouse CI in
+        # #3802. Re-apply the CDK-declared OAuth settings (must match the
+        # `o_auth=...` block on UiAuthClient in cdk/stacks/static_site_stack.py) on
+        # every deploy so this can never silently recur.
+        #
+        # CALLBACK_URL assumes the non-customDomain deployment path (the only one
+        # this workflow uses today): `https://${FRONTEND_DOMAIN}/`, matching
+        # ui_auth_callback_url's `_enable_custom_domain=False` branch. If this
+        # workflow is ever changed to deploy with `-c customDomain=true`, this step
+        # must be updated to use the custom domain URL instead.
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
+        run: |
+          set -euo pipefail
+          USER_POOL_ID="$(aws cloudformation describe-stacks \
+            --stack-name StaticSiteStack \
+            --query "Stacks[0].Outputs[?OutputKey=='UiAuthUserPoolId'].OutputValue" \
+            --output text)"
+          CLIENT_ID="$(aws cloudformation describe-stacks \
+            --stack-name StaticSiteStack \
+            --query "Stacks[0].Outputs[?OutputKey=='UiAuthUserPoolClientId'].OutputValue" \
+            --output text)"
+          if [ -z "$USER_POOL_ID" ] || [ "$USER_POOL_ID" = "None" ] \
+            || [ -z "$CLIENT_ID" ] || [ "$CLIENT_ID" = "None" ]; then
+            echo "UiAuthUserPoolId/UiAuthUserPoolClientId outputs missing from StaticSiteStack" >&2
+            exit 1
+          fi
+          CLIENT_NAME="$(aws cognito-idp describe-user-pool-client \
+            --user-pool-id "$USER_POOL_ID" --client-id "$CLIENT_ID" \
+            --query "UserPoolClient.ClientName" --output text)"
+          CALLBACK_URL="https://${FRONTEND_DOMAIN}/"
+          UPDATE_FILE="$(mktemp)"
+          cat > "$UPDATE_FILE" <<JSON
+          {
+            "UserPoolId": "${USER_POOL_ID}",
+            "ClientId": "${CLIENT_ID}",
+            "ClientName": "${CLIENT_NAME}",
+            "RefreshTokenValidity": 30,
+            "ExplicitAuthFlows": ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+            "SupportedIdentityProviders": ["COGNITO"],
+            "CallbackURLs": ["${CALLBACK_URL}"],
+            "LogoutURLs": ["${CALLBACK_URL}"],
+            "AllowedOAuthFlows": ["code"],
+            "AllowedOAuthScopes": ["email", "openid", "profile"],
+            "AllowedOAuthFlowsUserPoolClient": true,
+            "PreventUserExistenceErrors": "ENABLED",
+            "EnableTokenRevocation": true,
+            "EnablePropagateAdditionalUserContextData": false,
+            "AuthSessionValidity": 3
+          }
+          JSON
+          aws cognito-idp update-user-pool-client --cli-input-json "file://${UPDATE_FILE}" >/dev/null
+          rm -f "$UPDATE_FILE"
+          echo "UiAuthClient ($CLIENT_ID) OAuth configuration reconciled to ${CALLBACK_URL}"
 
       - name: Verify price snapshot seeded in S3
         # Belt-and-suspenders check after the CDK Trigger (REQUEST_RESPONSE) has

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -472,14 +472,28 @@ jobs:
             echo "UiAuthUserPoolId/UiAuthUserPoolClientId outputs missing from StaticSiteStack" >&2
             exit 1
           fi
+          if [ -z "${FRONTEND_DOMAIN:-}" ]; then
+            echo "FRONTEND_DOMAIN is unset; refusing to write an empty CallbackURL" >&2
+            exit 1
+          fi
           CLIENT_NAME="$(aws cognito-idp describe-user-pool-client \
             --user-pool-id "$USER_POOL_ID" --client-id "$CLIENT_ID" \
             --query "UserPoolClient.ClientName" --output text)"
           CALLBACK_URL="https://${FRONTEND_DOMAIN}/"
           UPDATE_FILE="$(mktemp)"
+          trap 'rm -f "$UPDATE_FILE"' EXIT
           # Build the payload with jq (not a heredoc) so CLIENT_NAME is JSON-escaped;
           # a client name containing a quote or backslash would otherwise produce
           # malformed --cli-input-json.
+          #
+          # RefreshTokenValidity (30 days) and AuthSessionValidity (3 minutes) are
+          # the AWS API defaults, applied identically whether or not CDK specifies
+          # them; UiAuthClient's o_auth=... block in static_site_stack.py does not
+          # override either, so this matches the CDK-declared (and currently
+          # deployed) state. AccessTokenValidity/IdTokenValidity are likewise left
+          # unset here and in CDK, so they fall back to the same 1-hour API default
+          # on both sides. If UiAuthClient ever sets any of these explicitly, this
+          # payload must be updated to match.
           jq -n \
             --arg userPoolId "$USER_POOL_ID" \
             --arg clientId "$CLIENT_ID" \
@@ -503,7 +517,6 @@ jobs:
               AuthSessionValidity: 3
             }' > "$UPDATE_FILE"
           aws cognito-idp update-user-pool-client --cli-input-json "file://${UPDATE_FILE}" >/dev/null
-          rm -f "$UPDATE_FILE"
           echo "UiAuthClient ($CLIENT_ID) OAuth configuration reconciled to ${CALLBACK_URL}"
 
       - name: Verify price snapshot seeded in S3

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -444,6 +444,27 @@ class StaticSiteStack(Stack):
                     resources=["*"],
                 )
             )
+            # Lets the deploy workflow re-apply the CDK-declared UiAuthClient OAuth
+            # settings (CallbackURLs, LogoutURLs, AllowedOAuthFlows, etc.) on every
+            # deploy. UpdateUserPoolClient replaces all writable client attributes in
+            # one call, so any out-of-band edit that omits these fields silently wipes
+            # them; CloudFormation does not detect or correct this drift on its own
+            # unless the template itself changes. See #3802.
+            github_role.add_to_principal_policy(
+                iam.PolicyStatement(
+                    actions=[
+                        "cognito-idp:DescribeUserPoolClient",
+                        "cognito-idp:UpdateUserPoolClient",
+                    ],
+                    resources=[
+                        self.format_arn(
+                            service="cognito-idp",
+                            resource="userpool",
+                            resource_name=ui_auth_pool.user_pool_id,
+                        )
+                    ],
+                )
+            )
 
         CfnOutput(self, "SiteBucket", value=site_bucket.bucket_name)
         CfnOutput(self, "DistributionId", value=distribution.distribution_id)

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -829,3 +829,76 @@ def test_no_simulate_principal_policy_grant_when_role_arn_absent(
     assert not _has_simulate_principal_policy_grant(raw, "allotmint-github-deploy"), (
         "Expected no iam:SimulatePrincipalPolicy in StaticSiteStack when GITHUB_DEPLOY_ROLE_ARN is unset"
     )
+
+
+# ---------------------------------------------------------------------------
+# GitHub deploy role — cognito-idp:UpdateUserPoolClient (issue #3802)
+# ---------------------------------------------------------------------------
+
+
+def _cognito_user_pool_client_resources(raw_template: dict, role_name: str) -> list[object]:
+    """Return Resource entries from cognito-idp:UpdateUserPoolClient statements for role_name."""
+    found: list[object] = []
+    for res in raw_template["Resources"].values():
+        if res.get("Type") != "AWS::IAM::Policy":
+            continue
+        if role_name not in res.get("Properties", {}).get("Roles", []):
+            continue
+        for stmt in res["Properties"]["PolicyDocument"].get("Statement", []):
+            actions = stmt.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+            if "cognito-idp:UpdateUserPoolClient" not in actions:
+                continue
+            assert "cognito-idp:DescribeUserPoolClient" in actions, (
+                "cognito-idp:UpdateUserPoolClient grant should be paired with "
+                "cognito-idp:DescribeUserPoolClient"
+            )
+            resources = stmt.get("Resource", [])
+            if isinstance(resources, (str, dict)):
+                resources = [resources]
+            found.extend(resources)
+    return found
+
+
+def test_github_deploy_role_gets_cognito_user_pool_client_permissions(
+    monkeypatch, tmp_path
+) -> None:
+    """StaticSiteStack must grant the deploy role cognito-idp:UpdateUserPoolClient and
+    cognito-idp:DescribeUserPoolClient, scoped to the UiAuthUserPool, when
+    GITHUB_DEPLOY_ROLE_ARN is set. This lets the deploy workflow re-apply the
+    CDK-declared UiAuthClient OAuth settings on every deploy, self-healing the
+    drift described in #3802."""
+    role_arn = "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    monkeypatch.setenv("GITHUB_DEPLOY_ROLE_ARN", role_arn)
+    (tmp_path / "index.html").write_text("<html></html>")
+    app = App()
+    stack = StaticSiteStack(app, "CognitoGrantStaticSiteStack", frontend_dist_path=str(tmp_path))
+    raw = assertions.Template.from_stack(stack).to_json()
+
+    resources = _cognito_user_pool_client_resources(raw, "allotmint-github-deploy")
+    assert resources, (
+        "cognito-idp:UpdateUserPoolClient statement not found in StaticSiteStack template; "
+        "GITHUB_DEPLOY_ROLE_ARN was set"
+    )
+    resources_str = str(resources)
+    assert "userpool/" in resources_str, (
+        f"cognito-idp grant should be scoped to a userpool/ resource ARN; got: {resources_str}"
+    )
+
+
+def test_no_cognito_user_pool_client_grant_when_github_deploy_role_arn_absent(
+    monkeypatch, tmp_path
+) -> None:
+    """When GITHUB_DEPLOY_ROLE_ARN is unset, no cognito-idp:UpdateUserPoolClient
+    policy should be synthesised."""
+    monkeypatch.delenv("GITHUB_DEPLOY_ROLE_ARN", raising=False)
+    (tmp_path / "index.html").write_text("<html></html>")
+    app = App()
+    stack = StaticSiteStack(app, "NoCognitoGrantStack", frontend_dist_path=str(tmp_path))
+    raw = assertions.Template.from_stack(stack).to_json()
+    resources = _cognito_user_pool_client_resources(raw, "allotmint-github-deploy")
+    assert not resources, (
+        "Expected no cognito-idp:UpdateUserPoolClient in StaticSiteStack when "
+        "GITHUB_DEPLOY_ROLE_ARN is unset"
+    )


### PR DESCRIPTION
## Summary

- Root cause of #3802: the live `UiAuthClient` (`AWS::Cognito::UserPoolClient`) had drifted from the CDK-declared template — `CallbackURLs`, `LogoutURLs`, `AllowedOAuthFlows`, `AllowedOAuthScopes`, `SupportedIdentityProviders` were wiped to empty/false, and `ExplicitAuthFlows` had a stray `ALLOW_USER_PASSWORD_AUTH`. `cognito-idp:UpdateUserPoolClient` replaces *all* writable client attributes in one call, so any out-of-band update that omits these fields silently wipes them — and CloudFormation does not detect or correct this drift unless the template itself changes.
- This caused the Cognito Hosted UI to reject every login with `redirect_mismatch` (400), which is what failed Lighthouse CI on every deploy.
- **Immediate remediation (already applied live)**: ran `update-user-pool-client` to restore the live `UiAuthClient` to the CDK-declared desired state. `detect-stack-drift` now reports `IN_SYNC`, and `https://d32n5ua14kb82t.cloudfront.net/` returns `200 OK`.
- **This PR (self-healing)**: adds a "Reconcile UiAuthClient OAuth configuration" step to `.github/workflows/deploy-lambda.yml`, run on every deploy after `FRONTEND_DOMAIN` is resolved, that re-applies the CDK-declared OAuth settings via `update-user-pool-client --cli-input-json`. Grants the GitHub deploy role `cognito-idp:DescribeUserPoolClient` / `cognito-idp:UpdateUserPoolClient`, scoped to the `UiAuthUserPool` ARN, in `cdk/stacks/static_site_stack.py` (same pattern as the existing `iam:SimulatePrincipalPolicy` / changeset grants, #3192/#3208).
- Added CDK tests asserting the new IAM grant is present when `GITHUB_DEPLOY_ROLE_ARN` is set and absent when it isn't.

## Test plan

- [x] `pytest cdk/tests/test_static_site_stack.py -k "cognito_user_pool_client or changeset_permissions or simulate_principal"` — 5 passed
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-lambda.yml'))"` — valid YAML
- [x] Verified no new `black`/`ruff` issues introduced by the diff (pre-existing issues in these files are unrelated to this change)
- [ ] CI deploy run executes the new reconcile step successfully and Lighthouse CI passes

Closes #3802

🤖 Generated with [Claude Code](https://claude.com/claude-code)