### PR TITLE
docs: reconcile deploy/CI documentation with actual workflow behaviour

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1110,6 +1110,10 @@ jobs:
           npx lhci autorun --collect.url="$LIGHTHOUSE_URL" \
             --upload.target=temporary-public-storage
 
+  # The `verify-smoke-tests` job below references this job by the exact
+  # literal name `smoke-test` (`needs: smoke-test`, `needs.smoke-test.result`).
+  # If this job is ever renamed, `verify-smoke-tests` must be updated to
+  # match or its `needs`/`if` expressions will fail to resolve. See #4222.
   smoke-test:
     runs-on: ubuntu-latest
     needs: deploy
@@ -1318,6 +1322,30 @@ jobs:
           echo "=== BackendLambda CloudWatch logs (last 15 minutes) ==="
           bash scripts/bash/fetch-cloudwatch-logs.sh "$log_group" 900
 
+  # verify-smoke-tests: gate job that fails unless `smoke-test` (see #4222 for
+  # why the exact job name matters) actually succeeded.
+  #
+  # Why `if: always()` instead of relying on branch protection alone: a
+  # required-status-check branch protection rule only blocks a *failed*
+  # `smoke-test` run — a *skipped* run is not treated as blocking by GitHub,
+  # so it would silently satisfy the rule. `if: always()` makes this job run
+  # regardless of `smoke-test`'s outcome so the `needs.smoke-test.result !=
+  # 'success'` check below can explicitly catch `failure`, `cancelled`, AND
+  # `skipped` — the three states other than a genuine `success`. The two
+  # mechanisms are complementary, not redundant: branch protection enforces
+  # that this job itself must pass; this job is what makes a skip actually
+  # count as a failure. See #4149.
+  #
+  # Documented skip paths for `smoke-test` (#4154): as of this writing,
+  # `smoke-test` has no `if:` condition of its own — it runs unconditionally
+  # whenever `deploy` completes. The only way `smoke-test` can end up
+  # `skipped` today is if an upstream job in its `needs` chain (`check-ci` or
+  # `deploy`) fails or is cancelled, which correctly should block the
+  # deployment. There is currently no dry-run/docs-only path in this workflow
+  # that intentionally skips live smoke tests. If a conditional `if:` is ever
+  # added to the `smoke-test` job to introduce one, list the condition and
+  # rationale here so this gate's `skipped` handling can be reviewed against
+  # the new intentional case.
   verify-smoke-tests:
     name: Verify post-deploy smoke tests passed
     runs-on: ubuntu-latest

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -424,6 +424,7 @@ Only run the deploy commands when you intentionally want to deploy; they are lis
 - **Smoke preflight fails**: start the local backend/frontend or set `SMOKE_URL` to a reachable deployment.
 - **Google auth errors locally**: verify `GOOGLE_AUTH_ENABLED=true`, `DISABLE_AUTH=false`, and a non-empty `GOOGLE_CLIENT_ID`.
 - **Price snapshot absent after deploy (`[WARNING] Price snapshot not yet seeded`)**: the CDK Trigger automatically invokes `PriceRefreshLambda` synchronously during `cdk deploy BackendLambdaStack`, blocking until the snapshot is written. If the warning still appears, the Trigger Lambda likely timed out or the price-refresh Lambda failed. Check `PriceRefreshLambdaLogGroup` in CloudWatch and re-trigger manually: `aws lambda invoke --function-name <PriceRefreshLambda-physical-name> /dev/null`.
