### PR TITLE
feat(ci): add non-blocking shellcheck lint for .github/scripts/*.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,17 @@ jobs:
         # respective dependency sets.
         run: .venv-lambda/bin/pytest tests/
 
+  lint-shell-scripts:
+    name: Lint .github/scripts shell scripts (shellcheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # ubuntu-latest ships shellcheck preinstalled; non-blocking (continue-on-error)
+      # until the existing scripts are cleaned up and this can be made required.
+      - name: Run shellcheck
+        continue-on-error: true
+        run: shellcheck .github/scripts/*.sh
+
   lint-workflows:
     name: Lint GitHub Actions workflows
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `lint-shell-scripts` job to `.github/workflows/ci.yml` that runs `shellcheck .github/scripts/*.sh` on every push/PR.
- Non-blocking (`continue-on-error: true`) so existing script warnings can't unexpectedly block PRs, per the issue's constraints.
- Scoped only to `.github/scripts/*.sh`; no `.sh` files modified.

Closes #4833

## Test plan
- [x] Validated `ci.yml` parses as valid YAML.
- [x] `shellcheck` is preinstalled on `ubuntu-latest` runners, so no install step is needed.
- [ ] Confirm the new job appears and runs in the PR's CI checks.