### PR TITLE
test(frontend): add integration test for full logout flow (#4802)

### DIFF
--- a/frontend/tests/unit/logoutFlowCognito.test.tsx
+++ b/frontend/tests/unit/logoutFlowCognito.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '@/i18n';
 
 // Full logout lifecycle in Cognito mode (issue #4802): click -> cognitoLogout()
 // called -> session cleared -> redirect to the Cognito hosted-UI logout
@@ -80,13 +81,17 @@ describe('Logout flow: Cognito mode (#4802)', () => {
       default: () => <div data-testid="login-page">sign in</div>,
     }));
 
-    vi.doMock('@/App.tsx', () => ({
-      default: ({ onLogout }: { onLogout?: () => void }) => (
-        <button type="button" data-testid="logout-button" onClick={onLogout}>
-          logout
-        </button>
-      ),
-    }));
+    // Render the real Menu component (the actual logout button end users
+    // click), not a stand-in, so a regression in Menu's onClick wiring would
+    // be caught here too.
+    vi.doMock('@/App.tsx', async () => {
+      const { default: Menu } = await import('@/components/Menu');
+      return {
+        default: ({ onLogout }: { onLogout?: () => void }) => (
+          <Menu onLogout={onLogout} />
+        ),
+      };
+    });
 
     window.localStorage.setItem('authToken', 'cognito-id-token');
     window.localStorage.setItem(
@@ -107,7 +112,13 @@ describe('Logout flow: Cognito mode (#4802)', () => {
 
     await mountRoot();
 
-    const logoutButton = await screen.findByTestId('logout-button');
+    const preferencesToggle = await screen.findByRole('button', {
+      name: i18n.t('app.menuCategories.preferences'),
+    });
+    fireEvent.click(preferencesToggle);
+    const logoutButton = await screen.findByRole('menuitem', {
+      name: i18n.t('app.logout'),
+    });
     fireEvent.click(logoutButton);
 
     // cognitoLogout() was called: the hosted-UI logout endpoint is reached
@@ -125,6 +136,8 @@ describe('Logout flow: Cognito mode (#4802)', () => {
 
     // The app falls back to the login screen once authed flips to false.
     expect(await screen.findByTestId('login-page')).toBeInTheDocument();
-    expect(screen.queryByTestId('logout-button')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: i18n.t('app.logout') })
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/logoutFlowCognito.test.tsx
+++ b/frontend/tests/unit/logoutFlowCognito.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Full logout lifecycle in Cognito mode (issue #4802): click -> cognitoLogout()
+// called -> session cleared -> redirect to the Cognito hosted-UI logout
+// endpoint. The unit tests in Menu.test.tsx only assert that the logout
+// callback is invoked; this exercises the real callback registered by
+// src/main.tsx's Root component end to end.
+
+const assignMock = vi.fn();
+
+const setLocation = () => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      origin: 'https://app.example.test',
+      pathname: '/',
+      search: '',
+      hash: '',
+      assign: assignMock,
+    },
+  });
+};
+
+const mountRoot = async () => {
+  document.body.innerHTML = '<div id="root"></div>';
+  const { Root } = await import('@/main');
+  const { AuthProvider } = await import('@/AuthContext');
+  const { UserProvider } = await import('@/UserContext');
+  return render(
+    <AuthProvider>
+      <UserProvider>
+        <BrowserRouter>
+          <Root />
+        </BrowserRouter>
+      </UserProvider>
+    </AuthProvider>
+  );
+};
+
+beforeEach(() => {
+  setLocation();
+  assignMock.mockClear();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe('Logout flow: Cognito mode (#4802)', () => {
+  it('clicking logout clears the session and redirects to the Cognito hosted-UI logout endpoint', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() }),
+    }));
+
+    vi.doMock('@/api', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/api')>();
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: false,
+          google_client_id: '',
+          disable_auth: true,
+          awsUiAuth: {
+            enabled: true,
+            domain: 'https://cognito.example.test',
+            clientId: 'client-abc',
+            redirectPath: '/',
+          },
+        }),
+        getStoredAuthToken: vi.fn(() => 'cognito-id-token'),
+      };
+    });
+
+    vi.doMock('@/LoginPage', () => ({
+      default: () => <div data-testid="login-page">sign in</div>,
+    }));
+
+    vi.doMock('@/App.tsx', () => ({
+      default: ({ onLogout }: { onLogout?: () => void }) => (
+        <button type="button" data-testid="logout-button" onClick={onLogout}>
+          logout
+        </button>
+      ),
+    }));
+
+    window.localStorage.setItem('authToken', 'cognito-id-token');
+    window.localStorage.setItem(
+      'auth.user',
+      JSON.stringify({ email: 'demo@example.test' })
+    );
+    window.localStorage.setItem(
+      'user.profile',
+      JSON.stringify({ email: 'demo@example.test' })
+    );
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({
+        idToken: 'cognito-id-token',
+        expiresAt: Date.now() + 60_000,
+      })
+    );
+
+    await mountRoot();
+
+    const logoutButton = await screen.findByTestId('logout-button');
+    fireEvent.click(logoutButton);
+
+    // cognitoLogout() was called: the hosted-UI logout endpoint is reached
+    // via window.location.assign() with the configured client_id.
+    await waitFor(() => expect(assignMock).toHaveBeenCalledTimes(1));
+    const [redirectUrl] = assignMock.mock.calls[0] as [string];
+    expect(redirectUrl).toMatch(/^https:\/\/cognito\.example\.test\/logout\?/);
+    expect(redirectUrl).toContain('client_id=client-abc');
+
+    // Session state is cleared before the redirect fires.
+    expect(window.sessionStorage.getItem('awsUiAuthSession')).toBeNull();
+    expect(window.localStorage.getItem('authToken')).toBeNull();
+    expect(window.localStorage.getItem('auth.user')).toBeNull();
+    expect(window.localStorage.getItem('user.profile')).toBeNull();
+
+    // The app falls back to the login screen once authed flips to false.
+    expect(await screen.findByTestId('login-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('logout-button')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/logoutFlowLocalDev.test.tsx
+++ b/frontend/tests/unit/logoutFlowLocalDev.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Full logout lifecycle in local dev mode (issue #4802): click -> navigate('/')
+// -> redirect occurs, with no Cognito hosted-UI round trip. Exercises the real
+// logout callback registered by src/main.tsx's Root component end to end,
+// rather than a mocked stand-in as in Menu.test.tsx's unit coverage.
+//
+// src/setupTests.ts globally stubs react-router-dom's useNavigate with a
+// no-op vi.fn() (see #4810), so this test opts back into the real hook to
+// observe navigate('/') actually changing the browser location.
+
+const mountRoot = async () => {
+  document.body.innerHTML = '<div id="root"></div>';
+  const { Root } = await import('@/main');
+  const { AuthProvider } = await import('@/AuthContext');
+  const { UserProvider } = await import('@/UserContext');
+  return render(
+    <AuthProvider>
+      <UserProvider>
+        <BrowserRouter>
+          <Root />
+        </BrowserRouter>
+      </UserProvider>
+    </AuthProvider>
+  );
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  window.history.pushState({}, '', '/portfolio/demo-owner');
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  window.history.pushState({}, '', '/');
+});
+
+describe('Logout flow: local dev mode (#4802)', () => {
+  it('clicking logout clears the session and navigates to / with no Cognito redirect', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() }),
+    }));
+
+    vi.doMock('react-router-dom', async () =>
+      vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+    );
+
+    vi.doMock('@/api', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/api')>();
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: false,
+          google_client_id: '',
+          disable_auth: true,
+          local_login_email: 'demo@example.test',
+        }),
+        getStoredAuthToken: vi.fn(() => null),
+      };
+    });
+
+    const cognitoLogout = vi.fn();
+    vi.doMock('@/awsUiAuth', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/awsUiAuth')>();
+      return { ...mod, cognitoLogout };
+    });
+
+    vi.doMock('@/App.tsx', () => ({
+      default: ({ onLogout }: { onLogout?: () => void }) => (
+        <button type="button" data-testid="logout-button" onClick={onLogout}>
+          logout
+        </button>
+      ),
+    }));
+
+    window.localStorage.setItem(
+      'auth.user',
+      JSON.stringify({ email: 'demo@example.test' })
+    );
+    window.localStorage.setItem(
+      'user.profile',
+      JSON.stringify({ email: 'demo@example.test' })
+    );
+
+    await mountRoot();
+
+    const logoutButton = await screen.findByTestId('logout-button');
+    fireEvent.click(logoutButton);
+
+    // navigate('/') was called: the browser location changes to '/'.
+    await waitFor(() => expect(window.location.pathname).toBe('/'));
+
+    // Session state is cleared.
+    expect(window.localStorage.getItem('auth.user')).toBeNull();
+    expect(window.localStorage.getItem('user.profile')).toBeNull();
+
+    // No Cognito hosted-UI round trip in local dev mode.
+    expect(cognitoLogout).not.toHaveBeenCalled();
+
+    // Auth is disabled with no awsUiAuth config, so the app shell (not a
+    // login screen) remains reachable after the redirect.
+    expect(await screen.findByTestId('logout-button')).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/logoutFlowLocalDev.test.tsx
+++ b/frontend/tests/unit/logoutFlowLocalDev.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '@/i18n';
 
 // Full logout lifecycle in local dev mode (issue #4802): click -> navigate('/')
 // -> redirect occurs, with no Cognito hosted-UI round trip. Exercises the real
