### PR TITLE
feat(auth): surface OAuth error reason in admin-facing sign-in error

### DIFF
--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -5,6 +5,23 @@ export class UserCancelledError extends Error {
   }
 }
 
+const TOKEN_EXCHANGE_FAILURE_PREFIX =
+  'AWS UI authentication token exchange failed';
+
+/**
+ * Extracts the OAuth error code (e.g. "invalid_grant") appended to a token
+ * exchange failure message, or null if `error` is not such a failure.
+ */
+export const extractTokenExchangeErrorReason = (
+  error: unknown
+): string | null => {
+  if (!(error instanceof Error)) return null;
+  const match = error.message.match(
+    new RegExp(`^${TOKEN_EXCHANGE_FAILURE_PREFIX}: (.+)$`)
+  );
+  return match ? match[1] : null;
+};
+
 export interface AwsUiAuthConfig {
   enabled?: boolean | string;
   domain?: string;
@@ -178,6 +195,21 @@ export const refreshCognitoSession = async (
   return data.id_token;
 };
 
+/**
+ * Extracts the OAuth 2.0 `error` field (RFC 6749) from a failed token
+ * endpoint response, falling back to the HTTP status when the body is
+ * missing, unparseable, or lacks an `error` field.
+ */
+const extractOAuthErrorCode = async (response: Response): Promise<string> => {
+  try {
+    const body = (await response.json()) as { error?: unknown };
+    if (typeof body?.error === 'string' && body.error) return body.error;
+  } catch {
+    // Response body was missing or not valid JSON; fall back below.
+  }
+  return response.status ? `HTTP ${response.status}` : 'unknown_error';
+};
+
 const exchangeCode = async (config: AuthConfig) => {
   const params = new URLSearchParams(window.location.search);
   const code = params.get('code');
@@ -224,7 +256,9 @@ const exchangeCode = async (config: AuthConfig) => {
     // The authorization code is single-use; strip it from the URL so a
     // reload restarts the hosted-UI flow instead of replaying a dead code.
     window.history.replaceState({}, document.title, window.location.pathname);
-    throw new Error('AWS UI authentication token exchange failed');
+    throw new Error(
+      `${TOKEN_EXCHANGE_FAILURE_PREFIX}: ${await extractOAuthErrorCode(response)}`
+    );
   }
   storeSession(
     (await response.json()) as {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -38,7 +38,7 @@ import { UserProvider, useUser } from './UserContext';
 import ErrorBoundary from './ErrorBoundary';
 import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage';
 import { RouteProvider } from './RouteContext';
-import { clearCognitoSession, ensureAwsUiAuth, getCognitoSessionExpiresAt, getStoredCognitoIdToken, refreshCognitoSession, UserCancelledError, type AwsUiAuthConfig } from './awsUiAuth';
+import { clearCognitoSession, ensureAwsUiAuth, extractTokenExchangeErrorReason, getCognitoSessionExpiresAt, getStoredCognitoIdToken, refreshCognitoSession, UserCancelledError, type AwsUiAuthConfig } from './awsUiAuth';
 import {
   deriveBootstrapMode,
   deriveModeFromPathname,
@@ -543,9 +543,11 @@ void bootstrapRuntimeConfig()
         </div>
       );
     } else {
+      const reason = extractTokenExchangeErrorReason(error);
       createRoot(rootEl).render(
         <div role="alert" className="app-offline">
           <p>Authentication is unavailable. Please contact your administrator.</p>
+          {reason && <p>Sign-in failed. Reason: {reason}</p>}
           <button type="button" onClick={() => window.location.reload()}>
             Sign in
           </button>

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearCognitoSession, ensureAwsUiAuth, getCognitoSessionExpiresAt, getStoredCognitoAccessToken, getStoredCognitoIdToken, refreshCognitoSession, UserCancelledError } from '@/awsUiAuth';
+import { clearCognitoSession, ensureAwsUiAuth, extractTokenExchangeErrorReason, getCognitoSessionExpiresAt, getStoredCognitoAccessToken, getStoredCognitoIdToken, refreshCognitoSession, UserCancelledError } from '@/awsUiAuth';
 
 const assignMock = vi.fn();
 
@@ -253,6 +253,61 @@ describe('ensureAwsUiAuth', () => {
       );
       expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
     });
+
+    it('includes the OAuth error code from the response body when token exchange fails', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ error: 'invalid_grant' }),
+        })
+      );
+
+      await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
+        'AWS UI authentication token exchange failed: invalid_grant'
+      );
+    });
+
+    it('falls back to the HTTP status when the error response body has no error field', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({}),
+        })
+      );
+
+      await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
+        'AWS UI authentication token exchange failed: HTTP 401'
+      );
+    });
+
+    it('falls back to a generic reason when the error response body is unparseable', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+      await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
+        'AWS UI authentication token exchange failed: HTTP 500'
+      );
+    });
+  });
+});
+
+describe('extractTokenExchangeErrorReason', () => {
+  it('extracts the OAuth error code from a token exchange failure', () => {
+    const error = new Error(
+      'AWS UI authentication token exchange failed: invalid_grant'
+    );
+    expect(extractTokenExchangeErrorReason(error)).toBe('invalid_grant');
+  });
+
+  it('returns null for unrelated errors', () => {
+    expect(extractTokenExchangeErrorReason(new Error('some other error'))).toBeNull();
+  });
+
+  it('returns null for non-Error values', () => {
+    expect(extractTokenExchangeErrorReason('oops')).toBeNull();
   });
 });
 

