### PR TITLE
fix(infra): grant BackendLambda s3:ListBucket on instruments/ prefix

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -250,14 +250,21 @@ class BackendLambdaStack(Stack):
 
         bucket_name = data_bucket.bucket_name
         lambda_list_prefixes = {
-            # alerts/ and prices/ are included because S3 returns 403 (not 404) when
-            # a key is absent and the caller lacks s3:ListBucket on that prefix, which
-            # prevents the fallback logic in alerts.py and the price-snapshot loader
-            # from distinguishing "missing" from "denied". PriceRefreshLambda and
-            # TradingAgentLambda also import the price loader during cold start.
+            # alerts/, prices/, and instruments/ are included because S3 returns 403
+            # (not 404) when a key is absent and the caller lacks s3:ListBucket on
+            # that prefix, which prevents the fallback logic in alerts.py, the
+            # price-snapshot loader, and instruments.py from distinguishing "missing"
+            # from "denied". Without ListBucket on instruments/, every metadata lookup
+            # for a ticker not already cached locally falls back to a live Yahoo
+            # Finance call plus a failed local write (the Lambda filesystem is
+            # read-only), which is slow enough per-ticker to time out the whole
+            # request once repeated across a portfolio's instruments (issue #5015).
+            # PriceRefreshLambda and TradingAgentLambda also import the price loader
+            # during cold start.
             "backend": (
                 "accounts",
                 "alerts",
+                "instruments",
                 "prices",
                 "queries",
                 "timeseries/meta",

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -22,6 +22,7 @@ from stacks.backend_lambda_stack import (
 BACKEND_LIST_PREFIXES = (
     "accounts",
     "alerts",
+    "instruments",
     "prices",
     "queries",
     "timeseries/meta",


### PR DESCRIPTION
## Summary
- BackendLambda's role was missing `s3:ListBucket` on the `instruments/` prefix (only `accounts`, `alerts`, `prices`, `queries`, `timeseries/meta`, `transactions`, and the writable-accounts prefix were listed).
- S3 returns `403 AccessDenied` (not `404`) for a key when the caller lacks `ListBucket` on that prefix, so every instrument metadata lookup for a ticker not already cached locally fell back to a live Yahoo Finance call plus a failed local write attempt (the Lambda filesystem is read-only) — this repeated across ~200+ instruments was enough to blow the Lambda's 30s timeout on every invocation, returning 503 from API Gateway.
- Adds `instruments` to `lambda_list_prefixes["backend"]` in `cdk/stacks/backend_lambda_stack.py`, following the existing pattern already used for `alerts`/`prices`/etc, and updates the CDK synth test's `BACKEND_LIST_PREFIXES` to assert the new prefix condition.

Closes #5015

## Test plan
- [x] `python -m pytest cdk/tests/test_backend_lambda_stack_permissions.py cdk/tests/test_backend_lambda_stack.py -q` — 64 passed (the reported coverage-gate failure is the repo-wide 90% backend coverage requirement, unrelated to these CDK-only tests)
- [x] `python -m black --check` / `python -m ruff check` on both changed files — clean (pre-existing lint findings elsewhere in the test file are untouched by this change)
- [ ] After merge, redeploy and confirm `Verify CORS configuration` and `Check recent BackendLambda CloudWatch errors` pass, and BackendLambda invocation duration drops from ~30000ms (timeout) back to normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)