### PR TITLE
docs: document both account-creation paths (implicit + admin-approval)

### DIFF
--- a/backend/common/accounts_store.py
+++ b/backend/common/accounts_store.py
@@ -206,6 +206,18 @@ class LocalAccountsStore:
             yield owner, account_raw, data
 
     def ensure_owner(self, owner: str) -> None:
+        """Implicit account-creation path for the local/file-backed store.
+
+        Scaffolds a minimal owner directory (person.json with holdings and
+        viewers keys) the first time a write endpoint is called for an owner
+        that does not yet exist.  This is **not** the only creation path: when
+        an admin approves a signup request,
+        :func:`backend.common.compliance.ensure_owner_scaffold` is used
+        instead, which also records the owner's email so that
+        :func:`backend.auth._allowed_emails` admits them at login — before any
+        write is made.  Do not call directly unless you understand the full
+        account-creation lifecycle.
+        """
         if self.is_global or self.root is None:
             return
         if self.read_document(owner, "person.json") is not None:
@@ -322,6 +334,18 @@ class S3AccountsStore:
             yield str(data.get("owner") or owner), account_raw, data
 
     def ensure_owner(self, owner: str) -> None:
+        """Implicit account-creation path for the S3-backed store.
+
+        Scaffolds a minimal owner directory (person.json with holdings and
+        viewers keys) the first time a write endpoint is called for an owner
+        that does not yet exist.  This is **not** the only creation path: when
+        an admin approves a signup request,
+        :func:`backend.common.compliance.ensure_owner_scaffold` is used
+        instead, which also records the owner's email so that
+        :func:`backend.auth._allowed_emails` admits them at login — before any
+        write is made.  Do not call directly unless you understand the full
+        account-creation lifecycle.
+        """
         if self.read_document(owner, "person.json") is not None:
             return
         with self.edit_document(owner, "person.json", default=_default_person_payload(owner)) as data:

--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -91,7 +91,14 @@ def _parse_date(val: str | None) -> date | None:
 
 
 def ensure_owner_scaffold(owner: str, accounts_root: Optional[Path] = None) -> Path:
-    """Create the default compliance scaffold for ``owner`` if needed.
+    """Explicit account-provisioning path used by the admin signup-approval flow.
+
+    Called from :mod:`backend.common.signup_provision` when an admin approves a
+    pending signup request.  Unlike
+    :meth:`~backend.common.accounts_store.AccountsStore.ensure_owner`, this
+    path runs *before* any user write and also records the owner's email in
+    ``person.json`` so :func:`backend.auth._allowed_emails` admits them at
+    login.  Idempotent: re-provisioning the same owner is a no-op.
 
     Returns the resolved owner directory after ensuring the default files are
     present.

--- a/backend/common/signup_provision.py
+++ b/backend/common/signup_provision.py
@@ -14,6 +14,14 @@ user can actually authenticate:
 The owner slug is derived from the request email. If the derived slug is
 already taken by a *different* email we pick the next free suffix rather than
 overwriting someone else's account.
+
+Note: a user who somehow reaches a write endpoint (e.g. ``POST /transactions``
+or ``POST /holdings/manual``) without going through the approval flow will have
+their account created implicitly by
+:meth:`~backend.common.accounts_store.AccountsStore.ensure_owner` — a
+minimal scaffold without their email, which means
+:func:`backend.auth._allowed_emails` will not admit them until their email is
+recorded via this provisioning path.
 """
 
 from __future__ import annotations

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -530,7 +530,14 @@ def _validate_component(value: str, field: str) -> str:
 
 @router.post("/transactions", status_code=201)
 async def create_transaction(request: Request, tx: TransactionCreate) -> dict:
-    """Store a new transaction and return it."""
+    """Store a new transaction and return it.
+
+    If the owner does not yet have a writable account root, one is created
+    implicitly via :meth:`~backend.common.accounts_store.AccountsStore.ensure_owner`.
+    There is no separate account-creation endpoint; see
+    :mod:`backend.common.signup_provision` for the admin-approval provisioning
+    path that runs before any user write.
+    """
 
     store = _require_writable_store(request)
 
@@ -711,6 +718,14 @@ async def import_holdings(
 
 @router.post("/holdings/manual")
 async def create_manual_holding(request: Request, payload: ManualHoldingCreate) -> dict[str, Any]:
+    """Create a manual holding for the authenticated owner.
+
+    If the owner does not yet have a writable account root, one is created
+    implicitly via :meth:`~backend.common.accounts_store.AccountsStore.ensure_owner`.
+    There is no separate account-creation endpoint; see
+    :mod:`backend.common.signup_provision` for the admin-approval provisioning
+    path that runs before any user write.
+    """
     _validate_manual_holding_payload(payload)
     owner = _validate_component(payload.owner, "owner")
     account = _validate_component(payload.account, "account")

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -155,3 +155,30 @@ To investigate a gateway 401: open the `BackendApiAccessLogGroup` log group in
 CloudWatch, filter to the failing `routeKey`, and read `authorizerError`. The
 format deliberately logs claims/status only — the raw `Authorization` header /
 bearer token is never logged.
+
+## Account creation
+
+Two distinct paths can create an owner's data directory:
+
+### Admin-provisioned (signup-approval flow)
+
+A visitor submits `POST /signup/request` with their email. An admin clicks the
+approve link in the resulting notification email. The backend then:
+
+1. Calls `ensure_owner_scaffold()` (`backend/common/compliance.py`) to create
+   the default compliance scaffold under `data/accounts/<owner>/`.
+2. Writes the visitor's email into `person.json` so that `_allowed_emails()`
+   (`backend/auth.py`) admits them at login.
+3. Sends the user a "login ready" email.
+
+The account exists and the user can authenticate **before** making any write.
+
+### Implicit (first-write path)
+
+If a user reaches a write endpoint (`POST /transactions`, `POST /holdings/manual`)
+without having been provisioned via the approval flow, `ensure_owner()`
+(`backend/common/accounts_store.py`) creates a minimal `person.json` as a
+side-effect. There is no dedicated `POST /accounts` endpoint. Note that
+implicitly-created accounts contain no email, so `_allowed_emails()` will not
+admit the user until their email is recorded — typically this only applies in
+local/test environments where auth is relaxed.


### PR DESCRIPTION
## Summary

- Adds docstrings to both `LocalAccountsStore.ensure_owner()` and `S3AccountsStore.ensure_owner()` cross-referencing `ensure_owner_scaffold()` and explaining the auth-gate difference
- Expands the `ensure_owner_scaffold()` docstring in `compliance.py` to clarify when it is used vs `ensure_owner()` and its role in recording email for `_allowed_emails()`
- Adds a module-level note in `signup_provision.py` explaining the implicit fallback and its auth-gate limitation
- Adds docstrings to `create_transaction()` and `create_manual_holding()` in `transactions.py` noting implicit creation and pointing to the explicit provisioning path
- Adds a new **Account creation** section to `docs/AUTH.md` documenting both paths with their respective flows

## Test plan

- [ ] `make lint` passes clean
- [ ] Existing test suite passes (no behaviour changes — documentation only)
- [ ] `docs/AUTH.md` Account creation section renders correctly

Closes #4325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified account creation process, documenting two provisioning paths: admin-approval signup flow and implicit creation on first write.
  * Enhanced guidance on email recording for login admission and account eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->