--- a/frontend/tests/unit/main.tokenExchangeFailure.test.tsx
+++ b/frontend/tests/unit/main.tokenExchangeFailure.test.tsx
@@ -44,6 +44,43 @@ afterEach(() => {
 });
 
 describe('bootstrapRuntimeConfig — generic auth bootstrap failure', () => {
+  it('displays the OAuth error code from the token endpoint response', async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    window.history.replaceState({}, '', '/?code=auth-code-123&state=test-state');
+    sessionStorage.setItem('awsUiAuthState', 'test-state');
+    sessionStorage.setItem('awsUiAuthCodeVerifier', 'test-verifier');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (String(url).endsWith('/config.json')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(CONFIG_WITH_COGNITO),
+          });
+        }
+        if (String(url).endsWith('/oauth2/token')) {
+          return Promise.resolve({
+            ok: false,
+            status: 400,
+            json: () => Promise.resolve({ error: 'invalid_grant' }),
+          });
+        }
+        return Promise.resolve({ ok: false });
+      }),
+    );
+
+    await import('@/main');
+
+    await vi.waitFor(() => expect(renderedElement).not.toBeNull());
+
+    render(renderedElement!);
+    expect(screen.getByText(/Authentication is unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sign-in failed\. Reason: invalid_grant/i)).toBeInTheDocument();
+  });
+
   it('renders a "Sign in" retry button when token exchange fails', async () => {
     document.body.innerHTML = '<div id="root"></div>';
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- When the Cognito hosted-UI token exchange fails, extract the standard OAuth 2.0 `error` field (e.g. `invalid_grant`, `unauthorized_client`) from the token endpoint's response body and include it in the thrown error.
- Falls back to `HTTP <status>` or `unknown_error` if the response body is missing, unparseable, or has no `error` field.
- The admin-facing generic error page now shows a second line: "Sign-in failed. Reason: <code>" alongside the existing "Authentication is unavailable" message, so admins/support can diagnose without checking logs.
- The `UserCancelledError` path and the retry "Sign in" button behavior are unchanged.
- No sensitive data (tokens, client IDs) is exposed — only the OAuth error code/HTTP status.

## Test plan
- [x] `awsUiAuth.test.ts`: new tests cover error-code extraction from the response body, fallback to HTTP status, and fallback when the body is unparseable, plus unit tests for `extractTokenExchangeErrorReason`.
- [x] `main.tokenExchangeFailure.test.tsx`: new test asserts the rendered error page shows "Sign-in failed. Reason: invalid_grant" while preserving the existing "Authentication is unavailable" text and retry button.
- [x] Full frontend test suite (`npm run test -- --run`) passes (498/498).
- [x] `npm run lint` passes clean.

Closes #3951

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error messaging. When sign-in token exchange fails, users now receive detailed failure reasons instead of generic error messages. Specific OAuth error codes are displayed to help diagnose authentication issues.

* **Tests**
  * Added comprehensive unit test coverage for token exchange failure scenarios, including validation of error code extraction, HTTP status handling, and conditional rendering of detailed error messages in the authentication interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->