### PR TITLE
Add .aiderignore to reduce repo-map size for large monorepo

### DIFF
--- a/.aiderignore
+++ b/.aiderignore
@@ -1,0 +1,24 @@
+# Aider context exclusions for large/non-source paths.
+# Keeps aider's repo map focused on source code in this large repo.
+# See: https://aider.chat/docs/faq.html#can-i-use-aider-in-a-large-mono-repo
+
+# Test fixtures and generated data
+tests/data/
+data/
+frontend/test-results/
+
+# Coverage / build artifacts
+cdk/.coverage
+.coverage
+htmlcov/
+cdk.out/
+cdk/cdk.out/
+cdk/cdk.out.backend/
+
+# Dependencies and build output
+node_modules/
+dist/
+build/
+
+# Logs
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ backend.log
 # Jenkins
 jenkins_home/
 .aider*
+!.aiderignore


### PR DESCRIPTION
## Summary
- Adds a `.aiderignore` excluding test fixtures (`data/`, `tests/data/`), build/coverage artifacts, and `node_modules`/`dist`/`build` from aider's context.
- Adjusts `.aider*` rule in `.gitignore` so `.aiderignore` itself can be tracked and shared.

Addresses aider's warning on this 1,100+ file repo:
> Warning: For large repos, consider using --subtree-only and .aiderignore

## Test plan
- [x] Verified `.aiderignore` is no longer caught by `.gitignore`'s `.aider*` rule (`git check-ignore`).
- [x] Confirmed `git add .aiderignore` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration files to refine repository structure and optimise development workflows. Changes improve handling of generated artefacts, build outputs, test results, and dependencies. These updates enhance development efficiency and streamline repository mapping processes. No impact to application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->