### PR TITLE
fix: re-show login on 401 instead of looping on a stale auth token

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -129,6 +129,17 @@ const defaultGetCsrfToken = () =>
         .find((row) => row.startsWith("csrftoken="))
         ?.split("=")[1] || null;
 
+/**
+ * Dispatched on `window` whenever an API call receives HTTP 401. A stored
+ * auth token (Cognito ID token or backend JWT) can go stale independently of
+ * the app's in-memory auth state — e.g. localStorage persists it past the
+ * ~1h Cognito ID token lifetime, or past a Cognito session that sessionStorage
+ * already dropped on tab close. Listening for this event lets the app clear
+ * the stale credential and re-show the login screen instead of retrying the
+ * same rejected token forever.
+ */
+export const UNAUTHORIZED_EVENT = "allotmint:unauthorized";
+
 export function createClient(
   base: string | (() => string),
   token: string | null = null,
@@ -226,6 +237,9 @@ export function createClient(
       credentials: "include",
     });
     if (!res.ok) {
+      if (res.status === 401 && typeof window !== "undefined") {
+        window.dispatchEvent(new Event(UNAUTHORIZED_EVENT));
+      }
       const err = new Error(`HTTP ${res.status} - ${res.statusText} (${safeUrl})`);
       (err as any).status = res.status;
       (err as any).headers = res.headers;

--- a/frontend/src/components/BackendUnavailableCard.tsx
+++ b/frontend/src/components/BackendUnavailableCard.tsx
@@ -4,32 +4,23 @@ interface Props {
 
 export default function BackendUnavailableCard({ onRetry }: Props) {
   return (
-    <div
-      style={{
-        maxWidth: 400,
-        margin: "2rem auto",
-        padding: "1rem",
-        border: "1px solid #ccc",
-        borderRadius: "8px",
-        textAlign: "center",
-      }}
-    >
+    <div className="mx-auto my-8 max-w-[400px] rounded-lg border border-gray-300 p-4 text-center">
       <h2>Backend unavailable</h2>
-      <p style={{ color: "#555", marginBottom: "1rem" }}>
+      <p className="mb-4 text-gray-600">
         The backend service could not be reached. You can retry or open a
         cached read-only view.
       </p>
-      <div style={{ marginBottom: "1rem" }}>
+      <div className="mb-4">
         <button onClick={onRetry} disabled={!onRetry}>
           Retry
         </button>
       </div>
-      <div style={{ fontSize: "0.9rem" }}>
+      <div className="text-sm">
         <a
           href="/snapshots/index.html"
           target="_blank"
           rel="noopener noreferrer"
-          style={{ marginRight: "0.5rem" }}
+          className="mr-2"
         >
           Cached view
         </a>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -32,6 +32,7 @@ import {
   getStoredAuthToken,
   setApiBase,
   setAuthToken,
+  UNAUTHORIZED_EVENT,
 } from './api';
 import LoginPage from './LoginPage';
 import { UserProvider, useUser } from './UserContext';
@@ -185,6 +186,26 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
     if (existingUser) setUser(existingUser);
     const existingProfile = loadStoredUserProfile();
     if (existingProfile) setProfile(existingProfile);
+  }, [setProfile, setUser]);
+
+  // A stored auth token can go stale independently of this component's state
+  // (e.g. localStorage outlives the ~1h Cognito ID token, or outlives a
+  // Cognito session sessionStorage already dropped on tab close). Without
+  // this, a stale token keeps `authed` true forever, so every protected API
+  // call 401s and the app just shows a "backend unavailable" retry loop
+  // instead of returning to the login screen. See issue #4674.
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      clearCognitoRefreshTimer();
+      clearCognitoSession();
+      apiLogout();
+      setUser(null);
+      setProfile(undefined);
+      setAuthed(false);
+    };
+    window.addEventListener(UNAUTHORIZED_EVENT, handleUnauthorized);
+    return () =>
+      window.removeEventListener(UNAUTHORIZED_EVENT, handleUnauthorized);
   }, [setProfile, setUser]);
 
   // Derive a stable boolean from the /config.json-sourced prop so the

--- a/frontend/tests/unit/api.test.ts
+++ b/frontend/tests/unit/api.test.ts
@@ -13,6 +13,7 @@ import {
   getPortfolio,
   getPensionForecast,
   getConfig,
+  UNAUTHORIZED_EVENT,
 } from "@/api";
 
 describe("auth token handling", () => {
@@ -35,6 +36,46 @@ describe("auth token handling", () => {
     const args = mockFetch.mock.calls[0];
     const headers = args[1].headers as Headers;
     expect(headers.get("Authorization")).toBe("Bearer token123");
+  });
+});
+
+describe("unauthorized event (issue #4674)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setAuthToken(null);
+    setApiBase(DEFAULT_API_BASE);
+  });
+
+  it("dispatches UNAUTHORIZED_EVENT and still rejects on a 401 response", async () => {
+    const handler = vi.fn();
+    window.addEventListener(UNAUTHORIZED_EVENT, handler);
+    try {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 401, statusText: "Unauthorized" });
+      // @ts-expect-error: replacing global fetch with mock
+      global.fetch = mockFetch;
+      await expect(fetchJson("/owners")).rejects.toThrow("HTTP 401");
+      expect(handler).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(UNAUTHORIZED_EVENT, handler);
+    }
+  });
+
+  it("does not dispatch UNAUTHORIZED_EVENT for other error statuses", async () => {
+    const handler = vi.fn();
+    window.addEventListener(UNAUTHORIZED_EVENT, handler);
+    try {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 500, statusText: "Server Error" });
+      // @ts-expect-error: replacing global fetch with mock
+      global.fetch = mockFetch;
+      await expect(fetchJson("/owners")).rejects.toThrow("HTTP 500");
+      expect(handler).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener(UNAUTHORIZED_EVENT, handler);
+    }
   });
 });
 

