### PR TITLE
Add Playwright smoke test for Cognito hosted UI to backend token exchange

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "coverage": "vitest run --coverage",
     "test:jsdom": "vitest --environment=jsdom",
     "type-check": "tsc -b --noEmit",
-    "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts",
+    "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts tests/cognito-auth-flow.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",
     "deploy:aws:linux": "bash scripts/deploy-to-aws.sh -b $S3_BUCKET ${CLOUDFRONT_DISTRIBUTION_ID:+-d $CLOUDFRONT_DISTRIBUTION_ID}",

--- a/frontend/tests/cognito-auth-flow.spec.ts
+++ b/frontend/tests/cognito-auth-flow.spec.ts
@@ -11,6 +11,13 @@ const COGNITO_ID_TOKEN = 'cognito-id-token';
 const COGNITO_ACCESS_TOKEN = 'cognito-access-token';
 const BACKEND_ACCESS_TOKEN = 'backend-access-token';
 
+type TokenRequest = { url: string; body: string };
+type CognitoExchangeRequest = {
+  authorization: string | undefined;
+  body: { id_token?: string; client_id?: string };
+};
+type ConfigRequest = { authorization: string | undefined };
+
 /**
  * Seed the PKCE state/verifier that awsUiAuth.ts writes before redirecting to
  * the hosted UI, so the simulated callback (?code=...&state=...) is accepted
@@ -72,6 +79,105 @@ const mockAppApiEndpoints = async (page: Page) => {
   });
 };
 
+const mockCognitoTokenEndpoint = async (page: Page, tokenRequests: TokenRequest[]) => {
+  await page.route(`${COGNITO_DOMAIN}/oauth2/token`, async (route) => {
+    tokenRequests.push({
+      url: route.request().url(),
+      body: route.request().postData() ?? '',
+    });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id_token: COGNITO_ID_TOKEN,
+        access_token: COGNITO_ACCESS_TOKEN,
+        expires_in: 3600,
+      }),
+    });
+  });
+};
+
+const mockBackendTokenExchange = async (
+  page: Page,
+  cognitoExchangeRequests: CognitoExchangeRequest[],
+) => {
+  await page.route('**/token/cognito', async (route) => {
+    const request = route.request();
+    cognitoExchangeRequests.push({
+      authorization: request.headers()['authorization'],
+      body: JSON.parse(request.postData() ?? '{}'),
+    });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ access_token: BACKEND_ACCESS_TOKEN }),
+    });
+  });
+};
+
+const mockConfigEndpoint = async (page: Page, configRequests: ConfigRequest[]) => {
+  await page.route('**/config', async (route) => {
+    configRequests.push({ authorization: route.request().headers()['authorization'] });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        app_env: 'test',
+        theme: null,
+        tabs: { trail: true, taxtools: true, 'trade-compliance': true, reports: true },
+        relative_view_enabled: false,
+        google_auth_enabled: false,
+        google_client_id: null,
+        disable_auth: false,
+        allowed_emails: null,
+        local_login_email: null,
+        disabled_tabs: [],
+        enable_family_mvp: false,
+      }),
+    });
+  });
+};
+
+const navigateToCallback = async (page: Page) => {
+  const callbackUrl = new URL('/', baseUrl);
+  callbackUrl.searchParams.set('code', AUTH_CODE);
+  callbackUrl.searchParams.set('state', PKCE_STATE);
+  await page.goto(callbackUrl.href);
+};
+
+/**
+ * The Cognito hosted UI token endpoint was called with the authorization
+ * code and PKCE verifier from the simulated callback.
+ */
+const assertCognitoTokenRequest = (tokenRequests: TokenRequest[]) => {
+  expect(tokenRequests).toHaveLength(1);
+  expect(tokenRequests[0].body).toContain(`code=${AUTH_CODE}`);
+  expect(tokenRequests[0].body).toContain(`code_verifier=${PKCE_VERIFIER}`);
+};
+
+/**
+ * The /token/cognito exchange carried the Cognito access token as a Bearer
+ * header (regression coverage for #4238/#4239).
+ */
+const assertBackendTokenExchange = (cognitoExchangeRequests: CognitoExchangeRequest[]) => {
+  expect(cognitoExchangeRequests[0].authorization).toBe(`Bearer ${COGNITO_ACCESS_TOKEN}`);
+  expect(cognitoExchangeRequests[0].body.id_token).toBe(COGNITO_ID_TOKEN);
+  expect(cognitoExchangeRequests[0].body.client_id).toBe(CLIENT_ID);
+};
+
+/**
+ * The exchanged backend token is stored and reused for subsequent API calls,
+ * and the one-time authorization code/state are stripped from the URL.
+ */
+const assertBackendTokenIsReused = async (page: Page, configRequests: ConfigRequest[]) => {
+  await expect
+    .poll(() => page.evaluate(() => window.localStorage.getItem('authToken')))
+    .toBe(BACKEND_ACCESS_TOKEN);
+  await expect.poll(() => configRequests.length).toBeGreaterThan(0);
+  expect(configRequests[0].authorization).toBe(`Bearer ${BACKEND_ACCESS_TOKEN}`);
+  await expect.poll(() => new URL(page.url()).search).toBe('');
+};
+
 test.describe('Cognito hosted UI to backend token exchange', () => {
   test('exchanges the hosted UI callback for a backend token and uses it for API calls', async ({
     page,
@@ -80,91 +186,20 @@ test.describe('Cognito hosted UI to backend token exchange', () => {
     await mockRuntimeConfig(page);
     await mockAppApiEndpoints(page);
 
-    const tokenRequests: { url: string; body: string }[] = [];
-    await page.route(`${COGNITO_DOMAIN}/oauth2/token`, async (route) => {
-      tokenRequests.push({
-        url: route.request().url(),
-        body: route.request().postData() ?? '',
-      });
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          id_token: COGNITO_ID_TOKEN,
-          access_token: COGNITO_ACCESS_TOKEN,
-          expires_in: 3600,
-        }),
-      });
-    });
+    const tokenRequests: TokenRequest[] = [];
+    const cognitoExchangeRequests: CognitoExchangeRequest[] = [];
+    const configRequests: ConfigRequest[] = [];
+    await mockCognitoTokenEndpoint(page, tokenRequests);
+    await mockBackendTokenExchange(page, cognitoExchangeRequests);
+    await mockConfigEndpoint(page, configRequests);
 
-    const cognitoExchangeRequests: {
-      authorization: string | undefined;
-      body: { id_token?: string; client_id?: string };
-    }[] = [];
-    await page.route('**/token/cognito', async (route) => {
-      const request = route.request();
-      cognitoExchangeRequests.push({
-        authorization: request.headers()['authorization'],
-        body: JSON.parse(request.postData() ?? '{}'),
-      });
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ access_token: BACKEND_ACCESS_TOKEN }),
-      });
-    });
-
-    const configRequests: { authorization: string | undefined }[] = [];
-    await page.route('**/config', async (route) => {
-      configRequests.push({ authorization: route.request().headers()['authorization'] });
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          app_env: 'test',
-          theme: null,
-          tabs: { trail: true, taxtools: true, 'trade-compliance': true, reports: true },
-          relative_view_enabled: false,
-          google_auth_enabled: false,
-          google_client_id: null,
-          disable_auth: false,
-          allowed_emails: null,
-          local_login_email: null,
-          disabled_tabs: [],
-          enable_family_mvp: false,
-        }),
-      });
-    });
-
-    const callbackUrl = new URL('/', baseUrl);
-    callbackUrl.searchParams.set('code', AUTH_CODE);
-    callbackUrl.searchParams.set('state', PKCE_STATE);
-
-    await page.goto(callbackUrl.href);
+    await navigateToCallback(page);
 
     // Wait until the backend token exchange has completed.
     await expect.poll(() => cognitoExchangeRequests.length).toBeGreaterThan(0);
 
