### PR TITLE
fix(frontend): add Trail edge-case tests and fix error-state precedence

### DIFF
--- a/frontend/src/pages/Trail.tsx
+++ b/frontend/src/pages/Trail.tsx
@@ -34,6 +34,10 @@ export default function Trail() {
       .catch((e) => setError(String(e)));
   };
 
+  // Both states reset to null on every mount (useState has no persistence
+  // across unmounts), so there is no "stale error" case here: error must be
+  // checked before !data, otherwise a failed getTrailTasks() call leaves the
+  // UI stuck on the loading message forever since data is never set.
   if (error) return <div style={{ color: "red" }}>{error}</div>;
   if (!data) return <div>{t("common.loading")}</div>;
 

--- a/frontend/src/pages/Trail.tsx
+++ b/frontend/src/pages/Trail.tsx
@@ -34,8 +34,8 @@ export default function Trail() {
       .catch((e) => setError(String(e)));
   };
 
-  if (!data) return <div>{t("common.loading")}</div>;
   if (error) return <div style={{ color: "red" }}>{error}</div>;
+  if (!data) return <div>{t("common.loading")}</div>;
 
   const daily = data.tasks.filter((t) => t.type === "daily");
   const once = data.tasks.filter((t) => t.type === "once");

--- a/frontend/tests/unit/pages/Trail.test.tsx
+++ b/frontend/tests/unit/pages/Trail.test.tsx
@@ -110,4 +110,100 @@ describe("Trail page", () => {
     expect(await screen.findByText(en.trail.dailyComplete)).toBeInTheDocument();
     expect(screen.getByText(en.trail.allDone)).toBeInTheDocument();
   });
+
+  it("shows a loading state before data arrives", () => {
+    mockGetTrailTasks.mockReturnValue(new Promise(() => undefined));
+
+    render(<Trail />);
+
+    expect(screen.getByText(en.common.loading)).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: en.trail.title })).not.toBeInTheDocument();
+  });
+
+  it("shows an error state when loading trail data fails", async () => {
+    mockGetTrailTasks.mockRejectedValue(new Error("network down"));
+
+    render(<Trail />);
+
+    expect(await screen.findByText("Error: network down")).toBeInTheDocument();
+    expect(screen.queryByText(en.common.loading)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: en.trail.title })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an empty task list without daily or completion sections", async () => {
+    const today = "2024-01-17";
+    mockGetTrailTasks.mockResolvedValue({
+      tasks: [],
+      xp: 0,
+      streak: 0,
+      daily_totals: {},
+      today,
+    });
+
+    render(<Trail />);
+
+    expect(
+      await screen.findByRole("heading", { name: en.trail.title })
+    ).toBeInTheDocument();
+
+    const progressText = en.trail.progressLabel
+      .replace("{{completed}}", "0")
+      .replace("{{total}}", "0")
+      .replace("{{percent}}", "0");
+    expect(screen.getByText(progressText)).toBeInTheDocument();
+    expect(screen.queryByText("Check")).not.toBeInTheDocument();
+    // An empty task list is vacuously "all complete", so the completion
+    // banner shows, but the daily-specific message must not (0 of 0 daily
+    // tasks isn't a meaningful "daily complete").
+    expect(screen.queryByText(en.trail.dailyComplete)).not.toBeInTheDocument();
+    expect(screen.getByText(en.trail.allDone)).toBeInTheDocument();
+  });
+
+  it("shows partial-completion state without the celebration banner", async () => {
+    const today = "2024-01-18";
+    mockGetTrailTasks.mockResolvedValue({
+      tasks: [
+        {
+          id: "check_market",
+          title: "Check",
+          type: "daily",
+          commentary: "",
+          completed: true,
+        },
+        {
+          id: "review_portfolio",
+          title: "Review",
+          type: "daily",
+          commentary: "",
+          completed: false,
+        },
+        {
+          id: "create_goal",
+          title: "Goal",
+          type: "once",
+          commentary: "",
+          completed: false,
+        },
+      ],
+      xp: 10,
+      streak: 1,
+      daily_totals: { [today]: { completed: 1, total: 2 } },
+      today,
+    });
+
+    render(<Trail />);
+
+    expect(
+      await screen.findByRole("heading", { name: en.trail.title })
+    ).toBeInTheDocument();
+
+    const progressBar = await screen.findByRole("progressbar");
+    expect(progressBar).toHaveAttribute("aria-valuenow", "1");
+    expect(progressBar).toHaveAttribute("aria-valuemax", "2");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByText(en.trail.dailyComplete)).not.toBeInTheDocument();
+    expect(screen.queryByText(en.trail.allDone)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds edge-case test coverage for `Trail.tsx`'s data loading: fetch/API error, empty task list, loading state, and partial-completion state.
- Writing the error-state test surfaced a real bug in `Trail.tsx`: the `!data` loading check ran before the `error` check, so a failed initial `getTrailTasks()` call left the UI stuck showing "Loading…" forever instead of the error message. Swapped the order so the error state takes precedence.

## Test plan
- [x] `npm run test -- --run tests/unit/pages/Trail.test.tsx` — 6/6 pass
- [x] `npm run test -- --run` (full frontend suite) — 95 files / 632 tests pass
- [x] `npm run lint` — clean

Closes #4230