### PR TITLE
docs: add GitHub community health files, consolidate contributor policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Report something that is broken or behaving incorrectly
+title: ""
+labels: bug
+assignees: ""
+---
+
+## What
+
+<!-- What is broken? Describe the observed behavior, including exact error
+messages, screenshots, or logs where relevant. -->
+
+## Why
+
+<!-- Why does this matter? What's the user/dev impact of leaving it broken? -->
+
+## How
+
+<!-- Steps to reproduce, and (if you know it) what the fix likely involves. -->
+
+1.
+2.
+3.
+
+**Expected behavior:**
+
+**Actual behavior:**
+
+**Environment:** (backend/frontend/CDK, browser, OS, commit/branch)
+
+## Constraints
+
+<!-- Anything the fix must not break, e.g. "must not change the public API
+shape" or "must preserve bash/PowerShell parity". -->
+
+## LLM tier
+
+<!-- If this will be worked by an AI agent, suggest a tier: haiku / sonnet / opus -->
+
+## Success looks like
+
+- [ ]
+
+## Failure looks like
+
+-

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,40 @@
+---
+name: Feature request
+about: Propose a new feature or enhancement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## What
+
+<!-- What should be built or changed? -->
+
+## Why
+
+<!-- Why is this needed? What problem does it solve, or what value does it add? -->
+
+## How
+
+<!-- Outline the intended approach at a high level. Link to affected files or
+areas of the codebase if known. -->
+
+## Constraints
+
+<!-- Anything the implementation must respect, e.g. "no application code
+changes", "must confirm licensing decisions before implementing", scope
+boundaries, backwards compatibility requirements. -->
+
+## LLM tier
+
+<!-- If this will be worked by an AI agent, suggest a tier and briefly justify
+it: haiku (mechanical/additive) / sonnet (judgment required) / opus (complex,
+cross-cutting) -->
+
+## Success looks like
+
+- [ ]
+
+## Failure looks like
+
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What / Why
+
+<!-- What changed, and why. -->
+
+Closes #
+
+## How I validated this
+
+- [ ] Relevant tests updated/added and passing (`pytest`, `npm --prefix frontend run test -- --run`)
+- [ ] Lint passing (`make lint`, `npm --prefix frontend run lint`)
+- [ ] Manually verified the change (describe how, or attach screenshots for UI changes)
+
+## Notes for reviewers
+
+<!-- Anything reviewers should pay special attention to, known follow-ups, or risks. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in AllotMint, please report it
+privately rather than opening a public issue.
+
+- Preferred: use [GitHub's private vulnerability reporting](https://github.com/leonarduk/allotmint/security/advisories/new)
+  for this repository.
+- Alternative: email the maintainer directly with details of the issue.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof-of-concept.
+- The affected component (backend, frontend, CDK/infrastructure, etc.) and
+  version/commit.
+
+You should receive an acknowledgement within a few days. We'll work with you
+to understand and confirm the issue, and will let you know when a fix has
+shipped. Please give us a reasonable amount of time to address the issue
+before any public disclosure.
+
+## Supported Versions
+
+AllotMint is deployed continuously from the `main` branch; there are no
+maintained release branches or long-term support versions. Security fixes are
+applied to `main` and deployed as part of the normal release process.
+
+## Scope
+
+For details on the deployed application's authentication model, Content
+Security Policy, and known trust-boundary risks, see
+[docs/SECURITY.md](../docs/SECURITY.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,10 +20,6 @@ Read `AGENTS.md` for full repository guidance. Use these short rules while gener
 
 ## Code quality invariants (non-negotiable)
 
-Derived from NASA/JPL Power of Ten — applicable subset only (C-specific rules omitted):
-
-- **Function length**: ~60 lines max. Refactor before adding more to an oversized function.
-- **Zero lint warnings**: `make lint` and `npm --prefix frontend run lint` must pass clean. Rewrite code that triggers false positives rather than suppressing them.
-- **No silent error swallowing**: no bare `except: pass`, no silent `catch` blocks, no unhandled Promise rejections.
-- **No ignored return values**: if you discard a return value intentionally, make it explicit and add a comment explaining why.
-- **Minimum scope**: declare variables as late and as locally as possible; avoid unnecessary module-level mutable state.
+See `docs/CONTRIBUTING.md` ("Code quality invariants" section) for the
+canonical rules: function length, zero lint warnings, no silent error
+swallowing, no ignored return values, minimum scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,19 +74,10 @@ This repository has a Python/FastAPI backend, a React/Vite frontend, AWS CDK inf
 
 ## 5. Branch and PR policy
 
-**Never commit directly to `main`.** This applies without exception to all changes: code, documentation, config, and trivial fixes.
-
-This rule exists to preserve CI gating, review history, and the ability to revert cleanly. A direct push to `main` bypasses all of these and cannot be undone without rewriting history.
-
-Agents must treat branch creation as a first step, not a release step at the end. Before editing files, create or switch to a non-`main` branch. If the current checkout is dirty or already tied to unrelated work, create a clean worktree from `main` first and do the task there.
-
-Required workflow for every change:
-1. Create a branch from `main`
-2. Push all changes to that branch
-3. Open a PR targeting `main`
-4. Wait for review before merging
-
-Branch naming convention: `fix/issue-NNNN-short-description`, `feat/issue-NNNN-short-description`, `docs/short-description`, or `chore/short-description`.
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#branch-and-pr-policy) for the
+canonical branch/PR rules (never commit to `main`, worktree-first for dirty
+checkouts, required PR steps, branch naming, `Closes #NNNN` linking). Agents
+must treat branch creation as a first step, not a release step at the end.
 
 ## 6. How to work safely in this codebase
 
@@ -145,23 +136,7 @@ When updating one of these, consider whether the same repo facts or command chan
 
 ## 10. Code quality invariants (non-negotiable)
 
-Derived from the NASA/JPL Power of Ten guidelines — applicable subset only. C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limits, recursion ban) are not applicable to this stack and are intentionally omitted.
-
-### Function length (P10 Rule 4)
-Keep functions to approximately 60 lines or fewer — roughly one screen. If a function exceeds this, refactor it before making further changes. Excessively long functions are a signal of poorly structured code, not a style preference.
-
-### Zero lint warnings (P10 Rule 10)
-`make lint` (Python) and `npm --prefix frontend run lint` (TypeScript) must both pass with zero warnings. If a tool flags something incorrectly, rewrite the code until it no longer triggers — do not suppress or ignore warnings without a documented justification inline. Zero-warning compliance must hold from the first day of work on a branch, not just before merge.
-
-### No silent error swallowing (P10 Rules 5 and 7)
-Every error path must be explicitly handled:
-- No bare `except: pass` or `except Exception: pass` in Python.
-- No `catch` blocks that silently discard exceptions in TypeScript.
-- No unhandled Promise rejections.
-- No `assert False, "unreachable"` used as a substitute for real error handling in production paths.
-
-### No ignored return values (P10 Rule 7)
-Check return values of functions that can signal failure. If you deliberately discard a return value, make it explicit (`_ =` in Python; a `void`-cast comment in TypeScript) and add a brief inline comment explaining why the return value is safe to ignore in that context.
-
-### Minimum scope (P10 Rule 6)
-Declare variables as late as possible and as locally as possible. Avoid module-level or class-level mutable state unless there is a clear, documented reason. Unnecessary broad scope makes fault diagnosis harder and increases the risk of unintended mutation across call sites.
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#code-quality-invariants-non-negotiable)
+for the canonical rules (function length, zero lint warnings, no silent error
+swallowing, no ignored return values, minimum scope), derived from the
+NASA/JPL Power of Ten guidelines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,21 +42,9 @@ npm run smoke:test:codex:poc
 
 ## Branch and PR policy
 
-**Never commit directly to `main`.** This applies to all changes including documentation, config, and trivial fixes.
-
-This rule exists to preserve CI gating, review history, and the ability to revert cleanly.
-A direct push to `main` bypasses all of these and cannot be undone without rewriting history.
-
-Treat branch creation as the first implementation step. Before editing files, create or switch to a non-`main` branch. If the current checkout is dirty or already contains unrelated work, create a clean worktree from `main` and do the task there.
-
-Always:
-1. Create a branch (`git checkout -b <branch-name>` or via API)
-2. Push changes to the branch
-3. Open a PR targeting `main`
-4. Wait for review/merge
-5. If implementing a GitHub issue, include an auto-closing reference in the PR body (for example: `Closes #1234`).
-
-Branch naming convention: `fix/issue-NNNN-short-description` or `feat/issue-NNNN-short-description` or `docs/short-description`.
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#branch-and-pr-policy) for the
+canonical branch/PR rules (never commit to `main`, worktree-first for dirty
+checkouts, required PR steps, branch naming, `Closes #NNNN` linking).
 
 ## Preferred workflow
 
@@ -70,14 +58,9 @@ Branch naming convention: `fix/issue-NNNN-short-description` or `feat/issue-NNNN
 
 ## Code quality invariants (non-negotiable)
 
-Derived from the NASA/JPL Power of Ten guidelines — applicable subset only.
-C-specific rules (no dynamic allocation, pointer restrictions, preprocessor limits, recursion ban) are omitted as inapplicable to this stack.
-
-- **Function length**: keep functions to ~60 lines or fewer. If a function no longer fits on one screen, refactor before making further changes.
-- **Zero lint warnings**: `make lint` and `npm --prefix frontend run lint` must pass clean. If a tool flags something incorrectly, rewrite the code until it doesn't — do not suppress warnings without a documented justification inline.
-- **No silent error swallowing**: every error path must be explicitly handled. No bare `except: pass`, no `catch` blocks that discard exceptions silently, no unhandled Promise rejections.
-- **No ignored return values**: check return values of functions that can fail. If you deliberately discard a return value, make it explicit (`_ =` in Python, explicit `void` comment in TS) and add a brief comment explaining why.
-- **Minimum scope**: declare variables as late as possible and as locally as possible. Avoid module-level mutable state unless genuinely necessary.
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#code-quality-invariants-non-negotiable)
+for the canonical rules (function length, zero lint warnings, no silent error
+swallowing, no ignored return values, minimum scope).
 
 ## If you touch specific areas
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer via the process described in
+[SECURITY.md](.github/SECURITY.md) or by opening a confidential report through
+GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+1. **Correction** — A private, written warning, providing clarity around the
+   nature of the violation and an explanation of why the behavior was
+   inappropriate.
+2. **Warning** — A warning with consequences for continued behavior. No
+   interaction with the people involved for a specified period of time.
+3. **Temporary Ban** — A temporary ban from any sort of interaction or public
+   communication with the community for a specified period of time.
+4. **Permanent Ban** — A permanent ban from any sort of public interaction
+   within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,134 @@
+PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+Copyright (c) Steve Leonard. All rights reserved.
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright in it
+for any permitted purpose. However, you may only distribute
+the software according to Distribution License and make
+changes or new works based on the software according to
+Changes and New Works License.
+
+## Distribution License
+
+The licensor grants you an additional copyright license to
+distribute copies of the software. Your license to
+distribute covers distributing the software with changes and
+new works permitted by Changes and New Works License.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text
+lines beginning with `Required Notice:` that the licensor
+provided with the software. For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software
+that covers patent claims the licensor can license, or becomes
+able to license, that you would infringe by using the
+software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+doesn't count as a commercial purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization, or
+government institution is a permitted purpose regardless of
+the source of funding or obligations resulting from the
+funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else. These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent
+license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the
+software not covered by your licenses, your licenses can
+nonetheless continue if you come into full compliance with
+these terms, and take practical steps to correct past
+violations, within 32 days of receiving notice. Otherwise,
+all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is,
+without any warranty or condition, and the licensor will not
+be liable to you for any damages arising out of these terms
+or the use or nature of the software, under any kind of
+legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship, or
+other kind of organization that you work for, plus all
+organizations that have control over, are under the control
+of, or are under common control with that organization.
+**Control** means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies
+by vote, contract, or otherwise. Control can be direct or
+indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,15 +51,17 @@ For smoke tests, pre-deploy checks, or CI workflows:
 
 See `docs/DEPLOY.md` for detailed background and troubleshooting.
 
-## Code quality expectations
+## Code quality invariants (non-negotiable)
 
-AllotMint follows these non-negotiable standards (derived from NASA/JPL Power of Ten):
+Derived from the NASA/JPL Power of Ten guidelines — applicable subset only.
+C-specific rules (no dynamic allocation, pointer restrictions, preprocessor
+limits, recursion ban) are omitted as inapplicable to this stack.
 
-- **Function length**: Keep functions under ~60 lines. If a function no longer fits on one screen, refactor before making changes.
-- **Zero lint warnings**: `make lint` and `npm --prefix frontend run lint` must pass clean. Rewrite code until it passes — do not suppress warnings without documented justification.
-- **No silent error swallowing**: Every error path must be explicit. No bare `except: pass`, no `catch` blocks that silently discard errors, no unhandled Promise rejections.
-- **Return values checked**: Check return values of functions that can fail. If deliberately discarding one, make it explicit: `_ = function()` in Python or a comment in TypeScript.
-- **Minimum scope**: Declare variables as late as possible and as locally as possible. Avoid module-level mutable state.
+- **Function length**: Keep functions to ~60 lines or fewer — roughly one screen. If a function no longer fits on one screen, refactor before making further changes.
+- **Zero lint warnings**: `make lint` and `npm --prefix frontend run lint` must pass clean. If a tool flags something incorrectly, rewrite the code until it doesn't — do not suppress warnings without a documented justification inline.
+- **No silent error swallowing**: every error path must be explicitly handled. No bare `except: pass`, no `catch` blocks that discard exceptions silently, no unhandled Promise rejections.
+- **No ignored return values**: check return values of functions that can fail. If you deliberately discard a return value, make it explicit (`_ =` in Python, explicit `void` comment in TS) and add a brief comment explaining why.
+- **Minimum scope**: declare variables as late as possible and as locally as possible. Avoid module-level mutable state unless genuinely necessary.
 
 ## Running tests and validation
 
@@ -110,17 +112,31 @@ pwsh scripts/powershell/pre-deploy-check.ps1
 
 This validates environment variables, dependency resolution, CDK synthesis, IAM permissions, linting, and testing in one run.
 
-## Git and GitHub workflow
+## Branch and PR policy
 
-- **Never commit directly to `main`.** Always create a feature branch (`fix/issue-NNNN-...` or `feat/issue-NNNN-...`).
-- **Stage files explicitly**: never use `git commit -am` — this can sweep in lock file changes from `npm ci` or `npm install` that strip platform-specific dependencies.
-- **Provide issue context**: if implementing a GitHub issue, include `Closes #NNNN` in your PR body so GitHub auto-closes the issue.
-- **Wait for review**: all changes require review and CI to pass before merging.
+**Never commit directly to `main`.** This applies to all changes including
+documentation, config, and trivial fixes.
 
-Branch naming convention:
-- Bug fixes: `fix/issue-NNNN-short-description`
-- Features: `feat/issue-NNNN-short-description`
-- Docs/chore: `docs/short-description` or `chore/short-description`
+This rule exists to preserve CI gating, review history, and the ability to
+revert cleanly. A direct push to `main` bypasses all of these and cannot be
+undone without rewriting history.
+
+Treat branch creation as the first implementation step, not something to do
+at the end. If the current checkout is dirty or already contains unrelated
+work, create a clean worktree from `main` and do the task there.
+
+Always:
+1. Create a branch (`fix/issue-NNNN-short-description`, `feat/issue-NNNN-short-description`, `docs/short-description`, or `chore/short-description`)
+2. Push changes to the branch
+3. Open a PR targeting `main`
+4. Wait for review/merge
+
+If implementing a GitHub issue, include an auto-closing reference in the PR
+body (for example: `Closes #1234`).
+
+**Stage files explicitly**: never use `git commit -am` — this can sweep in
+lock file changes from `npm ci` or `npm install` that strip platform-specific
+dependencies.
 
 ## Automated code reviews
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,5 +1,7 @@
 # Security
 
+To report a vulnerability, see [.github/SECURITY.md](../.github/SECURITY.md).
+
 ## AWS-hosted UI authentication
 
 The AWS static site stack protects the hosted frontend with an Amazon Cognito user pool and hosted UI. `StaticSiteStack` creates the user pool, a public SPA client that uses the OAuth 2.0 authorization-code flow with PKCE, and a Cognito domain. The deployed `/config.json` includes the Cognito domain and client ID so the React app redirects unauthenticated visitors before rendering the portfolio dashboard.


### PR DESCRIPTION
## Summary
- Adds `LICENSE` (PolyForm Noncommercial 1.0.0 — noncommercial/personal use permitted, commercial use prohibited; confirmed with maintainer), `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `.github/SECURITY.md` (vulnerability reporting/supported versions), `.github/ISSUE_TEMPLATE/{bug_report.md,feature_request.md,config.yml}`, and `.github/PULL_REQUEST_TEMPLATE.md` so the repo's Community Standards checklist is complete.
- Issue templates follow this repo's existing structured issue convention (What/Why/How/Constraints/LLM tier/Success/Failure).
- Consolidates the duplicated "Branch and PR policy" and "Code quality invariants" sections from `CLAUDE.md` and `AGENTS.md` into `docs/CONTRIBUTING.md` as the single canonical copy; both files (and `.github/copilot-instructions.md`) now point back to it instead of restating the text. Agent-specific framing (workspace rules, handoff checklists, tool-use notes) is left in place in `CLAUDE.md`/`AGENTS.md`.
- `docs/SECURITY.md` (pre-existing, describes the deployed app's auth/CSP architecture) now cross-links to the new `.github/SECURITY.md` (vulnerability reporting process), since they serve different purposes.

## Test plan
- [x] `gh api repos/leonarduk/allotmint/community/profile` will be re-checked post-merge to confirm `license`, `code_of_conduct`, `issue_template`, and `pull_request_template` all resolve.
- [x] Verified `.github/ISSUE_TEMPLATE/config.yml` doesn't link to GitHub Discussions (not enabled on this repo).
- [x] Docs-only change — no application code touched.

Closes #4820

🤖 Generated with [Claude Code](https://claude.com/claude-code)