### PR TITLE
feat: opt PRs into deepseek-reasoner via Deep Review Required label

### DIFF
--- a/.github/scripts/deepseek_review.py
+++ b/.github/scripts/deepseek_review.py
@@ -21,9 +21,10 @@ def get_deepseek_model() -> str:
     """Return the DeepSeek model ID to call for advisory reviews.
 
     Defaults to `deepseek-chat` (the latest DeepSeek-V3 alias). Set
-    `DEEPSEEK_MODEL` to override (e.g. for a specific version pin).
+    `DEEPSEEK_MODEL` to override (e.g. to `deepseek-reasoner` for a deeper
+    review). An unset or empty value falls back to the default.
     """
-    return os.environ.get("DEEPSEEK_MODEL", DEFAULT_DEEPSEEK_MODEL)
+    return os.environ.get("DEEPSEEK_MODEL") or DEFAULT_DEEPSEEK_MODEL
 
 
 def get_max_tokens() -> int:

--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -24,6 +24,16 @@ on:
         required: false
         type: string
         default: ""
+      deepseek_model:
+        description: "DEEPSEEK_MODEL override passed to the review script, if any"
+        required: false
+        type: string
+        default: ""
+      deepseek_max_tokens:
+        description: "DEEPSEEK_MAX_TOKENS override passed to the review script, if any"
+        required: false
+        type: string
+        default: ""
     secrets:
       anthropic_api_key:
         description: "Anthropic API key, used for Claude reviews and follow-up issue creation"
@@ -90,6 +100,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.openai_api_key }}
           DEEPSEEK_API_KEY: ${{ secrets.deepseek_api_key }}
           ANTHROPIC_MAX_TOKENS: ${{ inputs.anthropic_max_tokens }}
+          DEEPSEEK_MODEL: ${{ inputs.deepseek_model }}
+          DEEPSEEK_MAX_TOKENS: ${{ inputs.deepseek_max_tokens }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           DIFF: ${{ steps.diff.outputs.diff }}
           ISSUE_BODY: ${{ steps.issue.outputs.body }}

--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -2,7 +2,7 @@ name: DeepSeek PR Review
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
   ai-review:
@@ -17,6 +17,12 @@ jobs:
       provider_id: deepseek
       review_script: .github/scripts/deepseek_review.py
       workflow_file: deepseek-pr-review.yml
+      # "Deep Review Required" opts a PR into the stronger reasoning model
+      # with a larger token budget (its chain-of-thought tokens count
+      # against max_tokens). Without the label, the script falls back to
+      # its defaults (deepseek-chat, 4096 tokens).
+      deepseek_model: ${{ contains(github.event.pull_request.labels.*.name, 'Deep Review Required') && 'deepseek-reasoner' || '' }}
+      deepseek_max_tokens: ${{ contains(github.event.pull_request.labels.*.name, 'Deep Review Required') && '16000' || '' }}
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -6,6 +6,12 @@ on:
 
 jobs:
   ai-review:
+    # For labeled/unlabeled events, github.event.label.name is the label that
+    # was just added or removed. Gating on it here covers both directions:
+    # adding "Deep Review Required" triggers a run that picks up the stronger
+    # model below, and removing it triggers a run that reverts to the
+    # defaults (since `contains(...)` on the current labels is then false).
+    # Any other label add/remove is ignored.
     if: >-
       ${{ github.actor != 'dependabot[bot]' && vars.ENABLE_DEEPSEEK_REVIEW != 'false' &&
       (github.event.action != 'labeled' && github.event.action != 'unlabeled' ||

--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   ai-review:
-    if: ${{ github.actor != 'dependabot[bot]' && vars.ENABLE_DEEPSEEK_REVIEW != 'false' }}
+    if: >-
+      ${{ github.actor != 'dependabot[bot]' && vars.ENABLE_DEEPSEEK_REVIEW != 'false' &&
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
+      github.event.label.name == 'Deep Review Required') }}
     permissions:
       pull-requests: write
       contents: read

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -61,6 +61,11 @@ def test_deepseek_review_uses_current_default_model_and_allows_override(
     monkeypatch.setenv("DEEPSEEK_MODEL", "deepseek-reasoner")
     assert module.get_deepseek_model() == "deepseek-reasoner"
 
+    # An empty override (e.g. an unset workflow input) falls back to the default
+    # rather than sending an empty model string to the API.
+    monkeypatch.setenv("DEEPSEEK_MODEL", "")
+    assert module.get_deepseek_model() == "deepseek-chat"
+
 
 @pytest.mark.parametrize(
     ("module_name", "file_name", "api_env"),


### PR DESCRIPTION
## Summary
- PRs labeled `Deep Review Required` get the DeepSeek review run with `deepseek-reasoner` and a 16000-token budget instead of the default `deepseek-chat` / 4096.
- Adding/removing the label takes effect on the next push or re-run (`labeled`/`unlabeled` added to the workflow triggers).
- `get_deepseek_model()` now treats an empty `DEEPSEEK_MODEL` override (the no-label case) the same as unset, falling back to `deepseek-chat`.
- Created the `Deep Review Required` label in the repo.

Closes #4249

## Test plan
- [x] `pytest tests/test_ai_review_scripts.py` passes (26 passed), including a new case for empty `DEEPSEEK_MODEL`
- [x] YAML syntax of `_ai-pr-review.yml` and `deepseek-pr-review.yml` validated with `yaml.safe_load`
- [ ] Manually verify on a real PR: add the `Deep Review Required` label and confirm the DeepSeek review step uses `deepseek-reasoner` with `DEEPSEEK_MAX_TOKENS=16000`; remove it and confirm the next run falls back to `deepseek-chat`/4096


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable DeepSeek model selection and max tokens to PR review workflows via new workflow parameters.
* **Workflow Updates**
  * PR DeepSeek reviews now respond to label changes, running only when the “Deep Review Required” label is present (with existing gating preserved).
* **Bug Fixes**
  * DeepSeek now falls back to the default model when the model setting is unset or empty.
* **Tests**
  * Extended tests to verify empty model configuration uses the default model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->