### PR TITLE
ci: harden retry/backoff in cloudwatch fetch, gh_api_with_retry, and S3 checks

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -34,21 +34,43 @@ jobs:
           set -euo pipefail
           echo "Checking ci.yml status for commit ${COMMIT_SHA}..."
 
-          # Helper function to call gh api with retry logic for transient failures
+          # Poll for the most recent ci.yml run on this exact commit and wait for
+          # it to finish before deciding whether to proceed with the deploy.
+          timeout_seconds=1800
+          poll_interval=30
+          start_epoch=$(date +%s)
+
+          # Helper function to call gh api with retry logic for transient failures.
+          # Retries share the same $timeout_seconds budget as the outer polling loop
+          # below (via $start_epoch) so a run of failed attempts can't silently push
+          # this step past that ~30-minute wait window before the outer loop's own
+          # elapsed check ever gets a chance to fire.
           gh_api_with_retry() {
             local max_attempts=5
             local attempt=1
             local wait_seconds=2
-            local output
+            local output stderr_file err now deadline
+
+            deadline=$((start_epoch + timeout_seconds))
 
             while [ $attempt -le $max_attempts ]; do
-              if output=$(gh api "$@"); then
+              stderr_file="$(mktemp)"
+              if output=$(gh api "$@" 2>"$stderr_file"); then
+                rm -f "$stderr_file"
                 echo "$output"
                 return 0
               fi
+              err="$(cat "$stderr_file")"
+              rm -f "$stderr_file"
+
+              now=$(date +%s)
+              if [ "$((now + wait_seconds))" -ge "$deadline" ]; then
+                echo "::error::gh api call failed and retrying would exceed the ${timeout_seconds}s CI-run-wait budget: ${err}" >&2
+                return 1
+              fi
 
               if [ $attempt -lt $max_attempts ]; then
-                echo "::warning::gh api call failed (attempt $attempt/$max_attempts), retrying in ${wait_seconds}s..." >&2
+                echo "::warning::gh api call failed (attempt $attempt/$max_attempts): ${err}; retrying in ${wait_seconds}s..." >&2
                 sleep "$wait_seconds"
                 wait_seconds=$((wait_seconds * 2))
               fi
@@ -56,19 +78,19 @@ jobs:
               attempt=$((attempt + 1))
             done
 
-            echo "::error::gh api call failed after $max_attempts attempts" >&2
+            echo "::error::gh api call failed after $max_attempts attempts: ${err}" >&2
             return 1
           }
 
-          # Poll for the most recent ci.yml run on this exact commit and wait for
-          # it to finish before deciding whether to proceed with the deploy.
-          timeout_seconds=1800
-          poll_interval=30
           elapsed=0
           while true; do
+            # per_page=1&sort=created&direction=desc asks the API to return the
+            # latest run directly, instead of fetching a page of runs and
+            # sorting them client-side (which could still miss the true latest
+            # run if more than per_page runs exist for this commit).
             run_json="$(gh_api_with_retry \
-              "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${COMMIT_SHA}&per_page=10" \
-              --jq '.workflow_runs | sort_by(.id) | reverse | .[0]')"
+              "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${COMMIT_SHA}&per_page=1&sort=created&direction=desc" \
+              --jq '.workflow_runs[0]')"
 
             if [ "${run_json}" = "null" ]; then
               echo "::error::No ci.yml run found for commit ${COMMIT_SHA}." \
@@ -680,6 +702,16 @@ jobs:
           # consistent — a freshly granted permission may not be visible to the
           # very next API call for up to a minute or two. Any other failure, or
           # exhausting all attempts, fails immediately. See #3858.
