### PR TITLE
fix: make _resolve_identity_when_auth_disabled return None explicitly

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -293,7 +293,10 @@ def _resolve_identity_when_auth_disabled(token: str | None) -> str | None:
             )
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Unauthorized email")
         return email
-    return local_login_identity()
+    identity = local_login_identity()
+    if identity is None:
+        return None
+    return identity
 
 
 async def get_current_user(token: str | None = Depends(oauth2_scheme)) -> str:


### PR DESCRIPTION
## Summary
- `_resolve_identity_when_auth_disabled` returned `local_login_identity()` directly, which propagates `None` implicitly rather than via an explicit terminal path
- Made the `None` return explicit so the control flow is unambiguous to readers/callers

Closes #4794

## Test plan
- [x] `python -m pytest tests/test_auth.py tests/test_auth_get_active_user.py -q` — 59 passed
- [x] `python -m black --check backend/auth.py`
- [x] `python -m isort --check backend/auth.py`
- [x] `python -m ruff check backend/auth.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)