### PR TITLE
fix(deploy): set GITHUB_DEPLOY_ROLE_ARN for CDK diff and StaticSiteStack deploy steps

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -263,15 +263,23 @@ jobs:
           DATA_BUCKET: ${{ secrets.DATA_BUCKET }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
         run: npx cdk diff BackendLambdaStack StaticSiteStack --method=template -c prod=true
         working-directory: cdk
 
       - name: Deploy StaticSiteStack auth resources
+        # GITHUB_DEPLOY_ROLE_ARN must be set here so CDK can synthesize the
+        # deploy-role IAM grants in static_site_stack.py (SimulatePrincipalPolicy,
+        # changeset perms, cognito-idp Describe/UpdateUserPoolClient). Without it,
+        # those grants are silently omitted from the deployed StaticSiteStack
+        # template and every dependent step (e.g. "Reconcile UiAuthClient OAuth
+        # configuration") fails with AccessDenied. See #3846.
         env:
           DATA_BUCKET: ${{ secrets.DATA_BUCKET }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
         run: npx cdk deploy StaticSiteStack --require-approval never -c prod=true
         working-directory: cdk


### PR DESCRIPTION
## Summary
- Deploy run [73422064458](https://github.com/leonarduk/allotmint/actions/runs/73422064458) failed at "Reconcile UiAuthClient OAuth configuration" (#3818) with `AccessDenied` on `cognito-idp:DescribeUserPoolClient`.
- Root cause: `cdk/stacks/static_site_stack.py` only adds the deploy-role IAM grants (`iam:SimulatePrincipalPolicy`, CFN changeset perms, `cognito-idp:Describe/UpdateUserPoolClient`) when `GITHUB_DEPLOY_ROLE_ARN` is set at synth time, but the "CDK diff" and "Deploy StaticSiteStack auth resources" steps never set it — so the deployed `StaticSiteStack` template never contained these grants (explaining the perpetual "no changes" and #3791).
- Fix: add `GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}` to both steps' `env:` blocks, matching the existing "Deploy BackendLambdaStack" step.

Closes #3846

## Test plan
- [x] `python -m pytest cdk/tests/test_static_site_stack.py -q` — 45 passed
- [x] Validated `.github/workflows/deploy-lambda.yml` parses as YAML
- [ ] Next deploy run: confirm `cdk diff`/`cdk deploy StaticSiteStack` show the new IAM statement changes (no longer "no changes"), step 13 pre-flight check passes without `SimulatePrincipalPolicy` warnings, and step 24 ("Reconcile UiAuthClient OAuth configuration") succeeds