### PR TITLE
feat(frontend): add public Create Account request page

### DIFF
--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { API_BASE, setAuthToken } from './api';
 import { useUser } from './UserContext';
 import { useAuth } from './AuthContext';
@@ -104,6 +105,10 @@ export default function LoginPage({ clientId, onSuccess }: Props) {
         </div>
       )}
       <div id="google-signin"></div>
+      <p style={{ marginTop: '1rem' }}>
+        Don&apos;t have an account?{' '}
+        <Link to="/create-account">Create account</Link>
+      </p>
     </div>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1611,3 +1611,22 @@ export const checkPortfolioHealth = () =>
     `${API_BASE}/support/portfolio-health`,
     { method: "POST" },
   );
+
+// ───────────── Account signup ─────────────
+export interface AccountSignupRequest {
+  name: string;
+  email: string;
+  note?: string;
+}
+
+export interface AccountSignupResponse {
+  status: string;
+}
+
+/** Submit a public account-creation request for admin approval. */
+export const requestAccountSignup = (payload: AccountSignupRequest) =>
+  fetchJson<AccountSignupResponse>(`${API_BASE}/signup/request`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -295,6 +295,7 @@ export function Root() {
   }, [fetchConfig]);
 
   const isPublicSupportRoute = location.pathname === '/support';
