### PR TITLE
chore: add agent execution-first rule and workspace root to AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,9 @@
-# GitHub Copilot Instructions for AllotMint
+# GitHub Copilot / Kun Agent Instructions for AllotMint
 
 Read `AGENTS.md` for full repository guidance. Use these short rules while generating code or PRs in this repo:
 
+- **Workspace root:** Use the repository root as the base for all file reads and writes. If you are unsure, call `ls` or `bash pwd` to determine it at the start of each session.
+- **Execution-first:** In your first response after loading a skill or receiving a clear action request, you MUST call the first relevant tool. Do not narrate your plan. Call the tool now.
 - Create or switch to a non-`main` branch before editing files; if the checkout is dirty with unrelated work, use a clean worktree from `main`.
 - For contributor setup/run-mode guidance, prefer `docs/CONTRIBUTOR_RUNBOOK.md`.
 - Backend entrypoint: `backend.app:create_app`; local app: `backend.local_api.main:app`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ This repository has a Python/FastAPI backend, a React/Vite frontend, AWS CDK inf
 
 **Language:** always respond in English only, never in Chinese or any other language.
 
+## Agent execution rules
+
+- **Workspace root:** Use the repository root as the base for all file reads and writes. If you are unsure, call `ls` or `bash pwd` to determine it at the start of each session.
+- **Execution-first:** In your first response after loading a skill or receiving a clear action request, you MUST call the first relevant tool. Do not narrate your plan, do not ask rhetorical questions, do not describe what you are about to do — call the tool. The tool output is your plan.
+
 ## 1. Repo map and mental model
 
 - `backend/`: FastAPI application code, domain services, importers, tasks, and Lambda/local entrypoints.


### PR DESCRIPTION
Add two missing pieces that caused the local LLM to stall instead of executing tasks:\n\n- **Workspace root** path so agents don't guess wrong file paths\n- **Execution-first rule** so agents call the first tool immediately instead of narrating plans\n\n## What changed\n- AGENTS.md: Added new section 0 with workspace root and execution-first rule\n- .github/copilot-instructions.md: Added the same two rules at the top\n\n## Why changed\nThe local model (Kun desktop app) spent its first response narrating plans and guessing paths instead of calling web_fetch or reading files. These two facts eliminate both failure modes.\n\n## What was verified\n- Both files read correctly after edit\n- No code, config, or docs were modified\n\n## Known risks / follow-up\n- The Kun app's operating contract (system prompt) is outside the repo — if the app reads these files, they'll take effect; if not, the workspace root path still needs to be injected at the app level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated internal AI/agent guidance to clarify workspace-root handling for file operations and enforce an execution-first approach for tool usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->