### PR TITLE
docs(ci): explain test/lambda-compat split in branch protection check

### DIFF
--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -18,6 +18,10 @@ RULESET_PATH = REPO_ROOT / ".github" / "rulesets" / "default-branch-protection.j
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
 EXPECTED_REQUIRED_CHECKS = {
+    # `test` runs cdk/tests/ (CDK infrastructure) against root deps; the
+    # backend `tests/` suite runs once, under Lambda-pinned deps, in
+    # `lambda-compat` below. Keeping each suite to a single dependency set
+    # avoids running `tests/` twice per PR (see PR #4464).
     "CI / test",
     "CI / Validate backend/requirements.txt (dry-run)",
     "CI / Lambda-compat pytest (backend/requirements.txt)",


### PR DESCRIPTION
## Summary

- Issue #4465 asked to update the job-to-path mapping in `scripts/check_branch_protection_required_checks.py` for the CI restructuring done in #4464.
- Investigation: the script has no such mapping — it only validates required-check *names* against the ruleset and workflow/job names (`EXPECTED_REQUIRED_CHECKS`), and it already lists `CI / test` and `CI / Lambda-compat pytest (backend/requirements.txt)` correctly (confirmed by running the script against current `main`: it reports no mismatches). `validate-backend-deps` is unrelated to `lambda-compat` and stays as-is.
- No functional change was needed. Added the clarifying comment the issue requested, mirroring the rationale already in `ci.yml`'s `lambda-compat` job, so future readers understand why `test` and `lambda-compat` are both required checks and what each covers.

Closes #4465

## Test plan

- [x] `python scripts/check_branch_protection_required_checks.py` passes locally against current `main`