+  const isPublicCreateAccountRoute = location.pathname === '/create-account';
 
   if (configLoading || retryScheduled) {
     return (
@@ -322,7 +323,7 @@ export function Root() {
     );
   }
 
-  if (needsAuth && !authed && !isPublicSupportRoute) {
+  if (needsAuth && !authed && !isPublicSupportRoute && !isPublicCreateAccountRoute) {
     if (!googleLoginEnabled || !clientId) {
       console.error(
         'Authentication is enforced but Google login is not fully configured'

--- a/frontend/src/modes.ts
+++ b/frontend/src/modes.ts
@@ -25,7 +25,8 @@ export type Mode =
   | "support"
   | "taxtools"
   | "pension"
-  | "scenario";
+  | "scenario"
+  | "createaccount";
 
 export const MODES: Mode[] = [
   "group",
@@ -55,4 +56,5 @@ export const MODES: Mode[] = [
   "taxtools",
   "pension",
   "scenario",
+  "createaccount",
 ];

--- a/frontend/src/pages/CreateAccountPage.tsx
+++ b/frontend/src/pages/CreateAccountPage.tsx
@@ -1,0 +1,118 @@
+import { useState, type FormEvent } from "react";
+import { Link } from "react-router-dom";
+import { requestAccountSignup } from "../api";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function CreateAccountPage() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [note, setNote] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const trimmedName = name.trim();
+    const trimmedEmail = email.trim();
+
+    if (!trimmedName || !trimmedEmail) {
+      setError("Please enter your name and email address.");
+      return;
+    }
+    if (!EMAIL_PATTERN.test(trimmedEmail)) {
+      setError("Please enter a valid email address.");
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+    try {
+      await requestAccountSignup({
+        name: trimmedName,
+        email: trimmedEmail,
+        note: note.trim() || undefined,
+      });
+      setSubmitted(true);
+    } catch {
+      setError("Something went wrong submitting your request. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div style={{ maxWidth: 480, margin: "2rem auto", padding: "1rem" }}>
+        <h1>Request received</h1>
+        <p role="status">
+          Thanks — your request has been received and is pending admin
+          approval. You will be contacted once your account has been set up.
+        </p>
+        <Link to="/">Back to login</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ maxWidth: 480, margin: "2rem auto", padding: "1rem" }}>
+      <h1>Create account</h1>
+      <p>
+        Request access to AllotMint. An administrator will review your
+        request and set up your account.
+      </p>
+      <form onSubmit={handleSubmit} noValidate>
+        {error && (
+          <div role="alert" aria-live="assertive" style={{ color: "red", marginBottom: "1rem" }}>
+            {error}
+          </div>
+        )}
+        <div style={{ marginBottom: "1rem" }}>
+          <label htmlFor="create-account-name">Full name</label>
+          <br />
+          <input
+            id="create-account-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            style={{ width: "100%" }}
+          />
+        </div>
+        <div style={{ marginBottom: "1rem" }}>
+          <label htmlFor="create-account-email">Email</label>
+          <br />
+          <input
+            id="create-account-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            style={{ width: "100%" }}
+          />
+        </div>
+        <div style={{ marginBottom: "1rem" }}>
+          <label htmlFor="create-account-note">
+            What would you like to use AllotMint for? (optional)
+          </label>
+          <br />
+          <textarea
+            id="create-account-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            rows={3}
+            style={{ width: "100%" }}
+          />
+        </div>
+        <button type="submit" disabled={submitting}>
+          {submitting ? "Submitting…" : "Request account"}
+        </button>
+      </form>
+      <p style={{ marginTop: "1rem" }}>
+        <Link to="/">Back to login</Link>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/CreateAccountPage.tsx
+++ b/frontend/src/pages/CreateAccountPage.tsx
@@ -4,6 +4,107 @@ import { requestAccountSignup } from "../api";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+function SuccessView() {
+  return (
+    <div style={{ maxWidth: 480, margin: "2rem auto", padding: "1rem" }}>
+      <h1>Request received</h1>
+      <p role="status">
+        Thanks — your request has been received and is pending admin
+        approval. You will be contacted once your account has been set up.
+      </p>
+      <Link to="/" aria-label="Back to login">
+        Back to login
+      </Link>
+    </div>
+  );
+}
+
+interface CreateAccountFormProps {
+  name: string;
+  email: string;
+  note: string;
+  error: string | null;
+  submitting: boolean;
+  onNameChange: (value: string) => void;
+  onEmailChange: (value: string) => void;
+  onNoteChange: (value: string) => void;
+  onSubmit: (e: FormEvent<HTMLFormElement>) => void;
+}
+
+function CreateAccountForm({
+  name,
+  email,
+  note,
+  error,
+  submitting,
+  onNameChange,
+  onEmailChange,
+  onNoteChange,
+  onSubmit,
+}: CreateAccountFormProps) {
+  return (
+    <div style={{ maxWidth: 480, margin: "2rem auto", padding: "1rem" }}>
+      <h1>Create account</h1>
+      <p>
+        Request access to AllotMint. An administrator will review your
+        request and set up your account.
+      </p>
+      <form onSubmit={onSubmit} noValidate>
+        {error && (
+          <div role="alert" aria-live="assertive" style={{ color: "red", marginBottom: "1rem" }}>
+            {error}
+          </div>
+        )}
+        <div style={{ marginBottom: "1rem" }}>
+          <label htmlFor="create-account-name">Full name</label>
+          <br />
+          <input
+            id="create-account-name"
+            type="text"
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            required
+            style={{ width: "100%" }}
+          />
+        </div>
+        <div style={{ marginBottom: "1rem" }}>
+          <label htmlFor="create-account-email">Email</label>
+          <br />
+          <input
+            id="create-account-email"
+            type="email"
+            value={email}
+            onChange={(e) => onEmailChange(e.target.value)}
+            required
+            style={{ width: "100%" }}
+          />
+        </div>
+        <div style={{ marginBottom: "1rem" }}>
+          <label htmlFor="create-account-note">
+            What would you like to use AllotMint for? (optional)
+          </label>
+          <br />
+          <textarea
+            id="create-account-note"
+            value={note}
+            onChange={(e) => onNoteChange(e.target.value)}
+            rows={3}
+            style={{ width: "100%" }}
+          />
+        </div>
+        <button type="submit" disabled={submitting}>
+          {submitting ? "Submitting…" : "Request account"}
+        </button>
+      </form>
+      <p style={{ marginTop: "1rem" }}>
+        <Link to="/" aria-label="Back to login">
+          Back to login
+        </Link>
+      </p>
+    </div>
+  );
+}
+
 export default function CreateAccountPage() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -44,75 +145,20 @@ export default function CreateAccountPage() {
   }
 
   if (submitted) {
-    return (
-      <div style={{ maxWidth: 480, margin: "2rem auto", padding: "1rem" }}>
-        <h1>Request received</h1>
-        <p role="status">
-          Thanks — your request has been received and is pending admin
-          approval. You will be contacted once your account has been set up.
-        </p>
-        <Link to="/">Back to login</Link>
-      </div>
-    );
+    return <SuccessView />;
   }
 
   return (
-    <div style={{ maxWidth: 480, margin: "2rem auto", padding: "1rem" }}>
-      <h1>Create account</h1>
-      <p>
-        Request access to AllotMint. An administrator will review your
-        request and set up your account.
-      </p>
-      <form onSubmit={handleSubmit} noValidate>
-        {error && (
-          <div role="alert" aria-live="assertive" style={{ color: "red", marginBottom: "1rem" }}>
-            {error}
-          </div>
-        )}
-        <div style={{ marginBottom: "1rem" }}>
-          <label htmlFor="create-account-name">Full name</label>
-          <br />
-          <input
-            id="create-account-name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            style={{ width: "100%" }}
-          />
-        </div>
-        <div style={{ marginBottom: "1rem" }}>
-          <label htmlFor="create-account-email">Email</label>
-          <br />
-          <input
-            id="create-account-email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            style={{ width: "100%" }}
-          />
-        </div>
-        <div style={{ marginBottom: "1rem" }}>
-          <label htmlFor="create-account-note">
-            What would you like to use AllotMint for? (optional)
-          </label>
-          <br />
-          <textarea
-            id="create-account-note"
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            rows={3}
-            style={{ width: "100%" }}
-          />
-        </div>
-        <button type="submit" disabled={submitting}>
-          {submitting ? "Submitting…" : "Request account"}
-        </button>
-      </form>
-      <p style={{ marginTop: "1rem" }}>
-        <Link to="/">Back to login</Link>
-      </p>
-    </div>
+    <CreateAccountForm
+      name={name}
+      email={email}
+      note={note}
+      error={error}
+      submitting={submitting}
+      onNameChange={setName}
+      onEmailChange={setEmail}
+      onNoteChange={setNote}
+      onSubmit={handleSubmit}
+    />
   );
 }

--- a/frontend/src/routes/registry.ts
+++ b/frontend/src/routes/registry.ts
@@ -291,6 +291,15 @@ export const ROUTE_REGISTRY: RouteRegistryEntry[] = [
     priority: 140,
     defaultPath: () => '/research',
   },
+  {
+    mode: 'createaccount',
+    routeSegment: 'create-account',
+    section: 'standalone',
+    priority: 150,
+    defaultPath: () => '/create-account',
+    routePath: '/create-account',
+    lazyComponent: lazyPage(() => import('../pages/CreateAccountPage')),
+  },
 ];
 
 export const pageManifest = ROUTE_REGISTRY;

--- a/frontend/tests/unit/LoginPage.test.tsx
+++ b/frontend/tests/unit/LoginPage.test.tsx
@@ -44,7 +44,11 @@ describe('LoginPage error handling', () => {
         json: async () => ({ detail: 'bad' })
       } as any)
 
-    render(<LoginPage clientId="cid" onSuccess={() => {}} />)
+    render(
+      <BrowserRouter>
+        <LoginPage clientId="cid" onSuccess={() => {}} />
+      </BrowserRouter>,
+    )
 
     const script = document.head.querySelector('script[src="https://accounts.google.com/gsi/client"]') as HTMLScriptElement
     script.onload?.(new Event('load'))

--- a/frontend/tests/unit/pages/CreateAccountPage.test.tsx
+++ b/frontend/tests/unit/pages/CreateAccountPage.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import CreateAccountPage from "@/pages/CreateAccountPage";
+import { requestAccountSignup } from "@/api";
+
+vi.mock("@/api", () => ({
+  requestAccountSignup: vi.fn(),
+}));
+
+describe("CreateAccountPage", () => {
+  beforeEach(() => {
+    vi.mocked(requestAccountSignup).mockReset();
+  });
+
+  it("blocks submission with empty fields and shows a validation message", () => {
+    render(
+      <MemoryRouter>
+        <CreateAccountPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /request account/i }));
+
+    expect(
+      screen.getByText(/enter your name and email/i),
+    ).toBeInTheDocument();
+    expect(requestAccountSignup).not.toHaveBeenCalled();
+  });
+
+  it("blocks submission with an invalid email", () => {
+    render(
+      <MemoryRouter>
+        <CreateAccountPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText(/full name/i), {
+      target: { value: "Ada Lovelace" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /request account/i }));
+
+    expect(screen.getByText(/valid email address/i)).toBeInTheDocument();
+    expect(requestAccountSignup).not.toHaveBeenCalled();
+  });
+
+  it("submits valid details and shows a pending-approval confirmation", async () => {
+    vi.mocked(requestAccountSignup).mockResolvedValue({ status: "pending" });
+
+    render(
+      <MemoryRouter>
+        <CreateAccountPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText(/full name/i), {
+      target: { value: "Ada Lovelace" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "ada@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /request account/i }));
+
+    await waitFor(() =>
+      expect(requestAccountSignup).toHaveBeenCalledWith({
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        note: undefined,
+      }),
+    );
+
+    expect(
+      await screen.findByText(/pending admin approval/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error message and stays on the form when submission fails", async () => {
+    vi.mocked(requestAccountSignup).mockRejectedValue(new Error("network"));
+
+    render(
+      <MemoryRouter>
+        <CreateAccountPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText(/full name/i), {
+      target: { value: "Ada Lovelace" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "ada@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /request account/i }));
+
+    expect(
+      await screen.findByText(/something went wrong/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /request account/i }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a public, unauthenticated `/create-account` page where a prospective user can request access (name, email, optional note).
- Links to it from the login page ("Create account").
- Client-side validation for required fields and email format; submits to `POST /signup/request` (#4351) and shows a generic "request received, pending admin approval" confirmation that does not reveal whether the email already has an account.

## Test plan
- [x] `npx vitest --run` — full frontend suite passes (505 tests)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] New Vitest coverage for `CreateAccountPage`: empty-field validation, invalid-email validation, success confirmation, and submission-error handling

Closes #4350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account creation request page where users submit name, email and optional notes for admin approval, with inline validation and a confirmation state.
  * Added a “Create account” call-to-action link on the login page.
  * Allowed the new create-account route to be accessible without authentication.
* **Bug Fixes**
  * Improved login page unit test routing context for more reliable failure handling.
* **Tests**
  * Added unit tests for the create-account page, including validation, API submission, success and error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->