### PR TITLE
fix: allow explicit String type for non-secret SSM-backed storage

### DIFF
--- a/backend/common/storage.py
+++ b/backend/common/storage.py
@@ -121,13 +121,18 @@ class ParameterStoreJSONStorage:
         )
 
 
-def get_storage(uri: str) -> JSONStorage:
+def get_storage(uri: str, *, param_type: str = "SecureString") -> JSONStorage:
     """Return a :class:`JSONStorage` for ``uri``.
 
     Parameters
     ----------
     uri:
         Storage location specified as ``file://``, ``s3://`` or ``ssm://``.
+    param_type:
+        SSM parameter type used when ``uri`` resolves to a
+        :class:`ParameterStoreJSONStorage`. Defaults to ``SecureString``;
+        pass ``"String"`` for non-secret config so it isn't needlessly
+        encrypted. Ignored for other schemes.
     """
 
     parsed = urlparse(uri)
@@ -139,7 +144,7 @@ def get_storage(uri: str) -> JSONStorage:
     if scheme in {"ssm", "ssm-param", "parameter"}:
         name = parsed.netloc + parsed.path
         name = name.lstrip("/")
-        return ParameterStoreJSONStorage(name=name)
+        return ParameterStoreJSONStorage(name=name, type=param_type)
 
     # default to file-based storage
     if scheme in {"file", ""}:

--- a/backend/lambda_api/pension_report.py
+++ b/backend/lambda_api/pension_report.py
@@ -81,7 +81,9 @@ def _load_recipient_owners() -> Optional[List[str]]:
     """Return the configured list of owners to report on, or ``None`` for "all owners"."""
 
     uri = os.getenv("PENSION_REPORT_RECIPIENTS_URI", _DEFAULT_RECIPIENTS_URI)
-    data = get_storage(uri).load()
+    # Owner keys only (no emails or other secrets are stored here -- see
+    # module docstring), so this doesn't need SecureString encryption.
+    data = get_storage(uri, param_type="String").load()
     owners = data.get("owners")
     if not owners:
         return None

--- a/tests/backend/common/test_storage.py
+++ b/tests/backend/common/test_storage.py
@@ -161,3 +161,13 @@ def test_get_storage_supported_schemes(uri: str, expected_type: type, attrs: dic
 def test_get_storage_unsupported_scheme() -> None:
     with pytest.raises(ValueError):
         get_storage("ftp://example.com/resource")
+
+
+def test_get_storage_ssm_defaults_to_secure_string() -> None:
+    storage = get_storage("ssm://parameter/name")
+    assert storage.type == "SecureString"
+
+
+def test_get_storage_ssm_explicit_string_type() -> None:
+    storage = get_storage("ssm://parameter/name", param_type="String")
+    assert storage.type == "String"


### PR DESCRIPTION
## Summary
- Audited `ParameterStoreJSONStorage` instantiations after PR #5020 changed the default `type` to `SecureString`.
- Found one production call site storing genuinely non-secret data: the pension-report recipients list (`backend/lambda_api/pension_report.py`) stores owner keys only — no emails or secrets (see module docstring) — so it doesn't need SSM encryption.
- `get_storage()` now accepts an optional `param_type` kwarg so callers can opt out of `SecureString` per call site, instead of hardcoding the type inside `ParameterStoreJSONStorage` construction.
- All other `get_storage()`/`ParameterStoreJSONStorage` call sites (alerts, goals, quests, nudges, pension snapshots) store user financial/subscription data and correctly keep the `SecureString` default.

Closes #5022

## Test plan
- [x] `python -m pytest tests/backend/common/test_storage.py tests/test_storage.py tests/test_pension_report_lambda.py -q` — 26 passed
- [x] `python -m black --check` on changed files
- [x] `python -m ruff check` on changed files
- [x] Added tests for both the default (`SecureString`) and explicit (`String`) `param_type` paths in `get_storage()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)