### PR TITLE
fix(scripts): strip leaked LLM preamble from follow-up issue bodies

### DIFF
--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.error
@@ -15,9 +16,57 @@ from llm_labels import extract_tier_label
 
 _FALLBACK_BODY_TEMPLATE = "Follow-up suggested by AI review of PR #{pr_number}."
 
+# Conversational preamble the model sometimes prepends before the real body,
+# e.g. "Here is a complete, actionable GitHub issue body based on your request."
+_PREAMBLE_RE = re.compile(
+    r"^(here('?s| is| are)|below (is|are)|sure|certainly|of course|okay|ok|"
+    r"this is|i('ve| have) (written|drafted|created))\b",
+    re.IGNORECASE,
+)
+_HORIZONTAL_RULES = {"---", "***", "___"}
+
 # Provider used to generate rich issue bodies, selectable via FOLLOWUP_LLM_PROVIDER.
 # Defaults to deepseek, the repo's primary required PR reviewer.
 _DEFAULT_PROVIDER = "deepseek"
+
+
+def _strip_wrapping_code_fence(body: str) -> str:
+    """Unwrap a body the model enclosed in a single ``` or ```markdown fence."""
+    lines = body.splitlines()
+    if len(lines) >= 2 and lines[0].lstrip().startswith("```") and lines[-1].strip() == "```":
+        return "\n".join(lines[1:-1]).strip()
+    return body
+
+
+def _drop_leading_hrule(lines: list[str]) -> list[str]:
+    """Drop leading blank lines and a single leftover horizontal-rule separator."""
+    idx = 0
+    while idx < len(lines) and not lines[idx].strip():
+        idx += 1
+    if idx < len(lines) and lines[idx].strip() in _HORIZONTAL_RULES:
+        return lines[idx + 1 :]
+    return lines
+
+
+def _sanitize_body(text: str) -> str:
+    """Strip conversational preamble and wrapping fences the LLM may add.
+
+    Models occasionally prefix the body with a line like "Here is a complete,
+    actionable GitHub issue body ..." followed by a `---` separator, or wrap the
+    whole body in a ```markdown code fence. That wrapper text leaked verbatim
+    into many historical issues; strip it so only the Markdown body remains.
+    Internal `---` section dividers are preserved — only a leading one is removed.
+    """
+    body = _strip_wrapping_code_fence(text.strip())
+    lines = body.splitlines()
+
+    first = next((line for line in lines if line.strip()), "")
+    if _PREAMBLE_RE.match(first.strip()):
+        # Drop everything up to and including the preamble line, then any blank
+        # lines and a `---` separator that follows it.
+        lines = _drop_leading_hrule(lines[lines.index(first) + 1 :])
+
+    return "\n".join(_drop_leading_hrule(lines)).strip()
 
 
 def _build_prompt(title: str, pr_number: str, review_text: str) -> str:
@@ -57,6 +106,12 @@ Write a complete, actionable GitHub issue body in Markdown covering:
 7. **Failure looks like** — what would indicate the implementation went wrong
 
 Be concise but complete. Do not pad with generic advice.
+
+Output ONLY the raw Markdown issue body. Do not wrap it in a code fence and do
+not add any preamble (e.g. "Here is the issue body") — start directly with the
+first heading. When you name a file, function, or line number, use only paths
+you can confirm from the review text above; if you are unsure, describe the
+location instead of guessing a concrete path.
 End with: _Follow-up from AI review of PR #{pr_number}._"""
 
 
@@ -144,7 +199,7 @@ def _generate_body_via_llm(title: str, pr_number: str, review_text: str) -> str:
 
     prompt = _build_prompt(title, pr_number, review_text)
     try:
