### PR TITLE
test(frontend): strengthen money() lib tests — replace circular assertions with concrete values

### DIFF
--- a/frontend/tests/unit/lib/money.test.ts
+++ b/frontend/tests/unit/lib/money.test.ts
@@ -2,13 +2,28 @@ import { describe, expect, it, vi } from "vitest";
 import { money, normalizeDisplayCurrency, percentOrNa } from "@/lib/money";
 
 describe("money", () => {
+  it("formats a GBP value to the correct string for en-GB locale", () => {
+    expect(money(123.45, "GBP", "en-GB")).toBe("£123.45");
+  });
+
+  it("returns the em dash sentinel for null", () => {
+    expect(money(null, "GBP", "en-GB")).toBe("—");
+  });
+
+  it("returns the em dash sentinel for undefined", () => {
+    expect(money(undefined, "GBP", "en-GB")).toBe("—");
+  });
+
+  it("returns the em dash sentinel for non-finite values", () => {
+    expect(money(NaN, "GBP", "en-GB")).toBe("—");
+    expect(money(Infinity, "GBP", "en-GB")).toBe("—");
+    expect(money(-Infinity, "GBP", "en-GB")).toBe("—");
+  });
+
   it.each(["GBX", "GBXP", "GBPX", "GBpx", "GBp"])(
-    "formats %s values using pound units",
+    "formats pence-code %s as £123.45 (same as GBP)",
     (currency) => {
-      const value = 123.45;
-      expect(money(value, currency, "en-GB")).toBe(
-        money(value, "GBP", "en-GB"),
-      );
+      expect(money(123.45, currency, "en-GB")).toBe("£123.45");
     },
   );
 });


### PR DESCRIPTION
## Summary

Implements the first batch of fixes from the test quality audit in #4416.

- The five `money()` pence-code tests were **circular**: `money(v, GBX) === money(v, "GBP")` — if the function returned the same value for every input both sides would be equal, so deleting the implementation wouldn't break them.
- Three null/non-finite input paths (`null`, `undefined`, `NaN`, `Infinity`, `-Infinity`) had **no test coverage** at all.

### Changes

`frontend/tests/unit/lib/money.test.ts`:
- Added ground-truth assertion: `money(123.45, "GBP", "en-GB")` must equal `"£123.45"` (en-GB locale format).
- Added four new tests for `null`, `undefined`, `NaN`, `±Infinity` — all must return the `"—"` sentinel.
- Pence-code tests now compare against the **literal** `"£123.45"` rather than another call to the function under test.

`normalizeDisplayCurrency` and `percentOrNa` tests were reviewed and are already substantive — no changes needed there.

## Test plan

- [x] `npm --prefix frontend run test -- --run` → 512/512 passed

Closes #4416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for currency formatting, including validation of GBP formatting for en-GB locale and proper handling of null, undefined, and non-finite numerical values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->