### PR TITLE
fix(ci): tolerate unbolded AI-review verdict lines in extract_verdict

### DIFF
--- a/.github/scripts/extract_verdict.py
+++ b/.github/scripts/extract_verdict.py
@@ -6,6 +6,22 @@ import re
 import sys
 from pathlib import Path
 
+# Primary format: bold verdict, optionally with backticks inside the bold markers, e.g.
+# `**APPROVE**` or `` **`APPROVE`** ``. Matched anywhere in the text (first occurrence wins),
+# since this is the format the prompt instructs models to use.
+_BOLD_VERDICT_RE = re.compile(r"\*\*`?(APPROVE|REQUEST CHANGES)`?\*\*")
+
+# Fallback format: some models (observed with DeepSeek) drop the bold markers and emit the
+# verdict as a plain or bulleted line instead, e.g. `- APPROVE` or `APPROVE — no concerns`.
+# Anchored to the whole line (modulo an optional leading bullet marker and a trailing
+# " - explanation") so a stray mention of APPROVE/REQUEST CHANGES inside prose or an echoed
+# acceptance-criteria checklist item doesn't false-positive. Since the prompt asks for the
+# verdict as the last line, the LAST matching line is preferred over the first.
+_LINE_VERDICT_RE = re.compile(
+    r"^[ \t]*(?:[-*•]\s+)?(APPROVE|REQUEST CHANGES)\b(?:\s*[-—:].*)?$",
+    re.MULTILINE,
+)
+
 
 def extract_verdict(review_text: str) -> str | None:
     """Extract the verdict from review text.
@@ -14,12 +30,20 @@ def extract_verdict(review_text: str) -> str | None:
     - `**APPROVE**` or `` **`APPROVE`** ``
     - `**REQUEST CHANGES**` or `` **`REQUEST CHANGES`** ``
 
+    Falls back to a plain or bulleted line consisting solely of the verdict
+    (e.g. `- APPROVE`) when no bold verdict is present, to tolerate models
+    that drop the markdown bold markers.
+
     Returns 'APPROVE' or 'REQUEST CHANGES' if found, None otherwise.
     """
-    # Look for verdict lines that match the expected format, with or without backticks inside the bold markers
-    match = re.search(r'\*\*`?(APPROVE|REQUEST CHANGES)`?\*\*', review_text)
+    match = _BOLD_VERDICT_RE.search(review_text)
     if match:
         return match.group(1)
+
+    line_matches = list(_LINE_VERDICT_RE.finditer(review_text))
+    if line_matches:
+        return line_matches[-1].group(1)
+
     return None
 
 

--- a/.github/scripts/review_common.py
+++ b/.github/scripts/review_common.py
@@ -145,13 +145,15 @@ opportunities, test coverage gaps, etc.) that are real but should not block
 this PR: list each as a one-line suggested GitHub issue title. Do not request
 changes for these — they belong in the backlog, not this review.
 
-End with a **verdict line** in exactly this format (do not add backticks around the verdict):
+End with a **verdict line** as the very last line of your review, in exactly this format
+(do not add backticks around the verdict, and do not add a list marker such as `-` before it):
 
 - `**APPROVE**` — no blocking concerns (non-blocking items go in section 5 above)
 - `**REQUEST CHANGES**` — one or more blocking bugs, security issues, or unmet AC items (list them)
 
-Do not use COMMENT as a verdict. If there are only non-blocking observations,
-use APPROVE and put them in section 5."""
+The verdict line must contain nothing but the bold verdict itself, optionally followed
+by a short "— explanation" on the same line. Do not use COMMENT as a verdict. If there
+are only non-blocking observations, use APPROVE and put them in section 5."""
 
 
 def emit_empty_diff_notice(provider_name: str) -> int:

--- a/.github/scripts/test_extract_verdict.py
+++ b/.github/scripts/test_extract_verdict.py
@@ -144,10 +144,15 @@ Found one.
         review_text = "**approve** — no issues"
         assert extract_verdict(review_text) is None
 
-    def test_partial_verdict_no_match(self) -> None:
-        """Test that incomplete verdict formats don't match."""
-        review_text = "APPROVE — no issues"  # missing bold markers
+    def test_verdict_embedded_in_sentence_no_match(self) -> None:
+        """Test that a verdict word embedded in a sentence (not alone on its line) doesn't match."""
+        review_text = "I think we should APPROVE — no issues"
         assert extract_verdict(review_text) is None
