### PR TITLE
feat(backend): add GET /prices/live endpoint

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -17,15 +17,12 @@ import logging
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Optional, Sequence, Tuple
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.security import OAuth2PasswordBearer
-from pydantic import BaseModel, Field
-
 from backend.auth import get_current_user
 from backend.common import (
     constants,
     data_loader,
     group_portfolio,
+    holding_utils,
     instrument_api,
     portfolio_utils,
     prices,
@@ -38,6 +35,9 @@ from backend.logging_setup import sanitise_log_value
 from backend.routes._accounts import resolve_accounts_root, resolve_owner_directory
 from backend.utils.pricing_dates import PricingDateCalculator
 from backend.utils.timeseries_helpers import resolve_date_range
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.security import OAuth2PasswordBearer
+from pydantic import BaseModel, Field
 
 log = logging.getLogger("routes.portfolio")
 router = APIRouter(tags=["portfolio"])
@@ -995,3 +995,41 @@ async def refresh_prices_get():
 @router.post("/prices/refresh", operation_id="refresh_prices_post")
 async def refresh_prices_post():
     return await _do_refresh_prices()
+
+
+@router.get("/prices/live", operation_id="prices_live_get")
+async def prices_live(
+    tickers: Annotated[
+        Optional[str],
+        Query(description="Comma-separated tickers, e.g. HFEL.L,VOD.L. Defaults to the full portfolio universe."),
+    ] = None,
+):
+    """Return live and stored/last-known prices side by side for each ticker.
+
+    Unlike ``get_price_snapshot`` (which collapses live and stored prices into
+    a single ``last_price`` fallback), this endpoint surfaces both values so
+    callers can compare them directly.
+    """
+    ticker_list = (
+        [t.strip() for t in tickers.split(",") if t.strip()] if tickers else portfolio_utils.list_all_unique_tickers()
+    )
+
+    live = await asyncio.to_thread(holding_utils.load_live_prices, ticker_list)
+    stored = await asyncio.to_thread(holding_utils.load_latest_prices, ticker_list)
+    now = dt.datetime.now(dt.timezone.utc)
+
+    result: Dict[str, Dict[str, Any]] = {}
+    for ticker in ticker_list:
+        live_info = live.get(ticker.upper())
+        live_price = live_info.get("price") if live_info else None
+        ts = live_info.get("timestamp") if live_info else None
+        is_stale = (now - ts) > dt.timedelta(minutes=15) if ts else True
+
+        result[ticker] = {
+            "live_price": float(live_price) if live_price is not None else None,
+            "stored_price": stored.get(ticker),
+            "last_price_time": ts.isoformat().replace("+00:00", "Z") if ts else None,
+            "is_stale": is_stale,
+        }
+
+    return {"prices": result}

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -1,14 +1,14 @@
-from pathlib import Path
 import shutil
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.common.instruments import get_instrument_meta
 import backend.common.alerts as alerts
-from backend.app import create_app
 from backend import config as backend_config
 from backend import config_module
+from backend.app import create_app
+from backend.common.instruments import get_instrument_meta
 
 
 @pytest.fixture
@@ -280,6 +280,57 @@ def test_prices_refresh(client):
     assert "status" in resp.json()
 
 
+def test_prices_live_explicit_tickers(client, monkeypatch):
+    import datetime as dt
+
+    live_ts = dt.datetime.now(dt.UTC)
+    stale_ts = dt.datetime.now(dt.UTC) - dt.timedelta(hours=1)
+
+    def _fake_live(full_tickers):
+        return {
+            "HFEL.L": {"price": 12.5, "timestamp": live_ts},
+            "STALE.L": {"price": 3.0, "timestamp": stale_ts},
+        }
+
+    def _fake_latest(full_tickers):
+        return {"HFEL.L": 12.0, "STALE.L": 2.9, "NODATA.L": 5.0}
+
+    monkeypatch.setattr("backend.common.holding_utils.load_live_prices", _fake_live)
+    monkeypatch.setattr("backend.common.holding_utils.load_latest_prices", _fake_latest)
+
+    resp = client.get("/prices/live", params={"tickers": "HFEL.L,STALE.L,NODATA.L"})
+    assert resp.status_code == 200
+    prices = resp.json()["prices"]
+
+    assert prices["HFEL.L"]["live_price"] == 12.5
+    assert prices["HFEL.L"]["stored_price"] == 12.0
+    assert prices["HFEL.L"]["is_stale"] is False
+    assert prices["HFEL.L"]["last_price_time"] is not None
+
+    assert prices["STALE.L"]["live_price"] == 3.0
+    assert prices["STALE.L"]["is_stale"] is True
+
+    assert prices["NODATA.L"]["live_price"] is None
+    assert prices["NODATA.L"]["stored_price"] == 5.0
+    assert prices["NODATA.L"]["last_price_time"] is None
+    assert prices["NODATA.L"]["is_stale"] is True
+
+
+def test_prices_live_defaults_to_portfolio_universe(client, monkeypatch):
+    monkeypatch.setattr(
+        "backend.common.portfolio_utils.list_all_unique_tickers", lambda: ["STUB.L"]
+    )
+    monkeypatch.setattr("backend.common.holding_utils.load_live_prices", lambda t: {})
+    monkeypatch.setattr("backend.common.holding_utils.load_latest_prices", lambda t: {})
+
+    resp = client.get("/prices/live")
+    assert resp.status_code == 200
+    prices = resp.json()["prices"]
+    assert list(prices.keys()) == ["STUB.L"]
+    assert prices["STUB.L"]["live_price"] is None
+    assert prices["STUB.L"]["is_stale"] is True
+
+
 def test_group_instruments(client):
     groups = _get_groups(client)
     slug = groups[0]["slug"]
@@ -468,8 +519,8 @@ def test_screener_endpoint(client, monkeypatch):
 
 
 def test_hash_params_helper(monkeypatch):
-    from backend.screener import Fundamentals
     from backend.routes.screener import _hash_params
+    from backend.screener import Fundamentals
 
     def mock_fetch(ticker: str) -> Fundamentals:
         if ticker == "AAA":


### PR DESCRIPTION
## Summary
- Adds `GET /prices/live` to `backend/routes/portfolio.py`, returning live price, stored/last-known price, `last_price_time`, and `is_stale` per ticker.
- Reuses `holding_utils.load_live_prices` / `holding_utils.load_latest_prices` (not a reimplementation of the fallback chain), and duplicates only the 15-minute staleness comparison already used in `get_price_snapshot`.
- Accepts an optional `tickers` query param (comma-separated); defaults to the full portfolio universe via `portfolio_utils.list_all_unique_tickers()`.
- Frontend not touched — confirmed no current consumer needs a separate "stored" price field (per issue's review notes).

## Test plan
- [x] `python -m pytest tests/test_backend_api.py -k prices_live -q --no-cov` — new tests for explicit tickers (live/stale/no-data cases) and default-universe behavior
- [x] Full `tests/test_backend_api.py` suite passes (25 passed)
- [x] `ruff check` / `black --check` clean on changed lines

Closes #3422

🤖 Generated with [Claude Code](https://claude.com/claude-code)