+          #
+          # This loop is still needed (confirmed 2026-07, see #4748): the root
+          # cause is IAM's eventually-consistent policy propagation, which is an
+          # inherent AWS platform behaviour, not a bug in this repo's CDK grants
+          # or workflow ordering — there is no code change here that removes the
+          # propagation delay itself. It could only be removed if AWS started
+          # guaranteeing synchronous IAM policy propagation, or if this step were
+          # restructured to poll for grant visibility before calling
+          # update-user-pool-client (which would just move the same retry logic
+          # elsewhere). Until then, keep the retry.
           cognito_retry() {
             local desc="$1"; shift
             local attempt out
@@ -765,17 +797,39 @@ jobs:
             echo "DATA_BUCKET not set; skipping price snapshot verification." >&2
             exit 0
           fi
-          head_output="$(aws s3api head-object \
-              --bucket "$DATA_BUCKET" \
-              --key "prices/latest_prices.json" 2>&1)" && head_exit=0 || head_exit=$?
-          if [ "$head_exit" -eq 0 ]; then
-            echo "Price snapshot prices/latest_prices.json is present in s3://${DATA_BUCKET} — OK"
-          elif echo "$head_output" | grep -qi "NoSuchKey\|Not Found\|404"; then
-            echo "::warning::Price snapshot prices/latest_prices.json is NOT present in s3://${DATA_BUCKET}. Portfolio prices will be unavailable until the price-refresh job runs. Trigger it manually: aws lambda invoke --function-name <PriceRefreshLambda-physical-name>:live /dev/null"
-          else
+          # Retry only transient S3 errors (throttling, 5xx, timeouts) with backoff;
+          # NoSuchKey/404 remains a soft pass and AccessDenied/other errors fail
+          # immediately since retrying them would only mask a real problem.
+          max_attempts=4
+          wait_seconds=5
+          attempt=1
+          while :; do
+            head_output="$(aws s3api head-object \
+                --bucket "$DATA_BUCKET" \
+                --key "prices/latest_prices.json" 2>&1)" && head_exit=0 || head_exit=$?
+            if [ "$head_exit" -eq 0 ]; then
+              echo "Price snapshot prices/latest_prices.json is present in s3://${DATA_BUCKET} — OK"
+              break
+            fi
+            if echo "$head_output" | grep -qi "NoSuchKey\|Not Found\|404"; then
+              echo "::warning::Price snapshot prices/latest_prices.json is NOT present in s3://${DATA_BUCKET}. Portfolio prices will be unavailable until the price-refresh job runs. Trigger it manually: aws lambda invoke --function-name <PriceRefreshLambda-physical-name>:live /dev/null"
+              break
+            fi
+            if echo "$head_output" | grep -qiE "Throttling|SlowDown|RequestTimeout|InternalError|ServiceUnavailable|\(50[0-9]\)"; then
+              if [ "$attempt" -eq "$max_attempts" ]; then
+                echo "ERROR: S3 bucket access check failed after ${max_attempts} attempts (transient error persisted): head-object returned exit ${head_exit}: ${head_output}" >&2
+                exit 1
+              fi
+              echo "head-object attempt ${attempt}/${max_attempts} hit a transient S3 error; retrying in ${wait_seconds}s..." >&2
+              echo "$head_output" >&2
+              sleep "$wait_seconds"
+              wait_seconds=$((wait_seconds * 2))
+              attempt=$((attempt + 1))
+              continue
+            fi
             echo "ERROR: S3 bucket access check failed: head-object returned exit ${head_exit}: ${head_output}" >&2
             exit 1
-          fi
+          done
 
       - name: Warm up backend Lambda (absorb cold-start before validation)
         env:

--- a/scripts/bash/fetch-cloudwatch-logs.sh
+++ b/scripts/bash/fetch-cloudwatch-logs.sh
@@ -14,22 +14,33 @@
 # emits a `::warning::` GitHub Actions annotation instead of failing or
 # silently printing "(no log events found)".
 
-set -uo pipefail
+set -euo pipefail
 
 log_group="${1:?log group name required}"
 lookback_seconds="${2:?lookback window in seconds required}"
+
+# Reject non-numeric input before it reaches the date arithmetic below, where
+# a bad value (e.g. empty string, negative number, or non-numeric garbage)
+# would otherwise produce a bogus start-time or a confusing arithmetic error.
+if ! [[ "$lookback_seconds" =~ ^[0-9]+$ ]]; then
+    echo "::warning::lookback-seconds must be a non-negative integer, got '$lookback_seconds' for $log_group; skipping log fetch" >&2
+    exit 0
+fi
 
 start_ms=$(( ($(date +%s) - lookback_seconds) * 1000 ))
 
 # Capture stdout (log data) separately from stderr (warnings/diagnostics).
 # Stderr from AWS CLI is allowed to flow to the workflow log; only stdout
 # is processed through grep -v to filter "None" entries.
+# The `|| exit_code=$?` form keeps this command-substitution failure
+# "checked" so `set -e` doesn't abort the script before the exit_code
+# handling below runs.
+exit_code=0
 output="$(aws logs filter-log-events \
     --log-group-name "$log_group" \
     --start-time "$start_ms" \
     --query 'events[].message' \
-    --output text)"
-exit_code=$?
+    --output text)" || exit_code=$?
 
 if [ "$exit_code" -ne 0 ]; then
     if printf '%s' "$output" | grep -q "AccessDeniedException"; then

