### PR TITLE
fix(ci): use maxWorkers instead of removed poolOptions.forks.maxForks

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -52,11 +52,9 @@ export default defineConfig(() => {
       // the runner's heap and crashed workers mid-suite (zero real test
       // failures, just "Worker exited unexpectedly") — see #4810. Capping
       // concurrency trades some wall-clock time for reliability.
-      poolOptions: {
-        forks: {
-          maxForks: 2
-        }
-      },
+      // NOTE: `poolOptions.forks.maxForks` was removed in Vitest 4 — options
+      // are now top-level (see the migration guide). Use `maxWorkers`.
+      maxWorkers: 2,
       coverage: {
         provider: 'v8' as const, // literal required by CoverageV8Options — widened to string without explicit annotation
         reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary
Follow-up to #4811, which merged with a mistake: I set `test.poolOptions.forks.maxForks` in `frontend/vite.config.ts` to cap concurrency, but **`poolOptions` was removed in Vitest 4** â€” options are now flat, top-level fields. Vitest accepted the unknown key silently, so the concurrency cap had **zero effect**: the frontend `test` CI job went right on spawning unbounded forks and OOM-crashed again with the identical symptom on PR #4801, after that PR picked up #4811's change from `main`.

Confirmed via `node_modules/vitest/dist/chunks/config.d.A1h_Y6Jt.d.ts`: Vitest 4's `TestOptions` has a top-level `maxWorkers: number`, not `poolOptions.forks.maxForks`.

## Fix
Replace the removed key with the correct one:
```diff
- poolOptions: {
-   forks: {
-     maxForks: 2
-   }
- },
+ maxWorkers: 2,
```

## Test plan
- [x] `npx vitest run tests/unit --reporter=dot` locally â€” no `poolOptions was removed` deprecation warning, clean run: 87/87 test files, 560/560 tests, no worker crashes.
- [x] `npm run lint` â€” clean.
- [x] `npx tsc --noEmit -p tsconfig.json` â€” clean.
- [x] This PR's own `test` job passed cleanly on the real CI runner (2m56s, no worker crashes) â€” verified on-runner, not just locally.

Relates to #4810

Apologies for the churn â€” this corrects the mistake merged in #4811.
