### PR TITLE
Frontend: build /data-quality timeseries dashboard page

### DIFF
--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -39,6 +39,7 @@ export interface TabsConfig {
   'trade-compliance': boolean;
   reports: boolean;
   scenario: boolean;
+  dataquality: boolean;
 }
 
 export interface AppConfig {
@@ -100,6 +101,7 @@ const defaultTabs: TabsConfig = {
   'trade-compliance': false,
   reports: false,
   scenario: true,
+  dataquality: true,
 };
 
 export interface ConfigContextValue extends AppConfig {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -49,6 +49,7 @@ import type {
   AnalyticsEventPayload,
   AnalyticsFunnelSummary,
   AnalyticsSource,
+  DataQualityTimeseriesResponse,
 } from "./types";
 import {
   configContractSchema,
@@ -57,6 +58,7 @@ import {
   ownersContractSchema,
   portfolioContractSchema,
   transactionsContractSchema,
+  dataQualityTimeseriesContractSchema,
 } from "./contracts/apiContracts";
 
 const cleanOptionalString = (value: unknown): string | null => {
@@ -1465,6 +1467,33 @@ export const getVarBreakdown = (
           varLossPercent: response.var_loss_percent ?? null,
         }
   ));
+};
+
+/** Fetch timeseries data quality metrics (gaps, duplicates, outliers) per cached position. */
+export const getDataQualityTimeseries = async (
+  opts: {
+    ticker?: string;
+    exchange?: string;
+    gapThresholdDays?: number;
+    outlierSigma?: number;
+    rollingWindow?: number;
+  } = {},
+): Promise<DataQualityTimeseriesResponse> => {
+  const params = new URLSearchParams();
+  if (opts.ticker) params.set("ticker", opts.ticker);
+  if (opts.exchange) params.set("exchange", opts.exchange);
+  if (opts.gapThresholdDays != null)
+    params.set("gap_threshold_days", String(opts.gapThresholdDays));
+  if (opts.outlierSigma != null)
+    params.set("outlier_sigma", String(opts.outlierSigma));
+  if (opts.rollingWindow != null)
+    params.set("rolling_window", String(opts.rollingWindow));
+  const qs = params.toString();
+  return dataQualityTimeseriesContractSchema.parse(
+    await fetchJson<DataQualityTimeseriesResponse>(
+      `${API_BASE}/data-quality/timeseries${qs ? `?${qs}` : ""}`,
+    ),
+  );
 };
 
 // ───────────── Goals API ─────────────

--- a/frontend/src/components/DataQualityDrilldownModal.tsx
+++ b/frontend/src/components/DataQualityDrilldownModal.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import type { TimeseriesQualityPosition } from "../types";
+
+interface Props {
+  position: TimeseriesQualityPosition;
+  onClose: () => void;
+}
+
+export function DataQualityDrilldownModal({ position, onClose }: Props) {
+  const { t } = useTranslation();
+  const hasGaps = position.gaps.length > 0;
+  const hasDuplicates = position.duplicate_dates.length > 0;
+  const hasOutliers = position.outliers.length > 0;
+  const hasIssues = hasGaps || hasDuplicates || hasOutliers;
+
+  // Keep a stable ref to onClose so the keydown listener is registered only
+  // once (on mount) and never needs to be removed/re-added when the parent
+  // re-renders with a new inline callback reference.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onCloseRef.current();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: "rgba(0,0,0,0.3)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          background: "var(--surface-card-bg, #fff)",
+          color: "var(--surface-card-color, #111)",
+          border: "1px solid var(--surface-card-border, #d9d9d9)",
+          padding: "1rem",
+          maxHeight: "80%",
+          minWidth: "20rem",
+          overflow: "auto",
+        }}
+      >
+        <h3>
+          {t("dataQuality.drilldown.title", {
+            ticker: position.ticker,
+            exchange: position.exchange,
+          })}
+        </h3>
+
+        {hasGaps && (
+          <div style={{ marginBottom: "1rem" }}>
+            <h4 style={{ margin: "0 0 0.5rem 0" }}>{t("dataQuality.drilldown.gaps")}</h4>
+            <ul style={{ margin: 0, paddingLeft: "1rem" }}>
+              {position.gaps.map((gap) => (
+                <li key={`${gap.start}-${gap.end}`}>
+                  {gap.start} – {gap.end} (
+                  {t("dataQuality.drilldown.missingDays", { count: gap.missing_business_days })})
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {hasDuplicates && (
+          <div style={{ marginBottom: "1rem" }}>
+            <h4 style={{ margin: "0 0 0.5rem 0" }}>{t("dataQuality.drilldown.duplicates")}</h4>
+            <ul style={{ margin: 0, paddingLeft: "1rem" }}>
+              {position.duplicate_dates.map((date) => (
+                <li key={date}>{date}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {hasOutliers && (
+          <div style={{ marginBottom: "1rem" }}>
+            <h4 style={{ margin: "0 0 0.5rem 0" }}>{t("dataQuality.drilldown.outliers")}</h4>
+            <table>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: "left", paddingRight: "1rem" }}>
+                    {t("dataQuality.drilldown.date")}
+                  </th>
+                  <th style={{ textAlign: "right", paddingRight: "1rem" }}>
+                    {t("dataQuality.drilldown.value")}
+                  </th>
+                  <th style={{ textAlign: "right" }}>{t("dataQuality.drilldown.zScore")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {position.outliers.map((outlier) => (
+                  <tr key={outlier.date}>
+                    <td style={{ paddingRight: "1rem" }}>{outlier.date}</td>
+                    <td style={{ textAlign: "right", paddingRight: "1rem" }}>
+                      {outlier.value.toFixed(2)}
+                    </td>
+                    <td style={{ textAlign: "right" }}>{outlier.z_score.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {!hasIssues && <p style={{ margin: 0 }}>{t("dataQuality.drilldown.noIssues")}</p>}
+
+        <button onClick={onClose} style={{ marginTop: "1rem" }}>
+          {t("dataQuality.drilldown.close")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default DataQualityDrilldownModal;

--- a/frontend/src/components/QualityStatusBadge.tsx
+++ b/frontend/src/components/QualityStatusBadge.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from "react-i18next";
+import type { QualityStatus } from "../lib/dataQualityStatus";
+
+const STATUS_COLORS: Record<QualityStatus, { bg: string; fg: string }> = {
+  green: { bg: "#1e7e34", fg: "#fff" },
+  amber: { bg: "#b8860b", fg: "#fff" },
+  red: { bg: "#b02a37", fg: "#fff" },
+};
+
+interface Props {
+  status: QualityStatus;
+}
+
+export function QualityStatusBadge({ status }: Props) {
+  const { t } = useTranslation();
+  const colors = STATUS_COLORS[status];
+  return (
+    <span
+      role="status"
+      style={{
+        display: "inline-block",
+        padding: "0.15rem 0.6rem",
+        borderRadius: "999px",
+        fontSize: "0.75rem",
+        fontWeight: 600,
+        backgroundColor: colors.bg,
+        color: colors.fg,
+      }}
+    >
+      {t(`dataQuality.status.${status}`)}
+    </span>
+  );
+}
+
+export default QualityStatusBadge;

--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -164,6 +164,35 @@ export const transactionContractSchema = z.object({
 
 export const transactionsContractSchema = z.array(transactionContractSchema);
 
+const dataQualityGapPeriodSchema = z.object({
+  start: z.string(),
+  end: z.string(),
+  missing_business_days: z.number(),
+});
+
+const dataQualityOutlierSchema = z.object({
+  date: z.string(),
+  value: z.number(),
+  z_score: z.number(),
+});
+
+const timeseriesQualityPositionSchema = z.object({
+  ticker: z.string(),
+  exchange: z.string(),
+  total_points: z.number(),
+  first_date: nullableString,
+  last_date: nullableString,
+  gap_count: z.number(),
+  gaps: z.array(dataQualityGapPeriodSchema),
+  duplicate_dates: z.array(z.string()),
+  outliers: z.array(dataQualityOutlierSchema),
+});
+
+export const dataQualityTimeseriesContractSchema = z.object({
+  count: z.number(),
+  positions: z.array(timeseriesQualityPositionSchema),
+});
+
 export const apiContractSchemas = {
   config: configContractSchema,
   owners: ownersContractSchema,
@@ -171,6 +200,7 @@ export const apiContractSchemas = {
   groupPortfolio: groupPortfolioContractSchema,
   portfolio: portfolioContractSchema,
   transactions: transactionsContractSchema,
+  dataQualityTimeseries: dataQualityTimeseriesContractSchema,
 } as const;
 
 // satisfies Record<keyof typeof apiContractSchemas, object> enforces that every
@@ -186,4 +216,5 @@ export const apiContractJsonSchemas = {
   groupPortfolio: toJSONSchema(groupPortfolioContractSchema),
   portfolio: toJSONSchema(portfolioContractSchema),
   transactions: toJSONSchema(transactionsContractSchema),
+  dataQualityTimeseries: toJSONSchema(dataQualityTimeseriesContractSchema),
 } satisfies Record<keyof typeof apiContractSchemas, object>;

--- a/frontend/src/lib/dataQualityStatus.ts
+++ b/frontend/src/lib/dataQualityStatus.ts
@@ -1,0 +1,20 @@
+import type { TimeseriesQualityPosition } from "../types";
+
+export type QualityStatus = "green" | "amber" | "red";
+
+/**
+ * Derives a tri-color RAG status from counts the backend already computed
+ * (see #4897's compute_quality). This is a display-only bucketing of
+ * existing counts, not a reimplementation of gap/outlier detection.
+ */
+export function getQualityStatus(
+  position: Pick<TimeseriesQualityPosition, "gap_count" | "duplicate_dates" | "outliers">,
+): QualityStatus {
+  if (position.duplicate_dates.length > 0 || position.outliers.length > 0) {
+    return "red";
+  }
+  if (position.gap_count > 0) {
+    return "amber";
+  }
+  return "green";
+}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -70,6 +70,7 @@
       "allocation": "Allokation",
       "compliance": "Compliance-Warnungen",
       "dataadmin": "Datenverwaltung",
+      "dataquality": "Datenqualität",
       "group": "Gruppe",
       "instrument": "Instrument",
       "instrumentadmin": "Instrumentverwaltung",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -64,6 +64,7 @@
       "allocation": "Allocation",
       "compliance": "Compliance Warnings",
       "dataadmin": "Data Admin",
+      "dataquality": "Data Quality",
       "group": "Group",
       "instrument": "Instrument",
       "instrumentadmin": "Instrument Admin",
@@ -106,6 +107,39 @@
     "ticker": "Ticker",
     "cancel": "Cancel",
     "close": "Close"
+  },
+  "dataQuality": {
+    "title": "Data Quality",
+    "noData": "No cached timeseries positions found.",
+    "viewDetails": "View details",
+    "columns": {
+      "ticker": "Ticker",
+      "exchange": "Exchange",
+      "totalPoints": "Total points",
+      "dateRange": "Date range",
+      "gapCount": "Gaps",
+      "duplicateCount": "Duplicates",
+      "outlierCount": "Outliers",
+      "status": "Status"
+    },
+    "status": {
+      "green": "Clean",
+      "amber": "Has gaps",
+      "red": "Has issues"
+    },
+    "drilldown": {
+      "title": "Data quality details: {{ticker}}.{{exchange}}",
+      "gaps": "Gaps",
+      "duplicates": "Duplicate dates",
+      "outliers": "Outliers",
+      "date": "Date",
+      "value": "Value",
+      "zScore": "Z-score",
+      "missingDays_one": "{{count}} missing business day",
+      "missingDays_other": "{{count}} missing business days",
+      "noIssues": "No data quality issues found for this position.",
+      "close": "Close"
+    }
   },
   "dashboard": {
     "alphaVsBenchmark": "Alpha vs Benchmark",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -70,6 +70,7 @@
       "allocation": "Asignación",
       "compliance": "Alertas de cumplimiento",
       "dataadmin": "Administración de datos",
+      "dataquality": "Calidad de datos",
       "group": "Grupo",
       "instrument": "Instrumento",
       "instrumentadmin": "Administración de instrumentos",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -70,6 +70,7 @@
       "allocation": "Allocation",
       "compliance": "Alertes de conformité",
       "dataadmin": "Administration des données",
+      "dataquality": "Qualité des données",
       "group": "Groupe",
       "instrument": "Instrument",
       "instrumentadmin": "Administration des instruments",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -70,6 +70,7 @@
       "allocation": "Allocazione",
       "compliance": "Avvisi di conformità",
       "dataadmin": "Amministrazione dati",
+      "dataquality": "Qualità dei dati",
       "group": "Gruppo",
       "instrument": "Strumento",
       "instrumentadmin": "Amministrazione strumenti",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -70,6 +70,7 @@
       "allocation": "Alocação",
       "compliance": "Alertas de conformidade",
       "dataadmin": "Administração de dados",
+      "dataquality": "Qualidade dos dados",
       "group": "Grupo",
       "instrument": "Instrumento",
       "instrumentadmin": "Administração de instrumentos",

--- a/frontend/src/modes.ts
+++ b/frontend/src/modes.ts
@@ -26,7 +26,8 @@ export type Mode =
   | "taxtools"
   | "pension"
   | "scenario"
-  | "createaccount";
+  | "createaccount"
+  | "dataquality";
 
 export const MODES: Mode[] = [
   "group",
@@ -57,4 +58,5 @@ export const MODES: Mode[] = [
   "pension",
   "scenario",
   "createaccount",
+  "dataquality",
 ];

--- a/frontend/src/pages/DataQuality.tsx
+++ b/frontend/src/pages/DataQuality.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getDataQualityTimeseries } from "../api";
+import type { TimeseriesQualityPosition } from "../types";
+import { useSortableTable } from "../hooks/useSortableTable";
+import tableStyles from "../styles/table.module.css";
+import { QualityStatusBadge } from "../components/QualityStatusBadge";
+import { getQualityStatus, type QualityStatus } from "../lib/dataQualityStatus";
+import { DataQualityDrilldownModal } from "../components/DataQualityDrilldownModal";
+import EmptyState from "../components/EmptyState";
+
+type Row = TimeseriesQualityPosition & {
+  duplicate_count: number;
+  outlier_count: number;
+  status: QualityStatus;
+};
+
+export default function DataQuality() {
+  const { t } = useTranslation();
+  const [positions, setPositions] = useState<TimeseriesQualityPosition[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<TimeseriesQualityPosition | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getDataQualityTimeseries()
+      .then((res) => {
+        if (cancelled) return;
+        setPositions(res.positions);
+        setError(null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setPositions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const rows: Row[] = useMemo(
+    () =>
+      positions.map((p) => ({
+        ...p,
+        duplicate_count: p.duplicate_dates.length,
+        outlier_count: p.outliers.length,
+        status: getQualityStatus(p),
+      })),
+    [positions],
+  );
+
+  const { sorted, sortKey, asc, handleSort } = useSortableTable(rows, "ticker");
+
+  return (
+    <div style={{ maxWidth: 1000, margin: "0 auto", padding: "1rem" }}>
+      <h1>{t("dataQuality.title")}</h1>
+
+      {loading && <div>{t("common.loading")}</div>}
+      {error && <p style={{ color: "red" }}>{error}</p>}
+
+      {!loading && !error && sorted.length === 0 && (
+        <EmptyState message={t("dataQuality.noData")} actions={[]} />
+      )}
+
+      {!loading && !error && sorted.length > 0 && (
+        <table className={`${tableStyles.table} mb-4 w-full`}>
+          <thead>
+            <tr>
+              <th
+                className={`${tableStyles.cell} ${tableStyles.clickable}`}
+                onClick={() => handleSort("ticker")}
+              >
+                {t("dataQuality.columns.ticker")}
+                {sortKey === "ticker" ? (asc ? " ▲" : " ▼") : ""}
+              </th>
+              <th className={tableStyles.cell}>{t("dataQuality.columns.exchange")}</th>
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort("total_points")}
+              >
+                {t("dataQuality.columns.totalPoints")}
+                {sortKey === "total_points" ? (asc ? " ▲" : " ▼") : ""}
+              </th>
+              <th className={tableStyles.cell}>{t("dataQuality.columns.dateRange")}</th>
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort("gap_count")}
+              >
+                {t("dataQuality.columns.gapCount")}
+                {sortKey === "gap_count" ? (asc ? " ▲" : " ▼") : ""}
+              </th>
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort("duplicate_count")}
+              >
+                {t("dataQuality.columns.duplicateCount")}
+                {sortKey === "duplicate_count" ? (asc ? " ▲" : " ▼") : ""}
+              </th>
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort("outlier_count")}
+              >
+                {t("dataQuality.columns.outlierCount")}
+                {sortKey === "outlier_count" ? (asc ? " ▲" : " ▼") : ""}
+              </th>
+              <th className={`${tableStyles.cell} ${tableStyles.center}`}>
+                {t("dataQuality.columns.status")}
+              </th>
+              <th className={tableStyles.cell}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((row) => (
+              <tr key={`${row.ticker}.${row.exchange}`}>
+                <td className={tableStyles.cell}>{row.ticker}</td>
+                <td className={tableStyles.cell}>{row.exchange}</td>
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{row.total_points}</td>
+                <td className={tableStyles.cell}>
+                  {row.first_date && row.last_date
+                    ? `${row.first_date} – ${row.last_date}`
+                    : "—"}
+                </td>
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{row.gap_count}</td>
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{row.duplicate_count}</td>
+                <td className={`${tableStyles.cell} ${tableStyles.right}`}>{row.outlier_count}</td>
+                <td className={`${tableStyles.cell} ${tableStyles.center}`}>
+                  <QualityStatusBadge status={row.status} />
+                </td>
+                <td className={tableStyles.cell}>
+                  <button type="button" onClick={() => setSelected(row)}>
+                    {t("dataQuality.viewDetails")}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {selected && (
+        <DataQualityDrilldownModal position={selected} onClose={() => setSelected(null)} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/registry.ts
+++ b/frontend/src/routes/registry.ts
@@ -183,6 +183,16 @@ export const ROUTE_REGISTRY: RouteRegistryEntry[] = [
     defaultPath: () => '/dataadmin',
   },
   {
+    mode: 'dataquality',
+    routeSegment: 'data-quality',
+    section: 'support',
+    menuCategory: 'operations',
+    priority: 91,
+    defaultPath: () => '/data-quality',
+    routePath: '/data-quality',
+    lazyComponent: lazyPage(() => import('../pages/DataQuality')),
+  },
+  {
     mode: 'reports',
     routeSegment: 'reports',
     section: 'user',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -217,6 +217,35 @@ export interface ValueAtRiskResponse {
   sharpe_ratio?: number | null;
 }
 
+export interface DataQualityGapPeriod {
+  start: string;
+  end: string;
+  missing_business_days: number;
+}
+
+export interface DataQualityOutlier {
+  date: string;
+  value: number;
+  z_score: number;
+}
+
+export interface TimeseriesQualityPosition {
+  ticker: string;
+  exchange: string;
+  total_points: number;
+  first_date: string | null;
+  last_date: string | null;
+  gap_count: number;
+  gaps: DataQualityGapPeriod[];
+  duplicate_dates: string[];
+  outliers: DataQualityOutlier[];
+}
+
+export interface DataQualityTimeseriesResponse {
+  count: number;
+  positions: TimeseriesQualityPosition[];
+}
+
 export interface AlphaSeriesPoint {
   date: string;
   portfolio_cumulative_return: number;

--- a/frontend/tests/unit/pages/DataQuality.test.tsx
+++ b/frontend/tests/unit/pages/DataQuality.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import en from "@/locales/en/translation.json";
+import DataQuality from "@/pages/DataQuality";
+
+const mockGetDataQualityTimeseries = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api", async () => {
+  const actual = await vi.importActual<typeof import("@/api")>("@/api");
+  return {
+    ...actual,
+    getDataQualityTimeseries: mockGetDataQualityTimeseries,
+  };
+});
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+});
+
+describe("DataQuality page", () => {
+  it("renders a row per position with counts and RAG status", async () => {
+    mockGetDataQualityTimeseries.mockResolvedValue({
+      count: 3,
+      positions: [
+        {
+          ticker: "CLEAN",
+          exchange: "L",
+          total_points: 100,
+          first_date: "2026-01-01",
+          last_date: "2026-06-01",
+          gap_count: 0,
+          gaps: [],
+          duplicate_dates: [],
+          outliers: [],
+        },
+        {
+          ticker: "GAPPY",
+          exchange: "L",
+          total_points: 50,
+          first_date: "2026-01-01",
+          last_date: "2026-06-01",
+          gap_count: 1,
+          gaps: [{ start: "2026-02-01", end: "2026-02-05", missing_business_days: 4 }],
+          duplicate_dates: [],
+          outliers: [],
+        },
+        {
+          ticker: "DUPED",
+          exchange: "N",
+          total_points: 30,
+          first_date: "2026-01-01",
+          last_date: "2026-06-01",
+          gap_count: 0,
+          gaps: [],
+          duplicate_dates: ["2026-03-01"],
+          outliers: [{ date: "2026-04-01", value: 999, z_score: 5.2 }],
+        },
+      ],
+    });
+
+    render(<DataQuality />);
+
+    expect(await screen.findByRole("heading", { name: en.dataQuality.title })).toBeInTheDocument();
+    expect(await screen.findByText("CLEAN")).toBeInTheDocument();
+    expect(screen.getByText("GAPPY")).toBeInTheDocument();
+    expect(screen.getByText("DUPED")).toBeInTheDocument();
+
+    expect(screen.getByText(en.dataQuality.status.green)).toBeInTheDocument();
+    expect(screen.getByText(en.dataQuality.status.amber)).toBeInTheDocument();
+    expect(screen.getByText(en.dataQuality.status.red)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when no positions are cached", async () => {
+    mockGetDataQualityTimeseries.mockResolvedValue({ count: 0, positions: [] });
+
+    render(<DataQuality />);
+
+    expect(await screen.findByText(en.dataQuality.noData)).toBeInTheDocument();
+  });
+
+  it("shows an error message when the request fails", async () => {
+    mockGetDataQualityTimeseries.mockRejectedValueOnce(new Error("boom"));
+
+    render(<DataQuality />);
+
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+  });
+
+  it("opens the drill-down modal with problematic dates for a position", async () => {
+    mockGetDataQualityTimeseries.mockResolvedValue({
+      count: 1,
+      positions: [
+        {
+          ticker: "DUPED",
+          exchange: "N",
+          total_points: 30,
+          first_date: "2026-01-01",
+          last_date: "2026-06-01",
+          gap_count: 1,
+          gaps: [{ start: "2026-02-01", end: "2026-02-05", missing_business_days: 4 }],
+          duplicate_dates: ["2026-03-01"],
+          outliers: [{ date: "2026-04-01", value: 999, z_score: 5.2 }],
+        },
+      ],
+    });
+
+    render(<DataQuality />);
+
+    const viewDetailsButton = await screen.findByRole("button", {
+      name: en.dataQuality.viewDetails,
+    });
+    await act(async () => {
+      await userEvent.click(viewDetailsButton);
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("2026-03-01");
+    expect(dialog).toHaveTextContent("2026-04-01");
+    expect(dialog).toHaveTextContent("2026-02-01");
+
+    const closeButton = screen.getByRole("button", { name: en.dataQuality.drilldown.close });
+    await act(async () => {
+      await userEvent.click(closeButton);
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a read-only `/data-quality` React page consuming #4897's `GET /data-quality/timeseries` endpoint via a new `getDataQualityTimeseries()` in `api.ts` + a Zod contract schema, with no client-side recomputation of quality metrics.
- Renders a sortable table (one row per cached position) with total points, date range, gap/duplicate/outlier counts, and a new tri-color RAG status badge (green=clean, amber=gaps, red=duplicates/outliers) — status is derived purely by bucketing counts the backend already computed.
- Adds a drill-down modal (following `VarBreakdownModal`'s dialog pattern: `role="dialog"`, Escape-to-close) showing the specific gap periods, duplicate dates, and outliers for a selected position.
- Registers the route through `routes/registry.ts`'s `ROUTE_REGISTRY` (mode `dataquality`, standalone lazy-loaded page, `support`/`operations` menu category alongside `dataadmin`/`instrumentadmin`), with a new `dataquality` tab (default enabled) in `ConfigContext`.
- Adds `app.modes.dataquality` + a `dataQuality.*` translation namespace to all 6 locales (full strings in `en`, mode label only in the others — falls back to English for the rest via `fallbackLng`).

Closes #4898

## Test plan
- [x] `npx vitest run` — all 573 frontend unit tests pass, including new `tests/unit/pages/DataQuality.test.tsx` (renders rows/status, empty state, error state, drill-down open/close)
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — clean
- [ ] `npm run build` fails in this sandboxed worktree due to a missing native `esbuild` binary (pre-existing Windows optional-dependency environment issue, unrelated to this change — `tsc -b` completes successfully before the `vite build` step fails)