### PR TITLE
feat(backend): Moneyhub CSV importer with dedupe-on-import

### DIFF
--- a/backend/contracts_spa.py
+++ b/backend/contracts_spa.py
@@ -4,7 +4,7 @@ from typing import List
 
 from pydantic import BaseModel, ConfigDict, Field
 
-SPA_RESPONSE_CONTRACT_VERSION = "2026-03-22"
+SPA_RESPONSE_CONTRACT_VERSION = "2026-07-08"
 
 
 class SpaContractBase(BaseModel):
@@ -122,6 +122,7 @@ class TransactionContract(SpaContractBase):
     owner: str
     account: str
     id: str | None = None
+    external_id: str | None = None
     date: str | None = None
     ticker: str | None = None
     type: str | None = None

--- a/backend/importers/__init__.py
+++ b/backend/importers/__init__.py
@@ -50,8 +50,11 @@ def dedupe_against_existing(candidates: List[Transaction], existing: List[Transa
     ``_build_transaction_id`` in ``backend.routes.transactions``), so it never
     matches across a re-import of the same source row. Candidates without an
     ``external_id`` have no stable key to compare against and are always
-    treated as new. Shared across import providers so this scheme isn't
-    reimplemented per-provider.
+    treated as new (this includes providers like ``degiro``/``hargreaves``
+    that don't set ``external_id`` at all). Shared across import providers
+    so this scheme isn't reimplemented per-provider -- see issue #3425,
+    which independently needs the same dedupe behaviour for the live
+    Moneyhub API importer.
     """
     existing_ids = {t.external_id for t in existing if t.external_id}
     return [t for t in candidates if not (t.external_id and t.external_id in existing_ids)]

--- a/backend/importers/__init__.py
+++ b/backend/importers/__init__.py
@@ -18,6 +18,7 @@ class UnknownProvider(Exception):
 _IMPORTER_PATHS: Dict[str, str] = {
     "degiro": "backend.importers.degiro",
     "hargreaves": "backend.importers.hargreaves",
+    "moneyhub": "backend.importers.moneyhub",
     "test": "backend.importers.test",
 }
 
@@ -37,3 +38,20 @@ def parse(provider: str, data: bytes) -> List[Transaction]:
         raise UnknownProvider(provider)
     module: Callable[[bytes], List[Transaction]] = import_module(module_path)
     return module.parse(data)  # type: ignore[attr-defined]
+
+
+def dedupe_against_existing(candidates: List[Transaction], existing: List[Transaction]) -> List[Transaction]:
+    """Filter ``candidates`` down to those not already present in ``existing``.
+
+    Comparison is keyed on ``Transaction.external_id`` -- the source
+    provider's own stable transaction id (e.g. Moneyhub's per-row ``Id``).
+    ``Transaction.id`` cannot be used for this: it is a synthetic
+    ``owner:account:index`` value regenerated positionally on every load (see
+    ``_build_transaction_id`` in ``backend.routes.transactions``), so it never
+    matches across a re-import of the same source row. Candidates without an
+    ``external_id`` have no stable key to compare against and are always
+    treated as new. Shared across import providers so this scheme isn't
+    reimplemented per-provider.
+    """
+    existing_ids = {t.external_id for t in existing if t.external_id}
+    return [t for t in candidates if not (t.external_id and t.external_id in existing_ids)]

--- a/backend/importers/moneyhub.py
+++ b/backend/importers/moneyhub.py
@@ -18,7 +18,10 @@ from backend.routes.transactions import Transaction
 
 
 def _to_float(value: str | None) -> float | None:
-    if value in (None, ""):
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
         return None
     try:
         return float(value)

--- a/backend/importers/moneyhub.py
+++ b/backend/importers/moneyhub.py
@@ -2,10 +2,19 @@
 
 No real Moneyhub sample export was available when this was written (see
 issue #3426), so the column layout below is a best-effort guess based on
-Moneyhub's documented transaction fields: a stable per-transaction ``Id``,
-``Date``, ``Amount``, ``Description``, ``Category`` and account identifiers.
-Adjust the column names here once a real export is available to verify
-against.
+Moneyhub's documented transaction fields: ``Date``, ``Amount``,
+``Description``, ``Category`` and account identifiers, plus an optional
+per-row ``Id``. Adjust the column names here once a real export is
+available to verify against.
+
+Per issue #3426's guidance: a manual CSV export is not guaranteed to carry
+a source-provided transaction id. When an ``Id`` column is present it is
+used directly; otherwise a synthetic composite key is derived from
+date+account+amount+description. The composite key can under-dedupe (two
+genuinely distinct transactions sharing date/account/amount/description
+collide) but that is the documented, accepted trade-off in the absence of
+a real id -- see ``dedupe_against_existing`` in
+``backend.importers``.
 """
 
 from __future__ import annotations
@@ -29,25 +38,43 @@ def _to_float(value: str | None) -> float | None:
         return None
 
 
+def _composite_key(date: str | None, account: str, amount: float | None, description: str | None) -> str | None:
+    """Derive a synthetic dedupe key when no source-provided id is available.
+
+    Returns ``None`` (no stable key) unless both ``date`` and ``amount`` are
+    present, since those two fields carry the most identifying weight for a
+    bank/aggregator transaction row.
+    """
+    if not date or amount is None:
+        return None
+    normalised_description = (description or "").strip().lower()
+    return f"{date}|{account}|{amount:.2f}|{normalised_description}"
+
+
 def parse(data: bytes) -> List[Transaction]:
     """Parse a Moneyhub manual CSV export into transactions.
 
-    Expected columns: ``Id``, ``Owner``, ``Account``, ``Date``, ``Amount``,
-    ``Description``, ``Category``.
+    Expected columns: ``Owner``, ``Account``, ``Date``, ``Amount``,
+    ``Description``, ``Category``, and optionally ``Id``.
     """
     text = data.decode("utf-8-sig")
     reader = csv.DictReader(io.StringIO(text))
     transactions: List[Transaction] = []
     for row in reader:
+        account = row.get("Account") or row.get("account") or ""
+        date = row.get("Date") or row.get("date")
+        amount = _to_float(row.get("Amount") or row.get("amount"))
+        description = row.get("Description") or row.get("description")
+        row_id = (row.get("Id") or row.get("id") or "").strip() or None
         transactions.append(
             Transaction(
-                external_id=(row.get("Id") or row.get("id") or "").strip() or None,
+                external_id=row_id or _composite_key(date, account, amount, description),
                 owner=row.get("Owner") or row.get("owner") or "",
-                account=row.get("Account") or row.get("account") or "",
-                date=row.get("Date") or row.get("date"),
+                account=account,
+                date=date,
                 type=row.get("Category") or row.get("category"),
-                amount_minor=_to_float(row.get("Amount") or row.get("amount")),
-                comments=row.get("Description") or row.get("description"),
+                amount_minor=amount,
+                comments=description,
             )
         )
     return transactions

--- a/backend/importers/moneyhub.py
+++ b/backend/importers/moneyhub.py
@@ -1,0 +1,50 @@
+"""Parser for Moneyhub manual CSV exports.
+
+No real Moneyhub sample export was available when this was written (see
+issue #3426), so the column layout below is a best-effort guess based on
+Moneyhub's documented transaction fields: a stable per-transaction ``Id``,
+``Date``, ``Amount``, ``Description``, ``Category`` and account identifiers.
+Adjust the column names here once a real export is available to verify
+against.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import List
+
+from backend.routes.transactions import Transaction
+
+
+def _to_float(value: str | None) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def parse(data: bytes) -> List[Transaction]:
+    """Parse a Moneyhub manual CSV export into transactions.
+
+    Expected columns: ``Id``, ``Owner``, ``Account``, ``Date``, ``Amount``,
+    ``Description``, ``Category``.
+    """
+    text = data.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    transactions: List[Transaction] = []
+    for row in reader:
+        transactions.append(
+            Transaction(
+                external_id=(row.get("Id") or row.get("id") or "").strip() or None,
+                owner=row.get("Owner") or row.get("owner") or "",
+                account=row.get("Account") or row.get("account") or "",
+                date=row.get("Date") or row.get("date"),
+                type=row.get("Category") or row.get("category"),
+                amount_minor=_to_float(row.get("Amount") or row.get("amount")),
+                comments=row.get("Description") or row.get("description"),
+            )
+        )
+    return transactions

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -693,6 +693,13 @@ async def import_transactions(
     except Exception as exc:  # pragma: no cover - parsing errors
         raise HTTPException(status_code=400, detail=f"Failed to parse file: {exc}")
 
+    if not any(t.external_id for t in parsed):
+        # No candidate carries a stable key (e.g. degiro/hargreaves never set
+        # external_id), so dedupe would be a no-op. Skip the store lookup
+        # entirely rather than paying for it on every import regardless of
+        # provider.
+        return parsed
+
     store, _ = resolve_writable_store(request)
     existing = _load_all_transactions(store)
     return importers.dedupe_against_existing(parsed, existing)

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -36,6 +36,7 @@ class Transaction(BaseModel):
     owner: str
     account: str
     id: str | None = None
+    external_id: str | None = None
     date: str | None = None
     ticker: str | None = None
     type: str | None = None
@@ -198,6 +199,7 @@ class TransactionCreate(BaseModel):
     fees: Optional[float] = None
     comments: Optional[str] = None
     reason: Optional[str] = None
+    external_id: Optional[str] = None
 
 
 class TransactionUpdate(TransactionCreate):
@@ -672,16 +674,28 @@ async def delete_transaction(request: Request, tx_id: str) -> dict:
 
 
 @router.post("/transactions/import", response_model=List[Transaction])
-async def import_transactions(provider: str = Form(...), file: UploadFile = File(...)) -> List[Transaction]:
-    """Parse a transaction export and return the contained transactions."""
+async def import_transactions(
+    request: Request, provider: str = Form(...), file: UploadFile = File(...)
+) -> List[Transaction]:
+    """Parse a transaction export and return transactions not already imported.
+
+    Candidates carrying a stable ``external_id`` (e.g. Moneyhub's per-row
+    ``Id``) are filtered against previously persisted transactions so
+    re-importing the same export file does not surface duplicates to the
+    caller.
+    """
 
     data = await file.read()
     try:
-        return importers.parse(provider, data)
+        parsed = importers.parse(provider, data)
     except importers.UnknownProvider as exc:
         raise HTTPException(status_code=400, detail=f"Unknown provider: {exc}")
     except Exception as exc:  # pragma: no cover - parsing errors
         raise HTTPException(status_code=400, detail=f"Failed to parse file: {exc}")
+
+    store, _ = resolve_writable_store(request)
+    existing = _load_all_transactions(store)
+    return importers.dedupe_against_existing(parsed, existing)
 
 
 @router.post("/holdings/import")

--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -139,6 +139,7 @@ export const transactionContractSchema = z.object({
   owner: z.string(),
   account: z.string(),
   id: nullableString.optional(),
+  external_id: nullableString.optional(),
   date: nullableString.optional(),
   ticker: nullableString.optional(),
   type: nullableString.optional(),

--- a/frontend/src/contracts/generated/api-contract-schemas.v1.json
+++ b/frontend/src/contracts/generated/api-contract-schemas.v1.json
@@ -1046,6 +1046,16 @@
                 }
               ]
             },
+            "external_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "date": {
               "anyOf": [
                 {

--- a/frontend/src/contracts/spa.ts
+++ b/frontend/src/contracts/spa.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const SPA_RESPONSE_CONTRACT_VERSION = "2026-03-22";
+export const SPA_RESPONSE_CONTRACT_VERSION = "2026-07-08";
 
 const nullableString = z.string().nullable().optional();
 const nullableNumber = z.number().nullable().optional();
@@ -121,6 +121,7 @@ export const transactionContractSchema = z
     owner: z.string(),
     account: z.string(),
     id: nullableString,
+    external_id: nullableString,
     date: nullableString,
     ticker: nullableString,
     type: nullableString,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -333,6 +333,7 @@ export interface Transaction {
   owner: string;
   account: string;
   id?: string | null;
+  external_id?: string | null;
   date?: string | null;
   kind?: string | null;
   type?: string | null;

--- a/frontend/tests/fixtures/spaContracts.json
+++ b/frontend/tests/fixtures/spaContracts.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-03-22",
+  "version": "2026-07-08",
   "config": {
     "app_env": "local",
     "google_auth_enabled": false,

--- a/tests/backend/routes/test_transactions.py
+++ b/tests/backend/routes/test_transactions.py
@@ -358,6 +358,7 @@ async def test_create_transaction_records_valid_payload(monkeypatch, tmp_path):
             "fees": None,
             "comments": None,
             "reason": "Rebalance",
+            "external_id": None,
         }
     ]
     assert transactions_module._PORTFOLIO_IMPACT["alice"] == pytest.approx(7.5)

--- a/tests/backend/test_spa_response_contracts.py
+++ b/tests/backend/test_spa_response_contracts.py
@@ -169,7 +169,7 @@ def test_target_spa_endpoints_match_contracts(monkeypatch, tmp_path):
     portfolio_payload = client.get("/portfolio/alice").json()
     transactions_payload = client.get("/transactions").json()
 
-    assert SPA_RESPONSE_CONTRACT_VERSION == "2026-03-22"
+    assert SPA_RESPONSE_CONTRACT_VERSION == "2026-07-08"
     ConfigContract.model_validate(config_payload)
     TypeAdapter(List[OwnerSummaryContract]).validate_python(owners_payload)
     TypeAdapter(List[GroupSummaryContract]).validate_python(groups_payload)

--- a/tests/data/moneyhub_sample.csv
+++ b/tests/data/moneyhub_sample.csv
@@ -1,0 +1,3 @@
+Id,Owner,Account,Date,Amount,Description,Category
+mh-1001,alice,Current,2024-05-01,-42.50,Tesco Store,Groceries
+mh-1002,alice,Current,2024-05-02,1500.00,Salary,Income

--- a/tests/data/moneyhub_sample.csv
+++ b/tests/data/moneyhub_sample.csv
@@ -1,3 +1,3 @@
-Id,Owner,Account,Date,Amount,Description,Category
-mh-1001,alice,Current,2024-05-01,-42.50,Tesco Store,Groceries
-mh-1002,alice,Current,2024-05-02,1500.00,Salary,Income
+Owner,Account,Date,Amount,Description,Category
+alice,Current,2024-05-01,-42.50,Tesco Store,Groceries
+alice,Current,2024-05-02,1500.00,Salary,Income

--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -3,9 +3,11 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+from backend import importers
 from backend.app import create_app
 from backend.config import config
 from backend.importers import degiro, moneyhub
+from backend.routes.transactions import Transaction
 
 MONEYHUB_SAMPLE = Path(__file__).parent / "data" / "moneyhub_sample.csv"
 
@@ -68,6 +70,49 @@ def test_moneyhub_to_float_invalid_inputs():
     assert moneyhub._to_float("") is None
     assert moneyhub._to_float("not-a-number") is None
     assert moneyhub._to_float(None) is None
+
+
+def test_moneyhub_parse_empty_csv_returns_no_transactions():
+    csv_data = "Id,Owner,Account,Date,Amount,Description,Category\n"
+    assert moneyhub.parse(csv_data.encode("utf-8")) == []
+
+
+def test_moneyhub_parse_unrecognised_columns_yields_empty_fields():
+    csv_data = "Foo,Bar\nx,y\n"
+    txs = moneyhub.parse(csv_data.encode("utf-8"))
+    assert len(txs) == 1
+    tx = txs[0]
+    assert tx.external_id is None
+    assert tx.owner == ""
+    assert tx.account == ""
+    assert tx.amount_minor is None
+
+
+def _tx(external_id=None, **kwargs):
+    return Transaction(owner="alice", account="ISA", external_id=external_id, **kwargs)
+
+
+def test_dedupe_against_existing_returns_all_when_existing_empty():
+    candidates = [_tx(external_id="a"), _tx(external_id="b")]
+    assert importers.dedupe_against_existing(candidates, []) == candidates
+
+
+def test_dedupe_against_existing_returns_empty_when_candidates_empty():
+    assert importers.dedupe_against_existing([], [_tx(external_id="a")]) == []
+
+
+def test_dedupe_against_existing_filters_matching_external_ids():
+    candidates = [_tx(external_id="a"), _tx(external_id="b")]
+    existing = [_tx(external_id="a")]
+    result = importers.dedupe_against_existing(candidates, existing)
+    assert [t.external_id for t in result] == ["b"]
+
+
+def test_dedupe_against_existing_treats_missing_external_id_as_always_new():
+    candidate = _tx(external_id=None)
+    existing = [_tx(external_id=None)]
+    result = importers.dedupe_against_existing([candidate], existing)
+    assert result == [candidate]
 
 
 def test_import_transactions_moneyhub_dedupes_on_reimport(tmp_path, monkeypatch):

--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -58,12 +58,29 @@ def test_degiro_parse_handles_bad_data():
 def test_moneyhub_parse_fixture():
     txs = moneyhub.parse(MONEYHUB_SAMPLE.read_bytes())
     assert len(txs) == 2
-    assert txs[0].external_id == "mh-1001"
+    # No Id column in the fixture, so external_id falls back to the
+    # date+account+amount+description composite key (see issue #3426).
+    assert txs[0].external_id == "2024-05-01|Current|-42.50|tesco store"
     assert txs[0].owner == "alice"
     assert txs[0].account == "Current"
     assert txs[0].amount_minor == -42.50
     assert txs[0].comments == "Tesco Store"
     assert txs[0].type == "Groceries"
+
+
+def test_moneyhub_parse_uses_id_column_when_present():
+    csv_data = (
+        "Id,Owner,Account,Date,Amount,Description,Category\n"
+        "mh-1001,alice,Current,2024-05-01,-42.50,Tesco Store,Groceries\n"
+    )
+    txs = moneyhub.parse(csv_data.encode("utf-8"))
+    assert txs[0].external_id == "mh-1001"
+
+
+def test_moneyhub_composite_key_requires_date_and_amount():
+    assert moneyhub._composite_key(None, "Current", -42.50, "Tesco") is None
+    assert moneyhub._composite_key("2024-05-01", "Current", None, "Tesco") is None
+    assert moneyhub._composite_key("2024-05-01", "Current", -42.50, "Tesco") == "2024-05-01|Current|-42.50|tesco"
 
 
 def test_moneyhub_to_float_invalid_inputs():
@@ -117,6 +134,8 @@ def test_dedupe_against_existing_treats_missing_external_id_as_always_new():
 
 def test_import_transactions_moneyhub_dedupes_on_reimport(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch)
+    key_row1 = "2024-05-01|Current|-42.50|tesco store"
+    key_row2 = "2024-05-02|Current|1500.00|salary"
 
     # First import: nothing persisted yet, so both rows come back as new.
     resp = client.post(
@@ -126,7 +145,7 @@ def test_import_transactions_moneyhub_dedupes_on_reimport(tmp_path, monkeypatch)
     )
     assert resp.status_code == 200
     first = resp.json()
-    assert {t["external_id"] for t in first} == {"mh-1001", "mh-1002"}
+    assert {t["external_id"] for t in first} == {key_row1, key_row2}
 
     # Persist one of the two rows directly, mimicking what a caller would do
     # after reviewing the parsed-but-not-yet-saved import result.
@@ -137,7 +156,7 @@ def test_import_transactions_moneyhub_dedupes_on_reimport(tmp_path, monkeypatch)
             {
                 "owner": "alice",
                 "account_type": "Current",
-                "transactions": [{"external_id": "mh-1001", "comments": "Tesco Store"}],
+                "transactions": [{"external_id": key_row1, "comments": "Tesco Store"}],
             }
         )
     )
@@ -151,4 +170,4 @@ def test_import_transactions_moneyhub_dedupes_on_reimport(tmp_path, monkeypatch)
     )
     assert resp.status_code == 200
     second = resp.json()
-    assert {t["external_id"] for t in second} == {"mh-1002"}
+    assert {t["external_id"] for t in second} == {key_row2}

--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -1,8 +1,13 @@
+import json
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.config import config
-from backend.importers import degiro
+from backend.importers import degiro, moneyhub
+
+MONEYHUB_SAMPLE = Path(__file__).parent / "data" / "moneyhub_sample.csv"
 
 
 def _make_client(tmp_path, monkeypatch):
@@ -46,3 +51,59 @@ def test_degiro_parse_handles_bad_data():
     assert tx.units is None
     assert tx.fees is None
     assert tx.amount_minor is None
+
+
+def test_moneyhub_parse_fixture():
+    txs = moneyhub.parse(MONEYHUB_SAMPLE.read_bytes())
+    assert len(txs) == 2
+    assert txs[0].external_id == "mh-1001"
+    assert txs[0].owner == "alice"
+    assert txs[0].account == "Current"
+    assert txs[0].amount_minor == -42.50
+    assert txs[0].comments == "Tesco Store"
+    assert txs[0].type == "Groceries"
+
+
+def test_moneyhub_to_float_invalid_inputs():
+    assert moneyhub._to_float("") is None
+    assert moneyhub._to_float("not-a-number") is None
+    assert moneyhub._to_float(None) is None
+
+
+def test_import_transactions_moneyhub_dedupes_on_reimport(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+
+    # First import: nothing persisted yet, so both rows come back as new.
+    resp = client.post(
+        "/transactions/import",
+        data={"provider": "moneyhub"},
+        files={"file": ("tx.csv", MONEYHUB_SAMPLE.read_bytes(), "text/csv")},
+    )
+    assert resp.status_code == 200
+    first = resp.json()
+    assert {t["external_id"] for t in first} == {"mh-1001", "mh-1002"}
+
+    # Persist one of the two rows directly, mimicking what a caller would do
+    # after reviewing the parsed-but-not-yet-saved import result.
+    owner_dir = tmp_path / "alice"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "Current_transactions.json").write_text(
+        json.dumps(
+            {
+                "owner": "alice",
+                "account_type": "Current",
+                "transactions": [{"external_id": "mh-1001", "comments": "Tesco Store"}],
+            }
+        )
+    )
+
+    # Re-importing the same export should no longer surface the already
+    # persisted row, only the still-new one.
+    resp = client.post(
+        "/transactions/import",
+        data={"provider": "moneyhub"},
+        files={"file": ("tx.csv", MONEYHUB_SAMPLE.read_bytes(), "text/csv")},
+    )
+    assert resp.status_code == 200
+    second = resp.json()
+    assert {t["external_id"] for t in second} == {"mh-1002"}

--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from backend import importers
@@ -63,7 +64,7 @@ def test_moneyhub_parse_fixture():
     assert txs[0].external_id == "2024-05-01|Current|-42.50|tesco store"
     assert txs[0].owner == "alice"
     assert txs[0].account == "Current"
-    assert txs[0].amount_minor == -42.50
+    assert txs[0].amount_minor == pytest.approx(-42.50)
     assert txs[0].comments == "Tesco Store"
     assert txs[0].type == "Groceries"
 

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -58,6 +58,7 @@ def test_create_transaction_success(tmp_path, monkeypatch):
     expected_tx = payload.copy()
     expected_tx.pop("owner")
     expected_tx.pop("account")
+    expected_tx.setdefault("external_id", None)
     assert expected_tx in stored["transactions"]
     for tx in stored["transactions"]:
         assert "owner" not in tx


### PR DESCRIPTION
## Summary
- Adds a `moneyhub` provider to `backend/importers/_IMPORTER_PATHS`, following `degiro.py`'s CSV template (see [backend/importers/moneyhub.py](backend/importers/moneyhub.py)). CSV only — no OFX parser, since neither format could be verified against a real export.
- **No real Moneyhub sample export exists anywhere in the repo or issue.** The column layout (`Owner`, `Account`, `Date`, `Amount`, `Description`, `Category`, optional `Id`) is a documented best-effort guess and should be verified/corrected against a real anonymized export before this is trusted in production.
- Adds a shared, provider-agnostic `importers.dedupe_against_existing()` helper and wires it into `POST /transactions/import`, so re-importing the same export file no longer surfaces already-persisted rows to the caller. The endpoint skips the store lookup entirely when no parsed row carries a stable id, so degiro/hargreaves imports pay no added cost.
- Dedupe key derivation: uses a real `Id` CSV column when present, otherwise falls back to a synthetic `date+account+amount+description` composite key — per updated guidance on issue #3426 noting a manual CSV export isn't guaranteed to carry a source id. The composite key can under-dedupe two genuinely distinct rows that share all four fields; that's a documented, accepted trade-off in the absence of a real id.
- Adds `Transaction.external_id` (backend model + SPA response contract, both Python and TypeScript sides). This was necessary because the existing `Transaction.id` is a synthetic `owner:account:index` value regenerated positionally on every load (`_build_transaction_id`) — it can never match across a re-import of the same source row, so a real stable key had to be introduced. Bumped `SPA_RESPONSE_CONTRACT_VERSION` accordingly and kept the Python/TypeScript copies in sync per `scripts/check_contract_version_sync.py`.
- **Persistence is deliberately out of scope**, matching the parent issue's own descoped alternative: `POST /transactions/import` parses and dedupes but does not persist, the same as it already behaves for degiro/hargreaves today (this is pre-existing behavior, not a regression). Filed #4965 to track wiring actual persistence for all three providers.

## Test plan
- [x] `python -m pytest tests/ --no-cov` — full suite passing (excluding pre-existing, unrelated WSL/bash-dependent failures in `test_review_comment.py`)
- [x] `npx vitest --run` (frontend) — passing (1 pre-existing flaky jsdom-navigation test, passes in isolation)
- [x] `ruff` / `black` / `eslint` / `tsc --noEmit` / `mypy` clean on all touched files
- [ ] Verify parser column assumptions against a real Moneyhub export once one is available (tracked as an open risk, not blocking per explicit product decision to proceed with a documented best-effort format)

Closes #3426
Follow-up filed: #4965

🤖 Generated with [Claude Code](https://claude.com/claude-code)