### PR TITLE
fix(scripts): grep backtick-quoted identifiers to disambiguate aider file targets

### DIFF
--- a/scripts/aider-issue.ps1
+++ b/scripts/aider-issue.ps1
@@ -155,7 +155,30 @@ $basenameMatches = @(
         ForEach-Object { Join-Path $repoRoot $_ }
 )
 
-$referencedFiles = @(($directMatches + $basenameMatches) | Sort-Object -Unique)
+# Identifier matches: issue text often calls out a specific function/method/
+# symbol in backticks (e.g. a test method name). When multiple files share a
+# basename (see above), a weak local model can't tell
+# which one is relevant and may produce a no-op edit against the wrong file.
+# Grepping tracked files for the exact identifier pinpoints the file that
+# actually defines/uses it. `git grep -l -F` only searches tracked files, so
+# results stay inside the repo. Listed first so it's the model's primary cue.
+# Require an underscore so generic backtick-quoted words (e.g. `APPROVE`)
+# don't turn into noisy, repo-wide grep matches - snake_case identifiers
+# (function/method/variable names) are the useful signal here.
+$identifierPattern = '`([A-Za-z_][A-Za-z0-9_]*_[A-Za-z0-9_]*)`'
+$identifiers = @(
+    [regex]::Matches("$title`n$issueBody", $identifierPattern) |
+        ForEach-Object { $_.Groups[1].Value } |
+        Sort-Object -Unique
+)
+$identifierMatches = @(
+    $identifiers |
+        ForEach-Object { git -C $repoRoot grep -l -F -- $_ 2>$null } |
+        Sort-Object -Unique |
+        ForEach-Object { Join-Path $repoRoot $_ }
+)
+
+$referencedFiles = @(($identifierMatches + $directMatches + $basenameMatches) | Select-Object -Unique)
 if ($referencedFiles.Count -gt 0) {
     Write-Host "    Adding referenced files to aider context: $($referencedFiles -join ', ')"
 } else {


### PR DESCRIPTION
## Summary
- After #4293's basename fallback, re-running `.\scripts\aider-issue.ps1 4284` got further but still failed with "Aider made no commits" — two files (`.github/scripts/test_extract_verdict.py` and `tests/test_extract_verdict.py`) shared the basename `test_extract_verdict.py`, and the small local model (`ollama/DeepSeek-Qwen3-8B`) picked the wrong one and produced a no-op edit.
- Added: extract snake_case identifiers quoted in backticks from the issue title/body (e.g. a referenced test method name like `` `test_malformed_backticks_single_side` ``), and `git grep -l -F` tracked files for each one, prepending any matches to `$referencedFiles`. This gives the model an unambiguous primary edit target.
- Required identifiers to contain an underscore so generic backtick-quoted words (e.g. `` `APPROVE` ``) don't produce noisy, repo-wide matches.

Closes #4297

## Test plan
- [x] Verified the script still parses with `ParseFile` (no syntax errors)
- [x] Simulated the discovery logic against issue #4284's title/body: the identifier `test_malformed_backticks_single_side` greps to exactly `.github/scripts/test_extract_verdict.py`, which is now listed first ahead of the basename matches
- [ ] Re-run `.\scripts\aider-issue.ps1 4284` to confirm aider edits the correct file and produces a real commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced file identification in issue processing: The system now extracts backtick-quoted identifiers from GitHub issue titles and body content to discover and match additional referenced files, expanding file matching scope and providing more comprehensive context for automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->