### PR TITLE
chore(codeowners): Add CODEOWNERS file and require code-owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# CODEOWNERS file for AllotMint
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Code owners are automatically requested for review when someone opens a PR that modifies paths they own.
+# This file maps file patterns to owners who should review changes in those areas.
+
+# Backend code and API logic
+/backend/ @leonarduk
+
+# Backend tests
+/tests/ @leonarduk
+
+# Frontend code
+/frontend/ @leonarduk
+
+# CDK infrastructure-as-code
+/cdk/ @leonarduk
+
+# Infrastructure and deployment configuration
+/infra/ @leonarduk
+
+# GitHub configuration, workflows, and CI/CD
+/.github/ @leonarduk
+
+# Scripts and automation tools
+/scripts/ @leonarduk
+
+# Data files and fixtures
+/data/ @leonarduk

--- a/.github/rulesets/default-branch-protection.json
+++ b/.github/rulesets/default-branch-protection.json
@@ -21,7 +21,7 @@
       "parameters": {
         "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": false,
+        "require_code_owner_review": true,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "allowed_merge_methods": ["merge", "squash", "rebase"]

--- a/.github/scripts/prepare_review_diff.py
+++ b/.github/scripts/prepare_review_diff.py
@@ -8,7 +8,7 @@ import sys
 
 from review_common import MAX_DIFF_CHARS, format_truncation_log, truncate_diff
 
-DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml", "Makefile", "*.mk", "*.sh", "*.ps1", "*.txt", ]
+DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml", "Makefile", "*.mk", "*.sh", "*.ps1", "*.txt", "*CODEOWNERS*", ]
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import subprocess
 import sys
+import urllib.error
 from pathlib import Path
 from types import ModuleType
-import urllib.error
 
 import pytest
-
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".github" / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
@@ -216,3 +216,33 @@ def test_review_script_reports_mocked_api_failure(
 
     assert exc.value.code == 1
     assert expected_message in capsys.readouterr().err
+
+
+def _run_git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def test_default_globs_include_codeowners_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_script_module("prepare_review_diff", "prepare_review_diff.py")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git(["init", "-b", "main"], repo)
+    _run_git(["config", "user.email", "test@example.com"], repo)
+    _run_git(["config", "user.name", "Test"], repo)
+
+    (repo / "README.md").write_text("hello\n")
+    _run_git(["add", "README.md"], repo)
+    _run_git(["commit", "-m", "init"], repo)
+    _run_git(["update-ref", "refs/remotes/origin/main", "HEAD"], repo)
+
+    github_dir = repo / ".github"
+    github_dir.mkdir()
+    (github_dir / "CODEOWNERS").write_text("/backend/ @leonarduk\n")
+    _run_git(["add", ".github/CODEOWNERS"], repo)
+    _run_git(["commit", "-m", "add codeowners"], repo)
+
+    monkeypatch.chdir(repo)
+    diff = module.git_diff("main", module.DEFAULT_GLOBS)
+
+    assert ".github/CODEOWNERS" in diff


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` file with mappings for sensitive paths to @leonarduk
- Enable `require_code_owner_review` in the default branch protection ruleset
- Ensures targeted human review for high-risk areas including backend, CDK, infrastructure, and GitHub workflows

## Changes
- Created `.github/CODEOWNERS` with ownership mappings for:
  - `/backend/` - API and domain logic
  - `/tests/` - Test suite and fixtures
  - `/frontend/` - React application code
  - `/cdk/` - Infrastructure-as-code
  - `/infra/` - Deployment configuration
  - `/.github/` - Workflows and CI/CD
  - `/scripts/` - Build and automation scripts
  - `/data/` - Data files and fixtures

- Updated `.github/rulesets/default-branch-protection.json`:
  - Set `require_code_owner_review: true` to enforce code-owner approval

## Impact
Pull requests that modify any of the listed paths will automatically request review from the code owners, providing targeted security and quality gates for sensitive areas of the codebase.

Closes #2905