### PR TITLE
fix: use owner_dir / "person.json" instead of safe_join for consistency

### DIFF
--- a/backend/common/signup_provision.py
+++ b/backend/common/signup_provision.py
@@ -32,7 +32,6 @@ import re
 from pathlib import Path
 
 from backend.common.compliance import ensure_owner_scaffold
-from backend.common.path_utils import safe_join
 from backend.common.signup_requests import SignupRequest
 
 logger = logging.getLogger(__name__)
@@ -114,7 +113,7 @@ def _write_person_identity(owner_dir: Path, email: str, full_name: str) -> None:
     the user. Existing keys are preserved.
     """
 
-    person_path = safe_join(owner_dir, "person.json")
+    person_path = owner_dir / "person.json"
     try:
         loaded = json.loads(person_path.read_text())
     except (OSError, json.JSONDecodeError):


### PR DESCRIPTION
## Summary
- `_write_person_identity` in `backend/common/signup_provision.py` built the `person.json` path with `safe_join(owner_dir, "person.json")`; switched to plain `owner_dir / "person.json"` since the filename is a hardcoded literal (traversal guard is a no-op here) and the sibling `_read_person_email` already uses plain division for the same path.
- Removed the now-unused `safe_join` import from this file (still used elsewhere in the codebase).

## Test plan
- [x] `python -m pytest tests/backend/test_signup_provision.py -q` — 12 passed
- [x] `python -m black --check backend/common/signup_provision.py`
- [x] `python -m isort --check backend/common/signup_provision.py`
- [x] `python -m ruff check backend/common/signup_provision.py`

Closes #4383