### PR TITLE
Upgrade starlette to >=1.3.1 to fix CVE-2026-54283 (DoS via urlencoded form parsing)

### DIFF
--- a/backend/requirements-lambda.txt
+++ b/backend/requirements-lambda.txt
@@ -30,7 +30,7 @@ charset-normalizer~=3.4.7
 fastparquet
 python-dateutil~=2.9.0post0
 certifi~=2026.5.20
-starlette~=1.2.1
+starlette~=1.3.1
 pydantic~=2.13.4
 requests>=2.34.2,<3
 peewee~=4.0.6

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,7 +37,7 @@ pyarrow~=24.0.0
 numexpr~=2.14.1
 python-dateutil~=2.9.0post0
 certifi~=2026.5.20
-starlette~=1.2.1
+starlette~=1.3.1
 
 pydantic~=2.13.4
 requests>=2.34.2,<3


### PR DESCRIPTION
Implement #4578

Closes #4578

## What changed
- Updated \starlette~=1.2.1\ to \starlette~=1.3.1\ in \ackend/requirements.txt\
- Updated \starlette~=1.2.1\ to \starlette~=1.3.1\ in \ackend/requirements-lambda.txt\

## Why changed
Dependabot alert #25: CVE-2026-54283 / GHSA-82w8-qh3p-5jfq — \equest.form()\ \max_fields\ and \max_part_size\ limits are silently ignored for \pplication/x-www-form-urlencoded\ bodies, enabling DoS attacks. The vulnerable range is \starlette >=0.4.1, <1.3.1\; the fix is in \1.3.1\.

## What was verified
- Diff confirmed only the two version bumps
- \uff check\ shows no new errors (215 pre-existing unrelated lint issues)
- Both files updated consistently

## Known risks / follow-up
- \~=1.3.1\ allows patch bumps within 1.3.x, which is the same pinning strategy as before
- No API-breaking changes between 1.2.1 and 1.3.1 per the Starlette changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend dependencies to the latest versions for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->