### PR TITLE
fix: close signup owner-slug race window between mkdir and person.json write

### DIFF
--- a/backend/common/signup_provision.py
+++ b/backend/common/signup_provision.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 from pathlib import Path
 
 from backend.common.compliance import ensure_owner_scaffold
@@ -78,7 +79,7 @@ def _read_person_email(owner_dir: Path) -> str:
     return email.strip().lower() if isinstance(email, str) else ""
 
 
-def _resolve_owner_slug(email: str, accounts_root: Path) -> str:
+def _resolve_owner_slug(email: str, accounts_root: Path, full_name: str = "") -> str:
     """Atomically claim an owner slug for ``email`` under ``accounts_root``.
 
     The candidate directory is created with ``mkdir`` (no ``exist_ok``) so two
@@ -88,13 +89,17 @@ def _resolve_owner_slug(email: str, accounts_root: Path) -> str:
     another user's data. ``email`` is lowercased to match the normalised form
     stored in ``person.json``.
 
-    ``person.json`` is scaffolded and stamped with ``email`` immediately after
-    ``mkdir`` wins, before returning. Without this, a second concurrent
-    approval for the *same* email that loses the ``mkdir`` race would hit
-    ``FileExistsError`` and find no ``person.json`` yet (the winner hadn't
-    written it), read no matching email via ``_read_person_email``, and go on
-    to claim a second slug for the same person. Writing it here closes that
-    window instead of leaving it to the caller's later, non-atomic write.
+    ``person.json`` is scaffolded and stamped with the full identity
+    (``email`` + ``full_name``) immediately after ``mkdir`` wins, before
+    returning. Without this, a second concurrent approval for the *same* email
+    that loses the ``mkdir`` race would hit ``FileExistsError`` and find no
+    ``person.json`` yet (the winner hadn't written it), read no matching email
+    via ``_read_person_email``, and go on to claim a second slug for the same
+    person. Writing it here closes that window instead of leaving it to the
+    caller's later, non-atomic write.
+
+    If the scaffold or identity write fails, the created directory is removed
+    so we never leave an orphan directory behind.
     """
 
     email = email.strip().lower()
@@ -109,8 +114,12 @@ def _resolve_owner_slug(email: str, accounts_root: Path) -> str:
             if _read_person_email(owner_dir) == email:
                 return candidate
             continue
-        ensure_owner_scaffold(candidate, accounts_root)
-        _write_person_identity(owner_dir, email, "")
+        try:
+            ensure_owner_scaffold(candidate, accounts_root)
+            _write_person_identity(owner_dir, email, full_name)
+        except Exception:
+            shutil.rmtree(owner_dir, ignore_errors=True)
+            raise
         return candidate
     raise RuntimeError(f"could not allocate an owner slug for base {base!r}")
 
@@ -154,7 +163,7 @@ def provision_owner(
 
     accounts_root = Path(accounts_root)
     email = record.email.strip().lower()
-    owner = _resolve_owner_slug(email, accounts_root)
+    owner = _resolve_owner_slug(email, accounts_root, record.name)
     owner_dir = ensure_owner_scaffold(owner, accounts_root)
     _write_person_identity(owner_dir, email, record.name)
 

--- a/backend/common/signup_provision.py
+++ b/backend/common/signup_provision.py
@@ -87,6 +87,14 @@ def _resolve_owner_slug(email: str, accounts_root: Path) -> str:
     re-provision); one owned by a different email is skipped so we never clobber
     another user's data. ``email`` is lowercased to match the normalised form
     stored in ``person.json``.
+
+    ``person.json`` is scaffolded and stamped with ``email`` immediately after
+    ``mkdir`` wins, before returning. Without this, a second concurrent
+    approval for the *same* email that loses the ``mkdir`` race would hit
+    ``FileExistsError`` and find no ``person.json`` yet (the winner hadn't
+    written it), read no matching email via ``_read_person_email``, and go on
+    to claim a second slug for the same person. Writing it here closes that
+    window instead of leaving it to the caller's later, non-atomic write.
     """
 
     email = email.strip().lower()
@@ -101,6 +109,8 @@ def _resolve_owner_slug(email: str, accounts_root: Path) -> str:
             if _read_person_email(owner_dir) == email:
                 return candidate
             continue
+        ensure_owner_scaffold(candidate, accounts_root)
+        _write_person_identity(owner_dir, email, "")
         return candidate
     raise RuntimeError(f"could not allocate an owner slug for base {base!r}")
 

--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -129,6 +129,32 @@ def test_provision_owner_skips_slug_with_corrupted_person_json(tmp_path):
     assert (accounts_root / "jane" / "person.json").read_text() == "{ not json"
 
 
+def test_resolve_owner_slug_stamps_email_immediately_after_mkdir(tmp_path):
+    """Regression test for #4402.
+
+    A concurrent approval for the *same* email that loses the ``mkdir`` race
+    must see the winner's email via ``_read_person_email`` right away, not
+    after the caller gets around to calling ``_write_person_identity``. This
+    simulates the losing side of that race by calling ``_resolve_owner_slug``
+    directly (not through ``provision_owner``, which would also write the
+    email but only after returning).
+    """
+
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+
+    winner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root)
+    assert winner == "jane"
+
+    # The loser of the mkdir race hits FileExistsError on "jane" immediately
+    # after the winner's mkdir succeeds. Without the fix, person.json is not
+    # written yet at this point, so the loser would fail to recognise the
+    # slug as already claimed by this email and allocate "jane-2" instead.
+    loser = signup_provision._resolve_owner_slug("jane@example.com", accounts_root)
+    assert loser == "jane"
+    assert sorted(p.name for p in accounts_root.iterdir()) == ["jane"]
+
+
 def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()

--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -129,22 +129,30 @@ def test_provision_owner_skips_slug_with_corrupted_person_json(tmp_path):
     assert (accounts_root / "jane" / "person.json").read_text() == "{ not json"
 
 
-def test_resolve_owner_slug_stamps_email_immediately_after_mkdir(tmp_path):
+def test_resolve_owner_slug_stamps_identity_immediately_after_mkdir(tmp_path):
     """Regression test for #4402.
 
     A concurrent approval for the *same* email that loses the ``mkdir`` race
