### PR TITLE
fix(cdk): fail synthesis loudly when GITHUB_DEPLOY_ROLE_ARN is missing in prod

### DIFF
--- a/.github/workflows/cdk-dry-run.yml
+++ b/.github/workflows/cdk-dry-run.yml
@@ -61,6 +61,8 @@ jobs:
         # npm ci step above), so npx resolves the correct version without a
         # separate npm ci inside cdk/. No cdk/package.json exists in this repo.
         # JWT_SECRET and GOOGLE_CLIENT_ID are required non-empty by backend_lambda_stack.py.
+        # GITHUB_DEPLOY_ROLE_ARN is required by static_site_stack.py when prod=true
+        # (issue #3870) so synth fails loudly if the deploy workflow ever forgets it.
         # Dummy placeholder values are safe — synth only generates the
         # CloudFormation template; no deploy or AWS call is made.
         # --output flag (not CDK_OUTDIR env var) guarantees isolation per run
@@ -68,6 +70,7 @@ jobs:
         env:
           JWT_SECRET: dry-run-placeholder
           GOOGLE_CLIENT_ID: dry-run-placeholder.apps.googleusercontent.com
+          GITHUB_DEPLOY_ROLE_ARN: arn:aws:iam::123456789012:role/dry-run-placeholder
         run: npx cdk synth BackendLambdaStack StaticSiteStack -c prod=true --output /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
         working-directory: cdk
 

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -47,6 +47,19 @@ class StaticSiteStack(Stack):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
+        # Fail synthesis loudly if the GitHub deploy role grant would be
+        # silently omitted in a production deploy. A missing GITHUB_DEPLOY_ROLE_ARN
+        # previously caused CloudFormation to delete the IAM grant resource
+        # without any signal, masking the real cause of a deploy failure.
+        # See #3847 and #3866 for context.
+        github_deploy_role_arn = os.getenv("GITHUB_DEPLOY_ROLE_ARN", "")
+        if _is_truthy_context(self.node.try_get_context("prod")) and not github_deploy_role_arn:
+            raise ValueError(
+                "GITHUB_DEPLOY_ROLE_ARN is required for prod StaticSiteStack "
+                "(passed via the GITHUB_DEPLOY_ROLE_ARN env var). "
+                "See #3847 and #3866 for context."
+            )
+
         ui_auth_removal_policy = _ui_auth_removal_policy(self)
 
         # BucketDeployment.Source.json_data() only accepts intra-stack tokens
@@ -413,7 +426,6 @@ class StaticSiteStack(Stack):
         # access. Anchoring the grant in StaticSiteStack—deployed first in the
         # workflow—ensures the permissions persist regardless of BackendLambdaStack
         # churn. Covers both stacks because `cdk diff` targets both. See #3192.
-        github_deploy_role_arn = os.getenv("GITHUB_DEPLOY_ROLE_ARN", "")
         if github_deploy_role_arn:
             # mutable=True is required: the role is bootstrapped externally
             # (bootstrap-deploy-role.sh) but CDK is the source of truth for

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -378,7 +378,10 @@ def test_ui_auth_user_pool_is_destroyed_by_default(tmp_path):
     )
 
 
-def test_ui_auth_user_pool_is_retained_for_prod_context(tmp_path):
+def test_ui_auth_user_pool_is_retained_for_prod_context(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "GITHUB_DEPLOY_ROLE_ARN", "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    )
     template = _template_with_context(tmp_path, {"prod": "true"})
     template.has_resource(
         "AWS::Cognito::UserPool",
@@ -902,3 +905,42 @@ def test_no_cognito_user_pool_client_grant_when_github_deploy_role_arn_absent(
         "Expected no cognito-idp:UpdateUserPoolClient in StaticSiteStack when "
         "GITHUB_DEPLOY_ROLE_ARN is unset"
     )
+
+
+# ---------------------------------------------------------------------------
+# GitHub deploy role — required in prod (issue #3870)
+# ---------------------------------------------------------------------------
+
+
+def test_prod_without_github_deploy_role_arn_raises(monkeypatch, tmp_path) -> None:
+    """A prod-context synth must fail loudly when GITHUB_DEPLOY_ROLE_ARN is unset
+    rather than silently omitting the IAM grant. See #3847 and #3866."""
+    monkeypatch.delenv("GITHUB_DEPLOY_ROLE_ARN", raising=False)
+    (tmp_path / "index.html").write_text("<html></html>")
+    app = App(context={"prod": "true"})
+    with pytest.raises(ValueError, match="GITHUB_DEPLOY_ROLE_ARN"):
+        StaticSiteStack(app, "ProdNoRoleStack", frontend_dist_path=str(tmp_path))
+
+
+def test_prod_with_github_deploy_role_arn_synthesises(monkeypatch, tmp_path) -> None:
+    """A prod-context synth must succeed when GITHUB_DEPLOY_ROLE_ARN is set."""
+    monkeypatch.setenv(
+        "GITHUB_DEPLOY_ROLE_ARN", "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    )
+    (tmp_path / "index.html").write_text("<html></html>")
+    app = App(context={"prod": "true"})
+    # Must not raise.
+    stack = StaticSiteStack(app, "ProdWithRoleStack", frontend_dist_path=str(tmp_path))
+    app.synth()
+    assert stack is not None
+
+
+def test_non_prod_without_github_deploy_role_arn_synthesises(monkeypatch, tmp_path) -> None:
+    """Non-prod (dev/staging) stacks must synthesise without GITHUB_DEPLOY_ROLE_ARN set."""
+    monkeypatch.delenv("GITHUB_DEPLOY_ROLE_ARN", raising=False)
+    (tmp_path / "index.html").write_text("<html></html>")
+    app = App()
+    # Must not raise.
+    stack = StaticSiteStack(app, "DevNoRoleStack", frontend_dist_path=str(tmp_path))
+    app.synth()
+    assert stack is not None


### PR DESCRIPTION
## Summary
- `StaticSiteStack.__init__` now raises a `ValueError` early during synthesis if `prod` context is truthy and `GITHUB_DEPLOY_ROLE_ARN` is unset/empty, instead of silently omitting the IAM grant.
- Non-prod stages (dev/staging) continue to synthesize fine without the env var, since the existing `if github_deploy_role_arn:` block remains optional.

## Why
A missing `GITHUB_DEPLOY_ROLE_ARN` previously caused CloudFormation to silently delete the deploy-role IAM grant resource with no signal, masking the real cause of a deploy failure across multiple cycles (see #3847, #3866).

## Test plan
- [x] `python -m pytest cdk/tests/test_static_site_stack.py -q` — 48 passed
- [x] New test `test_prod_without_github_deploy_role_arn_raises` confirms prod synth fails fast with a clear error naming `GITHUB_DEPLOY_ROLE_ARN`
- [x] New test `test_prod_with_github_deploy_role_arn_synthesises` confirms prod synth succeeds when the env var is set
- [x] New test `test_non_prod_without_github_deploy_role_arn_synthesises` confirms dev/staging still synth without it
- [x] Existing `test_ui_auth_user_pool_is_retained_for_prod_context` updated to set the env var since it uses `prod=true` context

Closes #3870