### PR TITLE
fix(frontend): add missing app.close i18n translation key

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -46,6 +46,7 @@
     "sector": "Branchen"
   },
   "app": {
+    "close": "Schließen",
     "last": "Zuletzt:",
     "loading": "Laden…",
     "logout": "Abmelden",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -46,6 +46,7 @@
     "sector": "Industries"
   },
   "app": {
+    "close": "Close",
     "last": "Last:",
     "loading": "Loading…",
     "logout": "Logout",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -46,6 +46,7 @@
     "sector": "Industrias"
   },
   "app": {
+    "close": "Cerrar",
     "last": "Último:",
     "loading": "Cargando…",
     "logout": "Cerrar sesión",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -46,6 +46,7 @@
     "sector": "Secteurs"
   },
   "app": {
+    "close": "Fermer",
     "last": "Dernier :",
     "loading": "Chargement…",
     "logout": "Déconnexion",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -46,6 +46,7 @@
     "sector": "Industrie"
   },
   "app": {
+    "close": "Chiudi",
     "last": "Scorso:",
     "loading": "Caricamento…",
     "logout": "Logout",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -46,6 +46,7 @@
     "sector": "Indústrias"
   },
   "app": {
+    "close": "Fechar",
     "last": "Último:",
     "loading": "Carregando…",
     "logout": "Sair",


### PR DESCRIPTION
## Summary
- Adds the missing `app.close` translation key to all six locale files (en, de, es, fr, it, pt)
- The mobile nav toggle button rendered the literal key `app.close` instead of a translated "Close" label when the menu was expanded, since the key had never been added — same class of bug as the previously fixed `app.modes.research` (#5075)

## Test plan
- [x] Validated all six edited `translation.json` files parse as valid JSON
- [ ] Manually verify in the deployed app: expand the mobile nav menu and confirm the toggle button reads "Close" (or the localized equivalent) instead of `app.close`

Closes #5186