### PR TITLE
ci: add structural regression guards and docs for frontend-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,13 @@ jobs:
       - name: Build preview
         run: npm run build:preview
         working-directory: frontend
+      - name: Guard against absolute base href in built index.html
+        run: |
+          if grep -oE '<base [^>]*href="http[^"]*"' dist/index.html; then
+            echo "::error::dist/index.html has an absolute <base href> — this breaks relative asset/routing resolution when served from a subpath."
+            exit 1
+          fi
+        working-directory: frontend
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
         working-directory: frontend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -74,6 +74,7 @@ Optional build-time environment variables:
 * `VITE_API_URL` – legacy fallback used when `VITE_ALLOTMINT_API_BASE` is unset.
 * `VITE_API_TOKEN` – optional token sent as `X-API-Token` with every request.
 * `VITE_GIT_COMMIT` / `VITE_GIT_BRANCH` – optional git metadata shown on the Support page for build provenance (set them manually or rely on `build.sh` / `scripts/deploy-to-aws.sh`).
+* `VITE_APP_BASE_URL` – public URL of the deployed frontend, substituted into `index.html`'s canonical link, Open Graph `og:url`, and JSON-LD `url` fields at build time (see `.env.example` / `.env.production`). It does not affect the `<base href>` tag, which stays `/`. Safe to omit for local dev and preview builds; only set it for a production deploy where those metadata URLs matter (e.g. SEO, social link previews).
 
 To provide the token, add it to your environment or a `.env` file in `frontend`:
 

--- a/tests/scripts/test_frontend_smoke_workflow.py
+++ b/tests/scripts/test_frontend_smoke_workflow.py
@@ -1,0 +1,51 @@
+"""Regression tests guarding the frontend-smoke CI job and its build output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+CI_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+DEPLOY_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy-lambda.yml"
+)
+
+
+def _step_run(step: dict) -> str:
+    return step.get("run", "") or ""
+
+
+def test_frontend_smoke_builds_preview_before_running_playwright() -> None:
+    workflow = yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    smoke_job = workflow["jobs"]["frontend-smoke"]
+    steps = smoke_job["steps"]
+
+    build_idx = next(
+        i for i, step in enumerate(steps) if "build:preview" in _step_run(step)
+    )
+    playwright_idx = next(
+        i for i, step in enumerate(steps) if "playwright test" in _step_run(step)
+    )
+
+    assert build_idx < playwright_idx, (
+        "frontend-smoke must run 'npm run build:preview' before the Playwright "
+        "test step, otherwise smoke tests would run against a stale/missing build"
+    )
+
+
+def test_deploy_workflow_verify_smoke_tests_references_existing_job() -> None:
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    jobs = workflow["jobs"]
+    verify_job = jobs["verify-smoke-tests"]
+
+    needs = verify_job["needs"]
+    needed_jobs = [needs] if isinstance(needs, str) else list(needs)
+
+    for job_name in needed_jobs:
+        assert job_name in jobs, (
+            f"verify-smoke-tests needs '{job_name}', but no such job exists in "
+            "deploy-lambda.yml — the referenced job may have been renamed"
+        )


### PR DESCRIPTION
## Summary
- Add `tests/scripts/test_frontend_smoke_workflow.py`: asserts `ci.yml`'s `frontend-smoke` job runs `build:preview` before the Playwright test step, and that `deploy-lambda.yml`'s `verify-smoke-tests` job's `needs:` references a job name that actually exists in the same workflow.
- Add a "Guard against absolute base href in built index.html" step to `frontend-smoke` in `.github/workflows/ci.yml`, which greps the just-built `frontend/dist/index.html` for an absolute `<base href="http...">` and fails the job if found (scoped to the `<base>` tag, so it won't false-positive on other `href="http..."` values).
- Document `VITE_APP_BASE_URL` in `frontend/README.md`: what it controls (canonical URL / OG / JSON-LD `url` fields), that it doesn't affect `<base href>`, and that it's safe to omit locally/in preview builds.

## Test plan
- [x] `python -m pytest tests/scripts/test_frontend_smoke_workflow.py -v` — both new tests pass.
- [x] `python -m pytest tests/scripts/ -v --no-cov` — all 46 tests in the directory pass, no regressions.
- [x] Ran `npm ci` (root + `frontend/`) and `npm run build:preview` locally; confirmed the guard grep does **not** match the current healthy `dist/index.html` (`<base href="/"/>`).
- [x] Simulated a broken build with `<base href="https://example.com/"/>` and confirmed the guard grep matches it (would fail the job with a clear error).
- [x] Validated `ci.yml` still parses with `yaml.safe_load`.

Closes #4745
