### PR TITLE
fix: default ParameterStoreJSONStorage to SecureString for secrets

### DIFF
--- a/backend/common/storage.py
+++ b/backend/common/storage.py
@@ -85,8 +85,17 @@ class S3JSONStorage:
 
 @dataclass
 class ParameterStoreJSONStorage:
+    """Parameter Store backed JSON storage.
+
+    Defaults to ``SecureString`` since the JSON payloads persisted through
+    this class (alert thresholds, push subscription secrets, etc.) are
+    treated as secrets. Pass ``type="String"`` explicitly for parameters
+    that must remain readable in plaintext.
+    """
+
     name: str
     client: Any | None = None
+    type: str = "SecureString"
 
     def _client(self):
         if self.client is None:
@@ -107,7 +116,7 @@ class ParameterStoreJSONStorage:
         self._client().put_parameter(
             Name=self.name,
             Value=json.dumps(data),
-            Type="String",
+            Type=self.type,
             Overwrite=True,
         )
 

--- a/tests/backend/common/test_storage.py
+++ b/tests/backend/common/test_storage.py
@@ -43,7 +43,9 @@ def test_file_storage_save_and_load(tmp_path: Path) -> None:
     assert storage.load() == payload
 
 
-def test_file_storage_invalid_json_logs_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_file_storage_invalid_json_logs_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     path = tmp_path / "invalid.json"
     path.write_text("{not-valid-json}")
     storage = FileJSONStorage(path=path)
@@ -95,9 +97,7 @@ def test_s3_storage_load_error_logs_warning(caplog: pytest.LogCaptureFixture) ->
 def test_parameter_store_load_and_save() -> None:
     client = Mock()
     expected = {"value": 1}
-    client.get_parameter.return_value = {
-        "Parameter": {"Value": json.dumps(expected)}
-    }
+    client.get_parameter.return_value = {"Parameter": {"Value": json.dumps(expected)}}
     storage = ParameterStoreJSONStorage(name="/param/name", client=client)
 
     result = storage.load()
@@ -111,6 +111,20 @@ def test_parameter_store_load_and_save() -> None:
     client.put_parameter.assert_called_once_with(
         Name="/param/name",
         Value=json.dumps(payload),
+        Type="SecureString",
+        Overwrite=True,
+    )
+
+
+def test_parameter_store_save_explicit_string_type() -> None:
+    client = Mock()
+    storage = ParameterStoreJSONStorage(name="/param/name", client=client, type="String")
+
+    storage.save({"next": "value"})
+
+    client.put_parameter.assert_called_once_with(
+        Name="/param/name",
+        Value=json.dumps({"next": "value"}),
         Type="String",
         Overwrite=True,
     )


### PR DESCRIPTION
## Summary
- `ParameterStoreJSONStorage` (`backend/common/storage.py`) now defaults its SSM `Type` to `SecureString` instead of `String`, since it backs secret payloads such as alert thresholds and push subscription tokens.
- The `type` field is overridable per-instance (`ParameterStoreJSONStorage(name=..., type="String")`) for callers that intentionally need plaintext parameters — no existing caller in this repo passes an explicit type, so all `ssm://` storage now writes `SecureString` by default.
- Public API is unchanged aside from the new optional `type` field with a safe default.

## Test plan
- [x] `python -m pytest tests/backend/common/test_storage.py tests/test_storage.py -q` — 17 passed, including a new test asserting explicit `type="String"` still writes `String`
- [x] `black`, `isort`, `ruff check` on changed files

Closes #4961