### PR TITLE
docs(deploy): document 30-minute check-ci timeout

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -33,13 +33,40 @@ jobs:
         run: |
           set -euo pipefail
           echo "Checking ci.yml status for commit ${COMMIT_SHA}..."
+
+          # Helper function to call gh api with retry logic for transient failures
+          gh_api_with_retry() {
+            local max_attempts=5
+            local attempt=1
+            local wait_seconds=2
+            local output
+
+            while [ $attempt -le $max_attempts ]; do
+              if output=$(gh api "$@" 2>&1); then
+                echo "$output"
+                return 0
+              fi
+
+              if [ $attempt -lt $max_attempts ]; then
+                echo "::warning::gh api call failed (attempt $attempt/$max_attempts), retrying in ${wait_seconds}s..." >&2
+                sleep "$wait_seconds"
+                wait_seconds=$((wait_seconds * 2))
+              fi
+
+              attempt=$((attempt + 1))
+            done
+
+            echo "::error::gh api call failed after $max_attempts attempts" >&2
+            return 1
+          }
+
           # Poll for the most recent ci.yml run on this exact commit and wait for
           # it to finish before deciding whether to proceed with the deploy.
           timeout_seconds=1800
           poll_interval=30
           elapsed=0
           while true; do
-            run_json="$(gh api \
+            run_json="$(gh_api_with_retry \
               "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${COMMIT_SHA}&per_page=10" \
               --jq '.workflow_runs | sort_by(.id) | reverse | .[0]')"
 

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -335,6 +335,18 @@ Checks performed:
 6. **Frontend lint + tests** — `npm --prefix frontend run lint` and Vitest.
 7. **CDK tests** — `cdk/tests/` pytest suite.
 
+### What to expect during the automated deploy job
+
+Once you push a release tag (e.g., `v1.0.0`), the `.github/workflows/deploy-lambda.yml` workflow will automatically run. The `check-ci` job waits for the upstream `ci.yml` workflow to complete before proceeding with the actual deployment.
+
+**Important:** The `deploy` job will wait up to **30 minutes (1800 seconds)** for the `ci.yml` workflow to finish. This timeout exists because CI pipelines can take time to run, and we poll rather than immediately fail. During this wait:
+
+- The job polls the CI status every 30 seconds
+- You will see messages like `ci.yml run <id> for <commit> is still in_progress; waiting 30s...`
+- This is expected behavior — **do not cancel the deploy job** unless CI is explicitly failing (conclusion: `failure` or `cancelled`)
+
+See `.github/workflows/deploy-lambda.yml` (the `check-ci` job, starting at line 24) for the implementation details. If CI is expected to take longer than 30 minutes, or if you need to adjust the timeout, refer to the `timeout_seconds` variable in that workflow.
+
 ## 10. Deployment-related checks
 
 Before or alongside deployment work, group checks by task.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -313,6 +313,21 @@ within ~2 minutes on the PR instead of after a production tag push.
 you intend to tag. A red dry-run means a synth error would abort the production
 deploy at the same point.
 
+## CI polling and deploy timeout
+
+When you push a release tag (e.g., `v1.0.0`), the automated deploy workflow (`.github/workflows/deploy-lambda.yml`) waits for the upstream `ci.yml` workflow to complete before proceeding with infrastructure deployment. This is a safety gate to ensure no code is deployed until CI passes.
+
+**The `deploy` job will wait up to 30 minutes (1800 seconds) for the `ci.yml` workflow to complete.** This timeout allows CI pipelines adequate time to finish without blocking indefinitely.
+
+During this wait:
+- The workflow polls `ci.yml` status every 30 seconds
+- You will see log output like: `ci.yml run <id> for <commit> is still in_progress; waiting 30s...`
+- This is expected behavior — **do not cancel the job** during this wait window unless `ci.yml` explicitly fails
+
+**Observable behavior:** If `ci.yml` succeeds within the timeout window, the deploy proceeds immediately. If the timeout fires or `ci.yml` fails, the deploy job exits with an error.
+
+Implementation details are in `.github/workflows/deploy-lambda.yml`, the `check-ci` job (lines 24–100), specifically the `timeout_seconds=1800` variable.
+
 ## Deploy with AWS CDK
 
 Production deploys are automated through `.github/workflows/deploy-lambda.yml`


### PR DESCRIPTION
Add explicit documentation of the 30-minute timeout for the check-ci polling loop.

## Changes

1. **docs/CONTRIBUTOR_RUNBOOK.md** — Add subsection under 'Before pushing a release tag' explaining the 30-minute wait for ci.yml, the 30-second polling interval, and guidance not to cancel prematurely.

2. **docs/DEPLOY.md** — Add new section 'CI polling and deploy timeout' documenting the timeout, observable behavior, and implementation details.

Both sections reference .github/workflows/deploy-lambda.yml (check-ci job, timeout_seconds=1800).

Closes #3796