### PR TITLE
Fix: allow null day_change_gbp in group portfolio API contract

### DIFF
--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -70,7 +70,7 @@ export const holdingContractSchema = z.object({
   last_price_time: nullableString.optional(),
   is_stale: z.boolean().optional(),
   latest_source: nullableString.optional(),
-  day_change_gbp: z.number().optional(),
+  day_change_gbp: nullableNumber.optional(),
   day_change_currency: nullableString.optional(),
   instrument_type: nullableString.optional(),
   sector: nullableString.optional(),

--- a/frontend/src/contracts/generated/api-contract-schemas.v1.json
+++ b/frontend/src/contracts/generated/api-contract-schemas.v1.json
@@ -410,7 +410,14 @@
                         ]
                       },
                       "day_change_gbp": {
-                        "type": "number"
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       },
                       "day_change_currency": {
                         "anyOf": [
@@ -846,7 +853,14 @@
                         ]
                       },
                       "day_change_gbp": {
-                        "type": "number"
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       },
                       "day_change_currency": {
                         "anyOf": [

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -31,7 +31,7 @@ export interface Holding {
   /** Whether the current price may be stale */
   is_stale?: boolean;
   latest_source?: string | null;
-  day_change_gbp?: number;
+  day_change_gbp?: number | null;
   day_change_currency?: string | null;
   instrument_type?: string | null;
   sector?: string | null;


### PR DESCRIPTION
## Summary
- `frontend/src/contracts/apiContracts.ts` declared `day_change_gbp: z.number().optional()`, which rejects `null`
- The backend (`backend/common/holding_utils.py`) legitimately sets `day_change_gbp = None` when there's no previous price to diff against, causing a Zod validation error and breaking `/?group=all`
- Made the schema field `nullableNumber.optional()` (matching the equivalent field in `frontend/src/contracts/spa.ts`) and widened the `Holding.day_change_gbp` type in `frontend/src/types.ts` to `number | null`

Closes #5357

## Test plan
- [x] Verified locally: `/?group=all` failed with `Invalid input: expected number, received null` before the fix, and loads cleanly with full portfolio data after
- [x] Confirmed no console/network errors after the fix in the browser preview