### PR TITLE
fix: run-local-api.sh now resolves repo root instead of scripts/bash

### DIFF
--- a/scripts/bash/run-local-api.sh
+++ b/scripts/bash/run-local-api.sh
@@ -3,12 +3,13 @@ set -euo pipefail
 
 # ensure script runs from repository root so log files are written consistently
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
 
 # ensure data directory exists
 if [[ ! -d data || -z "$(ls -A data 2>/dev/null)" ]]; then
   echo "Data directory missing; syncing..." >&2
-  scripts/sync_data.sh
+  "$SCRIPT_DIR/sync_data.sh"
 fi
 
 # Load Telegram credentials if available


### PR DESCRIPTION
## Summary
- `scripts/bash/run-local-api.sh` `cd`'d into its own directory (`scripts/bash`) instead of the repo root, so its `data/` existence check always looked in the wrong place (`scripts/bash/data`) and reported "missing" even when a populated `data/` existed at the repo root.
- The `sync_data.sh` fallback it invoked (`scripts/sync_data.sh`) doesn't exist at that path — the real script lives at `scripts/bash/sync_data.sh`.
- Fix: compute `REPO_ROOT` from `SCRIPT_DIR` and `cd` there (matching the script's own comment about running from the repo root), and invoke `sync_data.sh` via an absolute path so it no longer depends on CWD.

## Test plan
- [x] Populated `data/` at repo root: script no longer reports "Data directory missing" and does not invoke `sync_data.sh` (verified in an isolated sandbox dir with `bash -x`).
- [x] Empty/missing `data/`: script correctly invokes `scripts/bash/sync_data.sh` (verified with a stub `sync_data.sh` in an isolated sandbox dir).
- [x] Ran the fixed script for real against this repo from a clean worktree: uvicorn started successfully and `GET /prices/refresh` returned `200`.

Closes #5317