### PR TITLE
fix(deploy): export CORS_ORIGINS including app.allotmint.io for custom-domain readiness

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -436,6 +436,7 @@ jobs:
             echo "UI_AUTH_USER_POOL_CLIENT_ID=$UI_AUTH_USER_POOL_CLIENT_ID"
             echo "SMOKE_TEST_USER_POOL_CLIENT_ID=$SMOKE_TEST_USER_POOL_CLIENT_ID"
             echo "FRONTEND_ORIGIN=https://${DISTRIBUTION_DOMAIN}"
+            echo "CORS_ORIGINS=https://${DISTRIBUTION_DOMAIN},https://app.allotmint.io"
           } >> "$GITHUB_ENV"
 
       - name: Deploy BackendLambdaStack
@@ -454,6 +455,7 @@ jobs:
           GITHUB_DEPLOY_ROLE_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
           FRONTEND_ORIGIN: ${{ env.FRONTEND_ORIGIN }}
+          CORS_ORIGINS: ${{ env.CORS_ORIGINS }}
         run: >
           npx cdk deploy BackendLambdaStack --require-approval never
           --parameters BackendLambdaStack:UiAuthUserPoolId="$UI_AUTH_USER_POOL_ID"


### PR DESCRIPTION
Closes #3994

## What

Adds `app.allotmint.io` to the `CORS_ORIGINS` environment variable exported during the GitHub Actions deploy workflow, alongside the dynamically-captured CloudFront domain. Also passes `CORS_ORIGINS` to the "Deploy BackendLambdaStack" step's `env:` block.

## Changes

**`.github/workflows/deploy-lambda.yml`** — two additions:

1. **"Capture StaticSiteStack outputs" step** (line 439): Exports `CORS_ORIGINS=https://${DISTRIBUTION_DOMAIN},https://app.allotmint.io` alongside the existing `FRONTEND_ORIGIN` export.

2. **"Deploy BackendLambdaStack" step** (new `env:` entry): Passes `CORS_ORIGINS` to the CDK deploy step, matching `backend_lambda_stack.py`'s existing `os.getenv("CORS_ORIGINS")` read.

## Verification

- The CDK stack already reads `CORS_ORIGINS` from the environment (line 220) and merges it into the CORS allowlist
- The CDK stack already includes `https://app.allotmint.io` in its hardcoded defaults (line 225) as a safety net
- Deduplication is in place: `cors_origins = list(dict.fromkeys(cors_origins))` (line 233)
- The CloudFront domain remains at position 0 of the allowlist (the `FRONTEND_ORIGIN` path is unchanged)
- Localhost defaults are untouched
- No frontend changes
