### PR TITLE
fix(backend): stop S3 HeadObject retry storm for permanently-uncached tickers

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import time
 from datetime import date, datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
@@ -317,6 +318,21 @@ def load_stooq_timeseries(ticker: str, exchange: str, days: int) -> pd.DataFrame
 # Track cache file mtimes to detect updates
 _CACHE_FILE_MTIMES: Dict[str, float] = {}
 
+# Remember S3 objects recently confirmed missing (HeadObject 404) so repeat
+# lookups for the same permanently-uncached ticker within the TTL skip the
+# live network round-trip. Without this, a request touching a delisted/
+# unresolvable ticker (no data from any provider, ever) re-issues a
+# synchronous S3 HeadObject call on every check -- observed in production to
+# stack up into hundreds of calls within a single request and exhaust the
+# Lambda's 30s timeout.
+_S3_HEAD_MISS_TTL_SECONDS = 60.0
+_S3_HEAD_MISS_CACHE: Dict[str, float] = {}
+
+
+def _s3_object_recently_confirmed_missing(cache: str) -> bool:
+    missed_at = _S3_HEAD_MISS_CACHE.get(cache)
+    return missed_at is not None and time.monotonic() - missed_at < _S3_HEAD_MISS_TTL_SECONDS
+
 
 @lru_cache(maxsize=1)
 def _s3_client():
@@ -341,12 +357,23 @@ def _s3_object_mtime(cache: str) -> float:
         return 0.0
     bucket, key = parsed
 
+    if _s3_object_recently_confirmed_missing(cache):
+        return 0.0
+
     try:
         resp = _s3_client().head_object(Bucket=bucket, Key=key)
-    except (BotoCoreError, ClientError) as exc:  # pragma: no cover - defensive AWS path
+    except ClientError as exc:
+        error_code = exc.response.get("Error", {}).get("Code")
+        if error_code in {"404", "NoSuchKey", "NotFound"}:
+            _S3_HEAD_MISS_CACHE[cache] = time.monotonic()
+        else:
+            logger.warning("Unable to read S3 cache metadata for %s: %s", _sanitize_for_log(cache), exc)
+        return 0.0
+    except BotoCoreError as exc:  # pragma: no cover - defensive AWS path
         logger.warning("Unable to read S3 cache metadata for %s: %s", _sanitize_for_log(cache), exc)
         return 0.0
 
+    _S3_HEAD_MISS_CACHE.pop(cache, None)
     last_modified = resp.get("LastModified")
     if not hasattr(last_modified, "timestamp"):
         logger.warning("S3 cache metadata for %s is missing LastModified", _sanitize_for_log(cache))
@@ -612,17 +639,22 @@ def _s3_cache_object_exists(cache: str) -> bool:
         return False
     bucket, key = parsed
 
+    if _s3_object_recently_confirmed_missing(cache):
+        return False
+
     try:
         _s3_client().head_object(Bucket=bucket, Key=key)
     except ClientError as exc:
         error_code = exc.response.get("Error", {}).get("Code")
         if error_code in {"404", "NoSuchKey", "NotFound"}:
+            _S3_HEAD_MISS_CACHE[cache] = time.monotonic()
             return False
         logger.error("Unable to check S3 timeseries cache object %s: %s", _sanitize_for_log(cache), exc)
         return False
     except BotoCoreError as exc:
         logger.error("AWS client error checking S3 timeseries cache object %s: %s", _sanitize_for_log(cache), exc)
         return False
+    _S3_HEAD_MISS_CACHE.pop(cache, None)
     return True
 
 

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -94,6 +94,35 @@ def test_has_cached_meta_timeseries_returns_false_for_missing_s3_object(monkeypa
     assert created_clients == ["s3"]
 
 
+def test_has_cached_meta_timeseries_skips_repeat_head_object_for_confirmed_missing(monkeypatch):
+    """A permanently-uncached ticker should only pay for one live HeadObject
+    call within the negative-cache TTL, not one per lookup.
+
+    Regression guard for the retry storm in issue #5093: requests touching a
+    delisted/unresolvable ticker were issuing a synchronous S3 HeadObject call
+    on every check, stacking up into hundreds of calls within a single
+    request and exhausting the Lambda's 30s timeout.
+    """
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+    calls = []
+
+    class FakeS3Client:
+        def head_object(self, Bucket, Key):  # noqa: N803 - boto3 API parameter names
+            calls.append((Bucket, Key))
+            raise cache.ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadObject",
+            )
+
+    patch_s3_client(monkeypatch, cache, FakeS3Client())
+
+    for _ in range(5):
+        assert cache.has_cached_meta_timeseries("missing", "us") is False
+
+    assert len(calls) == 1
+
+
 def test_has_cached_meta_timeseries_keeps_local_path_behaviour(monkeypatch, tmp_path):
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
     cache = import_cache()
