### PR TITLE
fix(backend): sanitise share count and transaction fields in compliance log

### DIFF
--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -208,7 +208,12 @@ def _check_transactions(owner: str, txs: List[Dict[str, Any]], accounts_root: Op
         try:
             shares = float(raw_shares or 0.0)
         except (TypeError, ValueError):
-            logger.warning("invalid share count %r in transaction %s", raw_shares, t)
+            logger.warning(
+                "invalid share count %s in transaction (ticker=%s, date=%s)",
+                sanitise_log_value(raw_shares),
+                sanitise_log_value(t.get("ticker")),
+                sanitise_log_value(t.get("date")),
+            )
             shares = 0.0
         if action in {"buy", "purchase"}:
             last_buy[ticker] = d


### PR DESCRIPTION
## Summary
- Resolves CodeQL alerts [#87](https://github.com/leonarduk/allotmint/security/code-scanning/87) and [#88](https://github.com/leonarduk/allotmint/security/code-scanning/88) (CWE-117, log injection) at `backend/common/compliance.py:211`.
- Replaces the raw `%r`/`%s` logging of `raw_shares` and the full transaction dict `t` with sanitised values via `sanitise_log_value()`, logging only the ticker and date for diagnostics, consistent with the existing pattern used elsewhere in this file.

Closes #4000

## Test plan
- [x] `pytest tests/ -k compliance` (52 passed)
- [x] `ruff check backend/common/compliance.py` (clean)