### PR TITLE
fix(backend): sanitise owner/account extra fields in data_loader fallback log

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -1047,8 +1047,8 @@ def load_account(
                 sanitise_log_value(exc),
                 extra={
                     "event": "data_loader.account_provider_unavailable",
-                    "owner": owner,
-                    "account": account,
+                    "owner": sanitise_log_value(owner),
+                    "account": sanitise_log_value(account),
                     "fallback_to_local": bool(local_root),
                     "provider": "s3",
                 },


### PR DESCRIPTION
## Summary
- Sanitises the `owner`/`account` values passed via `extra={}` in the S3-to-local fallback warning in `backend/common/data_loader.py`, mirroring the sanitisation already applied to the positional format args (lines 1045-1047).
- Resolves CodeQL log-injection alert #156 (CWE-117).

## Test plan
- [x] Existing `tests/` coverage for `data_loader.load_account` fallback behaviour passes (16 passed)

Closes #3999