@@ -69,13 +70,17 @@ describe('Logout flow: local dev mode (#4802)', () => {
       return { ...mod, cognitoLogout };
     });
 
-    vi.doMock('@/App.tsx', () => ({
-      default: ({ onLogout }: { onLogout?: () => void }) => (
-        <button type="button" data-testid="logout-button" onClick={onLogout}>
-          logout
-        </button>
-      ),
-    }));
+    // Render the real Menu component (the actual logout button end users
+    // click), not a stand-in, so a regression in Menu's onClick wiring would
+    // be caught here too.
+    vi.doMock('@/App.tsx', async () => {
+      const { default: Menu } = await import('@/components/Menu');
+      return {
+        default: ({ onLogout }: { onLogout?: () => void }) => (
+          <Menu onLogout={onLogout} />
+        ),
+      };
+    });
 
     window.localStorage.setItem(
       'auth.user',
@@ -88,7 +93,13 @@ describe('Logout flow: local dev mode (#4802)', () => {
 
     await mountRoot();
 
-    const logoutButton = await screen.findByTestId('logout-button');
+    const preferencesToggle = await screen.findByRole('button', {
+      name: i18n.t('app.menuCategories.preferences'),
+    });
+    fireEvent.click(preferencesToggle);
+    const logoutButton = await screen.findByRole('menuitem', {
+      name: i18n.t('app.logout'),
+    });
     fireEvent.click(logoutButton);
 
     // navigate('/') was called: the browser location changes to '/'.
@@ -102,7 +113,16 @@ describe('Logout flow: local dev mode (#4802)', () => {
     expect(cognitoLogout).not.toHaveBeenCalled();
 
     // Auth is disabled with no awsUiAuth config, so the app shell (not a
-    // login screen) remains reachable after the redirect.
-    expect(await screen.findByTestId('logout-button')).toBeInTheDocument();
+    // login screen) remains reachable after the redirect. Menu closes its
+    // open category on route change (navigate('/') just fired), so reopen
+    // it to confirm the logout control is still there, not that the app
+    // fell back to a login/error screen.
+    const preferencesToggleAfterLogout = await screen.findByRole('button', {
+      name: i18n.t('app.menuCategories.preferences'),
+    });
+    fireEvent.click(preferencesToggleAfterLogout);
+    expect(
+      await screen.findByRole('menuitem', { name: i18n.t('app.logout') })
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- The unit tests in `Menu.test.tsx` only assert that the logout callback is *invoked* (via a mocked `contextLogout`), not that the real logout lifecycle in `src/main.tsx`'s `Root` component behaves correctly.
- Adds two Vitest integration tests that mount the real `Root` component (`AuthProvider` + `UserProvider` + `BrowserRouter` + `Root`, following the existing `rootBootstrap.test.tsx` convention) and click through the actual logout callback end to end:
  - `frontend/tests/unit/logoutFlowCognito.test.tsx`: Cognito mode — click → `cognitoLogout()` redirects to the hosted-UI logout endpoint via `window.location.assign()`, and `authToken`/`auth.user`/`user.profile`/`awsUiAuthSession` are all cleared before the redirect.
  - `frontend/tests/unit/logoutFlowLocalDev.test.tsx`: local dev mode (`disable_auth: true`, no `awsUiAuth`) — click → `navigate('/')` (opting back into the real `useNavigate` per the `App.test.tsx` convention, since `src/setupTests.ts` globally stubs it), session cleared, no Cognito round trip.
- Note: the repo doesn't use Cypress (issue #4802 assumed it did) — Playwright is the e2e tool and Vitest+RTL is the existing "integration test" convention (see `rootBootstrap.test.tsx`, `main.cognito*.test.tsx`), so these tests follow that established pattern instead.

Closes #4802

## Test plan
- [x] `npx vitest run tests/unit/logoutFlowCognito.test.tsx tests/unit/logoutFlowLocalDev.test.tsx` — both pass
- [x] `npx vitest run tests/unit/components/Menu.test.tsx tests/unit/rootBootstrap.test.tsx tests/unit/App.test.tsx` — all 48 existing tests still pass (no regressions)
- [x] `npx eslint` and `npx prettier --check` clean on the new files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for logout behaviour in both Cognito and local development modes.
  * Verified that signing out clears saved session data and returns users to the login screen.
  * Confirmed redirect behaviour differs correctly between hosted sign-out and local sign-out flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->