### PR TITLE
fix(frontend): show loading/empty states for authorized owners in UserConfigPage

### DIFF
--- a/frontend/src/pages/UserConfig.tsx
+++ b/frontend/src/pages/UserConfig.tsx
@@ -18,6 +18,7 @@ export default function UserConfigPage() {
   const { user } = useAuth();
   const { theme } = useConfig();
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
+  const [ownersLoading, setOwnersLoading] = useState(true);
   const [owner, setOwner] = useState('');
   const [cfg, setCfg] = useState<UserConfig>({});
   const [status, setStatus] = useState<string | null>(null);
@@ -33,8 +34,9 @@ export default function UserConfigPage() {
     getOwners()
       .then((os) => setOwners(sanitizeOwners(os)))
       .catch(() => {
-        /* ignore */
-      });
+        setOwners([]);
+      })
+      .finally(() => setOwnersLoading(false));
   }, []);
 
   useEffect(() => {
@@ -148,18 +150,31 @@ export default function UserConfigPage() {
           </p>
         </section>
       )}
-      <select
-        className="w-full border p-2"
-        value={owner}
-        onChange={(e) => setOwner(e.target.value)}
-      >
-        <option value="">{t('userConfig.selectOwner', 'Select owner')}</option>
-        {owners.map((o) => (
-          <option key={o.owner} value={o.owner}>
-            {o.full_name?.trim() ? o.full_name : o.owner}
-          </option>
-        ))}
-      </select>
+      {ownersLoading ? (
+        <p className="text-gray-800 dark:text-gray-200">
+          {t('userConfig.loadingOwners', 'Loading owners...')}
+        </p>
+      ) : owners.length === 0 ? (
+        <p className="text-gray-800 dark:text-gray-200">
+          {t(
+            'userConfig.noOwners',
+            'No accounts are available for your account. Contact an administrator if you believe this is an error.'
+          )}
+        </p>
+      ) : (
+        <select
+          className="w-full border p-2"
+          value={owner}
+          onChange={(e) => setOwner(e.target.value)}
+        >
+          <option value="">{t('userConfig.selectOwner', 'Select owner')}</option>
+          {owners.map((o) => (
+            <option key={o.owner} value={o.owner}>
+              {o.full_name?.trim() ? o.full_name : o.owner}
+            </option>
+          ))}
+        </select>
+      )}
       {owner && (
         <>
           <form onSubmit={save} className="space-y-2">

--- a/frontend/tests/unit/pages/UserConfig.test.tsx
+++ b/frontend/tests/unit/pages/UserConfig.test.tsx
@@ -97,5 +97,37 @@ describe("UserConfig page", () => {
     const select = await screen.findByRole("combobox");
     expect((select as HTMLSelectElement).value).toBe("");
   });
+
+  it("shows a loading indicator while the authorized owners are being fetched", async () => {
+    let resolveOwners: (value: unknown) => void = () => {};
+    mockGetOwners.mockReturnValue(
+      new Promise((resolve) => {
+        resolveOwners = resolve;
+      }),
+    );
+    mockGetApprovals.mockResolvedValue({ approvals: [] });
+
+    render(<UserConfig />);
+
+    expect(screen.getByText(/loading owners/i)).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveOwners([{ owner: "alex", accounts: [] }]);
+    });
+
+    expect(await screen.findByRole("combobox")).toBeInTheDocument();
+    expect(screen.queryByText(/loading owners/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a meaningful empty state when the user has no authorized owners", async () => {
+    mockGetOwners.mockResolvedValue([]);
+    mockGetApprovals.mockResolvedValue({ approvals: [] });
+
+    render(<UserConfig />);
+
+    expect(await screen.findByText(/no accounts are available/i)).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
 });
 


### PR DESCRIPTION
## Summary

- Closes #4725.
- The `/owners` endpoint (`backend/routes/portfolio.py`) already scopes the returned list to owners the current authenticated identity may access, via `data_loader.list_plots` → `_is_authorized` → `identity_can_access_owner` (`backend/common/authz.py`, added in #4717 and the earlier `_list_local_plots` scoping). So `UserConfigPage`'s dropdown was already only ever populated from an authorized owner list — there was no unscoped/"show everything" bug to fix in the fetch itself.
- What was actually missing, per the issue's "Constraints" (no backend/endpoint changes) and "Handle edge cases" step: the page gave no feedback while `getOwners()` was in flight, and rendered a bare `<select>` with only the placeholder option when the authorized list came back empty — exactly the kind of silent, confusing state the issue calls out.
- Added an explicit `ownersLoading` state: shows a "Loading owners..." message while the owners fetch is in flight (dropdown is not rendered until it resolves), and shows a "No accounts are available..." message when the (already-authorized) list is empty, instead of an empty dropdown.
- Existing owner-selection behavior (auto-selecting the logged-in user's owner, fetching config/approvals on selection) is unchanged.

## Test plan

- [x] `npx vitest run tests/unit/pages/UserConfig.test.tsx` — 5/5 passing (added loading-state and empty-state cases)
- [x] `npx vitest run` (full frontend suite) — 591/591 passing, no regressions
- [x] `npx eslint src/pages/UserConfig.tsx tests/unit/pages/UserConfig.test.tsx` — clean
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)