### PR TITLE
Add gh CLI availability check before PR creation

### DIFF
--- a/scripts/dev_tools/publish_pr.py
+++ b/scripts/dev_tools/publish_pr.py
@@ -359,10 +359,6 @@ def create_pr(
 
 def check_gh_available() -> None:
     """Verify gh CLI is installed and authenticated, exiting with a clear message if not."""
-    error_message = (
-        "Error: GitHub CLI (gh) is not installed or not authenticated. "
-        "Install from https://cli.github.com/ and run 'gh auth login'."
-    )
     try:
         result = subprocess.run(
             ["gh", "auth", "status"],
@@ -371,11 +367,19 @@ def check_gh_available() -> None:
             check=False,
         )
     except FileNotFoundError:
-        print(error_message, file=sys.stderr)
+        print(
+            "Error: GitHub CLI (gh) is not installed. "
+            "Install from https://cli.github.com/",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     if result.returncode != 0:
-        print(error_message, file=sys.stderr)
+        print(
+            "Error: GitHub CLI (gh) is not authenticated. "
+            "Run 'gh auth login'.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 

--- a/scripts/dev_tools/publish_pr.py
+++ b/scripts/dev_tools/publish_pr.py
@@ -357,18 +357,26 @@ def create_pr(
             body_file.unlink(missing_ok=True)
 
 
-def check_gh_installed() -> bool:
-    """Check if gh CLI is installed and accessible."""
+def check_gh_available() -> None:
+    """Verify gh CLI is installed and authenticated, exiting with a clear message if not."""
+    error_message = (
+        "Error: GitHub CLI (gh) is not installed or not authenticated. "
+        "Install from https://cli.github.com/ and run 'gh auth login'."
+    )
     try:
-        subprocess.run(
-            ["gh", "--version"],
+        result = subprocess.run(
+            ["gh", "auth", "status"],
             capture_output=True,
             text=True,
-            check=True,
+            check=False,
         )
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
+    except FileNotFoundError:
+        print(error_message, file=sys.stderr)
+        sys.exit(1)
+
+    if result.returncode != 0:
+        print(error_message, file=sys.stderr)
+        sys.exit(1)
 
 
 def main() -> None:
@@ -410,11 +418,6 @@ def main() -> None:
         os.chdir(git_root)
     except subprocess.CalledProcessError:
         print("Error: Could not determine git root directory", file=sys.stderr)
-        sys.exit(1)
-
-    # Check prerequisites
-    if not check_gh_installed():
-        print("Error: 'gh' CLI not found. Install it from https://github.com/cli/cli", file=sys.stderr)
         sys.exit(1)
 
     # Get repo info
@@ -496,6 +499,7 @@ def main() -> None:
         pr_body += f"\n\nCloses #{issue_id}"
 
     # Create PR
+    check_gh_available()
     print("Creating PR...")
     pr_url = create_pr(owner, repo, branch, default_branch, f"[Issue #{issue_id}] {issue_title}", pr_body)
 

--- a/tests/test_publish_pr.py
+++ b/tests/test_publish_pr.py
@@ -1,0 +1,47 @@
+"""Unit tests for publish_pr script."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "dev_tools"))
+from publish_pr import check_gh_available
+
+
+class TestCheckGhAvailable:
+    @mock.patch("publish_pr.subprocess.run")
+    def test_gh_not_installed(self, mock_run, capsys):
+        """Should exit 1 with a not-installed message when gh is missing."""
+        mock_run.side_effect = FileNotFoundError()
+
+        with pytest.raises(SystemExit) as exc_info:
+            check_gh_available()
+
+        assert exc_info.value.code == 1
+        assert "not installed" in capsys.readouterr().err
+
+    @mock.patch("publish_pr.subprocess.run")
+    def test_gh_not_authenticated(self, mock_run, capsys):
+        """Should exit 1 with a not-authenticated message when gh auth status fails."""
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 1
+        mock_run.return_value = mock_result
+
+        with pytest.raises(SystemExit) as exc_info:
+            check_gh_available()
+
+        assert exc_info.value.code == 1
+        assert "not authenticated" in capsys.readouterr().err
+
+    @mock.patch("publish_pr.subprocess.run")
+    def test_gh_available(self, mock_run):
+        """Should return without raising when gh is installed and authenticated."""
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        check_gh_available()


### PR DESCRIPTION
## Summary
- Replaces `check_gh_installed()` with `check_gh_available()`, which runs `gh auth status` to verify both that `gh` is installed and that the user is authenticated.
- Moves the check from `main()`'s start (before commit/push) to immediately before PR creation, so commit/push still work when `gh` is absent or unauthenticated.

## Why
`create_pr()` called `gh pr create` with no prior validation, so a missing/unauthenticated `gh` CLI surfaced a confusing shell-level or generic error. The previous install-only check also ran too early, blocking manual commit/push workflows when `gh` wasn't available.

## Testing
- `python -m py_compile scripts/dev_tools/publish_pr.py`
- Manually exercised `check_gh_available()` with monkeypatched `subprocess.run` for: `gh` not found, `gh auth status` non-zero exit, and success — confirmed exit code 1 with the documented error message in the first two cases and no exit in the third.

Closes #4479