### PR TITLE
fix(backend): use typed load_account_record in get_account route

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -863,7 +863,7 @@ async def get_account(owner: str, account: str, request: Request):
     root = resolve_accounts_root(request)
 
     try:
-        data = data_loader.load_account(owner, account, root)
+        data = data_loader.load_account_record(owner, account, root).model_dump(exclude_unset=True)
     except data_loader.ProviderUnavailable as exc:
         log.warning(
             "portfolio.account_provider_unavailable",
@@ -907,7 +907,9 @@ async def get_account(owner: str, account: str, request: Request):
         if not match:
             raise HTTPException(status_code=404, detail="Account not found")
         try:
-            data = data_loader.load_account(owner_dir.name, match, owner_dir.parent)
+            data = data_loader.load_account_record(owner_dir.name, match, owner_dir.parent).model_dump(
+                exclude_unset=True
+            )
         except data_loader.ProviderUnavailable as exc:
             raise HTTPException(status_code=503, detail="Account data provider unavailable") from exc
         except data_loader.InvalidPayload as exc:


### PR DESCRIPTION
## Summary
- `get_account` (`/account/{owner}/{account}`) previously called the raw dict-returning `data_loader.load_account()`, even though that function already validates internally against `AccountRecord`.
- Switched both call sites in the route to `data_loader.load_account_record()` + `.model_dump(exclude_unset=True)`, matching the typed-access pattern already used by `backend/common/portfolio.py`, `backend/routes/pension.py`, and `backend/auth.py`.
- No change to error handling (validation already happened inside `load_account`) or response shape (`exclude_unset=True` preserves the original key set from the source JSON).

## Scope note
This closes #4878, but only implements one of the four call sites originally listed there. During implementation I found the other three (`backend/quests/trail.py`, `backend/common/authz.py`, `backend/common/portfolio_loader.py`) intentionally rely on the *lenient* loaders (`load_person_meta`/`load_account`, which degrade to `{}`/skip on bad data) rather than the *strict* typed accessors, and converting them would introduce real regressions (crashing owner lookups, turning clean 403s into unhandled 500s, or cascading a `list[dict]` → `list[AccountRecord]` change across half a dozen unrelated consumers). Full reasoning is in [the issue comment](https://github.com/leonarduk/allotmint/issues/4878#issuecomment-4919369393).

## Test plan
- [x] `pytest tests/test_accounts_api.py tests/backend/test_portfolio_routes.py -q --no-cov` — 13 passed, 1 xfailed
- [x] `pytest tests/ -k "account or portfolio" -q --no-cov` — 442 passed, 1 xfailed, 1 xpassed
- [x] Confirmed pre-existing `ruff`/`black` import-order warning on this file predates this change (verified via `git stash`)

Closes #4878