### PR TITLE
fix(ci): cap vitest fork concurrency to stop worker OOM crashes

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -46,6 +46,17 @@ export default defineConfig(() => {
       environment: 'jsdom',
       setupFiles: './src/setupTests.ts',
       include: ['tests/unit/**/*.test.ts?(x)'],
+      // CI runners have limited, variable RAM shared with other concurrent
+      // jobs. Vitest's default fork pool spawns roughly one worker per CPU
+      // with no per-worker memory cap, which has intermittently exhausted
+      // the runner's heap and crashed workers mid-suite (zero real test
+      // failures, just "Worker exited unexpectedly") — see #4810. Capping
+      // concurrency trades some wall-clock time for reliability.
+      poolOptions: {
+        forks: {
+          maxForks: 2
+        }
+      },
       coverage: {
         provider: 'v8' as const, // literal required by CoverageV8Options — widened to string without explicit annotation
         reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary
- The frontend `test` CI job (`.github/workflows/ci.yml`, `npm test -- --run`) intermittently crashed vitest worker forks with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`, even though every actual test assertion passed (observed 549-560/560 passing, zero `FAIL` lines, purely "Worker exited unexpectedly" from crashed forks leaving a handful of files unexecuted). Reproduced 3/3 times in a row on PR #4801 with an unrelated diff.
- Root cause: vitest's default `forks` pool spawns roughly one worker per CPU with no per-worker memory cap in `frontend/vite.config.ts`. `ubuntu-latest` GitHub-hosted runners are shared and their available memory varies with other concurrent jobs/PRs on the runner pool — other unrelated PRs hit failures on different jobs in the same time window and passed on retry, consistent with resource contention rather than a code defect.
- Fix: cap `test.poolOptions.forks.maxForks` to `2` in `frontend/vite.config.ts`, trading some wall-clock time for reliability.

## Test plan
- [x] `npx vitest run tests/unit --reporter=dot` locally with the cap applied — clean run: 87/87 test files, 560/560 tests, no worker crashes (previously this same command intermittently OOM'd with the default pool config).
- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.

Closes #4810