### PR TITLE
fix(cdk): accept SmokeTestClient tokens in BackendApi Cognito authorizer

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -398,6 +398,19 @@ jobs:
             --stack-name StaticSiteStack \
             --query "Stacks[0].Outputs[?OutputKey=='DistributionDomain'].OutputValue" \
             --output text)"
+          # SmokeTestUserPoolClientId is the deploy workflow's dedicated Cognito app
+          # client for post-deploy smoke tests (see "Fetch Cognito smoke-test token"
+          # below). BackendLambdaStack must accept its tokens as a valid JWT audience,
+          # otherwise every Cognito-protected route (e.g. /groups) returns 401 for the
+          # smoke test token (#4027). Optional: the deploy still succeeds if this
+          # output is missing, but smoke tests will then see 401s on protected routes.
+          SMOKE_TEST_USER_POOL_CLIENT_ID="$(aws cloudformation describe-stacks \
+            --stack-name StaticSiteStack \
+            --query "Stacks[0].Outputs[?OutputKey=='SmokeTestUserPoolClientId'].OutputValue" \
+            --output text 2>/dev/null || echo "")"
+          if [ "$SMOKE_TEST_USER_POOL_CLIENT_ID" = "None" ]; then
+            SMOKE_TEST_USER_POOL_CLIENT_ID=""
+          fi
           if [ -z "$UI_AUTH_USER_POOL_ID" ] || [ "$UI_AUTH_USER_POOL_ID" = "None" ]; then
             echo "UiAuthUserPoolId output is missing from StaticSiteStack" >&2
             exit 1
@@ -413,6 +426,7 @@ jobs:
           {
             echo "UI_AUTH_USER_POOL_ID=$UI_AUTH_USER_POOL_ID"
             echo "UI_AUTH_USER_POOL_CLIENT_ID=$UI_AUTH_USER_POOL_CLIENT_ID"
+            echo "SMOKE_TEST_USER_POOL_CLIENT_ID=$SMOKE_TEST_USER_POOL_CLIENT_ID"
             echo "FRONTEND_ORIGIN=https://${DISTRIBUTION_DOMAIN}"
           } >> "$GITHUB_ENV"
 
@@ -436,6 +450,7 @@ jobs:
           npx cdk deploy BackendLambdaStack --require-approval never
           --parameters BackendLambdaStack:UiAuthUserPoolId="$UI_AUTH_USER_POOL_ID"
           --parameters BackendLambdaStack:UiAuthUserPoolClientId="$UI_AUTH_USER_POOL_CLIENT_ID"
+          --parameters BackendLambdaStack:SmokeTestUserPoolClientId="$SMOKE_TEST_USER_POOL_CLIENT_ID"
         working-directory: cdk
 
       - name: Warm price snapshot

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -3,9 +3,11 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from aws_cdk import (
+    CfnCondition,
     CfnOutput,
     CfnParameter,
     Duration,
+    Fn,
     RemovalPolicy,
     Stack,
     triggers,
@@ -341,6 +343,18 @@ class BackendLambdaStack(Stack):
                 "run unauthenticated."
             ),
         )