--- a/frontend/tests/unit/rootBootstrap.test.tsx
+++ b/frontend/tests/unit/rootBootstrap.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { UNAUTHORIZED_EVENT } from '@/api'
 
 const mountRoot = async () => {
   document.body.innerHTML = '<div id="root"></div>'
@@ -175,6 +176,56 @@ describe('Root bootstrap integration coverage', () => {
       )
     )
     expect(screen.queryByTestId('login-page')).not.toBeInTheDocument()
+  })
+
+  it('returns to the login page when a stale stored token is rejected with 401 (issue #4674)', async () => {
+    // Simulates: localStorage['authToken'] outlived the Cognito session (e.g.
+    // sessionStorage was cleared on tab close, or the ID token expired), so
+    // Root seeds `authed=true` and renders the app shell — but the first API
+    // call the app shell makes 401s against the stale token. The app should
+    // clear the stale credential and fall back to the login screen instead of
+    // looping on the rejected token.
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    localStorage.setItem('authToken', 'stale-expired-token')
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: true,
+          google_client_id: 'client-123',
+          disable_auth: false
+        }),
+        getStoredAuthToken: vi.fn(() => 'stale-expired-token')
+      }
+    })
+
+    vi.doMock('@/LoginPage', () => ({
+      default: () => <div data-testid="login-page">sign in</div>
+    }))
+
+    vi.doMock('@/App.tsx', async () => {
+      const { useEffect } = await import('react')
+      // Simulates App.tsx's own data-fetching effect discovering the stale
+      // token is rejected as soon as it mounts and makes its first API call.
+      function StaleTokenApp() {
+        useEffect(() => {
+          window.dispatchEvent(new Event(UNAUTHORIZED_EVENT))
+        }, [])
+        return <div data-testid="app-shell">App ready</div>
+      }
+      return { default: StaleTokenApp }
+    })
+
+    await mountRoot()
+
+    expect(await screen.findByTestId('login-page')).toBeInTheDocument()
+    expect(screen.queryByTestId('app-shell')).not.toBeInTheDocument()
+    expect(localStorage.getItem('authToken')).toBeNull()
   })
 
   it('shows login page when backend cfg carries awsUiAuth.enabled and disable_auth=true', async () => {


### PR DESCRIPTION
## Summary

- On the deployed app, reopening the app after the Cognito session has expired (tab closed, or ID token past its ~1h lifetime) rendered the full app UI instead of the login screen, because `localStorage['authToken']` outlives the sessionStorage-scoped Cognito session and has no expiry check in `Root`'s initial `authed` state.
- Every API call then went out with the stale token, API Gateway's Cognito authorizer 401'd all of them, and `App.tsx` showed a generic "Backend unavailable" card — clicking Retry just resent the same dead token forever, with no way to recover except manually clearing storage.
- `fetchJson` in `api.ts` now dispatches a new `UNAUTHORIZED_EVENT` on any 401 response. `Root` in `main.tsx` listens for it and clears the stale Cognito session + auth token, returning the user to the login screen.
- Also converted `BackendUnavailableCard.tsx`'s inline `style={{...}}` props to Tailwind classes, since the deployed CSP has no `style-src` directive (falls back to `default-src 'self'`), which was silently blocking this card's styling — visible in the reported console output as a CSP violation.

Confirmed this is a distinct bug from the previously-fixed #4577 (missing `awsUiAuth` in `/config`) — I checked the live `/config` endpoint directly and it currently returns a correct `awsUiAuth` block, so that fix is deployed and working.

Filed #4675 separately for the broader CSP inline-style problem (541 occurrences across 56 frontend files) — out of scope for this fix, needs its own design decision (loosen CSP vs. Tailwind migration vs. nonce-based CSP).

Closes #4674

## Test plan

- [x] `npm --prefix frontend run lint` — clean
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run` — 541 tests pass, including 3 new tests covering: `fetchJson` dispatches `UNAUTHORIZED_EVENT` only on 401 (not other error statuses), and a `Root` integration test simulating a stale stored token being rejected mid-session, verifying it clears the token and falls back to the login page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now detects unauthorised API responses and resets the session automatically, returning users to the login screen.

* **Bug Fixes**
  * Stale sign-in tokens are cleared when access is rejected, helping prevent repeated failed retries.
  * The backend unavailable screen has been visually refreshed for a more consistent layout and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->