### PR TITLE
fix: stop blocking Lambda startup on live price/metadata warmup

### DIFF
--- a/backend/bootstrap/startup.py
+++ b/backend/bootstrap/startup.py
@@ -24,7 +24,7 @@ class AppLifecycleService:
 
     async def startup(self, app: FastAPI) -> None:
         if not self.cfg.skip_snapshot_warm:
-            await self._warm_snapshot()
+            await self._warm_snapshot(app)
 
         # Deferred import: portfolio_utils pulls in pandas; loading it here
         # (inside the lifespan startup hook) rather than at module level keeps
@@ -51,7 +51,7 @@ class AppLifecycleService:
         for temp_dir in self.temp_dirs:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
-    async def _warm_snapshot(self) -> None:
+    async def _warm_snapshot(self, app: FastAPI) -> None:
         # Deferred imports: both pull in pandas transitively.
         from backend.common.portfolio_utils import (
             _load_snapshot,
@@ -76,13 +76,25 @@ class AppLifecycleService:
         except Exception:
             logger.exception("Failed to update latest prices from snapshot")
 
+        # instrument_api.prime_latest_prices() can trigger a live Yahoo Finance
+        # HTTP call per unknown/uncached ticker (price history and/or metadata
+        # auto-create). On a Lambda cold start with many uncached tickers this
+        # can take well over the function timeout. Run it as a background task
+        # instead of awaiting it here, so lifespan startup (and therefore every
+        # route, including /health) is never blocked on it.
+        task = asyncio.create_task(self._prime_latest_prices_background())
+        app.state.background_tasks.append(task)
+
+    @staticmethod
+    async def _prime_latest_prices_background() -> None:
+        from backend.common import instrument_api
+
         try:
             await asyncio.to_thread(instrument_api.prime_latest_prices)
         except Exception:
             # Non-fatal: price priming is a startup optimisation. If it fails (e.g.
             # network unavailable on Lambda cold start) the app should still serve
-            # requests; a re-raise here propagates through the ASGI lifespan and
-            # causes every subsequent request to return 500.
+            # requests.
             logger.exception("Failed to prime latest prices from warmed snapshot")
 
     @staticmethod

--- a/backend/config.py
+++ b/backend/config.py
@@ -284,6 +284,10 @@ def load_config() -> Config:
     if disable_auth_env is not None:
         data["disable_auth"] = disable_auth_env
 
+    skip_snapshot_warm_env = _env_flag("SKIP_SNAPSHOT_WARM")
+    if skip_snapshot_warm_env is not None:
+        data["skip_snapshot_warm"] = skip_snapshot_warm_env
+
     telegram_token_env = os.getenv("TELEGRAM_BOT_TOKEN")
     if telegram_token_env is not None:
         data["telegram_bot_token"] = telegram_token_env

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -36,6 +36,13 @@ from stacks.exports import BACKEND_API_URL_EXPORT
 # distinct from the read-only ``accounts/`` demo prefix (issue #4275).
 WRITABLE_ACCOUNTS_PREFIX = "writable-accounts"
 
+# S3 prefix (relative to the data bucket) under which auto-created instrument
+# metadata is persisted when the local filesystem is read-only (Lambda).
+# Kept in sync with the default in
+# ``backend.common.instruments._s3_location()`` via the ``METADATA_PREFIX``
+# Lambda environment variable below (issue #4930).
+METADATA_PREFIX = "instruments"
+
 # API Gateway access-log format for the backend HTTP API's default stage.
 # Deliberately logs claims/status/source IP only — never the raw bearer
 # token or Authorization header — so no credentials land in the logs.
@@ -328,6 +335,13 @@ class BackendLambdaStack(Stack):
             "JWT_SECRET": jwt_secret,
             "GOOGLE_CLIENT_ID": google_client_id,
             "TIMESERIES_CACHE_BASE": f"s3://{bucket_name}/timeseries",
+            # Without this, backend.common.instruments._s3_location() returns
+            # None and auto-created instrument metadata falls back to writing
+            # under /var/task, which is read-only in Lambda (issue #4930).
+            # Shares the existing data bucket/grants rather than a dedicated
+            # bucket, mirroring TIMESERIES_CACHE_BASE above.
+            "METADATA_BUCKET": bucket_name,
+            "METADATA_PREFIX": METADATA_PREFIX,
         }
         if data_repo:
             backend_env["DATA_REPO"] = data_repo