-    // The Cognito hosted UI token endpoint was called with the authorization
-    // code and PKCE verifier from the simulated callback.
-    expect(tokenRequests).toHaveLength(1);
-    expect(tokenRequests[0].body).toContain(`code=${AUTH_CODE}`);
-    expect(tokenRequests[0].body).toContain(`code_verifier=${PKCE_VERIFIER}`);
-
-    // The /token/cognito exchange carried the Cognito access token as a
-    // Bearer header (regression coverage for #4238/#4239).
-    expect(cognitoExchangeRequests[0].authorization).toBe(`Bearer ${COGNITO_ACCESS_TOKEN}`);
-    expect(cognitoExchangeRequests[0].body.id_token).toBe(COGNITO_ID_TOKEN);
-    expect(cognitoExchangeRequests[0].body.client_id).toBe(CLIENT_ID);
-
-    // The exchanged backend token is stored and reused for subsequent API calls.
-    await expect.poll(() => page.evaluate(() => window.localStorage.getItem('authToken'))).toBe(
-      BACKEND_ACCESS_TOKEN,
-    );
-    await expect.poll(() => configRequests.length).toBeGreaterThan(0);
-    expect(configRequests[0].authorization).toBe(`Bearer ${BACKEND_ACCESS_TOKEN}`);
-
-    // The one-time authorization code/state are stripped from the URL after exchange.
-    await expect.poll(() => new URL(page.url()).search).toBe('');
+    assertCognitoTokenRequest(tokenRequests);
+    assertBackendTokenExchange(cognitoExchangeRequests);
+    await assertBackendTokenIsReused(page, configRequests);
   });
 });

