### PR TITLE
feat(backend): public signup-request endpoint with admin SES notification

### DIFF
--- a/backend/bootstrap/routers.py
+++ b/backend/bootstrap/routers.py
@@ -36,6 +36,7 @@ from backend.routes.rebalance import router as rebalance_router
 from backend.routes.reports import router as reports_router
 from backend.routes.scenario import router as scenario_router
 from backend.routes.screener import router as screener_router
+from backend.routes.signup import router as signup_router
 from backend.routes.support import router as support_router
 from backend.routes.tax import router as tax_router
 from backend.routes.timeseries_admin import router as timeseries_admin_router
@@ -70,6 +71,7 @@ def register_routers(app: FastAPI, cfg: Config) -> None:
     app.include_router(trail_router, dependencies=protected)
     app.include_router(compliance_router)
     app.include_router(screener_router)
+    app.include_router(signup_router)
     app.include_router(support_router)
     app.include_router(query_router, dependencies=protected)
     app.include_router(virtual_portfolio_router, dependencies=protected)

--- a/backend/common/signup_requests.py
+++ b/backend/common/signup_requests.py
@@ -1,0 +1,134 @@
+"""Domain logic for public account-signup requests.
+
+Keeps validation, token generation, and persistence out of the route handler
+(see :mod:`backend.routes.signup`). A signup request records a visitor's
+interest in an account and produces an unguessable, expiring approval token.
+
+Only the SHA-256 hash of the approval token is persisted; the plaintext token
+is returned once (to be embedded in the admin notification email) and never
+stored, so a leak of the request store cannot reconstruct a usable link. The
+approval flow (#4352) verifies an inbound token by hashing it and comparing it
+to the stored ``token_sha256`` while ``status == "pending"`` and the request
+has not expired, giving single-use, time-bound semantics.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import secrets
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Deliberately permissive: we only guard against obviously malformed input.
+# RFC-complete email validation is intractable and not required here — the
+# real check is that a human at the address can act on the admin notification.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+_TOKEN_TTL = timedelta(days=7)
+_MAX_NAME_LEN = 200
+_MAX_EMAIL_LEN = 320  # RFC 5321 maximum length of a forward-path address
+_MAX_NOTE_LEN = 2000
+
+
+class SignupValidationError(ValueError):
+    """Raised when a signup request payload fails validation."""
+
+
+@dataclass(frozen=True)
+class SignupRequest:
+    """A persisted pending signup request.
+
+    ``token_sha256`` is the hash of the single-use approval token; the
+    plaintext token is never stored on this record.
+    """
+
+    id: str
+    name: str
+    email: str
+    note: str
+    status: str
+    created_at: str
+    expires_at: str
+    token_sha256: str
+
+
+def normalise_payload(payload: object) -> tuple[str, str, str]:
+    """Validate and normalise a raw signup payload.
+
+    Returns ``(name, email, note)`` with the email lowercased and all fields
+    trimmed. Raises :class:`SignupValidationError` on any malformed field.
+    """
+
+    if not isinstance(payload, dict):
+        raise SignupValidationError("invalid payload")
+
+    name = str(payload.get("name") or "").strip()
+    email = str(payload.get("email") or "").strip().lower()
+    note = str(payload.get("note") or "").strip()
+
+    if not name or len(name) > _MAX_NAME_LEN:
+        raise SignupValidationError("invalid name")
+    if len(email) > _MAX_EMAIL_LEN or not _EMAIL_RE.match(email):
+        raise SignupValidationError("invalid email")
+    if len(note) > _MAX_NOTE_LEN:
+        raise SignupValidationError("note too long")
+
+    return name, email, note
+
+
+def hash_token(token: str) -> str:
+    """Return the hex SHA-256 digest used to persist an approval token."""
+
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def signup_requests_dir(data_root: Path) -> Path:
+    """Return the directory holding pending signup requests."""
+
+    return Path(data_root) / "signup_requests"
+
+
+def create_signup_request(
+    name: str,
+    email: str,
+    note: str,
+    store_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> tuple[SignupRequest, str]:
+    """Persist a pending request and return it with the plaintext token.
+
+    The returned token is the only time the plaintext exists; callers embed it
+    in the admin email and discard it. ``now`` is injectable for tests.
+    """
+
+    moment = now or datetime.now(timezone.utc)
+    token = secrets.token_urlsafe(32)
+    record = SignupRequest(
+        id=secrets.token_hex(16),
+        name=name,
+        email=email,
+        note=note,
+        status="pending",
+        created_at=moment.isoformat(),
+        expires_at=(moment + _TOKEN_TTL).isoformat(),
+        token_sha256=hash_token(token),
+    )
+    _persist(record, store_dir)
+    return record, token
+
+
+def _persist(record: SignupRequest, store_dir: Path) -> None:
+    """Write ``record`` to ``store_dir`` as ``<id>.json``."""
+
+    directory = Path(store_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{record.id}.json"
+    path.write_text(json.dumps(asdict(record), indent=2, sort_keys=True))
+    logger.info("Recorded pending signup request %s", record.id)

--- a/backend/common/signup_requests.py
+++ b/backend/common/signup_requests.py
@@ -17,18 +17,12 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import re
 import secrets
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
-
-# Deliberately permissive: we only guard against obviously malformed input.
-# RFC-complete email validation is intractable and not required here — the
-# real check is that a human at the address can act on the admin notification.
-_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 _TOKEN_TTL = timedelta(days=7)
 _MAX_NAME_LEN = 200
@@ -38,6 +32,25 @@ _MAX_NOTE_LEN = 2000
 
 class SignupValidationError(ValueError):
     """Raised when a signup request payload fails validation."""
+
+
+def _looks_like_email(email: str) -> bool:
+    """Cheap, linear-time sanity check for an email address.
+
+    Deliberately permissive: we only guard against obviously malformed input
+    (the real check is that a human at the address can act on the admin
+    notification). Implemented with string operations rather than a regex to
+    avoid catastrophic backtracking (ReDoS) on adversarial input.
+    """
+
+    if any(ch.isspace() for ch in email) or email.count("@") != 1:
+        return False
+    local, _, domain = email.partition("@")
+    if not local or not domain:
+        return False
+    if domain.startswith(".") or domain.endswith(".") or "." not in domain:
+        return False
+    return ".." not in domain
 
 
 @dataclass(frozen=True)
@@ -74,7 +87,7 @@ def normalise_payload(payload: object) -> tuple[str, str, str]:
 
     if not name or len(name) > _MAX_NAME_LEN:
         raise SignupValidationError("invalid name")
-    if len(email) > _MAX_EMAIL_LEN or not _EMAIL_RE.match(email):
+    if len(email) > _MAX_EMAIL_LEN or not _looks_like_email(email):
         raise SignupValidationError("invalid email")
     if len(note) > _MAX_NOTE_LEN:
         raise SignupValidationError("note too long")

--- a/backend/emails/signup_request.py
+++ b/backend/emails/signup_request.py
@@ -1,0 +1,77 @@
+"""Admin notification email for public account-signup requests.
+
+Reuses the SES pattern established in :mod:`backend.emails.weekly_report`
+(``boto3.client("ses")`` and the ``WEEKLY_REPORT_FROM`` sender). The recipient
+is the admin address configured by the caller (``SIGNUP_ADMIN_EMAIL``).
+
+All visitor-supplied fields are HTML-escaped before being placed in the email
+body so a hostile name/note cannot inject markup into the admin's inbox.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+import boto3
+from markupsafe import escape
+
+logger = logging.getLogger(__name__)
+
+_SENDER_EMAIL = os.getenv("WEEKLY_REPORT_FROM", "no-reply@allotmint.com")
+
+
+@dataclass
+class SignupAdminNotification:
+    """Data required to render the admin notification email."""
+
+    request_id: str
+    name: str
+    email: str
+    note: str
+    approve_url: str
+    reject_url: str
+    expires_at: str
+
+
+def render_signup_admin_email(notification: SignupAdminNotification) -> str:
+    """Render the admin notification HTML, escaping all visitor input."""
+
+    note_html = escape(notification.note) if notification.note else "<em>(none)</em>"
+    return (
+        "<html><body>"
+        "<h2>New AllotMint access request</h2>"
+        f"<p><strong>Name:</strong> {escape(notification.name)}</p>"
+        f"<p><strong>Email:</strong> {escape(notification.email)}</p>"
+        f"<p><strong>Note:</strong> {note_html}</p>"
+        f"<p><strong>Request ID:</strong> {escape(notification.request_id)}</p>"
+        "<p>"
+        f'<a href="{escape(notification.approve_url)}">Approve</a>'
+        " &nbsp;|&nbsp; "
+        f'<a href="{escape(notification.reject_url)}">Reject</a>'
+        "</p>"
+        f"<p>These links expire at {escape(notification.expires_at)}.</p>"
+        "</body></html>"
+    )
+
+
+def send_signup_admin_email(admin_email: str, notification: SignupAdminNotification) -> None:
+    """Send the admin notification email via AWS SES.
+
+    Any SES failure propagates to the caller — it must not be swallowed, so the
+    route can surface the failure rather than silently dropping the request.
+    """
+
+    body_html = render_signup_admin_email(notification)
+    subject = f"AllotMint access request from {notification.name}"
+
+    ses = boto3.client("ses", region_name=os.getenv("AWS_REGION", "us-east-1"))
+    ses.send_email(
+        Source=_SENDER_EMAIL,
+        Destination={"ToAddresses": [admin_email]},
+        Message={
+            "Subject": {"Data": subject},
+            "Body": {"Html": {"Data": body_html}},
+        },
+    )

