### PR TITLE
test(scripts): add live smoke test for extract_pr_comments.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint local-up local-down lambda-up lambda-down lambda-test lambda-test-price lambda-test-trading
+.PHONY: format lint local-up local-down lambda-up lambda-down lambda-test lambda-test-price lambda-test-trading smoke-test-pr-comments
 
 format:
 	isort --sp backend/pyproject.toml backend tests
@@ -9,6 +9,11 @@ lint:
 	black --check --config backend/pyproject.toml backend tests
 	pytest
 
+
+# Requires `gh` CLI (authenticated) and network access — hits the live
+# GitHub API against a stable, merged PR. Not part of `make lint`/`pytest`.
+smoke-test-pr-comments:
+	python scripts/dev_tools/smoke_test_extract_pr_comments.py
 
 local-up:
 	docker compose -f docker-compose.local.yml --env-file .env.local up --build

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -82,6 +82,17 @@ pytest tests/<path_to_test>.py
 bash scripts/bash/validate-deployment-env.sh
 ```
 
+Some checks depend on live external services and are intentionally excluded
+from `pytest`/`make lint` (which must stay hermetic and mock external
+integrations — see `CLAUDE.md`). Run these explicitly, and only when you have
+the prerequisite installed/authenticated:
+
+```bash
+# Smoke-tests scripts/dev_tools/extract_pr_comments.py against a known,
+# merged PR. Requires: gh CLI, authenticated, and network access.
+make smoke-test-pr-comments
+```
+
 ### Frontend
 
 ```bash

--- a/scripts/dev_tools/smoke_test_extract_pr_comments.py
+++ b/scripts/dev_tools/smoke_test_extract_pr_comments.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Smoke test for extract_pr_comments.py against a known, stable public PR.
+
+Runs the real script end-to-end (subprocess, live GitHub API via `gh`) rather
+than mocking it, to catch regressions in pagination, timestamp filtering, and
+output shape that unit tests against internal functions would miss. Not part
+of the default `pytest`/`make lint` run (see docs/CONTRIBUTING.md) since it
+depends on network access and `gh` auth; run it explicitly with:
+
+    make smoke-test-pr-comments
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# PR #4840 in this repo is merged (immutable comment history) and its
+# top-level comments are all from bot accounts (chatgpt-codex-connector,
+# github-actions), so there's no risk of a null `user` field from a deleted
+# account — unlike octocat/Hello-World#1, whose review comments include a
+# deleted-account commenter and crash extract_pr_comments.py's
+# format_inline_comment() (a real bug, out of scope for this smoke test per
+# #4531's constraints). --since predates the repo's creation so every
+# comment on the PR is included regardless of when its head commit landed.
+REPO = "leonarduk/allotmint"
+PR_NUMBER = "4840"
+SINCE = "2011-01-01T00:00:00Z"
+REQUIRED_FIELDS = ("id", "created_at", "body", "type")
+
+SCRIPT_PATH = Path(__file__).parent / "extract_pr_comments.py"
+
+
+def run_extract_pr_comments() -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--pr",
+            PR_NUMBER,
+            "--repo",
+            REPO,
+            "--since",
+            SINCE,
+            "--format",
+            "jsonl",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def parse_jsonl(stdout: str) -> list[dict]:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        raise AssertionError("Expected non-empty JSONL output, got none")
+    return [json.loads(line) for line in lines]
+
+
+def check_required_fields(comments: list[dict]) -> None:
+    for comment in comments:
+        missing = [field for field in REQUIRED_FIELDS if field not in comment]
+        if missing:
+            raise AssertionError(f"Comment {comment.get('id')} missing field(s): {missing}")
+
+
+def check_ascending_order(comments: list[dict]) -> None:
+    timestamps = [c["created_at"] for c in comments]
+    if timestamps != sorted(timestamps):
+        raise AssertionError("Comments are not sorted by created_at ascending")
+
+
+def main() -> int:
+    result = run_extract_pr_comments()
+    if result.returncode != 0:
+        print(
+            f"FAIL: extract_pr_comments.py exited {result.returncode}\n" f"stderr:\n{result.stderr}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        comments = parse_jsonl(result.stdout)
+        check_required_fields(comments)
+        check_ascending_order(comments)
+    except (AssertionError, json.JSONDecodeError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"PASS: {len(comments)} comment(s) fetched from {REPO}#{PR_NUMBER}, all checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
Adds `scripts/dev_tools/smoke_test_extract_pr_comments.py`, an end-to-end smoke test that runs the real `extract_pr_comments.py` via subprocess against a known, stable, merged PR and checks:
- exit code 0
- non-empty JSONL output, one valid JSON object per line
- every comment has `id`, `created_at`, `body`, `type`
- comments are ordered by `created_at` ascending

Also adds `make smoke-test-pr-comments` and documents the prerequisites (`gh` CLI, network) in `docs/CONTRIBUTING.md`.

## Why
#4526 introduced `extract_pr_comments.py` (pagination, timestamp filtering, dedup) with no tests — regression risk for future changes to pagination/filtering logic.

## Re-scoping from the original issue
The issue as filed named a non-existent `allotmint.fetch_pr_comments` module and suggested `octocat/Hello-World#1` as the target PR. Two corrections:
1. The real script is `scripts/dev_tools/extract_pr_comments.py` (same phantom-path pattern as #5035's cluster, just from a different source PR).
2. `octocat/Hello-World#1` turns out to hit a **real bug**: one of its review comments is from a deleted account (`"user": null`), which crashes `format_inline_comment()` with `AttributeError`. Fixing that is out of scope here per the issue's own constraint ("must not modify the existing script logic") — flagged separately. This PR instead targets `leonarduk/allotmint#4840`, a merged PR in this repo whose comments are all from bot accounts (no deleted-user risk).

## Why not wired into the required CI gate
`CLAUDE.md` and `docs/CONTRIBUTING.md` both call for mocking external integrations in the default `pytest`/`make lint` run, which is what backs the required PR checks. A test that hits the live GitHub API doesn't belong in that gate (flakiness, `gh` auth requirements for external contributors). Following the existing `lambda-test` precedent (also outside `testpaths`), this ships as an opt-in `make` target instead.

## Testing
- Ran `make smoke-test-pr-comments` locally — passes (`PASS: 5 comment(s) fetched from leonarduk/allotmint#4840, all checks passed.`)
- Verified the failure-path checks (missing field, out-of-order timestamps) raise correctly in isolation
- `python -m black`, `python -m ruff check` — clean

Closes #4531