### PR TITLE
chore(cdk): document mutable=True audit for imported deploy roles

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -435,6 +435,11 @@ class BackendLambdaStack(Stack):
         # BackendLambdaStack deploy, keeping the permission current. See #3368.
         github_deploy_role_arn = os.getenv("GITHUB_DEPLOY_ROLE_ARN", "")
         if github_deploy_role_arn:
+            # mutable=True is required: the role is bootstrapped externally
+            # (bootstrap-deploy-role.sh) but CDK is the source of truth for
+            # the inline policies attached below via add_to_principal_policy.
+            # With mutable=False those calls would be no-ops and the grants
+            # in this block would silently fail to apply. See #3370.
             github_role = iam.Role.from_role_arn(
                 self, "GithubDeployRoleForLambdaInvoke", github_deploy_role_arn, mutable=True
             )

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -415,6 +415,11 @@ class StaticSiteStack(Stack):
         # churn. Covers both stacks because `cdk diff` targets both. See #3192.
         github_deploy_role_arn = os.getenv("GITHUB_DEPLOY_ROLE_ARN", "")
         if github_deploy_role_arn:
+            # mutable=True is required: the role is bootstrapped externally
+            # (bootstrap-deploy-role.sh) but CDK is the source of truth for
+            # the inline policies attached below via add_to_principal_policy.
+            # With mutable=False those calls would be no-ops and the grants
+            # in this block would silently fail to apply. See #3370.
             github_role = iam.Role.from_role_arn(
                 self, "GithubDeployRole", github_deploy_role_arn, mutable=True
             )


### PR DESCRIPTION
## Summary
- Audited both `mutable=True` occurrences in `cdk/` (the imported GitHub Actions deploy role in `BackendLambdaStack` and `StaticSiteStack`).
- Both are externally-bootstrapped roles (via `bootstrap-deploy-role.sh`) where CDK is the source of truth for specific inline policies attached via `add_to_principal_policy`. With `mutable=False`, those `add_to_principal_policy` calls would silently no-op and the documented grants (price snapshot read, log access, changeset permissions, Cognito client updates, etc.) would never be applied.
- Added inline comments at each `mutable=True` documenting why it is required, per the audit checklist in the issue.
- No behavior change — `mutable=True` retained in both cases as the correct, intentional choice.

## Test plan
- [x] `python -m pytest cdk/tests/test_static_site_stack.py cdk/tests/test_backend_lambda_stack.py cdk/tests/test_backend_lambda_stack_permissions.py` — 91 passed

Closes #3370