### PR TITLE
fix(frontend): logout hardening, accessibility label, MVP visibility test coverage

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -114,6 +114,7 @@
     "title": "Data Quality",
     "noData": "No cached timeseries positions found.",
     "viewDetails": "View details",
+    "viewDetailsFor": "View details for {{ticker}}.{{exchange}}",
     "columns": {
       "ticker": "Ticker",
       "exchange": "Exchange",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -191,7 +191,13 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
     // A deliberate, user-initiated logout is not a session expiry.
     setSessionExpired(false);
     if (resolvedAwsUiAuth?.enabled) {
-      cognitoLogout(resolvedAwsUiAuth);
+      // Local session state is already cleared above; a failed hosted-UI
+      // redirect (e.g. a malformed domain) must not crash the app mid-logout.
+      try {
+        cognitoLogout(resolvedAwsUiAuth);
+      } catch (err) {
+        console.error('cognitoLogout failed', err);
+      }
     } else {
       navigate('/');
     }

--- a/frontend/src/pages/DataQuality.tsx
+++ b/frontend/src/pages/DataQuality.tsx
@@ -133,7 +133,14 @@ export default function DataQuality() {
                   <QualityStatusBadge status={row.status} />
                 </td>
                 <td className={tableStyles.cell}>
-                  <button type="button" onClick={() => setSelected(row)}>
+                  <button
+                    type="button"
+                    onClick={() => setSelected(row)}
+                    aria-label={t("dataQuality.viewDetailsFor", {
+                      ticker: row.ticker,
+                      exchange: row.exchange,
+                    })}
+                  >
                     {t("dataQuality.viewDetails")}
                   </button>
                 </td>

--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -342,4 +342,36 @@ describe('Menu', () => {
       screen.queryByRole('menuitem', { name: i18n.t('app.logout') })
     ).not.toBeInTheDocument();
   });
+
+  it.each([
+    ['MVP', true],
+    ['non-MVP', false],
+  ])(
+    'shows the logout button in %s mode (#4490)',
+    async (_label, familyMvpEnabled) => {
+      // The !familyMvpEnabled guard around the logout button was removed in
+      // PR #4482; assert visibility explicitly in both modes so a regression
+      // reintroducing that guard is caught directly.
+      const onLogout = vi.fn();
+      const config: ConfigContextValue = {
+        ...configWithTransactions,
+        familyMvpEnabled,
+      };
+      render(
+        <configContext.Provider value={config}>
+          <MemoryRouter>
+            <Menu onLogout={onLogout} />
+          </MemoryRouter>
+        </configContext.Provider>
+      );
+      const preferencesToggle = screen.getByRole('button', {
+        name: i18n.t('app.menuCategories.preferences'),
+      });
+      fireEvent.click(preferencesToggle);
+
+      expect(
+        await screen.findByRole('menuitem', { name: i18n.t('app.logout') })
+      ).toBeInTheDocument();
+    }
+  );
 });

--- a/frontend/tests/unit/logoutFlowCognito.test.tsx
+++ b/frontend/tests/unit/logoutFlowCognito.test.tsx
@@ -140,4 +140,94 @@ describe('Logout flow: Cognito mode (#4802)', () => {
       screen.queryByRole('menuitem', { name: i18n.t('app.logout') })
     ).not.toBeInTheDocument();
   });
+
+  it('does not crash when cognitoLogout throws, and logs the failure', async () => {
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() }),
+    }));
+
+    vi.doMock('@/api', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/api')>();
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: false,
+          google_client_id: '',
+          disable_auth: true,
+          awsUiAuth: {
+            enabled: true,
+            domain: 'https://cognito.example.test',
+            clientId: 'client-abc',
+            redirectPath: '/',
+          },
+        }),
+        getStoredAuthToken: vi.fn(() => 'cognito-id-token'),
+      };
+    });
+
+    const cognitoLogout = vi.fn(() => {
+      throw new Error('redirect boom');
+    });
+    vi.doMock('@/awsUiAuth', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/awsUiAuth')>();
+      return { ...mod, cognitoLogout };
+    });
+
+    vi.doMock('@/App.tsx', async () => {
+      const { default: Menu } = await import('@/components/Menu');
+      return {
+        default: ({ onLogout }: { onLogout?: () => void }) => (
+          <Menu onLogout={onLogout} />
+        ),
+      };
+    });
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    window.localStorage.setItem('authToken', 'cognito-id-token');
+    window.localStorage.setItem(
+      'auth.user',
+      JSON.stringify({ email: 'demo@example.test' })
+    );
+    window.sessionStorage.setItem(
+      'awsUiAuthSession',
+      JSON.stringify({
+        idToken: 'cognito-id-token',
+        expiresAt: Date.now() + 60_000,
+      })
+    );
+
+    await mountRoot();
+
+    const preferencesToggle = await screen.findByRole('button', {
+      name: i18n.t('app.menuCategories.preferences'),
+    });
+    fireEvent.click(preferencesToggle);
+    const logoutButton = await screen.findByRole('menuitem', {
+      name: i18n.t('app.logout'),
+    });
+    fireEvent.click(logoutButton);
+
+    // cognitoLogout's throw is caught: the app keeps rendering instead of
+    // crashing, and the failure is surfaced via console.error rather than
+    // being silently swallowed.
+    await waitFor(() => expect(cognitoLogout).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'cognitoLogout failed',
+        expect.any(Error)
+      )
+    );
+
+    // Local app-level auth state is still cleared even though the redirect
+    // failed (the mocked cognitoLogout throws before reaching the real
+    // implementation's own sessionStorage cleanup, so that isn't asserted
+    // here — see the happy-path test above for that).
+    expect(window.localStorage.getItem('authToken')).toBeNull();
+    expect(window.localStorage.getItem('auth.user')).toBeNull();
+
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/frontend/tests/unit/logoutFlowLocalDev.test.tsx
+++ b/frontend/tests/unit/logoutFlowLocalDev.test.tsx
@@ -125,4 +125,76 @@ describe('Logout flow: local dev mode (#4802)', () => {
       await screen.findByRole('menuitem', { name: i18n.t('app.logout') })
     ).toBeInTheDocument();
   });
