### PR TITLE
fix: recognise DIVIDEND alongside DIVIDENDS in cash-flow sign tables

### DIFF
--- a/backend/common/dividends.py
+++ b/backend/common/dividends.py
@@ -6,13 +6,12 @@ hand. See issue #2750.
 
 Design notes / known v1 limitations
 ------------------------------------
-* Transaction type literal: the codebase is inconsistent between ``DIVIDEND``
-  (``backend/reports.py`` income aggregation, ``backend/utils/positions.py``)
-  and ``DIVIDENDS`` (cash-flow sign tables in ``portfolio_loader.py`` and
-  ``portfolio_utils.py`` used by TWR/XIRR). This module writes ``DIVIDEND`` to
-  match the income-reporting path and the issue's stated acceptance criteria.
-  Fixing the cash-flow sign tables to also recognise ``DIVIDEND`` is tracked
-  separately and out of scope here.
+* Transaction type literal: this module writes ``DIVIDEND`` to match the
+  income-reporting path (``backend/reports.py``, ``backend/utils/positions.py``)
+  and the issue's stated acceptance criteria. The cash-flow sign tables in
+  ``portfolio_loader.py`` and ``portfolio_utils.py`` (used by TWR/XIRR) also
+  recognise ``DIVIDEND`` alongside the legacy ``DIVIDENDS`` literal (#4948),
+  so both transaction-type spellings are treated consistently everywhere.
 * Amount calculation: yfinance's ``Ticker.dividends`` returns a per-share
   amount, not the total cash received. This module approximates the total by
   multiplying the per-share amount by the *currently* held unit count for

--- a/backend/common/portfolio_loader.py
+++ b/backend/common/portfolio_loader.py
@@ -212,6 +212,7 @@ def compute_holdings_from_transactions(
     CASH_SIGNS = {
         "DEPOSIT": 1,
         "WITHDRAWAL": -1,
+        "DIVIDEND": 1,
         "DIVIDENDS": 1,
         "INTEREST": 1,
     }

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -1733,6 +1733,7 @@ def _parse_date(val: Any) -> date | None:
 _CASH_FLOW_SIGNS = {
     "DEPOSIT": 1,
     "WITHDRAWAL": -1,
+    "DIVIDEND": 1,
     "DIVIDENDS": 1,
     "INTEREST": 1,
 }

--- a/tests/common/test_portfolio_loader.py
+++ b/tests/common/test_portfolio_loader.py
@@ -41,6 +41,30 @@ def test_rebuild_account_holdings(tmp_path: Path) -> None:
     assert holdings["CASH.GBP"]["units"] == pytest.approx(75.0)
 
 
+def test_rebuild_account_holdings_treats_dividend_singular_like_dividends(tmp_path: Path) -> None:
+    """Regression test for #4948: the sign table must recognise both
+    ``DIVIDEND`` (written by backend/common/dividends.py) and the legacy
+    ``DIVIDENDS`` literal identically, not silently drop one of them.
+    """
+
+    owner_dir = tmp_path / "alice"
+    owner_dir.mkdir()
+    tx_file = owner_dir / "ISA_transactions.json"
+    tx_data = {
+        "currency": "GBP",
+        "transactions": [
+            {"type": "DEPOSIT", "amount_minor": 10000},
+            {"type": "DIVIDEND", "amount_minor": 2500},
+        ],
+    }
+    tx_file.write_text(json.dumps(tx_data))
+
+    result = rebuild_account_holdings("alice", "isa", accounts_root=tmp_path)
+
+    holdings = {h["ticker"]: h for h in result["holdings"]}
+    assert holdings["CASH.GBP"]["units"] == pytest.approx(125.0)
+
+
 def test_rebuild_account_holdings_missing_file(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.ERROR, logger="portfolio_loader")
 

--- a/tests/test_portfolio_utils_returns.py
+++ b/tests/test_portfolio_utils_returns.py
@@ -529,3 +529,14 @@ def test_detect_single_day_flash_crash_handles_duplicate_index():
 
     assert len(cleaned) == 4
     assert len(issues) >= 1
+
+
+def test_cash_flow_signs_treat_dividend_singular_same_as_plural():
+    """Regression test for #4948: backend/common/dividends.py writes the
+    ``DIVIDEND`` (singular) transaction type, but the TWR/XIRR cash-flow sign
+    table previously only recognised ``DIVIDENDS`` (plural), silently
+    excluding automated dividend transactions from return calculations.
+    """
+
+    assert "DIVIDEND" in pu._CASH_FLOW_SIGNS
+    assert pu._CASH_FLOW_SIGNS["DIVIDEND"] == pu._CASH_FLOW_SIGNS["DIVIDENDS"]


### PR DESCRIPTION
## Summary
- `backend/common/dividends.py` (automated dividend collection, #2750) writes transactions with type `"DIVIDEND"` (singular), matching the income-reporting path in `backend/reports.py` / `backend/utils/positions.py`.
- The TWR/XIRR cash-flow sign tables (`_CASH_FLOW_SIGNS` in `portfolio_utils.py`, `CASH_SIGNS` in `portfolio_loader.py`) only recognised the legacy `"DIVIDENDS"` (plural) literal — so every automated dividend transaction was silently excluded from cash-flow-based return calculations and the `CASH.GBP` ledger built by `rebuild_account_holdings`.
- Added `"DIVIDEND": 1` to both tables (same sign as `"DIVIDENDS"`) and updated the now-stale "known limitation" note in `dividends.py`'s module docstring.

## Test plan
- [x] `test_rebuild_account_holdings_treats_dividend_singular_like_dividends` — new, exercises `portfolio_loader.py`'s `CASH_SIGNS` via `rebuild_account_holdings`.
- [x] `test_cash_flow_signs_treat_dividend_singular_same_as_plural` — new, direct check on `portfolio_utils._CASH_FLOW_SIGNS`.
- [x] `pytest tests/common/test_portfolio_loader.py tests/test_portfolio_utils_returns.py tests/common/test_portfolio_utils_snapshot.py tests/test_dividends.py` — 54 passed.
- [x] Confirmed the touched files' pre-existing lint findings (isort ordering, one long line) predate this change — not introduced by this diff.

Closes #4948

🤖 Generated with [Claude Code](https://claude.com/claude-code)