+- **"Verify price snapshot seeded in S3" deploy step fails with a 403**: this step (`deploy-lambda.yml`) hard-fails the deploy on any `head-object` error other than a missing key (`NoSuchKey`/404, which is a soft pass -- the price-refresh job just hasn't run yet). A 403 means the deploy role genuinely lacks `s3:GetObject`/`s3:ListBucket` on the data bucket, or the bucket policy changed; retrying will not help. Check the CDK grants for `GITHUB_DEPLOY_ROLE_ARN` in `cdk/stacks/backend_lambda_stack.py` (see issue #3191) and re-run once the grant is fixed.
 
 ## 12. Canonical command index by task
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -94,6 +94,25 @@ repository variable is only used as a fallback in expressions like
 For new deployers: set `AWS_ROLE_TO_ASSUME` as a **secret**, not a variable,
 to ensure the workflow uses your intended value and prevent accidental shadowing.
 
+### `DISTRIBUTION_DOMAIN` format
+
+`DISTRIBUTION_DOMAIN` is not a secret or variable you configure -- it is the
+`DistributionDomain` `CfnOutput` from `StaticSiteStack`, a bare CloudFront
+hostname with no scheme and no trailing slash (e.g. `d1234abcd.cloudfront.net`).
+The "Get Cognito UI auth outputs" step in `deploy-lambda.yml` reads it via
+`aws cloudformation describe-stacks` and strips any `https://`/`http://`
+prefix, trailing slash, or stray whitespace as a defensive guard against future
+CDK output changes, then derives:
+
+- `FRONTEND_ORIGIN=https://${DISTRIBUTION_DOMAIN}`
+- `CORS_ORIGINS=https://${DISTRIBUTION_DOMAIN},https://app.allotmint.io`
+
+`FRONTEND_ORIGIN` is passed into `BackendLambdaStack` so its CORS allow-list
+includes the live CloudFront origin (see #3944) -- without it, the deployed
+frontend's `GET /config` call never receives an
+`Access-Control-Allow-Origin` header and gets stuck on
+"Loading... retrying configuration."
+
 ### Setup checklist
 
 New deployers and fork maintainers should:
@@ -104,15 +123,23 @@ New deployers and fork maintainers should:
 
    The workflow guards against an empty value for you, well before
    `cdk deploy` runs. The "Verify required AWS secrets" step validates that
-   `AWS_ROLE_TO_ASSUME` is non-empty by checking both the secret and variable:
+   `AWS_ROLE_TO_ASSUME` (and `AWS_REGION`) are non-empty by checking both the
+   secret and variable for each -- this snippet is kept in sync with the
+   literal step in `deploy-lambda.yml`:
 
    ```yaml
    - name: Verify required AWS secrets
      run: |
+       missing=0
+       if [ -z "${{ secrets.AWS_REGION }}${{ vars.AWS_REGION }}" ]; then
+         echo "AWS_REGION is not configured (set as secret or repository variable)" >&2
+         missing=1
+       fi
        if [ -z "${{ secrets.AWS_ROLE_TO_ASSUME }}${{ vars.AWS_ROLE_TO_ASSUME }}" ]; then
          echo "AWS_ROLE_TO_ASSUME is not configured (set as secret or repository variable)" >&2
-         exit 1
+         missing=1
        fi
+       if [ "$missing" -eq 1 ]; then exit 1; fi
    ```
 
    A non-empty-but-malformed ARN is caught shortly after, when

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,18 @@ The backend API must be running and reachable from the browser (local, LAN IP, o
 - `npm run dev` – start the Vite development server.
 - `npm test` – execute the test suite with Vitest and Testing Library.
   Test files should be named `*.test.ts`, `*.test.tsx`, or `*.test.js` to be picked up.
+- `npm run build` – production build: runs `tsc -b` (full type-check) then
+  `vite build`. This is the build used before any real deploy or CDK synth
+  (`deploy-lambda.yml`, `cdk-dry-run.yml`, `iac-validation.yml`, and the
+  `scripts/deploy-to-AWS.ps1`/`build-and-deploy.ps1` helpers) since
+  `StaticSiteStack` bundles `frontend/dist` as a CDK asset and a type error
+  should block a deploy.
+- `npm run build:preview` – fast build: `vite build` only, skipping the
+  `tsc -b` type-check. Used where speed matters more than a full type-check
+  because type-checking already happens elsewhere in the same run: `ci.yml`
+  (a separate `npm run lint`/`type-check` job already covers it) and the
+  smoke-test scripts (`smoke:frontend`, `smoke:codex:poc`) that build a local
+  preview server to drive Playwright.
 
 ### Smoke test page
 


### PR DESCRIPTION
## Summary
- Fixes DEPLOY.md's stale "Verify required AWS secrets" snippet (drifted from the workflow's current AWS_REGION check + `missing` flag pattern).
- Documents `DISTRIBUTION_DOMAIN`'s expected format and how `FRONTEND_ORIGIN`/`CORS_ORIGINS` derive from it.
- Adds a runbook entry for the 403-on-S3-snapshot hard-fail.
- Documents `npm run build` vs `npm run build:preview` in `frontend/README.md`.
- Adds inline workflow comments explaining `verify-smoke-tests`'s `if: always()`, the (currently nonexistent) skip paths for `smoke-test`, and the exact-job-name dependency between the two jobs.

All 12 sub-issues consolidated into this one were bulk-closed as duplicates without any actual doc changes — I verified each against the current repo state and found several still had real drift or gaps (see below), and fixed those; the rest were already covered by earlier work.

| Issue | Status found | Action |
| --- | --- | --- |
| #3899 | Stale snippet | Fixed |
| #3903 | Already accurate | No change |
| #4064 | Already documented (CONTRIBUTING.md) | No change |
| #4074 | Already documented (script + workflow comments) | No change |
| #4081 | No stale references found | No change |
| #4091 | Missing from docs | Added |
| #4095 | Already documented | No change |
| #4127 | Missing runbook entry | Added |
| #4135 | Missing entirely | Added |
| #4149 | Missing | Added |
| #4154 | Missing | Added |
| #4222 | Missing | Added |

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-lambda.yml'))"` — valid YAML
- [x] `actionlint .github/workflows/deploy-lambda.yml` — clean
- [x] Doc-only diff outside the workflow comments (no logic changes)

Closes #4730