### PR TITLE
fix(deploy): scope pre-flight IAM check resources to match CDK grants

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -183,9 +183,13 @@ jobs:
       - name: Pre-flight IAM permission check
         # Verifies that the deploy role has every permission needed by this
         # workflow before spending ~8 minutes on CDK deploy.
-        # Each action is simulated against its correct resource ARN so that
-        # scoped grants (e.g. bucket-level s3:ListBucket vs object-level
-        # s3:GetObject) do not produce false implicitDeny results.
+        # Each action is simulated against the *same* resource ARN(s) (and, where
+        # relevant, condition context) that the CDK-managed grants actually scope
+        # the permission to. The deploy role's grants are narrowly scoped per
+        # stack/function/log-group/object (see GithubDeployRolePolicy* and
+        # allotmint-deploy-permissions), so simulating against "*" produces false
+        # implicitDeny results even when the real `cdk deploy`/sync steps below
+        # would succeed. See issue #4945.
         # If the role itself lacks iam:SimulatePrincipalPolicy the simulate
         # call returns an error, which is surfaced as a distinct message so the
         # operator knows to add that meta-permission to the base role.
@@ -193,6 +197,7 @@ jobs:
           DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         run: |
           set -euo pipefail
+
           data_bucket="$(aws cloudformation list-stack-resources \
             --stack-name BackendLambdaStack \
             --query "StackResourceSummaries[?starts_with(LogicalResourceId,'PortfolioDataBucket')].PhysicalResourceId|[0]" \
@@ -202,24 +207,66 @@ jobs:
             data_bucket="*"
           fi
 
