### PR TITLE
docs(cdk): document cors_origins lifecycle and add CORS snapshot test

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -229,14 +229,30 @@ class BackendLambdaStack(Stack):
         )
 
         env = self.node.try_get_context("app_env") or os.getenv("APP_ENV") or "aws"
+        # Per-deploy override (e.g. a preview environment's own frontend URL),
+        # supplied via CDK context or env var. Inserted at position 0 below so
+        # it takes priority when dict.fromkeys() dedupes the final list.
         frontend_origin = self.node.try_get_context("frontend_origin") or os.getenv(
             "FRONTEND_ORIGIN"
         )
+        # Operator-supplied additional origins (comma-separated), for cases the
+        # base list + frontend_origin don't cover — e.g. a temporary staging
+        # domain. Supplied via CDK context or the CORS_ORIGINS env var.
         extra_cors_origins = self.node.try_get_context("cors_origins") or os.getenv("CORS_ORIGINS")
 
         cors_origins = [
+            # Vite dev server default port. Always present so `npm run dev`
+            # works against a deployed backend without extra config.
             "http://localhost:3000",
+            # CRA-style / alternate local dev server port, kept for the same
+            # reason as above. Both localhost entries are dev-only convenience:
+            # they're baked in at synth time and only ever reach a deployed
+            # stack if a developer points their local frontend at it, so they
+            # are not normalised or rejected for non-local environments here
+            # (audit for #4113 — no change needed).
             "http://localhost:5173",
+            # Production frontend. Remove only if app.allotmint.io stops being
+            # the production domain.
             "https://app.allotmint.io",
         ]
         if frontend_origin:

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -30,7 +30,15 @@ def template():
         os.environ.setdefault(key, value)
     # Remove optional auth env vars so CfnParameters have no Default,
     # keeping the synthesised template deterministic regardless of local env.
-    _auth_env_vars = ("UI_AUTH_USER_POOL_ID", "UI_AUTH_USER_POOL_CLIENT_ID", "UI_AUTH_DOMAIN")
+    # Also remove FRONTEND_ORIGIN/CORS_ORIGINS so the CORS allow_origins list
+    # synthesises to its hardcoded default (see test_backend_api_cors_allow_origins_default).
+    _auth_env_vars = (
+        "UI_AUTH_USER_POOL_ID",
+        "UI_AUTH_USER_POOL_CLIENT_ID",
+        "UI_AUTH_DOMAIN",
+        "FRONTEND_ORIGIN",
+        "CORS_ORIGINS",
+    )
     saved = {k: os.environ.pop(k, None) for k in _auth_env_vars}
     try:
         app = App()
@@ -689,6 +697,34 @@ def test_backend_api_routes_require_cognito_authorizer(template):
         "GET /health route key not found in synthesized template — "
         "CDK may have changed the RouteKey format; update UNAUTHENTICATED_ROUTES to match"
     )
+
+
+# ---------------------------------------------------------------------------
+# CORS configuration (issue #4828)
+# ---------------------------------------------------------------------------
+
+
+def test_backend_api_cors_allow_origins_default(template):
+    """With FRONTEND_ORIGIN/CORS_ORIGINS unset (the `template` fixture's default
+    env), the HttpApi's CORS preflight AllowOrigins must be exactly the
+    hardcoded base list, in order: the two local dev servers, then prod.
+
+    This pins the default list so a future edit to backend_lambda_stack.py's
+    cors_origins construction is caught here rather than only at deploy time.
+    """
+    apis = template.find_resources("AWS::ApiGatewayV2::Api")
+    assert apis, "Expected an AWS::ApiGatewayV2::Api resource"
+
+    api = next(iter(apis.values()))
+    cors = api["Properties"]["CorsConfiguration"]
+    assert cors["AllowOrigins"] == [
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "https://app.allotmint.io",
+    ]
+    assert cors["AllowCredentials"] is True
+    assert cors["AllowMethods"] == ["*"]
+    assert set(cors["AllowHeaders"]) == {"Authorization", "Content-Type", "X-CSRFToken"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds inline comments to each `cors_origins` entry in `cdk/stacks/backend_lambda_stack.py` explaining its purpose and lifecycle (local dev ports, production frontend, `frontend_origin` per-deploy override, `extra_cors_origins` operator-supplied additions).
- Documents the decision that `http://` localhost entries are synth-time-only dev convenience and don't need normalisation for non-local environments (audit item from #4113) — no runtime behavior change.
- Adds `test_backend_api_cors_allow_origins_default` in `cdk/tests/test_backend_lambda_stack.py`, asserting the exact default `AllowOrigins`/`AllowCredentials`/`AllowMethods`/`AllowHeaders` on the synthesized `AWS::ApiGatewayV2::Api` CORS configuration.
- Extends the `template` test fixture to also scrub `FRONTEND_ORIGIN`/`CORS_ORIGINS` from the environment so the new test's asserted list is deterministic regardless of local env vars.

Closes #4828

## Test plan
- [x] `python -m pytest cdk/tests/test_backend_lambda_stack.py -v --no-cov` — 37/37 pass, including the new CORS test
- [x] `python -m pytest cdk/tests/ -q --no-cov` — 115/115 pass (no regressions)
- [x] Confirmed `cdk/` is not covered by `make lint`/`make format` (both target only `backend`/`tests` per the Makefile), so no lint config change was needed