### PR TITLE
fix(ci): pin github/super-linter to commit SHA

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v7
+        uses: github/super-linter@b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1 # v7
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: "main"


### PR DESCRIPTION
## Summary
- Audited every `uses:` reference in `.github/workflows/*.yml` (and the composite action in `.github/actions/`) for 3rd-party actions still pinned by mutable tag.
- Found and pinned the one remaining offender: `github/super-linter@v7` → `github/super-linter@b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1 # v7` in `.github/workflows/super-linter.yml`.
- All other 3rd-party actions (`dorny/paths-filter`, `aws-actions/configure-aws-credentials`, `codecov/codecov-action`, `pnpm/action-setup`) were already pinned by SHA (from PR #4815 and follow-ups). All `actions/` org references (`checkout`, `setup-python`, `setup-node`, `cache`, `upload-artifact`, `stale`, `first-interaction`, `dependency-review-action`) are intentionally excluded per the issue's scope.
- Verified `b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1` is the exact commit the `v7` tag on `github/super-linter` currently points to (`gh api repos/github/super-linter/git/refs/tags/v7`), so this is a pure pin with no behavioral/version change.

Closes #4817

## Test plan
- [x] `git diff` shows only the SHA-pin change, no version bumps or logic changes.
- [x] YAML parses cleanly (`yaml.safe_load`).
- [ ] CI passes on this PR (workflow behavior unchanged since SHA matches current tag).