### PR TITLE
feat(frontend): CSV import UI wired to POST /holdings/import

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1630,3 +1630,49 @@ export const requestAccountSignup = (payload: AccountSignupRequest) =>
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
+
+// ───────────── Holdings CSV import ─────────────
+export interface ImportHoldingsCsvResponse {
+  path: string;
+}
+
+/**
+ * Upload a CSV export of holdings/transactions for `owner`/`account` and have
+ * the backend parse it with the given `provider` and persist the result.
+ */
+export const importHoldingsCsv = async (
+  owner: string,
+  account: string,
+  provider: string,
+  file: File,
+): Promise<ImportHoldingsCsvResponse> => {
+  const formData = new FormData();
+  formData.append("owner", owner);
+  formData.append("account", account);
+  formData.append("provider", provider);
+  formData.append("file", file);
+
+  const headers = new Headers();
+  const token = getStoredAuthToken();
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const csrf = defaultGetCsrfToken();
+  if (csrf) headers.set("X-CSRFToken", csrf);
+
+  const res = await dynamicFetch(`${API_BASE}/holdings/import`, {
+    method: "POST",
+    headers,
+    credentials: "include",
+    body: formData,
+  });
+  if (!res.ok) {
+    let detail = `HTTP ${res.status} - ${res.statusText}`;
+    try {
+      const body = await res.json();
+      if (typeof body?.detail === "string") detail = body.detail;
+    } catch {
+      // response body was not JSON; fall back to the status text above
+    }
+    throw new Error(detail);
+  }
+  return res.json() as Promise<ImportHoldingsCsvResponse>;
+};

