### PR TITLE
docs: CDK docstring cross-reference and PR template AC-verification item

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ Closes #
 - [ ] Relevant tests updated/added and passing (`pytest`, `npm --prefix frontend run test -- --run`)
 - [ ] Lint passing (`make lint`, `npm --prefix frontend run lint`)
 - [ ] Manually verified the change (describe how, or attach screenshots for UI changes)
+- [ ] If this description states a "from" version or prior state (e.g. a dependency bump), verified it against the actual current file content (e.g. `grep` the version pin) rather than an assumed baseline
 
 ## Notes for reviewers
 

--- a/cdk/stacks/prod_env.py
+++ b/cdk/stacks/prod_env.py
@@ -27,6 +27,12 @@ def assert_prod_env_vars(scope: Construct, required_vars: dict[str, str]) -> Non
     used in the error message. Validation only runs when the ``prod`` CDK
     context is truthy; dev/staging synths are unaffected. See #3847, #3866,
     #4731.
+
+    Note: not every prod-only check goes through this helper. Some checks
+    (e.g. ``_ui_auth_removal_policy`` in ``static_site_stack.py``) depend on
+    CDK *context* values (``node.try_get_context``) rather than *environment*
+    variables (``os.getenv``), so they read their own context directly
+    instead of calling this function — see that function's docstring for why.
     """
 
     if not is_truthy_context(scope.node.try_get_context("prod")):


### PR DESCRIPTION
## Summary
Two small, unrelated documentation fixes bundled together since both are one-line doc changes:

- **#4995** — `assert_prod_env_vars` (`cdk/stacks/prod_env.py`) gets the missing reverse cross-reference to `_ui_auth_removal_policy` (`cdk/stacks/static_site_stack.py`), which already explains why it reads CDK context directly instead of calling this helper. Now the boundary between context-based and env-var-based prod checks is discoverable from either function.
- **#4629** — Adds a checklist item to `.github/PULL_REQUEST_TEMPLATE.md`'s "How I validated this" section, prompting authors to verify any stated "from" version/prior state against actual current file content before submitting (motivated by a stale AC mismatch found reviewing PR #4606). Note: the original issue assumed a separate "Acceptance Criteria" section that doesn't exist in this template — the item was added to the existing checklist instead.

Both changes are docs/comment-only; no runtime or template structure changes beyond the one added line each.

Closes #4995, closes #4629

## Test plan
- [x] `ast.parse` on `prod_env.py` to confirm no syntax errors
- [x] Traced both `assert_prod_env_vars` and `_ui_auth_removal_policy` call sites/docstrings to confirm the cross-reference is accurate
- [x] Confirmed the PR template's actual structure (no AC section) before deciding where to place the new checklist item