### PR TITLE
fix(contracts): add missing holding fields to close schema drift gap

### DIFF
--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -81,6 +81,11 @@ export const holdingContractSchema = z.object({
   sell_eligible: z.boolean().optional(),
   days_until_eligible: nullableNumber.optional(),
   next_eligible_sell_date: nullableString.optional(),
+  eligible_on: nullableString.optional(),
+  cost_basis_source: nullableString.optional(),
+  asset_class: nullableString.optional(),
+  unrealised_gain_gbp: nullableNumber.optional(),
+  unrealized_gain_gbp: nullableNumber.optional(),
 });
 
 export const accountContractSchema = z.object({

--- a/frontend/src/contracts/generated/api-contract-schemas.v1.json
+++ b/frontend/src/contracts/generated/api-contract-schemas.v1.json
@@ -473,7 +473,14 @@
                         ]
                       },
                       "days_held": {
-                        "type": "number"
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       },
                       "sell_eligible": {
                         "type": "boolean"
@@ -492,6 +499,56 @@
                         "anyOf": [
                           {
                             "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "eligible_on": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "cost_basis_source": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "asset_class": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "unrealised_gain_gbp": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "unrealized_gain_gbp": {
+                        "anyOf": [
+                          {
+                            "type": "number"
                           },
                           {
                             "type": "null"
@@ -570,9 +627,7 @@
           "as_of",
           "members",
           "total_value_estimate_gbp",
-          "accounts",
-          "members_summary",
-          "subtotals_by_account_type"
+          "accounts"
         ],
         "additionalProperties": false
       }
@@ -854,7 +909,14 @@
                         ]
                       },
                       "days_held": {
-                        "type": "number"
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       },
                       "sell_eligible": {
                         "type": "boolean"
@@ -873,6 +935,56 @@
                         "anyOf": [
                           {
                             "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "eligible_on": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "cost_basis_source": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "asset_class": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "unrealised_gain_gbp": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "unrealized_gain_gbp": {
+                        "anyOf": [
+                          {
+                            "type": "number"
                           },
                           {
                             "type": "null"


### PR DESCRIPTION
Closes #4883

## Summary
- `groupPortfolioContractSchema`'s nested `holdingContractSchema` (in `frontend/src/contracts/apiContracts.ts`) was missing `cost_basis_source`, `eligible_on`, `unrealised_gain_gbp`, `unrealized_gain_gbp`, and `asset_class` — real fields already returned by the live `/portfolio-group/all` response (see `backend/common/holding_utils.py`).
- Since `holdingContractSchema` has no `.passthrough()`, the generated JSON Schema set `additionalProperties: false`, so `tests/contracts/test_api_response_contracts.py::test_live_endpoints_match_versioned_contract_schema[groupPortfolio-/portfolio-group/all]` failed against the live response.
- Added the fields as nullable/optional (matching the nullability seen in `holding_utils.py`, e.g. these are set to `None` for cash/zero-unit holdings) and regenerated `frontend/src/contracts/generated/api-contract-schemas.v1.json` via `node --experimental-strip-types frontend/scripts/generate-api-contract-schemas.mjs`.
- No route response shapes were changed — only the schema was extended to reflect what the route already returns.

## Test plan
- [x] `python -m pytest tests/contracts/test_api_response_contracts.py -q --no-cov` — 16 passed
- [x] `npx vitest run apiContracts.test apiContractSchemaGeneration` (from `frontend/`) — 14 passed
- [x] `npx eslint src/contracts/apiContracts.ts` (from `frontend/`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)