### PR TITLE
test(timeseries): add TTL expiry test for S3 negative cache

### DIFF
--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -123,6 +123,49 @@ def test_has_cached_meta_timeseries_skips_repeat_head_object_for_confirmed_missi
     assert len(calls) == 1
 
 
+def test_has_cached_meta_timeseries_rechecks_after_negative_cache_ttl_expires(monkeypatch):
+    """The negative cache must expire after ``_S3_HEAD_MISS_TTL_SECONDS`` so a
+    ticker whose data appears in S3 after an initial 404 (e.g. delayed data
+    load) is re-checked instead of being reported missing forever.
+    """
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+    calls = []
+
+    # Advance by a fixed 61s (not derived from the module constant) so the
+    # test actually exercises the documented 60s TTL: if a future change sets
+    # _S3_HEAD_MISS_TTL_SECONDS to e.g. 3600, the cache would still be valid
+    # after 61s and this test would correctly fail instead of silently
+    # adapting to the new value.
+    assert cache._S3_HEAD_MISS_TTL_SECONDS == 60.0
+
+    class FakeS3Client:
+        def head_object(self, Bucket, Key):  # noqa: N803 - boto3 API parameter names
+            calls.append((Bucket, Key))
+            raise cache.ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadObject",
+            )
+
+    patch_s3_client(monkeypatch, cache, FakeS3Client())
+
+    current_time = [1000.0]
+    monkeypatch.setattr(cache.time, "monotonic", lambda: current_time[0])
+
+    assert cache.has_cached_meta_timeseries("missing", "us") is False
+    assert len(calls) == 1
+
+    # Still within the TTL: cached negative result, no new HeadObject call.
+    current_time[0] += 59
+    assert cache.has_cached_meta_timeseries("missing", "us") is False
+    assert len(calls) == 1
+
+    # TTL has elapsed: the cache must expire and re-check S3.
+    current_time[0] += 2
+    assert cache.has_cached_meta_timeseries("missing", "us") is False
+    assert len(calls) == 2
+
+
 def test_has_cached_meta_timeseries_keeps_local_path_behaviour(monkeypatch, tmp_path):
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
     cache = import_cache()


### PR DESCRIPTION
## Summary
- Add `test_has_cached_meta_timeseries_rechecks_after_negative_cache_ttl_expires` to `tests/test_timeseries_cache_base.py`, alongside the existing negative-cache tests
- Mocks `time.monotonic` to advance past the 60s `_S3_HEAD_MISS_TTL_SECONDS` TTL and asserts a second `HeadObject` call is issued once the cache entry expires
- Verified the test actually exercises the TTL (not just the mechanism) by temporarily patching `_S3_HEAD_MISS_TTL_SECONDS` to 3600 locally and confirming the test fails, then reverted — no production code changed

## Test plan
- [x] `python -m pytest tests/test_timeseries_cache_base.py --no-cov -q` — 15 passed
- [x] `python -m black --check tests/test_timeseries_cache_base.py` — clean
- [x] `python -m ruff check tests/test_timeseries_cache_base.py` — no new findings (pre-existing `UP017` hits are on lines untouched by this change)
- [x] Confirmed test fails when TTL is regressed to a large value, confirming it isn't a false-positive test

Closes #5105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
