### PR TITLE
test: add unit tests for log-field sanitisation and rendering escaping

### DIFF
--- a/tests/backend/common/test_compliance.py
+++ b/tests/backend/common/test_compliance.py
@@ -115,6 +115,39 @@ def test_check_trade_requires_owner(monkeypatch):
     assert called is False
 
 
+def test_check_transactions_logs_sanitised_invalid_share_count(monkeypatch, stubbed_env, caplog):
+    """Malformed ``shares`` values are logged with control chars stripped.
+
+    Regression test for #4015: the warning must not leak raw ``\\r``/``\\n``
+    from attacker-controlled transaction fields into the log stream
+    (CWE-117 log injection) - sanitise_log_value() must run on every logged
+    field, and the sanitised shares/ticker/date values must appear in the
+    warning message.
+    """
+    txs = [
+        {
+            "date": "2024-01-05",
+            "ticker": "ABC\r\ninjected",
+            "type": "buy",
+            "shares": "not-a-number\r\nmalicious",
+        }
+    ]
+
+    with caplog.at_level("WARNING"):
+        result = compliance._check_transactions("alice", txs)
+
+    assert result["warnings"] == []
+
+    warning_records = [r for r in caplog.records if "invalid share count" in r.getMessage()]
+    assert len(warning_records) == 1
+    message = warning_records[0].getMessage()
+
+    assert "\r" not in message
+    assert "\n" not in message
+    assert "not-a-numbermalicious" in message
+    assert "ABCinjected" in message
+
+
 def test_evaluate_trades_attach_warnings_once(monkeypatch, stubbed_env):
     trades = [
         {"date": "2024-01-01", "ticker": "ABC", "type": "buy", "shares": 10},

--- a/tests/routes/test_timeseries_meta.py
+++ b/tests/routes/test_timeseries_meta.py
@@ -165,6 +165,35 @@ def test_resolve_rejects_oversized_segments(ticker, exchange):
     assert exc_info.value.status_code == 400
 
 
+@pytest.mark.parametrize("char,should_match", [
+    ("A", True),
+    ("Z", True),
+    ("0", True),
+    ("9", True),
+    ("_", True),
+    ("-", True),
+    (".", False),
+    (" ", False),
+    ("@", False),
+    ("!", False),
+    ("/", False),
+    ("$", False),
+])
+def test_ticker_symbol_regex_pins_character_class(char, should_match):
+    """Pin the [A-Z0-9_-] allowlist of _TICKER_SYMBOL_RE.
+
+    Regression test for #4163: locks down exactly which characters the
+    ticker-symbol allowlist regex accepts, so a future edit to the pattern
+    can't silently widen (security risk) or narrow (legitimate tickers like
+    BRK-B breaking) it without a test failing.
+    """
+    import backend.routes.timeseries_meta as ts_meta
+
+    candidate = f"AB{char}CD"
+    matched = bool(ts_meta._TICKER_SYMBOL_RE.match(candidate))
+    assert matched == should_match
+
+
 # ---- /timeseries/meta route tests -----------------------------------------
 
 

--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -294,6 +294,51 @@ def test_load_account_falls_back_to_local(tmp_path, monkeypatch, caplog, cleanup
     )
 
 
+def test_load_account_falls_back_sanitises_log_fields(
+    tmp_path, monkeypatch, caplog, cleanup_boto3_module
+):
+    """Owner/account values are sanitised before being logged on fallback.
+
+    Regression test for #4009: a malicious owner/account containing CRLF
+    must not be able to inject fake log lines (CWE-117) into the fallback
+    warning emitted by ``load_account``.
+    """
+    monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
+    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
+
+    owner = "owner\r\nFAKE LOG LINE"
+    account = "acct\r\ninjected"
+
+    owner_dir = tmp_path / "owner"
+    owner_dir.mkdir()
+    (owner_dir / "account.json").write_text('{"value": 7}')
+
+    def fake_client(name):
+        assert name == "s3"
+
+        def get_object(Bucket, Key):
+            raise RuntimeError("boom")
+
+        return SimpleNamespace(get_object=get_object)
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(FileNotFoundError):
+            dl.load_account(owner, account, data_root=tmp_path)
+
+    warning_records = [
+        r for r in caplog.records if "falling back to local file" in r.getMessage()
+    ]
+    assert len(warning_records) == 1
+    record = warning_records[0]
+
+    assert "\r" not in record.getMessage()
+    assert "\n" not in record.getMessage()
+    assert record.owner == "ownerFAKE LOG LINE"
+    assert record.account == "acctinjected"
+
+
 def test_load_account_missing_bucket(monkeypatch):
     monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
     monkeypatch.delenv(dl.DATA_BUCKET_ENV, raising=False)

--- a/tests/utils/test_html_render.py
+++ b/tests/utils/test_html_render.py
@@ -119,9 +119,13 @@ def test_render_timeseries_html_escapes_cell_values():
     # Also confirm the cell content is still readable text (entities decoded
     # by the browser/lxml into harmless display text, not executable HTML).
     tree = html.fromstring(html_str)
+    headers = [th.text_content() for th in tree.xpath(".//th")]
     rows = tree.xpath(".//tr")
-    cells = [td.text for td in rows[1].xpath(".//td")]
-    ticker_idx = 6  # Ticker is the 7th column (0-indexed)
-    source_idx = 7  # Source is the 8th column
+    # text_content() (not .text) is used here because .text only returns the
+    # text directly inside the element, ignoring nested children, which is
+    # fragile if the row markup ever changes shape.
+    cells = [td.text_content() for td in rows[1].xpath(".//td")]
+    ticker_idx = headers.index("Ticker")
+    source_idx = headers.index("Source")
     assert 'alert("XSS")' in cells[ticker_idx]
     assert "alert(1)" in cells[source_idx]


### PR DESCRIPTION
## Summary
Consolidates AI-review follow-ups about missing/weak unit-test coverage for log sanitisation and HTML-escaping logic (#4009, #4015, #4162, #4163, #4164).

- `tests/test_data_loader_aws.py`: new test asserting `data_loader.load_account`'s fallback warning sanitises owner/account values (strips `\r`/`\n`) before logging (CWE-117).
- `tests/backend/common/test_compliance.py`: new test asserting `compliance._check_transactions` sanitises the ticker/shares/date fields it logs when an invalid share count is encountered.
- `tests/utils/test_html_render.py`: `test_render_timeseries_html_escapes_cell_values` now uses lxml's `td.text_content()` instead of `td.text` (more robust if the cell markup ever contains nested elements), and looks up the Ticker/Source column indices dynamically from the table header instead of hardcoded magic indices.
- `tests/routes/test_timeseries_meta.py`: new parametrized regression test pinning the `_TICKER_SYMBOL_RE` `[A-Z0-9_-]` character class, so a future edit can't silently widen or narrow the allowlist without a test failing.

## Test plan
- [x] `pytest tests/utils/test_html_render.py tests/backend/common/test_compliance.py tests/test_data_loader_aws.py tests/routes/test_timeseries_meta.py` — 88 passed
- [x] Full `pytest tests/` suite (excluding a pre-existing, unrelated `test_review_comment.py` bash-environment failure) — 2782 passed, 0 new failures

Closes #4740

🤖 Generated with [Claude Code](https://claude.com/claude-code)