### PR TITLE
fix: hide Google GIS button when awsUiAuth.enabled — single sign-in path on AWS (#4637)

### DIFF
--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -30,7 +30,13 @@ export default function LoginPage({ clientId, awsUiAuth, onSuccess }: Props) {
   const [cognitoError, setCognitoError] = useState<string | null>(null);
   const awsUiAuthEnabled =
     awsUiAuth?.enabled === true || awsUiAuth?.enabled === 'true';
+
+  // Only load the Google GIS script when Cognito auth is not in use.
+  // On AWS, API Gateway uses a Cognito JWT authorizer so the Google-minted
+  // HS256 token is rejected before the Lambda runs (see #4256, #4637).
   useEffect(() => {
+    if (awsUiAuthEnabled) return;
+
     const script = document.createElement('script');
     script.src = 'https://accounts.google.com/gsi/client';
     script.async = true;
@@ -89,7 +95,7 @@ export default function LoginPage({ clientId, awsUiAuth, onSuccess }: Props) {
     return () => {
       document.head.removeChild(script);
     };
-  }, [clientId, onSuccess, setProfile, setUser]);
+  }, [awsUiAuthEnabled, clientId, onSuccess, setProfile, setUser]);
 
   return (
     <div
@@ -100,18 +106,8 @@ export default function LoginPage({ clientId, awsUiAuth, onSuccess }: Props) {
         marginTop: '2rem',
       }}
     >
-      {error && (
-        <div
-          role="alert"
-          aria-live="assertive"
-          style={{ color: 'red', marginBottom: '1rem' }}
-        >
-          Error: {error}
-        </div>
-      )}
-      <div id="google-signin"></div>
-      {awsUiAuthEnabled && (
-        <div style={{ marginTop: '1rem' }}>
+      {awsUiAuthEnabled ? (
+        <div>
           {cognitoError && (
             <div
               role="alert"
@@ -134,10 +130,23 @@ export default function LoginPage({ clientId, awsUiAuth, onSuccess }: Props) {
             Sign in
           </button>
         </div>
+      ) : (
+        <>
+          {error && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              style={{ color: 'red', marginBottom: '1rem' }}
+            >
+              Error: {error}
+            </div>
+          )}
+          <div id="google-signin"></div>
+        </>
       )}
       <p style={{ marginTop: '1rem' }}>
         Don&apos;t have an account?{' '}
-        <Link to="/create-account">Create account</Link>
+        <Link to="/create-account">Request access</Link>
       </p>
     </div>
   );

--- a/frontend/tests/unit/LoginPage.test.tsx
+++ b/frontend/tests/unit/LoginPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import { describe, it, expect, vi } from 'vitest'
 import LoginPage from '@/LoginPage'
+import type { AwsUiAuthConfig } from '@/awsUiAuth'
 
 vi.mock('@/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/api')>()
@@ -58,5 +59,42 @@ describe('LoginPage error handling', () => {
     expect(await screen.findByText(/bad/)).toBeInTheDocument()
 
     fetchMock.mockRestore()
+  })
+})
+
+describe('LoginPage awsUiAuth mode', () => {
+  it('shows only the Cognito sign-in button when awsUiAuth.enabled is true', () => {
+    const awsUiAuth: AwsUiAuthConfig = { enabled: true, clientId: 'test-pool-client' }
+
+    render(
+      <BrowserRouter>
+        <LoginPage clientId="" awsUiAuth={awsUiAuth} onSuccess={() => {}} />
+      </BrowserRouter>,
+    )
+
+    // Cognito sign-in button must be present
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+
+    // Google GIS script must NOT be injected
+    expect(
+      document.head.querySelector('script[src="https://accounts.google.com/gsi/client"]'),
+    ).toBeNull()
+
+    // Google sign-in container must NOT be rendered
+    expect(document.getElementById('google-signin')).toBeNull()
+  })
+
+  it('shows only the Google sign-in container when awsUiAuth is not enabled', () => {
+    render(
+      <BrowserRouter>
+        <LoginPage clientId="google-cid" onSuccess={() => {}} />
+      </BrowserRouter>,
+    )
+
+    // Google sign-in container must be present
+    expect(document.getElementById('google-signin')).toBeInTheDocument()
+
+    // Cognito sign-in button must NOT be rendered
+    expect(screen.queryByRole('button', { name: /sign in/i })).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- When `awsUiAuth.enabled` is `true` (deployed AWS stack), the Google Identity Services button is no longer rendered and its script is no longer injected. Users see only the Cognito hosted-UI sign-in button.
- When `awsUiAuth` is not enabled (local/dev with `disable_auth=true`), the Google GIS button is shown as before — no regression to that path.
- The "Request access" link (`/create-account`) is preserved in both branches so first-time users always have a visible route to the admin-approval flow.

## Root cause (from issue)

On the deployed AWS stack, API Gateway protects every route with a Cognito JWT authorizer. The Google-minted HS256 token is **rejected with 401 before the Lambda runs**, so a user who clicked "Sign in with Google" got `authed = true` in the SPA but every API call failed — forcing a second sign-in via the Cognito button.

## Changes

### `frontend/src/LoginPage.tsx`
- The `useEffect` that injects the Google GIS script now returns early when `awsUiAuthEnabled` is `true`.
- The JSX now uses an `awsUiAuthEnabled ? <CognitoSection> : <GoogleSection>` ternary, making the mutual exclusion explicit and removing the `#google-signin` div from the DOM on AWS.
- Added `awsUiAuthEnabled` to the `useEffect` dependency array.

### `frontend/tests/unit/LoginPage.test.tsx`
- New `LoginPage awsUiAuth mode` describe block with two tests:
  - Asserts Cognito "Sign in" button is present and no Google script/div exist when `awsUiAuth.enabled=true`.
  - Asserts `#google-signin` div is present and no Cognito button exists when `awsUiAuth` is absent.

## Test plan

- [x] All 532 existing unit tests pass (`npm --prefix frontend run test -- --run`)
- [x] New tests cover the mutual-exclusion behaviour
- [x] ESLint passes (`npm --prefix frontend run lint`)
- [ ] Manual: verify on deployed AWS app — Cognito button only, no Google button
- [ ] Manual: verify local dev (`disable_auth=true`) — Google button only, Cognito button absent

## Constraints respected

- Existing Cognito email/password users: unaffected (same hosted-UI redirect)
- Local/dev auth-disabled mode: unaffected (Google path unchanged)
- Admin-approval model (`self_sign_up_enabled=False`): unchanged
- No new deps, no CDK/infrastructure changes

Closes #4637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login now adapts to the selected authentication mode, showing the appropriate sign-in experience for Cognito or Google.
  * The account access link text has been updated to “Request access”.

* **Bug Fixes**
  * Prevented the Google sign-in script and related UI from loading when Cognito authentication is enabled.
  * Ensured the non-Cognito sign-in elements only appear when relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->