### PR TITLE
fix: emit truncated flag when PR comment pagination fails mid-stream

### DIFF
--- a/scripts/dev_tools/extract_pr_comments.py
+++ b/scripts/dev_tools/extract_pr_comments.py
@@ -87,8 +87,8 @@ def get_pr_head_commit_date(owner: str, repo: str, pr: int) -> str:
     return get_commit_date(owner, repo, sha.strip())
 
 
-def fetch_paginated(owner: str, repo: str, endpoint: str) -> list[dict[str, Any]]:
-    """Fetch paginated API endpoint, return all items."""
+def fetch_paginated(owner: str, repo: str, endpoint: str) -> tuple[list[dict[str, Any]], bool]:
+    """Fetch paginated API endpoint, return (items, truncated)."""
     items: list[dict[str, Any]] = []
     page = 1
 
@@ -105,15 +105,15 @@ def fetch_paginated(owner: str, repo: str, endpoint: str) -> list[dict[str, Any]
                     f"collecting {len(items)} items. Returning partial results.",
                     file=sys.stderr,
                 )
-                return items
+                return items, True
             print(f"Error: API request to {endpoint} page {page} failed.", file=sys.stderr)
-            return []
+            return [], True
 
         try:
             data = json.loads(output) if output else []
         except json.JSONDecodeError:
             print(f"Error: Failed to parse JSON from {endpoint} page {page}.", file=sys.stderr)
-            return items
+            return items, True
 
         if not isinstance(data, list) or len(data) == 0:
             break
@@ -121,13 +121,13 @@ def fetch_paginated(owner: str, repo: str, endpoint: str) -> list[dict[str, Any]
         items.extend(data)
         page += 1
 
-    return items
+    return items, False
 
 
-def fetch_reviews(owner: str, repo: str, pr: int) -> dict[int, bool]:
+def fetch_reviews(owner: str, repo: str, pr: int) -> tuple[dict[int, bool], bool]:
     """Fetch reviews and map review_id -> is_currently_dismissed (resolved)."""
     endpoint = f"/repos/{owner}/{repo}/pulls/{pr}/reviews"
-    reviews = fetch_paginated(owner, repo, endpoint)
+    reviews, truncated = fetch_paginated(owner, repo, endpoint)
     review_dismissed: dict[int, bool] = {}
 
     if not reviews:
@@ -136,7 +136,7 @@ def fetch_reviews(owner: str, repo: str, pr: int) -> dict[int, bool]:
             "will default to false. This may indicate an API error.",
             file=sys.stderr,
         )
-        return review_dismissed
+        return review_dismissed, truncated
 
     for review in reviews:
         if isinstance(review, dict):
@@ -146,16 +146,16 @@ def fetch_reviews(owner: str, repo: str, pr: int) -> dict[int, bool]:
             if review_id is not None:
                 review_dismissed[review_id] = is_dismissed
 
-    return review_dismissed
+    return review_dismissed, truncated
 
 
-def fetch_inline_comments(owner: str, repo: str, pr: int) -> list[dict[str, Any]]:
+def fetch_inline_comments(owner: str, repo: str, pr: int) -> tuple[list[dict[str, Any]], bool]:
     """Fetch inline review thread comments."""
     endpoint = f"/repos/{owner}/{repo}/pulls/{pr}/comments"
     return fetch_paginated(owner, repo, endpoint)
 
 
-def fetch_top_level_comments(owner: str, repo: str, pr: int) -> list[dict[str, Any]]:
+def fetch_top_level_comments(owner: str, repo: str, pr: int) -> tuple[list[dict[str, Any]], bool]:
     """Fetch top-level issue/PR comments."""
     endpoint = f"/repos/{owner}/{repo}/issues/{pr}/comments"
     return fetch_paginated(owner, repo, endpoint)
@@ -253,11 +253,12 @@ def process_comments(
     pr_number: int,
     since_timestamp: datetime,
     skip_resolved: bool,
-) -> list[dict[str, Any]]:
-    """Fetch, filter, and deduplicate comments."""
-    review_dismissed = fetch_reviews(owner, repo, pr_number)
-    inline_comments = fetch_inline_comments(owner, repo, pr_number)
-    top_level_comments = fetch_top_level_comments(owner, repo, pr_number)
+) -> tuple[list[dict[str, Any]], bool]:
+    """Fetch, filter, and deduplicate comments. Returns (comments, truncated)."""
+    review_dismissed, reviews_truncated = fetch_reviews(owner, repo, pr_number)
+    inline_comments, inline_truncated = fetch_inline_comments(owner, repo, pr_number)
+    top_level_comments, top_level_truncated = fetch_top_level_comments(owner, repo, pr_number)
+    truncated = reviews_truncated or inline_truncated or top_level_truncated
 
     inline_comments = filter_by_timestamp(inline_comments, since_timestamp)
     top_level_comments = filter_by_timestamp(top_level_comments, since_timestamp)
