### PR TITLE
test(cdk): positively assert /signup/* routes use HttpNoneAuthorizer

### DIFF
--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -708,6 +708,48 @@ def test_backend_api_routes_require_cognito_authorizer(template):
     assert "POST /token/cognito" not in actual_none_routes
 
 
+def test_signup_routes_use_http_none_authorizer(template):
+    """Positively assert that the /signup/* routes are registered with
+    HttpNoneAuthorizer (AuthorizationType NONE), rather than only checking
+    that they are absent from the Cognito-authorizer set.
+
+    test_backend_api_routes_require_cognito_authorizer above already proves
+    these routes are unauthenticated via a negative check (not in the JWT
+    set). That alone would also pass if a future change accidentally moved
+    them to a different non-JWT authorizer (e.g. IAM). This test documents
+    and enforces the specific intended authorizer (#4799, follow-up from
+    review of PR #4798).
+    """
+    routes = template.find_resources("AWS::ApiGatewayV2::Route")
+    assert routes, "Expected at least one API Gateway route"
+
+    signup_routes = {
+        resource["Properties"].get("RouteKey", logical_id): resource["Properties"]
+        for logical_id, resource in routes.items()
+        if "/signup/" in resource["Properties"].get("RouteKey", "")
+    }
+
+    expected_route_keys = {
+        "POST /signup/request",
+        "GET /signup/approve",
+        "POST /signup/approve",
+        "GET /signup/reject",
+        "POST /signup/reject",
+    }
+    assert set(signup_routes) == expected_route_keys, (
+        f"Unexpected /signup/* route set: {set(signup_routes)}"
+    )
+
+    for route_key, properties in signup_routes.items():
+        assert properties.get("AuthorizationType") == "NONE", (
+            f"Route {route_key} must use HttpNoneAuthorizer (AuthorizationType "
+            f"NONE), got {properties.get('AuthorizationType')!r}"
+        )
+        assert "AuthorizerId" not in properties, (
+            f"Route {route_key} must not reference an authorizer resource"
+        )
+
+
 # ---------------------------------------------------------------------------
 # CORS configuration (issue #4828)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `test_signup_routes_use_http_none_authorizer` alongside the existing `test_backend_api_routes_require_cognito_authorizer` in `cdk/tests/test_backend_lambda_stack.py`
- Positively asserts each `/signup/*` route (`POST /signup/request`, `GET+POST /signup/approve`, `GET+POST /signup/reject`) has `AuthorizationType: NONE` and no `AuthorizerId`, rather than only checking their absence from the JWT-authorizer set

## Why
The existing test is a negative check — it proves signup routes aren't JWT-protected, but would still pass if a future change accidentally moved them to a different non-JWT authorizer (e.g. IAM). This makes the intended authorizer explicit and enforced.

Closes #4799

## Test plan
- [x] `pytest cdk/tests/test_backend_lambda_stack.py -v -k "signup_routes_use_http_none or routes_require_cognito"` — 2 passed
- [x] `ruff check cdk/tests/test_backend_lambda_stack.py` — all checks passed