### PR TITLE
docs: document conflict-check check-run contract and label sync rules

### DIFF
--- a/docs/AI_REVIEW_WORKFLOWS.md
+++ b/docs/AI_REVIEW_WORKFLOWS.md
@@ -157,6 +157,30 @@ for `gh` CLI calls. Pass any provider-specific secret (e.g. a `GEMINI_API_KEY`) 
 a new optional secret to `_ai-pr-review.yml` and threading it through to the "Call API"
 step's `env:` block, following the existing `openai_api_key` pattern.
 
+## 'Changes Requested' label contract
+
+`claude-pr-review.yml` and `gpt-pr-review.yml` each add the `Changes
+Requested` label to a PR when their own verdict is REQUEST CHANGES (see
+[Verdict Behavior](#verdict-behavior) above). Removing the label is handled
+separately by `.github/workflows/sync-changes-requested-label.yml`, which is
+triggered via `workflow_run` after either review workflow completes.
+
+The contract: the label is removed **only when both** the `Claude AI code
+review` and `GPT AI code review` check-runs for the current head SHA have
+concluded with `success`. This cannot be done from inside either review
+job, because a job's own check-run conclusion isn't finalized until the job
+completes — so neither workflow can observe the other's conclusion in time
+when both run concurrently on the same push.
+
+When the label is removed, `sync-changes-requested-label.yml` also posts a
+PR comment confirming both AI reviews passed. If the label was not present
+(e.g. both reviews approved on the first pass), no comment is posted.
+
+If a third reviewer is added (see [Adding a new AI reviewer](#adding-a-new-ai-reviewer)),
+update `sync-changes-requested-label.yml`'s `workflows:` trigger list and its
+conclusion checks to include the new provider's check-run name — otherwise
+the label will never be removed once the new reviewer also requests changes.
+
 ## Debugging
 
 When a review fails to post, check the Actions logs for:

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -47,6 +47,35 @@ the required-check ruleset:
 - `GPT PR Review / GPT AI code review`
 - `Claude PR Review / Claude AI code review`
 
+## Merge conflict check-run
+
+`.github/workflows/conflict-check.yml` produces a check-run named
+`"Check for merge conflicts with main"` (the literal value lives in the
+workflow's `env.CHECK_RUN_NAME`) from two different triggers:
+
+- `check-merge-conflicts` runs on `pull_request` and reports the result for
+  that PR's head SHA directly via the job's own check-run.
+- `recheck-open-prs` runs on `push` to `main` and re-validates every open PR
+  against the new `main`, posting a fresh check-run under the same name for
+  each PR's head SHA via `gh api repos/$REPO/check-runs`.
+
+Both triggers must keep using the exact same check-run name so that GitHub
+branch protection's "most recent check-run per name+SHA" evaluation treats
+them as the same required check. `recheck-open-prs` always **POSTs** a new
+check-run rather than attempting a GET-then-PATCH update: the GitHub Checks
+API ties `PATCH /repos/{owner}/{repo}/check-runs/{id}` to the specific
+installation token that created the check-run, and the `pull_request` and
+`push` triggers receive distinct installation tokens even though both run as
+`github-actions[bot]`. A cross-trigger PATCH therefore returns `403`. The
+accepted trade-off is that older check-run entries accumulate (cosmetically)
+in the "Checks" tab of long-lived PRs; see the inline comments in
+`conflict-check.yml` for the full investigation history (issue #3738, PR
+#3731).
+
+This check-run is currently advisory (not in the required-checks list above).
+If it is ever added to the ruleset, update this document and the ruleset in
+the same pull request.
+
 ## CodeQL
 
 CodeQL should be added to the required-check set only after a CodeQL workflow is


### PR DESCRIPTION
## Summary
- Adds a "Merge conflict check-run" section to `docs/BRANCH_PROTECTION.md` explaining why `conflict-check.yml`'s two triggers (`check-merge-conflicts` on `pull_request`, `recheck-open-prs` on `push`) must share one check-run name (`env.CHECK_RUN_NAME`), and why `recheck-open-prs` always POSTs a new check-run instead of PATCHing (cross-trigger installation tokens return 403 on PATCH).
- Adds a "'Changes Requested' label contract" section to `docs/AI_REVIEW_WORKFLOWS.md` documenting `sync-changes-requested-label.yml`'s "both reviews must succeed" rule and the PR comment it now posts when removing the label, plus a note for anyone adding a third AI reviewer.

Closes #3680 / #3753 / #3756 / #3735 from the consolidated tracking issue #3816.

## Test plan
- Documentation only — no code changes. Reviewed for accuracy against the current `conflict-check.yml` and `sync-changes-requested-label.yml` contents.

Part of #3816