### PR TITLE
fix(instruments): remove live Yahoo Finance call from read path

### DIFF
--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -146,7 +146,8 @@ def get_instrument_meta(ticker: str) -> Dict[str, Any]:
     """Return metadata for ``ticker`` from disk or S3.
 
     The data files live under ``data/instruments`` or the configured S3
-    location; failures return an empty dict.
+    location; failures return an empty dict. This never makes a live Yahoo
+    Finance call — that only happens via an explicit sync/refresh operation.
     """
     path = _instrument_path(ticker)
     s3_loc = _s3_location()
@@ -170,8 +171,13 @@ def get_instrument_meta(ticker: str) -> Dict[str, Any]:
         with path.open("r", encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
-        created = _auto_create_instrument_meta(ticker)
-        return created or {}
+        # Do not fall back to a live Yahoo Finance lookup here: this is the
+        # normal read path (portfolio/report rendering, etc.) and every
+        # cache-miss would otherwise turn into a network call. Fetching and
+        # persisting fresh metadata is an explicit, separate operation — see
+        # ``_auto_create_instrument_meta`` / the ``/instrument/admin/.../refresh``
+        # route — that callers must invoke deliberately, not on every read.
+        return {}
     except json.JSONDecodeError as exc:
         logger.warning("Invalid instrument JSON %s: %s", sanitise_log_value(path), sanitise_log_value(exc))
         return {}

--- a/tests/backend/test_instruments_autocreate.py
+++ b/tests/backend/test_instruments_autocreate.py
@@ -11,8 +11,37 @@ def _reset_state(monkeypatch, tmp_path):
     instruments.get_instrument_meta.cache_clear()
 
 
-def test_get_instrument_meta_auto_creates_using_yahoo(tmp_path, monkeypatch):
+def test_get_instrument_meta_does_not_call_yahoo_on_cache_miss(tmp_path, monkeypatch):
+    """The read path must never make a live Yahoo Finance call.
+
+    Auto-creating metadata from Yahoo is an explicit, separate operation
+    (``_auto_create_instrument_meta`` / the admin ``refresh`` route), not
+    something a cache-miss read should trigger.
+    """
+
     _reset_state(monkeypatch, tmp_path)
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_fetch(symbol: str, exchange: str):  # pragma: no cover - should not be called
+        calls.append((symbol, exchange))
+        return {"name": "Should not happen"}
+
+    monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", fake_fetch)
+
+    meta = instruments.get_instrument_meta("aapl.n")
+
+    assert meta == {}
+    assert calls == []
+    assert not list(tmp_path.rglob("*.json"))
+
+
+def test_auto_create_instrument_meta_still_available_for_explicit_use(tmp_path, monkeypatch):
+    """``_auto_create_instrument_meta`` remains callable explicitly (not from reads)."""
+
+    _reset_state(monkeypatch, tmp_path)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setattr(instruments.config, "offline_mode", False)
 
     fetched = {
         "name": "Apple Inc.",
@@ -31,21 +60,17 @@ def test_get_instrument_meta_auto_creates_using_yahoo(tmp_path, monkeypatch):
 
     monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", fake_fetch)
 
-    meta = instruments.get_instrument_meta("aapl.n")
+    created = instruments._auto_create_instrument_meta("aapl.n")
 
-    assert meta["ticker"] == "AAPL.N"
-    assert meta["name"] == fetched["name"]
-    assert meta["currency"] == fetched["currency"]
-    assert meta["sector"] == fetched["sector"]
+    assert created is not None
+    assert created["ticker"] == "AAPL.N"
+    assert created["name"] == fetched["name"]
     assert calls == [("AAPL", "N")]
 
     path = tmp_path / "N" / "AAPL.json"
     assert path.exists()
     saved = json.loads(path.read_text(encoding="utf-8"))
     assert saved["ticker"] == "AAPL.N"
-    assert saved["name"] == fetched["name"]
-    assert saved["currency"] == fetched["currency"]
-    assert saved["sector"] == fetched["sector"]
 
 
 def test_auto_create_skips_when_fetch_fails(tmp_path, monkeypatch):
@@ -60,15 +85,14 @@ def test_auto_create_skips_when_fetch_fails(tmp_path, monkeypatch):
 
     monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", fake_fetch)
 
-    meta = instruments.get_instrument_meta("MISS.N")
-    assert meta == {}
+    result = instruments._auto_create_instrument_meta("MISS.N")
+    assert result is None
     assert "MISS.N" in instruments._AUTO_CREATE_FAILURES
     assert calls == 1
     assert not list(tmp_path.rglob("*.json"))
 
-    instruments.get_instrument_meta.cache_clear()
-    meta_again = instruments.get_instrument_meta("MISS.N")
-    assert meta_again == {}
+    result_again = instruments._auto_create_instrument_meta("MISS.N")
+    assert result_again is None
     assert calls == 1  # failure cached, no retry
 
 
@@ -83,7 +107,7 @@ def test_auto_create_requires_exchange(tmp_path, monkeypatch):
 
     monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", fake_fetch)
 
-    meta = instruments.get_instrument_meta("PFE")
-    assert meta == {}
+    result = instruments._auto_create_instrument_meta("PFE")
+    assert result is None
     assert calls == []
     assert not list(tmp_path.rglob("*.json"))


### PR DESCRIPTION
## Summary
- `get_instrument_meta` (the normal read path used for portfolio/report rendering) previously called `_auto_create_instrument_meta`, which made a live `yfinance` HTTP call whenever a local metadata file was missing.
- Reads now simply return `{}` on a cache-miss. The Yahoo lookup logic (`_auto_create_instrument_meta`, `_fetch_metadata_from_yahoo`) is preserved and remains callable explicitly — it's already exercised deliberately via the existing `/instrument/admin/{exchange}/{ticker}/refresh` route, so no new sync entrypoint was needed.
- Updated `tests/backend/test_instruments_autocreate.py` to assert the read path no longer triggers a Yahoo fetch, while keeping direct-invocation coverage of `_auto_create_instrument_meta`.

## Why
Follow-up from AI review of #5016: mixing live external calls into a read path causes intermittent failures/rate-limiting and makes read behavior unpredictable. This does not touch IAM/CDK (already fixed in #5016) or read-only-filesystem handling (tracked separately in #5019).

Closes #5017

## Test plan
- [x] `pytest tests/backend/test_instruments_autocreate.py tests/backend/common/test_instruments.py tests/test_instruments.py tests/backend/routes/test_instrument_admin.py tests/backend/test_instrument_admin.py` — 72 passed
- [x] Full `pytest tests/` — 2361 passed, 1 pre-existing unrelated failure (`test_review_comment.py`, a Git-Bash `pipefail` compatibility issue, reproduces identically on `main`), 6 skipped, 15 xfailed, 1 xpassed