### PR TITLE
fix: sanitise Telegram send-failure log message, remove from CWE-117 baseline

### DIFF
--- a/backend/routes/trading_agent.py
+++ b/backend/routes/trading_agent.py
@@ -13,6 +13,7 @@ from backend.agent import trading_agent
 from backend.agent.models import TradingSignal
 from backend.common.alerts import publish_alert
 from backend.config import config
+from backend.logging_setup import sanitise_log_value
 from backend.utils.telegram_utils import send_message, redact_token
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,12 @@ async def signals(
             try:
                 send_message(text)
             except Exception as exc:  # pragma: no cover - network errors
-                logger.warning("Telegram send failed: %s", redact_token(str(exc)))
+                # redact_token() only strips the bot token; the exception message
+                # can otherwise carry embedded newlines from a signal's ticker or
+                # reason text (composed into `text` above), so it also needs
+                # sanitise_log_value's CRLF stripping (#5260).
+                logger.warning(
+                    "Telegram send failed: %s", sanitise_log_value(redact_token(str(exc)))
+                )
 
     return [TradingSignal.model_validate(sig) for sig in raw_signals]

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -108,7 +108,6 @@ backend/routes/market.py:138
 backend/routes/market.py:145
 backend/routes/timeseries_admin.py:110
 backend/routes/timeseries_admin.py:88
-backend/routes/trading_agent.py:60
 backend/timeseries/cache.py:114
 backend/timeseries/cache.py:242
 backend/timeseries/cache.py:258

--- a/tests/routes/test_trading_agent.py
+++ b/tests/routes/test_trading_agent.py
@@ -108,6 +108,40 @@ def test_notify_telegram_env_gating(monkeypatch):
     assert sent["text"] == "BUY AAA: r"
 
 
+def test_telegram_send_failure_is_logged_sanitised(monkeypatch, caplog):
+    """A Telegram send failure must not crash the endpoint, and the logged
+    exception message must have embedded newlines stripped (#5260) --
+    redact_token() only strips the bot token, not CRLF characters."""
+    fake_signals = [
+        {
+            "ticker": "AAA",
+            "action": "BUY",
+            "reason": "r",
+        }
+    ]
+    monkeypatch.setattr("backend.agent.trading_agent.run", lambda **_: fake_signals)
+
+    def boom(text: str) -> None:
+        raise RuntimeError("connection failed\nFAKE INJECTED LOG LINE")
+
+    monkeypatch.setattr("backend.routes.trading_agent.send_message", boom)
+    monkeypatch.setattr("backend.routes.trading_agent.config.app_env", "local", raising=False)
+
+    client = make_client()
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat")
+
+    with caplog.at_level("WARNING", logger="backend.routes.trading_agent"):
+        resp = client.get("/trading-agent/signals", params={"notify_telegram": "true"})
+
+    assert resp.status_code == 200
+    warning_records = [r for r in caplog.records if "Telegram send failed" in r.message]
+    assert len(warning_records) == 1
+    assert "\n" not in warning_records[0].message
+    assert "connection failed" in warning_records[0].message
+    assert "FAKE INJECTED LOG LINE" in warning_records[0].message
+
+
 def test_no_signals(monkeypatch):
     monkeypatch.setattr("backend.agent.trading_agent.run", lambda **_: [])
 


### PR DESCRIPTION
## Summary
Partial pass on issue #5260's 132-entry grandfathered log-sanitization baseline (`tests/data/log_sanitization_baseline.txt`) — see scope note below for why this is intentionally partial.

`backend/routes/trading_agent.py`'s Telegram send-failure handler already called `redact_token(str(exc))`, but that function only strips the bot token substring, not embedded newlines (`backend/utils/telegram_utils.py:36-41`). Since `text` (composed from a trading signal's ticker/reason) flows into the Telegram API call whose failure raises this exception, an attacker-influenced value could theoretically inject a fake log line via CWE-117. Composed `sanitise_log_value()` on top of the existing `redact_token()` call and removed the now-fixed entry from the baseline.

### Scope note: why this isn't the full 132-entry fix
I sampled roughly a dozen of the 132 baseline entries across several files (`backend/common/signup_requests.py`, `backend/routes/market.py`, `backend/routes/trading_agent.py`, `backend/app.py`) before deciding what to fix. Most turn out to be **false positives** from the AST scanner's lack of dataflow analysis:
- `signup_requests.py` logs a `secrets.token_hex(16)` request ID that's already regex-validated elsewhere (`_REQUEST_ID_RE`) — not attacker-controlled.
- `market.py` logs sector/symbol keys sourced from a hardcoded internal dict (`US_SECTOR_ETFS`) — never touches user input.

The regression test's own docstring anticipates this: *"most are internal-only data... that the AST scan can't distinguish without full dataflow analysis."* A correct, complete audit of all 132 entries needs the same per-site security judgment call this one required, file by file — not something to responsibly rush through in one pass. This PR fixes the one clear-cut case I found with real (if low-probability) attacker-influenced data; completing the rest is left for incremental follow-up, consistent with the issue's own "commit changes in batches" guidance. Not using the `Closes` keyword since the issue's actual success criterion (baseline reduced to 0 entries) is far from met — 131 entries remain.

## Test plan
- [x] New regression test `test_telegram_send_failure_is_logged_sanitised`: injects a newline into the exception message, asserts the endpoint still returns 200 and the logged warning has no `\n`
- [x] `pytest tests/routes/test_trading_agent.py` — 5 passed
- [x] `pytest tests/test_log_sanitization_audit.py` — passes with the reduced baseline
- [x] `pytest tests/backend tests/test_log_sanitization_audit.py` — 786 passed, 1 skipped, 12 xfailed — no regressions
- [x] `ruff check --config backend/pyproject.toml` — no new findings (pre-existing unrelated `I001`/`F401` findings confirmed via `git stash`)

Progress on #5260 (partial — 1 of 132 baseline entries resolved; not closing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)