### PR TITLE
feat(backend): make list_plots return typed OwnerSummaryRecord

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -29,6 +29,7 @@ from backend.common.virtual_portfolio import VirtualPortfolio
 from backend.config import config
 from backend.config import demo_identity as get_demo_identity
 from backend.logging_setup import sanitise_log_value
+from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -839,57 +840,8 @@ def _list_aws_plots(current_user: Optional[str] = None) -> List[Dict[str, Any]]:
 # ------------------------------------------------------------------
 # Public discovery API
 # ------------------------------------------------------------------
-def list_plots(
-    data_root: Optional[Path] = None,
-    current_user: Optional[str] = None,
-) -> List[Dict[str, Any]]:
-    """Public helper to list available account plots.
-
-    Parameters
-    ----------
-    data_root:
-        Optional base directory containing account data when running locally.
-    current_user:
-        Username of the authenticated user or ``None`` if unauthenticated.
-
-    Returns
-    -------
-    List[Dict[str, Any]]
-        A list of dictionaries each containing an ``owner`` identifier, a
-        human-friendly ``full_name`` (if available) and their available
-        ``accounts``.
-    """
-
-    if config.app_env == "aws":
-        try:
-            aws_results = _list_aws_plots(current_user)
-            if data_root is None or aws_results:
-                return aws_results
-        except ProviderUnavailable:
-            logger.warning(
-                "data_loader.list_plots_provider_unavailable",
-                extra={
-                    "event": "data_loader.list_plots_provider_unavailable",
-                    "current_user": sanitise_log_value(current_user),
-                    "fallback_to_local": data_root is not None,
-                    "provider": "s3",
-                },
-                exc_info=True,
-            )
-            if data_root is None:
-                raise
-        local_loader = _list_local_plots
-        try:
-            params = inspect.signature(local_loader).parameters
-        except (TypeError, ValueError):  # pragma: no cover - defensive
-            params = {}
-        if "apply_default_full_name" in params:
-            return local_loader(
-                data_root,
-                current_user,
-                apply_default_full_name=False,
-            )
-        return local_loader(data_root, current_user)
+def _call_local_loader(data_root: Optional[Path], current_user: Optional[str]) -> List[Dict[str, Any]]:
+    """Invoke ``_list_local_plots``, tolerating simplified test doubles."""
 
     local_loader = _list_local_plots
     try:
@@ -903,6 +855,75 @@ def list_plots(
             apply_default_full_name=False,
         )
     return local_loader(data_root, current_user)
