### PR TITLE
feat(ci): move PR-linked issues to In Review on the project board

### DIFF
--- a/.github/workflows/project-status-in-review.yml
+++ b/.github/workflows/project-status-in-review.yml
@@ -7,7 +7,8 @@ name: Project Status — In Review
 #   - repo secret GH_PROJECT_TOKEN: a PAT with the `project` scope. The default
 #     GITHUB_TOKEN cannot write to Projects V2, so a PAT is required.
 #   - repo variable PROJECT_NUMBER: the project board number (defaults to 1).
-#   - a Status field on that board with an option named exactly "In Review".
+#   - a Status field on that board with an option named exactly "In review"
+#     (matches this repo's board; case-sensitive).
 #
 # If the PR body has no Closes/Fixes/Resolves #N reference, or the linked
 # issue isn't on the project board, this exits cleanly with no failure.
@@ -41,7 +42,7 @@ jobs:
         env:
           PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER || '1' }}
           ISSUE_NUMBER: ${{ steps.extract.outputs.issue_number }}
-          STATUS_OPTION_NAME: "In Review"
+          STATUS_OPTION_NAME: "In review"
         with:
           github-token: ${{ secrets.GH_PROJECT_TOKEN }}
           script: |

--- a/.github/workflows/project-status-in-review.yml
+++ b/.github/workflows/project-status-in-review.yml
@@ -50,99 +50,114 @@ jobs:
             const issueNumber = parseInt(process.env.ISSUE_NUMBER, 10);
             const statusOptionName = process.env.STATUS_OPTION_NAME;
 
-            // repositoryOwner + the ProjectV2Owner interface works for both
-            // user-owned and org-owned boards without needing to know which.
-            const { repositoryOwner } = await github.graphql(
-              `query($login: String!, $number: Int!) {
-                repositoryOwner(login: $login) {
-                  ... on ProjectV2Owner {
-                    projectV2(number: $number) { id }
-                  }
-                }
-              }`,
-              { login: owner, number: projectNumber }
-            );
-            const projectId = repositoryOwner?.projectV2?.id;
-            if (!projectId) {
-              core.setFailed(`Project #${projectNumber} not found for owner '${owner}'. Check the PROJECT_NUMBER repo variable.`);
-              return;
-            }
-
-            let statusFieldId;
-            let statusOptions;
-            let itemId;
-            let cursor = null;
-
-            do {
-              const result = await github.graphql(
-                `query($projectId: ID!, $cursor: String) {
-                  node(id: $projectId) {
-                    ... on ProjectV2 {
-                      field(name: "Status") {
-                        ... on ProjectV2SingleSelectField {
-                          id
-                          options { id name }
-                        }
-                      }
-                      items(first: 100, after: $cursor) {
-                        pageInfo { hasNextPage endCursor }
-                        nodes {
-                          id
-                          content { ... on Issue { number } }
-                        }
-                      }
+            // Wrapped so a GraphQL failure (e.g. GH_PROJECT_TOKEN missing the
+            // `project` scope) surfaces as one clear setFailed message instead
+            // of an unhandled-rejection stack trace.
+            try {
+              // repositoryOwner + the ProjectV2Owner interface works for both
+              // user-owned and org-owned boards without needing to know which.
+              const { repositoryOwner } = await github.graphql(
+                `query($login: String!, $number: Int!) {
+                  repositoryOwner(login: $login) {
+                    ... on ProjectV2Owner {
+                      projectV2(number: $number) { id }
                     }
                   }
                 }`,
-                { projectId, cursor }
+                { login: owner, number: projectNumber }
               );
-
-              const project = result.node;
-              statusFieldId = statusFieldId ?? project.field?.id;
-              statusOptions = statusOptions ?? project.field?.options;
-
-              const match = project.items.nodes.find(
-                (item) => item.content?.number === issueNumber
-              );
-              if (match) {
-                itemId = match.id;
-                break;
+              const projectId = repositoryOwner?.projectV2?.id;
+              if (!projectId) {
+                core.setFailed(`Project #${projectNumber} not found for owner '${owner}'. Check the PROJECT_NUMBER repo variable.`);
+                return;
               }
 
-              cursor = project.items.pageInfo.hasNextPage ? project.items.pageInfo.endCursor : null;
-            } while (cursor);
+              let statusFieldId;
+              let statusOptions;
+              let itemId;
+              let cursor = null;
 
