### PR TITLE
fix: Family MVP controls only the default landing page, not route access (#4641)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,7 +63,7 @@ import {
   downloadInstrumentsCsv,
   printInstrumentsPdf,
 } from './lib/instrumentExports';
-import { getFamilyMvpEntryPath, isFamilyMvpMode } from './familyMvp';
+import { getFamilyMvpEntryPath } from './familyMvp';
 
 const PerformanceDashboard = lazyWithDelay(
   () => import('./components/PerformanceDashboard')
@@ -131,9 +131,12 @@ export function getFamilyMvpRedirectPath(
   if (!familyMvpEnabled) {
     return null;
   }
-  // Family MVP redirect policy:
-  // - Bare root lands on the configured entry flow.
-  // - Any other non-MVP route gets sent to that same entry flow.
+  // Family MVP redirect policy (#4641):
+  // - Family MVP controls ONLY the default landing page. The single redirect we
+  //   keep sends the bare root ('/' with no query) to the configured entry flow.
+  // - Every other route is left untouched: enabled tabs (search, settings, …)
+  //   must be fully navigable. Truly disabled tabs are handled separately by the
+  //   tab gating in the route-sync effect, which redirects them to '/'.
   // - If every Family MVP tab is disabled, leave route selection to the caller.
   //
   // This is intentionally separate from getOwnerRootRedirectPath, which only
@@ -143,11 +146,6 @@ export function getFamilyMvpRedirectPath(
   }
   if (pathname === '/' && !search) {
     return entryPath;
-  }
-
-  const routeMode = deriveModeFromPathname(pathname);
-  if (!isFamilyMvpMode(routeMode)) {
-    return pathname === entryPath ? null : entryPath;
   }
   return null;
 }
@@ -265,9 +263,10 @@ export default function App({ onLogout }: AppProps) {
   );
   const selectedOwnerIsGroup = selectedOwnerGroup !== null;
 
-  // Redirect to the Family MVP entry path whenever the current route is not
-  // in FAMILY_MVP_MODES. Fires on every location change and whenever the
-  // config (and therefore familyMvpEnabled / familyMvpEntryPath) resolves.
+  // Redirect the bare root to the Family MVP entry path (the only Family MVP
+  // redirect that remains — see getFamilyMvpRedirectPath, #4641). Fires on every
+  // location change and whenever the config (and therefore familyMvpEnabled /
+  // familyMvpEntryPath) resolves.
   useEffect(() => {
     const redirectPath = getFamilyMvpRedirectPath(
       location.pathname,
@@ -614,7 +613,7 @@ export default function App({ onLogout }: AppProps) {
         )}
 
         {/* GROUP VIEW */}
-        {mode === 'group' && selectedGroup && (!familyMvpEnabled || !familyMvpEntryPath) && (
+        {mode === 'group' && selectedGroup && (
           <>
             <ComplianceWarnings owners={selectedGroupSummary?.members ?? []} />
             <GroupPortfolioView slug={selectedGroup} owners={owners} />
@@ -708,7 +707,7 @@ export default function App({ onLogout }: AppProps) {
         {mode === 'allocation' && <AllocationCharts />}
         {mode === 'rebalance' && <Rebalance />}
         {mode === 'market' && <MarketOverview />}
-        {mode === 'movers' && (!familyMvpEnabled || !familyMvpEntryPath) && <TopMovers />}
+        {mode === 'movers' && <TopMovers />}
         {mode === 'reports' &&
           (isReportCreationRoute ? <ReportTemplateCreator /> : <Reports />)}
         {mode === 'alerts' && <Alerts />}

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -9,7 +9,6 @@ import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useConfig } from '../ConfigContext';
 import type { TabPluginId } from '../tabPlugins';
-import { isFamilyMvpMode } from '../familyMvp';
 import { SUPPORT_TABS } from '../tabPlugins';
 import {
   buildPathForMode,
@@ -47,9 +46,10 @@ export default function Menu({
   const mode = deriveModeFromPathname(location.pathname) as TabPluginId;
   const isSupportMode = (SUPPORT_TABS as readonly string[]).includes(mode);
   const inSupport = mode === 'support';
-  // Support link is only shown for non-MVP users who have the support tab enabled.
-  // (Previously gated by isFamilyMvpMode('support') which always returned false
-  // because 'support' is not in FAMILY_MVP_MODES — this is equivalent but explicit.)
+  // Support link is shown whenever the support tab is enabled. It stays gated on
+  // !familyMvpEnabled because the support section is a distinct operations surface
+  // (not a normal config tab); Family MVP keeps that surface out of the simplified
+  // experience. Tab navigability itself is governed purely by config (#4641).
   const supportEnabled =
     !familyMvpEnabled &&
     tabs.support !== false &&
@@ -74,11 +74,12 @@ export default function Menu({
           return false;
         }
 
-        // In Family MVP mode, only show tabs that are in FAMILY_MVP_MODES.
-        const modeAllowed = !familyMvpEnabled || isFamilyMvpMode(entry.mode);
-        return modeAllowed && tabs[entry.mode] === true && !disabledTabs?.includes(entry.mode);
+        // Family MVP no longer restricts which tabs appear (#4641): every tab
+        // enabled in config is navigable from the menu. Visibility is driven
+        // purely by the config tab gating below.
+        return tabs[entry.mode] === true && !disabledTabs?.includes(entry.mode);
       }),
-    [disabledTabs, familyMvpEnabled, inSupport, isSupportMode, tabs]
+    [disabledTabs, inSupport, isSupportMode, tabs]
   );
 
   const categoriesToRender = useMemo<CategorizedMenu[]>(

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -400,14 +400,14 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
               />
             </div>
           )}
-          {!familyMvpEnabled && (
-            <div className="mb-6">
-              <CsvImportForm
-                owner={data.owner}
-                accountTypes={data.accounts.map((acct) => acct.account_type)}
-              />
-            </div>
-          )}
+          {/* CSV import is available in all modes (#4392/#4641): setting up
+              accounts/positions is part of the Family MVP experience too. */}
+          <div className="mb-6">
+            <CsvImportForm
+              owner={data.owner}
+              accountTypes={data.accounts.map((acct) => acct.account_type)}
+            />
+          </div>
           {hasWarnings && (
             <div className="mb-4">
               <Link

--- a/frontend/src/familyMvp.ts
+++ b/frontend/src/familyMvp.ts
@@ -1,22 +1,16 @@
 import type { TabsConfig } from './ConfigContext';
 import { isModeEnabled } from './pageManifest';
-import type { Mode } from './modes';
 
 /**
- * Routes that are permitted in the Family MVP experience.
- *   'owner'        — portfolio view (/portfolio/:owner)
- *   'transactions' — transaction history / input screen (/transactions)
+ * Family MVP affects exactly one thing: the default landing page.
  *
- * All other modes are redirected to the configured MVP entry path when
- * familyMvpEnabled is true. 'performance' was deliberately removed from
- * this set in #2725 — it is a non-MVP route.
- */
-export const FAMILY_MVP_MODES: ReadonlySet<Mode> = new Set<Mode>([
-  'transactions',
-  'owner',
-]);
-
-/**
+ * It does NOT restrict which routes a user may reach. Any tab that is enabled
+ * in config is fully navigable; route reachability is governed solely by the
+ * tab gating in App.tsx (isModeEnabled / tabs / disabledTabs). The previous
+ * FAMILY_MVP_MODES allowlist + isFamilyMvpMode redirect guard were removed in
+ * #4641 because they silently bounced enabled tabs (search, settings, …) back
+ * to the entry path.
+ *
  * Ordered list of entry-path candidates for the Family MVP experience.
  * The first enabled candidate wins (see getFamilyMvpEntryPath).
  *
@@ -32,10 +26,6 @@ const FAMILY_MVP_ENTRY_CANDIDATES = [
   { mode: 'owner', path: '/portfolio' },
   { mode: 'performance', path: '/performance' },
 ] as const;
-
-export function isFamilyMvpMode(mode: Mode): boolean {
-  return FAMILY_MVP_MODES.has(mode);
-}
 
 export function getFamilyMvpEntryPath(
   tabs: TabsConfig,

--- a/frontend/tests/unit/App.familyMvpRedirect.test.tsx
+++ b/frontend/tests/unit/App.familyMvpRedirect.test.tsx
@@ -111,7 +111,9 @@ describe("App family MVP redirects", () => {
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
   });
 
-  it("hides movers page content when family MVP is enabled and an entry route exists", async () => {
+  it("renders movers page content when family MVP is enabled and the movers tab is enabled", async () => {
+    // #4641: Family MVP no longer hides enabled tabs. With movers enabled the
+    // page must render instead of being bounced back to the entry path.
     mockConfig({
       configLoaded: true,
       familyMvpEnabled: true,
@@ -119,6 +121,7 @@ describe("App family MVP redirects", () => {
       tabs: {
         ...baseConfig.tabs,
         owner: true,
+        movers: true,
       },
     });
 
@@ -128,11 +131,10 @@ describe("App family MVP redirects", () => {
 
     await mockCommonAppDependencies();
 
-    await renderAppAt("/movers");
+    const router = await renderAppAt("/movers");
 
-    await waitFor(() => {
-      expect(screen.queryByRole("heading", { name: /movers/i })).not.toBeInTheDocument();
-    });
+    expect(await screen.findByRole("heading", { name: /movers/i })).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe("/movers");
   });
 
   it("renders movers page content when family MVP is disabled", async () => {
@@ -181,7 +183,9 @@ describe("App family MVP redirects", () => {
     expect(await screen.findByRole("heading", { name: /movers/i })).toBeInTheDocument();
   });
 
-  it("hides group view content when family MVP is enabled and an entry route exists", async () => {
+  it("renders group view content when family MVP is enabled and the group tab is enabled", async () => {
+    // #4641: an enabled group tab is reachable in Family MVP mode. The bare-root
+    // redirect only fires for '/' with no query, so '/?group=kids' stays put.
     mockConfig({
       configLoaded: true,
       familyMvpEnabled: true,
@@ -189,6 +193,7 @@ describe("App family MVP redirects", () => {
       tabs: {
         ...baseConfig.tabs,
         owner: true,
+        group: true,
       },
     });
 
@@ -198,10 +203,91 @@ describe("App family MVP redirects", () => {
 
     await mockCommonAppDependencies();
 
-    await renderAppAt("/?group=kids");
+    const router = await renderAppAt("/?group=kids");
+
+    expect(await screen.findByText("Group Portfolio View")).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe("/");
+    expect(router.state.location.search).toBe("?group=kids");
+  });
+
+  it("does not bounce /research/:ticker back to the entry path in Family MVP mode", async () => {
+    // The reported bug (#4641): the header search bar navigates to /research/:t,
+    // which Family MVP previously reverted to /input. With research enabled it
+    // must now stay on the research route.
+    mockConfig({
+      configLoaded: true,
+      familyMvpEnabled: true,
+      disabledTabs: [],
+      tabs: {
+        ...baseConfig.tabs,
+        owner: true,
+        research: true,
+      },
+    });
+
+    await mockCommonAppDependencies();
+
+    const router = await renderAppAt("/research/MSFT");
 
     await waitFor(() => {
-      expect(screen.queryByText("Group Portfolio View")).not.toBeInTheDocument();
+      const marker = screen.getByTestId("active-route-marker");
+      expect(marker).toHaveAttribute("data-mode", "research");
     });
+    expect(router.state.location.pathname).toBe("/research/MSFT");
+  });
+
+  it("does not bounce /settings back to the entry path in Family MVP mode", async () => {
+    // The avatar/user-settings link targets /settings, also previously reverted.
+    mockConfig({
+      configLoaded: true,
+      familyMvpEnabled: true,
+      disabledTabs: [],
+      tabs: {
+        ...baseConfig.tabs,
+        owner: true,
+        settings: true,
+      },
+    });
+
+    await mockCommonAppDependencies();
+
+    const router = await renderAppAt("/settings");
+
+    await waitFor(() => {
+      const marker = screen.getByTestId("active-route-marker");
+      expect(marker).toHaveAttribute("data-mode", "settings");
+    });
+    expect(router.state.location.pathname).toBe("/settings");
+  });
+
+  it("still redirects a disabled tab away in Family MVP mode", async () => {
+    // Tab gating remains the source of truth: a disabled tab is unreachable and
+    // is redirected off its route (to '/', then onward to the entry path).
+    mockConfig({
+      configLoaded: true,
+      familyMvpEnabled: true,
+      disabledTabs: ["movers"],
+      tabs: {
+        ...baseConfig.tabs,
+        owner: true,
+        movers: false,
+      },
+    });
+
+    vi.doMock("@/pages/TopMovers", () => ({
+      default: () => <h1>Movers</h1>,
+    }));
+
+    await mockCommonAppDependencies();
+
+    await renderAppAt("/movers");
+
+    // The disabled-tab guard flips the mode off 'movers' (to the default 'group'
+    // view) and the movers content never renders.
+    await waitFor(() => {
+      const marker = screen.getByTestId("active-route-marker");
+      expect(marker).not.toHaveAttribute("data-mode", "movers");
+    });
+    expect(screen.queryByRole("heading", { name: /movers/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/ConfigContext.familyMvp.test.tsx
+++ b/frontend/tests/unit/ConfigContext.familyMvp.test.tsx
@@ -78,7 +78,8 @@ describe("ConfigProvider Family MVP gating", () => {
       );
 
       expect(probe.getAttribute("data-config-loaded")).toBe("true");
-      // transactions is in FAMILY_MVP_MODES — it is an allowed MVP route, not gated
+      // transactions stays enabled — Family MVP only force-disables the optional
+      // feature tabs below; it does not gate the core transactions route.
       expect(tabs["trade-compliance"]).toBe(false);
       expect(tabs.trail).toBe(false);
       expect(tabs.taxtools).toBe(false);
@@ -127,7 +128,8 @@ describe("ConfigProvider Family MVP gating", () => {
       expect(disabledTabs.has("trade-compliance")).toBe(false);
       expect(disabledTabs.has("reports")).toBe(false);
       expect(disabledTabs.has("scenario")).toBe(false);
-      // transactions is in FAMILY_MVP_MODES — it is an allowed MVP route, not gated
+      // transactions stays enabled — Family MVP only force-disables the optional
+      // feature tabs below; it does not gate the core transactions route.
     });
   });
 

--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -110,7 +110,10 @@ describe('Menu', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('hides support toggle when support tab disabled', () => {
+  it('hides the support link when the support tab is disabled', () => {
+    // The preferences category still renders (settings, logout) — but the
+    // Support link inside it must be absent when the support tab is disabled.
+    const onLogout = vi.fn();
     const config: ConfigContextValue = {
       relativeViewEnabled: false,
       disabledTabs: ['support'],
@@ -147,15 +150,21 @@ describe('Menu', () => {
     render(
       <configContext.Provider value={config}>
         <MemoryRouter>
-          <Menu />
+          <Menu onLogout={onLogout} />
         </MemoryRouter>
       </configContext.Provider>
     );
+    const preferencesToggle = screen.getByRole('button', {
+      name: i18n.t('app.menuCategories.preferences'),
+    });
+    fireEvent.click(preferencesToggle);
     expect(
-      screen.queryByRole('button', {
-        name: i18n.t('app.menuCategories.preferences'),
-      })
-    ).toBeNull();
+      screen.queryByRole('menuitem', { name: i18n.t('app.supportLink') })
+    ).not.toBeInTheDocument();
+    // Logout remains available in the same category.
+    expect(
+      screen.getByRole('menuitem', { name: i18n.t('app.logout') })
+    ).toBeInTheDocument();
   });
 
   it('renders logout button when callback provided', async () => {
@@ -236,11 +245,45 @@ describe('Menu', () => {
     expect(list).toHaveClass('gap-2');
   });
 
-  it('does not render non-MVP menu categories', () => {
-    // familyMvpEnabled: true is required — the context default is false ("fail open")
-    // so an explicit provider is needed for the MVP-gating assertion to hold.
+  it('renders enabled menu categories in Family MVP mode (#4641)', () => {
+    // Family MVP no longer hides categories: insights/goals tabs are enabled in
+    // familyMvpConfig, so their category toggles must appear.
     render(
       <configContext.Provider value={familyMvpConfig}>
+        <MemoryRouter>
+          <Menu />
+        </MemoryRouter>
+      </configContext.Provider>
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: i18n.t('app.menuCategories.insights'),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: i18n.t('app.menuCategories.goals') })
+    ).toBeInTheDocument();
+  });
+
+  it('hides menu categories whose tabs are all disabled, even in Family MVP mode', () => {
+    // Visibility is driven purely by config: disable every insights/goals tab and
+    // those categories disappear regardless of Family MVP being enabled.
+    const config: ConfigContextValue = {
+      ...familyMvpConfig,
+      tabs: {
+        ...familyMvpConfig.tabs,
+        instrument: false,
+        screener: false,
+        trading: false,
+        watchlist: false,
+        rebalance: false,
+        scenario: false,
+        pension: false,
+      },
+    };
+    render(
+      <configContext.Provider value={config}>
         <MemoryRouter>
           <Menu />
         </MemoryRouter>

--- a/frontend/tests/unit/familyMvpRedirect.test.ts
+++ b/frontend/tests/unit/familyMvpRedirect.test.ts
@@ -35,46 +35,42 @@ const baseTabs: TabsConfig = {
 };
 
 describe('getFamilyMvpRedirectPath', () => {
+  // #4641: Family MVP controls ONLY the default landing page. The bare root
+  // ('/' with no query) redirects to the entry path; every other route — even
+  // non-MVP routes like /market, /support, /research — is left untouched so
+  // enabled tabs stay fully navigable.
+
   it('does not redirect when family MVP is disabled', () => {
     expect(getFamilyMvpRedirectPath('/market', '', false)).toBeNull();
     expect(getFamilyMvpRedirectPath('/performance/alex', '', false)).toBeNull();
+    expect(getFamilyMvpRedirectPath('/', '', false, '/transactions')).toBeNull();
   });
 
-  it('redirects non-MVP routes to transactions', () => {
-    // Pass '/transactions' explicitly — the default entryPath is '/portfolio';
-    // at runtime familyMvpEntryPath is always computed and passed explicitly.
-    expect(getFamilyMvpRedirectPath('/market', '', true, '/transactions')).toBe('/transactions');
-    expect(getFamilyMvpRedirectPath('/support', '', true, '/transactions')).toBe('/transactions');
-    expect(getFamilyMvpRedirectPath('/performance/alex', '', true, '/transactions')).toBe('/transactions');
+  it('redirects bare root to the configured entry path', () => {
+    expect(getFamilyMvpRedirectPath('/', '', true, '/transactions')).toBe('/transactions');
+    expect(getFamilyMvpRedirectPath('/', '', true, '/portfolio')).toBe('/portfolio');
+    expect(getFamilyMvpRedirectPath('/', '', true, '/performance')).toBe('/performance');
+  });
+
+  it('does NOT redirect non-MVP routes back to the entry path', () => {
+    // Previously these bounced to the entry path; now they must stay put so the
+    // search bar, settings link and other enabled tabs work in Family MVP mode.
+    expect(getFamilyMvpRedirectPath('/market', '', true, '/transactions')).toBeNull();
+    expect(getFamilyMvpRedirectPath('/support', '', true, '/transactions')).toBeNull();
+    expect(getFamilyMvpRedirectPath('/performance/alex', '', true, '/transactions')).toBeNull();
+    expect(getFamilyMvpRedirectPath('/research/MSFT', '', true, '/transactions')).toBeNull();
+    expect(getFamilyMvpRedirectPath('/settings', '', true, '/transactions')).toBeNull();
   });
 
   it('does not redirect MVP routes', () => {
     expect(getFamilyMvpRedirectPath('/transactions', '', true)).toBeNull();
     expect(getFamilyMvpRedirectPath('/portfolio/alex', '', true)).toBeNull();
-  });
-
-  it('redirects bare root to the configured entry path', () => {
-    expect(getFamilyMvpRedirectPath('/', '', true, '/transactions')).toBe('/transactions');
-  });
-
-  it('redirects group query routes to the entry path because group mode is non-MVP', () => {
-    expect(getFamilyMvpRedirectPath('/', '?group=kids', true, '/transactions')).toBe('/transactions');
-  });
-
-  it('redirects non-MVP routes to an explicit entry path override', () => {
-    expect(getFamilyMvpRedirectPath('/market', '', true, '/portfolio')).toBe('/portfolio');
-    expect(getFamilyMvpRedirectPath('/support', '', true, '/portfolio')).toBe('/portfolio');
-  });
-
-  it('does not redirect MVP routes regardless of entry path', () => {
     expect(getFamilyMvpRedirectPath('/portfolio', '', true, '/portfolio')).toBeNull();
-    expect(getFamilyMvpRedirectPath('/transactions', '', true)).toBeNull();
-    expect(getFamilyMvpRedirectPath('/portfolio/alex', '', true)).toBeNull();
   });
 
-  it('supports overriding the entry path when a different MVP route is enabled', () => {
-    expect(getFamilyMvpRedirectPath('/', '', true, '/performance')).toBe('/performance');
-    expect(getFamilyMvpRedirectPath('/support', '', true, '/transactions')).toBe('/transactions');
+  it('does not redirect a group query route (it carries a query string)', () => {
+    // '/' only redirects when there is no search; '/?group=kids' is left alone.
+    expect(getFamilyMvpRedirectPath('/', '?group=kids', true, '/transactions')).toBeNull();
   });
 
   it('skips redirecting when every family MVP route is disabled (null entryPath)', () => {


### PR DESCRIPTION
## Summary

On the deployed demo (Family MVP mode), the header **search bar** and **avatar/user-settings** link silently no-op'd: clicking a search result or the avatar bounced the user straight back to `/input`. Root cause was the Family MVP redirect, which sent every route whose mode was not in `FAMILY_MVP_MODES` back to the entry path.

Per the owner's decision on #4641 (2026-06-26), this supersedes the original Option A/B framing: **`familyMvpEnabled` should decide only the default landing page, not which routes a user may reach.** Any tab enabled in config is now fully navigable; only the bare root (`/` with no query) still redirects to the entry path. Truly disabled tabs remain unreachable via the existing tab gating.

## Changes

- **`frontend/src/App.tsx`** — `getFamilyMvpRedirectPath` keeps only the bare-root redirect; the `FAMILY_MVP_MODES` allowlist branch is removed. The `familyMvpEnabled` render guards on the **movers** and **group** views are removed so enabled tabs render instead of going blank.
- **`frontend/src/familyMvp.ts`** — removes the now-redundant `FAMILY_MVP_MODES` set and `isFamilyMvpMode`; keeps `getFamilyMvpEntryPath` for default-landing resolution.
- **`frontend/src/components/Menu.tsx`** — drops the `isFamilyMvpMode` allowlist so enabled tabs appear in the menu; visibility is now driven purely by config tab gating. The support-link gate is unchanged (the support section is a distinct operations surface).
- **`frontend/src/components/PortfolioView.tsx`** — un-gates `CsvImportForm` (closes #4392): account/position setup is part of the Family MVP experience.
- **Tests** — rewrite the redirect/menu expectations for the new behaviour and add coverage asserting `/research/:ticker` and `/settings` are **not** bounced under `familyMvpEnabled`, while a **disabled** tab still redirects away. Logout-visibility coverage (#4490) stays green.

## Verification

- `npm --prefix frontend run lint` — clean
- `npx tsc --noEmit` — clean
- Full vitest suite — **535 passed**
- Smoke tests run with `enable_family_mvp: false`, so this change (which only alters behaviour when `familyMvpEnabled` is true) does not affect them.

## Success criteria (from the issue)

- ✅ In Family MVP mode, search (`/research/:t`) and settings (`/settings`) load instead of bouncing to `/input`.
- ✅ Logout still works in both modes.
- ✅ Non-MVP mode unaffected (search/settings/notifications still work).
- ✅ New automated tests cover the behaviour; lint and frontend tests pass.

Closes #4641
Closes #4392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Family MVP now redirects only from the bare home page to the configured entry page; other routes stay on the page you opened.
  * Group, Top Movers, and CSV import views now appear when available, even in Family MVP mode.
  * Menu categories and tabs now respect current configuration more consistently, including support-link visibility and disabled tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->