### PR TITLE
chore: remove stray root __init__.py, fix import order, drop misleading pragma

### DIFF
--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -17,6 +17,10 @@ import logging
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Optional, Sequence, Tuple
 
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.security import OAuth2PasswordBearer
+from pydantic import BaseModel, Field
+
 from backend.auth import get_current_user
 from backend.common import (
     constants,
@@ -35,9 +39,6 @@ from backend.logging_setup import sanitise_log_value
 from backend.routes._accounts import resolve_accounts_root, resolve_owner_directory
 from backend.utils.pricing_dates import PricingDateCalculator
 from backend.utils.timeseries_helpers import resolve_date_range
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.security import OAuth2PasswordBearer
-from pydantic import BaseModel, Field
 
 log = logging.getLogger("routes.portfolio")
 router = APIRouter(tags=["portfolio"])

--- a/tests/backend/test_instruments_autocreate.py
+++ b/tests/backend/test_instruments_autocreate.py
@@ -23,7 +23,7 @@ def test_get_instrument_meta_does_not_call_yahoo_on_cache_miss(tmp_path, monkeyp
 
     calls: list[tuple[str, str]] = []
 
-    def fake_fetch(symbol: str, exchange: str):  # pragma: no cover - should not be called
+    def fake_fetch(symbol: str, exchange: str):
         calls.append((symbol, exchange))
         return {"name": "Should not happen"}
 


### PR DESCRIPTION
## Summary
Three independent trivial cleanups, verified live before touching:

- **#4841**: removed the empty (0-byte), unreferenced `__init__.py` at the repo root — added unintentionally in PR #4840 alongside an unrelated type-hint change. A root-level `__init__.py` risks turning the whole repo into a Python package and shadowing pytest test discovery.
- **#4942**: `backend/routes/portfolio.py` had `fastapi`/`pydantic` imports below `backend.*` imports (an earlier diff inverted standard ordering). Moved third-party imports back above local imports.
- **#5024**: removed `# pragma: no cover` from the `fake_fetch` stand-in in `test_get_instrument_meta_does_not_call_yahoo_on_cache_miss` (`tests/backend/test_instruments_autocreate.py`). The pragma hid this test-only fake from coverage, which is misleading — the test's own `calls == []` assertion already guards against it ever being called, so it should show up as genuinely uncovered, not excluded. Left the identical pattern in the unrelated `test_auto_create_requires_exchange` test untouched, since it's outside this issue's scope.

## Test plan
- [x] `pytest tests/backend/test_instruments_autocreate.py tests/backend/routes` — 235 passed
- [x] `pytest tests/backend` — 782 passed, 1 skipped, 12 xfailed — no regressions
- [x] `ruff check --config backend/pyproject.toml` — clean

Closes #4841
Closes #4942
Closes #5024

🤖 Generated with [Claude Code](https://claude.com/claude-code)