+
+
+def _validate_owner_summaries(raw_results: List[Dict[str, Any]]) -> List[OwnerSummaryRecord]:
+    """Validate raw owner-summary dicts, dropping (and logging) invalid entries.
+
+    A single malformed entry (e.g. a missing ``owner``) should not take down
+    the whole listing for every other owner, so validation failures are
+    skipped individually rather than raised.
+    """
+
+    validated: List[OwnerSummaryRecord] = []
+    for entry in raw_results:
+        try:
+            validated.append(OwnerSummaryRecord.model_validate(entry))
+        except ValidationError:
+            logger.warning(
+                "data_loader.list_plots_invalid_entry",
+                extra={"event": "data_loader.list_plots_invalid_entry"},
+                exc_info=True,
+            )
+    return validated
+
+
+def list_plots(
+    data_root: Optional[Path] = None,
+    current_user: Optional[str] = None,
+) -> List[OwnerSummaryRecord]:
+    """Public helper to list available account plots.
+
+    Parameters
+    ----------
+    data_root:
+        Optional base directory containing account data when running locally.
+    current_user:
+        Username of the authenticated user or ``None`` if unauthenticated.
+
+    Returns
+    -------
+    List[OwnerSummaryRecord]
+        A typed owner summary for each discovered plot, each containing an
+        ``owner`` identifier, a human-friendly ``full_name`` (if available)
+        and their available ``accounts``.
+    """
+
+    raw_results: List[Dict[str, Any]]
+
+    if config.app_env == "aws":
+        try:
+            aws_results = _list_aws_plots(current_user)
+            if data_root is None or aws_results:
+                return _validate_owner_summaries(aws_results)
+        except ProviderUnavailable:
+            logger.warning(
+                "data_loader.list_plots_provider_unavailable",
+                extra={
+                    "event": "data_loader.list_plots_provider_unavailable",
+                    "current_user": sanitise_log_value(current_user),
+                    "fallback_to_local": data_root is not None,
+                    "provider": "s3",
+                },
+                exc_info=True,
+            )
+            if data_root is None:
+                raise
+        raw_results = _call_local_loader(data_root, current_user)
+    else:
+        raw_results = _call_local_loader(data_root, current_user)
+
+    return _validate_owner_summaries(raw_results)
 
 
 def load_account_record(

--- a/backend/common/portfolio.py
+++ b/backend/common/portfolio.py
@@ -135,10 +135,10 @@ def build_owner_portfolio(
     today = calc.today
     pricing_date = calc.reporting_date
 
-    plots = [p for p in list_plots(accounts_root) if p.get("owner") == owner]
+    plots = [p for p in list_plots(accounts_root) if p.owner == owner]
     if not plots:
         raise FileNotFoundError(f"No plot for owner '{owner}'")
-    accounts_meta = plots[0].get("accounts", [])
+    accounts_meta = plots[0].accounts
 
     trades = load_trades(owner, accounts_root)
     trades_this = 0

--- a/backend/common/portfolio_loader.py
+++ b/backend/common/portfolio_loader.py
@@ -18,6 +18,7 @@ from typing import Any, cast
 
 _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
+from backend.common.account_models import OwnerSummaryRecord
 from backend.common.data_loader import (
     list_plots,  # owner -> ["isa", "sipp", ...]
     load_account,  # (owner, account) -> parsed JSON
@@ -53,17 +54,17 @@ def _load_accounts_for_owner(owner: str, acct_names: list[str]) -> list[dict]:
     return accounts
 
 
-def _build_owner_portfolio(owner_summary: dict) -> dict:
+def _build_owner_portfolio(owner_summary: OwnerSummaryRecord) -> dict:
     """
-    owner_summary ≅ {'owner': 'alex', 'accounts': ['isa', 'sipp']}
+    owner_summary ≅ OwnerSummaryRecord(owner='alex', accounts=['isa', 'sipp'])
     returns        ≅ {
                         'owner'   : 'alex',
                         'person'  : {...},          # person.json (may be {})
                         'accounts': [ {...}, ... ]  # parsed account JSON
                       }
     """
-    owner = owner_summary["owner"]
-    names = owner_summary.get("accounts", [])
+    owner = owner_summary.owner
+    names = owner_summary.accounts
 
     return {
         "owner": owner,

--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -70,7 +70,7 @@ def _known_owners(accounts_root) -> KnownOwnerSet:
         allow_demo_injection = True
 
     for entry in entries:
-        owner = (entry.get("owner") or "").strip()
+        owner = (entry.owner or "").strip()
         if owner:
             owners.add(owner.lower())
 

--- a/backend/routes/nudges.py
+++ b/backend/routes/nudges.py
@@ -17,7 +17,7 @@ def _validate_owner(
     allow_unknown: bool = False,
 ) -> None:
     try:
-        owners = {o["owner"] for o in data_loader.list_plots(request.app.state.accounts_root)}
+        owners = {o.owner for o in data_loader.list_plots(request.app.state.accounts_root)}
     except data_loader.ProviderUnavailable as exc:
         raise HTTPException(status_code=503, detail="Account data provider unavailable") from exc
     if user not in owners and not allow_unknown:

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -472,10 +472,7 @@ def _list_owner_summaries(
 
     accounts_root = resolve_accounts_root(request, allow_missing=True)
 
-    raw_entries = [
-        OwnerSummaryRecord.model_validate(entry)
-        for entry in data_loader.list_plots(accounts_root, current_user)
-    ]
+    raw_entries = data_loader.list_plots(accounts_root, current_user)
     summaries: List[Dict[str, Any]] = []
 
     for entry in raw_entries:

--- a/backend/routes/scenario.py
+++ b/backend/routes/scenario.py
@@ -23,7 +23,7 @@ def run_scenario(
     """Apply a percentage price shock to all portfolios for ``ticker``."""
     results = []
     try:
-        owners = [p["owner"] for p in list_plots() if p.get("accounts")]
+        owners = [p.owner for p in list_plots() if p.accounts]
     except ProviderUnavailable as exc:
         raise HTTPException(status_code=503, detail="Account data provider unavailable") from exc
     for owner in owners:
@@ -95,7 +95,7 @@ def run_historical_scenario(
 
     results = []
     try:
-        owners = [p["owner"] for p in list_plots() if p.get("accounts")]
+        owners = [p.owner for p in list_plots() if p.accounts]
     except ProviderUnavailable as exc:
         raise HTTPException(status_code=503, detail="Account data provider unavailable") from exc
     for owner in owners:

--- a/tests/backend/common/test_account_models.py
+++ b/tests/backend/common/test_account_models.py
@@ -1,0 +1,102 @@
+import pytest
+from pydantic import ValidationError
+
+from backend.common.account_models import AccountRecord, OwnerSummaryRecord, PersonMetadata
+
+
+class TestOwnerSummaryRecord:
+    def test_missing_owner_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            OwnerSummaryRecord.model_validate({})
+
+    def test_blank_owner_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            OwnerSummaryRecord.model_validate({"owner": "   "})
+
+    def test_none_owner_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            OwnerSummaryRecord.model_validate({"owner": None})
+
+    def test_defaults_when_optional_fields_missing(self) -> None:
+        record = OwnerSummaryRecord.model_validate({"owner": "alice"})
+
+        assert record.accounts == []
+        assert record.full_name is None
+        assert record.email is None
+        assert record.has_transactions_artifact is False
+
+    def test_non_string_account_items_are_dropped(self) -> None:
+        record = OwnerSummaryRecord.model_validate(
+            {"owner": "alice", "accounts": ["isa", 1, None, {"slug": "sipp"}, "  "]}
+        )
+
+        assert record.accounts == ["isa"]
+
+    def test_accounts_must_be_a_list(self) -> None:
+        with pytest.raises(ValidationError):
+            OwnerSummaryRecord.model_validate({"owner": "alice", "accounts": "isa"})
+
+    def test_duplicate_accounts_are_deduped_case_insensitively(self) -> None:
+        record = OwnerSummaryRecord.model_validate(
+            {"owner": "alice", "accounts": ["isa", "ISA", "Isa", "sipp"]}
+        )
+
+        assert record.accounts == ["isa", "sipp"]
+
+    def test_unknown_extra_fields_are_ignored(self) -> None:
+        record = OwnerSummaryRecord.model_validate({"owner": "alice", "unexpected": "value"})
+
+        assert not hasattr(record, "unexpected")
+
+
+class TestPersonMetadata:
+    def test_all_fields_optional(self) -> None:
+        record = PersonMetadata.model_validate({})
+
+        assert record.owner is None
+        assert record.full_name is None
+        assert record.holdings == []
+        assert record.viewers == []
+
+    def test_blank_strings_normalise_to_none(self) -> None:
+        record = PersonMetadata.model_validate({"full_name": "   "})
+
+        assert record.full_name is None
+
+    def test_non_string_optional_field_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            PersonMetadata.model_validate({"email": 123})
+
+    def test_dob_datetime_normalises_to_isoformat(self) -> None:
+        import datetime as dt
+
+        record = PersonMetadata.model_validate({"dob": dt.date(1990, 1, 2)})
+
+        assert record.dob == "1990-01-02"
+
+    def test_viewers_deduped_case_insensitively(self) -> None:
+        record = PersonMetadata.model_validate({"viewers": ["Bob", "bob", "alice", ""]})
+
+        assert record.viewers == ["Bob", "alice"]
+
+    def test_viewers_must_be_list(self) -> None:
+        with pytest.raises(ValidationError):
+            PersonMetadata.model_validate({"viewers": "bob"})
+
+
+class TestAccountRecord:
+    def test_defaults_when_fields_missing(self) -> None:
+        record = AccountRecord.model_validate({})
+
+        assert record.account_type is None
+        assert record.holdings == []
+        assert record.approvals == []
+
+    def test_extra_keys_are_preserved(self) -> None:
+        record = AccountRecord.model_validate({"account_type": "ISA", "custom_field": "kept"})
+
+        assert record.model_extra["custom_field"] == "kept"
+
+    def test_holdings_must_be_list(self) -> None:
+        with pytest.raises(ValidationError):
+            AccountRecord.model_validate({"holdings": "not-a-list"})

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 import backend.common.data_loader as data_loader
+from backend.common.account_models import OwnerSummaryRecord
 from backend.common.data_loader import (
     DATA_BUCKET_ENV,
     ResolvedPaths,
@@ -558,10 +559,10 @@ class TestListLocalPlots:
         result = list_plots(data_root=explicit_root, current_user=None)
 
         assert result == [
-            {"owner": "carol", "accounts": ["gamma"]},
+            OwnerSummaryRecord(owner="carol", accounts=["gamma"]),
         ]
-        assert all("full_name" not in entry for entry in result)
-        assert all(entry["owner"] not in {"demo", ".idea"} for entry in result)
+        assert all(entry.full_name is None for entry in result)
+        assert all(entry.owner not in {"demo", ".idea"} for entry in result)
 
     def test_allows_access_when_user_matches_owner_email(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -772,7 +773,7 @@ def test_list_plots_prefers_aws_results(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     result = list_plots(data_root=None, current_user="user@example.com")
 
-    assert result == expected
+    assert result == [OwnerSummaryRecord.model_validate(entry) for entry in expected]
 
 
 def test_list_plots_aws_falls_back_to_local(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -799,8 +800,36 @@ def test_list_plots_aws_falls_back_to_local(monkeypatch: pytest.MonkeyPatch, tmp
 
     result = list_plots(data_root=tmp_path, current_user="viewer")
 
-    assert result == [{"owner": "local", "full_name": "local", "accounts": ["isa"]}]
+    assert result == [OwnerSummaryRecord(owner="local", full_name="local", accounts=["isa"])]
     assert captured["call"] == (tmp_path, "viewer")
+
+
+def test_list_plots_skips_invalid_entries_without_failing_whole_batch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A single malformed owner entry must not take down the whole listing."""
+
+    cfg = Config()
+    cfg.app_env = "local"
+    cfg.disable_auth = True
+    cfg.repo_root = tmp_path
+    cfg.accounts_root = tmp_path / "accounts"
+    monkeypatch.setattr("backend.common.data_loader.config", cfg)
+
+    monkeypatch.setattr(
+        "backend.common.data_loader._list_local_plots",
+        lambda data_root, current_user=None: [
+            {"owner": "carol", "accounts": ["gamma"]},
+            {"owner": None},
+            {},
+        ],
+    )
+
+    with caplog.at_level("WARNING", logger="backend.common.data_loader"):
+        result = list_plots(data_root=tmp_path, current_user=None)
+
+    assert result == [OwnerSummaryRecord(owner="carol", accounts=["gamma"])]
+    assert "data_loader.list_plots_invalid_entry" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/common/test_data_provider_parity.py
+++ b/tests/backend/common/test_data_provider_parity.py
@@ -126,14 +126,14 @@ def _configure_aws(
     )
 
 
-def _normalise_owner_listing(entries: list[dict[str, object]]) -> list[dict[str, object]]:
+def _normalise_owner_listing(entries: list) -> list[dict[str, object]]:
     return sorted(
         [
             {
-                "owner": str(entry["owner"]).lower(),
-                "accounts": sorted(str(account).lower() for account in entry.get("accounts", [])),
-                "full_name": entry.get("full_name"),
-                "email": entry.get("email"),
+                "owner": entry.owner.lower(),
+                "accounts": sorted(account.lower() for account in entry.accounts),
+                "full_name": entry.full_name,
+                "email": entry.email,
             }
             for entry in entries
         ],

--- a/tests/backend/common/test_portfolio_builder.py
+++ b/tests/backend/common/test_portfolio_builder.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 import pytest
 
-from backend.common.account_models import AccountRecord
+from backend.common.account_models import AccountRecord, OwnerSummaryRecord
 from backend.common.portfolio import build_owner_portfolio
 from backend.common.user_config import UserConfig
 
@@ -31,7 +31,7 @@ def fixture_portfolio_stubs(monkeypatch, today):
     ]
 
     def fake_list_plots(accounts_root=None):  # noqa: ARG001 - signature matches target
-        return [{"owner": owner, "accounts": [{"slug": "account-one"}]}]
+        return [OwnerSummaryRecord(owner=owner, accounts=["account-one"])]
 
     def fake_load_trades(owner_name, accounts_root=None):  # noqa: ARG001
         return [

--- a/tests/backend/routes/test_compliance.py
+++ b/tests/backend/routes/test_compliance.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
+from backend.common.account_models import OwnerSummaryRecord
 from backend.common.errors import AppError, OwnerNotFoundError
 from backend.routes import compliance as compliance_module
 
@@ -52,11 +53,9 @@ def test_known_owners_aggregates_plot_metadata(tmp_path, monkeypatch):
         compliance_module.data_loader,
         "list_plots",
         lambda root: [
-            {"owner": "Alice"},
-            {"owner": "Bob"},
-            {"owner": "ALICE"},
-            {"owner": None},
-            {},
+            OwnerSummaryRecord(owner="Alice"),
+            OwnerSummaryRecord(owner="Bob"),
+            OwnerSummaryRecord(owner="ALICE"),
         ],
     )
     monkeypatch.setattr(
@@ -112,7 +111,7 @@ def test_known_owners_adds_demo_owner_when_available(tmp_path, monkeypatch):
     monkeypatch.setattr(
         compliance_module.data_loader,
         "list_plots",
-        lambda _: [{"owner": "Alice"}],
+        lambda _: [OwnerSummaryRecord(owner="Alice")],
     )
     monkeypatch.setattr(
         compliance_module.data_loader,
@@ -135,7 +134,7 @@ def test_known_owners_uses_metadata_when_root_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(
         compliance_module.data_loader,
         "list_plots",
-        lambda _: [{"owner": "Alice"}],
+        lambda _: [OwnerSummaryRecord(owner="Alice")],
     )
     monkeypatch.setattr(
         compliance_module.data_loader,

--- a/tests/backend/routes/test_portfolio_helpers.py
+++ b/tests/backend/routes/test_portfolio_helpers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from backend.common.account_models import OwnerSummaryRecord
 from backend.routes import portfolio
 
 
@@ -112,7 +113,7 @@ def test_list_owner_summaries_appends_demo_when_missing(monkeypatch: pytest.Monk
     def fake_list_plots(root: Path, current_user):
         call_counter["count"] += 1
         if call_counter["count"] == 1:
-            return [{"owner": "alex", "accounts": ["isa"]}]
+            return [OwnerSummaryRecord(owner="alex", accounts=["isa"])]
         return []
 
     def fake_load_person_meta(owner: str, root: Path) -> dict:

--- a/tests/backend/test_async_endpoints.py
+++ b/tests/backend/test_async_endpoints.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 
 from backend.app import create_app
+from backend.common.account_models import OwnerSummaryRecord
 
 
 @pytest.mark.asyncio
@@ -13,8 +14,8 @@ async def test_auth_alerts_portfolio(monkeypatch):
     monkeypatch.setattr(
         "backend.common.data_loader.list_plots",
         lambda root, current_user=None: [
-            {"owner": "alice", "accounts": ["brokerage"]},
-            {"owner": "demo", "accounts": ["demo"]},
+            OwnerSummaryRecord(owner="alice", accounts=["brokerage"]),
+            OwnerSummaryRecord(owner="demo", accounts=["demo"]),
         ],
     )
     transport = ASGITransport(app=app)

--- a/tests/backend/test_scenario_routes.py
+++ b/tests/backend/test_scenario_routes.py
@@ -2,13 +2,15 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import pytest
 
+from backend.common.account_models import OwnerSummaryRecord
 from backend.routes import scenario
 
 
 def _client(monkeypatch, list_plots_return, build_map=None):
     app = FastAPI()
     app.include_router(scenario.router)
-    monkeypatch.setattr("backend.routes.scenario.list_plots", lambda: list_plots_return)
+    records = [OwnerSummaryRecord.model_validate(entry) for entry in list_plots_return]
+    monkeypatch.setattr("backend.routes.scenario.list_plots", lambda: records)
 
     def build(owner):
         action = None
@@ -40,7 +42,7 @@ def _client(monkeypatch, list_plots_return, build_map=None):
 
 
 def test_run_scenario_basic(monkeypatch):
-    client = _client(monkeypatch, [{"owner": "alice", "accounts": [1]}])
+    client = _client(monkeypatch, [{"owner": "alice", "accounts": ["acc1"]}])
     resp = client.get("/scenario", params={"ticker": "ABC", "pct": 0.1})
     assert resp.status_code == 200
     data = resp.json()
@@ -50,7 +52,7 @@ def test_run_scenario_basic(monkeypatch):
 
 def test_run_scenario_skips_missing_portfolio(monkeypatch):
     build_map = {"alice": "error"}
-    client = _client(monkeypatch, [{"owner": "alice", "accounts": [1]}], build_map)
+    client = _client(monkeypatch, [{"owner": "alice", "accounts": ["acc1"]}], build_map)
     resp = client.get("/scenario", params={"ticker": "ABC", "pct": 0.1})
     assert resp.status_code == 200
     assert resp.json() == []
@@ -62,7 +64,7 @@ def test_run_scenario_derives_baseline(monkeypatch):
             "accounts": [{"value_estimate_gbp": 50}, {"value_estimate_gbp": 70}],
         }
     }
-    client = _client(monkeypatch, [{"owner": "bob", "accounts": [1]}], build_map)
+    client = _client(monkeypatch, [{"owner": "bob", "accounts": ["acc1"]}], build_map)
     resp = client.get("/scenario", params={"ticker": "XYZ", "pct": 0.1})
     assert resp.status_code == 200
     data = resp.json()[0]
@@ -72,7 +74,7 @@ def test_run_scenario_derives_baseline(monkeypatch):
 
 @pytest.mark.xfail(reason="Scenario data structure changed")
 def test_historical_scenario_parses_tokens(monkeypatch):
-    client = _client(monkeypatch, [{"owner": "alice", "accounts": [1]}])
+    client = _client(monkeypatch, [{"owner": "alice", "accounts": ["acc1"]}])
     resp = client.get(
         "/scenario/historical", params={"event_id": "evt", "horizons": "1d,1w"}
     )

--- a/tests/common/test_portfolio_loader.py
+++ b/tests/common/test_portfolio_loader.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from backend.common import portfolio_loader
+from backend.common.account_models import OwnerSummaryRecord
 from backend.common.portfolio_loader import rebuild_account_holdings
 
 
@@ -82,13 +83,13 @@ def test_load_accounts_for_owner_json_error(
 
 
 @pytest.fixture
-def patched_portfolio_loader(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+def patched_portfolio_loader(monkeypatch: pytest.MonkeyPatch) -> list[OwnerSummaryRecord]:
     owners = [
-        {"owner": "alex", "accounts": ["isa"]},
-        {"owner": "beth", "accounts": ["sipp", "taxable"]},
+        OwnerSummaryRecord(owner="alex", accounts=["isa"]),
+        OwnerSummaryRecord(owner="beth", accounts=["sipp", "taxable"]),
     ]
 
-    def _fake_list_plots() -> list[dict[str, object]]:
+    def _fake_list_plots() -> list[OwnerSummaryRecord]:
         return owners
 
     def _fake_person(owner: str) -> dict[str, str]:
@@ -108,20 +109,20 @@ def patched_portfolio_loader(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, 
     return owners
 
 
-def test_list_portfolios_aggregates_owners(patched_portfolio_loader: list[dict[str, object]]) -> None:
+def test_list_portfolios_aggregates_owners(patched_portfolio_loader: list[OwnerSummaryRecord]) -> None:
     result = portfolio_loader.list_portfolios()
 
     expected = [
         {
-            "owner": row["owner"],
-            "person": {"owner": row["owner"], "full_name": row["owner"].title()},
+            "owner": row.owner,
+            "person": {"owner": row.owner, "full_name": row.owner.title()},
             "accounts": [
                 {
-                    "owner": row["owner"],
+                    "owner": row.owner,
                     "account": account.upper(),
-                    "path": f"{row['owner']}/{account}.json",
+                    "path": f"{row.owner}/{account}.json",
                 }
-                for account in row["accounts"]
+                for account in row.accounts
             ],
         }
         for row in patched_portfolio_loader
@@ -131,7 +132,7 @@ def test_list_portfolios_aggregates_owners(patched_portfolio_loader: list[dict[s
 
 
 def test_load_portfolio_case_insensitive(
-    patched_portfolio_loader: list[dict[str, object]]
+    patched_portfolio_loader: list[OwnerSummaryRecord]
 ) -> None:
     all_portfolios = portfolio_loader.list_portfolios()
 

--- a/tests/routes/test_nudges_route.py
+++ b/tests/routes/test_nudges_route.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 import backend.routes.nudges as nudges
+from backend.common.account_models import OwnerSummaryRecord
 
 
 def make_client(tmp_path, monkeypatch, owners=None) -> TestClient:
@@ -15,7 +16,7 @@ def make_client(tmp_path, monkeypatch, owners=None) -> TestClient:
     monkeypatch.setattr(
         nudges.data_loader,
         "list_plots",
-        lambda root: [{"owner": owner} for owner in owners],
+        lambda root: [OwnerSummaryRecord(owner=owner) for owner in owners],
     )
 
     return TestClient(app)
@@ -27,7 +28,7 @@ def test_validate_owner_unknown_user(tmp_path, monkeypatch):
     monkeypatch.setattr(
         nudges.data_loader,
         "list_plots",
-        lambda root: [{"owner": "alice"}],
+        lambda root: [OwnerSummaryRecord(owner="alice")],
     )
     request = Request({"type": "http", "app": app})
     with pytest.raises(HTTPException):

--- a/tests/routes/test_scenario.py
+++ b/tests/routes/test_scenario.py
@@ -1,15 +1,16 @@
 import pytest
 from fastapi import HTTPException
 
+from backend.common.account_models import OwnerSummaryRecord
 from backend.routes import scenario
 
 
 def test_run_scenario_multiple_owners_and_missing_data(monkeypatch):
     plots = [
-        {"owner": "alice", "full_name": "Alice Example", "accounts": [{"id": 1}]},
-        {"owner": "bob", "full_name": "Bob Example", "accounts": [{"id": 2}]},
-        {"owner": "carol", "full_name": "Carol Example", "accounts": []},
-        {"owner": "dave", "full_name": "Dave Example"},
+        OwnerSummaryRecord(owner="alice", full_name="Alice Example", accounts=["acc1"]),
+        OwnerSummaryRecord(owner="bob", full_name="Bob Example", accounts=["acc2"]),
+        OwnerSummaryRecord(owner="carol", full_name="Carol Example", accounts=[]),
+        OwnerSummaryRecord(owner="dave", full_name="Dave Example"),
     ]
 
     monkeypatch.setattr(scenario, "list_plots", lambda: plots)
@@ -60,7 +61,7 @@ def test_run_historical_scenario_valid_horizons(monkeypatch):
     monkeypatch.setattr(
         scenario,
         "list_plots",
-        lambda: [{"owner": "alice", "full_name": "Alice Example", "accounts": [{"id": 1}]}],
+        lambda: [OwnerSummaryRecord(owner="alice", full_name="Alice Example", accounts=["acc1"])],
     )
 
     def fake_build_owner_portfolio(owner, *, pricing_date=None):

--- a/tests/test_compliance_route.py
+++ b/tests/test_compliance_route.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.common import compliance
+from backend.common.account_models import OwnerSummaryRecord
 
 
 def _setup_app(tmp_path):
@@ -165,7 +166,7 @@ def test_validate_trade_accepts_owner_directories_even_when_filtered(tmp_path, m
 
     monkeypatch.setattr(
         "backend.common.data_loader.list_plots",
-        lambda accounts_root: [{"owner": "alice"}],
+        lambda accounts_root: [OwnerSummaryRecord(owner="alice")],
     )
     monkeypatch.setattr(
         "backend.common.compliance.get_instrument_meta",

--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -550,7 +550,7 @@ def test_extract_person_meta_non_list_viewers_drops_key_preserves_rest(monkeypat
 def test_list_plots_delegates_to_aws(monkeypatch):
     monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
 
-    sentinel = object()
+    sentinel = [{"owner": "aws-owner", "accounts": ["isa"]}]
 
     def fake_aws(current_user=None):
         assert current_user == "alice"
@@ -558,13 +558,14 @@ def test_list_plots_delegates_to_aws(monkeypatch):
 
     monkeypatch.setattr(dl, "_list_aws_plots", fake_aws)
 
-    assert dl.list_plots(current_user="alice") is sentinel
+    result = dl.list_plots(current_user="alice")
+    assert result == [dl.OwnerSummaryRecord(owner="aws-owner", accounts=["isa"])]
 
 
 def test_list_plots_uses_local_when_not_aws(monkeypatch):
     monkeypatch.setattr(dl.config, "app_env", "local", raising=False)
 
-    sentinel = object()
+    sentinel = [{"owner": "local-owner", "accounts": ["sipp"]}]
 
     def fake_local(data_root=None, current_user=None):
         assert data_root == "root"
@@ -573,4 +574,5 @@ def test_list_plots_uses_local_when_not_aws(monkeypatch):
 
     monkeypatch.setattr(dl, "_list_local_plots", fake_local)
 
-    assert dl.list_plots(data_root="root", current_user="bob") is sentinel
+    result = dl.list_plots(data_root="root", current_user="bob")
+    assert result == [dl.OwnerSummaryRecord(owner="local-owner", accounts=["sipp"])]

--- a/tests/test_scenario_route.py
+++ b/tests/test_scenario_route.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import json
 
 from backend.app import create_app
+from backend.common.account_models import OwnerSummaryRecord
 from backend.routes import scenario as scenario_route
 
 
@@ -18,7 +19,7 @@ def test_scenario_route(monkeypatch):
     monkeypatch.setattr(
         scenario_route,
         "list_plots",
-        lambda: [{"owner": "alice", "full_name": "Alice Example", "accounts": [{}]}],
+        lambda: [OwnerSummaryRecord(owner="alice", full_name="Alice Example", accounts=["acc1"])],
     )
     monkeypatch.setattr(
         scenario_route,
@@ -61,7 +62,7 @@ def test_historical_scenario_route(monkeypatch):
     monkeypatch.setattr(
         scenario_route,
         "list_plots",
-        lambda: [{"owner": "alice", "full_name": "Alice Example", "accounts": [{}]}],
+        lambda: [OwnerSummaryRecord(owner="alice", full_name="Alice Example", accounts=["acc1"])],
     )
     monkeypatch.setattr(
         scenario_route,


### PR DESCRIPTION
## Summary
- `data_loader.list_plots()` now validates raw owner-summary dicts against the existing `OwnerSummaryRecord` Pydantic model at the load boundary and returns `List[OwnerSummaryRecord]` instead of `List[Dict[str, Any]]`. A single malformed entry is dropped (with a logged warning) rather than failing the whole batch.
- Updated the six call sites that consumed the old dict shape (`routes/portfolio.py`, `routes/scenario.py`, `routes/nudges.py`, `routes/compliance.py`, `common/portfolio.py`, `common/portfolio_loader.py`) to use attribute access (`entry.owner`, `entry.accounts`) instead of `dict.get()` chains, and removed a now-redundant re-validation step in `routes/portfolio.py`.
- Added `tests/backend/common/test_account_models.py` covering `OwnerSummaryRecord`/`PersonMetadata`/`AccountRecord` edge cases (missing/blank owner, non-string account items, dedupe, extra fields), plus a `list_plots` test verifying one bad entry doesn't take down the whole listing.
- Updated ~14 existing tests that monkeypatched `list_plots` with raw dicts to use `OwnerSummaryRecord` instead.

Scope note: the broader ask in #4412 (typed `PersonMetadata`/`AccountRecord` models) was already delivered by #4411 — `load_person_metadata`/`load_account_record` and `routes/pension.py` were already typed. The remaining gap was specifically `list_plots()` still returning untyped dicts, so this PR closes that gap rather than duplicating existing models.

## Test plan
- [x] `pytest tests/` — 2806 passed, 0 failed (one pre-existing unrelated contract-schema failure confirmed present on `main` too)
- [x] `black`/`ruff` clean on all touched files

Closes #4412