### PR TITLE
test: rename test_malformed_backticks_single_side to match its actual assertion

### DIFF
--- a/.github/scripts/test_extract_verdict.py
+++ b/.github/scripts/test_extract_verdict.py
@@ -149,20 +149,10 @@ Found one.
         review_text = "APPROVE — no issues"  # missing bold markers
         assert extract_verdict(review_text) is None
 
-    def test_malformed_backticks_single_side(self) -> None:
-        """Test that mismatched backticks don't create false positives."""
+    def test_single_backtick_malformed_format_matches(self) -> None:
+        """Test that the regex matches a single-backtick malformed format (e.g., **`APPROVE**)."""
         review_text = "**`APPROVE** — missing closing backtick"
-        # This could match if the regex is too loose, so verify it doesn't
-        # Actually, with the pattern \*\*`?(APPROVE|REQUEST CHANGES)`?\*\*,
-        # **`APPROVE** would not match because we'd have **`APPROVE** (backtick at start but not at end)
-        # Let me trace through: \*\* matches first **, then `? optionally matches `,
-        # then (APPROVE|REQUEST CHANGES) matches APPROVE, then `? optionally matches nothing
-        # (but the next character is *, so it continues), then \*\* matches the **
-        # So this would actually match. Let me verify...
         verdict = extract_verdict(review_text)
-        # The regex \*\*`?(APPROVE|REQUEST CHANGES)`?\*\* would match **`APPROVE**
-        # because `? means 0 or 1 backticks on each side
-        # So this test should expect APPROVE
         assert verdict == "APPROVE"
 
     def test_multiple_verdicts_returns_first(self) -> None:


### PR DESCRIPTION
## Summary
- Renames `test_malformed_backticks_single_side` to `test_single_backtick_malformed_format_matches` in `.github/scripts/test_extract_verdict.py`, since the test asserts the regex *does* match a malformed single-backtick verdict (`**\`APPROVE**`), not that it rejects it.
- Trims the rambling inline "let me trace through the regex" comments down to a single accurate docstring.
- No production code, regex, or assertion changes.

Closes #4284

## Test plan
- [x] `python -m pytest test_extract_verdict.py -k backtick` — renamed test passes
- [x] Confirmed the one remaining failure (`test_main_with_backtick_approve`, a subprocess path issue) is pre-existing and unrelated (reproduces on `main` too)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced verdict extraction handling to recognise malformed single-backtick patterns as valid verdicts, improving robustness when processing approval decisions with inconsistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->