### PR TITLE
chore(ci): extract conflict-check check-run name to shared env var

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -7,14 +7,24 @@ on:
   push:
     branches: [main]
 
+env:
+  # Single source of truth for the check-run name shared by both jobs
+  # below. The recheck-open-prs job reads this via `$CHECK_RUN_NAME` in
+  # its `gh api` call. GitHub Actions does NOT expose the workflow-level
+  # `env` context to `jobs.<job_id>.name`, so the literal `name:` field
+  # on check-merge-conflicts (below) cannot reference this variable and
+  # must be kept in sync with it manually.
+  CHECK_RUN_NAME: "Check for merge conflicts with main"
+
 jobs:
   check-merge-conflicts:
     if: github.event_name == 'pull_request'
-    # GitHub derives the check-run name from this `name:` field.
-    # The recheck-open-prs job posts a new check-run under the same name
-    # on every push to main. GitHub branch protection evaluates the most
-    # recent check-run per name+SHA, so both triggers satisfy the same
-    # required check without any additional configuration.
+    # GitHub derives the check-run name from this `name:` field. It must
+    # match `env.CHECK_RUN_NAME` above exactly -- the recheck-open-prs
+    # job posts a new check-run under that name on every push to main.
+    # GitHub branch protection evaluates the most recent check-run per
+    # name+SHA, so both triggers satisfy the same required check without
+    # any additional configuration.
     name: Check for merge conflicts with main
     runs-on: ubuntu-latest
     permissions:
@@ -120,7 +130,7 @@ jobs:
             # name+SHA, so the fresh POST reliably satisfies the required-check
             # gate without extra configuration.
             if ! gh api "repos/$REPO/check-runs" \
-              -f name="Check for merge conflicts with main" \
+              -f name="$CHECK_RUN_NAME" \
               -f head_sha="$sha" \
               -f status="completed" \
               -f conclusion="$conclusion" \


### PR DESCRIPTION
## Summary
- Hoists the duplicated literal `"Check for merge conflicts with main"` check-run name into a workflow-level `env.CHECK_RUN_NAME` in `.github/workflows/conflict-check.yml`, used by the `recheck-open-prs` job's `gh api check-runs` call.
- The `check-merge-conflicts` job's `name:` field cannot reference `env` (GitHub Actions doesn't expose workflow-level `env` to `jobs.<job_id>.name`), so it stays a literal string with a comment pointing back to `env.CHECK_RUN_NAME` as the source of truth it must match.

Closes #3677 / Closes #3739 from the consolidated tracking issue #3816.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/conflict-check.yml'))"` confirms the YAML is still valid.
- [x] No behavioral change — `gh api` receives the same string value via `$CHECK_RUN_NAME` as before.
- [ ] CI run on this PR exercises the `check-merge-conflicts` job under the new `env` block.

Part of #3816