### PR TITLE
fix(scripts): handle git grep exit code 1 in aider-issue.ps1 when no matches found

### DIFF
--- a/scripts/aider-issue.ps1
+++ b/scripts/aider-issue.ps1
@@ -209,7 +209,15 @@ $identifiers = @(
 )
 $identifierMatches = @(
     $identifiers |
-        ForEach-Object { git -C $repoRoot grep -l -F -- $_ 2>$null } |
+        ForEach-Object {
+            # `git grep` exits 1 (not a terminating error) when an identifier has no
+            # matches. Under $PSNativeCommandUseErrorActionPreference with
+            # $ErrorActionPreference = 'Stop', that non-zero exit becomes a
+            # terminating NativeCommandExitException, which would otherwise abort
+            # this whole ForEach-Object pipeline on the first non-matching
+            # identifier. Catch per-identifier so a miss just yields no matches.
+            try { git -C $repoRoot grep -l -F -- $_ 2>$null } catch { @() }
+        } |
         Sort-Object -Unique |
         ForEach-Object { Join-Path $repoRoot $_ }
 )


### PR DESCRIPTION
## Summary
- `git grep -l -F` exits 1 (not a real error) when an identifier has no matches. Under strict PowerShell error handling (`$PSNativeCommandUseErrorActionPreference` + `$ErrorActionPreference = 'Stop'`), that non-zero exit becomes a terminating exception that aborts the whole identifier-matching `ForEach-Object` pipeline.
- Wraps the `git grep` call in try/catch so a non-matching identifier just yields no result instead of killing the pipeline; matching behavior is unchanged.

Closes #4301

## Test plan
- [x] Manual repro with `$ErrorActionPreference = 'Stop'` and `$PSNativeCommandUseErrorActionPreference = $true`: an identifier with no matches no longer aborts the pipeline.
- [x] Confirmed identifiers that do match (e.g. `ErrorActionPreference`) still return the correct file list, unchanged from before the fix.
- [x] Diff is scoped to the single `ForEach-Object` block; direct-path/basename matching logic untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)