### PR TITLE
fix: add error handling for filepath.unlink() permission errors

### DIFF
--- a/scripts/dev_tools/sync_issues.py
+++ b/scripts/dev_tools/sync_issues.py
@@ -160,7 +160,13 @@ def main():
         current_name = open_ids_to_filenames.get(issue_id)
         is_outdated = current_name and current_name != filepath.name
         if is_closed or is_outdated:
-            filepath.unlink()
+            try:
+                filepath.unlink()
+            except PermissionError as e:
+                print(
+                    f"Warning: Could not delete {filepath}: {e}",
+                    file=sys.stderr,
+                )
 
     print(f"Synced {len(open_issues)} open issues to {ISSUES_DIR}")
 


### PR DESCRIPTION
Implement #4522: Add error handling for `filepath.unlink()` permission errors

## What changed
- Wrapped `filepath.unlink()` call in `scripts/dev_tools/sync_issues.py` (line 163) with a `try/except PermissionError` block
- On permission error, logs a warning to stderr and continues instead of crashing the entire sync

## Why changed
If another process holds a file open (e.g., a text editor, file watcher, or concurrent script run), `unlink()` raises `PermissionError`, which currently crashes the entire sync, leaving the script in an inconsistent state and requiring manual re-run.

## What was verified
- `python -m ruff check scripts/dev_tools/sync_issues.py` passes with zero warnings
- Only `PermissionError` is caught; `FileNotFoundError` and other genuine errors still propagate
- No new dependencies (stdlib only)

## Known risks / follow-up
- None

Closes #4522
