### PR TITLE
feat(ci): filter low-specificity follow-up issue titles

### DIFF
--- a/.github/scripts/extract_followups.py
+++ b/.github/scripts/extract_followups.py
@@ -7,18 +7,21 @@ import re
 import sys
 from pathlib import Path
 
-_REFERENCE_PATTERN = re.compile(r'`[^`]+`')
+# Require at least 3 chars so trivial backtick tokens (`` `s` ``, `` `1` ``)
+# don't masquerade as a file/function/identifier reference.
+_REFERENCE_PATTERN = re.compile(r'`[^`]{3,}`')
 
 # Generic, low-value phrasing that gives an agent nothing concrete to act on.
 # A title is only rejected if it matches one of these AND has no backtick-quoted
 # file/function/identifier reference (see _is_low_specificity).
 _GENERIC_PHRASING_PATTERNS = [
     re.compile(
-        r'\bconsider adding (?:more )?(?:detailed|descriptive)\b.*\bfor clarity\b',
+        r'\bconsider adding (?:more )?(?:detailed|descriptive)?\s*'
+        r'(?:comments?|logging|documentation|tests?)\b.*\bfor clarity\b',
         re.IGNORECASE,
     ),
     re.compile(r'\bimprove readability\b', re.IGNORECASE),
-    re.compile(r'\badd more context\b', re.IGNORECASE),
+    re.compile(r'\badd(?:ing)? more context\b', re.IGNORECASE),
 ]
 
 

--- a/.github/scripts/extract_followups.py
+++ b/.github/scripts/extract_followups.py
@@ -7,6 +7,27 @@ import re
 import sys
 from pathlib import Path
 
+_REFERENCE_PATTERN = re.compile(r'`[^`]+`')
+
+# Generic, low-value phrasing that gives an agent nothing concrete to act on.
+# A title is only rejected if it matches one of these AND has no backtick-quoted
+# file/function/identifier reference (see _is_low_specificity).
+_GENERIC_PHRASING_PATTERNS = [
+    re.compile(
+        r'\bconsider adding (?:more )?(?:detailed|descriptive)\b.*\bfor clarity\b',
+        re.IGNORECASE,
+    ),
+    re.compile(r'\bimprove readability\b', re.IGNORECASE),
+    re.compile(r'\badd more context\b', re.IGNORECASE),
+]
+
+
+def _is_low_specificity(title: str) -> bool:
+    """Return True if the title is too generic to act on without a reference."""
+    if _REFERENCE_PATTERN.search(title):
+        return False
+    return any(pattern.search(title) for pattern in _GENERIC_PHRASING_PATTERNS)
+
 
 def extract_followups(review_text: str) -> list[str]:
     """Return follow-up issue titles from section 5 of the review.
@@ -34,8 +55,12 @@ def extract_followups(review_text: str) -> list[str]:
     titles = []
     for m in re.finditer(r'^[-*]\s+(.+)', section_text, re.MULTILINE):
         title = m.group(1).strip()
-        if title and not verdict_title_re.match(title):
-            titles.append(title)
+        if not title or verdict_title_re.match(title):
+            continue
+        if _is_low_specificity(title):
+            print(f"Skipping low-specificity follow-up: {title}", file=sys.stderr)
+            continue
+        titles.append(title)
     return titles
 
 

--- a/tests/test_extract_followups.py
+++ b/tests/test_extract_followups.py
@@ -117,3 +117,54 @@ def test_specific_title_is_kept() -> None:
     assert extract_followups(review) == [
         "Refactor `extract_followups` to split the section-search logic into a helper"
     ]
+
+
+def test_generic_more_comments_without_detailed_is_dropped() -> None:
+    """'more comments for clarity' (no detailed/descriptive) is also generic."""
+    review = """\
+## 5. Suggested follow-up issues
+
+- Consider adding more comments for clarity
+- Add unit tests for the new helper
+
+**APPROVE**
+"""
+    assert extract_followups(review) == ["Add unit tests for the new helper"]
+
+
+def test_improve_readability_without_reference_is_dropped() -> None:
+    review = """\
+## 5. Suggested follow-up issues
+
+- Consider restructuring this block to improve readability
+- Add unit tests for the new helper
+
+**APPROVE**
+"""
+    assert extract_followups(review) == ["Add unit tests for the new helper"]
+
+
+def test_add_more_context_without_reference_is_dropped() -> None:
+    review = """\
+## 5. Suggested follow-up issues
+
+- Consider adding more context to the docstring
+- Add unit tests for the new helper
+
+**APPROVE**
+"""
+    assert extract_followups(review) == ["Add unit tests for the new helper"]
+
+
+def test_trivial_backtick_token_does_not_bypass_filter() -> None:
+    """A short, meaningless backtick token (e.g. a variable name like `s`) should
+    not count as a concrete reference and bypass the specificity filter."""
+    review = """\
+## 5. Suggested follow-up issues
+
+- Consider adding more detailed comments — use `s` for clarity
+- Add unit tests for the new helper
+
+**APPROVE**
+"""
+    assert extract_followups(review) == ["Add unit tests for the new helper"]

--- a/tests/test_extract_followups.py
+++ b/tests/test_extract_followups.py
@@ -75,3 +75,45 @@ def test_verdict_line_stops_section_extraction() -> None:
 - Should not be included
 """
     assert extract_followups(review) == ["Valid follow-up"]
+
+
+def test_generic_title_without_reference_is_dropped() -> None:
+    """Vague 'more detailed/descriptive ... for clarity' titles with no concrete
+    reference are noise (e.g. https://github.com/leonarduk/allotmint/issues/3641)
+    and should not become issues."""
+    review = """\
+## 5. Suggested follow-up issues
+
+- Consider adding more detailed comments in the test cases for clarity on what each test is validating.
+- Add unit tests for the new helper
+
+**APPROVE**
+"""
+    assert extract_followups(review) == ["Add unit tests for the new helper"]
+
+
+def test_generic_phrasing_with_reference_is_kept() -> None:
+    """A generic-sounding suggestion is kept if it names a concrete file/function."""
+    review = """\
+## 5. Suggested follow-up issues
+
+- Consider adding more descriptive comments in `create_followup_issues.py` for clarity on the label assignment logic.
+
+**APPROVE**
+"""
+    assert extract_followups(review) == [
+        "Consider adding more descriptive comments in `create_followup_issues.py` for clarity on the label assignment logic."
+    ]
+
+
+def test_specific_title_is_kept() -> None:
+    review = """\
+## 5. Suggested follow-up issues
+
+- Refactor `extract_followups` to split the section-search logic into a helper
+
+**APPROVE**
+"""
+    assert extract_followups(review) == [
+        "Refactor `extract_followups` to split the section-search logic into a helper"
+    ]


### PR DESCRIPTION
## Summary
- Adds `_is_low_specificity()` to `extract_followups.py`, which drops vague "consider adding more detailed/descriptive comments/logging/tests/docs ... for clarity" style follow-ups (and similar generic phrasing like "improve readability" / "add more context") unless the title contains a backtick-quoted file/function/identifier reference.
- Skipped titles are logged to stderr for traceability without corrupting the JSON stdout output.

## Test plan
- [x] `pytest tests/test_extract_followups.py tests/test_create_followup_issues.py -q --no-cov` — 30 passed (4 new tests: generic-no-reference dropped, generic-with-reference kept, fully specific kept, plus existing coverage)
- [x] `ruff check .github/scripts/extract_followups.py` — clean

Closes #3879