### PR TITLE
feat(backend): add POST /accounts to create empty named portfolio account

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -214,6 +214,12 @@ class ManualHoldingCreate(BaseModel):
     currency: str | None = None
 
 
+class AccountCreate(BaseModel):
+    owner: str
+    account_type: str
+    currency: str | None = None
+
+
 def _normalise_account_file_name(account: str) -> str:
     return account.strip().lower()
 
@@ -744,6 +750,44 @@ async def create_manual_holding(request: Request, payload: ManualHoldingCreate) 
         "owner": owner,
         "account": account_slug,
         "holding": holding,
+    }
+
+
+@router.post("/accounts", status_code=201)
+async def create_account(request: Request, payload: AccountCreate) -> dict[str, Any]:
+    """Create an empty named portfolio account for ``payload.owner``.
+
+    Produces a skeleton ``{account_type}.json`` document (owner, account_type,
+    currency, empty holdings) without requiring a holding to be added first.
+    Returns 409 if an account of that type already exists for the owner.
+    """
+
+    owner = _validate_component(payload.owner, "owner")
+    account_type = _validate_component(payload.account_type, "account_type")
+    account_slug = _normalise_account_file_name(account_type)
+    filename = f"{account_slug}.json"
+    if _is_non_holdings_file(filename):
+        raise HTTPException(status_code=400, detail="Invalid account_type")
+
+    store = _require_writable_store(request)
+
+    if store.read_document(owner, filename) is not None:
+        raise HTTPException(status_code=409, detail="Account already exists")
+
+    store.ensure_owner(owner)
+    currency = (payload.currency or "GBP").strip().upper() or "GBP"
+
+    with _locked_account_holdings_data(owner, account_slug, store) as (account_payload, _):
+        account_payload["owner"] = owner
+        account_payload["account_type"] = account_slug
+        account_payload["currency"] = currency
+        account_payload["last_updated"] = date.today().isoformat()
+
+    return {
+        "status": "created",
+        "owner": owner,
+        "account": account_slug,
+        "currency": currency,
     }
 
 

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -618,6 +618,76 @@ def test_create_manual_holding_rejects_invalid_metric_combo(tmp_path, monkeypatc
         assert resp.json()["detail"] == "Provide either value_gbp or both units and price_gbp"
 
 
+def test_create_account_creates_empty_skeleton(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/accounts", json={"owner": "alice", "account_type": "ISA"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data == {
+        "status": "created",
+        "owner": "alice",
+        "account": "isa",
+        "currency": "GBP",
+    }
+
+    account_path = tmp_path / "alice" / "isa.json"
+    assert account_path.exists()
+    saved = json.loads(account_path.read_text())
+    assert saved["owner"] == "alice"
+    assert saved["account_type"] == "isa"
+    assert saved["currency"] == "GBP"
+    assert saved["holdings"] == []
+    assert "last_updated" in saved
+
+
+def test_create_account_with_custom_currency(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/accounts", json={"owner": "alice", "account_type": "brokerage", "currency": "usd"})
+    assert resp.status_code == 201
+    assert resp.json()["currency"] == "USD"
+
+    account_path = tmp_path / "alice" / "brokerage.json"
+    saved = json.loads(account_path.read_text())
+    assert saved["currency"] == "USD"
+
+
+def test_create_account_rejects_duplicate(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+
+    first = client.post("/accounts", json={"owner": "alice", "account_type": "isa"})
+    assert first.status_code == 201
+
+    second = client.post("/accounts", json={"owner": "alice", "account_type": "ISA"})
+    assert second.status_code == 409
+    assert second.json()["detail"] == "Account already exists"
+
+
+def test_create_account_rejects_invalid_owner_slug(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/accounts", json={"owner": "../etc", "account_type": "isa"})
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid owner"
+
+
+def test_create_account_rejects_invalid_account_type_slug(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/accounts", json={"owner": "alice", "account_type": "../etc"})
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid account_type"
+
+
+def test_create_account_rejects_reserved_account_type(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+
+    resp = client.post("/accounts", json={"owner": "alice", "account_type": "person"})
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid account_type"
+
+
 def test_list_manual_holdings_returns_accounts(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch)
     owner_dir = tmp_path / "alice"


### PR DESCRIPTION
## Summary
- Adds `POST /accounts` taking `owner`, `account_type`, and optional `currency`, producing a skeleton `data/accounts/{owner}/{account_type}.json` (owner, account_type, currency default GBP, empty holdings, last_updated) without requiring a holding first.
- Reuses `_validate_component`/`_normalise_account_file_name` for slug validation, `_require_writable_store` for the writable-store path, `store.ensure_owner()`, and `_locked_account_holdings_data` for scaffold writing — same machinery as `create_manual_holding`.
- Returns 409 if an account of that type already exists (no overwrite), 400 for invalid slugs (path traversal/invalid chars) and reserved names (`person`, `settings`, `approvals`, `*_transactions`).

## Test plan
- [x] `pytest tests/test_transactions_route.py -k create_account` — covers create, custom currency, duplicate (409), invalid owner/account slugs (400), reserved account type (400)
- [x] Full `tests/test_transactions_route.py` suite passes (38 passed)

Closes #4353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account creation endpoint enabling users to create new portfolio accounts with owner and account type validation, optional currency selection (defaults to GBP), and automatic duplicate account detection.

* **Tests**
  * Comprehensive test coverage for account creation including input validation, error handling for duplicates and invalid values, and currency override functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->