### PR TITLE
ci: harden frontend-smoke job robustness (artifacts, shared setup, step naming)

### DIFF
--- a/.github/actions/setup-frontend-deps/action.yml
+++ b/.github/actions/setup-frontend-deps/action.yml
@@ -3,6 +3,16 @@ description: >-
   Set up Node.js and install root + frontend npm dependencies. Shared by
   ci.yml's frontend-smoke job and deploy-lambda.yml's deploy and smoke-test
   jobs. Assumes the caller has already checked out the repository.
+inputs:
+  enable-cache:
+    description: >-
+      Whether to enable actions/setup-node's npm cache. Defaults to 'true' to
+      preserve frontend-smoke's original caching behavior. deploy-lambda.yml's
+      deploy and smoke-test jobs pass 'false' since they never had npm caching
+      before this action existed, and enabling it there would be a caching
+      behavior change outside this action's scope.
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -10,7 +20,7 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: '24'
-        cache: npm
+        cache: ${{ inputs.enable-cache == 'true' && 'npm' || '' }}
         cache-dependency-path: |
           package-lock.json
           frontend/package-lock.json

--- a/.github/actions/setup-frontend-deps/action.yml
+++ b/.github/actions/setup-frontend-deps/action.yml
@@ -1,0 +1,29 @@
+name: 'Setup frontend dependencies'
+description: >-
+  Set up Node.js and install root + frontend npm dependencies. Shared by
+  ci.yml's frontend-smoke job and deploy-lambda.yml's deploy and smoke-test
+  jobs. Assumes the caller has already checked out the repository.
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+        cache: npm
+        cache-dependency-path: |
+          package-lock.json
+          frontend/package-lock.json
+
+    # Root install brings in esbuild (a transitive dependency of the root
+    # tsx devDependency). Vite v8 treats esbuild as an optional peer
+    # dependency, so frontend/node_modules alone does not contain it;
+    # Node resolves it from the root node_modules instead.
+    - name: Install root dependencies
+      run: npm ci
+      shell: bash
+
+    - name: Install frontend dependencies
+      run: npm ci
+      working-directory: frontend
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,21 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            frontend/package-lock.json
-      # Root install brings in esbuild (a transitive dependency of the root
-      # tsx devDependency). Vite v8 treats esbuild as an optional peer
-      # dependency, so frontend/node_modules alone does not contain it;
-      # Node resolves it from the root node_modules instead, matching the
-      # working deploy-lambda.yml smoke-test job.
-      - run: npm ci
-      - run: npm ci
-        working-directory: frontend
+      - uses: ./.github/actions/setup-frontend-deps
       - name: Build preview
         run: npm run build:preview
         working-directory: frontend
@@ -182,3 +168,12 @@ jobs:
       - name: Run frontend smoke tests
         run: npx playwright test --config playwright.config.ts tests/smoke.spec.ts
         working-directory: frontend
+      - name: Upload Playwright smoke-test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-frontend-smoke-artifacts
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -116,6 +116,8 @@ jobs:
 
       - name: Setup frontend dependencies
         uses: ./.github/actions/setup-frontend-deps
+        with:
+          enable-cache: 'false'
 
       - name: Build frontend
         run: npm run build
@@ -1011,6 +1013,8 @@ jobs:
 
       - name: Setup frontend dependencies
         uses: ./.github/actions/setup-frontend-deps
+        with:
+          enable-cache: 'false'
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -114,17 +114,8 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Install root dependencies
-        run: npm ci
-
-      - name: Install frontend dependencies
-        run: npm ci
-        working-directory: frontend
+      - name: Setup frontend dependencies
+        uses: ./.github/actions/setup-frontend-deps
 
       - name: Build frontend
         run: npm run build
@@ -1012,23 +1003,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION || vars.AWS_REGION }}
 
-      - name: Install root dependencies
-        run: npm ci
-
-      - name: Install frontend dependencies
-        run: npm ci
-        working-directory: frontend
+      - name: Setup frontend dependencies
+        uses: ./.github/actions/setup-frontend-deps
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
## Summary
- Upload Playwright trace/screenshot/report artifacts on `frontend-smoke` failure in `ci.yml`, mirroring the existing `deploy-lambda.yml` `smoke-test` job pattern (`playwright-frontend-smoke-artifacts`).
- Name both previously-unnamed `npm ci` steps ("Install root dependencies" / "Install frontend dependencies") so failed installs are identifiable in the Actions UI.
- Extract the duplicated root+frontend `npm ci` setup (identical across `ci.yml`'s `frontend-smoke` and `deploy-lambda.yml`'s `deploy`/`smoke-test` jobs) into a new composite action, `.github/actions/setup-frontend-deps`.

## Details
- The composite action preserves `frontend-smoke`'s `cache: npm` + two-file `cache-dependency-path` setup-node config exactly as before.
- `deploy-lambda.yml`'s `deploy` and `smoke-test` jobs now consume the same composite action instead of duplicating the setup-node/npm ci steps; working directories and env vars used by later steps in those jobs (e.g. `frontend/node_modules`) are unaffected since the composite action's steps run identically to what they replace.
- No gating behavior changes: this only affects debuggability (artifacts, step naming) and reuse (composite action), not what causes a job to pass or fail.

Closes #4744

## Test plan
- [x] `actionlint` passes with zero warnings.
- [ ] CI run on this PR is green for `frontend-smoke` (and other affected jobs).
- [ ] Manually verify a deliberately-broken smoke test produces a downloadable `playwright-frontend-smoke-artifacts` artifact (follow-up if not exercised by this PR's own CI run).