### PR TITLE
fix(infra): scope PensionReportLambda s3:PutObject to pension-reports/ prefix

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -85,6 +85,7 @@ class BackendLambdaStack(Stack):
         allow_put: bool,
         allow_list: bool,
         list_prefix: str | Sequence[str] | None = None,
+        put_prefix: str | Sequence[str] | None = None,
     ) -> None:
         """Grant the minimum required S3 actions for a Lambda function.
 
@@ -92,7 +93,12 @@ class BackendLambdaStack(Stack):
         (useful in unit tests that don't synthesise a full stack).
 
         ``allow_list`` controls ``s3:ListBucket`` on the bucket ARN while
-        ``allow_read``/``allow_put`` scope object-level actions to ``/*``.
+        ``allow_read`` scopes ``s3:GetObject`` to ``/*``. ``allow_put`` scopes
+        ``s3:PutObject`` to ``/*`` by default; pass ``put_prefix`` to instead
+        scope the write grant to specific prefix(es) (e.g. the Lambda's own
+        snapshot path) for least privilege. ``put_prefix`` is independent of
+        ``list_prefix`` — a caller may need to list one set of prefixes but
+        write only to a narrower one (issue #5013).
         """
 
         if bucket is None and bucket_name is None:
@@ -113,17 +119,36 @@ class BackendLambdaStack(Stack):
             object_arn = f"arn:aws:s3:::{bucket_name}/*"
             bucket_arn = f"arn:aws:s3:::{bucket_name}"
 
-        object_actions: list[str] = []
         if allow_read:
-            object_actions.append("s3:GetObject")
-        if allow_put:
-            object_actions.append("s3:PutObject")
-
-        if object_actions:
             fn.add_to_role_policy(
                 iam.PolicyStatement(
-                    actions=object_actions,
+                    actions=["s3:GetObject"],
                     resources=[object_arn],
+                )
+            )
+
+        if allow_put:
+            if put_prefix is not None:
+                raw_put_prefixes = [put_prefix] if isinstance(put_prefix, str) else list(put_prefix)
+                normalized_put_prefixes = [prefix.strip().strip("/") for prefix in raw_put_prefixes]
+                normalized_put_prefixes = [prefix for prefix in normalized_put_prefixes if prefix]
+                if not normalized_put_prefixes:
+                    raise ValueError("put_prefix, if provided, must contain a non-empty prefix")
+                if bucket is not None:
+                    put_resources = [
+                        bucket.arn_for_objects(f"{prefix}/*") for prefix in normalized_put_prefixes
+                    ]
+                else:
+                    put_resources = [
+                        f"arn:aws:s3:::{bucket_name}/{prefix}/*"
+                        for prefix in normalized_put_prefixes
+                    ]
+            else:
+                put_resources = [object_arn]
+            fn.add_to_role_policy(
+                iam.PolicyStatement(
+                    actions=["s3:PutObject"],
+                    resources=put_resources,
                 )
             )
 
@@ -973,7 +998,10 @@ class BackendLambdaStack(Stack):
 
         # PensionReportLambda: read-only on accounts/ (list_portfolios() ->
         # list_plots() needs ListBucket, same reasoning as price_refresh above),
-        # plus read+write on its own pension-reports/ snapshot object.
+        # plus write access scoped to pension-reports/ — the only prefix this
+        # Lambda ever writes to (PENSION_SNAPSHOTS_URI above). Scoping the
+        # s3:PutObject resource this way (rather than bucket-wide) prevents the
+        # Lambda from writing outside its own snapshot path (issue #5013).
         self._grant_bucket_access(
             pension_report_fn,
             bucket=data_bucket,
@@ -981,6 +1009,7 @@ class BackendLambdaStack(Stack):
             allow_put=True,
             allow_list=True,
             list_prefix=lambda_list_prefixes["pension_report"],
+            put_prefix="pension-reports",
         )
 
         pension_report_schedule = (

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -281,7 +281,9 @@ def test_dividend_refresh_lambda_has_scoped_s3_permissions() -> None:
     ), f"DividendRefreshLambda has unexpected S3 actions: {dividend_actions - DIVIDEND_REFRESH_MAX_S3}"
 
     list_bucket_resources = _resources_for_s3_action(template, dividend_role, "s3:ListBucket")
