### PR TITLE
fix: deep-copy routes in signup create_router to prevent shared-reference mutation

### DIFF
--- a/backend/routes/signup.py
+++ b/backend/routes/signup.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import logging
 import os
+from copy import deepcopy
 from json import JSONDecodeError
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -286,10 +287,12 @@ def create_router(
     limited_request = limiter.limit(rate_limit)(_post_signup_request_impl)
     limited.post("/request")(limited_request)
 
-    # Other routes are copied from the module-level router without rate limits
+    # Other routes are copied from the module-level router without rate limits.
+    # Deep-copy so mutating a route on `limited` can't corrupt the shared
+    # module-level `router` (and vice versa).
     for route in router.routes:
         if getattr(route, "path", None) == "/request":
             continue  # already registered above with rate limit
-        limited.routes.append(route)
+        limited.routes.append(deepcopy(route))
 
     return limited

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -486,6 +486,27 @@ def test_rate_limited_invalid_payload_still_400(rate_limited_client, monkeypatch
     assert resp.status_code == 429
 
 
+def test_create_router_copies_are_independent_of_module_router():
+    """Routes on the rate-limited router (#4436) must not alias module-level ones.
+
+    ``create_router`` copies non-``/request`` routes from the module-level
+    ``router`` onto the new limited router. If those were the same objects,
+    mutating a route on one router would silently corrupt the other.
+    """
+
+    limiter = Limiter(key_func=get_remote_address, storage_uri="memory://")
+    limited = signup_module.create_router(limiter, "3/minute")
+
+    module_route = next(r for r in signup_module.router.routes if r.path == "/signup/approve")
+    limited_route = next(r for r in limited.routes if r.path == "/signup/approve")
+
+    assert limited_route is not module_route
+
+    original_endpoint = module_route.endpoint
+    limited_route.endpoint = lambda: None
+    assert module_route.endpoint is original_endpoint
+
+
 def test_throttling_response_is_identical_for_all_emails(rate_limited_client, monkeypatch):
     """Rate-limit response must not leak whether an email has an account."""
 


### PR DESCRIPTION
## Summary
- `create_router()` in `backend/routes/signup.py` copied non-`/request` routes from the module-level `router` onto the new rate-limited router by appending the same `APIRoute` objects, creating a shared reference between the two routers.
- Mutating a route on `limited` (e.g. adding middleware/dependencies) would have silently corrupted the module-level `router` used elsewhere (and by tests).
- Fixed by `copy.deepcopy`-ing each route before appending it to `limited`.

## Test plan
- [x] Added `test_create_router_copies_are_independent_of_module_router` asserting the copied route is a distinct object and that mutating its endpoint doesn't affect the module-level route.
- [x] `python -m pytest tests/backend/routes/test_signup.py -q --no-cov` — 26 passed.

Closes #4436

🤖 Generated with [Claude Code](https://claude.com/claude-code)