### PR TITLE
feat(market): surface stale headline indicator on /market page

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -234,16 +234,18 @@ def _fetch_uk_sectors() -> List[SectorPayload]:
     return out
 
 
-def _fetch_headlines() -> List[Dict[str, str]]:
+def _fetch_headlines() -> List[Dict[str, Any]]:
     """Fetch latest headlines for all known index symbols.
 
     Each index symbol is queried individually; results are aggregated and
-    de-duplicated by URL or headline.  If all requests fail, an error is logged
-    so callers have some visibility into the failure.
+    de-duplicated by URL or headline.  Each item carries the ``stale`` flag
+    from ``get_cached_news`` so the frontend can flag headlines served from
+    an aged cache.  If all requests fail, an error is logged so callers have
+    some visibility into the failure.
     """
 
     logger = logging.getLogger(__name__)
-    headlines: List[Dict[str, str]] = []
+    headlines: List[Dict[str, Any]] = []
     seen: set[str] = set()
     success = False
 

--- a/backend/routes/news.py
+++ b/backend/routes/news.py
@@ -52,7 +52,6 @@ _FINANCE_KEYWORDS = (
 )
 
 
-
 def _make_news_item(
     headline: object,
     url: object,
@@ -227,9 +226,7 @@ def fetch_news_yahoo(ticker: str) -> List[Dict[str, str]]:
             _parse_epoch_time(item.get("providerPublishTime")),
             item.get("publisher"),
         )
-        if news_item is not None and _is_finance_related(
-            news_item["headline"], clean_ticker, instrument_name
-        ):
+        if news_item is not None and _is_finance_related(news_item["headline"], clean_ticker, instrument_name):
             out.append(news_item)
     return out
 
@@ -253,9 +250,7 @@ def fetch_news_google(ticker: str) -> List[Dict[str, str]]:
             _parse_rss_time(item.findtext("pubDate")),
             item.findtext("source"),
         )
-        if news_item is not None and _is_finance_related(
-            news_item["headline"], clean_ticker, instrument_name
-        ):
+        if news_item is not None and _is_finance_related(news_item["headline"], clean_ticker, instrument_name):
             out.append(news_item)
     return out
 
@@ -357,6 +352,13 @@ def _fetch_news(ticker: str) -> List[Dict[str, str]]:
     return []
 
 
+def _is_cache_stale(page: str) -> bool:
+    """Return True when the cache for ``page`` exceeds ``NEWS_MAX_STALENESS``."""
+
+    age = page_cache.cache_age(page)
+    return age is not None and age > NEWS_MAX_STALENESS
+
+
 def _warn_if_stale(page: str) -> None:
     """Log a warning when the cache being served is dangerously old.
 
@@ -377,13 +379,28 @@ def _warn_if_stale(page: str) -> None:
         )
 
 
+def _tag_stale(items: List[Dict[str, Any]], stale: bool) -> List[Dict[str, Any]]:
+    """Return a copy of ``items`` with a ``stale`` flag attached to each.
+
+    ``stale`` reflects whether the cache backing ``items`` exceeds
+    ``NEWS_MAX_STALENESS``, so the frontend can flag headlines it would
+    otherwise silently re-serve during a quota outage or fetch failure.
+    """
+
+    return [{**item, "stale": stale} for item in items]
+
+
 def get_cached_news(
     ticker: str,
     *,
     cache_writer: Callable[[str, List[Dict[str, str]]], None] | None = None,
     raise_on_quota_exhausted: bool = False,
-) -> List[Dict[str, str]]:
+) -> List[Dict[str, Any]]:
     """Return cached or freshly fetched news for ``ticker``.
+
+    Each returned item carries a ``stale`` flag (True when the cache backing
+    it exceeds ``NEWS_MAX_STALENESS``) so callers can surface staleness to
+    users instead of silently re-serving an old payload.
 
     The helper mirrors the caching and quota handling used by the ``/news``
     endpoint so that other modules can reuse the same logic synchronously.