+
+  it('logs out cleanly when no auth mode is configured at all', async () => {
+    // Distinct from the happy-path test above: no awsUiAuth, no Google auth,
+    // and no local_login_email either, so there is no demo identity and no
+    // hosted-UI to redirect to — auth is fully disabled with nothing to log
+    // out *of*. The logout control (registered via AuthContext regardless of
+    // auth state, see #4751) must still behave gracefully rather than error.
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() }),
+    }));
+
+    vi.doMock('react-router-dom', async () =>
+      vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+    );
+
+    vi.doMock('@/api', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/api')>();
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: false,
+          google_client_id: '',
+          disable_auth: true,
+        }),
+        getStoredAuthToken: vi.fn(() => null),
+      };
+    });
+
+    const cognitoLogout = vi.fn();
+    vi.doMock('@/awsUiAuth', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('@/awsUiAuth')>();
+      return { ...mod, cognitoLogout };
+    });
+
+    vi.doMock('@/App.tsx', async () => {
+      const { default: Menu } = await import('@/components/Menu');
+      return {
+        default: ({ onLogout }: { onLogout?: () => void }) => (
+          <Menu onLogout={onLogout} />
+        ),
+      };
+    });
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    await mountRoot();
+
+    const preferencesToggle = await screen.findByRole('button', {
+      name: i18n.t('app.menuCategories.preferences'),
+    });
+    fireEvent.click(preferencesToggle);
+    const logoutButton = await screen.findByRole('menuitem', {
+      name: i18n.t('app.logout'),
+    });
+    fireEvent.click(logoutButton);
+
+    // navigate('/') fires (there is no Cognito hosted-UI to redirect to).
+    await waitFor(() => expect(window.location.pathname).toBe('/'));
+
+    // No Cognito round trip, and no unexpected application errors logged
+    // during a logout that has no session to actually tear down (ignoring
+    // React's unrelated "not wrapped in act" test-environment warnings).
+    expect(cognitoLogout).not.toHaveBeenCalled();
+    const unexpectedErrors = consoleErrorSpy.mock.calls.filter(
+      ([message]) => !String(message).includes('not wrapped in act')
+    );
+    expect(unexpectedErrors).toEqual([]);
+
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/frontend/tests/unit/pages/DataQuality.test.tsx
+++ b/frontend/tests/unit/pages/DataQuality.test.tsx
@@ -111,7 +111,9 @@ describe("DataQuality page", () => {
     render(<DataQuality />);
 
     const viewDetailsButton = await screen.findByRole("button", {
-      name: en.dataQuality.viewDetails,
+      name: en.dataQuality.viewDetailsFor
+        .replace("{{ticker}}", "DUPED")
+        .replace("{{exchange}}", "N"),
     });
     await act(async () => {
       await userEvent.click(viewDetailsButton);


### PR DESCRIPTION
## Summary
Bundled fix for the three Tier-1 issues from milestone 14 (Frontend Hardening & Test Coverage):

- **#4970** — add `aria-label` to the per-row "View details" button in `DataQuality.tsx` so screen readers can distinguish which row it refers to.
- **#5014** — `main.tsx`'s `logout()` called `cognitoLogout()` with no error handling; a thrown error (e.g. malformed domain) would go uncaught mid-logout. Wrapped it in try/catch with `console.error` logging, and added integration test coverage for: the error path (cognitoLogout throwing), console.error assertions, and the no-auth-mode case (no awsUiAuth, no Google auth, no local_login_email at all).
- **#4490** — added an explicit parametrized test in `Menu.test.tsx` asserting the logout button is visible in both Family MVP and non-MVP modes, guarding against the `!familyMvpEnabled` guard (removed in #4482) being reintroduced.

## Test plan
- [x] `npx vitest run` on the touched test files — all pass
- [x] Full frontend unit suite — 621/622 pass (1 pre-existing flaky timing test in `rootBootstrap.test.tsx`, unrelated to this change, confirmed passing in isolation)
- [x] `npx eslint` on changed files — clean
- [x] `npx tsc --noEmit` — clean

Closes #4970, Closes #5014, Closes #4490

🤖 Generated with [Claude Code](https://claude.com/claude-code)