### PR TITLE
chore(ci): add post-deploy smoke test asserting CORS headers on /config

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -538,7 +538,7 @@ jobs:
 
       - name: Smoke test — assert CORS headers on /config from CloudFront origin
         run: |
-          set -e
+          set -eu
 
           # Retrieve the deployed backend URL and CloudFront origin
           BACKEND_URL="${{ env.BACKEND_URL }}"
@@ -546,13 +546,15 @@ jobs:
 
           echo "Testing CORS on ${BACKEND_URL}/config with Origin: ${ORIGIN}"
 
-          # Curl /config with Origin header, capture full response including headers
-          RESPONSE=$(curl -s -i \
+          # Curl /config with Origin header, capture full response including headers.
+          # Use --http1.1 to preserve header case; HTTP/2 lowercases headers which
+          # would cause the case-sensitive grep below to fail on correctly configured CORS.
+          RESPONSE=$(curl -s -i --http1.1 \
             -H "Origin: ${ORIGIN}" \
             "${BACKEND_URL}/config")
 
-          # Assert header is present and matches
-          if echo "${RESPONSE}" | grep -q "Access-Control-Allow-Origin: ${ORIGIN}"; then
+          # Assert header is present and matches (case-insensitive to handle HTTP/2 responses).
+          if echo "${RESPONSE}" | grep -qi "Access-Control-Allow-Origin: ${ORIGIN}"; then
             echo "✓ CORS header correctly set to: ${ORIGIN}"
           else
             echo "✗ CORS header missing or mismatched"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -428,7 +428,6 @@ jobs:
             echo "UI_AUTH_USER_POOL_CLIENT_ID=$UI_AUTH_USER_POOL_CLIENT_ID"
             echo "SMOKE_TEST_USER_POOL_CLIENT_ID=$SMOKE_TEST_USER_POOL_CLIENT_ID"
             echo "FRONTEND_ORIGIN=https://${DISTRIBUTION_DOMAIN}"
-            echo "CORS_ORIGINS=https://${DISTRIBUTION_DOMAIN},https://app.allotmint.io"
           } >> "$GITHUB_ENV"
 
       - name: Deploy BackendLambdaStack
@@ -540,7 +539,8 @@ jobs:
         run: |
           set -eu
 
-          # Retrieve the deployed backend URL and CloudFront origin
+          # Retrieve the deployed backend URL (exported by "Get backend API URL" step)
+          # and CloudFront origin (exported by "Get Cognito UI auth outputs" step).
           BACKEND_URL="${{ env.BACKEND_URL }}"
           ORIGIN="${{ env.FRONTEND_ORIGIN }}"
 

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -553,8 +553,9 @@ jobs:
             -H "Origin: ${ORIGIN}" \
             "${BACKEND_URL}/config")
 
-          # Assert header is present and matches (case-insensitive to handle HTTP/2 responses).
-          if echo "${RESPONSE}" | grep -qi "Access-Control-Allow-Origin: ${ORIGIN}"; then
+          # Assert header is present and matches. Use -F for fixed-string matching (ORIGIN
+          # contains `.` which is a regex metacharacter), and -i for case-insensitive matching.
+          if echo "${RESPONSE}" | grep -qFi "Access-Control-Allow-Origin: ${ORIGIN}"; then
             echo "✓ CORS header correctly set to: ${ORIGIN}"
           else
             echo "✗ CORS header missing or mismatched"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -428,6 +428,7 @@ jobs:
             echo "UI_AUTH_USER_POOL_CLIENT_ID=$UI_AUTH_USER_POOL_CLIENT_ID"
             echo "SMOKE_TEST_USER_POOL_CLIENT_ID=$SMOKE_TEST_USER_POOL_CLIENT_ID"
             echo "FRONTEND_ORIGIN=https://${DISTRIBUTION_DOMAIN}"
+            echo "CORS_ORIGINS=https://${DISTRIBUTION_DOMAIN},https://app.allotmint.io"
           } >> "$GITHUB_ENV"
 
       - name: Deploy BackendLambdaStack
@@ -534,6 +535,31 @@ jobs:
           # backend API URL as required by issue #3193.
           echo "SMOKE_TEST_URL=$BACKEND_URL" >> "$GITHUB_ENV"
           echo "backend_url=$BACKEND_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test — assert CORS headers on /config from CloudFront origin
+        run: |
+          set -e
+
+          # Retrieve the deployed backend URL and CloudFront origin
+          BACKEND_URL="${{ env.BACKEND_URL }}"
+          ORIGIN="${{ env.FRONTEND_ORIGIN }}"
+
+          echo "Testing CORS on ${BACKEND_URL}/config with Origin: ${ORIGIN}"
+
+          # Curl /config with Origin header, capture full response including headers
+          RESPONSE=$(curl -s -i \
+            -H "Origin: ${ORIGIN}" \
+            "${BACKEND_URL}/config")
+
+          # Assert header is present and matches
+          if echo "${RESPONSE}" | grep -q "Access-Control-Allow-Origin: ${ORIGIN}"; then
+            echo "✓ CORS header correctly set to: ${ORIGIN}"
+          else
+            echo "✗ CORS header missing or mismatched"
+            echo "Response headers:"
+            echo "${RESPONSE}" | head -20
+            exit 1
+          fi
 
       - name: Refresh StaticSiteStack runtime config
         # GITHUB_DEPLOY_ROLE_ARN must be set here too (see "Deploy StaticSiteStack


### PR DESCRIPTION
## Summary
Add a new GitHub Actions step to the deploy workflow that validates CORS headers on the `/config` endpoint after deployment. This smoke test ensures the CloudFront origin is correctly included in the backend's CORS allow-list at deploy time.

## Test plan
- The step runs after `Deploy BackendLambdaStack` and uses the captured `BACKEND_URL` and `FRONTEND_ORIGIN` environment variables
- Curls the `/config` endpoint with an `Origin` header set to the CloudFront domain
- Asserts that the response includes `Access-Control-Allow-Origin: <CloudFront domain>`
- Fails the workflow if the header is missing or mismatched

## Why this matters
PR #3954 injects the live CloudFront origin into the CORS allow-list at deploy time, but this was only validated manually. Without automated assertion:
- Future changes to `backend_lambda_stack.py` or env-var capture logic could silently break CORS
- Refactoring risks would only be caught by manual post-deploy testing
- The integration between the CloudFront domain capture and CORS configuration is untested

This smoke test makes the CORS contract explicit and executable, preventing regressions.

Closes #3993