### PR TITLE
fix: resolve pension_snapshots storage backend lazily, not at import time

### DIFF
--- a/backend/common/pension_snapshots.py
+++ b/backend/common/pension_snapshots.py
@@ -19,14 +19,26 @@ _DEFAULT_SNAPSHOTS_URI = (
     f"file://{(config.repo_root or Path(__file__).resolve().parents[1]) / 'data' / 'pension_snapshots.json'}"
 )
 
-try:
-    _STORAGE: JSONStorage = get_storage(os.getenv("PENSION_SNAPSHOTS_URI", _DEFAULT_SNAPSHOTS_URI))
-except Exception:
-    _STORAGE = get_storage(_DEFAULT_SNAPSHOTS_URI)
+
+def _get_storage() -> JSONStorage:
+    """Resolve the snapshots storage backend, reading ``PENSION_SNAPSHOTS_URI``
+    at call time rather than import time.
+
+    A module-level constant would freeze whichever value (or fallback) was in
+    effect the moment this module was first imported — e.g. before a
+    framework or test finishes setting env vars — and never re-evaluate it.
+    Resolving lazily on each call means the configured backend is always
+    honoured once the env var is actually set. Intentionally not cached at
+    module level (#5010).
+    """
+    try:
+        return get_storage(os.getenv("PENSION_SNAPSHOTS_URI", _DEFAULT_SNAPSHOTS_URI))
+    except Exception:
+        return get_storage(_DEFAULT_SNAPSHOTS_URI)
 
 
 def _load_raw() -> Dict[str, Dict[str, Any]]:
-    data = _STORAGE.load()
+    data = _get_storage().load()
     if not isinstance(data, dict):
         return {}
     return {k: v for k, v in data.items() if isinstance(v, dict)}
@@ -69,7 +81,7 @@ def record_snapshot(owner: str, *, pot_gbp: float, as_of: dt.date) -> None:
         "last_pot_gbp": pot_gbp,
         "last_as_of": as_of.isoformat(),
     }
-    _STORAGE.save(data)
+    _get_storage().save(data)
 
 
 __all__ = [

--- a/tests/common/test_pension_snapshots.py
+++ b/tests/common/test_pension_snapshots.py
@@ -12,7 +12,7 @@ from backend.common.storage import get_storage
 def snapshot_storage(tmp_path, monkeypatch):
     storage = get_storage(f"file://{tmp_path / 'pension_snapshots.json'}")
     storage.save({})
-    monkeypatch.setattr(snapshots_mod, "_STORAGE", storage)
+    monkeypatch.setattr(snapshots_mod, "_get_storage", lambda: storage)
     return storage
 
 
@@ -64,3 +64,21 @@ def test_previous_period_pot_gbp_no_previous_uses_current() -> None:
 def test_previous_period_pot_gbp_returns_last_pot() -> None:
     previous = {"last_pot_gbp": 4200}
     assert snapshots_mod.previous_period_pot_gbp(previous, 5000) == 4200
+
+
+def test_get_storage_reads_env_var_set_after_module_import(tmp_path, monkeypatch) -> None:
+    """Regression test for #5010.
+
+    The module is already imported (it has to be, to write this test), well
+    before this test sets PENSION_SNAPSHOTS_URI. A module-level ``_STORAGE``
+    constant would have frozen the fallback default at import time and never
+    seen this env var; the lazy accessor must resolve it on this call.
+    """
+    target = tmp_path / "custom_snapshots.json"
+    monkeypatch.setenv("PENSION_SNAPSHOTS_URI", f"file://{target}")
+
+    storage = snapshots_mod._get_storage()
+    storage.save({"alice": {"year": 2024}})
+
+    assert target.exists()
+    assert snapshots_mod.get_previous_snapshot("alice") == {"year": 2024}


### PR DESCRIPTION
## Summary
- `_STORAGE` in `backend/common/pension_snapshots.py` was a module-level constant, initialised from `PENSION_SNAPSHOTS_URI` the instant the module was first imported.
- If the module is imported before that env var is set — test collection order, local dev, certain Lambda cold-start orderings — the `file://` fallback is taken and never re-evaluated. A value set after import is silently ignored, so the module keeps writing to the wrong backend for the lifetime of the process.
- Replaced the constant with `_get_storage()`, resolved fresh on every call (not cached at module level, per the issue's constraint), preserving the same `try`/`except` fallback behaviour.

## Test plan
- [x] `test_get_storage_reads_env_var_set_after_module_import` — new. The module is already imported when this test runs; it sets `PENSION_SNAPSHOTS_URI` afterward and confirms the lazy accessor picks it up (a module-level constant would have missed it).
- [x] Updated the `snapshot_storage` fixture to monkeypatch `_get_storage` instead of the now-removed `_STORAGE` constant.
- [x] `pytest tests/common/test_pension_snapshots.py` — 8 passed.
- [x] `pytest tests/ -k pension` — 75 passed, 1 xfailed (pre-existing, unrelated).
- [x] `black`/`ruff` clean on the changed file.

Closes #5010

🤖 Generated with [Claude Code](https://claude.com/claude-code)