### PR TITLE
test(frontend): dedupe fetch mock setup in awsUiAuth OAuth callback tests

### DIFF
--- a/frontend/tests/unit/awsUiAuth.test.ts
+++ b/frontend/tests/unit/awsUiAuth.test.ts
@@ -9,6 +9,14 @@ const AUTH_CONFIG = {
   clientId: 'client123',
 };
 
+// Shared by the "no OAuth params" and "OAuth params present" exchangeCode
+// tests below, which otherwise duplicate this stubGlobal/mock setup.
+const stubFetch = (resolvedValue?: unknown) => {
+  const fetchMock = resolvedValue === undefined ? vi.fn() : vi.fn().mockResolvedValue(resolvedValue);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
 const setLocation = (search = '') => {
   Object.defineProperty(window, 'location', {
     configurable: true,
@@ -69,8 +77,7 @@ describe('ensureAwsUiAuth', () => {
     // (exchangeCode is an unexported module-internal function and, under
     // Vitest/ESM, spying on it directly would not intercept the in-module call
     // from ensureAwsUiAuth anyway).
-    const fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = stubFetch();
 
     await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(true);
 
@@ -187,11 +194,10 @@ describe('ensureAwsUiAuth', () => {
       // Same proxy reasoning as the "no OAuth params" test above: exchangeCode
       // itself isn't mockable across the module boundary, so we assert on its
       // one externally observable effect — the /oauth2/token fetch call.
-      const fetchMock = vi.fn().mockResolvedValue({
+      const fetchMock = stubFetch({
         ok: true,
         json: () => Promise.resolve({ id_token: 'tok', expires_in: 3600 }),
       });
-      vi.stubGlobal('fetch', fetchMock);
 
       await expect(ensureAwsUiAuth(AUTH_CONFIG)).resolves.toBe(true);
 


### PR DESCRIPTION
## Summary
- Extracts a `stubFetch(resolvedValue?)` helper in `frontend/tests/unit/awsUiAuth.test.ts` and uses it in the two exchangeCode tests added by #4988 ("does not invoke exchangeCode when no OAuth callback params are present" and "invokes exchangeCode ... when OAuth callback params are present"), which previously duplicated the `vi.stubGlobal('fetch', ...)` setup inline.
- Scoped to just those two tests per the issue; left the rest of the file's fetch-stubbing (each with its own distinct response shape) untouched to keep the change minimal.

## Test plan
- [x] `npm run test -- --run tests/unit/awsUiAuth.test.ts` — 55/55 pass
- [x] `npm run test -- --run` (full frontend suite) — 95 files / 628 tests pass
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean

Closes #4994