### PR TITLE
test(frontend): guard exchangeCode invocation in ensureAwsUiAuth OAuth callback path

### DIFF
--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -63,6 +63,20 @@ describe('ensureAwsUiAuth', () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
+  it('does not invoke exchangeCode when no OAuth callback params are present', async () => {
+    // exchangeCode's only externally observable side effect is the token-endpoint
+    // fetch, so absence of that call is the proxy for "exchangeCode was not run"
+    // (exchangeCode is an unexported module-internal function and, under
+    // Vitest/ESM, spying on it directly would not intercept the in-module call
+    // from ensureAwsUiAuth anyway).
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(true);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('skips redirect when a valid session is already stored', async () => {
     window.sessionStorage.setItem(
       'awsUiAuthSession',
@@ -167,6 +181,22 @@ describe('ensureAwsUiAuth', () => {
       expect(stored.accessToken).toBe('access-tok');
       // The refresh token is persisted so the session can be silently renewed.
       expect(stored.refreshToken).toBe('refresh-tok');
+    });
+
+    it('invokes exchangeCode (hits the token endpoint exactly once) when OAuth callback params are present', async () => {
+      // Same proxy reasoning as the "no OAuth params" test above: exchangeCode
+      // itself isn't mockable across the module boundary, so we assert on its
+      // one externally observable effect — the /oauth2/token fetch call.
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id_token: 'tok', expires_in: 3600 }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(true);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('https://auth.example.test/oauth2/token');
     });
 
     it('uses configured redirectPath in the token exchange request', async () => {


### PR DESCRIPTION
## Summary
- Adds regression coverage for `ensureAwsUiAuth`'s OAuth callback path: asserts the token-endpoint `fetch` call (the only externally observable effect of the internal `exchangeCode` function) fires exactly once when `?code=`/`?state=` callback params are present, and asserts it does **not** fire on a normal fresh visit with no callback params.
- `exchangeCode` is an unexported, module-internal function. Under Vitest/ESM, `vi.spyOn` on a same-module export doesn't intercept an in-module call to that function, so directly mocking `exchangeCode` as described in the issue isn't achievable without changing its calling convention. Following the existing test suite's established pattern, the tests assert on the `fetch` boundary instead — functionally equivalent proof that `exchangeCode` ran (or didn't).

Closes #4460

## Test plan
- [x] `npm run test -- --run tests/unit/awsUiAuth.test.ts` — 47/47 passing (45 existing + 2 new)
- [x] `npm run lint` — clean