### PR TITLE
fix: harden PR automation scripts (temp file, slugify, binary diffs, reopened issues)

### DIFF
--- a/.github/scripts/review_common.py
+++ b/.github/scripts/review_common.py
@@ -273,6 +273,20 @@ def split_diff_blocks(diff_text: str) -> list[str]:
     return blocks
 
 
+def filter_binary_files(diff_text: str) -> str:
+    """Drop binary file entries from a git diff before it reaches the model.
+
+    Binary blocks (images, compiled artifacts) waste review budget and can
+    confuse the model with non-text content; reuses ``split_diff_blocks`` so
+    whole-file boundaries are preserved even for renamed binary files.
+    """
+    blocks = split_diff_blocks(diff_text)
+    text_blocks = [
+        block for block in blocks if "Binary files" not in block and "GIT binary patch" not in block
+    ]
+    return "".join(text_blocks)
+
+
 def truncate_diff(diff_text: str, limit: int = MAX_DIFF_CHARS) -> tuple[str, bool]:
     """Truncate a diff on whole-file boundaries and emit a notice when files are skipped.
 

--- a/scripts/dev_tools/pr_review.py
+++ b/scripts/dev_tools/pr_review.py
@@ -21,7 +21,13 @@ from ollama_common import (
     get_ollama_model,
     validate_ollama_connection,
 )
-from review_common import build_prompt, emit_empty_diff_notice, finalize_review, truncate_diff
+from review_common import (
+    build_prompt,
+    emit_empty_diff_notice,
+    filter_binary_files,
+    finalize_review,
+    truncate_diff,
+)
 
 
 def get_repo_info() -> tuple[str, str]:
@@ -86,7 +92,7 @@ def fetch_pr_diff(owner: str, repo: str, pr_id: int) -> str:
             text=True,
             check=True,
         )
-        return result.stdout
+        return filter_binary_files(result.stdout)
     except FileNotFoundError as exc:
         print(f"ERROR: gh CLI not found. Is GitHub CLI installed? {exc}", file=sys.stderr)
         raise SystemExit(1) from exc

--- a/scripts/dev_tools/publish_pr.py
+++ b/scripts/dev_tools/publish_pr.py
@@ -7,6 +7,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -356,9 +357,15 @@ def create_pr(
 
     body_file = None
     try:
-        # Write body to temp file to avoid command-line quoting issues
-        body_file = Path.home() / f".pr-body-{os.getpid()}.txt"
-        body_file.write_text(body, encoding="utf-8")
+        # Write body to temp file to avoid command-line quoting issues.
+        # delete=False + explicit unlink (rather than delete=True) because an
+        # open NamedTemporaryFile can't be reopened by the `gh` subprocess on
+        # Windows while this process still holds the handle.
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write(body)
+            body_file = Path(tmp.name)
 
         result = subprocess.run(
             [

--- a/scripts/dev_tools/sync_issues.py
+++ b/scripts/dev_tools/sync_issues.py
@@ -148,6 +148,12 @@ def main():
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(content)
 
+    # An issue closed and reopened between the two paginated fetches above
+    # would otherwise appear in both sets; only treat it as closed when it's
+    # not also open, so a reopened issue's file is never deleted then
+    # recreated on the next run.
+    truly_closed_ids = closed_ids - open_ids_to_filenames.keys()
+
     # Remove files that are:
     # 1. For closed issues, or
     # 2. For open issues but with outdated filenames (e.g., issue was renamed)
@@ -156,7 +162,7 @@ def main():
         if not match:
             continue
         issue_id = int(match.group(1))
-        is_closed = issue_id in closed_ids
+        is_closed = issue_id in truly_closed_ids
         current_name = open_ids_to_filenames.get(issue_id)
         is_outdated = current_name and current_name != filepath.name
         if is_closed or is_outdated:

--- a/scripts/dev_tools/work_on_issue.py
+++ b/scripts/dev_tools/work_on_issue.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import re
 import subprocess
@@ -41,11 +42,19 @@ def get_repo_info() -> tuple[str, str]:
 
 
 def slugify(text: str) -> str:
-    """Convert text to a URL-friendly slug."""
-    text = text.lower()
-    text = re.sub(r"[^\w\s-]", "", text)
-    text = re.sub(r"[-\s]+", "-", text)
-    return text.strip("-")[:50]
+    """Convert text to a URL-friendly slug.
+
+    Falls back to a deterministic hash when the title has no ASCII
+    word characters (e.g. emoji-only titles), so branch names never end up
+    with a trailing hyphen like ``fix/issue-4445-``.
+    """
+    slug = text.lower()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[-\s]+", "-", slug)
+    slug = slug.strip("-")[:50]
+    if not slug:
+        slug = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+    return slug
 
 
 def fetch_issue(owner: str, repo: str, issue_id: int) -> dict:

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -688,3 +688,46 @@ def test_gh_api_list_parses_paginated_json_arrays(monkeypatch: pytest.MonkeyPatc
     )
 
     assert module.gh_api_list("repos/owner/repo/issues/1/comments") == [{"id": 1}, {"id": 2}]
+
+
+class TestFilterBinaryFiles:
+    def test_empty_diff(self) -> None:
+        assert review_common.filter_binary_files("") == ""
+
+    def test_text_only_diff_is_unchanged(self) -> None:
+        diff = "diff --git a/file.py b/file.py\n--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n-old\n+new\n"
+        assert review_common.filter_binary_files(diff) == diff
+
+    def test_binary_only_diff_becomes_empty(self) -> None:
+        diff = "diff --git a/logo.png b/logo.png\nBinary files a/logo.png and b/logo.png differ\n"
+        assert review_common.filter_binary_files(diff) == ""
+
+    def test_mixed_diff_keeps_only_text_files(self) -> None:
+        diff = (
+            "diff --git a/logo.png b/logo.png\n"
+            "Binary files a/logo.png and b/logo.png differ\n"
+            "diff --git a/file.py b/file.py\n"
+            "--- a/file.py\n"
+            "+++ b/file.py\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+        )
+        filtered = review_common.filter_binary_files(diff)
+        assert "logo.png" not in filtered
+        assert "file.py" in filtered
+        assert "+new" in filtered
+
+    def test_git_binary_patch_form_is_also_filtered(self) -> None:
+        diff = "diff --git a/data.bin b/data.bin\nGIT binary patch\nliteral 10\n...\n"
+        assert review_common.filter_binary_files(diff) == ""
+
+    def test_renamed_binary_file_is_filtered(self) -> None:
+        diff = (
+            "diff --git a/old.png b/new.png\n"
+            "similarity index 100%\n"
+            "rename from old.png\n"
+            "rename to new.png\n"
+            "Binary files a/old.png and b/new.png differ\n"
+        )
+        assert review_common.filter_binary_files(diff) == ""

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -95,6 +95,29 @@ class TestFetchPrDiff:
             fetch_pr_diff("owner", "repo", 789)
         assert exc_info.value.code == 1
 
+    @mock.patch("pr_review.subprocess.run")
+    def test_binary_file_entries_are_filtered_out(self, mock_run):
+        """Binary file diffs must not reach the model."""
+        mock_result = mock.MagicMock()
+        mock_result.stdout = (
+            "diff --git a/logo.png b/logo.png\n"
+            "Binary files a/logo.png and b/logo.png differ\n"
+            "diff --git a/file.py b/file.py\n"
+            "--- a/file.py\n"
+            "+++ b/file.py\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+        )
+        mock_run.return_value = mock_result
+
+        diff = fetch_pr_diff("owner", "repo", 789)
+
+        assert "logo.png" not in diff
+        assert "Binary files" not in diff
+        assert "file.py" in diff
+        assert "+new" in diff
+
 
 class TestExtractIssueBody:
     @mock.patch("pr_review.subprocess.run")

--- a/tests/test_publish_pr.py
+++ b/tests/test_publish_pr.py
@@ -110,6 +110,33 @@ class TestCreatePr:
         assert url == "https://github.com/leonarduk/allotmint/pull/123"
         mock_run.assert_not_called()
 
+    @mock.patch("publish_pr.find_existing_pr")
+    @mock.patch("publish_pr.subprocess.run")
+    def test_body_temp_file_is_outside_home_dir_and_cleaned_up(self, mock_run, mock_find_existing):
+        """The PR body temp file must live in the system temp dir, not ~, and be removed after."""
+        from publish_pr import create_pr
+
+        mock_find_existing.return_value = None
+        seen_path = {}
+
+        def fake_run(cmd, **kwargs):
+            body_file_arg = Path(cmd[cmd.index("--body-file") + 1])
+            seen_path["path"] = body_file_arg
+            assert body_file_arg.read_text(encoding="utf-8") == "pr body text"
+            return mock.MagicMock(
+                returncode=0,
+                stdout="https://github.com/leonarduk/allotmint/pull/456\n",
+            )
+
+        mock_run.side_effect = fake_run
+
+        url = create_pr("leonarduk", "allotmint", "fix/issue-4445-slug", "main", "title", "pr body text")
+
+        assert url == "https://github.com/leonarduk/allotmint/pull/456"
+        assert not seen_path["path"].name.startswith(".pr-body-")
+        assert seen_path["path"].parent != Path.home()
+        assert not seen_path["path"].exists()
+
 
 class TestCheckGhAvailable:
     @mock.patch("publish_pr.subprocess.run")

--- a/tests/test_sync_issues.py
+++ b/tests/test_sync_issues.py
@@ -1,0 +1,63 @@
+"""Unit tests for sync_issues script."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "dev_tools"))
+import sync_issues  # noqa: E402
+
+
+def _issue(number: int, title: str = "Some issue", state: str = "open") -> dict:
+    return {
+        "number": number,
+        "title": title,
+        "html_url": f"https://github.com/leonarduk/allotmint/issues/{number}",
+        "labels": [],
+        "state": state,
+        "body": "body text",
+    }
+
+
+def _run_main(monkeypatch, tmp_path, open_issues, closed_issues):
+    monkeypatch.setattr(sync_issues, "ISSUES_DIR", tmp_path)
+    monkeypatch.setattr(sync_issues, "get_github_token", lambda: "fake-token")
+
+    def fake_fetch_issues(token, state):
+        return open_issues if state == "open" else closed_issues
+
+    monkeypatch.setattr(sync_issues, "fetch_issues", fake_fetch_issues)
+    sync_issues.main()
+
+
+def test_reopened_issue_file_is_not_deleted(monkeypatch, tmp_path):
+    """An issue appearing in both the open and closed fetches (e.g. a race between the two
+    paginated calls, or a reopen mid-sync) must keep its file rather than being deleted."""
+    issue = _issue(4521, title="Reopened issue")
+    _run_main(monkeypatch, tmp_path, open_issues=[issue], closed_issues=[issue])
+
+    filepath = tmp_path / sync_issues.make_filename(4521, "Reopened issue")
+    assert filepath.exists()
+
+
+def test_genuinely_closed_issue_file_is_deleted(monkeypatch, tmp_path):
+    filename = sync_issues.make_filename(4522, "Closed issue")
+    (tmp_path / filename).write_text("stale content", encoding="utf-8")
+
+    _run_main(
+        monkeypatch,
+        tmp_path,
+        open_issues=[],
+        closed_issues=[_issue(4522, title="Closed issue", state="closed")],
+    )
+
+    assert not (tmp_path / filename).exists()
+
+
+def test_open_issue_file_is_created(monkeypatch, tmp_path):
+    _run_main(monkeypatch, tmp_path, open_issues=[_issue(4523, title="Open issue")], closed_issues=[])
+
+    filepath = tmp_path / sync_issues.make_filename(4523, "Open issue")
+    assert filepath.exists()
+    assert "Open issue" in filepath.read_text(encoding="utf-8")

