### PR TITLE
ci: add Dependabot pass-through job to AI review workflows

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -30,6 +30,7 @@ jobs:
   dependabot-pass:
     name: ai-review
     if: github.actor == 'dependabot[bot]'
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - run: echo "Dependabot PR — Claude review not required, passing."

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,3 +23,13 @@ jobs:
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
       gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Dependabot PRs skip the review job above, which GitHub records as "skipped"
+  # rather than "success". If this check is required, Dependabot PRs are blocked.
+  # This pass-through job runs instead and satisfies the required check.
+  dependabot-pass:
+    name: ai-review
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Dependabot PR — Claude review not required, passing."

--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -37,3 +37,13 @@ jobs:
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
       gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Dependabot PRs skip the review job above, which GitHub records as "skipped"
+  # rather than "success". If this check is required, Dependabot PRs are blocked.
+  # This pass-through job runs instead and satisfies the required check.
+  dependabot-pass:
+    name: ai-review
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Dependabot PR — DeepSeek review not required, passing."

--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -44,6 +44,7 @@ jobs:
   dependabot-pass:
     name: ai-review
     if: github.actor == 'dependabot[bot]'
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - run: echo "Dependabot PR — DeepSeek review not required, passing."

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -29,6 +29,7 @@ jobs:
   dependabot-pass:
     name: ai-review
     if: github.actor == 'dependabot[bot]'
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - run: echo "Dependabot PR — GPT review not required, passing."

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -22,3 +22,13 @@ jobs:
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
       gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Dependabot PRs skip the review job above, which GitHub records as "skipped"
+  # rather than "success". If this check is required, Dependabot PRs are blocked.
+  # This pass-through job runs instead and satisfies the required check.
+  dependabot-pass:
+    name: ai-review
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Dependabot PR — GPT review not required, passing."


### PR DESCRIPTION
## Summary

Dependabot PRs were blocked because the `ai-review` job was skipped by the `dependabot[bot]` guard, and GitHub records skipped jobs as "skipped" (not "success") — which doesn't satisfy a required branch-protection check.

- Adds a sibling `dependabot-pass` job to each of the three AI review caller workflows (`deepseek-pr-review.yml`, `claude-pr-review.yml`, `gpt-pr-review.yml`)
- The job is named `ai-review` (matching the required check name) and runs only for Dependabot PRs, exiting immediately with success
- Non-Dependabot PRs are unaffected — the full review still runs

## Test plan
- [ ] Confirm an existing Dependabot PR (e.g. #4651) now shows the `ai-review` checks as **passed** (green) rather than skipped after this merges and the next Dependabot sync triggers the workflows
- [ ] Confirm a normal human PR still gets the full AI review as before

Closes #4668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request check handling for Dependabot updates so required review checks complete successfully instead of remaining skipped.
  * Applied the same Dependabot-specific fallback across multiple automated review workflows for consistent status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->