@@ -420,15 +437,16 @@ def get_cached_news(
     if cache_fresh:
         delay = page_cache.time_until_stale(page, NEWS_TTL)
         _schedule_refresh(delay)
-        return cached if cached is not None else []
+        return _tag_stale(cached if cached is not None else [], False)
 
     try:
         payload = _call()
     except RuntimeError:
         if cached is not None:
             _warn_if_stale(page)
+            stale = _is_cache_stale(page)
             _schedule_refresh()
-            return cached
+            return _tag_stale(cached, stale)
         _schedule_refresh()
         if raise_on_quota_exhausted:
             raise
@@ -441,14 +459,14 @@ def get_cached_news(
         page_cache.save_cache(page, payload)
 
     _schedule_refresh(NEWS_TTL)
-    return payload
+    return _tag_stale(payload, False)
 
 
 @router.get("/news")
 async def get_news(
     background_tasks: BackgroundTasks,
     ticker: str = Query(..., min_length=1),
-) -> List[Dict[str, str]]:
+) -> List[Dict[str, Any]]:
     """Return recent news headlines for ``ticker``."""
 
     tkr = ticker.strip().upper()
@@ -457,9 +475,7 @@ async def get_news(
     try:
         return get_cached_news(
             tkr,
-            cache_writer=lambda page, data: background_tasks.add_task(
-                page_cache.save_cache, page, data
-            ),
+            cache_writer=lambda page, data: background_tasks.add_task(page_cache.save_cache, page, data),
             raise_on_quota_exhausted=True,
         )
     except RuntimeError as exc:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -384,6 +384,7 @@ export const getNews = (ticker: string, signal?: AbortSignal) => {
       url: item.url,
       source: cleanOptionalString(item.source ?? null),
       published_at: cleanOptionalString(item.published_at ?? null),
+      stale: item.stale ?? false,
     })),
   );
 };

--- a/frontend/src/pages/MarketOverview.tsx
+++ b/frontend/src/pages/MarketOverview.tsx
@@ -185,6 +185,17 @@ export default function MarketOverview() {
                       — {age}
                     </span>
                   )}
