### PR TITLE
docs(ci): document why validate-backend-deps is not redundant with lambda-compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,14 @@ jobs:
           $config.Output.Verbosity = 'Detailed'
           Invoke-Pester -Configuration $config
 
+  # Not redundant with lambda-compat below despite both installing
+  # backend/requirements.txt: this job is a pure dependency-resolution check
+  # (pip install --dry-run, no packages actually installed, no tests run)
+  # that also asserts no duplicate package names in the requirements file --
+  # both fast, install-free checks lambda-compat doesn't perform. lambda-compat
+  # does a full real install plus the entire pytest suite, which is slower and
+  # gives no earlier signal on a dependency conflict than this job already
+  # gives. Keep both (issue #4467).
   validate-backend-deps:
     name: Validate backend/requirements.txt (dry-run)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Chose Option B (document) over Option A (remove) after comparing what each job actually does:

- **`validate-backend-deps`**: a static duplicate-package-name check plus `pip install --dry-run` — fast, install-free dependency resolution check.
- **`lambda-compat`**: a full real install of `backend/requirements.txt` + `backend/requirements-test.txt`, then runs the entire `tests/` pytest suite.

`lambda-compat` doesn't perform the duplicate-package-name check at all, and being a real install + full test run, it's strictly slower to give the same dependency-conflict signal `validate-backend-deps` already gives via `--dry-run`. Removing it would lose a real, faster feedback loop, not just deduplicate identical work — so I documented the distinction with an inline comment instead of removing the job.

Also checked `scripts/check_branch_protection_required_checks.py` per the issue's constraint — it doesn't reference `validate-backend-deps` by name, so no other file needed updating.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML
- [x] No behavior change — comment-only edit to `.github/workflows/ci.yml`

Closes #4467

🤖 Generated with [Claude Code](https://claude.com/claude-code)