### PR TITLE
fix: remove redundant provision_owner scaffold/identity calls, add scaffold-failure test

### DIFF
--- a/backend/common/signup_provision.py
+++ b/backend/common/signup_provision.py
@@ -156,16 +156,18 @@ def provision_owner(
     """Provision the owner for an approved request and return the owner slug.
 
     Scaffolds the owner directory under ``accounts_root`` and records the
-    request email in ``person.json`` so the user can authenticate. When a
-    writable ``store`` is supplied its ``ensure_owner`` is also invoked so the
-    deployed writable-store path stays consistent with #4353.
+    request email in ``person.json`` so the user can authenticate.
+    ``_resolve_owner_slug`` already performs both the scaffold and the
+    identity write (with the real ``full_name``) as part of atomically
+    claiming the slug, so there is nothing left to do here for a fresh
+    or re-provisioned owner. When a writable ``store`` is supplied its
+    ``ensure_owner`` is also invoked so the deployed writable-store path
+    stays consistent with #4353.
     """
 
     accounts_root = Path(accounts_root)
     email = record.email.strip().lower()
     owner = _resolve_owner_slug(email, accounts_root, record.name)
-    owner_dir = ensure_owner_scaffold(owner, accounts_root)
-    _write_person_identity(owner_dir, email, record.name)
 
     if store is not None:
         ensure = getattr(store, "ensure_owner", None)

--- a/backend/common/signup_provision.py
+++ b/backend/common/signup_provision.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 from backend.common.compliance import ensure_owner_scaffold
 from backend.common.signup_requests import SignupRequest
+from backend.logging_setup import sanitise_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -174,5 +175,9 @@ def provision_owner(
         if callable(ensure):
             ensure(owner)
 
-    logger.info("Provisioned owner %s for approved signup request %s", owner, record.id)
+    logger.info(
+        "Provisioned owner %s for approved signup request %s",
+        sanitise_log_value(owner),
+        sanitise_log_value(record.id),
+    )
     return owner

--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -181,6 +181,36 @@ def test_resolve_owner_slug_cleans_up_on_write_failure(tmp_path, monkeypatch):
     assert not (accounts_root / "jane").exists()
 
 
+def test_resolve_owner_slug_cleans_up_on_scaffold_failure(tmp_path, monkeypatch):
+    """Regression test for #5259.
+
+    The cleanup on failure must also cover ``ensure_owner_scaffold`` raising,
+    not just ``_write_person_identity`` — both calls sit inside the same
+    try/except in ``_resolve_owner_slug``, but ``ensure_owner_scaffold`` runs
+    first in that sequence and needs its own assertion.
+    """
+
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+
+    def _failing_scaffold(*_args, **_kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(signup_provision, "ensure_owner_scaffold", _failing_scaffold)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
+
+    # The directory created by mkdir must be cleaned up.
+    assert not (accounts_root / "jane").exists()
+
+    # A retry after the transient failure clears must succeed and reclaim
+    # the same slug rather than being stuck skipping over it forever.
+    monkeypatch.undo()
+    owner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
+    assert owner == "jane"
+
+
 def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -66,10 +66,9 @@ backend/common/portfolio.py:81
 backend/common/prices.py:242
 backend/common/prices.py:297
 backend/common/prices.py:301
-backend/common/signup_provision.py:175
-backend/common/signup_provision.py:70
-backend/common/signup_provision.py:73
-backend/common/signup_provision.py:76
+backend/common/signup_provision.py:71
+backend/common/signup_provision.py:74
+backend/common/signup_provision.py:77
 backend/common/signup_requests.py:206
 backend/common/signup_requests.py:254
 backend/common/signup_requests.py:274


### PR DESCRIPTION
## Summary
- `_resolve_owner_slug` (landed via #5237) already scaffolds the owner directory and writes the full identity (`email` + `full_name`) as part of atomically claiming the slug. `provision_owner`'s second `ensure_owner_scaffold` + `_write_person_identity` calls duplicated that work with identical data on every fresh-provision path, and did nothing on the idempotent-reuse path (which returns early without touching `person.json`). Removed the redundant calls.
- Added a regression test asserting the mkdir-won directory is cleaned up when `ensure_owner_scaffold` itself fails, not just when `_write_person_identity` fails — both calls share one `try`/`except` in `_resolve_owner_slug`, but only the write-failure path had coverage before this.

## Test plan
- [x] `pytest tests/backend/test_signup_provision.py tests/backend/routes/test_signup.py tests/backend/common/test_compliance.py` — 47 passed.
- [x] `black --check --config backend/pyproject.toml` / `ruff check --config backend/pyproject.toml` on the changed files — clean.

Closes #5258
Closes #5259

🤖 Generated with [Claude Code](https://claude.com/claude-code)