### PR TITLE
test: add regression test for CVE-2026-54283 urlencoded form limit

### DIFF
--- a/tests/backend/test_form_limits.py
+++ b/tests/backend/test_form_limits.py
@@ -1,0 +1,48 @@
+"""Regression test for CVE-2026-54283 (Starlette urlencoded form-data limit bypass).
+
+Starlette >=1.3.1 enforces a 1 MiB per-field size limit when parsing
+``application/x-www-form-urlencoded`` bodies via ``Request.form()``. Before the
+fix, an oversized field was not rejected cleanly and instead surfaced as an
+unhandled server error, allowing memory exhaustion via a single large request.
+"""
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+OVERSIZED_FIELD_BYTES = 2_000_000
+WITHIN_LIMIT_FIELD_BYTES = 100_000
+
+
+def _build_form_echo_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.post("/echo-form")
+    async def echo_form(request: Request):
+        form = await request.form()
+        return {"keys": list(form.keys())}
+
+    return app
+
+
+def _post_urlencoded_field(client: TestClient, field_size: int):
+    payload = "a" * field_size
+    return client.post(
+        "/echo-form",
+        content=f"field={payload}",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+
+def test_oversized_urlencoded_form_is_rejected():
+    app = _build_form_echo_app()
+    with TestClient(app) as client:
+        resp = _post_urlencoded_field(client, OVERSIZED_FIELD_BYTES)
+        assert resp.status_code in (400, 413)
+
+
+def test_within_limit_urlencoded_form_is_accepted():
+    app = _build_form_echo_app()
+    with TestClient(app) as client:
+        resp = _post_urlencoded_field(client, WITHIN_LIMIT_FIELD_BYTES)
+        assert resp.status_code == 200
+        assert resp.json() == {"keys": ["field"]}


### PR DESCRIPTION
## Summary
- Adds `tests/backend/test_form_limits.py`, a regression test verifying Starlette enforces its per-field size limit on `application/x-www-form-urlencoded` bodies (the fix for CVE-2026-54283, Starlette >=1.3.1).
- Test builds a minimal throwaway FastAPI app with a single `/echo-form` route (no production endpoints added), since no existing route currently calls `request.form()`.
- Verified manually against Starlette 1.3.0 (pre-fix) in an isolated venv: the oversized-field request raises an unhandled exception (500) instead of a clean 400, confirming this test would catch a downgrade regression.

## Test plan
- [x] `python -m pytest tests/backend/test_form_limits.py -v` — 2 passed
- [x] `python -m pytest tests/backend/ -q --no-cov` — 713 passed, 1 skipped, 12 xfailed, no regressions
- [x] Confirmed test fails (500 instead of 400) against pre-fix Starlette 1.3.0 in an isolated venv

Closes #4628

🤖 Generated with [Claude Code](https://claude.com/claude-code)
