### PR TITLE
docs(ci): explain why mypy needs --explicit-package-bases

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -56,6 +56,13 @@ jobs:
           aws s3 sync "s3://$DATA_BUCKET/" data/
 
       - name: Type-check backend
+        # --explicit-package-bases is required because of the root-level __init__.py
+        # (added in #4840 so `backend.contracts_spa` imports resolve from the repo
+        # root). Without it, mypy walks up from that __init__.py to infer a module
+        # name from the checkout directory itself, which fails whenever that
+        # directory name isn't a valid Python identifier (e.g. a worktree path
+        # like allotmint-issue-4842 or any path containing a hyphen) with
+        # "contains __init__.py but is not a valid Python package name".
         run: |
           test -f mypy.ini
           python -m mypy --version


### PR DESCRIPTION
## What
Add a comment above the `Type-check backend` step in `.github/workflows/backend-integration.yml` explaining why `--explicit-package-bases` is needed on the mypy invocation.

## Why
#4842 asked to either revert the flag (added in #4840 alongside a new root-level `__init__.py`, with no explanation) or document it. I reproduced the failure mode locally: mypy walks up from a root `__init__.py` to infer a module name from the containing directory, and fails with `"<dir> contains __init__.py but is not a valid Python package name"` whenever that directory name isn't a valid identifier — e.g. any worktree path containing a hyphen, which this repo uses constantly (`allotmint-issue-NNNN`). `--explicit-package-bases` avoids that walk-up entirely.

Reverting would make CI fragile to checkout path naming; the flag is load-bearing, so documenting in place is the right call per #4842's own "alternative" option.

## Testing
- Confirmed the failure by running `python -m mypy backend --config-file mypy.ini` (no flag) from inside a hyphenated worktree path — reproduces the exact error the comment describes.
- `python -m mypy backend --config-file mypy.ini --show-error-codes --pretty --explicit-package-bases` — passes as before (no functional change, comment only)
- `actionlint` — clean

Closes #4842