### PR TITLE
fix(deploy): pass CloudFront distribution domain as FRONTEND_ORIGIN to BackendLambdaStack

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -387,6 +387,17 @@ jobs:
             --stack-name StaticSiteStack \
             --query "Stacks[0].Outputs[?OutputKey=='UiAuthUserPoolClientId'].OutputValue" \
             --output text)"
+          # DistributionDomain is the CloudFront domain the frontend is actually served
+          # from (customDomain is currently disabled — see cdk.json). BackendLambdaStack
+          # needs this as FRONTEND_ORIGIN so its CORS allow-list includes the live
+          # frontend origin (see #3944); without it, cors_origins defaults to
+          # localhost-only and the deployed frontend's GET /config never gets an
+          # Access-Control-Allow-Origin header, leaving it stuck on
+          # "Loading... retrying configuration."
+          DISTRIBUTION_DOMAIN="$(aws cloudformation describe-stacks \
+            --stack-name StaticSiteStack \
+            --query "Stacks[0].Outputs[?OutputKey=='DistributionDomain'].OutputValue" \
+            --output text)"
           if [ -z "$UI_AUTH_USER_POOL_ID" ] || [ "$UI_AUTH_USER_POOL_ID" = "None" ]; then
             echo "UiAuthUserPoolId output is missing from StaticSiteStack" >&2
             exit 1
@@ -395,8 +406,13 @@ jobs:
             echo "UiAuthUserPoolClientId output is missing from StaticSiteStack" >&2
             exit 1
           fi
+          if [ -z "$DISTRIBUTION_DOMAIN" ] || [ "$DISTRIBUTION_DOMAIN" = "None" ]; then
+            echo "DistributionDomain output is missing from StaticSiteStack" >&2
+            exit 1
+          fi
           echo "UI_AUTH_USER_POOL_ID=$UI_AUTH_USER_POOL_ID" >> "$GITHUB_ENV"
           echo "UI_AUTH_USER_POOL_CLIENT_ID=$UI_AUTH_USER_POOL_CLIENT_ID" >> "$GITHUB_ENV"
+          echo "FRONTEND_ORIGIN=https://${DISTRIBUTION_DOMAIN}" >> "$GITHUB_ENV"
 
       - name: Deploy BackendLambdaStack
         # GITHUB_DEPLOY_ROLE_ARN must be set here so CDK can read it during synthesis.
@@ -413,6 +429,7 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
+          FRONTEND_ORIGIN: ${{ env.FRONTEND_ORIGIN }}
         run: >
           npx cdk deploy BackendLambdaStack --require-approval never
           --parameters BackendLambdaStack:UiAuthUserPoolId="$UI_AUTH_USER_POOL_ID"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -410,9 +410,11 @@ jobs:
             echo "DistributionDomain output is missing from StaticSiteStack" >&2
             exit 1
           fi
-          echo "UI_AUTH_USER_POOL_ID=$UI_AUTH_USER_POOL_ID" >> "$GITHUB_ENV"
-          echo "UI_AUTH_USER_POOL_CLIENT_ID=$UI_AUTH_USER_POOL_CLIENT_ID" >> "$GITHUB_ENV"
-          echo "FRONTEND_ORIGIN=https://${DISTRIBUTION_DOMAIN}" >> "$GITHUB_ENV"
+          {
+            echo "UI_AUTH_USER_POOL_ID=$UI_AUTH_USER_POOL_ID"
+            echo "UI_AUTH_USER_POOL_CLIENT_ID=$UI_AUTH_USER_POOL_CLIENT_ID"
+            echo "FRONTEND_ORIGIN=https://${DISTRIBUTION_DOMAIN}"
+          } >> "$GITHUB_ENV"
 
       - name: Deploy BackendLambdaStack
         # GITHUB_DEPLOY_ROLE_ARN must be set here so CDK can read it during synthesis.


### PR DESCRIPTION
## Summary
- The deploy workflow never set `FRONTEND_ORIGIN`/`CORS_ORIGINS` when deploying `BackendLambdaStack`, so the deployed Lambda's CORS allow-list defaulted to `["http://localhost:3000", "http://localhost:5173"]` only.
- This means `GET /config` (and every other backend route) responds with no `Access-Control-Allow-Origin` header for the live CloudFront frontend origin (`https://d32n5ua14kb82t.cloudfront.net`), so the browser rejects the response and the frontend is stuck on "Loading... retrying configuration." forever.
- Fix: after `StaticSiteStack` deploys, read its `DistributionDomain` output (same pattern already used later in the workflow for `LIGHTHOUSE_URL`) and pass it as `FRONTEND_ORIGIN=https://<distribution-domain>` to the `BackendLambdaStack` deploy step. `cdk/stacks/backend_lambda_stack.py` already reads `os.getenv("FRONTEND_ORIGIN")` and prepends it to `cors_origins` — no CDK code changes needed.
- Verified locally via `cdk synth BackendLambdaStack` with `FRONTEND_ORIGIN=https://d32n5ua14kb82t.cloudfront.net`: `CORS_ORIGINS` env var and the API Gateway `AllowOrigins` both correctly include the CloudFront origin.

## Test plan
- [x] `cdk synth BackendLambdaStack -c prod=true` with `FRONTEND_ORIGIN` set shows the CloudFront origin in both the Lambda's `CORS_ORIGINS` env var and the HTTP API's `CorsPreflightOptions.AllowOrigins`.
- [ ] After deploy, `curl -i https://<api>/config -H "Origin: https://<cloudfront-domain>"` returns `Access-Control-Allow-Origin: https://<cloudfront-domain>` and `cors_origins` in the JSON body includes that origin.
- [ ] Deployed frontend at the CloudFront URL no longer gets stuck on "Loading... retrying configuration." (note: full end-to-end auth flow also needs #3945).

Closes #3944