### PR TITLE
ci: clean up AI PR-review workflows (DeepSeek reliability, docs, dead code)

### DIFF
--- a/.github/scripts/deepseek_review.py
+++ b/.github/scripts/deepseek_review.py
@@ -40,8 +40,10 @@ def get_max_tokens() -> int:
 def extract_deepseek_review(data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     """Extract review text from DeepSeek chat-completions responses.
 
-    DeepSeek's API is OpenAI-compatible: the response shape is
-    `{"choices": [{"message": {"content": "..."}}]}`.
+    DeepSeek's API is OpenAI-compatible: the response shape is always
+    `{"choices": [{"message": {"content": "<string>"}}]}` — unlike Anthropic's
+    content-block format, DeepSeek never returns `content` as a list, so no
+    list-handling branch is needed here.
     """
     choices = data.get("choices", [])
     if not choices:
@@ -49,12 +51,7 @@ def extract_deepseek_review(data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
 
     message = choices[0].get("message", {})
     content = message.get("content", "")
-    if isinstance(content, list):
-        review = "\n".join(part.get("text", "") for part in content if part.get("type") == "text").strip()
-    elif isinstance(content, str):
-        review = content.strip()
-    else:
-        review = ""
+    review = content.strip() if isinstance(content, str) else ""
     return review, {}
 
 

--- a/.github/scripts/reconcile_changes_requested_label.sh
+++ b/.github/scripts/reconcile_changes_requested_label.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Reconcile the 'Changes Requested' label on a single PR against the conclusions
+# of all enabled AI review check-runs for its current head SHA.
+#
+# Shared by both triggers of sync-changes-requested-label.yml:
+#   - the workflow_run-triggered job, which reconciles the PR tied to the review
+#     workflow that just completed
+#   - the schedule-triggered job, which sweeps every open PR still carrying the
+#     label as a fallback for the "stuck label" scenario (see
+#     docs/AI_REVIEW_WORKFLOWS.md#stuck-label-fallback) where workflow_run never
+#     fires (e.g. the triggering run was cancelled before completion)
+#
+# Usage: reconcile_changes_requested_label.sh <pr_number>
+# Required env: GH_TOKEN, REPO, ENABLE_CLAUDE, ENABLE_GPT, ENABLE_DEEPSEEK
+set -euo pipefail
+
+PR_NUMBER="${1:?Usage: reconcile_changes_requested_label.sh <pr_number>}"
+
+HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+if [ -z "$HEAD_SHA" ]; then
+  echo "Could not resolve head SHA for PR #${PR_NUMBER}; skipping."
+  exit 0
+fi
+
+# Build the list of enabled reviewers from their check-run names.
+# When a reviewer is disabled (vars.ENABLE_*_REVIEW=false), its workflow
+# job is skipped entirely, so no check-run exists. This excludes disabled
+# reviewers so it doesn't wait forever for a check-run that will never appear.
+ENABLED_CHECK_NAMES=""
+
+if [ "${ENABLE_CLAUDE:-true}" != "false" ]; then
+  ENABLED_CHECK_NAMES="$ENABLED_CHECK_NAMES Claude AI code review"
+fi
+
+if [ "${ENABLE_GPT:-true}" != "false" ]; then
+  ENABLED_CHECK_NAMES="$ENABLED_CHECK_NAMES GPT AI code review"
+fi
+
+if [ "${ENABLE_DEEPSEEK:-true}" != "false" ]; then
+  ENABLED_CHECK_NAMES="$ENABLED_CHECK_NAMES DeepSeek AI code review"
+fi
+
+if [ -z "$ENABLED_CHECK_NAMES" ]; then
+  echo "No AI reviewers are enabled; nothing to reconcile for PR #${PR_NUMBER}."
+  exit 0
+fi
+
+echo "PR #${PR_NUMBER} (${HEAD_SHA}) — enabled reviewers:${ENABLED_CHECK_NAMES}"
+
+ALL_SUCCESS=true
+for NAME in $ENABLED_CHECK_NAMES; do
+  CONCLUSION=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
+    --jq "[.check_runs[] | select(.name == \"${NAME}\")] | sort_by(.started_at) | last | .conclusion // \"pending\"")
+  echo "  ${NAME}: ${CONCLUSION}"
+  if [ "$CONCLUSION" != "success" ]; then
+    ALL_SUCCESS=false
+  fi
+done
+
+if [ "$ALL_SUCCESS" != "true" ]; then
+  echo "At least one enabled review hasn't approved yet; leaving 'Changes Requested' label as-is."
+  exit 0
+fi
+
+HAS_LABEL=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
+  --jq '[.labels[].name] | any(. == "Changes Requested")')
+
+if [ "$HAS_LABEL" != "true" ]; then
+  echo "Label not present on PR #${PR_NUMBER}; nothing to remove."
+  exit 0
+fi
+
+gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "Changes Requested"
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+  "All enabled AI reviews have passed for the latest commit -- removing the 'Changes Requested' label."

