### PR TITLE
fix: check inline PR comments for review anchor markers

### DIFF
--- a/.github/scripts/prepare_review_discussion.py
+++ b/.github/scripts/prepare_review_discussion.py
@@ -56,8 +56,12 @@ def is_human_comment(comment: dict) -> bool:
     return user.get("type") != "Bot"
 
 
-def find_review_anchor(issue_comments: list[dict], provider_name: str) -> str:
+def find_review_anchor(comments: list[dict], provider_name: str) -> str:
     """Return the timestamp of the provider's most recent posted review comment.
+
+    Reviews are normally posted as top-level issue comments, but this accepts
+    any list of comments, so callers can pass inline (PR review) comments too
+    in case a review ever lands there instead.
 
     Returns an empty string if no prior review comment exists, meaning the full
     discussion history should be included.
@@ -65,7 +69,7 @@ def find_review_anchor(issue_comments: list[dict], provider_name: str) -> str:
     marker = f"## {provider_name} AI Code Review"
     timestamps = [
         comment["created_at"]
-        for comment in issue_comments
+        for comment in comments
         if not is_human_comment(comment) and comment.get("body", "").startswith(marker)
     ]
     return max(timestamps, default="")
@@ -83,7 +87,7 @@ def collect_discussion(repo: str, pr_number: str, provider_name: str) -> str:
     issue_comments = gh_api_list(f"repos/{repo}/issues/{pr_number}/comments")
     inline_comments = gh_api_list(f"repos/{repo}/pulls/{pr_number}/comments")
 
-    anchor = find_review_anchor(issue_comments, provider_name)
+    anchor = find_review_anchor(issue_comments + inline_comments, provider_name)
 
     entries: list[tuple[str, str]] = []
     for comment in issue_comments:

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -502,6 +502,39 @@ def test_collect_discussion_filters_to_after_last_review_and_excludes_bots(
     assert "AI Code Review" not in discussion
 
 
+def test_collect_discussion_anchors_to_inline_review_comment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_script_module("prepare_review_discussion", "prepare_review_discussion.py")
+
+    issue_comments = [
+        _comment("alice", "Old comment before the review, ignore me", "2023-12-31T00:00:00Z"),
+        _comment("alice", "Addressed your concern about the null check", "2024-01-02T00:00:00Z"),
+    ]
+    inline_comments = [
+        _comment(
+            "github-actions[bot]",
+            "## DeepSeek AI Code Review\nLooks fine\n**APPROVE**",
+            "2024-01-01T00:00:00Z",
+            user_type="Bot",
+            path="frontend/src/foo.ts",
+        ),
+    ]
+
+    def fake_gh_api_list(path: str) -> list[dict]:
+        if path.startswith("repos/owner/repo/issues/"):
+            return issue_comments
+        return inline_comments
+
+    monkeypatch.setattr(module, "gh_api_list", fake_gh_api_list)
+
+    discussion = module.collect_discussion("owner/repo", "1", "DeepSeek")
+
+    assert "Addressed your concern about the null check" in discussion
+    assert "Old comment before the review" not in discussion
+    assert "AI Code Review" not in discussion
+
+
 def test_collect_discussion_includes_everything_when_no_prior_review(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- `find_review_anchor` previously only scanned issue comments for a provider's prior review marker (`## {provider} AI Code Review`). Reviews are currently posted via `gh pr comment`, which hits the issue-comments endpoint, so this was correct in practice — but the function would silently miss the anchor if a review ever landed as an inline PR review comment instead, causing `collect_discussion` to fall back to including the full (possibly stale) discussion history.
- Fixed by passing both `issue_comments` and `inline_comments` (already fetched by `collect_discussion`) into `find_review_anchor`. No signature or return-type change, and no extra API call — it just scans the union of comments it's given.

## Test plan
- [x] Added `test_collect_discussion_anchors_to_inline_review_comment`, which mocks a review marker only on an inline PR comment and asserts the anchor correctly excludes discussion before it.
- [x] `python -m pytest tests/test_ai_review_scripts.py -q --no-cov` — 35 passed.

Closes #4271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