-            if (!itemId) {
-              core.info(`Issue #${issueNumber} is not on project #${projectNumber}; nothing to do.`);
-              return;
-            }
+              do {
+                const result = await github.graphql(
+                  `query($projectId: ID!, $cursor: String) {
+                    node(id: $projectId) {
+                      ... on ProjectV2 {
+                        field(name: "Status") {
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            options { id name }
+                          }
+                        }
+                        items(first: 100, after: $cursor) {
+                          pageInfo { hasNextPage endCursor }
+                          nodes {
+                            id
+                            content { ... on Issue { number } }
+                          }
+                        }
+                      }
+                    }
+                  }`,
+                  { projectId, cursor }
+                );
 
-            if (!statusFieldId || !statusOptions) {
-              core.setFailed(`Project #${projectNumber} has no "Status" single-select field.`);
-              return;
-            }
+                const project = result.node;
+                statusFieldId = statusFieldId ?? project.field?.id;
+                statusOptions = statusOptions ?? project.field?.options;
 
-            const targetOption = statusOptions.find((o) => o.name === statusOptionName);
-            if (!targetOption) {
-              core.setFailed(
-                `Project #${projectNumber}'s Status field has no option named "${statusOptionName}" ` +
-                `(found: ${statusOptions.map((o) => o.name).join(", ")}).`
-              );
-              return;
-            }
-
-            await github.graphql(
-              `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $projectId,
-                  itemId: $itemId,
-                  fieldId: $fieldId,
-                  value: { singleSelectOptionId: $optionId }
-                }) {
-                  projectV2Item { id }
+                const match = project.items.nodes.find(
+                  (item) => item.content?.number === issueNumber
+                );
+                if (match) {
+                  itemId = match.id;
+                  break;
                 }
-              }`,
-              { projectId, itemId, fieldId: statusFieldId, optionId: targetOption.id }
-            );
 
-            core.info(`Moved issue #${issueNumber} to "${statusOptionName}" on project #${projectNumber}.`);
+                cursor = project.items.pageInfo.hasNextPage ? project.items.pageInfo.endCursor : null;
+              } while (cursor);
+
+              if (!itemId) {
+                core.info(`Issue #${issueNumber} is not on project #${projectNumber}; nothing to do.`);
+                return;
+              }
+
+              if (!statusFieldId || !statusOptions) {
+                core.setFailed(`Project #${projectNumber} has no "Status" single-select field.`);
+                return;
+              }
+
+              const targetOption = statusOptions.find((o) => o.name === statusOptionName);
+              if (!targetOption) {
+                core.setFailed(
+                  `Project #${projectNumber}'s Status field has no option named "${statusOptionName}" ` +
+                  `(found: ${statusOptions.map((o) => o.name).join(", ")}).`
+                );
+                return;
+              }
+
+              await github.graphql(
+                `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId,
+                    itemId: $itemId,
+                    fieldId: $fieldId,
+                    value: { singleSelectOptionId: $optionId }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }`,
+                { projectId, itemId, fieldId: statusFieldId, optionId: targetOption.id }
+              );
+
+              core.info(`Moved issue #${issueNumber} to "${statusOptionName}" on project #${projectNumber}.`);
+            } catch (error) {
+              if (error.message?.includes("INSUFFICIENT_SCOPES") || error.message?.includes("required scopes")) {
+                core.setFailed(
+                  `GH_PROJECT_TOKEN is missing the 'project' scope required for Projects V2 access. ` +
+                  `Regenerate the PAT with the 'project' scope (classic) or 'Projects' permission ` +
+                  `(fine-grained) and update the repo secret. Original error: ${error.message}`
+                );
+              } else {
+                core.setFailed(`Failed to update project status: ${error.message}`);
+              }
+            }

