### PR TITLE
feat: switch aider model to ollama/qwen2.5-coder:14b

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,4 +1,4 @@
-model: "ollama/DeepSeek-Qwen3-8B"
+model: "ollama/qwen2.5-coder:14b"
 
 auto-commits: true
 yes-always: true


### PR DESCRIPTION
## Summary

- Updates `.aider.conf.yml` to use `ollama/qwen2.5-coder:14b` instead of `DeepSeek-Qwen3-8B`
- Context window config (`num_ctx: 49152`) already exists in `.aider.model.settings.yml` (local-only, gitignored)

## Test plan

- [ ] Run `aider` locally and confirm it picks up `qwen2.5-coder:14b`
- [ ] Run a test issue via `aider-issue.ps1` and verify no model fallback or context errors

Closes #4427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->