### PR TITLE
Automate pension reports and push insights proactively

### DIFF
--- a/backend/common/pension.py
+++ b/backend/common/pension.py
@@ -14,9 +14,15 @@ Returns dict with fields used in API response.
 """
 
 import datetime as dt
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 DEFAULT_ANNUITY_MULTIPLE = 20  # crude capitalisation proxy
+
+# Lower-case substrings that indicate a defined contribution account whose value
+# should be treated as part of the pension pot.  New data files should stick to
+# one of these identifiers (e.g. "sipp" or vendor-prefixed variants such as
+# "kz:sipp") so that they are included automatically.
+DEFINED_CONTRIBUTION_ACCOUNT_MARKERS = ("sipp",)
 
 
 def state_pension_age_uk(dob: str) -> int:
@@ -41,9 +47,7 @@ def state_pension_age_uk(dob: str) -> int:
     return 68
 
 
-def _age_from_dob(
-    dob_str: Optional[str], today: Optional[dt.date] = None
-) -> Optional[float]:
+def _age_from_dob(dob_str: Optional[str], today: Optional[dt.date] = None) -> Optional[float]:
     """Convert YYYY-MM-DD string to fractional years age."""
     if not dob_str:
         return None
@@ -192,9 +196,7 @@ def forecast_pension(
                 continue
         forecast.append({"age": age, "income": income})
 
-    desired_income_value = (
-        float(desired_income_annual) if desired_income_annual is not None else None
-    )
+    desired_income_value = float(desired_income_annual) if desired_income_annual is not None else None
     state_income = float(state_pension_annual or 0.0)
     db_income_retirement = 0.0
     for pension in pensions:
@@ -225,4 +227,69 @@ def forecast_pension(
         "contribution_annual": float(contribution_annual),
         "desired_income_annual": desired_income_value,
         "annuity_multiple_used": float(annuity_multiple),
+    }
+
+
+def dc_pension_pot_gbp(accounts: List[Dict[str, Any]]) -> float:
+    """Sum ``value_estimate_gbp`` across defined-contribution pension accounts.
+
+    An account is treated as a DC pension pot when its ``account_type``
+    contains one of :data:`DEFINED_CONTRIBUTION_ACCOUNT_MARKERS`. Shared by
+    ``backend.routes.pension`` and the scheduled pension report Lambda so the
+    pot-value derivation only lives in one place.
+    """
+    total = 0.0
+    for account in accounts:
+        account_type = str(account.get("account_type", "")).lower()
+        if any(marker in account_type for marker in DEFINED_CONTRIBUTION_ACCOUNT_MARKERS):
+            total += float(account.get("value_estimate_gbp") or 0.0)
+    return total
+
+
+def pension_ytd_return(
+    *,
+    current_pot_gbp: float,
+    pot_start_of_year_gbp: float,
+    contributions_ytd_gbp: float = 0.0,
+) -> Dict[str, Any]:
+    """Return the year-to-date investment growth of a DC pension pot.
+
+    ``pot_start_of_year_gbp`` is the pot value at the start of the current
+    calendar year (or the earliest known snapshot, e.g. via
+    ``backend.common.pension_snapshots``). ``contributions_ytd_gbp`` is
+    subtracted from the raw pot change so the returned figures reflect
+    investment growth rather than money paid in.
+    """
+    ytd_gain_gbp = current_pot_gbp - pot_start_of_year_gbp - contributions_ytd_gbp
+    ytd_return_pct = (ytd_gain_gbp / pot_start_of_year_gbp) * 100.0 if pot_start_of_year_gbp else None
+    return {
+        "current_pot_gbp": float(current_pot_gbp),
+        "pot_start_of_year_gbp": float(pot_start_of_year_gbp),
+        "contributions_ytd_gbp": float(contributions_ytd_gbp),
+        "ytd_gain_gbp": ytd_gain_gbp,
+        "ytd_return_pct": ytd_return_pct,
+    }
+
+
+def pension_shortfall_vs_target(
+    *,
+    projected_pot_gbp: float,
+    desired_income_annual: float,
+    annuity_multiple: float = DEFAULT_ANNUITY_MULTIPLE,
+) -> Dict[str, Any]:
+    """Compare a projected pot against the pot required to support a target income.
+
+    Mirrors ``forecast_pension()``'s ``earliest_retirement_age`` comparison
+    (``pot / annuity_multiple >= desired_income_annual``) but expressed as a
+    pot-value shortfall/surplus rather than an age.
+    """
+    target_pot_gbp = desired_income_annual * annuity_multiple
+    shortfall_gbp = target_pot_gbp - projected_pot_gbp
+    shortfall_pct = (shortfall_gbp / target_pot_gbp * 100.0) if target_pot_gbp else None
+    return {
+        "target_pot_gbp": float(target_pot_gbp),
+        "projected_pot_gbp": float(projected_pot_gbp),
+        "shortfall_gbp": float(shortfall_gbp),
+        "shortfall_pct": shortfall_pct,
+        "on_track": shortfall_gbp <= 0,
     }

--- a/backend/common/pension_snapshots.py
+++ b/backend/common/pension_snapshots.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Persisted pot-value snapshots for pension YTD/period-over-period tracking.
+
+Mirrors ``backend.common.goals``'s use of ``backend.common.storage.get_storage``
+for env-var-configurable JSON persistence (local file, S3 or SSM Parameter
+Store, selected via URI scheme).
+"""
+
+import datetime as dt
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from backend.common.storage import JSONStorage, get_storage
+from backend.config import config
+
+_DEFAULT_SNAPSHOTS_URI = (
+    f"file://{(config.repo_root or Path(__file__).resolve().parents[1]) / 'data' / 'pension_snapshots.json'}"
+)
+
+try:
+    _STORAGE: JSONStorage = get_storage(os.getenv("PENSION_SNAPSHOTS_URI", _DEFAULT_SNAPSHOTS_URI))
+except Exception:
+    _STORAGE = get_storage(_DEFAULT_SNAPSHOTS_URI)
+
+
+def _load_raw() -> Dict[str, Dict[str, Any]]:
+    data = _STORAGE.load()
+    if not isinstance(data, dict):
+        return {}
+    return {k: v for k, v in data.items() if isinstance(v, dict)}
+
+
+def get_previous_snapshot(owner: str) -> Optional[Dict[str, Any]]:
+    """Return the last persisted pot snapshot for ``owner``, or ``None``."""
+    return _load_raw().get(owner)
+
+
+def ytd_baseline_pot_gbp(previous: Optional[Dict[str, Any]], current_pot_gbp: float, today: dt.date) -> float:
+    """Return the pot value to use as the start-of-year YTD baseline.
+
+    Falls back to the last known pot value on year rollover (or the current
+    pot if no snapshot has ever been recorded), since only one snapshot per
+    report run is kept rather than a full intra-year history.
+    """
+    if not previous:
+        return current_pot_gbp
+    if previous.get("year") == today.year:
+        return float(previous.get("start_of_year_pot_gbp", current_pot_gbp))
+    return float(previous.get("last_pot_gbp", current_pot_gbp))
+
+
+def previous_period_pot_gbp(previous: Optional[Dict[str, Any]], current_pot_gbp: float) -> float:
+    """Return the pot value recorded at the previous report run, or the current pot."""
+    if not previous:
+        return current_pot_gbp
+    return float(previous.get("last_pot_gbp", current_pot_gbp))
+
+
+def record_snapshot(owner: str, *, pot_gbp: float, as_of: dt.date) -> None:
+    """Persist ``pot_gbp`` as the latest known snapshot for ``owner``."""
+    data = _load_raw()
+    previous = data.get(owner)
+    start_of_year_pot_gbp = ytd_baseline_pot_gbp(previous, pot_gbp, as_of)
+    data[owner] = {
+        "year": as_of.year,
+        "start_of_year_pot_gbp": start_of_year_pot_gbp,
+        "last_pot_gbp": pot_gbp,
+        "last_as_of": as_of.isoformat(),
+    }
+    _STORAGE.save(data)
+
+
+__all__ = [
+    "get_previous_snapshot",
+    "ytd_baseline_pot_gbp",
+    "previous_period_pot_gbp",
+    "record_snapshot",
+]

