### PR TITLE
docs: add CI/license badges and mention TypeScript in README stack summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # AllotMint 🌱💷
 
+[![CI](https://github.com/leonarduk/allotmint/actions/workflows/ci.yml/badge.svg)](https://github.com/leonarduk/allotmint/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/leonarduk/allotmint/branch/main/graph/badge.svg)](https://codecov.io/gh/leonarduk/allotmint)
+[![License: PolyForm Noncommercial 1.0.0](https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-blue.svg)](LICENSE)
 
-AllotMint is a family investing platform with a FastAPI backend, React frontend, and AWS deployment support.
+AllotMint is a family investing platform with a FastAPI backend, React/TypeScript frontend, and AWS deployment support.
 
 ## Language guidelines
 


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI status badge next to the existing Codecov badge
- Add a license badge linking to the repo's PolyForm Noncommercial 1.0.0 `LICENSE`
- Explicitly mention TypeScript in the frontend stack summary

Closes #4450

## Test plan
- [x] Verified both new badge URLs return HTTP 200
- [x] Visual diff review of README.md rendering