### PR TITLE
feat(auth): enforce per-owner authorization on settings & approvals (#4710)

### DIFF
--- a/backend/common/authz.py
+++ b/backend/common/authz.py
@@ -1,0 +1,72 @@
+"""Per-owner authorization helpers.
+
+AllotMint uses a family/viewer access model: an authenticated identity may
+access an owner's data when the identity matches the owner id, the owner's
+configured ``email``, or appears in the owner's ``viewers`` list. This mirrors
+the scoping already applied by :func:`backend.common.data_loader.list_plots`
+for the ``/owners`` listing (see ``_is_authorized`` in ``_list_local_plots``),
+and is applied here to per-owner endpoints that were previously authenticated
+but not authorized (e.g. ``/user-config/<owner>`` and
+``/accounts/<owner>/approvals``).
+
+When ``config.disable_auth`` is truthy the API runs in local/demo mode where
+the ``/owners`` listing exposes every owner and no identity is enforced; these
+helpers deliberately no-op in that mode so demo and no-auth flows are not
+restricted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Optional, Set
+
+from backend.common.data_loader import load_person_meta
+from backend.common.errors import PermissionDeniedError
+from backend.config import config
+
+_FORBIDDEN_DETAIL = "Not authorized for this owner"
+
+
+def _allowed_identities(owner: str, meta: Mapping[str, Any]) -> Set[str]:
+    """Return the lower-cased identities permitted to access ``owner``."""
+
+    allowed: Set[str] = set()
+    if isinstance(owner, str) and owner.strip():
+        allowed.add(owner.strip().lower())
+
+    email = meta.get("email") if isinstance(meta, Mapping) else None
+    if isinstance(email, str) and email.strip():
+        allowed.add(email.strip().lower())
+
+    viewers = meta.get("viewers") if isinstance(meta, Mapping) else None
+    if isinstance(viewers, list):
+        allowed.update(viewer.strip().lower() for viewer in viewers if isinstance(viewer, str) and viewer.strip())
+    return allowed
+
+
+def identity_can_access_owner(identity: Optional[str], owner: str, meta: Mapping[str, Any]) -> bool:
+    """Return ``True`` when ``identity`` may access ``owner`` given ``meta``."""
+
+    if not isinstance(identity, str) or not identity.strip():
+        return False
+    return identity.strip().lower() in _allowed_identities(owner, meta)
+
+
+def ensure_owner_access(
+    identity: Optional[str],
+    owner: str,
+    accounts_root: Optional[Path] = None,
+) -> None:
+    """Raise :class:`PermissionDeniedError` when ``identity`` lacks access.
+
+    No-op when authentication is disabled (local/demo mode). Otherwise the
+    owner's person metadata is consulted and the caller must match the owner
+    id, the owner's email, or a listed viewer.
+    """
+
+    if config.disable_auth:
+        return
+
+    meta = load_person_meta(owner, accounts_root)
+    if not identity_can_access_owner(identity, owner, meta):
+        raise PermissionDeniedError(_FORBIDDEN_DETAIL, safe_detail=_FORBIDDEN_DETAIL)

--- a/backend/routes/approvals.py
+++ b/backend/routes/approvals.py
@@ -62,9 +62,9 @@ def _resolve_owner_dir(root: Path, owner: str) -> Path:
 @handle_owner_not_found
 async def get_approvals(owner: str, request: Request, identity: str | None = Depends(get_active_user)):
     root = resolve_accounts_root(request)
+    ensure_owner_access(identity, owner, root)
     owner_dir = _resolve_owner_dir(root, owner)
     approvals_root = owner_dir.parent
-    ensure_owner_access(identity, owner, approvals_root)
     try:
         approvals = load_approvals(owner, approvals_root)
     except FileNotFoundError:
@@ -81,8 +81,8 @@ async def post_approval_request(owner: str, request: Request, identity: str | No
     if not ticker:
         raise HTTPException(status_code=400, detail="ticker is required")
     root = resolve_accounts_root(request)
+    ensure_owner_access(identity, owner, root)
     owner_dir = _resolve_owner_dir(root, owner)
-    ensure_owner_access(identity, owner, owner_dir.parent)
     path = owner_dir / "approval_requests.json"
     try:
         raw = json.loads(path.read_text())
@@ -113,9 +113,9 @@ async def post_approval(owner: str, request: Request, identity: str | None = Dep
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="invalid approved_on") from exc
     root = resolve_accounts_root(request)
+    ensure_owner_access(identity, owner, root)
     owner_dir = _resolve_owner_dir(root, owner)
     approvals_root = owner_dir.parent
-    ensure_owner_access(identity, owner, approvals_root)
     approvals = upsert_approval(owner, ticker, approved_on, approvals_root)
     entries = [{"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()]
     return {"approvals": entries}
@@ -127,9 +127,9 @@ async def delete_approval_route(owner: str, request: Request, identity: str | No
     data = await request.json()
     ticker = (data.get("ticker") or "").upper()
     root = resolve_accounts_root(request)
+    ensure_owner_access(identity, owner, root)
     owner_dir = _resolve_owner_dir(root, owner)
     approvals_root = owner_dir.parent
-    ensure_owner_access(identity, owner, approvals_root)
     approvals = delete_approval(owner, ticker, approvals_root)
     entries = [{"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()]
     return {"approvals": entries}

--- a/backend/routes/approvals.py
+++ b/backend/routes/approvals.py
@@ -3,10 +3,12 @@ import os
 from datetime import date
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
+from backend.auth import get_active_user
 from backend.common import data_loader
 from backend.common.approvals import delete_approval, load_approvals, upsert_approval
+from backend.common.authz import ensure_owner_access
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
 from backend.routes._accounts import resolve_accounts_root
 
@@ -58,29 +60,29 @@ def _resolve_owner_dir(root: Path, owner: str) -> Path:
 
 @router.get("/{owner}/approvals")
 @handle_owner_not_found
-async def get_approvals(owner: str, request: Request):
+async def get_approvals(owner: str, request: Request, identity: str | None = Depends(get_active_user)):
     root = resolve_accounts_root(request)
     owner_dir = _resolve_owner_dir(root, owner)
     approvals_root = owner_dir.parent
+    ensure_owner_access(identity, owner, approvals_root)
     try:
         approvals = load_approvals(owner, approvals_root)
     except FileNotFoundError:
         approvals = {}
-    entries = [
-        {"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()
-    ]
+    entries = [{"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()]
     return {"approvals": entries}
 
 
 @router.post("/{owner}/approval-requests")
 @handle_owner_not_found
-async def post_approval_request(owner: str, request: Request):
+async def post_approval_request(owner: str, request: Request, identity: str | None = Depends(get_active_user)):
     data = await request.json()
     ticker = (data.get("ticker") or "").upper()
     if not ticker:
         raise HTTPException(status_code=400, detail="ticker is required")
     root = resolve_accounts_root(request)
     owner_dir = _resolve_owner_dir(root, owner)
+    ensure_owner_access(identity, owner, owner_dir.parent)
     path = owner_dir / "approval_requests.json"
     try:
         raw = json.loads(path.read_text())
@@ -100,7 +102,7 @@ async def post_approval_request(owner: str, request: Request):
 
 @router.post("/{owner}/approvals")
 @handle_owner_not_found
-async def post_approval(owner: str, request: Request):
+async def post_approval(owner: str, request: Request, identity: str | None = Depends(get_active_user)):
     data = await request.json()
     ticker = (data.get("ticker") or "").upper()
     when = data.get("approved_on")
@@ -113,23 +115,21 @@ async def post_approval(owner: str, request: Request):
     root = resolve_accounts_root(request)
     owner_dir = _resolve_owner_dir(root, owner)
     approvals_root = owner_dir.parent
+    ensure_owner_access(identity, owner, approvals_root)
     approvals = upsert_approval(owner, ticker, approved_on, approvals_root)
-    entries = [
-        {"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()
-    ]
+    entries = [{"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()]
     return {"approvals": entries}
 
 
 @router.delete("/{owner}/approvals")
 @handle_owner_not_found
-async def delete_approval_route(owner: str, request: Request):
+async def delete_approval_route(owner: str, request: Request, identity: str | None = Depends(get_active_user)):
     data = await request.json()
     ticker = (data.get("ticker") or "").upper()
     root = resolve_accounts_root(request)
     owner_dir = _resolve_owner_dir(root, owner)
     approvals_root = owner_dir.parent
+    ensure_owner_access(identity, owner, approvals_root)
     approvals = delete_approval(owner, ticker, approvals_root)
-    entries = [
-        {"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()
-    ]
+    entries = [{"ticker": t, "approved_on": d.isoformat()} for t, d in approvals.items()]
     return {"approvals": entries}

--- a/backend/routes/user_config.py
+++ b/backend/routes/user_config.py
@@ -4,15 +4,17 @@ from backend.auth import get_active_user
 from backend.common.authz import ensure_owner_access
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
 from backend.common.user_config import load_user_config, save_user_config
+from backend.routes._accounts import resolve_accounts_root
 
 router = APIRouter(prefix="/user-config", tags=["user-config"])
 
 
 @handle_owner_not_found
 async def get_user_config(owner: str, request: Request, identity: str | None = Depends(get_active_user)):
-    ensure_owner_access(identity, owner, request.app.state.accounts_root)
+    accounts_root = resolve_accounts_root(request, allow_missing=True)
+    ensure_owner_access(identity, owner, accounts_root)
     try:
-        cfg = load_user_config(owner, request.app.state.accounts_root)
+        cfg = load_user_config(owner, accounts_root)
     except FileNotFoundError:
         raise_owner_not_found()
     return cfg.to_dict()
@@ -20,11 +22,12 @@ async def get_user_config(owner: str, request: Request, identity: str | None = D
 
 @handle_owner_not_found
 async def update_user_config(owner: str, request: Request, identity: str | None = Depends(get_active_user)):
-    ensure_owner_access(identity, owner, request.app.state.accounts_root)
+    accounts_root = resolve_accounts_root(request, allow_missing=True)
+    ensure_owner_access(identity, owner, accounts_root)
     data = await request.json()
     try:
-        save_user_config(owner, data, request.app.state.accounts_root)
-        cfg = load_user_config(owner, request.app.state.accounts_root)
+        save_user_config(owner, data, accounts_root)
+        cfg = load_user_config(owner, accounts_root)
         return cfg.to_dict()
     except FileNotFoundError:
         raise_owner_not_found()

--- a/backend/routes/user_config.py
+++ b/backend/routes/user_config.py
@@ -1,12 +1,16 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
+from backend.auth import get_active_user
+from backend.common.authz import ensure_owner_access
 from backend.common.errors import handle_owner_not_found, raise_owner_not_found
 from backend.common.user_config import load_user_config, save_user_config
 
 router = APIRouter(prefix="/user-config", tags=["user-config"])
 
+
 @handle_owner_not_found
-async def get_user_config(owner: str, request: Request):
+async def get_user_config(owner: str, request: Request, identity: str | None = Depends(get_active_user)):
+    ensure_owner_access(identity, owner, request.app.state.accounts_root)
     try:
         cfg = load_user_config(owner, request.app.state.accounts_root)
     except FileNotFoundError:
@@ -15,7 +19,8 @@ async def get_user_config(owner: str, request: Request):
 
 
 @handle_owner_not_found
-async def update_user_config(owner: str, request: Request):
+async def update_user_config(owner: str, request: Request, identity: str | None = Depends(get_active_user)):
+    ensure_owner_access(identity, owner, request.app.state.accounts_root)
     data = await request.json()
     try:
         save_user_config(owner, data, request.app.state.accounts_root)

--- a/tests/backend/common/test_authz.py
+++ b/tests/backend/common/test_authz.py
@@ -1,0 +1,78 @@
+"""Unit tests for per-owner authorization helpers."""
+
+import pytest
+
+from backend.common import authz
+from backend.common.errors import PermissionDeniedError
+from backend.config import config
+
+
+@pytest.mark.parametrize(
+    "identity,owner,meta,expected",
+    [
+        # Identity equals the owner id (case-insensitive).
+        ("alice", "alice", {}, True),
+        ("ALICE", "alice", {}, True),
+        ("  alice  ", "alice", {}, True),
+        # Identity matches the owner's configured email.
+        ("alice@example.com", "alice", {"email": "alice@example.com"}, True),
+        ("ALICE@EXAMPLE.COM", "alice", {"email": "alice@example.com"}, True),
+        # Identity appears in the viewers list (family/household model).
+        ("mum@example.com", "alice", {"viewers": ["mum@example.com"]}, True),
+        # Unrelated identity is rejected even when metadata is populated.
+        (
+            "bob",
+            "alice",
+            {"email": "alice@example.com", "viewers": ["mum@example.com"]},
+            False,
+        ),
+        ("bob", "alice", {}, False),
+        # Missing / blank identities are never authorized.
+        (None, "alice", {}, False),
+        ("", "alice", {}, False),
+        ("   ", "alice", {}, False),
+        # Malformed metadata degrades safely.
+        ("bob", "alice", {"viewers": "not-a-list"}, False),
+    ],
+)
+def test_identity_can_access_owner(identity, owner, meta, expected):
+    assert authz.identity_can_access_owner(identity, owner, meta) is expected
+
+
+def test_ensure_owner_access_noop_when_auth_disabled(monkeypatch):
+    """Local/demo mode must not enforce owner scoping or read metadata."""
+
+    monkeypatch.setattr(config, "disable_auth", True)
+    calls = {"count": 0}
+
+    def fake_meta(owner, root=None):
+        calls["count"] += 1
+        return {}
+
+    monkeypatch.setattr(authz, "load_person_meta", fake_meta)
+
+    authz.ensure_owner_access("bob", "alice")
+    assert calls["count"] == 0
+
+
+def test_ensure_owner_access_allows_authorized(monkeypatch):
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setattr(authz, "load_person_meta", lambda owner, root=None: {"email": "alice@example.com"})
+
+    authz.ensure_owner_access("alice@example.com", "alice")
+
+
+def test_ensure_owner_access_rejects_unauthorized(monkeypatch):
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setattr(authz, "load_person_meta", lambda owner, root=None: {})
+
+    with pytest.raises(PermissionDeniedError):
+        authz.ensure_owner_access("bob", "alice")
+
+
+def test_ensure_owner_access_rejects_missing_identity(monkeypatch):
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setattr(authz, "load_person_meta", lambda owner, root=None: {})
+
+    with pytest.raises(PermissionDeniedError):
+        authz.ensure_owner_access(None, "alice")

--- a/tests/backend/test_approvals_route.py
+++ b/tests/backend/test_approvals_route.py
@@ -4,6 +4,44 @@ from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.common.data_loader import ResolvedPaths
+from backend.config import config
+
+
+def _write_owner(root, owner, email):
+    owner_dir = root / owner
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "person.json").write_text(json.dumps({"owner": owner, "email": email}))
+    return owner_dir
+
+
+def test_approvals_authorization_enforced(tmp_path, monkeypatch):
+    """With auth enabled, a user may only touch approvals for their own owner."""
+
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+
+    root = tmp_path / "accounts"
+    _write_owner(root, "alice", "user@example.com")
+    _write_owner(root, "alex", "other@example.com")
+
+    app = create_app()
+    app.state.accounts_root = root
+    client = TestClient(app)
+    token = client.post("/token", json={"id_token": "good"}).json()["access_token"]
+    client.headers.update({"Authorization": f"Bearer {token}"})
+
+    assert client.get("/accounts/alice/approvals").status_code == 200
+
+    assert client.get("/accounts/alex/approvals").status_code == 403
+    forbidden_post = client.post(
+        "/accounts/alex/approvals",
+        json={"ticker": "PFE", "approved_on": "2024-01-01"},
+    )
+    assert forbidden_post.status_code == 403
+    forbidden_delete = client.request("DELETE", "/accounts/alex/approvals", json={"ticker": "PFE"})
+    assert forbidden_delete.status_code == 403
+    # The rejected write must not have created an approvals file for ``alex``.
+    assert not (root / "alex" / "approvals.json").exists()
 
 
 def test_post_approval_request_falls_back_to_default_accounts_root(tmp_path, monkeypatch):

--- a/tests/backend/test_approvals_route.py
+++ b/tests/backend/test_approvals_route.py
@@ -7,10 +7,13 @@ from backend.common.data_loader import ResolvedPaths
 from backend.config import config
 
 
-def _write_owner(root, owner, email):
+def _write_owner(root, owner, email, viewers=None):
     owner_dir = root / owner
     owner_dir.mkdir(parents=True)
-    (owner_dir / "person.json").write_text(json.dumps({"owner": owner, "email": email}))
+    payload = {"owner": owner, "email": email}
+    if viewers is not None:
+        payload["viewers"] = viewers
+    (owner_dir / "person.json").write_text(json.dumps(payload))
     return owner_dir
 
 
@@ -23,6 +26,9 @@ def test_approvals_authorization_enforced(tmp_path, monkeypatch):
     root = tmp_path / "accounts"
     _write_owner(root, "alice", "user@example.com")
     _write_owner(root, "alex", "other@example.com")
+    # ``carol`` belongs to someone else but explicitly lists our identity as a
+    # viewer (the family/household path).
+    _write_owner(root, "carol", "carol@example.com", viewers=["user@example.com"])
 
     app = create_app()
     app.state.accounts_root = root
@@ -30,7 +36,9 @@ def test_approvals_authorization_enforced(tmp_path, monkeypatch):
     token = client.post("/token", json={"id_token": "good"}).json()["access_token"]
     client.headers.update({"Authorization": f"Bearer {token}"})
 
+    # Owner match and viewer match are both authorized.
     assert client.get("/accounts/alice/approvals").status_code == 200
+    assert client.get("/accounts/carol/approvals").status_code == 200
 
     assert client.get("/accounts/alex/approvals").status_code == 403
     forbidden_post = client.post(
@@ -42,6 +50,10 @@ def test_approvals_authorization_enforced(tmp_path, monkeypatch):
     assert forbidden_delete.status_code == 403
     # The rejected write must not have created an approvals file for ``alex``.
     assert not (root / "alex" / "approvals.json").exists()
+
+    # A non-existent owner is rejected with 403 (not 404): authorization runs
+    # before owner resolution so owner existence is not leaked.
+    assert client.get("/accounts/ghost/approvals").status_code == 403
 
 
 def test_post_approval_request_falls_back_to_default_accounts_root(tmp_path, monkeypatch):

--- a/tests/test_user_config_route.py
+++ b/tests/test_user_config_route.py
@@ -87,3 +87,38 @@ def test_defaults_from_config_return_lists(client, mock_user_config):
     data = resp.json()
     assert data["approval_exempt_types"] == ["ETF"]
     assert data["approval_exempt_tickers"] == []
+
+
+def _auth_enabled_client(monkeypatch):
+    """Build a client with authentication (and thus owner scoping) enabled.
+
+    ``disable_auth`` is an override attribute preserved across ``create_app``'s
+    config reload, so setting it before app creation makes both the router-level
+    auth dependency and the per-owner authorization check active.
+    """
+
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    return _auth_client()
+
+
+def test_owner_config_authorization_enforced(monkeypatch, mock_user_config):
+    """A logged-in user may only read/write owners they are authorized for."""
+
+    # ``user@example.com`` (the identity behind the "good" token) is mapped to
+    # owner ``alice`` only; ``alex`` belongs to someone else.
+    def fake_meta(owner, root=None):
+        return {"email": "user@example.com"} if owner == "alice" else {}
+
+    monkeypatch.setattr("backend.common.authz.load_person_meta", fake_meta)
+    client = _auth_enabled_client(monkeypatch)
+
+    assert client.get("/user-config/alice").status_code == 200
+
+    forbidden_get = client.get("/user-config/alex")
+    assert forbidden_get.status_code == 403
+
+    forbidden_post = client.post("/user-config/alex", json={"hold_days_min": 1})
+    assert forbidden_post.status_code == 403
+    # The unauthorized write must not have mutated the other owner's config.
+    assert "hold_days_min" not in mock_user_config["alex"]


### PR DESCRIPTION
## Summary

Fixes the server-side authorization gap in #4710: the `/user-config/<owner>` and `/accounts/<owner>/approvals` endpoints were **authenticated but not authorized**, so any logged-in user with a valid token could read or mutate **any** owner's config (hold-days, max-trades, exempt tickers/types) and trade approvals via a direct API call.

## Access model (confirmed from code, not assumed)

The intended model is already implemented in `backend/common/data_loader.py` (`_is_authorized` inside `_list_local_plots`, used to scope the `/owners` listing — and therefore the Settings dropdown). It is a **family/viewer model**: an identity may access an owner when it matches

- the owner id, **or**
- the owner's `email` in `person.json`, **or**
- an entry in the owner's `viewers` list.

This PR does **not** invent a new model — it applies the existing one to the endpoints that were missing it.

## What changed

- **New** `backend/common/authz.py` — reusable `identity_can_access_owner()` / `ensure_owner_access()` centralizing the owner-id / email / viewers rule.
- `backend/routes/user_config.py` — `GET`/`POST /user-config/<owner>` now call `ensure_owner_access`.
- `backend/routes/approvals.py` — `GET`/`POST`/`DELETE /accounts/<owner>/approvals` and `POST /accounts/<owner>/approval-requests` now call `ensure_owner_access`.
- Unauthorized access returns **403** (`PermissionDeniedError`, already wired to the app error handler).
- Authorization is a **no-op when `config.disable_auth` is set** (local/demo mode), matching how `/owners` exposes all owners there — so demo / no-auth flows are unaffected (issue constraint).

## Frontend / dropdown

No frontend change was required for the dropdown-scoping success criterion: `getOwners()` already calls the `/owners` endpoint (with the bearer token), which is **already scoped by the logged-in identity** via the same `_is_authorized` rule when auth is enabled. The remaining, real gap was the direct-API access on the two per-owner endpoints — now closed as defense at the API layer.

## Tests

- `tests/backend/common/test_authz.py` — unit tests for the helper (owner-id / email / viewers match, case-insensitivity, blank/None identity, malformed metadata, disable_auth no-op).
- `tests/test_user_config_route.py` — auth-enabled test: authorized owner → 200, other owner → 403 on read and write (and no mutation occurs).
- `tests/backend/test_approvals_route.py` — auth-enabled test: authorized owner → 200; other owner → 403 on GET/POST/DELETE (and no approvals file is created).

Existing tests run with `disable_auth: true` (repo default `config.yaml`) and are unaffected. `ruff`, `black`, and `isort` pass clean on the changed files.

## Scope note

Limited to the two endpoint groups named in #4710 (settings + approvals). Broadening owner-level authorization to other per-owner endpoints (e.g. `/portfolio/<owner>`) would be a larger, separate change and is out of scope here.

Closes #4710

🤖 Generated with [Claude Code](https://claude.com/claude-code)
