### PR TITLE
Add --max-chars parameter to prepare_review_discussion.py

### DIFF
--- a/.github/scripts/prepare_review_discussion.py
+++ b/.github/scripts/prepare_review_discussion.py
@@ -24,6 +24,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repo", required=True)
     parser.add_argument("--pr-number", required=True)
     parser.add_argument("--provider-name", required=True)
+    parser.add_argument("--max-chars", type=int, default=MAX_DISCUSSION_CHARS)
     return parser.parse_args()
 
 
@@ -78,7 +79,9 @@ def format_comment(comment: dict, location: str) -> str:
     return f"[{comment['created_at']}] {author} ({location}): {body}"
 
 
-def collect_discussion(repo: str, pr_number: str, provider_name: str) -> str:
+def collect_discussion(
+    repo: str, pr_number: str, provider_name: str, max_chars: int = MAX_DISCUSSION_CHARS
+) -> str:
     """Return formatted human discussion created after the provider's last review."""
     issue_comments = gh_api_list(f"repos/{repo}/issues/{pr_number}/comments")
     inline_comments = gh_api_list(f"repos/{repo}/pulls/{pr_number}/comments")
@@ -97,8 +100,8 @@ def collect_discussion(repo: str, pr_number: str, provider_name: str) -> str:
     entries.sort(key=lambda entry: entry[0])
     discussion = "\n\n".join(text for _, text in entries)
 
-    if len(discussion) > MAX_DISCUSSION_CHARS:
-        cut = discussion[: MAX_DISCUSSION_CHARS - len(TRUNCATION_NOTICE)]
+    if len(discussion) > max_chars:
+        cut = discussion[: max_chars - len(TRUNCATION_NOTICE)]
         discussion = cut.rsplit("\n\n", 1)[0] + TRUNCATION_NOTICE
 
     return discussion
@@ -107,7 +110,7 @@ def collect_discussion(repo: str, pr_number: str, provider_name: str) -> str:
 def main() -> int:
     """Fetch and print PR discussion since the provider's last review."""
     args = parse_args()
-    discussion = collect_discussion(args.repo, args.pr_number, args.provider_name)
+    discussion = collect_discussion(args.repo, args.pr_number, args.provider_name, args.max_chars)
     sys.stdout.write(discussion)
     return 0
 

--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: ""
+      discussion_max_chars:
+        description: "Max characters of PR discussion to include in the review prompt, if any (default 20000)"
+        required: false
+        type: string
+        default: ""
     secrets:
       anthropic_api_key:
         description: "Anthropic API key, used for Claude reviews and follow-up issue creation"
@@ -105,11 +110,17 @@ jobs:
         id: discussion
         env:
           GH_TOKEN: ${{ secrets.gh_token }}
+          DISCUSSION_MAX_CHARS: ${{ inputs.discussion_max_chars }}
         run: |
