### PR TITLE
ci: gate frontend-smoke on test success, bound runtime, skip on backend-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,9 +153,28 @@ jobs:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
         run: pytest --no-cov tests/test_backend_api.py::test_health tests/backend/common/test_data_provider_parity.py -q
 
+  detect-frontend-changes:
+    name: Detect frontend-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+              - 'package.json'
+              - 'package-lock.json'
+
   frontend-smoke:
     name: Frontend smoke tests (preview build)
+    needs: [test, detect-frontend-changes]
+    if: needs.detect-frontend-changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- `frontend-smoke` is already a required merge-blocking check (added in #4728), but the job definition itself didn't reflect that: it still ran to completion on backend-only PRs and even after `test` had already failed, with no timeout to bound a runaway Playwright/browser install.
- Add a `detect-frontend-changes` job using `dorny/paths-filter@v4` to detect whether a PR touches `frontend/**`, `package.json`, or `package-lock.json`.
- Gate `frontend-smoke` with `needs: [test, detect-frontend-changes]` and `if: needs.detect-frontend-changes.outputs.frontend == 'true'` — it now only runs when `test` succeeds and the PR touches frontend-relevant paths. Skipped (not failed) jobs count as passing for required-status-check purposes, so this doesn't reopen the merge gate.
- Add `timeout-minutes: 15` to bound the job.

**Scope note:** #4743 lists 4 sub-items. Items 1-2 (add `CI / Frontend smoke tests (preview build)` to `.github/rulesets/default-branch-protection.json` and to `EXPECTED_REQUIRED_CHECKS` in `scripts/check_branch_protection_required_checks.py`) were already shipped in #4728, before this PR branched - verified by running `python scripts/check_branch_protection_required_checks.py` against `main`, which passes with no changes from this PR. This PR covers the remaining items 3-4: `needs`/`timeout-minutes`/paths-filter on the `frontend-smoke` job.

Closes #4743

## Test plan
- [x] `actionlint .github/workflows/ci.yml` passes
- [x] `python scripts/check_branch_protection_required_checks.py` passes
- [x] CI green on this PR
- [x] Recent `frontend-smoke` run history reviewed for flakiness before merge (spot-checked: mostly green over the last 24h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