--- a/.github/workflows/project-status-in-review.yml
+++ b/.github/workflows/project-status-in-review.yml
@@ -1,0 +1,148 @@
+name: Project Status — In Review
+
+# Moves a PR's linked issue to the "In Review" status on the GitHub Projects V2
+# board when the PR is opened or reopened. See #4431.
+#
+# Requires:
+#   - repo secret GH_PROJECT_TOKEN: a PAT with the `project` scope. The default
+#     GITHUB_TOKEN cannot write to Projects V2, so a PAT is required.
+#   - repo variable PROJECT_NUMBER: the project board number (defaults to 1).
+#   - a Status field on that board with an option named exactly "In Review".
+#
+# If the PR body has no Closes/Fixes/Resolves #N reference, or the linked
+# issue isn't on the project board, this exits cleanly with no failure.
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  set-in-review:
+    name: Move linked issue to In Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract linked issue number
+        id: extract
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          issue_number=$(printf '%s' "$PR_BODY" | grep -ioE '(closes|fixes|resolves)[[:space:]]+#[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+          if [ -z "$issue_number" ]; then
+            echo "No linked issue found (no Closes/Fixes/Resolves #N in PR body); exiting cleanly."
+          fi
+          echo "issue_number=$issue_number" >> "$GITHUB_OUTPUT"
+
+      - name: Move issue to In Review
+        if: steps.extract.outputs.issue_number != ''
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71  # v9.0.0
+        env:
+          PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER || '1' }}
+          ISSUE_NUMBER: ${{ steps.extract.outputs.issue_number }}
+          STATUS_OPTION_NAME: "In Review"
+        with:
+          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const projectNumber = parseInt(process.env.PROJECT_NUMBER, 10);
+            const issueNumber = parseInt(process.env.ISSUE_NUMBER, 10);
+            const statusOptionName = process.env.STATUS_OPTION_NAME;
+
+            // repositoryOwner + the ProjectV2Owner interface works for both
+            // user-owned and org-owned boards without needing to know which.
+            const { repositoryOwner } = await github.graphql(
+              `query($login: String!, $number: Int!) {
+                repositoryOwner(login: $login) {
+                  ... on ProjectV2Owner {
+                    projectV2(number: $number) { id }
+                  }
+                }
+              }`,
+              { login: owner, number: projectNumber }
+            );
+            const projectId = repositoryOwner?.projectV2?.id;
+            if (!projectId) {
+              core.setFailed(`Project #${projectNumber} not found for owner '${owner}'. Check the PROJECT_NUMBER repo variable.`);
+              return;
+            }
+
+            let statusFieldId;
+            let statusOptions;
+            let itemId;
+            let cursor = null;
+
+            do {
+              const result = await github.graphql(
+                `query($projectId: ID!, $cursor: String) {
+                  node(id: $projectId) {
+                    ... on ProjectV2 {
+                      field(name: "Status") {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          options { id name }
+                        }
+                      }
+                      items(first: 100, after: $cursor) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          id
+                          content { ... on Issue { number } }
+                        }
+                      }
+                    }
+                  }
+                }`,
+                { projectId, cursor }
+              );
+
+              const project = result.node;
+              statusFieldId = statusFieldId ?? project.field?.id;
+              statusOptions = statusOptions ?? project.field?.options;
+
+              const match = project.items.nodes.find(
+                (item) => item.content?.number === issueNumber
+              );
+              if (match) {
+                itemId = match.id;
+                break;
+              }
+
+              cursor = project.items.pageInfo.hasNextPage ? project.items.pageInfo.endCursor : null;
+            } while (cursor);
+
+            if (!itemId) {
+              core.info(`Issue #${issueNumber} is not on project #${projectNumber}; nothing to do.`);
+              return;
+            }
+
+            if (!statusFieldId || !statusOptions) {
+              core.setFailed(`Project #${projectNumber} has no "Status" single-select field.`);
+              return;
+            }
+
+            const targetOption = statusOptions.find((o) => o.name === statusOptionName);
+            if (!targetOption) {
+              core.setFailed(
+                `Project #${projectNumber}'s Status field has no option named "${statusOptionName}" ` +
+                `(found: ${statusOptions.map((o) => o.name).join(", ")}).`
+              );
+              return;
+            }
+
+            await github.graphql(
+              `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId,
+                  itemId: $itemId,
+                  fieldId: $fieldId,
+                  value: { singleSelectOptionId: $optionId }
+                }) {
+                  projectV2Item { id }
+                }
+              }`,
+              { projectId, itemId, fieldId: statusFieldId, optionId: targetOption.id }
+            );
+
+            core.info(`Moved issue #${issueNumber} to "${statusOptionName}" on project #${projectNumber}.`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ checkouts, required PR steps, branch naming, `Closes #NNNN` linking).
 0. For any change touching existing files, read the current file content in full from disk before writing; do not rely on diff snippets or memory of earlier reads.
 1. Inspect `git status` and avoid disturbing user changes.
 2. Create or switch to the task branch before editing files; if the checkout is dirty with unrelated work, create a clean worktree from `main`.
