### PR TITLE
docs(cdk): explain why _ui_auth_removal_policy keeps is_truthy_context

### DIFF
--- a/cdk/stacks/static_site_stack.py
+++ b/cdk/stacks/static_site_stack.py
@@ -18,7 +18,19 @@ from stacks.prod_env import assert_prod_env_vars, is_truthy_context
 
 
 def _ui_auth_removal_policy(scope: Construct) -> RemovalPolicy:
-    """Retain the Cognito user pool when production retention is requested."""
+    """Retain the Cognito user pool when production retention is requested.
+
+    Deliberately uses ``is_truthy_context`` rather than ``assert_prod_env_vars``:
+    ``retainUserPool`` and ``prod`` are CDK *context* values read via
+    ``node.try_get_context``, while ``assert_prod_env_vars`` validates
+    required-in-prod *environment* variables via ``os.getenv`` and raises
+    instead of returning a value. The two check different kinds of inputs for
+    different purposes, so they aren't interchangeable here. ``retainUserPool``
+    is intentionally not added to any required-in-prod validation: setting
+    ``prod`` already forces ``RemovalPolicy.RETAIN`` on its own (see below), so
+    ``retainUserPool`` has a safe default in prod and is only needed to opt a
+    non-prod stack into retention. See #4771.
+    """
     retain_user_pool = is_truthy_context(scope.node.try_get_context("retainUserPool"))
     prod = is_truthy_context(scope.node.try_get_context("prod"))
     if retain_user_pool or prod:

--- a/cdk/tests/test_static_site_stack.py
+++ b/cdk/tests/test_static_site_stack.py
@@ -422,6 +422,26 @@ def test_ui_auth_user_pool_is_retained_for_retain_user_pool_context(tmp_path):
     )
 
 
+def test_ui_auth_user_pool_retain_not_required_in_prod_env_vars(monkeypatch, tmp_path):
+    """retainUserPool is a CDK context flag, not a required-in-prod env var.
+
+    Synthesising with prod=true and no retainUserPool context (and without
+    any retain-related env var) must not raise via assert_prod_env_vars, and
+    the pool must still be retained because prod alone forces RETAIN. See
+    #4771: retainUserPool is intentionally exempt from required-in-prod
+    validation since it has a safe default under prod.
+    """
+    monkeypatch.setenv(
+        "GITHUB_DEPLOY_ROLE_ARN", "arn:aws:iam::123456789012:role/allotmint-github-deploy"
+    )
+    monkeypatch.delenv("RETAIN_USER_POOL", raising=False)
+    template = _template_with_context(tmp_path, {"prod": "true"})
+    template.has_resource(
+        "AWS::Cognito::UserPool",
+        {"DeletionPolicy": "Retain", "UpdateReplacePolicy": "Retain"},
+    )
+
+
 def test_ui_auth_outputs_exist(template):
     template.has_output("UiAuthUserPoolId", {})
     template.has_output("UiAuthUserPoolClientId", {})


### PR DESCRIPTION
## Summary
- Investigated issue #4771's suggested refactor: replace `is_truthy_context` with `assert_prod_env_vars` in `_ui_auth_removal_policy`.
- Concluded the two helpers aren't interchangeable: `assert_prod_env_vars` validates required-in-prod **environment variables** (`os.getenv`) and raises `ValueError`, while `_ui_auth_removal_policy` reads CDK **context values** (`node.try_get_context`) to compute a `RemovalPolicy` enum. Forcing the literal suggested call (`assert_prod_env_vars(prod, ["retainUserPool"])`) would either change runtime behavior or require changing the helper's signature — both out of scope per the issue's own constraints.
- Evaluated whether `retainUserPool` should be validated as required-in-prod: it should **not** be — setting `prod=true` alone already forces `RemovalPolicy.RETAIN` (see `test_ui_auth_user_pool_is_retained_for_prod_context`), so `retainUserPool` has a safe default under prod and is only needed to opt a non-prod deploy into retention.
- Documented this reasoning directly in `_ui_auth_removal_policy`'s docstring and added a regression test (`test_ui_auth_user_pool_retain_not_required_in_prod_env_vars`) locking in that prod-only synths still retain the user pool without needing any additional required env var.

## Test plan
- [x] `pytest cdk/tests/test_static_site_stack.py cdk/tests/test_prod_env.py -v` — 65 passed
- [x] Verified diff is scoped to the docstring and one new test; no behavior change

Closes #4771