### PR TITLE
fix(instruments): handle read-only filesystem gracefully in save_instrument_meta

### DIFF
--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -195,11 +195,15 @@ def save_instrument_meta(
     ticker: str,
     exchange: str | Dict[str, Any],
     data: Optional[Dict[str, Any]] = None,
-) -> Path:
+) -> Optional[Path]:
     """Persist metadata for an instrument and optionally upload to S3.
 
     Supports calling as ``save_instrument_meta("ABC", "L", {...})`` or
     ``save_instrument_meta("ABC.L", {...})``.
+
+    Returns the path written on success, or ``None`` if the local filesystem
+    write failed (e.g. a read-only filesystem in the Lambda runtime). A
+    failed local write does not prevent the S3 upload below from proceeding.
     """
 
     if data is None:
@@ -220,9 +224,13 @@ def save_instrument_meta(
         with path.open("w", encoding="utf-8") as fh:
             json.dump(data, fh, indent=2, sort_keys=True)
             fh.write("\n")
-    except OSError as exc:  # pragma: no cover - filesystem errors are rare
-        logger.exception("Failed to write instrument metadata %s", path)
-        raise
+    except OSError as exc:
+        logger.warning(
+            "Cannot write instrument metadata to %s (read-only filesystem?): %s",
+            sanitise_log_value(path),
+            sanitise_log_value(exc),
+        )
+        path = None
 
     s3_loc = _s3_location()
     if s3_loc:

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -325,6 +325,28 @@ def test_save_instrument_meta_variants(monkeypatch, tmp_path) -> None:
         instruments.save_instrument_meta("ABC", {"name": "ABC"})
 
 
+def test_save_instrument_meta_handles_read_only_filesystem(monkeypatch, tmp_path, caplog) -> None:
+    monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", tmp_path)
+    monkeypatch.setattr(instruments.config, "data_root", tmp_path)
+    monkeypatch.delenv(instruments.METADATA_BUCKET_ENV, raising=False)
+    monkeypatch.delenv(instruments.METADATA_PREFIX_ENV, raising=False)
+
+    def raise_permission_error(*args, **kwargs):
+        raise PermissionError("read-only file system")
+
+    monkeypatch.setattr(Path, "open", raise_permission_error)
+
+    with caplog.at_level("WARNING"):
+        result = instruments.save_instrument_meta("ABC", "L", {"name": "ABC"})
+
+    assert result is None
+    assert any(
+        "Cannot write instrument metadata" in record.getMessage()
+        and record.levelname == "WARNING"
+        for record in caplog.records
+    )
+
+
 def test_fetch_metadata_from_yahoo_builds_normalized_payload(monkeypatch) -> None:
     expected_info = {
         "shortName": "Alpha plc  ",


### PR DESCRIPTION
## Summary
- `save_instrument_meta` in `backend/common/instruments.py` now catches `OSError` from the local metadata write and logs a warning instead of raising, so a read-only Lambda filesystem no longer crashes the instrument processing pipeline.
- The S3 upload path is unaffected — it still runs even when the local write fails.
- Return type changed to `Optional[Path]`; verified all callers (`instrument_admin.py`, internal auto-create path) discard or don't branch on the return value, so this is safe.

## Test plan
- [x] Added `test_save_instrument_meta_handles_read_only_filesystem` covering the `PermissionError` path, asserting `None` is returned and a warning is logged.
- [x] `python -m pytest tests/backend/common/test_instruments.py tests/backend/test_instrument_admin.py tests/test_instruments.py -q --no-cov` — 58 passed, 1 xfailed.
- [x] `python -m black --config backend/pyproject.toml --diff` / `python -m ruff check --config backend/pyproject.toml` on changed files — no new issues introduced.

Closes #5019

🤖 Generated with [Claude Code](https://claude.com/claude-code)