### PR TITLE
feat: include PR discussion since last AI review in review prompt

### DIFF
--- a/.github/scripts/claude_review.py
+++ b/.github/scripts/claude_review.py
@@ -73,7 +73,7 @@ def main() -> int:
     if not context.diff.strip():
         return emit_empty_diff_notice("Claude")
 
-    prompt = build_prompt(context.pr_title, context.diff, context.issue_body)
+    prompt = build_prompt(context.pr_title, context.diff, context.issue_body, context.discussion)
     review = fetch_claude_review(context.api_key, prompt)
     return finalize_review(review, "ERROR: Claude API returned an empty review")
 

--- a/.github/scripts/deepseek_review.py
+++ b/.github/scripts/deepseek_review.py
@@ -92,7 +92,7 @@ def main() -> int:
     if not context.diff.strip():
         return emit_empty_diff_notice("DeepSeek")
 
-    prompt = build_prompt(context.pr_title, context.diff, context.issue_body)
+    prompt = build_prompt(context.pr_title, context.diff, context.issue_body, context.discussion)
     review = fetch_deepseek_review(context.api_key, prompt)
     return finalize_review(review, "ERROR: DeepSeek API returned an empty review")
 

--- a/.github/scripts/gpt_review.py
+++ b/.github/scripts/gpt_review.py
@@ -52,7 +52,7 @@ def main() -> int:
     if not context.diff.strip():
         return emit_empty_diff_notice("GPT")
 
-    prompt = build_prompt(context.pr_title, context.diff, context.issue_body)
+    prompt = build_prompt(context.pr_title, context.diff, context.issue_body, context.discussion)
     review = fetch_openai_review(context.api_key, prompt)
     return finalize_review(review, "ERROR: OpenAI API returned an empty review")
 

--- a/.github/scripts/prepare_review_discussion.py
+++ b/.github/scripts/prepare_review_discussion.py
@@ -1,0 +1,116 @@
+"""Prepare PR discussion since a provider's last review for advisory AI reviews.
+
+Fetches both inline review-thread comments (`pulls/{n}/comments`) and top-level
+conversation comments (`issues/{n}/comments`) via `gh api`, filters out bots and
+the reviewing provider's own prior review bodies, anchors the window to the
+provider's last posted review comment, and prints the remaining human discussion
+sorted by creation time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+MAX_DISCUSSION_CHARS = 20_000
+TRUNCATION_NOTICE = "\n\n[discussion truncated to stay within the review budget]"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments identifying the repo, PR, and reviewing provider."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr-number", required=True)
+    parser.add_argument("--provider-name", required=True)
+    return parser.parse_args()
+
+
+def gh_api_list(path: str) -> list[dict]:
+    """Return all paginated JSON objects for a `gh api` list endpoint."""
+    result = subprocess.run(
+        ["gh", "api", path, "--paginate"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    items: list[dict] = []
+    decoder = json.JSONDecoder()
+    text = result.stdout
+    pos = 0
+    while pos < len(text):
+        while pos < len(text) and text[pos].isspace():
+            pos += 1
+        if pos >= len(text):
+            break
+        page, end = decoder.raw_decode(text, pos)
+        items.extend(page)
+        pos = end
+    return items
+
+
+def is_human_comment(comment: dict) -> bool:
+    """Return True if a comment was posted by a human account."""
+    user = comment.get("user") or {}
+    return user.get("type") != "Bot"
+
+
+def find_review_anchor(issue_comments: list[dict], provider_name: str) -> str:
+    """Return the timestamp of the provider's most recent posted review comment.
+
+    Returns an empty string if no prior review comment exists, meaning the full
+    discussion history should be included.
+    """
+    marker = f"## {provider_name} AI Code Review"
+    timestamps = [
+        comment["created_at"]
+        for comment in issue_comments
+        if not is_human_comment(comment) and comment.get("body", "").startswith(marker)
+    ]
+    return max(timestamps, default="")
+
+
+def format_comment(comment: dict, location: str) -> str:
+    """Render a single comment as one discussion line."""
+    author = (comment.get("user") or {}).get("login", "unknown")
+    body = (comment.get("body") or "").strip()
+    return f"[{comment['created_at']}] {author} ({location}): {body}"
+
+
+def collect_discussion(repo: str, pr_number: str, provider_name: str) -> str:
+    """Return formatted human discussion created after the provider's last review."""
+    issue_comments = gh_api_list(f"repos/{repo}/issues/{pr_number}/comments")
+    inline_comments = gh_api_list(f"repos/{repo}/pulls/{pr_number}/comments")
+
+    anchor = find_review_anchor(issue_comments, provider_name)
+
+    entries: list[tuple[str, str]] = []
+    for comment in issue_comments:
+        if is_human_comment(comment) and comment["created_at"] > anchor:
+            entries.append((comment["created_at"], format_comment(comment, "conversation")))
+    for comment in inline_comments:
+        if is_human_comment(comment) and comment["created_at"] > anchor:
+            location = f"inline on {comment.get('path', 'unknown file')}"
+            entries.append((comment["created_at"], format_comment(comment, location)))
+
+    entries.sort(key=lambda entry: entry[0])
+    discussion = "\n\n".join(text for _, text in entries)
+
+    if len(discussion) > MAX_DISCUSSION_CHARS:
+        cut = discussion[: MAX_DISCUSSION_CHARS - len(TRUNCATION_NOTICE)]
+        discussion = cut.rsplit("\n\n", 1)[0] + TRUNCATION_NOTICE
+
+    return discussion
+
+
+def main() -> int:
+    """Fetch and print PR discussion since the provider's last review."""
+    args = parse_args()
+    discussion = collect_discussion(args.repo, args.pr_number, args.provider_name)
+    sys.stdout.write(discussion)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/review_common.py
+++ b/.github/scripts/review_common.py
@@ -26,6 +26,7 @@ class ReviewContext:
     pr_title: str
     diff: str
     issue_body: str
