### PR TITLE
docs(ci): add comment explaining why cancel-in-progress is safe in DeepSeek PR review workflow

### DIFF
--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -14,6 +14,9 @@ on:
 # accumulating stale ones from earlier label toggles or pushes.
 concurrency:
   group: deepseek-pr-review-${{ github.event.pull_request.number }}
+  # cancel-in-progress is safe here because this workflow has only one job (ai-review).
+  # No other jobs have side effects (deployments, state mutations, cleanup) that would
+  # be dangerous to interrupt. If additional jobs are added, reassess this setting.
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Implement #4721: Add comment explaining why cancel-in-progress is safe

Closes #4721

## What changed
- Added a comment in \.github/workflows/deepseek-pr-review.yml\ directly above \cancel-in-progress: true\ explaining why cancellation is safe (single executing job, no side effects from interruption).

## Why changed
Automated tooling (including AI code review agents) may flag \cancel-in-progress: true\ as a risk if they cannot infer the single-job context. The comment makes the intent unambiguous and reminds future contributors to reassess the setting if additional jobs are added.

## What was verified
- YAML syntax validated with Python's yaml.safe_load (no parse errors)
- Comment placement is correct: directly above \cancel-in-progress: true\ within the concurrency block
- Only the target file was modified; no other workflows were changed

## Known risks / follow-up
None. This is a comment-only change with no behavioural impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer workflow comments explaining when interrupting in-progress runs is safe.
  * No functional behaviour, triggers, or job settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->