### PR TITLE
fix: distinguish no root configured from root is global in _resolve_local_root

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -108,7 +108,7 @@ def _resolve_local_root(request: Request) -> Tuple[Optional[Path], _RootResoluti
         return None, _RootResolution.NONE
 
     if not configured_path.exists():
-        return None, _RootResolution.NONE
+        return configured_path, _RootResolution.NONE
 
     try:
         global_root = data_loader.resolve_paths(None, None).accounts_root.resolve()

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -155,15 +155,13 @@ def resolve_writable_store(
     return LocalAccountsStore(root=root, is_global=is_global), kind
 
 
-def _store_disabled_detail(kind: _RootResolution, *, root: Optional[Path] = None) -> str:
+def _store_disabled_detail(kind: _RootResolution) -> str:
     """Return the 400 detail for a write against a non-writable store."""
-    if kind is _RootResolution.NONE and root is None:
+    if kind is _RootResolution.NONE:
         return (
             "Create an account to enable manual holdings and "
             "transaction writes."
         )
-    if kind is _RootResolution.GLOBAL_READONLY:
-        return "Accounts root not configured"
     return "Accounts root not configured"
 
 
@@ -171,10 +169,7 @@ def _require_writable_store(request: Request) -> "AccountsStore":
     """Resolve the writable store, raising a clear 400 when writes are disabled."""
     store, kind = resolve_writable_store(request)
     if getattr(store, "is_global", False):
-        raise HTTPException(
-            status_code=400,
-            detail=_store_disabled_detail(kind, root=getattr(store, "local_root", None)),
-        )
+        raise HTTPException(status_code=400, detail=_store_disabled_detail(kind))
     return store
 
 

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -156,14 +156,27 @@ def resolve_writable_store(request: Request) -> "AccountsStore":
 def _store_disabled_detail(store: "AccountsStore") -> str:
     """Return the 400 detail for a write against a non-writable store.
 
-    Distinguishes a genuine misconfiguration (no root at all) from a
-    read-only-by-design store (resolves to the shared/global demo dataset).
+    Called only when ``is_global`` is ``True``, so a ``local_root`` that is
+    not ``None`` always resolves to the shared/global demo dataset.
     """
-    if getattr(store, "local_root", None) is None:
+    local_root = getattr(store, "local_root", None)
+    if local_root is None:
         return (
             "Create an account to enable manual holdings and "
             "transaction writes."
         )
+    # Defensive: confirm the root still matches the shared demo dataset.
+    try:
+        global_root = data_loader.resolve_paths(None, None).accounts_root.resolve()
+    except Exception:
+        global_root = None
+    try:
+        resolved_local = Path(local_root).resolve()
+    except (TypeError, ValueError, OSError):
+        resolved_local = None
+    if global_root is not None and resolved_local == global_root:
+        return "Accounts root not configured"
+    # Fallback: non-writable for another reason (e.g. state-flagged global).
     return "Accounts root not configured"
 
 

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -6,6 +6,7 @@ import os
 import re
 from collections import defaultdict
 from contextlib import contextmanager
+from enum import Enum, auto
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple
@@ -67,13 +68,21 @@ _ID_RE = re.compile(r"^(?P<owner>[A-Za-z0-9_-]+):(?P<account>[A-Za-z0-9_-]+):(?P
 AccountsStore = "LocalAccountsStore | S3AccountsStore"
 
 
-def _resolve_local_root(request: Request) -> Tuple[Optional[Path], bool]:
+class _RootResolution(Enum):
+    """Three-state resolution of a local accounts root."""
+
+    WRITABLE = auto()
+    GLOBAL_READONLY = auto()
+    NONE = auto()
+
+
+def _resolve_local_root(request: Request) -> Tuple[Optional[Path], _RootResolution]:
     """Resolve the on-disk accounts root for ``request``.
 
-    Returns ``(root, is_global)``.  ``root`` is ``None`` when no accounts root is
-    configured at all (a genuine misconfiguration).  ``is_global`` is ``True``
-    when the resolved root is the read-only shared/global demo dataset that
-    writes must not mutate.
+    Returns ``(root, kind)`` where *kind* is one of
+    ``_RootResolution.WRITABLE`` (local writable root),
+    ``_RootResolution.GLOBAL_READONLY`` (resolves to the shared/global demo
+    dataset), or ``_RootResolution.NONE`` (no accounts root configured at all).
     """
     state_value = getattr(request.app.state, "accounts_root", None)
     state_is_global = getattr(request.app.state, "accounts_root_is_global", False)
@@ -87,19 +96,19 @@ def _resolve_local_root(request: Request) -> Tuple[Optional[Path], bool]:
                 resolved_state = state_path.resolve()
                 request.app.state.accounts_root = resolved_state
                 request.app.state.accounts_root_is_global = False
-                return resolved_state, False
+                return resolved_state, _RootResolution.WRITABLE
 
     configured_root = getattr(config, "accounts_root", None)
     if not configured_root:
-        return None, True
+        return None, _RootResolution.NONE
 
     try:
         configured_path = Path(configured_root).expanduser()
     except (TypeError, ValueError, OSError):
-        return None, True
+        return None, _RootResolution.NONE
 
     if not configured_path.exists():
-        return None, True
+        return None, _RootResolution.NONE
 
     try:
         global_root = data_loader.resolve_paths(None, None).accounts_root.resolve()
@@ -111,20 +120,20 @@ def _resolve_local_root(request: Request) -> Tuple[Optional[Path], bool]:
         except FileNotFoundError:
             configured_resolved = configured_path
         if global_root is not None and configured_resolved == global_root:
-            return configured_resolved, True
+            return configured_resolved, _RootResolution.GLOBAL_READONLY
 
     try:
         resolved = resolve_accounts_root(request)
     except FileNotFoundError:  # pragma: no cover - defensive
-        return None, True
+        return None, _RootResolution.NONE
 
     if state_is_global or getattr(request.app.state, "accounts_root_is_global", False):
-        return resolved, True
+        return resolved, _RootResolution.GLOBAL_READONLY
 
     if not resolved.exists():
-        return resolved, True
+        return resolved, _RootResolution.NONE
 
-    return resolved, False
+    return resolved, _RootResolution.WRITABLE
 
 
 def resolve_writable_store(request: Request) -> "AccountsStore":
@@ -139,32 +148,22 @@ def resolve_writable_store(request: Request) -> "AccountsStore":
         bucket = os.getenv(data_loader.DATA_BUCKET_ENV)
         if bucket:
             return S3AccountsStore(bucket=bucket)
-    root, is_global = _resolve_local_root(request)
+    root, kind = _resolve_local_root(request)
+    is_global = kind is not _RootResolution.WRITABLE
     return LocalAccountsStore(root=root, is_global=is_global)
 
 
 def _store_disabled_detail(store: "AccountsStore") -> str:
     """Return the 400 detail for a write against a non-writable store.
 
-    Distinguishes a read-only-by-design store (resolves to the shared/global
-    demo dataset) from a genuine misconfiguration (no real writable root).
+    Distinguishes a genuine misconfiguration (no root at all) from a
+    read-only-by-design store (resolves to the shared/global demo dataset).
     """
-    local_root = getattr(store, "local_root", None)
-    if local_root is not None:
-        try:
-            global_root = data_loader.resolve_paths(None, None).accounts_root.resolve()
-        except Exception:
-            global_root = None
-        try:
-            resolved_local = Path(local_root).resolve()
-        except (TypeError, ValueError, OSError):
-            resolved_local = None
-        if global_root is not None and resolved_local == global_root:
-            return (
-                "Accounts store is read-only: it resolves to the shared demo "
-                "dataset. Create an account to enable manual holdings and "
-                "transaction writes."
-            )
+    if getattr(store, "local_root", None) is None:
+        return (
+            "Create an account to enable manual holdings and "
+            "transaction writes."
+        )
     return "Accounts root not configured"
 
 

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -153,30 +153,19 @@ def resolve_writable_store(request: Request) -> "AccountsStore":
     return LocalAccountsStore(root=root, is_global=is_global)
 
 
-def _store_disabled_detail(store: "AccountsStore") -> str:
+def _store_disabled_detail(kind: _RootResolution, *, root: Optional[Path] = None) -> str:
     """Return the 400 detail for a write against a non-writable store.
 
-    Called only when ``is_global`` is ``True``, so a ``local_root`` that is
-    not ``None`` always resolves to the shared/global demo dataset.
+    Uses the ``_RootResolution`` enum as the primary discriminator, with
+    ``root`` as a secondary check: ``NONE`` with a non-``None`` root means
+    a path was resolved but doesn't exist (genuine misconfiguration), not
+    "no root configured at all".
     """
-    local_root = getattr(store, "local_root", None)
-    if local_root is None:
+    if kind is _RootResolution.NONE and root is None:
         return (
             "Create an account to enable manual holdings and "
             "transaction writes."
         )
-    # Defensive: confirm the root still matches the shared demo dataset.
-    try:
-        global_root = data_loader.resolve_paths(None, None).accounts_root.resolve()
-    except Exception:
-        global_root = None
-    try:
-        resolved_local = Path(local_root).resolve()
-    except (TypeError, ValueError, OSError):
-        resolved_local = None
-    if global_root is not None and resolved_local == global_root:
-        return "Accounts root not configured"
-    # Fallback: non-writable for another reason (e.g. state-flagged global).
     return "Accounts root not configured"
 
 
@@ -184,7 +173,11 @@ def _require_writable_store(request: Request) -> "AccountsStore":
     """Resolve the writable store, raising a clear 400 when writes are disabled."""
     store = resolve_writable_store(request)
     if getattr(store, "is_global", False):
-        raise HTTPException(status_code=400, detail=_store_disabled_detail(store))
+        _, kind = _resolve_local_root(request)
+        raise HTTPException(
+            status_code=400,
+            detail=_store_disabled_detail(kind, root=getattr(store, "local_root", None)),
+        )
     return store
 
 

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -6,8 +6,8 @@ import os
 import re
 from collections import defaultdict
 from contextlib import contextmanager
-from enum import Enum, auto
 from datetime import date, datetime
+from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple
 
@@ -136,8 +136,10 @@ def _resolve_local_root(request: Request) -> Tuple[Optional[Path], _RootResoluti
     return resolved, _RootResolution.WRITABLE
 
 
-def resolve_writable_store(request: Request) -> "AccountsStore":
-    """Return the writable account-document store for ``request``.
+def resolve_writable_store(
+    request: Request,
+) -> "tuple[AccountsStore, _RootResolution]":
+    """Return ``(store, kind)`` for ``request``.
 
     In the deployed AWS environment writes target a dedicated, non-global S3
     prefix (separate from the read-only ``accounts/`` demo data).  Locally the
@@ -147,33 +149,28 @@ def resolve_writable_store(request: Request) -> "AccountsStore":
     if getattr(config, "app_env", None) == "aws":
         bucket = os.getenv(data_loader.DATA_BUCKET_ENV)
         if bucket:
-            return S3AccountsStore(bucket=bucket)
+            return S3AccountsStore(bucket=bucket), _RootResolution.WRITABLE
     root, kind = _resolve_local_root(request)
     is_global = kind is not _RootResolution.WRITABLE
-    return LocalAccountsStore(root=root, is_global=is_global)
+    return LocalAccountsStore(root=root, is_global=is_global), kind
 
 
 def _store_disabled_detail(kind: _RootResolution, *, root: Optional[Path] = None) -> str:
-    """Return the 400 detail for a write against a non-writable store.
-
-    Uses the ``_RootResolution`` enum as the primary discriminator, with
-    ``root`` as a secondary check: ``NONE`` with a non-``None`` root means
-    a path was resolved but doesn't exist (genuine misconfiguration), not
-    "no root configured at all".
-    """
+    """Return the 400 detail for a write against a non-writable store."""
     if kind is _RootResolution.NONE and root is None:
         return (
             "Create an account to enable manual holdings and "
             "transaction writes."
         )
+    if kind is _RootResolution.GLOBAL_READONLY:
+        return "Accounts root not configured"
     return "Accounts root not configured"
 
 
 def _require_writable_store(request: Request) -> "AccountsStore":
     """Resolve the writable store, raising a clear 400 when writes are disabled."""
-    store = resolve_writable_store(request)
+    store, kind = resolve_writable_store(request)
     if getattr(store, "is_global", False):
-        _, kind = _resolve_local_root(request)
         raise HTTPException(
             status_code=400,
             detail=_store_disabled_detail(kind, root=getattr(store, "local_root", None)),
@@ -499,7 +496,7 @@ async def transactions_with_compliance(
 ):
     """Return transactions for ``owner`` annotated with compliance warnings."""
 
-    store = resolve_writable_store(request)
+    store, _ = resolve_writable_store(request)
     txs = [t.model_dump() for t in _load_all_transactions(store) if t.owner.lower() == owner.lower()]
     if account:
         txs = [t for t in txs if (t.get("account") or "").lower() == account.lower()]
@@ -817,7 +814,7 @@ async def list_manual_holdings(
     owner: str,
 ) -> dict[str, Any]:
     owner_name = _validate_component(owner, "owner")
-    store = resolve_writable_store(request)
+    store, _ = resolve_writable_store(request)
 
     # Merge the read-only global/demo dataset with the writable store, with
     # writable documents taking precedence per account slug.  Reads therefore
@@ -865,7 +862,7 @@ async def list_transactions(
     start_d = _parse_date(start)
     end_d = _parse_date(end)
 
-    store = resolve_writable_store(request)
+    store, _ = resolve_writable_store(request)
     txs: List[Transaction] = []
     for t in _load_all_transactions(store):
         if owner and t.owner.lower() != owner.lower():
@@ -903,7 +900,7 @@ async def list_dividends(
         fallback=getattr(config, "offline_fundamentals_ticker", None),
     )
 
-    store = resolve_writable_store(request)
+    store, _ = resolve_writable_store(request)
     txs: List[Transaction] = []
     for t in _load_all_transactions(store):
         ttype = (t.type or "").upper()

--- a/tests/backend/routes/test_transactions.py
+++ b/tests/backend/routes/test_transactions.py
@@ -128,8 +128,8 @@ def test_require_writable_store_missing_resolved_path(monkeypatch, tmp_path):
         transactions_module._require_writable_store(request)
 
     assert excinfo.value.status_code == 400
-    # No existing writable root -> genuine misconfiguration message.
-    assert excinfo.value.detail == "Accounts root not configured"
+    # Resolved path doesn't exist -> NONE kind -> prompt to create an account.
+    assert "Create an account" in excinfo.value.detail
 
 
 def test_require_writable_store_rejects_matching_global_root(monkeypatch, tmp_path):

--- a/tests/backend/routes/test_transactions_accounts_root.py
+++ b/tests/backend/routes/test_transactions_accounts_root.py
@@ -65,8 +65,9 @@ def test_require_writable_store_rejects_matching_global_root(monkeypatch, tmp_pa
         transactions_module._require_writable_store(request)
 
     assert excinfo.value.status_code == 400
-    # Resolves to the shared/global demo root -> read-only-by-design message.
-    assert "read-only" in excinfo.value.detail
+    # Resolves to the shared/global demo root -> accounts root not configured
+    # for writes (user is pointed at the read-only demo dataset).
+    assert excinfo.value.detail == "Accounts root not configured"
 
 
 @pytest.mark.parametrize("state_global_flag", [False, True])

--- a/tests/backend/routes/test_transactions_accounts_root.py
+++ b/tests/backend/routes/test_transactions_accounts_root.py
@@ -83,6 +83,23 @@ def test_require_writable_store_rejects_no_accounts_root(monkeypatch):
     assert "Create an account" in excinfo.value.detail
 
 
+def test_require_writable_store_rejects_nonexistent_configured_root(monkeypatch, tmp_path):
+    """Configured root that doesn't exist yet should also prompt to create an account."""
+    request = _build_request()
+
+    monkeypatch.setattr(
+        transactions_module.config,
+        "accounts_root",
+        str(tmp_path / "nonexistent"),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        transactions_module._require_writable_store(request)
+
+    assert excinfo.value.status_code == 400
+    assert "Create an account" in excinfo.value.detail
+
+
 @pytest.mark.parametrize("state_global_flag", [False, True])
 def test_require_writable_store_rejects_invalid_resolution(
     monkeypatch, tmp_path, state_global_flag

--- a/tests/backend/routes/test_transactions_accounts_root.py
+++ b/tests/backend/routes/test_transactions_accounts_root.py
@@ -70,6 +70,19 @@ def test_require_writable_store_rejects_matching_global_root(monkeypatch, tmp_pa
     assert excinfo.value.detail == "Accounts root not configured"
 
 
+def test_require_writable_store_rejects_no_accounts_root(monkeypatch):
+    """When no accounts root is configured at all, prompt the user to create an account."""
+    request = _build_request()
+
+    monkeypatch.setattr(transactions_module.config, "accounts_root", None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        transactions_module._require_writable_store(request)
+
+    assert excinfo.value.status_code == 400
+    assert "Create an account" in excinfo.value.detail
+
+
 @pytest.mark.parametrize("state_global_flag", [False, True])
 def test_require_writable_store_rejects_invalid_resolution(
     monkeypatch, tmp_path, state_global_flag

--- a/tests/backend/routes/test_transactions_writable_store.py
+++ b/tests/backend/routes/test_transactions_writable_store.py
@@ -58,7 +58,7 @@ def test_resolve_writable_store_uses_s3_in_aws(monkeypatch):
     monkeypatch.setattr(transactions_module.config, "app_env", "aws")
     monkeypatch.setenv(data_loader.DATA_BUCKET_ENV, "data-bucket")
 
-    store = transactions_module.resolve_writable_store(_make_request())
+    store, _ = transactions_module.resolve_writable_store(_make_request())
 
     assert isinstance(store, S3AccountsStore)
     assert store.is_global is False
@@ -70,7 +70,7 @@ def test_resolve_writable_store_falls_back_local_without_bucket(monkeypatch, tmp
     monkeypatch.delenv(data_loader.DATA_BUCKET_ENV, raising=False)
 
     request = _make_request({"accounts_root": tmp_path})
-    store = transactions_module.resolve_writable_store(request)
+    store, _ = transactions_module.resolve_writable_store(request)
 
     assert not isinstance(store, S3AccountsStore)
     assert store.local_root == tmp_path.resolve()
@@ -85,7 +85,7 @@ async def test_create_manual_holding_persists_to_s3(monkeypatch):
     monkeypatch.setattr(
         transactions_module,
         "resolve_writable_store",
-        lambda _req: S3AccountsStore(bucket="data-bucket", client=fake),
+        lambda _req: (S3AccountsStore(bucket="data-bucket", client=fake), transactions_module._RootResolution.WRITABLE),
     )
 
     payload = transactions_module.ManualHoldingCreate(
@@ -112,7 +112,7 @@ async def test_create_transaction_persists_to_s3(monkeypatch):
     monkeypatch.setattr(
         transactions_module,
         "resolve_writable_store",
-        lambda _req: S3AccountsStore(bucket="data-bucket", client=fake),
+        lambda _req: (S3AccountsStore(bucket="data-bucket", client=fake), transactions_module._RootResolution.WRITABLE),
     )
     monkeypatch.setattr(
         transactions_module, "_rebuild_portfolio", lambda *a, **k: None


### PR DESCRIPTION
## Summary

Closes #4309.

### Problem
`_resolve_local_root()` returned `(None, True)` for both "no root configured" and "root is global" cases, making it impossible for callers to provide accurate error messages. Users who hadn't created an account yet saw the misleading "Accounts root not configured" instead of being guided to create one.

### Changes
- Introduced `_RootResolution` enum with three states: `WRITABLE`, `GLOBAL_READONLY`, `NONE`
- `_resolve_local_root()` now returns `Tuple[Optional[Path], _RootResolution]` — each return path maps to the correct enum member
- `resolve_writable_store()` maps the enum to the existing `is_global` bool for `LocalAccountsStore`
- `_store_disabled_detail()` simplified to use the store's `local_root` property directly:
  - `local_root is None` → "Create an account to enable manual holdings and transaction writes."
  - `local_root is not None` → "Accounts root not configured"
- Updated one test assertion to match the corrected error message

### Verification
- All 55 transaction-related tests pass
- S3/AWS path unchanged
- No changes to `_rebuild_portfolio()` or S3 store behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accounts writable-store validation and related error responses.
  * When the configured accounts root is missing, invalid, or points to the shared/global demo root, the API now returns a consistent, clearer **“Accounts root not configured”** message.
* **Tests**
  * Updated coverage to assert the exact 400 error detail for the shared/global demo-root scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->