### PR TITLE
fix: allow Value to take precedence when Units+Price are also filled

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -275,7 +275,7 @@ def _validate_manual_holding_payload(payload: ManualHoldingCreate) -> None:
     has_price = payload.price_gbp is not None
     has_units_price = has_units and has_price
     has_partial_units_price = has_units != has_price
-    if has_partial_units_price or has_value == has_units_price:
+    if has_partial_units_price or not (has_value or has_units_price):
         raise HTTPException(
             status_code=400,
             detail="Provide either value_gbp or both units and price_gbp",

--- a/frontend/src/components/TransactionsPage.tsx
+++ b/frontend/src/components/TransactionsPage.tsx
@@ -245,7 +245,7 @@ export function TransactionsPage({ owners, inputOnly = false }: Props) {
 
     const hasValue = hasValueInput;
     const hasUnitsPrice = hasUnitsInput && hasPriceInput;
-    if (hasValue === hasUnitsPrice) {
+    if (!hasValue && !hasUnitsPrice) {
       setManualError('Provide either Value (GBP) or both Units + Price (GBP).');
       return;
     }

--- a/frontend/tests/unit/components/TransactionsPage.test.tsx
+++ b/frontend/tests/unit/components/TransactionsPage.test.tsx
@@ -301,6 +301,39 @@ describe('TransactionsPage', () => {
     expect(createManualHoldingMock).not.toHaveBeenCalled();
   });
 
+  it('saves using Value when Value, Units, and Price are all provided', async () => {
+    const user = userEvent.setup();
+    render(
+      <TransactionsPage
+        owners={[
+          { owner: 'alex', full_name: 'Alex Example', accounts: ['isa'] },
+        ]}
+        inputOnly
+      />
+    );
+
+    await screen.findByText('Account + Holdings Input');
+    await user.type(screen.getByLabelText('Account'), 'ISA');
+    await user.type(screen.getByLabelText(/^Ticker$/i), 'VUSA.L');
+    await user.type(screen.getByLabelText('Value (GBP)'), '500');
+    await user.type(screen.getByLabelText('Units'), '5');
+    await user.type(screen.getByLabelText('Price (GBP)'), '100');
+    await user.click(screen.getByRole('button', { name: 'Save holding' }));
+
+    await waitFor(() => {
+      expect(createManualHoldingMock).toHaveBeenCalledWith(
+        expect.objectContaining({ value_gbp: 500 })
+      );
+    });
+    expect(createManualHoldingMock.mock.calls[0][0]).not.toHaveProperty(
+      'units'
+    );
+    expect(createManualHoldingMock.mock.calls[0][0]).not.toHaveProperty(
+      'price_gbp'
+    );
+    expect(screen.getByText('Holding saved.')).toBeInTheDocument();
+  });
+
   it('defaults the manual owner input to the logged-in user\'s owner', async () => {
     render(
       <AuthContext.Provider

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -580,18 +580,28 @@ def test_create_manual_holding_updates_existing_ticker_in_account(tmp_path, monk
     assert saved["holdings"] == [{"ticker": "VUSA.L", "units": 3.0, "price": 100.0}]
 
 
+def test_create_manual_holding_with_value_takes_precedence_over_units_and_price(
+    tmp_path, monkeypatch
+):
+    client = _make_client(tmp_path, monkeypatch)
+    payload = {
+        "owner": "alice",
+        "account": "SIPP",
+        "ticker": "MSFT",
+        "value_gbp": 500,
+        "units": 5,
+        "price_gbp": 100,
+    }
+
+    resp = client.post("/holdings/manual", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["holding"] == {"ticker": "MSFT", "value_gbp": 500.0}
+
+
 def test_create_manual_holding_rejects_invalid_metric_combo(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch)
 
     invalid_payloads = [
-        {
-            "owner": "alice",
-            "account": "SIPP",
-            "ticker": "MSFT",
-            "value_gbp": 10,
-            "units": 1,
-            "price_gbp": 10,
-        },
         {
             "owner": "alice",
             "account": "SIPP",

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -621,6 +621,18 @@ def test_create_manual_holding_rejects_invalid_metric_combo(tmp_path, monkeypatc
             "value_gbp": 10,
             "price_gbp": 10,
         },
+        {
+            "owner": "alice",
+            "account": "SIPP",
+            "ticker": "MSFT",
+            "units": 1,
+        },
+        {
+            "owner": "alice",
+            "account": "SIPP",
+            "ticker": "MSFT",
+            "price_gbp": 10,
+        },
     ]
 
     for payload in invalid_payloads:


### PR DESCRIPTION
## Summary
- Fixes the manual holding form/API rejecting saves when Value, Units, and Price are all filled in at once.
- Value now takes precedence over Units+Price when both are provided; the error only fires when neither a Value nor a complete Units+Price pair is present.
- Applied the same fix to both the frontend validation (`TransactionsPage.tsx`) and the backend validation (`backend/routes/transactions.py`) — the backend handler already prioritized `value_gbp` when saving, so only the guard needed to change.

## Test plan
- [x] `python -m pytest tests/test_transactions_route.py -q` (39 passed)
- [x] `npm --prefix frontend run test -- --run TransactionsPage` (12 passed)
- [x] `npm --prefix frontend run lint` (clean)

Closes #5194