### PR TITLE
fix: harden _EXCHANGE_CODE_RE to reject degenerate dot patterns

### DIFF
--- a/backend/routes/timeseries_meta.py
+++ b/backend/routes/timeseries_meta.py
@@ -33,7 +33,7 @@ _TICKER_SEGMENT_RE = re.compile(r"^[A-Z0-9_-]{1,50}$")
 # Exchange codes use a separate, slightly broader regex: resolver-returned
 # codes can contain dots (e.g. NYSE.US), which ticker symbols never do.
 _TICKER_SYMBOL_RE = re.compile(r"^[A-Z0-9_-]{1,50}$")
-_EXCHANGE_CODE_RE = re.compile(r"^[A-Z0-9._-]{1,50}$")
+_EXCHANGE_CODE_RE = re.compile(r"^(?=.{1,50}$)[A-Z0-9]+([._-][A-Z0-9]+)*$")
 
 # Wider allowlist applied to resolver-returned values.  Permits dots so that
 # exchange codes like XLON.G are accepted, while still rejecting HTML-unsafe


### PR DESCRIPTION
Implement #4615: Harden exchange code regex to prevent degenerate dot patterns

Closes #4615

## What changed
- Changed \_EXCHANGE_CODE_RE\ from \^[A-Z0-9._-]{1,50}\$\ to \^(?=.{1,50}$)[A-Z0-9]+([._-][A-Z0-9]+)*\$\
- The new regex requires exchange codes to start and end with alphanumeric characters, preventing leading dots, trailing dots, and consecutive dot/separator patterns

## Why changed
The previous regex allowed degenerate dot patterns like \..US\, \.US.\, \US..\, \.\, and \..\ to pass validation. A resolver-returned exchange code with these patterns would create a correctness risk downstream. This is a one-line hardening measure with no behavioral change for valid inputs.

## What was validated
- Regex unit test: rejected \..US\, \.US.\, \US..\, \.\, \..\; accepted \NYSE\, \LSE\, \XETRA\, \US\, \ABC.DEF\, \L\, \N\
- \	ests/routes/test_timeseries_meta.py\: all 46 tests pass
- \	ests/routes/test_timeseries_edit.py\ + \	ests/timeseries/test_fetch_meta_timeseries.py\: all 65 tests pass
- \uff check\: zero warnings
- \lack\: formatted

## Known risks / follow-up
None — this is a purely restrictive change that only rejects inputs the old regex would have accepted incorrectly.