-    assert list_bucket_resources, "DividendRefreshLambda has s3:ListBucket but no associated resource ARN"
+    assert (
+        list_bucket_resources
+    ), "DividendRefreshLambda has s3:ListBucket but no associated resource ARN"
     for arn in list_bucket_resources:
         assert not arn.endswith("/*"), (
             f"DividendRefreshLambda s3:ListBucket is scoped to an object ARN ({arn}); "
@@ -382,6 +384,80 @@ def test_grant_bucket_access_accepts_multiple_list_prefixes() -> None:
     assert len(conditions) == 1, "Expected exactly one ListBucket statement"
 
     assert conditions[0] == _expected_prefix_condition(BACKEND_LIST_PREFIXES)
+
+
+def test_grant_bucket_access_scopes_put_object_to_put_prefix() -> None:
+    """allow_put=True with put_prefix restricts s3:PutObject to that prefix, not the bucket."""
+    app = App()
+    stack = BackendLambdaStack(app, "GrantBucketAccessPutPrefixStack")
+    fn = _lambda.Function(
+        stack,
+        "GrantBucketAccessPutPrefixFn",
+        runtime=_lambda.Runtime.PYTHON_3_11,
+        code=_lambda.Code.from_inline("def handler(event, context):\n    return None\n"),
+        handler="index.handler",
+    )
+
+    BackendLambdaStack._grant_bucket_access(
+        fn,
+        bucket_name="unit-test-bucket",
+        allow_read=False,
+        allow_put=True,
+        allow_list=False,
+        put_prefix="pension-reports",
+    )
+
+    template = Template.from_stack(stack).to_json()
+    role_logical_id = _role_logical_id_for_lambda(template, "GrantBucketAccessPutPrefixFn")
+    put_resources = _resources_for_s3_action(template, role_logical_id, "s3:PutObject")
+
+    assert put_resources == ["arn:aws:s3:::unit-test-bucket/pension-reports/*"]
+
+
+def test_grant_bucket_access_put_defaults_to_bucket_wide_without_put_prefix() -> None:
+    """Omitting put_prefix preserves the existing bucket-wide s3:PutObject grant."""
+    app = App()
+    stack = BackendLambdaStack(app, "GrantBucketAccessPutDefaultStack")
+    fn = _lambda.Function(
+        stack,
+        "GrantBucketAccessPutDefaultFn",
+        runtime=_lambda.Runtime.PYTHON_3_11,
+        code=_lambda.Code.from_inline("def handler(event, context):\n    return None\n"),
+        handler="index.handler",
+    )
+
+    BackendLambdaStack._grant_bucket_access(
+        fn,
+        bucket_name="unit-test-bucket",
+        allow_read=False,
+        allow_put=True,
+        allow_list=False,
+    )
+
+    template = Template.from_stack(stack).to_json()
+    role_logical_id = _role_logical_id_for_lambda(template, "GrantBucketAccessPutDefaultFn")
+    put_resources = _resources_for_s3_action(template, role_logical_id, "s3:PutObject")
+
+    assert put_resources == ["arn:aws:s3:::unit-test-bucket/*"]
+
+
+def test_pension_report_lambda_put_object_scoped_to_pension_reports_prefix() -> None:
+    """PensionReportLambda's s3:PutObject is scoped to pension-reports/*, not the whole bucket.
+
+    PENSION_SNAPSHOTS_URI (backend_lambda_stack.py) points at
+    pension-reports/pension_snapshots.json — the only path this Lambda ever
+    writes to — so its write grant must not extend to accounts/ or any other
+    prefix (issue #5013).
+    """
+    template = _stack_template()
+    role = _role_logical_id_for_lambda(template, "PensionReportLambda")
+    put_resources = _resources_for_s3_action(template, role, "s3:PutObject")
+
+    assert put_resources, "Expected PensionReportLambda to have an s3:PutObject grant"
+    for resource in put_resources:
+        assert (
+            "pension-reports/*" in resource
+        ), f"Expected s3:PutObject resource scoped to pension-reports/*, got {resource!r}"
 
 
 def test_lambda_roles_do_not_have_s3_delete_permissions() -> None:
@@ -530,16 +606,16 @@ def test_lambda_invoke_grant_scoped_to_alias_arn(monkeypatch) -> None:
     stack = BackendLambdaStack(app, "BackendLambdaStackLambdaAliasTest")
     raw = Template.from_stack(stack).to_json()
     resources = _lambda_invoke_resources_for_role_name(raw, "allotmint-github-deploy")
-    assert resources, (
-        "Expected lambda:InvokeFunction to be granted to the deploy role, but no Resource found"
-    )
+    assert (
+        resources
+    ), "Expected lambda:InvokeFunction to be granted to the deploy role, but no Resource found"
     for resource in resources:
-        assert "live" in resource.lower(), (
-            f"Expected lambda:InvokeFunction resource to include the ':live' alias, got: {resource}"
-        )
-        assert "*" not in resource, (
-            f"Expected lambda:InvokeFunction resource to be scoped (no wildcard), got: {resource}"
-        )
+        assert (
+            "live" in resource.lower()
+        ), f"Expected lambda:InvokeFunction resource to include the ':live' alias, got: {resource}"
+        assert (
+            "*" not in resource
+        ), f"Expected lambda:InvokeFunction resource to be scoped (no wildcard), got: {resource}"
 
 
 def _s3_statements_for_role_name(raw_template: dict, role_name: str) -> list[dict]:
@@ -705,7 +781,9 @@ def test_deploy_role_gets_describe_log_streams_on_backend_log_group(monkeypatch)
         resources = stmt.get("Resource", [])
         if isinstance(resources, (str, dict)):
             resources = [resources]
-        describe_log_streams_resources.extend(r if isinstance(r, str) else str(r) for r in resources)
+        describe_log_streams_resources.extend(
+            r if isinstance(r, str) else str(r) for r in resources
+        )
 
     assert describe_log_streams_resources, (
         "Expected the deploy role to be granted logs:DescribeLogStreams in "
@@ -761,7 +839,9 @@ def _fallback_string_literal(source_path: Path, assigned_name: str) -> str:
                 and sub.value not in (assigned_name, "/")
             ):
                 return sub.value
-    raise AssertionError(f"Could not statically find a fallback literal for {assigned_name!r} in {source_path}")
+    raise AssertionError(
+        f"Could not statically find a fallback literal for {assigned_name!r} in {source_path}"
+    )
 
 
 def test_writable_accounts_prefix_matches_backend_accounts_store() -> None:


### PR DESCRIPTION
## Summary
- `_grant_bucket_access` in `backend_lambda_stack.py` granted `s3:PutObject` on the entire data bucket for every `allow_put=True` caller, ignoring `list_prefix` — the security gap flagged in #5013.
- Adds a new, independent `put_prefix` parameter to scope the write grant to specific prefix(es), and applies it to `PensionReportLambda`.
- `PensionReportLambda`'s only write target is `pension-reports/pension_snapshots.json` (`PENSION_SNAPSHOTS_URI`, `backend_lambda_stack.py:958`), not `accounts/` — the demo-data prefix it lists via `list_portfolios()`. Its IAM policy now scopes `s3:PutObject` to `arn:...:bucket/pension-reports/*` accordingly.

### Deviation from the issue's literal ask
#5013's "Success looks like" section asked for `s3:PutObject` scoped to `accounts/*` (the `list_prefix` value). Tracing the actual runtime write path shows the Lambda never writes to `accounts/` — it's read-only there (confirmed by the existing `test_pension_report_lambda_read_only_on_accounts_prefix` test) and only writes its own snapshot file under `pension-reports/`. Scoping to `accounts/*` as literally requested would have broken `PensionReportLambda`'s ability to persist pot-value snapshots (`AccessDenied` at runtime). This PR scopes the grant to `pension-reports/*` instead, which satisfies the least-privilege intent of the issue without breaking functionality.

### Other callers unaffected
`BackendLambda` and `PriceRefreshLambda` (`allow_put=True`) omit `put_prefix` and keep their existing bucket-wide `s3:PutObject` grant, since they legitimately write to several distinct prefixes (`accounts/`, `alerts/`, `prices/`, `writable-accounts/`, etc.). `list_prefix` and `allow_put` for `PensionReportLambda` are unchanged, per the issue's constraints.

## Test plan
- [x] `pytest cdk/tests/test_backend_lambda_stack_permissions.py cdk/tests/test_backend_lambda_stack.py` — 67 passed, including 3 new tests:
  - `test_grant_bucket_access_scopes_put_object_to_put_prefix` — `put_prefix` scopes the resource ARN
  - `test_grant_bucket_access_put_defaults_to_bucket_wide_without_put_prefix` — omitting `put_prefix` preserves existing bucket-wide behavior (no regression for other callers)
  - `test_pension_report_lambda_put_object_scoped_to_pension_reports_prefix` — asserts `PensionReportLambda`'s synthesized IAM policy scopes `s3:PutObject` to `pension-reports/*`
- [x] `ruff check` clean on both touched files
- [x] `black`/formatting applied

Closes #5013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Restricted pension report Lambda write access to the `pension-reports/` storage path.
  * Added support for scoping object write permissions to specific storage prefixes, reducing unnecessary access.

* **Tests**
  * Expanded permission coverage to verify prefix-scoped and bucket-wide write access.
  * Improved validation of related storage, logging and deployment permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->