--- a/backend/routes/signup.py
+++ b/backend/routes/signup.py
@@ -1,0 +1,95 @@
+"""Public account-signup request endpoint.
+
+Exposes ``POST /signup/request``: an unauthenticated endpoint that records a
+visitor's interest in an account and emails the admin an approve/reject link.
+
+Anti-enumeration: the handler performs no lookup against existing accounts and
+always returns the same generic success body, so a caller cannot tell whether
+an email already has an account. Only malformed payloads (bad shape) yield a
+``400``; configuration/delivery failures yield ``5xx`` but reveal nothing about
+account existence.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from json import JSONDecodeError
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+
+from backend.common import signup_requests
+from backend.emails.signup_request import (
+    SignupAdminNotification,
+    send_signup_admin_email,
+)
+from backend.routes._accounts import resolve_accounts_root
+
+router = APIRouter(prefix="/signup", tags=["signup"])
+
+logger = logging.getLogger(__name__)
+
+# Identical for every accepted request so the endpoint cannot be used to probe
+# which emails already have accounts.
+_GENERIC_OK: dict[str, str] = {
+    "status": "ok",
+    "message": "If your request is valid, an administrator has been notified.",
+}
+
+
+def _store_dir(request: Request) -> Path:
+    """Return the writable directory for pending signup requests."""
+
+    accounts_root = resolve_accounts_root(request, allow_missing=True)
+    return signup_requests.signup_requests_dir(accounts_root.parent)
+
+
+def _build_links(request_id: str, token: str) -> tuple[str, str]:
+    """Build the approve/reject links consumed by the approval flow (#4352)."""
+
+    base = os.getenv("SIGNUP_APPROVAL_BASE_URL", "").rstrip("/")
+    query = f"id={request_id}&token={token}"
+    return f"{base}/signup/approve?{query}", f"{base}/signup/reject?{query}"
+
+
+@router.post("/request")
+async def post_signup_request(request: Request) -> dict[str, str]:
+    """Record a signup request and notify the admin; return a generic success."""
+
+    try:
+        payload = await request.json()
+    except (JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(status_code=400, detail="invalid request body") from exc
+
+    try:
+        name, email, note = signup_requests.normalise_payload(payload)
+    except signup_requests.SignupValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    admin_email = os.getenv("SIGNUP_ADMIN_EMAIL", "").strip()
+    if not admin_email:
+        # Misconfiguration, not a client error — and the same for every caller,
+        # so it leaks nothing about account existence.
+        logger.error("SIGNUP_ADMIN_EMAIL is not configured; cannot process signup requests")
+        raise HTTPException(status_code=503, detail="signup is not available")
+
+    record, token = signup_requests.create_signup_request(name, email, note, _store_dir(request))
+    approve_url, reject_url = _build_links(record.id, token)
+    notification = SignupAdminNotification(
+        request_id=record.id,
+        name=record.name,
+        email=record.email,
+        note=record.note,
+        approve_url=approve_url,
+        reject_url=reject_url,
+        expires_at=record.expires_at,
+    )
+
+    try:
+        send_signup_admin_email(admin_email, notification)
+    except Exception as exc:  # noqa: BLE001 - surface any SES failure, never swallow it
+        logger.exception("Failed to send signup admin email for request %s", record.id)
+        raise HTTPException(status_code=502, detail="failed to notify administrator") from exc
+
+    return dict(_GENERIC_OK)

--- a/backend/routes/signup.py
+++ b/backend/routes/signup.py
@@ -49,6 +49,13 @@ def _build_links(request_id: str, token: str) -> tuple[str, str]:
     """Build the approve/reject links consumed by the approval flow (#4352)."""
 
     base = os.getenv("SIGNUP_APPROVAL_BASE_URL", "").rstrip("/")
+    if not base:
+        # Without a base URL the emailed links are relative and unusable. Warn
+        # rather than fail so the admin still receives the request id + token
+        # and can act manually, but the misconfiguration is not silent.
+        logger.warning(
+            "SIGNUP_APPROVAL_BASE_URL is not set; admin approve/reject links will be relative"
+        )
     query = f"id={request_id}&token={token}"
     return f"{base}/signup/approve?{query}", f"{base}/signup/reject?{query}"
 

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -77,6 +77,21 @@ def test_invalid_payload_returns_400(client, monkeypatch):
     assert resp.status_code == 400
 
 
+def test_missing_base_url_warns_but_still_notifies(client, monkeypatch, caplog):
+    test_client, _ = client
+    sent = _capture_email(monkeypatch)
+    monkeypatch.delenv("SIGNUP_APPROVAL_BASE_URL", raising=False)
+
+    with caplog.at_level("WARNING"):
+        resp = test_client.post(
+            "/signup/request", json={"name": "Jane", "email": "jane@example.com"}
+        )
+
+    assert resp.status_code == 200
+    assert sent["notification"].approve_url.startswith("/signup/approve")
+    assert any("SIGNUP_APPROVAL_BASE_URL" in r.message for r in caplog.records)
+
+
 def test_existing_and_new_emails_are_indistinguishable(client, monkeypatch):
     test_client, _ = client
     _capture_email(monkeypatch)
@@ -97,9 +112,7 @@ def test_missing_admin_email_returns_503(client, monkeypatch):
     _capture_email(monkeypatch)
     monkeypatch.delenv("SIGNUP_ADMIN_EMAIL", raising=False)
 
-    resp = test_client.post(
-        "/signup/request", json={"name": "Jane", "email": "jane@example.com"}
-    )
+    resp = test_client.post("/signup/request", json={"name": "Jane", "email": "jane@example.com"})
     assert resp.status_code == 503
 
 
@@ -111,7 +124,5 @@ def test_email_send_failure_is_not_swallowed(client, monkeypatch):
 
     monkeypatch.setattr(signup_module, "send_signup_admin_email", boom)
 
-    resp = test_client.post(
-        "/signup/request", json={"name": "Jane", "email": "jane@example.com"}
-    )
+    resp = test_client.post("/signup/request", json={"name": "Jane", "email": "jane@example.com"})
     assert resp.status_code == 502

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -1,0 +1,117 @@
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes import signup as signup_module
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """A test client with the signup router and an isolated request store.
+
+    ``resolve_accounts_root`` is patched to point at a temp directory so the
+    handler never writes into the repo's ``data/`` tree.
+    """
+
+    accounts_root = tmp_path / "accounts"
+    monkeypatch.setattr(
+        signup_module,
+        "resolve_accounts_root",
+        lambda request, allow_missing=False: accounts_root,
+    )
+    monkeypatch.setenv("SIGNUP_ADMIN_EMAIL", "admin@example.com")
+
+    app = FastAPI()
+    app.include_router(signup_module.router)
+    return TestClient(app), tmp_path
+
+
+def _capture_email(monkeypatch):
+    sent = {}
+
+    def fake_send(admin_email, notification):
+        sent["admin_email"] = admin_email
+        sent["notification"] = notification
+
+    monkeypatch.setattr(signup_module, "send_signup_admin_email", fake_send)
+    return sent
+
+
+def test_valid_request_records_and_notifies(client, monkeypatch):
+    test_client, tmp_path = client
+    sent = _capture_email(monkeypatch)
+
+    resp = test_client.post(
+        "/signup/request",
+        json={"name": "Jane", "email": "Jane@Example.com", "note": "hi"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "ok",
+        "message": "If your request is valid, an administrator has been notified.",
+    }
+
+    # Persisted exactly one pending request with the normalised email.
+    store = tmp_path / "signup_requests"
+    files = list(store.glob("*.json"))
+    assert len(files) == 1
+    saved = json.loads(files[0].read_text())
+    assert saved["email"] == "jane@example.com"
+    assert saved["status"] == "pending"
+
+    # Admin was notified with approve/reject links.
+    assert sent["admin_email"] == "admin@example.com"
+    assert sent["notification"].request_id == saved["id"]
+    assert "/signup/approve" in sent["notification"].approve_url
+    assert "/signup/reject" in sent["notification"].reject_url
+
+
+def test_invalid_payload_returns_400(client, monkeypatch):
+    test_client, _ = client
+    _capture_email(monkeypatch)
+
+    resp = test_client.post("/signup/request", json={"name": "", "email": "nope"})
+    assert resp.status_code == 400
+
+
+def test_existing_and_new_emails_are_indistinguishable(client, monkeypatch):
+    test_client, _ = client
+    _capture_email(monkeypatch)
+
+    first = test_client.post(
+        "/signup/request", json={"name": "Existing", "email": "alice@example.com"}
+    )
+    second = test_client.post(
+        "/signup/request", json={"name": "New", "email": "brandnew@example.com"}
+    )
+
+    assert first.status_code == second.status_code == 200
+    assert first.json() == second.json()
+
+
+def test_missing_admin_email_returns_503(client, monkeypatch):
+    test_client, _ = client
+    _capture_email(monkeypatch)
+    monkeypatch.delenv("SIGNUP_ADMIN_EMAIL", raising=False)
+
+    resp = test_client.post(
+        "/signup/request", json={"name": "Jane", "email": "jane@example.com"}
+    )
+    assert resp.status_code == 503
+
+
+def test_email_send_failure_is_not_swallowed(client, monkeypatch):
+    test_client, _ = client
+
+    def boom(admin_email, notification):
+        raise RuntimeError("SES down")
+
+    monkeypatch.setattr(signup_module, "send_signup_admin_email", boom)
+
+    resp = test_client.post(
+        "/signup/request", json={"name": "Jane", "email": "jane@example.com"}
+    )
+    assert resp.status_code == 502

--- a/tests/backend/test_signup_request_email.py
+++ b/tests/backend/test_signup_request_email.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock, patch
+
+from backend.emails.signup_request import (
+    SignupAdminNotification,
+    render_signup_admin_email,
+    send_signup_admin_email,
+)
+
+
+def _notification(**overrides) -> SignupAdminNotification:
+    base = dict(
+        request_id="abc123",
+        name="Jane Doe",
+        email="jane@example.com",
+        note="please let me in",
+        approve_url="https://admin.example.com/signup/approve?id=abc123&token=t",
+        reject_url="https://admin.example.com/signup/reject?id=abc123&token=t",
+        expires_at="2026-06-22T12:00:00+00:00",
+    )
+    base.update(overrides)
+    return SignupAdminNotification(**base)
+
+
+def test_render_includes_request_details_and_links():
+    html = render_signup_admin_email(_notification())
+    assert "Jane Doe" in html
+    assert "jane@example.com" in html
+    assert "please let me in" in html
+    assert "/signup/approve?id=abc123" in html
+    assert "/signup/reject?id=abc123" in html
+
+
+def test_render_escapes_hostile_input():
+    html = render_signup_admin_email(
+        _notification(name="<script>alert(1)</script>", note="<img src=x onerror=y>")
+    )
+    assert "<script>" not in html
+    assert "<img" not in html
+    assert "&lt;script&gt;" in html
+    assert "&lt;img" in html
+
+
+def test_render_handles_missing_note():
+    html = render_signup_admin_email(_notification(note=""))
+    assert "(none)" in html
+
+
+def test_send_signup_admin_email_invokes_ses():
+    notification = _notification()
+    with patch("boto3.client") as client_factory:
+        ses_client = MagicMock()
+        client_factory.return_value = ses_client
+        send_signup_admin_email("admin@example.com", notification)
+
+    client_factory.assert_called_once()
+    assert client_factory.call_args.args[0] == "ses"
+    ses_client.send_email.assert_called_once()
+    _, kwargs = ses_client.send_email.call_args
+    assert kwargs["Destination"]["ToAddresses"] == ["admin@example.com"]
+    assert "Jane Doe" in kwargs["Message"]["Subject"]["Data"]
+    assert "/signup/approve" in kwargs["Message"]["Body"]["Html"]["Data"]

--- a/tests/backend/test_signup_requests.py
+++ b/tests/backend/test_signup_requests.py
@@ -1,0 +1,80 @@
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.common import signup_requests
+
+
+def test_normalise_payload_trims_and_lowercases_email():
+    name, email, note = signup_requests.normalise_payload(
+        {"name": "  Jane Doe ", "email": "  Jane@Example.COM ", "note": "  hi  "}
+    )
+    assert name == "Jane Doe"
+    assert email == "jane@example.com"
+    assert note == "hi"
+
+
+def test_normalise_payload_allows_missing_note():
+    name, email, note = signup_requests.normalise_payload(
+        {"name": "Jane", "email": "jane@example.com"}
+    )
+    assert (name, email, note) == ("Jane", "jane@example.com", "")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not a dict",
+        {"name": "", "email": "jane@example.com"},
+        {"name": "Jane", "email": "not-an-email"},
+        {"name": "Jane", "email": "missing-at.example.com"},
+        {"name": "Jane", "email": ""},
+        {"name": "x" * 201, "email": "jane@example.com"},
+        {"name": "Jane", "email": "jane@example.com", "note": "x" * 2001},
+    ],
+)
+def test_normalise_payload_rejects_invalid(payload):
+    with pytest.raises(signup_requests.SignupValidationError):
+        signup_requests.normalise_payload(payload)
+
+
+def test_create_signup_request_persists_record(tmp_path):
+    now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    store = signup_requests.signup_requests_dir(tmp_path)
+
+    record, token = signup_requests.create_signup_request(
+        "Jane", "jane@example.com", "hello", store, now=now
+    )
+
+    path = store / f"{record.id}.json"
+    assert path.exists()
+    saved = json.loads(path.read_text())
+    assert saved["email"] == "jane@example.com"
+    assert saved["status"] == "pending"
+    assert saved["created_at"] == now.isoformat()
+    # Expiry is in the future relative to creation.
+    assert saved["expires_at"] > saved["created_at"]
+
+
+def test_create_signup_request_stores_only_token_hash(tmp_path):
+    store = signup_requests.signup_requests_dir(tmp_path)
+    record, token = signup_requests.create_signup_request(
+        "Jane", "jane@example.com", "", store
+    )
+
+    raw = (store / f"{record.id}.json").read_text()
+    # Plaintext token must never be persisted; only its hash.
+    assert token not in raw
+    assert record.token_sha256 == signup_requests.hash_token(token)
+    assert "token_sha256" in json.loads(raw)
+
+
+def test_create_signup_request_tokens_are_unique_and_high_entropy(tmp_path):
+    store = signup_requests.signup_requests_dir(tmp_path)
+    _, token_a = signup_requests.create_signup_request("A", "a@example.com", "", store)
+    _, token_b = signup_requests.create_signup_request("B", "b@example.com", "", store)
+
+    assert token_a != token_b
+    # secrets.token_urlsafe(32) yields ~43 url-safe characters.
+    assert len(token_a) >= 32

--- a/tests/backend/test_signup_requests.py
+++ b/tests/backend/test_signup_requests.py
@@ -29,6 +29,12 @@ def test_normalise_payload_allows_missing_note():
         {"name": "", "email": "jane@example.com"},
         {"name": "Jane", "email": "not-an-email"},
         {"name": "Jane", "email": "missing-at.example.com"},
+        {"name": "Jane", "email": "two@at@example.com"},
+        {"name": "Jane", "email": "jane@example..com"},
+        {"name": "Jane", "email": "jane@.example.com"},
+        {"name": "Jane", "email": "jane@example."},
+        {"name": "Jane", "email": "jane@nodot"},
+        {"name": "Jane", "email": "jane doe@example.com"},
         {"name": "Jane", "email": ""},
         {"name": "x" * 201, "email": "jane@example.com"},
         {"name": "Jane", "email": "jane@example.com", "note": "x" * 2001},
@@ -37,6 +43,17 @@ def test_normalise_payload_allows_missing_note():
 def test_normalise_payload_rejects_invalid(payload):
     with pytest.raises(signup_requests.SignupValidationError):
         signup_requests.normalise_payload(payload)
+
+
+def test_email_validation_is_linear_on_adversarial_input():
+    """A ReDoS-style payload must be rejected quickly, not backtrack.
+
+    The previous regex (``[^@\\s]+@[^@\\s]+\\.[^@\\s]+``) was polynomial on
+    strings like ``!@!.!.!.!.``; the string-based check is linear.
+    """
+    adversarial = "!@" + "!." * 8000
+    with pytest.raises(signup_requests.SignupValidationError):
+        signup_requests.normalise_payload({"name": "Jane", "email": adversarial})
 
 
 def test_create_signup_request_persists_record(tmp_path):
@@ -59,9 +76,7 @@ def test_create_signup_request_persists_record(tmp_path):
 
 def test_create_signup_request_stores_only_token_hash(tmp_path):
     store = signup_requests.signup_requests_dir(tmp_path)
-    record, token = signup_requests.create_signup_request(
-        "Jane", "jane@example.com", "", store
-    )
+    record, token = signup_requests.create_signup_request("Jane", "jane@example.com", "", store)
 
     raw = (store / f"{record.id}.json").read_text()
     # Plaintext token must never be persisted; only its hash.


### PR DESCRIPTION
## What

Adds `POST /signup/request` — a public, unauthenticated endpoint that records a visitor's access request as a pending request and emails the admin (via SES) the request details with approve/reject links. This is the server side of the public "Create Account" page (#4350) and feeds the approval flow (#4352).

## How

- **`backend/common/signup_requests.py`** — domain logic kept out of the route: payload validation/normalisation (trim, lowercase email, basic email format, length caps), request persistence, and approval-token generation.
  - Token = `secrets.token_urlsafe(32)` (256-bit, unguessable). **Only the SHA‑256 hash is persisted**; the plaintext is returned once for the email and never stored, so a leak of the request store cannot reconstruct a usable link.
  - Each record carries `status: "pending"`, `created_at`, and `expires_at` (7‑day TTL). #4352 verifies an inbound token by hashing it and comparing to `token_sha256` while `status == "pending"` and unexpired → single‑use, time‑bound semantics.
- **`backend/emails/signup_request.py`** — admin notification reusing the `weekly_report` SES pattern (`boto3.client("ses")`, `WEEKLY_REPORT_FROM` sender). New recipient env var **`SIGNUP_ADMIN_EMAIL`**. All visitor input is HTML‑escaped via `markupsafe` before going into the email body.
- **`backend/routes/signup.py`** — anti‑enumeration handler: performs **no** account lookup and always returns the same generic success body. `400` on malformed payload, `503` when `SIGNUP_ADMIN_EMAIL` is unconfigured, `502` when SES delivery fails (logged, **never swallowed**). Links carry `id` + `token` under an optional `SIGNUP_APPROVAL_BASE_URL`.
- Registered the router (public, no auth dependency) in `backend/bootstrap/routers.py`.

## Token / response shape (to agree with #4352)

- Request: `{ "name": str, "email": str, "note"?: str }`
- Response (always): `{ "status": "ok", "message": "If your request is valid, an administrator has been notified." }`
- Approval link: `<SIGNUP_APPROVAL_BASE_URL>/signup/approve?id=<id>&token=<token>` (and `/signup/reject`)
- Stored record: `id, name, email, note, status, created_at, expires_at, token_sha256`

## Tests (21, all passing — SES mocked, no live AWS)

- Validation/normalisation, token uniqueness, hash-only persistence.
- Email rendering (details + links present, hostile input escaped) and SES invocation.
- Route: happy path persists + notifies; invalid payload → 400; existing vs new emails indistinguishable; missing admin email → 503; SES failure → 502 (not swallowed).

## Notes / follow-ups

- Coordinate the token/response shape above with #4352 before that PR consumes it.
- Requests are written under `<accounts_root>/../signup_requests/` (writable store) via `resolve_accounts_root`.

Closes #4351

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public account-signup request endpoint with admin approval/rejection links
  * Generates time-limited, single-use approval tokens for pending requests
  * Added admin email notifications for signup requests
  * Protects against account enumeration by returning the same response for valid/duplicate requests
* **Tests**
  * Added comprehensive integration and unit tests covering validation, persistence, email rendering/sending, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->