### PR TITLE
chore(cdk): sanitise DISTRIBUTION_DOMAIN CfnOutput to guarantee bare-hostname format

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -398,6 +398,14 @@ jobs:
             --stack-name StaticSiteStack \
             --query "Stacks[0].Outputs[?OutputKey=='DistributionDomain'].OutputValue" \
             --output text)"
+          # Sanitise DISTRIBUTION_DOMAIN to guarantee bare-hostname format (no scheme, no trailing slash).
+          # This guards against future CDK output changes that might include a scheme (e.g.,
+          # https://d32n5ua14kb82t.cloudfront.net) or trailing artifacts from shell capture.
+          # Defensive strip operations ensure FRONTEND_ORIGIN is always https://<bare-hostname>.
+          DISTRIBUTION_DOMAIN="${DISTRIBUTION_DOMAIN#https://}"
+          DISTRIBUTION_DOMAIN="${DISTRIBUTION_DOMAIN#http://}"
+          DISTRIBUTION_DOMAIN="${DISTRIBUTION_DOMAIN%/}"
+          DISTRIBUTION_DOMAIN="$(echo "$DISTRIBUTION_DOMAIN" | xargs)"
           # SmokeTestUserPoolClientId is the deploy workflow's dedicated Cognito app
           # client for post-deploy smoke tests (see "Fetch Cognito smoke-test token"
           # below). BackendLambdaStack must accept its tokens as a valid JWT audience,


### PR DESCRIPTION
## Summary

Sanitise the `DISTRIBUTION_DOMAIN` value captured from the StaticSiteStack CloudFormation output before using it to construct `FRONTEND_ORIGIN`. Specifically:

1. Strip any leading `https://` or `http://` scheme (defensive guard against future CDK output changes)
2. Strip any trailing whitespace or `/` (defensive guard against shell capture artifacts)

## Correctness Risk

The current code assumes `DISTRIBUTION_DOMAIN` is a bare hostname:
```bash
echo "FRONTEND_ORIGIN=https://${DISTRIBUTION_DOMAIN}"
```

If the CDK output were ever changed to include a scheme (e.g., `https://d32n5ua14kb82t.cloudfront.net`), this would silently produce `FRONTEND_ORIGIN=https://https://d32n5ua14kb82t.cloudfront.net`. The CORS validation would fail without obvious error because the malformed origin would never match the `Origin` header in incoming requests.

Similarly, if `describe-stacks` ever returns trailing whitespace, the CORS origin would silently mismatch.

## Defensive Implementation

The defensive strip operations document the contract: "this output must be a bare hostname" and guard against the assumption breaking on future changes.

Closes #3995

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>