### PR TITLE
ci: harden pre-deploy-check cleanup, python invocation, and S3 error logging

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -523,13 +523,13 @@ jobs:
           for attempt in 1 2 3 4 5; do
             head_out="$(aws s3api head-object --bucket "$data_bucket" --key prices/latest_prices.json 2>&1)" && break
             if echo "$head_out" | grep -q "(403)"; then
-              echo "head-object returned 403 Forbidden — deploy role lacks s3:GetObject or s3:ListBucket on the data bucket. Check CDK grants for GITHUB_DEPLOY_ROLE_ARN. See issue #3191." >&2
-              echo "$head_out" >&2
+              echo "head-object returned 403 Forbidden for bucket=${data_bucket} key=prices/latest_prices.json — deploy role lacks s3:GetObject or s3:ListBucket on the data bucket. Check CDK grants for GITHUB_DEPLOY_ROLE_ARN. See issue #3191." >&2
+              echo "  AWS response: $head_out" >&2
               exit 1
             fi
             if [ "$attempt" -eq 5 ]; then
-              echo "head-object failed on attempt 5/5; giving up." >&2
-              echo "$head_out" >&2
+              echo "head-object failed on attempt 5/5 for bucket=${data_bucket} key=prices/latest_prices.json; giving up." >&2
+              echo "  AWS response: $head_out" >&2
               exit 1
             fi
             echo "head-object attempt $attempt/5 failed (key not yet written); retrying in 20s..." >&2
@@ -773,7 +773,8 @@ jobs:
           elif echo "$head_output" | grep -qi "NoSuchKey\|Not Found\|404"; then
             echo "::warning::Price snapshot prices/latest_prices.json is NOT present in s3://${DATA_BUCKET}. Portfolio prices will be unavailable until the price-refresh job runs. Trigger it manually: aws lambda invoke --function-name <PriceRefreshLambda-physical-name>:live /dev/null"
           else
-            echo "ERROR: S3 bucket access check failed: head-object returned exit ${head_exit}: ${head_output}" >&2
+            echo "ERROR: S3 bucket access check failed for bucket=${DATA_BUCKET} key=prices/latest_prices.json (head-object exit ${head_exit})" >&2
+            echo "  AWS response: ${head_output}" >&2
             exit 1
           fi
 

--- a/scripts/bash/pre-deploy-check.sh
+++ b/scripts/bash/pre-deploy-check.sh
@@ -13,6 +13,17 @@ set -uo pipefail
 # Always run from the repository root regardless of where the script is invoked from.
 cd "$(dirname "$0")/../.." || exit 1
 
+# Prefer python3 when present, falling back to python, so the interpreter used here
+# matches whatever scripts/powershell/pre-deploy-check.ps1 resolves to on the same machine.
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN=python3
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN=python
+else
+    echo "Error: neither python3 nor python found in PATH" >&2
+    exit 1
+fi
+
 PASS=0
 FAIL=0
 SKIP=0
@@ -34,7 +45,7 @@ fi
 echo ""
 echo "=== 1. Dependency dry-run ==="
 rm -rf /tmp/pre-deploy-venv
-if python -m venv /tmp/pre-deploy-venv && /tmp/pre-deploy-venv/bin/pip install --dry-run -r backend/requirements.txt -q; then
+if "$PYTHON_BIN" -m venv /tmp/pre-deploy-venv && /tmp/pre-deploy-venv/bin/pip install --dry-run -r backend/requirements.txt -q; then
     pass "pip dependency dry-run"
 else
     fail "pip dependency dry-run"
