### PR TITLE
fix(frontend): seed Cognito session in smoke tests to avoid hosted-UI redirect

### DIFF
--- a/frontend/tests/config-retry.spec.ts
+++ b/frontend/tests/config-retry.spec.ts
@@ -10,6 +10,13 @@ const applyAuth = async (page: Page) => {
 
   await page.addInitScript((token: string) => {
     window.localStorage.setItem('authToken', token);
+    // Seed a valid AWS UI auth (Cognito) session so ensureAwsUiAuth() finds an
+    // unexpired session and skips the hosted-UI redirect, which would navigate
+    // away from the app before it renders. See awsUiAuth.ts hasValidSession().
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({ idToken: token, expiresAt: Date.now() + 60 * 60 * 1000 })
+    );
   }, authToken);
 };
 

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -13,6 +13,13 @@ const applyAuth = async (page: Page) => {
 
   await page.addInitScript((token: string) => {
     window.localStorage.setItem('authToken', token);
+    // Seed a valid AWS UI auth (Cognito) session so ensureAwsUiAuth() finds an
+    // unexpired session and skips the hosted-UI redirect, which would navigate
+    // away from the app before it renders. See awsUiAuth.ts hasValidSession().
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({ idToken: token, expiresAt: Date.now() + 60 * 60 * 1000 })
+    );
   }, authToken);
 };
 


### PR DESCRIPTION
## Summary

- The `Deploy Infrastructure` workflow's `smoke-test` job has been failing for many recent versions (v0.19.2 through v0.19.10), with ~20/45 Playwright smoke tests timing out waiting for page headings/route markers (see https://github.com/leonarduk/allotmint/actions/runs/27439458424/job/81112387647).
- Root cause: in the deployed environment, `/config.json` always sets `awsUiAuth.enabled = true` (`cdk/stacks/static_site_stack.py:387`). On bootstrap, `ensureAwsUiAuth()` (`frontend/src/awsUiAuth.ts:199`) checks `hasValidSession()` (Cognito session in `sessionStorage`); if absent and there's no `?code=&state=` callback in the URL, it calls `redirectToHostedUi()`, which navigates the page away to the Cognito hosted UI **before the React app renders anything**. The smoke tests' `applyAuth()` only seeded `localStorage.authToken` (backend token), not a Cognito session, so every fresh-navigation test hit this redirect and never found its expected heading/route marker.
- Fix: `applyAuth()` in `frontend/tests/smoke.spec.ts` and `frontend/tests/config-retry.spec.ts` now also seeds `sessionStorage.awsUiAuthSession` (matching the `StoredSession` shape `awsUiAuth.ts` expects) with the smoke-test Cognito ID token and a future `expiresAt`, so `hasValidSession()` returns true and the hosted-UI redirect is skipped.

## Test plan

- [x] `npx eslint tests/smoke.spec.ts tests/config-retry.spec.ts` — clean
- [x] `npx vitest run tests/unit/awsUiAuth.test.ts` — 22/22 passing (unchanged app code)
- [ ] CI: `Deploy Infrastructure` workflow's `smoke-test` job should pass on the next deploy run

Closes #3997