### PR TITLE
fix(auth): resolve real caller identity when disable_auth trusts a Cognito token

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -244,24 +244,61 @@ def _user_from_token(token: str | None) -> str:
     return email
 
 
+def _identity_from_unverified_token(token: str) -> str | None:
+    """Return the ``email``/``sub`` claim from ``token`` without checking its signature.
+
+    Only called when ``config.disable_auth`` is true and ``decode_token`` (the
+    backend's own HS256 verifier) could not decode the token. In that
+    configuration the token is a Cognito ID token whose signature and
+    audience API Gateway's JWT authorizer already validated before this
+    Lambda ever ran (see docs/AUTH.md), so re-deriving the claims here without
+    re-checking the signature is safe — it is not the first check performed.
+    """
+    claims = _unverified_claims(token)
+    email = claims.get("email") or claims.get("sub")
+    return email if isinstance(email, str) and email else None
+
+
+def _resolve_identity_when_auth_disabled(token: str | None) -> str | None:
+    """Resolve the caller's identity when ``config.disable_auth`` is true.
+
+    A present token is trusted to have already been verified upstream: either
+    it is an app-signed backend JWT (Google flow), or a Cognito ID token
+    validated by API Gateway's JWT authorizer before invoking this Lambda
+    (Cognito flow). Either way its claimed email must belong to a provisioned
+    account — an unrecognized email is rejected explicitly rather than
+    silently collapsing every caller into the shared local/demo identity.
+    Only a request with no token at all (bare local dev, no client-side auth)
+    falls back to the configured local login identity.
+    """
+    if isinstance(token, str) and token:
+        user = decode_token(token)
+        if user:
+            return user
+        email = _identity_from_unverified_token(token)
+        if email is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authentication credentials",
+            )
+        if email.lower() not in _allowed_emails():
+            logger.warning(
+                "Unauthorized identity on disable_auth path for %s",
+                sanitise_log_value(email),
+            )
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Unauthorized email")
+        return email
+    return local_login_identity()
+
+
 async def get_current_user(token: str | None = Depends(oauth2_scheme)) -> str:
     """Return the authenticated user extracted from the bearer token."""
 
     if config.disable_auth:
-        # When auth is disabled (e.g. DISABLE_AUTH=true with a Cognito JWT authorizer
-        # at API Gateway), try to extract identity from an app-signed JWT if present.
-        # Non-app tokens (e.g. Cognito ID tokens signed with RS256) will not decode
-        # with the HS256 app secret — decode_token returns None for those — so we fall
-        # back to the local identity rather than raising 401.
-        if isinstance(token, str) and token:
-            user = decode_token(token)
-            if user:
-                current_user.set(user)
-                return user
-        fallback = local_login_identity()
-        if fallback:
-            current_user.set(fallback)
-            return fallback
+        identity = _resolve_identity_when_auth_disabled(token)
+        if identity:
+            current_user.set(identity)
+            return identity
         current_user.set(None)
     token_str = token if isinstance(token, str) else None
     return _user_from_token(token_str)
