### PR TITLE
test: add direct unit test for sanitise_log_value

### DIFF
--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -6,6 +6,7 @@ import sys
 from types import SimpleNamespace
 
 import backend.common.data_loader as dl
+from backend.logging_setup import sanitise_log_value
 from botocore.exceptions import ClientError
 import pytest
 
@@ -337,6 +338,39 @@ def test_load_account_falls_back_sanitises_log_fields(
     assert "\n" not in record.getMessage()
     assert record.owner == "ownerFAKE LOG LINE"
     assert record.account == "acctinjected"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # CRLF sequences are stripped (the CWE-117 log-injection vector this
+        # function guards against).
+        ("line\r\nbreak", "linebreak"),
+        ("bare\rcr", "barecr"),
+        ("bare\nlf", "barelf"),
+        # Mixed normal text with a CRLF injection attempt.
+        ("owner\r\nFAKE LOG LINE", "ownerFAKE LOG LINE"),
+        # Empty string is a no-op.
+        ("", ""),
+        # Already-safe strings pass through unchanged.
+        ("hello world", "hello world"),
+        # Non-string input is coerced to str first.
+        (123, "123"),
+        # Null bytes and other Unicode control characters are NOT stripped;
+        # sanitise_log_value only targets CRLF (CWE-117), not general control
+        # characters, so they must be preserved as-is.
+        ("bad\x00value", "bad\x00value"),
+        ("ctrl\x01char", "ctrl\x01char"),
+        ("del\x7fchar", "del\x7fchar"),
+    ],
+)
+def test_sanitise_log_value_direct(value, expected):
+    """Direct unit test documenting sanitise_log_value's exact contract.
+
+    Complements the integration tests above (which only assert on the final
+    log record) by exercising the function itself for each edge case.
+    """
+    assert sanitise_log_value(value) == expected
 
 
 def test_load_account_missing_bucket(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds `test_sanitise_log_value_direct`, a parametrized unit test that calls `sanitise_log_value` directly instead of only inferring its behaviour from log records.
- Documents the function's actual contract: it strips CRLF (`\r`, `\n`) to prevent CWE-117 log injection, coerces non-strings via `str()`, and leaves null bytes / other Unicode control characters untouched (it does not attempt general control-character sanitisation).

Note: the issue's "How" section assumed the function also strips null bytes and Unicode control characters. I verified against the actual implementation (`backend/logging_setup.py::sanitise_log_value`, which only does `.replace("\r", "").replace("\n", "")`) and wrote the test to match real behaviour, per the issue's own failure criteria ("Test fails on valid inputs that should be preserved").

Closes #4868

## Test plan
- [x] `python -m pytest tests/test_data_loader_aws.py -q --no-cov` — 32 passed
- [x] `python -m pytest tests/test_data_loader_aws.py -k sanitise --no-cov -v` — 11 passed
- [x] `ruff check tests/test_data_loader_aws.py` — no new findings (pre-existing I001/B010 unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)