### PR TITLE
refactor(frontend): extract stripAuthCallbackParams to shared urlUtils

### DIFF
--- a/frontend/src/awsUiAuth.ts
+++ b/frontend/src/awsUiAuth.ts
@@ -1,3 +1,5 @@
+import { stripAuthCallbackParams } from './utils/urlUtils';
+
 export class UserCancelledError extends Error {
   constructor() {
     super('User cancelled Cognito login');
@@ -70,14 +72,6 @@ const normaliseDomain = (domain: string) => {
   const trimmed = domain.trim().replace(/\/+$/, '');
   if (!trimmed) return '';
   return trimmed.startsWith('https://') ? trimmed : `https://${trimmed}`;
-};
-
-// Strip the given OAuth callback params, preserving any other query params.
-const stripAuthCallbackParams = (keys: string[] = ['code', 'state']) => {
-  const params = new URLSearchParams(window.location.search);
-  keys.forEach((key) => params.delete(key));
-  const search = params.toString() ? `?${params.toString()}` : '';
-  window.history.replaceState({}, document.title, `${window.location.pathname}${search}`);
 };
 
 const redirectUri = (redirectPath?: string) => {

--- a/frontend/src/utils/urlUtils.ts
+++ b/frontend/src/utils/urlUtils.ts
@@ -33,3 +33,21 @@ export function decodePathSegment(segment: string): string {
 export function encodePathSegment(segment: string): string {
   return encodeURIComponent(segment.trim());
 }
+
+/**
+ * Strip the given OAuth callback params (default: code, state) from the
+ * current URL's query string, preserving any other query params, and
+ * replace the history entry so the params don't linger on reload/back.
+ */
+export function stripAuthCallbackParams(
+  keys: string[] = ['code', 'state']
+): void {
+  const params = new URLSearchParams(window.location.search);
+  keys.forEach((key) => params.delete(key));
+  const search = params.toString() ? `?${params.toString()}` : '';
+  window.history.replaceState(
+    {},
+    document.title,
+    `${window.location.pathname}${search}`
+  );
+}

--- a/frontend/tests/unit/urlUtils.test.ts
+++ b/frontend/tests/unit/urlUtils.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
-import { decodePathSegment, encodePathSegment } from "@/utils/urlUtils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  decodePathSegment,
+  encodePathSegment,
+  stripAuthCallbackParams,
+} from "@/utils/urlUtils";
 
 describe("encodePathSegment", () => {
   it("encodes spaces as %20", () => {
@@ -80,5 +84,59 @@ describe("getOwnerRootRedirectPath URL encoding", () => {
       { owner: "alice", accounts: [] },
     ]);
     expect(result).toBe("/performance/alice");
+  });
+});
+
+describe("stripAuthCallbackParams", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("strips the default code/state params, preserving other query params", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/callback?code=abc123&state=xyz&foo=bar",
+    );
+    const replaceState = vi.spyOn(window.history, "replaceState");
+
+    stripAuthCallbackParams();
+
+    expect(replaceState).toHaveBeenCalledWith(
+      {},
+      document.title,
+      "/callback?foo=bar",
+    );
+  });
+
+  it("strips a custom set of keys, including error", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/callback?code=abc123&state=xyz&error=access_denied",
+    );
+    const replaceState = vi.spyOn(window.history, "replaceState");
+
+    stripAuthCallbackParams(["code", "state", "error"]);
+
+    expect(replaceState).toHaveBeenCalledWith(
+      {},
+      document.title,
+      "/callback",
+    );
+  });
+
+  it("omits the query string entirely when no params remain", () => {
+    window.history.replaceState({}, "", "/callback?code=abc123&state=xyz");
+    const replaceState = vi.spyOn(window.history, "replaceState");
+
+    stripAuthCallbackParams();
+
+    expect(replaceState).toHaveBeenCalledWith(
+      {},
+      document.title,
+      "/callback",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Moves `stripAuthCallbackParams` out of `awsUiAuth.ts` into `frontend/src/utils/urlUtils.ts`, alongside the existing URL helpers (`encodePathSegment`/`decodePathSegment`).
- `awsUiAuth.ts` now imports the shared function; behavior and call sites (`stripAuthCallbackParams(['code', 'state', 'error'])`) are unchanged.
- Investigation found only one implementation existed (in `awsUiAuth.ts`), not multiple duplicated copies — the extraction still gives future call sites a shared location instead of another inline copy.

## Test plan
- [x] `npx vitest run tests/unit/urlUtils.test.ts tests/unit/awsUiAuth.test.ts` — added coverage for `stripAuthCallbackParams` (default keys, custom keys incl. `error`, no-remaining-params case) plus existing `awsUiAuth` tests, all pass
- [x] `npm run test -- --run` — full frontend suite (572 tests) passes
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean

Closes #4854