--- a/backend/emails/pension_report.py
+++ b/backend/emails/pension_report.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+
+import boto3
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+logger = logging.getLogger(__name__)
+
+# Directory containing HTML templates
+_TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+# Jinja2 environment for rendering email templates
+_env = Environment(
+    loader=FileSystemLoader(_TEMPLATES_DIR),
+    autoescape=select_autoescape(["html", "xml"]),
+)
+
+
+@dataclass
+class PensionReport:
+    """Data required to render a pension report email."""
+
+    owner_name: str
+    stats: Dict[str, str]
+    scenarios: List[Dict[str, str]]
+    alerts: List[str] = field(default_factory=list)
+
+
+def render_pension_report(report: PensionReport) -> str:
+    """Render the pension report email HTML from a template."""
+
+    template = _env.get_template("pension_report.html")
+    return template.render(
+        owner_name=report.owner_name,
+        stats=report.stats,
+        scenarios=report.scenarios,
+        alerts=report.alerts,
+    )
+
+
+_SENDER_EMAIL = os.getenv("PENSION_REPORT_FROM", "no-reply@allotmint.com")
+
+
+def send_pension_report_email(user_email: str, report: PensionReport) -> None:
+    """Send the pension report email via AWS SES."""
+
+    body_html = render_pension_report(report)
+    subject = f"Pension Report - {report.owner_name}"
+
+    ses = boto3.client("ses", region_name=os.getenv("AWS_REGION", "us-east-1"))
+    ses.send_email(
+        Source=_SENDER_EMAIL,
+        Destination={"ToAddresses": [user_email]},
+        Message={
+            "Subject": {"Data": subject},
+            "Body": {"Html": {"Data": body_html}},
+        },
+    )

