### PR TITLE
fix: clear Cognito refresh timer on logout and page unload

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -156,6 +156,7 @@ export function Root() {
   }, []);
 
   const logout = () => {
+    clearCognitoRefreshTimer();
     apiLogout();
     setUser(null);
     setProfile(undefined);
@@ -440,13 +441,26 @@ const applyCognitoIdToken = (awsUiAuth?: AwsUiAuthConfig | null): boolean => {
 // header never goes stale mid-session (Cognito ID tokens last ~1h).
 const COGNITO_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
+let cognitoRefreshTimerId: ReturnType<typeof window.setTimeout> | null = null;
+
+// Cancels any pending Cognito refresh timer so a stale refresh callback can't
+// fire after logout or page unload. Idempotent.
+const clearCognitoRefreshTimer = () => {
+  if (cognitoRefreshTimerId !== null) {
+    window.clearTimeout(cognitoRefreshTimerId);
+    cognitoRefreshTimerId = null;
+  }
+};
+
 const scheduleCognitoRefresh = (awsUiAuth?: AwsUiAuthConfig | null) => {
+  clearCognitoRefreshTimer();
   const expiresAt = getCognitoSessionExpiresAt();
   if (expiresAt === null) return;
   // Clamp to >= 0 so an already-near-expiry session refreshes immediately
   // rather than scheduling a timer in the past.
   const delay = Math.max(0, expiresAt - Date.now() - COGNITO_REFRESH_BUFFER_MS);
-  window.setTimeout(() => {
+  cognitoRefreshTimerId = window.setTimeout(() => {
+    cognitoRefreshTimerId = null;
     void refreshCognitoSession(awsUiAuth)
       .then((idToken) => {
         if (idToken) {
@@ -468,6 +482,8 @@ const scheduleCognitoRefresh = (awsUiAuth?: AwsUiAuthConfig | null) => {
       });
   }, delay);
 };
+
+window.addEventListener('beforeunload', clearCognitoRefreshTimer);
 
 const bootstrapRuntimeConfig = async () => {
   let payload: { apiBaseUrl?: unknown; awsUiAuth?: AwsUiAuthConfig } | undefined;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -441,7 +441,7 @@ const applyCognitoIdToken = (awsUiAuth?: AwsUiAuthConfig | null): boolean => {
 // header never goes stale mid-session (Cognito ID tokens last ~1h).
 const COGNITO_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
-let cognitoRefreshTimerId: ReturnType<typeof window.setTimeout> | null = null;
+let cognitoRefreshTimerId: number | null = null;
 
 // Cancels any pending Cognito refresh timer so a stale refresh callback can't
 // fire after logout or page unload. Idempotent.


### PR DESCRIPTION
## Summary
- Store the `setTimeout` id from `scheduleCognitoRefresh` in a module-level variable and add `clearCognitoRefreshTimer()` to cancel it idempotently.
- `scheduleCognitoRefresh` now clears any existing timer before scheduling a new one (handles re-arm on refresh).
- The in-app `logout` handler clears the timer before calling `apiLogout()`.
- A `beforeunload` listener clears the timer on page unload.

## Test plan
- [x] `npx eslint --format unix src/main.tsx` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: log in via Cognito, log out, confirm no refresh callback fires afterward

Closes #4266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Cognito session refresh handling to cancel any pending refresh when users log out, preventing stale callbacks after sign-out and improving logout reliability.
  * Added cleanup for scheduled refresh on page unload/navigation to support more stable, predictable session behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->