### PR TITLE
feat(backend): add max_results to data-quality/timeseries endpoint

### DIFF
--- a/backend/routes/data_quality.py
+++ b/backend/routes/data_quality.py
@@ -60,6 +60,9 @@ async def get_timeseries_quality(
     rolling_window: int = Query(
         DEFAULT_ROLLING_WINDOW, ge=2, le=250, description="Rolling window size (trading days) for outlier detection"
     ),
+    max_results: int | None = Query(
+        None, ge=1, le=1000, description="Limit the number of distinct ticker/exchange pairs processed"
+    ),
 ):
     if bool(ticker) != bool(exchange):
         raise HTTPException(status_code=400, detail="ticker and exchange must be provided together")
@@ -72,6 +75,10 @@ async def get_timeseries_quality(
         pairs = [(tkr, exch)]
     else:
         pairs = list_cached_meta_tickers()
+
+    truncated = max_results is not None and len(pairs) > max_results
+    if max_results is not None:
+        pairs = pairs[:max_results]
 
     results = []
     for tkr, exch in pairs:
@@ -96,4 +103,4 @@ async def get_timeseries_quality(
             )
         )
 
-    return JSONResponse(content={"count": len(results), "positions": results})
+    return JSONResponse(content={"count": len(results), "positions": results, "truncated": truncated})

--- a/tests/routes/test_data_quality.py
+++ b/tests/routes/test_data_quality.py
@@ -39,8 +39,35 @@ def test_lists_quality_for_all_cached_tickers(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["count"] == 2
+    assert data["truncated"] is False
     tickers = {(p["ticker"], p["exchange"]) for p in data["positions"]}
     assert tickers == {("ABC", "L"), ("XYZ", "N")}
+
+
+def test_max_results_limits_pairs_and_sets_truncated(monkeypatch):
+    cached = {("ABC", "L"): _clean_df(), ("XYZ", "N"): _clean_df()}
+    client = _client(monkeypatch, cached)
+    resp = client.get("/data-quality/timeseries?max_results=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["truncated"] is True
+
+
+def test_max_results_larger_than_total_is_not_truncated(monkeypatch):
+    cached = {("ABC", "L"): _clean_df(), ("XYZ", "N"): _clean_df()}
+    client = _client(monkeypatch, cached)
+    resp = client.get("/data-quality/timeseries?max_results=10")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 2
+    assert data["truncated"] is False
+
+
+def test_max_results_out_of_range_rejected(monkeypatch):
+    client = _client(monkeypatch, {})
+    resp = client.get("/data-quality/timeseries?max_results=0")
+    assert resp.status_code == 400
 
 
 def test_filters_to_single_ticker(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds an optional `max_results` query parameter (1-1000) to `GET /data-quality/timeseries` that limits the number of distinct ticker/exchange pairs processed in a single request.
- Adds a `truncated: bool` field to the response, set to `true` when the pair list was capped.
- No change to existing behavior when `max_results` is omitted.

## Why
Guards against Lambda timeouts and oversized payloads as the cached ticker universe grows, per #4956 (follow-up from #4946).

## Test plan
- [x] `pytest tests/routes/test_data_quality.py tests/timeseries/test_quality.py tests/test_data_quality_cache_helpers.py` — 25 passed
- [x] `black --check --config backend/pyproject.toml` / `ruff check --config backend/pyproject.toml` on changed files — clean
- [x] New tests cover: limiting + truncated=true, limit larger than total (truncated=false), and out-of-range value rejected (400)

Closes #4956