### PR TITLE
fix(frontend): explain session-expiry on the sign-in wall instead of a bare gate

### DIFF
--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -9,6 +9,9 @@ interface Props {
   clientId: string;
   awsUiAuth?: AwsUiAuthConfig;
   onSuccess: () => void;
+  /** True when this page appeared because a previously-active session expired
+   * mid-use, rather than on a fresh, never-signed-in visit. See issue #5183. */
+  sessionExpired?: boolean;
 }
 
 declare global {
@@ -23,7 +26,12 @@ function sanitize(input: string): string {
   );
 }
 
-export default function LoginPage({ clientId, awsUiAuth, onSuccess }: Props) {
+export default function LoginPage({
+  clientId,
+  awsUiAuth,
+  onSuccess,
+  sessionExpired = false,
+}: Props) {
   const { setProfile } = useUser();
   const { setUser } = useAuth();
   const [error, setError] = useState<string | null>(null);
@@ -106,6 +114,15 @@ export default function LoginPage({ clientId, awsUiAuth, onSuccess }: Props) {
         marginTop: '2rem',
       }}
     >
+      {sessionExpired && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{ marginBottom: '1rem', textAlign: 'center' }}
+        >
+          Your session has expired. Please sign in again to continue.
+        </div>
+      )}
       {awsUiAuthEnabled ? (
         <div>
           {cognitoError && (

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -144,6 +144,14 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
   const [authed, setAuthed] = useState(
     Boolean(storedToken) || Boolean(getStoredCognitoIdToken()),
   );
+  // Distinguishes "session expired mid-use" from "never signed in yet" so the
+  // sign-in wall can explain *why* it appeared instead of silently discarding
+  // the user's in-progress session with no context. See issue #5183.
+  const [sessionExpired, setSessionExpired] = useState(false);
+  const authedRef = useRef(authed);
+  useEffect(() => {
+    authedRef.current = authed;
+  }, [authed]);
   // Resolved awsUiAuth: starts from the /config.json-derived prop; may be
   // overridden by cfg.awsUiAuth from the backend GET /config response (which
   // is authoritative and the source that #4610 was designed to enable).
@@ -180,6 +188,8 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
     setUser(null);
     setProfile(undefined);
     setAuthed(false);
+    // A deliberate, user-initiated logout is not a session expiry.
+    setSessionExpired(false);
     if (resolvedAwsUiAuth?.enabled) {
       cognitoLogout(resolvedAwsUiAuth);
     } else {
@@ -216,6 +226,10 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
       apiLogout();
       setUser(null);
       setProfile(undefined);
+      // Only a token that was previously valid (the user was actively using
+      // the app) counts as a session "expiring" — a first-time visitor with
+      // no prior session should still see the plain sign-in wall.
+      if (authedRef.current) setSessionExpired(true);
       setAuthed(false);
     };
     window.addEventListener(UNAUTHORIZED_EVENT, handleUnauthorized);
@@ -412,7 +426,11 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
         <LoginPage
           clientId={clientId}
           awsUiAuth={resolvedAwsUiAuth}
-          onSuccess={() => setAuthed(true)}
+          sessionExpired={sessionExpired}
+          onSuccess={() => {
+            setSessionExpired(false);
+            setAuthed(true);
+          }}
         />
       </>
     );

--- a/frontend/tests/unit/LoginPage.test.tsx
+++ b/frontend/tests/unit/LoginPage.test.tsx
@@ -98,3 +98,27 @@ describe('LoginPage awsUiAuth mode', () => {
     expect(screen.queryByRole('button', { name: /sign in/i })).toBeNull()
   })
 })
+
+describe('LoginPage sessionExpired messaging', () => {
+  it('shows a session-expired explanation when sessionExpired is true', () => {
+    render(
+      <BrowserRouter>
+        <LoginPage clientId="google-cid" onSuccess={() => {}} sessionExpired />
+      </BrowserRouter>,
+    )
+
+    expect(
+      screen.getByText(/your session has expired/i),
+    ).toBeInTheDocument()
+  })
+
+  it('does not show the session-expired explanation on a fresh visit', () => {
+    render(
+      <BrowserRouter>
+        <LoginPage clientId="google-cid" onSuccess={() => {}} />
+      </BrowserRouter>,
+    )
+
+    expect(screen.queryByText(/your session has expired/i)).toBeNull()
+  })
+})

--- a/frontend/tests/unit/rootBootstrap.test.tsx
+++ b/frontend/tests/unit/rootBootstrap.test.tsx
@@ -228,6 +228,86 @@ describe('Root bootstrap integration coverage', () => {
     expect(localStorage.getItem('authToken')).toBeNull()
   })
 
+  it('tells the login page the session expired when a previously-valid token is rejected mid-session (issue #5183)', async () => {
+    // Same stale-token setup as the #4674 test above, but asserts the
+    // sign-in wall is told *why* it appeared, so it can show a clear,
+    // recoverable message instead of a bare, unexplained "Sign in" button.
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    localStorage.setItem('authToken', 'stale-expired-token')
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: true,
+          google_client_id: 'client-123',
+          disable_auth: false
+        }),
+        getStoredAuthToken: vi.fn(() => 'stale-expired-token')
+      }
+    })
+
+    vi.doMock('@/LoginPage', () => ({
+      default: ({ sessionExpired }: { sessionExpired?: boolean }) => (
+        <div data-testid="login-page" data-session-expired={String(Boolean(sessionExpired))}>
+          sign in
+        </div>
+      )
+    }))
+
+    vi.doMock('@/App.tsx', async () => {
+      const { useEffect } = await import('react')
+      function StaleTokenApp() {
+        useEffect(() => {
+          window.dispatchEvent(new Event(UNAUTHORIZED_EVENT))
+        }, [])
+        return <div data-testid="app-shell">App ready</div>
+      }
+      return { default: StaleTokenApp }
+    })
+
+    await mountRoot()
+
+    const loginPage = await screen.findByTestId('login-page')
+    expect(loginPage).toHaveAttribute('data-session-expired', 'true')
+  })
+
+  it('does not tell the login page the session expired on a first-time, never-authenticated visit', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: true,
+          google_client_id: 'client-123',
+          disable_auth: false
+        }),
+        getStoredAuthToken: vi.fn(() => null)
+      }
+    })
+
+    vi.doMock('@/LoginPage', () => ({
+      default: ({ sessionExpired }: { sessionExpired?: boolean }) => (
+        <div data-testid="login-page" data-session-expired={String(Boolean(sessionExpired))}>
+          sign in
+        </div>
+      )
+    }))
+
+    await mountRoot()
+
+    const loginPage = await screen.findByTestId('login-page')
+    expect(loginPage).toHaveAttribute('data-session-expired', 'false')
+  })
+
   it('shows login page when backend cfg carries awsUiAuth.enabled and disable_auth=true', async () => {
     // Covers the primary path: backend GET /config is authoritative.
     // /config.json has no awsUiAuth (prop is absent), but the backend response


### PR DESCRIPTION
## Summary

- Investigated #5183 (anonymous session hard-locks to a bare "Sign in" wall after a backend 403). Code review of `frontend/src` and `backend/auth.py`/`backend/common/authz.py` confirms: a **403** from a single endpoint (e.g. `/accounts/{owner}/approvals`) is already handled locally by its caller and does **not** propagate to any global "must sign in" state — only a **401** does, via `UNAUTHORIZED_EVENT` in `api.ts` → `Root`'s listener in `main.tsx`.
- The reproducible bug is in that 401 path: when a previously-valid session's token is rejected mid-use, `Root` correctly falls back to `authed=false` and renders `LoginPage` — but with zero context. It's visually identical to a brand-new visitor's first-ever sign-in screen, which matches the report's "bare, contentless Sign in wall... no explanation" symptom exactly.
- This PR tracks whether the sign-in wall appeared because an *active* session expired vs. a fresh/never-authenticated visit, and shows "Your session has expired. Please sign in again to continue." in the former case, addressing the issue's "Success looks like" criterion directly.
- A deliberate, user-initiated logout is explicitly excluded from this messaging (it isn't a surprise expiry).

## Note on scope

I could not fully reconstruct the exact mechanism that produced the specific 403 seen in the deployed build (`GET /accounts/alex/approvals` → 403) from code alone — `ensure_owner_access` and `_resolve_identity_when_auth_disabled` no-op/gracefully reject as designed in `disable_auth` mode, and no code path converts a bare 403 into a global auth gate today. This PR fixes the concrete, reproducible UX gap (unexplained sign-in wall on session expiry) rather than guessing at an unconfirmed backend cause. If the 403 recurs, the backend identity/token logs around `_resolve_identity_when_auth_disabled` (backend/auth.py) would be the next place to look.

## Test plan

- [x] `npx vitest --run tests/unit/LoginPage.test.tsx tests/unit/rootBootstrap.test.tsx` — new coverage for `sessionExpired` messaging and the Root→LoginPage wiring (issue #4674-style stale-token scenario)
- [x] `npx vitest --run tests/unit/main.test.tsx tests/unit/logoutFlowCognito.test.tsx tests/unit/logoutFlowLocalDev.test.tsx tests/unit/main.cognitoRefreshCleanup.test.tsx tests/unit/configRetrySuccess.test.tsx tests/unit/loginClientId.test.tsx` — no regressions in adjacent auth flows
- [x] `npx eslint` / `npx tsc --noEmit` clean on changed files

Closes #5183