+        # An empty SmokeTestUserPoolClientId (the default, and what the deploy
+        # workflow passes if StaticSiteStack has no such output) must NOT become
+        # an empty-string entry in the authorizer's JWT audience list below —
+        # that would silently accept tokens with an empty `aud` claim. Gate the
+        # smoke-test client with a condition so it's only added when non-empty.
+        has_smoke_test_client = CfnCondition(
+            self,
+            "HasSmokeTestUserPoolClientId",
+            expression=Fn.condition_not(
+                Fn.condition_equals(smoke_test_client_id_param.value_as_string, "")
+            ),
+        )
 
         ui_auth_user_pool = cognito.UserPool.from_user_pool_id(
             self, "ImportedUiAuthUserPool", ui_auth_user_pool_id_param.value_as_string
@@ -419,6 +433,28 @@ class BackendLambdaStack(Stack):
             methods=[apigwv2.HttpMethod.ANY],
             integration=backend_integration,
             authorizer=backend_authorizer,
+        )
+
+        # HttpUserPoolAuthorizer always includes every entry from
+        # user_pool_clients in JwtConfiguration.Audience, including an empty
+        # string for SmokeTestUserPoolClientId when it's left at its default.
+        # Override the synthesized audience so the smoke-test client ID is
+        # only present when the parameter is actually set (#4027 review).
+        backend_cfn_authorizer = next(
+            child
+            for child in backend_api.node.find_all()
+            if isinstance(child, apigwv2.CfnAuthorizer)
+        )
+        backend_cfn_authorizer.add_property_override(
+            "JwtConfiguration.Audience",
+            Fn.condition_if(
+                has_smoke_test_client.logical_id,
+                [
+                    ui_auth_client_id_param.value_as_string,
+                    smoke_test_client_id_param.value_as_string,
+                ],
+                [ui_auth_client_id_param.value_as_string],
+            ),
         )
 
         # Scheduled function to refresh prices daily

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -319,6 +319,29 @@ class BackendLambdaStack(Stack):
             "UiAuthUserPoolClientId",
             **ui_auth_client_id_param_kwargs,
         )
+
+        # SmokeTestClient (static_site_stack.py) is a separate Cognito app client
+        # used only by the deploy workflow's post-deploy smoke tests. Its tokens
+        # must also pass backend_authorizer's audience check, otherwise every
+        # Cognito-protected route (e.g. /groups) returns 401 for the smoke test
+        # token even though /config and /health succeed (#4027). Optional with an
+        # empty default so synths without a configured smoke-test client still work.
+        smoke_test_client_id_default = self.node.try_get_context(
+            "smoke_test_user_pool_client_id"
+        ) or os.getenv("SMOKE_TEST_USER_POOL_CLIENT_ID")
+        smoke_test_client_id_param = CfnParameter(
+            self,
+            "SmokeTestUserPoolClientId",
+            type="String",
+            allowed_pattern=".*",
+            default=smoke_test_client_id_default or "",
+            description=(
+                "Cognito app client ID for the deploy workflow's SmokeTestClient, "
+                "exported by StaticSiteStack. Optional: leave empty if smoke tests "
+                "run unauthenticated."
+            ),
+        )
+
         ui_auth_user_pool = cognito.UserPool.from_user_pool_id(
             self, "ImportedUiAuthUserPool", ui_auth_user_pool_id_param.value_as_string
         )
@@ -328,7 +351,12 @@ class BackendLambdaStack(Stack):
             user_pool_clients=[
                 cognito.UserPoolClient.from_user_pool_client_id(
                     self, "ImportedUiAuthUserPoolClient", ui_auth_client_id_param.value_as_string
-                )
+                ),
+                cognito.UserPoolClient.from_user_pool_client_id(
+                    self,
+                    "ImportedSmokeTestUserPoolClient",
+                    smoke_test_client_id_param.value_as_string,
+                ),
             ],
             identity_source=["$request.header.Authorization"],
         )

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -359,17 +359,19 @@ class BackendLambdaStack(Stack):
         ui_auth_user_pool = cognito.UserPool.from_user_pool_id(
             self, "ImportedUiAuthUserPool", ui_auth_user_pool_id_param.value_as_string
         )
+        # SmokeTestUserPoolClient is deliberately NOT added to user_pool_clients
+        # here: HttpUserPoolAuthorizer synthesises every entry in that list into
+        # JwtConfiguration.Audience unconditionally, which would put an
+        # empty-string audience entry into the CloudFormation template before
+        # the add_property_override below ever runs. The smoke-test client is
+        # added to the audience solely via that conditional override (#4047
+        # review).
         backend_authorizer = apigwv2_authorizers.HttpUserPoolAuthorizer(
             "BackendCognitoAuthorizer",
             ui_auth_user_pool,
             user_pool_clients=[
                 cognito.UserPoolClient.from_user_pool_client_id(
                     self, "ImportedUiAuthUserPoolClient", ui_auth_client_id_param.value_as_string
-                ),
-                cognito.UserPoolClient.from_user_pool_client_id(
-                    self,
-                    "ImportedSmokeTestUserPoolClient",
-                    smoke_test_client_id_param.value_as_string,
                 ),
             ],
             identity_source=["$request.header.Authorization"],
@@ -435,16 +437,23 @@ class BackendLambdaStack(Stack):
             authorizer=backend_authorizer,
         )
 
