### PR TITLE
fix: guard against account slug collisions before aws s3 sync data/accounts

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -313,11 +313,25 @@ git push
 ```
 
 To update the S3 bucket, sync the local data and ensure your IAM role allows
-``s3:PutObject`` and ``s3:DeleteObject`` on the target paths:
+``s3:PutObject`` and ``s3:DeleteObject`` on the target paths.
+
+`aws s3 sync` has no notion of account ownership — it will silently overwrite
+any object at a matching key. Since account directories are named by owner
+slug (`derive_owner_slug` in `backend/common/signup_provision.py`), a local
+`data/accounts/<slug>/` directory that happens to share a slug with a
+*different* owner already in the bucket (e.g. from a stale branch or a
+rename) would otherwise overwrite that owner's data with no warning. Run the
+collision check first and only sync if it passes:
 
 ```bash
+python scripts/check_account_slug_collisions.py --bucket "$DATA_BUCKET"
 aws s3 sync data/accounts s3://$DATA_BUCKET/accounts/
 ```
+
+The check compares each local `data/accounts/<slug>/person.json` email
+against the same key already in the bucket. It exits non-zero and lists the
+offending slugs if any collide with a different owner; matching or new slugs
+are left alone.
 
 ## Install dependencies
 

--- a/scripts/check_account_slug_collisions.py
+++ b/scripts/check_account_slug_collisions.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Guard against slug collisions before `aws s3 sync data/accounts` deploys.
+
+`derive_owner_slug`/`provision_owner` (backend/common/signup_provision.py)
+never let live signups overwrite a different owner's directory, but the
+manual `aws s3 sync data/accounts s3://$DATA_BUCKET/accounts/` deploy step
+(see docs/DEPLOY.md) bypasses that entirely: `aws s3 sync` has no notion of
+slug ownership and will silently overwrite any object at a matching key.
+
+This script compares each local `data/accounts/<slug>/person.json` email
+against the same key already in the target bucket. A slug present in both
+places with a *different* email is a collision and aborts the sync; a slug
+that is new, or belongs to the same owner, is left alone. See #4796.
+
+Usage:
+    python scripts/check_account_slug_collisions.py --bucket my-data-bucket \
+        [--accounts-dir data/accounts] [--prefix accounts/]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+
+class Collision:
+    def __init__(self, slug: str, local_email: str, remote_email: str) -> None:
+        self.slug = slug
+        self.local_email = local_email
+        self.remote_email = remote_email
+
+    def __str__(self) -> str:
+        return (
+            f"slug '{self.slug}': local owner ({self.local_email or '<no email>'}) "
+            f"!= existing S3 owner ({self.remote_email or '<no email>'})"
+        )
+
+
+def local_slugs(accounts_dir: Path) -> list[str]:
+    """Return the owner slugs present as subdirectories of `accounts_dir`."""
+    if not accounts_dir.is_dir():
+        return []
+    return sorted(p.name for p in accounts_dir.iterdir() if p.is_dir())
+
+
+def _read_local_email(accounts_dir: Path, slug: str) -> str:
+    person_path = accounts_dir / slug / "person.json"
+    try:
+        data = json.loads(person_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return ""
+    email = data.get("email") if isinstance(data, dict) else None
+    return email.strip().lower() if isinstance(email, str) else ""
+
+
+def remote_slugs(s3_client, bucket: str, prefix: str) -> set[str]:
+    """Return the owner slugs already present under `prefix` in `bucket`.
+
+    Uses a delimited (non-recursive) listing so this stays a cheap "which
+    slugs exist" call rather than a full bucket scan.
+    """
+    normalized_prefix = prefix if prefix.endswith("/") or not prefix else f"{prefix}/"
+    slugs: set[str] = set()
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=normalized_prefix, Delimiter="/"):
+        for entry in page.get("CommonPrefixes", []):
+            key_prefix = entry["Prefix"]
+            slug = key_prefix[len(normalized_prefix) :].rstrip("/")
+            if slug:
+                slugs.add(slug)
+    return slugs
+
+
+def _read_remote_email(s3_client, bucket: str, prefix: str, slug: str) -> str:
+    key = f"{prefix.rstrip('/')}/{slug}/person.json" if prefix else f"{slug}/person.json"
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=key)
+        data = json.loads(obj["Body"].read())
+    except (ClientError, BotoCoreError, json.JSONDecodeError, OSError):
+        return ""
+    email = data.get("email") if isinstance(data, dict) else None
+    return email.strip().lower() if isinstance(email, str) else ""
+
+
+def find_collisions(
+    accounts_dir: Path,
+    s3_client,
+    bucket: str,
+    prefix: str,
+    slugs: Iterable[str] | None = None,
+) -> list[Collision]:
+    """Return collisions between local and remote slugs with different owners.
+
+    A slug counts as a collision only when both sides have a slug directory
+    *and* their `person.json` emails disagree; a slug missing on either side,
+    or matching on email, is not a collision.
+    """
+    candidate_slugs = list(slugs) if slugs is not None else local_slugs(accounts_dir)
+    existing_remote = remote_slugs(s3_client, bucket, prefix)
+
+    collisions: list[Collision] = []
+    for slug in candidate_slugs:
+        if slug not in existing_remote:
+            continue
+        local_email = _read_local_email(accounts_dir, slug)
+        remote_email = _read_remote_email(s3_client, bucket, prefix, slug)
+        if local_email and remote_email and local_email != remote_email:
+            collisions.append(Collision(slug, local_email, remote_email))
+    return collisions
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bucket", required=True, help="Target S3 bucket (DATA_BUCKET)")
+    parser.add_argument(
+        "--accounts-dir",
+        default="data/accounts",
+        type=Path,
+        help="Local accounts directory (default: data/accounts)",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="accounts/",
+        help="S3 key prefix for accounts (default: accounts/)",
+    )
+    args = parser.parse_args(argv[1:])
+
+    s3_client = boto3.client("s3")
+    collisions = find_collisions(args.accounts_dir, s3_client, args.bucket, args.prefix)
+
+    if collisions:
+        print(
+            "ERROR: refusing to sync — the following local account slugs "
+            "collide with a different owner already in S3:",
+            file=sys.stderr,
+        )
+        for collision in collisions:
+            print(f"  - {collision}", file=sys.stderr)
+        print(
+            "Resolve the collision manually (rename the local slug or confirm "
+            "the S3 owner) before running `aws s3 sync`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("No account slug collisions found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/scripts/test_check_account_slug_collisions.py
+++ b/tests/scripts/test_check_account_slug_collisions.py
@@ -1,0 +1,128 @@
+"""Unit tests for scripts/check_account_slug_collisions.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+
+import boto3
+from botocore.stub import Stubber
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_account_slug_collisions.py"
+spec = importlib.util.spec_from_file_location("check_account_slug_collisions", _SCRIPT)
+_mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+find_collisions = _mod.find_collisions
+local_slugs = _mod.local_slugs
+remote_slugs = _mod.remote_slugs
+
+BUCKET = "test-data-bucket"
+PREFIX = "accounts/"
+
+
+def _make_local_account(accounts_dir: Path, slug: str, email: str) -> None:
+    owner_dir = accounts_dir / slug
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "person.json").write_text(json.dumps({"email": email}))
+
+
+def _body(data: dict) -> io.BytesIO:
+    return io.BytesIO(json.dumps(data).encode("utf-8"))
+
+
+def _stubbed_client(list_prefixes: list[str], get_object_by_key: dict[str, dict | None]):
+    """Build an S3 client stubbed with one list_objects_v2 call and one
+    get_object call per key in `get_object_by_key` (a None value stubs a
+    NoSuchKey error, matching a missing remote person.json)."""
+    client = boto3.client("s3", region_name="us-east-1")
+    stubber = Stubber(client)
+    stubber.add_response(
+        "list_objects_v2",
+        {"CommonPrefixes": [{"Prefix": prefix} for prefix in list_prefixes]},
+    )
+    for key, body_dict in get_object_by_key.items():
+        if body_dict is None:
+            stubber.add_client_error(
+                "get_object",
+                service_error_code="NoSuchKey",
+                expected_params={"Bucket": BUCKET, "Key": key},
+            )
+        else:
+            stubber.add_response(
+                "get_object", {"Body": _body(body_dict)}, {"Bucket": BUCKET, "Key": key}
+            )
+    stubber.activate()
+    return client
+
+
+def test_local_slugs_lists_subdirectories(tmp_path) -> None:
+    accounts_dir = tmp_path / "accounts"
+    _make_local_account(accounts_dir, "alice", "alice@example.com")
+    _make_local_account(accounts_dir, "bob", "bob@example.com")
+    (accounts_dir / "not-a-dir.txt").write_text("noise")
+
+    assert local_slugs(accounts_dir) == ["alice", "bob"]
+
+
+def test_local_slugs_missing_directory_returns_empty(tmp_path) -> None:
+    assert local_slugs(tmp_path / "nope") == []
+
+
+def test_remote_slugs_parses_common_prefixes() -> None:
+    client = _stubbed_client(["accounts/alice/", "accounts/bob/"], {})
+    assert remote_slugs(client, BUCKET, PREFIX) == {"alice", "bob"}
+
+
+def test_new_local_slug_is_not_a_collision(tmp_path) -> None:
+    accounts_dir = tmp_path / "accounts"
+    _make_local_account(accounts_dir, "carol", "carol@example.com")
+    client = _stubbed_client(["accounts/alice/"], {})
+
+    assert find_collisions(accounts_dir, client, BUCKET, PREFIX) == []
+
+
+def test_same_owner_reslug_is_not_a_collision(tmp_path) -> None:
+    accounts_dir = tmp_path / "accounts"
+    _make_local_account(accounts_dir, "alice", "alice@example.com")
+    client = _stubbed_client(
+        ["accounts/alice/"],
+        {"accounts/alice/person.json": {"email": "alice@example.com"}},
+    )
+
+    assert find_collisions(accounts_dir, client, BUCKET, PREFIX) == []
+
+
+def test_different_owner_same_slug_is_a_collision(tmp_path) -> None:
+    accounts_dir = tmp_path / "accounts"
+    _make_local_account(accounts_dir, "alice", "new-alice@example.com")
+    client = _stubbed_client(
+        ["accounts/alice/"],
+        {"accounts/alice/person.json": {"email": "old-alice@example.com"}},
+    )
+
+    collisions = find_collisions(accounts_dir, client, BUCKET, PREFIX)
+    assert len(collisions) == 1
+    assert collisions[0].slug == "alice"
+    assert "new-alice@example.com" in str(collisions[0])
+    assert "old-alice@example.com" in str(collisions[0])
+
+
+def test_missing_remote_person_json_is_not_treated_as_collision(tmp_path) -> None:
+    accounts_dir = tmp_path / "accounts"
+    _make_local_account(accounts_dir, "alice", "alice@example.com")
+    client = _stubbed_client(["accounts/alice/"], {"accounts/alice/person.json": None})
+
+    assert find_collisions(accounts_dir, client, BUCKET, PREFIX) == []
+
+
+def test_missing_local_person_json_is_not_treated_as_collision(tmp_path) -> None:
+    accounts_dir = tmp_path / "accounts"
+    (accounts_dir / "alice").mkdir(parents=True)
+    client = _stubbed_client(
+        ["accounts/alice/"],
+        {"accounts/alice/person.json": {"email": "old-alice@example.com"}},
+    )
+
+    assert find_collisions(accounts_dir, client, BUCKET, PREFIX) == []


### PR DESCRIPTION
## Summary
- `aws s3 sync data/accounts s3://$DATA_BUCKET/accounts/` has no notion of slug/ownership and will silently overwrite a different owner's `person.json`/`approvals.json`/`settings.json` if a local account directory happens to share a slug with an existing S3 owner.
- Adds `scripts/check_account_slug_collisions.py`, which lists local vs. remote account slugs, compares `person.json` emails for any slug present in both, and fails loudly on a mismatch (same-owner re-syncs are unaffected).
- Documents the check in `docs/DEPLOY.md` right before the existing `aws s3 sync` instructions.

Does not change `derive_owner_slug`/`provision_owner` — this is a deploy-time safeguard only, per the issue's constraints.

## Test plan
- [x] `python -m pytest tests/scripts/test_check_account_slug_collisions.py -q --no-cov` — 8/8 passing
- [x] `python -m ruff check scripts/check_account_slug_collisions.py tests/scripts/test_check_account_slug_collisions.py`
- [x] `python -m black --check scripts/check_account_slug_collisions.py tests/scripts/test_check_account_slug_collisions.py`

Closes #4796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-sync check to detect account name clashes before uploading local data.
  * Added a command-line tool to scan local and remote account records and report potential collisions.

* **Documentation**
  * Updated deployment guidance with the new collision-check step and clearer sync behaviour.

* **Tests**
  * Added coverage for local and remote account discovery, plus collision handling for matching, differing, and missing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->