### PR TITLE
fix(frontend): recover from failed Cognito token exchange

### DIFF
--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -156,8 +156,12 @@ const exchangeCode = async (config: AuthConfig) => {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: tokenParams.toString(),
   });
-  if (!response.ok)
+  if (!response.ok) {
+    // The authorization code is single-use; strip it from the URL so a
+    // reload restarts the hosted-UI flow instead of replaying a dead code.
+    window.history.replaceState({}, document.title, window.location.pathname);
     throw new Error('AWS UI authentication token exchange failed');
+  }
   storeSession(
     (await response.json()) as {
       id_token: string;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -527,7 +527,10 @@ void bootstrapRuntimeConfig()
     } else {
       createRoot(rootEl).render(
         <div role="alert" className="app-offline">
-          Authentication is unavailable. Please contact your administrator.
+          <p>Authentication is unavailable. Please contact your administrator.</p>
+          <button type="button" onClick={() => window.location.reload()}>
+            Sign in
+          </button>
         </div>
       );
     }

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -241,12 +241,14 @@ describe('ensureAwsUiAuth', () => {
       expect(window.sessionStorage.getItem('awsUiAuthCodeVerifier')).toBeNull();
     });
 
-    it('throws when token endpoint returns an error response', async () => {
+    it('throws and cleans up URL when token endpoint returns an error response', async () => {
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+      const replaceState = vi.spyOn(window.history, 'replaceState');
 
       await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
         'AWS UI authentication token exchange failed'
       );
+      expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
     });
   });
 });

--- a/frontend/tests/unit/main.tokenExchangeFailure.test.tsx
+++ b/frontend/tests/unit/main.tokenExchangeFailure.test.tsx
@@ -1,0 +1,87 @@
+import type { ReactElement } from 'react';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let renderedElement: ReactElement | null = null;
+
+vi.mock('react-dom/client', () => ({
+  createRoot: () => ({
+    render: (el: ReactElement) => {
+      renderedElement = el;
+    },
+  }),
+}));
+
+vi.mock('@/api', () => ({
+  getConfig: vi.fn(),
+  setAuthToken: vi.fn(),
+  getStoredAuthToken: vi.fn(() => null),
+  getApiBase: vi.fn(() => 'http://localhost:8000'),
+  setApiBase: vi.fn(),
+  logout: vi.fn(),
+}));
+
+const CONFIG_WITH_COGNITO = {
+  awsUiAuth: {
+    enabled: true,
+    domain: 'https://auth.example.test',
+    clientId: 'cognito-client-123',
+  },
+};
+
+beforeEach(() => {
+  renderedElement = null;
+  vi.resetModules();
+  sessionStorage.clear();
+  localStorage.clear();
+  window.history.replaceState({}, '', '/');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('bootstrapRuntimeConfig — generic auth bootstrap failure', () => {
+  it('renders a "Sign in" retry button when token exchange fails', async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    window.history.replaceState({}, '', '/?code=auth-code-123&state=test-state');
+    sessionStorage.setItem('awsUiAuthState', 'test-state');
+    sessionStorage.setItem('awsUiAuthCodeVerifier', 'test-verifier');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (String(url).endsWith('/config.json')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(CONFIG_WITH_COGNITO),
+          });
+        }
+        if (String(url).endsWith('/oauth2/token')) {
+          return Promise.resolve({ ok: false });
+        }
+        return Promise.resolve({ ok: false });
+      }),
+    );
+
+    await import('@/main');
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'AWS UI authentication bootstrap failed',
+      expect.any(Error),
+    );
+    expect(renderedElement).not.toBeNull();
+
+    render(renderedElement!);
+    const retryButton = screen.getByRole('button', { name: /sign in/i });
+    expect(retryButton).toBeInTheDocument();
+    expect(screen.getByText(/Authentication is unavailable/i)).toBeInTheDocument();
+
+    // The dead authorization code must be cleared so a reload restarts the hosted-UI flow.
+    expect(window.location.search).toBe('');
+  });
+});

--- a/frontend/tests/unit/main.tokenExchangeFailure.test.tsx
+++ b/frontend/tests/unit/main.tokenExchangeFailure.test.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let renderedElement: ReactElement | null = null;
@@ -68,13 +69,13 @@ describe('bootstrapRuntimeConfig — generic auth bootstrap failure', () => {
     );
 
     await import('@/main');
-    await new Promise((r) => setTimeout(r, 0));
+
+    await vi.waitFor(() => expect(renderedElement).not.toBeNull());
 
     expect(consoleError).toHaveBeenCalledWith(
       'AWS UI authentication bootstrap failed',
       expect.any(Error),
     );
-    expect(renderedElement).not.toBeNull();
 
     render(renderedElement!);
     const retryButton = screen.getByRole('button', { name: /sign in/i });
@@ -83,5 +84,14 @@ describe('bootstrapRuntimeConfig — generic auth bootstrap failure', () => {
 
     // The dead authorization code must be cleared so a reload restarts the hosted-UI flow.
     expect(window.location.search).toBe('');
+
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+
+    await userEvent.click(retryButton);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- `exchangeCode()` now strips `?code=&state=` from the URL before throwing on a non-OK `/oauth2/token` response, mirroring the existing `access_denied` and state-mismatch branches, so a reload restarts the hosted-UI flow instead of replaying a single-use authorization code.
- `bootstrapRuntimeConfig().catch(...)` in `main.tsx` now renders a "Sign in" retry button (calling `window.location.reload()`) for the generic auth-bootstrap-failure case, keeping the existing "Authentication is unavailable. Please contact your administrator." message.

Closes #3936

## Test plan
- [x] `npx vitest run tests/unit/awsUiAuth.test.ts tests/unit/main.tokenExchangeFailure.test.tsx` — passes
- [x] `npx vitest run tests/unit/main.test.tsx tests/unit/main.cognitoExchange.test.ts tests/unit/rootBootstrap.test.tsx tests/unit/main.familyMvpRoutes.test.tsx tests/unit/rootConfigStates.test.tsx` — passes
- [x] `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)