--- a/.github/scripts/review_common.py
+++ b/.github/scripts/review_common.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from typing import Any, Callable
 
 MAX_DIFF_CHARS = 120_000
+REQUEST_TIMEOUT_SECONDS = 60
+MAX_FETCH_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = 2
+RETRYABLE_HTTP_STATUSES = {429, 500, 502, 503, 504}
 DEFAULT_ISSUE_BODY = "No linked issue found. Review code on its own merits."
 TRUNCATION_NOTICE_TEMPLATE = (
     "\n\n[diff truncated after {kept_files} file(s); skipped {skipped_files} additional file(s) "
@@ -332,6 +337,22 @@ def format_truncation_log(original_diff: str, truncated_diff: str) -> str:
     )
 
 
+def _post_once(request: urllib.request.Request, provider_label: str) -> dict[str, Any]:
+    """Issue a single POST attempt and return the parsed JSON body.
+
+    Raises `urllib.error.HTTPError`/`URLError`/`json.JSONDecodeError` on failure;
+    the caller decides which of those are worth retrying.
+    """
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        status = getattr(response, "status", None)
+        raw = response.read()
+        print(
+            f"INFO: {provider_label} API responded status={status} bytes={len(raw)}",
+            file=sys.stderr,
+        )
+        return json.loads(raw)
+
+
 def fetch_review(
     url: str,
     headers: dict[str, str],
@@ -341,11 +362,18 @@ def fetch_review(
 ) -> tuple[str, dict[str, Any]]:
     """POST `payload` to `url` and return the review text plus provider-specific extras.
 
-    Shared by the Claude and GPT review scripts: handles the HTTP POST, timeout,
-    `HTTPError` reporting, and empty-response warning so each script only has to
-    supply its endpoint, headers, payload, and an `extractor` that turns the parsed
-    JSON response into `(review_text, extra)`. `extra` carries provider-specific
-    metadata (e.g. Claude's `stop_reason`) back to the caller.
+    Shared by the Claude, GPT, and DeepSeek review scripts: handles the HTTP POST,
+    timeout, retry-with-backoff on transient failures, `HTTPError` reporting, and
+    empty-response warning so each script only has to supply its endpoint, headers,
+    payload, and an `extractor` that turns the parsed JSON response into
+    `(review_text, extra)`. `extra` carries provider-specific metadata (e.g.
+    Claude's `stop_reason`) back to the caller.
+
+    Retries up to `MAX_FETCH_ATTEMPTS` times with a linear backoff (`attempt *
+    RETRY_BACKOFF_SECONDS`) on network errors (`URLError`, including timeouts) and
+    HTTP statuses in `RETRYABLE_HTTP_STATUSES` (429 rate limiting, 5xx server
+    errors). Non-retryable HTTP errors (e.g. 401/403 auth failures) and malformed
+    JSON responses fail immediately without retrying.
     """
     request = urllib.request.Request(
         url,
@@ -354,32 +382,37 @@ def fetch_review(
         method="POST",
     )
 
-    status: int | None = None
-    try:
-        with urllib.request.urlopen(request, timeout=60) as response:
-            status = getattr(response, "status", None)
-            raw = response.read()
-            print(
-                f"INFO: {provider_label} API responded status={status} bytes={len(raw)}",
-                file=sys.stderr,
-            )
-            data = json.loads(raw)
-    except urllib.error.HTTPError as exc:
-        # Keep the provider response in stderr so maintainers can distinguish auth, quota, and API failures.
-        body = exc.read().decode()
-        print(f"ERROR: {provider_label} API returned {exc.code}: {body}", file=sys.stderr)
-        raise SystemExit(1) from exc
-    except urllib.error.URLError as exc:
-        print(f"ERROR: {provider_label} API request failed: {exc.reason}", file=sys.stderr)
-        raise SystemExit(1) from exc
-    except json.JSONDecodeError as exc:
-        print(f"ERROR: {provider_label} API returned non-JSON response: {exc}", file=sys.stderr)
-        raise SystemExit(1) from exc
+    data: dict[str, Any] | None = None
+    for attempt in range(1, MAX_FETCH_ATTEMPTS + 1):
+        try:
+            data = _post_once(request, provider_label)
+            break
+        except urllib.error.HTTPError as exc:
+            # Keep the provider response in stderr so maintainers can distinguish auth, quota, and API failures.
+            body = exc.read().decode()
+            print(f"ERROR: {provider_label} API returned {exc.code}: {body}", file=sys.stderr)
+            if exc.code not in RETRYABLE_HTTP_STATUSES or attempt == MAX_FETCH_ATTEMPTS:
+                raise SystemExit(1) from exc
+        except urllib.error.URLError as exc:
+            print(f"ERROR: {provider_label} API request failed: {exc.reason}", file=sys.stderr)
+            if attempt == MAX_FETCH_ATTEMPTS:
+                raise SystemExit(1) from exc
+        except json.JSONDecodeError as exc:
+            print(f"ERROR: {provider_label} API returned non-JSON response: {exc}", file=sys.stderr)
+            raise SystemExit(1) from exc
+
+        delay = attempt * RETRY_BACKOFF_SECONDS
+        print(
+            f"INFO: {provider_label} attempt {attempt}/{MAX_FETCH_ATTEMPTS} failed; "
+            f"retrying in {delay}s",
+            file=sys.stderr,
+        )
+        time.sleep(delay)
 
     review, extra = extractor(data)
     if not review.strip():
         print(
-            f"WARNING: {provider_label} API returned an empty review body (status={status})",
+            f"WARNING: {provider_label} API returned an empty review body",
             file=sys.stderr,
         )
     return review, extra

--- a/.github/workflows/sync-changes-requested-label.yml
+++ b/.github/workflows/sync-changes-requested-label.yml
@@ -20,13 +20,24 @@ name: Sync Changes Requested label
 #   ENABLE_DEEPSEEK_REVIEW=false
 # When a variable is 'false', the corresponding workflow job is skipped and
 # no check-run is created; this workflow also excludes that reviewer.
+#
+# The workflow_run trigger can miss a PR (e.g. the triggering review run was
+# cancelled by a superseding push before its "completed" event fired, or the
+# webhook delivery was dropped), leaving the label "stuck" even though the
+# latest commit's reviews all later succeeded. The scheduled job below sweeps
+# every open PR still carrying the label as a fallback reconciliation pass —
+# see docs/AI_REVIEW_WORKFLOWS.md#stuck-label-fallback.
 on:
   workflow_run:
     workflows: ["Claude PR Review", "GPT PR Review", "DeepSeek PR Review"]
     types: [completed]
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
 
 jobs:
   sync-label:
+    if: github.event_name == 'workflow_run'
     name: Remove 'Changes Requested' label once all enabled reviews approve
     runs-on: ubuntu-latest
     permissions:
@@ -38,6 +49,10 @@ jobs:
       ENABLE_GPT: ${{ vars.ENABLE_GPT_REVIEW || 'true' }}
       ENABLE_DEEPSEEK: ${{ vars.ENABLE_DEEPSEEK_REVIEW || 'true' }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
       - name: Reconcile label against enabled review verdicts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,53 +67,38 @@ jobs:
             exit 0
           fi
 
-          # Build the list of enabled reviewers from their check-run names.
-          # When a reviewer is disabled (vars.ENABLE_*_REVIEW=false), its workflow
-          # job is skipped entirely, so no check-run exists. This workflow excludes
-          # disabled reviewers here so it doesn't wait forever for a check-run
-          # that will never appear.
-          ENABLED_CHECK_NAMES=""
+          bash .github/scripts/reconcile_changes_requested_label.sh "$PR_NUMBER"
 
-          if [ "$ENABLE_CLAUDE" != "false" ]; then
-            ENABLED_CHECK_NAMES="$ENABLED_CHECK_NAMES Claude AI code review"
-          fi
+  sync-label-scheduled:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: "[fallback] Sweep open PRs for stuck 'Changes Requested' labels"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      checks: read
+    env:
+      ENABLE_CLAUDE: ${{ vars.ENABLE_CLAUDE_REVIEW || 'true' }}
+      ENABLE_GPT: ${{ vars.ENABLE_GPT_REVIEW || 'true' }}
+      ENABLE_DEEPSEEK: ${{ vars.ENABLE_DEEPSEEK_REVIEW || 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Reconcile label on every open PR that still carries it
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --label "Changes Requested" \
+            --json number --jq '.[].number')
 
-          if [ "$ENABLE_GPT" != "false" ]; then
-            ENABLED_CHECK_NAMES="$ENABLED_CHECK_NAMES GPT AI code review"
-          fi
-
-          if [ "$ENABLE_DEEPSEEK" != "false" ]; then
-            ENABLED_CHECK_NAMES="$ENABLED_CHECK_NAMES DeepSeek AI code review"
-          fi
-
-          if [ -z "$ENABLED_CHECK_NAMES" ]; then
-            echo "No AI reviewers are enabled; nothing to reconcile."
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "No open PRs carry the 'Changes Requested' label."
             exit 0
           fi
 
-          echo "Enabled reviewers:${ENABLED_CHECK_NAMES}"
-
-          ALL_SUCCESS=true
-          for NAME in $ENABLED_CHECK_NAMES; do
-            CONCLUSION=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
-              --jq "[.check_runs[] | select(.name == \"${NAME}\")] | sort_by(.started_at) | last | .conclusion // \"pending\"")
-            echo "  ${NAME}: ${CONCLUSION}"
-            if [ "$CONCLUSION" != "success" ]; then
-              ALL_SUCCESS=false
-            fi
+          for PR_NUMBER in $PR_NUMBERS; do
+            bash .github/scripts/reconcile_changes_requested_label.sh "$PR_NUMBER"
           done
-
-          if [ "$ALL_SUCCESS" = "true" ]; then
-            HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels \
-              --jq '[.labels[].name] | any(. == "Changes Requested")')
-
-            if [ "$HAS_LABEL" = "true" ]; then
-              gh pr edit "$PR_NUMBER" --remove-label "Changes Requested"
-              gh pr comment "$PR_NUMBER" --body \
-                "All enabled AI reviews have passed for the latest commit -- removing the 'Changes Requested' label."
-            else
-              echo "Label not present on PR #${PR_NUMBER}; nothing to remove."
-            fi
-          else
-            echo "At least one enabled review hasn't approved yet; leaving 'Changes Requested' label as-is."
-          fi

--- a/docs/AI_REVIEW_WORKFLOWS.md
+++ b/docs/AI_REVIEW_WORKFLOWS.md
@@ -16,6 +16,32 @@ reusable workflow:
 All three providers follow the same pattern: generate a review, extract a verdict (APPROVE or
 REQUEST CHANGES), and post the full review to the PR regardless of verdict.
 
+## Onboarding: provisioning API key secrets
+
+Each reviewer requires its provider's API key to be configured as a repository
+secret before its workflow can run successfully:
+
+| Reviewer | Secret name | Workflow |
+| --- | --- | --- |
+| Claude | `ANTHROPIC_API_KEY` | `claude-pr-review.yml` |
+| GPT | `OPENAI_API_KEY` | `gpt-pr-review.yml` |
+| DeepSeek | `DEEPSEEK_API_KEY` | `deepseek-pr-review.yml` |
+
+To provision a key, go to **Settings → Secrets and variables → Actions →
+Secrets** and add the relevant `*_API_KEY` secret. `DEEPSEEK_API_KEY` is the
+one new contributors most often need to set up first, since DeepSeek is the
+only reviewer currently required by branch protection (see
+[Why only DeepSeek is required](#why-only-deepseek-is-required)) — obtain the
+key from the [DeepSeek platform](https://platform.deepseek.com/api_keys) and
+add it under that name.
+
+If a secret is missing, the corresponding reviewer's API call fails and the
+workflow posts a failure notice on the PR instead of a review (see
+[Failed Review](#failed-review)) rather than silently skipping. A reviewer
+can also be disabled outright via its `ENABLE_*_REVIEW` variable — see
+[Disabling individual reviewers](#disabling-individual-reviewers) — which
+avoids the failure notice entirely when a key won't be provisioned.
+
 ## Disabling individual reviewers
 
 Each reviewer can be toggled individually via repository variables.
@@ -29,6 +55,68 @@ When a variable is `false`, the workflow job is skipped (no check-run is created
 and `sync-changes-requested-label.yml` automatically excludes that reviewer
 from its conclusion checks. Set these via **Settings → Secrets and variables →
 Actions → Variables**. When a variable is absent, the reviewer runs (default `true`).
+
+## Why only DeepSeek is required
+
+`.github/rulesets/default-branch-protection.json` lists `ai-review / DeepSeek
+AI code review` as the only AI reviewer in `required_status_checks`. Claude
+and GPT are **not** required checks — they still run, still post full
+reviews and non-blocking follow-up suggestions on every PR (see
+[Review Posting Behavior](#review-posting-behavior)), but a REQUEST CHANGES
+verdict from either does not block a merge. This replaced an earlier setup
+where Claude and GPT were both required (PR #3279); DeepSeek was added as a
+third reviewer and then made the sole required gate in PR #4188.
+
+Rationale:
+
+- **Fewer blocking gates, less flakiness surface.** Each required AI
+  reviewer is a blocking dependency on an external LLM API — timeouts, rate
+  limits, or transient errors from any *one* of them can stall every PR.
+  Requiring only one (with the [timeout/retry handling](#failed-review)
+  described above) narrows that surface to a single provider instead of
+  three.
+- **Redundant review value without redundant blocking.** All three
+  reviewers use the same shared prompt (`build_prompt` in
+  `review_common.py`) and verdict format, so their blocking value overlaps
+  significantly. Keeping Claude and GPT advisory-only preserves their
+  review coverage — a human can still read all three opinions — without
+  multiplying the failure points that can hold up a merge.
+- **DeepSeek was chosen as the sole gate** because it was already running
+  successfully across the existing PR set at the time of PR #4188 with no
+  reliability concerns distinct from the other two providers.
+
+### Risk of relying on a single required reviewer
+
+Making DeepSeek the only required AI gate concentrates risk: if the
+DeepSeek API has an extended outage, changes its response format in a
+breaking way, or the `DEEPSEEK_API_KEY` secret is revoked, PRs cannot merge
+until the issue is fixed or the reviewer is disabled (via
+`ENABLE_DEEPSEEK_REVIEW=false`, which requires updating both the repo
+variable **and** `.github/rulesets/default-branch-protection.json`/
+`EXPECTED_REQUIRED_CHECKS` in `scripts/check_branch_protection_required_checks.py`
+to keep them in sync — see [Adding a new AI reviewer](#adding-a-new-ai-reviewer)
+for the equivalent registration steps in reverse).
+
+Mitigations already in place:
+
+- The [retry-with-backoff mechanism](#failed-review) in `fetch_review()`
+  absorbs transient DeepSeek API failures (429/5xx, network errors) without
+  needing a human to intervene.
+- `scripts/check_branch_protection_required_checks.py` runs in CI
+  (`.github/workflows/ci.yml`) and fails the build if the ruleset's
+  `required_status_checks` entries drift from either the deterministic
+  workflow/job names it discovers or the `EXPECTED_REQUIRED_CHECKS` set
+  hardcoded in the script — this is what prevents the required-check list
+  and the actual workflows from silently diverging (e.g. a reviewer being
+  renamed in one place but not the other).
+- If DeepSeek needs to be dropped as the required gate entirely, Claude or
+  GPT can be promoted to required by adding their check-run context back to
+  both `default-branch-protection.json` and `EXPECTED_REQUIRED_CHECKS`,
+  since both already run on every PR and their check-run names are stable.
+
+No automated failover between providers exists — promoting a different
+reviewer to required is a manual config change, not something the
+workflows do automatically.
 
 ## Choosing the follow-up issue body provider
 
@@ -211,6 +299,20 @@ conclusions in time when all run concurrently on the same push.
 When the label is removed, `sync-changes-requested-label.yml` also posts a
 PR comment confirming all enabled AI reviews passed. If the label was not present
 (e.g. all reviews approved on the first pass), no comment is posted.
+
+### Stuck-label fallback
+
+The `workflow_run` trigger can miss a PR — e.g. the triggering review run is
+cancelled by a superseding push before its `completed` event fires, or the
+webhook delivery is dropped — leaving the label "stuck" even though the
+latest commit's reviews all later succeeded. To recover from this,
+`sync-changes-requested-label.yml` also runs on a `schedule` (every 30
+minutes) and via `workflow_dispatch` (for manual triggering). The scheduled
+run lists every open PR that still carries the `Changes Requested` label and
+re-runs the same reconciliation logic (shared via
+`.github/scripts/reconcile_changes_requested_label.sh`) against each one, so
+a PR whose reviews have actually passed gets its label cleared within the
+next scheduled sweep even if the triggering event was lost.
 
 If a fourth reviewer is added (see [Adding a new AI reviewer](#adding-a-new-ai-reviewer)),
 update `sync-changes-requested-label.yml`'s `workflows:` trigger list and its


### PR DESCRIPTION
## Summary
Implements the consolidated follow-ups from #4741 (originally #4172-4176, #4190, #4192, #4194):

- **#4172** (grammar fix) and **#4192** (ruleset-drift CI check via `scripts/check_branch_protection_required_checks.py`) were already implemented on `main` — verified, no changes needed.
- **#4173**: Added an "Onboarding: provisioning API key secrets" section to `docs/AI_REVIEW_WORKFLOWS.md` documenting `DEEPSEEK_API_KEY` (and the other providers') secret setup.
- **#4174**: Removed the dead `isinstance(content, list)` branch in `extract_deepseek_review` — DeepSeek's OpenAI-compatible API never returns list content, only Anthropic's content-block format does.
- **#4175**: Added retry-with-backoff to `review_common.fetch_review()` for transient failures (429/5xx HTTP statuses, network errors), on top of the existing 60s timeout. Non-retryable errors (auth failures, malformed JSON) still fail immediately.
- **#4176**: Added a `schedule` (every 30 min) and `workflow_dispatch` trigger to `sync-changes-requested-label.yml` as a fallback sweep over all open PRs still carrying the `Changes Requested` label, for cases where the `workflow_run` trigger is missed. Extracted the shared reconciliation logic into `.github/scripts/reconcile_changes_requested_label.sh` to avoid duplicating it between the two triggers.
- **#4190 / #4194**: Added a "Why only DeepSeek is required" section documenting the rationale for DeepSeek being the sole required AI reviewer, plus the risks of relying on a single required reviewer and the mitigations already in place.

## Test plan
- [x] `python -m pytest .github/scripts/` — no new failures introduced (4 pre-existing failures in `test_extract_verdict.py` confirmed present on `main` too, unrelated to this change)
- [x] `python scripts/check_branch_protection_required_checks.py` — passes
- [x] YAML syntax validated for `sync-changes-requested-label.yml`
- [x] Bash syntax validated for `reconcile_changes_requested_label.sh`
- [x] Manually exercised `extract_deepseek_review` for string/empty/None content cases
- [ ] Live workflow_run and schedule triggers will be exercised by CI once merged

Closes #4741