### PR TITLE
fix(backend): writable S3-backed accounts store for deployed writes (#4275)

### DIFF
--- a/backend/common/accounts_store.py
+++ b/backend/common/accounts_store.py
@@ -56,19 +56,19 @@ WRITABLE_ACCOUNTS_PREFIX = (os.getenv("WRITABLE_ACCOUNTS_PREFIX") or "writable-a
 def _lock_file(f) -> None:
     """Lock ``f`` for exclusive access."""
     if fcntl:
-        fcntl.flock(f, fcntl.LOCK_EX)
+        fcntl.flock(f, fcntl.LOCK_EX)  # type: ignore[attr-defined]
     else:  # pragma: no cover - Windows
         f.seek(0)
-        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 0x7FFFFFFF)
+        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 0x7FFFFFFF)  # type: ignore[attr-defined]
 
 
 def _unlock_file(f) -> None:
     """Unlock ``f``."""
     if fcntl:
-        fcntl.flock(f, fcntl.LOCK_UN)
+        fcntl.flock(f, fcntl.LOCK_UN)  # type: ignore[attr-defined]
     else:  # pragma: no cover - Windows
         f.seek(0)
-        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 0x7FFFFFFF)
+        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 0x7FFFFFFF)  # type: ignore[attr-defined]
 
 
 def _coerce_document(loaded: Any, default: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/common/accounts_store.py
+++ b/backend/common/accounts_store.py
@@ -1,0 +1,366 @@
+"""Pluggable persistence for writable account documents.
+
+Local development persists account JSON files under an on-disk accounts root,
+mutating them in place with file locking.  The deployed AWS environment has no
+writable, non-global on-disk root: ``configure_runtime_paths`` always falls
+back to the read-only shared/global demo dataset baked into the Lambda image,
+so every write tripped the ``accounts_root_is_global`` guard and returned
+``HTTP 400`` (issue #4275).
+
+This module abstracts the read/modify/write of a single account *document*
+(a holdings file or a transactions file) so write handlers can persist manual
+holdings and transactions to a writable store that is **separate** from the
+read-only ``accounts/`` demo data:
+
+* :class:`LocalAccountsStore` keeps the existing on-disk, file-locked behaviour
+  used by local development and the test suite.
+* :class:`S3AccountsStore` writes each document directly to a dedicated S3
+  prefix (``writable-accounts/`` by default) that never overlaps the shared
+  ``accounts/`` demo dataset, satisfying the "never mutate the shared dataset"
+  constraint while still persisting across the ephemeral Lambda filesystem.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import platform
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from backend.common.path_utils import safe_join
+
+try:  # Unix-like systems
+    import fcntl  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+    if platform.system() == "Windows":
+        import msvcrt  # type: ignore
+    else:  # pragma: no cover - unsupported platform
+        raise
+else:  # pragma: no cover - Unix
+    msvcrt = None  # type: ignore[assignment]
+
+logger = logging.getLogger("accounts_store")
+
+# Prefix (relative to the data bucket) under which per-owner writable account
+# documents live.  Kept distinct from the read-only ``accounts/`` demo prefix
+# so writes can never mutate the shared dataset.
+WRITABLE_ACCOUNTS_PREFIX = (os.getenv("WRITABLE_ACCOUNTS_PREFIX") or "writable-accounts").strip("/")
+
+
+def _lock_file(f) -> None:
+    """Lock ``f`` for exclusive access."""
+    if fcntl:
+        fcntl.flock(f, fcntl.LOCK_EX)
+    else:  # pragma: no cover - Windows
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 0x7FFFFFFF)
+
+
+def _unlock_file(f) -> None:
+    """Unlock ``f``."""
+    if fcntl:
+        fcntl.flock(f, fcntl.LOCK_UN)
+    else:  # pragma: no cover - Windows
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 0x7FFFFFFF)
+
+
+def _coerce_document(loaded: Any, default: Dict[str, Any]) -> Dict[str, Any]:
+    """Return ``loaded`` if it is a dict, otherwise a fresh copy of ``default``."""
+    if isinstance(loaded, dict):
+        return loaded
+    return copy.deepcopy(default)
+
+
+def _default_person_payload(owner: str) -> Dict[str, Any]:
+    return {
+        "dob": "",
+        "email": "",
+        "full_name": "",
+        "owner": owner,
+        "holdings": [],
+        "viewers": [],
+    }
+
+
+@dataclass
+class LocalAccountsStore:
+    """On-disk, file-locked account document store (local dev / tests).
+
+    ``is_global`` marks the resolved root as the read-only shared demo dataset;
+    write handlers refuse to mutate it.  ``local_root`` exposes the directory so
+    callers can still drive path-based helpers (e.g. portfolio rebuild).
+    """
+
+    root: Optional[Path]
+    is_global: bool = False
+
+    @property
+    def local_root(self) -> Optional[Path]:
+        return self.root
+
+    def _owner_dir(self, owner: str, *, create: bool) -> Path:
+        if self.root is None:
+            raise FileNotFoundError("accounts root not configured")
+        owner_dir = safe_join(self.root, owner)
+        if create:
+            owner_dir.mkdir(parents=True, exist_ok=True)
+        return owner_dir
+
+    @contextmanager
+    def edit_document(
+        self,
+        owner: str,
+        filename: str,
+        *,
+        default: Dict[str, Any],
+        trailing_newline: bool = False,
+    ) -> Iterator[Dict[str, Any]]:
+        owner_dir = self._owner_dir(owner, create=True)
+        file_path = safe_join(owner_dir, filename)
+        file_existed = file_path.exists()
+        mode = "r+" if file_existed else "w+"
+        committed = False
+        pending_error: BaseException | None = None
+        pending_traceback = None
+        with file_path.open(mode, encoding="utf-8") as f:
+            _lock_file(f)
+            try:
+                f.seek(0)
+                try:
+                    loaded = json.load(f)
+                except (json.JSONDecodeError, OSError):
+                    loaded = None
+                data = _coerce_document(loaded, default)
+                try:
+                    yield data
+                except BaseException as exc:  # noqa: BLE001 - re-raised below
+                    pending_error = exc
+                    pending_traceback = exc.__traceback__
+                else:
+                    f.seek(0)
+                    f.truncate()
+                    json.dump(data, f, indent=2)
+                    if trailing_newline:
+                        f.write("\n")
+                    f.flush()
+                    os.fsync(f.fileno())
+                    committed = True
+            finally:
+                _unlock_file(f)
+
+        if not committed and not file_existed:
+            with suppress(FileNotFoundError):
+                file_path.unlink()
+        if pending_error is not None:
+            raise pending_error.with_traceback(pending_traceback)
+
+    def read_document(self, owner: str, filename: str) -> Optional[Dict[str, Any]]:
+        try:
+            owner_dir = self._owner_dir(owner, create=False)
+            file_path = safe_join(owner_dir, filename)
+        except (FileNotFoundError, ValueError):
+            return None
+        if not file_path.exists():
+            return None
+        try:
+            loaded = json.loads(file_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        return loaded if isinstance(loaded, dict) else None
+
+    def list_owner_files(self, owner: str) -> List[str]:
+        try:
+            owner_dir = self._owner_dir(owner, create=False)
+        except (FileNotFoundError, ValueError):
+            return []
+        if not owner_dir.exists():
+            return []
+        return sorted(p.name for p in owner_dir.glob("*.json") if p.is_file())
+
+    def owner_exists(self, owner: str) -> bool:
+        try:
+            owner_dir = self._owner_dir(owner, create=False)
+        except (FileNotFoundError, ValueError):
+            return False
+        return owner_dir.exists()
+
+    def iter_transaction_documents(self) -> Iterator[Tuple[str, str, Dict[str, Any]]]:
+        if self.root is None or not self.root.exists():
+            return
+        for path in self.root.glob("*/*_transactions.json"):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            owner = str(data.get("owner") or path.parent.name)
+            account_raw = str(data.get("account_type") or path.stem.replace("_transactions", ""))
+            yield owner, account_raw, data
+
+    def ensure_owner(self, owner: str) -> None:
+        if self.is_global or self.root is None:
+            return
+        if self.read_document(owner, "person.json") is not None:
+            return
+        with self.edit_document(owner, "person.json", default=_default_person_payload(owner)) as data:
+            data.setdefault("owner", owner)
+            data.setdefault("holdings", [])
+            data.setdefault("viewers", [])
+
+
+@dataclass
+class S3AccountsStore:
+    """Direct-to-S3 account document store for the deployed AWS environment.
+
+    Each document is a single S3 object under ``{prefix}/{owner}/{filename}``.
+    Writes read the current object fresh before mutating, so concurrent Lambda
+    instances never persist stale local state.  The prefix is deliberately
+    distinct from the read-only ``accounts/`` demo prefix.
+    """
+
+    bucket: str
+    prefix: str = WRITABLE_ACCOUNTS_PREFIX
+    client: Any | None = None
+    is_global: bool = False
+    local_root: Optional[Path] = field(default=None)
+
+    def _s3(self):
+        if self.client is None:
+            import boto3  # type: ignore
+
+            self.client = boto3.client("s3")
+        return self.client
+
+    def _key(self, owner: str, filename: str) -> str:
+        return f"{self.prefix}/{owner}/{filename}"
+
+    def read_document(self, owner: str, filename: str) -> Optional[Dict[str, Any]]:
+        from botocore.exceptions import BotoCoreError, ClientError
+
+        key = self._key(owner, filename)
+        try:
+            obj = self._s3().get_object(Bucket=self.bucket, Key=key)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in {"NoSuchKey", "404", "NotFound"}:
+                return None
+            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, key, exc)
+            return None
+        except BotoCoreError as exc:
+            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, key, exc)
+            return None
+        body = obj.get("Body")
+        text = body.read().decode("utf-8-sig").strip() if body else ""
+        if not text:
+            return None
+        try:
+            loaded = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        return loaded if isinstance(loaded, dict) else None
+
+    def _put_document(self, owner: str, filename: str, data: Dict[str, Any]) -> None:
+        key = self._key(owner, filename)
+        body = json.dumps(data, indent=2).encode("utf-8")
+        self._s3().put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=body,
+            ContentType="application/json",
+        )
+
+    @contextmanager
+    def edit_document(
+        self,
+        owner: str,
+        filename: str,
+        *,
+        default: Dict[str, Any],
+        trailing_newline: bool = False,
+    ) -> Iterator[Dict[str, Any]]:
+        # ``trailing_newline`` is accepted for signature parity with the local
+        # store; S3 objects are stored without a trailing newline.
+        del trailing_newline
+        existing = self.read_document(owner, filename)
+        data = _coerce_document(existing if existing is not None else None, default)
+        yield data
+        self._put_document(owner, filename, data)
+
+    def list_owner_files(self, owner: str) -> List[str]:
+        prefix = f"{self.prefix}/{owner}/"
+        names: List[str] = []
+        for key in self._iter_keys(prefix):
+            name = key[len(prefix) :]
+            if name and "/" not in name:
+                names.append(name)
+        return sorted(names)
+
+    def owner_exists(self, owner: str) -> bool:
+        prefix = f"{self.prefix}/{owner}/"
+        return any(True for _ in self._iter_keys(prefix, limit=1))
+
+    def iter_transaction_documents(self) -> Iterator[Tuple[str, str, Dict[str, Any]]]:
+        prefix = f"{self.prefix}/"
+        for key in self._iter_keys(prefix):
+            name = key[len(prefix) :]
+            parts = name.split("/")
+            if len(parts) != 2 or not parts[1].endswith("_transactions.json"):
+                continue
+            owner = parts[0]
+            data = self.read_document(owner, parts[1])
+            if not isinstance(data, dict):
+                continue
+            account_raw = str(data.get("account_type") or parts[1].replace("_transactions.json", ""))
+            yield str(data.get("owner") or owner), account_raw, data
+
+    def ensure_owner(self, owner: str) -> None:
+        if self.read_document(owner, "person.json") is not None:
+            return
+        with self.edit_document(owner, "person.json", default=_default_person_payload(owner)) as data:
+            data.setdefault("owner", owner)
+            data.setdefault("holdings", [])
+            data.setdefault("viewers", [])
+
+    def _iter_keys(self, prefix: str, *, limit: Optional[int] = None) -> Iterator[str]:
+        from botocore.exceptions import BotoCoreError, ClientError
+
+        client = self._s3()
+        token: Optional[str] = None
+        seen = 0
+        while True:
+            kwargs: Dict[str, Any] = {"Bucket": self.bucket, "Prefix": prefix}
+            if token:
+                kwargs["ContinuationToken"] = token
+            try:
+                resp = client.list_objects_v2(**kwargs)
+            except (ClientError, BotoCoreError) as exc:
+                logger.warning("S3 list failed for s3://%s/%s: %s", self.bucket, prefix, exc)
+                return
+            for entry in resp.get("Contents", []) or []:
+                key = entry.get("Key")
+                if not key:
+                    continue
+                yield key
+                seen += 1
+                if limit is not None and seen >= limit:
+                    return
+            if not resp.get("IsTruncated"):
+                return
+            token = resp.get("NextContinuationToken")
+            if not token:
+                return
+
+
+__all__ = [
+    "WRITABLE_ACCOUNTS_PREFIX",
+    "LocalAccountsStore",
+    "S3AccountsStore",
+]

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -3,36 +3,26 @@ from __future__ import annotations
 import json
 import logging
 import os
-import platform
 import re
 from collections import defaultdict
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple, TextIO
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple
 
-try:  # Unix-like systems
-    import fcntl  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - Windows
-    fcntl = None  # type: ignore[assignment]
-    if platform.system() == "Windows":
-        import msvcrt  # type: ignore
-    else:  # pragma: no cover - unsupported platform
-        raise
-else:  # pragma: no cover - Unix
-    msvcrt = None  # type: ignore[assignment]
-
-from fastapi import APIRouter, HTTPException, Query
-from fastapi import Request, UploadFile, File, Form
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
 from pydantic import BaseModel, ConfigDict, Field
 
-from backend.common import data_loader, portfolio as portfolio_mod
-from backend.common import portfolio_loader
-from backend.common.ticker_utils import normalise_filter_ticker
-from backend.common import compliance
-from backend.common.instruments import get_instrument_meta
-from backend.config import config
 from backend import importers
+from backend.common import compliance, data_loader, portfolio_loader
+from backend.common import portfolio as portfolio_mod
+from backend.common.accounts_store import (
+    LocalAccountsStore,
+    S3AccountsStore,
+)
+from backend.common.instruments import get_instrument_meta
+from backend.common.ticker_utils import normalise_filter_ticker
+from backend.config import config
 from backend.routes._accounts import resolve_accounts_root
 from backend.utils import update_holdings_from_csv
 
@@ -71,30 +61,20 @@ _POSTED_TRANSACTIONS: List[dict] = []
 _PORTFOLIO_IMPACT: defaultdict[str, float] = defaultdict(float)
 
 _SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
-_ID_RE = re.compile(
-    r"^(?P<owner>[A-Za-z0-9_-]+):(?P<account>[A-Za-z0-9_-]+):(?P<index>\d+)$"
-)
+_ID_RE = re.compile(r"^(?P<owner>[A-Za-z0-9_-]+):(?P<account>[A-Za-z0-9_-]+):(?P<index>\d+)$")
 
 
-def _lock_file(f) -> None:
-    """Lock ``f`` for exclusive access."""
-    if fcntl:
-        fcntl.flock(f, fcntl.LOCK_EX)
-    else:  # pragma: no cover - Windows
-        f.seek(0)
-        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 0x7FFFFFFF)
+AccountsStore = "LocalAccountsStore | S3AccountsStore"
 
 
-def _unlock_file(f) -> None:
-    """Unlock ``f``."""
-    if fcntl:
-        fcntl.flock(f, fcntl.LOCK_UN)
-    else:  # pragma: no cover - Windows
-        f.seek(0)
-        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 0x7FFFFFFF)
+def _resolve_local_root(request: Request) -> Tuple[Optional[Path], bool]:
+    """Resolve the on-disk accounts root for ``request``.
 
-
-def _require_accounts_root(request: Request) -> Path:
+    Returns ``(root, is_global)``.  ``root`` is ``None`` when no accounts root is
+    configured at all (a genuine misconfiguration).  ``is_global`` is ``True``
+    when the resolved root is the read-only shared/global demo dataset that
+    writes must not mutate.
+    """
     state_value = getattr(request.app.state, "accounts_root", None)
     state_is_global = getattr(request.app.state, "accounts_root_is_global", False)
     if state_value:
@@ -107,19 +87,19 @@ def _require_accounts_root(request: Request) -> Path:
                 resolved_state = state_path.resolve()
                 request.app.state.accounts_root = resolved_state
                 request.app.state.accounts_root_is_global = False
-                return resolved_state
+                return resolved_state, False
 
     configured_root = getattr(config, "accounts_root", None)
     if not configured_root:
-        raise HTTPException(status_code=400, detail="Accounts root not configured")
+        return None, True
 
     try:
         configured_path = Path(configured_root).expanduser()
-    except (TypeError, ValueError, OSError) as exc:
-        raise HTTPException(status_code=400, detail="Accounts root not configured") from exc
+    except (TypeError, ValueError, OSError):
+        return None, True
 
     if not configured_path.exists():
-        raise HTTPException(status_code=400, detail="Accounts root not configured")
+        return None, True
 
     try:
         global_root = data_loader.resolve_paths(None, None).accounts_root.resolve()
@@ -131,20 +111,81 @@ def _require_accounts_root(request: Request) -> Path:
         except FileNotFoundError:
             configured_resolved = configured_path
         if global_root is not None and configured_resolved == global_root:
-            raise HTTPException(status_code=400, detail="Accounts root not configured")
+            return configured_resolved, True
 
     try:
         resolved = resolve_accounts_root(request)
-    except FileNotFoundError as exc:  # pragma: no cover - defensive
-        raise HTTPException(status_code=400, detail="Accounts root not configured") from exc
+    except FileNotFoundError:  # pragma: no cover - defensive
+        return None, True
 
     if state_is_global or getattr(request.app.state, "accounts_root_is_global", False):
-        raise HTTPException(status_code=400, detail="Accounts root not configured")
+        return resolved, True
 
     if not resolved.exists():
-        raise HTTPException(status_code=400, detail="Accounts root not configured")
+        return resolved, True
 
-    return resolved
+    return resolved, False
+
+
+def resolve_writable_store(request: Request) -> "AccountsStore":
+    """Return the writable account-document store for ``request``.
+
+    In the deployed AWS environment writes target a dedicated, non-global S3
+    prefix (separate from the read-only ``accounts/`` demo data).  Locally the
+    on-disk accounts root is used, flagged ``is_global`` when it resolves to the
+    shared demo dataset so write handlers refuse to mutate it.
+    """
+    if getattr(config, "app_env", None) == "aws":
+        bucket = os.getenv(data_loader.DATA_BUCKET_ENV)
+        if bucket:
+            return S3AccountsStore(bucket=bucket)
+    root, is_global = _resolve_local_root(request)
+    return LocalAccountsStore(root=root, is_global=is_global)
+
+
+def _store_disabled_detail(store: "AccountsStore") -> str:
+    """Return the 400 detail for a write against a non-writable store.
+
+    Distinguishes a read-only-by-design store (resolves to the shared/global
+    demo dataset) from a genuine misconfiguration (no real writable root).
+    """
+    local_root = getattr(store, "local_root", None)
+    if local_root is not None:
+        try:
+            global_root = data_loader.resolve_paths(None, None).accounts_root.resolve()
+        except Exception:
+            global_root = None
+        try:
+            resolved_local = Path(local_root).resolve()
+        except (TypeError, ValueError, OSError):
+            resolved_local = None
+        if global_root is not None and resolved_local == global_root:
+            return (
+                "Accounts store is read-only: it resolves to the shared demo "
+                "dataset. Create an account to enable manual holdings and "
+                "transaction writes."
+            )
+    return "Accounts root not configured"
+
+
+def _require_writable_store(request: Request) -> "AccountsStore":
+    """Resolve the writable store, raising a clear 400 when writes are disabled."""
+    store = resolve_writable_store(request)
+    if getattr(store, "is_global", False):
+        raise HTTPException(status_code=400, detail=_store_disabled_detail(store))
+    return store
+
+
+def _global_accounts_root() -> Optional[Path]:
+    """Return the read-only global/demo accounts root for read merges, if any."""
+    for args in ((config.repo_root, config.accounts_root), (None, None)):
+        try:
+            root = data_loader.resolve_paths(*args).accounts_root
+        except Exception:
+            continue
+        if root and root.exists():
+            return root.resolve()
+    return None
 
 
 class TransactionCreate(BaseModel):
@@ -175,6 +216,15 @@ class ManualHoldingCreate(BaseModel):
 
 def _normalise_account_file_name(account: str) -> str:
     return account.strip().lower()
+
+
+# Metadata/scaffold files that live alongside account holdings JSON but are not
+# themselves holdings accounts.
+_NON_HOLDINGS_FILES = frozenset({"person.json", "settings.json", "approvals.json"})
+
+
+def _is_non_holdings_file(name: str) -> bool:
+    return name.endswith("_transactions.json") or name in _NON_HOLDINGS_FILES
 
 
 def _load_account_holdings_file(path: Path, owner: str, account: str) -> dict[str, Any]:
@@ -308,157 +358,119 @@ def _prepare_updated_transaction(existing: Mapping[str, object], update: Mapping
     return updated
 
 
-def _load_all_transactions() -> List[Transaction]:
+def _transactions_from_doc(owner: str, account_raw: str, data: Mapping[str, Any]) -> List[Transaction]:
     results: List[Transaction] = []
-    if not config.accounts_root:
-        return results
-
-    data_root = Path(config.accounts_root)
-    if not data_root.exists():
-        return results
-
-    # files look like data/accounts/<owner>/<ACCOUNT>_transactions.json
-    for path in data_root.glob("*/*_transactions.json"):
-        try:
-            data = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
-            continue
-        owner = data.get("owner", path.parent.name)
-        account_raw = data.get("account_type") or path.stem.replace("_transactions", "")
-        account = account_raw.lower()
-        transactions = data.get("transactions", []) or []
-        for idx, t in enumerate(transactions):
-            t = dict(t)
-            t.pop("account", None)
-            instrument_name = _instrument_name_from_entry(t)
-            if instrument_name:
-                t["instrument_name"] = instrument_name
-            results.append(
-                Transaction(
-                    owner=owner,
-                    account=account,
-                    id=_build_transaction_id(owner, account_raw, idx),
-                    **t,
-                )
+    account = account_raw.lower()
+    transactions = data.get("transactions", []) or []
+    for idx, t in enumerate(transactions):
+        t = dict(t)
+        t.pop("account", None)
+        instrument_name = _instrument_name_from_entry(t)
+        if instrument_name:
+            t["instrument_name"] = instrument_name
+        results.append(
+            Transaction(
+                owner=owner,
+                account=account,
+                id=_build_transaction_id(owner, account_raw, idx),
+                **t,
             )
+        )
     return results
 
 
-def _find_transaction_file(owner: str, account: str, accounts_root: Path) -> Tuple[Path, str]:
-    owner_dir = accounts_root / owner
-    if not owner_dir.exists():
-        raise HTTPException(status_code=404, detail="Transaction not found")
+def _load_all_transactions(store: Optional["AccountsStore"] = None) -> List[Transaction]:
+    """Load transactions from the global demo dataset, overlaid by writable store.
 
+    Writable documents take precedence over the read-only global dataset for the
+    same ``(owner, account)`` so freshly written transactions are reflected in
+    deployed read endpoints.
+    """
+    # files look like data/accounts/<owner>/<ACCOUNT>_transactions.json
+    merged: Dict[Tuple[str, str], List[Transaction]] = {}
+
+    if config.accounts_root:
+        data_root = Path(config.accounts_root)
+        if data_root.exists():
+            for path in data_root.glob("*/*_transactions.json"):
+                try:
+                    data = json.loads(path.read_text())
+                except (OSError, json.JSONDecodeError):
+                    continue
+                if not isinstance(data, dict):
+                    continue
+                owner = str(data.get("owner") or path.parent.name)
+                account_raw = str(data.get("account_type") or path.stem.replace("_transactions", ""))
+                merged[(owner.lower(), account_raw.lower())] = _transactions_from_doc(owner, account_raw, data)
+
+    if store is not None:
+        for owner, account_raw, data in store.iter_transaction_documents():
+            merged[(owner.lower(), account_raw.lower())] = _transactions_from_doc(owner, account_raw, data)
+
+    results: List[Transaction] = []
+    for txs in merged.values():
+        results.extend(txs)
+    return results
+
+
+def _find_transaction_account(owner: str, account: str, store: "AccountsStore") -> str:
+    """Return the canonical account name for ``owner``'s transactions file.
+
+    Looks in the writable store first, then falls back to the read-only global
+    dataset.  Raises ``404`` when no matching transactions file exists.
+    """
     account_lower = account.lower()
-    for candidate in owner_dir.glob("*_transactions.json"):
-        candidate_account = candidate.stem.replace("_transactions", "")
+    suffix = "_transactions.json"
+    for name in store.list_owner_files(owner):
+        if not name.endswith(suffix):
+            continue
+        candidate_account = name[: -len(suffix)]
         if candidate_account.lower() == account_lower:
-            return candidate, candidate_account
+            return candidate_account
+
+    global_root = _global_accounts_root()
+    if global_root is not None:
+        owner_dir = global_root / owner
+        if owner_dir.exists():
+            for candidate in owner_dir.glob("*_transactions.json"):
+                candidate_account = candidate.stem.replace("_transactions", "")
+                if candidate_account.lower() == account_lower:
+                    return candidate_account
+
     raise HTTPException(status_code=404, detail="Transaction not found")
 
 
 @contextmanager
-def _locked_transactions_data(
-    owner: str, account: str, accounts_root: Path
-) -> Iterator[Tuple[dict, TextIO]]:
-    owner_dir = accounts_root / owner
-    owner_dir.mkdir(parents=True, exist_ok=True)
-    file_path = owner_dir / f"{account}_transactions.json"
-    file_existed = file_path.exists()
-    mode = "r+" if file_existed else "w+"
-    committed = False
-    pending_error: BaseException | None = None
-    pending_traceback = None
-    with file_path.open(mode, encoding="utf-8") as f:
-        _lock_file(f)
-        try:
-            f.seek(0)
-            try:
-                data = json.load(f)
-            except (json.JSONDecodeError, OSError):
-                data = {"owner": owner, "account_type": account, "transactions": []}
-            else:
-                data.setdefault("owner", owner)
-                data.setdefault("account_type", account)
-                data.setdefault("transactions", [])
-
-            try:
-                yield data, f
-            except BaseException as exc:
-                pending_error = exc
-                pending_traceback = exc.__traceback__
-            else:
-                f.seek(0)
-                f.truncate()
-                json.dump(data, f, indent=2)
-                f.flush()
-                os.fsync(f.fileno())
-                committed = True
-        finally:
-            _unlock_file(f)
-
-    if not committed and not file_existed:
-        with suppress(FileNotFoundError):
-            file_path.unlink()
-    if pending_error is not None:
-        raise pending_error.with_traceback(pending_traceback)
+def _locked_transactions_data(owner: str, account: str, store: "AccountsStore") -> Iterator[Tuple[dict, None]]:
+    default = {"owner": owner, "account_type": account, "transactions": []}
+    with store.edit_document(owner, f"{account}_transactions.json", default=default) as data:
+        data.setdefault("owner", owner)
+        data.setdefault("account_type", account)
+        if not isinstance(data.get("transactions"), list):
+            data["transactions"] = []
+        yield data, None
 
 
 @contextmanager
 def _locked_account_holdings_data(
-    owner: str, account: str, accounts_root: Path
-) -> Iterator[Tuple[dict[str, Any], TextIO]]:
-    owner_dir = accounts_root / owner
-    owner_dir.mkdir(parents=True, exist_ok=True)
-    file_path = owner_dir / f"{account}.json"
-    file_existed = file_path.exists()
-    mode = "r+" if file_existed else "w+"
-    committed = False
-    pending_error: BaseException | None = None
-    pending_traceback = None
-    with file_path.open(mode, encoding="utf-8") as f:
-        _lock_file(f)
-        try:
-            f.seek(0)
-            try:
-                data = json.load(f)
-            except (json.JSONDecodeError, OSError):
-                data = {}
-
-            if not isinstance(data, dict):
-                data = {}
-
-            data.setdefault("owner", owner)
-            data.setdefault("account_type", account)
-            data.setdefault("currency", "GBP")
-            holdings = data.get("holdings")
-            if not isinstance(holdings, list):
-                data["holdings"] = []
-
-            try:
-                yield data, f
-            except BaseException as exc:
-                pending_error = exc
-                pending_traceback = exc.__traceback__
-            else:
-                f.seek(0)
-                f.truncate()
-                json.dump(data, f, indent=2)
-                f.write("\n")
-                f.flush()
-                os.fsync(f.fileno())
-                committed = True
-        finally:
-            _unlock_file(f)
-
-    if not committed and not file_existed:
-        with suppress(FileNotFoundError):
-            file_path.unlink()
-    if pending_error is not None:
-        raise pending_error.with_traceback(pending_traceback)
+    owner: str, account: str, store: "AccountsStore"
+) -> Iterator[Tuple[dict[str, Any], None]]:
+    with store.edit_document(owner, f"{account}.json", default={}, trailing_newline=True) as data:
+        data.setdefault("owner", owner)
+        data.setdefault("account_type", account)
+        data.setdefault("currency", "GBP")
+        if not isinstance(data.get("holdings"), list):
+            data["holdings"] = []
+        yield data, None
 
 
-def _rebuild_portfolio(owner: str, account: str, accounts_root: Path) -> None:
+def _rebuild_portfolio(owner: str, account: str, store: "AccountsStore") -> None:
+    # Portfolio rebuild is path-based; it only runs against an on-disk root.
+    # The deployed S3-backed store has no local root, so rebuild is skipped
+    # there (portfolio reads continue to resolve via the S3 data loader).
+    accounts_root = getattr(store, "local_root", None)
+    if accounts_root is None:
+        return
     try:
         if not config.offline_mode:
             portfolio_loader.rebuild_account_holdings(owner, account, accounts_root)
@@ -476,13 +488,10 @@ async def transactions_with_compliance(
 ):
     """Return transactions for ``owner`` annotated with compliance warnings."""
 
-    txs = [t.model_dump() for t in _load_all_transactions() if t.owner.lower() == owner.lower()]
+    store = resolve_writable_store(request)
+    txs = [t.model_dump() for t in _load_all_transactions(store) if t.owner.lower() == owner.lower()]
     if account:
-        txs = [
-            t
-            for t in txs
-            if (t.get("account") or "").lower() == account.lower()
-        ]
+        txs = [t for t in txs if (t.get("account") or "").lower() == account.lower()]
     norm_ticker = normalise_filter_ticker(
         ticker,
         offline_mode=bool(config.offline_mode),
@@ -517,7 +526,7 @@ def _validate_component(value: str, field: str) -> str:
 async def create_transaction(request: Request, tx: TransactionCreate) -> dict:
     """Store a new transaction and return it."""
 
-    accounts_root = _require_accounts_root(request)
+    store = _require_writable_store(request)
 
     tx_data = tx.model_dump(mode="json")
     owner = _validate_component(tx_data.pop("owner"), "owner")
@@ -533,14 +542,15 @@ async def create_transaction(request: Request, tx: TransactionCreate) -> dict:
     _PORTFOLIO_IMPACT[owner] += impact
     _POSTED_TRANSACTIONS.append({"owner": owner, "account": account, **tx_data})
 
-    with _locked_transactions_data(owner, account, accounts_root) as (data, _file):
+    store.ensure_owner(owner)
+    with _locked_transactions_data(owner, account, store) as (data, _file):
         transactions = data.setdefault("transactions", [])
         transactions.append(tx_data)
         data["owner"] = owner
         data["account_type"] = account
         new_index = len(transactions) - 1
 
-    _rebuild_portfolio(owner, account, accounts_root)
+    _rebuild_portfolio(owner, account, store)
 
     tx_id = _build_transaction_id(owner, account, new_index)
     return _format_transaction_response(owner, account, tx_data, tx_id)
@@ -548,7 +558,7 @@ async def create_transaction(request: Request, tx: TransactionCreate) -> dict:
 
 @router.put("/transactions/{tx_id}")
 async def update_transaction(request: Request, tx_id: str, tx: TransactionUpdate) -> dict:
-    accounts_root = _require_accounts_root(request)
+    store = _require_writable_store(request)
 
     original_owner, original_account_raw, index = _parse_transaction_id(tx_id)
     original_owner = _validate_component(original_owner, "owner")
@@ -560,9 +570,7 @@ async def update_transaction(request: Request, tx_id: str, tx: TransactionUpdate
     if not tx_data.get("reason"):
         raise HTTPException(status_code=400, detail="reason is required")
 
-    _, original_account_canonical = _find_transaction_file(
-        original_owner, original_account, accounts_root
-    )
+    original_account_canonical = _find_transaction_account(original_owner, original_account, store)
 
     same_owner = new_owner.lower() == original_owner.lower()
     same_account = new_account.lower() == original_account_canonical.lower()
@@ -572,9 +580,8 @@ async def update_transaction(request: Request, tx_id: str, tx: TransactionUpdate
     new_entry: Dict[str, object]
     pending_entry: Optional[Dict[str, object]] = None
 
-    with _locked_transactions_data(
-        original_owner, original_account_canonical, accounts_root
-    ) as (data, _):
+    store.ensure_owner(new_owner)
+    with _locked_transactions_data(original_owner, original_account_canonical, store) as (data, _):
         transactions = data.setdefault("transactions", [])
         if index >= len(transactions) or index < 0:
             raise HTTPException(status_code=404, detail="Transaction not found")
@@ -599,7 +606,7 @@ async def update_transaction(request: Request, tx_id: str, tx: TransactionUpdate
     if not same_location:
         if pending_entry is None:
             raise HTTPException(status_code=500, detail="Failed to update transaction")
-        with _locked_transactions_data(new_owner, new_account, accounts_root) as (data, _):
+        with _locked_transactions_data(new_owner, new_account, store) as (data, _):
             transactions = data.setdefault("transactions", [])
             transactions.append(pending_entry)
             data["owner"] = new_owner
@@ -619,7 +626,7 @@ async def update_transaction(request: Request, tx_id: str, tx: TransactionUpdate
         affected.append((original_owner, original_account_canonical))
 
     for owner_val, account_val in affected:
-        _rebuild_portfolio(owner_val, account_val, accounts_root)
+        _rebuild_portfolio(owner_val, account_val, store)
 
     new_id = _build_transaction_id(new_owner, new_account, new_index)
     account_response = new_account.lower()
@@ -628,17 +635,17 @@ async def update_transaction(request: Request, tx_id: str, tx: TransactionUpdate
 
 @router.delete("/transactions/{tx_id}")
 async def delete_transaction(request: Request, tx_id: str) -> dict:
-    accounts_root = _require_accounts_root(request)
+    store = _require_writable_store(request)
 
     owner, account_raw, index = _parse_transaction_id(tx_id)
     owner = _validate_component(owner, "owner")
     account = _validate_component(account_raw, "account")
 
-    _, account_canonical = _find_transaction_file(owner, account, accounts_root)
+    account_canonical = _find_transaction_account(owner, account, store)
 
     removed_entry: Optional[Mapping[str, object]] = None
 
-    with _locked_transactions_data(owner, account_canonical, accounts_root) as (data, _):
+    with _locked_transactions_data(owner, account_canonical, store) as (data, _):
         transactions = data.setdefault("transactions", [])
         if index >= len(transactions) or index < 0:
             raise HTTPException(status_code=404, detail="Transaction not found")
@@ -652,15 +659,13 @@ async def delete_transaction(request: Request, tx_id: str) -> dict:
     impact = _calculate_portfolio_impact(removed_entry)
     _PORTFOLIO_IMPACT[owner] -= impact
 
-    _rebuild_portfolio(owner, account_canonical, accounts_root)
+    _rebuild_portfolio(owner, account_canonical, store)
 
     return {"status": "deleted"}
 
 
 @router.post("/transactions/import", response_model=List[Transaction])
-async def import_transactions(
-    provider: str = Form(...), file: UploadFile = File(...)
-) -> List[Transaction]:
+async def import_transactions(provider: str = Form(...), file: UploadFile = File(...)) -> List[Transaction]:
     """Parse a transaction export and return the contained transactions."""
 
     data = await file.read()
@@ -707,7 +712,7 @@ async def create_manual_holding(request: Request, payload: ManualHoldingCreate) 
     if not ticker:
         raise HTTPException(status_code=400, detail="ticker is required")
 
-    accounts_root = _require_accounts_root(request)
+    store = _require_writable_store(request)
     account_slug = _normalise_account_file_name(account)
 
     holding: dict[str, Any] = {"ticker": ticker}
@@ -717,7 +722,8 @@ async def create_manual_holding(request: Request, payload: ManualHoldingCreate) 
         holding["units"] = float(payload.units)
         holding["price"] = float(payload.price_gbp)
 
-    with _locked_account_holdings_data(owner, account_slug, accounts_root) as (account_payload, _):
+    store.ensure_owner(owner)
+    with _locked_account_holdings_data(owner, account_slug, store) as (account_payload, _):
         if payload.currency:
             account_payload["currency"] = payload.currency.strip().upper() or "GBP"
         account_payload["last_updated"] = date.today().isoformat()
@@ -726,11 +732,7 @@ async def create_manual_holding(request: Request, payload: ManualHoldingCreate) 
 
         holdings = account_payload.setdefault("holdings", [])
         for index, existing in enumerate(holdings):
-            existing_ticker = (
-                str(existing.get("ticker") or "").strip().upper()
-                if isinstance(existing, Mapping)
-                else ""
-            )
+            existing_ticker = str(existing.get("ticker") or "").strip().upper() if isinstance(existing, Mapping) else ""
             if existing_ticker == ticker:
                 holdings[index] = holding
                 break
@@ -751,23 +753,43 @@ async def list_manual_holdings(
     owner: str,
 ) -> dict[str, Any]:
     owner_name = _validate_component(owner, "owner")
-    accounts_root = _require_accounts_root(request)
-    owner_dir = accounts_root / owner_name
-    if not owner_dir.exists():
-        return {"owner": owner_name, "accounts": []}
+    store = resolve_writable_store(request)
 
-    accounts: list[dict[str, Any]] = []
-    for path in sorted(owner_dir.glob("*.json")):
-        if path.name.endswith("_transactions.json") or path.name == "person.json":
+    # Merge the read-only global/demo dataset with the writable store, with
+    # writable documents taking precedence per account slug.  Reads therefore
+    # still surface demo content while reflecting any manual writes.
+    summaries: dict[str, dict[str, Any]] = {}
+
+    global_root = _global_accounts_root()
+    if global_root is not None:
+        owner_dir = global_root / owner_name
+        if owner_dir.exists():
+            for path in sorted(owner_dir.glob("*.json")):
+                if _is_non_holdings_file(path.name):
+                    continue
+                payload = _load_account_holdings_file(path, owner_name, path.stem.lower())
+                summaries[path.stem.lower()] = _account_payload_summary(payload)
+
+    for name in store.list_owner_files(owner_name):
+        if _is_non_holdings_file(name):
             continue
-        payload = _load_account_holdings_file(path, owner_name, path.stem.lower())
-        accounts.append(_account_payload_summary(payload))
+        slug = name[:-5].lower() if name.endswith(".json") else name.lower()
+        doc = store.read_document(owner_name, name)
+        if doc is None:
+            continue
+        doc.setdefault("owner", owner_name)
+        doc.setdefault("account_type", slug)
+        if not isinstance(doc.get("holdings"), list):
+            doc["holdings"] = []
+        summaries[slug] = _account_payload_summary(doc)
 
+    accounts = [summaries[slug] for slug in sorted(summaries)]
     return {"owner": owner_name, "accounts": accounts}
 
 
 @router.get("/transactions", response_model=List[Transaction])
 async def list_transactions(
+    request: Request,
     owner: Optional[str] = None,
     account: Optional[str] = None,
     start: Optional[str] = None,
@@ -779,8 +801,9 @@ async def list_transactions(
     start_d = _parse_date(start)
     end_d = _parse_date(end)
 
+    store = resolve_writable_store(request)
     txs: List[Transaction] = []
-    for t in _load_all_transactions():
+    for t in _load_all_transactions(store):
         if owner and t.owner.lower() != owner.lower():
             continue
         if account and t.account.lower() != account.lower():
@@ -799,6 +822,7 @@ async def list_transactions(
 
 @router.get("/dividends", response_model=List[Transaction])
 async def list_dividends(
+    request: Request,
     owner: Optional[str] = None,
     account: Optional[str] = None,
     start: Optional[str] = None,
@@ -815,8 +839,9 @@ async def list_dividends(
         fallback=getattr(config, "offline_fundamentals_ticker", None),
     )
 
+    store = resolve_writable_store(request)
     txs: List[Transaction] = []
-    for t in _load_all_transactions():
+    for t in _load_all_transactions(store):
         ttype = (t.type or "").upper()
         if ttype not in {"DIVIDEND", "DIVIDENDS"}:
             continue

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -29,6 +29,13 @@ from constructs import Construct
 
 from stacks.exports import BACKEND_API_URL_EXPORT
 
+# S3 prefix (relative to the data bucket) under which per-owner writable account
+# documents are persisted. Kept in sync with
+# ``backend.common.accounts_store.WRITABLE_ACCOUNTS_PREFIX`` via the
+# ``WRITABLE_ACCOUNTS_PREFIX`` Lambda environment variable below. Deliberately
+# distinct from the read-only ``accounts/`` demo prefix (issue #4275).
+WRITABLE_ACCOUNTS_PREFIX = "writable-accounts"
+
 
 class BackendLambdaStack(Stack):
     """CDK stack that builds and deploys the backend Lambda."""
@@ -201,6 +208,13 @@ class BackendLambdaStack(Stack):
                 "queries",
                 "timeseries/meta",
                 "transactions",
+                # Writable, per-owner account documents (manual holdings and
+                # transaction writes) live under a dedicated prefix that is
+                # separate from the read-only ``accounts/`` demo dataset so
+                # writes never mutate shared data (issue #4275). ListBucket on
+                # this prefix is required by AccountsStore list/iter paths;
+                # object-level Get/Put are already granted bucket-wide below.
+                WRITABLE_ACCOUNTS_PREFIX,
             ),
             # price_refresh needs accounts/ to call list_objects_v2 via
             # S3DataProvider.list_plots() → list_all_unique_tickers() → list_portfolios().
@@ -248,6 +262,9 @@ class BackendLambdaStack(Stack):
             "DISABLE_AUTH": "true",
             "DATA_BUCKET": bucket_name,
             "DATA_BRANCH": data_branch,
+            # Writable per-owner account documents are persisted under this S3
+            # prefix, separate from the read-only accounts/ demo data (#4275).
+            "WRITABLE_ACCOUNTS_PREFIX": WRITABLE_ACCOUNTS_PREFIX,
             # APP_REGION is used instead of AWS_REGION because AWS_REGION is a reserved
             # Lambda runtime variable and cannot be set as a custom environment variable.
             "APP_REGION": self.region,

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -13,7 +13,10 @@ CDK_DIR = Path(__file__).resolve().parents[1]
 if str(CDK_DIR) not in sys.path:
     sys.path.insert(0, str(CDK_DIR))
 
-from stacks.backend_lambda_stack import BackendLambdaStack
+from stacks.backend_lambda_stack import (
+    WRITABLE_ACCOUNTS_PREFIX,
+    BackendLambdaStack,
+)
 
 BACKEND_LIST_PREFIXES = (
     "accounts",
@@ -22,6 +25,9 @@ BACKEND_LIST_PREFIXES = (
     "queries",
     "timeseries/meta",
     "transactions",
+    # Writable per-owner account documents (manual holdings / transactions);
+    # separate from the read-only accounts/ demo prefix (issue #4275).
+    WRITABLE_ACCOUNTS_PREFIX,
 )
 # accounts/ is required because refresh_prices() → list_all_unique_tickers() →
 # list_portfolios() → S3DataProvider.list_plots() calls list_objects_v2 on that prefix.

--- a/tests/backend/common/test_accounts_store.py
+++ b/tests/backend/common/test_accounts_store.py
@@ -1,0 +1,188 @@
+"""Tests for the pluggable writable accounts store (issue #4275)."""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from backend.common.accounts_store import (
+    WRITABLE_ACCOUNTS_PREFIX,
+    LocalAccountsStore,
+    S3AccountsStore,
+)
+
+# ---------------------------------------------------------------------------
+# LocalAccountsStore
+# ---------------------------------------------------------------------------
+
+
+def test_local_store_edit_creates_and_updates(tmp_path):
+    store = LocalAccountsStore(root=tmp_path)
+
+    with store.edit_document("alice", "isa.json", default={}) as data:
+        data["holdings"] = [{"ticker": "AAA", "value_gbp": 100}]
+
+    saved = json.loads((tmp_path / "alice" / "isa.json").read_text())
+    assert saved["holdings"] == [{"ticker": "AAA", "value_gbp": 100}]
+
+    with store.edit_document("alice", "isa.json", default={}) as data:
+        data["holdings"].append({"ticker": "BBB", "value_gbp": 50})
+
+    saved = json.loads((tmp_path / "alice" / "isa.json").read_text())
+    assert len(saved["holdings"]) == 2
+
+
+def test_local_store_edit_discards_new_file_on_error(tmp_path):
+    store = LocalAccountsStore(root=tmp_path)
+    file_path = tmp_path / "alice" / "isa.json"
+
+    with pytest.raises(RuntimeError):
+        with store.edit_document("alice", "isa.json", default={}) as data:
+            data["holdings"] = [{"ticker": "AAA"}]
+            raise RuntimeError("boom")
+
+    assert not file_path.exists()
+
+
+def test_local_store_coerces_non_dict_to_default(tmp_path):
+    owner_dir = tmp_path / "alice"
+    owner_dir.mkdir()
+    (owner_dir / "isa.json").write_text("[1, 2, 3]")
+    store = LocalAccountsStore(root=tmp_path)
+
+    with store.edit_document("alice", "isa.json", default={"holdings": []}) as data:
+        assert data == {"holdings": []}
+        data["holdings"].append({"ticker": "AAA"})
+
+    saved = json.loads((owner_dir / "isa.json").read_text())
+    assert saved["holdings"] == [{"ticker": "AAA"}]
+
+
+def test_local_store_ensure_owner_scaffolds_person(tmp_path):
+    store = LocalAccountsStore(root=tmp_path)
+    store.ensure_owner("alice")
+    person = json.loads((tmp_path / "alice" / "person.json").read_text())
+    assert person["owner"] == "alice"
+
+
+def test_local_store_global_is_read_only(tmp_path):
+    store = LocalAccountsStore(root=tmp_path, is_global=True)
+    # ensure_owner must not scaffold against a read-only/global root.
+    store.ensure_owner("alice")
+    assert not (tmp_path / "alice").exists()
+
+
+def test_local_store_none_root_lists_empty():
+    store = LocalAccountsStore(root=None)
+    assert store.list_owner_files("alice") == []
+    assert store.owner_exists("alice") is False
+    assert list(store.iter_transaction_documents()) == []
+
+
+# ---------------------------------------------------------------------------
+# S3AccountsStore (in-memory fake S3 client)
+# ---------------------------------------------------------------------------
+
+
+class _FakeS3:
+    """Minimal in-memory stand-in for the boto3 S3 client surface used here."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    def get_object(self, Bucket: str, Key: str):  # noqa: N803 - boto3 kwarg names
+        from botocore.exceptions import ClientError
+
+        if Key not in self.objects:
+            raise ClientError(
+                {"Error": {"Code": "NoSuchKey"}}, "GetObject"
+            )
+        return {"Body": io.BytesIO(self.objects[Key])}
+
+    def put_object(self, Bucket: str, Key: str, Body: bytes, **_kwargs):  # noqa: N803
+        self.objects[Key] = Body
+
+    def list_objects_v2(self, Bucket: str, Prefix: str, **_kwargs):  # noqa: N803
+        contents = [
+            {"Key": key} for key in sorted(self.objects) if key.startswith(Prefix)
+        ]
+        return {"Contents": contents, "IsTruncated": False}
+
+
+@pytest.fixture
+def s3_store():
+    fake = _FakeS3()
+    store = S3AccountsStore(bucket="data-bucket", client=fake)
+    return store, fake
+
+
+def test_s3_store_write_uses_writable_prefix(s3_store):
+    store, fake = s3_store
+    with store.edit_document("alice", "isa.json", default={"holdings": []}) as data:
+        data["holdings"].append({"ticker": "AAA", "value_gbp": 100})
+
+    expected_key = f"{WRITABLE_ACCOUNTS_PREFIX}/alice/isa.json"
+    assert expected_key in fake.objects
+    # Never write under the read-only shared demo prefix.
+    assert not any(k.startswith("accounts/") for k in fake.objects)
+
+    stored = json.loads(fake.objects[expected_key].decode("utf-8"))
+    assert stored["holdings"] == [{"ticker": "AAA", "value_gbp": 100}]
+
+
+def test_s3_store_read_missing_returns_none(s3_store):
+    store, _ = s3_store
+    assert store.read_document("ghost", "isa.json") is None
+
+
+def test_s3_store_edit_reads_existing_then_writes(s3_store):
+    store, fake = s3_store
+    with store.edit_document("alice", "isa.json", default={"holdings": []}) as data:
+        data["holdings"].append({"ticker": "AAA"})
+    with store.edit_document("alice", "isa.json", default={"holdings": []}) as data:
+        assert data["holdings"] == [{"ticker": "AAA"}]
+        data["holdings"].append({"ticker": "BBB"})
+
+    stored = json.loads(
+        fake.objects[f"{WRITABLE_ACCOUNTS_PREFIX}/alice/isa.json"].decode("utf-8")
+    )
+    assert [h["ticker"] for h in stored["holdings"]] == ["AAA", "BBB"]
+
+
+def test_s3_store_list_and_iter(s3_store):
+    store, _ = s3_store
+    with store.edit_document("alice", "isa.json", default={}) as data:
+        data["holdings"] = []
+    with store.edit_document(
+        "alice", "isa_transactions.json", default={}
+    ) as data:
+        data["account_type"] = "isa"
+        data["transactions"] = [{"ticker": "AAA"}]
+
+    assert set(store.list_owner_files("alice")) == {
+        "isa.json",
+        "isa_transactions.json",
+    }
+    assert store.owner_exists("alice") is True
+    assert store.owner_exists("bob") is False
+
+    docs = list(store.iter_transaction_documents())
+    assert len(docs) == 1
+    owner, account_raw, data = docs[0]
+    assert owner == "alice"
+    assert account_raw == "isa"
+    assert data["transactions"] == [{"ticker": "AAA"}]
+
+
+def test_s3_store_ensure_owner_idempotent(s3_store):
+    store, fake = s3_store
+    store.ensure_owner("alice")
+    assert f"{WRITABLE_ACCOUNTS_PREFIX}/alice/person.json" in fake.objects
+    # Second call must not overwrite / error.
+    store.ensure_owner("alice")
+    person = json.loads(
+        fake.objects[f"{WRITABLE_ACCOUNTS_PREFIX}/alice/person.json"].decode("utf-8")
+    )
+    assert person["owner"] == "alice"

--- a/tests/backend/routes/test_transactions.py
+++ b/tests/backend/routes/test_transactions.py
@@ -8,8 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from fastapi import FastAPI, HTTPException
-from fastapi import Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
@@ -57,20 +56,21 @@ def _seed_transactions_file(
     return file_path
 
 
-def test_require_accounts_root_uses_cached_value(tmp_path):
+def test_require_writable_store_uses_cached_value(tmp_path):
     accounts_dir = tmp_path / "accounts"
     accounts_dir.mkdir()
 
     request = _make_request({"accounts_root": accounts_dir})
 
-    resolved = transactions_module._require_accounts_root(request)
+    store = transactions_module._require_writable_store(request)
 
-    assert resolved == accounts_dir.resolve()
+    assert store.is_global is False
+    assert store.local_root == accounts_dir.resolve()
     assert request.app.state.accounts_root == accounts_dir.resolve()
     assert request.app.state.accounts_root_is_global is False
 
 
-def test_require_accounts_root_rejects_global_cache(monkeypatch, tmp_path):
+def test_require_writable_store_rejects_global_cache(monkeypatch, tmp_path):
     accounts_dir = tmp_path / "accounts"
     accounts_dir.mkdir()
 
@@ -96,12 +96,12 @@ def test_require_accounts_root_rejects_global_cache(monkeypatch, tmp_path):
     )
 
     with pytest.raises(HTTPException) as excinfo:
-        transactions_module._require_accounts_root(request)
+        transactions_module._require_writable_store(request)
 
     assert excinfo.value.status_code == 400
 
 
-def test_require_accounts_root_missing_resolved_path(monkeypatch, tmp_path):
+def test_require_writable_store_missing_resolved_path(monkeypatch, tmp_path):
     configured_dir = tmp_path / "configured"
     configured_dir.mkdir()
 
@@ -125,12 +125,14 @@ def test_require_accounts_root_missing_resolved_path(monkeypatch, tmp_path):
     )
 
     with pytest.raises(HTTPException) as excinfo:
-        transactions_module._require_accounts_root(request)
+        transactions_module._require_writable_store(request)
 
     assert excinfo.value.status_code == 400
+    # No existing writable root -> genuine misconfiguration message.
+    assert excinfo.value.detail == "Accounts root not configured"
 
 
-def test_require_accounts_root_rejects_matching_global_root(monkeypatch, tmp_path):
+def test_require_writable_store_rejects_matching_global_root(monkeypatch, tmp_path):
     configured_dir = tmp_path / "configured"
     configured_dir.mkdir()
 
@@ -147,7 +149,7 @@ def test_require_accounts_root_rejects_matching_global_root(monkeypatch, tmp_pat
     )
 
     with pytest.raises(HTTPException) as excinfo:
-        transactions_module._require_accounts_root(request)
+        transactions_module._require_writable_store(request)
 
     assert excinfo.value.status_code == 400
 

--- a/tests/backend/routes/test_transactions_accounts_root.py
+++ b/tests/backend/routes/test_transactions_accounts_root.py
@@ -27,20 +27,21 @@ def _build_request(state: dict | None = None) -> Request:
     return Request(scope)
 
 
-def test_require_accounts_root_returns_cached_value(tmp_path):
+def test_require_writable_store_returns_cached_value(tmp_path):
     accounts_dir = tmp_path / "accounts"
     accounts_dir.mkdir()
 
     request = _build_request({"accounts_root": accounts_dir})
 
-    resolved = transactions_module._require_accounts_root(request)
+    store = transactions_module._require_writable_store(request)
 
-    assert resolved == accounts_dir.resolve()
+    assert store.is_global is False
+    assert store.local_root == accounts_dir.resolve()
     assert request.app.state.accounts_root == accounts_dir.resolve()
     assert request.app.state.accounts_root_is_global is False
 
 
-def test_require_accounts_root_rejects_matching_global_root(monkeypatch, tmp_path):
+def test_require_writable_store_rejects_matching_global_root(monkeypatch, tmp_path):
     configured_dir = tmp_path / "configured"
     configured_dir.mkdir()
 
@@ -61,13 +62,15 @@ def test_require_accounts_root_rejects_matching_global_root(monkeypatch, tmp_pat
     )
 
     with pytest.raises(HTTPException) as excinfo:
-        transactions_module._require_accounts_root(request)
+        transactions_module._require_writable_store(request)
 
     assert excinfo.value.status_code == 400
+    # Resolves to the shared/global demo root -> read-only-by-design message.
+    assert "read-only" in excinfo.value.detail
 
 
 @pytest.mark.parametrize("state_global_flag", [False, True])
-def test_require_accounts_root_rejects_invalid_resolution(
+def test_require_writable_store_rejects_invalid_resolution(
     monkeypatch, tmp_path, state_global_flag
 ):
     configured_dir = tmp_path / "configured"
@@ -104,6 +107,6 @@ def test_require_accounts_root_rejects_invalid_resolution(
         )
 
     with pytest.raises(HTTPException) as excinfo:
-        transactions_module._require_accounts_root(request)
+        transactions_module._require_writable_store(request)
 
     assert excinfo.value.status_code == 400

--- a/tests/backend/routes/test_transactions_writable_store.py
+++ b/tests/backend/routes/test_transactions_writable_store.py
@@ -1,0 +1,139 @@
+"""Deployed (AWS) writable-store behaviour for transactions routes (issue #4275)."""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+from fastapi import FastAPI, Request
+
+from backend.common import data_loader
+from backend.common.accounts_store import (
+    WRITABLE_ACCOUNTS_PREFIX,
+    S3AccountsStore,
+)
+from backend.routes import transactions as transactions_module
+
+
+def _make_request(state: dict | None = None) -> Request:
+    app = FastAPI()
+    for key, value in (state or {}).items():
+        setattr(app.state, key, value)
+    scope = {
+        "type": "http",
+        "app": app,
+        "method": "POST",
+        "headers": [],
+        "path": "/",
+        "query_string": b"",
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+class _FakeS3:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    def get_object(self, Bucket: str, Key: str):  # noqa: N803
+        from botocore.exceptions import ClientError
+
+        if Key not in self.objects:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return {"Body": io.BytesIO(self.objects[Key])}
+
+    def put_object(self, Bucket: str, Key: str, Body: bytes, **_kwargs):  # noqa: N803
+        self.objects[Key] = Body
+
+    def list_objects_v2(self, Bucket: str, Prefix: str, **_kwargs):  # noqa: N803
+        contents = [
+            {"Key": key} for key in sorted(self.objects) if key.startswith(Prefix)
+        ]
+        return {"Contents": contents, "IsTruncated": False}
+
+
+def test_resolve_writable_store_uses_s3_in_aws(monkeypatch):
+    monkeypatch.setattr(transactions_module.config, "app_env", "aws")
+    monkeypatch.setenv(data_loader.DATA_BUCKET_ENV, "data-bucket")
+
+    store = transactions_module.resolve_writable_store(_make_request())
+
+    assert isinstance(store, S3AccountsStore)
+    assert store.is_global is False
+    assert store.bucket == "data-bucket"
+
+
+def test_resolve_writable_store_falls_back_local_without_bucket(monkeypatch, tmp_path):
+    monkeypatch.setattr(transactions_module.config, "app_env", "aws")
+    monkeypatch.delenv(data_loader.DATA_BUCKET_ENV, raising=False)
+
+    request = _make_request({"accounts_root": tmp_path})
+    store = transactions_module.resolve_writable_store(request)
+
+    assert not isinstance(store, S3AccountsStore)
+    assert store.local_root == tmp_path.resolve()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_holding_persists_to_s3(monkeypatch):
+    monkeypatch.setattr(transactions_module.config, "app_env", "aws")
+    monkeypatch.setenv(data_loader.DATA_BUCKET_ENV, "data-bucket")
+
+    fake = _FakeS3()
+    monkeypatch.setattr(
+        transactions_module,
+        "resolve_writable_store",
+        lambda _req: S3AccountsStore(bucket="data-bucket", client=fake),
+    )
+
+    payload = transactions_module.ManualHoldingCreate(
+        owner="alice", account="ISA", ticker="aaa", value_gbp=1000
+    )
+    result = await transactions_module.create_manual_holding(_make_request(), payload)
+
+    assert result["status"] == "saved"
+    key = f"{WRITABLE_ACCOUNTS_PREFIX}/alice/isa.json"
+    assert key in fake.objects
+    stored = json.loads(fake.objects[key].decode("utf-8"))
+    assert stored["holdings"] == [{"ticker": "AAA", "value_gbp": 1000.0}]
+    # The owner scaffold (person.json) is created in the writable prefix only.
+    assert f"{WRITABLE_ACCOUNTS_PREFIX}/alice/person.json" in fake.objects
+    assert not any(k.startswith("accounts/") for k in fake.objects)
+
+
+@pytest.mark.asyncio
+async def test_create_transaction_persists_to_s3(monkeypatch):
+    monkeypatch.setattr(transactions_module.config, "app_env", "aws")
+    monkeypatch.setenv(data_loader.DATA_BUCKET_ENV, "data-bucket")
+
+    fake = _FakeS3()
+    monkeypatch.setattr(
+        transactions_module,
+        "resolve_writable_store",
+        lambda _req: S3AccountsStore(bucket="data-bucket", client=fake),
+    )
+    monkeypatch.setattr(
+        transactions_module, "_rebuild_portfolio", lambda *a, **k: None
+    )
+
+    from datetime import date
+
+    tx = transactions_module.TransactionCreate(
+        owner="alice",
+        account="ISA",
+        ticker="AAA",
+        date=date(2024, 1, 1),
+        price_gbp=10.0,
+        units=2.0,
+        reason="diversify",
+    )
+    result = await transactions_module.create_transaction(_make_request(), tx)
+
+    assert result["owner"] == "alice"
+    key = f"{WRITABLE_ACCOUNTS_PREFIX}/alice/ISA_transactions.json"
+    assert key in fake.objects
+    stored = json.loads(fake.objects[key].decode("utf-8"))
+    assert len(stored["transactions"]) == 1
+    assert stored["transactions"][0]["ticker"] == "AAA"

--- a/tests/backend/test_spa_response_contracts.py
+++ b/tests/backend/test_spa_response_contracts.py
@@ -143,7 +143,7 @@ def test_target_spa_endpoints_match_contracts(monkeypatch, tmp_path):
     monkeypatch.setattr(
         transactions_routes,
         "_load_all_transactions",
-        lambda: [
+        lambda *_a, **_k: [
             transactions_routes.Transaction(
                 owner="alice",
                 account="isa",

--- a/tests/backend/test_transactions_route.py
+++ b/tests/backend/test_transactions_route.py
@@ -5,14 +5,21 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from backend.common import accounts_store
 from backend.routes import transactions
 
 
 def _client(monkeypatch, tmp_path):
     app = FastAPI()
     app.include_router(transactions.router)
+    # Pin the writable accounts root to the temp dir so writes never fall through
+    # to the real repo data directory via resolve_accounts_root().
+    app.state.accounts_root = tmp_path
+    app.state.accounts_root_is_global = False
     monkeypatch.setattr(
-        transactions, "config", SimpleNamespace(accounts_root=tmp_path, offline_mode=False)
+        transactions,
+        "config",
+        SimpleNamespace(accounts_root=tmp_path, offline_mode=False, app_env="local"),
     )
     monkeypatch.setattr(
         transactions,
@@ -24,8 +31,9 @@ def _client(monkeypatch, tmp_path):
         "portfolio_mod",
         SimpleNamespace(build_owner_portfolio=lambda *a, **k: None),
     )
-    monkeypatch.setattr(transactions, "_lock_file", lambda f: None)
-    monkeypatch.setattr(transactions, "_unlock_file", lambda f: None)
+    # File locking now lives in the accounts_store module.
+    monkeypatch.setattr(accounts_store, "_lock_file", lambda f: None)
+    monkeypatch.setattr(accounts_store, "_unlock_file", lambda f: None)
     transactions._PORTFOLIO_IMPACT.clear()
     transactions._POSTED_TRANSACTIONS.clear()
     return TestClient(app)
@@ -37,7 +45,6 @@ def test_validate_component():
     assert transactions._validate_component("good_name-1", "owner") == "good_name-1"
 
 
-@pytest.mark.xfail(reason="File operations mocking needs investigation")
 def test_create_transaction_success(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
     data = {
@@ -63,7 +70,6 @@ def test_create_transaction_success(monkeypatch, tmp_path):
     assert transactions._PORTFOLIO_IMPACT["bob"] == pytest.approx(3.0)
 
 
-@pytest.mark.xfail(reason="File operations mocking needs investigation")
 def test_transaction_instrument_name(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
     data = {
@@ -101,7 +107,6 @@ def test_create_transaction_missing_reason(monkeypatch, tmp_path):
     assert resp.status_code == 400
 
 
-@pytest.mark.xfail(reason="File operations mocking needs investigation")
 def test_update_transaction_same_location(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
     create_data = {
@@ -137,7 +142,6 @@ def test_update_transaction_same_location(monkeypatch, tmp_path):
     assert transactions._PORTFOLIO_IMPACT["bob"] == pytest.approx(4.0)
 
 
-@pytest.mark.xfail(reason="File operations mocking needs investigation")
 def test_update_transaction_move_account(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
     create_data = {
@@ -178,7 +182,6 @@ def test_update_transaction_move_account(monkeypatch, tmp_path):
     assert transactions._PORTFOLIO_IMPACT["bob"] == pytest.approx(5.0)
 
 
-@pytest.mark.xfail(reason="File operations mocking needs investigation")
 def test_delete_transaction(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
     create_data = {
@@ -232,7 +235,7 @@ def test_list_transactions_filter(monkeypatch):
         transactions.Transaction(owner="a", account="sipp", date="2024-02-01"),
         transactions.Transaction(owner="b", account="isa", date="2024-01-01"),
     ]
-    monkeypatch.setattr(transactions, "_load_all_transactions", lambda: sample)
+    monkeypatch.setattr(transactions, "_load_all_transactions", lambda *_a, **_k: sample)
     resp = client.get(
         "/transactions",
         params={
@@ -254,7 +257,7 @@ def test_transactions_with_compliance_account_case(monkeypatch, tmp_path):
     app.state.accounts_root = tmp_path
     client = TestClient(app)
     sample = [transactions.Transaction(owner="a", account="isa", date="2024-01-01")]
-    monkeypatch.setattr(transactions, "_load_all_transactions", lambda: sample)
+    monkeypatch.setattr(transactions, "_load_all_transactions", lambda *_a, **_k: sample)
     monkeypatch.setattr(
         transactions,
         "compliance",
@@ -281,7 +284,7 @@ def test_list_dividends_account_case(monkeypatch):
             date="2024-01-01",
         )
     ]
-    monkeypatch.setattr(transactions, "_load_all_transactions", lambda: sample)
+    monkeypatch.setattr(transactions, "_load_all_transactions", lambda *_a, **_k: sample)
     resp = client.get(
         "/dividends",
         params={"owner": "a", "account": "ISA"},

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
+from backend.common.accounts_store import LocalAccountsStore
 from backend.config import config
 from backend.routes import transactions
 
@@ -193,15 +194,16 @@ def test_locked_transactions_data_does_not_persist_failed_update(tmp_path, monke
         )
     )
 
+    store = LocalAccountsStore(root=tmp_path)
     with pytest.raises(RuntimeError):
-        with transactions._locked_transactions_data("alice", "ISA", tmp_path) as (data, _):
+        with transactions._locked_transactions_data("alice", "ISA", store) as (data, _):
             data["transactions"].append({"ticker": "MSFT", "price_gbp": 20, "units": 2})
             raise RuntimeError("boom")
 
     saved = json.loads(file_path.read_text())
     assert saved["transactions"] == [{"ticker": "PFE", "price_gbp": 10, "units": 1}]
 
-    with transactions._locked_transactions_data("alice", "ISA", tmp_path) as (data, _):
+    with transactions._locked_transactions_data("alice", "ISA", store) as (data, _):
         data["transactions"].append({"ticker": "MSFT", "price_gbp": 20, "units": 2})
 
     saved = json.loads(file_path.read_text())
@@ -215,14 +217,15 @@ def test_locked_account_holdings_data_discards_failed_new_file(tmp_path, monkeyp
     monkeypatch.setattr(config, "accounts_root", tmp_path)
     file_path = tmp_path / "alice" / "isa.json"
 
+    store = LocalAccountsStore(root=tmp_path)
     with pytest.raises(RuntimeError):
-        with transactions._locked_account_holdings_data("alice", "isa", tmp_path) as (data, _):
+        with transactions._locked_account_holdings_data("alice", "isa", store) as (data, _):
             data["holdings"].append({"ticker": "VUSA.L", "value_gbp": 1000})
             raise RuntimeError("boom")
 
     assert not file_path.exists()
 
-    with transactions._locked_account_holdings_data("alice", "isa", tmp_path) as (data, _):
+    with transactions._locked_account_holdings_data("alice", "isa", store) as (data, _):
         data["holdings"].append({"ticker": "VUSA.L", "value_gbp": 1000})
 
     saved = json.loads(file_path.read_text())
@@ -295,7 +298,7 @@ def test_transactions_compliance_filters(tmp_path, monkeypatch):
         transactions.Transaction(owner="alice", account="gia", date="2024-01-02", ticker="MSFT"),
         transactions.Transaction(owner="bob", account="isa", date="2024-01-02", ticker="PFE"),
     ]
-    monkeypatch.setattr(transactions, "_load_all_transactions", lambda: sample)
+    monkeypatch.setattr(transactions, "_load_all_transactions", lambda *_a, **_k: sample)
 
     captured = {}
 


### PR DESCRIPTION
## Summary

In the deployed AWS environment every write to `POST /holdings/manual`, `GET /holdings/manual`, and transaction create/edit/delete returned `HTTP 400 "Accounts root not configured"`. The only on-disk accounts root in Lambda is the read-only shared/global demo dataset, so `configure_runtime_paths()` always set `accounts_root_is_global=True` and the guard in `_require_accounts_root` fired on every request.

This implements a writable, **direct-to-S3** account-document store on a dedicated prefix, separate from the read-only `accounts/` demo data, so writes persist in AWS without mutating the shared dataset.

## Changes

**New `backend/common/accounts_store.py`** — pluggable writable store:
- `LocalAccountsStore` — preserves the existing on-disk, file-locked write behaviour (local dev / tests).
- `S3AccountsStore` — writes each account document directly to a `writable-accounts/<owner>/<file>.json` S3 object. Reads the current object fresh before each write (no `/tmp` divergence across Lambda instances). Prefix is deliberately distinct from `accounts/`.

**`backend/routes/transactions.py`:**
- Resolve a writable store per request — S3 in AWS (`DATA_BUCKET` set), on-disk otherwise (flagged `is_global` when it resolves to the demo dataset).
- Manual-holding and transaction create/update/delete persist via the store; the owner is scaffolded under the writable root on first write (`ensure_owner`), tying account creation to a writable, non-global root.
- Read endpoints (`GET /holdings/manual`, `/transactions`, `/dividends`, `/transactions/compliance`) merge the read-only global demo dataset with the writable store, **writable-over-global**, so demo content still surfaces.
- Clearer 400 distinguishes *read-only-by-design* (resolves to the shared demo dataset) from a genuine *misconfiguration*.
- Portfolio rebuild is skipped for the S3 store (path-based; portfolio reads continue via the S3 data loader).

**CDK (`cdk/stacks/backend_lambda_stack.py`):**
- Add the `writable-accounts/` prefix to the BackendLambda `s3:ListBucket` grant and expose `WRITABLE_ACCOUNTS_PREFIX` as a Lambda env var. Object-level `s3:GetObject`/`s3:PutObject` are already granted bucket-wide, so no new object-level grant is required.

## Tests
- New: `tests/backend/common/test_accounts_store.py` (incl. an in-memory S3 fake) and `tests/backend/routes/test_transactions_writable_store.py` (AWS write path end-to-end).
- Updated existing transaction tests for the new store signature; pinned the writable root in a route test helper so writes no longer leak into the repo `data/` dir; removed 5 now-passing `xfail` markers.
- Updated the CDK permissions test to expect the new list prefix.

Backend transaction/store suites: **74 passed, no data leak**. CDK permissions: **15 passed**. The one unrelated pre-existing failure (`groupPortfolio` contract schema drift) fails on `main` without these changes too.

## Notes / limitations
- The AWS path is unit-tested with a mocked S3 client; it has **not** been live-verified against the deployed API (no deploy access from this environment).
- Cross-instance write locking is not implemented; S3 `PutObject` is atomic per object, which is sufficient for this single-document read-modify-write flow.

Closes #4275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a writable accounts persistence layer (local or AWS S3) for transaction and holdings data.
  * Transactions and holdings endpoints now automatically use the writable storage in deployed environments.
* **Bug Fixes**
  * Prevents unintended edits to the read-only demo dataset by routing all updates through the writable store and merging results for reads.
* **Tests**
  * Added extensive local and S3-backed tests, including error handling, request caching, and persistence verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->