### PR TITLE
fix: add CodeQL suppression comment for response_class removal

### DIFF
--- a/backend/routes/timeseries_meta.py
+++ b/backend/routes/timeseries_meta.py
@@ -82,6 +82,8 @@ def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> tuple[str, st
     return sym, ex
 
 
+# lgtm[py/reflective-xss] — response_class=HTMLResponse intentionally omitted;
+# each return path below constructs its own response type.
 @router.get("/meta")
 async def get_meta_timeseries(
     ticker: str = Query(...),


### PR DESCRIPTION
## Summary
- Adds a `# lgtm[py/reflective-xss]` suppression comment above the `/meta` route decorator in `backend/routes/timeseries_meta.py`, documenting why `response_class=HTMLResponse` was intentionally removed in #4582 (each return path constructs its own response type: JSON, CSV, or HTML).
- Prevents a future contributor from re-adding `response_class=HTMLResponse` and reintroducing the CodeQL py/reflective-xss alert.

Closes #4626

## Test plan
- [x] `python -m pytest tests/routes/test_timeseries_meta.py tests/test_timeseries_meta_route.py -q` — 69 passed
- [x] `python -m ruff check --config backend/pyproject.toml backend/routes/timeseries_meta.py` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)