### PR TITLE
test: make enable_family_mvp required in MockConfigBody now the backend contract includes it

### DIFF
--- a/frontend/tests/support/smokeFixtures.ts
+++ b/frontend/tests/support/smokeFixtures.ts
@@ -7,10 +7,13 @@ import {
 } from '../../src/contracts/apiContracts';
 
 export type MockConfigBody = z.infer<typeof configContractSchema> & {
-  // enable_family_mvp is not part of the versioned /config contract yet, but the
-  // frontend already reads it (Family MVP route gating). configContractSchema is
-  // .passthrough(), so carrying it here does not fail validation.
-  enable_family_mvp?: boolean;
+  // enable_family_mvp is not enumerated in the versioned configContractSchema
+  // (it stays .passthrough() deliberately -- see apiContracts.ts), but the
+  // backend's /config response now always includes it (backend.config.Config
+  // is serialised in full via asdict()) and the frontend reads it for Family
+  // MVP route gating, so every mock body must set it explicitly rather than
+  // silently omitting a field real responses always carry.
+  enable_family_mvp: boolean;
 };
 export type MockOwnersBody = z.infer<typeof ownersContractSchema>;
 export type MockGroupsBody = z.infer<typeof groupsContractSchema>;


### PR DESCRIPTION
## Summary
This issue was blocked pending a backend change; I checked and it's now unblocked. `backend.config.Config` has had a real `enable_family_mvp` field since #4845, and `backend/routes/config.py`'s `serialise_config()` sends the full dataclass via `asdict()`, so every real `/config` response now carries the field.

- Removed the `?` from `MockConfigBody.enable_family_mvp` in `frontend/tests/support/smokeFixtures.ts` so mock bodies can no longer silently omit a field real responses always include.
- `DEFAULT_CONFIG_BODY` (the only literal construction of this type in the test suite) already sets `enable_family_mvp: false`, so no other test file needed updating.
- Updated the stale comment that said the field wasn't part of the contract yet.

### Left untouched: `configContractSchema`'s `.passthrough()`
The issue's step 4 suggested removing `.passthrough()` from the zod schema "if it was added solely to accommodate this field." Checked `apiContracts.ts` — it wasn't. The `.passthrough()` there is deliberate and separately documented: *"backend is allowed to carry additional backend-only fields... frontend does not need to enumerate."* Removing it would be a production contract change, which the issue's own constraints explicitly rule out ("Do not change the production API contract or zod schemas in `src/contracts/apiContracts.ts` — only the test-side `MockConfigBody` type").

## Test plan
- [x] `npm run type-check` — clean
- [x] `npx vitest run tests/unit/smokeFixtures.test.ts tests/unit/ConfigContext.familyMvp.test.tsx` — 9 passed
- [x] `npx vitest run tests/unit` — 633 passed, no regressions
- [x] `npx eslint tests/support/smokeFixtures.ts` — clean

Closes #4847

🤖 Generated with [Claude Code](https://claude.com/claude-code)