### PR TITLE
fix(test): correct stale #4258 Cognito smoke test to match no-auto-redirect behavior

### DIFF
--- a/frontend/tests/cognito-auth-flow.spec.ts
+++ b/frontend/tests/cognito-auth-flow.spec.ts
@@ -193,19 +193,26 @@ test.describe('Cognito hosted UI authentication', () => {
     expect(backendExchangeHits).toHaveLength(0);
   });
 
-  test('recovers by redirecting to the hosted UI when sessionStorage has a corrupted Cognito session (#4258)', async ({
+  test('discards a corrupted Cognito session and boots to the login page, redirecting only on explicit sign-in (#4258)', async ({
     page,
   }) => {
     // Simulates a session entry that failed to round-trip through JSON (e.g.
     // truncated by a storage quota error). loadSession() in awsUiAuth.ts must
-    // discard it rather than throwing, so applyCognitoIdToken() sees no stored
-    // ID token and the app falls through to a normal hosted-UI redirect
-    // instead of getting stuck on a bootstrap error screen.
+    // discard it rather than throwing, so the app boots cleanly to the
+    // LoginPage's "Sign in" button instead of getting stuck on a bootstrap
+    // error screen. The hosted-UI redirect is user-triggered (a Sign in click),
+    // NOT automatic on page load — see #4458, which removed the silent boot
+    // redirect so new visitors can reach the create-account page first.
     await page.addInitScript(() => {
       window.sessionStorage.setItem('awsUiAuthSession', 'not-valid-json');
     });
     await mockRuntimeConfig(page);
+    const configRequests: ConfigRequest[] = [];
+    await mockConfigEndpoint(page, configRequests);
+
+    let authorizeHits = 0;
     await page.route(`${COGNITO_DOMAIN}/oauth2/authorize**`, async (route) => {
+      authorizeHits += 1;
       await route.fulfill({
         status: 200,
         contentType: 'text/html',
@@ -215,11 +222,19 @@ test.describe('Cognito hosted UI authentication', () => {
 
     await page.goto(baseUrl);
 
-    await expect.poll(() => new URL(page.url()).origin).toBe(new URL(COGNITO_DOMAIN).origin);
+    // The app boots to the LoginPage without auto-redirecting to Cognito.
+    const signInButton = page.getByRole('button', { name: 'Sign in' });
+    await expect(signInButton).toBeVisible();
+    expect(new URL(page.url()).origin).toBe(new URL(baseUrl).origin);
+    expect(authorizeHits).toBe(0);
     // The unreadable entry is discarded rather than left behind to re-trigger
     // the same failure on the next load.
     expect(
       await page.evaluate(() => window.sessionStorage.getItem('awsUiAuthSession')),
     ).toBeNull();
+
+    // The hosted-UI redirect happens on the explicit Sign in action.
+    await signInButton.click();
+    await expect.poll(() => new URL(page.url()).origin).toBe(new URL(COGNITO_DOMAIN).origin);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the last remaining blocker for the `deploy-lambda.yml` deploy, which has failed on every release since **v0.24.4**.

The infra root cause (BackendLambda 503 on `/config` from read-only-filesystem writes) was already resolved on `main` by #5021 and #5023, and the `deploy` job now succeeds (verified on the v0.26.2 run). The remaining red âœ— is the **post-deploy smoke validation** tripping on one stale frontend test.

`frontend/tests/cognito-auth-flow.spec.ts` (the #4258 case) asserted that a corrupted `sessionStorage` Cognito session triggers an **automatic redirect to the hosted UI on page load**. That behavior was intentionally removed in #4458 (*"stop awsUiAuth auto-redirecting to Cognito before React mounts"*), which lands new visitors on the React `LoginPage` so they can choose **Sign in** or **Create account**. The test was added later (#4853) against the old model, so it encoded the removed behavior.

Because frontend smoke tests are **skipped in PR CI** and only run in the deploy workflow, the test merged broken and has failed every deploy since v0.24.4. The instrument-metadata 503 masked it on v0.25.1â€“v0.26.1; with that fixed, this stale test is the remaining deploy blocker.

## What changed

Rewrote the #4258 test to assert the **actual** recovery contract:
- the corrupted `awsUiAuthSession` entry is discarded (the real regression this test guards),
- the app boots to the `LoginPage` "Sign in" button without getting stuck **and without auto-redirecting** (stays on the app origin, zero `/oauth2/authorize` hits),
- the hosted-UI redirect fires only on the **explicit Sign in click**.

Test-only change; no app code touched.

## Test plan

- [x] Built the preview bundle and ran the exact deploy smoke set locally against it:
  `playwright test tests/smoke.spec.ts tests/cognito-auth-flow.spec.ts` â†’ **48 passed** (previously 47 passed, 1 failed).
- [x] Confirmed the #4258 test fails on the old assertion and passes on the new one.

## Follow-up

Once merged, cut a new release tag (e.g. `v0.26.3`) to get a fully green `deploy-lambda.yml` run. Separately, frontend smoke tests only run at deploy time â€” wiring them into PR CI would have caught this at review; worth a follow-up issue.

Closes #5036
