### PR TITLE
feat(news): surface published dates and flag stale market headlines

### DIFF
--- a/backend/routes/news.py
+++ b/backend/routes/news.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import date, datetime, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -24,6 +25,10 @@ config = cfg
 router = APIRouter(tags=["news"])
 
 NEWS_TTL = 900  # seconds
+# Serving cached news older than this (in seconds) is treated as a fault worth
+# surfacing: it means live fetches have not succeeded for far longer than the
+# normal refresh interval (``NEWS_TTL``) and the user is seeing stale stories.
+NEWS_MAX_STALENESS = 24 * 60 * 60  # 1 day
 BASE_URL = "https://www.alphavantage.co/query"
 COUNTER_FILE: Path = page_cache.CACHE_DIR / "news_requests.json"
 
@@ -48,14 +53,32 @@ _FINANCE_KEYWORDS = (
 
 
 
-def _make_news_item(headline: object, url: object) -> Dict[str, str] | None:
-    """Return a minimal news item when both ``headline`` and ``url`` are valid."""
+def _make_news_item(
+    headline: object,
+    url: object,
+    published_at: object = None,
+    source: object = None,
+) -> Dict[str, str] | None:
+    """Return a news item when both ``headline`` and ``url`` are valid.
+
+    ``published_at`` (an already-normalised ISO-8601 string) and ``source`` are
+    optional and only included when present, so callers that lack them still
+    produce the minimal ``{"headline", "url"}`` shape.
+    """
 
     clean_headline = _clean_str(headline)
     clean_url = _clean_str(url)
-    if clean_headline and clean_url:
-        return {"headline": clean_headline, "url": clean_url}
-    return None
+    if not (clean_headline and clean_url):
+        return None
+
+    item: Dict[str, str] = {"headline": clean_headline, "url": clean_url}
+    clean_published = _clean_str(published_at)
+    if clean_published:
+        item["published_at"] = clean_published
+    clean_source = _clean_str(source)
+    if clean_source:
+        item["source"] = clean_source
+    return item
 
 
 def _load_counter() -> Dict[str, int]:
@@ -115,7 +138,12 @@ def _trim_payload(payload: Any) -> List[Dict[str, str]]:
     for item in payload:
         if not isinstance(item, dict):
             continue
-        news_item = _make_news_item(item.get("headline"), item.get("url"))
+        news_item = _make_news_item(
+            item.get("headline"),
+            item.get("url"),
+            item.get("published_at"),
+            item.get("source"),
+        )
         if news_item is not None:
             trimmed.append(news_item)
     return trimmed
@@ -193,7 +221,12 @@ def fetch_news_yahoo(ticker: str) -> List[Dict[str, str]]:
     items = data.get("news", [])
     out: List[Dict[str, str]] = []
     for item in items:
-        news_item = _make_news_item(item.get("title"), item.get("link"))
+        news_item = _make_news_item(
+            item.get("title"),
+            item.get("link"),
+            _parse_epoch_time(item.get("providerPublishTime")),
+            item.get("publisher"),
+        )
         if news_item is not None and _is_finance_related(
             news_item["headline"], clean_ticker, instrument_name
         ):
@@ -214,7 +247,12 @@ def fetch_news_google(ticker: str) -> List[Dict[str, str]]:
     root = ET.fromstring(resp.text)
     out: List[Dict[str, str]] = []
     for item in root.findall(".//item"):
-        news_item = _make_news_item(item.findtext("title"), item.findtext("link"))
+        news_item = _make_news_item(
+            item.findtext("title"),
+            item.findtext("link"),
+            _parse_rss_time(item.findtext("pubDate")),
+            item.findtext("source"),
+        )
         if news_item is not None and _is_finance_related(
             news_item["headline"], clean_ticker, instrument_name
         ):
@@ -245,6 +283,35 @@ def _parse_alpha_time(value: Optional[str]) -> Optional[str]:
     return _isoformat(dt)
 
 
+def _parse_epoch_time(value: object) -> Optional[str]:
+    """Convert a Unix epoch timestamp (Yahoo ``providerPublishTime``) to ISO."""
+
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        dt = datetime.fromtimestamp(float(value), tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+    return _isoformat(dt)
+
+
+def _parse_rss_time(value: Optional[str]) -> Optional[str]:
+    """Convert an RSS ``pubDate`` (RFC 822) string to ISO-8601."""
+
+    if not value or not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        dt = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if dt is None:
+        return None
+    return _isoformat(dt)
+
+
 def _fetch_news(ticker: str) -> List[Dict[str, str]]:
     """Fetch news from AlphaVantage with fallbacks to Yahoo and Google."""
 
@@ -262,7 +329,12 @@ def _fetch_news(ticker: str) -> List[Dict[str, str]]:
         if feed:
             enriched: List[Dict[str, str]] = []
             for item in feed:
-                news_item = _make_news_item(item.get("title"), item.get("url"))
+                news_item = _make_news_item(
+                    item.get("title"),
+                    item.get("url"),
+                    _parse_alpha_time(item.get("time_published")),
+                    item.get("source"),
+                )
                 if news_item is None:
                     continue
                 enriched.append(news_item)
@@ -283,6 +355,26 @@ def _fetch_news(ticker: str) -> List[Dict[str, str]]:
                 "Fallback news fetch failed for %s: %s", sanitise_log_value(ticker), sanitise_log_value(exc)
             )
     return []
+
+
+def _warn_if_stale(page: str) -> None:
+    """Log a warning when the cache being served is dangerously old.
+
+    Silently re-serving a months-old payload (e.g. because live fetches keep
+    failing or the quota is perpetually exhausted) is exactly the failure mode
+    reported in issue #4708.  Surfacing it in the logs gives operators a signal
+    instead of the data ageing invisibly.
+    """
+
+    age = page_cache.cache_age(page)
+    if age is not None and age > NEWS_MAX_STALENESS:
+        logging.getLogger(__name__).warning(
+            "Serving stale cached news for %s: cache is %d seconds old "
+            "(threshold %d); live fetch has not succeeded recently",
+            sanitise_log_value(page),
+            int(age),
+            NEWS_MAX_STALENESS,
+        )
 
 
 def get_cached_news(
@@ -334,6 +426,7 @@ def get_cached_news(
         payload = _call()
     except RuntimeError:
         if cached is not None:
+            _warn_if_stale(page)
             _schedule_refresh()
             return cached
         _schedule_refresh()

--- a/backend/utils/page_cache.py
+++ b/backend/utils/page_cache.py
@@ -66,6 +66,15 @@ def is_stale(page_name: str, ttl: int) -> bool:
     return age > ttl
 
 
+def cache_age(page_name: str) -> float | None:
+    """Return the age in seconds of ``page_name``'s cache file, or ``None``."""
+
+    path = _cache_path(page_name)
+    if not path.exists():
+        return None
+    return time.time() - path.stat().st_mtime
+
+
 def time_until_stale(page_name: str, ttl: int) -> float | None:
     """Return seconds until ``page_name`` becomes stale or ``None`` if missing."""
 

--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -1,3 +1,40 @@
 export function formatDateISO(date: Date): string {
   return date.toISOString().split('T')[0];
 }
+
+const RELATIVE_UNITS: Array<{ limit: number; unit: Intl.RelativeTimeFormatUnit; secs: number }> = [
+  { limit: 60, unit: 'second', secs: 1 },
+  { limit: 3600, unit: 'minute', secs: 60 },
+  { limit: 86400, unit: 'hour', secs: 3600 },
+  { limit: 604800, unit: 'day', secs: 86400 },
+  { limit: 2629800, unit: 'week', secs: 604800 },
+  { limit: 31557600, unit: 'month', secs: 2629800 },
+  { limit: Infinity, unit: 'year', secs: 31557600 },
+];
+
+/**
+ * Format an ISO-8601 timestamp as a short human-friendly age, e.g. "3 days ago".
+ *
+ * Returns ``null`` when the value is missing or cannot be parsed, so callers can
+ * decide whether to render anything at all.
+ */
+export function formatPublishedAt(value: string | null | undefined, now: Date = new Date()): string | null {
+  if (!value) {
+    return null;
+  }
+  const published = new Date(value);
+  const ms = published.getTime();
+  if (Number.isNaN(ms)) {
+    return null;
+  }
+
+  const diffSecs = Math.round((ms - now.getTime()) / 1000);
+  const absSecs = Math.abs(diffSecs);
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+  for (const { limit, unit, secs } of RELATIVE_UNITS) {
+    if (absSecs < limit) {
+      return rtf.format(Math.round(diffSecs / secs), unit);
+    }
+  }
+  return rtf.format(Math.round(diffSecs / 31557600), 'year');
+}

--- a/frontend/src/pages/MarketOverview.tsx
+++ b/frontend/src/pages/MarketOverview.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { getMarketOverview } from '../api';
 import type { MarketOverview as MarketOverviewData } from '../types';
 import EmptyState from '../components/EmptyState';
+import { formatPublishedAt } from '../lib/date';
 import {
   ResponsiveContainer,
   BarChart,
@@ -164,18 +165,29 @@ export default function MarketOverview() {
           />
         ) : (
           <ul className="list-disc pl-4">
-            {data.headlines.map((h, idx) => (
-              <li key={idx}>
-                <a
-                  href={h.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-500 hover:underline"
-                >
-                  {h.headline}
-                </a>
-              </li>
-            ))}
+            {data.headlines.map((h, idx) => {
+              const age = formatPublishedAt(h.published_at);
+              return (
+                <li key={idx}>
+                  <a
+                    href={h.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 hover:underline"
+                  >
+                    {h.headline}
+                  </a>
+                  {age && (
+                    <span
+                      className="ml-2 text-sm text-gray-500"
+                      title={h.published_at ?? undefined}
+                    >
+                      — {age}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/frontend/tests/unit/lib/date.test.ts
+++ b/frontend/tests/unit/lib/date.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { formatPublishedAt } from "@/lib/date";
+
+const NOW = new Date("2024-06-10T12:00:00Z");
+
+describe("formatPublishedAt", () => {
+  it("returns null for missing or unparseable values", () => {
+    expect(formatPublishedAt(null, NOW)).toBeNull();
+    expect(formatPublishedAt(undefined, NOW)).toBeNull();
+    expect(formatPublishedAt("", NOW)).toBeNull();
+    expect(formatPublishedAt("not-a-date", NOW)).toBeNull();
+  });
+
+  it("formats recent timestamps as a relative age", () => {
+    expect(formatPublishedAt("2024-06-07T12:00:00Z", NOW)).toBe("3 days ago");
+    expect(formatPublishedAt("2024-06-10T10:00:00Z", NOW)).toBe("2 hours ago");
+  });
+
+  it("formats older timestamps in coarser units", () => {
+    expect(formatPublishedAt("2024-03-10T12:00:00Z", NOW)).toBe("3 months ago");
+    expect(formatPublishedAt("2022-06-10T12:00:00Z", NOW)).toBe("2 years ago");
+  });
+});

--- a/frontend/tests/unit/pages/MarketOverview.test.tsx
+++ b/frontend/tests/unit/pages/MarketOverview.test.tsx
@@ -60,6 +60,35 @@ describe("MarketOverview", () => {
     expect(await screen.findByText("Some News")).toBeInTheDocument();
   });
 
+  it("renders the published age next to a dated headline", async () => {
+    const published = new Date(Date.now() - 3 * 86400 * 1000).toISOString();
+    mockGetMarketOverview.mockResolvedValueOnce({
+      indexes: {},
+      sectors: [],
+      headlines: [
+        {
+          headline: "Dated News",
+          url: "https://example.com/dated",
+          published_at: published,
+        },
+      ],
+    });
+    render(<MarketOverview />);
+    expect(await screen.findByText("Dated News")).toBeInTheDocument();
+    expect(screen.getByText(/3 days ago/)).toBeInTheDocument();
+  });
+
+  it("omits the age when a headline has no published date", async () => {
+    mockGetMarketOverview.mockResolvedValueOnce({
+      indexes: {},
+      sectors: [],
+      headlines: [{ headline: "Undated News", url: "https://example.com/undated" }],
+    });
+    render(<MarketOverview />);
+    expect(await screen.findByText("Undated News")).toBeInTheDocument();
+    expect(screen.queryByText(/ago/)).not.toBeInTheDocument();
+  });
+
   it("renders index tooltip values from value and change", () => {
     render(
       <IndexTooltip

--- a/tests/backend/test_news_route.py
+++ b/tests/backend/test_news_route.py
@@ -87,23 +87,14 @@ def test_get_news_trims_payload_and_caches(monkeypatch):
     resp = client.get("/news", params={"ticker": "AAA"})
     assert resp.status_code == 200
     payload = resp.json()
-    assert payload == [
-        {
-            "headline": "Alpha headline",
-            "url": "https://example.com/article",
-        }
-    ]
-    assert saved == [
-        (
-            "news_AAA",
-            [
-                {
-                    "headline": "Alpha headline",
-                    "url": "https://example.com/article",
-                }
-            ],
-        )
-    ]
+    expected_item = {
+        "headline": "Alpha headline",
+        "url": "https://example.com/article",
+        "published_at": "2023-08-25T16:00:00Z",
+        "source": "AlphaVantage",
+    }
+    assert payload == [expected_item]
+    assert saved == [("news_AAA", [expected_item])]
 
 
 def test_parse_alpha_time_legacy_format():

--- a/tests/routes/test_news.py
+++ b/tests/routes/test_news.py
@@ -135,6 +135,108 @@ def test_fetch_news_google(monkeypatch):
     assert "stock" in query.lower()
 
 
+def test_fetch_news_yahoo_populates_published_at_and_source(monkeypatch):
+    def fake_get(url, params=None, timeout=10, **kwargs):
+        class Response:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {
+                    "news": [
+                        {
+                            "title": "Stock update",
+                            "link": "https://example.com/1",
+                            "providerPublishTime": 1717245296,
+                            "publisher": "Reuters",
+                        }
+                    ]
+                }
+
+        return Response()
+
+    monkeypatch.setattr(news_module.requests, "get", fake_get)
+
+    items = news_module.fetch_news_yahoo("PFE")
+    assert items == [
+        {
+            "headline": "Stock update",
+            "url": "https://example.com/1",
+            "published_at": "2024-06-01T12:34:56Z",
+            "source": "Reuters",
+        }
+    ]
+
+
+def test_fetch_news_google_populates_published_at(monkeypatch):
+    xml = """
+        <rss>
+          <channel>
+            <item>
+              <title>Story stock update</title>
+              <link>https://example.com/story</link>
+              <pubDate>Sat, 01 Jun 2024 12:34:56 GMT</pubDate>
+              <source>Example News</source>
+            </item>
+          </channel>
+        </rss>
+    """
+
+    def fake_get(url, params=None, timeout=10, **kwargs):
+        class Response:
+            text = xml
+
+            def raise_for_status(self):
+                return None
+
+        return Response()
+
+    monkeypatch.setattr(news_module.requests, "get", fake_get)
+
+    items = news_module.fetch_news_google("MSFT")
+    assert items == [
+        {
+            "headline": "Story stock update",
+            "url": "https://example.com/story",
+            "published_at": "2024-06-01T12:34:56Z",
+            "source": "Example News",
+        }
+    ]
+
+
+def test_fetch_news_alpha_populates_published_at(monkeypatch):
+    def fake_get(url, params=None, timeout=10, **kwargs):
+        class Response:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {
+                    "feed": [
+                        {
+                            "title": "Alpha headline",
+                            "url": "https://example.com/alpha",
+                            "time_published": "20240601T123456",
+                            "source": "AlphaWire",
+                        }
+                    ]
+                }
+
+        return Response()
+
+    monkeypatch.setattr(news_module.requests, "get", fake_get)
+
+    items = news_module._fetch_news("AAPL")
+    assert items == [
+        {
+            "headline": "Alpha headline",
+            "url": "https://example.com/alpha",
+            "published_at": "2024-06-01T12:34:56Z",
+            "source": "AlphaWire",
+        }
+    ]
+
+
 def test_fetch_news_fallback(monkeypatch):
     alpha_calls = {"count": 0}
     yahoo_calls = {"count": 0}

--- a/tests/routes/test_news.py
+++ b/tests/routes/test_news.py
@@ -237,6 +237,32 @@ def test_fetch_news_alpha_populates_published_at(monkeypatch):
     ]
 
 
+def test_fetch_news_alpha_omits_published_at_when_missing(monkeypatch):
+    def fake_get(url, params=None, timeout=10, **kwargs):
+        class Response:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {
+                    "feed": [
+                        {
+                            "title": "Undated headline",
+                            "url": "https://example.com/undated",
+                        }
+                    ]
+                }
+
+        return Response()
+
+    monkeypatch.setattr(news_module.requests, "get", fake_get)
+
+    items = news_module._fetch_news("AAPL")
+    assert items == [
+        {"headline": "Undated headline", "url": "https://example.com/undated"}
+    ]
+
+
 def test_fetch_news_fallback(monkeypatch):
     alpha_calls = {"count": 0}
     yahoo_calls = {"count": 0}

--- a/tests/routes/test_news_helpers.py
+++ b/tests/routes/test_news_helpers.py
@@ -37,6 +37,80 @@ def test_make_news_item_requires_headline_and_url():
     assert news_module._make_news_item("   ", url) is None
 
 
+def test_make_news_item_includes_published_at_and_source():
+    item = news_module._make_news_item(
+        "Headline",
+        "https://example.com/story",
+        "2024-06-01T12:34:56Z",
+        " Reuters ",
+    )
+    assert item == {
+        "headline": "Headline",
+        "url": "https://example.com/story",
+        "published_at": "2024-06-01T12:34:56Z",
+        "source": "Reuters",
+    }
+
+
+def test_make_news_item_omits_blank_optional_fields():
+    item = news_module._make_news_item(
+        "Headline",
+        "https://example.com/story",
+        "   ",
+        None,
+    )
+    assert item == {"headline": "Headline", "url": "https://example.com/story"}
+
+
+def test_trim_payload_preserves_published_at_and_source():
+    payload = [
+        {
+            "headline": "First",
+            "url": "https://example.com/1",
+            "published_at": "2024-06-01T12:34:56Z",
+            "source": "Reuters",
+        }
+    ]
+    assert news_module._trim_payload(payload) == [
+        {
+            "headline": "First",
+            "url": "https://example.com/1",
+            "published_at": "2024-06-01T12:34:56Z",
+            "source": "Reuters",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, None),
+        (True, None),
+        ("not-a-number", None),
+        (0, "1970-01-01T00:00:00Z"),
+        (1717245296, "2024-06-01T12:34:56Z"),
+        (1717245296.0, "2024-06-01T12:34:56Z"),
+    ],
+)
+def test_parse_epoch_time_handles_values(value, expected):
+    assert news_module._parse_epoch_time(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("not-a-date", None),
+        ("Sat, 01 Jun 2024 12:34:56 GMT", "2024-06-01T12:34:56Z"),
+        ("Sat, 01 Jun 2024 14:34:56 +0200", "2024-06-01T12:34:56Z"),
+    ],
+)
+def test_parse_rss_time_handles_formats(value, expected):
+    assert news_module._parse_rss_time(value) == expected
+
+
 def test_trim_payload_filters_invalid_entries():
     payload: List[Dict[str, Any]] = [
         {"headline": " First ", "url": " https://example.com/1 "},
@@ -120,6 +194,50 @@ def test_get_cached_news_raises_on_quota_exhausted_without_cache(monkeypatch):
 
     assert len(scheduled) == 1
     _assert_refresh_call(scheduled[0], page="news_LIMITED", delay=None)
+
+
+def test_warn_if_stale_logs_when_cache_too_old(monkeypatch, caplog):
+    monkeypatch.setattr(
+        news_module.page_cache,
+        "cache_age",
+        lambda page: news_module.NEWS_MAX_STALENESS + 1,
+    )
+    with caplog.at_level("WARNING"):
+        news_module._warn_if_stale("news_ABC")
+    assert any("Serving stale cached news" in rec.message for rec in caplog.records)
+
+
+def test_warn_if_stale_silent_when_fresh_or_missing(monkeypatch, caplog):
+    monkeypatch.setattr(news_module.page_cache, "cache_age", lambda page: 10.0)
+    with caplog.at_level("WARNING"):
+        news_module._warn_if_stale("news_ABC")
+    assert caplog.records == []
+
+    monkeypatch.setattr(news_module.page_cache, "cache_age", lambda page: None)
+    with caplog.at_level("WARNING"):
+        news_module._warn_if_stale("news_MISSING")
+    assert caplog.records == []
+
+
+def test_get_cached_news_warns_when_serving_stale_on_quota(monkeypatch, caplog):
+    cached_payload = [{"headline": "Cached", "url": "https://example.com/cached"}]
+
+    monkeypatch.setattr(news_module.page_cache, "load_cache", lambda page: cached_payload)
+    monkeypatch.setattr(news_module.page_cache, "is_stale", lambda page, ttl: True)
+    monkeypatch.setattr(news_module.page_cache, "time_until_stale", lambda page, ttl: 0)
+    monkeypatch.setattr(news_module.page_cache, "schedule_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(
+        news_module.page_cache,
+        "cache_age",
+        lambda page: news_module.NEWS_MAX_STALENESS + 1,
+    )
+    monkeypatch.setattr(news_module, "_try_consume_quota", lambda: False)
+
+    with caplog.at_level("WARNING"):
+        result = news_module.get_cached_news("cached")
+
+    assert result == cached_payload
+    assert any("Serving stale cached news" in rec.message for rec in caplog.records)
 
 
 def test_get_cached_news_reuses_fresh_cache(monkeypatch):


### PR DESCRIPTION
## What
Fixes the two related gaps from #4708: market headlines had no publish date, and `published_at` was never populated by the backend (the `_parse_alpha_time` helper was dead code). Separately, months-stale cached news was being re-served silently.

## Changes

### Backend (`backend/routes/news.py`)
- `_make_news_item` now accepts optional `published_at` (already-normalised ISO-8601) and `source`, including them only when present so the minimal `{headline, url}` shape is unchanged for sources that lack them.
- `_trim_payload` preserves `published_at`/`source` from cached payloads.
- Publish times wired through for all three sources:
  - **AlphaVantage** `time_published` → existing `_parse_alpha_time` (no longer dead code).
  - **Yahoo** `providerPublishTime` (Unix epoch) → new `_parse_epoch_time`.
  - **Google RSS** `pubDate` (RFC 822) → new `_parse_rss_time`.
- `source` populated from each provider's publisher/source field.

### Staleness visibility
- New `page_cache.cache_age()` helper.
- `get_cached_news` logs a warning (`NEWS_MAX_STALENESS`, 1 day) when it re-serves a cached payload that has aged out because live fetches keep failing / quota stays exhausted — surfacing the root cause of months-old headlines instead of ageing invisibly. No extra request volume, so AlphaVantage quota is unaffected; the fallback chain and background refresh are untouched.

### Frontend
- `formatPublishedAt` helper in `lib/date.ts` renders a relative age via `Intl.RelativeTimeFormat`, returning `null` for missing/unparseable values.
- `MarketOverview.tsx` shows "Headline — 3 days ago" next to each link (with the exact timestamp as a tooltip), omitting the age when `published_at` is absent.

## Tests
- pytest: `published_at`/`source` population for all three fetchers, the new time parsers, `_trim_payload` preservation, and the staleness-warning path; updated one existing route test that asserted the old minimal shape.
- Vitest: `formatPublishedAt` unit tests + `MarketOverview` rendering (dated vs. undated headlines).

All targeted backend (72) and frontend (8) tests pass; `tsc --noEmit` and `eslint` clean on changed files. (Backend `ruff`/`black` not installed in this environment — no formatting run locally.)

Closes #4708

🤖 Generated with [Claude Code](https://claude.com/claude-code)