-          # Map each action to its correct resource ARN.
-          # s3:ListBucket acts on the bucket; s3:GetObject acts on objects.
-          # CloudFormation, Lambda, and logs actions are wildcarded because the
-          # deploy role's grants target multiple stacks/functions/log groups.
-          declare -A action_resource=(
-            ["cloudformation:CreateChangeSet"]="*"
-            ["cloudformation:DescribeChangeSet"]="*"
-            ["cloudformation:DeleteChangeSet"]="*"
-            ["lambda:InvokeFunction"]="*"
-            ["s3:ListBucket"]="arn:aws:s3:::${data_bucket}"
-            ["s3:GetObject"]="arn:aws:s3:::${data_bucket}/*"
-            ["logs:FilterLogEvents"]="*"
+          backend_stack_arn="$(aws cloudformation describe-stacks \
+            --stack-name BackendLambdaStack --query "Stacks[0].StackId" --output text 2>/dev/null || echo "")"
+          static_site_stack_arn="$(aws cloudformation describe-stacks \
+            --stack-name StaticSiteStack --query "Stacks[0].StackId" --output text 2>/dev/null || echo "")"
+          [ -n "$backend_stack_arn" ] || backend_stack_arn="*"
+          [ -n "$static_site_stack_arn" ] || static_site_stack_arn="*"
+
+          price_refresh_alias_arn="$(aws cloudformation list-stack-resources \
+            --stack-name BackendLambdaStack \
+            --query "StackResourceSummaries[?starts_with(LogicalResourceId,'PriceRefreshLambdaLiveAlias')].PhysicalResourceId|[0]" \
+            --output text 2>/dev/null || echo "")"
+          if [ -z "$price_refresh_alias_arn" ] || [ "$price_refresh_alias_arn" = "None" ]; then
+            price_refresh_alias_arn="*"
+          fi
+
+          backend_log_group="$(aws cloudformation list-stack-resources \
+            --stack-name BackendLambdaStack \
+            --query "StackResourceSummaries[?starts_with(LogicalResourceId,'BackendLambdaLogGroup')].PhysicalResourceId|[0]" \
+            --output text 2>/dev/null || echo "")"
+          if [ -z "$backend_log_group" ] || [ "$backend_log_group" = "None" ]; then
+            backend_log_group_arn="*"
+          else
+            account_id="$(aws sts get-caller-identity --query Account --output text)"
+            region="$(aws configure get region)"
+            backend_log_group_arn="arn:aws:logs:${region}:${account_id}:log-group:${backend_log_group}:*"
+          fi
+
+          if [ "$data_bucket" = "*" ]; then
+            get_object_resource="*"
+            list_bucket_resource="*"
+          else
+            get_object_resource="arn:aws:s3:::${data_bucket}/prices/latest_prices.json"
+            list_bucket_resource="arn:aws:s3:::${data_bucket}"
+          fi
+
+          # Each entry: "action|resource arns (space-separated)|context key=value (optional)"
+          # cloudformation:* and s3:ListBucket use grants that aren't visible from a
+          # single resource: the changeset perms cover both stacks, and ListBucket is
+          # conditioned on an s3:prefix. Pass both stack ARNs / the matching condition
+          # so simulate-principal-policy evaluates the grant CDK actually created.
+          checks=(
+            "cloudformation:CreateChangeSet|${backend_stack_arn} ${static_site_stack_arn}|"
+            "cloudformation:DescribeChangeSet|${backend_stack_arn} ${static_site_stack_arn}|"
+            "cloudformation:DeleteChangeSet|${backend_stack_arn} ${static_site_stack_arn}|"
+            "lambda:InvokeFunction|${price_refresh_alias_arn}|"
+            "s3:ListBucket|${list_bucket_resource}|s3:prefix=prices"
+            "s3:GetObject|${get_object_resource}|"
+            "logs:FilterLogEvents|${backend_log_group_arn}|"
           )
 
           failed=0
           simulate_unavailable=0
-          for action in "${!action_resource[@]}"; do
-            resource="${action_resource[$action]}"
+          for check in "${checks[@]}"; do
+            IFS='|' read -r action resources context <<< "$check"
+            context_args=()
+            if [ -n "$context" ]; then
+              context_key="${context%%=*}"
+              context_value="${context#*=}"
+              context_args=(--context-entries "ContextKeyName=${context_key},ContextKeyValues=${context_value},ContextKeyType=string")
+            fi
             # || true prevents set -e from aborting; 2>&1 already captures the real
             # AWS error into raw_result. Using || raw_result="error" would overwrite
             # the actual message and break the AccessDenied/SimulatePrincipalPolicy
@@ -227,9 +274,12 @@ jobs:
             raw_result="$(aws iam simulate-principal-policy \
               --policy-source-arn "$DEPLOY_ROLE_ARN" \
               --action-names "$action" \
-              --resource-arns "$resource" \
-              --query "EvaluationResults[0].EvalDecision" --output text 2>&1)" || true
-            result="$(echo "$raw_result" | tail -1)"
+              --resource-arns $resources \
+              "${context_args[@]}" \
+              --query "EvaluationResults[].EvalDecision" --output text 2>&1)" || true
+            # Multiple resource ARNs come back tab-separated on one line; every one
+            # must be "allowed" for the action to be considered granted.
+            results="$(echo "$raw_result" | tail -1 | tr '\t' '\n')"
             # Distinguish three cases:
             # 1. AccessDenied specifically for iam:SimulatePrincipalPolicy itself —
             #    role lacks the meta-permission; degrade gracefully so the bootstrap
@@ -246,12 +296,12 @@ jobs:
               echo "  Raw AWS response: $raw_result" >&2
               simulate_unavailable=1
             elif echo "$raw_result" | grep -qi "exception\|error\|AccessDenied"; then
-              # Use $raw_result (full response) not $result (last line only) to catch
+              # Use $raw_result (full response) not $results (last line only) to catch
               # multi-line AWS error payloads where the error type is on line 1.
               echo "::error::simulate-principal-policy call failed unexpectedly for $action. Raw response: $raw_result" >&2
               failed=1
-            elif [ "$result" != "allowed" ]; then
-              echo "::error::Deploy role is missing $action on $resource (got: $result). Fix the CDK grant or base role policy before deploying." >&2
+            elif echo "$results" | grep -qv "^allowed$"; then
+              echo "::error::Deploy role is missing $action on $resources (got: $(echo "$results" | tr '\n' ' ')). Fix the CDK grant or base role policy before deploying." >&2
               failed=1
             fi
           done

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -211,8 +211,12 @@ jobs:
             --stack-name BackendLambdaStack --query "Stacks[0].StackId" --output text 2>/dev/null || echo "")"
           static_site_stack_arn="$(aws cloudformation describe-stacks \
             --stack-name StaticSiteStack --query "Stacks[0].StackId" --output text 2>/dev/null || echo "")"
