### PR TITLE
fix: stop awsUiAuth auto-redirecting to Cognito before React mounts

### DIFF
--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -125,7 +125,8 @@ export default function LoginPage({ clientId, awsUiAuth, onSuccess }: Props) {
             type="button"
             onClick={() => {
               setCognitoError(null);
-              signInWithCognito(awsUiAuth).catch(() => {
+              signInWithCognito(awsUiAuth).catch((err: unknown) => {
+                console.error('Cognito sign-in initiation failed:', err);
                 setCognitoError('Failed to start sign-in. Please try again.');
               });
             }}

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -3,9 +3,11 @@ import { Link } from 'react-router-dom';
 import { API_BASE, setAuthToken } from './api';
 import { useUser } from './UserContext';
 import { useAuth } from './AuthContext';
+import { signInWithCognito, type AwsUiAuthConfig } from './awsUiAuth';
 
 interface Props {
   clientId: string;
+  awsUiAuth?: AwsUiAuthConfig;
   onSuccess: () => void;
 }
 
@@ -21,10 +23,13 @@ function sanitize(input: string): string {
   );
 }
 
-export default function LoginPage({ clientId, onSuccess }: Props) {
+export default function LoginPage({ clientId, awsUiAuth, onSuccess }: Props) {
   const { setProfile } = useUser();
   const { setUser } = useAuth();
   const [error, setError] = useState<string | null>(null);
+  const [cognitoError, setCognitoError] = useState<string | null>(null);
+  const awsUiAuthEnabled =
+    awsUiAuth?.enabled === true || awsUiAuth?.enabled === 'true';
   useEffect(() => {
     const script = document.createElement('script');
     script.src = 'https://accounts.google.com/gsi/client';
@@ -105,6 +110,30 @@ export default function LoginPage({ clientId, onSuccess }: Props) {
         </div>
       )}
       <div id="google-signin"></div>
+      {awsUiAuthEnabled && (
+        <div style={{ marginTop: '1rem' }}>
+          {cognitoError && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              style={{ color: 'red', marginBottom: '0.5rem' }}
+            >
+              {cognitoError}
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              setCognitoError(null);
+              signInWithCognito(awsUiAuth).catch(() => {
+                setCognitoError('Failed to start sign-in. Please try again.');
+              });
+            }}
+          >
+            Sign in
+          </button>
+        </div>
+      )}
       <p style={{ marginTop: '1rem' }}>
         Don&apos;t have an account?{' '}
         <Link to="/create-account">Create account</Link>

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -323,10 +323,14 @@ export const ensureAwsUiAuth = async (config?: AwsUiAuthConfig | null) => {
   // skip exchangeCode entirely to avoid a state-mismatch error when ?code= params
   // are present in the URL from a previous (already-consumed) callback.
   if (hasValidSession()) return true;
-  // Return value intentionally unused: true means the code exchange succeeded
-  // and a session was stored; false means no OAuth callback was present.
-  // Either way we let React mount — the login page handles the unauthenticated
-  // state, and failures throw (propagating to bootstrapRuntimeConfig's catch).
+  // exchangeCode() return value intentionally unused.
+  //   true  — OAuth callback present and code exchange succeeded; session stored.
+  //   false — no OAuth callback in the URL at all (normal fresh visit).
+  // Either way we return true and let React mount the login page.
+  // NOTE: exchangeCode() never returns false for *failures* — every error path
+  // (state mismatch, expired code, token endpoint error, OAuth error param)
+  // throws. Those exceptions propagate to bootstrapRuntimeConfig's .catch(),
+  // which renders an error screen with a "Sign in" reload button (recovery path).
   void (await exchangeCode(authConfig));
   return true;
 };

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -323,9 +323,11 @@ export const ensureAwsUiAuth = async (config?: AwsUiAuthConfig | null) => {
   // skip exchangeCode entirely to avoid a state-mismatch error when ?code= params
   // are present in the URL from a previous (already-consumed) callback.
   if (hasValidSession()) return true;
-  await exchangeCode(authConfig);
-  // No auto-redirect: let the React login page mount so the user can choose to
-  // sign in via Cognito or request an account.
+  // Return value intentionally unused: true means the code exchange succeeded
+  // and a session was stored; false means no OAuth callback was present.
+  // Either way we let React mount — the login page handles the unauthenticated
+  // state, and failures throw (propagating to bootstrapRuntimeConfig's catch).
+  void (await exchangeCode(authConfig));
   return true;
 };
 

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -323,7 +323,26 @@ export const ensureAwsUiAuth = async (config?: AwsUiAuthConfig | null) => {
   // skip exchangeCode entirely to avoid a state-mismatch error when ?code= params
   // are present in the URL from a previous (already-consumed) callback.
   if (hasValidSession()) return true;
-  if (await exchangeCode(authConfig)) return true;
-  await redirectToHostedUi(authConfig);
-  return false;
+  await exchangeCode(authConfig);
+  // No auto-redirect: let the React login page mount so the user can choose to
+  // sign in via Cognito or request an account.
+  return true;
+};
+
+/**
+ * Initiates a Cognito hosted-UI sign-in by redirecting the browser to the
+ * PKCE authorisation endpoint. Call this in response to an explicit user
+ * action (e.g. a "Sign in" button click) rather than automatically on page
+ * load, so new visitors can reach the create-account page first.
+ */
+export const signInWithCognito = async (
+  config?: AwsUiAuthConfig | null,
+): Promise<void> => {
+  if (!isEnabled(config?.enabled)) return;
+  const domain = normaliseDomain(config?.domain ?? '');
+  const clientId = config?.clientId?.trim() ?? '';
+  if (!domain || !clientId)
+    throw new Error('AWS UI authentication is enabled but not configured');
+  const redirectPath = config?.redirectPath ?? DEFAULT_REDIRECT_PATH;
+  await redirectToHostedUi({ domain, clientId, redirectPath });
 };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -57,6 +57,10 @@ interface BootstrapConfig {
 const storedToken = getStoredAuthToken();
 if (storedToken) setAuthToken(storedToken);
 
+// Populated by bootstrapRuntimeConfig before React mounts so Root can pass it
+// to LoginPage for the explicit Cognito sign-in button.
+let runtimeAwsUiAuth: AwsUiAuthConfig | undefined;
+
 const App = lazy(() => import('./App.tsx'));
 const ComplianceWarnings = lazy(() => import('./pages/ComplianceWarnings'));
 const Goals = lazy(() => import('./pages/Goals'));
@@ -121,14 +125,16 @@ const renderRouteMarker = (
   );
 };
 
-export function Root() {
+export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthConfig } = {}) {
   const [configLoading, setConfigLoading] = useState(true);
   const [configError, setConfigError] = useState<Error | null>(null);
   const [retryScheduled, setRetryScheduled] = useState(false);
   const [needsAuth, setNeedsAuth] = useState(false);
   const [googleLoginEnabled, setGoogleLoginEnabled] = useState(false);
   const [clientId, setClientId] = useState('');
-  const [authed, setAuthed] = useState(Boolean(storedToken));
+  const [authed, setAuthed] = useState(
+    Boolean(storedToken) || Boolean(getStoredCognitoIdToken()),
+  );
   const { setUser } = useAuth();
   const { setProfile } = useUser();
   const navigate = useNavigate();
@@ -324,9 +330,14 @@ export function Root() {
   }
 
   if (needsAuth && !authed && !isPublicSupportRoute && !isPublicCreateAccountRoute) {
-    if (!googleLoginEnabled || !clientId) {
+    const awsUiAuthEnabled =
+      awsUiAuth?.enabled === true || awsUiAuth?.enabled === 'true';
+    const hasAnyLoginMethod =
+      (googleLoginEnabled && Boolean(clientId)) || awsUiAuthEnabled;
+
+    if (!hasAnyLoginMethod) {
       console.error(
-        'Authentication is enforced but Google login is not fully configured'
+        'Authentication is enforced but no login method is configured'
       );
       return (
         <>
@@ -339,7 +350,11 @@ export function Root() {
     return (
       <>
         {renderRouteMarker(location.pathname, 'auth')}
-        <LoginPage clientId={clientId} onSuccess={() => setAuthed(true)} />
+        <LoginPage
+          clientId={clientId}
+          awsUiAuth={awsUiAuth}
+          onSuccess={() => setAuthed(true)}
+        />
       </>
     );
   }
@@ -508,6 +523,7 @@ const bootstrapRuntimeConfig = async () => {
   if (typeof payload.apiBaseUrl === 'string') {
     setApiBase(payload.apiBaseUrl);
   }
+  runtimeAwsUiAuth = payload.awsUiAuth;
   const shouldRender = await ensureAwsUiAuth(payload.awsUiAuth);
   if (shouldRender) {
     try {

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearCognitoSession, ensureAwsUiAuth, extractTokenExchangeErrorReason, getCognitoSessionExpiresAt, getStoredCognitoAccessToken, getStoredCognitoIdToken, refreshCognitoSession, UserCancelledError } from '@/awsUiAuth';
+import { clearCognitoSession, ensureAwsUiAuth, extractTokenExchangeErrorReason, getCognitoSessionExpiresAt, getStoredCognitoAccessToken, getStoredCognitoIdToken, refreshCognitoSession, signInWithCognito, UserCancelledError } from '@/awsUiAuth';
 
 const assignMock = vi.fn();
 
@@ -40,16 +40,10 @@ describe('ensureAwsUiAuth', () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
-  it('redirects to Cognito when enabled is the string "true"', async () => {
-    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
-      (array as Uint8Array).fill(1);
-      return array;
-    });
-    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
-
+  it('returns true without redirecting when enabled is the string "true" and no session', async () => {
     const result = await ensureAwsUiAuth({ ...AUTH_CONFIG, enabled: 'true' });
-    expect(result).toBe(false);
-    expect(assignMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(true);
+    expect(assignMock).not.toHaveBeenCalled();
   });
 
   it('throws when enabled but domain is missing', async () => {
@@ -64,43 +58,9 @@ describe('ensureAwsUiAuth', () => {
     ).rejects.toThrow('AWS UI authentication is enabled but not configured');
   });
 
-  it('redirects enabled unauthenticated users to the Cognito hosted UI', async () => {
-    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
-      const bytes = array as Uint8Array;
-      bytes.fill(1);
-      return array;
-    });
-    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(
-      new Uint8Array(32).buffer
-    );
-
-    await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(false);
-
-    expect(assignMock).toHaveBeenCalledTimes(1);
-    const target = new URL(assignMock.mock.calls[0][0]);
-    expect(target.origin).toBe('https://auth.example.test');
-    expect(target.pathname).toBe('/oauth2/authorize');
-    expect(target.searchParams.get('response_type')).toBe('code');
-    expect(target.searchParams.get('client_id')).toBe('client123');
-    expect(target.searchParams.get('redirect_uri')).toBe(
-      'https://app.example.test/'
-    );
-    expect(target.searchParams.get('scope')).toBe('openid email profile');
-  });
-
-  it('uses a configured redirectPath in the hosted UI redirect URL', async () => {
-    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
-      (array as Uint8Array).fill(1);
-      return array;
-    });
-    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
-
-    await ensureAwsUiAuth({ ...AUTH_CONFIG, redirectPath: '/callback' });
-
-    const target = new URL(assignMock.mock.calls[0][0]);
-    expect(target.searchParams.get('redirect_uri')).toBe(
-      'https://app.example.test/callback'
-    );
+  it('does not auto-redirect unauthenticated users — returns true to let React mount', async () => {
+    await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(true);
+    expect(assignMock).not.toHaveBeenCalled();
   });
 
   it('skips redirect when a valid session is already stored', async () => {
@@ -126,21 +86,15 @@ describe('ensureAwsUiAuth', () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
-  it('redirects back to Cognito when session is expired', async () => {
-    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
-      (array as Uint8Array).fill(1);
-      return array;
-    });
-    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
-
+  it('returns true without redirecting when session is expired', async () => {
     window.sessionStorage.setItem(
       'awsUiAuthSession',
       JSON.stringify({ idToken: 'tok', expiresAt: Date.now() - 1000 })
     );
 
     const result = await ensureAwsUiAuth(AUTH_CONFIG);
-    expect(result).toBe(false);
-    expect(assignMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(true);
+    expect(assignMock).not.toHaveBeenCalled();
   });
 
   it('throws UserCancelledError and cleans up URL when user cancels (access_denied)', async () => {
@@ -333,6 +287,49 @@ describe('ensureAwsUiAuth', () => {
         'AWS UI authentication token exchange failed: HTTP 500'
       );
     });
+  });
+});
+
+describe('signInWithCognito', () => {
+  const setupCrypto = () => {
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+      (array as Uint8Array).fill(1);
+      return array;
+    });
+    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
+  };
+
+  it('is a no-op when awsUiAuth is disabled', async () => {
+    await signInWithCognito({ enabled: false, domain: 'auth.example.test', clientId: 'client123' });
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when enabled but config is incomplete', async () => {
+    await expect(
+      signInWithCognito({ enabled: true, domain: 'auth.example.test' })
+    ).rejects.toThrow('AWS UI authentication is enabled but not configured');
+  });
+
+  it('redirects to the Cognito hosted UI', async () => {
+    setupCrypto();
+    await signInWithCognito(AUTH_CONFIG);
+
+    expect(assignMock).toHaveBeenCalledTimes(1);
+    const target = new URL(assignMock.mock.calls[0][0]);
+    expect(target.origin).toBe('https://auth.example.test');
+    expect(target.pathname).toBe('/oauth2/authorize');
+    expect(target.searchParams.get('response_type')).toBe('code');
+    expect(target.searchParams.get('client_id')).toBe('client123');
+    expect(target.searchParams.get('redirect_uri')).toBe('https://app.example.test/');
+    expect(target.searchParams.get('scope')).toBe('openid email profile');
+  });
+
+  it('uses a configured redirectPath in the hosted UI redirect URL', async () => {
+    setupCrypto();
+    await signInWithCognito({ ...AUTH_CONFIG, redirectPath: '/callback' });
+
+    const target = new URL(assignMock.mock.calls[0][0]);
+    expect(target.searchParams.get('redirect_uri')).toBe('https://app.example.test/callback');
   });
 });
 

--- a/frontend/tests/unit/loginClientId.test.tsx
+++ b/frontend/tests/unit/loginClientId.test.tsx
@@ -169,6 +169,55 @@ describe('Root login behaviour', () => {
     expect(loginRender).not.toHaveBeenCalled();
   });
 
+  it('shows login page when awsUiAuth is configured without Google', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() }),
+    }));
+
+    vi.doMock('@/api', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/api')>();
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          disable_auth: false,
+          google_auth_enabled: false,
+          google_client_id: '',
+        }),
+        getStoredAuthToken: vi.fn(() => null),
+      };
+    });
+
+    vi.doMock('@/awsUiAuth', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/awsUiAuth')>();
+      return { ...mod, getStoredCognitoIdToken: vi.fn(() => null) };
+    });
+
+    const loginRender = vi.fn(() => <div data-testid="login-page">login</div>);
+    vi.doMock('@/LoginPage', () => ({ default: loginRender }));
+
+    vi.doMock('@/App.tsx', () => ({
+      default: () => <div data-testid="app-shell">app-shell</div>,
+    }));
+
+    document.body.innerHTML = '<div id="root"></div>';
+    const { Root } = await import('@/main');
+
+    const awsUiAuth = {
+      enabled: true as const,
+      domain: 'https://auth.example.amazoncognito.com',
+      clientId: 'mock-cognito-client',
+    };
+
+    render(
+      <BrowserRouter>
+        <Root awsUiAuth={awsUiAuth} />
+      </BrowserRouter>
+    );
+
+    expect(await screen.findByTestId('login-page')).toBeInTheDocument();
+    expect(screen.queryByText(/google login is not configured/i)).toBeNull();
+  });
+
   it('keeps the support route reachable when auth is enforced but Google sign-in is unavailable', async () => {
     vi.doMock('react-dom/client', () => ({
       createRoot: () => ({ render: vi.fn() }),


### PR DESCRIPTION
## Summary

- Removes the silent Cognito redirect from `ensureAwsUiAuth()` so all visitors land on the React `LoginPage` instead of being bounced to Cognito before React mounts
- Exports `signInWithCognito()` as an explicit helper that callers invoke on user action
- Adds a **Sign in** button to `LoginPage` when `awsUiAuth` is enabled, alongside the existing Google Sign-In button and "Create account" link
- Initialises `Root`'s `authed` state from the stored Cognito session so returning users (post-callback) are not shown the login page again

## Test plan

- [ ] All 530 frontend unit tests pass (`npm --prefix frontend run test -- --run`)
- [ ] Lint clean (`npm --prefix frontend run lint`)
- [ ] Visiting the root URL renders the React `LoginPage` with a "Sign in" button and "Create account" link
- [ ] Clicking "Sign in" redirects to Cognito hosted UI
- [ ] Completing Cognito login returns to the app and grants access as before
- [ ] `/create-account` is reachable directly from the root URL
- [ ] Google Sign-In path is unaffected

Closes #4457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS Cognito Hosted UI sign-in is now available as an alternative to the existing sign-in method when configured.
  * The sign-in button is shown conditionally, and successful sessions can be detected via a stored Cognito ID token.
* **Bug Fixes**
  * Improved authentication gating logic and clearer login-failure handling when no configured sign-in method is available.
  * Better user-facing feedback for Hosted UI sign-in initiation errors.
* **Tests**
  * Added/updated unit coverage for the new Cognito sign-in scenarios and configuration combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->