### PR TITLE
fix(frontend): clear CreateAccountPage error when user edits a field

### DIFF
--- a/frontend/src/pages/CreateAccountPage.tsx
+++ b/frontend/src/pages/CreateAccountPage.tsx
@@ -149,6 +149,21 @@ export default function CreateAccountPage() {
     return <SuccessView />;
   }
 
+  function handleNameChange(value: string) {
+    setName(value);
+    setError(null);
+  }
+
+  function handleEmailChange(value: string) {
+    setEmail(value);
+    setError(null);
+  }
+
+  function handleNoteChange(value: string) {
+    setNote(value);
+    setError(null);
+  }
+
   return (
     <CreateAccountForm
       name={name}
@@ -156,9 +171,9 @@ export default function CreateAccountPage() {
       note={note}
       error={error}
       submitting={submitting}
-      onNameChange={setName}
-      onEmailChange={setEmail}
-      onNoteChange={setNote}
+      onNameChange={handleNameChange}
+      onEmailChange={handleEmailChange}
+      onNoteChange={handleNoteChange}
       onSubmit={handleSubmit}
     />
   );

--- a/frontend/tests/unit/pages/CreateAccountPage.test.tsx
+++ b/frontend/tests/unit/pages/CreateAccountPage.test.tsx
@@ -77,6 +77,27 @@ describe("CreateAccountPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("clears the validation error once the user edits a field", () => {
+    render(
+      <MemoryRouter>
+        <CreateAccountPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /request account/i }));
+    expect(
+      screen.getByText(/enter your name and email/i),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/full name/i), {
+      target: { value: "A" },
+    });
+
+    expect(
+      screen.queryByText(/enter your name and email/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows an error message and stays on the form when submission fails", async () => {
     vi.mocked(requestAccountSignup).mockRejectedValue(new Error("network"));
 


### PR DESCRIPTION
## Summary
- The `error` state in `CreateAccountPage.tsx` previously persisted after a validation or submission failure, even once the user started correcting the input.
- Wrapped the name/email/note change handlers so any edit clears the current error, while the error still shows on submit if the input is still invalid.

## Test plan
- [x] `npm --prefix frontend run test -- --run CreateAccountPage` — 5 tests pass, including a new test that edits a field after a validation error and confirms the message disappears.
- [x] `npx eslint` on the changed files — clean.

Closes #4376