### PR TITLE
fix: show retryable backend-unavailable state on trading signals fetch failure

### DIFF
--- a/frontend/src/pages/Trading.tsx
+++ b/frontend/src/pages/Trading.tsx
@@ -1,27 +1,35 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTradingSignals } from '../api';
 import type { TradingSignal } from '../types';
 import { InstrumentDetail } from '../components/InstrumentDetail';
+import BackendUnavailableCard from '../components/BackendUnavailableCard';
+import useFetchWithRetry from '../hooks/useFetchWithRetry';
 import tableStyles from '../styles/table.module.css';
 import { MAX_TRADING_SIGNAL_ROWS } from '../constants/renderLimits';
 
 export default function Trading() {
   const { t } = useTranslation();
-  const [signals, setSignals] = useState<TradingSignal[]>([]);
-  const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<TradingSignal | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+  const handleRetry = useCallback(() => setRetryNonce((n) => n + 1), []);
 
-  useEffect(() => {
-    getTradingSignals()
-      .then(setSignals)
-      .catch((e) => setError(e instanceof Error ? e.message : String(e)));
-  }, []);
+  const { data, loading, error } = useFetchWithRetry(
+    getTradingSignals,
+    500,
+    5,
+    retryNonce,
+  );
 
   if (error) {
-    return <p style={{ color: 'red' }}>{error}</p>;
+    return <BackendUnavailableCard onRetry={handleRetry} />;
   }
 
+  if (loading) {
+    return <p>{t('common.loading')}</p>;
+  }
+
+  const signals = data ?? [];
   if (!signals.length) {
     return <p>{t('trading.noSignals')}</p>;
   }

--- a/frontend/tests/unit/pages/Trading.test.tsx
+++ b/frontend/tests/unit/pages/Trading.test.tsx
@@ -2,11 +2,16 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { axe } from 'jest-axe';
 import Trading from '@/pages/Trading';
-import * as api from '@/api';
+import useFetchWithRetry from '@/hooks/useFetchWithRetry';
+import type { TradingSignal } from '@/types';
 
-vi.mock('@/api');
+vi.mock('@/api', () => ({
+  getTradingSignals: vi.fn(),
+}));
 
-const mockGetTradingSignals = vi.mocked(api.getTradingSignals);
+vi.mock('@/hooks/useFetchWithRetry');
+
+const mockUseFetchWithRetry = vi.mocked(useFetchWithRetry);
 
 vi.mock('@/components/InstrumentDetail', () => ({
   InstrumentDetail: ({
@@ -30,18 +35,33 @@ vi.mock('@/components/InstrumentDetail', () => ({
   ),
 }));
 
+const sampleSignal: TradingSignal = {
+  ticker: 'AAA',
+  name: 'AAA',
+  action: 'buy',
+  reason: 'cheap',
+  currency: 'USD',
+  instrument_type: 'equity',
+};
+
+function mockFetchState(overrides: {
+  data?: TradingSignal[] | null;
+  loading?: boolean;
+  error?: Error | null;
+}) {
+  mockUseFetchWithRetry.mockReturnValue({
+    data: overrides.data ?? null,
+    loading: overrides.loading ?? false,
+    error: overrides.error ?? null,
+    attempt: 0,
+    maxAttempts: 5,
+    unauthorized: false,
+  });
+}
+
 describe('Trading page', () => {
   it('passes signal to InstrumentDetail', async () => {
-    mockGetTradingSignals.mockResolvedValue([
-      {
-        ticker: 'AAA',
-        name: 'AAA',
-        action: 'buy',
-        reason: 'cheap',
-        currency: 'USD',
-        instrument_type: 'equity',
-      },
-    ]);
+    mockFetchState({ data: [sampleSignal] });
 
     render(<Trading />);
 
@@ -54,20 +74,38 @@ describe('Trading page', () => {
   });
 
   it('has no accessibility violations', async () => {
-    mockGetTradingSignals.mockResolvedValue([
-      {
-        ticker: 'AAA',
-        name: 'AAA',
-        action: 'buy',
-        reason: 'cheap',
-        currency: 'USD',
-        instrument_type: 'equity',
-      },
-    ]);
+    mockFetchState({ data: [sampleSignal] });
 
     const { container } = render(<Trading />);
     await screen.findByText('AAA');
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('shows the empty state when the fetch succeeds with no signals', async () => {
+    mockFetchState({ data: [] });
+
+    render(<Trading />);
+
+    expect(await screen.findByText('No signals.')).toBeInTheDocument();
+    expect(screen.queryByText(/backend unavailable/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a retryable backend-unavailable state on failure, distinct from the empty state', async () => {
+    mockFetchState({ error: new Error('HTTP 503 - Service Unavailable') });
+
+    render(<Trading />);
+
+    const retryButton = await screen.findByRole('button', { name: /retry/i });
+    expect(screen.getByText(/backend unavailable/i)).toBeInTheDocument();
+    expect(screen.queryByText('No signals.')).not.toBeInTheDocument();
+
+    fireEvent.click(retryButton);
+    expect(mockUseFetchWithRetry).toHaveBeenLastCalledWith(
+      expect.any(Function),
+      500,
+      5,
+      1,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- `/trading` previously surfaced a raw `HTTP 503 - Service Unavailable (...)` error string with no retry affordance, and was indistinguishable in kind from the generic "No signals" empty state.
- `Trading.tsx` now uses the existing `useFetchWithRetry` + `BackendUnavailableCard` pattern already used by `App.tsx`/`MainApp.tsx`, so transient 503s are retried automatically with exponential backoff, and a persistent failure renders a clear "Backend unavailable" card with a Retry button, distinct from the true empty-signals state.

## Test plan
- [x] `npx vitest run tests/unit/pages/Trading.test.tsx` — added tests covering success, empty, and error/retry states
- [x] `npx vitest run` (full frontend suite) — 594/595 passing; the one failure (`App.familyMvpRedirect.test.tsx`) is a pre-existing jsdom navigation flake unrelated to this change, reproduced and passes in isolation
- [x] `npx eslint src/pages/Trading.tsx tests/unit/pages/Trading.test.tsx` — clean
- [x] `npx tsc --noEmit` — clean

Closes #5088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
