### PR TITLE
test: verify sanitise_log_value wrapping for alerts.py and pension_report.py call sites

### DIFF
--- a/tests/test_alerts_storage.py
+++ b/tests/test_alerts_storage.py
@@ -41,6 +41,38 @@ def test_parse_subscriptions_discards_non_dict_entries():
     assert alerts._parse_subscriptions(data) == {"u1": {"k": "v"}}
 
 
+def test_parse_thresholds_sanitises_key_in_warning_log(caplog):
+    """Regression for issue #5261: the invalid-threshold warning must strip
+    embedded newlines from the (attacker-controlled) dict key before logging,
+    via sanitise_log_value."""
+    data = {"legit\nFAKE INJECTED LOG LINE": "not-a-number"}
+
+    with caplog.at_level("WARNING", logger=alerts.logger.name):
+        alerts._parse_thresholds(data)
+
+    warnings = [r for r in caplog.records if "Invalid threshold value" in r.message]
+    assert len(warnings) == 1
+    assert "\n" not in warnings[0].message
+    assert "legit" in warnings[0].message
+    assert "FAKE INJECTED LOG LINE" in warnings[0].message
+
+
+def test_parse_subscriptions_sanitises_user_in_warning_log(caplog):
+    """Regression for issue #5261: the invalid-subscription warning must strip
+    embedded newlines from the (attacker-controlled) user key before logging,
+    via sanitise_log_value."""
+    data = {"alice\nFAKE INJECTED LOG LINE": "not-a-dict"}
+
+    with caplog.at_level("WARNING", logger=alerts.logger.name):
+        alerts._parse_subscriptions(data)
+
+    warnings = [r for r in caplog.records if "Push subscription for" in r.message]
+    assert len(warnings) == 1
+    assert "\n" not in warnings[0].message
+    assert "alice" in warnings[0].message
+    assert "FAKE INJECTED LOG LINE" in warnings[0].message
+
+
 def test_load_settings_uses_local_when_no_bucket(monkeypatch):
     local = {"a": "0.3", "b": "bad"}
 

--- a/tests/test_pension_report_lambda.py
+++ b/tests/test_pension_report_lambda.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 
 import pytest
@@ -183,3 +184,50 @@ def test_build_report_flags_shortfall_when_desired_income_configured(monkeypatch
 
     email, report = stub_environment["sent_emails"][0]
     assert any("short of the" in alert for alert in report.alerts)
+
+
+def test_build_report_for_owner_sanitises_owner_when_missing_dob_or_email(caplog):
+    """Regression for issue #5261: the missing-dob/email skip warning must
+    strip embedded newlines from the (user-supplied) owner name."""
+    person = {"dob": None, "email": "alice@example.com"}
+    with caplog.at_level("WARNING", logger=lam.logger.name):
+        result = lam._build_report_for_owner("alice\nFAKE INJECTED LOG LINE", person, [], dt.date(2026, 1, 1))
+
+    assert result is None
+    warnings = [r for r in caplog.records if "missing dob or email" in r.message]
+    assert len(warnings) == 1
+    assert "\n" not in warnings[0].message
+    assert "FAKE INJECTED LOG LINE" in warnings[0].message
+
+
+def test_build_report_for_owner_sanitises_owner_when_invalid_dob(caplog):
+    """Regression for issue #5261: the invalid-dob skip warning must strip
+    embedded newlines from the (user-supplied) owner name."""
+    person = {"dob": "not-a-date", "email": "alice@example.com"}
+    with caplog.at_level("WARNING", logger=lam.logger.name):
+        result = lam._build_report_for_owner("alice\nFAKE INJECTED LOG LINE", person, [], dt.date(2026, 1, 1))
+
+    assert result is None
+    warnings = [r for r in caplog.records if "invalid dob" in r.message]
+    assert len(warnings) == 1
+    assert "\n" not in warnings[0].message
+    assert "FAKE INJECTED LOG LINE" in warnings[0].message
+
+
+def test_lambda_handler_sanitises_owner_on_per_owner_failure(monkeypatch, stub_environment, caplog):
+    """Regression for issue #5261: the per-owner failure error log must strip
+    embedded newlines from the (user-supplied) owner name."""
+
+    def boom(owner, person, accounts, today):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(lam, "_build_report_for_owner", boom)
+    monkeypatch.setattr(lam, "list_portfolios", lambda: [_portfolio(owner="alice\nFAKE INJECTED LOG LINE")])
+
+    with caplog.at_level("ERROR", logger=lam.logger.name):
+        lam.lambda_handler({}, {})
+
+    errors = [r for r in caplog.records if "Pension report failed for owner" in r.message]
+    assert len(errors) == 1
+    assert "\n" not in errors[0].message
+    assert "FAKE INJECTED LOG LINE" in errors[0].message


### PR DESCRIPTION
## Summary
Partial pass on issue #5261's 8 call sites from PR #5253 — see scope note for why this is intentionally partial.

- **`tests/test_alerts_storage.py`**: 2 new tests covering `backend/alerts.py`'s `_parse_thresholds` (line 93) and `_parse_subscriptions` (line 104), asserting the logged warning has no embedded newline when the (attacker-controlled) dict key contains one.
- **`tests/test_pension_report_lambda.py`**: 3 new tests covering `backend/lambda_api/pension_report.py`'s `_build_report_for_owner` (missing-dob/email and invalid-dob skip warnings, lines 103/108) and the per-owner failure error log in `lambda_handler` (line 225), same pattern.

Each test uses `caplog` to assert on the actual rendered log message (no `\n` present) rather than mocking `sanitise_log_value` and asserting it was called — this verifies the real defended behavior end-to-end, not just that a function reference was invoked, matching the pattern already used for the equivalent `trading_agent.py` fix in #5260/PR #5361.

### Scope note: 5 of 8 call sites
Not covering in this pass:
- **`holding_utils.py`** (lines 170-173) — `load_latest_prices`'s external price-provider dependency needs more involved mocking to trigger its `except` block cleanly.
- **`reports.py`** (line ~1437) — not yet investigated.
- **`routes/config.py`** (lines 210, 247) — checked `validate_google_auth`, and the `ConfigValidationError` it raises is currently a static, non-attacker-controlled string, so the sanitization there is defensive-but-currently-unexercisable rather than a live vector; lower value to test right now than the others.

Left for incremental follow-up. Test-only; no production code changed; no changes to `test_log_sanitization_audit.py` or the baseline file.

## Test plan
- [x] `pytest tests/test_alerts_storage.py` — 27 passed
- [x] `pytest tests/test_pension_report_lambda.py` — 13 passed
- [x] `pytest tests/backend tests/test_alerts_storage.py tests/test_pension_report_lambda.py` — 825 passed, 1 skipped, 12 xfailed — no regressions
- [x] `ruff check` / `black --check` (`--config backend/pyproject.toml`) — clean

Progress on #5261 (partial — 5 of 8 call sites covered; not closing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)