### PR TITLE
fix(frontend): resolve CodeQL CSRF/SSRF alert on fetchJson base URL

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -210,17 +210,23 @@ export function createClient(
         `Blocked request: ${parsedFull.href} does not start with configured API base`,
       );
     }
+    // Build the request URL from the trusted base origin plus the path/query/hash
+    // that just passed the checks above, rather than passing the raw `fullUrl`
+    // (derived directly from the `url` argument) to fetch. This keeps the value
+    // reaching fetchImpl tied to the validated `parsedFull` object so CodeQL's
+    // taint tracking can see it as guarded (js/client-side-request-forgery, CWE-918).
+    const safeUrl = `${baseOrigin}${parsedFull.pathname}${parsedFull.search}${parsedFull.hash}`;
     const headers = new Headers(init.headers);
     if (authToken) headers.set("Authorization", `Bearer ${authToken}`);
     const csrf = getCsrfToken();
     if (csrf) headers.set("X-CSRFToken", csrf);
-    const res = await fetchImpl(fullUrl, {
+    const res = await fetchImpl(safeUrl, {
       ...init,
       headers,
       credentials: "include",
     });
     if (!res.ok) {
-      const err = new Error(`HTTP ${res.status} - ${res.statusText} (${fullUrl})`);
+      const err = new Error(`HTTP ${res.status} - ${res.statusText} (${safeUrl})`);
       (err as any).status = res.status;
       (err as any).headers = res.headers;
       throw err;

--- a/frontend/tests/unit/api.test.ts
+++ b/frontend/tests/unit/api.test.ts
@@ -305,6 +305,37 @@ describe("client-side request forgery guard (CodeQL #218)", () => {
   });
 });
 
+describe("safe URL reconstruction (CodeQL #218 follow-up)", () => {
+  it("rebuilds the request URL from the trusted base origin and validated path/query", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    const { fetchJson: testFetchJson } = createClient(
+      "http://localhost:8000/api/v1",
+      null,
+      mockFetch as unknown as typeof fetch,
+    );
+    await testFetchJson("/holdings?owner=alice#section");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8000/api/v1/holdings?owner=alice#section",
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+  });
+
+  it("still blocks a same-origin path outside the configured prefix when reconstructing", async () => {
+    const mockFetch = vi.fn();
+    const { fetchJson: testFetchJson } = createClient(
+      "http://localhost:8000/api/v1",
+      null,
+      mockFetch as unknown as typeof fetch,
+    );
+    await expect(
+      testFetchJson("http://localhost:8000/other-app/steal?x=1"),
+    ).rejects.toThrow("does not start with configured API base");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
 describe("path-prefix guard (issue #3170)", () => {
   it("blocks a same-origin URL that does not match the configured API path prefix", async () => {
     const { fetchJson: testFetchJson } = createClient("http://localhost:8000/api/v1");


### PR DESCRIPTION
## Summary
- `fetchJson()` already validated the request URL's origin and path prefix against the configured API base, but CodeQL's taint analysis didn't connect those guards (checked on a separately-constructed `parsedFull` URL) to the value actually passed to `fetchImpl` (`fullUrl`, derived directly from the `url` argument).
- Reconstruct the final request URL (`safeUrl`) from the trusted `baseOrigin` constant plus `parsedFull.pathname`/`search`/`hash` — the same `parsedFull` object the origin and path-prefix checks operate on — so the value reaching `fetch` is tied to the guarded object.
- No validation logic was weakened or removed; behaviour for relative-path callers is unchanged (verified by existing + new tests).

Closes #3998

## Test plan
- [x] `npm --prefix frontend run test -- --run tests/unit/api.test.ts` — 28/28 pass (added 2 new tests covering safe-URL reconstruction with query/hash, and continued blocking of out-of-prefix same-origin paths)
- [x] `npm --prefix frontend run lint` — clean
- [ ] Confirm CodeQL alert #218 resolves on this PR's checks