### PR TITLE
feat(scripts): progress message, existing-PR guard, and tests for publish_pr.py

### DIFF
--- a/scripts/dev_tools/publish_pr.py
+++ b/scripts/dev_tools/publish_pr.py
@@ -135,9 +135,7 @@ def get_changed_files(branch: str, default_branch: str = "main") -> list[str]:
     return list(set(changed_files))
 
 
-def stage_and_commit(
-    files: Optional[list[str]], message: str, branch: str, default_branch: str = "main"
-) -> bool:
+def stage_and_commit(files: Optional[list[str]], message: str, branch: str, default_branch: str = "main") -> bool:
     """Stage and commit the specified files (or changed files in branch if none specified)."""
     try:
         if not files:
@@ -206,14 +204,16 @@ def fetch_issue(owner: str, repo: str, issue_id: int) -> Optional[dict]:
         print(f"Failed to fetch issue #{issue_id}: {exc}", file=sys.stderr)
         return None
 
+
 def get_ollama_server_url(host: str = "localhost", port: int = 11434) -> str:
     """Get Ollama server url."""
     return f"http://{host}:{port}"
 
+
 def is_ollama_running(host: str = "localhost", port: int = 11434) -> bool:
     """Check if Ollama is running locally."""
     try:
-        host_url= get_ollama_server_url(host=host, port=port)
+        host_url = get_ollama_server_url(host=host, port=port)
         resp = requests.get(f"{host_url}/api/tags", timeout=2)
         return resp.status_code == 200
     except requests.RequestException:
@@ -273,6 +273,7 @@ Issue body:
 Generate only the sections above, no preamble."""
 
     ollama_url = get_ollama_server_url()
+    print(f"Waiting for Ollama ({model}) to generate the PR body, this can take up to 60s...")
     try:
         resp = requests.post(
             f"{ollama_url}/api/generate",
@@ -311,6 +312,34 @@ def create_placeholder_pr_body(issue_id: int, issue_title: str, issue_body: str)
 Closes #{issue_id}"""
 
 
