### PR TITLE
ci: add structural regression guards and docs for frontend-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,13 +184,6 @@ jobs:
             exit 1
           fi
           echo "✓ base href is relative (no absolute http:// or https:// base found)"
-      - name: Guard against absolute base href in built index.html
-        run: |
-          if grep -oE '<base [^>]*href="http[^"]*"' dist/index.html; then
-            echo "::error::dist/index.html has an absolute <base href> — this breaks relative asset/routing resolution when served from a subpath."
-            exit 1
-          fi
-        working-directory: frontend
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,15 @@ jobs:
       - name: Build preview
         run: npm run build:preview
         working-directory: frontend
+      - name: Verify base href is relative in built index.html
+        run: |
+          set -euo pipefail
+          if grep -q '<base href="http' frontend/dist/index.html; then
+            echo "::error file=frontend/index.html::Built index.html contains an absolute <base href=\"http...\"> which breaks routing in deployed environments (the base URL must be relative, e.g. <base href=\"/\">). Check that index.html's <base href> is hardcoded to a relative path and not dynamically set."
+            exit 1
+          fi
+          echo "✓ base href is relative (no absolute http:// or https:// base found)"
+        working-directory: frontend
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
         working-directory: frontend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -70,6 +70,8 @@ Preferred runtime setting:
 
 Optional build-time environment variables:
 
+* `VITE_APP_BASE_URL` – base URL of the deployed frontend (e.g. `https://app.allotmint.io`).
+  Controls the canonical link, Open Graph tags, Twitter card URLs, and JSON-LD `url` fields in `index.html`. The default in `.env.production` is `https://app.allotmint.io`. Local and preview builds can omit this variable — Vite will leave the `%VITE_APP_BASE_URL%` placeholders unresolved, which has no practical effect outside production because search-engine crawlers and social-media scrapers only encounter the production site.
 * `VITE_ALLOTMINT_API_BASE` – full base URL to the backend.
 * `VITE_API_URL` – legacy fallback used when `VITE_ALLOTMINT_API_BASE` is unset.
 * `VITE_API_TOKEN` – optional token sent as `X-API-Token` with every request.

--- a/tests/routes/test_market.py
+++ b/tests/routes/test_market.py
@@ -1,7 +1,6 @@
 """Tests for the market overview helpers and HTTP endpoint."""
 
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -332,76 +331,3 @@ def test_market_overview_uk_region_handles_fetch_errors(monkeypatch):
     assert data["sectors"] == []
     assert data["headlines"] == []
     assert calls == ["uk", "headlines"]
-
-
-# ---------------------------------------------------------------------------
-# Tests using unittest.mock.patch instead of monkeypatch
-# ---------------------------------------------------------------------------
-
-
-@patch("backend.routes.market._fetch_indexes", return_value={})
-@patch("backend.routes.market._fetch_sectors", return_value=[])
-@patch("backend.routes.market._fetch_headlines", return_value=[])
-def test_market_overview_returns_200(
-    mock_headlines,
-    mock_sectors,
-    mock_indexes,
-) -> None:
-    """All three fetchers return empty data; endpoint responds 200 with expected keys."""
-    client = _client()
-    resp = client.get("/market/overview")
-    assert resp.status_code == 200
-    assert resp.json() == {"indexes": {}, "sectors": [], "headlines": []}
-
-
-@patch(
-    "backend.routes.market._fetch_indexes",
-    return_value={"S&P 500": {"value": 5000.0, "change": 0.5}},
-)
-@patch("backend.routes.market._fetch_sectors")
-@patch(
-    "backend.routes.market._fetch_uk_sectors",
-    return_value=[{"sector": "Tech", "change": 1.2, "source": "lse"}],
-)
-@patch("backend.routes.market._fetch_headlines", return_value=[{"headline": "Markets rally"}])
-def test_market_overview_uk_region(
-    mock_headlines,
-    mock_uk_sectors,
-    mock_sectors,
-    mock_indexes,
-) -> None:
-    """Passing region=uk routes to _fetch_uk_sectors instead of _fetch_sectors."""
-    client = _client()
-    resp = client.get("/market/overview", params={"region": "uk"})
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["indexes"] == {"S&P 500": {"value": 5000.0, "change": 0.5}}
-    assert data["sectors"] == [{"sector": "Tech", "change": 1.2, "source": "lse"}]
-    assert data["headlines"] == [{"headline": "Markets rally"}]
-    mock_sectors.assert_not_called()
-    mock_uk_sectors.assert_called_once()
-
-
-@patch(
-    "backend.routes.market._fetch_indexes",
-    return_value={"S&P 500": {"value": 5000.0, "change": 0.5}},
-)
-@patch(
-    "backend.routes.market._fetch_sectors",
-    return_value=[{"sector": "Energy", "change": -0.3, "source": "lse"}],
-)
-@patch("backend.routes.market._fetch_headlines", side_effect=Exception("headlines down"))
-def test_market_overview_fetcher_exception_returns_default(
-    mock_headlines,
-    mock_sectors,
-    mock_indexes,
-) -> None:
-    """When one fetcher raises, the endpoint still returns 200 with default values
-    for the failing field and real data for the other fields (thanks to _safe)."""
-    client = _client()
-    resp = client.get("/market/overview")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["indexes"] == {"S&P 500": {"value": 5000.0, "change": 0.5}}
-    assert data["sectors"] == [{"sector": "Energy", "change": -0.3, "source": "lse"}]
-    assert data["headlines"] == []

