### PR TITLE
chore: repo hygiene follow-ups (CODEOWNERS, sanitisation, docs)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,3 +27,6 @@
 
 # Data files and fixtures
 /data/ @leonarduk
+
+# Default owner for any path not matched above
+* @leonarduk

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -420,7 +420,8 @@ jobs:
           DISTRIBUTION_DOMAIN="${DISTRIBUTION_DOMAIN#https://}"
           DISTRIBUTION_DOMAIN="${DISTRIBUTION_DOMAIN#http://}"
           DISTRIBUTION_DOMAIN="${DISTRIBUTION_DOMAIN%/}"
-          DISTRIBUTION_DOMAIN="$(echo "$DISTRIBUTION_DOMAIN" | xargs)"
+          DISTRIBUTION_DOMAIN="${DISTRIBUTION_DOMAIN#"${DISTRIBUTION_DOMAIN%%[![:space:]]*}"}"
+          DISTRIBUTION_DOMAIN="${DISTRIBUTION_DOMAIN%"${DISTRIBUTION_DOMAIN##*[![:space:]]}"}"
           # SmokeTestUserPoolClientId is the deploy workflow's dedicated Cognito app
           # client for post-deploy smoke tests (see "Fetch Cognito smoke-test token"
           # below). BackendLambdaStack must accept its tokens as a valid JWT audience,

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 AllotMint is a family investing platform with a FastAPI backend, React frontend, and AWS deployment support.
 
+## Language guidelines
+
+All code, comments, commit messages, documentation, and PR/issue text in this
+repository must be written in English only, regardless of the contributor's
+or AI agent's default language.
+
 - **Contributing**: [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) — environment variables, code quality expectations, and first PR walkthrough
 - **Product and architecture overview**: [docs/README.md](docs/README.md)
 - **Local setup and contributor workflow**: [docs/CONTRIBUTOR_RUNBOOK.md](docs/CONTRIBUTOR_RUNBOOK.md) — installation, running locally, testing, and pre-deploy checks

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -138,6 +138,16 @@ body (for example: `Closes #1234`).
 lock file changes from `npm ci` or `npm install` that strip platform-specific
 dependencies.
 
+**Frontend optional dependency handling**: `frontend/package-lock.json` pins
+platform-specific optional packages (for example the Linux-only
+`@emnapi/core`/`@emnapi/runtime` entries under `@tailwindcss/oxide-wasm32-wasi`,
+needed for CI to run `npm ci` on Linux). Regenerating the lock file with
+`npm install` on Windows or macOS can silently strip these entries or add
+incorrect `peer: true` annotations, which then makes Linux CI fail with
+`EUSAGE` even though the change looks unrelated. Before committing any
+`frontend/package-lock.json` diff, review it for removed `@emnapi/*` or other
+`optionalDependencies`/`peer` entries and restore them if present.
+
 ## Automated code reviews
 
 Pull requests trigger automated AI code reviews via Claude and GPT (advisory-only, will not block merges). See [docs/AI_REVIEW_WORKFLOWS.md](AI_REVIEW_WORKFLOWS.md) for details on these workflows and how to debug review failures.


### PR DESCRIPTION
## Summary
- Add catch-all `*` default owner to `.github/CODEOWNERS` so newly added top-level paths are automatically covered (#3914).
- Replace the `xargs`-based whitespace trim in `deploy-lambda.yml`'s domain sanitisation step with pure bash parameter expansion, removing the `xargs` dependency (#4078).
- Add an English-only language guideline section to `README.md` (#4165).
- Document (in `docs/CONTRIBUTING.md`) the recurring issue where regenerating `frontend/package-lock.json` on Windows/macOS strips Linux-only optional dependencies (`@emnapi/*`) or adds spurious `peer: true` flags, breaking Linux CI's `npm ci`, and how to catch it before committing (#4203). Verified the current lock file still has these entries intact.

Closes #4742

## Test plan
- [x] Validated `deploy-lambda.yml` YAML parses correctly
- [x] Verified the new bash parameter-expansion trim behaves identically to `xargs` (leading/trailing whitespace stripped)
- [x] Verified `frontend/package-lock.json` currently retains all `@emnapi/*` optional entries
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)