### PR TITLE
fix(ci): gate deploy on the same ref that gets checked out

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -28,11 +28,33 @@ jobs:
       - name: Check ci.yml passed for this commit
         env:
           GH_TOKEN: ${{ github.token }}
-          COMMIT_SHA: ${{ github.sha }}
+          # Resolve the same ref the deploy job's checkout step will use (see
+          # "Checkout repository" below: ref: ${{ inputs.ref || github.ref }}).
+          # For a plain tag push, inputs.ref is empty and this falls back to
+          # github.sha as before. For a workflow_dispatch that sets inputs.ref
+          # to a different tag/branch/SHA, resolving it here ensures check-ci
+          # gates on the exact commit that will actually be deployed, instead
+          # of always validating github.sha (the commit the dispatch itself
+          # ran from) while a different ref gets checked out and deployed.
+          TARGET_REF: ${{ inputs.ref || github.ref }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          echo "Checking ci.yml status for commit ${COMMIT_SHA}..."
+
+          # inputs.ref is documented as a bare tag/branch/SHA, while github.ref
+          # (used as the fallback for a plain tag push) is a fully-qualified
+          # ref like refs/tags/v1.2.3. Strip the prefix so both forms resolve
+          # the same way via the commits API.
+          API_REF="${TARGET_REF#refs/tags/}"
+          API_REF="${API_REF#refs/heads/}"
+
+          COMMIT_SHA="$(gh api "repos/${REPO}/commits/${API_REF}" --jq '.sha')"
+          if [ -z "${COMMIT_SHA}" ] || [ "${COMMIT_SHA}" = "null" ]; then
+            echo "::error::Unable to resolve ref '${TARGET_REF}' to a commit SHA via the GitHub API." >&2
+            exit 1
+          fi
+
+          echo "Checking ci.yml status for commit ${COMMIT_SHA} (resolved from ref ${TARGET_REF})..."
 
           # Poll for the most recent ci.yml run on this exact commit and wait for
           # it to finish before deciding whether to proceed with the deploy.


### PR DESCRIPTION
## Summary
- \`check-ci\` always validated \`ci.yml\` status for \`github.sha\`, but the \`deploy\` job's checkout step uses \`inputs.ref || github.ref\`.
- For a plain tag push these are the same commit, so the gate worked. But for a \`workflow_dispatch\` that sets \`inputs.ref\` to a different tag/branch/SHA than the one the dispatch itself was triggered from, \`deploy\` would check out and deploy \`inputs.ref\` while \`check-ci\` only ever validated CI status for \`github.sha\` — a different commit. An operator could deploy a commit whose CI never actually passed.
- \`check-ci\` now resolves \`inputs.ref || github.ref\` to a commit SHA via \`gh api repos/{repo}/commits/{ref}\` (stripping the \`refs/tags/\`/\`refs/heads/\` prefix from \`github.ref\`'s fully-qualified form) before polling \`ci.yml\`, so both jobs gate on and deploy the same commit.

Closes #4890

Found while reviewing #4887 — a reviewer flagged that the PR's description of the CI gate was inaccurate, which led to discovering this underlying workflow bug. That PR only fixes README wording; this PR fixes the actual workflow behavior.

## Test plan
- [ ] Manually trigger \`workflow_dispatch\` with \`inputs.ref\` unset — confirm \`check-ci\` resolves to \`github.sha\` and behaves as before (plain tag push equivalent).
- [ ] Manually trigger \`workflow_dispatch\` with \`inputs.ref\` set to a tag/branch/SHA that has no \`ci.yml\` run — confirm \`check-ci\` fails with "No ci.yml run found for commit ..." referencing the resolved SHA of \`inputs.ref\`, not \`github.sha\`.
- [ ] Manually trigger \`workflow_dispatch\` with \`inputs.ref\` set to a commit whose \`ci.yml\` run failed — confirm the gate blocks deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)