### PR TITLE
chore(deploy): add post-deploy CORS smoke-test step to deploy-lambda.yml

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -555,7 +555,7 @@ jobs:
             echo "$response" >&2
             exit 1
           fi
-          cors_header="$(echo "$response" | grep -i '^access-control-allow-origin:' | tr -d '\r' | sed 's/^[Aa]ccess-[Cc]ontrol-[Aa]llow-[Oo]rigin: *//')"
+          cors_header="$( (echo "$response" | grep -i '^access-control-allow-origin:' || true) | head -n 1 | tr -d '\r' | sed 's/^[^:]*: *//')"
           if [ -z "$cors_header" ]; then
             echo "::error::Access-Control-Allow-Origin header missing from ${BACKEND_URL%/}/config response" >&2
             echo "$response" >&2

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -545,25 +545,27 @@ jobs:
         run: |
           set -euo pipefail
           echo "Checking CORS headers on ${BACKEND_URL%/}/config for Origin: ${FRONTEND_ORIGIN}"
-          response="$(curl --retry 3 --retry-delay 5 --retry-all-errors \
-            --max-time 60 --silent --include \
+          headers_file="$(mktemp)"
+          trap 'rm -f "$headers_file"' EXIT
+          status="$(curl --retry 3 --retry-delay 5 --retry-all-errors \
+            --max-time 60 --silent --output /dev/null --write-out "%{http_code}" \
+            -D "$headers_file" \
             -H "Origin: ${FRONTEND_ORIGIN}" \
             "${BACKEND_URL%/}/config")"
-          status="$(echo "$response" | head -n 1 | tr -d '\r' | awk '{print $2}')"
           if [ "$status" != "200" ]; then
             echo "::error::Expected HTTP 200 from ${BACKEND_URL%/}/config, got $status" >&2
-            echo "$response" >&2
+            cat "$headers_file" >&2
             exit 1
           fi
-          cors_header="$( (echo "$response" | grep -i '^access-control-allow-origin:' || true) | head -n 1 | tr -d '\r' | sed 's/^[^:]*: *//')"
+          cors_header="$( (grep -i '^access-control-allow-origin:' "$headers_file" || true) | tail -n 1 | tr -d '\r' | sed 's/^[^:]*: *//')"
           if [ -z "$cors_header" ]; then
             echo "::error::Access-Control-Allow-Origin header missing from ${BACKEND_URL%/}/config response" >&2
-            echo "$response" >&2
+            cat "$headers_file" >&2
             exit 1
           fi
           if [ "$cors_header" != "${FRONTEND_ORIGIN}" ]; then
             echo "::error::Access-Control-Allow-Origin mismatch: expected ${FRONTEND_ORIGIN}, got ${cors_header}" >&2
-            echo "$response" >&2
+            cat "$headers_file" >&2
             exit 1
           fi
           echo "CORS configuration OK: Access-Control-Allow-Origin: ${cors_header}"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -535,6 +535,39 @@ jobs:
           echo "SMOKE_TEST_URL=$BACKEND_URL" >> "$GITHUB_ENV"
           echo "backend_url=$BACKEND_URL" >> "$GITHUB_OUTPUT"
 
+      - name: Verify CORS configuration
+        # Validates the CORS fix from PR #3954: BackendLambdaStack's /config
+        # route must echo back FRONTEND_ORIGIN (the CloudFront distribution
+        # domain) in Access-Control-Allow-Origin when called with a matching
+        # Origin header. If the CDK code path fails to pick up FRONTEND_ORIGIN,
+        # this would otherwise pass CI silently and break the deployed
+        # frontend (stuck on "Loading... retrying configuration"). See #3984.
+        run: |
+          set -euo pipefail
+          echo "Checking CORS headers on ${BACKEND_URL%/}/config for Origin: ${FRONTEND_ORIGIN}"
+          response="$(curl --retry 3 --retry-delay 5 --retry-all-errors \
+            --max-time 60 --silent --include \
+            -H "Origin: ${FRONTEND_ORIGIN}" \
+            "${BACKEND_URL%/}/config")"
+          status="$(echo "$response" | head -n 1 | tr -d '\r' | awk '{print $2}')"
+          if [ "$status" != "200" ]; then
+            echo "::error::Expected HTTP 200 from ${BACKEND_URL%/}/config, got $status" >&2
+            echo "$response" >&2
+            exit 1
+          fi
+          cors_header="$(echo "$response" | grep -i '^access-control-allow-origin:' | tr -d '\r' | sed 's/^[Aa]ccess-[Cc]ontrol-[Aa]llow-[Oo]rigin: *//')"
+          if [ -z "$cors_header" ]; then
+            echo "::error::Access-Control-Allow-Origin header missing from ${BACKEND_URL%/}/config response" >&2
+            echo "$response" >&2
+            exit 1
+          fi
+          if [ "$cors_header" != "${FRONTEND_ORIGIN}" ]; then
+            echo "::error::Access-Control-Allow-Origin mismatch: expected ${FRONTEND_ORIGIN}, got ${cors_header}" >&2
+            echo "$response" >&2
+            exit 1
+          fi
+          echo "CORS configuration OK: Access-Control-Allow-Origin: ${cors_header}"
+
       - name: Refresh StaticSiteStack runtime config
         # GITHUB_DEPLOY_ROLE_ARN must be set here too (see "Deploy StaticSiteStack
         # auth resources" above and #3846): without it, this redeploy of


### PR DESCRIPTION
## Summary
- Adds a "Verify CORS configuration" step to `.github/workflows/deploy-lambda.yml`, run after the backend API URL is resolved post-deploy
- Issues a `curl` to `${BACKEND_URL}/config` with an `Origin: ${FRONTEND_ORIGIN}` header and asserts:
  - HTTP 200 response
  - `Access-Control-Allow-Origin` header present and equal to `FRONTEND_ORIGIN`
- Fails the workflow with a clear `::error::` message (and dumps the response) if either check fails

This catches regressions where the CORS fix from PR #3954 (dynamically deriving `FRONTEND_ORIGIN` and passing it to `BackendLambdaStack`) silently breaks, which would otherwise leave the deployed frontend stuck on "Loading... retrying configuration."

Closes #3984

## Test plan
- [x] `yaml.safe_load` confirms the workflow file is valid YAML
- [ ] Next production deploy run on tag push will exercise the new step against the real Lambda/CloudFront stacks