### PR TITLE
fix(cdk): add unauthenticated OPTIONS routes for CORS preflight on BackendApi

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -363,6 +363,23 @@ class BackendLambdaStack(Stack):
             integration=backend_integration,
             authorizer=apigwv2.HttpNoneAuthorizer(),
         )
+        # CORS preflight OPTIONS requests must never reach backend_authorizer:
+        # browsers send them without an Authorization header, so a JWT
+        # authorizer would reject them with 401 before CORS headers are
+        # returned. Register explicit OPTIONS routes with NONE authorization
+        # so they take precedence over the ANY-method routes below.
+        backend_api.add_routes(
+            path="/",
+            methods=[apigwv2.HttpMethod.OPTIONS],
+            integration=backend_integration,
+            authorizer=apigwv2.HttpNoneAuthorizer(),
+        )
+        backend_api.add_routes(
+            path="/{proxy+}",
+            methods=[apigwv2.HttpMethod.OPTIONS],
+            integration=backend_integration,
+            authorizer=apigwv2.HttpNoneAuthorizer(),
+        )
         backend_api.add_routes(
             path="/",
             methods=[apigwv2.HttpMethod.ANY],

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -557,7 +557,7 @@ def test_backend_api_has_cognito_jwt_authorizer(template):
 
 def test_backend_api_routes_require_cognito_authorizer(template):
     """All API Gateway routes must require Cognito JWT authorization except
-    /health and GET /config.
+    /health, GET /config, and the CORS preflight OPTIONS routes.
 
     /health is intentionally unauthenticated so that post-deploy probes and
     smoke tests can confirm Lambda is reachable without needing a Cognito token.
@@ -565,10 +565,18 @@ def test_backend_api_routes_require_cognito_authorizer(template):
     pre-auth bootstrap endpoint (frontend/src/main.tsx Root.fetchConfig) used
     to determine whether auth is required at all; PUT /config remains
     JWT-protected via the /{proxy+} catch-all.
+    OPTIONS / and OPTIONS /{proxy+} are unauthenticated so that browser CORS
+    preflight requests (which never carry an Authorization header) are not
+    rejected with 401 before the real request is sent (see issue #3945).
     Asserts the full route set so that adding any other unprotected route will
     fail this test rather than silently bypassing the authorizer.
     """
-    UNAUTHENTICATED_ROUTES = {"GET /health", "GET /config"}
+    UNAUTHENTICATED_ROUTES = {
+        "GET /health",
+        "GET /config",
+        "OPTIONS /",
+        "OPTIONS /{proxy+}",
+    }
 
     routes = template.find_resources("AWS::ApiGatewayV2::Route")
     assert routes, "Expected at least one API Gateway route"


### PR DESCRIPTION
## Summary
- Add explicit `OPTIONS /` and `OPTIONS /{proxy+}` routes on `BackendApi` with `apigwv2.HttpNoneAuthorizer()`, registered before the `ANY`-method routes so they take precedence.
- Previously, those `ANY` routes (with `backend_authorizer`) also matched `OPTIONS` requests, causing every CORS preflight to return `401 Unauthorized` and blocking authenticated frontend API calls (which send a non-simple `Authorization` header, triggering a preflight).
- Update `test_backend_api_routes_require_cognito_authorizer` to include `OPTIONS /` and `OPTIONS /{proxy+}` in the expected unauthenticated route set.

## Test plan
- [x] `cdk/tests/test_backend_lambda_stack.py` (31 tests) passes, including the updated route-authorizer assertion which now verifies `OPTIONS /` and `OPTIONS /{proxy+}` have `AuthorizationType: NONE` while `/health` and `GET /config` remain the only other unauthenticated routes, and `ANY` GET/POST/etc. routes still require the Cognito JWT authorizer.
- [ ] After deploy, verify with curl that `OPTIONS /config`, `OPTIONS /health`, `OPTIONS /owners` return non-401 with `Access-Control-Allow-*` headers, and that authenticated requests from the CloudFront frontend succeed end-to-end (should be validated together with #3944).

Closes #3945