### PR TITLE
docs: warn about unprotected signup router and document YTD contribution limitation

### DIFF
--- a/backend/lambda_api/pension_report.py
+++ b/backend/lambda_api/pension_report.py
@@ -123,6 +123,12 @@ def _build_report_for_owner(
     ytd = pension_ytd_return(
         current_pot_gbp=pot_gbp,
         pot_start_of_year_gbp=start_of_year_pot,
+        # Known limitation: contributions made so far this year are not
+        # tracked here, so this YTD return is overstated by that amount (it
+        # can't distinguish investment growth from new money paid in).
+        # TODO: prorate contribution_annual over the elapsed year, e.g.
+        # contribution_annual * (today.timetuple().tm_yday / 365.25), once a
+        # per-owner contribution history is available to validate against.
         contributions_ytd_gbp=0.0,
     )
 

--- a/backend/routes/signup.py
+++ b/backend/routes/signup.py
@@ -53,9 +53,11 @@ from backend.routes.transactions import resolve_writable_store
 if TYPE_CHECKING:
     from slowapi import Limiter
 
-# Module-level router kept for backward compatibility (tests and direct imports).
-# It is unlimited — callers should prefer :func:`create_router` when a limiter
-# is available.
+# WARNING: this module-level router has NO rate limiting applied. It exists
+# for backward compatibility (tests and direct imports) only. Production code
+# must call create_router(limiter=...) instead -- create_router(limiter=None)
+# (its own default) also returns this same unprotected router, so passing a
+# limiter is not optional for a production mount.
 router = APIRouter(prefix="/signup", tags=["signup"])
 
 logger = logging.getLogger(__name__)
@@ -283,6 +285,10 @@ def create_router(
     is decorated via ``limiter.limit(rate_limit)``. The limiter must be the
     same instance registered on ``app.state.limiter`` so rate-limit counters
     are shared across the application.
+
+    If ``limiter`` is ``None`` (the default) or ``rate_limit`` is falsy, this
+    returns the unprotected module-level ``router`` with no rate limiting at
+    all -- always pass both for a production mount.
 
     Approve and reject endpoints are not rate-limited — they already require
     unguessable single-use tokens.

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -81,8 +81,8 @@ backend/common/transaction_reconciliation.py:186
 backend/common/transaction_reconciliation.py:39
 backend/common/transaction_reconciliation.py:44
 backend/lambda_api/dividend_refresh.py:27
-backend/lambda_api/pension_report.py:200
-backend/lambda_api/pension_report.py:225
+backend/lambda_api/pension_report.py:206
+backend/lambda_api/pension_report.py:231
 backend/lambda_api/price_refresh.py:61
 backend/lambda_api/price_refresh.py:63
 backend/lambda_api/price_refresh.py:78


### PR DESCRIPTION
## Summary
Two independent documentation-only fixes:

- **#4446**: strengthened the warning on `backend/routes/signup.py`'s module-level `router` (it already had a brief backward-compat comment, but not an explicit "NO rate limiting" warning) and added the missing note to `create_router()`'s docstring that `limiter=None` — its own default — returns this same unprotected router.
- **#5012**: documented that `contributions_ytd_gbp=0.0` in `backend/lambda_api/pension_report.py` is a known limitation that overstates YTD return, with a `TODO` sketching the prorated fix.

No behavior change in either file.

## Test plan
- [x] `pytest tests/backend/routes/test_signup.py tests/test_pension_report_lambda.py tests/test_pension_report_email.py` — 35 passed

Closes #4446
Closes #5012

🤖 Generated with [Claude Code](https://claude.com/claude-code)