### PR TITLE
fix: stop /transactions from double-rendering the holdings input form

### DIFF
--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -594,7 +594,7 @@ export function TransactionsPage({ owners, inputOnly = false }: Props) {
 
   return (
     <div>
-      {manualHoldingsSection}
+      {inputOnly && manualHoldingsSection}
       {!inputOnly && (
         <>
           <TransactionsFilters

--- a/frontend/tests/unit/components/TransactionsPage.test.tsx
+++ b/frontend/tests/unit/components/TransactionsPage.test.tsx
@@ -70,11 +70,13 @@ describe('TransactionsPage', () => {
     return within(row).getByRole('button', { name: 'Edit' });
   };
 
-  const getFilterOwner = () => screen.getAllByLabelText(/owner/i)[1];
-  const getFilterAccount = () => screen.getAllByLabelText(/account/i)[1];
-  const getEditorTicker = () => screen.getAllByLabelText('Ticker')[1];
-  const getEditorPrice = () => screen.getAllByLabelText('Price (GBP)')[1];
-  const getEditorUnits = () => screen.getAllByLabelText('Units')[1];
+  // The Account + Holdings Input form only renders when inputOnly is true
+  // (#5089), so outside that mode these labels only match the filters/editor.
+  const getFilterOwner = () => screen.getAllByLabelText(/owner/i)[0];
+  const getFilterAccount = () => screen.getAllByLabelText(/account/i)[0];
+  const getEditorTicker = () => screen.getAllByLabelText('Ticker')[0];
+  const getEditorPrice = () => screen.getAllByLabelText('Price (GBP)')[0];
+  const getEditorUnits = () => screen.getAllByLabelText('Units')[0];
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -93,6 +95,20 @@ describe('TransactionsPage', () => {
     expect(
       (await screen.findAllByText('Alex Example')).at(-1)
     ).toBeInTheDocument();
+  });
+
+  it('does not render the Account + Holdings Input form when inputOnly is false', async () => {
+    render(
+      <TransactionsPage
+        owners={[
+          { owner: 'alex', full_name: 'Alex Example', accounts: ['isa'] },
+        ]}
+      />
+    );
+    await screen.findByText('PFE');
+    expect(
+      screen.queryByText('Account + Holdings Input')
+    ).not.toBeInTheDocument();
   });
 
   it('locks owner and account filters while editing', async () => {


### PR DESCRIPTION
## Summary
- \`TransactionsPage\` rendered the "Account + Holdings Input" section unconditionally, while the filters/table were correctly gated behind \`!inputOnly\`. So on \`/transactions\` (\`inputOnly=false\`), the page showed the Account + Holdings Input form stacked on top of the real Transactions filter/table UI.
- Fix: gate the holdings-input section on \`inputOnly\`, matching the \`/input\` route's intent, so \`/transactions\` only renders the Transactions filter/table.

## Test plan
- [x] Added a regression test asserting the "Account + Holdings Input" form is absent when \`inputOnly\` is false.
- [x] Updated existing tests' label-index assumptions (\`[1]\` → \`[0]\`) since the duplicate form fields no longer render outside \`inputOnly\`.
- [x] \`npx vitest run TransactionsPage\` — 11/11 passing.
- [x] \`npx eslint\` on changed files — clean.

Closes #5089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the Transactions page so the Account + Holdings Input form only appears when input-only mode is enabled.
  - Prevented the form from appearing alongside the standard transaction filters, editor and table.

- **Tests**
  - Added coverage to verify the form is hidden in standard mode.
  - Updated control selection checks to reflect the corrected page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->