### PR TITLE
fix: cap config-fetch retries to stop infinite "Loading configuration..." hang

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -59,6 +59,12 @@ interface BootstrapConfig {
 const storedToken = getStoredAuthToken();
 if (storedToken) setAuthToken(storedToken);
 
+// Cap automatic config-fetch retries so a persistently failing backend
+// surfaces the "Unable to load configuration" screen (with a manual Retry
+// button) instead of leaving the app stuck on "Loading configuration..."
+// forever. See issue #5073.
+const MAX_CONFIG_FETCH_ATTEMPTS = 5;
+
 // Populated by bootstrapRuntimeConfig before React mounts so Root can pass it
 // to LoginPage for the explicit Cognito sign-in button.
 let runtimeAwsUiAuth: AwsUiAuthConfig | undefined;
@@ -307,7 +313,7 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
                 ? err
                 : new Error(String(err));
           setConfigError(error);
-          shouldRetry = true;
+          shouldRetry = attempt + 1 < MAX_CONFIG_FETCH_ATTEMPTS;
           nextAttempt = attempt + 1;
           retryDelay = Math.min(30000, 2000 * 2 ** attempt);
         })
@@ -318,7 +324,7 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
           if (isCurrent) {
             activeRequest.current = null;
             setConfigLoading(false);
-            if (shouldRetry) setRetryScheduled(true);
+            setRetryScheduled(shouldRetry);
           }
           if (shouldRetry && isMounted.current) {
             retryTimer.current = window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- `Root`'s config-fetch bootstrap (`frontend/src/main.tsx`) retried on every failure indefinitely (`shouldRetry` was hardcoded `true`), and `retryScheduled` was only ever set to `true`, never reset when a retry attempt was abandoned.
- Combined, a persistently failing/unreachable backend (e.g. Lambda cold starts/timeouts as noted in the issue) left the whole app stuck on the "Loading configuration..." screen forever, instead of falling through to the existing "Unable to load configuration" error screen with its manual Retry button.
- Caps automatic retries at 5 attempts (exponential backoff up to 30s, unchanged) and always sets `retryScheduled` to the current retry decision so the error screen renders once attempts are exhausted.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run test -- --run` — 567/567 tests pass
- [x] Manual code trace of the retry state machine confirms the error screen (with manual Retry button) now renders after 5 failed attempts instead of looping forever

Closes #5073

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited automatic configuration-loading retries to prevent endless retry loops.
  * Added a clear failure state with an option to retry manually when configuration cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->