### PR TITLE
test: verify enrich_holding's Monday fallback reaches the previous Friday's close

### DIFF
--- a/tests/backend/test_holding_utils.py
+++ b/tests/backend/test_holding_utils.py
@@ -190,3 +190,37 @@ def test_enrich_holding_falls_back_to_previous_close_when_today_missing(monkeypa
     assert result["price"] == pytest.approx(50.0)
     assert result["current_price_gbp"] == pytest.approx(50.0)
     assert result["market_value_gbp"] == pytest.approx(500.0)
+
+
+def test_enrich_holding_monday_fallback_reaches_previous_friday(monkeypatch):
+    """Regression for issue #5208: when pricing_date lands on a Monday and
+    Monday's own close is missing, the fallback must reach back to the
+    previous Friday's close rather than Sunday (a non-trading day). Uses
+    PricingDateCalculator.previous_pricing_date (already weekend-aware via
+    _nearest_weekday), not a naive pricing_date - timedelta(days=1)."""
+    import backend.common.portfolio_utils as pu
+
+    monkeypatch.setattr(hu, "get_instrument_meta", lambda *_: {"currency": "GBP"})
+    monkeypatch.setattr(pu, "get_security_meta", lambda *_: {})
+    monkeypatch.setattr(pu, "_PRICE_SNAPSHOT", {})
+
+    previous_friday = dt.date(2026, 5, 15)
+
+    def fake_price_for_date(ticker, exchange, d, field="Close_gbp"):
+        # Monday's close is missing; only the previous Friday has a price.
+        if d == previous_friday:
+            return 42.0, "Yahoo"
+        return None, None
+
+    monkeypatch.setattr(hu, "_get_price_for_date_scaled", fake_price_for_date)
+    monkeypatch.setattr(hu, "get_effective_cost_basis_gbp", lambda h, cache, price_hint=None: 0.0)
+
+    holding = {TICKER: "FOO.L", UNITS: 10, COST_BASIS_GBP: 0.0, ACQUIRED_DATE: "2025-01-01"}
+    # today = Tuesday so calc.reporting_date resolves to the preceding Monday.
+    today = dt.date(2026, 5, 19)
+    result = hu.enrich_holding(holding, today, price_cache={})
+
+    assert result["price"] == pytest.approx(42.0)
+    assert result["current_price_gbp"] == pytest.approx(42.0)
+    assert result["market_value_gbp"] == pytest.approx(420.0)
+    assert result["is_stale"] is True


### PR DESCRIPTION
## Summary
Investigated before implementing: this issue describes `enrich_holding`'s fallback using a naive `prev_date = pricing_date - timedelta(days=1)`, which would land on a non-trading Sunday when `pricing_date` is a Monday. Checked `backend/common/holding_utils.py` and that code doesn't exist — the fallback already uses `calc.previous_pricing_date` (`PricingDateCalculator`, weekend-aware via `_nearest_weekday`), so the bug this issue describes doesn't reproduce on current `main`.

Added `test_enrich_holding_monday_fallback_reaches_previous_friday` to lock this in as a regression test, since it wasn't directly covered — the existing `test_enrich_holding_falls_back_to_previous_close_when_today_missing` (despite its docstring) doesn't actually exercise the fallback branch at all; tracing through it, its fake `today` resolves `reporting_date` directly to the one date with a price, so `px` is set on the first lookup and the `prev_px` fallback path never triggers.

**Verified the new test has teeth**: manually monkeypatched `PricingDateCalculator.previous_pricing_date` to the naive `reporting_date - timedelta(days=1)` formula the issue describes and confirmed the assertions would then fail (`price` resolves to `None` instead of `42.0`), before reverting and confirming they pass against the real implementation.

### Scope note
The issue's secondary concern — "or any market holiday" — is a real, narrower gap: `_nearest_weekday` only skips weekends, not UK bank holidays. Left out of scope here since it's not covered by the issue's own stated success criteria (which specifically target the Monday/weekend case) and would need its own design decision about which UK-holiday calendar utility to wire in.

## Test plan
- [x] `pytest tests/backend/test_holding_utils.py` — 5 passed
- [x] Manual verification that the test fails against the naive buggy `previous_pricing_date` formula (see above)
- [x] `pytest tests/backend` — 783 passed, 1 skipped, 12 xfailed — no regressions
- [x] `ruff check --config backend/pyproject.toml` — clean

Closes #5208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price-date handling for holdings when pricing falls on a Monday.
  * Holdings now correctly use the previous Friday’s closing price instead of a non-trading day.
  * Stale pricing is accurately indicated when fallback pricing is used.

* **Tests**
  * Added regression coverage for Monday pricing fallback behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->