### PR TITLE
fix: warn when DATA_BUCKET is unset in AWS env before local fallback

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -149,6 +149,10 @@ def resolve_writable_store(
         bucket = os.getenv(data_loader.DATA_BUCKET_ENV)
         if bucket:
             return S3AccountsStore(bucket=bucket), _RootResolution.WRITABLE
+        log.warning(
+            "%s is not set; falling back to local accounts store.",
+            data_loader.DATA_BUCKET_ENV,
+        )
     root, kind = _resolve_local_root(request)
     is_global = kind is not _RootResolution.WRITABLE
     return LocalAccountsStore(root=root, is_global=is_global), kind

--- a/tests/backend/routes/test_transactions_writable_store.py
+++ b/tests/backend/routes/test_transactions_writable_store.py
@@ -65,15 +65,34 @@ def test_resolve_writable_store_uses_s3_in_aws(monkeypatch):
     assert store.bucket == "data-bucket"
 
 
-def test_resolve_writable_store_falls_back_local_without_bucket(monkeypatch, tmp_path):
+def test_resolve_writable_store_falls_back_local_without_bucket(
+    monkeypatch, tmp_path, caplog
+):
     monkeypatch.setattr(transactions_module.config, "app_env", "aws")
     monkeypatch.delenv(data_loader.DATA_BUCKET_ENV, raising=False)
 
     request = _make_request({"accounts_root": tmp_path})
-    store, _ = transactions_module.resolve_writable_store(request)
+    with caplog.at_level("WARNING", logger="transactions"):
+        store, _ = transactions_module.resolve_writable_store(request)
 
     assert not isinstance(store, S3AccountsStore)
     assert store.local_root == tmp_path.resolve()
+    assert any(
+        data_loader.DATA_BUCKET_ENV in record.message for record in caplog.records
+    )
+
+
+def test_resolve_writable_store_no_warning_outside_aws(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(transactions_module.config, "app_env", "local")
+    monkeypatch.delenv(data_loader.DATA_BUCKET_ENV, raising=False)
+
+    request = _make_request({"accounts_root": tmp_path})
+    with caplog.at_level("WARNING", logger="transactions"):
+        transactions_module.resolve_writable_store(request)
+
+    assert not any(
+        data_loader.DATA_BUCKET_ENV in record.message for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `resolve_writable_store()` silently fell back to `LocalAccountsStore` when `app_env == "aws"` but `DATA_BUCKET` was unset, leaving operators no log trail when the resulting write handlers reject requests with a generic 400.
- Adds a `log.warning(...)` naming the actual env var (`DATA_BUCKET`) before falling through, gated strictly on `app_env == "aws"` so no false positives fire locally/in tests.
- No change to fallback behavior — same store, same `_RootResolution` outcome as before.

## Test plan
- [x] Extended `tests/backend/routes/test_transactions_writable_store.py::test_resolve_writable_store_falls_back_local_without_bucket` to assert the warning is logged via `caplog`.
- [x] Added `test_resolve_writable_store_no_warning_outside_aws` asserting no warning fires when `app_env != "aws"`.
- [x] `python -m pytest tests/backend/routes/test_transactions_writable_store.py -v` — all 5 tests pass.
- [x] Confirmed via `git stash` that pre-existing black/ruff findings in the touched files are unrelated to this diff.

Closes #4315