### PR TITLE
fix: register POST /token as unauthenticated at API Gateway

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -632,6 +632,22 @@ class BackendLambdaStack(Stack):
             integration=backend_integration,
             authorizer=apigwv2.HttpNoneAuthorizer(),
         )
+        # POST /token is the Google-login exchange endpoint documented in
+        # docs/AUTH.md ("The frontend POSTs { id_token } to POST /token") and
+        # called directly by mobile/App.tsx. Like POST /token/google above, the
+        # caller has no Cognito/app token yet — they are presenting a Google ID
+        # token (or, in local/dev-only branches, a username) to obtain a backend
+        # JWT. Without an explicit route here it falls through to the
+        # /{proxy+} ANY catch-all and backend_authorizer rejects it with 401
+        # before backend/app.py's login() ever runs — the same class of bug
+        # already fixed for GET /config, POST /token/google, and POST
+        # /signup/* (audit follow-up from #4798, issue #4800).
+        backend_api.add_routes(
+            path="/token",
+            methods=[apigwv2.HttpMethod.POST],
+            integration=backend_integration,
+            authorizer=apigwv2.HttpNoneAuthorizer(),
+        )
         # POST /signup/request, and the /signup/approve and /signup/reject
         # GET+POST pairs, are the public account-request/admin-approval flow
         # (see the module docstring in backend/routes/signup.py). None of these

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -627,8 +627,8 @@ def test_backend_api_authorizer_accepts_cognito_id_token_contract(template):
 
 def test_backend_api_routes_require_cognito_authorizer(template):
     """All API Gateway routes must require Cognito JWT authorization except
-    /health, GET /config, POST /token/google, the public /signup/* routes, and
-    the CORS preflight OPTIONS routes.
+    /health, GET /config, POST /token, POST /token/google, the public
+    /signup/* routes, and the CORS preflight OPTIONS routes.
 
     /health is intentionally unauthenticated so that post-deploy probes and
     smoke tests can confirm Lambda is reachable without needing a Cognito token.
@@ -636,6 +636,13 @@ def test_backend_api_routes_require_cognito_authorizer(template):
     pre-auth bootstrap endpoint (frontend/src/main.tsx Root.fetchConfig) used
     to determine whether auth is required at all; PUT /config remains
     JWT-protected via the /{proxy+} catch-all.
+    POST /token is intentionally unauthenticated: it is the Google-login
+    exchange endpoint documented in docs/AUTH.md and called directly by
+    mobile/App.tsx. The caller presents a Google ID token (or, in local/dev
+    branches, a username) with no Authorization header at all, so
+    backend_authorizer would reject it with 401 before backend/app.py's
+    login() ever runs — the same class of bug as POST /token/google below
+    (audit follow-up from #4798, issue #4800).
     POST /token/google is intentionally unauthenticated because it exchanges a
     Google ID token (frontend/src/LoginPage.tsx, sent with no Authorization
     header) for an app JWT — backend_authorizer would reject it with 401 before
@@ -659,6 +666,7 @@ def test_backend_api_routes_require_cognito_authorizer(template):
     UNAUTHENTICATED_ROUTES = {
         "GET /health",
         "GET /config",
+        "POST /token",
         "POST /token/google",
         "POST /signup/request",
         "GET /signup/approve",
@@ -741,6 +749,37 @@ def test_signup_routes_use_http_none_authorizer(template):
     )
 
     for route_key, properties in signup_routes.items():
+        assert properties.get("AuthorizationType") == "NONE", (
+            f"Route {route_key} must use HttpNoneAuthorizer (AuthorizationType "
+            f"NONE), got {properties.get('AuthorizationType')!r}"
+        )
+        assert "AuthorizerId" not in properties, (
+            f"Route {route_key} must not reference an authorizer resource"
+        )
+
+
+def test_token_route_uses_http_none_authorizer(template):
+    """Positively assert that POST /token is registered with
+    HttpNoneAuthorizer (AuthorizationType NONE), not just absent from the
+    Cognito-authorizer set.
+
+    test_backend_api_routes_require_cognito_authorizer above already proves
+    this route is unauthenticated via a negative check (not in the JWT set).
+    This test documents and enforces the specific intended authorizer,
+    mirroring test_signup_routes_use_http_none_authorizer (audit follow-up
+    from #4798, issue #4800).
+    """
+    routes = template.find_resources("AWS::ApiGatewayV2::Route")
+    assert routes, "Expected at least one API Gateway route"
+
+    token_routes = {
+        resource["Properties"].get("RouteKey", logical_id): resource["Properties"]
+        for logical_id, resource in routes.items()
+        if resource["Properties"].get("RouteKey", "") == "POST /token"
+    }
+    assert set(token_routes) == {"POST /token"}
+
+    for route_key, properties in token_routes.items():
         assert properties.get("AuthorizationType") == "NONE", (
             f"Route {route_key} must use HttpNoneAuthorizer (AuthorizationType "
             f"NONE), got {properties.get('AuthorizationType')!r}"


### PR DESCRIPTION
## Summary
- Audited the `/{proxy+}` catch-all's implicit route set (issue #4800, follow-up from #4798) for other endpoints that should be public but were falling through to `backend_authorizer` (Cognito JWT).
- Found `POST /token` — the Google-login exchange endpoint documented in `docs/AUTH.md` ("The frontend POSTs `{ id_token }` to `POST /token`") and called directly by `mobile/App.tsx` (and `frontend/src/api.ts`'s `login()` helper). The caller presents a Google ID token before it has any Cognito/app credential, so without an explicit route it fell through to the `/{proxy+}` ANY catch-all and would be rejected with 401 by `backend_authorizer` before `backend/app.py`'s `login()` ever ran — the same class of bug already fixed for `GET /config`, `POST /token/google`, and `POST /signup/*`.
- Added an explicit `HttpNoneAuthorizer()` route registration for `POST /token` in `cdk/stacks/backend_lambda_stack.py`, mirroring the existing `POST /token/google` pattern.
- Extended `test_backend_api_routes_require_cognito_authorizer`'s `UNAUTHENTICATED_ROUTES` set to include `POST /token`.
- Added `test_token_route_uses_http_none_authorizer`, a positive assertion (not just absence from the Cognito set) that the route uses `HttpNoneAuthorizer` specifically, mirroring `test_signup_routes_use_http_none_authorizer`.

No other unregistered public endpoints were found in this audit: `/whoami` and `/api-console` are intentionally admin-gated (`require_admin`) and correctly stay behind Cognito via the catch-all; `POST /token/cognito` is deliberately left Cognito-protected (documented, with an existing regression test).

## Test plan
- [x] `python -m pytest cdk/tests/test_backend_lambda_stack.py -v --no-cov` — 48 passed
- [x] `python -m pytest tests/test_main.py tests/test_google_auth.py tests/test_auth_google.py --no-cov -q` — 36 passed
- [x] `python -m black --check cdk/stacks/backend_lambda_stack.py` — clean (pre-existing formatting drift in the test file is unrelated to this change and left untouched)
- [x] `python -m ruff check cdk/stacks/backend_lambda_stack.py cdk/tests/test_backend_lambda_stack.py` — clean

Closes #4800
