### PR TITLE
fix(csp): add style-src directive to CloudFront CSP

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -77,18 +77,27 @@ class StaticSiteStack(Stack):
         # A static wildcard like *.execute-api.*.amazonaws.com is invalid CSP
         # syntax (wildcards are only permitted as the leftmost hostname label)
         # and would be silently ignored by browsers, blocking all API calls.
-        _csp = "; ".join(
-            [
-                "default-src 'self'",
-                "script-src 'self' https://accounts.google.com/gsi/client",
-                "frame-src 'self' https://accounts.google.com/gsi/",
-                f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazoncognito.com",
-                "img-src 'self' https://raw.githubusercontent.com https://avatars.githubusercontent.com https://www.gravatar.com https://*.gravatar.com https://*.googleusercontent.com",
-                "frame-ancestors 'none'",
-                "object-src 'none'",
-                "base-uri 'self'",
-            ]
-        ) + ";"
+        _csp = (
+            "; ".join(
+                [
+                    "default-src 'self'",
+                    "script-src 'self' https://accounts.google.com/gsi/client",
+                    # 'unsafe-inline' for styles only (not script) is a common, low-risk
+                    # tradeoff: it can't execute arbitrary JS, and the frontend relies
+                    # heavily on React's style={{...}} prop, which compiles to inline
+                    # style attributes. Without this, default-src's fallback blocks all
+                    # inline styles, breaking layout across the deployed site.
+                    "style-src 'self' 'unsafe-inline'",
+                    "frame-src 'self' https://accounts.google.com/gsi/",
+                    f"connect-src 'self' {backend_url_param.value_as_string} https://*.amazoncognito.com",
+                    "img-src 'self' https://raw.githubusercontent.com https://avatars.githubusercontent.com https://www.gravatar.com https://*.gravatar.com https://*.googleusercontent.com",
+                    "frame-ancestors 'none'",
+                    "object-src 'none'",
+                    "base-uri 'self'",
+                ]
+            )
+            + ";"
+        )
 
         site_bucket = s3.Bucket(
             self,

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -219,6 +219,7 @@ def test_csp_connect_src_uses_backend_api_url_parameter(template):
     assert "connect-src 'self' " in static_text
     assert "https://*.amazoncognito.com" in static_text
     assert "script-src 'self' https://accounts.google.com/gsi/client" in static_text
+    assert "style-src 'self' 'unsafe-inline'" in static_text
     assert "frame-src 'self' https://accounts.google.com/gsi/" in static_text
     assert "frame-ancestors 'none'" in static_text
     assert static_text.count("object-src 'none'") == 1


### PR DESCRIPTION
## Summary
- Adds an explicit `style-src 'self' 'unsafe-inline'` directive to the CloudFront CSP in `cdk/stacks/static_site_stack.py`, so inline styles (React's widely-used `style={{...}}` prop) are no longer silently blocked by the `default-src 'self'` fallback.
- `'unsafe-inline'` is scoped to styles only, not scripts — documented inline as a deliberate, low-risk tradeoff since CSS can't execute arbitrary JS.
- Extends `cdk/tests/test_static_site_stack.py::test_csp_connect_src_uses_backend_api_url_parameter` to assert `style-src` is present in the synthesized CSP.

## Test plan
- [x] `python -m pytest cdk/tests/test_static_site_stack.py -q --no-cov` — 49 passed
- [x] `python -m black --check` / `ruff check` on changed files — clean (pre-existing unrelated lint findings in the file left untouched)

Closes #4786