### PR TITLE
ci: add concurrency, npm audit, and label-check caching (CI hygiene batch)

### DIFF
--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -53,6 +53,15 @@ on:
         description: "Token used for gh CLI calls (PR/issue read and write)"
         required: true
 
+# github.workflow resolves to the *calling* workflow's name (Claude/DeepSeek/GPT
+# PR Review), so this groups per-provider without cross-cancelling other
+# providers' runs for the same PR. Mirrors the pattern in deepseek-pr-review.yml
+# (#4719): only one job here with no side effects other workflows depend on, so
+# cancelling an in-progress run is safe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   ai-review:
     name: ${{ inputs.provider_name }} AI code review
@@ -209,15 +218,22 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.deepseek_api_key }}
           FOLLOWUP_LLM_PROVIDER: ${{ vars.FOLLOWUP_LLM_PROVIDER }}
         run: |
-          # Ensure required labels exist before creating issues
-          gh label create "ai-suggested" --color "0075ca" --description "Suggested by AI code review" \
-            2>/dev/null || true
-          gh label create "haiku" --color "C5DEF5" --description "Suitable for Claude Haiku (simple/mechanical task)" \
-            2>/dev/null || true
-          gh label create "sonnet" --color "BFD4F2" --description "Suitable for Claude Sonnet (moderate reasoning)" \
-            2>/dev/null || true
-          gh label create "opus" --color "0052CC" --description "Suitable for Claude Opus (complex design/architecture)" \
-            2>/dev/null || true
+          # Fetch existing label names once and only create the ones missing,
+          # instead of firing a gh label create call (and eating a 422) for
+          # every label on every run.
+          existing_labels="$(gh label list --json name -q '.[].name')"
+
+          create_label_if_missing() {
+            local name="$1" color="$2" description="$3"
+            if ! grep -qxF "$name" <<< "$existing_labels"; then
+              gh label create "$name" --color "$color" --description "$description" 2>/dev/null || true
+            fi
+          }
+
+          create_label_if_missing "ai-suggested" "0075ca" "Suggested by AI code review"
+          create_label_if_missing "haiku" "C5DEF5" "Suitable for Claude Haiku (simple/mechanical task)"
+          create_label_if_missing "sonnet" "BFD4F2" "Suitable for Claude Sonnet (moderate reasoning)"
+          create_label_if_missing "opus" "0052CC" "Suitable for Claude Opus (complex design/architecture)"
 
           # Extract titles to a file, then create issues via Python subprocess (no shell injection)
           python3 .github/scripts/extract_followups.py /tmp/${{ inputs.provider_id }}_review_body.md \
@@ -232,9 +248,11 @@ jobs:
           GH_TOKEN: ${{ secrets.gh_token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Create the label if it doesn't exist
-          gh label create "Changes Requested" --color "d73a49" --description "PR requested changes from code review" \
-            2>/dev/null || true
+          # Create the label only if it doesn't already exist
+          if ! gh label list --json name -q '.[].name' | grep -qxF "Changes Requested"; then
+            gh label create "Changes Requested" --color "d73a49" --description "PR requested changes from code review" \
+              2>/dev/null || true
+          fi
 
           # Add the label to the PR
           gh pr edit "$PR_NUMBER" --add-label "Changes Requested"

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -35,6 +35,10 @@ jobs:
         working-directory: frontend
         run: pnpm install --no-frozen-lockfile
 
+      - name: Audit dependencies
+        working-directory: frontend
+        run: pnpm audit --audit-level=high
+
       # tsc -b resolves frontend/tsconfig.json, which references
       # tsconfig.app.json (src/) and tsconfig.node.json (vite.config.ts).
       # Both are checked in one pass; no Vite build required.


### PR DESCRIPTION
## What
Batches three small, independent CI-hygiene fixes from milestone 9, each touching a different workflow file:

- **#4720** — add a top-level `concurrency:` block to `.github/workflows/_ai-pr-review.yml`, mirroring the pattern added to `deepseek-pr-review.yml` in #4719. Since `github.workflow` resolves to the *calling* workflow's name inside a reusable workflow, this single block also covers `claude-pr-review.yml` and `gpt-pr-review.yml` — which had no concurrency group at all before this — without cross-cancelling different providers' runs on the same PR (each caller's `github.workflow` is distinct: "Claude PR Review", "GPT PR Review", "DeepSeek PR Review").
- **#4670** — add a `pnpm audit --audit-level=high` step to `frontend-tests.yml` after dependency install. Verified clean against the current lockfile locally.
- **#4914** — cache the label-existence check in `_ai-pr-review.yml`. Previously every run fired a `gh label create` call (and ate a 422) for all 4-5 labels regardless of whether they already existed. Now it fetches the label list once via `gh label list` and only creates what's missing.

## Why
All three are small, uncorrelated CI/workflow tweaks — batching avoids three near-trivial single-line PRs.

## Testing
- `python -c "import yaml; yaml.safe_load(...)"` — both changed workflow files parse
- `actionlint` (repo's pinned version) against the full `.github/workflows/` tree — clean
- Manually dry-ran the label-caching bash logic locally against a mixed existing/missing label list — correctly skips existing labels and only "creates" missing ones
- `pnpm audit --audit-level=high` run locally against `frontend/` — no known vulnerabilities

Closes #4720
Closes #4670
Closes #4914