-    must see the winner's email via ``_read_person_email`` right away, not
-    after the caller gets around to calling ``_write_person_identity``. This
-    simulates the losing side of that race by calling ``_resolve_owner_slug``
-    directly (not through ``provision_owner``, which would also write the
-    email but only after returning).
+    must see the winner's identity (email + full_name) via
+    ``_read_person_email`` right away, not after the caller gets around to
+    calling ``_write_person_identity``. This simulates the losing side of that
+    race by calling ``_resolve_owner_slug`` directly (not through
+    ``provision_owner``, which would also write the email but only after
+    returning).
     """
 
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
 
-    winner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root)
+    winner = signup_provision._resolve_owner_slug(
+        "jane@example.com", accounts_root, "Jane Doe"
+    )
     assert winner == "jane"
+
+    # The winner's person.json must carry the complete identity immediately.
+    person = json.loads((accounts_root / "jane" / "person.json").read_text())
+    assert person["email"] == "jane@example.com"
+    assert person["full_name"] == "Jane Doe"
 
     # The loser of the mkdir race hits FileExistsError on "jane" immediately
     # after the winner's mkdir succeeds. Without the fix, person.json is not
@@ -155,6 +163,24 @@ def test_resolve_owner_slug_stamps_email_immediately_after_mkdir(tmp_path):
     assert sorted(p.name for p in accounts_root.iterdir()) == ["jane"]
 
 
+def test_resolve_owner_slug_cleans_up_on_write_failure(tmp_path, monkeypatch):
+    """If the identity write fails after mkdir, the orphan directory is removed."""
+
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+
+    def _failing_write(*_args, **_kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(signup_provision, "_write_person_identity", _failing_write)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
+
+    # The directory created by mkdir must be cleaned up.
+    assert not (accounts_root / "jane").exists()
+
+
 def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
@@ -163,7 +189,9 @@ def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     # Occupy both candidate slugs with a different email so none can be reused.
     for name in ("jane", "jane-2"):
         (accounts_root / name).mkdir()
-        (accounts_root / name / "person.json").write_text(json.dumps({"email": "other@example.com"}))
+        (accounts_root / name / "person.json").write_text(
+            json.dumps({"email": "other@example.com"})
+        )
 
     with pytest.raises(RuntimeError):
         signup_provision.provision_owner(_record("jane@example.com"), accounts_root)


### PR DESCRIPTION
## Summary
- `_resolve_owner_slug` claims a slug atomically via `mkdir`, but previously only wrote `email` into `person.json` much later, inside `provision_owner`.
- A second concurrent approval for the *same* email that lost the `mkdir` race would hit `FileExistsError`, find no `person.json` yet, fail the `_read_person_email` match, and allocate a second slug for the same person — an orphan account.
- Fix: scaffold and stamp `person.json` with the email immediately after `mkdir` succeeds, closing the race window at the source instead of leaving it to a later non-atomic write.

## Test plan
- [x] Added `test_resolve_owner_slug_stamps_email_immediately_after_mkdir`, which simulates the losing side of the race by calling `_resolve_owner_slug` twice directly.
- [x] Verified the new test fails on the pre-fix code (`jane-2` instead of reusing `jane`) and passes after the fix.
- [x] `pytest tests/backend/test_signup_provision.py tests/backend/routes/test_signup.py` — 39 passed.
- [x] `black --check` / `ruff check` on the changed file — clean.

Closes #4402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate owner directories from being created when concurrent sign-up requests use the same email address.
  * Ensured owner details are recorded immediately during provisioning, allowing subsequent requests to reuse the existing owner identity.

* **Tests**
  * Added regression coverage for concurrent owner provisioning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->