-        return call(api_key, prompt)
+        return _sanitize_body(call(api_key, prompt))
     except (urllib.error.HTTPError, urllib.error.URLError, KeyError, IndexError, json.JSONDecodeError) as exc:
         print(f"WARNING: failed to generate issue body via {provider}: {exc}", file=sys.stderr)
         return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -161,6 +161,72 @@ def test_generate_body_falls_back_on_api_error(
     assert "failed to generate" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # Preamble + `---` separator (the most common leaked pattern in milestone 9).
+        "Here is a complete, actionable GitHub issue body based on your request.\n\n"
+        "---\n\n## What\nDo the thing.",
+        "Here is the complete, actionable GitHub issue body in Markdown:\n\n"
+        "---\n\n## What\nDo the thing.",
+        "Here's the issue body:\n\n## What\nDo the thing.",
+        "Below is the issue body.\n\n***\n\n## What\nDo the thing.",
+        # Whole body wrapped in a ```markdown fence (as in issue #4870).
+        "```markdown\n## What\nDo the thing.\n```",
+        # Bare leading horizontal rule with no preamble.
+        "---\n\n## What\nDo the thing.",
+    ],
+)
+def test_sanitize_body_strips_preamble_and_fences(raw: str) -> None:
+    mod = load_module()
+    cleaned = mod._sanitize_body(raw)
+    assert cleaned.startswith("## What")
+    assert cleaned.endswith("Do the thing.")
+    assert "Here" not in cleaned
+    assert "```" not in cleaned
+
+
+def test_sanitize_body_preserves_internal_horizontal_rules() -> None:
+    """A `---` divider inside the body is content, not a leftover separator."""
+    mod = load_module()
+    body = "## What\nFirst section.\n\n---\n\n## Why\nSecond section."
+    assert mod._sanitize_body(body) == body
+
+
+def test_sanitize_body_leaves_clean_body_unchanged() -> None:
+    mod = load_module()
+    body = "## What\nAlready clean.\n\n_Follow-up from AI review of PR #42._"
+    assert mod._sanitize_body(body) == body
+
+
+def test_generate_body_sanitizes_llm_preamble(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: preamble returned by the provider is stripped before use."""
+    mod = load_module()
+    monkeypatch.delenv("FOLLOWUP_LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    fake_payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "Here is a complete, actionable GitHub issue body "
+                    "based on your request.\n\n---\n\n## What\nFix the thing.\n\n"
+                    "_Follow-up from AI review of PR #42._"
+                }
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: FakeResponse(fake_payload),
+    )
+    body = mod._generate_body_via_llm("Fix the thing", "42", "Review text here")
+    assert body.startswith("## What")
+    assert "Here is" not in body
+
+
 def test_build_body_uses_fallback_when_no_review_text(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What

`create_followup_issues.py` passed raw LLM output straight to `gh issue create`, so wrapper text leaked verbatim into AI-suggested issues:

- Conversational preamble like *"Here is a complete, actionable GitHub issue body based on your request."* followed by a `---` separator (seen across ~20 open milestone-9 issues, e.g. #4270, #4295, #4479, #4670, #4900).
- Whole bodies wrapped in a ```` ```markdown ```` code fence (e.g. #4870).

This adds a deterministic sanitizer plus a prompt hardening so future generated issues start cleanly at the first heading.

## How

- New `_sanitize_body()` applied to **provider output only** (not the fallback template). It strips:
  - a leading conversational preamble line (`Here is…`, `Here's…`, `Below is…`, `Sure…`, `This is…`, `I've written…`),
  - a leftover leading `---`/`***`/`___` horizontal rule (with or without a preceding preamble),
  - a wrapping ```` ``` ```` / ```` ```markdown ```` code fence around the whole body.
  - **Internal** `---` section dividers are preserved — only a leading one is removed.
- Prompt hardened to tell the model to emit only the raw Markdown body (no preamble, no code fence) and to describe a location rather than guess a concrete file path it can't confirm from the review text (a nudge against the phantom-file problem also seen in that milestone).

## Tests

- Parametrized `test_sanitize_body_strips_preamble_and_fences` built from the **actual** leaked strings.
- Tests that internal `---` dividers survive, that clean bodies pass through unchanged, and an end-to-end check that provider preamble is stripped in `_generate_body_via_llm`.
- `25 passed`.

## Scope / notes

- This fixes **new** issues going forward; existing issue bodies still contain leaked text (separate cleanup pass if wanted).
- Follow-up issue #5037 tracks cleaning up existing affected issue bodies (Closes #5037).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated follow-up issue content by removing conversational preambles, unnecessary separators, and surrounding Markdown code fences.
  * Preserved valid Markdown formatting within issue bodies.

* **Tests**
  * Added coverage for sanitisation, clean content, internal separators, and end-to-end generated issue output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->