### PR TITLE
feat(signup): admin approval flow provisions user and emails login-ready (#4352)

### DIFF
--- a/backend/common/signup_provision.py
+++ b/backend/common/signup_provision.py
@@ -47,37 +47,54 @@ def derive_owner_slug(email: str) -> str:
 
 
 def _read_person_email(owner_dir: Path) -> str:
-    """Return the lowercased email stored in ``owner_dir/person.json`` (or "")."""
+    """Return the lowercased email stored in ``owner_dir/person.json`` (or "").
+
+    A malformed ``person.json`` is logged and treated as having no email so a
+    corrupt file never silently masks an existing account owner.
+    """
 
     person_path = owner_dir / "person.json"
     if not person_path.exists():
         return ""
     try:
         data = json.loads(person_path.read_text())
-    except (OSError, json.JSONDecodeError):
+    except OSError as exc:
+        logger.warning("Could not read %s: %s", person_path, exc)
+        return ""
+    except json.JSONDecodeError as exc:
+        logger.warning("Malformed person.json at %s: %s", person_path, exc)
         return ""
     if not isinstance(data, dict):
+        logger.warning("person.json at %s is not an object", person_path)
         return ""
     email = data.get("email")
     return email.strip().lower() if isinstance(email, str) else ""
 
 
 def _resolve_owner_slug(email: str, accounts_root: Path) -> str:
-    """Pick an owner slug for ``email`` under ``accounts_root``.
+    """Atomically claim an owner slug for ``email`` under ``accounts_root``.
 
-    Reuses an existing directory already owned by this email (idempotency) and
-    otherwise returns the first free ``base``/``base-2``/``base-3`` ... slug so
-    we never clobber a different user's data.
+    The candidate directory is created with ``mkdir`` (no ``exist_ok``) so two
+    concurrent approvals can never both believe the same slug is free. An
+    existing directory owned by this same email is reused (idempotent
+    re-provision); one owned by a different email is skipped so we never clobber
+    another user's data. ``email`` is lowercased to match the normalised form
+    stored in ``person.json``.
     """
 
+    email = email.strip().lower()
     base = derive_owner_slug(email)
     for suffix in range(1, _MAX_SLUG_CANDIDATES + 1):
         candidate = base if suffix == 1 else f"{base}-{suffix}"
         owner_dir = accounts_root / candidate
-        if not owner_dir.exists():
-            return candidate
-        if _read_person_email(owner_dir) == email:
-            return candidate
+        try:
+            owner_dir.mkdir(parents=True)
+        except FileExistsError:
+            # Lost the race or pre-existing: reuse only if it is this email's.
+            if _read_person_email(owner_dir) == email:
+                return candidate
+            continue
+        return candidate
     raise RuntimeError(f"could not allocate an owner slug for base {base!r}")
 
 
@@ -119,9 +136,10 @@ def provision_owner(
     """
 
     accounts_root = Path(accounts_root)
-    owner = _resolve_owner_slug(record.email, accounts_root)
+    email = record.email.strip().lower()
+    owner = _resolve_owner_slug(email, accounts_root)
     owner_dir = ensure_owner_scaffold(owner, accounts_root)
-    _write_person_identity(owner_dir, record.email, record.name)
+    _write_person_identity(owner_dir, email, record.name)
 
     if store is not None:
         ensure = getattr(store, "ensure_owner", None)

--- a/backend/common/signup_provision.py
+++ b/backend/common/signup_provision.py
@@ -1,0 +1,132 @@
+"""Owner provisioning for approved signup requests.
+
+Keeps the "grant a login" logic out of the route handler (see
+:mod:`backend.routes.signup`). Approving a request must do two things so the
+user can actually authenticate:
+
+* scaffold the owner's data directory via
+  :func:`backend.common.compliance.ensure_owner_scaffold` (the same path used
+  everywhere else — never hand-write the JSON), and
+* record the user's email in their ``person.json`` so it becomes part of
+  :func:`backend.auth._allowed_emails`, which reads each owner's
+  ``person.json`` email from the accounts root.
+
+The owner slug is derived from the request email. If the derived slug is
+already taken by a *different* email we pick the next free suffix rather than
+overwriting someone else's account.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+from backend.common.compliance import ensure_owner_scaffold
+from backend.common.path_utils import safe_join
+from backend.common.signup_requests import SignupRequest
+
+logger = logging.getLogger(__name__)
+
+# Bounded so a pathological run of collisions can never loop unbounded.
+_MAX_SLUG_CANDIDATES = 100
+
+
+def derive_owner_slug(email: str) -> str:
+    """Return a filesystem-safe base owner slug derived from ``email``.
+
+    Uses the local part of the address, lowercased, with any run of
+    non-alphanumeric characters collapsed to a single hyphen. Falls back to
+    ``"user"`` when nothing usable remains.
+    """
+
+    local = email.split("@", 1)[0].lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", local).strip("-")
+    return slug or "user"
+
+
+def _read_person_email(owner_dir: Path) -> str:
+    """Return the lowercased email stored in ``owner_dir/person.json`` (or "")."""
+
+    person_path = owner_dir / "person.json"
+    if not person_path.exists():
+        return ""
+    try:
+        data = json.loads(person_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    email = data.get("email")
+    return email.strip().lower() if isinstance(email, str) else ""
+
+
+def _resolve_owner_slug(email: str, accounts_root: Path) -> str:
+    """Pick an owner slug for ``email`` under ``accounts_root``.
+
+    Reuses an existing directory already owned by this email (idempotency) and
+    otherwise returns the first free ``base``/``base-2``/``base-3`` ... slug so
+    we never clobber a different user's data.
+    """
+
+    base = derive_owner_slug(email)
+    for suffix in range(1, _MAX_SLUG_CANDIDATES + 1):
+        candidate = base if suffix == 1 else f"{base}-{suffix}"
+        owner_dir = accounts_root / candidate
+        if not owner_dir.exists():
+            return candidate
+        if _read_person_email(owner_dir) == email:
+            return candidate
+    raise RuntimeError(f"could not allocate an owner slug for base {base!r}")
+
+
+def _write_person_identity(owner_dir: Path, email: str, full_name: str) -> None:
+    """Merge ``email``/``full_name`` into the scaffolded ``person.json``.
+
+    ``ensure_owner_scaffold`` creates ``person.json`` with empty identity
+    fields; this fills them in so :func:`backend.auth._allowed_emails` admits
+    the user. Existing keys are preserved.
+    """
+
+    person_path = safe_join(owner_dir, "person.json")
+    try:
+        loaded = json.loads(person_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        loaded = {}
+    if not isinstance(loaded, dict):
+        loaded = {}
+
+    loaded["email"] = email
+    if full_name and not str(loaded.get("full_name") or "").strip():
+        loaded["full_name"] = full_name
+
+    person_path.write_text(json.dumps(loaded, indent=2, sort_keys=True))
+
+
+def provision_owner(
+    record: SignupRequest,
+    accounts_root: Path,
+    *,
+    store: object | None = None,
+) -> str:
+    """Provision the owner for an approved request and return the owner slug.
+
+    Scaffolds the owner directory under ``accounts_root`` and records the
+    request email in ``person.json`` so the user can authenticate. When a
+    writable ``store`` is supplied its ``ensure_owner`` is also invoked so the
+    deployed writable-store path stays consistent with #4353.
+    """
+
+    accounts_root = Path(accounts_root)
+    owner = _resolve_owner_slug(record.email, accounts_root)
+    owner_dir = ensure_owner_scaffold(owner, accounts_root)
+    _write_person_identity(owner_dir, record.email, record.name)
+
+    if store is not None:
+        ensure = getattr(store, "ensure_owner", None)
+        if callable(ensure):
+            ensure(owner)
+
+    logger.info("Provisioned owner %s for approved signup request %s", owner, record.id)
+    return owner

--- a/backend/common/signup_requests.py
+++ b/backend/common/signup_requests.py
@@ -171,22 +171,30 @@ def _persist(record: SignupRequest, store_dir: Path) -> None:
     logger.info("Recorded pending signup request %s", record.id)
 
 
-_VALID_REQUEST_ID = set("0123456789abcdef")
+_VALID_REQUEST_ID = frozenset("0123456789abcdef")
+_REQUEST_ID_LEN = 32  # secrets.token_hex(16) -> 32 lowercase hex chars
 
 
 def _request_path(request_id: str, store_dir: Path) -> Path | None:
     """Return the on-disk path for ``request_id`` or ``None`` if malformed.
 
-    Request ids are 32-char lowercase hex (``secrets.token_hex(16)``); anything
-    else is rejected outright so a hostile id cannot escape ``store_dir`` via
-    path traversal.
+    Request ids are exactly 32 lowercase hex chars (``secrets.token_hex(16)``);
+    anything else is rejected. As defence in depth, the fully resolved path is
+    also confirmed to stay inside ``store_dir`` so a hostile id can never escape
+    via path traversal.
     """
 
-    if not request_id or len(request_id) > 64:
+    if len(request_id) != _REQUEST_ID_LEN:
         return None
     if any(ch not in _VALID_REQUEST_ID for ch in request_id):
         return None
-    return Path(store_dir) / f"{request_id}.json"
+    base_dir = Path(store_dir).resolve()
+    candidate = (base_dir / f"{request_id}.json").resolve()
+    try:
+        candidate.relative_to(base_dir)
+    except ValueError:
+        return None
+    return candidate
 
 
 def load_request(request_id: str, store_dir: Path) -> SignupRequest | None:

--- a/backend/common/signup_requests.py
+++ b/backend/common/signup_requests.py
@@ -18,7 +18,7 @@ import hashlib
 import json
 import logging
 import secrets
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -32,6 +32,30 @@ _MAX_NOTE_LEN = 2000
 
 class SignupValidationError(ValueError):
     """Raised when a signup request payload fails validation."""
+
+
+class SignupTokenError(Exception):
+    """Base class for failures when consuming an approval/reject token."""
+
+
+class RequestNotFound(SignupTokenError):
+    """Raised when no pending request matches the supplied id."""
+
+
+class TokenInvalid(SignupTokenError):
+    """Raised when the supplied token does not match the stored hash."""
+
+
+class RequestExpired(SignupTokenError):
+    """Raised when the request's approval window has elapsed."""
+
+
+class RequestAlreadyProcessed(SignupTokenError):
+    """Raised when the request has already been approved or rejected.
+
+    This is what makes approval single-use: a consumed token cannot
+    re-provision or change the request a second time.
+    """
 
 
 def _looks_like_email(email: str) -> bool:
@@ -145,3 +169,104 @@ def _persist(record: SignupRequest, store_dir: Path) -> None:
     path = directory / f"{record.id}.json"
     path.write_text(json.dumps(asdict(record), indent=2, sort_keys=True))
     logger.info("Recorded pending signup request %s", record.id)
+
+
+_VALID_REQUEST_ID = set("0123456789abcdef")
+
+
+def _request_path(request_id: str, store_dir: Path) -> Path | None:
+    """Return the on-disk path for ``request_id`` or ``None`` if malformed.
+
+    Request ids are 32-char lowercase hex (``secrets.token_hex(16)``); anything
+    else is rejected outright so a hostile id cannot escape ``store_dir`` via
+    path traversal.
+    """
+
+    if not request_id or len(request_id) > 64:
+        return None
+    if any(ch not in _VALID_REQUEST_ID for ch in request_id):
+        return None
+    return Path(store_dir) / f"{request_id}.json"
+
+
+def load_request(request_id: str, store_dir: Path) -> SignupRequest | None:
+    """Load the persisted request for ``request_id`` or ``None`` if absent."""
+
+    path = _request_path(request_id, store_dir)
+    if path is None or not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        return SignupRequest(**data)
+    except TypeError:
+        # Stored shape no longer matches the dataclass; treat as unusable.
+        return None
+
+
+def _is_expired(record: SignupRequest, now: datetime) -> bool:
+    try:
+        expires = datetime.fromisoformat(record.expires_at)
+    except ValueError:
+        # A request we cannot date is treated as expired rather than usable.
+        return True
+    return now >= expires
+
+
+def validate_request(
+    request_id: str,
+    token: str,
+    store_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> SignupRequest:
+    """Return the pending request for a valid token without mutating it.
+
+    The token is verified by hashing it and comparing to the stored
+    ``token_sha256`` with a constant-time comparison. The request must still be
+    ``pending`` and unexpired. Raises a :class:`SignupTokenError` subclass on
+    every failure so the caller can map each to an unambiguous response.
+
+    This performs no write, so callers can validate, do irreversible work (e.g.
+    provisioning), and only then :func:`consume_request` to burn the token.
+    """
+
+    moment = now or datetime.now(timezone.utc)
+    record = load_request(request_id, store_dir)
+    if record is None:
+        raise RequestNotFound("no such request")
+    if not token or not secrets.compare_digest(record.token_sha256, hash_token(token)):
+        raise TokenInvalid("token does not match")
+    if record.status != "pending":
+        raise RequestAlreadyProcessed(f"request already {record.status}")
+    if _is_expired(record, moment):
+        raise RequestExpired("approval window has elapsed")
+    return record
+
+
+def consume_request(
+    request_id: str,
+    token: str,
+    store_dir: Path,
+    *,
+    new_status: str,
+    now: datetime | None = None,
+) -> SignupRequest:
+    """Validate an approval token and atomically move the request to ``new_status``.
+
+    On success the request's status is rewritten so the token cannot be reused
+    (single-use); reusing it then raises :class:`RequestAlreadyProcessed`.
+    """
+
+    if new_status not in {"approved", "rejected"}:
+        raise ValueError(f"invalid status: {new_status!r}")
+
+    record = validate_request(request_id, token, store_dir, now=now)
+    updated = replace(record, status=new_status)
+    _persist(updated, store_dir)
+    logger.info("Signup request %s moved to %s", record.id, new_status)
+    return updated

--- a/backend/common/signup_requests.py
+++ b/backend/common/signup_requests.py
@@ -17,10 +17,13 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import secrets
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from backend.common.path_utils import safe_join
 
 logger = logging.getLogger(__name__)
 
@@ -171,30 +174,26 @@ def _persist(record: SignupRequest, store_dir: Path) -> None:
     logger.info("Recorded pending signup request %s", record.id)
 
 
-_VALID_REQUEST_ID = frozenset("0123456789abcdef")
-_REQUEST_ID_LEN = 32  # secrets.token_hex(16) -> 32 lowercase hex chars
+# secrets.token_hex(16) -> exactly 32 lowercase hex chars and nothing else.
+_REQUEST_ID_RE = re.compile(r"\A[0-9a-f]{32}\Z")
 
 
 def _request_path(request_id: str, store_dir: Path) -> Path | None:
     """Return the on-disk path for ``request_id`` or ``None`` if malformed.
 
-    Request ids are exactly 32 lowercase hex chars (``secrets.token_hex(16)``);
-    anything else is rejected. As defence in depth, the fully resolved path is
-    also confirmed to stay inside ``store_dir`` so a hostile id can never escape
-    via path traversal.
+    The id is first constrained to exactly 32 lowercase hex chars (a strict
+    allowlist — no separators or dots can survive), then joined with
+    :func:`safe_join`, which resolves both paths and rejects anything escaping
+    ``store_dir``. The two independent barriers ensure a hostile id can never be
+    used to read outside the request store.
     """
 
-    if len(request_id) != _REQUEST_ID_LEN:
+    if not _REQUEST_ID_RE.fullmatch(request_id):
         return None
-    if any(ch not in _VALID_REQUEST_ID for ch in request_id):
-        return None
-    base_dir = Path(store_dir).resolve()
-    candidate = (base_dir / f"{request_id}.json").resolve()
     try:
-        candidate.relative_to(base_dir)
+        return safe_join(Path(store_dir), f"{request_id}.json")
     except ValueError:
         return None
-    return candidate
 
 
 def load_request(request_id: str, store_dir: Path) -> SignupRequest | None:

--- a/backend/emails/signup_approved.py
+++ b/backend/emails/signup_approved.py
@@ -1,0 +1,62 @@
+"""User-facing "your login is ready" email for approved signup requests.
+
+Reuses the SES pattern established in :mod:`backend.emails.weekly_report`
+(``boto3.client("ses")`` and the ``WEEKLY_REPORT_FROM`` sender). Sent to the
+requesting visitor after an admin approves their access request (#4352).
+
+The visitor-supplied name is HTML-escaped before being placed in the body so a
+hostile name cannot inject markup into the recipient's inbox.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import boto3
+from markupsafe import escape
+
+logger = logging.getLogger(__name__)
+
+_SENDER_EMAIL = os.getenv("WEEKLY_REPORT_FROM", "no-reply@allotmint.com")
+
+
+def render_signup_approved_email(name: str, login_url: str) -> str:
+    """Render the "login ready" HTML, escaping all visitor input."""
+
+    greeting = f"Hi {escape(name)}," if name else "Hi,"
+    if login_url:
+        action = f'<p><a href="{escape(login_url)}">Log in to AllotMint</a></p>'
+    else:
+        action = "<p>You can now log in to AllotMint.</p>"
+    return (
+        "<html><body>"
+        f"<p>{greeting}</p>"
+        "<h2>Your AllotMint login is ready</h2>"
+        "<p>Your access request has been approved. You can now sign in with "
+        "this email address.</p>"
+        f"{action}"
+        "</body></html>"
+    )
+
+
+def send_signup_approved_email(user_email: str, name: str, login_url: str) -> None:
+    """Send the "login ready" email via AWS SES.
+
+    Any SES failure propagates to the caller so the route can decide how to
+    surface it — the user has already been provisioned by this point, so the
+    caller must not let a delivery failure silently undo that.
+    """
+
+    body_html = render_signup_approved_email(name, login_url)
+    subject = "Your AllotMint login is ready"
+
+    ses = boto3.client("ses", region_name=os.getenv("AWS_REGION", "us-east-1"))
+    ses.send_email(
+        Source=_SENDER_EMAIL,
+        Destination={"ToAddresses": [user_email]},
+        Message={
+            "Subject": {"Data": subject},
+            "Body": {"Html": {"Data": body_html}},
+        },
+    )

--- a/backend/routes/signup.py
+++ b/backend/routes/signup.py
@@ -1,13 +1,21 @@
-"""Public account-signup request endpoint.
+"""Public account-signup request endpoint and admin approval flow.
 
-Exposes ``POST /signup/request``: an unauthenticated endpoint that records a
-visitor's interest in an account and emails the admin an approve/reject link.
+Exposes:
 
-Anti-enumeration: the handler performs no lookup against existing accounts and
-always returns the same generic success body, so a caller cannot tell whether
-an email already has an account. Only malformed payloads (bad shape) yield a
-``400``; configuration/delivery failures yield ``5xx`` but reveal nothing about
-account existence.
+* ``POST /signup/request`` — an unauthenticated endpoint that records a
+  visitor's interest in an account and emails the admin an approve/reject link.
+* ``POST``/``GET`` ``/signup/approve`` and ``/signup/reject`` — the admin
+  approval flow (#4352). The unguessable, single-use token from the admin email
+  authorises the action, so these need no session auth. Approving provisions
+  the owner (adds their email to the login allowlist via ``person.json``) and
+  emails the user that their login is ready. ``GET`` is supported so the links
+  embedded in the admin email work when clicked.
+
+Anti-enumeration: the request handler performs no lookup against existing
+accounts and always returns the same generic success body, so a caller cannot
+tell whether an email already has an account. Only malformed payloads (bad
+shape) yield a ``400``; configuration/delivery failures yield ``5xx`` but
+reveal nothing about account existence.
 """
 
 from __future__ import annotations
@@ -19,12 +27,18 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
 
-from backend.common import signup_requests
+from backend.common import signup_provision, signup_requests
+from backend.common.signup_requests import (
+    RequestAlreadyProcessed,
+    SignupTokenError,
+)
+from backend.emails.signup_approved import send_signup_approved_email
 from backend.emails.signup_request import (
     SignupAdminNotification,
     send_signup_admin_email,
 )
 from backend.routes._accounts import resolve_accounts_root
+from backend.routes.transactions import resolve_writable_store
 
 router = APIRouter(prefix="/signup", tags=["signup"])
 
@@ -53,9 +67,7 @@ def _build_links(request_id: str, token: str) -> tuple[str, str]:
         # Without a base URL the emailed links are relative and unusable. Warn
         # rather than fail so the admin still receives the request id + token
         # and can act manually, but the misconfiguration is not silent.
-        logger.warning(
-            "SIGNUP_APPROVAL_BASE_URL is not set; admin approve/reject links will be relative"
-        )
+        logger.warning("SIGNUP_APPROVAL_BASE_URL is not set; admin approve/reject links will be relative")
     query = f"id={request_id}&token={token}"
     return f"{base}/signup/approve?{query}", f"{base}/signup/reject?{query}"
 
@@ -100,3 +112,73 @@ async def post_signup_request(request: Request) -> dict[str, str]:
         raise HTTPException(status_code=502, detail="failed to notify administrator") from exc
 
     return dict(_GENERIC_OK)
+
+
+def _login_url() -> str:
+    """Return the login page URL emailed to a newly approved user."""
+
+    return os.getenv("SIGNUP_LOGIN_URL", "").strip()
+
+
+def _token_error_to_http(exc: SignupTokenError) -> HTTPException:
+    """Map a token-consumption failure to an unambiguous HTTP response.
+
+    Not-found, bad-token, and expired all collapse to the same ``400`` so a
+    caller cannot distinguish a wrong token from a missing/expired request
+    (no enumeration of valid request ids). Already-processed is a distinct
+    ``409`` so a replay is clearly — and safely — rejected.
+    """
+
+    if isinstance(exc, RequestAlreadyProcessed):
+        return HTTPException(status_code=409, detail="this request has already been processed")
+    return HTTPException(status_code=400, detail="invalid or expired approval token")
+
+
+@router.get("/approve")
+@router.post("/approve")
+async def approve_signup_request(request: Request, id: str = "", token: str = "") -> dict[str, str]:
+    """Provision the requesting user and notify them their login is ready.
+
+    Validates the single-use token first, then provisions (idempotently) and
+    only then consumes the token, so a transient provisioning failure does not
+    burn the request. The user-notification email failure is surfaced rather
+    than swallowed.
+    """
+
+    store_dir = _store_dir(request)
+    try:
+        record = signup_requests.validate_request(id, token, store_dir)
+    except SignupTokenError as exc:
+        raise _token_error_to_http(exc) from exc
+
+    accounts_root = resolve_accounts_root(request, allow_missing=True)
+    store = resolve_writable_store(request)
+    owner = signup_provision.provision_owner(record, accounts_root, store=store)
+
+    # Burn the token only after provisioning succeeded.
+    try:
+        signup_requests.consume_request(id, token, store_dir, new_status="approved")
+    except SignupTokenError as exc:  # pragma: no cover - lost race with another approver
+        raise _token_error_to_http(exc) from exc
+
+    try:
+        send_signup_approved_email(record.email, record.name, _login_url())
+    except Exception as exc:  # noqa: BLE001 - surface any SES failure, never swallow it
+        logger.exception("Failed to send login-ready email for request %s", record.id)
+        raise HTTPException(status_code=502, detail="failed to notify user") from exc
+
+    return {"status": "approved", "owner": owner}
+
+
+@router.get("/reject")
+@router.post("/reject")
+async def reject_signup_request(request: Request, id: str = "", token: str = "") -> dict[str, str]:
+    """Mark a pending request rejected so its token can no longer be used."""
+
+    store_dir = _store_dir(request)
+    try:
+        signup_requests.consume_request(id, token, store_dir, new_status="rejected")
+    except SignupTokenError as exc:
+        raise _token_error_to_http(exc) from exc
+
+    return {"status": "rejected"}

--- a/backend/routes/signup.py
+++ b/backend/routes/signup.py
@@ -4,12 +4,13 @@ Exposes:
 
 * ``POST /signup/request`` — an unauthenticated endpoint that records a
   visitor's interest in an account and emails the admin an approve/reject link.
-* ``POST``/``GET`` ``/signup/approve`` and ``/signup/reject`` — the admin
-  approval flow (#4352). The unguessable, single-use token from the admin email
-  authorises the action, so these need no session auth. Approving provisions
+* ``/signup/approve`` and ``/signup/reject`` — the admin approval flow
+  (#4352). The unguessable, single-use token from the admin email authorises
+  the action, so these need no session auth. ``GET`` (a clicked email link)
+  renders a side-effect-free confirmation page; the state change happens only
+  on ``POST`` so link prefetchers cannot consume a token. Approving provisions
   the owner (adds their email to the login allowlist via ``person.json``) and
-  emails the user that their login is ready. ``GET`` is supported so the links
-  embedded in the admin email work when clicked.
+  emails the user that their login is ready.
 
 Anti-enumeration: the request handler performs no lookup against existing
 accounts and always returns the same generic success body, so a caller cannot
@@ -26,6 +27,8 @@ from json import JSONDecodeError
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from markupsafe import escape
 
 from backend.common import signup_provision, signup_requests
 from backend.common.signup_requests import (
@@ -134,7 +137,43 @@ def _token_error_to_http(exc: SignupTokenError) -> HTTPException:
     return HTTPException(status_code=400, detail="invalid or expired approval token")
 
 
-@router.get("/approve")
+def _confirmation_page(action: str, request: Request, id: str, token: str) -> HTMLResponse:
+    """Render a side-effect-free confirmation page for a clicked email link.
+
+    ``GET`` must not mutate state: email clients and link scanners routinely
+    prefetch links, which would otherwise consume a single-use token before the
+    admin acts. The page validates the token read-only and presents a form that
+    POSTs the actual action, so only a deliberate human click takes effect.
+    """
+
+    store_dir = _store_dir(request)
+    try:
+        record = signup_requests.validate_request(id, token, store_dir)
+    except SignupTokenError as exc:
+        body = f"<p>This request cannot be {action}d: {escape(_token_error_to_http(exc).detail)}.</p>"
+        return HTMLResponse(f"<html><body>{body}</body></html>", status_code=400)
+
+    verb = action.capitalize()
+    page = (
+        "<html><body>"
+        f"<h2>{verb} access request</h2>"
+        f"<p>Request from <strong>{escape(record.name)}</strong> "
+        f"(<strong>{escape(record.email)}</strong>).</p>"
+        f'<form method="post" action="/signup/{action}?id={escape(id)}&amp;token={escape(token)}">'
+        f'<button type="submit">Confirm {action}</button>'
+        "</form>"
+        "</body></html>"
+    )
+    return HTMLResponse(page)
+
+
+@router.get("/approve", response_class=HTMLResponse)
+async def approve_signup_confirm(request: Request, id: str = "", token: str = "") -> HTMLResponse:
+    """Show a confirmation page; the approval itself is performed by ``POST``."""
+
+    return _confirmation_page("approve", request, id, token)
+
+
 @router.post("/approve")
 async def approve_signup_request(request: Request, id: str = "", token: str = "") -> dict[str, str]:
     """Provision the requesting user and notify them their login is ready.
@@ -155,9 +194,10 @@ async def approve_signup_request(request: Request, id: str = "", token: str = ""
     store = resolve_writable_store(request)
     owner = signup_provision.provision_owner(record, accounts_root, store=store)
 
-    # Burn the token only after provisioning succeeded.
+    # Burn the token only after provisioning succeeded. The returned record is
+    # not needed here — the status flip is the side effect we want.
     try:
-        signup_requests.consume_request(id, token, store_dir, new_status="approved")
+        _ = signup_requests.consume_request(id, token, store_dir, new_status="approved")
     except SignupTokenError as exc:  # pragma: no cover - lost race with another approver
         raise _token_error_to_http(exc) from exc
 
@@ -170,14 +210,21 @@ async def approve_signup_request(request: Request, id: str = "", token: str = ""
     return {"status": "approved", "owner": owner}
 
 
-@router.get("/reject")
+@router.get("/reject", response_class=HTMLResponse)
+async def reject_signup_confirm(request: Request, id: str = "", token: str = "") -> HTMLResponse:
+    """Show a confirmation page; the rejection itself is performed by ``POST``."""
+
+    return _confirmation_page("reject", request, id, token)
+
+
 @router.post("/reject")
 async def reject_signup_request(request: Request, id: str = "", token: str = "") -> dict[str, str]:
     """Mark a pending request rejected so its token can no longer be used."""
 
     store_dir = _store_dir(request)
+    # The status flip is the side effect we want; the record is not needed.
     try:
-        signup_requests.consume_request(id, token, store_dir, new_status="rejected")
+        _ = signup_requests.consume_request(id, token, store_dir, new_status="rejected")
     except SignupTokenError as exc:
         raise _token_error_to_http(exc) from exc
 

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -236,7 +236,7 @@ def test_approve_invalid_token_rejected(client, monkeypatch):
 
 
 def test_approve_unknown_request_rejected(client, monkeypatch):
-    test_client, tmp_path = client
+    test_client, _ = client
     _capture_user_email(monkeypatch)
     _stub_store(monkeypatch)
 
@@ -285,14 +285,38 @@ def test_approve_user_email_failure_is_not_swallowed(client, monkeypatch):
     assert resp.status_code == 502
 
 
-def test_approve_link_works_via_get(client, monkeypatch):
-    """The approve/reject links in the admin email are clicked (GET)."""
+def test_get_approve_is_a_safe_confirmation_page(client, monkeypatch):
+    """GET (e.g. a clicked/prefetched email link) must not consume the token."""
 
     test_client, tmp_path = client
-    _capture_user_email(monkeypatch)
+    sent = _capture_user_email(monkeypatch)
     _stub_store(monkeypatch)
 
     request_id, token = _pending_request(tmp_path)
     resp = test_client.get(f"/signup/approve?id={request_id}&token={token}")
+
     assert resp.status_code == 200
-    assert resp.json()["status"] == "approved"
+    assert "text/html" in resp.headers["content-type"]
+    # A confirmation form that POSTs the real action — no side effects yet.
+    assert "<form" in resp.text and 'method="post"' in resp.text
+    assert "jane@example.com" in resp.text
+    # The request is still pending and nothing was provisioned or emailed.
+    store_dir = signup_requests.signup_requests_dir(tmp_path)
+    assert json.loads((store_dir / f"{request_id}.json").read_text())["status"] == "pending"
+    assert not (tmp_path / "accounts" / "jane").exists()
+    assert sent == {}
+
+    # The POSTed action still works after the confirmation page.
+    posted = test_client.post(f"/signup/approve?id={request_id}&token={token}")
+    assert posted.status_code == 200
+    assert posted.json()["status"] == "approved"
+
+
+def test_get_approve_invalid_token_renders_error_page(client, monkeypatch):
+    test_client, tmp_path = client
+    _stub_store(monkeypatch)
+
+    request_id, _ = _pending_request(tmp_path)
+    resp = test_client.get(f"/signup/approve?id={request_id}&token=wrong")
+    assert resp.status_code == 400
+    assert "text/html" in resp.headers["content-type"]

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from backend.common import signup_requests
 from backend.routes import signup as signup_module
 
 
@@ -83,9 +84,7 @@ def test_missing_base_url_warns_but_still_notifies(client, monkeypatch, caplog):
     monkeypatch.delenv("SIGNUP_APPROVAL_BASE_URL", raising=False)
 
     with caplog.at_level("WARNING"):
-        resp = test_client.post(
-            "/signup/request", json={"name": "Jane", "email": "jane@example.com"}
-        )
+        resp = test_client.post("/signup/request", json={"name": "Jane", "email": "jane@example.com"})
 
     assert resp.status_code == 200
     assert sent["notification"].approve_url.startswith("/signup/approve")
@@ -96,12 +95,8 @@ def test_existing_and_new_emails_are_indistinguishable(client, monkeypatch):
     test_client, _ = client
     _capture_email(monkeypatch)
 
-    first = test_client.post(
-        "/signup/request", json={"name": "Existing", "email": "alice@example.com"}
-    )
-    second = test_client.post(
-        "/signup/request", json={"name": "New", "email": "brandnew@example.com"}
-    )
+    first = test_client.post("/signup/request", json={"name": "Existing", "email": "alice@example.com"})
+    second = test_client.post("/signup/request", json={"name": "New", "email": "brandnew@example.com"})
 
     assert first.status_code == second.status_code == 200
     assert first.json() == second.json()
@@ -126,3 +121,178 @@ def test_email_send_failure_is_not_swallowed(client, monkeypatch):
 
     resp = test_client.post("/signup/request", json={"name": "Jane", "email": "jane@example.com"})
     assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# Approval flow (#4352)
+# ---------------------------------------------------------------------------
+
+
+class _FakeStore:
+    """Minimal writable-store stand-in recording ensure_owner calls."""
+
+    is_global = False
+
+    def __init__(self):
+        self.ensured = []
+
+    def ensure_owner(self, owner):
+        self.ensured.append(owner)
+
+
+def _pending_request(tmp_path, email="jane@example.com", name="Jane Doe"):
+    """Create a pending request in the router's store and return (id, token)."""
+
+    store_dir = signup_requests.signup_requests_dir(tmp_path)
+    record, token = signup_requests.create_signup_request(name, email, "", store_dir)
+    return record.id, token
+
+
+def _capture_user_email(monkeypatch):
+    sent = {}
+
+    def fake_send(user_email, name, login_url):
+        sent["user_email"] = user_email
+        sent["name"] = name
+        sent["login_url"] = login_url
+
+    monkeypatch.setattr(signup_module, "send_signup_approved_email", fake_send)
+    return sent
+
+
+def _stub_store(monkeypatch):
+    store = _FakeStore()
+    monkeypatch.setattr(signup_module, "resolve_writable_store", lambda request: store)
+    return store
+
+
+def test_approve_provisions_owner_and_notifies_user(client, monkeypatch):
+    test_client, tmp_path = client
+    sent = _capture_user_email(monkeypatch)
+    store = _stub_store(monkeypatch)
+    monkeypatch.setenv("SIGNUP_LOGIN_URL", "https://allotmint.example/login")
+
+    request_id, token = _pending_request(tmp_path)
+
+    resp = test_client.post(f"/signup/approve?id={request_id}&token={token}")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "approved", "owner": "jane"}
+
+    # Owner scaffolded and email written so auth._allowed_emails admits them.
+    person = json.loads((tmp_path / "accounts" / "jane" / "person.json").read_text())
+    assert person["email"] == "jane@example.com"
+    assert store.ensured == ["jane"]
+
+    # User was emailed their login-ready notice.
+    assert sent["user_email"] == "jane@example.com"
+    assert sent["login_url"] == "https://allotmint.example/login"
+
+    # Request is consumed.
+    store_dir = signup_requests.signup_requests_dir(tmp_path)
+    assert json.loads((store_dir / f"{request_id}.json").read_text())["status"] == "approved"
+
+
+def test_approved_email_is_in_allowed_emails(client, monkeypatch):
+    """End-to-end: an approved user's email becomes part of the login allowlist."""
+
+    test_client, tmp_path = client
+    _capture_user_email(monkeypatch)
+    _stub_store(monkeypatch)
+
+    request_id, token = _pending_request(tmp_path)
+    resp = test_client.post(f"/signup/approve?id={request_id}&token={token}")
+    assert resp.status_code == 200
+
+    import backend.auth as auth
+
+    monkeypatch.setattr(auth.config, "accounts_root", str(tmp_path / "accounts"))
+    monkeypatch.setattr(auth.config, "app_env", "local", raising=False)
+    assert "jane@example.com" in auth._allowed_emails()
+
+
+def test_approve_is_single_use(client, monkeypatch):
+    test_client, tmp_path = client
+    _capture_user_email(monkeypatch)
+    _stub_store(monkeypatch)
+
+    request_id, token = _pending_request(tmp_path)
+    first = test_client.post(f"/signup/approve?id={request_id}&token={token}")
+    assert first.status_code == 200
+
+    second = test_client.post(f"/signup/approve?id={request_id}&token={token}")
+    assert second.status_code == 409
+
+
+def test_approve_invalid_token_rejected(client, monkeypatch):
+    test_client, tmp_path = client
+    _capture_user_email(monkeypatch)
+    _stub_store(monkeypatch)
+
+    request_id, _ = _pending_request(tmp_path)
+    resp = test_client.post(f"/signup/approve?id={request_id}&token=not-the-token")
+    assert resp.status_code == 400
+    # Nothing was provisioned.
+    assert not (tmp_path / "accounts" / "jane").exists()
+
+
+def test_approve_unknown_request_rejected(client, monkeypatch):
+    test_client, tmp_path = client
+    _capture_user_email(monkeypatch)
+    _stub_store(monkeypatch)
+
+    resp = test_client.post(f"/signup/approve?id={'a' * 32}&token=whatever")
+    assert resp.status_code == 400
+
+
+def test_reject_marks_request_and_blocks_later_approval(client, monkeypatch):
+    test_client, tmp_path = client
+    _capture_user_email(monkeypatch)
+    _stub_store(monkeypatch)
+
+    request_id, token = _pending_request(tmp_path)
+    resp = test_client.post(f"/signup/reject?id={request_id}&token={token}")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "rejected"}
+
+    store_dir = signup_requests.signup_requests_dir(tmp_path)
+    assert json.loads((store_dir / f"{request_id}.json").read_text())["status"] == "rejected"
+
+    # A rejected request can no longer be approved with the same token.
+    later = test_client.post(f"/signup/approve?id={request_id}&token={token}")
+    assert later.status_code == 409
+
+
+def test_reject_invalid_token_rejected(client, monkeypatch):
+    test_client, tmp_path = client
+    _stub_store(monkeypatch)
+
+    request_id, _ = _pending_request(tmp_path)
+    resp = test_client.post(f"/signup/reject?id={request_id}&token=nope")
+    assert resp.status_code == 400
+
+
+def test_approve_user_email_failure_is_not_swallowed(client, monkeypatch):
+    test_client, tmp_path = client
+    _stub_store(monkeypatch)
+
+    def boom(user_email, name, login_url):
+        raise RuntimeError("SES down")
+
+    monkeypatch.setattr(signup_module, "send_signup_approved_email", boom)
+
+    request_id, token = _pending_request(tmp_path)
+    resp = test_client.post(f"/signup/approve?id={request_id}&token={token}")
+    assert resp.status_code == 502
+
+
+def test_approve_link_works_via_get(client, monkeypatch):
+    """The approve/reject links in the admin email are clicked (GET)."""
+
+    test_client, tmp_path = client
+    _capture_user_email(monkeypatch)
+    _stub_store(monkeypatch)
+
+    request_id, token = _pending_request(tmp_path)
+    resp = test_client.get(f"/signup/approve?id={request_id}&token={token}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "approved"

--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -1,0 +1,87 @@
+import json
+
+import pytest
+
+from backend.common import signup_provision
+from backend.common.signup_requests import SignupRequest
+
+
+def _record(email: str, name: str = "Jane Doe") -> SignupRequest:
+    return SignupRequest(
+        id="a" * 32,
+        name=name,
+        email=email,
+        note="",
+        status="pending",
+        created_at="2026-06-15T12:00:00+00:00",
+        expires_at="2026-06-22T12:00:00+00:00",
+        token_sha256="deadbeef",
+    )
+
+
+@pytest.mark.parametrize(
+    "email,expected",
+    [
+        ("jane.doe@example.com", "jane-doe"),
+        ("JANE@example.com", "jane"),
+        ("a+b_c@example.com", "a-b-c"),
+        ("@example.com", "user"),
+    ],
+)
+def test_derive_owner_slug(email, expected):
+    assert signup_provision.derive_owner_slug(email) == expected
+
+
+def test_provision_owner_scaffolds_and_writes_email(tmp_path):
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+
+    owner = signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+
+    assert owner == "jane"
+    person = json.loads((accounts_root / "jane" / "person.json").read_text())
+    assert person["email"] == "jane@example.com"
+    assert person["full_name"] == "Jane Doe"
+    # Scaffold also produced the standard companion files.
+    assert (accounts_root / "jane" / "settings.json").exists()
+    assert (accounts_root / "jane" / "approvals.json").exists()
+
+
+def test_provision_owner_is_idempotent_for_same_email(tmp_path):
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+    record = _record("jane@example.com")
+
+    first = signup_provision.provision_owner(record, accounts_root)
+    second = signup_provision.provision_owner(record, accounts_root)
+
+    assert first == second == "jane"
+    assert sorted(p.name for p in accounts_root.iterdir()) == ["jane"]
+
+
+def test_provision_owner_avoids_clobbering_a_different_email(tmp_path):
+    accounts_root = tmp_path / "accounts"
+    (accounts_root / "jane").mkdir(parents=True)
+    (accounts_root / "jane" / "person.json").write_text(
+        json.dumps({"owner": "jane", "email": "someone-else@example.com"})
+    )
+
+    owner = signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+
+    assert owner == "jane-2"
+    # The pre-existing account is untouched.
+    existing = json.loads((accounts_root / "jane" / "person.json").read_text())
+    assert existing["email"] == "someone-else@example.com"
+
+
+def test_provision_owner_calls_store_ensure_owner(tmp_path):
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+    calls = []
+
+    class FakeStore:
+        def ensure_owner(self, owner):
+            calls.append(owner)
+
+    signup_provision.provision_owner(_record("jane@example.com"), accounts_root, store=FakeStore())
+    assert calls == ["jane"]

--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -85,3 +85,59 @@ def test_provision_owner_calls_store_ensure_owner(tmp_path):
 
     signup_provision.provision_owner(_record("jane@example.com"), accounts_root, store=FakeStore())
     assert calls == ["jane"]
+
+
+def test_provision_owner_reuses_slug_for_mixed_case_email(tmp_path):
+    """A re-request with different email casing must not split into a new slug."""
+
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+
+    first = signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+    # record.email is normalised at creation, but provisioning must also be
+    # case-insensitive defensively.
+    second = signup_provision.provision_owner(_record("JANE@example.com"), accounts_root)
+
+    assert first == second == "jane"
+
+
+def test_provision_owner_preserves_existing_full_name(tmp_path):
+    accounts_root = tmp_path / "accounts"
+    (accounts_root / "jane").mkdir(parents=True)
+    (accounts_root / "jane" / "person.json").write_text(
+        json.dumps({"owner": "jane", "email": "jane@example.com", "full_name": "Existing Name"})
+    )
+
+    signup_provision.provision_owner(_record("jane@example.com", name="New Name"), accounts_root)
+
+    person = json.loads((accounts_root / "jane" / "person.json").read_text())
+    assert person["full_name"] == "Existing Name"
+
+
+def test_provision_owner_skips_slug_with_corrupted_person_json(tmp_path):
+    """A corrupt person.json must not be treated as this email's account."""
+
+    accounts_root = tmp_path / "accounts"
+    (accounts_root / "jane").mkdir(parents=True)
+    (accounts_root / "jane" / "person.json").write_text("{ not json")
+
+    owner = signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+
+    # The corrupt directory is not reused; a fresh slug is allocated.
+    assert owner == "jane-2"
+    # The corrupt file is left untouched.
+    assert (accounts_root / "jane" / "person.json").read_text() == "{ not json"
+
+
+def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+    monkeypatch.setattr(signup_provision, "_MAX_SLUG_CANDIDATES", 2)
+
+    # Occupy both candidate slugs with a different email so none can be reused.
+    for name in ("jane", "jane-2"):
+        (accounts_root / name).mkdir()
+        (accounts_root / name / "person.json").write_text(json.dumps({"email": "other@example.com"}))
+
+    with pytest.raises(RuntimeError):
+        signup_provision.provision_owner(_record("jane@example.com"), accounts_root)

--- a/tests/backend/test_signup_requests.py
+++ b/tests/backend/test_signup_requests.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -16,9 +16,7 @@ def test_normalise_payload_trims_and_lowercases_email():
 
 
 def test_normalise_payload_allows_missing_note():
-    name, email, note = signup_requests.normalise_payload(
-        {"name": "Jane", "email": "jane@example.com"}
-    )
+    name, email, note = signup_requests.normalise_payload({"name": "Jane", "email": "jane@example.com"})
     assert (name, email, note) == ("Jane", "jane@example.com", "")
 
 
@@ -60,9 +58,7 @@ def test_create_signup_request_persists_record(tmp_path):
     now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
     store = signup_requests.signup_requests_dir(tmp_path)
 
-    record, token = signup_requests.create_signup_request(
-        "Jane", "jane@example.com", "hello", store, now=now
-    )
+    record, token = signup_requests.create_signup_request("Jane", "jane@example.com", "hello", store, now=now)
 
     path = store / f"{record.id}.json"
     assert path.exists()
@@ -93,3 +89,70 @@ def test_create_signup_request_tokens_are_unique_and_high_entropy(tmp_path):
     assert token_a != token_b
     # secrets.token_urlsafe(32) yields ~43 url-safe characters.
     assert len(token_a) >= 32
+
+
+def test_load_request_round_trips(tmp_path):
+    store = signup_requests.signup_requests_dir(tmp_path)
+    record, _ = signup_requests.create_signup_request("Jane", "jane@example.com", "", store)
+
+    loaded = signup_requests.load_request(record.id, store)
+    assert loaded == record
+
+
+def test_load_request_rejects_traversal_ids(tmp_path):
+    store = signup_requests.signup_requests_dir(tmp_path)
+    assert signup_requests.load_request("../secret", store) is None
+    assert signup_requests.load_request("not-hex!!", store) is None
+    assert signup_requests.load_request("", store) is None
+
+
+def test_consume_request_marks_status_and_is_single_use(tmp_path):
+    store = signup_requests.signup_requests_dir(tmp_path)
+    record, token = signup_requests.create_signup_request("Jane", "jane@example.com", "", store)
+
+    updated = signup_requests.consume_request(record.id, token, store, new_status="approved")
+    assert updated.status == "approved"
+    saved = json.loads((store / f"{record.id}.json").read_text())
+    assert saved["status"] == "approved"
+
+    # Re-using the same token is rejected — single-use.
+    with pytest.raises(signup_requests.RequestAlreadyProcessed):
+        signup_requests.consume_request(record.id, token, store, new_status="approved")
+
+
+def test_consume_request_rejects_bad_token(tmp_path):
+    store = signup_requests.signup_requests_dir(tmp_path)
+    record, _ = signup_requests.create_signup_request("Jane", "jane@example.com", "", store)
+
+    with pytest.raises(signup_requests.TokenInvalid):
+        signup_requests.consume_request(record.id, "wrong-token", store, new_status="approved")
+    # A failed attempt must not flip the status.
+    assert json.loads((store / f"{record.id}.json").read_text())["status"] == "pending"
+
+
+def test_consume_request_rejects_unknown_id(tmp_path):
+    store = signup_requests.signup_requests_dir(tmp_path)
+    with pytest.raises(signup_requests.RequestNotFound):
+        signup_requests.consume_request("a" * 32, "tok", store, new_status="approved")
+
+
+def test_consume_request_rejects_expired_token(tmp_path):
+    store = signup_requests.signup_requests_dir(tmp_path)
+    created = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    record, token = signup_requests.create_signup_request("Jane", "jane@example.com", "", store, now=created)
+
+    later = created + timedelta(days=365)
+    with pytest.raises(signup_requests.RequestExpired):
+        signup_requests.consume_request(record.id, token, store, new_status="approved", now=later)
+
+
+def test_validate_request_does_not_mutate(tmp_path):
+    store = signup_requests.signup_requests_dir(tmp_path)
+    record, token = signup_requests.create_signup_request("Jane", "jane@example.com", "", store)
+
+    validated = signup_requests.validate_request(record.id, token, store)
+    assert validated.status == "pending"
+    # No write occurred, so the token can still be consumed afterwards.
+    assert json.loads((store / f"{record.id}.json").read_text())["status"] == "pending"
+    consumed = signup_requests.consume_request(record.id, token, store, new_status="approved")
+    assert consumed.status == "approved"


### PR DESCRIPTION
## What
Implements the admin-facing **approve/reject** actions for a pending signup request, closing the onboarding loop started in #4351. Approving provisions the user (scaffolds owner data + adds their email to the login allowlist) and emails them that their login is ready; rejecting closes the request.

Closes #4352

## How
- **`backend/common/signup_requests.py`** — single-use token consumption:
  - `validate_request()` (non-mutating) and `consume_request()` (atomic status flip) hash the inbound token and compare it to the stored `token_sha256` with a **constant-time** compare, require the request to be `pending` and unexpired, and raise distinct `SignupTokenError` subclasses for not-found / bad-token / expired / already-processed.
  - `_request_path()` requires an exact 32-char hex id and confirms the resolved path stays inside the store dir (`relative_to`) — defence in depth against path traversal.
- **`backend/common/signup_provision.py`** (new) — domain service (logic kept out of the route):
  - derives a filesystem-safe owner slug from the email and **atomically claims** it via `mkdir` (no race between concurrent approvals); reuses an existing dir owned by the same email (idempotent, case-insensitive) and never clobbers a different user's account.
  - scaffolds via `ensure_owner_scaffold()` (no hand-written JSON) and writes the email into `person.json` so `backend/auth._allowed_emails()` admits the user. Existing `full_name` is preserved; unreadable/malformed `person.json` is logged, not silently masked.
  - also calls the writable store's `ensure_owner()` to stay consistent with #4353.
- **`backend/emails/signup_approved.py`** (new) — SES "login ready" email reusing the `weekly_report` pattern; all visitor input HTML-escaped.
- **`backend/routes/signup.py`** — `/signup/approve` and `/signup/reject`:
  - **GET** (a clicked email link) renders a **side-effect-free confirmation page** that POSTs the real action, so email-link prefetchers/scanners cannot consume a single-use token.
  - **POST** performs the action: approve **validates → provisions → burns the token** (so a transient provisioning failure does not consume it), then emails the user; a SES failure surfaces as `502` rather than being swallowed.
  - token failures map to `400` (invalid / expired / unknown — indistinguishable, no enumeration) or `409` (already processed).

## Security notes
- Tokens are single-use and time-bound; replay, expiry, and bad tokens are safely rejected. Only the token hash is ever stored (from #4351).
- State changes never happen on GET, so link scanners cannot trigger provisioning.
- Approval is the only path that grants login access; provisioning is idempotent so a double-click cannot escalate.
- Known pre-existing limitation: in the deployed AWS environment `_allowed_emails()` sources `person.json` from the read-only `accounts/` S3 prefix, which is separate from the writable store — the same split that affects all writable data today. This change follows the issue's prescribed local-first `ensure_owner_scaffold()` + `person.json` approach; wiring the AWS allowlist to the writable prefix is out of scope here.

## Tests
`tests/` cover approve, reject, invalid-token, unknown-id, already-consumed, expired, single-use, GET-confirmation (no mutation) + error page, mixed-case slug reuse, `full_name` preservation, corrupted `person.json`, slug-candidate exhaustion, allowlist membership end-to-end, and SES-failure surfacing — with SES and the writable store mocked (no live AWS). 58 signup tests pass; `ruff` + `black` clean.

Follow-up issues raised by review bots (#4383, #4384, #4386, #4387, #4388) are addressed by this update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an admin signup approval/rejection workflow with secure, single-use tokens and safe confirmation pages.
  * Automatically provisions approved accounts, handling identity data updates safely and without overwriting mismatched records.
  * Sends an “approved signup” email to the approved user with a login link when available.

* **Tests**
  * Expanded coverage for token validation, single-use behaviour, safe confirmation GETs, provisioning/idempotency edge cases, and notification failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->