### PR TITLE
feat(scripts): add -Force flag to aider-issue.ps1 to bypass active-operation check

### DIFF
--- a/scripts/aider-issue.ps1
+++ b/scripts/aider-issue.ps1
@@ -1,5 +1,9 @@
 param(
-    [Parameter(Mandatory)][string]$Issue
+    [Parameter(Mandatory)][string]$Issue,
+    # Bypass the active-operation check below (MERGE_HEAD/CHERRY_PICK_HEAD/
+    # rebase-merge/rebase-apply) for emergency recovery from a stale git state.
+    # Does not affect the unmerged-path detection or reset logic that follows.
+    [switch]$Force
 )
 
 # Pre-flight: require gh and aider on PATH
@@ -17,18 +21,23 @@ foreach ($cmd in @('gh', 'aider')) {
 # index first" regardless of which issue is being worked.
 $unmergedPaths = @(git diff --name-only --diff-filter=U 2>$null | Where-Object { $_ })
 if ($unmergedPaths.Count -gt 0) {
-    $gitDir = git rev-parse --git-dir
-    $opInProgress = @('MERGE_HEAD', 'CHERRY_PICK_HEAD', 'rebase-merge', 'rebase-apply') |
-        Where-Object { Test-Path (Join-Path $gitDir $_) }
-    if ($opInProgress) {
-        Write-Error "A git operation ($($opInProgress -join ', ')) is in progress with unresolved conflicts in: $($unmergedPaths -join ', '). Resolve or abort it manually before running this script."
-        exit 1
+    if ($Force) {
+        Write-Warning "Bypassing active-operation check due to -Force flag."
+    } else {
+        $gitDir = git rev-parse --git-dir
+        $opInProgress = @('MERGE_HEAD', 'CHERRY_PICK_HEAD', 'rebase-merge', 'rebase-apply') |
+            Where-Object { Test-Path (Join-Path $gitDir $_) }
+        if ($opInProgress) {
+            Write-Error "A git operation ($($opInProgress -join ', ')) is in progress with unresolved conflicts in: $($unmergedPaths -join ', '). Resolve or abort it manually before running this script."
+            exit 1
+        }
     }
-    # No merge/rebase/cherry-pick in progress, so this is leftover from an
-    # interrupted `git stash pop`. Reset just these paths to HEAD to clear the
-    # conflict. Deliberately do NOT run `git stash drop` - the corresponding
-    # stash entry (if any) is left in place for manual review, since choosing
-    # which side to keep is a judgment call this script shouldn't make.
+    # No merge/rebase/cherry-pick in progress (or -Force was passed), so treat
+    # this as leftover from an interrupted `git stash pop`. Reset just these
+    # paths to HEAD to clear the conflict. Deliberately do NOT run `git stash
+    # drop` - the corresponding stash entry (if any) is left in place for
+    # manual review, since choosing which side to keep is a judgment call
+    # this script shouldn't make.
     Write-Warning "Resetting leftover unresolved conflict in: $($unmergedPaths -join ', ') (likely from an interrupted 'git stash pop'). Any related stash entry is left in place for manual review."
     git checkout HEAD -- $unmergedPaths
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
## Summary
- Adds an opt-in `-Force` switch to `scripts/aider-issue.ps1` that skips the active-operation guard (`MERGE_HEAD`/`CHERRY_PICK_HEAD`/`rebase-merge`/`rebase-apply`), for emergency recovery from a stale git state.
- Without `-Force`, behavior is unchanged: the script still errors out and exits 1 when an active operation is detected.
- The unmerged-path detection and reset-to-HEAD logic are untouched; `-Force` only changes whether the active-operation guard runs before that reset.

## Why
Follow-up from AI review of #4304, filed as #4305. The active-operation check is a useful safety guard but has no escape hatch for legitimate emergencies (a broken merge/rebase that needs to be aborted and re-attempted, or a CI pipeline recovering from a stale state), forcing users to manually edit git internals.

## Test plan
- [x] Parsed the script with the PowerShell AST parser — no syntax errors.
- [x] Ran the existing Pester suite (`scripts/tests/aider-issue.Tests.ps1`) — all 7 tests pass unchanged, confirming the file-discovery logic (untouched by this change) still works.
- Manual test coverage for the new branch was intentionally not added: the active-operation-check block calls `exit 1` directly, and the existing test file's snippet-extraction technique deliberately avoids any code path containing `exit` (an `exit` inside a dot-sourced snippet would terminate the whole Pester process, not just fail an assertion).

Closes #4305