### PR TITLE
fix(deploy): set GITHUB_DEPLOY_ROLE_ARN for Refresh StaticSiteStack runtime config step

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -439,10 +439,18 @@ jobs:
           echo "backend_url=$BACKEND_URL" >> "$GITHUB_OUTPUT"
 
       - name: Refresh StaticSiteStack runtime config
+        # GITHUB_DEPLOY_ROLE_ARN must be set here too (see "Deploy StaticSiteStack
+        # auth resources" above and #3846): without it, this redeploy of
+        # StaticSiteStack synthesizes a template that omits the deploy-role IAM
+        # grants (SimulatePrincipalPolicy, changeset perms, cognito-idp Describe/
+        # UpdateUserPoolClient), and CloudFormation deletes the policy resource
+        # that the earlier step just created — right before the "Reconcile
+        # UiAuthClient OAuth configuration" step needs it.
         env:
           DATA_BUCKET: ${{ secrets.DATA_BUCKET }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
         run: >
           npx cdk deploy StaticSiteStack --require-approval never -c prod=true


### PR DESCRIPTION
## Summary
- Run [27356627003](https://github.com/leonarduk/allotmint/actions/runs/27356627003) (after #3847 + #3859 merged) still failed at "Reconcile UiAuthClient OAuth configuration" with `AccessDenied` on `cognito-idp:DescribeUserPoolClient`, even with the new retry loop exhausting all 5 attempts.
- CloudFormation stack events show `GithubDeployRolePolicyF418142D` was `CREATE_COMPLETE` at 15:15:45 (thanks to #3847), then `DELETE_COMPLETE` at 15:19:35 — deleted by the *next* `cdk deploy StaticSiteStack` invocation, the "Refresh StaticSiteStack runtime config" step, which still doesn't set `GITHUB_DEPLOY_ROLE_ARN`.
- Confirmed live: `aws iam list-role-policies --role-name allotmint-github-deploy` currently has no StaticSiteStack-anchored policy at all.
- Fix: add `GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}` to this step's `env:` block too, matching the other two StaticSiteStack steps.

Closes #3865

## Test plan
- [x] `python -m pytest cdk/tests/test_static_site_stack.py -q` — 45 passed
- [x] Validated `.github/workflows/deploy-lambda.yml` parses as YAML
- [ ] Next deploy run: confirm `GithubDeployRolePolicyF418142D` (or equivalent) persists through "Refresh StaticSiteStack runtime config" and "Reconcile UiAuthClient OAuth configuration" succeeds without retries