@@ -280,21 +281,27 @@ def process_comments(
             deduped.append(comment)
             seen_ids.add(comment_id)
 
-    return deduped
+    return deduped, truncated
 
 
 def write_output(
-    comments: list[dict[str, Any]], output_file: str | None, format_type: str
+    comments: list[dict[str, Any]],
+    output_file: str | None,
+    format_type: str,
+    truncated: bool = False,
 ) -> int:
     """Write comments to output file or stdout in the specified format."""
     formatter = to_fixer if format_type == "fixer" else to_jsonl
+    lines = list(formatter(comments))
+    if truncated and format_type == "jsonl":
+        lines.append(json.dumps({"truncated": True}))
     try:
         if output_file:
             with open(output_file, "w", encoding="utf-8") as f:
-                for line in formatter(comments):
+                for line in lines:
                     f.write(line + "\n")
         else:
-            for line in formatter(comments):
+            for line in lines:
                 print(line)
     except OSError as e:
         print(f"Error writing output: {e}", file=sys.stderr)
@@ -312,16 +319,18 @@ def main() -> int:
         owner, repo = infer_repo()
 
     since_timestamp = determine_since_timestamp(args, owner, repo)
-    deduped = process_comments(owner, repo, args.pr, since_timestamp, args.skip_resolved)
+    deduped, truncated = process_comments(
+        owner, repo, args.pr, since_timestamp, args.skip_resolved
+    )
 
-    if not deduped:
+    if not deduped and not truncated:
         print(
             f"No comments found for PR {args.pr} after {since_timestamp.isoformat()}.",
             file=sys.stderr,
         )
         return 0
 
-    return write_output(deduped, args.output, args.format)
+    return write_output(deduped, args.output, args.format, truncated)
 
 
 if __name__ == "__main__":

--- a/tests/test_extract_pr_comments.py
+++ b/tests/test_extract_pr_comments.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts" / "dev_tools"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def load_extract_pr_comments():
+    spec = importlib.util.spec_from_file_location(
+        "extract_pr_comments_test", SCRIPTS_DIR / "extract_pr_comments.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return load_extract_pr_comments()
+
+
+# --- fetch_paginated() truncation tests ---
+
+
+def test_fetch_paginated_all_pages_succeed(mod):
+    pages = [
+        json.dumps([{"id": 1}, {"id": 2}]),
+        json.dumps([]),
+    ]
+    with patch.object(mod, "run_gh_command", side_effect=[(p, 0) for p in pages]):
+        items, truncated = mod.fetch_paginated("owner", "repo", "/some/endpoint")
+
+    assert items == [{"id": 1}, {"id": 2}]
+    assert truncated is False
+
+
+def test_fetch_paginated_partial_failure_returns_truncated(mod):
+    responses = [
+        (json.dumps([{"id": 1}]), 0),
+        ("", 1),
+    ]
+    with patch.object(mod, "run_gh_command", side_effect=responses):
+        items, truncated = mod.fetch_paginated("owner", "repo", "/some/endpoint")
+
+    assert items == [{"id": 1}]
+    assert truncated is True
+
+
+def test_fetch_paginated_first_page_failure_returns_truncated(mod):
+    with patch.object(mod, "run_gh_command", return_value=("", 1)):
+        items, truncated = mod.fetch_paginated("owner", "repo", "/some/endpoint")
+
+    assert items == []
+    assert truncated is True
+
+
+def test_fetch_paginated_invalid_json_returns_truncated(mod):
+    responses = [
+        (json.dumps([{"id": 1}]), 0),
+        ("not json", 0),
+    ]
+    with patch.object(mod, "run_gh_command", side_effect=responses):
+        items, truncated = mod.fetch_paginated("owner", "repo", "/some/endpoint")
+
+    assert items == [{"id": 1}]
+    assert truncated is True
+
+
+# --- write_output() truncated-flag placement tests ---
+
+
+def test_write_output_jsonl_no_truncation_unchanged(mod, capsys):
+    comments = [{"id": 1, "body": "hi"}]
+    mod.write_output(comments, None, "jsonl", truncated=False)
+    out = capsys.readouterr().out.strip().splitlines()
+
+    assert out == [json.dumps({"id": 1, "body": "hi"})]
+
+
+def test_write_output_jsonl_truncated_appends_last_line(mod, capsys):
+    comments = [{"id": 1, "body": "hi"}]
+    mod.write_output(comments, None, "jsonl", truncated=True)
+    out = capsys.readouterr().out.strip().splitlines()
+
+    assert out[-1] == json.dumps({"truncated": True})
+    assert out[0] == json.dumps({"id": 1, "body": "hi"})
+
+
+def test_write_output_fixer_format_ignores_truncated(mod, capsys):
+    comments = [{"id": 1, "type": "top-level", "body": "hi"}]
+    mod.write_output(comments, None, "fixer", truncated=True)
+    out = capsys.readouterr().out
+
+    assert "truncated" not in out
+
+
+# --- process_comments() propagation test ---
+
+
+def test_process_comments_propagates_truncated(mod):
+    with (
+        patch.object(mod, "fetch_reviews", return_value=({}, False)),
+        patch.object(mod, "fetch_inline_comments", return_value=([], True)),
+        patch.object(mod, "fetch_top_level_comments", return_value=([], False)),
+    ):
+        comments, truncated = mod.process_comments(
+            "owner", "repo", 1, mod.parse_iso_datetime("2020-01-01T00:00:00Z"), False
+        )
+
+    assert comments == []
+    assert truncated is True


### PR DESCRIPTION
## Summary
- `fetch_paginated` in `scripts/dev_tools/extract_pr_comments.py` now returns `(items, truncated)` instead of a bare list, so a mid-stream pagination failure is no longer silent.
- `fetch_reviews`, `fetch_inline_comments`, `fetch_top_level_comments`, and `process_comments` propagate the truncation flag through to `main`.
- `write_output` appends a final `{"truncated": true}` line to `--format jsonl` output when any of the paginated fetches failed partway through. Non-truncated runs and the `fixer` format are byte-for-byte unchanged.

## Test plan
- [x] `python -m pytest tests/test_extract_pr_comments.py -q --no-cov` — 8 new unit tests covering: all-pages-succeed, partial-failure, first-page-failure, invalid-JSON, jsonl output with/without truncation, fixer format ignoring the flag, and propagation through `process_comments`.
- [x] `python -m py_compile scripts/dev_tools/extract_pr_comments.py`
- [x] `ruff check` on changed files (one pre-existing unused-import warning unrelated to this change)

Closes #4537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
