### PR TITLE
feat: add GitHub issue template linter workflow

### DIFF
--- a/.github/workflows/issue-lint.yml
+++ b/.github/workflows/issue-lint.yml
@@ -1,0 +1,53 @@
+name: Issue Template Lint
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  lint-issue-body:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Check required sections are present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          missing=()
+
+          check() {
+            printf '%s' "$ISSUE_BODY" | grep -Eiq "$1" || missing+=("$2")
+          }
+
+          check '##[[:space:]]*what\b'                                     "What"
+          check '##[[:space:]]*why\b'                                      "Why"
+          check '##[[:space:]]*how\b'                                      "How"
+          check '##[[:space:]]*constraints\b'                              "Constraints"
+          check '##[[:space:]]*success[[:space:]]+looks[[:space:]]+like'   "Success looks like"
+          check '##[[:space:]]*failure[[:space:]]+looks[[:space:]]+like'   "Failure looks like"
+
+          if [ "${#missing[@]}" -eq 0 ]; then
+            echo "All required sections present."
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "needs-info" 2>/dev/null || true
+            exit 0
+          fi
+
+          gh label create "needs-info" --repo "$REPO" \
+            --description "Automated: issue is missing required template sections" \
+            --color "d4c5f9" --force
+
+          list=$(printf -- '- %s\n' "${missing[@]}")
+          comment_body=$(printf '%s\n\n%s\n\n%s' \
+            "This issue is missing sections expected by the allotmint template:" \
+            "$list" \
+            "Please edit the issue to add them (see \`.github/ISSUE_TEMPLATE/bug_report.md\` for the format). This is an automated check, not a judgment on the issue's validity.")
+
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$comment_body"
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs-info"
+          exit 1

--- a/.github/workflows/issue-lint.yml
+++ b/.github/workflows/issue-lint.yml
@@ -50,4 +50,3 @@ jobs:
 
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$comment_body"
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs-info"
-          exit 1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/issue-lint.yml`, triggered on `issues: opened/edited`, checking the issue body for the required allotmint template sections (What/Why/How/Constraints/Success looks like/Failure looks like).
- If sections are missing: creates the `needs-info` label if needed, comments listing what's missing, and applies the label.
- If all sections are present: removes the `needs-info` label if it was previously applied.
- Skips `dependabot[bot]`, matching the pattern in `pr-lint.yml`.
- Deliberately does not check `## LLM tier` — that's already inferred/labeled by `label-ai-issues.yml`.

Closes #4911

## Test plan
- [x] `actionlint` run clean against the new workflow file.
- [x] Locally exercised the section-detection bash logic against the full `bug_report.md`/`feature_request.md` templates (no missing sections), a partial body (correctly flags missing sections), and an empty body (flags all sections) — used POSIX `[[:space:]]`/`-Ei` instead of PCRE `\s`/`-P` for portability across grep implementations.
- [ ] Verify end-to-end on GitHub by opening a test issue missing sections and confirming the comment + `needs-info` label appear, then editing it to confirm the label is removed.