### PR TITLE
Add Cognito logout functionality with visible logout button

### DIFF
--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -154,6 +154,25 @@ export const clearCognitoSession = (): void => {
   window.sessionStorage.removeItem(SESSION_KEY);
 };
 
+/**
+ * Initiates a Cognito logout by redirecting to the Cognito logout endpoint.
+ * This invalidates the user's Cognito session and redirects to the logout_uri.
+ */
+export const cognitoLogout = (config?: AwsUiAuthConfig | null): void => {
+  const domain = normaliseDomain(config?.domain ?? '');
+  const clientId = config?.clientId?.trim() ?? '';
+  if (!domain || !clientId) {
+    clearCognitoSession();
+    return;
+  }
+  const logoutUri = window.location.origin + (config?.redirectPath ?? '/');
+  const params = new URLSearchParams({
+    client_id: clientId,
+    logout_uri: logoutUri,
+  });
+  window.location.assign(`${domain}/logout?${params.toString()}`);
+};
+
 /** Epoch-ms expiry of the stored Cognito session, or null when none is stored. */
 export const getCognitoSessionExpiresAt = (): number | null => {
   const session = loadSession();

--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -156,15 +156,16 @@ export const clearCognitoSession = (): void => {
 
 /**
  * Initiates a Cognito logout by redirecting to the Cognito logout endpoint.
- * This invalidates the user's Cognito session and redirects to the logout_uri.
+ * Clears the local session before redirecting to ensure a clean state even if
+ * the redirect fails. The logout_uri must be pre-registered in the Cognito App
+ * Client's "Allowed sign-out URLs" setting.
  */
 export const cognitoLogout = (config?: AwsUiAuthConfig | null): void => {
   const domain = normaliseDomain(config?.domain ?? '');
   const clientId = config?.clientId?.trim() ?? '';
-  if (!domain || !clientId) {
-    clearCognitoSession();
-    return;
-  }
+  // Clear local session immediately, before any redirect
+  clearCognitoSession();
+  if (!domain || !clientId) return;
   const logoutUri = window.location.origin + (config?.redirectPath ?? '/');
   const params = new URLSearchParams({
     client_id: clientId,

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -92,10 +92,10 @@ export default function Menu({
           if (category.tabs.length > 0) return true;
           return (
             category.id === 'preferences' &&
-            (supportEnabled || (!familyMvpEnabled && Boolean(onLogout)))
+            (supportEnabled || Boolean(onLogout))
           );
         }),
-    [availableTabs, categoryDefinitions, familyMvpEnabled, onLogout, supportEnabled]
+    [availableTabs, categoryDefinitions, onLogout, supportEnabled]
   );
 
   const [openCategory, setOpenCategory] = useState<string | null>(null);
@@ -276,7 +276,7 @@ export default function Menu({
                       </Link>
                     </li>
                   )}
-                  {category.id === 'preferences' && !familyMvpEnabled && onLogout && (
+                  {category.id === 'preferences' && onLogout && (
                     <li key="logout">
                       <button
                         ref={(element) => assignFirstFocusable(element)}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -38,7 +38,7 @@ import { UserProvider, useUser } from './UserContext';
 import ErrorBoundary from './ErrorBoundary';
 import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage';
 import { RouteProvider } from './RouteContext';
-import { clearCognitoSession, ensureAwsUiAuth, extractTokenExchangeErrorReason, getCognitoSessionExpiresAt, getStoredCognitoIdToken, refreshCognitoSession, UserCancelledError, type AwsUiAuthConfig } from './awsUiAuth';
+import { clearCognitoSession, cognitoLogout, ensureAwsUiAuth, extractTokenExchangeErrorReason, getCognitoSessionExpiresAt, getStoredCognitoIdToken, refreshCognitoSession, UserCancelledError, type AwsUiAuthConfig } from './awsUiAuth';
 import {
   deriveBootstrapMode,
   deriveModeFromPathname,
@@ -167,7 +167,11 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
     setUser(null);
     setProfile(undefined);
     setAuthed(false);
-    navigate('/');
+    if (awsUiAuth?.enabled) {
+      cognitoLogout(awsUiAuth);
+    } else {
+      navigate('/');
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add `cognitoLogout()` function that redirects to Cognito logout endpoint to properly invalidate sessions
- Update logout flow to call `cognitoLogout` when Cognito auth is enabled
- Make logout button always visible when logout is available (removed MVP mode restriction)
- Show preferences menu category when logout is available, regardless of MVP mode

Closes #4483

## Why
Users on the AWS Cognito-authenticated deployment couldn't log out and log back in — the logout would only clear the local session but not invalidate the Cognito session, so they'd auto-login on the next page load without seeing the login screen.

## How it works
1. Click the **logout** button (in the Preferences menu)
2. Redirected to AWS Cognito's logout endpoint
3. Cognito session is invalidated
4. Redirected back to the login page
5. When you log in again, you see the full Cognito login screen (not auto-logged-in)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Cognito hosted UI logout support, redirecting users to Cognito’s logout endpoint when AWS UI authentication is enabled.

* **Bug Fixes**
  * Updated the preferences menu so the logout and support options appear based on the current configuration (support availability and whether a logout handler is provided).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->