+          MAX_CHARS_ARGS=()
+          if [ -n "$DISCUSSION_MAX_CHARS" ]; then
+            MAX_CHARS_ARGS=(--max-chars "$DISCUSSION_MAX_CHARS")
+          fi
           DISCUSSION=$(python3 .github/scripts/prepare_review_discussion.py \
             --repo "${{ github.repository }}" \
             --pr-number "${{ github.event.pull_request.number }}" \
-            --provider-name "${{ inputs.provider_name }}")
+            --provider-name "${{ inputs.provider_name }}" \
+            "${MAX_CHARS_ARGS[@]}")
           DELIM="EOF_$(uuidgen | tr -d '-')"
           {
             echo "text<<$DELIM"

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -114,7 +114,10 @@ def test_review_script_exits_cleanly_on_empty_diff(
     monkeypatch.setenv("DIFF", "   \n")
 
     assert module.main() == 0
-    assert f"No {provider_name} review generated because the filtered diff was empty." in capsys.readouterr().out
+    assert (
+        f"No {provider_name} review generated because the filtered diff was empty."
+        in capsys.readouterr().out
+    )
 
 
 @pytest.mark.parametrize(
@@ -153,7 +156,9 @@ def test_review_script_prints_review_on_mocked_api_success(
     monkeypatch.setenv("PR_TITLE", "Add thing")
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
-    monkeypatch.setattr(review_common.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload))
+    monkeypatch.setattr(
+        review_common.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload)
+    )
 
     assert module.main() == 0
     assert "Looks good" in capsys.readouterr().out
@@ -266,7 +271,9 @@ def test_review_script_exits_on_empty_api_response(
     monkeypatch.setenv("PR_TITLE", "Add thing")
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
-    monkeypatch.setattr(review_common.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload))
+    monkeypatch.setattr(
+        review_common.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload)
+    )
 
     assert module.main() == 1
     assert expected_err in capsys.readouterr().err
@@ -275,9 +282,24 @@ def test_review_script_exits_on_empty_api_response(
 @pytest.mark.parametrize(
     ("module_name", "file_name", "api_env", "expected_message"),
     [
-        ("gpt_review_failure", "gpt_review.py", "OPENAI_API_KEY", "ERROR: OpenAI API returned 500: upstream broke"),
-        ("claude_review_failure", "claude_review.py", "ANTHROPIC_API_KEY", "ERROR: Claude API returned 500: upstream broke"),
-        ("deepseek_review_failure", "deepseek_review.py", "DEEPSEEK_API_KEY", "ERROR: DeepSeek API returned 500: upstream broke"),
+        (
+            "gpt_review_failure",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
+            "ERROR: OpenAI API returned 500: upstream broke",
+        ),
+        (
+            "claude_review_failure",
+            "claude_review.py",
+            "ANTHROPIC_API_KEY",
+            "ERROR: Claude API returned 500: upstream broke",
+        ),
+        (
+            "deepseek_review_failure",
+            "deepseek_review.py",
+            "DEEPSEEK_API_KEY",
+            "ERROR: DeepSeek API returned 500: upstream broke",
+        ),
     ],
 )
 def test_review_script_reports_mocked_api_failure(
@@ -414,7 +436,9 @@ def _run_git(args: list[str], cwd: Path) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
 
 
-def test_default_globs_include_codeowners_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_globs_include_codeowners_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     module = load_script_module("prepare_review_diff", "prepare_review_diff.py")
 
     repo = tmp_path / "repo"
@@ -540,6 +564,80 @@ def test_collect_discussion_truncates_long_discussion(monkeypatch: pytest.Monkey
 
     assert len(discussion) <= module.MAX_DISCUSSION_CHARS
     assert "truncated" in discussion
+
+
+def test_collect_discussion_respects_custom_max_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_script_module(
+        "prepare_review_discussion_max_chars", "prepare_review_discussion.py"
+    )
+
+    issue_comments = [
+        _comment(
+            "alice", "x" * 500, f"2024-01-01T{i // 3600:02d}:{(i // 60) % 60:02d}:{i % 60:02d}Z"
+        )
+        for i in range(0, 300)
+    ]
+
+    monkeypatch.setattr(
+        module,
+        "gh_api_list",
+        lambda path: issue_comments if "issues" in path else [],
+    )
+
+    discussion = module.collect_discussion("owner/repo", "1", "DeepSeek", max_chars=1000)
+
+    assert len(discussion) <= 1000
+    assert "truncated" in discussion
+
+
+def test_parse_args_default_max_chars_is_backward_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_script_module("prepare_review_discussion_args", "prepare_review_discussion.py")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prepare_review_discussion.py",
+            "--repo",
+            "o/r",
+            "--pr-number",
+            "1",
+            "--provider-name",
+            "Claude",
+        ],
+    )
+
+    args = module.parse_args()
+
+    assert args.max_chars == module.MAX_DISCUSSION_CHARS
+
+
+def test_parse_args_accepts_custom_max_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_script_module(
+        "prepare_review_discussion_args_custom", "prepare_review_discussion.py"
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prepare_review_discussion.py",
+            "--repo",
+            "o/r",
+            "--pr-number",
+            "1",
+            "--provider-name",
+            "Claude",
+            "--max-chars",
+            "5000",
+        ],
+    )
+
+    args = module.parse_args()
+
+    assert args.max_chars == 5000
 
 
 def test_gh_api_list_parses_paginated_json_arrays(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Adds a `--max-chars` CLI argument to `prepare_review_discussion.py`, defaulting to the existing `MAX_DISCUSSION_CHARS` (20000) so behavior is unchanged when the flag isn't passed.
- `collect_discussion` now accepts a `max_chars` parameter used for truncation instead of the hardcoded constant.
- `_ai-pr-review.yml` gains an optional `discussion_max_chars` workflow input, forwarded to the script only when set (empty default preserves current callers).

## Test plan
- [x] `pytest tests/test_ai_review_scripts.py` — 37 passed, including new tests for custom `max_chars` truncation and `--max-chars` argparse behavior/default
- [x] `ruff check` / `black --check` on changed files (no new issues vs `main`)
- [x] Validated `_ai-pr-review.yml` YAML syntax

Closes #4270