### PR TITLE
fix: replace plain loading text with skeleton components (#5095)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,8 @@ import { InstrumentTable } from './components/InstrumentTable';
 import { TransactionsPage } from './components/TransactionsPage';
 import lazyWithDelay from './utils/lazyWithDelay';
 import PortfolioDashboardSkeleton from './components/skeletons/PortfolioDashboardSkeleton';
+import TableSkeleton from './components/skeletons/TableSkeleton';
+import ChartSkeleton from './components/skeletons/ChartSkeleton';
 
 import { NotificationsDrawer } from './components/NotificationsDrawer';
 import { ComplianceWarnings } from './components/ComplianceWarnings';
@@ -669,7 +671,7 @@ export default function App({ onLogout }: AppProps) {
             )}
             {err && <p style={{ color: 'red' }}>{err}</p>}
             {loading ? (
-              <p>{t('app.loading')}</p>
+              <TableSkeleton rows={8} columns={6} label={t('app.loading')} />
             ) : (
               <>
                 <InstrumentTable rows={visibleInstruments} />
@@ -713,7 +715,7 @@ export default function App({ onLogout }: AppProps) {
         {mode === 'screener' && <ScreenerQuery />}
         {mode === 'timeseries' && <TimeseriesEdit />}
         {mode === 'virtual' && (
-          <Suspense fallback={<p>{t('app.loading')}</p>}>
+          <Suspense fallback={<PortfolioDashboardSkeleton label={t('app.loading')} />}>
             <VirtualPortfolio />
           </Suspense>
         )}
@@ -732,7 +734,7 @@ export default function App({ onLogout }: AppProps) {
         {mode === 'settings' && <UserConfigPage />}
         {mode === 'scenario' && <ScenarioTester />}
         {mode === 'research' && (
-          <Suspense fallback={<p>{t('app.loading')}</p>}>
+          <Suspense fallback={<ChartSkeleton height={400} label={t('app.loading')} />}>
             <InstrumentResearch ticker={researchTicker} />
           </Suspense>
         )}

--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -27,6 +27,7 @@ import InstallPwaPrompt from "./components/InstallPwaPrompt";
 import BackendUnavailableCard from "./components/BackendUnavailableCard";
 import lazyWithDelay from "./utils/lazyWithDelay";
 import PortfolioDashboardSkeleton from "./components/skeletons/PortfolioDashboardSkeleton";
+import TableSkeleton from "./components/skeletons/TableSkeleton";
 import { sanitizeOwners, findOwnerForUser } from "./utils/owners";
 import { isDefaultGroupSlug } from "./utils/groups";
 import { useAuth } from "./AuthContext";
@@ -330,7 +331,11 @@ export default function MainApp() {
       {mode === "instrument" && groups.length > 0 && (
         <>
           {err && <p style={{ color: "red" }}>{err}</p>}
-          {loading ? <p>{t("app.loading")}</p> : <InstrumentTable rows={instruments} />}
+          {loading ? (
+            <TableSkeleton rows={8} columns={6} label={t("app.loading")} />
+          ) : (
+            <InstrumentTable rows={instruments} />
+          )}
         </>
       )}
 

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -11,6 +11,9 @@ import { useConfig } from "../ConfigContext";
 import type { InstrumentPosition, TradingSignal } from "../types";
 import { RelativeViewToggle } from "./RelativeViewToggle";
 import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+import ChartSkeleton from "./skeletons/ChartSkeleton";
+import TableRowsSkeleton from "./skeletons/TableRowsSkeleton";
+import TextSkeleton from "./skeletons/TextSkeleton";
 import {
   ResponsiveContainer,
   LineChart,
@@ -127,15 +130,12 @@ export function InstrumentPositionsTable({
       </thead>
       <tbody>
         {loading ? (
-          <tr>
-            <td
-              colSpan={relativeViewEnabled ? 2 : 5}
-              className={`${tableStyles.cell} ${tableStyles.center}`}
-              style={{ color: mutedColor }}
-            >
-              {t("app.loading")}
-            </td>
-          </tr>
+          <TableRowsSkeleton
+            rows={3}
+            colSpan={relativeViewEnabled ? 2 : 5}
+            label={t("app.loading")}
+            cellClassName={`${tableStyles.cell} ${tableStyles.center}`}
+          />
         ) : positions.length ? (
           positions.map((pos, i) => (
             <tr key={`${pos.owner}-${pos.account}-${i}`}>
@@ -532,9 +532,12 @@ export function InstrumentDetail({
               : undefined,
           }}
         >
-          {t("instrumentDetail.change7d")} {loading
-            ? t("app.loading")
-            : formatChangeSummary(change7dValue, change7dPct)}
+          {t("instrumentDetail.change7d")}{" "}
+          {loading ? (
+            <TextSkeleton width="4rem" label={t("app.loading")} />
+          ) : (
+            formatChangeSummary(change7dValue, change7dPct)
+          )}
         </span>
         {" • "}
         <span
@@ -546,9 +549,12 @@ export function InstrumentDetail({
               : undefined,
           }}
         >
-          {t("instrumentDetail.change30d")} {loading
-            ? t("app.loading")
-            : formatChangeSummary(change30dValue, change30dPct)}
+          {t("instrumentDetail.change30d")}{" "}
+          {loading ? (
+            <TextSkeleton width="4rem" label={t("app.loading")} />
+          ) : (
+            formatChangeSummary(change30dValue, change30dPct)
+          )}
         </span>
       </div>
       {err && <p style={{ color: palette.negative }}>{err}</p>}
@@ -633,16 +639,7 @@ export function InstrumentDetail({
       )}
       {priceMode === "intraday" ? (
         intradayLoading ? (
-          <div
-            style={{
-              height: 220,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            {t("app.loading")}
-          </div>
+          <ChartSkeleton height={220} label={t("app.loading")} />
         ) : (
           <ResponsiveContainer width="100%" height={220}>
             <LineChart data={intradayPrices}>
@@ -657,16 +654,7 @@ export function InstrumentDetail({
           </ResponsiveContainer>
         )
       ) : loading ? (
-        <div
-          style={{
-            height: 220,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          {t("app.loading")}
-        </div>
+        <ChartSkeleton height={220} label={t("app.loading")} />
       ) : (
         <ResponsiveContainer width="100%" height={220}>
           <LineChart data={prices}>
@@ -779,15 +767,12 @@ export function InstrumentDetail({
         </thead>
         <tbody>
           {loading ? (
-            <tr>
-              <td
-                colSpan={4}
-                className={`${tableStyles.cell} ${tableStyles.center}`}
-                style={{ color: palette.muted }}
-              >
-                {t("app.loading")}
-              </td>
-            </tr>
+            <TableRowsSkeleton
+              rows={5}
+              colSpan={4}
+              label={t("app.loading")}
+              cellClassName={`${tableStyles.cell} ${tableStyles.center}`}
+            />
           ) : prices.length ? (
             prices
               .slice(-60)

--- a/frontend/src/components/InstrumentHistoryChart.tsx
+++ b/frontend/src/components/InstrumentHistoryChart.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from "recharts";
+import ChartSkeleton from "./skeletons/ChartSkeleton";
 
 export type InstrumentHistoryPoint = {
   date: string;
@@ -40,18 +41,7 @@ export function InstrumentHistoryChart({ data, loading = false, showBollinger = 
   }, [data]);
 
   if (loading) {
-    return (
-      <div
-        style={{
-          height: 220,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        {t("app.loading")}
-      </div>
-    );
+    return <ChartSkeleton height={220} label={t("app.loading")} />;
   }
 
   return (

--- a/frontend/src/components/NotificationsDrawer.tsx
+++ b/frontend/src/components/NotificationsDrawer.tsx
@@ -1,7 +1,9 @@
+import { useTranslation } from "react-i18next";
 import { useFetch } from "../hooks/useFetch";
 import * as api from "../api";
 import type { Alert, Nudge } from "../types";
 import EmptyState from "./EmptyState";
+import ListSkeleton from "./skeletons/ListSkeleton";
 
 interface Props {
   open: boolean;
@@ -9,6 +11,7 @@ interface Props {
 }
 
 export function NotificationsDrawer({ open, onClose }: Props) {
+  const { t } = useTranslation();
   const {
     data: alerts,
     loading: alertLoading,
@@ -76,7 +79,7 @@ export function NotificationsDrawer({ open, onClose }: Props) {
             ×
           </button>
         </div>
-        {alertLoading && <div>Loading...</div>}
+        {alertLoading && <ListSkeleton rows={2} label={t("app.loading")} />}
         {alertError && <div>Cannot reach server</div>}
         {!alertLoading && !alertError && alertList.length === 0 && (
           <EmptyState message="No alerts" />
@@ -103,7 +106,7 @@ export function NotificationsDrawer({ open, onClose }: Props) {
         <div style={{ marginTop: "1rem" }}>
           <strong>Nudges</strong>
         </div>
-        {nudgeLoading && <div>Loading...</div>}
+        {nudgeLoading && <ListSkeleton rows={2} label={t("app.loading")} />}
         {nudgeError && <div>Cannot reach server</div>}
         {!nudgeLoading && !nudgeError && nudgeList.length === 0 && (
           <EmptyState message="No nudges" />

--- a/frontend/src/components/TopMoversSummary.tsx
+++ b/frontend/src/components/TopMoversSummary.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import type { OpportunityEntry } from "../types";
 import { getOpportunities } from "../api";
 import { useFetch } from "../hooks/useFetch";
@@ -8,6 +9,7 @@ import moversPlugin from "../plugins/movers";
 import { SignalBadge } from "./SignalBadge";
 import { InstrumentDetail } from "./InstrumentDetail";
 import EmptyState from "./EmptyState";
+import TableSkeleton from "./skeletons/TableSkeleton";
 
 interface Props {
   slug?: string;
@@ -16,6 +18,7 @@ interface Props {
 }
 
 export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
+  const { t } = useTranslation();
   const fetchOpportunities = useCallback(async () => {
     if (!slug) return null;
     try {
@@ -41,7 +44,7 @@ export function TopMoversSummary({ slug, days = 1, limit = 5 }: Props) {
   }, [data, limit]);
 
   if (!slug) return <EmptyState message="No group selected." />;
-  if (loading) return <div>Loading...</div>;
+  if (loading) return <TableSkeleton rows={limit} columns={4} label={t("app.loading")} />;
   if (error) return <div>Failed to load movers.</div>;
   if (rows.length === 0) return null;
 

--- a/frontend/src/components/skeletons/ChartSkeleton.tsx
+++ b/frontend/src/components/skeletons/ChartSkeleton.tsx
@@ -12,6 +12,8 @@ export default function ChartSkeleton({ height = 240, label }: Props = {}) {
       aria-label={label}
       className="w-full mb-4 bg-gray-900 border border-gray-700 rounded animate-pulse"
       style={{ height }}
-    />
+    >
+      {label && <span className="sr-only">{label}</span>}
+    </div>
   );
 }

--- a/frontend/src/components/skeletons/ChartSkeleton.tsx
+++ b/frontend/src/components/skeletons/ChartSkeleton.tsx
@@ -1,6 +1,17 @@
-/** Skeleton placeholder for charts. */
-export default function ChartSkeleton() {
+interface Props {
+  height?: number;
+  label?: string;
+}
+
+/** Skeleton placeholder for charts. Pass `label` to announce it to screen readers. */
+export default function ChartSkeleton({ height = 240, label }: Props = {}) {
   return (
-    <div className="w-full h-60 mb-4 bg-gray-900 border border-gray-700 rounded animate-pulse" />
+    <div
+      role={label ? "status" : undefined}
+      aria-live={label ? "polite" : undefined}
+      aria-label={label}
+      className="w-full mb-4 bg-gray-900 border border-gray-700 rounded animate-pulse"
+      style={{ height }}
+    />
   );
 }

--- a/frontend/src/components/skeletons/ListSkeleton.tsx
+++ b/frontend/src/components/skeletons/ListSkeleton.tsx
@@ -1,0 +1,30 @@
+interface Props {
+  rows?: number;
+  label: string;
+  /** Set false when an ancestor already provides the role="status" region. */
+  wrap?: boolean;
+}
+
+function ListSkeletonRows({ rows }: { rows: number }) {
+  return (
+    <ul style={{ listStyle: "none", padding: 0 }} aria-hidden="true">
+      {Array.from({ length: rows }).map((_, i) => (
+        <li key={i} style={{ marginBottom: "0.5rem" }}>
+          <div className="h-4 mb-1 bg-gray-700 rounded animate-pulse w-3/4" />
+          <div className="h-3 bg-gray-700 rounded animate-pulse w-1/3" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** Skeleton placeholder for short lists (drawers, sidebars, alert feeds). */
+export default function ListSkeleton({ rows = 3, label, wrap = true }: Props) {
+  if (!wrap) return <ListSkeletonRows rows={rows} />;
+  return (
+    <div role="status" aria-live="polite" aria-label={label}>
+      <span className="sr-only">{label}</span>
+      <ListSkeletonRows rows={rows} />
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/LoadingStatus.tsx
+++ b/frontend/src/components/skeletons/LoadingStatus.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}
+
+/** Wraps a visual skeleton so screen readers still announce a loading state. */
+export default function LoadingStatus({ label, children, className }: Props) {
+  return (
+    <div role="status" aria-live="polite" aria-label={label} className={className}>
+      <span className="sr-only">{label}</span>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
+++ b/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
@@ -19,6 +19,7 @@ export default function PortfolioDashboardSkeleton({ label }: Props = {}) {
 
   return (
     <div role="status" aria-live="polite" aria-label={label}>
+      <span className="sr-only">{label}</span>
       {content}
     </div>
   );

--- a/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
+++ b/frontend/src/components/skeletons/PortfolioDashboardSkeleton.tsx
@@ -1,13 +1,25 @@
 import KPISkeleton from "./KPISkeleton";
 import ChartSkeleton from "./ChartSkeleton";
 
-/** Skeleton placeholder mimicking the PortfolioDashboard layout. */
-export default function PortfolioDashboardSkeleton() {
-  return (
+interface Props {
+  label?: string;
+}
+
+/** Skeleton placeholder mimicking the PortfolioDashboard layout. Pass `label` to announce it to screen readers. */
+export default function PortfolioDashboardSkeleton({ label }: Props = {}) {
+  const content = (
     <>
       <KPISkeleton />
       <ChartSkeleton />
       <ChartSkeleton />
     </>
+  );
+
+  if (!label) return content;
+
+  return (
+    <div role="status" aria-live="polite" aria-label={label}>
+      {content}
+    </div>
   );
 }

--- a/frontend/src/components/skeletons/TableRowsSkeleton.tsx
+++ b/frontend/src/components/skeletons/TableRowsSkeleton.tsx
@@ -15,14 +15,13 @@ export default function TableRowsSkeleton({
   return (
     <>
       {Array.from({ length: rows }).map((_, i) => (
-        <tr
-          key={i}
-          role={i === 0 ? "status" : undefined}
-          aria-live={i === 0 ? "polite" : undefined}
-          aria-label={i === 0 ? label : undefined}
-        >
+        <tr key={i}>
           <td colSpan={colSpan} className={cellClassName}>
-            {i === 0 && <span className="sr-only">{label}</span>}
+            {i === 0 && (
+              <span role="status" aria-live="polite" aria-label={label} className="sr-only">
+                {label}
+              </span>
+            )}
             <div className="h-4 bg-gray-700 rounded animate-pulse" />
           </td>
         </tr>

--- a/frontend/src/components/skeletons/TableRowsSkeleton.tsx
+++ b/frontend/src/components/skeletons/TableRowsSkeleton.tsx
@@ -1,0 +1,32 @@
+interface Props {
+  rows?: number;
+  colSpan: number;
+  label: string;
+  cellClassName?: string;
+}
+
+/** Skeleton placeholder rows for use inside an existing table's <tbody>. */
+export default function TableRowsSkeleton({
+  rows = 3,
+  colSpan,
+  label,
+  cellClassName,
+}: Props) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, i) => (
+        <tr
+          key={i}
+          role={i === 0 ? "status" : undefined}
+          aria-live={i === 0 ? "polite" : undefined}
+          aria-label={i === 0 ? label : undefined}
+        >
+          <td colSpan={colSpan} className={cellClassName}>
+            {i === 0 && <span className="sr-only">{label}</span>}
+            <div className="h-4 bg-gray-700 rounded animate-pulse" />
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}

--- a/frontend/src/components/skeletons/TableSkeleton.tsx
+++ b/frontend/src/components/skeletons/TableSkeleton.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  rows?: number;
+  columns?: number;
+  label: string;
+}
+
+/** Skeleton placeholder for a full table (thead is omitted, rows only). */
+export default function TableSkeleton({ rows = 4, columns = 3, label }: Props) {
+  return (
+    <div role="status" aria-live="polite" aria-label={label}>
+      <span className="sr-only">{label}</span>
+      <table className="w-full border-collapse" aria-hidden="true">
+        <tbody>
+          {Array.from({ length: rows }).map((_, r) => (
+            <tr key={r}>
+              {Array.from({ length: columns }).map((_, c) => (
+                <td key={c} className="border border-gray-700 p-2">
+                  <div className="h-4 bg-gray-700 rounded animate-pulse" />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/TextSkeleton.tsx
+++ b/frontend/src/components/skeletons/TextSkeleton.tsx
@@ -1,0 +1,18 @@
+interface Props {
+  width?: string;
+  label: string;
+}
+
+/** Skeleton placeholder for a short inline text value. */
+export default function TextSkeleton({ width = "3rem", label }: Props) {
+  return (
+    <span role="status" aria-live="polite" aria-label={label}>
+      <span className="sr-only">{label}</span>
+      <span
+        aria-hidden="true"
+        className="inline-block h-3 align-middle bg-gray-700 rounded animate-pulse"
+        style={{ width }}
+      />
+    </span>
+  );
+}

--- a/frontend/src/pages/Alerts.tsx
+++ b/frontend/src/pages/Alerts.tsx
@@ -1,11 +1,14 @@
 import { Fragment, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import * as api from "../api";
 import type { Alert } from "../types";
 import EmptyState from "../components/EmptyState";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import errorToast from "../utils/errorToast";
+import ListSkeleton from "../components/skeletons/ListSkeleton";
 
 export default function Alerts() {
+  const { t } = useTranslation();
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [loading, setLoading] = useState(true);
   const parentRef = useRef<HTMLDivElement>(null);
@@ -68,7 +71,8 @@ export default function Alerts() {
         {heading}
         {marker}
         <div role="status" aria-live="polite">
-          Loading...
+          <span className="sr-only">{t("app.loading")}</span>
+          <ListSkeleton rows={5} label={t("app.loading")} wrap={false} />
         </div>
       </Fragment>
     );

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -6,6 +6,7 @@ import { translateInstrumentType } from "../lib/instrumentType";
 import { money } from "../lib/money";
 import { useConfig } from "../ConfigContext";
 import { RelativeViewToggle } from "../components/RelativeViewToggle";
+import ChartSkeleton from "../components/skeletons/ChartSkeleton";
 import {
   PieChart,
   Pie,
@@ -168,7 +169,13 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
     }
   }, [portfolio, selectedAccounts]);
 
-  if (loading && !portfolio) return <div>Loading...</div>;
+  if (loading && !portfolio) {
+    return (
+      <div className="container mx-auto p-4">
+        <ChartSkeleton height={400} label={t("app.loading")} />
+      </div>
+    );
+  }
 
   const chartData =
     view === "asset" ? assetData : view === "sector" ? sectorData : regionData;

--- a/frontend/src/pages/AllowanceTracker.tsx
+++ b/frontend/src/pages/AllowanceTracker.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { getAllowances } from "../api";
 import EmptyState from "../components/EmptyState";
+import TableSkeleton from "../components/skeletons/TableSkeleton";
 
 interface AllowanceInfo {
   used: number;
@@ -9,6 +11,7 @@ interface AllowanceInfo {
 }
 
 export default function AllowanceTracker() {
+  const { t } = useTranslation();
   const [data, setData] = useState<Record<string, AllowanceInfo> | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -23,7 +26,7 @@ export default function AllowanceTracker() {
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading) return <p>Loading...</p>;
+  if (loading) return <TableSkeleton rows={4} columns={3} label={t("app.loading")} />;
   if (error) return <p className="text-red-500">{error}</p>;
   if (!data) return <EmptyState message="No data" />;
 

--- a/frontend/src/pages/TaxTools.tsx
+++ b/frontend/src/pages/TaxTools.tsx
@@ -5,11 +5,14 @@ import {
   useState,
   type ChangeEvent,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { getAllowances, getOwners, getPortfolio, harvestTax } from "../api";
 import EmptyState from "../components/EmptyState";
 import { useRoute } from "../RouteContext";
 import type { Holding, OwnerSummary, Portfolio } from "../types";
 import { sanitizeOwners } from "../utils/owners";
+import LoadingStatus from "../components/skeletons/LoadingStatus";
+import TableSkeleton from "../components/skeletons/TableSkeleton";
 
 type Trade = {
   ticker: string;
@@ -246,6 +249,7 @@ function useHarvestCandidates(owner?: string) {
 }
 
 function TaxHarvestSection() {
+  const { t } = useTranslation();
   const { selectedOwner } = useRoute();
   const { form, updateField, position: manualPosition } = useHarvestForm();
   const { candidates, loading: candidatesLoading, error: candidateError } =
@@ -463,7 +467,11 @@ function TaxHarvestSection() {
       >
         Run Harvest
       </button>
-      {isLoading && <div data-testid="spinner">Loading...</div>}
+      {isLoading && (
+        <LoadingStatus label={t("app.loading")}>
+          <div data-testid="spinner" className="h-4 w-24 bg-gray-700 rounded animate-pulse" />
+        </LoadingStatus>
+      )}
       {error && <p className="text-red-500">{error}</p>}
       {trades && trades.length > 0 && (
         <div className="rounded-md border border-gray-200 bg-gray-50 p-4 text-sm" data-testid="harvest-results">
@@ -502,6 +510,7 @@ function formatAllowanceValue(value: number) {
 }
 
 function TaxAllowancesSection() {
+  const { t } = useTranslation();
   const { selectedOwner } = useRoute();
   const [data, setData] = useState<AllowanceResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -555,7 +564,7 @@ function TaxAllowancesSection() {
     );
   }
 
-  if (loading) return <p>Loading...</p>;
+  if (loading) return <TableSkeleton rows={4} columns={3} label={t("app.loading")} />;
   if (error) return <p className="text-red-500">{error}</p>;
   if (!data) return <EmptyState message="No data" />;
 

--- a/frontend/tests/unit/App.test.tsx
+++ b/frontend/tests/unit/App.test.tsx
@@ -150,19 +150,12 @@ describe("App", () => {
   it("loads /instrument/all rows from group holdings API", async () => {
     window.history.pushState({}, "", "/instrument/all");
 
-    const mockGetGroupInstruments = vi.fn().mockResolvedValue([
-      {
-        ticker: "FOO.L",
-        name: "Foo Plc",
-        grouping: "Technology",
-        exchange: "L",
-        currency: "GBP",
-        units: 10,
-        market_value_gbp: 1234.56,
-        gain_gbp: 100.0,
-        gain_pct: 8.81,
-      } as InstrumentSummary,
-    ]);
+    let resolveInstruments: (rows: InstrumentSummary[]) => void;
+    const mockGetGroupInstruments = vi.fn().mockReturnValue(
+      new Promise<InstrumentSummary[]>((resolve) => {
+        resolveInstruments = resolve;
+      }),
+    );
 
     let capturedRows: InstrumentSummary[] = [];
 
@@ -222,9 +215,27 @@ describe("App", () => {
     await waitFor(() => expect(mockGetGroupInstruments).toHaveBeenCalledTimes(1));
     expect(mockGetGroupInstruments).toHaveBeenCalledWith("all");
 
+    expect(await screen.findByRole("status", { name: /loading/i })).toBeInTheDocument();
+    expect(screen.queryByTestId("instrument-table")).not.toBeInTheDocument();
+
+    resolveInstruments!([
+      {
+        ticker: "FOO.L",
+        name: "Foo Plc",
+        grouping: "Technology",
+        exchange: "L",
+        currency: "GBP",
+        units: 10,
+        market_value_gbp: 1234.56,
+        gain_gbp: 100.0,
+        gain_pct: 8.81,
+      } as InstrumentSummary,
+    ]);
+
     const table = await screen.findByTestId("instrument-table");
     expect(within(table).getAllByText("FOO.L")).toHaveLength(1);
     expect(capturedRows[0]?.grouping).toBe("Technology");
+    expect(screen.queryByRole("status", { name: /loading/i })).not.toBeInTheDocument();
   });
 
   it("loads /portfolio/all using the group portfolio endpoint", async () => {

--- a/frontend/tests/unit/MainApp.demo.test.tsx
+++ b/frontend/tests/unit/MainApp.demo.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
@@ -59,5 +59,74 @@ describe("MainApp demo view", () => {
 
     await screen.findByText(/Refresh Prices/);
     expect(screen.queryByText(/Unauthorized/i)).toBeNull();
+  });
+
+  it("shows an accessible table skeleton while instrument rows are loading", async () => {
+    vi.resetModules();
+    window.history.pushState({}, "", "/instrument/all");
+
+    let resolveInstruments: (rows: unknown[]) => void;
+    const mockGetGroupInstruments = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveInstruments = resolve;
+      }),
+    );
+
+    vi.doMock("@/api", () => ({
+      getOwners: vi.fn().mockResolvedValue([]),
+      getGroups: vi
+        .fn()
+        .mockResolvedValue([{ slug: "all", name: "All Instruments", members: [] }]),
+      getGroupInstruments: mockGetGroupInstruments,
+      getPortfolio: vi.fn(),
+      refreshPrices: vi.fn(),
+      getAlerts: vi.fn().mockResolvedValue([]),
+      getNudges: vi.fn().mockResolvedValue([]),
+      getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
+      getCompliance: vi
+        .fn()
+        .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
+      getTradingSignals: vi.fn().mockResolvedValue([]),
+      getQuests: vi.fn().mockResolvedValue({ quests: [] }),
+      getTimeseries: vi.fn(),
+      saveTimeseries: vi.fn(),
+      refetchTimeseries: vi.fn(),
+      rebuildTimeseriesCache: vi.fn(),
+      getConfig: vi.fn().mockResolvedValue({}),
+      listInstrumentGroups: vi.fn().mockResolvedValue([]),
+      listInstrumentGroupingDefinitions: vi.fn().mockResolvedValue([]),
+      assignInstrumentGroup: vi.fn(),
+      clearInstrumentGroup: vi.fn(),
+      createInstrumentGroup: vi.fn(),
+    }));
+
+    const [{ default: MainApp }, { ConfigProvider }, { RouteProvider }, { PriceRefreshProvider }] =
+      await Promise.all([
+        import("@/MainApp"),
+        import("@/ConfigContext"),
+        import("@/RouteContext"),
+        import("@/PriceRefreshContext"),
+      ]);
+
+    render(
+      <MemoryRouter initialEntries={["/instrument/all"]}>
+        <ConfigProvider>
+          <RouteProvider>
+            <PriceRefreshProvider>
+              <MainApp />
+            </PriceRefreshProvider>
+          </RouteProvider>
+        </ConfigProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockGetGroupInstruments).toHaveBeenCalledWith("all"));
+    expect(await screen.findByRole("status", { name: /loading/i })).toBeInTheDocument();
+
+    resolveInstruments!([]);
+
+    await waitFor(() =>
+      expect(screen.queryByRole("status", { name: /loading/i })).not.toBeInTheDocument(),
+    );
   });
 });

--- a/frontend/tests/unit/components/InstrumentDetail.test.tsx
+++ b/frontend/tests/unit/components/InstrumentDetail.test.tsx
@@ -83,6 +83,28 @@ describe("InstrumentDetail", () => {
     mockGetInstrumentIntraday.mockReset();
   });
 
+  it("shows accessible loading skeletons before the instrument detail resolves", async () => {
+    let resolveDetail: (value: { prices: unknown[]; positions: unknown[]; currency: null }) => void;
+    mockGetInstrumentDetail.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDetail = resolve;
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <InstrumentDetail ticker="ABC.L" name="ABC" onClose={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByRole("status", { name: /loading/i }).length).toBeGreaterThan(0);
+
+    resolveDetail!({ prices: [], positions: [], currency: null });
+
+    await screen.findByRole("heading", { name: "ABC" });
+    expect(screen.queryAllByRole("status", { name: /loading/i })).toHaveLength(0);
+  });
+
   it("shows signal action and reason when provided", async () => {
     mockGetInstrumentDetail.mockResolvedValue({
       prices: [],

--- a/frontend/tests/unit/components/InstrumentHistoryChart.test.tsx
+++ b/frontend/tests/unit/components/InstrumentHistoryChart.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { InstrumentHistoryChart } from "@/components/InstrumentHistoryChart";
+
+describe("InstrumentHistoryChart", () => {
+  it("shows an accessible loading skeleton instead of the chart while loading", () => {
+    render(<InstrumentHistoryChart data={[]} loading />);
+
+    expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it("renders the chart once loading finishes", () => {
+    render(
+      <InstrumentHistoryChart
+        data={[{ date: "2026-01-01", close_gbp: 100 }]}
+        loading={false}
+      />,
+    );
+
+    expect(screen.queryByRole("status", { name: /loading/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/NotificationsDrawer.test.tsx
+++ b/frontend/tests/unit/components/NotificationsDrawer.test.tsx
@@ -17,4 +17,16 @@ describe("NotificationsDrawer", () => {
     expect(screen.getByText(/No nudges/i)).toBeInTheDocument();
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
   });
+
+  it("shows accessible loading skeletons for alerts and nudges while fetching", () => {
+    (useFetch as Mock)
+      .mockReturnValueOnce({ data: undefined, loading: true, error: undefined })
+      .mockReturnValueOnce({ data: undefined, loading: true, error: undefined });
+
+    render(<NotificationsDrawer open onClose={() => {}} />);
+
+    expect(screen.getAllByRole("status", { name: /loading/i })).toHaveLength(2);
+    expect(screen.queryByText(/No alerts/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/No nudges/i)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/tests/unit/components/TopMoversSummary.test.tsx
+++ b/frontend/tests/unit/components/TopMoversSummary.test.tsx
@@ -64,4 +64,32 @@ describe("TopMoversSummary", () => {
     await waitFor(() => expect(mockGetOpportunities).not.toHaveBeenCalled());
     expect(screen.getByText(/no group selected/i)).toBeInTheDocument();
   });
+
+  it("shows an accessible table skeleton while loading, then the movers table", async () => {
+    let resolveFn: (value: typeof samplePayload) => void;
+    const samplePayload = {
+      entries: baseEntries,
+      signals: [],
+      context: { source: "group", group: "all", days: 1, anomalies: [] },
+    };
+    mockGetOpportunities.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFn = resolve;
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <TopMoversSummary slug="all" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "AAA" })).not.toBeInTheDocument();
+
+    resolveFn!(samplePayload);
+
+    expect(await screen.findByRole("button", { name: "AAA" })).toBeInTheDocument();
+    expect(screen.queryByRole("status", { name: /loading/i })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/tests/unit/pages/AllocationCharts.test.tsx
+++ b/frontend/tests/unit/pages/AllocationCharts.test.tsx
@@ -88,11 +88,11 @@ describe("AllocationCharts page", () => {
     mockGetGroupPortfolio.mockReturnValueOnce(promise);
 
     render(<AllocationCharts />);
-    expect(screen.getByText(/Loading/)).toBeInTheDocument();
+    expect(screen.getByRole("status", { name: /Loading/ })).toBeInTheDocument();
 
     resolveFn!(samplePortfolio);
     expect(await screen.findByText(/Instrument Types/)).toBeInTheDocument();
-    expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("status", { name: /Loading/ })).not.toBeInTheDocument();
   });
 
   it("displays an error message when API call fails", async () => {

--- a/frontend/tests/unit/pages/AllowanceTracker.test.tsx
+++ b/frontend/tests/unit/pages/AllowanceTracker.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import AllowanceTracker from "@/pages/AllowanceTracker";
+import * as api from "@/api";
+
+vi.mock("@/api");
+const mockGetAllowances = vi.mocked(api.getAllowances);
+
+describe("AllowanceTracker page", () => {
+  it("shows an accessible skeleton while loading, then the table", async () => {
+    mockGetAllowances.mockReturnValue(new Promise(() => {}));
+    render(<AllowanceTracker />);
+
+    expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders the allowance table once data resolves", async () => {
+    mockGetAllowances.mockResolvedValue({
+      allowances: {
+        isa: { used: 1000, limit: 20000, remaining: 19000 },
+      },
+    });
+
+    render(<AllowanceTracker />);
+
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("isa")).toBeInTheDocument();
+    expect(screen.queryByRole("status", { name: /loading/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/pages/TaxTools.test.tsx
+++ b/frontend/tests/unit/pages/TaxTools.test.tsx
@@ -133,6 +133,29 @@ describe("TaxTools", () => {
     await screen.findByTestId("harvest-results");
   });
 
+  it("shows an accessible table skeleton while allowances are loading", async () => {
+    let resolveAllowances: (value: Awaited<ReturnType<typeof getAllowances>>) => void;
+    allowancesMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAllowances = resolve;
+      }),
+    );
+
+    render(<TaxTools />);
+
+    expect(await screen.findByRole("status", { name: /loading/i })).toBeInTheDocument();
+    expect(screen.queryByText(/tax year 2024/i)).not.toBeInTheDocument();
+
+    resolveAllowances!({
+      owner: "alice",
+      tax_year: "2024",
+      allowances: { isa: { used: 1000, limit: 20000, remaining: 19000 } },
+    });
+
+    await screen.findByText(/tax year 2024/i);
+    expect(screen.queryByRole("status", { name: /loading/i })).not.toBeInTheDocument();
+  });
+
   it("renders allowance data", async () => {
     render(<TaxTools />);
 


### PR DESCRIPTION
## Summary
- Replaces bare `Loading...` / `t('app.loading')` text with skeleton components across `App.tsx`, `MainApp.tsx`, `TaxTools.tsx`, `AllowanceTracker.tsx`, `AllocationCharts.tsx`, `Alerts.tsx`, `TopMoversSummary.tsx`, `NotificationsDrawer.tsx`, `InstrumentHistoryChart.tsx` and `InstrumentDetail.tsx`.
- Adds new reusable skeletons (`TableSkeleton`, `TableRowsSkeleton`, `ListSkeleton`, `TextSkeleton`, `LoadingStatus` wrapper) for shapes the existing `ChartSkeleton`/`KPISkeleton`/`PortfolioDashboardSkeleton` didn't cover, and gives `ChartSkeleton`/`PortfolioDashboardSkeleton` an optional configurable height / accessible `label`.
- Every skeleton carries `role="status"` + `aria-live="polite"` and an `aria-label`/sr-only announcement sourced from the `app.loading` translation key, so screen readers still get a loading announcement even though the visible text is gone.
- Adds Vitest coverage for the two components that had none (`AllowanceTracker`, `InstrumentHistoryChart`) and updates `AllocationCharts.test.tsx` to assert on the accessible status role/name instead of visible "Loading" text.

Closes #5095

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 597/597 passing (full frontend suite)
- [ ] Manual browser check (not run — dev server in this environment only serves the primary worktree, not this feature worktree; verified instead via the full automated test suite covering every changed loading state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Replaced plain loading messages with consistent skeleton placeholders for charts, tables, lists and text across the application.
  * Added translated loading labels and improved accessibility announcements for loading states.

* **Bug Fixes**
  * Loading indicators now better match the content being loaded and disappear correctly when data becomes available.

* **Tests**
  * Added and updated tests covering accessible loading states and their removal after content loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->