### PR TITLE
fix: stop test suite from mutating data/prices/latest_prices.json

### DIFF
--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -317,6 +317,9 @@ def _get_price_for_date_scaled(
     except (ValueError, TypeError, KeyError, IndexError):
         return None, None
 
+    if not pd.notna(price):
+        return None, None
+
     src = df.iloc[0].get("Source")
     if pd.isna(src):
         src = None
@@ -549,7 +552,11 @@ def enrich_holding(
         from backend.common import portfolio_utils as pu  # local import to avoid circular
 
         snap = pu._PRICE_SNAPSHOT.get(full) or pu._PRICE_SNAPSHOT.get(ticker)
-        if isinstance(snap, dict) and snap.get("last_price") is not None:
+        if (
+            isinstance(snap, dict)
+            and snap.get("last_price") is not None
+            and pd.notna(snap.get("last_price"))
+        ):
             px = float(snap["last_price"])
             last_price_time = snap.get("last_price_time")
             is_stale = bool(snap.get("is_stale", False))

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -1965,12 +1965,21 @@ def refresh_snapshot_in_memory_from_timeseries(days: int = 365) -> None:
                     or name_map.get("adj_close")
                 )
                 if close_col:
-                    latest_row = df.iloc[-1]
-                    snapshot[t] = {
-                        "last_price": float(latest_row[close_col]),
-                        "price_currency": "GBP",
-                        "last_price_date": pd.to_datetime(latest_row["Date"]).strftime("%Y-%m-%d"),
-                    }
+                    # Prefer the most recent row with a finite close over the
+                    # literal last row: the current day's row can be an
+                    # incomplete placeholder (NaN OHLC) before intraday data
+                    # arrives, and using it verbatim would drop a ticker with
+                    # a perfectly good prior close (issue #5192).
+                    valid_rows = df[pd.notna(df[close_col])]
+                    if not valid_rows.empty:
+                        latest_row = valid_rows.iloc[-1]
+                        price = float(latest_row[close_col])
+                        if price > 0:
+                            snapshot[t] = {
+                                "last_price": price,
+                                "price_currency": "GBP",
+                                "last_price_date": pd.to_datetime(latest_row["Date"]).strftime("%Y-%m-%d"),
+                            }
         except (OSError, ValueError, KeyError, IndexError, TypeError) as e:
             logger.warning("Could not get timeseries for %s: %s", sanitise_log_value(t), sanitise_log_value(e))
 

--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -242,10 +242,15 @@ def refresh_prices() -> Dict:
     path = Path(config.prices_json)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Merge strategy: only write entries where we successfully fetched a price.
-    # This preserves existing seed/cached prices for tickers that returned None
-    # (offline mode, market closed, data-source outage) rather than trashing them.
-    to_persist = {t: v for t, v in snapshot.items() if v.get("last_price") is not None}
+    # Merge strategy: only write entries where we successfully fetched a finite,
+    # positive price. This preserves existing seed/cached prices for tickers that
+    # returned None or a non-finite value (offline mode, market closed,
+    # data-source outage) rather than trashing them.
+    to_persist = {
+        t: v
+        for t, v in snapshot.items()
+        if v.get("last_price") is not None and pd.notna(v.get("last_price")) and v.get("last_price") > 0
+    }
     existing: Dict = {}
     if path.exists():
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import os
+import shutil
 from pathlib import Path
 
 try:
@@ -59,6 +60,44 @@ def enable_offline_mode():
         yield
     finally:
         config.offline_mode = previous
+
+
+@pytest.fixture(scope="session", autouse=True)
+def isolate_prices_json(tmp_path_factory):
+    """Redirect the default price-snapshot path to a session-scoped temp copy.
+
+    ``AppLifecycleService.startup`` (backend/bootstrap/startup.py) fires an
+    unconditional background task (``refresh_snapshot_async``) on every app
+    startup, which writes through ``portfolio_utils._PRICES_PATH`` — a path
+    bound once at import time from ``config.prices_json``. Any test that
+    boots the real app via ``TestClient`` therefore risks a background
+    refresh racing with the test run and overwriting the committed seed file
+    at data/prices/latest_prices.json with live-fetched data (see issue
+    #5192). Individual tests that need their own isolated path already
+    monkeypatch ``_PRICES_PATH``/``config.prices_json`` per-test; this
+    fixture only changes the *default* so nothing falls through to the real
+    repo file when a test forgets to.
+
+    Deliberately not restored at teardown: ``refresh_snapshot_async`` hands
+    its work to a real OS thread via ``asyncio.to_thread``, and cancelling
+    the wrapping asyncio task at app shutdown does not stop a thread already
+    in flight. If this fixture restored the original (real) path on
+    teardown, a straggler thread from an early test could still finish after
+    that restore and write live data into the committed seed file at the
+    very end of the run. Leaving the redirect in place for the rest of the
+    process lifetime closes that window; nothing after the test session
+    needs the original value back.
+    """
+    from backend.common import portfolio_utils
+
+    real_path = Path(config.prices_json) if config.prices_json else None
+    tmp_prices_json = tmp_path_factory.mktemp("prices") / "latest_prices.json"
+    if real_path and real_path.exists():
+        shutil.copy(real_path, tmp_prices_json)
+
+    config.prices_json = tmp_prices_json
+    portfolio_utils._PRICES_PATH = tmp_prices_json
+    yield tmp_prices_json
 
 
 @pytest.fixture(autouse=True)

--- a/tests/contracts/test_api_response_contracts.py
+++ b/tests/contracts/test_api_response_contracts.py
@@ -45,7 +45,12 @@ ENDPOINT_FIXTURES = {
 
 @pytest.fixture(scope="module")
 def client() -> TestClient:
-    return TestClient(create_app())
+    # Use as a context manager so the app's lifespan startup runs (it warms
+    # the in-memory price snapshot from the committed seed file). Without
+    # this, requests fall through to raw timeseries lookups that can surface
+    # stale/incomplete rows for the current trading day - see issue #5192.
+    with TestClient(create_app()) as test_client:
+        yield test_client
 
 
 def _validate_contract(name: str, payload: Any) -> list[str]:

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -274,7 +274,7 @@ def test_invalid_account(client):
     assert resp.status_code == 404
 
 
-def test_prices_refresh(client):
+def test_prices_refresh(client, mock_refresh_prices):
     resp = client.post("/prices/refresh")
     assert resp.status_code == 200
     assert "status" in resp.json()
@@ -491,7 +491,7 @@ def test_yahoo_timeseries_html(client):
     assert ticker.lower() in html
 
 
-def test_alerts_endpoint(client, monkeypatch):
+def test_alerts_endpoint(client, monkeypatch, mock_refresh_prices):
     alerts._RECENT_ALERTS.clear()
     alerts.clear_state()
     monkeypatch.setattr(alerts, "publish_alert", lambda alert: alerts._RECENT_ALERTS.append(alert))


### PR DESCRIPTION
## Summary

Root-causes the `Backend Integration Tests` / `CI` failures on `main` where `VWRL.L` seed price mysteriously turns to `NaN` mid-suite. This was a chain of related bugs, not a single one:

1. **Real endpoint hit with no mocks.** `tests/test_backend_api.py::test_prices_refresh` and `test_alerts_endpoint` call `client.post("/prices/refresh")` against the real app with no mocking, so `backend.common.prices.refresh_prices()` writes live-computed data straight over the committed `data/prices/latest_prices.json`. Fixed by using the already-existing (but unused) `mock_refresh_prices` fixture.
2. **Unconditional background refresh on every app startup.** `AppLifecycleService.startup` fires `refresh_snapshot_async` unconditionally (not gated by `skip_snapshot_warm`), which runs `refresh_snapshot_in_memory_from_timeseries()` on a background thread and writes through `portfolio_utils._PRICES_PATH` (bound once from `config.prices_json` at import time). Any test booting the real app can race this. Fixed with a new session-scoped, autouse `conftest.py` fixture (`isolate_prices_json`) that redirects the default price path to a temp copy for the whole test run — intentionally **not** restored at teardown, since the write happens on a real OS thread (`asyncio.to_thread`) that can outlive its wrapping asyncio task's cancellation.
3. **NaN treated as a valid price.** The real, committed `VWRL_L.parquet`/`ERNS_L.parquet` fixtures have an incomplete placeholder row for "today" (NaN OHLC, since intraday data hasn't landed yet). Several code paths took the literal last row and/or checked only `is not None` (which NaN passes), letting a NaN price get persisted to disk, pushed into the in-memory snapshot (silently discarding a perfectly good prior close via `refresh_snapshot_in_memory`'s full-replacement semantics), and eventually reach JSON serialization — producing the second failure, a 500 on the `groupPortfolio` contract test.
4. **Contract test skipped app startup.** `tests/contracts/test_api_response_contracts.py`'s `client` fixture built `TestClient(create_app())` without a `with` block, so the app's lifespan (and its snapshot warmup from the good seed file) never ran, forcing every request through the fragile raw-timeseries fallback instead of the cached snapshot.

Fixes applied:
- `backend/common/prices.py`: reject non-finite/non-positive prices before persisting (`refresh_prices`).
- `backend/common/portfolio_utils.py`: prefer the latest non-NaN timeseries row over the literal last row; reject non-finite/non-positive prices before adding to the snapshot (`refresh_snapshot_in_memory_from_timeseries`).
- `backend/common/holding_utils.py`: reject NaN prices in `_get_price_for_date_scaled` and the snapshot-price branch of `enrich_holding`.
- `tests/conftest.py`: new `isolate_prices_json` session fixture.
- `tests/contracts/test_api_response_contracts.py`: use `TestClient` as a context manager so lifespan startup runs.
- `tests/test_backend_api.py`: use the existing `mock_refresh_prices` fixture in the two tests that were hitting the real endpoint.

## Test plan
- [x] `pytest tests --ignore=tests/live` — 2967 passed (up from before), no regressions from these changes (remaining failures are pre-existing, unrelated: `tests/test_review_comment.py` bash/pipefail on Windows, `tests/backend/test_news_route.py` shared rate-limiter flakiness — both reproduced identically on unmodified `main`).
- [x] `git status` shows no diff to `data/prices/latest_prices.json` after a full local run.
- [x] `test_seed_prices_file_loads_demo_holdings` and the `groupPortfolio` contract test both pass.
- [x] Reproduced the original bug (confirmed the real file mutated pre-fix) and confirmed it no longer happens post-fix.

Closes #5192