@@ -452,22 +489,9 @@ async def get_active_user(request: Request, token: str | None = Depends(oauth2_s
         return override_result
 
     if config.disable_auth:
-        # When auth is disabled (e.g. DISABLE_AUTH=true with a Cognito JWT authorizer
-        # at API Gateway), try to extract identity from an app-signed JWT if present.
-        # Non-app tokens (e.g. Cognito ID tokens signed with RS256) will not decode
-        # with the HS256 app secret — decode_token returns None for those — so we fall
-        # back to the local identity rather than raising 401.
-        if isinstance(token, str) and token:
-            user = decode_token(token)
-            if user:
-                current_user.set(user)
-                return user
-        fallback = local_login_identity()
-        if fallback:
-            current_user.set(fallback)
-            return fallback
-        current_user.set(None)
-        return None
+        identity = _resolve_identity_when_auth_disabled(token)
+        current_user.set(identity)
+        return identity
 
     token_str = token if isinstance(token, str) else None
     user = _user_from_token(token_str)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -330,15 +330,34 @@ async def test_get_current_user_returns_token_user_when_decode_succeeds(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_get_current_user_falls_back_to_local_identity_when_token_not_app_jwt(monkeypatch):
-    """When disable_auth=True and decode_token returns None (e.g. Cognito RS256 token
-    forwarded by API Gateway), get_current_user falls back to local_login_identity."""
+async def test_get_current_user_reads_email_claim_when_token_not_app_jwt(monkeypatch):
+    """When disable_auth=True and decode_token returns None (e.g. a Cognito RS256
+    token whose signature API Gateway's authorizer already validated),
+    get_current_user resolves the caller's own email from the token's claims
+    rather than collapsing every caller into the shared local identity (#4750)."""
 
     monkeypatch.setattr(auth.config, "disable_auth", True, raising=False)
     monkeypatch.setattr(auth, "decode_token", lambda _token: None)
     monkeypatch.setattr(auth, "local_login_identity", lambda: "local@example.com")
+    monkeypatch.setattr(auth, "_unverified_claims", lambda _token: {"email": "steve@example.com"})
+    monkeypatch.setattr(auth, "_allowed_emails", lambda: {"steve@example.com"})
 
-    assert await auth.get_current_user(token="cognito-rs256-stub") == "local@example.com"
+    assert await auth.get_current_user(token="cognito-rs256-stub") == "steve@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_rejects_unrecognized_email_claim(monkeypatch):
+    """An unprovisioned email must be rejected, not mapped to the local/demo identity."""
+
+    monkeypatch.setattr(auth.config, "disable_auth", True, raising=False)
+    monkeypatch.setattr(auth, "decode_token", lambda _token: None)
+    monkeypatch.setattr(auth, "local_login_identity", lambda: "local@example.com")
+    monkeypatch.setattr(auth, "_unverified_claims", lambda _token: {"email": "unknown@example.com"})
+    monkeypatch.setattr(auth, "_allowed_emails", lambda: {"steve@example.com"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth.get_current_user(token="cognito-rs256-stub")
+    assert exc_info.value.status_code == 403
 
 
 @pytest.mark.asyncio

--- a/tests/test_auth_get_active_user.py
+++ b/tests/test_auth_get_active_user.py
@@ -8,20 +8,17 @@ from pathlib import Path
 from typing import Any, Callable, Literal
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from starlette.requests import Request
 
 from backend import auth
 from backend.auth import get_active_user, get_current_user
 
-
 _MISSING = object()
 
 
 @contextmanager
-def _provider_override(
-    app: FastAPI, override: Callable[[], Any], target: Literal["app", "router"] = "app"
-):
+def _provider_override(app: FastAPI, override: Callable[[], Any], target: Literal["app", "router"] = "app"):
     owner = app if target == "app" else app.router
     provider = type("OverrideProvider", (), {"dependency_overrides": {}})()
     previous = getattr(owner, "dependency_overrides_provider", _MISSING)
@@ -155,14 +152,16 @@ async def test_get_active_user_invokes_token_helper_when_disabled(
 
 
 @pytest.mark.anyio
-async def test_get_active_user_falls_back_to_local_identity_when_token_not_app_jwt(
+async def test_get_active_user_reads_email_claim_from_unverified_cognito_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """RS256 Cognito tokens cannot be decoded with the HS256 app secret.
 
     When disable_auth is True and decode_token returns None (e.g. a Cognito
-    RS256 ID token forwarded by API Gateway), get_active_user must fall back
-    to local_login_identity rather than returning the token user or raising.
+    RS256 ID token whose signature API Gateway's JWT authorizer already
+    validated), get_active_user must resolve the caller's own email from the
+    token's claims rather than collapsing every caller into the shared local
+    identity (#4750).
     """
 
     app = FastAPI()
@@ -171,8 +170,53 @@ async def test_get_active_user_falls_back_to_local_identity_when_token_not_app_j
     monkeypatch.setattr(auth.config, "disable_auth", True, raising=False)
     monkeypatch.setattr(auth, "decode_token", lambda _token: None)
     monkeypatch.setattr(auth, "local_login_identity", lambda: "local@example.com")
+    monkeypatch.setattr(auth, "_unverified_claims", lambda _token: {"email": "steve@example.com"})
+    monkeypatch.setattr(auth, "_allowed_emails", lambda: {"steve@example.com"})
 
-    assert await auth.get_active_user(request, token="cognito-rs256-stub") == "local@example.com"
+    assert await auth.get_active_user(request, token="cognito-rs256-stub") == "steve@example.com"
+
+
+@pytest.mark.anyio
+async def test_get_active_user_rejects_unrecognized_email_claim_instead_of_local_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An authenticated caller with no provisioned account must be rejected explicitly.
+
+    Before #4750 this silently mapped to local_login_identity/demo instead of
+    failing, which is exactly the data-integrity concern the issue raised.
+    """
+
+    app = FastAPI()
+    request = _make_request(app)
+
+    monkeypatch.setattr(auth.config, "disable_auth", True, raising=False)
+    monkeypatch.setattr(auth, "decode_token", lambda _token: None)
+    monkeypatch.setattr(auth, "local_login_identity", lambda: "local@example.com")
+    monkeypatch.setattr(auth, "_unverified_claims", lambda _token: {"email": "unknown@example.com"})
+    monkeypatch.setattr(auth, "_allowed_emails", lambda: {"steve@example.com"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth.get_active_user(request, token="cognito-rs256-stub")
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_get_active_user_rejects_token_with_no_email_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A present-but-unreadable token must fail rather than fall back locally."""
+
+    app = FastAPI()
+    request = _make_request(app)
+
+    monkeypatch.setattr(auth.config, "disable_auth", True, raising=False)
+    monkeypatch.setattr(auth, "decode_token", lambda _token: None)
+    monkeypatch.setattr(auth, "local_login_identity", lambda: "local@example.com")
+    monkeypatch.setattr(auth, "_unverified_claims", lambda _token: {})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth.get_active_user(request, token="opaque-stub")
+    assert exc_info.value.status_code == 401
 
 
 @pytest.mark.anyio
@@ -225,6 +269,5 @@ def test_allowed_emails_missing_accounts_root(
 
     assert auth._allowed_emails() == set()
     assert any(
-        record.levelno == logging.WARNING and "does not exist" in record.getMessage()
-        for record in caplog.records
+        record.levelno == logging.WARNING and "does not exist" in record.getMessage() for record in caplog.records
     )


### PR DESCRIPTION
## Summary

Reproduced and confirmed the issue's premise via code tracing: in the deployed Cognito/API Gateway path, `config.disable_auth=true` (API Gateway's Cognito JWT authorizer validates the token before the Lambda runs â€” see `docs/AUTH.md`). `get_current_user`/`get_active_user` tried to decode the Cognito ID token with the backend's own HS256 verifier, which always fails for an RS256 token, and fell back to a single shared `local_login_identity()`. That collapsed **every** real authenticated Cognito user into the same identity instead of resolving their own account â€” a real bug, not just a theoretical one.

- **`backend/auth.py`** â€” when a bearer token is present but not backend-decodable, extract its `email`/`sub` claim (safe: the signature was already verified upstream by the gateway) and authorize it against `_allowed_emails()`. An unrecognized email now gets an explicit 401/403 instead of silently becoming the shared local identity. Only a request with **no token at all** (bare local dev) still falls back to `local_login_identity()`.
- `smoke_identity()` / smoke-test flows are untouched â€” this only changes the token-present branch of the `disable_auth` path.

## Explicitly out of scope: account provisioning

This PR does **not** add `steveleonard11@gmail.com` to any `data/accounts/*/person.json`. An earlier revision of this branch did that, but `data/accounts/{alice,demo,demo-owner}` in this repo are synthetic fixtures for local dev/tests -- none of them carry a real email -- and committing a real user's email/name into a **public** git repository was a mistake, caught in review. Production account data belongs in the deployed data store (S3 in AWS, or an operator's own local data root), never in version control. Branch history was rewritten (squashed, force-pushed) to remove that data from the diff entirely.

Provisioning `steveleonard11@gmail.com` to a real account should go through the existing signup/admin-approval flow (`backend/common/signup_provision.py`) against the actual deployed environment, not a git commit. That's a separate, follow-up action for whoever operates the deployed instance -- not something this PR should do.

## Test plan
- [x] `tests/test_auth.py` / `tests/test_auth_get_active_user.py` â€” updated the two pre-existing tests that encoded the old (buggy) "any unparseable token â†’ shared local identity" behavior; added coverage for: resolving the real email claim from an unverified token, rejecting an unrecognized email claim (403), and rejecting a token with no readable claim (401), on both `get_current_user` and `get_active_user`.
- [x] `python -m pytest tests/test_auth.py tests/test_auth_get_active_user.py tests/backend/test_auth_module.py tests/test_google_auth.py tests/test_app.py tests/test_backend_api.py tests/test_accounts_api.py tests/test_main.py` â€” 152 passed, 4 skipped, 2 xfailed, 1 xpassed, no regressions.
- [x] `ruff check` / `black --check` clean on changed files (`backend/pyproject.toml` config).

Closes #4750