+def find_existing_pr(owner: str, repo: str, branch: str) -> Optional[str]:
+    """Return the URL of an existing open PR for this branch, if any."""
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            f"{owner}/{repo}",
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--json",
+            "url",
+            "-q",
+            ".[0].url",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        url = result.stdout.strip()
+        return url or None
+    return None
+
+
 def create_pr(
     owner: str,
     repo: str,
@@ -319,7 +348,12 @@ def create_pr(
     title: str,
     body: str,
 ) -> Optional[str]:
-    """Create a PR and return the URL."""
+    """Create a PR and return the URL, or the existing PR's URL if one is already open."""
+    existing_pr_url = find_existing_pr(owner, repo, branch)
+    if existing_pr_url:
+        print(f"PR already exists for branch '{branch}': {existing_pr_url}")
+        return existing_pr_url
+
     body_file = None
     try:
         # Write body to temp file to avoid command-line quoting issues
@@ -374,16 +408,14 @@ def check_gh_available() -> None:
         )
     except FileNotFoundError:
         print(
-            "Error: GitHub CLI (gh) is not installed. "
-            "Install from https://cli.github.com/",
+            "Error: GitHub CLI (gh) is not installed. " "Install from https://cli.github.com/",
             file=sys.stderr,
         )
         sys.exit(1)
 
     if result.returncode != 0:
         print(
-            "Error: GitHub CLI (gh) is not authenticated. "
-            "Run 'gh auth login'.",
+            "Error: GitHub CLI (gh) is not authenticated. " "Run 'gh auth login'.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -514,7 +546,7 @@ def main() -> None:
     pr_url = create_pr(owner, repo, branch, default_branch, f"[Issue #{issue_id}] {issue_title}", pr_body)
 
     if pr_url:
-        print(f"\n✓ PR created successfully!")
+        print("\n✓ PR created successfully!")
         print(f"  {pr_url}")
     else:
         print("Failed to create PR", file=sys.stderr)

--- a/tests/test_publish_pr.py
+++ b/tests/test_publish_pr.py
@@ -9,7 +9,106 @@ from unittest import mock
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "dev_tools"))
-from publish_pr import check_gh_available
+from publish_pr import (
+    check_gh_available,
+    create_placeholder_pr_body,
+    extract_issue_id,
+    find_existing_pr,
+    get_repo_info,
+)
+
+
+class TestExtractIssueId:
+    def test_extracts_id_from_fix_branch(self):
+        assert extract_issue_id("fix/issue-4445-slug") == 4445
+
+    def test_extracts_id_from_feat_branch(self):
+        assert extract_issue_id("feat/issue-42-some-feature") == 42
+
+    def test_falls_back_to_any_number_in_branch_name(self):
+        assert extract_issue_id("4445-slug") == 4445
+
+    def test_returns_none_when_no_number_present(self):
+        assert extract_issue_id("main") is None
+
+
+class TestGetRepoInfo:
+    @mock.patch("publish_pr.subprocess.run")
+    def test_parses_https_remote(self, mock_run):
+        mock_run.return_value = mock.MagicMock(stdout="https://github.com/leonarduk/allotmint.git\n", returncode=0)
+
+        assert get_repo_info() == ("leonarduk", "allotmint")
+
+    @mock.patch("publish_pr.subprocess.run")
+    def test_parses_ssh_remote(self, mock_run):
+        mock_run.return_value = mock.MagicMock(stdout="git@github.com:leonarduk/allotmint.git\n", returncode=0)
+
+        assert get_repo_info() == ("leonarduk", "allotmint")
+
+    @mock.patch("publish_pr.subprocess.run")
+    def test_raises_when_remote_command_fails(self, mock_run):
+        import subprocess
+
+        mock_run.side_effect = subprocess.CalledProcessError(1, ["git"])
+
+        with pytest.raises(ValueError):
+            get_repo_info()
+
+
+class TestCreatePlaceholderPrBody:
+    def test_includes_closes_directive(self):
+        body = create_placeholder_pr_body(4445, "Fix the thing", "Some issue body")
+
+        assert "Closes #4445" in body
+
+    def test_truncates_issue_body_to_200_chars(self):
+        long_body = "x" * 500
+
+        body = create_placeholder_pr_body(4445, "Fix the thing", long_body)
+
+        assert ("x" * 200) in body
+        assert ("x" * 201) not in body
+
+    def test_falls_back_to_placeholder_text_when_body_empty(self):
+        body = create_placeholder_pr_body(4445, "Fix the thing", "")
+
+        assert "<!-- Explain why this change matters -->" in body
+
+
+class TestFindExistingPr:
+    @mock.patch("publish_pr.subprocess.run")
+    def test_returns_url_when_pr_exists(self, mock_run):
+        mock_run.return_value = mock.MagicMock(stdout="https://github.com/leonarduk/allotmint/pull/123\n", returncode=0)
+
+        url = find_existing_pr("leonarduk", "allotmint", "fix/issue-4445-slug")
+
+        assert url == "https://github.com/leonarduk/allotmint/pull/123"
+
+    @mock.patch("publish_pr.subprocess.run")
+    def test_returns_none_when_no_pr_exists(self, mock_run):
+        mock_run.return_value = mock.MagicMock(stdout="\n", returncode=0)
+
+        assert find_existing_pr("leonarduk", "allotmint", "fix/issue-4445-slug") is None
+
+    @mock.patch("publish_pr.subprocess.run")
+    def test_returns_none_when_gh_command_fails(self, mock_run):
+        mock_run.return_value = mock.MagicMock(stdout="", returncode=1)
+
+        assert find_existing_pr("leonarduk", "allotmint", "fix/issue-4445-slug") is None
+
+
+class TestCreatePr:
+    @mock.patch("publish_pr.find_existing_pr")
+    @mock.patch("publish_pr.subprocess.run")
+    def test_returns_existing_pr_url_without_creating_new_pr(self, mock_run, mock_find_existing):
+        from publish_pr import create_pr
+
+        mock_find_existing.return_value = "https://github.com/leonarduk/allotmint/pull/123"
+
+        url = create_pr("leonarduk", "allotmint", "fix/issue-4445-slug", "main", "title", "body")
+
+        assert url == "https://github.com/leonarduk/allotmint/pull/123"
+        mock_run.assert_not_called()
 
 
 class TestCheckGhAvailable:


### PR DESCRIPTION
## What
Consolidates three related follow-ups (re-scoped by #5035) that all target `scripts/dev_tools/publish_pr.py`:

- **#4481** — print a progress message before the Ollama generation call in `generate_pr_body_with_ollama()`, since it can silently take up to 60s.
- **#4488** — add `find_existing_pr()` and use it in `create_pr()` to short-circuit with the existing PR URL via `gh pr list --head <branch>` instead of failing when a PR already exists for the branch.
- **#4486** — add unit tests for `extract_issue_id`, `get_repo_info`, `create_placeholder_pr_body`, and the new `find_existing_pr`/`create_pr` guard.

## Why
Per #5035's triage, these three issues all pointed at a phantom `scripts/create-pr.sh` that doesn't exist; the real target is `scripts/dev_tools/publish_pr.py`. Batching them avoids three near-conflicting single-line PRs against the same file.

## Testing
- `python -m pytest tests/test_publish_pr.py -q` — 17 passed
- `python -m black`, `python -m ruff check` — clean

Closes #4481
Closes #4486
Closes #4488