### PR TITLE
fix(ci): scope DeepSeek PR review runs per-PR with concurrency

### DIFF
--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -4,6 +4,18 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
 
+# labeled/unlabeled events on "Deep Review Required" fire an extra run
+# alongside the synchronize-triggered run, and the two runs' check results
+# (one often "skipped" via the ai-review job's `if`, the other "successful")
+# can both remain visible for the same head SHA. Grouping by PR number and
+# cancelling in-progress runs ensures only the most recent run's job is
+# still executing when a newer event arrives, so branch protection and the
+# checks UI settle on a single up-to-date result per SHA instead of
+# accumulating stale ones from earlier label toggles or pushes.
+concurrency:
+  group: deepseek-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   ai-review:
     # For labeled/unlabeled events, github.event.label.name is the label that


### PR DESCRIPTION
## Summary
- `deepseek-pr-review.yml` is the only AI review workflow that also fires on `labeled`/`unlabeled` events (for the `Deep Review Required` label). A label toggle triggers an extra workflow run for the same head SHA alongside the `synchronize`-triggered run, and each run produces its own `ai-review / DeepSeek AI code review` check result — one is often "skipped" (via the `ai-review` job's `if` condition not matching), the other "successful". Both can remain visible in the PR checks list simultaneously, making it unclear which run branch protection is actually keying off.
- Added a `concurrency` group scoped to the PR number with `cancel-in-progress: true`, so a newer run cancels an older still-running one for the same PR instead of letting both complete and linger in the checks list.
- Left `claude-pr-review.yml` and `gpt-pr-review.yml` unchanged — they only trigger on `opened`/`reopened`/`synchronize`, so they don't have the labeled/unlabeled-driven duplicate-run pattern that causes this issue.

## Root cause
Confirmed via workflow config: `deepseek-pr-review.yml`'s `pull_request.types` includes `labeled, unlabeled`, uniquely among the three review workflows. Adding/removing the `Deep Review Required` label starts a fresh workflow run producing the same check context (`ai-review / DeepSeek AI code review`) as any concurrent `synchronize` run, and GitHub does not collapse the resulting check runs from separate workflow/check-suite runs in the PR UI.

## Safety
- The Dependabot bypass job's check-context string (`ai-review / DeepSeek AI code review`) is untouched, so it still satisfies the required check for Dependabot PRs.
- `cancel-in-progress` only affects runs that are still executing; a cancelled run surfaces as cancelled, never as a stale success, so branch protection cannot be satisfied by an unreviewed commit.
- The concurrency group key includes the PR number, so it's scoped per-PR and doesn't cancel unrelated PRs' reviews.

## Test plan
- [ ] Confirm on a real PR: push a commit, then toggle the `Deep Review Required` label rapidly, and verify only one `ai-review / DeepSeek AI code review` check result remains for the latest head SHA (the older one shows as cancelled rather than skipped+successful side by side).
- [ ] Confirm Dependabot PRs still get an auto-passing `ai-review / DeepSeek AI code review` check.

Closes #4718