### PR TITLE
fix(frontend): make <base href> relative so smoke/preview builds load assets from localhost

### DIFF
--- a/.github/scripts/prepare_review_diff.py
+++ b/.github/scripts/prepare_review_diff.py
@@ -8,7 +8,7 @@ import sys
 
 from review_common import MAX_DIFF_CHARS, format_truncation_log, truncate_diff
 
-DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml", "Makefile", "*.mk", "*.sh", "*.ps1", "*.txt", "*CODEOWNERS*", ]
+DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml", "Makefile", "*.mk", "*.sh", "*.ps1", "*.txt", "*.html", "*CODEOWNERS*", ]
 
 
 def parse_args() -> argparse.Namespace:

--- a/.github/scripts/review_common.py
+++ b/.github/scripts/review_common.py
@@ -78,7 +78,7 @@ and avoid regressions in CI/deployment workflows.
 ## PR title
 {pr_title}
 
-## Diff (Python, TypeScript, JavaScript, JSON, Markdown, config files, shell scripts (.sh), PowerShell scripts (.ps1) — truncated at 30k chars)
+## Diff (Python, TypeScript, JavaScript, JSON, Markdown, HTML, config files, shell scripts (.sh), PowerShell scripts (.ps1) — truncated at 30k chars)
 {diff}
 
 If the diff is empty, this is likely a docs-only or config-only PR whose file types

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
-    <base href="%VITE_APP_BASE_URL%/"/>
+    <base href="/"/>
     <link rel="icon" type="image/svg+xml" href="/vite.svg"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="theme-color" content="#ffffff"/>


### PR DESCRIPTION
## Summary
- All 45 frontend Playwright smoke tests in the Deploy Infrastructure workflow fail with `element(s) not found` for the route marker, even on tests that don't depend on the backend (e.g. the smoke-test page itself).
- Root cause: `frontend/index.html` has `<base href="%VITE_APP_BASE_URL%/"/>`, and `frontend/.env.production` sets `VITE_APP_BASE_URL=https://app.allotmint.io`. `npm run build:preview` (`vite build`, mode=production) bakes `<base href="https://app.allotmint.io/"/>` into `dist/index.html`. Playwright then serves this build via `vite preview` on `http://localhost:5173`, but every relative URL (JS bundles, `/config.json`, API calls) resolves against `https://app.allotmint.io/` instead of `http://localhost:5173/` — so the React bundle never loads/mounts and no route marker ever appears.
- Fix: make `<base href="/"/>` static and independent of `VITE_APP_BASE_URL`. `/` works correctly for both production (served from app.allotmint.io) and preview/smoke (served from localhost:5173). Canonical/OG/JSON-LD tags continue to use `%VITE_APP_BASE_URL%` and remain absolute production URLs.

Closes #3931

## Test plan
- [x] `npm run build:preview` then inspect `dist/index.html`: confirms `<base href="/"/>` while `rel="canonical"` and `og:url` still point to `https://app.allotmint.io/`.
- [x] Ran `npx playwright test --config playwright.config.ts --grep "renders /$|smoke test page|bootstrap" tests/smoke.spec.ts` against the built preview locally — route-marker assertions that previously failed on every test now pass; remaining local failures are due to no live backend in this sandbox (tests assert backend-derived data), not the route marker/bootstrap issue.
- [ ] CI smoke-test job against the deployed backend (this PR's `deploy` workflow run) should now find route markers on all 45 smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)