### PR TITLE
feat: /whoami debug endpoint + API Gateway access logging (#4255)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -222,6 +222,31 @@ def create_app() -> FastAPI:
 
         return {"status": "ok", "env": cfg.app_env}
 
+    @app.get("/whoami")
+    async def whoami(
+        _: str = Depends(require_admin),
+        token: str | None = Depends(auth.oauth2_scheme),
+    ):
+        """Auth-boundary debug view of the bearer token the backend received.
+
+        Admin-gated (via ``require_admin`` / ``ADMIN_EMAILS``) so decoded claims
+        are never exposed to non-admins. Returns whether a token was presented,
+        an allowlisted subset of its claims (sub, email, exp, iss, token_use,
+        aud), and whether its email matches the backend allowed-emails set.
+
+        Limitation: when the API Gateway Cognito JWT authorizer rejects a
+        request it never reaches the Lambda, so this endpoint cannot diagnose
+        gateway-level 401s — those are visible in API Gateway access logs in
+        CloudWatch. See docs/AUTH.md.
+        """
+
+        result = auth.describe_token(token)
+        result["note"] = (
+            "Diagnoses backend token handling only. Gateway-rejected requests "
+            "never reach this endpoint; see API Gateway access logs in CloudWatch."
+        )
+        return result
+
     @app.get("/api-console", response_class=HTMLResponse, include_in_schema=False)
     async def api_console(_: str = Depends(require_admin)):
         """Interactive API console — restricted to admin users."""

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -179,6 +179,56 @@ def decode_token(token: str) -> Optional[str]:
         return None
 
 
+# Claim names surfaced by the admin /whoami debug endpoint. Deliberately a
+# fixed allowlist so the raw token and any unexpected/sensitive claims are
+# never echoed back — see describe_token and GET /whoami in backend/app.py.
+WHOAMI_CLAIM_FIELDS: Tuple[str, ...] = ("sub", "email", "exp", "iss", "token_use", "aud")
+
+
+def _unverified_claims(token: str) -> dict[str, Any]:
+    """Return a JWT's payload WITHOUT verifying its signature.
+
+    Used only by the admin-gated /whoami diagnostic to report what the backend
+    decodes from the presented token. For Cognito tokens the API Gateway
+    authorizer has already verified the signature upstream; here we only need
+    the claim values for observability, not to establish trust. Returns an
+    empty mapping when the token is not a decodable JWT.
+    """
+
+    try:
+        payload = jwt.decode(token, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def describe_token(token: str | None) -> dict[str, Any]:
+    """Return an admin-only diagnostic view of the presented bearer token.
+
+    Reports whether a token was presented, a fixed allowlist of decoded claims
+    (never the raw token), and whether the token's email matches the backend
+    allowed-emails set. The email claim is preferred; app-signed backend JWTs
+    carry the email in ``sub`` instead, so that is used as a fallback.
+    """
+
+    if not isinstance(token, str) or not token:
+        return {"token_present": False, "claims": {}, "allowed_email_match": False}
+
+    payload = _unverified_claims(token)
+    claims = {field: payload.get(field) for field in WHOAMI_CLAIM_FIELDS}
+
+    email = payload.get("email") or payload.get("sub")
+    allowed_email_match = False
+    if isinstance(email, str) and email:
+        allowed_email_match = email.lower() in _allowed_emails()
+
+    return {
+        "token_present": True,
+        "claims": claims,
+        "allowed_email_match": allowed_email_match,
+    }
+
+
 def _user_from_token(token: str | None) -> str:
     if not token:
         raise HTTPException(

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -1,3 +1,4 @@
+import json
 import os
 from collections.abc import Sequence
 from pathlib import Path
@@ -391,6 +392,42 @@ class BackendLambdaStack(Stack):
             ),
         )
         self.backend_api_url = backend_api.api_endpoint
+
+        # Access logging on the default ($default) stage. The Cognito JWT
+        # authorizer rejects unauthorized requests (e.g. the /owners 401 in
+        # #4256) BEFORE they reach the Lambda, so those rejections are invisible
+        # in the Lambda's own logs. Logging $context.authorizer.error alongside
+        # the status/route makes gateway-level 401s observable in CloudWatch.
+        # The format deliberately logs claims/status only — never the raw bearer
+        # token — so no credentials land in the logs.
+        access_log_group = logs.LogGroup(
+            self,
+            "BackendApiAccessLogGroup",
+            retention=logs.RetentionDays.ONE_WEEK,
+            removal_policy=RemovalPolicy.DESTROY,
+        )
+        access_log_format = json.dumps(
+            {
+                "requestId": "$context.requestId",
+                "routeKey": "$context.routeKey",
+                "status": "$context.status",
+                "errorMessage": "$context.error.message",
+                "authorizerError": "$context.authorizer.error",
+                "integrationStatus": "$context.integrationStatus",
+                "responseLatency": "$context.responseLatency",
+            }
+        )
+        default_stage = backend_api.default_stage
+        assert default_stage is not None, "BackendApi must expose a default stage"
+        cfn_default_stage = default_stage.node.default_child
+        assert isinstance(
+            cfn_default_stage, apigwv2.CfnStage
+        ), "Expected the default stage's default child to be a CfnStage"
+        cfn_default_stage.add_property_override(
+            "AccessLogSettings.DestinationArn", access_log_group.log_group_arn
+        )
+        cfn_default_stage.add_property_override("AccessLogSettings.Format", access_log_format)
+
         backend_integration = apigwv2_integrations.HttpLambdaIntegration(
             "BackendLambdaIntegration", backend_fn
         )

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -659,6 +659,69 @@ def test_backend_api_routes_require_cognito_authorizer(template):
 
 
 # ---------------------------------------------------------------------------
+# API Gateway access logging (auth-boundary observability — issue #4255)
+# ---------------------------------------------------------------------------
+
+
+def test_backend_api_stage_has_access_logging(template):
+    """The HTTP API default stage must have access logging configured so that
+    authorizer rejections (Cognito JWT 401s that never reach the Lambda) are
+    observable in CloudWatch.
+
+    Asserts the stage points at a CloudWatch log group and that the log format
+    includes the authorizer error, status, and route — but not the raw token.
+    """
+    stages = template.find_resources("AWS::ApiGatewayV2::Stage")
+    assert stages, "Expected an AWS::ApiGatewayV2::Stage resource"
+
+    access_log_settings = [
+        resource["Properties"].get("AccessLogSettings")
+        for resource in stages.values()
+        if resource.get("Properties", {}).get("AccessLogSettings")
+    ]
+    assert access_log_settings, (
+        "No AWS::ApiGatewayV2::Stage has AccessLogSettings configured; "
+        "the default stage must write access logs to CloudWatch so gateway "
+        "authorizer 401s are observable (issue #4255)"
+    )
+
+    settings = access_log_settings[0]
+    assert settings.get("DestinationArn"), (
+        "AccessLogSettings must reference a CloudWatch log group DestinationArn"
+    )
+    fmt = settings.get("Format", "")
+    assert "$context.authorizer.error" in fmt, (
+        "Access log format must include $context.authorizer.error so gateway "
+        "authorizer rejections record a reason"
+    )
+    assert "$context.status" in fmt, "Access log format must include $context.status"
+    assert "$context.routeKey" in fmt, "Access log format must include $context.routeKey"
+    # Guard against ever logging the raw bearer token / Authorization header.
+    assert "uthorization" not in fmt, (
+        "Access log format must not capture the Authorization header / raw token"
+    )
+
+
+def test_backend_api_access_log_group_has_one_week_retention(template):
+    """The access-log group must use the stack's standard one-week retention
+    and be destroyed with the stack, matching the Lambda log groups."""
+    resources = template.find_resources("AWS::Logs::LogGroup")
+    access_log_groups = {
+        logical_id: resource
+        for logical_id, resource in resources.items()
+        if logical_id.startswith("BackendApiAccessLogGroup")
+    }
+    assert access_log_groups, "Expected a BackendApiAccessLogGroup log group"
+    for logical_id, resource in access_log_groups.items():
+        assert resource["Properties"]["RetentionInDays"] == 7, (
+            f"{logical_id} must retain access logs for one week"
+        )
+        assert resource["DeletionPolicy"] == "Delete", (
+            f"{logical_id} must be destroyed with the stack"
+        )
+
+
+# ---------------------------------------------------------------------------
 # CfnOutputs
 # ---------------------------------------------------------------------------
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -58,3 +58,59 @@ Browser                        Cognito Hosted UI          Backend
 - The backend JWT is stored in `localStorage` via `setAuthToken` (consistent with the Google flow).
 - The allowed-emails list is enforced server-side in `verify_cognito_token` → `_authorize_email`.
 - The JWKS issuer is validated to start with `cognito-idp.` and end with `.amazonaws.com` to prevent attacker-controlled JWKS endpoints.
+
+## Diagnosing auth failures
+
+Auth can fail at two distinct boundaries, and each is observed differently.
+
+### Backend token handling — `GET /whoami` (admin only)
+
+`GET /whoami` reports what the **backend** decodes from the bearer token on the
+current request:
+
+```json
+{
+  "token_present": true,
+  "claims": { "sub": "...", "email": "...", "exp": 0, "iss": "...", "token_use": "id", "aud": "..." },
+  "allowed_email_match": true,
+  "note": "Diagnoses backend token handling only. ..."
+}
+```
+
+- **Admin-gated.** It is protected by the same `require_admin` dependency as
+  `/api-console` (the `ADMIN_EMAILS` allowlist), so decoded claims are never
+  exposed to non-admin users. It never returns the raw token, and only an
+  allowlist of claims (`sub`, `email`, `exp`, `iss`, `token_use`, `aud`) is
+  echoed back.
+- **How to call it:** authenticate through the app as an admin (so the backend
+  JWT is sent), then `GET /whoami` with `Authorization: Bearer <backend-jwt>`.
+  `allowed_email_match` reflects whether the token's email is in the backend
+  allowed-emails set.
+- **Limitation:** when the API Gateway Cognito JWT authorizer rejects a request,
+  it never reaches the Lambda — so `/whoami` cannot diagnose gateway-level 401s.
+  Those are covered by access logging below.
+
+Implemented in `backend/auth.py` (`describe_token`) and `backend/app.py`
+(`GET /whoami`).
+
+### Gateway authorizer rejections — API Gateway access logs (CloudWatch)
+
+A request rejected by the Cognito JWT authorizer at API Gateway (for example the
+`/owners` 401 in issue #4256) is returned **before** the backend Lambda runs, so
+it appears in neither the Lambda logs nor `/whoami`. The HTTP API `$default`
+stage is configured (in `cdk/stacks/backend_lambda_stack.py`) to write access
+logs to a CloudWatch log group (`BackendApiAccessLogGroup`). Each entry is JSON
+including:
+
+| Field | `$context` source | Use |
+|---|---|---|
+| `status` | `$context.status` | HTTP status returned to the client |
+| `routeKey` | `$context.routeKey` | Which route was hit (e.g. `GET /owners`) |
+| `authorizerError` | `$context.authorizer.error` | Why the JWT authorizer rejected the request |
+| `errorMessage` | `$context.error.message` | Gateway-level error detail |
+| `integrationStatus` | `$context.integrationStatus` | Status from the Lambda integration |
+
+To investigate a gateway 401: open the `BackendApiAccessLogGroup` log group in
+CloudWatch, filter to the failing `routeKey`, and read `authorizerError`. The
+format deliberately logs claims/status only — the raw `Authorization` header /
+bearer token is never logged.

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -249,6 +249,24 @@ Use this when you need to verify sign-in, protected routes, or production-like a
 - `ALLOWED_EMAILS` is not strictly mandatory, but without it you may get broader login access than intended.
 - Smoke and test flows may still use mock or token-driven auth instead of interactive Google sign-in.
 
+### Debugging auth failures
+
+Auth fails at two boundaries; check them in this order:
+
+1. **Gateway authorizer (deployed AWS only).** A request rejected by the API
+   Gateway Cognito JWT authorizer (e.g. a `/owners` 401) never reaches the
+   Lambda, so it is invisible in the Lambda logs. Open the
+   `BackendApiAccessLogGroup` CloudWatch log group, filter by the failing
+   `routeKey`, and read `authorizerError` / `status`.
+2. **Backend token handling.** As an admin (an email in `ADMIN_EMAILS`), call
+   `GET /whoami` with `Authorization: Bearer <token>`. It returns
+   `token_present`, the decoded `claims` (`sub`, `email`, `exp`, `iss`,
+   `token_use`, `aud`), and `allowed_email_match`. It is admin-gated and never
+   echoes the raw token. Note: `/whoami` cannot see gateway rejections — those
+   are step 1.
+
+See `docs/AUTH.md` → "Diagnosing auth failures" for full details.
+
 ## 7. Test mode
 
 Use the smallest validation that matches your change.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -121,6 +121,74 @@ def test_api_console_admin_check(monkeypatch, admin_emails, disable_auth, email,
     assert resp.status_code == expected_status
 
 
+def _whoami_app(monkeypatch, *, admin_emails="admin@example.com", disable_auth=True):
+    """Build an app configured for /whoami tests with the admin allowlist set."""
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+    monkeypatch.setattr(config, "disable_auth", disable_auth)
+    monkeypatch.setenv("ADMIN_EMAILS", admin_emails)
+    with patch("backend.common.portfolio_utils.refresh_snapshot_async"):
+        return create_app()
+
+
+def test_whoami_requires_admin(monkeypatch):
+    """Non-admin users must never see decoded token claims."""
+    app = _whoami_app(monkeypatch)
+    app.dependency_overrides[auth.get_current_user] = lambda: "other@example.com"
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/whoami")
+    assert resp.status_code == 403
+
+
+def test_whoami_returns_claims_for_admin(monkeypatch):
+    """An admin sees the allowlisted claim subset and the allowed-email result."""
+    import jwt
+
+    app = _whoami_app(monkeypatch)
+    app.dependency_overrides[auth.get_current_user] = lambda: "admin@example.com"
+    monkeypatch.setattr(auth, "_allowed_emails", lambda: {"admin@example.com"})
+
+    token = jwt.encode(
+        {
+            "sub": "cognito-sub-123",
+            "email": "admin@example.com",
+            "exp": 9999999999,
+            "iss": "https://cognito-idp.eu-west-2.amazonaws.com/pool",
+            "token_use": "id",
+            "aud": "client-abc",
+            "secret_claim": "should-not-leak",
+        },
+        "unverified-signature-secret-not-checked-by-whoami",
+        algorithm="HS256",
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["token_present"] is True
+    assert body["allowed_email_match"] is True
+    assert body["claims"]["email"] == "admin@example.com"
+    assert body["claims"]["token_use"] == "id"
+    assert body["claims"]["aud"] == "client-abc"
+    # Only the allowlisted claims are echoed; unexpected claims are dropped.
+    assert "secret_claim" not in body["claims"]
+    assert "note" in body
+
+
+def test_whoami_reports_token_absent(monkeypatch):
+    """With no bearer token the response reports token_present=False."""
+    app = _whoami_app(monkeypatch)
+    app.dependency_overrides[auth.get_current_user] = lambda: "admin@example.com"
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/whoami")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["token_present"] is False
+    assert body["claims"] == {}
+    assert body["allowed_email_match"] is False
+
+
 def test_health_returns_200_when_prime_latest_prices_fails(monkeypatch):
     """App must still serve /health even when optional snapshot warm-up fails."""
     monkeypatch.setattr(config, "skip_snapshot_warm", False)


### PR DESCRIPTION
## Summary

Adds auth-boundary observability so failures like the `/owners` 401 (#4256) can be diagnosed quickly, at the two distinct boundaries where auth can fail.

### 1. `GET /whoami` debug endpoint (backend)
- Returns `{ token_present, claims: {sub, email, exp, iss, token_use, aud}, allowed_email_match, note }` for the bearer token the **backend** received.
- **Admin-gated** via the existing `require_admin` / `ADMIN_EMAILS` dependency (same gate as `/api-console`) — claims are never exposed to non-admins.
- Never echoes the raw token; only a fixed allowlist of claims is returned (unexpected claims are dropped).
- Backed by a new `backend.auth.describe_token` helper that decodes claims without verifying the signature (the gateway already verified Cognito tokens upstream).
- Documents the limitation: when the API Gateway Cognito JWT authorizer rejects a request, the Lambda — and `/whoami` — is never reached. That gap is covered by access logging.

### 2. API Gateway access logging (CDK)
- Configures access logging on the HTTP API `$default` stage (`cdk/stacks/backend_lambda_stack.py`) writing to a one-week CloudWatch log group (`BackendApiAccessLogGroup`).
- JSON format includes `$context.authorizer.error`, `$context.status`, `$context.routeKey`, and `$context.error.message`, so gateway authorizer 401s become observable in CloudWatch.
- Format logs claims/status only — never the `Authorization` header / raw bearer token.

### Docs
- `docs/AUTH.md` — new "Diagnosing auth failures" section covering both mechanisms.
- `docs/CONTRIBUTOR_RUNBOOK.md` — "Debugging auth failures" subsection.

## Tests
- `tests/test_app.py`: `/whoami` admin gating (403 for non-admin), claim subset + allowed-email result for admin, token-absent case.
- `cdk/tests/test_backend_lambda_stack.py`: stage has access logging with the required `$context` fields and no Authorization capture; access-log group retention.

All backend and CDK tests pass locally (`pytest tests/test_app.py`, `pytest cdk/tests/test_backend_lambda_stack.py`).

## Notes for reviewers
- `/whoami` reflects what the backend sees on a normal request — the app-signed backend JWT (carries the email in `sub`). It also surfaces full claims if a Cognito token is presented directly.
- Reuses existing auth code paths; no parallel auth mechanism added.

Closes #4255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an admin-only diagnostic endpoint to help troubleshoot authentication issues and validate token handling
  * Enabled API Gateway access logging for improved visibility into request processing and error diagnosis

* **Documentation**
  * Added guidance for diagnosing and debugging authentication failures
  * Included instructions for interpreting API Gateway logs and validating backend token validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->