### PR TITLE
fix: register /signup/* routes as unauthenticated at API Gateway

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -525,6 +525,28 @@ class BackendLambdaStack(Stack):
             integration=backend_integration,
             authorizer=apigwv2.HttpNoneAuthorizer(),
         )
+        # POST /signup/request, and the /signup/approve and /signup/reject
+        # GET+POST pairs, are the public account-request/admin-approval flow
+        # (see the module docstring in backend/routes/signup.py). None of these
+        # callers hold a Cognito token: the visitor requesting an account has no
+        # session yet, and the admin authorises via an unguessable single-use
+        # token embedded in the emailed link, not a Bearer header. Without an
+        # explicit route here they fall through to the /{proxy+} ANY catch-all
+        # below and get rejected with 401 before backend/routes/signup.py ever
+        # runs — the same class of bug already fixed for GET /config in #3873
+        # and POST /token/google above (#4785).
+        for signup_path in ("/signup/request", "/signup/approve", "/signup/reject"):
+            methods = (
+                [apigwv2.HttpMethod.POST]
+                if signup_path == "/signup/request"
+                else [apigwv2.HttpMethod.GET, apigwv2.HttpMethod.POST]
+            )
+            backend_api.add_routes(
+                path=signup_path,
+                methods=methods,
+                integration=backend_integration,
+                authorizer=apigwv2.HttpNoneAuthorizer(),
+            )
         # CORS preflight OPTIONS requests must never reach backend_authorizer:
         # browsers send them without an Authorization header, so a JWT
         # authorizer would reject them with 401 before CORS headers are

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -619,8 +619,8 @@ def test_backend_api_authorizer_accepts_cognito_id_token_contract(template):
 
 def test_backend_api_routes_require_cognito_authorizer(template):
     """All API Gateway routes must require Cognito JWT authorization except
-    /health, GET /config, POST /token/google, and the CORS preflight OPTIONS
-    routes.
+    /health, GET /config, POST /token/google, the public /signup/* routes, and
+    the CORS preflight OPTIONS routes.
 
     /health is intentionally unauthenticated so that post-deploy probes and
     smoke tests can confirm Lambda is reachable without needing a Cognito token.
@@ -636,6 +636,12 @@ def test_backend_api_routes_require_cognito_authorizer(template):
     catch-all. The deployed frontend no longer calls it — frontend/src/main.tsx
     applyCognitoIdToken sends the Cognito ID token directly as the Bearer header,
     which backend_authorizer validates against the same user pool (#4256).
+    POST /signup/request and the GET+POST /signup/approve and /signup/reject
+    pairs are intentionally unauthenticated: the requesting visitor has no
+    Cognito session yet, and the admin approval flow authorises via an
+    unguessable single-use token in the emailed link rather than a Bearer
+    header (see backend/routes/signup.py) — the same class of bug fixed here
+    as for GET /config and POST /token/google (#4785).
     OPTIONS / and OPTIONS /{proxy+} are unauthenticated so that browser CORS
     preflight requests (which never carry an Authorization header) are not
     rejected with 401 before the real request is sent (see issue #3945).
@@ -646,6 +652,11 @@ def test_backend_api_routes_require_cognito_authorizer(template):
         "GET /health",
         "GET /config",
         "POST /token/google",
+        "POST /signup/request",
+        "GET /signup/approve",
+        "POST /signup/approve",
+        "GET /signup/reject",
+        "POST /signup/reject",
         "OPTIONS /",
         "OPTIONS /{proxy+}",
     }

--- a/frontend/src/pages/CreateAccountPage.tsx
+++ b/frontend/src/pages/CreateAccountPage.tsx
@@ -137,7 +137,8 @@ export default function CreateAccountPage() {
         note: note.trim() || undefined,
       });
       setSubmitted(true);
-    } catch {
+    } catch (err) {
+      console.error("Failed to submit account signup request", err);
       setError("Something went wrong submitting your request. Please try again.");
     } finally {
       setSubmitting(false);


### PR DESCRIPTION
## Summary
- `POST /signup/request`, `GET/POST /signup/approve`, and `GET/POST /signup/reject` had no explicit API Gateway route registration, so they fell through to the `/{proxy+}` ANY catch-all guarded by `backend_authorizer` (Cognito JWT) and were rejected with 401 before `backend/routes/signup.py` ever ran.
- These routes are deliberately public: the visitor requesting an account has no Cognito session yet, and the admin approval flow authorises via an unguessable single-use token in the emailed link, not a Bearer header.
- Added explicit `HttpNoneAuthorizer()` route registrations in `cdk/stacks/backend_lambda_stack.py`, following the same pattern already used for `GET /config` (#3873) and `POST /token/google`.
- Extended the existing `test_backend_api_routes_require_cognito_authorizer` synth test's `UNAUTHENTICATED_ROUTES` set so a future regression is caught at synth time.
- Logged the real fetch error via `console.error` in `frontend/src/pages/CreateAccountPage.tsx` before setting the generic user-facing error message (no copy change).

## Test plan
- [x] `python -m pytest cdk/tests/test_backend_lambda_stack.py -k "authorizer or routes"` — 5 passed
- [x] `npm --prefix frontend run lint` — clean
- [ ] Verify on the deployed CloudFront environment that submitting the create-account form no longer 401s

Closes #4785