### PR TITLE
fix(deploy): make GET /config public at API Gateway so the app can bootstrap

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -352,6 +352,17 @@ class BackendLambdaStack(Stack):
             integration=backend_integration,
             authorizer=apigwv2.HttpNoneAuthorizer(),
         )
+        # GET /config is the frontend's pre-auth bootstrap endpoint (see
+        # frontend/src/main.tsx Root.fetchConfig / getConfig()): it must be
+        # reachable before the caller has a Cognito token so the app can
+        # determine whether auth is required at all. PUT /config (admin
+        # config mutation) stays JWT-protected via the /{proxy+} catch-all.
+        backend_api.add_routes(
+            path="/config",
+            methods=[apigwv2.HttpMethod.GET],
+            integration=backend_integration,
+            authorizer=apigwv2.HttpNoneAuthorizer(),
+        )
         backend_api.add_routes(
             path="/",
             methods=[apigwv2.HttpMethod.ANY],

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -556,14 +556,19 @@ def test_backend_api_has_cognito_jwt_authorizer(template):
 
 
 def test_backend_api_routes_require_cognito_authorizer(template):
-    """All API Gateway routes must require Cognito JWT authorization except /health.
+    """All API Gateway routes must require Cognito JWT authorization except
+    /health and GET /config.
 
     /health is intentionally unauthenticated so that post-deploy probes and
     smoke tests can confirm Lambda is reachable without needing a Cognito token.
+    GET /config is intentionally unauthenticated because it is the frontend's
+    pre-auth bootstrap endpoint (frontend/src/main.tsx Root.fetchConfig) used
+    to determine whether auth is required at all; PUT /config remains
+    JWT-protected via the /{proxy+} catch-all.
     Asserts the full route set so that adding any other unprotected route will
     fail this test rather than silently bypassing the authorizer.
     """
-    UNAUTHENTICATED_ROUTES = {"GET /health"}
+    UNAUTHENTICATED_ROUTES = {"GET /health", "GET /config"}
 
     routes = template.find_resources("AWS::ApiGatewayV2::Route")
     assert routes, "Expected at least one API Gateway route"


### PR DESCRIPTION
## Summary

- The first deploy where the `deploy` job actually succeeded (run [27359600967](https://github.com/leonarduk/allotmint/actions/runs/27359600967), thanks to #3866) immediately exposed that **all 45 frontend smoke tests fail** — every page shows "Unable to load configuration" instead of its expected content.
- Root cause: `GET /config` is the frontend's pre-auth bootstrap endpoint (`Root.fetchConfig` → `getConfig()` in `frontend/src/main.tsx`), but at the API Gateway HTTP API layer (`cdk/stacks/backend_lambda_stack.py`) every route except `GET /health` requires the Cognito JWT authorizer. Confirmed live:
  ```
  $ curl -s -o /dev/null -w "%{http_code}\n" https://dxt34gh2i0.execute-api.eu-west-1.amazonaws.com/config
  401
  ```
  This blocks the request *before it reaches the FastAPI app*, where `config.py`'s `GET /config` is intentionally registered without auth (`backend/bootstrap/routers.py`).
- This isn't just a smoke-test problem — it breaks the live site for every unauthenticated visitor, since the app can never determine whether auth is required.

## Changes

- `cdk/stacks/backend_lambda_stack.py`: add an explicit `GET /config` route with `HttpNoneAuthorizer()`, mirroring the existing `/health` pattern. `PUT /config` (admin config mutation) remains JWT-protected via the `/{proxy+}` catch-all.
- `cdk/tests/test_backend_lambda_stack.py`: add `"GET /config"` to the `UNAUTHENTICATED_ROUTES` allowlist in `test_backend_api_routes_require_cognito_authorizer`, with explanation.

Closes #3872

## Test plan

- [x] `cdk/tests/test_backend_lambda_stack.py::test_backend_api_routes_require_cognito_authorizer` updated to assert `GET /config` is unauthenticated.
- [ ] Note: this test currently errors locally with `EACCES ... jenkins_home/.../acorn` due to an unrelated stray `jenkins_home/` directory in the local working tree (CDK Docker-asset packaging issue, flagged separately). Should run cleanly in CI.
- [ ] After merge/deploy, confirm `curl https://<backend-api-url>/config` (no auth header) returns 200, and the next "Run frontend smoke tests" step no longer fails on `configError` across all 45 tests.