### PR TITLE
docs: document that local Cognito development requires API Gateway

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -79,6 +79,11 @@ fresh two ways:
 - **`frontend/src/main.tsx`** — `applyCognitoIdToken()` runs after `ensureAwsUiAuth` returns. It reads the stored Cognito ID token and applies it directly as the API auth token via `setAuthToken`, which attaches it as `Authorization: Bearer` on every API call. No `POST /token/cognito` exchange happens on the deployed path.
 - **`backend/app.py` / `backend/auth.py`** — `POST /token/cognito` (which exchanges a Cognito token for a backend HS256 JWT via `verify_cognito_token`) still exists for any non-gateway use, but the deployed frontend no longer calls it: against the API Gateway authorizer the backend JWT cannot be validated. The Google path (`POST /token`) continues to use the backend HS256 JWT against the FastAPI-enforced (non-gateway) setup.
 
+> **Local development note:** The ID-token-direct flow requires API Gateway's
+> Cognito JWT authorizer. Local testing of the Cognito authentication path is
+> not supported without a local API Gateway instance. For local development, use
+> the Google authentication flow instead.
+
 ### config.json fields
 
 | Field | Description |


### PR DESCRIPTION
Implement #4267: Add a short note in docs/AUTH.md under the Cognito section explaining that the ID-token-direct flow relies on API Gateway's authorizer and that local testing of the Cognito path is not supported without it.

Closes #4267

## What changed
- Added a blockquote note in \docs/AUTH.md\ under the Cognito section (after the Key implementation points and before config.json fields) explaining that local Cognito testing requires API Gateway and that the Google auth flow should be used instead for local development.

## Why changed
A developer running the frontend locally with Cognito enabled (pointing to a local backend without API Gateway) will send the Cognito ID token directly. The local FastAPI auth middleware expects a backend HMAC-signed JWT and will reject the Cognito ID token, causing a confusing failure. This regression is acceptable for the deployed app but was undocumented, risking developer confusion.

## What was verified
- No code or configuration files were modified (only docs/AUTH.md)
- Existing documentation content was not altered
- The existing note about /token/cognito existing for non-gateway use remains unchanged

## Known risks / follow-up
- None — purely a documentation change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guidance to clarify deployment and local testing workflows. Added recommendations for local development authentication flow alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->