### PR TITLE
fix: add img-src to CSP for external images

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -95,7 +95,7 @@ class StaticSiteStack(Stack):
                 "script-src 'self' https://accounts.google.com/gsi/client",
                 "frame-src 'self' https://accounts.google.com/gsi/",
                 f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazoncognito.com",
-                "img-src 'self' https://raw.githubusercontent.com https://www.gravatar.com https:",
+                "img-src 'self' https://raw.githubusercontent.com https://www.gravatar.com https://*.googleusercontent.com https://*.gravatar.com",
                 "frame-ancestors 'none'",
                 "object-src 'none'",
                 "base-uri 'self'",

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -95,6 +95,7 @@ class StaticSiteStack(Stack):
                 "script-src 'self' https://accounts.google.com/gsi/client",
                 "frame-src 'self' https://accounts.google.com/gsi/",
                 f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazoncognito.com",
+                "img-src 'self' https://raw.githubusercontent.com https://www.gravatar.com https:",
                 "frame-ancestors 'none'",
                 "object-src 'none'",
                 "base-uri 'self'",

--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -95,7 +95,7 @@ class StaticSiteStack(Stack):
                 "script-src 'self' https://accounts.google.com/gsi/client",
                 "frame-src 'self' https://accounts.google.com/gsi/",
                 f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazoncognito.com",
-                "img-src 'self' https://raw.githubusercontent.com https://www.gravatar.com https://*.googleusercontent.com https://*.gravatar.com",
+                "img-src 'self' https://raw.githubusercontent.com https://avatars.githubusercontent.com https://www.gravatar.com https://*.gravatar.com https://*.googleusercontent.com",
                 "frame-ancestors 'none'",
                 "object-src 'none'",
                 "base-uri 'self'",


### PR DESCRIPTION
## Summary
Fixes CSP violation blocking external image resources (GitHub, Gravatar, user avatars) on the deployed frontend.

## Changes
- Added `img-src` directive to CloudFront security headers CSP
- Allows HTTPS images from:
  - `raw.githubusercontent.com` (apple-touch-icon)
  - `www.gravatar.com` (fallback avatars)
  - All HTTPS sources (user profile pictures from identity providers)

## Related issue
Closes #4550

## Testing
- [x] CSP allows images from external sources
- [ ] Deployment with new CSP validated in production

## Notes
This fixes the CSP violation part of the deployment issue (#4550). The backend unavailability ('Backend service could not be reached') requires separate diagnosis — verify config.json has correct apiBaseUrl from StaticSiteStack deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the site’s Content Security Policy to broaden the permitted image sources. Images are now allowed from `raw.githubusercontent.com`, `avatars.githubusercontent.com`, `www.gravatar.com`, Gravatar subdomains, and `*.googleusercontent.com` (while retaining existing `https:` support).
  * This improves image loading compatibility for common third-party avatars and hosted images across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->