### PR TITLE
test: cover unrecognised-ticker fallback, missing live-price timestamp, and multi-gap detection

### DIFF
--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -316,6 +316,31 @@ def test_prices_live_explicit_tickers(client, monkeypatch):
     assert prices["NODATA.L"]["is_stale"] is True
 
 
+def test_prices_live_missing_timestamp(client, monkeypatch):
+    """A ticker present in live prices but whose entry has no timestamp key
+    must not crash the endpoint (`(now - None)` would raise TypeError) --
+    it should be treated the same as "no live data": no last_price_time,
+    stale (#4944)."""
+
+    def _fake_live(full_tickers):
+        return {"MISSING_TS.L": {"price": 7.5}}
+
+    def _fake_latest(full_tickers):
+        return {"MISSING_TS.L": 7.0}
+
+    monkeypatch.setattr("backend.common.holding_utils.load_live_prices", _fake_live)
+    monkeypatch.setattr("backend.common.holding_utils.load_latest_prices", _fake_latest)
+
+    resp = client.get("/prices/live", params={"tickers": "MISSING_TS.L"})
+    assert resp.status_code == 200
+    prices = resp.json()["prices"]
+
+    assert prices["MISSING_TS.L"]["live_price"] == 7.5
+    assert prices["MISSING_TS.L"]["stored_price"] == 7.0
+    assert prices["MISSING_TS.L"]["last_price_time"] is None
+    assert prices["MISSING_TS.L"]["is_stale"] is True
+
+
 def test_prices_live_defaults_to_portfolio_universe(client, monkeypatch):
     monkeypatch.setattr(
         "backend.common.portfolio_utils.list_all_unique_tickers", lambda: ["STUB.L"]

--- a/tests/test_prices_snapshot.py
+++ b/tests/test_prices_snapshot.py
@@ -52,3 +52,24 @@ def test_get_price_snapshot(monkeypatch):
     assert weekday_calls[0] == (frozen_today - timedelta(days=1), False)
     assert (last_trading_day - timedelta(days=7), False) in weekday_calls
     assert (last_trading_day - timedelta(days=30), False) in weekday_calls
+
+
+def test_get_price_snapshot_unrecognised_ticker_falls_back_to_last_close(monkeypatch):
+    """When a ticker isn't recognised by the live-price provider (e.g. an OEIC
+    fund Yahoo Finance doesn't cover), get_price_snapshot must not raise and
+    must fall back to the last stored/close price with is_stale=True (#3423)."""
+    ticker = "UNKNOWN.FUND"
+
+    monkeypatch.setattr(prices, "_load_latest_prices", lambda tickers: {ticker: 42.5})
+    # Simulates load_live_prices returning nothing for an unrecognised ticker,
+    # rather than raising -- see backend.common.holding_utils.load_live_prices.
+    monkeypatch.setattr(prices, "load_live_prices", lambda tickers: {})
+    monkeypatch.setattr(prices, "load_meta_timeseries_range", lambda sym, exch, start_date, end_date: pd.DataFrame())
+
+    snap = prices.get_price_snapshot([ticker])
+    info = snap[ticker]
+
+    assert info["last_price"] == 42.5
+    assert info["price_currency"] == "GBP"
+    assert info["is_stale"] is True
+    assert info["last_price_time"] is None

--- a/tests/timeseries/test_quality.py
+++ b/tests/timeseries/test_quality.py
@@ -75,6 +75,28 @@ def test_find_gaps_ignores_uk_bank_holiday():
     assert find_gaps(df) == []
 
 
+def test_find_gaps_multiple_disjoint_gaps():
+    # Two separate 2-business-day gaps in one series, with a valid stretch
+    # between them: present Mon 5th-Fri 9th, gap Mon 12th-Tue 13th, present
+    # Wed 14th-Fri 16th, gap Mon 19th-Tue 20th, present Wed 21st (#4957).
+    present_days = [5, 6, 7, 8, 9, 14, 15, 16, 21]
+    df = _df([{"Date": f"2026-01-{d:02d}", "Close": 1.0} for d in present_days])
+
+    gaps = find_gaps(df)
+
+    assert len(gaps) == 2
+    assert gaps[0] == {
+        "start": "2026-01-12",
+        "end": "2026-01-13",
+        "missing_business_days": 2,
+    }
+    assert gaps[1] == {
+        "start": "2026-01-19",
+        "end": "2026-01-20",
+        "missing_business_days": 2,
+    }
+
+
 def test_find_outliers_flags_spike():
     rows = [{"Date": f"2026-01-{d:02d}", "Close": 100.0} for d in range(1, 21)]
     rows.append({"Date": "2026-01-21", "Close": 1000.0})


### PR DESCRIPTION
## Summary
Three independent test-only additions, all locking in already-correct behavior found on `main` (no production code changed):

- **#3423** (`tests/test_prices_snapshot.py`): `test_get_price_snapshot_unrecognised_ticker_falls_back_to_last_close` — asserts `get_price_snapshot()` doesn't raise for a ticker `load_live_prices` doesn't recognise (e.g. an OEIC fund Yahoo doesn't cover), falls back to the stored/last-close price, and sets `is_stale=True`.
- **#4944** (`tests/test_backend_api.py`): `test_prices_live_missing_timestamp` — asserts `GET /prices/live` doesn't crash when a ticker's live-price entry has no `timestamp` key. The endpoint already has `is_stale = (...) if ts else True` guarding this (no `(now - None)` crash as the issue described), so this was purely a missing regression test.
- **#4957** (`tests/timeseries/test_quality.py`): `test_find_gaps_multiple_disjoint_gaps` — covers a series with two separate 2-business-day gaps and a valid stretch between them; the existing tests only covered single-gap series.

## Test plan
- [x] `pytest tests/test_prices_snapshot.py tests/test_backend_api.py tests/timeseries/test_quality.py` — 39 passed
- [x] `pytest tests/backend tests/test_backend_api.py` — 808 passed, 5 skipped, 13 xfailed, 1 xpassed — no regressions
- [x] `ruff check` / `black --check` (`--config backend/pyproject.toml`) — clean

Closes #3423
Closes #4944
Closes #4957

🤖 Generated with [Claude Code](https://claude.com/claude-code)