+
+    def test_unbolded_verdict_alone_on_line_matches(self) -> None:
+        """Test that an unbolded verdict alone on its line matches via the fallback."""
+        review_text = "APPROVE — no issues"  # missing bold markers, but alone on the line
+        assert extract_verdict(review_text) == "APPROVE"
 
     def test_single_backtick_malformed_format_matches(self) -> None:
         """Test that the regex matches a single-backtick malformed format (e.g., **`APPROVE**)."""
@@ -163,6 +168,85 @@ Initial analysis: **APPROVE** — looks good
 Wait, I found an issue: **REQUEST CHANGES** — blocking bug
 """
         assert extract_verdict(review_text) == "APPROVE"
+
+    def test_bulleted_unbolded_approve(self) -> None:
+        """Test fallback for a bulleted, unbolded verdict (observed from DeepSeek on PR #4801)."""
+        review_text = """
+## Acceptance criteria
+All criteria met.
+
+## Bugs
+None found.
+
+- APPROVE
+"""
+        assert extract_verdict(review_text) == "APPROVE"
+
+    def test_bulleted_unbolded_request_changes(self) -> None:
+        """Test fallback for a bulleted, unbolded REQUEST CHANGES verdict."""
+        review_text = """
+## Bugs
+Found a blocking issue at line 42.
+
+- REQUEST CHANGES — unhandled null case
+"""
+        assert extract_verdict(review_text) == "REQUEST CHANGES"
+
+    def test_plain_unbolded_line_approve(self) -> None:
+        """Test fallback for a plain (non-bulleted) unbolded verdict line."""
+        review_text = """
+## Review
+
+Everything checks out.
+
+APPROVE
+"""
+        assert extract_verdict(review_text) == "APPROVE"
+
+    def test_unbolded_verdict_prefers_last_occurrence(self) -> None:
+        """When multiple unbolded verdict-only lines appear, the last one wins."""
+        review_text = """
+- APPROVE
+
+Actually, on reflection:
+
+- REQUEST CHANGES — found a blocking bug
+"""
+        assert extract_verdict(review_text) == "REQUEST CHANGES"
+
+    def test_unbolded_word_in_prose_does_not_match(self) -> None:
+        """A verdict word embedded in a sentence must not trigger the fallback."""
+        review_text = """
+## Acceptance criteria
+The reviewer should APPROVE this once the tests pass.
+
+## Bugs
+None found.
+"""
+        assert extract_verdict(review_text) is None
+
+    def test_unbolded_word_in_checklist_item_does_not_match(self) -> None:
+        """A checklist item that merely mentions the verdict word must not trigger the fallback."""
+        review_text = """
+## Acceptance criteria
+- [ ] Verify APPROVE flow renders the confirmation banner
+- [ ] REQUEST CHANGES button disabled while loading
+
+## Bugs
+None found.
+"""
+        assert extract_verdict(review_text) is None
+
+    def test_bold_verdict_preferred_over_unbolded_mention(self) -> None:
+        """When both a bold verdict and a stray unbolded mention exist, the bold one wins."""
+        review_text = """
+## Acceptance criteria
+- [ ] Verify APPROVE flow renders correctly
+
+## Verdict
+**REQUEST CHANGES** — missing test coverage
+"""
+        assert extract_verdict(review_text) == "REQUEST CHANGES"
 
 
 class TestExtractVerdictScriptMain:


### PR DESCRIPTION
Closes #4818

## Summary
- `extract_verdict.py` required the verdict as bold markdown (`**APPROVE**` / `**REQUEST CHANGES**`). On PR #4801, the DeepSeek AI review workflow produced a genuine approval written as an unbolded bullet (`- APPROVE`), which `extract_verdict.py` couldn't parse — turning a real approval into a failing required check.
- Added a fallback regex that recognizes a verdict alone on its own line (optionally with a leading bullet marker and a trailing "— explanation"), anchored so it won't false-positive on stray mentions of APPROVE/REQUEST CHANGES inside prose or an echoed acceptance-criteria checklist. The primary bold-markdown match still takes priority when present.
- Tightened the shared prompt in `review_common.py` (used by Claude, GPT, and DeepSeek reviewers) to more explicitly instruct the verdict be the last line with no leading bullet marker, as defense in depth.

## Test plan
- [x] `python -m pytest .github/scripts/test_extract_verdict.py --no-cov` — added tests for bulleted/plain unbolded verdicts, last-occurrence preference, and non-matches for verdict words embedded in prose/checklists; all pass (pre-existing `python3`-subprocess tests fail on this Windows dev box for unrelated reasons — same failures exist on `main`).
- [x] `black --check` / `ruff check` on the changed files show no *new* issues versus `main` (pre-existing long-line/import findings in untouched code remain unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)