### PR TITLE
refactor(backend): consolidate duplicated owner-access logic onto authz helper

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -512,10 +512,6 @@ def _list_local_plots(
     demo_lower = demo_aliases[0].lower() if demo_aliases else "demo"
 
     def _is_authorized(owner: str, meta: Dict[str, Any]) -> bool:
-        viewers = meta.get("viewers", []) if isinstance(meta, dict) else []
-        if not isinstance(viewers, list):
-            viewers = []
-
         if config.disable_auth:
             if user is None:
                 return True
@@ -528,13 +524,13 @@ def _list_local_plots(
             return False
 
         if isinstance(user, str):
-            allowed_identities = {owner.lower()}
-            email = meta.get("email") if isinstance(meta, dict) else None
-            if isinstance(email, str) and email:
-                allowed_identities.add(email.lower())
-            allowed_identities.update(v.lower() for v in viewers if isinstance(v, str))
-            return user.lower() in allowed_identities
+            from backend.common.authz import identity_can_access_owner
 
+            return identity_can_access_owner(user, owner, meta if isinstance(meta, dict) else {})
+
+        viewers = meta.get("viewers", []) if isinstance(meta, dict) else []
+        if not isinstance(viewers, list):
+            viewers = []
         if user and user != owner and user not in viewers:
             return False
 
@@ -823,15 +819,11 @@ def _list_aws_plots(current_user: Optional[str] = None) -> List[Dict[str, Any]]:
             continue
         meta = load_person_meta(owner)
         if current_user:
-            viewers = meta.get("viewers", []) if isinstance(meta, dict) else []
-            if not isinstance(viewers, list):
-                viewers = []
-            allowed_identities = {owner.lower()}
-            email = meta.get("email") if isinstance(meta, dict) else None
-            if isinstance(email, str) and email.strip():
-                allowed_identities.add(email.strip().lower())
-            allowed_identities.update(viewer.lower() for viewer in viewers if isinstance(viewer, str))
-            if not isinstance(user, str) or user.lower() not in allowed_identities:
+            from backend.common.authz import identity_can_access_owner
+
+            if not isinstance(user, str) or not identity_can_access_owner(
+                user, owner, meta if isinstance(meta, dict) else {}
+            ):
                 continue
         results.append(_build_owner_summary(owner, accounts, meta))
     return results

--- a/backend/common/portfolio.py
+++ b/backend/common/portfolio.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from backend.common.approvals import load_approvals
+from backend.common.authz import identity_can_access_owner
 from backend.common.data_loader import (
     DATA_BUCKET_ENV,
     PLOTS_PREFIX,
@@ -108,12 +109,7 @@ def list_owners(
         try:
             data = json.loads(pf.read_text())
             slug = data.get("owner") or data.get("slug")
-            viewers = list(data.get("viewers", []))
-            if slug and (
-                not current_user
-                or current_user == slug
-                or current_user in viewers
-            ):
+            if slug and (not current_user or identity_can_access_owner(current_user, slug, data)):
                 owners.append(slug)
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning("Skipping owner file %s: %s", pf, exc)

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -750,6 +750,44 @@ class TestLoadDemoOwner:
         result = _load_demo_owner(tmp_path)
 
         assert result is None
+
+
+def test_list_aws_plots_enforces_email_and_viewer_permissions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cfg = Config()
+    cfg.app_env = "aws"
+    cfg.disable_auth = False
+    cfg.repo_root = tmp_path
+    cfg.accounts_root = tmp_path / "accounts"
+    monkeypatch.setattr("backend.common.data_loader.config", cfg)
+
+    class _FakeS3DataProvider:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def list_plots(self, current_user=None):
+            return [
+                {"owner": "alice", "accounts": ["isa"]},
+                {"owner": "bob", "accounts": ["gia"]},
+            ]
+
+    meta_by_owner = {
+        "alice": {"email": "Alice@Example.com", "viewers": []},
+        "bob": {"email": "bob@example.com", "viewers": []},
+    }
+
+    monkeypatch.setattr("backend.common.data_loader.S3DataProvider", _FakeS3DataProvider)
+    monkeypatch.setattr(
+        "backend.common.data_loader.load_person_meta",
+        lambda owner, root=None: meta_by_owner[owner],
+    )
+
+    result = data_loader._list_aws_plots(current_user="alice@example.com")
+
+    assert [entry["owner"] for entry in result] == ["alice"]
+
+
 def test_list_plots_prefers_aws_results(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cfg = Config()
     cfg.app_env = "aws"

--- a/tests/test_portfolio_list_owners.py
+++ b/tests/test_portfolio_list_owners.py
@@ -27,3 +27,18 @@ def test_list_owners_filters_by_viewer(tmp_path):
 
     owners = portfolio.list_owners(accounts_root=tmp_path, current_user="bob")
     assert set(owners) == {"alice", "bob"}
+
+
+def test_list_owners_matches_email_case_insensitively(tmp_path):
+    """Aligns with /owners: identities matching an owner's email are authorized."""
+    alice = tmp_path / "alice"
+    alice.mkdir()
+    (alice / "person.json").write_text(
+        json.dumps({"owner": "alice", "email": "Alice@Example.com"})
+    )
+    bob = tmp_path / "bob"
+    bob.mkdir()
+    (bob / "person.json").write_text(json.dumps({"owner": "bob"}))
+
+    owners = portfolio.list_owners(accounts_root=tmp_path, current_user="alice@example.com")
+    assert owners == ["alice"]


### PR DESCRIPTION
## Summary
- `data_loader._is_authorized` (used by `_list_local_plots`), `data_loader._list_aws_plots`, and `portfolio.list_owners()` each hand-rolled their own "is this identity allowed to access this owner?" check, with slightly different semantics.
- `portfolio.list_owners()` was the outlier: it didn't check the owner's `email` and wasn't case-insensitive, so an owner reachable via `/owners` (email match) could be missing from `portfolio.list_owners()`.
- All three now delegate to the canonical `backend.common.authz.identity_can_access_owner` helper (introduced in #4710), which normalizes on `{owner, email, viewers}` with case-insensitive, whitespace-tolerant matching.
- `disable_auth` / `current_user is None` short-circuits stay in the callers (listing-context concerns), not in the pure predicate, per the issue's guidance.
- The AWS listing path's `current_user.get(None)` ContextVar-vs-string resolution is preserved.

## Test plan
- [x] `pytest tests/backend/common/test_authz.py tests/backend/common/test_data_loader.py tests/test_portfolio_list_owners.py` — 64 passed
- [x] Added `test_list_owners_matches_email_case_insensitively` covering the deliberate `portfolio.list_owners()` alignment with `/owners`
- [x] Added `test_list_aws_plots_enforces_email_and_viewer_permissions` covering the previously-untested AWS listing auth path
- [x] Full `pytest tests/` — same pass/fail set as `main` (6 pre-existing unrelated failures in `test_review_comment.py`, confirmed via `git stash`)

Closes #4726