### PR TITLE
chore(cdk): add app.allotmint.io to default CORS origins

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -219,7 +219,11 @@ class BackendLambdaStack(Stack):
         )
         extra_cors_origins = self.node.try_get_context("cors_origins") or os.getenv("CORS_ORIGINS")
 
-        cors_origins = ["http://localhost:3000", "http://localhost:5173"]
+        cors_origins = [
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "https://app.allotmint.io",
+        ]
         if frontend_origin:
             cors_origins.insert(0, frontend_origin)
         if extra_cors_origins:


### PR DESCRIPTION
## Summary
- Adds `https://app.allotmint.io` to the static `cors_origins` list in `BackendLambdaStack`, alongside the existing localhost dev origins, so the custom domain is allowed in CORS preflight responses ahead of the DNS cutover.
- This is independent of the dynamic `FRONTEND_ORIGIN`/`CORS_ORIGINS` env-driven entries added in #3954 — both mechanisms coexist via the existing dedup (`dict.fromkeys`).

## Test plan
- [x] `python -c "from stacks.backend_lambda_stack import BackendLambdaStack"` imports cleanly
- [ ] `cdk synth` includes `https://app.allotmint.io` in the Lambda `CORS_ORIGINS` env var and the HTTP API CORS preflight `allow_origins`
- [ ] Post-deploy: confirm `Access-Control-Allow-Origin: https://app.allotmint.io` on `/config` preflight from that origin

Closes #3957

🤖 Generated with [Claude Code](https://claude.com/claude-code)