### PR TITLE
test(contracts): guard generated API contract schema against drift

### DIFF
--- a/frontend/src/contracts/generated/api-contract-schemas.v1.json
+++ b/frontend/src/contracts/generated/api-contract-schemas.v1.json
@@ -473,7 +473,14 @@
                         ]
                       },
                       "days_held": {
-                        "type": "number"
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       },
                       "sell_eligible": {
                         "type": "boolean"
@@ -570,9 +577,7 @@
           "as_of",
           "members",
           "total_value_estimate_gbp",
-          "accounts",
-          "members_summary",
-          "subtotals_by_account_type"
+          "accounts"
         ],
         "additionalProperties": false
       }
@@ -854,7 +859,14 @@
                         ]
                       },
                       "days_held": {
-                        "type": "number"
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       },
                       "sell_eligible": {
                         "type": "boolean"

--- a/frontend/tests/unit/apiContractSchemaGeneration.test.ts
+++ b/frontend/tests/unit/apiContractSchemaGeneration.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { API_CONTRACT_VERSION, apiContractJsonSchemas } from "@/contracts/apiContracts";
+
+// Mirrors the payload shape written by frontend/scripts/generate-api-contract-schemas.mjs.
+// Keep this endpoint list in sync with that script.
+function buildExpectedBundle() {
+  return {
+    version: API_CONTRACT_VERSION,
+    endpoints: {
+      config: { path: "/config", schema: apiContractJsonSchemas.config },
+      owners: { path: "/owners", schema: apiContractJsonSchemas.owners },
+      groups: { path: "/groups", schema: apiContractJsonSchemas.groups },
+      groupPortfolio: { path: "/portfolio-group/all", schema: apiContractJsonSchemas.groupPortfolio },
+      portfolio: { path: "/portfolio/alice", schema: apiContractJsonSchemas.portfolio },
+      transactions: { path: "/transactions", schema: apiContractJsonSchemas.transactions },
+    },
+  };
+}
+
+const generatedSchemaPath = path.resolve(
+  process.cwd(),
+  "src/contracts/generated/api-contract-schemas.v1.json",
+);
+
+describe("generated API contract schema bundle", () => {
+  it("matches what generate-api-contract-schemas.mjs would produce from apiContracts.ts", () => {
+    const committed = JSON.parse(readFileSync(generatedSchemaPath, "utf8"));
+    const expected = buildExpectedBundle();
+
+    // Structural comparison (not byte-for-byte) so trailing-newline/formatting
+    // differences don't mask a real schema drift, and vice versa.
+    expect(committed).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #4414 asked for versioned response schemas / typed contracts for the SPA's core endpoints (config, owners, groups, portfolio, transactions), with backend + frontend tests protecting them and CI failing on undocumented drift.

Investigation found this is already substantially implemented on `main` via two existing mechanisms:
- `backend/contracts_spa.py` + `frontend/src/contracts/spa.ts` + `tests/backend/test_spa_response_contracts.py`
- `frontend/src/contracts/apiContracts.ts` (Zod, generates JSON Schema) + `tests/contracts/test_api_response_contracts.py`, which hits the live FastAPI app and validates real responses against the schema bundle in `frontend/src/contracts/generated/api-contract-schemas.v1.json`

The one concrete gap: nothing verified that the **committed generated schema bundle** actually matches what `frontend/scripts/generate-api-contract-schemas.mjs` would currently produce from `apiContracts.ts` — it could silently drift from its own source of truth.

- Added `frontend/tests/unit/apiContractSchemaGeneration.test.ts`, which rebuilds the schema bundle in-process from `apiContractJsonSchemas`/`API_CONTRACT_VERSION` and asserts it deep-equals the committed JSON file.
- Running the generator surfaced real pre-existing drift: `days_held` had lost its nullable variant, and `groupPortfolio`'s optional `members_summary`/`subtotals_by_account_type` fields were incorrectly marked required. Regenerated the committed file to fix both.

## Out of scope (flagged separately)

`tests/contracts/test_api_response_contracts.py::test_live_endpoints_match_versioned_contract_schema[groupPortfolio-/portfolio-group/all]` already fails on `main` (verified via `git stash` before any of my changes) — the live `/portfolio-group/all` response includes holding fields (`cost_basis_source`, `eligible_on`, `unrealised_gain_gbp`, `unrealized_gain_gbp`, `asset_class`) not declared in the contract schema. This is a genuine, separate drift issue that requires deciding the correct field types from the real route, which is out of scope for this drift-guard change (issue #4414 explicitly says not to redesign existing endpoint shapes). Spun off as a follow-up task.

## Test plan

- [x] `cd frontend && npx vitest run apiContractSchemaGeneration apiContracts.test` — both pass
- [x] `cd frontend && npx eslint --format unix tests/unit/apiContractSchemaGeneration.test.ts` — clean
- [x] `cd frontend && npx tsc -b --noEmit` — clean
- [x] `python -m pytest tests/contracts/test_api_response_contracts.py tests/backend/test_spa_response_contracts.py -q --no-cov -k "not groupPortfolio"` — 15 passed
- [x] Confirmed the pre-existing `groupPortfolio` failure exists on `main` independent of this change

Closes #4414

🤖 Generated with [Claude Code](https://claude.com/claude-code)