### PR TITLE
fix(scripts): match referenced files by basename in aider-issue.ps1

### DIFF
--- a/scripts/aider-issue.ps1
+++ b/scripts/aider-issue.ps1
@@ -123,14 +123,39 @@ if (-not $repoRoot) {
     exit 1
 }
 $pathPattern = '(?:[\w.-]+[\\/])*[\w.-]+\.[A-Za-z0-9]+'
-$referencedFiles = @(
+$candidates = @(
     [regex]::Matches("$title`n$issueBody", $pathPattern) |
         ForEach-Object { $_.Value } |
         Sort-Object -Unique |
-        Where-Object { $_ -notmatch '\.\.' -and -not [System.IO.Path]::IsPathRooted($_) } |
+        Where-Object { $_ -notmatch '\.\.' -and -not [System.IO.Path]::IsPathRooted($_) }
+)
+
+# Direct matches: candidate is already a valid path relative to the repo root.
+$directMatches = @(
+    $candidates |
         Where-Object { Test-Path -LiteralPath (Join-Path $repoRoot $_) -PathType Leaf } |
         ForEach-Object { Join-Path $repoRoot $_ }
 )
+
+# Basename fallback: issue text often names a bare filename (e.g.
+# "test_extract_verdict.py") without its directory, but the file actually
+# lives in a subdirectory (e.g. .github/scripts/test_extract_verdict.py).
+# Search tracked files for a matching leaf name so those still get added to
+# aider's context. Restricted to `git ls-files` output, so only files already
+# tracked in the repo can match - no path traversal outside the repo.
+$trackedFiles = @(git -C $repoRoot ls-files)
+$basenameMatches = @(
+    $candidates |
+        Where-Object { -not (Test-Path -LiteralPath (Join-Path $repoRoot $_) -PathType Leaf) } |
+        ForEach-Object {
+            $leaf = Split-Path -Leaf $_
+            $trackedFiles | Where-Object { (Split-Path -Leaf $_) -eq $leaf }
+        } |
+        Sort-Object -Unique |
+        ForEach-Object { Join-Path $repoRoot $_ }
+)
+
+$referencedFiles = @(($directMatches + $basenameMatches) | Sort-Object -Unique)
 if ($referencedFiles.Count -gt 0) {
     Write-Host "    Adding referenced files to aider context: $($referencedFiles -join ', ')"
 } else {


### PR DESCRIPTION
## Summary
- `scripts/aider-issue.ps1` only matched issue-referenced filenames against the repo root, so a bare filename like `test_extract_verdict.py` (which actually lives at `.github/scripts/test_extract_verdict.py` and `tests/test_extract_verdict.py`) was never found.
- Without an explicit `--file` target, small local models (e.g. `ollama/DeepSeek-Qwen3-8B`) replied with prose asking for the file instead of editing it, so aider made zero commits and the script aborted ("Aider made no commits...").
- Added a basename fallback: when a candidate doesn't exist directly under repo root, search `git ls-files` for tracked files with a matching leaf name and add those to aider's context too.

Closes #4292

## Test plan
- [x] Verified the script still parses with `ParseFile` (no syntax errors)
- [x] Verified the new basename-matching logic locates both `.github/scripts/test_extract_verdict.py` and `tests/test_extract_verdict.py` for the bare filename `test_extract_verdict.py` from issue #4284
- [ ] Re-run `.\scripts\aider-issue.ps1 4284` to confirm aider now receives `--file` targets and can make edits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced accuracy of file path detection in issue-based workflows through improved algorithmic handling of path references and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->