### PR TITLE
fix(deploy): make POST /token/google public at API Gateway

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -417,10 +417,23 @@ class BackendLambdaStack(Stack):
         # frontend/src/LoginPage.tsx sends this request with no Authorization
         # header at all — backend_authorizer (Cognito JWT) would reject it with
         # 401 before backend.auth.verify_google_token ever runs, the same class
-        # of bug fixed for GET /config in #3873. POST /token/cognito is NOT
-        # listed here: frontend/src/main.tsx exchangeCognitoForBackendToken sends
-        # a Cognito-issued access/ID token as a Bearer header, which
-        # backend_authorizer validates successfully against the same user pool.
+        # of bug fixed for GET /config in #3873.
+        #
+        # POST /token/cognito is NOT listed here: frontend/src/main.tsx
+        # exchangeCognitoForBackendToken sends a Cognito-issued access/ID token
+        # as a Bearer header, and backend_authorizer validates it successfully.
+        # This is not an assumption that the pools happen to match — it is the
+        # same pool/client by construction. ui_auth_user_pool_id_param and
+        # ui_auth_client_id_param (above) are documented as values exported by
+        # StaticSiteStack's UiAuthUserPool/UiAuthClient (see
+        # cdk/stacks/static_site_stack.py CfnOutputs UiAuthUserPoolId and
+        # UiAuthUserPoolClientId). That same UiAuthClient.user_pool_client_id is
+        # embedded in config.json's awsUiAuth.clientId (static_site_stack.py,
+        # DeployRuntimeConfig), which is what the frontend uses to sign in via
+        # Cognito before calling /token/cognito. So backend_authorizer and the
+        # frontend's Cognito sign-in resolve to the same UiAuthUserPool /
+        # UiAuthClient — there is only one Cognito user pool in this stack
+        # pairing, not two.
         backend_api.add_routes(
             path="/token/google",
             methods=[apigwv2.HttpMethod.POST],

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -411,6 +411,22 @@ class BackendLambdaStack(Stack):
             integration=backend_integration,
             authorizer=apigwv2.HttpNoneAuthorizer(),
         )
+        # POST /token/google exchanges a Google ID token (from the frontend's
+        # standalone Google Identity Services sign-in, frontend/src/LoginPage.tsx)
+        # for an app JWT. The caller authenticates with Google, not Cognito, and
+        # frontend/src/LoginPage.tsx sends this request with no Authorization
+        # header at all — backend_authorizer (Cognito JWT) would reject it with
+        # 401 before backend.auth.verify_google_token ever runs, the same class
+        # of bug fixed for GET /config in #3873. POST /token/cognito is NOT
+        # listed here: frontend/src/main.tsx exchangeCognitoForBackendToken sends
+        # a Cognito-issued access/ID token as a Bearer header, which
+        # backend_authorizer validates successfully against the same user pool.
+        backend_api.add_routes(
+            path="/token/google",
+            methods=[apigwv2.HttpMethod.POST],
+            integration=backend_integration,
+            authorizer=apigwv2.HttpNoneAuthorizer(),
+        )
         # CORS preflight OPTIONS requests must never reach backend_authorizer:
         # browsers send them without an Authorization header, so a JWT
         # authorizer would reject them with 401 before CORS headers are

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -598,7 +598,8 @@ def test_backend_api_authorizer_audience_excludes_empty_smoke_test_client(templa
 
 def test_backend_api_routes_require_cognito_authorizer(template):
     """All API Gateway routes must require Cognito JWT authorization except
-    /health, GET /config, and the CORS preflight OPTIONS routes.
+    /health, GET /config, POST /token/google, and the CORS preflight OPTIONS
+    routes.
 
     /health is intentionally unauthenticated so that post-deploy probes and
     smoke tests can confirm Lambda is reachable without needing a Cognito token.
@@ -606,6 +607,13 @@ def test_backend_api_routes_require_cognito_authorizer(template):
     pre-auth bootstrap endpoint (frontend/src/main.tsx Root.fetchConfig) used
     to determine whether auth is required at all; PUT /config remains
     JWT-protected via the /{proxy+} catch-all.
+    POST /token/google is intentionally unauthenticated because it exchanges a
+    Google ID token (frontend/src/LoginPage.tsx, sent with no Authorization
+    header) for an app JWT — backend_authorizer would reject it with 401 before
+    backend.auth.verify_google_token ever runs (#4240). POST /token/cognito is
+    NOT in this set: frontend/src/main.tsx exchangeCognitoForBackendToken sends
+    a Cognito-issued access/ID token as a Bearer header, which backend_authorizer
+    validates successfully against the same user pool.
     OPTIONS / and OPTIONS /{proxy+} are unauthenticated so that browser CORS
     preflight requests (which never carry an Authorization header) are not
     rejected with 401 before the real request is sent (see issue #3945).
@@ -615,6 +623,7 @@ def test_backend_api_routes_require_cognito_authorizer(template):
     UNAUTHENTICATED_ROUTES = {
         "GET /health",
         "GET /config",
+        "POST /token/google",
         "OPTIONS /",
         "OPTIONS /{proxy+}",
     }


### PR DESCRIPTION
## Summary

Audit result for #4240: of the two token-exchange endpoints, only `POST /token/google` needed to be added to the unauthenticated routes at API Gateway. `POST /token/cognito` does not need a change.

### `POST /token/google` — fixed

`frontend/src/LoginPage.tsx` (standalone Google Identity Services sign-in) calls `POST /token/google` with **no `Authorization` header at all**, sending only the Google ID token in the request body for `backend.auth.verify_google_token` to verify.

At API Gateway, every route except `GET /health`, `GET /config`, and the CORS `OPTIONS` routes falls under the `/{proxy+}` `ANY` route, which requires `backend_authorizer` (the Cognito JWT authorizer, `$request.header.Authorization`). With no `Authorization` header, API Gateway rejects the request with `401` **before it ever reaches the Lambda** — so `verify_google_token` never runs. This is the same class of bug fixed for `GET /config` in #3873.

### `POST /token/cognito` — no change needed

`frontend/src/main.tsx` `exchangeCognitoForBackendToken` sends `Authorization: Bearer <cognito-access-or-id-token>`. This is a JWT issued by the same Cognito user pool/client that `backend_authorizer` validates, so it passes the Gateway authorizer successfully and reaches `backend.auth.verify_cognito_token` as intended. No Gateway change required.

## Changes

- `cdk/stacks/backend_lambda_stack.py`: add an explicit `POST /token/google` route with `HttpNoneAuthorizer()`, mirroring the `GET /config` pattern from #3873, with a comment documenting the audit conclusion for both endpoints.
- `cdk/tests/test_backend_lambda_stack.py`: add `"POST /token/google"` to the `UNAUTHENTICATED_ROUTES` allowlist in `test_backend_api_routes_require_cognito_authorizer`, with updated docstring explaining why `/token/cognito` is intentionally excluded.

Closes #4240

## Test plan

- [x] `cdk/tests/test_backend_lambda_stack.py` (33 tests) passes, including the updated `test_backend_api_routes_require_cognito_authorizer`.
- [ ] After merge/deploy, confirm `curl -X POST https://<backend-api-url>/token/google -d '{"token":"..."}'` (no Authorization header) reaches the Lambda (no longer 401 at the Gateway).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new unauthenticated API route to exchange a Google token for an app JWT (`POST /token/google`), separate from the existing authenticated token flow.

* **Tests**
  * Updated the test suite to confirm `POST /token/google` is configured as intentionally unauthenticated, while other routes remain protected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->