### PR TITLE
fix: make missing SIGNUP_APPROVAL_BASE_URL a hard error, not a warning

### DIFF
--- a/backend/routes/signup.py
+++ b/backend/routes/signup.py
@@ -76,14 +76,17 @@ def _store_dir(request: Request) -> Path:
 
 
 def _build_links(request_id: str, token: str) -> tuple[str, str]:
-    """Build the approve/reject links consumed by the approval flow (#4352)."""
+    """Build the approve/reject links consumed by the approval flow (#4352).
+
+    Raises ``RuntimeError`` when ``SIGNUP_APPROVAL_BASE_URL`` is unset: a
+    relative link is unusable in the emailed notification (email clients
+    cannot resolve it), so failing loudly here beats silently sending the
+    admin a broken link (#4369).
+    """
 
     base = os.getenv("SIGNUP_APPROVAL_BASE_URL", "").rstrip("/")
     if not base:
-        # Without a base URL the emailed links are relative and unusable. Warn
-        # rather than fail so the admin still receives the request id + token
-        # and can act manually, but the misconfiguration is not silent.
-        logger.warning("SIGNUP_APPROVAL_BASE_URL is not set; admin approve/reject links will be relative")
+        raise RuntimeError("SIGNUP_APPROVAL_BASE_URL must be set")
     query = f"id={request_id}&token={token}"
     return f"{base}/signup/approve?{query}", f"{base}/signup/reject?{query}"
 
@@ -109,7 +112,14 @@ async def _post_signup_request_impl(request: Request) -> dict[str, str]:
         raise HTTPException(status_code=503, detail="signup is not available")
 
     record, token = signup_requests.create_signup_request(name, email, note, _store_dir(request))
-    approve_url, reject_url = _build_links(record.id, token)
+    try:
+        approve_url, reject_url = _build_links(record.id, token)
+    except RuntimeError:
+        # Misconfiguration, not a client error — and the same for every
+        # caller, so it leaks nothing about account existence (matches the
+        # SIGNUP_ADMIN_EMAIL check above).
+        logger.error("SIGNUP_APPROVAL_BASE_URL is not configured; cannot build admin approval links")
+        raise HTTPException(status_code=503, detail="signup is not available") from None
     notification = SignupAdminNotification(
         request_id=record.id,
         name=record.name,

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -27,6 +27,7 @@ def client(tmp_path, monkeypatch):
         lambda request, allow_missing=False: accounts_root,
     )
     monkeypatch.setenv("SIGNUP_ADMIN_EMAIL", "admin@example.com")
+    monkeypatch.setenv("SIGNUP_APPROVAL_BASE_URL", "https://admin.example.com")
 
     app = FastAPI()
     app.include_router(signup_module.router)
@@ -82,16 +83,19 @@ def test_invalid_payload_returns_400(client, monkeypatch):
     assert resp.status_code == 400
 
 
-def test_missing_base_url_warns_but_still_notifies(client, monkeypatch, caplog):
+def test_missing_base_url_returns_503(client, monkeypatch, caplog):
+    """#4369: a relative approve/reject link is unusable in the admin email,
+    so a missing SIGNUP_APPROVAL_BASE_URL must fail loudly (503) rather than
+    silently sending a broken link."""
     test_client, _ = client
     sent = _capture_email(monkeypatch)
     monkeypatch.delenv("SIGNUP_APPROVAL_BASE_URL", raising=False)
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("ERROR"):
         resp = test_client.post("/signup/request", json={"name": "Jane", "email": "jane@example.com"})
 
-    assert resp.status_code == 200
-    assert sent["notification"].approve_url.startswith("/signup/approve")
+    assert resp.status_code == 503
+    assert "notification" not in sent, "admin must not be emailed a broken relative link"
     assert any("SIGNUP_APPROVAL_BASE_URL" in r.message for r in caplog.records)
 
 
@@ -393,6 +397,7 @@ def rate_limited_client(tmp_path, monkeypatch):
         lambda request, allow_missing=False: accounts_root,
     )
     monkeypatch.setenv("SIGNUP_ADMIN_EMAIL", "admin@example.com")
+    monkeypatch.setenv("SIGNUP_APPROVAL_BASE_URL", "https://admin.example.com")
 
     limiter = Limiter(key_func=get_remote_address, storage_uri="memory://")
     router = signup_module.create_router(limiter, "3/minute")


### PR DESCRIPTION
## Summary
- `_build_links` (`backend/routes/signup.py`) silently fell back to relative approve/reject URLs when `SIGNUP_APPROVAL_BASE_URL` was unset, only logging a warning — the admin still got emailed a link (`/signup/approve?...`) that no email client can resolve to anything.
- `_build_links` now raises `RuntimeError` when the base URL is missing.
- `POST /signup/request` catches that and returns the same `503 "signup is not available"` response already used for a missing `SIGNUP_ADMIN_EMAIL` (matching that existing misconfiguration-handling pattern and its anti-enumeration guarantee — the response reveals nothing about account existence either way).

## Test plan
- [x] Renamed `test_missing_base_url_warns_but_still_notifies` → `test_missing_base_url_returns_503`, asserting the 503 and that the admin is never emailed a broken relative link.
- [x] Added a default `SIGNUP_APPROVAL_BASE_URL` to the `client` and `rate_limited_client` fixtures (every other test in the file exercises the happy path and previously relied on the old warn-and-continue fallback).
- [x] `pytest tests/backend/routes/test_signup.py tests/backend/test_signup_requests.py` — 54 passed.
- [x] Confirmed no other test file exercises `POST /signup/request`.
- [x] Confirmed the touched files' pre-existing lint findings (isort ordering, one long line elsewhere in the file) predate this change.

Closes #4369

🤖 Generated with [Claude Code](https://claude.com/claude-code)