### PR TITLE
fix: stop instrument-page cold start from blocking on eager S3 metadata build

### DIFF
--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -122,6 +122,21 @@ def _s3_location() -> tuple[str, str] | None:
     return bucket, prefix
 
 
+@lru_cache(maxsize=1)
+def _s3_client():
+    """Return a process-wide S3 client, built once instead of per call.
+
+    ``boto3.client()`` re-resolves credentials/config on every construction,
+    which is slow enough that building one per ticker turns a portfolio-wide
+    metadata scan (one call per unique ticker) into a multi-second-per-call
+    tax on top of the network round trip itself. See issue #5082.
+    """
+
+    import boto3  # type: ignore
+
+    return boto3.client("s3")
+
+
 def _instrument_path(ticker: str) -> Path:
     instruments_dir = _active_instruments_dir()
     sym, exch = (ticker.split(".", 1) + [None])[:2]
@@ -155,9 +170,7 @@ def get_instrument_meta(ticker: str) -> Dict[str, Any]:
         bucket, prefix = s3_loc
         key = _instrument_key(ticker, prefix)
         try:
-            import boto3  # type: ignore
-
-            obj = boto3.client("s3").get_object(Bucket=bucket, Key=key)
+            obj = _s3_client().get_object(Bucket=bucket, Key=key)
             return json.loads(obj["Body"].read())
         except Exception as exc:
             logger.warning(
@@ -243,10 +256,8 @@ def save_instrument_meta(
         bucket, prefix = s3_loc
         key = _instrument_key(f"{ticker}.{exchange}", prefix)
         try:
-            import boto3  # type: ignore
-
             body = json.dumps(data).encode("utf-8")
-            boto3.client("s3").put_object(Bucket=bucket, Key=key, Body=body)
+            _s3_client().put_object(Bucket=bucket, Key=key, Body=body)
         except Exception as exc:  # pragma: no cover - best effort
             logger.warning(
                 "Failed to upload instrument metadata for %s.%s to s3://%s/%s: %s",

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -454,7 +454,14 @@ def _build_securities_from_portfolios() -> Dict[str, Dict]:
     return securities
 
 
-_SECURITIES = _build_securities_from_portfolios()
+# Not built eagerly at import time: doing so triggers a get_instrument_meta
+# (S3 GetObject) call per unique ticker across every portfolio during Lambda
+# cold start, which blocks the ASGI app import itself (see backend/lambda_api/
+# handler.py, which defers app creation to the first invocation precisely to
+# avoid this class of blocking work). Building it lazily on first use keeps
+# that cost off requests that never need security metadata, matching the
+# _PRICE_SNAPSHOT precedent below (issue #5082, cf. issue #2975).
+_SECURITIES: Dict[str, Dict] | None = None
 
 
 def get_security_meta(ticker: str) -> Dict | None:
@@ -462,6 +469,9 @@ def get_security_meta(ticker: str) -> Dict | None:
 
     Falls back to instrument files if the ticker isn't present in portfolios.
     """
+    global _SECURITIES
+    if _SECURITIES is None:
+        _SECURITIES = _build_securities_from_portfolios()
     t = ticker.upper()
     meta = _SECURITIES.get(t)
     if meta:

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -80,6 +80,7 @@ def test_get_instrument_meta_prefers_s3_when_available(monkeypatch, tmp_path) ->
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
     instruments.get_instrument_meta.cache_clear()
+    instruments._s3_client.cache_clear()
     assert instruments.get_instrument_meta("ABC.L") == payload
 
 
@@ -104,6 +105,7 @@ def test_get_instrument_meta_falls_back_to_local_on_s3_error(monkeypatch, tmp_pa
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
     instruments.get_instrument_meta.cache_clear()
+    instruments._s3_client.cache_clear()
     with caplog.at_level("WARNING"):
         assert instruments.get_instrument_meta("ABC.L") == payload
     assert "falling back to local file" in caplog.text
@@ -136,6 +138,7 @@ def test_save_instrument_meta_writes_uploads_and_clears_cache(monkeypatch, tmp_p
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
     instruments.get_instrument_meta.cache_clear()
+    instruments._s3_client.cache_clear()
     with caplog.at_level("WARNING"):
         instruments.get_instrument_meta("ABC.L")
 

--- a/tests/backend/common/test_portfolio_utils.py
+++ b/tests/backend/common/test_portfolio_utils.py
@@ -884,3 +884,33 @@ def test_list_all_unique_tickers_logs_missing_and_counts_nulls(monkeypatch, capl
     assert any("Missing ticker" in message for message in warning_messages)
     info_messages = [rec.message for rec in caplog.records if rec.levelname == "INFO"]
     assert any("1 null tickers" in message for message in info_messages)
+
+
+def test_securities_are_not_built_at_import_time(monkeypatch):
+    """_SECURITIES must stay unbuilt until get_security_meta() is first called.
+
+    Building it eagerly at module import triggers an S3 GetObject per unique
+    ticker across every portfolio during Lambda cold start, which blocks the
+    ASGI app import itself (issue #5082) — the same class of bug already fixed
+    once for _PRICE_SNAPSHOT (issue #2975).
+    """
+    monkeypatch.setattr(portfolio_utils, "_SECURITIES", None)
+
+    calls: list[None] = []
+    real_build = portfolio_utils._build_securities_from_portfolios
+
+    def spy_build():
+        calls.append(None)
+        return real_build()
+
+    monkeypatch.setattr(portfolio_utils, "_build_securities_from_portfolios", spy_build)
+    monkeypatch.setattr(portfolio_utils, "list_portfolios", lambda: [])
+    monkeypatch.setattr(portfolio_utils, "list_virtual_portfolios", lambda: [])
+
+    assert portfolio_utils._SECURITIES is None
+
+    portfolio_utils.get_security_meta("AAA.L")
+    assert calls == [None]
+
+    portfolio_utils.get_security_meta("BBB.L")
+    assert calls == [None]  # second call reuses the already-built dict

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -69,6 +69,7 @@ def test_get_instrument_meta_from_s3(monkeypatch):
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
     instruments.get_instrument_meta.cache_clear()
+    instruments._s3_client.cache_clear()
     assert instruments.get_instrument_meta("ABC.L") == {"foo": 1}
 
 
@@ -90,6 +91,7 @@ def test_save_instrument_meta_uploads_s3(monkeypatch, tmp_path):
         return SimpleNamespace(put_object=put_object)
 
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
+    instruments._s3_client.cache_clear()
 
     instruments.save_instrument_meta("ABC.L", {"bar": 2})
     path = tmp_path / "L" / "ABC.json"


### PR DESCRIPTION
## Summary
- Root cause of the ~25-30s load + eventual HTTP 503 from `/portfolio-group/all/instruments`: `_SECURITIES` in `backend/common/portfolio_utils.py` was built **eagerly at module import time**, calling `get_instrument_meta()` (an S3 `GetObject`) once per unique ticker across every portfolio/owner.
- `backend/lambda_api/handler.py` intentionally defers FastAPI app creation (and therefore this module's import) to the **first Lambda invocation**, specifically to keep expensive cold-start work off the Lambda INIT phase. That means this eager build instead runs synchronously inside whichever request happens to be the cold-start request, burning through most of the Lambda's timeout budget before a response can be returned — matching the reported ~25-30s delay ending in a 503, and plausibly contributing to the collateral symptoms in #5072/#5073 (other pages stuck loading/erroring on a cold Lambda).
- This is the same class of bug already fixed once for `_PRICE_SNAPSHOT` (issue #2975 / commit `e414d4c7`) — `_SECURITIES` reintroduced the identical anti-pattern.
- Also fixed a smaller compounding cost: `get_instrument_meta`/`save_instrument_meta` in `backend/common/instruments.py` constructed a brand-new `boto3.client("s3")` on every call instead of reusing one — client construction re-resolves credentials/config each time, which adds up when looping over every ticker in a portfolio.

## Changes
- `backend/common/portfolio_utils.py`: `_SECURITIES` now builds lazily on first `get_security_meta()` call instead of at import.
- `backend/common/instruments.py`: added a cached `_s3_client()` helper reused by both S3 read and write paths.
- Updated/added tests: `tests/backend/common/test_portfolio_utils.py` (new `test_securities_are_not_built_at_import_time`), `tests/backend/common/test_instruments.py` and `tests/test_instruments.py` (clear the new client cache alongside the existing `get_instrument_meta.cache_clear()` pattern so mocked `boto3` clients don't leak across tests).

## Test plan
- [x] `pytest tests/backend/common/test_portfolio_utils.py tests/backend/common/test_instruments.py tests/test_instruments.py tests/test_portfolio_utils_meta.py tests/test_portfolio_utils_currency.py` — all passing
- [x] Full `pytest tests/` — 2928 passed, 6 pre-existing unrelated failures in `test_review_comment.py` (reproduces identically on `main`, a Git-Bash `pipefail` compatibility issue), 6 skipped, 16 xfailed, 1 xpassed

Closes #5082