### PR TITLE
test(scripts): add unit tests for aider-issue.ps1 file discovery logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,26 @@ jobs:
       - name: Run bats tests for deploy shell scripts
         run: npx --yes bats@1.13.0 tests/bash/*.bats
 
+  powershell-tests:
+    name: PowerShell script tests (Pester)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # ubuntu-latest ships pwsh but not Pester; pin the version so an
+      # upstream Pester release can't silently change test semantics.
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module -Name Pester -RequiredVersion 5.6.1 -Force -SkipPublisherCheck -Scope CurrentUser
+      - name: Run Pester tests for scripts/aider-issue.ps1
+        shell: pwsh
+        run: |
+          Import-Module Pester -RequiredVersion 5.6.1 -Force
+          $config = New-PesterConfiguration
+          $config.Run.Path = 'scripts/tests'
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $config
+
   validate-backend-deps:
     name: Validate backend/requirements.txt (dry-run)
     runs-on: ubuntu-latest

--- a/scripts/tests/aider-issue.Tests.ps1
+++ b/scripts/tests/aider-issue.Tests.ps1
@@ -1,0 +1,153 @@
+# Unit tests for the file discovery logic in ../aider-issue.ps1
+# (direct path matching + basename fallback via `git ls-files`, added by PR #4293).
+#
+# aider-issue.ps1 is a top-level script with real side effects (git checkout,
+# git reset --hard, git push, gh pr create) and no extracted function to call
+# in isolation, so these tests extract the discovery snippet verbatim from the
+# source file's text and dot-source it with git/Test-Path mocked. This runs the
+# exact shipped code (not a re-implementation), so a regression in the real
+# script fails these tests, while `git`/the filesystem are never touched.
+#
+# Constraint: this file must never modify aider-issue.ps1 (tests only).
+
+BeforeAll {
+    $script:ScriptUnderTest = (Resolve-Path (Join-Path $PSScriptRoot '..' 'aider-issue.ps1')).Path
+    $raw = Get-Content -LiteralPath $script:ScriptUnderTest -Raw
+
+    # Start marker: first line of the candidate-path regex setup.
+    # End marker: the line combining identifier/direct/basename matches into $referencedFiles.
+    # If aider-issue.ps1 is restructured, these IndexOf calls stop finding the
+    # markers and the throw below fails loudly instead of silently testing stale text.
+    $startToken = '$pathPattern'
+    $endToken = '$referencedFiles = @(('
+
+    $startIndex = $raw.IndexOf($startToken)
+    if ($startIndex -lt 0) {
+        throw "Could not locate start marker '$startToken' in aider-issue.ps1 - the file discovery logic may have moved. Update the extraction markers in this test file."
+    }
+
+    $endAnchor = $raw.IndexOf($endToken)
+    if ($endAnchor -lt 0) {
+        throw "Could not locate end marker '$endToken' in aider-issue.ps1 - the file discovery logic may have moved. Update the extraction markers in this test file."
+    }
+
+    $eol = $raw.IndexOf("`n", $endAnchor)
+    if ($eol -lt 0) { $eol = $raw.Length }
+
+    $script:DiscoverySnippet = $raw.Substring($startIndex, $eol - $startIndex)
+}
+
+Describe 'aider-issue.ps1 file discovery logic' {
+
+    BeforeEach {
+        # $title/$issueBody/$repoRoot are read by the dot-sourced snippet below;
+        # $candidates/$directMatches/$basenameMatches/$referencedFiles are set by it.
+        $repoRoot = 'C:\repo'
+    }
+
+    Context 'direct path match' {
+        It 'adds a candidate that already exists verbatim relative to the repo root' {
+            $title = 'Fix a bug'
+            $issueBody = 'See .github/scripts/test_extract_verdict.py for details.'
+
+            Mock -CommandName Test-Path -MockWith {
+                $LiteralPath -eq (Join-Path $repoRoot '.github/scripts/test_extract_verdict.py')
+            }
+            Mock -CommandName git -MockWith { @() }
+
+            . ([scriptblock]::Create($script:DiscoverySnippet))
+
+            $referencedFiles | Should -Contain (Join-Path $repoRoot '.github/scripts/test_extract_verdict.py')
+            $referencedFiles.Count | Should -Be 1
+        }
+    }
+
+    Context 'basename fallback via git ls-files' {
+        It 'finds a tracked file when the bare filename is not at the candidate path' {
+            $title = 'Fix a bug'
+            $issueBody = 'Bug in test_extract_verdict.py needs fixing'
+
+            Mock -CommandName Test-Path -MockWith { $false }
+            Mock -CommandName git -MockWith {
+                if ($args -contains 'ls-files') { return @('.github/scripts/test_extract_verdict.py') }
+                return @()
+            }
+
+            . ([scriptblock]::Create($script:DiscoverySnippet))
+
+            $referencedFiles | Should -Contain (Join-Path $repoRoot '.github/scripts/test_extract_verdict.py')
+            $referencedFiles.Count | Should -Be 1
+        }
+    }
+
+    Context 'duplicate basenames' {
+        It 'adds every tracked file sharing the basename, since the script has no disambiguation for this case' {
+            # This is one of the two known gaps flagged from PR #4293: with no
+            # identifier hint in the issue text, an ambiguous basename adds
+            # every matching tracked file rather than erroring or picking one.
+            $title = 'Fix a bug'
+            $issueBody = 'helper.py needs a fix'
+
+            Mock -CommandName Test-Path -MockWith { $false }
+            Mock -CommandName git -MockWith {
+                if ($args -contains 'ls-files') { return @('backend/helper.py', 'frontend/scripts/helper.py') }
+                return @()
+            }
+
+            . ([scriptblock]::Create($script:DiscoverySnippet))
+
+            $referencedFiles | Should -Contain (Join-Path $repoRoot 'backend/helper.py')
+            $referencedFiles | Should -Contain (Join-Path $repoRoot 'frontend/scripts/helper.py')
+            $referencedFiles.Count | Should -Be 2
+        }
+    }
+
+    Context 'no match anywhere' {
+        It 'adds nothing when the candidate exists neither at the path nor in git ls-files' {
+            $title = 'Fix a bug'
+            $issueBody = 'ghost_file.py has an issue'
+
+            Mock -CommandName Test-Path -MockWith { $false }
+            Mock -CommandName git -MockWith { @() }
+
+            . ([scriptblock]::Create($script:DiscoverySnippet))
+
+            $referencedFiles.Count | Should -Be 0
+        }
+    }
+
+    Context 'empty repository' {
+        It 'does not throw when git ls-files returns no output' {
+            # The other known gap from PR #4293: trackedFiles ends up an empty
+            # array (not $null) when git ls-files prints nothing, so the
+            # Where-Object basename filter below it must not dereference $null.
+            $title = 'Fix a bug'
+            $issueBody = 'anything.py is broken'
+
+            Mock -CommandName Test-Path -MockWith { $false }
+            Mock -CommandName git -MockWith { @() }
+
+            { . ([scriptblock]::Create($script:DiscoverySnippet)) } | Should -Not -Throw
+
+            $referencedFiles.Count | Should -Be 0
+        }
+    }
+
+    Context 'unconditional git ls-files call' {
+        It 'calls git ls-files even when every candidate already matched directly' {
+            # Known gap from PR #4293: git ls-files runs unconditionally, even
+            # when no candidate needs the basename fallback.
+            $title = 'Fix a bug'
+            $issueBody = 'See .github/scripts/test_extract_verdict.py for details.'
+
+            Mock -CommandName Test-Path -MockWith {
+                $LiteralPath -eq (Join-Path $repoRoot '.github/scripts/test_extract_verdict.py')
+            }
+            Mock -CommandName git -MockWith { @() }
+
+            . ([scriptblock]::Create($script:DiscoverySnippet))
+
+            Should -Invoke -CommandName git -ParameterFilter { $args -contains 'ls-files' } -Times 1 -Exactly
+        }
+    }
+}

--- a/scripts/tests/aider-issue.Tests.ps1
+++ b/scripts/tests/aider-issue.Tests.ps1
@@ -42,7 +42,10 @@ Describe 'aider-issue.ps1 file discovery logic' {
     BeforeEach {
         # $title/$issueBody/$repoRoot are read by the dot-sourced snippet below;
         # $candidates/$directMatches/$basenameMatches/$referencedFiles are set by it.
-        $repoRoot = 'C:\repo'
+        # A drive-letter path (e.g. 'C:\repo') makes Join-Path throw
+        # DriveNotFoundException on the Linux CI runner, so use a
+        # drive-neutral root that resolves the same on Windows and Linux.
+        $repoRoot = '/repo'
     }
 
     Context 'direct path match' {


### PR DESCRIPTION
## Summary
- Adds `scripts/tests/aider-issue.Tests.ps1`, a Pester 5 suite covering the file-discovery logic added in #4293 (direct path matching + basename fallback via `git ls-files`).
- No changes to `scripts/aider-issue.ps1` itself: the script has no extracted function for this logic, so the tests extract the discovery snippet verbatim from the source text and dot-source it with `git`/`Test-Path` mocked. This runs the exact shipped code, not a re-implementation, so a real regression fails these tests.
- Adds a `powershell-tests` job to `.github/workflows/ci.yml` (mirrors the existing `shell-tests`/bats job) that installs pinned Pester 5.6.1 and runs `Invoke-Pester` on `scripts/tests`.

## Coverage
- Direct match: candidate path exists verbatim at the repo root.
- Basename fallback: candidate not at the literal path, but `git ls-files` finds a tracked match.
- Duplicate basenames: multiple tracked files share a basename → both get added (documents the script's actual behavior; there's no disambiguation without an identifier hint).
- No match: candidate found neither directly nor via `git ls-files`.
- Empty repo: `git ls-files` returns nothing → no throw, no results (guards the null-reference risk noted in #4294).
- Pins the "`git ls-files` runs unconditionally" behavior even when every candidate already matched directly.

Sanity-checked locally by mutating a throwaway copy of the discovery logic and confirming the relevant tests fail — see local Pester runs in dev notes.

Closes #4294

## Test plan
- [x] `Invoke-Pester -Path scripts/tests` passes locally (Pester 5.6.1, PowerShell 7.6.3)
- [x] Confirmed `scripts/aider-issue.ps1` has zero diff (test-only change)
- [x] Confirmed tests fail against a deliberately mutated copy of the discovery logic
- [ ] CI `powershell-tests` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)