### PR TITLE
feat(scripts): add --region and --profile args to check_account_slug_collisions.py

### DIFF
--- a/scripts/check_account_slug_collisions.py
+++ b/scripts/check_account_slug_collisions.py
@@ -129,9 +129,20 @@ def main(argv: list[str]) -> int:
         default="accounts/",
         help="S3 key prefix for accounts (default: accounts/)",
     )
+    parser.add_argument(
+        "--region",
+        default=None,
+        help="AWS region to use (default: boto3's standard resolution order)",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help="AWS named profile to use (default: boto3's standard resolution order)",
+    )
     args = parser.parse_args(argv[1:])
 
-    s3_client = boto3.client("s3")
+    session = boto3.Session(profile_name=args.profile, region_name=args.region)
+    s3_client = session.client("s3")
     collisions = find_collisions(args.accounts_dir, s3_client, args.bucket, args.prefix)
 
     if collisions:

--- a/tests/scripts/test_check_account_slug_collisions.py
+++ b/tests/scripts/test_check_account_slug_collisions.py
@@ -6,6 +6,7 @@ import importlib.util
 import io
 import json
 from pathlib import Path
+from unittest import mock
 
 import boto3
 from botocore.stub import Stubber
@@ -17,6 +18,7 @@ spec.loader.exec_module(_mod)  # type: ignore[union-attr]
 find_collisions = _mod.find_collisions
 local_slugs = _mod.local_slugs
 remote_slugs = _mod.remote_slugs
+main = _mod.main
 
 BUCKET = "test-data-bucket"
 PREFIX = "accounts/"
@@ -50,9 +52,7 @@ def _stubbed_client(list_prefixes: list[str], get_object_by_key: dict[str, dict 
                 expected_params={"Bucket": BUCKET, "Key": key},
             )
         else:
-            stubber.add_response(
-                "get_object", {"Body": _body(body_dict)}, {"Bucket": BUCKET, "Key": key}
-            )
+            stubber.add_response("get_object", {"Body": _body(body_dict)}, {"Bucket": BUCKET, "Key": key})
     stubber.activate()
     return client
 
@@ -126,3 +126,38 @@ def test_missing_local_person_json_is_not_treated_as_collision(tmp_path) -> None
     )
 
     assert find_collisions(accounts_dir, client, BUCKET, PREFIX) == []
+
+
+def test_main_forwards_region_and_profile_to_boto_session(tmp_path) -> None:
+    with (
+        mock.patch.object(_mod, "boto3") as mock_boto3,
+        mock.patch.object(_mod, "find_collisions", return_value=[]),
+    ):
+        argv = [
+            "check_account_slug_collisions.py",
+            "--bucket",
+            BUCKET,
+            "--accounts-dir",
+            str(tmp_path),
+            "--region",
+            "eu-west-2",
+            "--profile",
+            "deployer",
+        ]
+
+        exit_code = main(argv)
+
+        assert exit_code == 0
+        mock_boto3.Session.assert_called_once_with(profile_name="deployer", region_name="eu-west-2")
+
+
+def test_main_defaults_region_and_profile_to_none(tmp_path) -> None:
+    with (
+        mock.patch.object(_mod, "boto3") as mock_boto3,
+        mock.patch.object(_mod, "find_collisions", return_value=[]),
+    ):
+        argv = ["check_account_slug_collisions.py", "--bucket", BUCKET, "--accounts-dir", str(tmp_path)]
+
+        main(argv)
+
+        mock_boto3.Session.assert_called_once_with(profile_name=None, region_name=None)


### PR DESCRIPTION
## What
Add optional `--region` and `--profile` CLI arguments to `scripts/check_account_slug_collisions.py`, forwarded to a `boto3.Session(profile_name=..., region_name=...)` used to build the S3 client.

## Why
Deployers with a non-default AWS profile or region previously had to export `AWS_PROFILE`/`AWS_DEFAULT_REGION` globally to point the collision check at the right account. Both flags default to `None`, which preserves boto3's standard resolution order for existing callers (env vars, `~/.aws/config`, instance role) — no behavior change for the common case.

## Testing
- `python -m pytest tests/scripts/test_check_account_slug_collisions.py -q` — 10 passed (2 new: region/profile forwarded, and default-None case)
- `python -m black`, `python -m ruff check` — clean

Closes #4924