-          [ -n "$backend_stack_arn" ] || backend_stack_arn="*"
-          [ -n "$static_site_stack_arn" ] || static_site_stack_arn="*"
+          if [ -z "$backend_stack_arn" ] || [ "$backend_stack_arn" = "None" ]; then
+            backend_stack_arn="*"
+          fi
+          if [ -z "$static_site_stack_arn" ] || [ "$static_site_stack_arn" = "None" ]; then
+            static_site_stack_arn="*"
+          fi
 
           price_refresh_alias_arn="$(aws cloudformation list-stack-resources \
             --stack-name BackendLambdaStack \
@@ -226,10 +230,10 @@ jobs:
             --stack-name BackendLambdaStack \
             --query "StackResourceSummaries[?starts_with(LogicalResourceId,'BackendLambdaLogGroup')].PhysicalResourceId|[0]" \
             --output text 2>/dev/null || echo "")"
-          if [ -z "$backend_log_group" ] || [ "$backend_log_group" = "None" ]; then
+          account_id="$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "")"
+          if [ -z "$backend_log_group" ] || [ "$backend_log_group" = "None" ] || [ -z "$account_id" ]; then
             backend_log_group_arn="*"
           else
-            account_id="$(aws sts get-caller-identity --query Account --output text)"
             # aws-actions/configure-aws-credentials sets AWS_REGION/AWS_DEFAULT_REGION
             # env vars rather than writing the CLI config file, so check those first;
             # fall back to `aws configure get region` for local/manual runs.

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -189,7 +189,7 @@ jobs:
         # stack/function/log-group/object (see GithubDeployRolePolicy* and
         # allotmint-deploy-permissions), so simulating against "*" produces false
         # implicitDeny results even when the real `cdk deploy`/sync steps below
-        # would succeed. See issue #4945.
+        # would succeed. See issue #3910.
         # If the role itself lacks iam:SimulatePrincipalPolicy the simulate
         # call returns an error, which is surfaced as a distinct message so the
         # operator knows to add that meta-permission to the base role.
@@ -230,7 +230,10 @@ jobs:
             backend_log_group_arn="*"
           else
             account_id="$(aws sts get-caller-identity --query Account --output text)"
-            region="$(aws configure get region)"
+            # aws-actions/configure-aws-credentials sets AWS_REGION/AWS_DEFAULT_REGION
+            # env vars rather than writing the CLI config file, so check those first;
+            # fall back to `aws configure get region` for local/manual runs.
+            region="${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region)}}"
             backend_log_group_arn="arn:aws:logs:${region}:${account_id}:log-group:${backend_log_group}:*"
           fi
 
@@ -238,6 +241,9 @@ jobs:
             get_object_resource="*"
             list_bucket_resource="*"
           else
+            # GithubDeployRoleForLambdaInvokePolicy's ReadPriceSnapshot statement
+            # grants s3:GetObject on this exact key only (not a prefix wildcard),
+            # so this is the only object the deploy role can read.
             get_object_resource="arn:aws:s3:::${data_bucket}/prices/latest_prices.json"
             list_bucket_resource="arn:aws:s3:::${data_bucket}"
           fi
@@ -261,6 +267,9 @@ jobs:
           simulate_unavailable=0
           for check in "${checks[@]}"; do
             IFS='|' read -r action resources context <<< "$check"
+            # Word-split intentionally: $resources is a space-separated list of one
+            # or more ARNs (e.g. both stack ARNs for the changeset checks).
+            read -r -a resource_arr <<< "$resources"
             context_args=()
             if [ -n "$context" ]; then
               context_key="${context%%=*}"
