### PR TITLE
fix: strip CR/LF from log calls in accounts_store.py (CWE-117, #4562)

### DIFF
--- a/backend/common/accounts_store.py
+++ b/backend/common/accounts_store.py
@@ -92,6 +92,11 @@ def _default_person_payload(owner: str) -> Dict[str, Any]:
     }
 
 
+def _sanitize_log(value: str) -> str:
+    """Strip CR/LF from user-controlled values before passing them to logger calls (CWE-117)."""
+    return str(value).replace("\r", "").replace("\n", "")
+
+
 @dataclass
 class LocalAccountsStore:
     """On-disk, file-locked account document store (local dev / tests).
@@ -279,10 +284,10 @@ class S3AccountsStore:
             code = exc.response.get("Error", {}).get("Code", "")
             if code in {"NoSuchKey", "404", "NotFound"}:
                 return None
-            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, key, exc)
+            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, _sanitize_log(key), exc)
             return None
         except BotoCoreError as exc:
-            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, key, exc)
+            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, _sanitize_log(key), exc)
             return None
         body = obj.get("Body")
         text = body.read().decode("utf-8-sig").strip() if body else ""
@@ -375,8 +380,8 @@ class S3AccountsStore:
         if tx_data is None:
             logger.warning(
                 "Portfolio rebuild skipped for %s/%s: no transaction document",
-                owner,
-                account,
+                _sanitize_log(owner),
+                _sanitize_log(account),
             )
             return
         holdings_data = portfolio_loader.compute_holdings_from_transactions(tx_data, owner, account)
@@ -396,7 +401,7 @@ class S3AccountsStore:
             try:
                 resp = client.list_objects_v2(**kwargs)
             except (ClientError, BotoCoreError) as exc:
-                logger.warning("S3 list failed for s3://%s/%s: %s", self.bucket, prefix, exc)
+                logger.warning("S3 list failed for s3://%s/%s: %s", self.bucket, _sanitize_log(prefix), exc)
                 return
             for entry in resp.get("Contents", []) or []:
                 key = entry.get("Key")

--- a/tests/backend/common/test_accounts_store.py
+++ b/tests/backend/common/test_accounts_store.py
@@ -15,6 +15,7 @@ from backend.common.accounts_store import (
     WRITABLE_ACCOUNTS_PREFIX,
     LocalAccountsStore,
     S3AccountsStore,
+    _sanitize_log,
 )
 from backend.common.data_loader import ResolvedPaths
 from backend.config import config
@@ -180,7 +181,8 @@ def test_s3_store_ensure_owner_idempotent(s3_store):
     assert f"{WRITABLE_ACCOUNTS_PREFIX}/alice/person.json" in fake.objects
     # Second call must not overwrite / error.
     store.ensure_owner("alice")
-    person = json.loads(fake.objects[f"{WRITABLE_ACCOUNTS_PREFIX}/alice/person.json"].decode("utf-8"))
+    raw = fake.objects[f"{WRITABLE_ACCOUNTS_PREFIX}/alice/person.json"]
+    person = json.loads(raw.decode("utf-8"))
     assert person["owner"] == "alice"
 
 
@@ -263,7 +265,9 @@ def test_s3_store_rebuild_portfolio(s3_store) -> None:
     assert tickers == {"ABC", "CASH.GBP"}
 
 
-def test_s3_store_rebuild_portfolio_missing_transactions(s3_store, caplog: pytest.LogCaptureFixture) -> None:
+def test_s3_store_rebuild_portfolio_missing_transactions(
+    s3_store, caplog: pytest.LogCaptureFixture
+) -> None:
     """S3 rebuild warns and returns early when no transaction document exists."""
     store, _ = s3_store
     caplog.set_level(logging.WARNING, logger="accounts_store")
@@ -460,3 +464,74 @@ class TestS3Integration:
         doc = store.read_document(owner, "isa.json")
         assert doc is not None
         assert doc["holdings"][0]["ticker"] == "GOOG"
+
+
+# ---------------------------------------------------------------------------
+# Log injection sanitisation (issue #4562, CWE-117)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_log_strips_newlines():
+    assert _sanitize_log("evil\nINJECTED") == "evilINJECTED"
+    assert _sanitize_log("evil\rINJECTED") == "evilINJECTED"
+    assert _sanitize_log("evil\r\nINJECTED") == "evilINJECTED"
+
+
+def test_sanitize_log_leaves_safe_values_unchanged():
+    assert _sanitize_log("alice") == "alice"
+    assert _sanitize_log("writable-accounts/alice/isa.json") == "writable-accounts/alice/isa.json"
+
+
+def _assert_no_injected_newlines(caplog: pytest.LogCaptureFixture) -> None:
+    """Assert that no log record's formatted message contains a bare CR or LF."""
+    for record in caplog.records:
+        msg = record.getMessage()
+        assert "\n" not in msg, f"Log injection found in record: {msg!r}"
+        assert "\r" not in msg, f"Log injection found in record: {msg!r}"
+
+
+def test_s3_read_document_log_injection_stripped(caplog: pytest.LogCaptureFixture) -> None:
+    """A malicious owner with newlines must not produce injected log lines."""
+    from botocore.exceptions import ClientError
+
+    class _ErrorS3:
+        def get_object(self, Bucket, Key):  # noqa: N803
+            raise ClientError({"Error": {"Code": "ServiceUnavailable"}}, "GetObject")
+
+    store = S3AccountsStore(bucket="b", client=_ErrorS3())
+    caplog.set_level(logging.WARNING, logger="accounts_store")
+
+    store.read_document("evil\nINJECTED", "isa.json")
+
+    # sanitisation strips the newline; "evil\nINJECTED" becomes "evilINJECTED" in the log
+    _assert_no_injected_newlines(caplog)
+    assert caplog.records  # at least one warning was emitted
+
+
+def test_s3_rebuild_portfolio_log_injection_stripped(caplog: pytest.LogCaptureFixture) -> None:
+    """Malicious owner/account values must not appear as bare newlines in the log."""
+    store = S3AccountsStore(bucket="b", client=_FakeS3())
+    caplog.set_level(logging.WARNING, logger="accounts_store")
+
+    store.rebuild_portfolio("evil\nINJECTED", "isa\nFAKE")
+
+    _assert_no_injected_newlines(caplog)
+    assert caplog.records
+
+
+def test_s3_iter_keys_log_injection_stripped(caplog: pytest.LogCaptureFixture) -> None:
+    """A malicious S3 prefix must not produce injected log lines."""
+    from botocore.exceptions import BotoCoreError
+
+    class _FailS3(_FakeS3):
+        def list_objects_v2(self, Bucket, Prefix, **_):  # noqa: N803
+            raise BotoCoreError()
+
+    store = S3AccountsStore(bucket="b", client=_FailS3())
+    caplog.set_level(logging.WARNING, logger="accounts_store")
+
+    # list_owner_files calls _iter_keys with an owner-controlled prefix
+    store.list_owner_files("evil\nINJECTED")
+
+    _assert_no_injected_newlines(caplog)
+    assert caplog.records