--- a/backend/lambda_api/pension_report.py
+++ b/backend/lambda_api/pension_report.py
@@ -1,0 +1,233 @@
+"""Lambda entry point to generate and email a pension performance report on a schedule.
+
+See ``backend.common.pension`` for the forecast/shortfall/YTD calculations and
+``backend.emails.pension_report`` for the SES/Jinja2 send pattern (mirrors
+``backend.emails.weekly_report``, issue #2758).
+
+Recipient selection
+--------------------
+The owners to report on are read from an SSM-backed (or local-file, in dev)
+JSON blob via ``backend.common.storage.get_storage`` -- the same
+env-var-configurable pattern already used by ``backend.alerts``,
+``backend.common.goals``, ``backend.nudges`` and ``backend.quests``. Each
+owner's email is taken from their existing person metadata rather than
+duplicating it in the recipient config. If no recipient config is present,
+every owner discovered by ``list_portfolios()`` is reported on.
+
+Failure handling
+-----------------
+Per-owner failures are caught and logged so one broken portfolio does not stop
+the report for everyone else. A failure notification is published via
+``backend.common.alerts.publish_sns_alert`` (not a silent failure) whenever
+initialisation fails outright or any owner's report could not be generated.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from backend.common.alerts import publish_sns_alert
+from backend.common.pension import (
+    _age_from_dob,
+    dc_pension_pot_gbp,
+    forecast_pension,
+    pension_shortfall_vs_target,
+    pension_ytd_return,
+    state_pension_age_uk,
+)
+from backend.common.pension_snapshots import (
+    get_previous_snapshot,
+    previous_period_pot_gbp,
+    record_snapshot,
+    ytd_baseline_pot_gbp,
+)
+from backend.common.portfolio_loader import list_portfolios
+from backend.common.storage import get_storage
+from backend.emails.pension_report import PensionReport, send_pension_report_email
+
+logger = logging.getLogger("pension_report")
+
+_DEFAULT_RECIPIENTS_URI = "ssm://pension-report-recipients"
+
+# (display label, env var, default growth %)
+_GROWTH_SCENARIOS: Tuple[Tuple[str, str, str], ...] = (
+    ("Pessimistic", "PENSION_REPORT_GROWTH_PESSIMISTIC_PCT", "2.0"),
+    ("Base", "PENSION_REPORT_GROWTH_BASE_PCT", "5.0"),
+    ("Optimistic", "PENSION_REPORT_GROWTH_OPTIMISTIC_PCT", "8.0"),
+)
+
+
+def _death_age() -> int:
+    return int(os.getenv("PENSION_REPORT_DEATH_AGE", "95"))
+
+
+def _desired_income_annual() -> Optional[float]:
+    value = os.getenv("PENSION_REPORT_DESIRED_INCOME_ANNUAL")
+    return float(value) if value else None
+
+
+def _contribution_annual() -> float:
+    return float(os.getenv("PENSION_REPORT_CONTRIBUTION_ANNUAL", "0"))
+
+
+def _drawdown_alert_pct() -> float:
+    return float(os.getenv("PENSION_REPORT_DRAWDOWN_ALERT_PCT", "10.0"))
+
+
+def _load_recipient_owners() -> Optional[List[str]]:
+    """Return the configured list of owners to report on, or ``None`` for "all owners"."""
+
+    uri = os.getenv("PENSION_REPORT_RECIPIENTS_URI", _DEFAULT_RECIPIENTS_URI)
+    data = get_storage(uri).load()
+    owners = data.get("owners")
+    if not owners:
+        return None
+    return [str(owner) for owner in owners]
+
+
+def _build_report_for_owner(
+    owner: str,
+    person: Dict[str, Any],
+    accounts: List[Dict[str, Any]],
+    today: dt.date,
+) -> Optional[Tuple[PensionReport, str]]:
+    dob = person.get("dob")
+    email = person.get("email")
+    if not dob or not email:
+        logger.warning("Skipping pension report for %s: missing dob or email", owner)
+        return None
+
+    current_age = _age_from_dob(dob, today)
+    if current_age is None:
+        logger.warning("Skipping pension report for %s: invalid dob", owner)
+        return None
+
+    retirement_age = state_pension_age_uk(dob)
+    # Keep the forecast beyond retirement even for a minimal configured death
+    # age, mirroring backend.routes.pension's forecast_death_age safeguard --
+    # forecast_pension() only populates projected_pot_gbp at retirement_age.
+    death_age = max(_death_age(), retirement_age + 1)
+    pot_gbp = dc_pension_pot_gbp(accounts)
+    contribution_annual = _contribution_annual()
+    desired_income_annual = _desired_income_annual()
+
+    previous = get_previous_snapshot(owner)
+    start_of_year_pot = ytd_baseline_pot_gbp(previous, pot_gbp, today)
+    previous_period_pot = previous_period_pot_gbp(previous, pot_gbp)
+    ytd = pension_ytd_return(
+        current_pot_gbp=pot_gbp,
+        pot_start_of_year_gbp=start_of_year_pot,
+        contributions_ytd_gbp=0.0,
+    )
+
+    ytd_change = f"£{ytd['ytd_gain_gbp']:,.2f}"
+    if ytd["ytd_return_pct"] is not None:
+        ytd_change += f" ({ytd['ytd_return_pct']:.1f}%)"
+    stats = {
+        "Current pot value": f"£{pot_gbp:,.2f}",
+        "YTD change": ytd_change,
+    }
+
+    scenarios: List[Dict[str, str]] = []
+    base_forecast: Optional[Dict[str, Any]] = None
+    for label, env_var, default in _GROWTH_SCENARIOS:
+        growth_pct = float(os.getenv(env_var, default))
+        forecast = forecast_pension(
+            dob=dob,
+            retirement_age=retirement_age,
+            death_age=death_age,
+            contribution_annual=contribution_annual,
+            investment_growth_pct=growth_pct,
+            desired_income_annual=desired_income_annual,
+            initial_pot=pot_gbp,
+            today=today,
+        )
+        if label == "Base":
+            base_forecast = forecast
+        scenarios.append(
+            {
+                "label": f"{label} ({growth_pct:.1f}% growth)",
+                "projected_pot_gbp": f"£{forecast['projected_pot_gbp']:,.2f}",
+            }
+        )
+
+    alerts: List[str] = []
+    if desired_income_annual is not None and base_forecast is not None:
+        shortfall = pension_shortfall_vs_target(
+            projected_pot_gbp=base_forecast["projected_pot_gbp"],
+            desired_income_annual=desired_income_annual,
+        )
+        if not shortfall["on_track"]:
+            alerts.append(
+                f"Projected pot is £{shortfall['shortfall_gbp']:,.2f} short of the "
+                f"target needed to support £{desired_income_annual:,.2f}/yr in retirement."
+            )
+
+    if previous_period_pot:
+        drawdown_pct = (pot_gbp - previous_period_pot) / previous_period_pot * 100.0
+        if drawdown_pct <= -_drawdown_alert_pct():
+            alerts.append(
+                f"Pot value dropped {abs(drawdown_pct):.1f}% since the last report "
+                f"(£{previous_period_pot:,.2f} -> £{pot_gbp:,.2f})."
+            )
+
+    record_snapshot(owner, pot_gbp=pot_gbp, as_of=today)
+
+    report = PensionReport(
+        owner_name=str(person.get("full_name") or owner),
+        stats=stats,
+        scenarios=scenarios,
+        alerts=alerts,
+    )
+    return report, email
+
+
+def lambda_handler(event, context):
+    """Lambda handler invoked by the scheduled EventBridge rule."""
+
+    today = dt.date.today()
+
+    try:
+        target_owners = _load_recipient_owners()
+        portfolios = list_portfolios()
+    except Exception as exc:
+        logger.error("Pension report failed to initialise: %s", exc, exc_info=True)
+        publish_sns_alert(
+            {
+                "message": f"Pension report Lambda failed to start: {exc}",
+                "ticker": "pension-report",
+            }
+        )
+        return {"sent": 0, "errors": [str(exc)]}
+
+    sent = 0
+    errors: List[str] = []
+    for portfolio in portfolios:
+        owner = portfolio["owner"]
+        if target_owners is not None and owner not in target_owners:
+            continue
+        try:
+            built = _build_report_for_owner(
+                owner, portfolio.get("person") or {}, portfolio.get("accounts") or [], today
+            )
+            if built is None:
+                continue
+            report, email = built
+            send_pension_report_email(email, report)
+            sent += 1
+        except Exception as exc:
+            logger.error("Pension report failed for owner %s: %s", owner, exc, exc_info=True)
+            errors.append(f"{owner}: {exc}")
+
+    if errors:
+        publish_sns_alert(
+            {
+                "message": f"Pension report failed for {len(errors)} owner(s): {'; '.join(errors)}",
+                "ticker": "pension-report",
+            }
+        )
+
+    return {"sent": sent, "errors": errors}

--- a/backend/routes/pension.py
+++ b/backend/routes/pension.py
@@ -4,18 +4,16 @@ from fastapi import APIRouter, HTTPException, Query, Request
 
 from backend.common.data_loader import load_person_metadata
 from backend.common.pension import (
+    DEFINED_CONTRIBUTION_ACCOUNT_MARKERS,
     _age_from_dob,
+    dc_pension_pot_gbp,
     forecast_pension,
     state_pension_age_uk,
 )
 from backend.common.portfolio import build_owner_portfolio
 from backend.routes._accounts import resolve_accounts_root
 
-# Lower-case substrings that indicate a defined contribution account whose value
-# should be treated as part of the pension pot.  New data files should stick to
-# one of these identifiers (e.g. "sipp" or vendor-prefixed variants such as
-# "kz:sipp") so that they are included automatically.
-DEFINED_CONTRIBUTION_ACCOUNT_MARKERS = ("sipp",)
+__all__ = ["DEFINED_CONTRIBUTION_ACCOUNT_MARKERS", "router"]
 
 router = APIRouter(tags=["pension"])
 
@@ -88,11 +86,7 @@ def pension_forecast(
         portfolio = build_owner_portfolio(owner, *portfolio_args, **portfolio_kwargs)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    pension_pot = 0.0
-    for account in portfolio.get("accounts", []):
-        account_type = str(account.get("account_type", "")).lower()
-        if any(marker in account_type for marker in DEFINED_CONTRIBUTION_ACCOUNT_MARKERS):
-            pension_pot += float(account.get("value_estimate_gbp") or 0.0)
+    pension_pot = dc_pension_pot_gbp(portfolio.get("accounts", []))
 
     db_pensions = []
     if db_income_annual is not None and db_normal_retirement_age is not None:
@@ -104,9 +98,7 @@ def pension_forecast(
         )
 
     annual_contribution = (
-        (contribution_monthly or 0.0) * 12
-        if contribution_monthly is not None
-        else contribution_annual or 0.0
+        (contribution_monthly or 0.0) * 12 if contribution_monthly is not None else contribution_annual or 0.0
     )
 
     try:

--- a/backend/templates/pension_report.html
+++ b/backend/templates/pension_report.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Pension Report - {{ owner_name }}</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 1rem; }
+    h1 { margin-bottom: 0.5rem; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 1rem; }
+    th, td { padding: 0.5rem; border: 1px solid #ddd; }
+    th { background: #f5f5f5; text-align: left; }
+    .alert { color: #b00020; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>Pension Report - {{ owner_name }}</h1>
+  <section>
+    <h2>Current Pot</h2>
+    <table>
+      <tbody>
+        {% for label, value in stats.items() %}
+        <tr>
+          <th>{{ label }}</th>
+          <td>{{ value }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+  <section>
+    <h2>Projected Value at Retirement</h2>
+    <table>
+      <thead>
+        <tr><th>Scenario</th><th>Projected pot</th></tr>
+      </thead>
+      <tbody>
+        {% for scenario in scenarios %}
+        <tr>
+          <td>{{ scenario.label }}</td>
+          <td>{{ scenario.projected_pot_gbp }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+  {% if alerts %}
+  <section>
+    <h2>Alerts</h2>
+    <ul>
+      {% for alert in alerts %}
+      <li class="alert">{{ alert }}</li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+</body>
+</html>

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -221,6 +221,19 @@ class BackendLambdaStack(Stack):
         budget_alert_email = self.node.try_get_context("budget_alert_email") or os.getenv(
             "BUDGET_ALERT_EMAIL"
         )
+        # Cadence for the pension report Lambda's EventBridge rule (issue #2758).
+        # "weekly" -> every Monday; "monthly" -> the 1st of the month. Configurable
+        # via CDK context or env var rather than hardcoded in the rule itself.
+        pension_report_cadence = (
+            self.node.try_get_context("pension_report_cadence")
+            or os.getenv("PENSION_REPORT_CADENCE")
+            or "weekly"
+        )
+        if pension_report_cadence not in {"weekly", "monthly"}:
+            raise ValueError(
+                "pension_report_cadence must be 'weekly' or 'monthly', got "
+                f"{pension_report_cadence!r}"
+            )
         data_bucket = s3.Bucket(
             self,
             "PortfolioDataBucket",
@@ -268,6 +281,10 @@ class BackendLambdaStack(Stack):
             # and writes new DIVIDEND transactions back to the same prefix.
             # See backend/common/dividends.py::refresh_dividends() (issue #2750).
             "dividend_refresh": (WRITABLE_ACCOUNTS_PREFIX,),
+            # pension_report calls list_portfolios() -> list_plots(), which needs
+            # ListBucket on accounts/ for the same reason as price_refresh above
+            # (issue #2758).
+            "pension_report": ("accounts",),
         }
 
         image_code = _lambda.DockerImageCode.from_image_asset(
@@ -917,6 +934,60 @@ class BackendLambdaStack(Stack):
             targets=[targets.LambdaFunction(dividend_fn)],
         )
 
+        # Scheduled function to email a pension performance report (issue #2758)
+        pension_report_code = _lambda.DockerImageCode.from_image_asset(
+            str(project_root),
+            file="backend/Dockerfile.lambda",
+            cmd=["backend.lambda_api.pension_report.lambda_handler"],
+        )
+        pension_report_env = {
+            "APP_ENV": env,
+            "DATA_BUCKET": bucket_name,
+            "DATA_BRANCH": data_branch,
+            "TIMESERIES_CACHE_BASE": f"s3://{bucket_name}/timeseries",
+            # Pot-value snapshots persisted for YTD / period-over-period tracking
+            # (backend/common/pension_snapshots.py), stored in the same data
+            # bucket rather than a dedicated resource.
+            "PENSION_SNAPSHOTS_URI": f"s3://{bucket_name}/pension-reports/pension_snapshots.json",
+        }
+        if data_repo:
+            pension_report_env["DATA_REPO"] = data_repo
+
+        pension_report_log_group = self._lambda_log_group(self, "PensionReportLambdaLogGroup")
+        pension_report_fn = _lambda.DockerImageFunction(
+            self,
+            "PensionReportLambda",
+            code=pension_report_code,
+            environment=pension_report_env,
+            log_group=pension_report_log_group,
+            timeout=Duration.minutes(5),
+            memory_size=512,
+        )
+
+        # PensionReportLambda: read-only on accounts/ (list_portfolios() ->
+        # list_plots() needs ListBucket, same reasoning as price_refresh above),
+        # plus read+write on its own pension-reports/ snapshot object.
+        self._grant_bucket_access(
+            pension_report_fn,
+            bucket=data_bucket,
+            allow_read=True,
+            allow_put=True,
+            allow_list=True,
+            list_prefix=lambda_list_prefixes["pension_report"],
+        )
+
+        pension_report_schedule = (
+            events.Schedule.cron(minute="0", hour="7", week_day="MON")
+            if pension_report_cadence == "weekly"
+            else events.Schedule.cron(minute="0", hour="7", day="1")
+        )
+        events.Rule(
+            self,
+            "PensionReportRun",
+            schedule=pension_report_schedule,
+            targets=[targets.LambdaFunction(pension_report_fn)],
+        )
+
         # IAM implicit deny covers all other principals; no explicit DENY
         # resource policy is needed (and a StringNotLike list-based DENY
         # would incorrectly lock out these roles too).
@@ -971,4 +1042,9 @@ class BackendLambdaStack(Stack):
         CfnOutput(self, "BackendLambdaLogGroupName", value=backend_log_group.log_group_name)
         CfnOutput(self, "PriceRefreshLambdaLogGroupName", value=refresh_log_group.log_group_name)
         CfnOutput(self, "TradingAgentLambdaLogGroupName", value=agent_log_group.log_group_name)
+        CfnOutput(
+            self,
+            "PensionReportLambdaLogGroupName",
+            value=pension_report_log_group.log_group_name,
+        )
         CfnOutput(self, "BackendLambdaErrorAlarmName", value=backend_error_alarm.alarm_name)

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -1005,3 +1005,101 @@ def test_daily_price_refresh_lambda_permission_scoped_to_alias(template):
             ),
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# PensionReportLambda / PensionReportRun (issue #2758)
+# ---------------------------------------------------------------------------
+
+
+def test_pension_report_rule_defaults_to_weekly_monday_cron(template):
+    """With no cadence context/env override, the rule fires weekly on Monday."""
+    template.has_resource_properties(
+        "AWS::Events::Rule",
+        {
+            "ScheduleExpression": assertions.Match.string_like_regexp(r"cron\(0 7 \? \* MON \*\)"),
+            "Targets": assertions.Match.array_with([
+                assertions.Match.object_like({
+                    "Arn": assertions.Match.object_like(
+                        {"Fn::GetAtt": assertions.Match.array_with([
+                            assertions.Match.string_like_regexp("PensionReportLambda")
+                        ])}
+                    )
+                })
+            ]),
+        },
+    )
+
+
+def test_pension_report_rule_monthly_cadence_via_context():
+    """pension_report_cadence="monthly" produces a 1st-of-month cron, not the weekly default."""
+    env_patch = {"JWT_SECRET": "test-secret", "GOOGLE_CLIENT_ID": "test-client-id"}
+    for key, value in env_patch.items():
+        os.environ.setdefault(key, value)
+
+    app = App(context={"pension_report_cadence": "monthly"})
+    stack = BackendLambdaStack(app, "MonthlyPensionReportStack")
+    monthly_template = assertions.Template.from_stack(stack)
+
+    monthly_template.has_resource_properties(
+        "AWS::Events::Rule",
+        {
+            "ScheduleExpression": assertions.Match.string_like_regexp(r"cron\(0 7 1 \* \? \*\)"),
+        },
+    )
+
+
+def test_pension_report_rule_rejects_invalid_cadence():
+    env_patch = {"JWT_SECRET": "test-secret", "GOOGLE_CLIENT_ID": "test-client-id"}
+    for key, value in env_patch.items():
+        os.environ.setdefault(key, value)
+
+    with pytest.raises(ValueError, match="pension_report_cadence"):
+        BackendLambdaStack(
+            App(context={"pension_report_cadence": "daily"}), "InvalidCadenceStack"
+        )
+
+
+def test_pension_report_lambda_read_only_on_accounts_prefix(template):
+    """PensionReportLambda gets scoped ListBucket on accounts/ (list_portfolios() needs it)."""
+    policies = template.find_resources("AWS::IAM::Policy")
+    matched = False
+    for resource in policies.values():
+        role_refs = [
+            ref.get("Ref", "")
+            for ref in resource.get("Properties", {}).get("Roles", [])
+            if isinstance(ref, dict)
+        ]
+        if not any("PensionReportLambda" in ref for ref in role_refs):
+            continue
+        statements = resource["Properties"]["PolicyDocument"]["Statement"]
+        for stmt in statements:
+            if stmt.get("Action") == "s3:ListBucket":
+                conditions = stmt.get("Condition", {}).get("StringLike", {}).get("s3:prefix", [])
+                if "accounts" in conditions:
+                    matched = True
+    assert matched, "Expected a ListBucket statement scoped to the accounts/ prefix"
+
+
+def test_pension_report_lambda_env_includes_snapshots_uri(template):
+    """PENSION_SNAPSHOTS_URI is built from the data bucket ref via Fn::Join, not a plain string."""
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Environment": {
+                "Variables": assertions.Match.object_like(
+                    {
+                        "PENSION_SNAPSHOTS_URI": {
+                            "Fn::Join": assertions.Match.array_with([
+                                assertions.Match.array_with([
+                                    assertions.Match.string_like_regexp(
+                                        r"/pension-reports/pension_snapshots\.json$"
+                                    )
+                                ])
+                            ])
+                        }
+                    }
+                )
+            }
+        },
+    )

--- a/tests/backend/common/test_pension.py
+++ b/tests/backend/common/test_pension.py
@@ -5,8 +5,11 @@ import pytest
 from backend.common.pension import (
     DEFAULT_ANNUITY_MULTIPLE,
     _age_from_dob,
+    dc_pension_pot_gbp,
     estimate_db_pension_value,
     forecast_pension,
+    pension_shortfall_vs_target,
+    pension_ytd_return,
     state_pension_age,
     state_pension_age_uk,
 )
@@ -133,12 +136,8 @@ def test_forecast_pension_scenario() -> None:
     assert incomes == [0.0, 5000.0, 14000.0, 16000.0, 16000.0]
     assert result["projected_pot_gbp"] == pytest.approx(15059.2)
     assert result["earliest_retirement_age"] == 34
-    assert result["retirement_income_breakdown"]["state_pension_annual"] == pytest.approx(
-        9000
-    )
-    assert result["retirement_income_breakdown"]["defined_benefit_annual"] == pytest.approx(
-        5000
-    )
+    assert result["retirement_income_breakdown"]["state_pension_annual"] == pytest.approx(9000)
+    assert result["retirement_income_breakdown"]["defined_benefit_annual"] == pytest.approx(5000)
     assert result["retirement_income_breakdown"]["defined_contribution_annual"] == pytest.approx(
         752.96,
         rel=1e-4,
@@ -148,3 +147,61 @@ def test_forecast_pension_scenario() -> None:
     assert result["contribution_annual"] == pytest.approx(2000)
     assert result["desired_income_annual"] == pytest.approx(800)
     assert result["annuity_multiple_used"] == pytest.approx(20)
+
+
+def test_dc_pension_pot_gbp_sums_sipp_accounts_only() -> None:
+    accounts = [
+        {"account_type": "isa", "value_estimate_gbp": 1000},
+        {"account_type": "sipp", "value_estimate_gbp": 5000},
+        {"account_type": "kz:sipp", "value_estimate_gbp": 2500},
+        {"account_type": "gia", "value_estimate_gbp": 750},
+    ]
+    assert dc_pension_pot_gbp(accounts) == pytest.approx(7500)
+
+
+def test_dc_pension_pot_gbp_handles_missing_and_none_values() -> None:
+    accounts = [
+        {"account_type": "sipp"},
+        {"account_type": "sipp", "value_estimate_gbp": None},
+        {"account_type": "sipp", "value_estimate_gbp": 100},
+    ]
+    assert dc_pension_pot_gbp(accounts) == pytest.approx(100)
+
+
+def test_pension_ytd_return_positive_growth() -> None:
+    result = pension_ytd_return(
+        current_pot_gbp=11000,
+        pot_start_of_year_gbp=10000,
+        contributions_ytd_gbp=500,
+    )
+    assert result["ytd_gain_gbp"] == pytest.approx(500)
+    assert result["ytd_return_pct"] == pytest.approx(5.0)
+
+
+def test_pension_ytd_return_zero_baseline_returns_none_pct() -> None:
+    result = pension_ytd_return(current_pot_gbp=1000, pot_start_of_year_gbp=0)
+    assert result["ytd_return_pct"] is None
+    assert result["ytd_gain_gbp"] == pytest.approx(1000)
+
+
+def test_pension_shortfall_vs_target_on_track() -> None:
+    result = pension_shortfall_vs_target(
+        projected_pot_gbp=200000,
+        desired_income_annual=8000,
+        annuity_multiple=20,
+    )
+    assert result["target_pot_gbp"] == pytest.approx(160000)
+    assert result["shortfall_gbp"] == pytest.approx(-40000)
+    assert result["on_track"] is True
+
+
+def test_pension_shortfall_vs_target_short_of_goal() -> None:
+    result = pension_shortfall_vs_target(
+        projected_pot_gbp=100000,
+        desired_income_annual=8000,
+        annuity_multiple=20,
+    )
+    assert result["target_pot_gbp"] == pytest.approx(160000)
+    assert result["shortfall_gbp"] == pytest.approx(60000)
+    assert result["shortfall_pct"] == pytest.approx(37.5)
+    assert result["on_track"] is False

--- a/tests/common/test_pension_snapshots.py
+++ b/tests/common/test_pension_snapshots.py
@@ -1,0 +1,66 @@
+"""Tests for pension pot snapshot persistence."""
+
+import datetime as dt
+
+import pytest
+
+from backend.common import pension_snapshots as snapshots_mod
+from backend.common.storage import get_storage
+
+
+@pytest.fixture
+def snapshot_storage(tmp_path, monkeypatch):
+    storage = get_storage(f"file://{tmp_path / 'pension_snapshots.json'}")
+    storage.save({})
+    monkeypatch.setattr(snapshots_mod, "_STORAGE", storage)
+    return storage
+
+
+def test_get_previous_snapshot_returns_none_when_absent(snapshot_storage) -> None:
+    assert snapshots_mod.get_previous_snapshot("alice") is None
+
+
+def test_record_snapshot_first_time_uses_current_pot_as_baseline(snapshot_storage) -> None:
+    today = dt.date(2024, 6, 1)
+    snapshots_mod.record_snapshot("alice", pot_gbp=10000, as_of=today)
+
+    stored = snapshots_mod.get_previous_snapshot("alice")
+    assert stored == {
+        "year": 2024,
+        "start_of_year_pot_gbp": 10000,
+        "last_pot_gbp": 10000,
+        "last_as_of": "2024-06-01",
+    }
+
+
+def test_record_snapshot_same_year_keeps_start_of_year_baseline(snapshot_storage) -> None:
+    snapshots_mod.record_snapshot("alice", pot_gbp=10000, as_of=dt.date(2024, 1, 5))
+    snapshots_mod.record_snapshot("alice", pot_gbp=10500, as_of=dt.date(2024, 6, 1))
+
+    stored = snapshots_mod.get_previous_snapshot("alice")
+    assert stored["start_of_year_pot_gbp"] == 10000
+    assert stored["last_pot_gbp"] == 10500
+
+
+def test_record_snapshot_year_rollover_resets_baseline_to_last_pot(snapshot_storage) -> None:
+    snapshots_mod.record_snapshot("alice", pot_gbp=10000, as_of=dt.date(2024, 12, 20))
+    snapshots_mod.record_snapshot("alice", pot_gbp=10800, as_of=dt.date(2025, 1, 4))
+
+    stored = snapshots_mod.get_previous_snapshot("alice")
+    assert stored["year"] == 2025
+    assert stored["start_of_year_pot_gbp"] == 10000
+    assert stored["last_pot_gbp"] == 10800
+
+
+def test_ytd_baseline_pot_gbp_no_previous_uses_current() -> None:
+    baseline = snapshots_mod.ytd_baseline_pot_gbp(None, 5000, dt.date(2024, 1, 1))
+    assert baseline == 5000
+
+
+def test_previous_period_pot_gbp_no_previous_uses_current() -> None:
+    assert snapshots_mod.previous_period_pot_gbp(None, 5000) == 5000
+
+
+def test_previous_period_pot_gbp_returns_last_pot() -> None:
+    previous = {"last_pot_gbp": 4200}
+    assert snapshots_mod.previous_period_pot_gbp(previous, 5000) == 4200

--- a/tests/test_pension_report_email.py
+++ b/tests/test_pension_report_email.py
@@ -1,0 +1,58 @@
+from backend.emails import pension_report
+
+
+def _sample_report() -> pension_report.PensionReport:
+    return pension_report.PensionReport(
+        owner_name="Alice",
+        stats={"Current pot value": "£10,000.00"},
+        scenarios=[{"label": "Base (5.0% growth)", "projected_pot_gbp": "£50,000.00"}],
+        alerts=["Pot value dropped 12.0% since the last report."],
+    )
+
+
+def test_render_pension_report_uses_template(monkeypatch):
+    captured = {}
+
+    class FakeTemplate:
+        def render(self, **context):
+            captured.update(context)
+            return "<html>rendered</html>"
+
+    monkeypatch.setattr(
+        pension_report._env,  # type: ignore[attr-defined]
+        "get_template",
+        lambda name: FakeTemplate(),
+    )
+
+    report = _sample_report()
+    html = pension_report.render_pension_report(report)
+
+    assert html == "<html>rendered</html>"
+    assert captured == {
+        "owner_name": "Alice",
+        "stats": {"Current pot value": "£10,000.00"},
+        "scenarios": [{"label": "Base (5.0% growth)", "projected_pot_gbp": "£50,000.00"}],
+        "alerts": ["Pot value dropped 12.0% since the last report."],
+    }
+
+
+def test_send_pension_report_email(monkeypatch):
+    sent = {}
+
+    def fake_render(report):
+        return "<html>body</html>"
+
+    class StubSES:
+        def send_email(self, **payload):
+            sent.update(payload)
+
+    monkeypatch.setattr(pension_report, "render_pension_report", fake_render)
+    monkeypatch.setattr(pension_report, "_SENDER_EMAIL", "reports@example.com", raising=False)
+    monkeypatch.setattr(pension_report.boto3, "client", lambda service, region_name=None: StubSES())
+
+    pension_report.send_pension_report_email("user@example.com", _sample_report())
+
+    assert sent["Source"] == "reports@example.com"
+    assert sent["Destination"] == {"ToAddresses": ["user@example.com"]}
+    assert sent["Message"]["Subject"]["Data"] == "Pension Report - Alice"
+    assert sent["Message"]["Body"]["Html"]["Data"] == "<html>body</html>"

--- a/tests/test_pension_report_lambda.py
+++ b/tests/test_pension_report_lambda.py
@@ -1,0 +1,122 @@
+import pytest
+
+from backend.lambda_api import pension_report as lam
+
+
+def _portfolio(owner="alice", dob="1990-01-01", email="alice@example.com", pot=10000.0):
+    return {
+        "owner": owner,
+        "person": {"dob": dob, "email": email, "full_name": owner.title()},
+        "accounts": [{"account_type": "sipp", "value_estimate_gbp": pot}],
+    }
+
+
+@pytest.fixture
+def stub_environment(monkeypatch):
+    monkeypatch.setattr(lam, "_load_recipient_owners", lambda: None)
+    monkeypatch.setattr(lam, "get_previous_snapshot", lambda owner: None)
+    monkeypatch.setattr(lam, "ytd_baseline_pot_gbp", lambda previous, pot, today: pot)
+    monkeypatch.setattr(lam, "previous_period_pot_gbp", lambda previous, pot: pot)
+    monkeypatch.setattr(lam, "record_snapshot", lambda owner, *, pot_gbp, as_of: None)
+
+    sent_emails = []
+    monkeypatch.setattr(lam, "send_pension_report_email", lambda email, report: sent_emails.append((email, report)))
+
+    alerts = []
+    monkeypatch.setattr(lam, "publish_sns_alert", lambda alert: alerts.append(alert))
+
+    return {"sent_emails": sent_emails, "alerts": alerts}
+
+
+def test_lambda_handler_sends_report_for_each_portfolio(monkeypatch, stub_environment):
+    monkeypatch.setattr(lam, "list_portfolios", lambda: [_portfolio()])
+
+    result = lam.lambda_handler({}, {})
+
+    assert result == {"sent": 1, "errors": []}
+    assert len(stub_environment["sent_emails"]) == 1
+    email, report = stub_environment["sent_emails"][0]
+    assert email == "alice@example.com"
+    assert report.owner_name == "Alice"
+    assert "Current pot value" in report.stats
+    assert len(report.scenarios) == 3
+    assert stub_environment["alerts"] == []
+
+
+def test_lambda_handler_skips_owner_missing_email(monkeypatch, stub_environment):
+    monkeypatch.setattr(lam, "list_portfolios", lambda: [_portfolio(email=None)])
+
+    result = lam.lambda_handler({}, {})
+
+    assert result == {"sent": 0, "errors": []}
+    assert stub_environment["sent_emails"] == []
+
+
+def test_lambda_handler_filters_by_recipient_owners(monkeypatch, stub_environment):
+    monkeypatch.setattr(lam, "_load_recipient_owners", lambda: ["bob"])
+    monkeypatch.setattr(
+        lam,
+        "list_portfolios",
+        lambda: [_portfolio(owner="alice"), _portfolio(owner="bob", email="bob@example.com")],
+    )
+
+    result = lam.lambda_handler({}, {})
+
+    assert result["sent"] == 1
+    assert stub_environment["sent_emails"][0][0] == "bob@example.com"
+
+
+def test_lambda_handler_continues_after_per_owner_failure(monkeypatch, stub_environment):
+    monkeypatch.setattr(
+        lam,
+        "list_portfolios",
+        lambda: [_portfolio(owner="alice"), _portfolio(owner="bob", email="bob@example.com")],
+    )
+
+    def failing_send(email, report):
+        if email == "alice@example.com":
+            raise RuntimeError("SES outage")
+        stub_environment["sent_emails"].append((email, report))
+
+    monkeypatch.setattr(lam, "send_pension_report_email", failing_send)
+
+    result = lam.lambda_handler({}, {})
+
+    assert result["sent"] == 1
+    assert len(result["errors"]) == 1
+    assert "alice" in result["errors"][0]
+    assert len(stub_environment["alerts"]) == 1
+
+
+def test_lambda_handler_publishes_alert_on_initialisation_failure(monkeypatch, stub_environment):
+    def raise_error():
+        raise RuntimeError("SSM unavailable")
+
+    monkeypatch.setattr(lam, "_load_recipient_owners", raise_error)
+
+    result = lam.lambda_handler({}, {})
+
+    assert result["sent"] == 0
+    assert "SSM unavailable" in result["errors"][0]
+    assert len(stub_environment["alerts"]) == 1
+    assert "failed to start" in stub_environment["alerts"][0]["message"]
+
+
+def test_build_report_flags_large_drawdown(monkeypatch, stub_environment):
+    monkeypatch.setattr(lam, "previous_period_pot_gbp", lambda previous, pot: 20000.0)
+    monkeypatch.setattr(lam, "list_portfolios", lambda: [_portfolio(pot=15000.0)])
+
+    lam.lambda_handler({}, {})
+
+    email, report = stub_environment["sent_emails"][0]
+    assert any("dropped" in alert for alert in report.alerts)
+
+
+def test_build_report_flags_shortfall_when_desired_income_configured(monkeypatch, stub_environment):
+    monkeypatch.setenv("PENSION_REPORT_DESIRED_INCOME_ANNUAL", "8000")
+    monkeypatch.setattr(lam, "list_portfolios", lambda: [_portfolio(pot=1000.0)])
+
+    lam.lambda_handler({}, {})
+
+    email, report = stub_environment["sent_emails"][0]
+    assert any("short of the" in alert for alert in report.alerts)


### PR DESCRIPTION
## Summary
- Adds YTD-return and shortfall-vs-target calculations to `backend/common/pension.py`, plus a shared `dc_pension_pot_gbp()` helper (previously duplicated inline in `routes/pension.py`).
- New `PensionReportLambda` (`backend/lambda_api/pension_report.py`) generates and emails a pension performance report per owner via the existing SES/Jinja2 pattern (`backend/emails/pension_report.py`, mirroring `weekly_report.py`), including base/optimistic/pessimistic growth scenarios and alerts for shortfall vs. target and large pot drawdowns.
- New `backend/common/pension_snapshots.py` persists pot-value snapshots (reusing the `get_storage()` pattern from `goals.py`/`alerts.py`/`nudges.py`/`quests`) so YTD and period-over-period comparisons work without an existing history mechanism.
- New `PensionReportRun` EventBridge rule in `cdk/stacks/backend_lambda_stack.py`, with cadence (weekly/monthly) configurable via CDK context or env var rather than hardcoded.
- Recipient owners are configured via an SSM-backed (or local file, in dev) JSON blob, not hardcoded; failures are never silent — per-owner errors and initialisation failures are published via `backend.common.alerts.publish_sns_alert()`.

## Test plan
- [x] `pytest tests/backend/common/test_pension.py tests/common/test_pension_snapshots.py tests/test_pension_report_email.py tests/test_pension_report_lambda.py tests/routes/test_pension_routes.py tests/backend/test_pension_route.py tests/test_pension_route.py` — 122 passed
- [x] `pytest cdk/tests/test_backend_lambda_stack.py cdk/tests/test_backend_lambda_stack_permissions.py` — covers new Lambda IAM scoping, env vars, and cron cadence (default weekly + monthly context override + invalid-cadence guard)
- [x] `isort`/`black`/`ruff` via `backend/pyproject.toml` on all touched backend/test files
- [x] Sanity import check of all new/modified modules

Closes #2758

🤖 Generated with [Claude Code](https://claude.com/claude-code)