### PR TITLE
ci: notify PR when 'Changes Requested' label is auto-removed

### DIFF
--- a/.github/workflows/sync-changes-requested-label.yml
+++ b/.github/workflows/sync-changes-requested-label.yml
@@ -49,8 +49,16 @@ jobs:
           echo "PR #${PR_NUMBER} @ ${HEAD_SHA}: Claude=${CLAUDE_CONCLUSION}, GPT=${GPT_CONCLUSION}"
 
           if [ "$CLAUDE_CONCLUSION" = "success" ] && [ "$GPT_CONCLUSION" = "success" ]; then
-            # Errors if the label isn't on the PR; that's fine, nothing to remove.
-            gh pr edit "$PR_NUMBER" --remove-label "Changes Requested" || true
+            HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels \
+              --jq '[.labels[].name] | any(. == "Changes Requested")')
+
+            if [ "$HAS_LABEL" = "true" ]; then
+              gh pr edit "$PR_NUMBER" --remove-label "Changes Requested"
+              gh pr comment "$PR_NUMBER" --body \
+                "Both Claude and GPT AI reviews have passed for the latest commit -- removing the 'Changes Requested' label."
+            else
+              echo "Label not present on PR #${PR_NUMBER}; nothing to remove."
+            fi
           else
             echo "At least one review hasn't approved yet; leaving 'Changes Requested' label as-is."
           fi


### PR DESCRIPTION
## Summary
- `sync-changes-requested-label.yml` already removes the 'Changes Requested' label once both the Claude and GPT AI review check runs succeed for the head SHA, but did so silently.
- Now posts a PR comment confirming both AI reviews passed, but only when the label was actually present (checked via `gh pr view --json labels`) to avoid commenting on every successful run.

Closes #3681 from the consolidated tracking issue #3816.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/sync-changes-requested-label.yml'))"` confirms the YAML is still valid.
- [ ] Exercise on a real PR: trigger Claude + GPT reviews to both pass after a 'Changes Requested' label was applied, confirm the label is removed and a comment is posted.

Part of #3816