--- a/tests/scripts/test_deploy_lambda_workflow.py
+++ b/tests/scripts/test_deploy_lambda_workflow.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import yaml
 
-
 WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy-lambda.yml"
 
 
@@ -17,9 +16,7 @@ def test_deploy_workflow_warms_price_snapshot() -> None:
     steps = deploy_job["steps"]
     step_names = [s.get("name", "") for s in steps]
 
-    warm_step = next(
-        step for step in steps if step.get("name") == "Warm price snapshot"
-    )
+    warm_step = next(step for step in steps if step.get("name") == "Warm price snapshot")
 
     run_script = warm_step["run"]
 
@@ -30,17 +27,15 @@ def test_deploy_workflow_warms_price_snapshot() -> None:
 
     # Bucket must be resolved from CloudFormation, not from the $DATA_BUCKET secret
     # (empty/masked secrets cause exit 255 from the AWS CLI).
-    assert "PortfolioDataBucket" in run_script, (
-        "head-object bucket must be derived from CloudFormation, not $DATA_BUCKET secret"
-    )
-    assert '--bucket "$DATA_BUCKET"' not in run_script, (
-        "head-object must not use $DATA_BUCKET directly — secret may be masked or empty"
-    )
+    assert (
+        "PortfolioDataBucket" in run_script
+    ), "head-object bucket must be derived from CloudFormation, not $DATA_BUCKET secret"
+    assert (
+        '--bucket "$DATA_BUCKET"' not in run_script
+    ), "head-object must not use $DATA_BUCKET directly — secret may be masked or empty"
 
     # Step must run after the CDK deploy that creates the bucket.
-    deploy_idx = next(
-        i for i, name in enumerate(step_names) if "Deploy BackendLambdaStack" in name
-    )
+    deploy_idx = next(i for i, name in enumerate(step_names) if "Deploy BackendLambdaStack" in name)
     warm_idx = step_names.index("Warm price snapshot")
     assert warm_idx > deploy_idx, "Warm price snapshot must run after Deploy BackendLambdaStack"
 
@@ -69,13 +64,11 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
     # head_output must capture stderr (where the AWS CLI writes error
     # details like "NoSuchKey"/"Access Denied"), otherwise the grep above
     # would never match and every error would hard-fail, including 404s.
-    capture_line = next(
-        line for line in run_script.splitlines() if "head_output=" in line
-    )
+    capture_line = next(line for line in run_script.splitlines() if "head_output=" in line)
     # The capture spans multiple continuation lines; the redirect is on the
     # final line that closes the command substitution.
