### PR TITLE
refactor(ci): consolidate Claude/GPT PR review workflows into shared scaffolding

### DIFF
--- a/.github/rulesets/default-branch-protection.json
+++ b/.github/rulesets/default-branch-protection.json
@@ -54,10 +54,10 @@
             "context": "CI / Lambda-compat pytest (backend/requirements.txt)"
           },
           {
-            "context": "Claude PR Review / Claude AI code review"
+            "context": "ai-review / Claude AI code review"
           },
           {
-            "context": "GPT PR Review / GPT AI code review"
+            "context": "ai-review / GPT AI code review"
           },
           {
             "context": "Merge Conflict Check / Check for merge conflicts with main"

--- a/.github/scripts/claude_review.py
+++ b/.github/scripts/claude_review.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-import json
 import os
-import sys
-import urllib.error
-import urllib.request
 from typing import Any
 
-from review_common import build_prompt, emit_empty_diff_notice, finalize_review, load_review_context
+from review_common import build_prompt, emit_empty_diff_notice, fetch_review, finalize_review, load_review_context
 
 DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS = 2500
@@ -35,13 +31,11 @@ def get_max_tokens() -> int:
     return max(256, value)
 
 
-def extract_claude_review(data: dict[str, Any]) -> tuple[str, str | None]:
+def extract_claude_review(data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     """Extract review text and stop reason from Anthropic messages responses."""
     content = data.get("content", [])
-    review = "\n".join(
-        block.get("text", "") for block in content if block.get("type") == "text"
-    ).strip()
-    return review, data.get("stop_reason")
+    review = "\n".join(block.get("text", "") for block in content if block.get("type") == "text").strip()
+    return review, {"stop_reason": data.get("stop_reason")}
 
 
 def fetch_claude_review(api_key: str, prompt: str) -> str:
@@ -55,40 +49,16 @@ def fetch_claude_review(api_key: str, prompt: str) -> str:
         "max_tokens": get_max_tokens(),
         "messages": [{"role": "user", "content": prompt}],
     }
-    request = urllib.request.Request(
-        "https://api.anthropic.com/v1/messages",
-        data=json.dumps(payload).encode(),
-        headers={
-            "x-api-key": api_key,
-            "anthropic-version": "2023-06-01",
-            "content-type": "application/json",
-        },
-        method="POST",
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+
+    review, extra = fetch_review(
+        "https://api.anthropic.com/v1/messages", headers, payload, extract_claude_review, "Claude"
     )
-
-    try:
-        with urllib.request.urlopen(request, timeout=60) as response:
-            status = getattr(response, "status", None)
-            raw = response.read()
-            print(
-                f"INFO: Claude API responded status={status} bytes={len(raw)}",
-                file=sys.stderr,
-            )
-            data = json.loads(raw)
-    except urllib.error.HTTPError as exc:
-        # Keep the provider response in stderr so maintainers can distinguish auth, quota, and API failures.
-        body = exc.read().decode()
-        print(f"ERROR: Claude API returned {exc.code}: {body}", file=sys.stderr)
-        raise SystemExit(1) from exc
-
-    review, stop_reason = extract_claude_review(data)
-    if not review.strip():
-        print(
-            f"WARNING: Claude API returned an empty review body "
-            f"(status={status}, stop_reason={stop_reason})",
-            file=sys.stderr,
-        )
-    if stop_reason == "max_tokens":
+    if extra.get("stop_reason") == "max_tokens":
         review = (
             f"{review}\n\n"
             "_Note: Claude hit the review token budget before finishing. "

--- a/.github/scripts/gpt_review.py
+++ b/.github/scripts/gpt_review.py
@@ -2,30 +2,26 @@
 
 from __future__ import annotations
 
-import json
-import sys
-import urllib.error
-import urllib.request
 from typing import Any
 
-from review_common import build_prompt, emit_empty_diff_notice, finalize_review, load_review_context
+from review_common import build_prompt, emit_empty_diff_notice, fetch_review, finalize_review, load_review_context
 
 
-def extract_openai_review(data: dict[str, Any]) -> str:
+def extract_openai_review(data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     """Extract review text from OpenAI chat-completions responses."""
     choices = data.get("choices", [])
     if not choices:
-        return ""
+        return "", {}
 
     message = choices[0].get("message", {})
     content = message.get("content", "")
     if isinstance(content, list):
-        return "\n".join(
-            part.get("text", "") for part in content if part.get("type") == "text"
-        ).strip()
-    if isinstance(content, str):
-        return content.strip()
-    return ""
+        review = "\n".join(part.get("text", "") for part in content if part.get("type") == "text").strip()
+    elif isinstance(content, str):
+        review = content.strip()
+    else:
+        review = ""
+    return review, {}
 
 
 def fetch_openai_review(api_key: str, prompt: str) -> str:
@@ -39,37 +35,14 @@ def fetch_openai_review(api_key: str, prompt: str) -> str:
         "messages": [{"role": "user", "content": prompt}],
         "temperature": 0.2,
     }
-    request = urllib.request.Request(
-        "https://api.openai.com/v1/chat/completions",
-        data=json.dumps(payload).encode(),
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        },
-        method="POST",
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    review, _extra = fetch_review(
+        "https://api.openai.com/v1/chat/completions", headers, payload, extract_openai_review, "OpenAI"
     )
-
-    try:
-        with urllib.request.urlopen(request, timeout=60) as response:
-            status = getattr(response, "status", None)
-            raw = response.read()
-            print(
-                f"INFO: OpenAI API responded status={status} bytes={len(raw)}",
-                file=sys.stderr,
-            )
-            data = json.loads(raw)
-    except urllib.error.HTTPError as exc:
-        # Keep the provider response in stderr so maintainers can distinguish auth, quota, and API failures.
-        body = exc.read().decode()
-        print(f"ERROR: OpenAI API returned {exc.code}: {body}", file=sys.stderr)
-        raise SystemExit(1) from exc
-
-    review = extract_openai_review(data)
-    if not review.strip():
-        print(
-            f"WARNING: OpenAI API returned an empty review body (status={status})",
-            file=sys.stderr,
-        )
     return review
 
 

--- a/.github/scripts/review_common.py
+++ b/.github/scripts/review_common.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
 import os
 import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable
 
 MAX_DIFF_CHARS = 30_000
 DEFAULT_ISSUE_BODY = "No linked issue found. Review code on its own merits."
@@ -228,3 +232,49 @@ def format_truncation_log(original_diff: str, truncated_diff: str) -> str:
         f"{len(original_diff)} to {len(truncated_diff)} characters across "
         f"{count_changed_files(original_diff)} file block(s) to preserve whole diff sections."
     )
+
+
+def fetch_review(
+    url: str,
+    headers: dict[str, str],
+    payload: dict[str, Any],
+    extractor: Callable[[dict[str, Any]], tuple[str, dict[str, Any]]],
+    provider_label: str,
+) -> tuple[str, dict[str, Any]]:
+    """POST `payload` to `url` and return the review text plus provider-specific extras.
+
+    Shared by the Claude and GPT review scripts: handles the HTTP POST, timeout,
+    `HTTPError` reporting, and empty-response warning so each script only has to
+    supply its endpoint, headers, payload, and an `extractor` that turns the parsed
+    JSON response into `(review_text, extra)`. `extra` carries provider-specific
+    metadata (e.g. Claude's `stop_reason`) back to the caller.
+    """
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers=headers,
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            status = getattr(response, "status", None)
+            raw = response.read()
+            print(
+                f"INFO: {provider_label} API responded status={status} bytes={len(raw)}",
+                file=sys.stderr,
+            )
+            data = json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        # Keep the provider response in stderr so maintainers can distinguish auth, quota, and API failures.
+        body = exc.read().decode()
+        print(f"ERROR: {provider_label} API returned {exc.code}: {body}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    review, extra = extractor(data)
+    if not review.strip():
+        print(
+            f"WARNING: {provider_label} API returned an empty review body (status={status})",
+            file=sys.stderr,
+        )
+    return review, extra

--- a/.github/scripts/review_common.py
+++ b/.github/scripts/review_common.py
@@ -256,6 +256,7 @@ def fetch_review(
         method="POST",
     )
 
+    status: int | None = None
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
             status = getattr(response, "status", None)
@@ -269,6 +270,12 @@ def fetch_review(
         # Keep the provider response in stderr so maintainers can distinguish auth, quota, and API failures.
         body = exc.read().decode()
         print(f"ERROR: {provider_label} API returned {exc.code}: {body}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    except urllib.error.URLError as exc:
+        print(f"ERROR: {provider_label} API request failed: {exc.reason}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: {provider_label} API returned non-JSON response: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
 
     review, extra = extractor(data)

--- a/.github/scripts/review_common.py
+++ b/.github/scripts/review_common.py
@@ -10,11 +10,11 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any, Callable
 
-MAX_DIFF_CHARS = 30_000
+MAX_DIFF_CHARS = 60_000
 DEFAULT_ISSUE_BODY = "No linked issue found. Review code on its own merits."
 TRUNCATION_NOTICE_TEMPLATE = (
     "\n\n[diff truncated after {kept_files} file(s); skipped {skipped_files} additional file(s) "
-    "to stay within the 30k-character review budget while preserving whole-file diff blocks]"
+    "to stay within the 60k-character review budget while preserving whole-file diff blocks]"
 )
 
 
@@ -82,7 +82,7 @@ and avoid regressions in CI/deployment workflows.
 ## PR title
 {pr_title}
 
-## Diff (Python, TypeScript, JavaScript, JSON, Markdown, HTML, config files, shell scripts (.sh), PowerShell scripts (.ps1) — truncated at 30k chars)
+## Diff (Python, TypeScript, JavaScript, JSON, Markdown, HTML, config files, shell scripts (.sh), PowerShell scripts (.ps1) — truncated at 60k chars)
 {diff}
 
 If the diff is empty, this is likely a docs-only or config-only PR whose file types
@@ -173,7 +173,7 @@ def split_diff_blocks(diff_text: str) -> list[str]:
 def truncate_diff(diff_text: str, limit: int = MAX_DIFF_CHARS) -> tuple[str, bool]:
     """Truncate a diff on whole-file boundaries and emit a notice when files are skipped.
 
-    The 30k-character cap exists to stay within model context and comment-size budgets. When the
+    The 60k-character cap exists to stay within model context and comment-size budgets. When the
     diff is too large, we keep only complete file blocks that fit and append a short summary rather
     than slicing through a line or partial YAML/JSON structure.
 

--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -1,0 +1,177 @@
+name: Reusable AI PR Review
+
+on:
+  workflow_call:
+    inputs:
+      provider_name:
+        description: "Display name of the reviewer (e.g. Claude, GPT)"
+        required: true
+        type: string
+      provider_id:
+        description: "Lowercase identifier used for file/output naming (e.g. claude, gpt)"
+        required: true
+        type: string
+      review_script:
+        description: "Path to the provider's review script"
+        required: true
+        type: string
+      workflow_file:
+        description: "Filename of the calling workflow, used in the posted comment link"
+        required: true
+        type: string
+      anthropic_max_tokens:
+        description: "ANTHROPIC_MAX_TOKENS override passed to the review script, if any"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      anthropic_api_key:
+        description: "Anthropic API key, used for Claude reviews and follow-up issue creation"
+        required: true
+      openai_api_key:
+        description: "OpenAI API key, used for GPT reviews"
+        required: false
+      gh_token:
+        description: "Token used for gh CLI calls (PR/issue read and write)"
+        required: true
+
+jobs:
+  ai-review:
+    name: ${{ inputs.provider_name }} AI code review
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get PR diff
+        id: diff
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          DIFF=$(python3 .github/scripts/prepare_review_diff.py --base-ref "${{ github.base_ref }}")
+          DELIM="EOF_$(uuidgen | tr -d '-')"
+          {
+            echo "diff<<$DELIM"
+            echo "$DIFF"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Get linked issue body
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.gh_token }}
+        run: |
+          ISSUE_NUM=$(gh pr view ${{ github.event.pull_request.number }} --json body,title \
+            | jq -r '[.title, .body] | join(" ")' \
+            | grep -oE '(Closes|Fixes|Refs) #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+          if [ -n "$ISSUE_NUM" ]; then
+            ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --json body -q .body 2>/dev/null || echo "Issue not found")
+          else
+            ISSUE_BODY="No linked issue found. Review code on its own merits."
+          fi
+          DELIM="EOF_$(uuidgen | tr -d '-')"
+          {
+            echo "body<<$DELIM"
+            echo "$ISSUE_BODY"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Call ${{ inputs.provider_name }} API
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
+          OPENAI_API_KEY: ${{ secrets.openai_api_key }}
+          ANTHROPIC_MAX_TOKENS: ${{ inputs.anthropic_max_tokens }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          DIFF: ${{ steps.diff.outputs.diff }}
+          ISSUE_BODY: ${{ steps.issue.outputs.body }}
+        run: |
+          python3 ${{ inputs.review_script }} > /tmp/${{ inputs.provider_id }}_review_body.md
+
+          # Guard: `-s` returns true only if the file exists AND has size > 0.
+          # This distinguishes a successful API response (review body written to stdout)
+          # from a failure (empty output, missing file, or API error).
+          # See docs/AI_REVIEW_WORKFLOWS.md for details.
+          if [ ! -s /tmp/${{ inputs.provider_id }}_review_body.md ]; then
+            echo "ERROR: ${{ inputs.provider_name }} review output was empty" >&2
+            exit 1
+          fi
+
+      - name: Check ${{ inputs.provider_name }} approval
+        id: check_approval
+        continue-on-error: true  # REQUEST CHANGES exits 1; allow later steps (post comment, create issues) to still run
+        run: |
+          if python3 .github/scripts/extract_verdict.py /tmp/${{ inputs.provider_id }}_review_body.md "${{ inputs.provider_name }}"; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Post ${{ inputs.provider_name }} review comment
+        if: success() || failure()
+        continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
+        env:
+          GH_TOKEN: ${{ secrets.gh_token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          bash .github/scripts/build_review_comment.sh /tmp/${{ inputs.provider_id }}_review_body.md \
+            "${{ inputs.provider_name }}" "${{ inputs.workflow_file }}" "$RUN_URL" > /tmp/${{ inputs.provider_id }}_comment_body.md
+
+          # Write to Actions job summary so the review is always visible in the UI,
+          # even if the gh pr comment call below fails.
+          cat /tmp/${{ inputs.provider_id }}_comment_body.md >> "$GITHUB_STEP_SUMMARY"
+
+          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/${{ inputs.provider_id }}_comment_body.md; then
+            echo "::warning title=${{ inputs.provider_name }} review comment::Failed to post the ${{ inputs.provider_name }} review comment to PR #$PR_NUMBER — check the Actions log above for the gh error (rate limit, token scope, or network)."
+            echo "WARNING: failed to post review comment — check the Actions log" >&2
+            exit 0
+          fi
+
+      - name: Create follow-up issues
+        if: steps.check_approval.outputs.approved == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.gh_token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
+        run: |
+          # Ensure required labels exist before creating issues
+          gh label create "ai-suggested" --color "0075ca" --description "Suggested by AI code review" \
+            2>/dev/null || true
+          gh label create "haiku" --color "C5DEF5" --description "Suitable for Claude Haiku (simple/mechanical task)" \
+            2>/dev/null || true
+          gh label create "sonnet" --color "BFD4F2" --description "Suitable for Claude Sonnet (moderate reasoning)" \
+            2>/dev/null || true
+          gh label create "opus" --color "0052CC" --description "Suitable for Claude Opus (complex design/architecture)" \
+            2>/dev/null || true
+
+          # Extract titles to a file, then create issues via Python subprocess (no shell injection)
+          python3 .github/scripts/extract_followups.py /tmp/${{ inputs.provider_id }}_review_body.md \
+            > /tmp/followups.json
+          python3 .github/scripts/create_followup_issues.py \
+            /tmp/followups.json "${PR_NUMBER}" /tmp/${{ inputs.provider_id }}_review_body.md
+
+      - name: Add 'Changes Requested' label if review failed
+        if: steps.check_approval.outputs.approved == 'false'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.gh_token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Create the label if it doesn't exist
+          gh label create "Changes Requested" --color "d73a49" --description "PR requested changes from code review" \
+            2>/dev/null || true
+
+          # Add the label to the PR
+          gh pr edit "$PR_NUMBER" --add-label "Changes Requested"
+
+      - name: Fail if ${{ inputs.provider_name }} did not approve
+        if: always() && steps.check_approval.outcome == 'failure'
+        run: |
+          echo "::error::${{ inputs.provider_name }} review: CHANGES REQUESTED — address the review findings before merging."
+          exit 1

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,140 +6,18 @@ on:
 
 jobs:
   ai-review:
-    name: Claude AI code review
-    runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       pull-requests: write
       contents: read
       issues: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Get PR diff
-        id: diff
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          DIFF=$(python3 .github/scripts/prepare_review_diff.py --base-ref "${{ github.base_ref }}")
-          DELIM="EOF_$(uuidgen | tr -d '-')"
-          {
-            echo "diff<<$DELIM"
-            echo "$DIFF"
-            echo "$DELIM"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Get linked issue body
-        id: issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ISSUE_NUM=$(gh pr view ${{ github.event.pull_request.number }} --json body,title \
-            | jq -r '[.title, .body] | join(" ")' \
-            | grep -oE '(Closes|Fixes|Refs) #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
-          if [ -n "$ISSUE_NUM" ]; then
-            ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --json body -q .body 2>/dev/null || echo "Issue not found")
-          else
-            ISSUE_BODY="No linked issue found. Review code on its own merits."
-          fi
-          DELIM="EOF_$(uuidgen | tr -d '-')"
-          {
-            echo "body<<$DELIM"
-            echo "$ISSUE_BODY"
-            echo "$DELIM"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Call Claude API
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_MAX_TOKENS: "6000"
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          DIFF: ${{ steps.diff.outputs.diff }}
-          ISSUE_BODY: ${{ steps.issue.outputs.body }}
-        run: |
-          python3 .github/scripts/claude_review.py > /tmp/claude_review_body.md
-
-          # Guard: `-s` returns true only if the file exists AND has size > 0.
-          # This distinguishes a successful API response (review body written to stdout)
-          # from a failure (empty output, missing file, or API error).
-          # See docs/AI_REVIEW_WORKFLOWS.md for details.
-          if [ ! -s /tmp/claude_review_body.md ]; then
-            echo "ERROR: Claude review output was empty" >&2
-            exit 1
-          fi
-
-      - name: Check Claude approval
-        id: check_claude_approval
-        continue-on-error: true  # REQUEST CHANGES exits 1; allow later steps (post comment, create issues) to still run
-        run: |
-          if python3 .github/scripts/extract_verdict.py /tmp/claude_review_body.md Claude; then
-            echo "approved=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "approved=false" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-      - name: Post Claude review comment
-        if: success() || failure()
-        continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          bash .github/scripts/build_review_comment.sh /tmp/claude_review_body.md \
-            "Claude" "claude-pr-review.yml" "$RUN_URL" > /tmp/claude_comment_body.md
-
-          # Write to Actions job summary so the review is always visible in the UI,
-          # even if the gh pr comment call below fails.
-          cat /tmp/claude_comment_body.md >> "$GITHUB_STEP_SUMMARY"
-
-          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/claude_comment_body.md; then
-            echo "::warning title=Claude review comment::Failed to post the Claude review comment to PR #$PR_NUMBER — check the Actions log above for the gh error (rate limit, token scope, or network)."
-            echo "WARNING: failed to post review comment — check the Actions log" >&2
-            exit 0
-          fi
-
-      - name: Create follow-up issues
-        if: steps.check_claude_approval.outputs.approved == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          # Ensure required labels exist before creating issues
-          gh label create "ai-suggested" --color "0075ca" --description "Suggested by AI code review" \
-            2>/dev/null || true
-          gh label create "haiku" --color "C5DEF5" --description "Suitable for Claude Haiku (simple/mechanical task)" \
-            2>/dev/null || true
-          gh label create "sonnet" --color "BFD4F2" --description "Suitable for Claude Sonnet (moderate reasoning)" \
-            2>/dev/null || true
-          gh label create "opus" --color "0052CC" --description "Suitable for Claude Opus (complex design/architecture)" \
-            2>/dev/null || true
-
-          # Extract titles to a file, then create issues via Python subprocess (no shell injection)
-          python3 .github/scripts/extract_followups.py /tmp/claude_review_body.md \
-            > /tmp/followups.json
-          python3 .github/scripts/create_followup_issues.py \
-            /tmp/followups.json "${PR_NUMBER}" /tmp/claude_review_body.md
-
-      - name: Add 'Changes Requested' label if review failed
-        if: steps.check_claude_approval.outputs.approved == 'false'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          # Create the label if it doesn't exist
-          gh label create "Changes Requested" --color "d73a49" --description "PR requested changes from code review" \
-            2>/dev/null || true
-
-          # Add the label to the PR
-          gh pr edit "$PR_NUMBER" --add-label "Changes Requested"
-
-      - name: Fail if Claude did not approve
-        if: always() && steps.check_claude_approval.outcome == 'failure'
-        run: |
-          echo "::error::Claude review: CHANGES REQUESTED — address the review findings before merging."
-          exit 1
+    uses: ./.github/workflows/_ai-pr-review.yml
+    with:
+      provider_name: Claude
+      provider_id: claude
+      review_script: .github/scripts/claude_review.py
+      workflow_file: claude-pr-review.yml
+      anthropic_max_tokens: "6000"
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -5,141 +5,19 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  gpt-review:
-    name: GPT AI code review
-    runs-on: ubuntu-latest
+  ai-review:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       pull-requests: write
       contents: read
       issues: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Get PR diff
-        id: diff
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          DIFF=$(python3 .github/scripts/prepare_review_diff.py --base-ref "${{ github.base_ref }}")
-          DELIM="EOF_$(uuidgen | tr -d '-')"
-          {
-            echo "diff<<$DELIM"
-            echo "$DIFF"
-            echo "$DELIM"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Get linked issue body
-        id: issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ISSUE_NUM=$(gh pr view ${{ github.event.pull_request.number }} --json body,title \
-            | jq -r '[.title, .body] | join(" ")' \
-            | grep -oE '(Closes|Fixes|Refs) #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
-          if [ -n "$ISSUE_NUM" ]; then
-            ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --json body -q .body 2>/dev/null || echo "Issue not found")
-          else
-            ISSUE_BODY="No linked issue found. Review code on its own merits."
-          fi
-          DELIM="EOF_$(uuidgen | tr -d '-')"
-          {
-            echo "body<<$DELIM"
-            echo "$ISSUE_BODY"
-            echo "$DELIM"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Call OpenAI API
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          DIFF: ${{ steps.diff.outputs.diff }}
-          ISSUE_BODY: ${{ steps.issue.outputs.body }}
-        run: |
-          python3 .github/scripts/gpt_review.py > /tmp/gpt_review_body.md
-
-          # Guard: `-s` returns true only if the file exists AND has size > 0.
-          # This distinguishes a successful API response (review body written to stdout)
-          # from a failure (empty output, missing file, or API error).
-          # See docs/AI_REVIEW_WORKFLOWS.md for details.
-          if [ ! -s /tmp/gpt_review_body.md ]; then
-            echo "ERROR: GPT review output was empty" >&2
-            exit 1
-          fi
-
-      - name: Check GPT approval
-        id: check_gpt_approval
-        continue-on-error: true  # REQUEST CHANGES exits 1; allow later steps (post comment, create issues, label) to still run
-        run: |
-          if python3 .github/scripts/extract_verdict.py /tmp/gpt_review_body.md GPT; then
-            echo "approved=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "approved=false" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-      - name: Post GPT review comment
-        if: always() && !cancelled()
-        continue-on-error: true  # If posting fails (e.g. API rate limit), don't fail job; review is also in Actions summary
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          bash .github/scripts/build_review_comment.sh /tmp/gpt_review_body.md \
-            "GPT" "gpt-pr-review.yml" "$RUN_URL" > /tmp/gpt_comment_body.md
-
-          # Write to Actions job summary so the review is always visible in the UI,
-          # even if the gh pr comment call below fails.
-          cat /tmp/gpt_comment_body.md >> "$GITHUB_STEP_SUMMARY"
-
-          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/gpt_comment_body.md; then
-            echo "::warning title=GPT review comment::Failed to post the GPT review comment to PR #$PR_NUMBER — check the Actions log above for the gh error (rate limit, token scope, or network)."
-            echo "WARNING: failed to post review comment — check the Actions log" >&2
-            exit 0
-          fi
-
-      - name: Create follow-up issues
-        if: always() && !cancelled()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          # Ensure required labels exist before creating issues
-          gh label create "ai-suggested" --color "0075ca" --description "Suggested by AI code review" \
-            2>/dev/null || true
-          gh label create "haiku" --color "C5DEF5" --description "Suitable for Claude Haiku (simple/mechanical task)" \
-            2>/dev/null || true
-          gh label create "sonnet" --color "BFD4F2" --description "Suitable for Claude Sonnet (moderate reasoning)" \
-            2>/dev/null || true
-          gh label create "opus" --color "0052CC" --description "Suitable for Claude Opus (complex design/architecture)" \
-            2>/dev/null || true
-
-          # Extract titles to a file, then create issues via Python subprocess (no shell injection)
-          python3 .github/scripts/extract_followups.py /tmp/gpt_review_body.md \
-            > /tmp/followups.json
-          python3 .github/scripts/create_followup_issues.py \
-            /tmp/followups.json "${PR_NUMBER}" /tmp/gpt_review_body.md
-
-      - name: Add 'Changes Requested' label if review failed
-        if: steps.check_gpt_approval.outputs.approved == 'false'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          # Create the label if it doesn't exist
-          gh label create "Changes Requested" --color "d73a49" --description "PR requested changes from code review" \
-            2>/dev/null || true
-
-          # Add the label to the PR
-          gh pr edit "$PR_NUMBER" --add-label "Changes Requested"
-
-      - name: Fail if GPT did not approve
-        if: always() && steps.check_gpt_approval.outcome == 'failure'
-        run: |
-          echo "::error::GPT review: CHANGES REQUESTED — address the review findings before merging."
-          exit 1
+    uses: ./.github/workflows/_ai-pr-review.yml
+    with:
+      provider_name: GPT
+      provider_id: gpt
+      review_script: .github/scripts/gpt_review.py
+      workflow_file: gpt-pr-review.yml
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/AI_REVIEW_WORKFLOWS.md
+++ b/docs/AI_REVIEW_WORKFLOWS.md
@@ -81,6 +81,10 @@ As a secondary fallback for visibility, the review body is also written to `$GIT
 - **`continue-on-error: true`**: Set on the "Post review comment" step in `_ai-pr-review.yml`. If the `gh pr comment` call fails, the job does not fail. The failure is recorded in the workflow logs but does not block the overall workflow.
 - **`if: steps.check_approval.outputs.approved == 'true'`**: The "Create follow-up issues" step only runs when the review is an APPROVE. On REQUEST CHANGES, no follow-up issues are created — the blocking findings belong in the review itself, not the backlog. This condition is identical for both Claude and GPT. Before this consolidation, GPT created follow-up issues on every verdict; the maintainer confirmed (PR #3933) that the APPROVE-only behavior — Claude's prior behavior — is the intended one for both providers.
 
+## End-to-end validation
+
+PR #3933 itself is the end-to-end validation for this reusable-workflow refactor: every push to that PR triggers both `claude-pr-review.yml` and `gpt-pr-review.yml`, which call `_ai-pr-review.yml` via `workflow_call` with the `anthropic_api_key`/`openai_api_key`/`gh_token` secrets threaded through. Successful runs of `ai-review / Claude AI code review` and `ai-review / GPT AI code review` on that PR (posting review comments, extracting verdicts, and gating follow-up issue creation) confirm the reusable-workflow secret passing and `if:` conditions work as intended.
+
 ## Adding a new AI reviewer
 
 The reusable workflow `_ai-pr-review.yml` and the shared `fetch_review()` helper in

--- a/docs/AI_REVIEW_WORKFLOWS.md
+++ b/docs/AI_REVIEW_WORKFLOWS.md
@@ -79,7 +79,7 @@ As a secondary fallback for visibility, the review body is also written to `$GIT
 
 - **`if: success() || failure()`**: The "Post review comment" step runs even if the verdict is REQUEST CHANGES (which exits the preceding step with a non-zero exit code), so the full review is always visible. The condition excludes cancelled runs to avoid spurious failure notices when a run is superseded by a new push.
 - **`continue-on-error: true`**: Set on the "Post review comment" step in `_ai-pr-review.yml`. If the `gh pr comment` call fails, the job does not fail. The failure is recorded in the workflow logs but does not block the overall workflow.
-- **`if: steps.check_approval.outputs.approved == 'true'`**: The "Create follow-up issues" step only runs when the review is an APPROVE. On REQUEST CHANGES, no follow-up issues are created — the blocking findings belong in the review itself, not the backlog. This condition is identical for both Claude and GPT.
+- **`if: steps.check_approval.outputs.approved == 'true'`**: The "Create follow-up issues" step only runs when the review is an APPROVE. On REQUEST CHANGES, no follow-up issues are created — the blocking findings belong in the review itself, not the backlog. This condition is identical for both Claude and GPT. Before this consolidation, GPT created follow-up issues on every verdict; the maintainer confirmed (PR #3933) that the APPROVE-only behavior — Claude's prior behavior — is the intended one for both providers.
 
 ## Adding a new AI reviewer
 

--- a/docs/AI_REVIEW_WORKFLOWS.md
+++ b/docs/AI_REVIEW_WORKFLOWS.md
@@ -4,12 +4,16 @@ This document describes how the Claude and GPT AI review workflows handle review
 
 ## Overview
 
-Two GitHub Actions workflows provide automated code reviews on pull requests:
+Two thin caller workflows trigger AI code reviews on pull requests by invoking a shared
+reusable workflow:
 
-- **claude-pr-review.yml**: Runs Claude AI review via the Anthropic API
-- **gpt-pr-review.yml**: Runs GPT review via the OpenAI API
+- **claude-pr-review.yml**: Calls the reusable workflow with the Anthropic provider config
+- **gpt-pr-review.yml**: Calls the reusable workflow with the OpenAI provider config
+- **_ai-pr-review.yml**: Reusable `workflow_call` workflow containing the actual review,
+  posting, verdict-checking, and follow-up-issue logic, parameterized per provider
 
-Both workflows follow the same pattern: generate a review, extract a verdict (APPROVE or REQUEST CHANGES), and post the full review to the PR regardless of verdict.
+Both providers follow the same pattern: generate a review, extract a verdict (APPROVE or
+REQUEST CHANGES), and post the full review to the PR regardless of verdict.
 
 ## Verdict Behavior
 
@@ -18,19 +22,19 @@ The verdict extraction step (`extract_verdict.py`) runs the AI review output thr
 1. **APPROVE** — the review found no blocking issues. The step exits 0 and sets `outputs.approved='true'`.
 2. **REQUEST CHANGES** — the review flagged issues that should be addressed before merge. The step exits 1 (non-zero) and sets `outputs.approved='false'`.
 
-**Important:** Downstream steps MUST check `steps.check_claude_approval.outputs.approved == 'true'`, NOT the step's exit status or `outcome`. The step is configured with `continue-on-error: true`, so a REQUEST CHANGES verdict (exit 1) does not block subsequent steps — they can run and decide what to do based on the output variable.
+**Important:** Downstream steps MUST check `steps.check_approval.outputs.approved == 'true'`, NOT the step's exit status or `outcome`. The step is configured with `continue-on-error: true`, so a REQUEST CHANGES verdict (exit 1) does not block subsequent steps — they can run and decide what to do based on the output variable.
 
 Example of correct pattern in a step:
 ```yaml
 - name: Take action based on review
-  if: steps.check_claude_approval.outputs.approved == 'true'
+  if: steps.check_approval.outputs.approved == 'true'
   run: echo "PR approved by AI"
 ```
 
 Example of **incorrect** pattern (will not work as intended):
 ```yaml
 - name: Take action based on review
-  if: steps.check_claude_approval.outcome == 'success'  # ❌ Wrong — continues even on REQUEST CHANGES
+  if: steps.check_approval.outcome == 'success'  # ❌ Wrong — continues even on REQUEST CHANGES
   run: echo "PR approved by AI"
 ```
 
@@ -42,7 +46,7 @@ When the AI API successfully generates a review, the full review content is post
 
 ### Failed Review
 
-If the AI API call fails before producing a non-empty review file (e.g., missing credentials, HTTP error, empty response), a fallback notice is posted instead. The exact text posted is generated in the `else` branch of the `-s` guard in each workflow's "Post review comment" step:
+If the AI API call fails before producing a non-empty review file (e.g., missing credentials, HTTP error, empty response), a fallback notice is posted instead. The exact text posted is generated in the `else` branch of the `-s` guard in `build_review_comment.sh`, called from the reusable workflow's "Post review comment" step:
 
 ```
 ## Claude AI Code Review - Failed
@@ -54,7 +58,7 @@ The Claude review failed to complete. Check [Actions](<run URL>) for error detai
 
 ### File-Existence Guard
 
-Both workflows use the POSIX test `[ -s /tmp/<reviewer>_review_body.md ]` to distinguish between:
+The reusable workflow uses the POSIX test `[ -s /tmp/<provider_id>_review_body.md ]` to distinguish between:
 
 1. **File exists and non-empty** (`-s` returns true): API call succeeded → post full review
 2. **File missing or empty** (`-s` returns false): API call failed → post fallback notice
@@ -74,7 +78,80 @@ As a secondary fallback for visibility, the review body is also written to `$GIT
 ## Workflow Step Configuration
 
 - **`if: success() || failure()`**: The "Post review comment" step runs even if the verdict is REQUEST CHANGES (which exits the preceding step with a non-zero exit code), so the full review is always visible. The condition excludes cancelled runs to avoid spurious failure notices when a run is superseded by a new push.
-- **`continue-on-error: true`**: Set on the "Post review comment" step in both `claude-pr-review.yml` and `gpt-pr-review.yml`. If the `gh pr comment` call fails, the job does not fail. The failure is recorded in the workflow logs but does not block the overall workflow.
+- **`continue-on-error: true`**: Set on the "Post review comment" step in `_ai-pr-review.yml`. If the `gh pr comment` call fails, the job does not fail. The failure is recorded in the workflow logs but does not block the overall workflow.
+- **`if: steps.check_approval.outputs.approved == 'true'`**: The "Create follow-up issues" step only runs when the review is an APPROVE. On REQUEST CHANGES, no follow-up issues are created — the blocking findings belong in the review itself, not the backlog. This condition is identical for both Claude and GPT.
+
+## Adding a new AI reviewer
+
+The reusable workflow `_ai-pr-review.yml` and the shared `fetch_review()` helper in
+`review_common.py` make it possible to add a third reviewer (e.g. Gemini) without copying
+the full workflow or HTTP/error-handling scaffolding. The contract:
+
+### 1. Shared prompt and verdict format
+
+Every reviewer must use:
+
+- `build_prompt(pr_title, diff, issue_body)` from `review_common.py` to construct the
+  review prompt — this keeps the review dimensions and repo-specific context identical
+  across providers.
+- The verdict markers `**APPROVE**` / `**REQUEST CHANGES**` at the end of the review, as
+  understood by `extract_verdict.py`. Do not introduce new verdict values.
+
+### 2. Review script
+
+Add `.github/scripts/<provider>_review.py` that:
+
+1. Calls `load_review_context(api_key_env)` to read `PR_TITLE`, `DIFF`, `ISSUE_BODY`, and
+   the provider's API key from the environment.
+2. Returns early via `emit_empty_diff_notice(provider_name)` if the diff is empty.
+3. Builds the prompt with `build_prompt(...)`.
+4. Calls `fetch_review(url, headers, payload, extractor, provider_label)` from
+   `review_common.py`, where `extractor(data) -> (review_text, extra)` parses the
+   provider's JSON response. `fetch_review()` handles the HTTP POST, timeout, `HTTPError`
+   reporting, and empty-response warning.
+5. Calls `finalize_review(review, empty_error_message)` to print the result or fail.
+
+### 3. Output file naming
+
+The reusable workflow writes the review to `/tmp/<provider_id>_review_body.md` and the
+posted comment to `/tmp/<provider_id>_comment_body.md`, where `<provider_id>` is the
+lowercase identifier passed via the `provider_id` input (e.g. `claude`, `gpt`, `gemini`).
+
+### 4. Registering the provider
+
+Add a new thin caller workflow, e.g. `.github/workflows/gemini-pr-review.yml`:
+
+```yaml
+name: Gemini PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  ai-review:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/_ai-pr-review.yml
+    with:
+      provider_name: Gemini
+      provider_id: gemini
+      review_script: .github/scripts/gemini_review.py
+      workflow_file: gemini-pr-review.yml
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+`anthropic_api_key` and `gh_token` are required by the reusable workflow regardless of
+provider: `anthropic_api_key` is used for follow-up issue creation
+(`create_followup_issues.py`) on every reviewer's APPROVE verdict, and `gh_token` is used
+for `gh` CLI calls. Pass any provider-specific secret (e.g. a `GEMINI_API_KEY`) by adding
+a new optional secret to `_ai-pr-review.yml` and threading it through to the "Call API"
+step's `env:` block, following the existing `openai_api_key` pattern.
 
 ## Debugging
 

--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -26,8 +26,8 @@ EXPECTED_REQUIRED_CHECKS = {
     "Merge Conflict Check / Check for merge conflicts with main",
     "PR Body Issue Reference Check / require-issue-reference",
     "Dependency Review / dependency-review",
-    "Claude PR Review / Claude AI code review",
-    "GPT PR Review / GPT AI code review",
+    "ai-review / Claude AI code review",
+    "ai-review / GPT AI code review",
 }
 
 
@@ -47,6 +47,33 @@ def load_ruleset_contexts() -> set[str]:
     return contexts
 
 
+def resolve_called_workflow_job_names(workflow_path: Path, with_inputs: dict) -> list[str]:
+    """Return display names for jobs in a reusable workflow referenced via `uses:`.
+
+    Job `name:` fields in the called workflow may reference `${{ inputs.<name> }}`
+    placeholders, which are substituted using the calling job's `with:` values.
+    """
+    try:
+        called = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError) as exc:
+        print(f"Warning: could not parse {workflow_path.name}: {exc}", file=sys.stderr)
+        return []
+    if not isinstance(called, dict):
+        return []
+    jobs = called.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+
+    names: list[str] = []
+    for called_job_id, called_job in jobs.items():
+        job_name = called_job.get("name") if isinstance(called_job, dict) else None
+        display_name = job_name if isinstance(job_name, str) else called_job_id
+        for key, value in with_inputs.items():
+            display_name = display_name.replace(f"${{{{ inputs.{key} }}}}", str(value))
+        names.append(display_name)
+    return names
+
+
 def workflow_check_contexts() -> set[str]:
     contexts: set[str] = set()
 
@@ -63,6 +90,14 @@ def workflow_check_contexts() -> set[str]:
         if not isinstance(workflow_name, str) or not isinstance(jobs, dict):
             continue
         for job_id, job in jobs.items():
+            uses = job.get("uses") if isinstance(job, dict) else None
+            if isinstance(uses, str) and uses.startswith("./"):
+                with_inputs = job.get("with", {})
+                with_inputs = with_inputs if isinstance(with_inputs, dict) else {}
+                called_path = REPO_ROOT / Path(uses)
+                for called_name in resolve_called_workflow_job_names(called_path, with_inputs):
+                    contexts.add(f"{job_id} / {called_name}")
+                continue
             job_name = job.get("name") if isinstance(job, dict) else None
             display_name = job_name if isinstance(job_name, str) else job_id
             contexts.add(f"{workflow_name} / {display_name}")
@@ -85,10 +120,7 @@ def main() -> int:
 
     missing_workflows = sorted(required_contexts - available_contexts)
     if missing_workflows:
-        errors.append(
-            "Required checks do not match workflow/job names: "
-            f"{missing_workflows}"
-        )
+        errors.append(f"Required checks do not match workflow/job names: {missing_workflows}")
 
     if errors:
         for error in errors:

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -27,8 +27,8 @@ def load_script_module(module_name: str, file_name: str) -> ModuleType:
 
 
 class FakeResponse:
-    def __init__(self, payload: dict[str, object]) -> None:
-        self._payload = json.dumps(payload).encode()
+    def __init__(self, payload: dict[str, object] | bytes, raw: bool = False) -> None:
+        self._payload = payload if raw else json.dumps(payload).encode()
 
     def read(self) -> bytes:
         return self._payload
@@ -212,6 +212,92 @@ def test_review_script_reports_mocked_api_failure(
         )
 
     monkeypatch.setattr(review_common.urllib.request, "urlopen", raise_http_error)
+
+    with pytest.raises(SystemExit) as exc:
+        module.main()
+
+    assert exc.value.code == 1
+    assert expected_message in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("module_name", "file_name", "api_env", "expected_message"),
+    [
+        (
+            "gpt_review_url_error",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
+            "ERROR: OpenAI API request failed: timed out",
+        ),
+        (
+            "claude_review_url_error",
+            "claude_review.py",
+            "ANTHROPIC_API_KEY",
+            "ERROR: Claude API request failed: timed out",
+        ),
+    ],
+)
+def test_review_script_reports_mocked_url_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    module_name: str,
+    file_name: str,
+    api_env: str,
+    expected_message: str,
+) -> None:
+    module = load_script_module(module_name, file_name)
+    monkeypatch.setenv(api_env, "test-key")
+    monkeypatch.setenv("PR_TITLE", "Add thing")
+    monkeypatch.setenv("ISSUE_BODY", "Do thing")
+    monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
+
+    def raise_url_error(*args, **kwargs):
+        raise urllib.error.URLError("timed out")
+
+    monkeypatch.setattr(review_common.urllib.request, "urlopen", raise_url_error)
+
+    with pytest.raises(SystemExit) as exc:
+        module.main()
+
+    assert exc.value.code == 1
+    assert expected_message in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("module_name", "file_name", "api_env", "expected_message"),
+    [
+        (
+            "gpt_review_bad_json",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
+            "ERROR: OpenAI API returned non-JSON response",
+        ),
+        (
+            "claude_review_bad_json",
+            "claude_review.py",
+            "ANTHROPIC_API_KEY",
+            "ERROR: Claude API returned non-JSON response",
+        ),
+    ],
+)
+def test_review_script_reports_mocked_non_json_response(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    module_name: str,
+    file_name: str,
+    api_env: str,
+    expected_message: str,
+) -> None:
+    module = load_script_module(module_name, file_name)
+    monkeypatch.setenv(api_env, "test-key")
+    monkeypatch.setenv("PR_TITLE", "Add thing")
+    monkeypatch.setenv("ISSUE_BODY", "Do thing")
+    monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
+    monkeypatch.setattr(
+        review_common.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: FakeResponse(b"<html>not json</html>", raw=True),
+    )
 
     with pytest.raises(SystemExit) as exc:
         module.main()

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -15,6 +15,8 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".github" / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
+import review_common  # noqa: E402
+
 
 def load_script_module(module_name: str, file_name: str) -> ModuleType:
     spec = importlib.util.spec_from_file_location(module_name, SCRIPTS_DIR / file_name)
@@ -127,7 +129,7 @@ def test_review_script_prints_review_on_mocked_api_success(
     monkeypatch.setenv("PR_TITLE", "Add thing")
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
-    monkeypatch.setattr(module.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload))
+    monkeypatch.setattr(review_common.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload))
 
     assert module.main() == 0
     assert "Looks good" in capsys.readouterr().out
@@ -173,7 +175,7 @@ def test_review_script_exits_on_empty_api_response(
     monkeypatch.setenv("PR_TITLE", "Add thing")
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
-    monkeypatch.setattr(module.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload))
+    monkeypatch.setattr(review_common.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload))
 
     assert module.main() == 1
     assert expected_err in capsys.readouterr().err
@@ -209,7 +211,7 @@ def test_review_script_reports_mocked_api_failure(
             fp=io.BytesIO(b"upstream broke"),
         )
 
-    monkeypatch.setattr(module.urllib.request, "urlopen", raise_http_error)
+    monkeypatch.setattr(review_common.urllib.request, "urlopen", raise_http_error)
 
     with pytest.raises(SystemExit) as exc:
         module.main()


### PR DESCRIPTION
## Summary
- Extract a reusable `workflow_call` workflow `.github/workflows/_ai-pr-review.yml` parameterized by `provider_name`, `provider_id`, `review_script`, `workflow_file`, and `anthropic_max_tokens`. `claude-pr-review.yml` and `gpt-pr-review.yml` are now thin callers (~22 lines each).
- Add a shared `fetch_review()` helper to `review_common.py` that handles the HTTP POST, timeout, `HTTPError` handling, status/size logging, and empty-response warning. `claude_review.py` and `gpt_review.py` now only build the payload/headers/extractor and call `fetch_review()`.
- Reconcile the divergent "Create follow-up issues" `if:` conditions: both providers now only create follow-up issues on an **APPROVE** verdict (matching Claude's prior behavior), per maintainer confirmation.
- Standardize the "Post review comment" step on `if: success() || failure()` for both providers.
- Document the contract for adding a new AI reviewer (e.g. Gemini) in `docs/AI_REVIEW_WORKFLOWS.md`, including prompt/verdict format, output file naming, and secret wiring via `_ai-pr-review.yml`.

## Constraints honored
- `extract_verdict.py` and `build_review_comment.sh` are unchanged — verdict and comment formats are identical.
- `github.actor != 'dependabot[bot]'` guard and the `permissions` block are preserved on both caller workflows and the reusable workflow.
- `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `GH_TOKEN` are passed explicitly via `secrets:` in each caller.

## Test plan
- [x] `pytest tests/test_ai_review_scripts.py tests/test_review_comment.py` — 19 passed
- [x] `ruff check` / `black --check` on touched Python files (no new issues vs. baseline)
- [x] YAML syntax validated for `_ai-pr-review.yml`, `claude-pr-review.yml`, `gpt-pr-review.yml`
- [ ] End-to-end validation: this PR itself will trigger both `claude-pr-review.yml` and `gpt-pr-review.yml` via the new reusable workflow — confirm both post review comments, extract verdicts, and gate follow-up issue creation correctly

Closes #3930