### PR TITLE
test: add METADATA_PREFIX cross-check test, mirroring the WRITABLE_ACCOUNTS_PREFIX guard

### DIFF
--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -878,6 +878,46 @@ def test_metadata_prefix_matches_backend_instruments_s3_location() -> None:
     )
 
 
+# Every module-level *_PREFIX string constant in backend_lambda_stack.py that is
+# duplicated in a backend fallback literal (see issue #4933's audit) must have a
+# corresponding cross-check test above. If this set drifts from what's actually
+# declared in the stack, either a new duplicated constant needs a cross-check
+# test, or this set is stale and should be trimmed.
+_COVERED_STACK_PREFIX_CONSTANTS = frozenset({"WRITABLE_ACCOUNTS_PREFIX", "METADATA_PREFIX"})
+
+
+def test_no_uncovered_duplicated_prefix_constants_in_backend_lambda_stack() -> None:
+    """Guards the issue #4933 audit finding: WRITABLE_ACCOUNTS_PREFIX and
+    METADATA_PREFIX are the only module-level ``*_PREFIX`` string constants in
+    ``backend_lambda_stack.py`` that duplicate a backend fallback literal, and
+    both already have a cross-check test. If a future change adds another
+    ``*_PREFIX`` constant here, this test fails as a reminder to either add a
+    matching cross-check test (and extend the covered set above) or, if the
+    new constant isn't actually duplicated in the backend, confirm that and
+    extend the set to acknowledge it's out of scope."""
+    stack_path = CDK_DIR / "stacks" / "backend_lambda_stack.py"
+    tree = ast.parse(stack_path.read_text(encoding="utf-8"))
+
+    declared_prefix_constants = {
+        target.id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+        and target.id.endswith("_PREFIX")
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    }
+
+    assert declared_prefix_constants == _COVERED_STACK_PREFIX_CONSTANTS, (
+        "Module-level *_PREFIX string constants in backend_lambda_stack.py "
+        f"({sorted(declared_prefix_constants)}) no longer match the audited/covered "
+        f"set ({sorted(_COVERED_STACK_PREFIX_CONSTANTS)}). Add a cross-check test "
+        "for any new constant that duplicates a backend fallback literal, or "
+        "update _COVERED_STACK_PREFIX_CONSTANTS if it's confirmed out of scope."
+    )
+
+
 def test_grant_bucket_access_raises_on_no_permissions() -> None:
     class _MockFn:
         def add_to_role_policy(self, policy_statement: object) -> None:

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -15,6 +15,7 @@ if str(CDK_DIR) not in sys.path:
     sys.path.insert(0, str(CDK_DIR))
 
 from stacks.backend_lambda_stack import (
+    METADATA_PREFIX,
     WRITABLE_ACCOUNTS_PREFIX,
     BackendLambdaStack,
 )
@@ -858,6 +859,22 @@ def test_writable_accounts_prefix_matches_backend_accounts_store() -> None:
         "backend.common.accounts_store.WRITABLE_ACCOUNTS_PREFIX ('{}')".format(
             WRITABLE_ACCOUNTS_PREFIX, backend_prefix
         )
+    )
+
+
+def test_metadata_prefix_matches_backend_instruments_s3_location() -> None:
+    """The CDK stack's METADATA_PREFIX literal must match the Python backend's
+    fallback literal in backend.common.instruments._s3_location(), since CDK
+    passes its value into the Lambda's METADATA_PREFIX env var and
+    _s3_location() only falls back to its own literal when that env var is
+    unset. See issue #4930 (the constants going out of sync would silently
+    change where auto-created instrument metadata is written)."""
+    instruments_path = CDK_DIR.parent / "backend" / "common" / "instruments.py"
+    backend_prefix = _fallback_string_literal(instruments_path, "prefix")
+
+    assert METADATA_PREFIX == backend_prefix, (
+        "CDK's METADATA_PREFIX ('{}') has drifted from the fallback literal in "
+        "backend.common.instruments._s3_location() ('{}')".format(METADATA_PREFIX, backend_prefix)
     )
 
 


### PR DESCRIPTION
## Summary
Follows the existing `test_writable_accounts_prefix_matches_backend_accounts_store` pattern (issue #4323): a new `test_metadata_prefix_matches_backend_instruments_s3_location` statically cross-checks `cdk/stacks/backend_lambda_stack.py`'s `METADATA_PREFIX = "instruments"` against the fallback literal in `backend/common/instruments.py`'s `_s3_location()` (`os.getenv(METADATA_PREFIX_ENV, "instruments")`), reusing the existing `_fallback_string_literal()` ast helper.

If these two literals drift, CDK would set `METADATA_PREFIX` to one value in the Lambda's environment while the backend's own fallback (used only if the env var is ever unset) would silently point somewhere else — see issue #4930 for why this matters for auto-created instrument metadata storage.

### Audit scope
I searched `cdk/stacks/*.py` for every module-level string constant and checked each against the backend for a matching fallback literal. Found only two: `WRITABLE_ACCOUNTS_PREFIX` (already covered) and `METADATA_PREFIX` (added here). No other duplicated configuration constants exist between `cdk/` and `backend/` at this time — the issue's suggested candidates (env var names, other prefix strings) either aren't duplicated as literals anywhere else, or are already single-sourced via import (e.g. `BACKEND_API_URL_EXPORT`).

## Test plan
- [x] Manually verified the new test fails when `METADATA_PREFIX` is changed to a different string in the CDK stack (confirms it actually catches drift), then reverted
- [x] `pytest cdk/tests/test_backend_lambda_stack_permissions.py cdk/tests/test_backend_lambda_stack.py` — 70 passed
- [x] `pytest tests/backend` — 782 passed, 1 skipped, 12 xfailed — no regressions
- [x] `ruff check --config backend/pyproject.toml` — clean

Closes #4933

🤖 Generated with [Claude Code](https://claude.com/claude-code)