### PR TITLE
Make DeepSeek the sole required AI reviewer, remove GPT/Claude from required checks

### DIFF
--- a/.github/rulesets/default-branch-protection.json
+++ b/.github/rulesets/default-branch-protection.json
@@ -54,12 +54,6 @@
             "context": "CI / Lambda-compat pytest (backend/requirements.txt)"
           },
           {
-            "context": "ai-review / Claude AI code review"
-          },
-          {
-            "context": "ai-review / GPT AI code review"
-          },
-          {
             "context": "ai-review / DeepSeek AI code review"
           },
           {

--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -26,8 +26,6 @@ EXPECTED_REQUIRED_CHECKS = {
     "Merge Conflict Check / Check for merge conflicts with main",
     "PR Body Issue Reference Check / require-issue-reference",
     "Dependency Review / dependency-review",
-    "ai-review / Claude AI code review",
-    "ai-review / GPT AI code review",
     "ai-review / DeepSeek AI code review",
 }
 


### PR DESCRIPTION
GPT and Claude AI reviewers are no longer required gates. Only DeepSeek remains as the required AI reviewer in the branch protection ruleset.

Changes:
- Removed \i-review / Claude AI code review\ and \i-review / GPT AI code review\ from required status checks in \.github/rulesets/default-branch-protection.json\
- Updated \scripts/check_branch_protection_required_checks.py\ to match

The GPT and Claude review workflows still run and post review comments — they just no longer block merging.