### PR TITLE
perf(scripts): defer git ls-files call until after direct match check in aider-issue.ps1

### DIFF
--- a/scripts/aider-issue.ps1
+++ b/scripts/aider-issue.ps1
@@ -170,17 +170,26 @@ $directMatches = @(
 # Search tracked files for a matching leaf name so those still get added to
 # aider's context. Restricted to `git ls-files` output, so only files already
 # tracked in the repo can match - no path traversal outside the repo.
-$trackedFiles = @(git -C $repoRoot ls-files)
-$basenameMatches = @(
+$unmatchedCandidates = @(
     $candidates |
-        Where-Object { -not (Test-Path -LiteralPath (Join-Path $repoRoot $_) -PathType Leaf) } |
-        ForEach-Object {
-            $leaf = Split-Path -Leaf $_
-            $trackedFiles | Where-Object { (Split-Path -Leaf $_) -eq $leaf }
-        } |
-        Sort-Object -Unique |
-        ForEach-Object { Join-Path $repoRoot $_ }
+        Where-Object { -not (Test-Path -LiteralPath (Join-Path $repoRoot $_) -PathType Leaf) }
 )
+$basenameMatches = @()
+if ($unmatchedCandidates.Count -gt 0) {
+    # Only pay for listing every tracked file when a direct match didn't
+    # already resolve every candidate (repos with thousands of files make
+    # this call non-trivial, so skip it in the common all-direct-match case).
+    $trackedFiles = @(git -C $repoRoot ls-files)
+    $basenameMatches = @(
+        $unmatchedCandidates |
+            ForEach-Object {
+                $leaf = Split-Path -Leaf $_
+                $trackedFiles | Where-Object { (Split-Path -Leaf $_) -eq $leaf }
+            } |
+            Sort-Object -Unique |
+            ForEach-Object { Join-Path $repoRoot $_ }
+    )
+}
 
 # Identifier matches: issue text often calls out a specific function/method/
 # symbol in backticks (e.g. a test method name). When multiple files share a

--- a/scripts/tests/aider-issue.Tests.ps1
+++ b/scripts/tests/aider-issue.Tests.ps1
@@ -136,10 +136,11 @@ Describe 'aider-issue.ps1 file discovery logic' {
         }
     }
 
-    Context 'unconditional git ls-files call' {
-        It 'calls git ls-files even when every candidate already matched directly' {
-            # Known gap from PR #4293: git ls-files runs unconditionally, even
-            # when no candidate needs the basename fallback.
+    Context 'deferred git ls-files call' {
+        It 'does not call git ls-files when every candidate already matched directly' {
+            # Fixed in issue #4295 (follow-up from PR #4293): git ls-files
+            # used to run unconditionally, even when no candidate needed the
+            # basename fallback. It should now be skipped in that case.
             $title = 'Fix a bug'
             $issueBody = 'See .github/scripts/test_extract_verdict.py for details.'
 
@@ -147,6 +148,21 @@ Describe 'aider-issue.ps1 file discovery logic' {
                 $LiteralPath -eq (Join-Path $repoRoot '.github/scripts/test_extract_verdict.py')
             }
             Mock -CommandName git -MockWith { @() }
+
+            . ([scriptblock]::Create($script:DiscoverySnippet))
+
+            Should -Invoke -CommandName git -ParameterFilter { $args -contains 'ls-files' } -Times 0 -Exactly
+        }
+
+        It 'calls git ls-files when at least one candidate is unmatched' {
+            $title = 'Fix a bug'
+            $issueBody = 'Bug in test_extract_verdict.py needs fixing'
+
+            Mock -CommandName Test-Path -MockWith { $false }
+            Mock -CommandName git -MockWith {
+                if ($args -contains 'ls-files') { return @('.github/scripts/test_extract_verdict.py') }
+                return @()
+            }
 
             . ([scriptblock]::Create($script:DiscoverySnippet))
 


### PR DESCRIPTION
## Summary
- `git ls-files` in `scripts/aider-issue.ps1`'s file-discovery logic used to run unconditionally, even when every issue-referenced candidate already resolved via a direct path match.
- It's now only invoked when at least one candidate remains unmatched after the direct-match pass, avoiding the cost on repos with many tracked files in the common all-direct-match case.
- Updated `scripts/tests/aider-issue.Tests.ps1`: the existing test that asserted the *old* unconditional-call behavior is flipped to assert `git ls-files` is skipped when unnecessary, plus a new test confirming it still runs when a candidate is unmatched.

## Test plan
- [x] `Invoke-Pester -Path scripts/tests/aider-issue.Tests.ps1 -Output Detailed` — all 7 tests pass
- [x] Verified script parses with no syntax errors (`[System.Management.Automation.Language.Parser]::ParseFile`)

Closes #4295