--- a/tests/routes/test_market.py
+++ b/tests/routes/test_market.py
@@ -1,6 +1,7 @@
 """Tests for the market overview helpers and HTTP endpoint."""
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -331,3 +332,76 @@ def test_market_overview_uk_region_handles_fetch_errors(monkeypatch):
     assert data["sectors"] == []
     assert data["headlines"] == []
     assert calls == ["uk", "headlines"]
+
+
+# ---------------------------------------------------------------------------
+# Tests using unittest.mock.patch instead of monkeypatch
+# ---------------------------------------------------------------------------
+
+
+@patch("backend.routes.market._fetch_indexes", return_value={})
+@patch("backend.routes.market._fetch_sectors", return_value=[])
+@patch("backend.routes.market._fetch_headlines", return_value=[])
+def test_market_overview_returns_200(
+    mock_headlines,
+    mock_sectors,
+    mock_indexes,
+) -> None:
+    """All three fetchers return empty data; endpoint responds 200 with expected keys."""
+    client = _client()
+    resp = client.get("/market/overview")
+    assert resp.status_code == 200
+    assert resp.json() == {"indexes": {}, "sectors": [], "headlines": []}
+
+
+@patch(
+    "backend.routes.market._fetch_indexes",
+    return_value={"S&P 500": {"value": 5000.0, "change": 0.5}},
+)
+@patch("backend.routes.market._fetch_sectors")
+@patch(
+    "backend.routes.market._fetch_uk_sectors",
+    return_value=[{"sector": "Tech", "change": 1.2, "source": "lse"}],
+)
+@patch("backend.routes.market._fetch_headlines", return_value=[{"headline": "Markets rally"}])
+def test_market_overview_uk_region(
+    mock_headlines,
+    mock_uk_sectors,
+    mock_sectors,
+    mock_indexes,
+) -> None:
+    """Passing region=uk routes to _fetch_uk_sectors instead of _fetch_sectors."""
+    client = _client()
+    resp = client.get("/market/overview", params={"region": "uk"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["indexes"] == {"S&P 500": {"value": 5000.0, "change": 0.5}}
+    assert data["sectors"] == [{"sector": "Tech", "change": 1.2, "source": "lse"}]
+    assert data["headlines"] == [{"headline": "Markets rally"}]
+    mock_sectors.assert_not_called()
+    mock_uk_sectors.assert_called_once()
+
+
+@patch(
+    "backend.routes.market._fetch_indexes",
+    return_value={"S&P 500": {"value": 5000.0, "change": 0.5}},
+)
+@patch(
+    "backend.routes.market._fetch_sectors",
+    return_value=[{"sector": "Energy", "change": -0.3, "source": "lse"}],
+)
+@patch("backend.routes.market._fetch_headlines", side_effect=Exception("headlines down"))
+def test_market_overview_fetcher_exception_returns_default(
+    mock_headlines,
+    mock_sectors,
+    mock_indexes,
+) -> None:
+    """When one fetcher raises, the endpoint still returns 200 with default values
+    for the failing field and real data for the other fields (thanks to _safe)."""
+    client = _client()
+    resp = client.get("/market/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["indexes"] == {"S&P 500": {"value": 5000.0, "change": 0.5}}
+    assert data["sectors"] == [{"sector": "Energy", "change": -0.3, "source": "lse"}]
+    assert data["headlines"] == []

--- a/tests/scripts/test_frontend_smoke_workflow.py
+++ b/tests/scripts/test_frontend_smoke_workflow.py
@@ -1,0 +1,90 @@
+"""Regression tests for the frontend-smoke workflow and related CI structure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+CI_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+DEPLOY_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy-lambda.yml"
+)
+
+
+def test_frontend_smoke_build_preview_before_playwright() -> None:
+    """The frontend-smoke job must build before running Playwright tests.
+
+    If build:preview is reordered to run after the Playwright step, the smoke
+    tests would run against stale or non-existent build output.  This test
+    checks semantic content (step name or run text) rather than hardcoded step
+    indices, so unrelated prepended or inserted steps don't break it.
+    """
+    workflow = yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["frontend-smoke"]
+    steps = job["steps"]
+
+    build_idx: int | None = None
+    playwright_idx: int | None = None
+
+    for i, step in enumerate(steps):
+        name = step.get("name", "")
+        run = step.get("run", "")
+        if "Build preview" in name or "build:preview" in run:
+            build_idx = i
+        if "Run frontend smoke tests" in name or "playwright test" in run:
+            playwright_idx = i
+
+    assert build_idx is not None, (
+        "frontend-smoke job has no step that builds the frontend "
+        "(expected a step with 'Build preview' in its name or 'build:preview' in its run)"
+    )
+    assert playwright_idx is not None, (
+        "frontend-smoke job has no Playwright test step "
+        "(expected a step with 'Run frontend smoke tests' in its name "
+        "or 'playwright test' in its run)"
+    )
+    assert build_idx < playwright_idx, (
+        "Build step must run before Playwright test step in frontend-smoke job. "
+        f"Found build at index {build_idx}, Playwright at index {playwright_idx}."
+    )
+
+
+def test_verify_smoke_tests_needs_existing_job() -> None:
+    """verify-smoke-tests needs: must reference a job that exists in deploy-lambda.yml.
+
+    If the smoke-test job is renamed without updating verify-smoke-tests's needs:
+    list, the deploy workflow's post-deploy validation would silently break
+    (the needs: dependency would resolve to a non-existent job, which GitHub
+    Actions would treat as an error during workflow dispatch).
+    """
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    # To keep the test readable, look specifically for verify-smoke-tests.
+    # If the job id ever changes, this test will need an update — but that is
+    # an explicit, rare change that justifies a deliberate update to the test.
+    verify_job = workflow["jobs"]["verify-smoke-tests"]
+    needed = verify_job.get("needs")
+
+    assert needed is not None, (
+        "verify-smoke-tests job must declare a needs: dependency on smoke-test"
+    )
+
+    # needs: can be a string or a list — normalise to a list for comparison.
+    needed_jobs = [needed] if isinstance(needed, str) else list(needed)
+
+    existing_jobs = set(workflow["jobs"].keys())
+    for needed_id in needed_jobs:
+        assert needed_id in existing_jobs, (
+            f"verify-smoke-tests references job {needed_id!r} in its needs: "
+            f"but no job with that id exists in deploy-lambda.yml. "
+            f"Existing job ids: {sorted(existing_jobs)}"
+        )
+
+    # Explicitly verify that smoke-test (the job that runs the actual smoke
+    # checks) is among the needed jobs — this is the critical dependency
+    # that validates pass/fail propagation.
+    assert "smoke-test" in needed_jobs, (
+        f"verify-smoke-tests must need smoke-test, but needs: is {needed_jobs}"
+    )


### PR DESCRIPTION
## Summary

Implements #4745: add structural regression guards and docs for the `frontend-smoke` workflow.

## Changes

### New: `tests/scripts/test_frontend_smoke_workflow.py`

Two structural workflow tests following the existing pattern from `test_deploy_lambda_workflow.py`:

- **`test_frontend_smoke_build_preview_before_playwright`** — Parses `ci.yml` with `yaml.safe_load`, locates the build and Playwright steps by semantic content (step name or `run` text), asserts build step runs before Playwright. Guards against reordering of `build:preview` after the test step.
- **`test_verify_smoke_tests_needs_existing_job`** — Parses `deploy-lambda.yml`, asserts `verify-smoke-tests`'s `needs:` references `smoke-test` which exists in the same workflow. Guards against job renames that would silently break post-deploy validation.

Both tests match the existing style — YAML parsing, semantic step matching (not hardcoded indices), clear assertion messages.

### Modified: `.github/workflows/ci.yml`

Added **"Verify base href is relative in built index.html"** step to `frontend-smoke`, right after `Build preview`. Greps `frontend/dist/index.html` for `<base href="http` and fails with `::error::` if found. Scoped to the `<base>` tag to avoid false positives.

### Modified: `frontend/README.md`

Added `VITE_APP_BASE_URL` to the "Optional build-time environment variables" section, documenting:
- What it controls (canonical link, OG tags, Twitter card URLs, JSON-LD `url` fields in `index.html`)
- Its default from `.env.production`
- Why local/preview builds can omit it (unresolved placeholders have no effect outside production)

## Verification

- `pytest tests/scripts/test_frontend_smoke_workflow.py -v --no-cov` — 2 passed
- `pytest tests/scripts/test_deploy_lambda_workflow.py -v --no-cov` — 2 passed (existing tests unaffected)

Closes #4745


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a CI check to catch invalid absolute base URLs in the frontend build before release.
  * Improved market overview handling so the page still loads with available data if one source fails.

* **Documentation**
  * Expanded guidance for the frontend base URL setting and its effect on links and metadata.

* **Tests**
  * Strengthened automated checks for frontend workflow order and deployment dependencies.
  * Added coverage for market overview responses, including empty and partial data cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->