### PR DESCRIPTION
## Summary

- Adds `_sanitize_log()` helper in `backend/common/accounts_store.py` that strips `\r` and `\n` from any string before it is passed to a `logging.*` call
- Applies the helper at all five CodeQL-flagged call sites (alerts #279, #280, #281, #288, #289) covering `S3AccountsStore.read_document`, `S3AccountsStore.rebuild_portfolio`, and `S3AccountsStore._iter_keys`
- Sanitisation is applied **only to the logging argument** — the underlying data values (`owner`, `account`, `key`, `prefix`) used in business logic are not modified

## Test plan

- [ ] `test_sanitize_log_strips_newlines` — unit-tests the helper directly
- [ ] `test_sanitize_log_leaves_safe_values_unchanged` — confirms safe values pass through unmodified
- [ ] `test_s3_read_document_log_injection_stripped` — passes `"evil\nINJECTED"` as owner; asserts no log record contains a bare newline
- [ ] `test_s3_rebuild_portfolio_log_injection_stripped` — same for `rebuild_portfolio`
- [ ] `test_s3_iter_keys_log_injection_stripped` — same for `_iter_keys` (via `list_owner_files`)
- [ ] `make lint` / `ruff check` passes clean (also fixed two pre-existing E501 lines in the test file)
- [ ] All 25 existing `test_accounts_store.py` tests still pass

Closes #4562

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability that prevented log injection attacks in account storage operations. User-supplied values are now properly sanitised before being logged, ensuring application log integrity cannot be compromised by malicious inputs. This protection applies across all account operations including read failures, portfolio rebuilds, and file management activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->