@@ -227,6 +256,39 @@ def test_local_meta_cache_still_invalidates_when_file_mtime_changes(monkeypatch,
     assert second["Close"].iloc[0] == 1.0
     assert third["Close"].iloc[0] == 2.0
     assert len(loads) == 2
+
+
+def test_load_meta_timeseries_skips_repeat_head_object_for_confirmed_missing_cache(monkeypatch):
+    """``_invalidate_meta_caches_if_stale`` must not re-issue a live S3
+    HeadObject call on every request for a ticker with no cache object at
+    all -- see issue #5093 for the production retry-storm this caused.
+    """
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+    calls = []
+
+    class FakeS3:
+        def head_object(self, *, Bucket, Key):
+            calls.append((Bucket, Key))
+            raise cache.ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadObject",
+            )
+
+    patch_s3_client(monkeypatch, cache, FakeS3())
+
+    loads = []
+
+    def fake_rolling_cache(*_args, **_kwargs):
+        loads.append(1)
+        return _frame(1.0)
+
+    monkeypatch.setattr(cache, "_rolling_cache", fake_rolling_cache)
+
+    for _ in range(5):
+        cache.load_meta_timeseries("MISSING", "L", 5)
+
+    assert len(calls) == 1
 
 
 def test_s3_range_cache_invalidates_when_last_modified_changes(monkeypatch):


### PR DESCRIPTION
## Summary

Investigated #5093's hypothesis that Lambda cold starts explain the reported 25-40s page-load delays. CloudWatch data over the last 7 days for `BackendLambdaStack-BackendLambdaD93C7B96` **rules out cold start**:

- 58 cold starts out of 684 invocations (~8.5%)
- Init Duration: avg 383ms, max 930ms, p99 930ms — negligible against a 30s timeout

Instead, ~8% of requests (55/684) were timing out at exactly `30000.00 ms`. Tracing one timed-out request's logs end to end showed 316 log lines in 30 seconds cycling through the same handful of permanently-broken tickers (`B.N`, `AIGE.L`, `AIE.L` — delisted/unresolvable instruments with no data from any provider), alternating:

```
[WARNING] No new timeseries data for B.N
[WARNING] Unable to read S3 cache metadata for s3://.../timeseries/meta/B_N.parquet: 404 Not Found
```

Root cause: `_invalidate_meta_caches_if_stale` in `backend/timeseries/cache.py` issues a **live synchronous S3 `HeadObject` call on every single lookup**, even for tickers that will never have a cache object (no data source has ever resolved them). Every portfolio holding referencing one of these tickers re-pays that network round-trip, and with ~100-150ms per round-trip that's enough to burn the full 30s Lambda budget on its own — no cold start required. This matches the duration distribution: p50 ~1s (healthy), p90 24.6s, p99 ~30s — a bimodal split driven by a few broken tickers, not a blanket per-request tax.

## Fix

Add a 60-second negative cache (`_S3_HEAD_MISS_CACHE`) so once a `HeadObject` confirms an S3 object is missing (404/NoSuchKey/NotFound), subsequent lookups for the same object within the TTL skip the network call entirely. Applied to both:
- `_s3_object_mtime` (the hot path — called by `_invalidate_meta_caches_if_stale` on every `load_meta_timeseries`/`load_meta_timeseries_range` call)
- `_s3_cache_object_exists` (used by `has_cached_meta_timeseries`)

No CDK/Lambda configuration changes — per the issue's constraint, cost-incurring infra changes (provisioned concurrency, memory bump) need explicit sign-off, and this evidence shows they wouldn't have fixed the actual problem anyway.

## Test plan

- [x] Added `test_has_cached_meta_timeseries_skips_repeat_head_object_for_confirmed_missing` — 5 repeat lookups for a missing object issue only 1 `HeadObject` call
- [x] Added `test_load_meta_timeseries_skips_repeat_head_object_for_confirmed_missing_cache` — same guarantee via the `load_meta_timeseries` hot path
- [x] Existing `tests/test_timeseries_cache_base.py` suite passes (14 tests)
- [x] Broader related suite passes: `pytest tests/test_timeseries_cache_base.py tests/backend -k "cache or timeseries or portfolio_utils or holding_utils"` → 72 passed, 1 skipped
- [x] `black`/`isort`/`ruff` clean on changed lines (pre-existing `I001`/`UP017` findings in these files predate this change, verified against `main`)

Closes #5093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
