### PR TITLE
fix: skip provider fallback fast-path for confirmed-missing S3 tickers

### DIFF
--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -349,8 +349,17 @@ def _split_s3_cache_uri(cache: str) -> tuple[str, str] | None:
     return bucket, key
 
 
-def _s3_object_mtime(cache: str) -> float:
-    """Return the S3 object's LastModified timestamp for cache invalidation."""
+def _s3_object_mtime(cache: str) -> float | None:
+    """Return the S3 object's LastModified timestamp for cache invalidation.
+
+    Returns ``None`` when the object was already confirmed missing within
+    the negative-cache TTL, signalling the caller to skip invalidation
+    entirely. Without this, the fallback ``0.0`` used for a genuine miss
+    gets compared against the previously recorded mtime on every call,
+    which is harmless on its own but leaves callers no way to distinguish
+    "still missing" from "just went missing" and short-circuit further
+    provider fallback work.
+    """
 
     parsed = _split_s3_cache_uri(cache)
     if parsed is None:
@@ -358,7 +367,7 @@ def _s3_object_mtime(cache: str) -> float:
     bucket, key = parsed
 
     if _s3_object_recently_confirmed_missing(cache):
-        return 0.0
+        return None
 
     try:
         resp = _s3_client().head_object(Bucket=bucket, Key=key)
@@ -386,6 +395,11 @@ def _invalidate_meta_caches_if_stale(ticker: str, exchange: str) -> None:
     cache = meta_timeseries_cache_path(ticker, exchange)
     if cache.startswith("s3://"):
         mtime = _s3_object_mtime(cache)
+        if mtime is None:
+            # Confirmed-missing within the negative-cache TTL: the previous
+            # miss already cleared the LRUs once, so there is nothing new
+            # to invalidate and no reason to touch _CACHE_FILE_MTIMES.
+            return
     else:
         p = Path(cache)
         mtime = p.stat().st_mtime if p.exists() else 0.0

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -291,6 +291,60 @@ def test_load_meta_timeseries_skips_repeat_head_object_for_confirmed_missing_cac
     assert len(calls) == 1
 
 
+def test_s3_object_mtime_returns_none_for_confirmed_missing(monkeypatch):
+    """``_s3_object_mtime`` must signal confirmed-missing objects with a
+    sentinel (``None``) rather than ``0.0``, so ``_invalidate_meta_caches_if_stale``
+    can short-circuit instead of treating every check as a stale-cache
+    transition. See issue #5107.
+    """
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+
+    class FakeS3:
+        def head_object(self, *, Bucket, Key):
+            raise cache.ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadObject",
+            )
+
+    patch_s3_client(monkeypatch, cache, FakeS3())
+
+    cache_uri = "s3://bucket/timeseries/meta/MISSING_L.parquet"
+    assert cache._s3_object_mtime(cache_uri) == 0.0
+    assert cache._s3_object_mtime(cache_uri) is None
+
+
+def test_invalidate_meta_caches_skips_update_for_confirmed_missing(monkeypatch):
+    """Once a ticker is confirmed missing, repeat invalidation checks must
+    not touch ``_CACHE_FILE_MTIMES`` or re-clear the LRUs -- the negative
+    cache should be a true no-op fast path, not just a HeadObject skip.
+    """
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+
+    class FakeS3:
+        def head_object(self, *, Bucket, Key):
+            raise cache.ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadObject",
+            )
+
+    patch_s3_client(monkeypatch, cache, FakeS3())
+
+    clears = []
+    monkeypatch.setattr(cache._load_meta_timeseries_cached, "cache_clear", lambda: clears.append(1))
+    monkeypatch.setattr(cache._memoized_range_cached, "cache_clear", lambda: clears.append(1))
+
+    cache._invalidate_meta_caches_if_stale("MISSING", "L")
+    cache_uri = cache.meta_timeseries_cache_path("MISSING", "L")
+    assert cache._CACHE_FILE_MTIMES[cache_uri] == 0.0
+    assert len(clears) == 0  # first-ever miss: prev was None, no clear triggered
+
+    cache._invalidate_meta_caches_if_stale("MISSING", "L")
+    assert cache._CACHE_FILE_MTIMES[cache_uri] == 0.0
+    assert len(clears) == 0  # confirmed-missing fast path: no further work
+
+
 def test_s3_range_cache_invalidates_when_last_modified_changes(monkeypatch):
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
     cache = import_cache()


### PR DESCRIPTION
## Summary
- `_s3_object_mtime` now returns `None` (instead of `0.0`) once a ticker is confirmed missing within the 60s negative-cache TTL, since `0.0` was indistinguishable from a genuine stale timestamp.
- `_invalidate_meta_caches_if_stale` short-circuits on that sentinel and returns early, skipping the mtime comparison/`_CACHE_FILE_MTIMES` update entirely for confirmed-missing tickers.
- First-ever miss detection is unaffected: the initial HeadObject 404 still flows through the normal invalidation path so any existing LRU entries get cleared correctly.

Closes #5107

## Test plan
- [x] `pytest tests/test_timeseries_cache_base.py -q` — 16 passed (added 2 new regression tests: `test_s3_object_mtime_returns_none_for_confirmed_missing`, `test_invalidate_meta_caches_skips_update_for_confirmed_missing`)
- [x] `pytest tests/ -k "timeseries_cache or meta_timeseries"` — 93 passed
- [x] `black --config backend/pyproject.toml`, `isort`, `ruff check` all clean on changed files