@@ -50,16 +61,16 @@ elif [[ -z "${GITHUB_DEPLOY_ROLE_ARN:-}" || -z "${JWT_SECRET:-}" || -z "${GOOGLE
     skip "CDK diff (requires GITHUB_DEPLOY_ROLE_ARN, JWT_SECRET, GOOGLE_CLIENT_ID, DATA_BUCKET)"
 else
     cdk_diff_output=$(mktemp)
+    trap 'rm -f "$cdk_diff_output"' EXIT
     (cd cdk && npx cdk diff BackendLambdaStack StaticSiteStack -c prod=true --method=changeset) | tee "$cdk_diff_output"
     cdk_diff_exit=${PIPESTATUS[0]}
     if [[ $cdk_diff_exit -ne 0 ]]; then
         fail "CDK diff"
-    elif ! python3 scripts/check_cdk_diff_iam_removals.py "$cdk_diff_output"; then
+    elif ! "$PYTHON_BIN" scripts/check_cdk_diff_iam_removals.py "$cdk_diff_output"; then
         fail "CDK diff (removes an IAM Allow grant for the deploy role — see #3741)"
     else
         pass "CDK diff"
     fi
-    rm -f "$cdk_diff_output"
 fi
 
 # 3. IAM permission simulation
@@ -160,7 +171,7 @@ else
     fail "make lint"
 fi
 
-if python -m pytest tests/ -x -q; then
+if "$PYTHON_BIN" -m pytest tests/ -x -q; then
     pass "backend pytest"
 else
     fail "backend pytest"
@@ -184,7 +195,7 @@ fi
 # 6. CDK tests
 echo ""
 echo "=== 6. CDK tests ==="
-if (cd cdk && python -m pytest tests/ -x -q); then
+if (cd cdk && "$PYTHON_BIN" -m pytest tests/ -x -q); then
     pass "CDK pytest"
 else
     fail "CDK pytest"

--- a/scripts/powershell/pre-deploy-check.ps1
+++ b/scripts/powershell/pre-deploy-check.ps1
@@ -12,6 +12,18 @@ $ErrorActionPreference = 'Continue'
 # Always run from the repository root regardless of where the script is invoked from.
 Set-Location (Join-Path $PSScriptRoot '..\..')
 
+# Prefer python3 when present, falling back to python, matching the normalisation
+# applied in scripts/bash/pre-deploy-check.sh so both scripts pick the same
+# interpreter on a given machine.
+if (Get-Command python3 -ErrorAction SilentlyContinue) {
+    $PythonBin = 'python3'
+} elseif (Get-Command python -ErrorAction SilentlyContinue) {
+    $PythonBin = 'python'
+} else {
+    Write-Host "Error: neither python3 nor python found in PATH" -ForegroundColor Red
+    exit 1
+}
+
 $Pass = 0
 $Fail = 0
 $Skip = 0
@@ -48,7 +60,7 @@ if ($LASTEXITCODE -eq 0) { Write-Pass "deployment environment variables" } else 
 Write-Host "`n=== 1. Dependency dry-run ==="
 $venvPath = Join-Path $env:TEMP 'pre-deploy-venv'
 if (Test-Path $venvPath) { Remove-Item -Recurse -Force $venvPath }
-python -m venv $venvPath | Out-Null
+& $PythonBin -m venv $venvPath | Out-Null
 & "$venvPath\Scripts\pip.exe" install --dry-run -r backend/requirements.txt -q
 if ($LASTEXITCODE -eq 0) { Write-Pass "pip dependency dry-run" } else { Write-Fail "pip dependency dry-run" }
 
@@ -77,7 +89,7 @@ if (-not $env:AWS_ACCESS_KEY_ID) {
         $tmpFile = New-TemporaryFile
         try {
             $cdkDiffOutput | Out-String | Set-Content -Path $tmpFile -Encoding utf8
-            python scripts/check_cdk_diff_iam_removals.py $tmpFile
+            & $PythonBin scripts/check_cdk_diff_iam_removals.py $tmpFile
             if ($LASTEXITCODE -eq 0) {
                 Write-Pass "CDK diff"
             } else {
@@ -194,7 +206,7 @@ if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
     if ($LASTEXITCODE -eq 0) { Write-Pass "make lint" } else { Write-Fail "make lint" }
 }
 
-python -m pytest tests/ -x -q
+& $PythonBin -m pytest tests/ -x -q
 if ($LASTEXITCODE -eq 0) { Write-Pass "backend pytest" } else { Write-Fail "backend pytest" }
 
 # 5. Frontend lint + tests
@@ -212,7 +224,7 @@ if (-not (Test-Path 'cdk')) {
 } else {
     try {
         Push-Location cdk -ErrorAction Stop
-        python -m pytest tests/ -x -q
+        & $PythonBin -m pytest tests/ -x -q
         if ($LASTEXITCODE -eq 0) { Write-Pass "CDK pytest" } else { Write-Fail "CDK pytest" }
     } finally {
         Pop-Location


### PR DESCRIPTION
## Summary
- Wrap `scripts/bash/pre-deploy-check.sh`'s `cdk_diff_output` mktemp usage in a `trap ... EXIT` so the temp file is always cleaned up, including on unexpected exits triggered by `set -u` — the intentional omission of `-e` (so all checks run and accumulate failures) is preserved.
- Resolve `python3`/`python` once at the top of `pre-deploy-check.sh` and reuse it for every Python invocation in the script (previously it mixed `python` and `python3` inconsistently). Add the equivalent resolution to `scripts/powershell/pre-deploy-check.ps1` so both scripts pick the same interpreter on a given machine.
- Add bucket/key/underlying-AWS-error context to the S3 `head-object` error logging in `.github/workflows/deploy-lambda.yml`'s "Verify price snapshot seeded in S3" and "Warm price snapshot" steps (this is the `deploy.sh`-equivalent S3 error handling referenced in #4118 / PR #4114 — there is no standalone `deploy.sh` file in this repo, the logic lives inline in the workflow). Exit codes and soft-pass/hard-fail behavior for 404 vs. other errors are unchanged.

Closes #4746

## Test plan
- [x] `bash -n scripts/bash/pre-deploy-check.sh` — syntax OK
- [x] PowerShell parser validates `pre-deploy-check.ps1` with no errors
- [x] `python -c "import yaml; yaml.safe_load(...)"` on `deploy-lambda.yml` — valid YAML
- [x] `pytest tests/scripts/test_deploy_lambda_workflow.py` — both existing tests pass (exit-code/soft-pass assertions on the S3 verify step still hold)