--- a/frontend/tests/cognito-auth-flow.spec.ts
+++ b/frontend/tests/cognito-auth-flow.spec.ts
@@ -1,0 +1,170 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const baseUrl = process.env.SMOKE_URL ?? 'http://localhost:5173';
+
+const COGNITO_DOMAIN = 'https://cognito-test.example.com';
+const CLIENT_ID = 'test-client-id';
+const PKCE_STATE = 'test-pkce-state';
+const PKCE_VERIFIER = 'test-pkce-verifier';
+const AUTH_CODE = 'test-auth-code';
+const COGNITO_ID_TOKEN = 'cognito-id-token';
+const COGNITO_ACCESS_TOKEN = 'cognito-access-token';
+const BACKEND_ACCESS_TOKEN = 'backend-access-token';
+
+/**
+ * Seed the PKCE state/verifier that awsUiAuth.ts writes before redirecting to
+ * the hosted UI, so the simulated callback (?code=...&state=...) is accepted
+ * by exchangeCode() instead of being rejected as an invalid callback state.
+ */
+const seedPkceState = async (page: Page) => {
+  await page.addInitScript(
+    ({ stateKey, verifierKey, state, verifier }) => {
+      window.sessionStorage.setItem(stateKey, state);
+      window.sessionStorage.setItem(verifierKey, verifier);
+    },
+    {
+      stateKey: 'awsUiAuthState',
+      verifierKey: 'awsUiAuthCodeVerifier',
+      state: PKCE_STATE,
+      verifier: PKCE_VERIFIER,
+    },
+  );
+};
+
+const mockRuntimeConfig = async (page: Page) => {
+  await page.route('**/config.json', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        awsUiAuth: {
+          enabled: true,
+          domain: COGNITO_DOMAIN,
+          clientId: CLIENT_ID,
+          redirectPath: '/',
+        },
+      }),
+    });
+  });
+};
+
+const mockAppApiEndpoints = async (page: Page) => {
+  await page.route('**/owners', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          owner: 'demo-owner',
+          full_name: 'Demo Owner',
+          accounts: ['ISA'],
+          has_transactions_artifact: false,
+        },
+      ]),
+    });
+  });
+  await page.route('**/groups', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ slug: 'all', name: 'All portfolios', members: ['demo-owner'] }]),
+    });
+  });
+};
+
+test.describe('Cognito hosted UI to backend token exchange', () => {
+  test('exchanges the hosted UI callback for a backend token and uses it for API calls', async ({
+    page,
+  }) => {
+    await seedPkceState(page);
+    await mockRuntimeConfig(page);
+    await mockAppApiEndpoints(page);
+
+    const tokenRequests: { url: string; body: string }[] = [];
+    await page.route(`${COGNITO_DOMAIN}/oauth2/token`, async (route) => {
+      tokenRequests.push({
+        url: route.request().url(),
+        body: route.request().postData() ?? '',
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id_token: COGNITO_ID_TOKEN,
+          access_token: COGNITO_ACCESS_TOKEN,
+          expires_in: 3600,
+        }),
+      });
+    });
+
+    const cognitoExchangeRequests: {
+      authorization: string | undefined;
+      body: { id_token?: string; client_id?: string };
+    }[] = [];
+    await page.route('**/token/cognito', async (route) => {
+      const request = route.request();
+      cognitoExchangeRequests.push({
+        authorization: request.headers()['authorization'],
+        body: JSON.parse(request.postData() ?? '{}'),
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ access_token: BACKEND_ACCESS_TOKEN }),
+      });
+    });
+
+    const configRequests: { authorization: string | undefined }[] = [];
+    await page.route('**/config', async (route) => {
+      configRequests.push({ authorization: route.request().headers()['authorization'] });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          app_env: 'test',
+          theme: null,
+          tabs: { trail: true, taxtools: true, 'trade-compliance': true, reports: true },
+          relative_view_enabled: false,
+          google_auth_enabled: false,
+          google_client_id: null,
+          disable_auth: false,
+          allowed_emails: null,
+          local_login_email: null,
+          disabled_tabs: [],
+          enable_family_mvp: false,
+        }),
+      });
+    });
+
+    const callbackUrl = new URL('/', baseUrl);
+    callbackUrl.searchParams.set('code', AUTH_CODE);
+    callbackUrl.searchParams.set('state', PKCE_STATE);
+
+    await page.goto(callbackUrl.href);
+
+    // Wait until the backend token exchange has completed.
+    await expect.poll(() => cognitoExchangeRequests.length).toBeGreaterThan(0);
+
+    // The Cognito hosted UI token endpoint was called with the authorization
+    // code and PKCE verifier from the simulated callback.
+    expect(tokenRequests).toHaveLength(1);
+    expect(tokenRequests[0].body).toContain(`code=${AUTH_CODE}`);
+    expect(tokenRequests[0].body).toContain(`code_verifier=${PKCE_VERIFIER}`);
+
+    // The /token/cognito exchange carried the Cognito access token as a
+    // Bearer header (regression coverage for #4238/#4239).
+    expect(cognitoExchangeRequests[0].authorization).toBe(`Bearer ${COGNITO_ACCESS_TOKEN}`);
+    expect(cognitoExchangeRequests[0].body.id_token).toBe(COGNITO_ID_TOKEN);
+    expect(cognitoExchangeRequests[0].body.client_id).toBe(CLIENT_ID);
+
+    // The exchanged backend token is stored and reused for subsequent API calls.
+    await expect.poll(() => page.evaluate(() => window.localStorage.getItem('authToken'))).toBe(
+      BACKEND_ACCESS_TOKEN,
+    );
+    await expect.poll(() => configRequests.length).toBeGreaterThan(0);
+    expect(configRequests[0].authorization).toBe(`Bearer ${BACKEND_ACCESS_TOKEN}`);
+
+    // The one-time authorization code/state are stripped from the URL after exchange.
+    await expect.poll(() => new URL(page.url()).search).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `frontend/tests/cognito-auth-flow.spec.ts`, a Playwright smoke test covering the full Cognito hosted UI redirect → callback → `/token/cognito` exchange → authenticated API call flow.
- Mocks the Cognito hosted UI token endpoint and `/token/cognito`, asserting the Cognito access token is sent as `Authorization: Bearer <token>` (regression coverage for #4238/#4239) and that the resulting backend token is then attached to subsequent API requests.
- Wires the new spec into `smoke:frontend` so it runs alongside the existing smoke suite in CI, without depending on live AWS Cognito infrastructure.

## Test plan
- [x] `npx playwright test --config playwright.config.ts tests/cognito-auth-flow.spec.ts` passes
- [x] `npx playwright test --config playwright.config.ts tests/smoke.spec.ts tests/cognito-auth-flow.spec.ts` — all 46 tests pass
- [x] `npx eslint --format unix tests/cognito-auth-flow.spec.ts` — clean

Closes #4241.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
- Expanded the existing frontend smoke coverage by adding a dedicated Playwright test for the complete Cognito hosted UI callback flow through the backend token exchange.
- The new test validates PKCE handling, correct token exchange payloads/headers, persistence and reuse of the backend auth token for follow-up requests, and removal of temporary OAuth query parameters after sign-in.
- The `smoke:frontend` script now runs both the standard smoke test and this new authentication-flow test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->