### PR TITLE
fix(ci): fail test job if cdk/tests/ is missing or empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
         working-directory: frontend
       - run: npm test -- --run
         working-directory: frontend
+      - name: Check cdk/tests/ exists and has tests
+        run: |
+          if [ ! -d "cdk/tests" ] || [ -z "$(ls -A cdk/tests/)" ]; then
+            echo "ERROR: cdk/tests/ is missing or empty. The test job requires at least one test file in cdk/tests/."
+            exit 1
+          fi
       - name: CDK infrastructure tests
         run: pytest cdk/tests/ --no-cov
 


### PR DESCRIPTION
## Summary
- Add an explicit guard step in the `test` job of `.github/workflows/ci.yml` that fails the job if `cdk/tests/` is missing or empty, before the `pytest cdk/tests/ --no-cov` step runs.

## Why
The `test` job runs `pytest cdk/tests/` directly. If `cdk/tests/` is ever removed or emptied, pytest can exit without running any tests, letting CI pass while silently skipping CDK infrastructure coverage. This guard fails fast with a clear error instead.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` confirms valid YAML
- [ ] CI run on this PR confirms the `test` job still passes normally (guard is a no-op when `cdk/tests/` is present and populated)

Closes #4466
