### PR TITLE
Make follow-up issue body LLM provider configurable (claude/gpt/deepseek)

### DIFF
--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -129,7 +129,9 @@ def _generate_body_via_llm(title: str, pr_number: str, review_text: str) -> str:
     defaults to deepseek). Falls back to a minimal template if the provider is
     unknown, its API key is unset, or the API call fails.
     """
-    provider = os.environ.get("FOLLOWUP_LLM_PROVIDER", _DEFAULT_PROVIDER).strip().lower()
+    # GitHub Actions sets unset `vars.*` to an empty string rather than omitting the
+    # env var entirely, so `os.environ.get(..., default)` would not apply the default.
+    provider = os.environ.get("FOLLOWUP_LLM_PROVIDER", "").strip().lower() or _DEFAULT_PROVIDER
     provider_config = _PROVIDERS.get(provider)
     if provider_config is None:
         print(f"WARNING: unknown FOLLOWUP_LLM_PROVIDER '{provider}', using fallback body", file=sys.stderr)

--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -9,21 +9,19 @@ import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Callable
 
 from llm_labels import extract_tier_label
 
-_ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
-_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
-_FALLBACK_BODY_TEMPLATE = "Follow-up suggested by Claude AI review of PR #{pr_number}."
+_FALLBACK_BODY_TEMPLATE = "Follow-up suggested by AI review of PR #{pr_number}."
+
+# Provider used to generate rich issue bodies, selectable via FOLLOWUP_LLM_PROVIDER.
+# Defaults to deepseek, the repo's primary required PR reviewer.
+_DEFAULT_PROVIDER = "deepseek"
 
 
-def _generate_body_via_claude(title: str, pr_number: str, review_text: str) -> str:
-    """Call Claude Haiku to generate a rich issue body. Returns the generated body."""
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-    if not api_key:
-        return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
-
-    prompt = f"""You are writing a GitHub issue for the allotmint repository.
+def _build_prompt(title: str, pr_number: str, review_text: str) -> str:
+    return f"""You are writing a GitHub issue for the allotmint repository.
 
 The issue title is: "{title}"
 
@@ -61,14 +59,16 @@ Write a complete, actionable GitHub issue body in Markdown covering:
 Be concise but complete. Do not pad with generic advice.
 End with: _Follow-up from AI review of PR #{pr_number}._"""
 
+
+def _call_anthropic(api_key: str, prompt: str) -> str:
+    model = os.environ.get("ANTHROPIC_FOLLOWUP_MODEL", "claude-haiku-4-5-20251001")
     payload = json.dumps({
-        "model": _ANTHROPIC_MODEL,
+        "model": model,
         "max_tokens": 1024,
         "messages": [{"role": "user", "content": prompt}],
     }).encode()
-
     req = urllib.request.Request(
-        _ANTHROPIC_API_URL,
+        "https://api.anthropic.com/v1/messages",
         data=payload,
         headers={
             "x-api-key": api_key,
@@ -76,18 +76,81 @@ End with: _Follow-up from AI review of PR #{pr_number}._"""
             "content-type": "application/json",
         },
     )
-    try:
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read())
+    return data["content"][0]["text"].strip()
+
+
+def _openai_compatible_caller(url: str, model_env: str, default_model: str) -> Callable[[str, str], str]:
+    """Return a caller for OpenAI-compatible chat-completions APIs (OpenAI, DeepSeek)."""
+
+    def _call(api_key: str, prompt: str) -> str:
+        payload = json.dumps({
+            "model": os.environ.get(model_env, default_model),
+            "max_tokens": 1024,
+            "temperature": 0.2,
+            "messages": [{"role": "user", "content": prompt}],
+        }).encode()
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+        )
         with urllib.request.urlopen(req) as resp:
             data = json.loads(resp.read())
