### PR TITLE
test(frontend): Tier 2 hardening — CreateAccountPage, PortfolioView, DataQuality, auth coercion

### DIFF
--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -400,6 +400,16 @@ describe('cognitoLogout', () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
+  it('does not throw when the domain contains invalid URL characters', () => {
+    // normaliseDomain only trims/prefixes the domain string — it never
+    // validates or parses it as a URL — so a malformed domain must not crash
+    // the logout flow, even though the resulting redirect target is bogus.
+    expect(() =>
+      cognitoLogout({ domain: 'auth example <invalid>', clientId: 'client123' }),
+    ).not.toThrow();
+    expect(assignMock).toHaveBeenCalledTimes(1);
+  });
+
   it('clears the local session before redirecting', () => {
     window.sessionStorage.setItem(
       'awsUiAuthSession',

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { PortfolioView } from "@/components/PortfolioView";
 import type { Portfolio } from "@/types";
@@ -125,6 +125,26 @@ describe("PortfolioView", () => {
         render(<PortfolioView data={mockOwner} />);
 
         expect(screen.getByText(/import csv/i)).toBeInTheDocument();
+    });
+
+    it("calls onPositionAdded when CsvImportForm triggers onImported", async () => {
+        const { importHoldingsCsv } = await import("@/api");
+        vi.mocked(importHoldingsCsv).mockResolvedValue({ path: "steve/ISA/import.csv" });
+        const onPositionAdded = vi.fn();
+
+        render(<PortfolioView data={mockOwner} onPositionAdded={onPositionAdded} />);
+
+        fireEvent.change(screen.getByLabelText(/provider/i), {
+            target: { value: "degiro" },
+        });
+        const file = new File(["ticker,qty\nAAPL,1"], "holdings.csv", { type: "text/csv" });
+        fireEvent.change(screen.getByLabelText(/csv file/i), {
+            target: { files: [file] },
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+
+        await waitFor(() => expect(onPositionAdded).toHaveBeenCalledTimes(1));
     });
 
     it("hides the CSV import form when no accounts exist", () => {

--- a/frontend/tests/unit/pages/CreateAccountPage.test.tsx
+++ b/frontend/tests/unit/pages/CreateAccountPage.test.tsx
@@ -98,6 +98,48 @@ describe("CreateAccountPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("clears the validation error once the user edits the email field", () => {
+    render(
+      <MemoryRouter>
+        <CreateAccountPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /request account/i }));
+    expect(
+      screen.getByText(/enter your name and email/i),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "a" },
+    });
+
+    expect(
+      screen.queryByText(/enter your name and email/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears the validation error once the user edits the note field", () => {
+    render(
+      <MemoryRouter>
+        <CreateAccountPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /request account/i }));
+    expect(
+      screen.getByText(/enter your name and email/i),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/what would you like to use allotmint for/i), {
+      target: { value: "Tracking my ISA" },
+    });
+
+    expect(
+      screen.queryByText(/enter your name and email/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows an error message and stays on the form when submission fails", async () => {
     vi.mocked(requestAccountSignup).mockRejectedValue(new Error("network"));
 

--- a/frontend/tests/unit/pages/DataQuality.test.tsx
+++ b/frontend/tests/unit/pages/DataQuality.test.tsx
@@ -74,6 +74,14 @@ describe("DataQuality page", () => {
     expect(screen.getByText(en.dataQuality.status.red)).toBeInTheDocument();
   });
 
+  it("shows loading state while fetching", async () => {
+    mockGetDataQualityTimeseries.mockReturnValue(new Promise(() => {}));
+
+    render(<DataQuality />);
+
+    expect(await screen.findByText(en.common.loading)).toBeInTheDocument();
+  });
+
   it("shows an empty state when no positions are cached", async () => {
     mockGetDataQualityTimeseries.mockResolvedValue({ count: 0, positions: [] });
 

--- a/frontend/tests/unit/rootBootstrap.test.tsx
+++ b/frontend/tests/unit/rootBootstrap.test.tsx
@@ -393,6 +393,41 @@ describe('Root bootstrap integration coverage', () => {
     expect(await screen.findByTestId('login-page')).toBeInTheDocument()
   })
 
+  it('shows login page when awsUiAuth.enabled is the string "true" even with disable_auth=false (issue #4986)', async () => {
+    // The string-coercion path (cfgAwsUiAuth?.enabled === 'true') must force
+    // the login page independently of disable_auth — disable_auth only tells
+    // the Lambda to skip its own auth check, not API Gateway's Cognito check.
+    vi.doMock('react-dom/client', () => ({
+      createRoot: () => ({ render: vi.fn() })
+    }))
+
+    vi.doMock('@/api', async importOriginal => {
+      const mod = await importOriginal<typeof import('@/api')>()
+      return {
+        ...mod,
+        getConfig: vi.fn().mockResolvedValue({
+          google_auth_enabled: false,
+          google_client_id: null,
+          disable_auth: false,
+          awsUiAuth: {
+            enabled: 'true',
+            domain: 'https://cognito.example.com',
+            clientId: 'client-from-backend',
+          },
+        }),
+        getStoredAuthToken: vi.fn(() => null),
+      }
+    })
+
+    vi.doMock('@/LoginPage', () => ({
+      default: () => <div data-testid="login-page">sign in</div>
+    }))
+
+    await mountRoot()
+
+    expect(await screen.findByTestId('login-page')).toBeInTheDocument()
+  })
+
   it('renders the app without a login page when backend cfg carries awsUiAuth.enabled as the string "false" (issue #4635)', async () => {
     vi.doMock('react-dom/client', () => ({
       createRoot: () => ({ render: vi.fn() })


### PR DESCRIPTION
## Summary
Test-only Tier 2 batch from milestone 14 (Frontend Hardening & Test Coverage):

- **#5018** — `CreateAccountPage.test.tsx`: add error-clearing tests for the email and note fields, mirroring the existing name-field test (consolidates #5007/#5008).
- **#5001** — `PortfolioView.test.tsx`: assert `onPositionAdded` is called when `CsvImportForm` triggers `onImported`, covering the component-boundary wiring from PR #5000.
- **#4969** — `DataQuality.test.tsx`: assert the loading indicator (`common.loading`) renders while the API request is in-flight.
- **#4986** — `rootBootstrap.test.tsx`: cover `awsUiAuth.enabled='true'` string coercion with `disable_auth=false`, confirming the login page is forced independently of the `disable_auth` flag.
- **#4992** — `awsUiAuth.test.ts`: cover `cognitoLogout` with a malformed domain string (invalid URL characters), confirming it doesn't throw.

No production code changes — test-only, as scoped by each issue.

## Test plan
- [x] `npx vitest run` on all 5 touched test files — 95/95 pass
- [x] Full frontend unit suite — 628/628 pass
- [x] `npx eslint` on changed files — clean
- [x] `npx tsc --noEmit` — clean

Closes #5018, Closes #5001, Closes #4969, Closes #4986, Closes #4992

🤖 Generated with [Claude Code](https://claude.com/claude-code)