### PR TITLE
fix: default owner selection to the logged-in user, not owners[0]

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,7 +54,9 @@ import Rebalance from './pages/Rebalance';
 import PensionForecast from './pages/PensionForecast';
 import TaxTools from './pages/TaxTools';
 import Alerts from './pages/Alerts';
-import { sanitizeOwners } from './utils/owners';
+import { sanitizeOwners, findOwnerForUser } from './utils/owners';
+import { useAuth } from './AuthContext';
+import type { UserProfile } from './AuthContext';
 import { isDefaultGroupSlug, normaliseGroupSlug } from './utils/groups';
 import { deriveModeFromPathname } from './pageManifest';
 import { MAX_INSTRUMENT_CATALOGUE_ROWS } from './constants/renderLimits';
@@ -107,14 +109,15 @@ function sameGroupList(left: GroupSummary[], right: GroupSummary[]): boolean {
 export function getOwnerRootRedirectPath(
   pathname: string,
   selectedOwner: string,
-  owners: OwnerSummary[]
+  owners: OwnerSummary[],
+  user?: UserProfile | null
 ): string | null {
   if (selectedOwner || owners.length === 0) return null;
   const segs = pathname.split('/').filter(Boolean);
   const atPortfolioRoot = segs[0] === 'portfolio' && segs.length === 1;
   const atPerformanceRoot = segs[0] === 'performance' && segs.length === 1;
   if (!atPortfolioRoot && !atPerformanceRoot) return null;
-  const owner = owners[0].owner;
+  const owner = findOwnerForUser(owners, user)?.owner ?? owners[0].owner;
   const encodedOwner = encodePathSegment(owner);
   return atPerformanceRoot
     ? `/performance/${encodedOwner}`
@@ -156,6 +159,7 @@ export default function App({ onLogout }: AppProps) {
   const { t } = useTranslation();
   const { tabs, disabledTabs, familyMvpEnabled, configLoaded } = useConfig();
   const { lastRefresh } = usePriceRefresh();
+  const { user } = useAuth();
   const familyMvpEntryPath = useMemo(
     () => (configLoaded ? getFamilyMvpEntryPath(tabs, disabledTabs) : null),
     [configLoaded, tabs, disabledTabs]
@@ -321,7 +325,7 @@ export default function App({ onLogout }: AppProps) {
         setSelectedOwner(decodePathSegment(segs[1]));
       } else if (owners.length > 0) {
         // URL redirect is handled by the render-time <Navigate> in renderMainContent.
-        setSelectedOwner(owners[0].owner);
+        setSelectedOwner(findOwnerForUser(owners, user)?.owner ?? owners[0].owner);
       }
     } else if (newMode === 'instrument') {
       setSelectedGroup(segs[1] ?? '');
@@ -344,6 +348,7 @@ export default function App({ onLogout }: AppProps) {
     disabledTabs,
     owners,
     navigate,
+    user,
   ]);
 
   useEffect(() => {
@@ -407,7 +412,8 @@ export default function App({ onLogout }: AppProps) {
     const nextPath = getOwnerRootRedirectPath(
       location.pathname,
       selectedOwner,
-      owners
+      owners,
+      user
     );
     if (nextPath) {
       navigate(nextPath, { replace: true });
@@ -440,6 +446,7 @@ export default function App({ onLogout }: AppProps) {
     navigate,
     location.pathname,
     location.search,
+    user,
   ]);
 
   // data fetching based on route
@@ -526,7 +533,7 @@ export default function App({ onLogout }: AppProps) {
       !redirectSegs[1] &&
       owners.length > 0
     ) {
-      const owner = owners[0].owner;
+      const owner = findOwnerForUser(owners, user)?.owner ?? owners[0].owner;
       const destPath = redirectMode === 'performance'
         ? `/performance/${encodePathSegment(owner)}`
         : `/portfolio/${encodePathSegment(owner)}`;

--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -27,8 +27,9 @@ import InstallPwaPrompt from "./components/InstallPwaPrompt";
 import BackendUnavailableCard from "./components/BackendUnavailableCard";
 import lazyWithDelay from "./utils/lazyWithDelay";
 import PortfolioDashboardSkeleton from "./components/skeletons/PortfolioDashboardSkeleton";
-import { sanitizeOwners } from "./utils/owners";
+import { sanitizeOwners, findOwnerForUser } from "./utils/owners";
 import { isDefaultGroupSlug } from "./utils/groups";
+import { useAuth } from "./AuthContext";
 
 const ScreenerQuery = lazy(() => import("./pages/ScreenerQuery"));
 const TimeseriesEdit = lazy(() =>
@@ -50,6 +51,7 @@ export default function MainApp() {
   const location = useLocation();
   const { t } = useTranslation();
   const { mode, setMode, selectedOwner, setSelectedOwner, selectedGroup, setSelectedGroup } = useRoute();
+  const { user } = useAuth();
 
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
   const [groups, setGroups] = useState<GroupSummary[]>([]);
@@ -127,7 +129,7 @@ export default function MainApp() {
   // redirect to defaults if no selection provided
   useEffect(() => {
     if (mode === "owner" && !selectedOwner && owners.length) {
-      const owner = owners[0].owner;
+      const owner = findOwnerForUser(owners, user)?.owner ?? owners[0].owner;
       setSelectedOwner(owner);
       navigate(`/portfolio/${owner}`, { replace: true });
     }
@@ -160,6 +162,7 @@ export default function MainApp() {
     setSelectedOwner,
     setSelectedGroup,
     location.search,
+    user,
   ]);
 
   // data fetching based on route

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -12,7 +12,8 @@ import {
 import { useFetch } from '../hooks/useFetch';
 import { useConfig } from '../ConfigContext';
 import { useTranslation } from 'react-i18next';
-import { createOwnerDisplayLookup } from '../utils/owners';
+import { createOwnerDisplayLookup, findOwnerForUser } from '../utils/owners';
+import { useAuth } from '../AuthContext';
 import { TransactionEditorForm } from './transactions/TransactionEditorForm';
 import { TransactionsFilters } from './transactions/TransactionsFilters';
 import {
@@ -62,6 +63,7 @@ export function TransactionsPage({ owners, inputOnly = false }: Props) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const { t } = useTranslation();
   const { baseCurrency } = useConfig();
+  const { user } = useAuth();
   const pageSizeOptions = [10, 20, 50, 100];
   const ownerLookup = useMemo(() => createOwnerDisplayLookup(owners), [owners]);
 
@@ -196,8 +198,9 @@ export function TransactionsPage({ owners, inputOnly = false }: Props) {
     if (owners.length === 0) {
       return;
     }
-    setManualOwner((current) => current || owners[0].owner);
-  }, [owners]);
+    const defaultOwner = findOwnerForUser(owners, user)?.owner ?? owners[0].owner;
+    setManualOwner((current) => current || defaultOwner);
+  }, [owners, user]);
 
   useEffect(() => {
     void fetchManualAccounts(manualOwner);

--- a/frontend/src/pages/UserConfig.tsx
+++ b/frontend/src/pages/UserConfig.tsx
@@ -11,7 +11,7 @@ import {
 import type { Approval, OwnerSummary, UserConfig } from '../types';
 import { useAuth } from '../AuthContext';
 import { useConfig } from '../ConfigContext';
-import { sanitizeOwners } from '../utils/owners';
+import { findOwnerForUser, sanitizeOwners } from '../utils/owners';
 
 export default function UserConfigPage() {
   const { t } = useTranslation();
@@ -36,6 +36,11 @@ export default function UserConfigPage() {
         /* ignore */
       });
   }, []);
+
+  useEffect(() => {
+    if (!owners.length) return;
+    setOwner((current) => current || findOwnerForUser(owners, user)?.owner || '');
+  }, [owners, user]);
 
   useEffect(() => {
     if (owner) {

--- a/frontend/src/utils/owners.ts
+++ b/frontend/src/utils/owners.ts
@@ -37,3 +37,19 @@ export function getOwnerDisplayName(
   }
   return lookup.get(owner) ?? fallback ?? owner;
 }
+
+/**
+ * Map a logged-in user to one of the available owners by email, so the app
+ * defaults to the current user's own owner rather than an arbitrary one.
+ * Returns undefined when there's no auth user or no matching owner (e.g.
+ * demo/local/no-auth mode), in which case callers should fall back to
+ * owners[0].
+ */
+export function findOwnerForUser(
+  owners: OwnerSummary[],
+  user: { email?: string | null } | null | undefined,
+): OwnerSummary | undefined {
+  const email = user?.email?.trim().toLowerCase();
+  if (!email) return undefined;
+  return owners.find((owner) => owner.email?.trim().toLowerCase() === email);
+}

--- a/frontend/tests/unit/App.test.tsx
+++ b/frontend/tests/unit/App.test.tsx
@@ -943,6 +943,72 @@ describe("App", () => {
     await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
   });
 
+  it("redirects /portfolio to the owner matching the logged-in user's email, not the first owner", async () => {
+    window.history.pushState({}, "", "/portfolio");
+
+    const mockGetOwners = vi.fn().mockResolvedValue([
+      { owner: "alice", accounts: [], email: "alice@example.com" },
+      { owner: "bob", accounts: [], email: "bob@example.com" },
+    ]);
+    const mockGetPortfolio = vi.fn().mockResolvedValue({
+      owner: "bob",
+      as_of: "2024-01-01T00:00:00.000Z",
+      trades_this_month: 0,
+      trades_remaining: 0,
+      total_value_estimate_gbp: 0,
+      accounts: [],
+    });
+
+    vi.doMock("@/api", async () => {
+      const actual = await vi.importActual<typeof import("@/api")>("@/api");
+      return {
+        ...actual,
+        getOwners: mockGetOwners,
+        getGroups: vi.fn().mockResolvedValue([]),
+        getPortfolio: mockGetPortfolio,
+        getGroupInstruments: vi.fn().mockResolvedValue([]),
+        getAlerts: vi.fn().mockResolvedValue([]),
+        getNudges: vi.fn().mockResolvedValue([]),
+        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+        getCompliance: vi
+          .fn()
+          .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+        complianceForOwner: vi
+          .fn()
+          .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+        getTradingSignals: vi.fn().mockResolvedValue([]),
+        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+      };
+    });
+
+    const { default: App } = await import("@/App");
+    const { configContext } = await import("@/ConfigContext");
+    const { AuthContext } = await import("@/AuthContext");
+
+    const router = createMemoryRouter(
+      [
+        {
+          path: "*",
+          element: (
+            <configContext.Provider value={makeConfigValue()}>
+              <AuthContext.Provider
+                value={{ user: { email: "bob@example.com" }, setUser: vi.fn() }}
+              >
+                <App />
+              </AuthContext.Provider>
+            </configContext.Provider>
+          ),
+        },
+      ],
+      { initialEntries: ["/portfolio"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/portfolio/bob"));
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
+  });
+
   it("redirects /performance to the first owner when multiple owners are available", async () => {
     window.history.pushState({}, "", "/performance");
 

--- a/frontend/tests/unit/components/TransactionsPage.test.tsx
+++ b/frontend/tests/unit/components/TransactionsPage.test.tsx
@@ -8,6 +8,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TransactionsPage } from '@/components/TransactionsPage';
+import { AuthContext } from '@/AuthContext';
 
 const {
   getTransactionsMock,
@@ -282,5 +283,41 @@ describe('TransactionsPage', () => {
       screen.getByText('Provide both Units and Price (GBP).')
     ).toBeInTheDocument();
     expect(createManualHoldingMock).not.toHaveBeenCalled();
+  });
+
+  it('defaults the manual owner input to the logged-in user\'s owner', async () => {
+    render(
+      <AuthContext.Provider
+        value={{ user: { email: 'sam@example.com' }, setUser: vi.fn() }}
+      >
+        <TransactionsPage
+          owners={[
+            { owner: 'alex', full_name: 'Alex Example', accounts: ['isa'], email: 'alex@example.com' },
+            { owner: 'sam', full_name: 'Sam Example', accounts: ['sipp'], email: 'sam@example.com' },
+          ]}
+          inputOnly
+        />
+      </AuthContext.Provider>
+    );
+
+    await screen.findByText('Account + Holdings Input');
+    const manualOwnerInput = screen.getByLabelText('Owner') as HTMLInputElement;
+    await waitFor(() => expect(manualOwnerInput.value).toBe('sam'));
+  });
+
+  it('falls back to the first owner for the manual owner input when there is no logged-in user', async () => {
+    render(
+      <TransactionsPage
+        owners={[
+          { owner: 'alex', full_name: 'Alex Example', accounts: ['isa'], email: 'alex@example.com' },
+          { owner: 'sam', full_name: 'Sam Example', accounts: ['sipp'], email: 'sam@example.com' },
+        ]}
+        inputOnly
+      />
+    );
+
+    await screen.findByText('Account + Holdings Input');
+    const manualOwnerInput = screen.getByLabelText('Owner') as HTMLInputElement;
+    await waitFor(() => expect(manualOwnerInput.value).toBe('alex'));
   });
 });

--- a/frontend/tests/unit/ownerRootRedirect.test.ts
+++ b/frontend/tests/unit/ownerRootRedirect.test.ts
@@ -24,4 +24,41 @@ describe("getOwnerRootRedirectPath", () => {
     expect(getOwnerRootRedirectPath("/portfolio/alice", "alice", owners)).toBeNull();
     expect(getOwnerRootRedirectPath("/performance/alice", "alice", owners)).toBeNull();
   });
+
+  describe("with a logged-in user", () => {
+    const multiOwners = [
+      { owner: "alice", accounts: [], email: "alice@example.com" },
+      { owner: "bob", accounts: [], email: "bob@example.com" },
+    ];
+
+    it("redirects to the owner matching the logged-in user's email", () => {
+      expect(
+        getOwnerRootRedirectPath("/portfolio", "", multiOwners, {
+          email: "bob@example.com",
+        })
+      ).toBe("/portfolio/bob");
+    });
+
+    it("matches email case-insensitively", () => {
+      expect(
+        getOwnerRootRedirectPath("/portfolio", "", multiOwners, {
+          email: "BOB@EXAMPLE.COM",
+        })
+      ).toBe("/portfolio/bob");
+    });
+
+    it("falls back to the first owner when the user has no matching owner", () => {
+      expect(
+        getOwnerRootRedirectPath("/portfolio", "", multiOwners, {
+          email: "nobody@example.com",
+        })
+      ).toBe("/portfolio/alice");
+    });
+
+    it("falls back to the first owner when there is no logged-in user", () => {
+      expect(getOwnerRootRedirectPath("/portfolio", "", multiOwners, null)).toBe(
+        "/portfolio/alice"
+      );
+    });
+  });
 });

--- a/frontend/tests/unit/pages/UserConfig.test.tsx
+++ b/frontend/tests/unit/pages/UserConfig.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@/api", () => ({
 }));
 
 import UserConfig from "@/pages/UserConfig";
+import { AuthContext } from "@/AuthContext";
 
 beforeEach(() => {
   (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -53,6 +54,40 @@ describe("UserConfig page", () => {
       approval_exempt_tickers: [],
       approval_exempt_types: null,
     });
+  });
+
+  it("defaults the owner dropdown to the logged-in user's owner", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alex", accounts: [], email: "alex@example.com" },
+      { owner: "jamie", accounts: [], email: "jamie@example.com" },
+    ]);
+    mockGetUserConfig.mockResolvedValue({});
+    mockGetApprovals.mockResolvedValue({ approvals: [] });
+
+    render(
+      <AuthContext.Provider
+        value={{ user: { email: "jamie@example.com" }, setUser: vi.fn() }}
+      >
+        <UserConfig />
+      </AuthContext.Provider>,
+    );
+
+    const select = await screen.findByRole("combobox");
+    await screen.findByDisplayValue("jamie");
+    expect((select as HTMLSelectElement).value).toBe("jamie");
+  });
+
+  it("leaves the owner dropdown unselected when there is no logged-in user", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alex", accounts: [], email: "alex@example.com" },
+      { owner: "jamie", accounts: [], email: "jamie@example.com" },
+    ]);
+    mockGetApprovals.mockResolvedValue({ approvals: [] });
+
+    render(<UserConfig />);
+
+    const select = await screen.findByRole("combobox");
+    expect((select as HTMLSelectElement).value).toBe("");
   });
 });
 

--- a/frontend/tests/unit/pages/UserConfig.test.tsx
+++ b/frontend/tests/unit/pages/UserConfig.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
@@ -75,6 +75,14 @@ describe("UserConfig page", () => {
     const select = await screen.findByRole("combobox");
     await screen.findByDisplayValue("jamie");
     expect((select as HTMLSelectElement).value).toBe("jamie");
+    // The config-fetch effect must run for the mapped owner, not "" or the
+    // first owner: proves the owner-default and config-fetch effects sequence
+    // correctly (the owner change re-triggers the fetch).
+    await waitFor(() =>
+      expect(mockGetUserConfig).toHaveBeenCalledWith("jamie"),
+    );
+    expect(mockGetUserConfig).not.toHaveBeenCalledWith("");
+    expect(mockGetUserConfig).not.toHaveBeenCalledWith("alex");
   });
 
   it("leaves the owner dropdown unselected when there is no logged-in user", async () => {

--- a/frontend/tests/unit/utils/owners.test.ts
+++ b/frontend/tests/unit/utils/owners.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizeOwners } from '@/utils/owners';
+import { findOwnerForUser, sanitizeOwners } from '@/utils/owners';
 
 const makeOwner = (owner: string) => ({ owner, accounts: [] as string[] });
 
@@ -21,5 +21,36 @@ describe('sanitizeOwners', () => {
 
   it('returns empty list when no owners provided', () => {
     expect(sanitizeOwners([])).toEqual([]);
+  });
+});
+
+describe('findOwnerForUser', () => {
+  const owners = [
+    { owner: 'alice', accounts: [] as string[], email: 'alice@example.com' },
+    { owner: 'bob', accounts: [] as string[], email: 'bob@example.com' },
+  ];
+
+  it('returns the owner whose email matches the logged-in user', () => {
+    expect(findOwnerForUser(owners, { email: 'bob@example.com' })?.owner).toBe('bob');
+  });
+
+  it('matches case-insensitively and ignores surrounding whitespace', () => {
+    expect(findOwnerForUser(owners, { email: '  ALICE@EXAMPLE.COM  ' })?.owner).toBe(
+      'alice',
+    );
+  });
+
+  it('returns undefined when there is no logged-in user', () => {
+    expect(findOwnerForUser(owners, null)).toBeUndefined();
+    expect(findOwnerForUser(owners, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when no owner matches the user email', () => {
+    expect(findOwnerForUser(owners, { email: 'nobody@example.com' })).toBeUndefined();
+  });
+
+  it('returns undefined when owners have no email set', () => {
+    const noEmailOwners = [{ owner: 'demo', accounts: [] as string[] }];
+    expect(findOwnerForUser(noEmailOwners, { email: 'demo@example.com' })).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `findOwnerForUser(owners, user)` in `frontend/src/utils/owners.ts`, which maps the authenticated user's email to a matching `OwnerSummary.email`.
- Uses it ahead of the `owners[0]` fallback everywhere a default owner is seeded from the shared owner list:
  - `App.tsx` — `getOwnerRootRedirectPath`, the route-sync effect, and the render-time owner-root redirect (all three previously duplicated `owners[0]` logic).
  - `MainApp.tsx` — the (currently unused, but still tested) legacy owner-view default.
  - `components/TransactionsPage.tsx` — the manual holdings "Owner" input default (the concrete bug from #4706).
  - `pages/UserConfig.tsx` — the settings owner dropdown default (the concrete bug from #4707).
- `Rebalance.tsx` and `PensionForecast.tsx` were audited per the issue's checklist — both already prefer `route.selectedOwner` over their own `owners[0]` fallback, so no page-specific fallback removal was needed there; they now inherit the corrected default via the shared context.
- Falls back to `owners[0]` unchanged whenever there's no auth user or no owner match (demo/local/no-auth mode), per the issue's constraint.

## Test plan
- [x] `npx vitest run` — full frontend suite passes (555/555)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] New Vitest coverage added for the corrected default-selection logic:
  - `utils/owners.test.ts` — `findOwnerForUser`
  - `ownerRootRedirect.test.ts` — `getOwnerRootRedirectPath` with a logged-in user
  - `App.test.tsx` — `/portfolio` redirects to the auth-matched owner, not the first owner
  - `UserConfig.test.tsx` — settings dropdown defaults to the auth-matched owner
  - `TransactionsPage.test.tsx` — manual holdings input defaults to the auth-matched owner

Closes #4706
Closes #4707
Closes #4709