### PR TITLE
test: strengthen deploy-workflow assertions and add fetch-cloudwatch-logs.sh coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,13 @@ jobs:
         with:
           node-version: '24'
       # bats-core is fetched on demand via npx rather than assuming it's
-      # preinstalled on the runner image; all aws CLI calls in these tests
-      # are mocked (see tests/bash/fetch-cloudwatch-logs.bats), so this is a
-      # pure dry-run with no live AWS network access.
+      # preinstalled on the runner image; pin the version so an upstream
+      # bats-core release can't silently change CI behaviour. All aws CLI
+      # calls in these tests are mocked (see
+      # tests/bash/fetch-cloudwatch-logs.bats), so this is a pure dry-run
+      # with no live AWS network access.
       - name: Run bats tests for deploy shell scripts
-        run: npx --yes bats tests/bash/*.bats
+        run: npx --yes bats@1.13.0 tests/bash/*.bats
 
   validate-backend-deps:
     name: Validate backend/requirements.txt (dry-run)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,21 @@ jobs:
       - name: CDK infrastructure tests
         run: pytest cdk/tests/ --no-cov
 
+  shell-tests:
+    name: Bash script tests (bats)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      # bats-core is fetched on demand via npx rather than assuming it's
+      # preinstalled on the runner image; all aws CLI calls in these tests
+      # are mocked (see tests/bash/fetch-cloudwatch-logs.bats), so this is a
+      # pure dry-run with no live AWS network access.
+      - name: Run bats tests for deploy shell scripts
+        run: npx --yes bats tests/bash/*.bats
+
   validate-backend-deps:
     name: Validate backend/requirements.txt (dry-run)
     runs-on: ubuntu-latest

--- a/tests/bash/fetch-cloudwatch-logs.bats
+++ b/tests/bash/fetch-cloudwatch-logs.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/bash/fetch-cloudwatch-logs.sh covering the
+# AccessDenied, empty-result, and success paths documented at the top of
+# the script under test. See #3807, #4075, #4076.
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/bash/fetch-cloudwatch-logs.sh"
+
+setup() {
+  FAKE_BIN="$(mktemp -d)"
+  PATH="$FAKE_BIN:$PATH"
+}
+
+teardown() {
+  rm -rf "$FAKE_BIN"
+}
+
+# Writes a fake `aws` executable to $FAKE_BIN that stands in for
+# `aws logs filter-log-events ...`. The script under test only inspects
+# stdout (see its "Capture stdout ... separately from stderr" comment), so
+# STDOUT_TEXT is what fetch-cloudwatch-logs.sh actually sees.
+write_fake_aws() {
+  local stdout_text="$1"
+  local exit_code="$2"
+  cat > "$FAKE_BIN/aws" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "$stdout_text"
+exit $exit_code
+EOF
+  chmod +x "$FAKE_BIN/aws"
+}
+
+@test "exits 0 and emits a scoped warning on AccessDeniedException" {
+  write_fake_aws "An error occurred (AccessDeniedException) when calling the FilterLogEvents operation" 1
+
+  run "$SCRIPT" "/aws/lambda/my-fn" 600
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning::logs:FilterLogEvents denied for /aws/lambda/my-fn; CloudWatch logs not available (see #3742)"* ]]
+}
+
+@test "exits 0 and emits a generic warning on a non-AccessDenied API error" {
+  write_fake_aws "An error occurred (ThrottlingException) when calling the FilterLogEvents operation" 1
+
+  run "$SCRIPT" "/aws/lambda/my-fn" 600
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning::Failed to fetch CloudWatch logs for /aws/lambda/my-fn:"* ]]
+  [[ "$output" == *"ThrottlingException"* ]]
+}
+
+@test "prints a friendly message when the log group has no matching events" {
+  write_fake_aws "None" 0
+
+  run "$SCRIPT" "/aws/lambda/my-fn" 600
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "(no log events found)" ]
+}
+
+@test "filters out None entries and prints real log messages on success" {
+  write_fake_aws "$(printf 'None\nFirst log line\nSecond log line')" 0
+
+  run "$SCRIPT" "/aws/lambda/my-fn" 600
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"None"* ]]
+  [[ "$output" == *"First log line"* ]]
+  [[ "$output" == *"Second log line"* ]]
+}
+
+@test "requires a log group name argument" {
+  run "$SCRIPT"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"log group name required"* ]]
+}
+
+@test "requires a lookback window argument" {
+  run "$SCRIPT" "/aws/lambda/my-fn"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"lookback window in seconds required"* ]]
+}

--- a/tests/bash/fetch-cloudwatch-logs.bats
+++ b/tests/bash/fetch-cloudwatch-logs.bats
@@ -32,7 +32,7 @@ EOF
 @test "exits 0 and emits a scoped warning on AccessDeniedException" {
   write_fake_aws "An error occurred (AccessDeniedException) when calling the FilterLogEvents operation" 1
 
-  run "$SCRIPT" "/aws/lambda/my-fn" 600
+  run bash "$SCRIPT" "/aws/lambda/my-fn" 600
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"::warning::logs:FilterLogEvents denied for /aws/lambda/my-fn; CloudWatch logs not available (see #3742)"* ]]
@@ -41,7 +41,7 @@ EOF
 @test "exits 0 and emits a generic warning on a non-AccessDenied API error" {
   write_fake_aws "An error occurred (ThrottlingException) when calling the FilterLogEvents operation" 1
 
-  run "$SCRIPT" "/aws/lambda/my-fn" 600
+  run bash "$SCRIPT" "/aws/lambda/my-fn" 600
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"::warning::Failed to fetch CloudWatch logs for /aws/lambda/my-fn:"* ]]
@@ -51,7 +51,7 @@ EOF
 @test "prints a friendly message when the log group has no matching events" {
   write_fake_aws "None" 0
 
-  run "$SCRIPT" "/aws/lambda/my-fn" 600
+  run bash "$SCRIPT" "/aws/lambda/my-fn" 600
 
   [ "$status" -eq 0 ]
   [ "$output" = "(no log events found)" ]
@@ -60,7 +60,7 @@ EOF
 @test "filters out None entries and prints real log messages on success" {
   write_fake_aws "$(printf 'None\nFirst log line\nSecond log line')" 0
 
-  run "$SCRIPT" "/aws/lambda/my-fn" 600
+  run bash "$SCRIPT" "/aws/lambda/my-fn" 600
 
   [ "$status" -eq 0 ]
   [[ "$output" != *"None"* ]]
@@ -69,14 +69,14 @@ EOF
 }
 
 @test "requires a log group name argument" {
-  run "$SCRIPT"
+  run bash "$SCRIPT"
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"log group name required"* ]]
 }
 
 @test "requires a lookback window argument" {
-  run "$SCRIPT" "/aws/lambda/my-fn"
+  run bash "$SCRIPT" "/aws/lambda/my-fn"
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"lookback window in seconds required"* ]]

--- a/tests/scripts/test_check_cdk_diff_iam_removals.py
+++ b/tests/scripts/test_check_cdk_diff_iam_removals.py
@@ -112,7 +112,7 @@ def test_no_iam_table_means_no_removals() -> None:
 def test_flags_removed_allow_grant_for_deploy_role() -> None:
     unmatched = find_unmatched_allow_removals(REMOVED_DEPLOY_ROLE_GRANT_DIFF)
     assert len(unmatched) == 1
-    assert "lambda:InvokeFunction" in unmatched[0]
+    assert "lambda:InvokeFunction" in " ".join(unmatched[0])
 
 
 def test_replace_pair_is_not_flagged() -> None:
@@ -142,19 +142,19 @@ def test_main_returns_one_for_removed_grant(tmp_path) -> None:
 def test_flags_removed_s3_grant_for_portfolio_data_bucket() -> None:
     unmatched = find_unmatched_allow_removals(REMOVED_S3_GRANT_DIFF)
     assert len(unmatched) == 1
-    assert "s3:GetObject" in unmatched[0]
+    assert "s3:GetObject" in " ".join(unmatched[0])
 
 
 def test_flags_removal_after_blank_line_mid_table() -> None:
     unmatched = find_unmatched_allow_removals(BLANK_LINE_MID_TABLE_DIFF)
     assert len(unmatched) == 1
-    assert "lambda:InvokeFunction" in unmatched[0]
+    assert "lambda:InvokeFunction" in " ".join(unmatched[0])
 
 
 def test_flags_removal_in_ansi_colored_diff() -> None:
     unmatched = find_unmatched_allow_removals(ANSI_COLORED_REMOVAL_DIFF)
     assert len(unmatched) == 1
-    assert "lambda:InvokeFunction" in unmatched[0]
+    assert "lambda:InvokeFunction" in " ".join(unmatched[0])
 
 
 def test_main_reads_from_stdin(monkeypatch) -> None:

--- a/tests/scripts/test_deploy_lambda_workflow.py
+++ b/tests/scripts/test_deploy_lambda_workflow.py
@@ -84,3 +84,19 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
     # The step must not swallow its own exit code via continue-on-error,
     # otherwise the hard failure above would not fail the job.
     assert "continue-on-error" not in verify_step
+
+    # head_exit must be captured on the same logical statement as the
+    # head_output subshell (via the `&& head_exit=0 || head_exit=$?` idiom),
+    # not by a later, separate `head_exit=$?` statement — any intervening
+    # command (e.g. the `grep` below) would overwrite `$?` before it is
+    # captured, leaving head_exit stale. The statement spans several
+    # continuation lines, so find the first line after the capture_block's
+    # closing `)"` and confirm head_exit is assigned before it.
+    statement_end = capture_block.index("\n", capture_end)
+    head_exit_statement = capture_block[capture_end:statement_end]
+    assert "head_exit=" in head_exit_statement, (
+        "head_exit must be captured in the same statement as the "
+        "head_output subshell (e.g. `&& head_exit=0 || head_exit=$?` "
+        "immediately after the closing `)\"`), not via a later, separate "
+        "statement that could capture a different command's exit code"
+    )

--- a/tests/scripts/test_deploy_lambda_workflow.py
+++ b/tests/scripts/test_deploy_lambda_workflow.py
@@ -85,13 +85,14 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
     # otherwise the hard failure above would not fail the job.
     assert "continue-on-error" not in verify_step
 
-    # head_exit must be captured on the same logical statement as the
-    # head_output subshell (via the `&& head_exit=0 || head_exit=$?` idiom),
-    # not by a later, separate `head_exit=$?` statement — any intervening
-    # command (e.g. the `grep` below) would overwrite `$?` before it is
-    # captured, leaving head_exit stale. The statement spans several
-    # continuation lines, so find the first line after the capture_block's
-    # closing `)"` and confirm head_exit is assigned before it.
+    # head_exit must be captured immediately after the head_output subshell
+    # runs — on the same logical statement, via the
+    # `&& head_exit=0 || head_exit=$?` idiom — not by a later, separate
+    # `head_exit=$?` statement. Any intervening command (e.g. the `grep`
+    # below) would overwrite `$?` before it is captured, leaving head_exit
+    # stale. The statement spans several continuation lines, so find the
+    # first line after the capture_block's closing `)"` and confirm
+    # head_exit is assigned there, before any other statement runs.
     statement_end = capture_block.index("\n", capture_end)
     head_exit_statement = capture_block[capture_end:statement_end]
     assert "head_exit=" in head_exit_statement, (
@@ -99,4 +100,15 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
         "head_output subshell (e.g. `&& head_exit=0 || head_exit=$?` "
         "immediately after the closing `)\"`), not via a later, separate "
         "statement that could capture a different command's exit code"
+    )
+    # Explicitly verify the ordering, not just co-occurrence: head_output's
+    # assignment (start of capture_block, by construction) must precede
+    # head_exit's capture — i.e. head_exit= must not appear before the
+    # closing `)"` of the head_output subshell — so head_output is fully
+    # populated by the time head_exit is captured.
+    head_output_pos = capture_block.index("head_output=")
+    head_exit_pos = capture_block.index("head_exit=")
+    assert head_output_pos < capture_end <= head_exit_pos, (
+        "head_output must be fully assigned (subshell closed) before "
+        "head_exit is captured"
     )


### PR DESCRIPTION
## Summary
- Add bats tests (`tests/bash/fetch-cloudwatch-logs.bats`) for `scripts/bash/fetch-cloudwatch-logs.sh`, covering the AccessDenied, generic-error, empty-result, and success/filtering paths plus argument validation. The `aws` CLI is mocked, so no network access is needed.
- Wire a new `shell-tests` job into `.github/workflows/ci.yml` that runs the bats suite via `npx bats` on every push/PR — a dry-run smoke test with no live AWS calls.
- Fix `tests/scripts/test_check_cdk_diff_iam_removals.py`: four assertions checked `"x" in unmatched[0]` (list-membership, which only passed by coincidence) instead of substring containment. Changed to `"x" in " ".join(unmatched[0])`.
- Add an assertion in `tests/scripts/test_deploy_lambda_workflow.py` that `head_exit` is captured in the same statement as the `head_output` subshell in the deploy-lambda workflow (guards against a future refactor leaving `head_exit` stale).

Note: the `2>&1` placement and `continue-on-error` absence assertions called for in the issue (sub-issues #4130/#4143) were already present in `test_deploy_lambda_workflow.py` from a prior commit — verified rather than re-added.

## Test plan
- [x] `npx bats tests/bash/fetch-cloudwatch-logs.bats` — 6/6 pass locally
- [x] `pytest tests/scripts/test_check_cdk_diff_iam_removals.py tests/scripts/test_deploy_lambda_workflow.py` — 13/13 pass
- [x] Full `pytest tests/` suite — 2745 passed, 6 pre-existing failures in `tests/test_review_comment.py` unrelated to this change (confirmed failing identically on `main`, caused by a `bash`/WSL `pipefail` option mismatch in the local environment)
- [x] `ruff check` / `black --check` on the two modified test files — clean (pre-existing repo-wide lint/format debt in unrelated files left untouched)

Closes #4762


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for shell script log-fetching behaviour, including warnings, empty results, successful filtering, and input validation.
  * Tightened regression checks for deployment and IAM-related scripts to better match expected output and error handling.
* **Chores**
  * Expanded CI to run Bash test suites as part of automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->