@@ -274,7 +283,7 @@ jobs:
             raw_result="$(aws iam simulate-principal-policy \
               --policy-source-arn "$DEPLOY_ROLE_ARN" \
               --action-names "$action" \
-              --resource-arns $resources \
+              --resource-arns "${resource_arr[@]}" \
               "${context_args[@]}" \
               --query "EvaluationResults[].EvalDecision" --output text 2>&1)" || true
             # Multiple resource ARNs come back tab-separated on one line; every one

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -352,6 +352,17 @@ class BackendLambdaStack(Stack):
             integration=backend_integration,
             authorizer=apigwv2.HttpNoneAuthorizer(),
         )
+        # GET /config is the frontend's pre-auth bootstrap endpoint (see
+        # frontend/src/main.tsx Root.fetchConfig / getConfig()): it must be
+        # reachable before the caller has a Cognito token so the app can
+        # determine whether auth is required at all. PUT /config (admin
+        # config mutation) stays JWT-protected via the /{proxy+} catch-all.
+        backend_api.add_routes(
+            path="/config",
+            methods=[apigwv2.HttpMethod.GET],
+            integration=backend_integration,
+            authorizer=apigwv2.HttpNoneAuthorizer(),
+        )
         backend_api.add_routes(
             path="/",
             methods=[apigwv2.HttpMethod.ANY],

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -556,14 +556,19 @@ def test_backend_api_has_cognito_jwt_authorizer(template):
 
 
 def test_backend_api_routes_require_cognito_authorizer(template):
-    """All API Gateway routes must require Cognito JWT authorization except /health.
+    """All API Gateway routes must require Cognito JWT authorization except
+    /health and GET /config.
 
     /health is intentionally unauthenticated so that post-deploy probes and
     smoke tests can confirm Lambda is reachable without needing a Cognito token.
+    GET /config is intentionally unauthenticated because it is the frontend's
+    pre-auth bootstrap endpoint (frontend/src/main.tsx Root.fetchConfig) used
+    to determine whether auth is required at all; PUT /config remains
+    JWT-protected via the /{proxy+} catch-all.
     Asserts the full route set so that adding any other unprotected route will
     fail this test rather than silently bypassing the authorizer.
     """
-    UNAUTHENTICATED_ROUTES = {"GET /health"}
+    UNAUTHENTICATED_ROUTES = {"GET /health", "GET /config"}
 
     routes = template.find_resources("AWS::ApiGatewayV2::Route")
     assert routes, "Expected at least one API Gateway route"


### PR DESCRIPTION
## Summary
- The deploy role's CDK-managed grants (`GithubDeployRolePolicy*`, `allotmint-deploy-permissions`) are scoped to specific stack ARNs, the `PriceRefreshLambda` live alias, the `BackendLambda` log group, and a single S3 object/prefix.
- The pre-flight IAM check in `.github/workflows/deploy-lambda.yml` simulated `cloudformation:*`/`lambda:InvokeFunction`/`logs:FilterLogEvents` against `*` and `s3:GetObject` against `<bucket>/*`, which IAM correctly evaluates as `implicitDeny` against those narrower grants — failing every deploy before any real work happened (e.g. run 27367975742 for v0.19.8).
- This PR derives the actual resource ARNs (stack ARNs via `describe-stacks`, the lambda alias and log group via `list-stack-resources`, and the `s3:prefix` condition for `ListBucket`) and requires every simulated resource to be `allowed`.
- Verified live against the AllotMint AWS account: all 7 actions now report `allowed` with the corrected resource ARNs (previously all 7 reported `implicitDeny`).
- Addressed review feedback: resolve region from `AWS_REGION`/`AWS_DEFAULT_REGION` (set by `aws-actions/configure-aws-credentials`) before falling back to `aws configure get region`; pass `--resource-arns` as a quoted array (shellcheck SC2086); document that the `s3:GetObject` grant is scoped to exactly `prices/latest_prices.json`.

This branch also includes the unrelated `GET /config` public endpoint fix (#3873/e6199f31), already merged via main as part of v0.19.8.

Closes #3910

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-lambda.yml'))"` — YAML parses
- [x] `actionlint .github/workflows/deploy-lambda.yml` — clean
- [x] Manually ran the corrected `simulate-principal-policy` checks against the live deploy role (`allotmint-github-deploy`) — all 7 actions return `allowed`
- [ ] Next tagged release's `deploy` workflow gets past the pre-flight check