### PR TITLE
fix(ci): hard-fail price snapshot check on non-404 S3 errors

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -700,7 +700,12 @@ jobs:
         # snapshot is still absent here it means the Trigger Lambda failed or timed
         # out; print a clear, actionable warning so operators know exactly what
         # to do rather than hunting through CloudWatch logs.
-        continue-on-error: true
+        #
+        # A missing key (NoSuchKey/404) is a soft pass: the price-refresh job
+        # hasn't run yet, which is recoverable. Any other error (403, 500,
+        # network timeout, etc.) indicates a genuine configuration problem
+        # (e.g. a misconfigured bucket policy) that will only get harder to
+        # diagnose later in the deploy, so it is treated as a hard failure.
         env:
           AWS_REGION: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
           DATA_BUCKET: ${{ secrets.DATA_BUCKET || vars.DATA_BUCKET }}
@@ -718,7 +723,8 @@ jobs:
           elif echo "$head_output" | grep -qi "NoSuchKey\|Not Found\|404"; then
             echo "::warning::Price snapshot prices/latest_prices.json is NOT present in s3://${DATA_BUCKET}. Portfolio prices will be unavailable until the price-refresh job runs. Trigger it manually: aws lambda invoke --function-name <PriceRefreshLambda-physical-name>:live /dev/null"
           else
-            echo "::warning::Could not verify price snapshot — s3api head-object returned exit ${head_exit}: ${head_output}"
+            echo "ERROR: S3 bucket access check failed: head-object returned exit ${head_exit}: ${head_output}" >&2
+            exit 1
           fi
 
       - name: Warm up backend Lambda (absorb cold-start before validation)

--- a/tests/scripts/test_deploy_lambda_workflow.py
+++ b/tests/scripts/test_deploy_lambda_workflow.py
@@ -69,7 +69,17 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
     # head_output must capture stderr (where the AWS CLI writes error
     # details like "NoSuchKey"/"Access Denied"), otherwise the grep above
     # would never match and every error would hard-fail, including 404s.
-    assert "2>&1" in run_script
+    capture_line = next(
+        line for line in run_script.splitlines() if "head_output=" in line
+    )
+    # The capture spans multiple continuation lines; the redirect is on the
+    # final line that closes the command substitution.
+    capture_block = run_script[run_script.index(capture_line):]
+    capture_end = capture_block.index(")\"") + len(")\"")
+    assert "2>&1" in capture_block[:capture_end], (
+        "head_output=$(...) must redirect stderr (2>&1) so NoSuchKey/Access "
+        "Denied errors are visible to the grep below"
+    )
 
     # The step must not swallow its own exit code via continue-on-error,
     # otherwise the hard failure above would not fail the job.

--- a/tests/scripts/test_deploy_lambda_workflow.py
+++ b/tests/scripts/test_deploy_lambda_workflow.py
@@ -66,6 +66,11 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
     assert "NoSuchKey\\|Not Found\\|404" in run_script
     assert "::warning::Price snapshot" in run_script
 
+    # head_output must capture stderr (where the AWS CLI writes error
+    # details like "NoSuchKey"/"Access Denied"), otherwise the grep above
+    # would never match and every error would hard-fail, including 404s.
+    assert "2>&1" in run_script
+
     # The step must not swallow its own exit code via continue-on-error,
     # otherwise the hard failure above would not fail the job.
     assert "continue-on-error" not in verify_step

--- a/tests/scripts/test_deploy_lambda_workflow.py
+++ b/tests/scripts/test_deploy_lambda_workflow.py
@@ -43,3 +43,29 @@ def test_deploy_workflow_warms_price_snapshot() -> None:
     )
     warm_idx = step_names.index("Warm price snapshot")
     assert warm_idx > deploy_idx, "Warm price snapshot must run after Deploy BackendLambdaStack"
+
+
+def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    deploy_job = workflow["jobs"]["deploy"]
+    steps = deploy_job["steps"]
+
+    verify_step = next(
+        step for step in steps if step.get("name") == "Verify price snapshot seeded in S3"
+    )
+
+    run_script = verify_step["run"]
+
+    # A genuine S3 error (403, 500, network failure, etc.) must hard-fail the
+    # deploy rather than being swallowed as a warning.
+    assert "exit 1" in run_script
+    assert "::warning::Could not verify price snapshot" not in run_script
+
+    # NoSuchKey/404 (bucket not yet seeded) must remain a soft pass.
+    assert "NoSuchKey\\|Not Found\\|404" in run_script
+    assert "::warning::Price snapshot" in run_script
+
+    # The step must not swallow its own exit code via continue-on-error,
+    # otherwise the hard failure above would not fail the job.
+    assert "continue-on-error" not in verify_step


### PR DESCRIPTION
## Summary
- The "Verify price snapshot seeded in S3" step in `deploy-lambda.yml` previously treated all non-zero `aws s3api head-object` results as warnings via `continue-on-error: true`.
- `NoSuchKey`/`Not Found`/`404` (bucket/key not yet seeded) remains a soft pass — the price-refresh job may not have run yet.
- Any other error (403 Access Denied, 500, network timeout, etc.) now logs `ERROR: S3 bucket access check failed: ...` and exits 1, failing the deploy job, instead of silently continuing to later, harder-to-diagnose stages.

## Test plan
- [x] `pytest tests/scripts/test_deploy_lambda_workflow.py -q` passes, including a new test asserting the hard-fail/soft-pass split and the absence of `continue-on-error` on this step.
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-lambda.yml'))"` confirms the workflow YAML is still valid.

Closes #3798