### PR TITLE
test: strengthen frontend Cognito auth/session test coverage (#4737)

### DIFF
--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -697,6 +697,15 @@ def test_backend_api_routes_require_cognito_authorizer(template):
         "GET /health route key not found in synthesized template — "
         "CDK may have changed the RouteKey format; update UNAUTHENTICATED_ROUTES to match"
     )
+    # Explicit regression guard (#4248): POST /token/cognito is the deprecated
+    # backend HS256 exchange (#4256) and must stay behind the Cognito JWT
+    # authorizer via the /{proxy+} catch-all, unlike POST /token/google above.
+    # The set-equality assert above would already catch this if /token/cognito
+    # had its own explicit NONE route, but it says nothing about a route that
+    # doesn't exist as a distinct resource at all — this assertion documents
+    # the intent directly rather than relying on that implication.
+    assert "POST /token/cognito" not in UNAUTHENTICATED_ROUTES
+    assert "POST /token/cognito" not in actual_none_routes
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/tests/cognito-auth-flow.spec.ts
+++ b/frontend/tests/cognito-auth-flow.spec.ts
@@ -96,12 +96,18 @@ const mockCognitoTokenEndpoint = async (page: Page, tokenRequests: TokenRequest[
 /**
  * Records any hit to the deprecated /token/cognito backend exchange so the test
  * can assert it is never called — the frontend now sends the Cognito ID token
- * directly (#4256).
+ * directly (#4256). Responds with 401 (not 200/empty) because API Gateway's
+ * Cognito authorizer rejects this route for real — a 200 here would mask a
+ * regression where the frontend starts calling it again (#4259).
  */
 const trackBackendTokenExchange = async (page: Page, hits: string[]) => {
   await page.route('**/token/cognito', async (route) => {
     hits.push(route.request().url());
-    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    await route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'Unauthorized' }),
+    });
   });
 };
 
@@ -185,5 +191,35 @@ test.describe('Cognito hosted UI authentication', () => {
     await assertIdTokenIsReused(page, configRequests);
     // The deprecated backend HS256 exchange must never be called (#4256).
     expect(backendExchangeHits).toHaveLength(0);
+  });
+
+  test('recovers by redirecting to the hosted UI when sessionStorage has a corrupted Cognito session (#4258)', async ({
+    page,
+  }) => {
+    // Simulates a session entry that failed to round-trip through JSON (e.g.
+    // truncated by a storage quota error). loadSession() in awsUiAuth.ts must
+    // discard it rather than throwing, so applyCognitoIdToken() sees no stored
+    // ID token and the app falls through to a normal hosted-UI redirect
+    // instead of getting stuck on a bootstrap error screen.
+    await page.addInitScript(() => {
+      window.sessionStorage.setItem('awsUiAuthSession', 'not-valid-json');
+    });
+    await mockRuntimeConfig(page);
+    await page.route(`${COGNITO_DOMAIN}/oauth2/authorize**`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>hosted ui</body></html>',
+      });
+    });
+
+    await page.goto(baseUrl);
+
+    await expect.poll(() => new URL(page.url()).origin).toBe(new URL(COGNITO_DOMAIN).origin);
+    // The unreadable entry is discarded rather than left behind to re-trigger
+    // the same failure on the next load.
+    expect(
+      await page.evaluate(() => window.sessionStorage.getItem('awsUiAuthSession')),
+    ).toBeNull();
   });
 });

--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -103,7 +103,9 @@ describe('ensureAwsUiAuth', () => {
 
     await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toBeInstanceOf(UserCancelledError);
     expect(assignMock).not.toHaveBeenCalled();
-    expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
+    // Assert against the live pathname rather than a hardcoded '/' so this
+    // stays correct if the test's simulated route ever changes (#3962).
+    expect(replaceState).toHaveBeenCalledWith({}, document.title, window.location.pathname);
     expect(window.sessionStorage.getItem('awsUiAuthState')).toBeNull();
     expect(window.sessionStorage.getItem('awsUiAuthCodeVerifier')).toBeNull();
   });
