### PR TITLE
fix: fall back to repo-local accounts root when configured root is missing

### DIFF
--- a/backend/common/approvals.py
+++ b/backend/common/approvals.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Dict, Optional
 
-from backend.common.path_utils import safe_join
+from backend.common.data_loader import resolve_owner_dir
 from backend.config import config
 from backend.logging_setup import sanitise_log_value
 
@@ -22,13 +22,7 @@ def approvals_path(owner: str, accounts_root: Path | None = None) -> Path:
     exist.  Callers are expected to handle or propagate this exception.
     """
 
-    root = Path(accounts_root or config.accounts_root)
-    try:
-        owner_dir = safe_join(root, owner)
-    except ValueError as exc:
-        raise FileNotFoundError("invalid owner") from exc
-    if not owner_dir.exists():
-        raise FileNotFoundError(owner_dir)
+    owner_dir = resolve_owner_dir(owner, accounts_root)
     return owner_dir / "approvals.json"
 
 

--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -280,6 +280,41 @@ def resolve_paths(
     return ResolvedPaths(repo_path, accounts_path, virtual_root)
 
 
+def resolve_default_accounts_root() -> Path:
+    """Resolve the process-default accounts root.
+
+    Falls back to the repo-local ``data/accounts`` tree when
+    ``config.accounts_root`` doesn't exist on disk, mirroring the fallback
+    already applied by ``list_plots`` and ``resolve_accounts_root``. Without
+    this, helpers that resolve their root lazily from ``config`` (rather than
+    being handed an explicit, existence-checked root by the caller) would
+    raise ``FileNotFoundError`` for valid owners whenever the configured root
+    is missing in the current environment.
+    """
+
+    primary = resolve_paths(config.repo_root, config.accounts_root).accounts_root
+    if primary.exists():
+        return primary
+    fallback = resolve_paths(None, None).accounts_root
+    return fallback if fallback.exists() else primary
+
+
+def resolve_owner_dir(owner: str, accounts_root: Optional[Path] = None) -> Path:
+    """Return ``owner``'s directory, falling back to the repo-local accounts root.
+
+    Raises ``FileNotFoundError`` if the owner isn't found.
+    """
+
+    root = Path(accounts_root) if accounts_root else resolve_default_accounts_root()
+    try:
+        owner_dir = safe_join(root, owner)
+    except ValueError as exc:
+        raise FileNotFoundError("invalid owner") from exc
+    if not owner_dir.exists():
+        raise FileNotFoundError(owner)
+    return owner_dir
+
+
 # ------------------------------------------------------------------
 # Local discovery
 # ------------------------------------------------------------------
@@ -940,7 +975,7 @@ def load_person_metadata(owner: str, data_root: Optional[Path] = None) -> Person
     local_root: Optional[Path] = data_root
     if local_root is None:
         try:
-            local_root = resolve_paths(config.repo_root, config.accounts_root).accounts_root
+            local_root = resolve_default_accounts_root()
         except Exception:  # pragma: no cover - extremely defensive
             local_root = None
 
@@ -1011,7 +1046,7 @@ def load_account(
     local_root: Optional[Path] = data_root
     if local_root is None:
         try:
-            local_root = resolve_paths(config.repo_root, config.accounts_root).accounts_root
+            local_root = resolve_default_accounts_root()
         except Exception:  # pragma: no cover - extremely defensive
             local_root = None
 
@@ -1082,7 +1117,7 @@ def load_person_meta(owner: str, data_root: Optional[Path] = None) -> Dict[str, 
     local_root: Optional[Path] = data_root
     if local_root is None:
         try:
-            local_root = resolve_paths(config.repo_root, config.accounts_root).accounts_root
+            local_root = resolve_default_accounts_root()
         except Exception:  # pragma: no cover - extremely defensive
             local_root = None
 

--- a/backend/common/user_config.py
+++ b/backend/common/user_config.py
@@ -5,8 +5,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import List, Optional
 
-from backend.common.data_loader import resolve_paths
-from backend.common.path_utils import safe_join
+from backend.common.data_loader import resolve_owner_dir
 from backend.config import config
 
 
@@ -41,14 +40,7 @@ class UserConfig:
 
 
 def _settings_path(owner: str, accounts_root: Path | None = None) -> Path:
-    paths = resolve_paths(config.repo_root, config.accounts_root)
-    root = Path(accounts_root) if accounts_root else paths.accounts_root
-    try:
-        owner_dir = safe_join(root, owner)
-    except ValueError as exc:
-        raise FileNotFoundError("invalid owner") from exc
-    if not owner_dir.exists():
-        raise FileNotFoundError(owner)
+    owner_dir = resolve_owner_dir(owner, accounts_root)
     return owner_dir / "settings.json"
 
 

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -24,6 +24,8 @@ from backend.common.data_loader import (
     load_person_meta,
     load_person_metadata,
     load_virtual_portfolio,
+    resolve_default_accounts_root,
+    resolve_owner_dir,
     resolve_paths,
     save_virtual_portfolio,
 )
@@ -295,6 +297,72 @@ class TestResolvePaths:
         expected_accounts = Path(windows_accounts).expanduser()
         expected_virtual = expected_accounts.parent / "virtual_portfolios"
         assert result == ResolvedPaths(repo_dir, expected_accounts, expected_virtual)
+
+
+class TestResolveDefaultAccountsRoot:
+    """Regression coverage for issue #5072: valid owners 404'd on /performance,
+    /var and portfolio-group endpoints whenever ``config.accounts_root`` pointed
+    at a directory that doesn't exist in the current environment, because
+    ``load_account``/``load_person_metadata``/``user_config``/``approvals``
+    resolved that root directly with no fallback (unlike ``list_plots`` and
+    ``resolve_accounts_root``, which already degrade to the repo-local
+    ``data/accounts`` tree)."""
+
+    def _patch_paths(self, monkeypatch, tmp_path, primary, fallback):
+        def fake_resolve_paths(repo_root, accounts_root):
+            if repo_root is None and accounts_root is None:
+                return ResolvedPaths(tmp_path, fallback, fallback.parent / "virtual_portfolios")
+            return ResolvedPaths(tmp_path, primary, primary.parent / "virtual_portfolios")
+
+        monkeypatch.setattr(data_loader, "resolve_paths", fake_resolve_paths)
+        monkeypatch.setattr(
+            data_loader,
+            "config",
+            type("Cfg", (), {"repo_root": tmp_path, "accounts_root": primary})(),
+        )
+
+    def test_falls_back_when_configured_root_missing(self, tmp_path, monkeypatch):
+        primary = tmp_path / "missing_primary"
+        fallback = tmp_path / "fallback"
+        fallback.mkdir()
+        self._patch_paths(monkeypatch, tmp_path, primary, fallback)
+
+        assert resolve_default_accounts_root() == fallback
+
+    def test_uses_configured_root_when_it_exists(self, tmp_path, monkeypatch):
+        primary = tmp_path / "primary"
+        primary.mkdir()
+        fallback = tmp_path / "fallback"
+        fallback.mkdir()
+        self._patch_paths(monkeypatch, tmp_path, primary, fallback)
+
+        assert resolve_default_accounts_root() == primary
+
+
+class TestResolveOwnerDir:
+    def test_finds_owner_under_fallback_root(self, tmp_path, monkeypatch):
+        primary = tmp_path / "missing_primary"
+        fallback = tmp_path / "fallback"
+        owner_dir = fallback / "alice"
+        owner_dir.mkdir(parents=True)
+        TestResolveDefaultAccountsRoot()._patch_paths(monkeypatch, tmp_path, primary, fallback)
+
+        assert resolve_owner_dir("alice") == owner_dir
+
+    def test_raises_when_owner_missing_everywhere(self, tmp_path, monkeypatch):
+        primary = tmp_path / "missing_primary"
+        fallback = tmp_path / "fallback"
+        fallback.mkdir()
+        TestResolveDefaultAccountsRoot()._patch_paths(monkeypatch, tmp_path, primary, fallback)
+
+        with pytest.raises(FileNotFoundError):
+            resolve_owner_dir("nobody")
+
+    def test_explicit_accounts_root_bypasses_fallback(self, tmp_path):
+        owner_dir = tmp_path / "explicit" / "alice"
+        owner_dir.mkdir(parents=True)
+
+        assert resolve_owner_dir("alice", tmp_path / "explicit") == owner_dir
 
 
 class TestVirtualPortfolioPersistence:

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -338,6 +338,22 @@ class TestResolveDefaultAccountsRoot:
 
         assert resolve_default_accounts_root() == primary
 
+    def test_returns_primary_when_neither_root_exists(self, tmp_path, monkeypatch):
+        """Neither root exists on disk (e.g. a fresh checkout with no data/
+        directory at all). There's nothing sensible to fall back to, so this
+        degrades to the pre-fallback behaviour: return the (non-existent)
+        configured root and let callers raise FileNotFoundError/MissingData
+        when they try to actually read from it."""
+        primary = tmp_path / "missing_primary"
+        fallback = tmp_path / "missing_fallback"
+        self._patch_paths(monkeypatch, tmp_path, primary, fallback)
+
+        assert resolve_default_accounts_root() == primary
+        assert not resolve_default_accounts_root().exists()
+
+        with pytest.raises(FileNotFoundError):
+            resolve_owner_dir("alice")
+
 
 class TestResolveOwnerDir:
     def test_finds_owner_under_fallback_root(self, tmp_path, monkeypatch):

--- a/tests/backend/test_user_config.py
+++ b/tests/backend/test_user_config.py
@@ -9,11 +9,6 @@ from backend.common import user_config as uc
 def _patch_defaults(monkeypatch, tmp_path):
     monkeypatch.setattr(
         uc,
-        "resolve_paths",
-        lambda repo_root, accounts_root: SimpleNamespace(accounts_root=tmp_path),
-    )
-    monkeypatch.setattr(
-        uc,
         "config",
         SimpleNamespace(
             repo_root=tmp_path,

--- a/tests/common/test_user_config.py
+++ b/tests/common/test_user_config.py
@@ -7,12 +7,7 @@ from backend.common import user_config as uc
 
 
 def _patch_defaults(monkeypatch, tmp_path):
-    """Patch config and resolve_paths to point at temporary directories."""
-    monkeypatch.setattr(
-        uc,
-        "resolve_paths",
-        lambda repo_root, accounts_root: SimpleNamespace(accounts_root=tmp_path),
-    )
+    """Patch config to point at a temporary directory."""
     monkeypatch.setattr(
         uc,
         "config",


### PR DESCRIPTION
## Summary
- Root cause of #5072: `/performance/{owner}`, `/var/{owner}*`, and `/portfolio-group/{slug}` (movers, allocation) resolve owner data via `load_account`/`load_person_metadata` in `backend/common/data_loader.py` and the `user_config`/`approvals` helpers. Unlike `list_plots` and `resolve_accounts_root` (used by the working `/portfolio/{owner}` route), these helpers resolved `config.accounts_root` directly with **no fallback**, so a valid owner 404'd/errored whenever that configured root didn't exist in the current environment.
- Confirmed live: `GET /portfolio/alice` → 200, `GET /performance/alice` → 404 "Owner not found" on an unmodified checkout, traced to `load_account`/`load_user_config`/`load_approvals` raising `FileNotFoundError` for a root that doesn't exist locally.
- Adds `resolve_default_accounts_root()` / `resolve_owner_dir()` in `data_loader.py`, mirroring the existing fallback-to-`data/accounts` behavior, and routes `load_account`, `load_person_metadata`, `load_person_meta`, `user_config._settings_path`, and `approvals.approvals_path` through it.
- The reported "Movers/Allocation stuck on Loading forever" symptom traces to the same `/portfolio-group/{slug}` endpoint (used by both pages) hitting this bug deep in `load_account_record`; no separate frontend bug was found for that part.

## Test plan
- [x] Reproduced the bug and verified the fix with a live `TestClient`: `/portfolio/alice` (200), `/performance/alice` (404 → 200), `/portfolio-group/all` (200), `/var/alice` (200), `/movers?tickers=...` (200)
- [x] Added regression coverage in `tests/backend/common/test_data_loader.py` (`TestResolveDefaultAccountsRoot`, `TestResolveOwnerDir`) for the fallback behavior
- [x] `python -m pytest tests/backend/test_user_config.py tests/common/test_user_config.py tests/backend/common/test_data_loader.py tests/routes/test_approvals.py tests/backend/test_approvals_route.py tests/test_var_route.py` — all pass
- [x] Full `tests/` suite passes (pre-existing, unrelated flaky failures in `TestLocalOwnerIndexCache` confirmed present on `main` too, before this change)
- [x] `ruff check` clean on all touched files

Closes #5072

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account directory resolution when the configured location is unavailable.
  - Added fallback support for the repository’s local accounts directory.
  - Improved handling of missing or invalid owner directories.
  - Ensured owner settings and approval files continue to be located correctly.

- **Tests**
  - Added coverage for configured and fallback account locations.
  - Added validation for missing owners and explicit directory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->