### PR TITLE
docs: document resolve_accounts_root's allow_missing contract

### DIFF
--- a/backend/routes/_accounts.py
+++ b/backend/routes/_accounts.py
@@ -21,6 +21,23 @@ def resolve_accounts_root(request: Request, *, allow_missing: bool = False) -> P
     or cannot be resolved to a valid path the function falls back to the
     configured repository paths, ultimately defaulting to the standard data
     directory discovered via :func:`data_loader.resolve_paths`.
+
+    This function always returns a ``Path`` — it never returns ``None`` and
+    never raises for a missing directory. ``allow_missing`` only controls
+    whether a *cached* ``request.app.state.accounts_root`` that points at a
+    directory that doesn't exist on disk is accepted as-is:
+
+    - ``allow_missing=False`` (default): a non-existent cached path is
+      discarded, and resolution falls through to the configured repository
+      paths (and ultimately the standard data directory) instead.
+    - ``allow_missing=True``: a non-existent cached path is returned
+      unchanged. Callers that pass this (e.g. account-creation/signup routes)
+      need the directory a new account *will* live in before it exists.
+
+    The configured-path and fallback branches below are unconditional and
+    always return a ``Path`` regardless of whether that directory currently
+    exists — callers must check existence themselves if it matters for their
+    use case.
     """
 
     accounts_root_value = getattr(request.app.state, "accounts_root", None)


### PR DESCRIPTION
## Summary
- Documents the actual contract of `resolve_accounts_root` (`backend/routes/_accounts.py`), traced against every call site rather than assumed.
- Corrects the issue's original premise: the function never raises and never returns `None` — it always returns a `Path`. `allow_missing` only controls whether a cached-but-nonexistent `request.app.state.accounts_root` is returned as-is (`True`, used by account-creation/signup routes that need a not-yet-existing directory) or discarded in favor of falling through to the configured/default paths (`False`).
- Docstring-only change; no runtime behavior modified, return type annotation (`Path`, already correct) left unchanged.

Closes #4723

## Test plan
- [x] Traced all 17 call sites across `alerts.py`, `approvals.py`, `compliance.py`, `pension.py`, `portfolio.py`, `signup.py`, `transactions.py`, `user_config.py` to confirm the described behavior
- [x] `python -m pytest tests/backend/routes/test_accounts_helpers.py -q` — 9 passed
- [x] Syntax-checked the edited file with `ast.parse`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the account directory resolution behaviour.
  * Documented that the resolver always returns a path, including when the directory does not exist.
  * Explained how missing cached paths are handled when missing directories are allowed.
  * Clarified that callers are responsible for checking whether the resolved path exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->