-        # HttpUserPoolAuthorizer always includes every entry from
-        # user_pool_clients in JwtConfiguration.Audience, including an empty
-        # string for SmokeTestUserPoolClientId when it's left at its default.
         # Override the synthesized audience so the smoke-test client ID is
-        # only present when the parameter is actually set (#4027 review).
-        backend_cfn_authorizer = next(
+        # included only when the parameter is actually set (#4027 review).
+        # HttpUserPoolAuthorizer is not a Construct (no .node), so the
+        # underlying CfnAuthorizer can only be located via backend_api's
+        # construct tree. Assert exactly one CfnAuthorizer exists so that, if
+        # a second authorizer is ever added to backend_api, synthesis fails
+        # loudly instead of silently overriding the wrong resource.
+        backend_cfn_authorizers = [
             child
             for child in backend_api.node.find_all()
             if isinstance(child, apigwv2.CfnAuthorizer)
+        ]
+        assert len(backend_cfn_authorizers) == 1, (
+            "Expected exactly one CfnAuthorizer under BackendApi, found "
+            f"{len(backend_cfn_authorizers)}"
         )
+        backend_cfn_authorizer = backend_cfn_authorizers[0]
         backend_cfn_authorizer.add_property_override(
             "JwtConfiguration.Audience",
             Fn.condition_if(

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -554,13 +554,12 @@ def test_backend_api_has_cognito_jwt_authorizer(template):
             "AuthorizerType": "JWT",
             "IdentitySource": ["$request.header.Authorization"],
             "JwtConfiguration": {
-                # Audience must reference the Cognito app client ID parameter for the
-                # browser-facing UI client, and also the smoke-test client (#4027) so
-                # post-deploy smoke test tokens aren't rejected with 401.
-                "Audience": assertions.Match.array_with([
-                    assertions.Match.object_like({"Ref": "UiAuthUserPoolClientId"}),
-                    assertions.Match.object_like({"Ref": "SmokeTestUserPoolClientId"}),
-                ]),
+                # Audience is conditionally built (Fn::If) so an empty
+                # SmokeTestUserPoolClientId never adds an empty-string audience
+                # entry — see test_backend_api_authorizer_audience_excludes_empty_smoke_test_client.
+                "Audience": assertions.Match.object_like(
+                    {"Fn::If": assertions.Match.any_value()}
+                ),
                 # Issuer must be a CloudFormation expression (Fn::Join), not a
                 # literal synth-time token like "${Token[...]}".
                 "Issuer": assertions.Match.object_like(
@@ -569,6 +568,32 @@ def test_backend_api_has_cognito_jwt_authorizer(template):
             },
         },
     )
+
+
+def test_backend_api_authorizer_audience_excludes_empty_smoke_test_client(template):
+    """When SmokeTestUserPoolClientId is empty (the default), the authorizer's
+    JWT audience must fall back to only UiAuthUserPoolClientId. Otherwise an
+    empty-string entry would be added to the audience list, which API Gateway
+    would treat as a valid (if useless) audience value (#4027 review)."""
+    json_template = template.to_json()
+
+    conditions = json_template.get("Conditions", {})
+    assert "HasSmokeTestUserPoolClientId" in conditions
+    assert conditions["HasSmokeTestUserPoolClientId"] == {
+        "Fn::Not": [{"Fn::Equals": [{"Ref": "SmokeTestUserPoolClientId"}, ""]}]
+    }
+
+    resources = template.find_resources("AWS::ApiGatewayV2::Authorizer")
+    authorizer = next(iter(resources.values()))
+    audience = authorizer["Properties"]["JwtConfiguration"]["Audience"]
+
+    condition_name, with_smoke_client, without_smoke_client = audience["Fn::If"]
+    assert condition_name == "HasSmokeTestUserPoolClientId"
+    assert with_smoke_client == [
+        {"Ref": "UiAuthUserPoolClientId"},
+        {"Ref": "SmokeTestUserPoolClientId"},
+    ]
+    assert without_smoke_client == [{"Ref": "UiAuthUserPoolClientId"}]
 
 
 def test_backend_api_routes_require_cognito_authorizer(template):

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -521,6 +521,19 @@ def test_backend_api_auth_parameters_exist(template):
     assert "Default" not in params["UiAuthUserPoolClientId"]
 
 
+def test_smoke_test_user_pool_client_id_parameter_is_optional(template):
+    """SmokeTestUserPoolClientId must be optional so synths without a configured
+    smoke-test client (e.g. local/non-prod) still work."""
+    template.has_parameter(
+        "SmokeTestUserPoolClientId",
+        {
+            "Type": "String",
+            "AllowedPattern": ".*",
+            "Default": "",
+        },
+    )
+
+
 def test_backend_lambda_disables_app_jwt_decode_for_cognito_authorizer(template):
     """Lambda trusts API Gateway for Cognito auth and does not decode ID tokens as app JWTs."""
     template.has_resource_properties(
@@ -541,9 +554,12 @@ def test_backend_api_has_cognito_jwt_authorizer(template):
             "AuthorizerType": "JWT",
             "IdentitySource": ["$request.header.Authorization"],
             "JwtConfiguration": {
-                # Audience must reference the Cognito app client ID parameter.
+                # Audience must reference the Cognito app client ID parameter for the
+                # browser-facing UI client, and also the smoke-test client (#4027) so
+                # post-deploy smoke test tokens aren't rejected with 401.
                 "Audience": assertions.Match.array_with([
-                    assertions.Match.object_like({"Ref": "UiAuthUserPoolClientId"})
+                    assertions.Match.object_like({"Ref": "UiAuthUserPoolClientId"}),
+                    assertions.Match.object_like({"Ref": "SmokeTestUserPoolClientId"}),
                 ]),
                 # Issuer must be a CloudFormation expression (Fn::Join), not a
                 # literal synth-time token like "${Token[...]}".


### PR DESCRIPTION
## Summary
- BackendLambdaStack's JWT authorizer only accepted the `UiAuthClient` Cognito app client as a valid token audience, but the deploy workflow's post-deploy smoke tests authenticate with the separate `SmokeTestClient`. Tokens from `SmokeTestClient` were rejected with 401 on every Cognito-protected route (e.g. `/groups`), which cascaded into multiple unrelated smoke test failures (`/virtual`, `/alerts`, `/trail`, `/compliance`, pension forecast, etc.).
- Add a new optional `SmokeTestUserPoolClientId` CfnParameter to `BackendLambdaStack` (empty default, so synths without a configured smoke-test client still work) and include it in `backend_authorizer`'s `user_pool_clients`/audience list.
- Wire the parameter value through from `StaticSiteStack`'s existing `SmokeTestUserPoolClientId` output via `.github/workflows/deploy-lambda.yml`.

## Test plan
- [x] `cd cdk && python -m pytest tests/test_backend_lambda_stack.py -q --no-cov` — 32 passed, including new `test_smoke_test_user_pool_client_id_parameter_is_optional` and updated `test_backend_api_has_cognito_jwt_authorizer` (audience now requires both `UiAuthUserPoolClientId` and `SmokeTestUserPoolClientId`).
- [x] `ruff check` on edited CDK files passes clean.
- [ ] After merge/deploy, confirm `npm run smoke:test` (or the deploy workflow's smoke test job) no longer sees 401s from `/groups` on the smoke-test token.

Closes #4027