--- a/tests/test_work_on_issue.py
+++ b/tests/test_work_on_issue.py
@@ -9,7 +9,25 @@ from unittest import mock
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "dev_tools"))
-from work_on_issue import main
+from work_on_issue import main, slugify
+
+
+class TestSlugify:
+    def test_normal_title(self):
+        assert slugify("Fix login bug") == "fix-login-bug"
+
+    def test_emoji_only_title_falls_back_to_deterministic_hash(self):
+        slug = slugify("\U0001f680\U0001f680\U0001f680")
+        assert slug
+        assert slug == slugify("\U0001f680\U0001f680\U0001f680")
+
+    def test_fallback_is_short_and_hex(self):
+        slug = slugify("\U0001f680")
+        assert len(slug) == 8
+        int(slug, 16)  # raises ValueError if not hex
+
+    def test_different_empty_titles_produce_different_fallbacks(self):
+        assert slugify("\U0001f680") != slugify("\U0001f389")
 
 
 def _run_main(monkeypatch, tmp_path, cli_args, sleep_mock):


### PR DESCRIPTION
## Summary
Batch of independent AI-review follow-ups against the same `scripts/dev_tools/` family, implemented together since they're all trivial same-file-area fixes:

- **`publish_pr.py`** (#4478): write the PR body to a system temp file via `tempfile.NamedTemporaryFile` instead of a fixed `~/.pr-body-{pid}.txt` path, so a crash before cleanup no longer litters the home directory. Uses `delete=False` + explicit `unlink` (not `delete=True`) because an open `NamedTemporaryFile` can't be reopened by the `gh` subprocess on Windows while this process still holds the handle.
- **`work_on_issue.py`** (#4491): `slugify()` now falls back to a deterministic 8-char hash when a title has no ASCII word characters (e.g. emoji-only titles), avoiding trailing-hyphen branch names like `fix/issue-4445-`.
- **`pr_review.py` / `review_common.py`** (#4516): binary file entries are now filtered out of the PR diff before it reaches Ollama, via a new shared `filter_binary_files()` helper built on the existing `split_diff_blocks()` so whole-file boundaries (including renames) are preserved.
- **`sync_issues.py`** (#4521): an issue's local file is now only deleted when it's closed *and not also open*, so a reopened issue's file survives a race between the two paginated open/closed API fetches instead of being deleted then recreated on the next run.

### Note on scope
Three other issues filed against this same script family — #4502, #4503, #4508 — turned out to already be fixed or moot on `main` when I checked the current code, so no changes were needed for them:
- #4502 (`get_changed_files()` hardcoded `origin/main`) — already uses `f"origin/{default_branch}"`.
- #4503 (wrapper script relative path) — the `scripts/publish_pr.py` wrapper it targets no longer exists in the repo.
- #4508 (`get_changed_files()` missing staged changes) — `git diff --name-only HEAD` already captures both staged and unstaged changes relative to HEAD.

## Test plan
- [x] New regression tests: temp-file location/cleanup, slugify emoji-only fallback (deterministic + distinct), `filter_binary_files` (empty/text-only/binary-only/mixed/`GIT binary patch`/renamed-binary diffs), reopened-issue file survival + genuinely-closed deletion + open-issue creation
- [x] `pytest tests/test_publish_pr.py tests/test_work_on_issue.py tests/test_pr_review.py tests/test_ai_review_scripts.py tests/test_sync_issues.py` — 85 passed
- [x] `black --config backend/pyproject.toml --check` / `ruff check --config backend/pyproject.toml` on touched `tests/` files — clean (touched `scripts/`/`.github/scripts/` files aren't covered by the repo's `make format`/`make lint` targets, which only run against `backend` and `tests`)

Closes #4478
Closes #4491
Closes #4516
Closes #4521

🤖 Generated with [Claude Code](https://claude.com/claude-code)