### PR TITLE
fix: Group menu link no longer bounces to Input page; add missing research i18n key

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -332,7 +332,16 @@ export default function App({ onLogout }: AppProps) {
     } else if (newMode === 'group') {
       const groupParam = params.get('group');
       setSelectedGroup(normaliseGroupSlug(groupParam));
-      if (groupParam && isDefaultGroupSlug(groupParam) && location.search) {
+      // Skip this cleanup under Family MVP: stripping `?group=all` down to a
+      // bare '/' would immediately re-trigger the entry-path redirect above
+      // (bare '/' with no query is treated as "go to the MVP landing page"),
+      // bouncing the group view straight back off (#5075).
+      if (
+        groupParam &&
+        isDefaultGroupSlug(groupParam) &&
+        location.search &&
+        !familyMvpEnabled
+      ) {
         navigate('/', { replace: true });
       }
     } else if (newMode === 'research') {

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -81,6 +81,7 @@
       "performance": "Leistung",
       "rebalance": "Neugewichtung",
       "reports": "Berichte",
+      "research": "Recherche",
       "scenario": "Szenario-Tester",
       "screener": "Filter & Abfrage",
       "settings": "Benutzereinstellungen",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -75,6 +75,7 @@
       "performance": "Performance",
       "rebalance": "Rebalance",
       "reports": "Reports",
+      "research": "Research",
       "scenario": "Scenario Tester",
       "screener": "Screener & Query",
       "settings": "User Settings",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -81,6 +81,7 @@
       "performance": "Rendimiento",
       "rebalance": "Reequilibrio",
       "reports": "Informes",
+      "research": "Investigación",
       "scenario": "Probador de Escenarios",
       "screener": "Filtro y consulta",
       "settings": "Configuración del usuario",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -81,6 +81,7 @@
       "performance": "Performance",
       "rebalance": "Rééquilibrage",
       "reports": "Rapports",
+      "research": "Recherche",
       "scenario": "Testeur de Scénario",
       "screener": "Filtre & Requête",
       "settings": "Paramètres utilisateur",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -81,6 +81,7 @@
       "performance": "Prestazione",
       "rebalance": "Riequilibrio",
       "reports": "Report",
+      "research": "Ricerca",
       "scenario": "Simulatore di scenari",
       "screener": "Filtro e interrogazione",
       "settings": "Impostazioni utente",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -81,6 +81,7 @@
       "performance": "Desempenho",
       "rebalance": "Rebalanceamento",
       "reports": "Relatórios",
+      "research": "Pesquisa",
       "scenario": "Testador de Cenários",
       "screener": "Filtro e consulta",
       "settings": "Configurações do usuário",

--- a/frontend/src/routes/registry.ts
+++ b/frontend/src/routes/registry.ts
@@ -1,7 +1,7 @@
 import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
 import type { TabsConfig } from '../ConfigContext';
 import type { Mode } from '../modes';
-import { isDefaultGroupSlug } from '../utils/groups';
+import { DEFAULT_GROUP_SLUG } from '../utils/groups';
 
 export type RouteSection = 'user' | 'support' | 'standalone';
 export type MenuSection = Extract<RouteSection, 'user' | 'support'>;
@@ -55,10 +55,13 @@ export const ROUTE_REGISTRY: RouteRegistryEntry[] = [
     menuCategory: 'dashboard',
     priority: 0,
     defaultPath: ({ group, selectedGroup }) => {
-      const resolvedGroup = group ?? selectedGroup ?? '';
-      return resolvedGroup && !isDefaultGroupSlug(resolvedGroup)
-        ? `/?group=${resolvedGroup}`
-        : '/';
+      // Always carry an explicit `group` query param, even for the default
+      // slug: a bare '/' collides with the Family MVP entry-path redirect
+      // (App.tsx's getFamilyMvpRedirectPath fires on '/' with no query),
+      // which silently bounced this menu link to the transactions/input page
+      // instead of the group view (#5075).
+      const resolvedGroup = group ?? selectedGroup ?? DEFAULT_GROUP_SLUG;
+      return `/?group=${resolvedGroup || DEFAULT_GROUP_SLUG}`;
     },
   },
   {

--- a/frontend/tests/unit/App.familyMvpRedirect.test.tsx
+++ b/frontend/tests/unit/App.familyMvpRedirect.test.tsx
@@ -210,6 +210,60 @@ describe("App family MVP redirects", () => {
     expect(router.state.location.search).toBe("?group=kids");
   });
 
+  it("does not bounce the default group view to the entry path in Family MVP mode (#5075)", async () => {
+    // Reported bug: clicking the "Group" menu link (which resolves to the
+    // default "all" group) landed on the transactions/input page instead of
+    // the group view. `/?group=all` used to get normalised straight back to a
+    // bare '/', which the entry-path redirect above then intercepted.
+    mockConfig({
+      configLoaded: true,
+      familyMvpEnabled: true,
+      disabledTabs: [],
+      tabs: {
+        ...baseConfig.tabs,
+        owner: true,
+        group: true,
+        transactions: true,
+      },
+    });
+
+    vi.doMock("@/components/GroupPortfolioView", () => ({
+      GroupPortfolioView: () => <section>Group Portfolio View</section>,
+    }));
+
+    vi.doMock("@/api", async () => {
+      const actual = await vi.importActual<typeof import("@/api")>("@/api");
+      return {
+        ...actual,
+        getOwners: vi.fn().mockResolvedValue([]),
+        getGroups: vi
+          .fn()
+          .mockResolvedValue([{ slug: "all", name: "At a glance", members: [] }]),
+        getGroupInstruments: vi.fn().mockResolvedValue([]),
+        getPortfolio: vi.fn(),
+        refreshPrices: vi.fn(),
+        getAlerts: vi.fn().mockResolvedValue([]),
+        getNudges: vi.fn().mockResolvedValue([]),
+        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+        getCompliance: vi
+          .fn()
+          .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+        getTimeseries: vi.fn().mockResolvedValue([]),
+        saveTimeseries: vi.fn(),
+        refetchTimeseries: vi.fn(),
+        rebuildTimeseriesCache: vi.fn(),
+        getTradingSignals: vi.fn().mockResolvedValue([]),
+        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+      };
+    });
+
+    const router = await renderAppAt("/?group=all");
+
+    expect(await screen.findByText("Group Portfolio View")).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe("/");
+    expect(router.state.location.search).toBe("?group=all");
+  });
+
   it("does not bounce /research/:ticker back to the entry path in Family MVP mode", async () => {
     // The reported bug (#4641): the header search bar navigates to /research/:t,
     // which Family MVP previously reverted to /input. With research enabled it

--- a/frontend/tests/unit/App.test.tsx
+++ b/frontend/tests/unit/App.test.tsx
@@ -1727,7 +1727,10 @@ describe("App", () => {
     );
 
     const groupLink = await screen.findByText("Group");
-    expect(groupLink).toHaveAttribute("href", "/");
+    // The link always carries an explicit `group=all` query param (even for
+    // the default group) so it never collides with the Family MVP bare-root
+    // redirect, which treats '/' with no query as "go to the entry page" (#5075).
+    expect(groupLink).toHaveAttribute("href", "/?group=all");
     expect(groupLink).toBeInTheDocument();
 
     const nav = screen.getByRole("navigation");

--- a/frontend/tests/unit/pageManifest.test.ts
+++ b/frontend/tests/unit/pageManifest.test.ts
@@ -57,7 +57,10 @@ describe('page manifest', () => {
     expect(deriveModeFromPathname('/totally-unknown')).toBe('movers');
     expect(deriveRouteFromPathname('/totally-unknown').mode).toBe('movers');
 
-    expect(buildPathForMode('group', { group: 'all' })).toBe('/');
+    // The default group slug still gets an explicit `group` query param (not
+    // a bare '/') so it never collides with the Family MVP entry-path
+    // redirect, which treats '/' with no query as "go to the entry page" (#5075).
+    expect(buildPathForMode('group', { group: 'all' })).toBe('/?group=all');
     expect(buildPathForMode('group', { group: 'kids' })).toBe('/?group=kids');
     expect(buildPathForMode('owner', { owner: 'alex' })).toBe('/portfolio/alex');
     expect(buildPathForMode('transactions')).toBe('/input');


### PR DESCRIPTION
## Summary
- The "Group" dashboard menu link resolved to a bare `/` for the default group, which collided with the Family MVP entry-path redirect (`App.tsx`'s `getFamilyMvpRedirectPath` treats any bare `/` with no query string as "go to the configured entry page"). This silently bounced users to the transactions/Input page instead of the group portfolio view, along with a "Failed to fetch" toast from that page's own data fetching.
- A second normalisation effect in `App.tsx` stripped `?group=all` back down to a bare `/` on every route sync, so simply adding the query param to the link wasn't enough — that normalisation is now skipped while Family MVP is enabled.
- The Insights menu displayed the raw untranslated key `app.modes.research` because the `research` mode was missing from the `app.modes` translation block in every locale file. Added `"research"` translations (EN/FR/ES/DE/IT/PT).

## Root cause
- [`frontend/src/routes/registry.ts`](frontend/src/routes/registry.ts): the `group` route's `defaultPath` collapsed to `/` for the default slug instead of always carrying `?group=<slug>`.
- [`frontend/src/App.tsx`](frontend/src/App.tsx): the route-sync effect normalised `?group=all` back to `/`, unconditionally — even when Family MVP was enabled, where a bare `/` has special meaning.
- [`frontend/src/locales/*/translation.json`](frontend/src/locales/en/translation.json): `app.modes.research` key was absent.

## Test plan
- [x] Added a regression test in `App.familyMvpRedirect.test.tsx` reproducing the exact reported bug (`/?group=all` under Family MVP no longer bounces to the entry path).
- [x] Updated `App.test.tsx` and `pageManifest.test.ts` assertions to match the corrected `/?group=all` href.
- [x] `npm --prefix frontend run test -- --run` — 593/593 passing.
- [x] `npm --prefix frontend run lint` — clean.

Closes #5075

🤖 Generated with [Claude Code](https://claude.com/claude-code)