### PR TITLE
test: cover auth-enabled token=None path and real SSM parameter-store pipeline

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -383,6 +383,28 @@ async def test_get_current_user_disabled_without_identity(monkeypatch):
     assert auth.current_user.get() is None
 
 
+@pytest.mark.asyncio
+async def test_get_current_user_enabled_without_token(monkeypatch):
+    """When disable_auth=False (the default) and token=None, get_current_user must
+    fall straight through to _user_from_token(None) and reject the request.
+    local_login_identity() is the disable_auth-only fallback (see
+    _resolve_identity_when_auth_disabled) and must never be consulted on the
+    auth-enabled path."""
+
+    monkeypatch.setattr(auth.config, "disable_auth", False, raising=False)
+
+    def fail_local_login_identity() -> str | None:  # pragma: no cover - safety guard
+        raise AssertionError("local_login_identity should not be called on the auth-enabled path")
+
+    monkeypatch.setattr(auth, "local_login_identity", fail_local_login_identity)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth.get_current_user(token=None)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid authentication credentials"
+
+
 def test_missing_secret_key_generates_ephemeral_secret(monkeypatch, caplog):
     monkeypatch.delenv("JWT_SECRET", raising=False)
     monkeypatch.delenv("APP_ENV", raising=False)

--- a/tests/test_pension_report_lambda.py
+++ b/tests/test_pension_report_lambda.py
@@ -1,6 +1,69 @@
+import json
+
 import pytest
 
 from backend.lambda_api import pension_report as lam
+
+
+def test_load_recipient_owners_reads_from_ssm_parameter_store(monkeypatch):
+    """Exercises the real get_storage() -> ssm:// -> ParameterStoreJSONStorage
+    pipeline (not a mock of _load_recipient_owners/get_storage themselves), so
+    a broken ssm:// scheme registration or a renamed parameter would be
+    caught here rather than only mocked out."""
+    monkeypatch.delenv("PENSION_REPORT_RECIPIENTS_URI", raising=False)
+
+    calls = []
+
+    class FakeSsmClient:
+        def get_parameter(self, Name, WithDecryption):  # noqa: N803
+            calls.append({"Name": Name, "WithDecryption": WithDecryption})
+            return {"Parameter": {"Value": json.dumps({"owners": ["alice", "bob"]})}}
+
+    monkeypatch.setattr("boto3.client", lambda service, *args, **kwargs: FakeSsmClient())
+
+    owners = lam._load_recipient_owners()
+
+    assert owners == ["alice", "bob"]
+    assert calls == [{"Name": "pension-report-recipients", "WithDecryption": True}]
+
+
+def test_load_recipient_owners_honours_recipients_uri_override(monkeypatch):
+    monkeypatch.setenv("PENSION_REPORT_RECIPIENTS_URI", "ssm://custom-recipients-param")
+
+    calls = []
+
+    class FakeSsmClient:
+        def get_parameter(self, Name, WithDecryption):  # noqa: N803
+            calls.append(Name)
+            return {"Parameter": {"Value": json.dumps({"owners": ["carol"]})}}
+
+    monkeypatch.setattr("boto3.client", lambda service, *args, **kwargs: FakeSsmClient())
+
+    owners = lam._load_recipient_owners()
+
+    assert owners == ["carol"]
+    assert calls == ["custom-recipients-param"]
+
+
+def test_load_recipient_owners_returns_none_when_ssm_parameter_missing(monkeypatch):
+    """ParameterStoreJSONStorage.load() swallows ClientError/BotoCoreError and
+    returns {} (see backend/common/storage.py), so a missing SSM parameter
+    surfaces here as "no recipients configured" (None) rather than an
+    exception -- matches the "all owners" default, not a hard failure."""
+    from botocore.exceptions import ClientError
+
+    monkeypatch.delenv("PENSION_REPORT_RECIPIENTS_URI", raising=False)
+
+    class FailingSsmClient:
+        def get_parameter(self, Name, WithDecryption):  # noqa: N803
+            raise ClientError(
+                {"Error": {"Code": "ParameterNotFound", "Message": "not found"}},
+                "GetParameter",
+            )
+
+    monkeypatch.setattr("boto3.client", lambda service, *args, **kwargs: FailingSsmClient())
+
+    assert lam._load_recipient_owners() is None
 
 
 def _portfolio(owner="alice", dob="1990-01-01", email="alice@example.com", pot=10000.0):


### PR DESCRIPTION
## Summary
Two independent test-coverage-gap issues, implemented together:

- **#5006** (`tests/test_auth.py`): added `test_get_current_user_enabled_without_token`, mirroring the existing `test_get_current_user_disabled_without_identity` guard test but for the auth-enabled (default `disable_auth=False`) path. Asserts `get_current_user` falls straight through to `_user_from_token(None)` (→ 401) and that `local_login_identity()` — the `disable_auth`-only fallback used inside `_resolve_identity_when_auth_disabled` — is never consulted on this path.
- **#5011** (`tests/test_pension_report_lambda.py`): added 3 tests exercising `_load_recipient_owners()` against the real `get_storage()` → `ssm://` → `ParameterStoreJSONStorage` pipeline, mocking only `boto3.client` (not `_load_recipient_owners`/`get_storage` themselves, per the issue's explicit constraint): default parameter name (`pension-report-recipients`), the `PENSION_REPORT_RECIPIENTS_URI` override, and the missing-parameter fallback.

### Note on the missing-parameter test
`ParameterStoreJSONStorage.load()` (`backend/common/storage.py`) already swallows `ClientError`/`BotoCoreError` and returns `{}` rather than raising, so a missing SSM parameter surfaces as `_load_recipient_owners()` returning `None` (the "report on all owners" default) — not an exception. The test asserts that actual behavior rather than the issue's suggested "raises or returns a fallback" framing.

### Scope note: #5004 not implemented
This cluster originally included **#5004** ("add startup-time validation for all required env vars"). I read the actual code before implementing and decided not to build it: the issue proposes a generic `validate_required_env_vars()` module using fabricated variable names (`DATABASE_URL`, `SECRET_KEY`, `SMTP_HOST`) that don't exist anywhere in this codebase (no SQL database, no SMTP — this app uses S3/SES). It also contradicts the deliberate, already-documented design in `backend/routes/signup.py` (see the `_login_url()`/`approve_signup_request` comments referencing issue #4385): `SIGNUP_LOGIN_URL` is checked lazily and fails loudly with a 503 *per-request*, not at Lambda cold-start, specifically so a misconfigured optional feature doesn't hard-crash the whole app on boot. Implementing #5004 as written would mean building speculative scaffolding around invented config that also reverses a deliberate design choice — recommend closing #5004 as not applicable rather than merging code for it.

## Test plan
- [x] `pytest tests/test_auth.py` — 31 passed
- [x] `pytest tests/test_pension_report_lambda.py` — 10 passed
- [x] `pytest tests/test_auth.py tests/test_pension_report_lambda.py tests/test_pension_report_email.py tests/backend/common/test_storage.py tests/test_storage.py` — 62 passed
- [x] `pytest tests/backend` — 782 passed, 1 skipped, 12 xfailed — no regressions
- [x] `ruff check` / `black --check` (`--config backend/pyproject.toml`) — clean

Closes #5006
Closes #5011

🤖 Generated with [Claude Code](https://claude.com/claude-code)