### PR TITLE
test(signup): cover expired-token path for GET /signup/approve

### DIFF
--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -326,6 +326,30 @@ def test_get_approve_invalid_token_renders_error_page(client, monkeypatch):
     assert "text/html" in resp.headers["content-type"]
 
 
+def test_get_approve_expired_token_renders_error_page(client, monkeypatch):
+    """A token whose approval window has elapsed hits the RequestExpired path."""
+
+    test_client, tmp_path = client
+    _stub_store(monkeypatch)
+
+    from datetime import datetime, timedelta, timezone
+
+    store_dir = signup_requests.signup_requests_dir(tmp_path)
+    long_ago = datetime.now(timezone.utc) - timedelta(days=8)
+    record, token = signup_requests.create_signup_request(
+        "Jane Doe", "jane@example.com", "", store_dir, now=long_ago
+    )
+
+    resp = test_client.get(f"/signup/approve?id={record.id}&token={token}")
+    assert resp.status_code == 400
+    assert "text/html" in resp.headers["content-type"]
+    assert "invalid or expired approval token" in resp.text
+
+    # The request is untouched: still pending, and nothing was provisioned.
+    assert json.loads((store_dir / f"{record.id}.json").read_text())["status"] == "pending"
+    assert not (tmp_path / "accounts" / "jane").exists()
+
+
 # ---------------------------------------------------------------------------
 # Rate limiting (#4364)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `test_get_approve_expired_token_renders_error_page`, which builds a signup request with an already-past `expires_at` (via `create_signup_request(..., now=<8 days ago>)`) and asserts the GET `/signup/approve` handler hits the `RequestExpired` branch of `validate_request`, returning a 400 HTML error page with `"invalid or expired approval token"`, and confirms nothing was mutated (request still `pending`, no account provisioned).
- Follows the same pattern as the existing `test_get_approve_invalid_token_renders_error_page` test, distinct in that it exercises expiry rather than a wrong token.

## Test plan
- [x] `python -m pytest tests/backend/routes/test_signup.py -v --no-cov` — 23 passed, including the new test and the existing invalid-token test unaffected.

Closes #4400