### PR TITLE
Add pytest tests for market_overview endpoint using TestClient and mock.patch

### DIFF
--- a/tests/routes/test_market.py
+++ b/tests/routes/test_market.py
@@ -1,6 +1,7 @@
 """Tests for the market overview helpers and HTTP endpoint."""
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -331,3 +332,76 @@ def test_market_overview_uk_region_handles_fetch_errors(monkeypatch):
     assert data["sectors"] == []
     assert data["headlines"] == []
     assert calls == ["uk", "headlines"]
+
+
+# ---------------------------------------------------------------------------
+# Tests using unittest.mock.patch instead of monkeypatch
+# ---------------------------------------------------------------------------
+
+
+@patch("backend.routes.market._fetch_indexes", return_value={})
+@patch("backend.routes.market._fetch_sectors", return_value=[])
+@patch("backend.routes.market._fetch_headlines", return_value=[])
+def test_market_overview_returns_200(
+    mock_headlines,
+    mock_sectors,
+    mock_indexes,
+) -> None:
+    """All three fetchers return empty data; endpoint responds 200 with expected keys."""
+    client = _client()
+    resp = client.get("/market/overview")
+    assert resp.status_code == 200
+    assert resp.json() == {"indexes": {}, "sectors": [], "headlines": []}
+
+
+@patch(
+    "backend.routes.market._fetch_indexes",
+    return_value={"S&P 500": {"value": 5000.0, "change": 0.5}},
+)
+@patch("backend.routes.market._fetch_sectors")
+@patch(
+    "backend.routes.market._fetch_uk_sectors",
+    return_value=[{"sector": "Tech", "change": 1.2, "source": "lse"}],
+)
+@patch("backend.routes.market._fetch_headlines", return_value=[{"headline": "Markets rally"}])
+def test_market_overview_uk_region(
+    mock_headlines,
+    mock_uk_sectors,
+    mock_sectors,
+    mock_indexes,
+) -> None:
+    """Passing region=uk routes to _fetch_uk_sectors instead of _fetch_sectors."""
+    client = _client()
+    resp = client.get("/market/overview", params={"region": "uk"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["indexes"] == {"S&P 500": {"value": 5000.0, "change": 0.5}}
+    assert data["sectors"] == [{"sector": "Tech", "change": 1.2, "source": "lse"}]
+    assert data["headlines"] == [{"headline": "Markets rally"}]
+    mock_sectors.assert_not_called()
+    mock_uk_sectors.assert_called_once()
+
+
+@patch(
+    "backend.routes.market._fetch_indexes",
+    return_value={"S&P 500": {"value": 5000.0, "change": 0.5}},
+)
+@patch(
+    "backend.routes.market._fetch_sectors",
+    return_value=[{"sector": "Energy", "change": -0.3, "source": "lse"}],
+)
+@patch("backend.routes.market._fetch_headlines", side_effect=Exception("headlines down"))
+def test_market_overview_fetcher_exception_returns_default(
+    mock_headlines,
+    mock_sectors,
+    mock_indexes,
+) -> None:
+    """When one fetcher raises, the endpoint still returns 200 with default values
+    for the failing field and real data for the other fields (thanks to _safe)."""
+    client = _client()
+    resp = client.get("/market/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["indexes"] == {"S&P 500": {"value": 5000.0, "change": 0.5}}
+    assert data["sectors"] == [{"sector": "Energy", "change": -0.3, "source": "lse"}]
+    assert data["headlines"] == []


### PR DESCRIPTION
Closes #4683

## What changed

Added three new test cases to `tests/routes/test_market.py` using `unittest.mock.patch` decorators (as requested in the issue), targeting module-level names in `backend.routes.market`:

- **test_market_overview_returns_200** — patches all three fetchers (`_fetch_indexes`, `_fetch_sectors`, `_fetch_headlines`) to return empty values, asserts 200 status and expected response keys
- **test_market_overview_uk_region** — passes `?region=uk`, asserts `_fetch_uk_sectors` is called and `_fetch_sectors` is not
- **test_market_overview_fetcher_exception_returns_default** — makes `_fetch_headlines` raise `Exception`, asserts the endpoint still returns 200 with that field defaulting to `[]` while other fields are populated

## What was validated

- `pytest tests/routes/test_market.py -v --no-cov` — all 14 tests pass (11 existing + 3 new)
- No network calls made during test run (verified via `--tb=short`, no timeout errors)
- `ruff check tests/routes/test_market.py` — no new warnings (pre-existing B007 on line 27 is unrelated)
- No changes to `market.py` — it was already testable via `patch`

## Success criteria

| Criterion | Status |
|-----------|--------|
| Tests pass without network | ✅ |
| `_fetch_uk_sectors` vs `_fetch_sectors` distinction tested | ✅ |
| Exception path covered | ✅ |
| `make lint` passes | ✅ (pre-existing B007 only) |