### PR TITLE
[Issue #4480] Make get_changed_files() use the dynamically determined default branch

### DIFF
--- a/scripts/dev_tools/publish_pr.py
+++ b/scripts/dev_tools/publish_pr.py
@@ -93,9 +93,10 @@ def check_working_tree_clean() -> bool:
         return False
 
 
-def get_changed_files(branch: str, default_branch: str = "origin/main") -> list[str]:
+def get_changed_files(branch: str, default_branch: str = "main") -> list[str]:
     """Get list of changed files: either uncommitted changes or commits on the branch."""
     changed_files = []
+    remote_default_branch = f"origin/{default_branch or 'main'}"
     try:
         # Check for both staged and unstaged changes
         result = subprocess.run(
@@ -110,7 +111,7 @@ def get_changed_files(branch: str, default_branch: str = "origin/main") -> list[
 
         # Check for commits on the branch only if we have a merge base
         result = subprocess.run(
-            ["git", "merge-base", branch, default_branch],
+            ["git", "merge-base", branch, remote_default_branch],
             capture_output=True,
             text=True,
             check=False,
@@ -134,7 +135,9 @@ def get_changed_files(branch: str, default_branch: str = "origin/main") -> list[
     return list(set(changed_files))
 
 
-def stage_and_commit(files: Optional[list[str]], message: str, branch: str, default_branch: str = "origin/main") -> bool:
+def stage_and_commit(
+    files: Optional[list[str]], message: str, branch: str, default_branch: str = "main"
+) -> bool:
     """Stage and commit the specified files (or changed files in branch if none specified)."""
     try:
         if not files:

--- a/tests/scripts/test_publish_pr.py
+++ b/tests/scripts/test_publish_pr.py
@@ -1,0 +1,45 @@
+import scripts.dev_tools.publish_pr as publish_pr
+
+
+class _FakeResult:
+    def __init__(self, returncode=0, stdout=""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def _merge_base_calls(calls):
+    return [c for c in calls if c[:2] == ["git", "merge-base"]]
+
+
+def test_get_changed_files_uses_origin_prefixed_default_branch(monkeypatch):
+    """merge-base/diff must run against origin/<default_branch>, not a bare local ref."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "diff", "--name-only", "HEAD"]:
+            return _FakeResult(0, "")
+        if cmd[:2] == ["git", "merge-base"]:
+            return _FakeResult(0, "abc123")
+        return _FakeResult(1, "")
+
+    monkeypatch.setattr(publish_pr.subprocess, "run", fake_run)
+
+    publish_pr.get_changed_files("feature-branch", default_branch="master")
+
+    assert _merge_base_calls(calls) == [["git", "merge-base", "feature-branch", "origin/master"]]
+
+
+def test_get_changed_files_defaults_to_origin_main(monkeypatch):
+    """With no default_branch supplied, the merge-base ref falls back to origin/main."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _FakeResult(1, "")
+
+    monkeypatch.setattr(publish_pr.subprocess, "run", fake_run)
+
+    publish_pr.get_changed_files("feature-branch")
+
+    assert _merge_base_calls(calls) == [["git", "merge-base", "feature-branch", "origin/main"]]


### PR DESCRIPTION
## What
`scripts/dev_tools/publish_pr.py::get_changed_files()` (and its caller `stage_and_commit()`) now builds the `git merge-base`/`git diff` comparison ref as `origin/<default_branch>` instead of using the bare branch name directly.

## Why
`main()` already calls `get_default_branch(owner, repo)` to resolve the repo's actual default branch (e.g. `"master"`), but that bare name was being passed straight into `get_changed_files()`, which ran `git merge-base branch <default_branch>` against a **local** ref. The function's own default parameter value (`"origin/main"`) implied a remote-tracking ref, so on any repo whose default branch isn't `main`, or where the local branch is stale/absent, the diff comparison would silently target the wrong ref — missing changed files or including unintended ones.

## How
- `get_changed_files(branch, default_branch="main")` now builds `remote_default_branch = f"origin/{default_branch or 'main'}"` and uses that for `git merge-base` / `git diff`.
- `stage_and_commit()`'s default parameter updated to match (`"main"` instead of `"origin/main"`) since it just forwards to `get_changed_files()`.
- Added `tests/scripts/test_publish_pr.py` covering both the explicit `default_branch="master"` case (asserts `origin/master` is used) and the no-argument case (asserts fallback to `origin/main`).

## Testing
```
python -m pytest tests/scripts/test_publish_pr.py -q --no-cov
```
2 passed.

Closes #4480