+                  {h.stale && (
+                    <span
+                      className="ml-2 rounded bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800"
+                      title={t('market.staleHeadlineTooltip', {
+                        defaultValue:
+                          'This headline is from a cache that has not refreshed recently; live news fetches may be failing or rate-limited.',
+                      })}
+                    >
+                      {t('market.staleHeadline', { defaultValue: 'Stale' })}
+                    </span>
+                  )}
                 </li>
               );
             })}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -285,6 +285,7 @@ export interface NewsItem {
   url: string;
   source?: string | null;
   published_at?: string | null;
+  stale?: boolean;
 }
 
 export interface SectorPerformance {

--- a/frontend/tests/unit/pages/MarketOverview.test.tsx
+++ b/frontend/tests/unit/pages/MarketOverview.test.tsx
@@ -89,6 +89,32 @@ describe("MarketOverview", () => {
     expect(screen.queryByText(/ago/)).not.toBeInTheDocument();
   });
 
+  it("shows a stale badge for a headline flagged as stale", async () => {
+    mockGetMarketOverview.mockResolvedValueOnce({
+      indexes: {},
+      sectors: [],
+      headlines: [
+        { headline: "Old News", url: "https://example.com/old", stale: true },
+      ],
+    });
+    render(<MarketOverview />);
+    expect(await screen.findByText("Old News")).toBeInTheDocument();
+    expect(screen.getByText("Stale")).toBeInTheDocument();
+  });
+
+  it("omits the stale badge for a fresh headline", async () => {
+    mockGetMarketOverview.mockResolvedValueOnce({
+      indexes: {},
+      sectors: [],
+      headlines: [
+        { headline: "Fresh News", url: "https://example.com/fresh", stale: false },
+      ],
+    });
+    render(<MarketOverview />);
+    expect(await screen.findByText("Fresh News")).toBeInTheDocument();
+    expect(screen.queryByText("Stale")).not.toBeInTheDocument();
+  });
+
   it("renders index tooltip values from value and change", () => {
     render(
       <IndexTooltip

--- a/tests/backend/test_news_route.py
+++ b/tests/backend/test_news_route.py
@@ -49,7 +49,7 @@ def test_get_news_falls_back(monkeypatch):
 
     resp = client.get("/news", params={"ticker": "AAA"})
     assert resp.status_code == 200
-    assert resp.json() == [{"headline": "h1", "url": "u1"}]
+    assert resp.json() == [{"headline": "h1", "url": "u1", "stale": False}]
 
 
 def test_get_news_trims_payload_and_caches(monkeypatch):
@@ -93,7 +93,7 @@ def test_get_news_trims_payload_and_caches(monkeypatch):
         "published_at": "2023-08-25T16:00:00Z",
         "source": "AlphaVantage",
     }
-    assert payload == [expected_item]
+    assert payload == [{**expected_item, "stale": False}]
     assert saved == [("news_AAA", [expected_item])]
 
 

--- a/tests/routes/test_market.py
+++ b/tests/routes/test_market.py
@@ -270,6 +270,34 @@ def test_fetch_headlines_with_mocked_news(monkeypatch):
     ]
 
 
+def test_fetch_headlines_propagates_stale_flag_from_get_cached_news(monkeypatch):
+    """End-to-end through market_overview: a stale cache flag from
+    ``get_cached_news`` must survive ``_fetch_headlines`` and reach the
+    ``/market/overview`` response, not just the unit-level helper.
+    """
+
+    from backend.routes import news as news_module
+    from backend.utils import page_cache
+
+    monkeypatch.setattr(market, "INDEX_SYMBOLS", {"One": "ONE"})
+    monkeypatch.setattr(market, "_fetch_indexes", lambda: {})
+    monkeypatch.setattr(market, "_fetch_sectors", lambda: [])
+
+    cache = {"news_ONE": [{"headline": "Old headline", "url": "https://example.test/old"}]}
+
+    monkeypatch.setattr(page_cache, "load_cache", lambda page: cache.get(page))
+    monkeypatch.setattr(page_cache, "is_stale", lambda page, ttl: True)
+    monkeypatch.setattr(page_cache, "cache_age", lambda page: news_module.NEWS_MAX_STALENESS + 1)
+    monkeypatch.setattr(page_cache, "schedule_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(news_module, "_try_consume_quota", lambda: False)
+
+    client = _client()
+    resp = client.get("/market/overview")
+
+    assert resp.status_code == 200
+    assert resp.json()["headlines"] == [{"headline": "Old headline", "url": "https://example.test/old", "stale": True}]
+
+
 def test_market_overview_default_region_handles_fetch_failures(monkeypatch):
     client = _client()
     monkeypatch.setattr(market.cfg, "default_sector_region", "US", raising=False)

--- a/tests/routes/test_news.py
+++ b/tests/routes/test_news.py
@@ -258,9 +258,7 @@ def test_fetch_news_alpha_omits_published_at_when_missing(monkeypatch):
     monkeypatch.setattr(news_module.requests, "get", fake_get)
 
     items = news_module._fetch_news("AAPL")
-    assert items == [
-        {"headline": "Undated headline", "url": "https://example.com/undated"}
-    ]
+    assert items == [{"headline": "Undated headline", "url": "https://example.com/undated"}]
 
 
 def test_fetch_news_fallback(monkeypatch):
@@ -312,9 +310,7 @@ def test_get_news_quota_and_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(news_module, "COUNTER_FILE", counter_path)
     monkeypatch.setattr(config_module.config, "disable_auth", True, raising=False)
     monkeypatch.setattr(config_module.config, "skip_snapshot_warm", True, raising=False)
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.refresh_snapshot_async", lambda days=0: None
-    )
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_async", lambda days=0: None)
 
     calls = {"alpha": 0}
 
@@ -346,25 +342,19 @@ def test_get_news_quota_and_cache(monkeypatch, tmp_path):
     with TestClient(app) as client:
         first = client.get("/news", params={"ticker": "ABC"})
         assert first.status_code == 200
-        assert first.json() == [
-            {"headline": "ABC headline", "url": "https://example.com/abc"}
-        ]
+        assert first.json() == [{"headline": "ABC headline", "url": "https://example.com/abc", "stale": False}]
         assert calls["alpha"] == 1
         assert json.loads(counter_path.read_text())["count"] == 1
 
         cached = client.get("/news", params={"ticker": "ABC"})
         assert cached.status_code == 200
-        assert cached.json() == [
-            {"headline": "ABC headline", "url": "https://example.com/abc"}
-        ]
+        assert cached.json() == [{"headline": "ABC headline", "url": "https://example.com/abc", "stale": False}]
         assert calls["alpha"] == 1
         assert json.loads(counter_path.read_text())["count"] == 1
 
         second = client.get("/news", params={"ticker": "XYZ"})
         assert second.status_code == 200
-        assert second.json() == [
-            {"headline": "XYZ headline", "url": "https://example.com/xyz"}
-        ]
+        assert second.json() == [{"headline": "XYZ headline", "url": "https://example.com/xyz", "stale": False}]
         assert calls["alpha"] == 2
         assert json.loads(counter_path.read_text())["count"] == 2
 
@@ -376,7 +366,7 @@ def test_get_news_quota_and_cache(monkeypatch, tmp_path):
         cached_after_limit = client.get("/news", params={"ticker": "ABC"})
         assert cached_after_limit.status_code == 200
         assert cached_after_limit.json() == [
-            {"headline": "ABC headline", "url": "https://example.com/abc"}
+            {"headline": "ABC headline", "url": "https://example.com/abc", "stale": False}
         ]
         assert calls["alpha"] == 2
 
@@ -413,7 +403,7 @@ def test_get_cached_news_cold_cache_fetches_once(monkeypatch):
     monkeypatch.setattr(news_module, "_try_consume_quota", fake_quota)
 
     first = news_module.get_cached_news("cold")
-    assert first == [{"headline": "COLD headline", "url": "https://example.com"}]
+    assert first == [{"headline": "COLD headline", "url": "https://example.com", "stale": False}]
     assert fetch_calls["count"] == 1
     assert quota_calls["count"] == 1
 
@@ -423,7 +413,50 @@ def test_get_cached_news_cold_cache_fetches_once(monkeypatch):
     assert quota_calls["count"] == 1
 
 
+def test_get_cached_news_flags_stale_cache_on_quota_exhaustion(monkeypatch):
+    cache: Dict[str, List[Dict[str, str]]] = {
+        "news_STALE": [{"headline": "Old headline", "url": "https://example.com/old"}]
+    }
+
+    monkeypatch.setattr(page_cache, "load_cache", lambda page: cache.get(page))
+    monkeypatch.setattr(page_cache, "is_stale", lambda page, ttl: True)
+    monkeypatch.setattr(page_cache, "cache_age", lambda page: news_module.NEWS_MAX_STALENESS + 1)
+    monkeypatch.setattr(page_cache, "schedule_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(news_module, "_try_consume_quota", lambda: False)
+
+    items = news_module.get_cached_news("stale")
+    assert items == [
+        {
+            "headline": "Old headline",
+            "url": "https://example.com/old",
+            "stale": True,
+        }
+    ]
+
+
+def test_get_cached_news_does_not_flag_recent_cache_on_quota_exhaustion(monkeypatch):
+    cache: Dict[str, List[Dict[str, str]]] = {
+        "news_RECENT": [{"headline": "Recent headline", "url": "https://example.com/recent"}]
+    }
+
+    monkeypatch.setattr(page_cache, "load_cache", lambda page: cache.get(page))
+    monkeypatch.setattr(page_cache, "is_stale", lambda page, ttl: True)
+    monkeypatch.setattr(page_cache, "cache_age", lambda page: news_module.NEWS_MAX_STALENESS - 1)
+    monkeypatch.setattr(page_cache, "schedule_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(news_module, "_try_consume_quota", lambda: False)
+
+    items = news_module.get_cached_news("recent")
+    assert items == [
+        {
+            "headline": "Recent headline",
+            "url": "https://example.com/recent",
+            "stale": False,
+        }
+    ]
+
+
 # ── SSRF guard wiring ─────────────────────────────────────────────────────────
+
 
 @pytest.mark.parametrize(
     "bad_endpoint",
@@ -453,13 +486,15 @@ def test_fetch_news_google_rejects_private_endpoint(monkeypatch, bad_endpoint: s
     monkeypatch.setattr(news_module.cfg, "google_news_endpoint", bad_endpoint)
     with pytest.raises(InvalidExternalURLError):
         news_module.fetch_news_google("AAPL")
+
+
 def test_fetch_news_google_billion_laughs_rejected(monkeypatch):
     bomb = (
         '<?xml version="1.0"?>'
         "<!DOCTYPE lolz ["
         '  <!ENTITY lol "lol">'
-        "  <!ENTITY lol2 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">"
-        "  <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">"
+        '  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">'
+        '  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">'
         "]>"
         "<lolz>&lol3;</lolz>"
     )

--- a/tests/routes/test_news_helpers.py
+++ b/tests/routes/test_news_helpers.py
@@ -236,7 +236,7 @@ def test_get_cached_news_warns_when_serving_stale_on_quota(monkeypatch, caplog):
     with caplog.at_level("WARNING"):
         result = news_module.get_cached_news("cached")
 
-    assert result == cached_payload
+    assert result == [{**item, "stale": True} for item in cached_payload]
     assert any("Serving stale cached news" in rec.message for rec in caplog.records)
 
 
@@ -272,8 +272,8 @@ def test_get_cached_news_reuses_fresh_cache(monkeypatch):
     result = news_module.get_cached_news("cached")
 
     assert result == [
-        {"headline": "Cached", "url": "https://example.com/cached"},
-        {"headline": "Trim", "url": "https://example.com/trim"},
+        {"headline": "Cached", "url": "https://example.com/cached", "stale": False},
+        {"headline": "Trim", "url": "https://example.com/trim", "stale": False},
     ]
     assert len(scheduled) == 1
     _assert_refresh_call(scheduled[0], page="news_CACHED", delay=42.0)


### PR DESCRIPTION
## Summary
- `get_cached_news` (backend/routes/news.py) now tags every returned headline with a `stale` boolean, computed from the existing `NEWS_MAX_STALENESS` threshold introduced in #4708. No new fetch paths or extra AlphaVantage calls are added — this reuses the existing cache/TTL/staleness logic.
- `_fetch_headlines` (backend/routes/market.py) and the `/market/overview` response pass the flag through unchanged.
- `MarketOverview.tsx` renders a "Stale" badge next to any headline whose backing cache exceeds the staleness threshold, so a quota outage or repeated live-fetch failure is visible to users instead of only logged server-side.
- `getNews` (frontend/src/api.ts) also passes the flag through for consistency, since it shares the same `NewsItem` shape.
- Headlines are still rendered (flagged, not filtered) so quota exhaustion degrades gracefully rather than producing a blank page.

## Test plan
- [x] `python -m pytest tests/routes/test_news.py tests/routes/test_market.py tests/backend/routes/test_market.py -q` — 41 passed, including two new cases covering the stale/not-stale quota-exhaustion paths
- [x] `npx vitest run tests/unit/pages/MarketOverview.test.tsx` — 7 passed, including two new cases for the stale badge
- [x] `npx eslint` on the touched frontend files — clean
- [x] `ruff check` / `black --check` / `isort --check-only` (backend/pyproject.toml config) on the touched backend files — clean

Closes #4749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * News headlines can now be marked as “stale” when cached data may be outdated, with a clear badge shown in the market view.
  * News responses now carry this status through to the app so the interface can reflect it consistently.

* **Bug Fixes**
  * Improved handling of cached news during quota limits so older items are still surfaced with the correct freshness indicator.
  * Updated coverage to ensure stale and non-stale headlines display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->