### PR TITLE
ci: fix Dependabot pass-through check name mismatch in AI review workflows

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -25,10 +25,12 @@ jobs:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Dependabot PRs skip the review job above, which GitHub records as "skipped"
-  # rather than "success". If this check is required, Dependabot PRs are blocked.
-  # This pass-through job runs instead and satisfies the required check.
+  # rather than "success". This job's name reproduces the composite check
+  # context a real reusable-workflow run would produce ("ai-review / Claude
+  # AI code review"), so any branch protection rule keyed on that exact
+  # string still gets satisfied for Dependabot PRs.
   dependabot-pass:
-    name: ai-review
+    name: ai-review / Claude AI code review
     if: github.actor == 'dependabot[bot]'
     permissions: {}
     runs-on: ubuntu-latest

--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -39,10 +39,13 @@ jobs:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Dependabot PRs skip the review job above, which GitHub records as "skipped"
-  # rather than "success". If this check is required, Dependabot PRs are blocked.
-  # This pass-through job runs instead and satisfies the required check.
+  # rather than "success". Branch protection requires the exact check context
+  # "ai-review / DeepSeek AI code review" (the composite name GitHub gives a
+  # reusable-workflow call) — a plain job named "ai-review" does NOT match
+  # that string, so it never satisfies the required check. This job's name
+  # reproduces the composite string literally so Dependabot PRs unblock.
   dependabot-pass:
-    name: ai-review
+    name: ai-review / DeepSeek AI code review
     if: github.actor == 'dependabot[bot]'
     permissions: {}
     runs-on: ubuntu-latest

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -24,10 +24,12 @@ jobs:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Dependabot PRs skip the review job above, which GitHub records as "skipped"
-  # rather than "success". If this check is required, Dependabot PRs are blocked.
-  # This pass-through job runs instead and satisfies the required check.
+  # rather than "success". This job's name reproduces the composite check
+  # context a real reusable-workflow run would produce ("ai-review / GPT AI
+  # code review"), so any branch protection rule keyed on that exact string
+  # still gets satisfied for Dependabot PRs.
   dependabot-pass:
-    name: ai-review
+    name: ai-review / GPT AI code review
     if: github.actor == 'dependabot[bot]'
     permissions: {}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #4703

## Summary
- Issue #4668 was closed by #4669, which added a `dependabot-pass` job to each AI review workflow to unblock Dependabot PRs. That job is named plain `ai-review`, but branch protection's required status check is the exact composite context `ai-review / DeepSeek AI code review` (the string GitHub generates when a caller job calls the reusable `_ai-pr-review.yml` workflow). GitHub requires an exact string match, so the flat-named job never satisfies it — the required check stays pending indefinitely and Dependabot PRs stay blocked (confirmed on #4701 and the ~17 other open Dependabot PRs, none of which have merged since #4669 landed). Filed as #4703.
- Renames each provider's `dependabot-pass` job to the exact composite string its real review job would produce (`ai-review / DeepSeek AI code review`, `ai-review / Claude AI code review`, `ai-review / GPT AI code review`), so Dependabot PRs post a check that actually matches what branch protection requires.

## Test plan
- [x] `actionlint` on the three edited workflow files — no findings
- [ ] Confirm on the next Dependabot PR (or by re-running checks on #4701) that the `ai-review / DeepSeek AI code review` context is posted and the required check clears without manual admin merge