### PR TITLE
ci: add dedicated step to run test_extract_verdict.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
           python-version: '3.12'
       - run: pip install -r requirements.txt -r requirements-dev.txt
       - run: python scripts/check_branch_protection_required_checks.py
+      - name: Run extract_verdict tests
+        run: pytest tests/test_extract_verdict.py -v --no-cov
       - uses: actions/setup-node@v6
         with:
           node-version: '24'


### PR DESCRIPTION
## Summary
- Adds an explicit `pytest tests/test_extract_verdict.py -v --no-cov` step to the main `test` job in `.github/workflows/ci.yml`, right after dependency install.
- Gives fast, dedicated CI feedback for the review-verdict regex logic on every push/PR, instead of relying solely on the slower `lambda-compat` job's full `pytest tests/` run.

## Why not a bigger change
Per the issue's constraints, this is scoped to only adding the CI step — no changes to `extract_verdict.py`'s logic, no new tests, and the two blocking bugs flagged in the original review (`test_malformed_backticks_single_side`, hardcoded paths in `test_main_*`) are explicitly out of scope here.

## Test plan
- [x] `pytest tests/test_extract_verdict.py -v --no-cov` passes locally (13 passed)
- [x] Validated `.github/workflows/ci.yml` YAML parses correctly
- [ ] Confirm the new step runs green in CI on this PR

Closes #4281

🤖 Generated with [Claude Code](https://claude.com/claude-code)