+    discussion: str
 
 
 def get_required_env(name: str) -> str:
@@ -49,11 +50,30 @@ def load_review_context(api_key_env: str) -> ReviewContext:
         pr_title=os.environ.get("PR_TITLE", ""),
         diff=os.environ.get("DIFF", ""),
         issue_body=os.environ.get("ISSUE_BODY", DEFAULT_ISSUE_BODY),
+        discussion=os.environ.get("DISCUSSION", ""),
     )
 
 
-def build_prompt(pr_title: str, diff: str, issue_body: str) -> str:
+def build_discussion_section(discussion: str) -> str:
+    """Return the prompt section covering discussion since the last review, if any."""
+    if not discussion.strip():
+        return ""
+    return f"""
+
+## Discussion since your last review
+The following PR comments were posted after your last review (oldest first).
+Treat them as **pointers**, not as proof: a comment claiming something is "fixed"
+or "addressed" does not by itself clear a blocking concern. Only down-rank or drop
+a concern you previously raised if the **diff above** shows it has actually been
+addressed. If a blocking concern is only verbally dismissed with no corresponding
+code change, you must still REQUEST CHANGES for it.
+
+{discussion}"""
+
+
+def build_prompt(pr_title: str, diff: str, issue_body: str, discussion: str = "") -> str:
     """Build the shared advisory review prompt used by both models."""