--- a/tests/backend/test_app_bootstrap.py
+++ b/tests/backend/test_app_bootstrap.py
@@ -80,8 +80,15 @@ async def test_lifecycle_service_warms_snapshot_and_registers_background_task(
 
     assert warmed == {"snapshot": {"ABC": 1}, "ts": "ts"}
     assert InstrumentApi.latest == {"ABC": 1}
+
+    # prime_latest_prices() can involve live network calls (issue #4930), so
+    # startup() schedules it as a background task instead of awaiting it
+    # in-line. Assert it was scheduled alongside the snapshot-refresh task,
+    # then await it directly to observe its effect.
+    assert snapshot_task in app.state.background_tasks
+    prime_task = next(t for t in app.state.background_tasks if t is not snapshot_task)
+    await prime_task
     assert InstrumentApi.primed is True
-    assert app.state.background_tasks == [snapshot_task]
 
 
 @pytest.mark.asyncio
@@ -148,6 +155,10 @@ async def test_lifecycle_service_startup_survives_prime_latest_prices_failure(
     with caplog.at_level(logging.ERROR):
         # Must not raise — previously the re-raise turned this into a 500 for all requests.
         await service.startup(app)
+        # prime_latest_prices() now runs as a background task (issue #4930); await
+        # it directly so its failure is logged before the assertion below.
+        prime_task = next(t for t in app.state.background_tasks if t is not None)
+        await prime_task
 
     assert any(
         "Failed to prime latest prices" in r.message for r in caplog.records

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,6 +115,24 @@ def test_timeseries_cache_base_env_override(monkeypatch, tmp_path):
     reload_config()
 
 
+def test_skip_snapshot_warm_env_override(monkeypatch):
+    """SKIP_SNAPSHOT_WARM lets Lambda disable blocking warmup without a code
+    change (issue #4930's fast rollback lever)."""
+    monkeypatch.delenv("SKIP_SNAPSHOT_WARM", raising=False)
+    default_value = reload_config().skip_snapshot_warm
+
+    monkeypatch.setenv("SKIP_SNAPSHOT_WARM", "true")
+    cfg = reload_config()
+    assert cfg.skip_snapshot_warm is True
+
+    monkeypatch.setenv("SKIP_SNAPSHOT_WARM", "false")
+    cfg = reload_config()
+    assert cfg.skip_snapshot_warm is False
+
+    monkeypatch.delenv("SKIP_SNAPSHOT_WARM")
+    assert reload_config().skip_snapshot_warm == default_value
+
+
 def test_auth_flags(monkeypatch):
     cfg = reload_config()
     assert cfg.google_auth_enabled is False


### PR DESCRIPTION
## Summary
- `instrument_api.prime_latest_prices()` can fire a live Yahoo Finance HTTP call per uncached ticker (price history and/or metadata auto-create), synchronously, on every Lambda cold start. Awaiting it in `AppLifecycleService.startup` blocked the ASGI lifespan long enough to exceed the 30s Lambda timeout, so no route — including `/health` — could ever respond.
- `prime_latest_prices()` now runs as a background task instead of being awaited during lifespan startup, so startup completes immediately regardless of how slow/failing the underlying Yahoo Finance calls are.
- Wired `METADATA_BUCKET`/`METADATA_PREFIX` into `BackendLambdaStack` (reusing the existing data bucket and its grants) so auto-created instrument metadata persists to S3 instead of failing against the read-only `/var/task` filesystem.
- Added a `SKIP_SNAPSHOT_WARM` env override so the existing blocking-warmup kill switch (`Config.skip_snapshot_warm`) is deployable as a fast rollback lever without a code change.

## Test plan
- [x] `pytest tests/backend/test_app_bootstrap.py tests/test_app.py tests/test_config.py cdk/tests/test_backend_lambda_stack.py cdk/tests/test_backend_lambda_stack_permissions.py` — 114 passed
- [x] `pytest tests/common/test_instrument_api_core.py tests/test_instrument_api_functions.py` — 16 passed
- [x] Verified ruff/black complaints on touched files are all pre-existing and unrelated to this diff
- [ ] Deploy to a non-prod environment and confirm `GET /health`/`GET /config` respond within a few seconds on a cold start with uncached tickers

Closes #4930

🤖 Generated with [Claude Code](https://claude.com/claude-code)