### PR TITLE
fix: replace hardcoded paths with dynamic Path-based construction in test_extract_verdict.py

### DIFF
--- a/.github/scripts/test_extract_verdict.py
+++ b/.github/scripts/test_extract_verdict.py
@@ -262,7 +262,7 @@ class TestExtractVerdictScriptMain:
         try:
             result = subprocess.run(
                 ["python3", ".github/scripts/extract_verdict.py", temp_path, "TestProvider"],
-                cwd="/mnt/c/Users/steph/workspace/GitHub/allotmint" if Path("/mnt/c/Users/steph/workspace/GitHub/allotmint").exists() else "C:\\Users\\steph\\workspace\\GitHub\\allotmint",
+                cwd=str(Path(__file__).parent.parent.parent),
                 capture_output=True,
                 text=True,
             )
@@ -281,7 +281,7 @@ class TestExtractVerdictScriptMain:
         try:
             result = subprocess.run(
                 ["python3", ".github/scripts/extract_verdict.py", temp_path, "TestProvider"],
-                cwd="/mnt/c/Users/steph/workspace/GitHub/allotmint" if Path("/mnt/c/Users/steph/workspace/GitHub/allotmint").exists() else "C:\\Users\\steph\\workspace\\GitHub\\allotmint",
+                cwd=str(Path(__file__).parent.parent.parent),
                 capture_output=True,
                 text=True,
             )
@@ -300,7 +300,7 @@ class TestExtractVerdictScriptMain:
         try:
             result = subprocess.run(
                 ["python3", ".github/scripts/extract_verdict.py", temp_path, "DeepSeek"],
-                cwd="/mnt/c/Users/steph/workspace/GitHub/allotmint" if Path("/mnt/c/Users/steph/workspace/GitHub/allotmint").exists() else "C:\\Users\\steph\\workspace\\GitHub\\allotmint",
+                cwd=str(Path(__file__).parent.parent.parent),
                 capture_output=True,
                 text=True,
             )
@@ -319,7 +319,7 @@ class TestExtractVerdictScriptMain:
         try:
             result = subprocess.run(
                 ["python3", ".github/scripts/extract_verdict.py", temp_path, "TestProvider"],
-                cwd="/mnt/c/Users/steph/workspace/GitHub/allotmint" if Path("/mnt/c/Users/steph/workspace/GitHub/allotmint").exists() else "C:\\Users\\steph\\workspace\\GitHub\\allotmint",
+                cwd=str(Path(__file__).parent.parent.parent),
                 capture_output=True,
                 text=True,
             )


### PR DESCRIPTION
## Summary
Replaces hardcoded absolute paths in `.github/scripts/test_extract_verdict.py` with dynamic relative paths using `Path(__file__).parent.parent.parent`.

## Changes
- `test_main_with_approve_verdict` (line 265)
- `test_main_with_request_changes_verdict` (line 284)  
- `test_main_with_backtick_approve` (line 303)
- `test_main_with_no_verdict` (line 322)

**Before:** Hardcoded paths like `/mnt/c/Users/steph/workspace/GitHub/allotmint` and `C:\\Users\\steph\\workspace\\GitHub\\allotmint`

**After:** `str(Path(__file__).parent.parent.parent)` — dynamic and machine-independent

## Why
These tests were non-portable and would fail on any machine other than the author's. The dynamic paths ensure the tests work across Linux, macOS, and Windows without modification.

## Closes
Closes #4287