+    discussion_section = build_discussion_section(discussion)
     return f"""You are a senior engineer reviewing a pull request for **allotmint**,
 a family investment management app.
 
@@ -88,6 +108,7 @@ and avoid regressions in CI/deployment workflows.
 If the diff is empty, this is likely a docs-only or config-only PR whose file types
 were not captured. In that case, review the PR based solely on the linked issue
 acceptance criteria and PR title, and note that no diff was available.
+{discussion_section}
 
 Review this PR across these dimensions. Be direct and specific — cite line numbers
 or function names where relevant. Spend your words on real concerns.

--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -94,6 +94,22 @@ jobs:
             echo "$DELIM"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Get PR discussion since last review
+        id: discussion
+        env:
+          GH_TOKEN: ${{ secrets.gh_token }}
+        run: |
+          DISCUSSION=$(python3 .github/scripts/prepare_review_discussion.py \
+            --repo "${{ github.repository }}" \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --provider-name "${{ inputs.provider_name }}")
+          DELIM="EOF_$(uuidgen | tr -d '-')"
+          {
+            echo "text<<$DELIM"
+            echo "$DISCUSSION"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Call ${{ inputs.provider_name }} API
         env:
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
@@ -105,6 +121,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           DIFF: ${{ steps.diff.outputs.diff }}
           ISSUE_BODY: ${{ steps.issue.outputs.body }}
+          DISCUSSION: ${{ steps.discussion.outputs.text }}
         run: |
           python3 ${{ inputs.review_script }} > /tmp/${{ inputs.provider_id }}_review_body.md
 

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -160,6 +160,59 @@ def test_review_script_prints_review_on_mocked_api_success(
 
 
 @pytest.mark.parametrize(
+    ("module_name", "file_name", "api_env", "payload"),
+    [
+        (
+            "gpt_review_discussion",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
+            {"choices": [{"message": {"content": "Looks good\n**APPROVE**"}}]},
+        ),
+        (
+            "claude_review_discussion",
+            "claude_review.py",
+            "ANTHROPIC_API_KEY",
+            {"content": [{"type": "text", "text": "Looks good\n**APPROVE**"}]},
+        ),
+        (
+            "deepseek_review_discussion",
+            "deepseek_review.py",
+            "DEEPSEEK_API_KEY",
+            {"choices": [{"message": {"content": "Looks good\n**APPROVE**"}}]},
+        ),
+    ],
+)
+def test_review_script_includes_discussion_in_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    file_name: str,
+    api_env: str,
+    payload: dict[str, object],
+) -> None:
+    module = load_script_module(module_name, file_name)
+    monkeypatch.setenv(api_env, "test-key")
+    monkeypatch.setenv("PR_TITLE", "Add thing")
+    monkeypatch.setenv("ISSUE_BODY", "Do thing")
+    monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
+    monkeypatch.setenv(
+        "DISCUSSION", "[2024-01-01T00:00:00Z] alice (conversation): please re-check the null check"
+    )
+
+    captured_payloads: list[dict[str, object]] = []
+
+    def fake_urlopen(request, *args, **kwargs):
+        captured_payloads.append(json.loads(request.data.decode()))
+        return FakeResponse(payload)
+
+    monkeypatch.setattr(review_common.urllib.request, "urlopen", fake_urlopen)
+
+    assert module.main() == 0
+    prompt = json.dumps(captured_payloads[0])
+    assert "Discussion since your last review" in prompt
+    assert "please re-check the null check" in prompt
+
+
+@pytest.mark.parametrize(
     ("module_name", "file_name", "api_env", "payload", "expected_err"),
     [
         (
@@ -385,3 +438,122 @@ def test_default_globs_include_codeowners_file(tmp_path: Path, monkeypatch: pyte
     diff = module.git_diff("main", module.DEFAULT_GLOBS)
 
     assert ".github/CODEOWNERS" in diff
+
+
+def _comment(
+    login: str, body: str, created_at: str, user_type: str = "User", path: str | None = None
+) -> dict:
+    comment = {
+        "user": {"login": login, "type": user_type},
+        "body": body,
+        "created_at": created_at,
+    }
+    if path is not None:
+        comment["path"] = path
+    return comment
+
+
+def test_collect_discussion_returns_empty_when_no_comments(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_script_module("prepare_review_discussion", "prepare_review_discussion.py")
+
+    monkeypatch.setattr(module, "gh_api_list", lambda path: [])
+
+    assert module.collect_discussion("owner/repo", "1", "DeepSeek") == ""
+
+
+def test_collect_discussion_filters_to_after_last_review_and_excludes_bots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_script_module("prepare_review_discussion", "prepare_review_discussion.py")
+
+    issue_comments = [
+        _comment(
+            "github-actions[bot]",
+            "## DeepSeek AI Code Review\nLooks fine\n**APPROVE**",
+            "2024-01-01T00:00:00Z",
+            user_type="Bot",
+        ),
+        _comment("alice", "Old comment before the review, ignore me", "2023-12-31T00:00:00Z"),
+        _comment("alice", "Addressed your concern about the null check", "2024-01-02T00:00:00Z"),
+        _comment("dependabot[bot]", "Bumped a dependency", "2024-01-03T00:00:00Z", user_type="Bot"),
+    ]
+    inline_comments = [
+        _comment(
+            "alice", "Fixed the off-by-one here", "2024-01-02T12:00:00Z", path="frontend/src/foo.ts"
+        ),
+        _comment("bob", "Old inline comment", "2023-12-30T00:00:00Z", path="frontend/src/foo.ts"),
+    ]
+
+    def fake_gh_api_list(path: str) -> list[dict]:
+        if path.startswith("repos/owner/repo/issues/"):
+            return issue_comments
+        return inline_comments
+
+    monkeypatch.setattr(module, "gh_api_list", fake_gh_api_list)
+
+    discussion = module.collect_discussion("owner/repo", "1", "DeepSeek")
+
+    assert "Addressed your concern about the null check" in discussion
+    assert "Fixed the off-by-one here" in discussion
+    assert "inline on frontend/src/foo.ts" in discussion
+    assert "Old comment before the review" not in discussion
+    assert "Old inline comment" not in discussion
+    assert "Bumped a dependency" not in discussion
+    assert "AI Code Review" not in discussion
+
+
+def test_collect_discussion_includes_everything_when_no_prior_review(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_script_module("prepare_review_discussion", "prepare_review_discussion.py")
+
+    issue_comments = [_comment("alice", "First pass discussion", "2024-01-01T00:00:00Z")]
+
+    monkeypatch.setattr(
+        module,
+        "gh_api_list",
+        lambda path: issue_comments if "issues" in path else [],
+    )
+
+    discussion = module.collect_discussion("owner/repo", "1", "DeepSeek")
+
+    assert "First pass discussion" in discussion
+
+
+def test_collect_discussion_truncates_long_discussion(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_script_module("prepare_review_discussion", "prepare_review_discussion.py")
+
+    issue_comments = [
+        _comment(
+            "alice", "x" * 500, f"2024-01-01T{i // 3600:02d}:{(i // 60) % 60:02d}:{i % 60:02d}Z"
+        )
+        for i in range(0, 300)
+    ]
+
+    monkeypatch.setattr(
+        module,
+        "gh_api_list",
+        lambda path: issue_comments if "issues" in path else [],
+    )
+
+    discussion = module.collect_discussion("owner/repo", "1", "DeepSeek")
+
+    assert len(discussion) <= module.MAX_DISCUSSION_CHARS
+    assert "truncated" in discussion
+
+
+def test_gh_api_list_parses_paginated_json_arrays(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_script_module(
+        "prepare_review_discussion_paginate", "prepare_review_discussion.py"
+    )
+
+    class FakeResult:
+        stdout = '[{"id": 1}]\n[{"id": 2}]'
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: FakeResult(),
+    )
+
+    assert module.gh_api_list("repos/owner/repo/issues/1/comments") == [{"id": 1}, {"id": 2}]


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/prepare_review_discussion.py`, which fetches both inline review-thread comments (`pulls/{n}/comments`) and top-level conversation comments (`issues/{n}/comments`), filters to human (non-bot) comments, anchors the window to the reviewing provider's last posted review comment, and returns the remaining discussion sorted by time (truncated to 20k chars).
- `_ai-pr-review.yml` adds a "Get PR discussion since last review" step and passes its output as `DISCUSSION` to the review script.
- `review_common.build_prompt` gains an optional `discussion` parameter and adds a "Discussion since your last review" prompt section when non-empty, instructing the model that comments are pointers only -- a blocking concern can only be cleared by the diff, never by a comment alone.
- `claude_review.py`, `gpt_review.py`, `deepseek_review.py` all pass `context.discussion` through (shared helper, all three providers benefit).

## Test plan
- [x] `python -m pytest tests/test_ai_review_scripts.py -q` -- 34 passed, including new tests for `prepare_review_discussion.collect_discussion` (empty case, filtering bots/old comments/own prior review, no-prior-review case, truncation, pagination) and for discussion inclusion in the built prompt across all three providers.
- [x] Verified empty-discussion case still produces the existing prompt unchanged (no "Discussion since your last review" section).

Closes #4268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI code reviews now incorporate prior PR discussion and comments as additional context, enabling more informed and contextually-aware advisory feedback across all review providers (Claude, DeepSeek, OpenAI GPT).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->