-        return data["content"][0]["text"].strip()
-    except (urllib.error.HTTPError, urllib.error.URLError, KeyError, IndexError) as exc:
-        print(f"WARNING: failed to generate issue body via Claude API: {exc}", file=sys.stderr)
+        return data["choices"][0]["message"]["content"].strip()
+
+    return _call
+
+
+# Maps FOLLOWUP_LLM_PROVIDER values to (API key env var, caller).
+_PROVIDERS: dict[str, tuple[str, Callable[[str, str], str]]] = {
+    "claude": ("ANTHROPIC_API_KEY", _call_anthropic),
+    "gpt": (
+        "OPENAI_API_KEY",
+        _openai_compatible_caller("https://api.openai.com/v1/chat/completions", "OPENAI_FOLLOWUP_MODEL", "gpt-4o-mini"),
+    ),
+    "deepseek": (
+        "DEEPSEEK_API_KEY",
+        _openai_compatible_caller(
+            "https://api.deepseek.com/v1/chat/completions", "DEEPSEEK_FOLLOWUP_MODEL", "deepseek-chat"
+        ),
+    ),
+}
+
+
+def _generate_body_via_llm(title: str, pr_number: str, review_text: str) -> str:
+    """Call the configured LLM provider to generate a rich issue body.
+
+    The provider is chosen via FOLLOWUP_LLM_PROVIDER (claude, gpt, or deepseek;
+    defaults to deepseek). Falls back to a minimal template if the provider is
+    unknown, its API key is unset, or the API call fails.
+    """
+    provider = os.environ.get("FOLLOWUP_LLM_PROVIDER", _DEFAULT_PROVIDER).strip().lower()
+    provider_config = _PROVIDERS.get(provider)
+    if provider_config is None:
+        print(f"WARNING: unknown FOLLOWUP_LLM_PROVIDER '{provider}', using fallback body", file=sys.stderr)
+        return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
+
+    api_key_env, call = provider_config
+    api_key = os.environ.get(api_key_env, "")
+    if not api_key:
+        return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
+
+    prompt = _build_prompt(title, pr_number, review_text)
+    try:
+        return call(api_key, prompt)
+    except (urllib.error.HTTPError, urllib.error.URLError, KeyError, IndexError, json.JSONDecodeError) as exc:
+        print(f"WARNING: failed to generate issue body via {provider}: {exc}", file=sys.stderr)
         return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
 
 
 def _build_body(title: str, pr_number: str, review_text: str | None) -> str:
     if review_text:
-        return _generate_body_via_claude(title, pr_number, review_text)
+        return _generate_body_via_llm(title, pr_number, review_text)
     return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
 
 

