### PR TITLE
fix: instrument cold-start warmup timing, fix static-method mismatch, add METADATA_BUCKET CDK test

### DIFF
--- a/backend/bootstrap/startup.py
+++ b/backend/bootstrap/startup.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
+import time
+from contextlib import contextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -13,6 +15,27 @@ from backend.config import Config
 from backend.utils import page_cache
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _timed_phase(name: str):
+    """Log how long a cold-start warmup phase took, in ``extra`` and in the message text.
+
+    ``extra`` keeps the fields structured for whenever a JSON log formatter is in
+    place; they're also inlined into the message so the timing is visible today
+    with the plain text formatter.
+    """
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        duration_ms = round((time.monotonic() - start) * 1000, 2)
+        logger.info(
+            "cold_start_phase phase=%s duration_ms=%s",
+            name,
+            duration_ms,
+            extra={"phase": name, "duration_ms": duration_ms},
+        )
 
 
 class AppLifecycleService:
@@ -59,7 +82,8 @@ class AppLifecycleService:
         )
 
         try:
-            result = _load_snapshot()
+            with _timed_phase("snapshot_load"):
+                result = _load_snapshot()
             if not isinstance(result, tuple) or len(result) != 2 or not isinstance(result[0], dict):
                 raise ValueError("Malformed snapshot")
             snapshot, ts = result
@@ -72,7 +96,8 @@ class AppLifecycleService:
         from backend.common import instrument_api
 
         try:
-            instrument_api.update_latest_prices_from_snapshot(snapshot)
+            with _timed_phase("metadata_update_from_snapshot"):
+                instrument_api.update_latest_prices_from_snapshot(snapshot)
         except Exception:
             logger.exception("Failed to update latest prices from snapshot")
 
@@ -85,12 +110,12 @@ class AppLifecycleService:
         task = asyncio.create_task(self._prime_latest_prices_background())
         app.state.background_tasks.append(task)
 
-    @staticmethod
-    async def _prime_latest_prices_background() -> None:
+    async def _prime_latest_prices_background(self) -> None:
         from backend.common import instrument_api
 
         try:
-            await asyncio.to_thread(instrument_api.prime_latest_prices)
+            with _timed_phase("price_history_fetch"):
+                await asyncio.to_thread(instrument_api.prime_latest_prices)
         except Exception:
             # Non-fatal: price priming is a startup optimisation. If it fails (e.g.
             # network unavailable on Lambda cold start) the app should still serve

--- a/backend/bootstrap/startup.py
+++ b/backend/bootstrap/startup.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from fastapi import FastAPI
 
 from backend.config import Config
+from backend.logging_setup import sanitise_log_value
 from backend.utils import page_cache
 
 logger = logging.getLogger(__name__)
@@ -32,8 +33,8 @@ def _timed_phase(name: str):
         duration_ms = round((time.monotonic() - start) * 1000, 2)
         logger.info(
             "cold_start_phase phase=%s duration_ms=%s",
-            name,
-            duration_ms,
+            sanitise_log_value(name),
+            sanitise_log_value(duration_ms),
             extra={"phase": name, "duration_ms": duration_ms},
         )
 

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -297,6 +297,26 @@ def test_backend_lambda_has_jwt_and_google_env_vars(template):
     )
 
 
+def test_backend_lambda_has_metadata_bucket_env_vars(template):
+    """BackendLambda must have METADATA_BUCKET/METADATA_PREFIX so
+    backend.common.instruments._s3_location() can resolve a writable S3
+    location for auto-created instrument metadata instead of falling back to
+    the read-only /var/task filesystem on Lambda (issue #4930)."""
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Environment": {
+                "Variables": assertions.Match.object_like(
+                    {
+                        "METADATA_BUCKET": assertions.Match.any_value(),
+                        "METADATA_PREFIX": "instruments",
+                    }
+                )
+            }
+        },
+    )
+
+
 def test_backend_lambda_timeout_is_at_least_30s(template):
     """BackendLambda must have a timeout > the 3 s default to survive cold starts."""
     functions = template.find_resources("AWS::Lambda::Function")

