### PR TITLE
Audit CfnOutput consumption in deploy-lambda.yml and document HTTP/2 review

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -587,6 +587,13 @@ jobs:
         # `|| true` on the curl assignment keeps set -e from short-circuiting
         # past the explicit status check below when --fail trips on a non-2xx
         # response.
+        # HTTP/2 review (issue #4830): none of the curl calls in this workflow pass
+        # --http2/--http2-prior-knowledge, so curl negotiates HTTP/1.1 over TLS here
+        # regardless of what API Gateway/CloudFront would otherwise support. Even if
+        # that changed, the header-matching below (`grep -i` + `tr -d '\r'`) is
+        # already case-insensitive and CR-tolerant, which is exactly what HTTP/2's
+        # mandatory-lowercase header names and LF-only line endings require. No
+        # change needed; this applies to the OPTIONS preflight check below too.
         run: |
           set -euo pipefail
           echo "Checking CORS headers on ${BACKEND_URL%/}/config for Origin: ${FRONTEND_ORIGIN}"
@@ -1302,7 +1309,7 @@ jobs:
           log_group="$(aws cloudformation describe-stacks \
             --stack-name BackendLambdaStack \
             --query "Stacks[0].Outputs[?OutputKey=='BackendLambdaLogGroupName'].OutputValue" \
-            --output text)"
+            --output text 2>/dev/null || echo "")"
           if [ -z "$log_group" ] || [ "$log_group" = "None" ]; then
             echo "BackendLambdaLogGroupName output not found in BackendLambdaStack; skipping" >&2
             exit 0


### PR DESCRIPTION
## Summary
- Audited every `describe-stacks`/`list-stack-resources --query ...OutputValue` call in `.github/workflows/deploy-lambda.yml` (25 call sites). All already use `--output text` and guard against `None`/empty, with one gap: the "Fetch Lambda logs from smoke test" step was missing the `2>/dev/null || echo ""` fallback its sibling deploy-job step uses, so a transient `describe-stacks` API error would hard-fail the step instead of degrading gracefully to "not found; skipping" — now fixed for consistency.
- Reviewed whether the CORS smoke-test curl checks need explicit HTTP/2 handling. Conclusion: none of the curl invocations request HTTP/2 (no `--http2`/`--http2-prior-knowledge`), so they negotiate HTTP/1.1 over TLS regardless of what API Gateway/CloudFront support; and the existing header-matching (`grep -i` + `tr -d '\r'`) is already case-insensitive and CR-tolerant, which is what HTTP/2's lowercase headers and LF-only lines would need anyway. Documented this conclusion as a comment near the CORS check so it doesn't need re-litigating later.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-lambda.yml'))"` — YAML parses cleanly
- [ ] Deploy workflow itself only runs on tag push / manual dispatch to production, so behavior is verified by inspection here; no local repro of the AWS-dependent steps

Closes #4830

🤖 Generated with [Claude Code](https://claude.com/claude-code)