### PR TITLE
fix: decouple owner portfolio fetch from owners catalog load

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -250,7 +250,9 @@ export default function App({ onLogout }: AppProps) {
 
   const ownersReq = useFetchWithRetry(getOwners, 500, 5, retryNonce);
   const groupsReq = useFetchWithRetry(getGroups, 500, 5, retryNonce);
-  const identityCatalogReady = ownersReq.data !== null && groupsReq.data !== null;
+  // The portfolio fetch below only needs `selectedOwnerIsGroup`, which is
+  // derived from groupsReq.data alone — it must not wait on ownersReq (#5094).
+  const groupsCatalogReady = groupsReq.data !== null;
   const selectedOwnerGroup = useMemo(
     () =>
       selectedOwner && groupsReq.data
@@ -460,7 +462,7 @@ export default function App({ onLogout }: AppProps) {
 
   // data fetching based on route
   useEffect(() => {
-    if (mode === 'owner' && selectedOwner && identityCatalogReady && !selectedOwnerIsGroup) {
+    if (mode === 'owner' && selectedOwner && groupsCatalogReady && !selectedOwnerIsGroup) {
       const cacheKey = `${selectedOwner}::${portfolioAsOf ?? ''}::${lastRefresh ?? ''}`;
       const cached = portfolioCache.current.get(cacheKey);
 
@@ -489,13 +491,13 @@ export default function App({ onLogout }: AppProps) {
         .catch((e) => setErr(String(e)))
         .finally(() => setLoading(false));
     }
-  }, [mode, selectedOwner, portfolioAsOf, lastRefresh, selectedOwnerIsGroup, identityCatalogReady]);
+  }, [mode, selectedOwner, portfolioAsOf, lastRefresh, selectedOwnerIsGroup, groupsCatalogReady]);
 
   useEffect(() => {
-    if (mode === 'owner' && selectedOwner && identityCatalogReady) {
+    if (mode === 'owner' && selectedOwner && groupsCatalogReady) {
       setPortfolioAsOf(null);
     }
-  }, [mode, selectedOwner, identityCatalogReady]);
+  }, [mode, selectedOwner, groupsCatalogReady]);
 
   useEffect(() => {
     if (mode === 'instrument' && selectedGroup) {

--- a/frontend/tests/unit/App.test.tsx
+++ b/frontend/tests/unit/App.test.tsx
@@ -401,6 +401,158 @@ describe("App", () => {
     expect(mockComplianceWarnings.mock.calls).toContainEqual([["alex"]]);
   });
 
+  it("fetches the owner portfolio as soon as groups resolve, without waiting for owners (#5094)", async () => {
+    window.history.pushState({}, "", "/portfolio/alice");
+
+    let resolveOwners:
+      | ((owners: { owner: string; accounts: unknown[] }[]) => void)
+      | undefined;
+    const ownersPromise = new Promise<{ owner: string; accounts: unknown[] }[]>(
+      (resolve) => {
+        resolveOwners = resolve;
+      },
+    );
+
+    const mockGetPortfolio = vi.fn().mockResolvedValue({
+      owner: "alice",
+      as_of: "2026-01-01",
+      trades_this_month: 0,
+      trades_remaining: 0,
+      total_value_estimate_gbp: 0,
+      accounts: [],
+    } as Portfolio);
+
+    vi.doMock("@/api", async () => {
+      const actual = await vi.importActual<typeof import("@/api")>("@/api");
+      return {
+        ...actual,
+        getOwners: vi.fn().mockReturnValue(ownersPromise),
+        getGroups: vi.fn().mockResolvedValue([]),
+        getPortfolio: mockGetPortfolio,
+        getGroupInstruments: vi.fn().mockResolvedValue([]),
+        getGroupPortfolio: vi.fn(),
+        getGroupAlphaVsBenchmark: vi.fn(),
+        getGroupTrackingError: vi.fn(),
+        getGroupMaxDrawdown: vi.fn(),
+        getGroupSectorContributions: vi.fn(),
+        getGroupRegionContributions: vi.fn(),
+        getGroupMovers: vi.fn(),
+        getCachedGroupInstruments: undefined,
+        listInstrumentGroups: vi.fn().mockResolvedValue([]),
+        listInstrumentGroupingDefinitions: vi.fn().mockResolvedValue([]),
+        refreshPrices: vi.fn(),
+        getAlerts: vi.fn().mockResolvedValue([]),
+        getNudges: vi.fn().mockResolvedValue([]),
+        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+        getCompliance: vi
+          .fn()
+          .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+        getTimeseries: vi.fn().mockResolvedValue([]),
+        saveTimeseries: vi.fn(),
+        refetchTimeseries: vi.fn(),
+        rebuildTimeseriesCache: vi.fn(),
+        getTradingSignals: vi.fn().mockResolvedValue([]),
+        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+      };
+    });
+
+    const { default: App } = await import("@/App");
+
+    render(
+      <MemoryRouter initialEntries={["/portfolio/alice"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    // getGroups already resolved (empty array) but getOwners is still pending —
+    // the portfolio fetch must not wait on it.
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+
+    resolveOwners?.([]);
+  });
+
+  it("does not fetch an owner portfolio for a slug that resolves to a group once groups load", async () => {
+    window.history.pushState({}, "", "/portfolio/kids");
+
+    let resolveGroups:
+      | ((groups: { slug: string; name: string; members: string[] }[]) => void)
+      | undefined;
+    const groupsPromise = new Promise<
+      { slug: string; name: string; members: string[] }[]
+    >((resolve) => {
+      resolveGroups = resolve;
+    });
+
+    const mockGetPortfolio = vi.fn().mockResolvedValue({
+      owner: "kids",
+      as_of: "2026-01-01",
+      trades_this_month: 0,
+      trades_remaining: 0,
+      total_value_estimate_gbp: 0,
+      accounts: [],
+    } as Portfolio);
+    const mockGetGroupPortfolio = vi.fn().mockResolvedValue({
+      name: "Kids",
+      slug: "kids",
+      accounts: [],
+      trades_this_month: 0,
+      trades_remaining: 0,
+    });
+
+    vi.doMock("@/api", async () => {
+      const actual = await vi.importActual<typeof import("@/api")>("@/api");
+      return {
+        ...actual,
+        getOwners: vi.fn().mockResolvedValue([]),
+        getGroups: vi.fn().mockReturnValue(groupsPromise),
+        getPortfolio: mockGetPortfolio,
+        getGroupPortfolio: mockGetGroupPortfolio,
+        getGroupInstruments: vi.fn().mockResolvedValue([]),
+        getGroupAlphaVsBenchmark: vi.fn().mockResolvedValue({ alpha_vs_benchmark: 0 }),
+        getGroupTrackingError: vi.fn().mockResolvedValue({ tracking_error: 0 }),
+        getGroupMaxDrawdown: vi.fn().mockResolvedValue({ max_drawdown: 0 }),
+        getGroupSectorContributions: vi.fn().mockResolvedValue([]),
+        getGroupRegionContributions: vi.fn().mockResolvedValue([]),
+        getGroupMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+        getCachedGroupInstruments: undefined,
+        listInstrumentGroups: vi.fn().mockResolvedValue([]),
+        listInstrumentGroupingDefinitions: vi.fn().mockResolvedValue([]),
+        refreshPrices: vi.fn(),
+        getAlerts: vi.fn().mockResolvedValue([]),
+        getNudges: vi.fn().mockResolvedValue([]),
+        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+        getCompliance: vi
+          .fn()
+          .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+        getTimeseries: vi.fn().mockResolvedValue([]),
+        saveTimeseries: vi.fn(),
+        refetchTimeseries: vi.fn(),
+        rebuildTimeseriesCache: vi.fn(),
+        getTradingSignals: vi.fn().mockResolvedValue([]),
+        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
+      };
+    });
+
+    const { default: App } = await import("@/App");
+
+    render(
+      <MemoryRouter initialEntries={["/portfolio/kids"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      resolveGroups?.([{ slug: "kids", name: "Kids", members: [] }]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockGetGroupPortfolio).toHaveBeenCalledWith(
+      "kids",
+      { asOf: undefined },
+    ));
+    expect(mockGetPortfolio).not.toHaveBeenCalled();
+  });
+
   it("renders timeseries editor when path is /timeseries", async () => {
     window.history.pushState({}, "", "/timeseries?ticker=ABC&exchange=L");
 


### PR DESCRIPTION
## Summary
- The Portfolio page's fetch effect (and its `setPortfolioAsOf(null)` reset) only need `selectedOwnerIsGroup`, which is derived from `groupsReq.data` alone, but both were gated behind `identityCatalogReady` (which also waits on `ownersReq`).
- Introduces `groupsCatalogReady = groupsReq.data !== null` and uses it in place of `identityCatalogReady` for these two effects, removing an unnecessary sequential round-trip on the Portfolio route.
- `identityCatalogReady` had no remaining usages after this change, so it was removed.

Closes #5094

## Test plan
- [x] Added a test asserting the owner portfolio fetch fires as soon as `getGroups()` resolves, without waiting for a still-pending `getOwners()`.
- [x] Added a test confirming a group slug is still excluded from the owner portfolio fetch (routed to the group endpoint instead) once groups resolve.
- [x] `npm run test -- --run tests/unit/App.test.tsx tests/unit/App.familyMvpRedirect.test.tsx` — 38/38 passed.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)