@@ -195,7 +197,7 @@ describe('ensureAwsUiAuth', () => {
 
       await ensureAwsUiAuth(AUTH_CONFIG);
 
-      expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
+      expect(replaceState).toHaveBeenCalledWith({}, document.title, window.location.pathname);
     });
 
     it('throws on state mismatch and cleans up URL', async () => {
@@ -205,7 +207,7 @@ describe('ensureAwsUiAuth', () => {
       await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
         'Invalid AWS UI authentication callback state'
       );
-      expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
+      expect(replaceState).toHaveBeenCalledWith({}, document.title, window.location.pathname);
       expect(window.sessionStorage.getItem('awsUiAuthState')).toBeNull();
       expect(window.sessionStorage.getItem('awsUiAuthCodeVerifier')).toBeNull();
     });
@@ -232,7 +234,7 @@ describe('ensureAwsUiAuth', () => {
       await expect(ensureAwsUiAuth(AUTH_CONFIG)).rejects.toThrow(
         'AWS UI authentication token exchange failed'
       );
-      expect(replaceState).toHaveBeenCalledWith({}, document.title, '/');
+      expect(replaceState).toHaveBeenCalledWith({}, document.title, window.location.pathname);
     });
 
     it('preserves non-auth query params when cleaning up after a token exchange failure', async () => {

--- a/frontend/tests/unit/main.cognitoRefreshCleanup.test.tsx
+++ b/frontend/tests/unit/main.cognitoRefreshCleanup.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// A deliberately unusual delay so the Cognito refresh timer's setTimeout call
+// can be picked out of the noise of every other setTimeout React/testing-library
+// schedules, without racing real wall-clock time to prove cancellation.
+const REFRESH_DELAY_MS = 123456;
+const sessionDueForRefreshIn = (ms: number) =>
+  JSON.stringify({
+    idToken: 'cognito-id-token',
+    accessToken: 'cognito-access-token',
+    refreshToken: 'cognito-refresh-token',
+    expiresAt: Date.now() + 5 * 60 * 1000 + ms,
+  });
+
+const CONFIG_WITH_COGNITO = {
+  awsUiAuth: {
+    enabled: true,
+    domain: 'https://auth.example.test',
+    clientId: 'cognito-client-123',
+  },
+};
+
+const stubFetch = () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url: string) => {
+      if (String(url).endsWith('/config.json')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(CONFIG_WITH_COGNITO),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    }),
+  );
+};
+
+// Finds the setTimeout call that scheduled the Cognito refresh (identified by
+// its unusually long delay — a few ms of real time elapse between computing
+// the session's expiry and scheduleCognitoRefresh() actually running, so the
+// delay won't match REFRESH_DELAY_MS exactly) and returns its timer id.
+const findRefreshTimerId = (setTimeoutSpy: ReturnType<typeof vi.spyOn>) => {
+  const callIndex = setTimeoutSpy.mock.calls.findIndex(
+    ([, delay]) => typeof delay === 'number' && delay > REFRESH_DELAY_MS / 2,
+  );
+  if (callIndex === -1) return null;
+  return setTimeoutSpy.mock.results[callIndex]?.value;
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  sessionStorage.clear();
+  localStorage.clear();
+  document.body.innerHTML = '<div id="root"></div>';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('Cognito refresh timer cleanup (#4298)', () => {
+  it('cancels the pending refresh timer on beforeunload', async () => {
+    sessionStorage.setItem('awsUiAuthSession', sessionDueForRefreshIn(REFRESH_DELAY_MS));
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() }),
+    }));
+    stubFetch();
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+
+    await import('@/main');
+    await vi.waitFor(() => expect(findRefreshTimerId(setTimeoutSpy)).not.toBeNull());
+    const timerId = findRefreshTimerId(setTimeoutSpy);
+
+    window.dispatchEvent(new Event('beforeunload'));
+
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId);
+  });
+
+  it('cancels the pending refresh timer on logout', async () => {
+    sessionStorage.setItem('awsUiAuthSession', sessionDueForRefreshIn(REFRESH_DELAY_MS));
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() }),
+    }));
+    stubFetch();
+
+    vi.doMock('@/api', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/api')>();
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: false,
+          google_client_id: null,
+          disable_auth: true,
+        }),
+        getStoredAuthToken: vi.fn(() => null),
+        logout: vi.fn(),
+      };
+    });
+
+    vi.doMock('@/App.tsx', () => ({
+      default: ({ onLogout }: { onLogout: () => void }) => (
+        <button type="button" onClick={onLogout}>
+          log out
+        </button>
+      ),
+    }));
+
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+
+    const { Root } = await import('@/main');
+    const { AuthProvider } = await import('@/AuthContext');
+    const { UserProvider } = await import('@/UserContext');
+
+    render(
+      <AuthProvider>
+        <UserProvider>
+          <BrowserRouter>
+            <Root />
+          </BrowserRouter>
+        </UserProvider>
+      </AuthProvider>,
+    );
+
+    const logoutButton = await screen.findByRole('button', { name: /log out/i });
+    await waitFor(() => expect(findRefreshTimerId(setTimeoutSpy)).not.toBeNull());
+    const timerId = findRefreshTimerId(setTimeoutSpy);
+
+    await userEvent.click(logoutButton);
+
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId);
+  });
+});

