### PR TITLE
test(frontend): cover awsUiAuth.enabled string coercion path

### DIFF
--- a/frontend/tests/unit/rootBootstrap.test.tsx
+++ b/frontend/tests/unit/rootBootstrap.test.tsx
@@ -277,6 +277,75 @@ describe('Root bootstrap integration coverage', () => {
     expect(await screen.findByTestId('login-page')).toBeInTheDocument()
   })
 
+  it('shows login page when backend cfg carries awsUiAuth.enabled as the string "true" (issue #4635)', async () => {
+    // CDK sometimes serializes booleans as strings, so the backend /config
+    // response can carry awsUiAuth.enabled: 'true' instead of boolean true.
+    // The coercion in main.tsx (cfgAwsUiAuth?.enabled === 'true') must still
+    // force the login page in that case.
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: false,
+          google_client_id: null,
+          disable_auth: true,
+          awsUiAuth: {
+            enabled: 'true',
+            domain: 'https://cognito.example.com',
+            clientId: 'client-from-backend',
+          },
+        }),
+        getStoredAuthToken: vi.fn(() => null),
+      }
+    })
+
+    vi.doMock('@/LoginPage', () => ({
+      default: () => <div data-testid="login-page">sign in</div>
+    }))
+
+    await mountRoot()
+
+    expect(await screen.findByTestId('login-page')).toBeInTheDocument()
+  })
+
+  it('renders the app without a login page when backend cfg carries awsUiAuth.enabled as the string "false" (issue #4635)', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: false,
+          google_client_id: null,
+          disable_auth: true,
+          awsUiAuth: {
+            enabled: 'false',
+            domain: 'https://cognito.example.com',
+            clientId: 'client-from-backend',
+          },
+        }),
+        getStoredAuthToken: vi.fn(() => null),
+      }
+    })
+
+    vi.doMock('@/App.tsx', () => ({
+      default: () => <div data-testid="app-shell">App ready</div>
+    }))
+
+    await mountRoot()
+
+    expect(await screen.findByTestId('app-shell')).toBeInTheDocument()
+    expect(screen.queryByTestId('login-page')).not.toBeInTheDocument()
+  })
+
   it('shows login page when /config.json awsUiAuth prop is set but disable_auth=true', async () => {
     // Covers the fallback path: /config.json has awsUiAuth but the backend
     // response does not (e.g. older backend deployment).


### PR DESCRIPTION
## Summary
- Adds two tests to `frontend/tests/unit/rootBootstrap.test.tsx` covering the `awsUiAuth.enabled` string-coercion path in `main.tsx` (`cfgAwsUiAuth?.enabled === 'true'`).
- `enabled: 'true'` (string) → login page is still forced, since CDK sometimes serializes booleans as strings.
- `enabled: 'false'` (string) → app renders normally, no login page.
- No production code changes; the coercion logic already exists (added in #4633), it was just uncovered.

Closes #4635

## Test plan
- [x] `npm run test -- --run rootBootstrap` — 12/12 passing (10 existing + 2 new)
- [x] `npx eslint tests/unit/rootBootstrap.test.tsx` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)