### PR TITLE
fix: replace plain loading text in PortfolioView with skeleton components

### DIFF
--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useState, useEffect, useCallback, useRef } from "react";
 import type { FormEvent } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import type { Portfolio, Account, SectorContribution } from "../types";
 import { AccountBlock } from "./AccountBlock";
 import { AddAccountForm } from "./AddAccountForm";
@@ -15,6 +16,7 @@ import { complianceForOwner, getOwnerSectorContributions } from "../api";
 import { getGrowthStage } from "../utils/growthStage";
 import lazyWithDelay from "../utils/lazyWithDelay";
 import PortfolioDashboardSkeleton from "./skeletons/PortfolioDashboardSkeleton";
+import TextSkeleton from "./skeletons/TextSkeleton";
 import { useFetch } from "../hooks/useFetch";
 import {
   ResponsiveContainer,
@@ -222,6 +224,7 @@ type Props = {
  * keep the JSX at the bottom easy to follow.
  */
 export function PortfolioView({ data, loading, error, onDateChange, onAccountAdded, onPositionAdded }: Props) {
+  const { t } = useTranslation();
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
   const [hasWarnings, setHasWarnings] = useState(false);
   const [pendingDate, setPendingDate] = useState<string>("");
@@ -278,7 +281,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
     };
   }, [owner]);
 
-  if (loading) return <div>Loading portfolio…</div>; // show a quick spinner
+  if (loading) return <PortfolioDashboardSkeleton label={t("app.loading")} />;
   if (error) return <div className="text-error">{error}</div>; // bubble errors
   if (!data) return <div>Select an owner.</div>; // nothing chosen yet
 
@@ -430,7 +433,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
                     Sector contribution
                   </h3>
                   {sectorLoading ? (
-                    <p className="text-sm text-gray-400">Loading sector data…</p>
+                    <TextSkeleton width="8rem" label={t("app.loading")} />
                   ) : sectorError ? (
                     <p className="text-sm text-red-500">
                       Failed to load sector contribution

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -99,6 +99,28 @@ describe("PortfolioView", () => {
         expect(screen.getByLabelText(/account type/i)).toBeInTheDocument();
     });
 
+    it("shows an accessible skeleton while the portfolio is loading", () => {
+        render(<PortfolioView data={null} loading />);
+
+        expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
+        expect(screen.queryByText(/Approx Total:/)).not.toBeInTheDocument();
+    });
+
+    it("renders the portfolio dashboard once loading completes", () => {
+        render(<PortfolioView data={mockOwner} loading={false} />);
+
+        expect(screen.getByText(/Approx Total:/)).toBeInTheDocument();
+    });
+
+    it("shows an accessible skeleton while sector data is loading", async () => {
+        const { getOwnerSectorContributions } = await import("@/api");
+        vi.mocked(getOwnerSectorContributions).mockReturnValue(new Promise(() => {}));
+
+        render(<PortfolioView data={mockOwner} />);
+
+        expect(await screen.findByRole("status", { name: /loading/i })).toBeInTheDocument();
+    });
+
     it("shows the CSV import form when accounts exist", () => {
         render(<PortfolioView data={mockOwner} />);
 


### PR DESCRIPTION
## Summary
- Replaces the full-dashboard `Loading portfolio…` text in `PortfolioView.tsx` with `PortfolioDashboardSkeleton`
- Replaces the inline `Loading sector data…` text in the Sector contribution card with `TextSkeleton`
- Both reuse the accessible `role="status"`/`aria-live="polite"` + `app.loading` translation pattern established in #5095/#5101

## Test plan
- [x] `npx vitest run tests/unit/components/PortfolioView.test.tsx` — new coverage for both loading states, 12/12 passing
- [x] `npx vitest run` — full frontend suite, 610/610 passing
- [x] `npx eslint` on changed files — no warnings
- [x] `npx tsc --noEmit` — clean

Closes #5102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
