### PR TITLE
fix: pass Cognito Bearer token to /token/cognito exchange (#4238)

### DIFF
--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -109,6 +109,13 @@ export const getStoredCognitoIdToken = (): string | null => {
   return session.idToken;
 };
 
+/** Returns the stored Cognito access token if the session is still valid, else null. */
+export const getStoredCognitoAccessToken = (): string | null => {
+  const session = loadSession();
+  if (!session || session.expiresAt <= Date.now()) return null;
+  return session.accessToken ?? null;
+};
+
 /** Removes the Cognito session from sessionStorage (e.g. after a failed backend exchange). */
 export const clearCognitoSession = (): void => {
   window.sessionStorage.removeItem(SESSION_KEY);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -39,7 +39,7 @@ import { UserProvider, useUser } from './UserContext';
 import ErrorBoundary from './ErrorBoundary';
 import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage';
 import { RouteProvider } from './RouteContext';
-import { clearCognitoSession, ensureAwsUiAuth, getStoredCognitoIdToken, UserCancelledError, type AwsUiAuthConfig } from './awsUiAuth';
+import { clearCognitoSession, ensureAwsUiAuth, getStoredCognitoAccessToken, getStoredCognitoIdToken, UserCancelledError, type AwsUiAuthConfig } from './awsUiAuth';
 import {
   deriveBootstrapMode,
   deriveModeFromPathname,
@@ -439,9 +439,16 @@ const exchangeCognitoForBackendToken = async (
   // Skip the round-trip if we already have a non-expired backend JWT (e.g. page refresh).
   const existing = getStoredAuthToken();
   if (existing && !isJwtExpired(existing)) return;
+  // Pass the Cognito access token as Bearer so API Gateway's JWT authorizer
+  // can validate the request. Fall back to the ID token if no access token
+  // was returned by the hosted UI (some configurations may omit it).
+  const bearerToken = getStoredCognitoAccessToken() ?? idToken;
   const res = await fetch(`${getApiBase()}/token/cognito`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${bearerToken}`,
+    },
     body: JSON.stringify({ id_token: idToken, client_id: clientId }),
   });
   if (!res.ok) {

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearCognitoSession, ensureAwsUiAuth, getStoredCognitoIdToken, UserCancelledError } from '@/awsUiAuth';
+import { clearCognitoSession, ensureAwsUiAuth, getStoredCognitoAccessToken, getStoredCognitoIdToken, UserCancelledError } from '@/awsUiAuth';
 
 const assignMock = vi.fn();
 
@@ -277,6 +277,49 @@ describe('getStoredCognitoIdToken', () => {
   it('returns null for a malformed session entry', () => {
     window.sessionStorage.setItem('awsUiAuthSession', 'not-json');
     expect(getStoredCognitoIdToken()).toBeNull();
+  });
+});
+
+describe('getStoredCognitoAccessToken', () => {
+  it('returns null when no session is stored', () => {
+    expect(getStoredCognitoAccessToken()).toBeNull();
+  });
+
+  it('returns the access_token from a valid session', () => {
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({
+        idToken: 'my-id-token',
+        accessToken: 'my-access-token',
+        expiresAt: Date.now() + 3600 * 1000,
+      }),
+    );
+    expect(getStoredCognitoAccessToken()).toBe('my-access-token');
+  });
+
+  it('returns null when session has no access token (only id token)', () => {
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({ idToken: 'my-id-token', expiresAt: Date.now() + 3600 * 1000 }),
+    );
+    expect(getStoredCognitoAccessToken()).toBeNull();
+  });
+
+  it('returns null for an expired session', () => {
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({
+        idToken: 'my-id-token',
+        accessToken: 'expired-access',
+        expiresAt: Date.now() - 1000,
+      }),
+    );
+    expect(getStoredCognitoAccessToken()).toBeNull();
+  });
+
+  it('returns null for a malformed session entry', () => {
+    window.sessionStorage.setItem('awsUiAuthSession', 'not-json');
+    expect(getStoredCognitoAccessToken()).toBeNull();
   });
 });
 

--- a/frontend/tests/unit/main.cognitoExchange.test.ts
+++ b/frontend/tests/unit/main.cognitoExchange.test.ts
@@ -20,6 +20,12 @@ vi.mock('@/api', () => ({
 
 const VALID_COGNITO_SESSION = JSON.stringify({
   idToken: 'cognito-id-token',
+  accessToken: 'cognito-access-token',
+  expiresAt: Date.now() + 3600 * 1000,
+});
+
+const VALID_COGNITO_SESSION_NO_ACCESS = JSON.stringify({
+  idToken: 'cognito-id-token',
   expiresAt: Date.now() + 3600 * 1000,
 });
 
@@ -85,7 +91,13 @@ describe('bootstrapRuntimeConfig — Cognito backend token exchange', () => {
       ([url]: [string]) => String(url).endsWith('/token/cognito'),
     );
     expect(cognitoFetch).toBeDefined();
-    const body = JSON.parse(cognitoFetch![1].body as string);
+    const [, init] = cognitoFetch!;
+    // Verify the Cognito access token is passed as Bearer so API Gateway's
+    // JWT authorizer can validate the request.
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer cognito-access-token',
+    });
+    const body = JSON.parse(init.body as string);
     expect(body.id_token).toBe('cognito-id-token');
     expect(body.client_id).toBe('cognito-client-123');
     expect(setAuthToken).toHaveBeenCalledWith('backend-jwt');
@@ -277,5 +289,44 @@ describe('bootstrapRuntimeConfig — Cognito backend token exchange', () => {
     );
     expect(cognitoFetch).toBeDefined();
     expect(setAuthToken).toHaveBeenCalledWith('new-backend-jwt');
+  });
+
+  it('falls back to ID token as Bearer when access token is not stored', async () => {
+    sessionStorage.setItem(
+      'awsUiAuthSession',
+      VALID_COGNITO_SESSION_NO_ACCESS,
+    );
+    document.body.innerHTML = '<div id="root"></div>';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (String(url).endsWith('/config.json')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(CONFIG_WITH_COGNITO),
+          });
+        }
+        if (String(url).endsWith('/token/cognito')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ access_token: 'backend-jwt' }),
+          });
+        }
+        return Promise.resolve({ ok: false });
+      }),
+    );
+
+    await import('@/main');
+    await new Promise((r) => setTimeout(r, 0));
+
+    const cognitoFetch = (fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([url]: [string]) => String(url).endsWith('/token/cognito'),
+    );
+    expect(cognitoFetch).toBeDefined();
+    const [, init] = cognitoFetch!;
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer cognito-id-token',
+    });
   });
 });


### PR DESCRIPTION
Closes #4238.

- Added getStoredCognitoAccessToken() to awsUiAuth.ts
- exchangeCognitoForBackendToken now passes Authorization: Bearer header to /token/cognito
- Falls back to ID token when access token not available
- 35 tests pass (2 test files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Cognito authentication to utilise access tokens when available, with fallback to ID tokens for improved security and token handling.

* **Tests**
  * Added comprehensive test coverage for Cognito access token retrieval and token exchange workflows, including edge cases and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->