### PR TITLE
docs(backend): document stale not-found window from S3 head-miss TTL

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -325,6 +325,13 @@ _CACHE_FILE_MTIMES: Dict[str, float] = {}
 # synchronous S3 HeadObject call on every check -- observed in production to
 # stack up into hundreds of calls within a single request and exhaust the
 # Lambda's 30s timeout.
+#
+# Trade-off: during this 60s window, confirmed-missing objects will not
+# trigger new HeadObject calls, so a ticker whose data appears in S3 shortly
+# after an initial 404 (e.g. a delayed data load) can keep returning stale
+# "not found" results for up to 60 seconds. Uses time.monotonic(), so the
+# TTL resets on Lambda freeze/thaw -- acceptable, since a thawed instance
+# re-checking S3 immediately is the safe direction to err in.
 _S3_HEAD_MISS_TTL_SECONDS = 60.0
 _S3_HEAD_MISS_CACHE: Dict[str, float] = {}
 


### PR DESCRIPTION
## Summary
- Documents `_S3_HEAD_MISS_TTL_SECONDS` in [backend/timeseries/cache.py](backend/timeseries/cache.py) to explain the up-to-60s stale "not found" window: confirmed-missing S3 objects skip re-checking for the TTL duration, so data that lands in S3 shortly after an initial 404 can still read as missing until the TTL expires.
- Notes that `time.monotonic()` resets on Lambda freeze/thaw, and why that's the safe direction to err in.
- No behavioral or logic changes — comment only, per the issue's constraints.

## Test plan
- [x] `pytest tests/ -k cache -q` — 111 passed, 1 skipped

Closes #5106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification about the 60-second caching behaviour for confirmed-missing objects.
  * Documented that newly created objects may temporarily continue to appear as unavailable during this period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->