### PR TITLE
fix: change /trail smoke test assertion from mode to heading

### DIFF
--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -211,7 +211,29 @@ const ROUTES: RouteConfig[] = [
   { path: '/alerts', assertion: { kind: 'heading', name: 'Alerts' } },
   { path: '/alert-settings', assertion: { kind: 'heading', name: 'Alert Settings' } },
   { path: '/goals', assertion: { kind: 'heading', name: 'Goals' } },
-  { path: '/trail', assertion: { kind: 'mode', mode: 'trail' } },
+  {
+    path: '/trail',
+    assertion: { kind: 'heading', name: 'Trail progress' },
+    setup: async (page) => {
+      await page.route('**/trail', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            tasks: [
+              { id: '1', title: 'Review portfolio', type: 'daily', commentary: '', completed: false },
+              { id: '2', title: 'Check alerts', type: 'daily', commentary: '', completed: true },
+              { id: '3', title: 'Setup watchlist', type: 'once', commentary: 'One-time task', completed: false },
+            ],
+            xp: 10,
+            streak: 3,
+            daily_totals: { '2025-01-01': { completed: 1, total: 2 } },
+            today: '2025-01-01',
+          }),
+        });
+      });
+    },
+  },
   { path: '/smoke-test', assertion: { kind: 'heading', name: 'Smoke test' } },
   {
     path: '/metrics-explained',

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -216,6 +216,11 @@ const ROUTES: RouteConfig[] = [
     assertion: { kind: 'heading', name: 'Trail progress' },
     setup: async (page) => {
       await page.route('**/trail', async (route) => {
+        // Only intercept API calls, not the page navigation to /trail itself.
+        if (route.request().resourceType() === 'document') {
+          await route.continue();
+          return;
+        }
         await route.fulfill({
           status: 200,
           contentType: 'application/json',


### PR DESCRIPTION
## Problem

The smoke test for `/trail` failed on deploy with:

```nError: expect(locator).toHaveAttribute(expected) failed
Locator: locator('[data-route-marker="active"], [data-testid="active-route-marker"]')
Expected: "trail"
Error: element(s) not found
```

## Root cause

`/trail` is a **standalone route** — rendered via `standalonePageRoutes` in `main.tsx` as `<Route path="/trail" element={<Trail />} />`, **outside** the `<App />` wrapper. The `data-route-marker="active"` element only lives inside `<App />`'s `<main>` section.

Every other standalone route (`/alert-settings`, `/trade-compliance`, `/support`, `/virtual`) correctly uses `{ kind: 'heading', ... }` assertion. Only `/trail` used `{ kind: 'mode', ... }` which expects the non-existent route marker.

## Fix

1. **Changed assertion** from `{ kind: 'mode', mode: 'trail' }` to `{ kind: 'heading', name: 'Trail progress' }` — matching the `<h1>` rendered by the `Trail` component.
2. **Added a `setup` mock** for the `**/trail` API endpoint so the `Trail` component can load data and render its heading (without it the component stays stuck on loading state).

Closes #4225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced smoke test coverage for the Trail route: assertions now verify the visible page heading ("Trail progress") and the test harness mocks the Trail API to return a task list, experience/streak information and daily totals to ensure consistent, repeatable checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->