--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -143,6 +143,9 @@ jobs:
           GH_TOKEN: ${{ secrets.gh_token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
+          OPENAI_API_KEY: ${{ secrets.openai_api_key }}
+          DEEPSEEK_API_KEY: ${{ secrets.deepseek_api_key }}
+          FOLLOWUP_LLM_PROVIDER: ${{ vars.FOLLOWUP_LLM_PROVIDER }}
         run: |
           # Ensure required labels exist before creating issues
           gh label create "ai-suggested" --color "0075ca" --description "Suggested by AI code review" \

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -20,4 +20,6 @@ jobs:
       anthropic_max_tokens: "6000"
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+      deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
       gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -20,4 +20,5 @@ jobs:
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+      deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
       gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/AI_REVIEW_WORKFLOWS.md
+++ b/docs/AI_REVIEW_WORKFLOWS.md
@@ -30,6 +30,24 @@ and `sync-changes-requested-label.yml` automatically excludes that reviewer
 from its conclusion checks. Set these via **Settings → Secrets and variables →
 Actions → Variables**. When a variable is absent, the reviewer runs (default `true`).
 
+## Choosing the follow-up issue body provider
+
+When a review APPROVEs and suggests non-blocking follow-ups (see
+[Workflow Step Configuration](#workflow-step-configuration)), `create_followup_issues.py`
+calls an LLM to expand each suggested title into a full issue body (What/Why/How/
+Constraints/LLM tier/Success/Failure). The provider used for this is independent of
+which reviewer (Claude/GPT/DeepSeek) approved the PR.
+
+Set the repository variable `FOLLOWUP_LLM_PROVIDER` to one of `claude`, `gpt`, or
+`deepseek` to choose the provider. If unset, it defaults to `deepseek`. Set it via
+**Settings → Secrets and variables → Actions → Variables**.
+
+Each provider requires its corresponding API key secret to be configured
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `DEEPSEEK_API_KEY`). If the selected
+provider's key is missing, the call fails, or `FOLLOWUP_LLM_PROVIDER` names an
+unrecognised provider, the issue is created with a minimal fallback body
+(`Follow-up suggested by AI review of PR #<n>.`) instead of failing the workflow.
+
 ## Verdict Behavior
 
 The verdict extraction step (`extract_verdict.py`) runs the AI review output through a parser that produces one of two results:
@@ -166,9 +184,11 @@ jobs:
 ```
 
 `anthropic_api_key` and `gh_token` are required by the reusable workflow regardless of
-provider: `anthropic_api_key` is used for follow-up issue creation
-(`create_followup_issues.py`) on every reviewer's APPROVE verdict, and `gh_token` is used
-for `gh` CLI calls. Pass any provider-specific secret (e.g. a `GEMINI_API_KEY`) by adding
+provider: `gh_token` is used for `gh` CLI calls, and `anthropic_api_key` (along with the
+optional `openai_api_key`/`deepseek_api_key`) is threaded through to follow-up issue
+creation (`create_followup_issues.py`) on every reviewer's APPROVE verdict — see
+[Choosing the follow-up issue body provider](#choosing-the-follow-up-issue-body-provider).
+Pass any provider-specific secret (e.g. a `GEMINI_API_KEY`) by adding
 a new optional secret to `_ai-pr-review.yml` and threading it through to the "Call API"
 step's `env:` block, following the existing `openai_api_key` pattern.
 

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -71,6 +71,30 @@ def test_generate_body_calls_deepseek_by_default_and_returns_content(
     assert "Follow-up" in body
 
 
+def test_generate_body_treats_empty_provider_env_as_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub Actions sets unset `vars.*` to an empty string, not an absent env var.
+
+    FOLLOWUP_LLM_PROVIDER="" must fall back to the default provider, not be
+    treated as an unrecognised provider name.
+    """
+    mod = load_module()
+    monkeypatch.setenv("FOLLOWUP_LLM_PROVIDER", "")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    fake_payload = {
+        "choices": [{"message": {"content": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}}]
+    }
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: FakeResponse(fake_payload),
+    )
+    body = mod._generate_body_via_llm("Fix the thing", "42", "Review text here")
+    assert "Fix the thing" in body
+    assert "Follow-up" in body
+
+
 def test_generate_body_calls_claude_when_selected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -44,16 +44,38 @@ def test_generate_body_returns_fallback_when_no_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     mod = load_module()
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("FOLLOWUP_LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     body = mod._build_body("Fix the thing", "42", "Some review text")
     assert "PR #42" in body
     assert "Follow-up" in body
 
 
-def test_generate_body_calls_claude_and_returns_content(
+def test_generate_body_calls_deepseek_by_default_and_returns_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no FOLLOWUP_LLM_PROVIDER set, the default provider is deepseek."""
+    mod = load_module()
+    monkeypatch.delenv("FOLLOWUP_LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    fake_payload = {
+        "choices": [{"message": {"content": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}}]
+    }
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: FakeResponse(fake_payload),
+    )
+    body = mod._generate_body_via_llm("Fix the thing", "42", "Review text here")
+    assert "Fix the thing" in body
+    assert "Follow-up" in body
+
+
+def test_generate_body_calls_claude_when_selected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     mod = load_module()
+    monkeypatch.setenv("FOLLOWUP_LLM_PROVIDER", "claude")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     fake_payload = {"content": [{"text": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}]}
     monkeypatch.setattr(
@@ -61,9 +83,39 @@ def test_generate_body_calls_claude_and_returns_content(
         "urlopen",
         lambda *args, **kwargs: FakeResponse(fake_payload),
     )
-    body = mod._generate_body_via_claude("Fix the thing", "42", "Review text here")
+    body = mod._generate_body_via_llm("Fix the thing", "42", "Review text here")
     assert "Fix the thing" in body
     assert "Follow-up" in body
+
+
+def test_generate_body_calls_gpt_when_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    monkeypatch.setenv("FOLLOWUP_LLM_PROVIDER", "gpt")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    fake_payload = {
+        "choices": [{"message": {"content": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}}]
+    }
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: FakeResponse(fake_payload),
+    )
+    body = mod._generate_body_via_llm("Fix the thing", "42", "Review text here")
+    assert "Fix the thing" in body
+    assert "Follow-up" in body
+
+
+def test_generate_body_falls_back_on_unknown_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mod = load_module()
+    monkeypatch.setenv("FOLLOWUP_LLM_PROVIDER", "bogus")
+    body = mod._generate_body_via_llm("Fix the thing", "42", "Review text here")
+    assert "PR #42" in body
+    assert "unknown FOLLOWUP_LLM_PROVIDER 'bogus'" in capsys.readouterr().err
 
 
 def test_generate_body_falls_back_on_api_error(
@@ -71,7 +123,8 @@ def test_generate_body_falls_back_on_api_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     mod = load_module()
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.delenv("FOLLOWUP_LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
 
     def raise_error(*args, **kwargs):
         raise urllib.error.HTTPError(
@@ -79,7 +132,7 @@ def test_generate_body_falls_back_on_api_error(
         )
 
     monkeypatch.setattr(mod.urllib.request, "urlopen", raise_error)
-    body = mod._generate_body_via_claude("Fix the thing", "42", "Review text here")
+    body = mod._generate_body_via_llm("Fix the thing", "42", "Review text here")
     assert "PR #42" in body
     assert "failed to generate" in capsys.readouterr().err
 
@@ -88,7 +141,7 @@ def test_build_body_uses_fallback_when_no_review_text(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     mod = load_module()
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
     body = mod._build_body("Fix the thing", "99", None)
     assert "PR #99" in body
 
@@ -99,7 +152,7 @@ def test_main_missing_review_file_falls_back(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     mod = load_module()
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
 
     followups = tmp_path / "followups.json"
     followups.write_text(json.dumps([]))
@@ -139,7 +192,7 @@ def test_create_issues_skips_empty_titles(
         "run",
         lambda cmd, **kwargs: calls.append(cmd),
     )
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
 
     mod.create_issues(["", "  ", "Real title"], "5", None)
     assert len(calls) == 1


### PR DESCRIPTION
## Summary
- `create_followup_issues.py` previously hardcoded a call to Claude Haiku via `ANTHROPIC_API_KEY` to expand AI-review follow-up suggestions into rich issue bodies — regardless of which reviewer actually approved the PR (now only DeepSeek per #4235).
- Adds a `FOLLOWUP_LLM_PROVIDER` repo variable (`claude`, `gpt`, or `deepseek`; default `deepseek`) so the body-generation model can be chosen independently of which reviewer ran, without code changes.
- Each provider falls back to a minimal `Follow-up suggested by AI review of PR #<n>.` body if its API key is missing, the provider name is unrecognised, or the API call fails — same graceful-degradation behavior as before.
- Threads `OPENAI_API_KEY`/`DEEPSEEK_API_KEY` secrets through `claude-pr-review.yml` and `gpt-pr-review.yml` (previously only `deepseek-pr-review.yml` passed all three) so follow-up issue creation works regardless of which reviewer triggers it.
- Documents the new variable in `docs/AI_REVIEW_WORKFLOWS.md`.

## Test plan
- [x] `pytest tests/test_create_followup_issues.py` — 15 tests covering default (deepseek), explicit claude/gpt selection, unknown-provider fallback, API-error fallback, and existing issue-creation/labeling behavior
- [x] `ruff check --config backend/pyproject.toml` on changed files
- [ ] Set `FOLLOWUP_LLM_PROVIDER` repo variable (optional — defaults to `deepseek`) and confirm a real PR's follow-up issue gets a rich body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Follow-up issue generation now supports multiple LLM providers (DeepSeek, Claude, and GPT) with `FOLLOWUP_LLM_PROVIDER`, defaulting to DeepSeek.

* **Bug Fixes**
  * Improved resilience: unknown providers and API failures now reliably fall back to a minimal “Follow-up” issue body.

* **Documentation**
  * Added guidance on selecting the follow-up provider independently of the PR review provider, including required API keys and fallback behaviour.

* **Tests**
  * Expanded coverage for provider selection and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->