### PR TITLE
fix: pass onImported callback to CsvImportForm from PortfolioView

### DIFF
--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -405,6 +405,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
               <CsvImportForm
                 owner={data.owner}
                 accountTypes={data.accounts.map((acct) => acct.account_type)}
+                onImported={onPositionAdded}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- `CsvImportForm` in `PortfolioView.tsx` never received the `onImported` prop it accepts, so after a successful CSV import the portfolio holdings list stayed stale until a manual page refresh.
- Wired `onImported={onPositionAdded}`, reusing the existing refetch handler already passed in for `AddPositionForm`'s `onAdded` callback.

## Test plan
- [x] `npx eslint src/components/PortfolioView.tsx src/components/CsvImportForm.tsx` — clean
- [x] `npx tsc --noEmit` — no errors
- [x] `npx vitest run` — 589 passed (92 files)

Closes #4391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV imports now correctly trigger the same update handling as manually added positions.
  * Portfolio views refresh consistently after a CSV import is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->