### PR TITLE
fix: use shared sanitise_log_value in accounts_store instead of local duplicate

### DIFF
--- a/backend/common/accounts_store.py
+++ b/backend/common/accounts_store.py
@@ -36,6 +36,7 @@ from backend.common import portfolio as portfolio_mod
 from backend.common import portfolio_loader
 from backend.common.path_utils import safe_join
 from backend.config import config
+from backend.logging_setup import sanitise_log_value
 
 try:  # Unix-like systems
     import fcntl  # type: ignore
@@ -90,11 +91,6 @@ def _default_person_payload(owner: str) -> Dict[str, Any]:
         "holdings": [],
         "viewers": [],
     }
-
-
-def _sanitize_log(value: str) -> str:
-    """Strip CR/LF from user-controlled values before passing them to logger calls (CWE-117)."""
-    return str(value).replace("\r", "").replace("\n", "")
 
 
 @dataclass
@@ -284,10 +280,10 @@ class S3AccountsStore:
             code = exc.response.get("Error", {}).get("Code", "")
             if code in {"NoSuchKey", "404", "NotFound"}:
                 return None
-            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, _sanitize_log(key), exc)
+            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, sanitise_log_value(key), exc)
             return None
         except BotoCoreError as exc:
-            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, _sanitize_log(key), exc)
+            logger.warning("S3 read failed for s3://%s/%s: %s", self.bucket, sanitise_log_value(key), exc)
             return None
         body = obj.get("Body")
         text = body.read().decode("utf-8-sig").strip() if body else ""
@@ -380,8 +376,8 @@ class S3AccountsStore:
         if tx_data is None:
             logger.warning(
                 "Portfolio rebuild skipped for %s/%s: no transaction document",
-                _sanitize_log(owner),
-                _sanitize_log(account),
+                sanitise_log_value(owner),
+                sanitise_log_value(account),
             )
             return
         holdings_data = portfolio_loader.compute_holdings_from_transactions(tx_data, owner, account)
@@ -401,7 +397,7 @@ class S3AccountsStore:
             try:
                 resp = client.list_objects_v2(**kwargs)
             except (ClientError, BotoCoreError) as exc:
-                logger.warning("S3 list failed for s3://%s/%s: %s", self.bucket, _sanitize_log(prefix), exc)
+                logger.warning("S3 list failed for s3://%s/%s: %s", self.bucket, sanitise_log_value(prefix), exc)
                 return
             for entry in resp.get("Contents", []) or []:
                 key = entry.get("Key")

--- a/tests/backend/common/test_accounts_store.py
+++ b/tests/backend/common/test_accounts_store.py
@@ -15,10 +15,10 @@ from backend.common.accounts_store import (
     WRITABLE_ACCOUNTS_PREFIX,
     LocalAccountsStore,
     S3AccountsStore,
-    _sanitize_log,
 )
 from backend.common.data_loader import ResolvedPaths
 from backend.config import config
+from backend.logging_setup import sanitise_log_value
 
 # ---------------------------------------------------------------------------
 # LocalAccountsStore
@@ -471,15 +471,12 @@ class TestS3Integration:
 # ---------------------------------------------------------------------------
 
 
-def test_sanitize_log_strips_newlines():
-    assert _sanitize_log("evil\nINJECTED") == "evilINJECTED"
-    assert _sanitize_log("evil\rINJECTED") == "evilINJECTED"
-    assert _sanitize_log("evil\r\nINJECTED") == "evilINJECTED"
+def test_accounts_store_uses_shared_sanitiser():
+    """accounts_store must delegate to the shared sanitiser, not a local copy."""
+    import backend.common.accounts_store as accounts_store_mod
 
-
-def test_sanitize_log_leaves_safe_values_unchanged():
-    assert _sanitize_log("alice") == "alice"
-    assert _sanitize_log("writable-accounts/alice/isa.json") == "writable-accounts/alice/isa.json"
+    assert accounts_store_mod.sanitise_log_value is sanitise_log_value
+    assert sanitise_log_value("evil\nINJECTED") == "evilINJECTED"
 
 
 def _assert_no_injected_newlines(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary
- Removed the local `_sanitize_log` helper in `backend/common/accounts_store.py` (CWE-117 log-injection guard) and replaced it with the already-established shared sanitiser `backend.logging_setup.sanitise_log_value`, which is used across most of the rest of the backend (`auth.py`, `compliance.py`, `approvals.py`, `data_loader.py`, `portfolio.py`, timeseries modules, etc).
- Both implementations were functionally identical (`str(value).replace("\r", "").replace("\n", "")`), so this is a pure dedup with no behavior change.
- Updated `tests/backend/common/test_accounts_store.py` to drop the now-removed local unit tests (already covered directly by `tests/backend/test_logging_setup.py`) and added a regression test asserting `accounts_store` uses the shared sanitiser rather than a local copy.
- Audited the codebase for other local CWE-117 sanitizer duplicates (`grep` for `def _sanitize`/`def sanitiz`) — `accounts_store.py` was the only file with a duplicate; `backend/common/path_utils.py` also defines a separate `sanitize_for_log`, but it's out of scope here (not used anywhere in production code, only in its own tests) and left untouched to keep this change minimal.

Closes #4567

## Test plan
- [x] `pytest tests/backend/common/test_accounts_store.py tests/backend/test_logging_setup.py` — 34 passed
- [x] `pytest tests/backend` (full backend suite) — 749 passed, 1 skipped, 12 xfailed
- [x] `ruff check backend/common/accounts_store.py tests/backend/common/test_accounts_store.py` — clean
- [x] `black --check` on both changed files shows no new formatting diffs introduced by this change