### PR TITLE
fix: add workflow_dispatch pr_number input to target one PR

### DIFF
--- a/.github/workflows/sync-changes-requested-label.yml
+++ b/.github/workflows/sync-changes-requested-label.yml
@@ -111,20 +111,27 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number }}
         run: |
-          if [ -n "${PR_NUMBER_INPUT// }" ]; then
+          # xargs collapses/trims surrounding whitespace so a blank or
+          # whitespace-only input is correctly treated as "not provided".
+          PR_NUMBER_INPUT="$(echo "$PR_NUMBER_INPUT" | xargs)"
+
+          if [ -n "$PR_NUMBER_INPUT" ]; then
+            if ! [[ "$PR_NUMBER_INPUT" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid pr_number '${PR_NUMBER_INPUT}': must be a positive integer."
+              exit 1
+            fi
             echo "Reconciling single PR #${PR_NUMBER_INPUT} (workflow_dispatch input)."
             bash .github/scripts/reconcile_changes_requested_label.sh "$PR_NUMBER_INPUT"
-            exit 0
+          else
+            PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --label "Changes Requested" \
+              --json number --jq '.[].number')
+
+            if [ -z "$PR_NUMBERS" ]; then
+              echo "No open PRs carry the 'Changes Requested' label."
+              exit 0
+            fi
+
+            for PR_NUMBER in $PR_NUMBERS; do
+              bash .github/scripts/reconcile_changes_requested_label.sh "$PR_NUMBER"
+            done
           fi
-
-          PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --label "Changes Requested" \
-            --json number --jq '.[].number')
-
-          if [ -z "$PR_NUMBERS" ]; then
-            echo "No open PRs carry the 'Changes Requested' label."
-            exit 0
-          fi
-
-          for PR_NUMBER in $PR_NUMBERS; do
-            bash .github/scripts/reconcile_changes_requested_label.sh "$PR_NUMBER"
-          done

--- a/.github/workflows/sync-changes-requested-label.yml
+++ b/.github/workflows/sync-changes-requested-label.yml
@@ -33,7 +33,12 @@ on:
     types: [completed]
   schedule:
     - cron: "*/30 * * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to reconcile (leave empty to sweep all open PRs)"
+        required: false
+        type: string
 
 # Multiple review workflows (Claude/GPT/DeepSeek) can complete in rapid
 # succession for the same PR, each triggering a workflow_run event that
@@ -104,7 +109,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number }}
         run: |
+          if [ -n "${PR_NUMBER_INPUT// }" ]; then
+            echo "Reconciling single PR #${PR_NUMBER_INPUT} (workflow_dispatch input)."
+            bash .github/scripts/reconcile_changes_requested_label.sh "$PR_NUMBER_INPUT"
+            exit 0
+          fi
+
           PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --label "Changes Requested" \
             --json number --jq '.[].number')
 

--- a/docs/AI_REVIEW_WORKFLOWS.md
+++ b/docs/AI_REVIEW_WORKFLOWS.md
@@ -314,6 +314,13 @@ re-runs the same reconciliation logic (shared via
 a PR whose reviews have actually passed gets its label cleared within the
 next scheduled sweep even if the triggering event was lost.
 
+`workflow_dispatch` also accepts an optional `pr_number` input to
+force-reconcile a single PR immediately, instead of waiting for the next
+scheduled sweep or scanning every open PR. Run it from the Actions tab (or
+`gh workflow run sync-changes-requested-label.yml -f pr_number=123`) when a
+specific PR's label is stuck. Leaving `pr_number` empty falls back to the
+full sweep, same as before.
+
 If a fourth reviewer is added (see [Adding a new AI reviewer](#adding-a-new-ai-reviewer)),
 update `sync-changes-requested-label.yml`'s `workflows:` trigger list and its
 conclusion checks to include the new provider's check-run name — otherwise


### PR DESCRIPTION
## Summary
- Adds an optional `pr_number` input to `sync-changes-requested-label.yml`'s `workflow_dispatch` trigger
- When `pr_number` is provided, the fallback job reconciles only that PR via the existing `.github/scripts/reconcile_changes_requested_label.sh` instead of sweeping every open PR
- Leaving `pr_number` empty (or the scheduled/no-input `workflow_dispatch` trigger) preserves the existing full-sweep behavior
- Documents the new input in `docs/AI_REVIEW_WORKFLOWS.md`

Invalid PR numbers are handled by the existing script, which already runs under `set -euo pipefail` and calls `gh pr view` first — an invalid number causes `gh` to error out with a non-zero exit and a clear message, satisfying the issue's "clear error, exit non-zero" requirement without extra validation code.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(...)"` to validate the workflow YAML parses
- [ ] Manually trigger the workflow with a `pr_number` input on a PR that carries the label and confirm only it is reconciled
- [ ] Manually trigger the workflow with no input and confirm the full sweep still runs

Closes #4834

🤖 Generated with [Claude Code](https://claude.com/claude-code)