--- a/frontend/tests/unit/main.tokenExchangeFailure.test.tsx
+++ b/frontend/tests/unit/main.tokenExchangeFailure.test.tsx
@@ -114,6 +114,15 @@ describe('bootstrapRuntimeConfig — generic auth bootstrap failure', () => {
       expect.any(Error),
     );
 
+    // Set up the reload spy before render() so the assertion stays valid even
+    // if a future refactor reads window.location.reload during render/mount
+    // rather than lazily inside the click handler (#3948).
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+
     render(renderedElement!);
     const retryButton = screen.getByRole('button', { name: /sign in/i });
     expect(retryButton).toBeInTheDocument();
@@ -121,12 +130,6 @@ describe('bootstrapRuntimeConfig — generic auth bootstrap failure', () => {
 
     // The dead authorization code must be cleared so a reload restarts the hosted-UI flow.
     expect(window.location.search).toBe('');
-
-    const reloadSpy = vi.fn();
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { ...window.location, reload: reloadSpy },
-    });
 
     await userEvent.click(retryButton);
     expect(reloadSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
Consolidated hardening pass across the frontend Cognito hosted-UI auth flow and its test suite, addressing the sub-items rolled into #4737:

- `awsUiAuth.test.ts`: assert `replaceState` cleanup against the live `window.location.pathname` instead of a hardcoded `'/'` (#3962).
- `main.tokenExchangeFailure.test.tsx`: set up the `reload` spy before `render()` so the assertion holds even if a future refactor reads `window.location.reload` earlier in the component lifecycle (#3948).
- `cognito-auth-flow.spec.ts`: the deprecated `/token/cognito` mock now returns 401 instead of 200/empty, matching what API Gateway's Cognito authorizer actually does (#4259). Also adds a Playwright test covering a corrupted `sessionStorage` entry, verifying the app discards it and falls through to the hosted-UI redirect instead of getting stuck (#4258).
- `main.cognitoRefreshCleanup.test.tsx` (new): unit tests proving `clearCognitoRefreshTimer` actually cancels the pending refresh timer on both logout and `beforeunload`, using `setTimeout`/`clearTimeout` spies rather than racing real wall-clock time (#4298).
- `cdk/tests/test_backend_lambda_stack.py`: explicit regression guard asserting `POST /token/cognito` is not in `UNAUTHENTICATED_ROUTES` (#4248).

Two sub-items were deliberately left as-is, with rationale:
- **#4276** (extract `stripAuthCallbackParams` to a shared utility): its only other call site in `awsUiAuth.ts` strips params differently — reusing it there would drop the preserved query string on a successful token exchange, a real behavior change. No other consumer exists yet, so there's nothing to extract to.
- **#4299** (remove the `beforeunload` listener in a cleanup function for HMR): moot — `main.tsx` has no `import.meta.hot` boundary, so Vite already does a full page reload on any edit to it, tearing down all listeners together rather than leaking one across an isolated module replacement.

## Test plan
- [x] `npx vitest run` — full frontend unit suite (88 files / 564 tests) passes
- [x] `npx eslint --format unix .` — clean
- [x] `npx tsc -b --noEmit` — clean
- [x] `pytest cdk/tests/test_backend_lambda_stack.py -k "unauthenticated or cognito_authorizer" -v` — both targeted tests pass
- [ ] Playwright `cognito-auth-flow.spec.ts` (requires a running dev server / CI environment)

Closes #4737