-    capture_block = run_script[run_script.index(capture_line):]
-    capture_end = capture_block.index(")\"") + len(")\"")
+    capture_block = run_script[run_script.index(capture_line) :]
+    capture_end = capture_block.index(')"') + len(')"')
     assert "2>&1" in capture_block[:capture_end], (
         "head_output=$(...) must redirect stderr (2>&1) so NoSuchKey/Access "
         "Denied errors are visible to the grep below"
@@ -84,3 +77,86 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
     # The step must not swallow its own exit code via continue-on-error,
     # otherwise the hard failure above would not fail the job.
     assert "continue-on-error" not in verify_step
+
+
+def test_deploy_workflow_verify_price_snapshot_retries_transient_s3_errors() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    deploy_job = workflow["jobs"]["deploy"]
+    steps = deploy_job["steps"]
+
+    verify_step = next(
+        step for step in steps if step.get("name") == "Verify price snapshot seeded in S3"
+    )
+    run_script = verify_step["run"]
+
+    # Transient S3 errors (throttling, 5xx, timeouts) must be retried with
+    # backoff rather than failing on the first attempt.
+    assert "Throttling" in run_script
+    assert "sleep" in run_script
+    assert "max_attempts" in run_script
+
+    # A persistent 403/AccessDenied must still fail immediately (not match the
+    # transient-error grep pattern), since retrying it would only mask a real
+    # permissions problem.
+    transient_grep_line = next(line for line in run_script.splitlines() if "Throttling" in line)
+    assert "AccessDenied" not in transient_grep_line
+
+
+def test_deploy_workflow_gh_api_with_retry_uses_single_page_sorted_lookup() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    check_ci_job = workflow["jobs"]["check-ci"]
+    run_script = check_ci_job["steps"][0]["run"]
+
+    # The ci.yml run lookup must ask the API for the latest run directly
+    # instead of paging and sorting client-side (which could still miss the
+    # true latest run if more runs exist than the page size).
+    assert "per_page=1&sort=created&direction=desc" in run_script
+    assert "sort_by(.id) | reverse" not in run_script
+
+
+def test_deploy_workflow_gh_api_with_retry_includes_stderr_in_warnings() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    check_ci_job = workflow["jobs"]["check-ci"]
+    run_script = check_ci_job["steps"][0]["run"]
+
+    # Retry warnings/errors must surface the underlying `gh api` stderr so a
+    # failure's actual cause (rate limit, auth, network) is visible instead of
+    # a bare "gh api call failed" message.
+    assert 'gh api "$@" 2>"$stderr_file"' in run_script
+    assert "${err}" in run_script
+
+
+def test_deploy_workflow_gh_api_with_retry_budgets_elapsed_time() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    check_ci_job = workflow["jobs"]["check-ci"]
+    run_script = check_ci_job["steps"][0]["run"]
+
+    # Retries must stop once continuing would exceed the same timeout_seconds
+    # budget the outer polling loop uses, instead of retrying a fixed attempt
+    # count blindly regardless of elapsed time.
+    assert "start_epoch=$(date +%s)" in run_script
+    assert "deadline=$((start_epoch + timeout_seconds))" in run_script
+    assert 'if [ "$((now + wait_seconds))" -ge "$deadline" ]' in run_script
+
+
+def test_deploy_workflow_cognito_retry_documents_why_it_remains() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    deploy_job = workflow["jobs"]["deploy"]
+    steps = deploy_job["steps"]
+
+    reconcile_step = next(
+        step for step in steps if step.get("name") == "Reconcile UiAuthClient OAuth configuration"
+    )
+    run_script = reconcile_step["run"]
+
+    assert "cognito_retry() {" in run_script
+    # The comment must explain that the loop is still needed because the root
+    # cause (IAM eventually-consistent policy propagation) is an inherent AWS
+    # platform behaviour, not something a code change here can eliminate.
+    assert "still needed" in run_script
+    assert "eventually-consistent" in run_script or "eventually consistent" in run_script

--- a/tests/scripts/test_fetch_cloudwatch_logs.py
+++ b/tests/scripts/test_fetch_cloudwatch_logs.py
@@ -1,0 +1,101 @@
+"""Regression tests for scripts/bash/fetch-cloudwatch-logs.sh.
+
+Exercises the script end-to-end with a stub `aws` binary on PATH so no live
+AWS network calls are made (per CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "bash" / "fetch-cloudwatch-logs.sh"
+
+# On Windows, a bare "bash" on PATH may resolve to the WSL launcher
+# (C:\Windows\System32\bash.exe), which cannot resolve native Windows paths.
+# Pin to Git Bash explicitly so these tests are stable across environments.
+_GIT_BASH = Path(r"C:\Program Files\Git\bin\bash.exe")
+BASH_EXE = str(_GIT_BASH) if _GIT_BASH.exists() else "bash"
+
+
+def _make_stub_aws(tmp_path: Path, stdout: str, exit_code: int) -> Path:
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    stub = stub_dir / "aws"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f"printf '%s' {os.fsdecode(_shell_quote(stdout))}\n"
+        f"exit {exit_code}\n",
+        encoding="utf-8",
+    )
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+    return stub_dir
+
+
+def _shell_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+def _run_script(*args: str, stub_dir: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env.get('PATH', '')}"
+    return subprocess.run(
+        [BASH_EXE, SCRIPT_PATH.as_posix(), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_rejects_non_numeric_lookback_seconds(tmp_path: Path) -> None:
+    stub_dir = _make_stub_aws(tmp_path, stdout="None\n", exit_code=0)
+
+    result = _run_script("my-log-group", "not-a-number", stub_dir=stub_dir)
+
+    assert result.returncode == 0, "diagnostic log fetch must not fail the calling step"
+    assert "::warning::lookback-seconds must be a non-negative integer" in result.stderr
+    assert "not-a-number" in result.stderr
+
+
+def test_rejects_negative_lookback_seconds(tmp_path: Path) -> None:
+    stub_dir = _make_stub_aws(tmp_path, stdout="None\n", exit_code=0)
+
+    result = _run_script("my-log-group", "-5", stub_dir=stub_dir)
+
+    assert result.returncode == 0
+    assert "::warning::lookback-seconds must be a non-negative integer" in result.stderr
+
+
+def test_filters_none_and_prints_log_events(tmp_path: Path) -> None:
+    stub_dir = _make_stub_aws(tmp_path, stdout="None\nlog line one\n", exit_code=0)
+
+    result = _run_script("my-log-group", "600", stub_dir=stub_dir)
+
+    assert result.returncode == 0
+    assert "log line one" in result.stdout
+    assert "None" not in result.stdout.splitlines()
+
+
+def test_no_log_events_prints_placeholder(tmp_path: Path) -> None:
+    stub_dir = _make_stub_aws(tmp_path, stdout="None\n", exit_code=0)
+
+    result = _run_script("my-log-group", "600", stub_dir=stub_dir)
+
+    assert result.returncode == 0
+    assert "(no log events found)" in result.stdout
+
+
+def test_aws_cli_failure_still_exits_zero_under_set_dash_e(tmp_path: Path) -> None:
+    # A failing `aws` call must not abort the script via `set -e` before the
+    # exit_code handling below it runs; this diagnostic step always exits 0.
+    stub_dir = _make_stub_aws(
+        tmp_path, stdout="AccessDeniedException: not authorized", exit_code=254
+    )
+
+    result = _run_script("my-log-group", "600", stub_dir=stub_dir)
+
+    assert result.returncode == 0
+    assert "::warning::logs:FilterLogEvents denied for my-log-group" in result.stdout


### PR DESCRIPTION
## Summary
- `scripts/bash/fetch-cloudwatch-logs.sh`: runs under `set -euo pipefail` and rejects a non-numeric `lookback_seconds` before it reaches the `date` arithmetic; the `aws logs filter-log-events` call is now a "checked" command substitution (`|| exit_code=$?`) so `set -e` can't short-circuit the existing exit-code handling.
- `gh_api_with_retry` (deploy-lambda.yml `check-ci` job): the ci.yml run lookup now uses `per_page=1&sort=created&direction=desc` instead of fetching a page and sorting client-side; retry warnings/errors now include the underlying `gh api` stderr; retries stop once continuing would exceed the same `timeout_seconds` budget the outer polling loop uses, instead of retrying a fixed count blindly.
- S3 head-object check ("Verify price snapshot seeded in S3" step): now retries transient errors (throttling, 5xx, timeouts) with backoff, while NoSuchKey/404 stays a soft pass and AccessDenied/other errors still hard-fail immediately.
- `cognito_retry`: confirmed the root cause (#3859, IAM's eventually-consistent policy propagation) is still present — it's an inherent AWS platform behaviour, not something a code change removes — so the loop stays, with an expanded inline comment documenting why and what would let it be removed.

Closes #4748

## Test plan
- [x] `bash -n` on the extracted `check-ci`, `Warm price snapshot`, `Verify price snapshot seeded in S3`, and `Reconcile UiAuthClient OAuth configuration` step scripts
- [x] `bash -n scripts/bash/fetch-cloudwatch-logs.sh`
- [x] New `tests/scripts/test_fetch_cloudwatch_logs.py` exercises the script end-to-end against a stub `aws` binary (no live AWS calls) covering: non-numeric/negative lookback rejection, log filtering, no-events placeholder, and that an `aws` failure still exits 0 under `set -e`
- [x] New tests in `tests/scripts/test_deploy_lambda_workflow.py` assert the S3 retry/backoff behavior, the single-page sorted ci.yml lookup, stderr surfacing and elapsed-time budgeting in `gh_api_with_retry`, and the `cognito_retry` documentation
- [x] `python -m pytest tests/scripts -q` (56 passed)
- [x] `ruff check` / `black --check` on new/changed test files