### PR TITLE
docs(ci): clarify which ai-review dependabot-pass contexts are actually required

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -29,6 +29,10 @@ jobs:
   # context a real reusable-workflow run would produce ("ai-review / Claude
   # AI code review"), so any branch protection rule keyed on that exact
   # string still gets satisfied for Dependabot PRs.
+  #
+  # This context is NOT currently a required status check on `main` (only
+  # DeepSeek's is — see deepseek-pr-review.yml). Kept here for consistency
+  # and in case this context is ever made required in the future.
   dependabot-pass:
     name: ai-review / Claude AI code review
     if: github.actor == 'dependabot[bot]'

--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -59,6 +59,12 @@ jobs:
   # reusable-workflow call) — a plain job named "ai-review" does NOT match
   # that string, so it never satisfies the required check. This job's name
   # reproduces the composite string literally so Dependabot PRs unblock.
+  #
+  # WARNING: of the three ai-review workflows (DeepSeek/Claude/GPT), only this
+  # one's context is currently a required status check on `main`. If you
+  # rename this job or the provider_name above, update both this job name AND
+  # the required_status_checks context in branch protection — otherwise
+  # Dependabot PRs will be blocked by a required check that can never pass.
   dependabot-pass:
     name: ai-review / DeepSeek AI code review
     if: github.actor == 'dependabot[bot]'

--- a/.github/workflows/gpt-pr-review.yml
+++ b/.github/workflows/gpt-pr-review.yml
@@ -28,6 +28,10 @@ jobs:
   # context a real reusable-workflow run would produce ("ai-review / GPT AI
   # code review"), so any branch protection rule keyed on that exact string
   # still gets satisfied for Dependabot PRs.
+  #
+  # This context is NOT currently a required status check on `main` (only
+  # DeepSeek's is — see deepseek-pr-review.yml). Kept here for consistency
+  # and in case this context is ever made required in the future.
   dependabot-pass:
     name: ai-review / GPT AI code review
     if: github.actor == 'dependabot[bot]'


### PR DESCRIPTION
## Summary
- Verified against `repos/leonarduk/allotmint/branches/main/protection/required_status_checks` that only `"ai-review / DeepSeek AI code review"` is currently a required status check on `main` — Claude's and GPT's contexts are not.
- Added an explicit warning comment to each workflow's `dependabot-pass` job stating this, so a future rename of the job name or `provider_name` doesn't silently desync from the branch protection rule (which would permanently block Dependabot PRs on a required check that can never pass).
- Comment-only change; no job names, `if` conditions, or workflow logic were modified.

Closes #4704

## Test plan
- [x] `yaml.safe_load` on all three edited workflow files to confirm no syntax errors introduced
- [x] Confirmed via GitHub API which context is actually required today, so the new comments state fact rather than assumption
- [ ] Reviewer: confirm existing CI checks still pass unchanged on this PR (no functional change expected)