### PR TITLE
ci: pin dorny/paths-filter action to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary
- Pins `dorny/paths-filter@v4` in `.github/workflows/ci.yml` to its commit SHA (`7b450fff21473bca461d4b92ce414b9d0420d706`) instead of the mutable `v4` tag, keeping the version as a trailing comment.
- Resolves CodeQL code scanning alert #295 (`actions/unpinned-tag`) — an unpinned 3rd-party Action tag can be repointed to malicious code, enabling a supply-chain attack.

## Test plan
- [ ] CI runs successfully on this PR with the pinned SHA (filter step still resolves frontend changes correctly)
- [ ] CodeQL alert #295 resolves after merge

Closes #4814