+2b. When implementing a GitHub issue that's tracked on the Projects board, move its status to **In Progress** before writing any implementation code (if you have the project-scoped access to do so — the default `GITHUB_TOKEN` cannot write to Projects V2, so this may not be possible in every environment). Opening a PR with `Closes #NNNN` in its body later moves the issue to **In Review** automatically (see `.github/workflows/project-status-in-review.yml`, #4431).
 3. Read the exact script/package targets you plan to mention or change.
 4. Make the smallest coherent change.
 5. Run the narrowest useful validation.


### PR DESCRIPTION
## What
Adds `.github/workflows/project-status-in-review.yml`: on `pull_request: [opened, reopened]`, extracts the linked issue from `Closes/Fixes/Resolves #N` in the PR body and moves its Status field to **In Review** on the Projects V2 board, via GraphQL using the `GH_PROJECT_TOKEN` PAT (already provisioned as a repo secret) and `PROJECT_NUMBER` (already set to `15` as a repo variable).

Also documents the "In Progress" half of #4431 in `CLAUDE.md`'s Preferred workflow.

## Why / history
Re-implements the design from #4430, which was closed unmerged — not because the feature was rejected, but because that branch's head commit had picked up large, unrelated `deploy-lambda.yml` changes from a bad merge (flagged by AI review at the time). The secret and variable it asked for were already added and are still present. This PR is a clean re-implementation of just the workflow file.

## ⚠️ Not verified against the live project board
My GitHub token for this session lacks the `read:project` scope, so I could not query the actual board to confirm the Status field is named exactly `Status` or that it has an option named exactly `In Review`. The workflow is defensive about this: if either is missing, it fails loudly with a clear message (listing the actual option names found) rather than silently no-op-ing — but the first real run against this board is effectively the first live test.

**Before relying on this**, please either:
- Manually trigger it once via a small test PR with `Closes #<some-issue-already-on-the-board>` in the body, or
- Confirm directly on the board that the Status field is named `Status` with an `In Review` option.

## Testing
- `python -c "import yaml; yaml.safe_load(...)"` and `actionlint` — clean
- Extracted and `node --check`'d the embedded script — valid JS
- Could not run it end-to-end (see caveat above)

Closes #4431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests linked to an issue now automatically move the issue to **In Review** when opened or reopened.
  * Pull requests without a linked issue continue without interruption.

* **Documentation**
  * Added guidance to set tracked issues to **In Progress** before implementation begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->