### PR TITLE
fix(frontend): downgrade transient config-fetch failures to warn level

### DIFF
--- a/frontend/src/configFetchLogging.ts
+++ b/frontend/src/configFetchLogging.ts
@@ -1,0 +1,12 @@
+// A single transient "Failed to fetch" that self-heals on the next attempt
+// isn't an app-breaking failure — log it at warn so it doesn't read as an
+// unhandled error in the console (#5109). Only the final, non-retryable
+// failure (retries exhausted) escalates to console.error, since that is a
+// genuine, user-visible failure ("Unable to load configuration" screen).
+export const logConfigFetchFailure = (err: unknown, willRetry: boolean) => {
+  if (willRetry) {
+    console.warn('Failed to load configuration, retrying', err);
+  } else {
+    console.error('Failed to load configuration', err);
+  }
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -313,7 +313,6 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
           if (!isMounted.current || activeRequest.current !== controller)
             return;
 
-          console.error('Failed to load configuration', err);
           const error =
             err instanceof DOMException && err.name === 'AbortError'
               ? new Error('Request timed out while loading configuration.')
@@ -324,6 +323,15 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
           shouldRetry = attempt + 1 < MAX_CONFIG_FETCH_ATTEMPTS;
           nextAttempt = attempt + 1;
           retryDelay = Math.min(30000, 2000 * 2 ** attempt);
+          // A single transient "Failed to fetch" that self-heals on the next
+          // attempt isn't an app-breaking failure — log it at warn so it
+          // doesn't read as an unhandled error in the console (#5109). Only
+          // the final, non-retryable failure escalates to console.error.
+          if (shouldRetry) {
+            console.warn('Failed to load configuration, retrying', err);
+          } else {
+            console.error('Failed to load configuration', err);
+          }
         })
         .finally(() => {
           window.clearTimeout(timeoutId);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -34,6 +34,7 @@ import {
   setAuthToken,
   UNAUTHORIZED_EVENT,
 } from './api';
+import { logConfigFetchFailure } from './configFetchLogging';
 import LoginPage from './LoginPage';
 import { UserProvider, useUser } from './UserContext';
 import ErrorBoundary from './ErrorBoundary';
@@ -323,15 +324,7 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
           shouldRetry = attempt + 1 < MAX_CONFIG_FETCH_ATTEMPTS;
           nextAttempt = attempt + 1;
           retryDelay = Math.min(30000, 2000 * 2 ** attempt);
-          // A single transient "Failed to fetch" that self-heals on the next
-          // attempt isn't an app-breaking failure — log it at warn so it
-          // doesn't read as an unhandled error in the console (#5109). Only
-          // the final, non-retryable failure escalates to console.error.
-          if (shouldRetry) {
-            console.warn('Failed to load configuration, retrying', err);
-          } else {
-            console.error('Failed to load configuration', err);
-          }
+          logConfigFetchFailure(err, shouldRetry);
         })
         .finally(() => {
           window.clearTimeout(timeoutId);

--- a/frontend/tests/unit/configRetrySuccess.test.tsx
+++ b/frontend/tests/unit/configRetrySuccess.test.tsx
@@ -11,6 +11,7 @@ afterEach(() => {
 describe('Root config retry flow', () => {
   it('recovers from a transient failure and renders the route marker', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const nativeSetTimeout = window.setTimeout
     const nativeClearTimeout = window.clearTimeout
@@ -77,10 +78,22 @@ describe('Root config retry flow', () => {
       const marker = await screen.findByTestId('active-route-marker')
       expect(marker).toHaveAttribute('data-mode', 'group')
       expect(marker).toHaveAttribute('data-pathname', '/')
+
+      // A transient failure that recovers on retry should not read as an
+      // unhandled console error (#5109) — it logs at warn instead.
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Failed to load configuration, retrying',
+        expect.any(Error),
+      )
+      expect(consoleError).not.toHaveBeenCalledWith(
+        'Failed to load configuration',
+        expect.anything(),
+      )
     } finally {
       setTimeoutSpy.mockRestore()
       clearTimeoutSpy.mockRestore()
       consoleError.mockRestore()
+      consoleWarn.mockRestore()
     }
   })
 })

--- a/frontend/tests/unit/logConfigFetchFailure.test.ts
+++ b/frontend/tests/unit/logConfigFetchFailure.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { logConfigFetchFailure } from '@/configFetchLogging'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('logConfigFetchFailure', () => {
+  it('logs at warn when a retry is scheduled', () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const err = new Error('network down')
+
+    logConfigFetchFailure(err, true)
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'Failed to load configuration, retrying',
+      err,
+    )
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('logs at error once retries are exhausted', () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const err = new Error('network down')
+
+    logConfigFetchFailure(err, false)
+
+    expect(consoleError).toHaveBeenCalledWith('Failed to load configuration', err)
+    expect(consoleWarn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- On initial app load, `GET /config` failures were logged with `console.error` on every attempt, even though this fetch is already auto-retried up to 5 times with exponential backoff (`frontend/src/main.tsx`). A single transient `TypeError: Failed to fetch` that self-heals on the next attempt read as an unhandled console error even though the app recovers within seconds.
- Only the final, non-retryable failure now logs at `console.error`; intermediate retryable attempts log at `console.warn` instead. No behavior change to the retry/backoff/timeout logic itself.

## Root cause note
This addresses the console-noise symptom described in the issue. The issue itself flags the underlying network fetch failure as unconfirmed/intermittent (observed once) — this change doesn't claim to fix an unconfirmed backend/network root cause, only to stop a self-healing, retried failure from presenting as an app-breaking error in the console.

## Test plan
- [x] `npx eslint src/main.tsx` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 607/607 tests pass
- [ ] Manual verification on the deployed CloudFront app (can't reproduce the transient network condition locally)

Closes #5109