--- a/tests/backend/test_app_bootstrap.py
+++ b/tests/backend/test_app_bootstrap.py
@@ -92,6 +92,73 @@ async def test_lifecycle_service_warms_snapshot_and_registers_background_task(
 
 
 @pytest.mark.asyncio
+async def test_lifecycle_service_warmup_logs_timed_phases(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Each cold-start warmup phase must log its own duration (issue #4937), so
+    which phase (snapshot load vs. metadata update vs. price-history fetch)
+    dominates a slow cold start can be diagnosed from the logs."""
+    snapshot_task = asyncio.Future()
+
+    monkeypatch.setattr("backend.common.portfolio_utils._load_snapshot", lambda: ({"ABC": 1}, "ts"))
+    monkeypatch.setattr(
+        "backend.common.portfolio_utils.refresh_snapshot_in_memory", lambda snapshot, ts: None
+    )
+    monkeypatch.setattr(
+        "backend.common.instrument_api.update_latest_prices_from_snapshot", lambda snapshot: None
+    )
+    monkeypatch.setattr("backend.common.instrument_api.prime_latest_prices", lambda: None)
+    monkeypatch.setattr(
+        "backend.common.portfolio_utils.refresh_snapshot_async", lambda days: snapshot_task
+    )
+
+    config.skip_snapshot_warm = False
+    config.snapshot_warm_days = 5
+    service = AppLifecycleService(cfg=config)
+    app = app_module.create_app()
+
+    with caplog.at_level(logging.INFO, logger="backend.bootstrap.startup"):
+        await service.startup(app)
+        prime_task = next(t for t in app.state.background_tasks if t is not snapshot_task)
+        await prime_task
+
+    phases = {
+        record.phase
+        for record in caplog.records
+        if getattr(record, "phase", None) is not None
+    }
+    assert phases == {"snapshot_load", "metadata_update_from_snapshot", "price_history_fetch"}
+    for record in caplog.records:
+        if getattr(record, "phase", None) is not None:
+            assert isinstance(record.duration_ms, float)
+            assert record.duration_ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_prime_latest_prices_background_is_an_instance_method(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression for issue #4938: this must be callable as a bound method (it
+    reads no instance state today, but @staticmethod was misleading given the
+    self.-prefixed call site in _warm_snapshot)."""
+    called = {"primed": False}
+    monkeypatch.setattr(
+        "backend.common.instrument_api.prime_latest_prices",
+        lambda: called.__setitem__("primed", True),
+    )
+
+    service = AppLifecycleService(cfg=config)
+    assert not isinstance(
+        type(service).__dict__["_prime_latest_prices_background"], staticmethod
+    )
+
+    await service._prime_latest_prices_background()
+
+    assert called["primed"] is True
+
+
+@pytest.mark.asyncio
 async def test_lifecycle_service_shutdown_cancels_tasks_and_temp_dirs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -21,7 +21,7 @@ backend/app.py:215
 backend/auth.py:126
 backend/auth.py:537
 backend/bootstrap/isolation.py:89
-backend/bootstrap/startup.py:67
+backend/bootstrap/startup.py:92
 backend/common/accounts_store.py:244
 backend/common/accounts_store.py:283
 backend/common/accounts_store.py:286


### PR DESCRIPTION
## Summary
Batch of independent AI-review follow-ups against `backend/bootstrap/startup.py` and its CDK stack, all stemming from PR #4934:

- **`backend/bootstrap/startup.py`** (#4937, #4938): wrap each cold-start warmup phase (`snapshot_load`, `metadata_update_from_snapshot`, `price_history_fetch`) with a new `_timed_phase()` context manager that logs `duration_ms` (via `extra=` for whenever a JSON formatter lands, and inlined into the message text so it's readable today). Also removed the misleading `@staticmethod` from `_prime_latest_prices_background` — it's always called via `self.` and reads no instance state today, but the decorator implied it never should.
- **`cdk/tests/test_backend_lambda_stack.py`** (#4939): new test asserting `BackendLambda` receives `METADATA_BUCKET`/`METADATA_PREFIX`, guarding against `instrument_api`'s auto-created-metadata write path silently falling back to the read-only `/var/task` filesystem on Lambda (issue #4930).

### Deliberately not in this PR
**#4940** ("make snapshot loading itself non-blocking or time-bounded") is left for a follow-up. Its own issue text says the decision depends on the timing data this PR now starts collecting ("without these metrics, the team cannot verify whether the background task approach alone is sufficient, or whether snapshot loading itself needs to be backgrounded... make data-driven decisions"). Implementing that change now, before any real cold-start numbers exist, would be exactly the premature optimisation the issue chain itself warns against. Once `snapshot_load` timings are visible in CloudWatch, #4940 can be revisited with actual data.

## Test plan
- [x] New regression tests: all three phases log `phase`/`duration_ms`; `_prime_latest_prices_background` is a bound instance method, not a `staticmethod`
- [x] `pytest tests/backend/test_app_bootstrap.py` — 7 passed
- [x] `pytest cdk/tests/test_backend_lambda_stack.py` — 49 passed (including the new `METADATA_BUCKET`/`METADATA_PREFIX` test)
- [x] `pytest tests/backend` — 780 passed, 1 skipped, 12 xfailed — no regressions
- [x] `ruff check --config backend/pyproject.toml` — clean

Closes #4937
Closes #4938
Closes #4939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Added timing information for key application start-up and warm-up phases, making performance diagnostics clearer.
  - Improved visibility into background price-data preparation during start-up.

- **Bug Fixes**
  - Ensured instrument metadata storage settings are correctly included in backend deployment configuration.

- **Tests**
  - Added coverage for start-up timing logs, background price preparation, and metadata configuration.
  - Updated logging test data to reflect the latest source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->