### PR TITLE
fix: guard CsvImportForm on account existence, not familyMvpEnabled

### DIFF
--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -400,7 +400,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
               />
             </div>
           )}
-          {!familyMvpEnabled && (
+          {data.accounts.length > 0 && (
             <div className="mb-6">
               <CsvImportForm
                 owner={data.owner}

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -99,6 +99,72 @@ describe("PortfolioView", () => {
         expect(screen.getByLabelText(/account type/i)).toBeInTheDocument();
     });
 
+    it("shows the CSV import form when accounts exist", () => {
+        render(<PortfolioView data={mockOwner} />);
+
+        expect(screen.getByText(/import csv/i)).toBeInTheDocument();
+    });
+
+    it("hides the CSV import form when no accounts exist", () => {
+        const emptyOwner: Portfolio = { ...mockOwner, accounts: [] };
+
+        render(<PortfolioView data={emptyOwner} />);
+
+        expect(screen.queryByText(/import csv/i)).not.toBeInTheDocument();
+    });
+
+    it("shows the CSV import form when accounts exist regardless of familyMvpEnabled", () => {
+        render(
+            <configContext.Provider
+                value={{
+                    relativeViewEnabled: false,
+                    tabs: {
+                        group: true,
+                        market: true,
+                        owner: true,
+                        instrument: true,
+                        performance: true,
+                        transactions: true,
+                        screener: true,
+                        trading: true,
+                        timeseries: true,
+                        watchlist: true,
+                        allocation: true,
+                        rebalance: true,
+                        movers: true,
+                        instrumentadmin: true,
+                        dataadmin: true,
+                        virtual: true,
+                        research: true,
+                        support: true,
+                        settings: true,
+                        profile: false,
+                        alerts: true,
+                        pension: true,
+                        trail: false,
+                        alertsettings: true,
+                        taxtools: false,
+                        "trade-compliance": false,
+                        reports: false,
+                        scenario: false,
+                    },
+                    theme: "system",
+                    baseCurrency: "GBP",
+                    enableAdvancedAnalytics: true,
+                    familyMvpEnabled: true,
+                    disabledTabs: [],
+                    refreshConfig: async () => {},
+                    setRelativeViewEnabled: () => {},
+                    setBaseCurrency: () => {},
+                }}
+            >
+                <PortfolioView data={mockOwner} />
+            </configContext.Provider>,
+        );
+
+        expect(screen.getByText(/import csv/i)).toBeInTheDocument();
+    });
+
     it("hides advanced analytics panels when feature flag is disabled", () => {
         render(
             <configContext.Provider


### PR DESCRIPTION
## Summary

- Changed the `CsvImportForm` rendering guard in `PortfolioView.tsx` from `!familyMvpEnabled` to `data.accounts.length > 0`
- The old guard incorrectly hid CSV import for users with accounts when `familyMvpEnabled=true`
- The new condition shows the form whenever accounts exist, regardless of the family MVP feature flag

## Test plan

- [x] `shows the CSV import form when accounts exist` — new test
- [x] `hides the CSV import form when no accounts exist` — new test
- [x] `shows the CSV import form when accounts exist regardless of familyMvpEnabled` — new test covering the key regression case
- [x] All 533 frontend tests pass
- [x] ESLint clean

Closes #4392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CSV import option now appears only when accounts are available, preventing it from showing on empty portfolios.
  * CSV import remains visible for portfolios with accounts, including when family-related settings are enabled.
* **Tests**
  * Added coverage for CSV import visibility with accounts present, no accounts present, and enabled family settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->