--- a/frontend/src/components/CsvImportForm.tsx
+++ b/frontend/src/components/CsvImportForm.tsx
@@ -1,0 +1,138 @@
+import { useId, useState, type ChangeEvent, type FormEvent } from "react";
+import { importHoldingsCsv } from "../api";
+
+/** Provider keys supported by `backend/importers`, excluding the `test` stub. */
+const PROVIDERS = [
+  { value: "degiro", label: "DEGIRO" },
+  { value: "hargreaves", label: "Hargreaves Lansdown" },
+];
+
+type Props = {
+  owner: string;
+  accountTypes: string[];
+  onImported?: () => void;
+};
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success"; path: string }
+  | { kind: "error"; message: string };
+
+const extractErrorMessage = (err: unknown): string => {
+  if (err instanceof Error) return err.message;
+  return "Failed to import file. Please try again.";
+};
+
+/** Form for uploading a CSV of holdings/transactions to `POST /holdings/import`. */
+export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
+  const [account, setAccount] = useState(accountTypes[0] ?? "");
+  const [provider, setProvider] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const formId = useId();
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setFile(e.target.files?.[0] ?? null);
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!account || !provider || !file) return;
+
+    setStatus({ kind: "submitting" });
+    try {
+      const result = await importHoldingsCsv(owner, account, provider, file);
+      setStatus({ kind: "success", path: result.path });
+      setFile(null);
+      onImported?.();
+    } catch (err) {
+      setStatus({ kind: "error", message: extractErrorMessage(err) });
+    }
+  };
+
+  const submitting = status.kind === "submitting";
+  const canSubmit = Boolean(account && provider && file) && !submitting;
+
+  return (
+    <div className="rounded-lg border border-gray-800 bg-black/20 p-3">
+      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+        Import CSV
+      </p>
+      <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-2">
+        <div>
+          <label
+            htmlFor={`${formId}-account`}
+            className="block text-xs text-gray-400"
+          >
+            Account
+          </label>
+          <select
+            id={`${formId}-account`}
+            value={account}
+            onChange={(e) => setAccount(e.target.value)}
+            className="rounded border border-gray-700 bg-gray-800 p-1 text-white"
+          >
+            {accountTypes.map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label
+            htmlFor={`${formId}-provider`}
+            className="block text-xs text-gray-400"
+          >
+            Provider
+          </label>
+          <select
+            id={`${formId}-provider`}
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+            className="rounded border border-gray-700 bg-gray-800 p-1 text-white"
+          >
+            <option value="">Select provider…</option>
+            {PROVIDERS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor={`${formId}-file`} className="block text-xs text-gray-400">
+            CSV file
+          </label>
+          <input
+            id={`${formId}-file`}
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleFileChange}
+            className="text-white"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="rounded border border-gray-700 px-3 py-1 text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? "Importing…" : "Import"}
+        </button>
+      </form>
+      {status.kind === "success" && (
+        <p role="status" className="mt-2 text-sm text-green-400">
+          Imported successfully. Saved to {status.path}.
+        </p>
+      )}
+      {status.kind === "error" && (
+        <p role="alert" className="mt-2 text-sm text-red-500">
+          {status.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default CsvImportForm;

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -3,6 +3,7 @@ import type { FormEvent } from "react";
 import { Link } from "react-router-dom";
 import type { Portfolio, Account, SectorContribution } from "../types";
 import { AccountBlock } from "./AccountBlock";
+import { CsvImportForm } from "./CsvImportForm";
 import { ValueAtRisk } from "./ValueAtRisk";
 import { money } from "../lib/money";
 import { formatDateISO } from "../lib/date";
@@ -369,6 +370,14 @@ export function PortfolioView({ data, loading, error, onDateChange }: Props) {
                   Export PDF
                 </button>
               </div>
+            </div>
+          )}
+          {!familyMvpEnabled && (
+            <div className="mb-6">
+              <CsvImportForm
+                owner={data.owner}
+                accountTypes={data.accounts.map((acct) => acct.account_type)}
+              />
             </div>
           )}
           {hasWarnings && (

--- a/frontend/tests/unit/components/CsvImportForm.test.tsx
+++ b/frontend/tests/unit/components/CsvImportForm.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CsvImportForm } from "@/components/CsvImportForm";
+import { importHoldingsCsv } from "@/api";
+
+vi.mock("@/api", () => ({
+  importHoldingsCsv: vi.fn(),
+}));
+
+describe("CsvImportForm", () => {
+  beforeEach(() => {
+    vi.mocked(importHoldingsCsv).mockReset();
+  });
+
+  const csvFile = new File(["a,b\n1,2"], "holdings.csv", { type: "text/csv" });
+
+  it("disables submit until a provider and file are chosen", async () => {
+    render(<CsvImportForm owner="alice" accountTypes={["ISA", "SIPP"]} />);
+
+    const submit = screen.getByRole("button", { name: "Import" });
+    expect(submit).toBeDisabled();
+
+    await userEvent.selectOptions(screen.getByLabelText("Provider"), "degiro");
+    expect(submit).toBeDisabled();
+
+    const fileInput = screen.getByLabelText("CSV file");
+    await userEvent.upload(fileInput, csvFile);
+    expect(submit).toBeEnabled();
+  });
+
+  it("submits the selected account, provider and file as multipart data", async () => {
+    vi.mocked(importHoldingsCsv).mockResolvedValue({
+      path: "/data/accounts/alice/ISA.json",
+    });
+
+    render(<CsvImportForm owner="alice" accountTypes={["ISA", "SIPP"]} />);
+
+    await userEvent.selectOptions(screen.getByLabelText("Account"), "SIPP");
+    await userEvent.selectOptions(screen.getByLabelText("Provider"), "hargreaves");
+    await userEvent.upload(screen.getByLabelText("CSV file"), csvFile);
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(importHoldingsCsv).toHaveBeenCalledWith(
+      "alice",
+      "SIPP",
+      "hargreaves",
+      csvFile,
+    );
+    expect(
+      await screen.findByText(/Imported successfully/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "/data/accounts/alice/ISA.json",
+    );
+  });
+
+  it("shows the backend error message for an unknown provider", async () => {
+    vi.mocked(importHoldingsCsv).mockRejectedValue(
+      new Error("Unknown provider: bogus"),
+    );
+
+    render(<CsvImportForm owner="alice" accountTypes={["ISA"]} />);
+
+    await userEvent.selectOptions(screen.getByLabelText("Provider"), "degiro");
+    await userEvent.upload(screen.getByLabelText("CSV file"), csvFile);
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Unknown provider: bogus",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an "Import CSV" form to the portfolio view (account selector, provider selector, file input) that uploads via `multipart/form-data` to the existing `POST /holdings/import` endpoint.
- Provider list (`degiro`, `hargreaves`) matches `backend/importers` (excluding the `test` stub importer).
- Shows a success message with the returned path, or the backend's 400 `detail` message (e.g. `Unknown provider`, `Failed to import file`) on error.
- Submit is disabled until an account, provider, and file are all selected.

## Test plan
- [x] `npm --prefix frontend run test -- --run tests/unit/components/CsvImportForm.test.tsx tests/unit/components/PortfolioView.test.tsx` passes
- [x] `npm --prefix frontend run lint` passes clean
- [ ] Manual check in browser (preview tooling was unavailable in this session due to a concurrent edit in the shared working tree)

Closes #4356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV import functionality for holdings data. Users can now upload CSV files containing holdings information across multiple providers and account types directly from the portfolio view. The form validates all required fields before submission and provides clear feedback messages confirming successful imports or detailing any errors encountered during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->