### PR TITLE
test(cdk): add snapshot/assertion coverage for BackendLambdaStack config

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -147,6 +147,23 @@ class BackendLambdaStack(Stack):
             )
 
     @staticmethod
+    def _require_single_cfn_authorizer(
+        cfn_authorizers: Sequence[apigwv2.CfnAuthorizer],
+    ) -> apigwv2.CfnAuthorizer:
+        """Return the sole entry in ``cfn_authorizers`` or raise ``ValueError``.
+
+        Guards against silently overriding the wrong resource if a second
+        authorizer is ever added to backend_api (#4057).
+        """
+
+        if len(cfn_authorizers) != 1:
+            raise ValueError(
+                "Expected exactly one CfnAuthorizer under BackendApi, found "
+                f"{len(cfn_authorizers)}"
+            )
+        return cfn_authorizers[0]
+
+    @staticmethod
     def _grant_timeseries_cache_access(
         fn: _lambda.DockerImageFunction,
         *,
@@ -625,11 +642,7 @@ class BackendLambdaStack(Stack):
             for child in backend_api.node.find_all()
             if isinstance(child, apigwv2.CfnAuthorizer)
         ]
-        assert len(backend_cfn_authorizers) == 1, (
-            "Expected exactly one CfnAuthorizer under BackendApi, found "
-            f"{len(backend_cfn_authorizers)}"
-        )
-        backend_cfn_authorizer = backend_cfn_authorizers[0]
+        backend_cfn_authorizer = self._require_single_cfn_authorizer(backend_cfn_authorizers)
         backend_cfn_authorizer.add_property_override(
             "JwtConfiguration.Audience",
             Fn.condition_if(

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -713,6 +713,30 @@ def test_backend_api_routes_require_cognito_authorizer(template):
 # ---------------------------------------------------------------------------
 
 
+def test_backend_api_cors_allow_origins_includes_frontend_origin(monkeypatch):
+    """When FRONTEND_ORIGIN is set, it must be included in the HttpApi's CORS
+    AllowOrigins, inserted first so it takes priority over the hardcoded base
+    list (issue #3958)."""
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("FRONTEND_ORIGIN", "https://preview.allotmint.io")
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+
+    app = App()
+    stack = BackendLambdaStack(app, "FrontendOriginTestStack")
+    template = assertions.Template.from_stack(stack)
+
+    apis = template.find_resources("AWS::ApiGatewayV2::Api")
+    api = next(iter(apis.values()))
+    cors = api["Properties"]["CorsConfiguration"]
+    assert cors["AllowOrigins"] == [
+        "https://preview.allotmint.io",
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "https://app.allotmint.io",
+    ]
+
+
 def test_backend_api_cors_allow_origins_default(template):
     """With FRONTEND_ORIGIN/CORS_ORIGINS unset (the `template` fixture's default
     env), the HttpApi's CORS preflight AllowOrigins must be exactly the
@@ -808,6 +832,25 @@ def test_backend_api_access_log_group_has_one_week_retention(template):
         assert resource["DeletionPolicy"] == "Delete", (
             f"{logical_id} must be destroyed with the stack"
         )
+
+
+# ---------------------------------------------------------------------------
+# CfnAuthorizer count guard (issue #4057)
+# ---------------------------------------------------------------------------
+
+
+def test_require_single_cfn_authorizer_returns_sole_authorizer():
+    sentinel = object()
+    assert BackendLambdaStack._require_single_cfn_authorizer([sentinel]) is sentinel
+
+
+@pytest.mark.parametrize("candidates", [[], [object(), object()]])
+def test_require_single_cfn_authorizer_raises_value_error_when_not_exactly_one(candidates):
+    """A missing or duplicated CfnAuthorizer must raise an explicit ValueError
+    (not a bare assert, which is stripped under `python -O`) so a future change
+    that adds a second authorizer to backend_api fails synthesis loudly."""
+    with pytest.raises(ValueError, match="Expected exactly one CfnAuthorizer"):
+        BackendLambdaStack._require_single_cfn_authorizer(candidates)
 
 
 # ---------------------------------------------------------------------------

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -5,6 +5,7 @@ Run from the repo root:
     pytest cdk/tests/test_static_site_stack.py -v
 """
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -250,6 +251,29 @@ def test_distribution_id_output_exists(template):
 
 def test_distribution_domain_output_exists(template):
     template.has_output("DistributionDomain", {})
+
+
+def test_distribution_domain_output_has_no_scheme_prefix(template):
+    """DistributionDomain must be the bare CloudFront hostname, not prefixed
+    with a scheme.
+
+    The deploy workflow builds FRONTEND_ORIGIN as
+    f"https://{DISTRIBUTION_DOMAIN}" (.github/workflows/deploy-lambda.yml); if
+    this output ever gained a "https://" prefix, FRONTEND_ORIGIN would become
+    "https://https://..." and break CORS for the deployed frontend (#3990).
+    distribution.domain_name resolves to a CloudFormation intrinsic
+    (Fn::GetAtt) at synth time, so asserting that structure (rather than a
+    literal string) guards against a future edit wrapping it in a scheme
+    prefix.
+    """
+    outputs = template.to_json()["Outputs"]
+    value = outputs["DistributionDomain"]["Value"]
+    assert "Fn::GetAtt" in value, (
+        f"Expected DistributionDomain to resolve to a bare Fn::GetAtt token, got: {value}"
+    )
+    assert "https://" not in json.dumps(value), (
+        f"DistributionDomain output must not embed a scheme prefix: {value}"
+    )
 
 
 def test_site_bucket_output_exists(template):


### PR DESCRIPTION
## Summary
- Add a synth-level assertion that `FRONTEND_ORIGIN` is included (and prioritized) in `BackendLambdaStack`'s HttpApi CORS `AllowOrigins` list.
- Add a synth-level assertion that `StaticSiteStack`'s `DistributionDomain` output resolves to a bare `Fn::GetAtt` token with no `https://` scheme prefix, guarding against a double-`https://` `FRONTEND_ORIGIN` in the deploy workflow.
- Replace the bare `assert` guarding the `CfnAuthorizer` count in `BackendLambdaStack` with an explicit `ValueError`, extracted into a `_require_single_cfn_authorizer` static method that's unit-tested directly (no synth required) for both the happy path and the 0/2+ failure cases.

Consolidates #3958, #3990, #4057 Closes #4739.

## Test plan
- [x] `python -m pytest cdk/tests -q --no-cov` — 120 passed