### PR TITLE
Fix create-account: add signup env vars and SES IAM permissions (#5367)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,13 @@ VITE_APP_BASE_URL=https://app.allotmint.io
 # Required for the signup-approval flow: unset/empty makes POST /signup/approve
 # return 503 rather than send an email with no login link.
 SIGNUP_LOGIN_URL=https://app.allotmint.io/login
+
+# Admin email address that receives new-signup-request notifications.
+# Required for POST /signup/request to work: unset/empty makes the endpoint
+# return 503 rather than silently dropping the request.
+SIGNUP_ADMIN_EMAIL=admin@example.com
+
+# Base URL used to build approve/reject links in the admin notification email.
+# Must be the backend's public base URL (API Gateway or CloudFront custom domain)
+# so the links are clickable from an email client. Required for the signup flow.
+SIGNUP_APPROVAL_BASE_URL=https://api.allotmint.io

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -246,6 +246,18 @@ class BackendLambdaStack(Stack):
         budget_alert_email = self.node.try_get_context("budget_alert_email") or os.getenv(
             "BUDGET_ALERT_EMAIL"
         )
+        # Public account-signup request flow (#4352, #5367). These vars must be
+        # set for the create-account form and admin approval email flow to work.
+        # Supplied via CDK context or env var rather than hardcoded in the stack.
+        signup_admin_email = self.node.try_get_context("signup_admin_email") or os.getenv(
+            "SIGNUP_ADMIN_EMAIL", ""
+        )
+        signup_approval_base_url = self.node.try_get_context("signup_approval_base_url") or os.getenv(
+            "SIGNUP_APPROVAL_BASE_URL", ""
+        )
+        signup_login_url = self.node.try_get_context("signup_login_url") or os.getenv(
+            "SIGNUP_LOGIN_URL", ""
+        )
         # Cadence for the pension report Lambda's EventBridge rule (issue #2758).
         # "weekly" -> every Monday; "monthly" -> the 1st of the month. Configurable
         # via CDK context or env var rather than hardcoded in the rule itself.
@@ -399,6 +411,15 @@ class BackendLambdaStack(Stack):
         }
         if data_repo:
             backend_env["DATA_REPO"] = data_repo
+        # Signup request env vars (#5367): conditional so empty/unset values
+        # are not injected, which lets the route handler's 503 guard fire
+        # cleanly instead of surfacing as a downstream SES error.
+        if signup_admin_email:
+            backend_env["SIGNUP_ADMIN_EMAIL"] = signup_admin_email
+        if signup_approval_base_url:
+            backend_env["SIGNUP_APPROVAL_BASE_URL"] = signup_approval_base_url
+        if signup_login_url:
+            backend_env["SIGNUP_LOGIN_URL"] = signup_login_url
 
         backend_log_group = self._lambda_log_group(self, "BackendLambdaLogGroup")
         backend_fn = _lambda.DockerImageFunction(
@@ -431,6 +452,18 @@ class BackendLambdaStack(Stack):
             list_prefix=lambda_list_prefixes["backend"],
         )
         self._grant_timeseries_cache_access(backend_fn, bucket=data_bucket, allow_put=True)
+
+        # SES send permission for signup admin/user notification emails (#5367).
+        # The Lambda calls ses:SendEmail to notify the admin of new account
+        # requests (signup_request.py) and to tell approved users their login
+        # is ready (signup_approved.py). The pension report Lambda also sends
+        # email via SES and receives the same grant further below.
+        backend_fn.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["ses:SendEmail"],
+                resources=["*"],
+            )
+        )
 
         ui_auth_user_pool_id_default = self.node.try_get_context(
             "ui_auth_user_pool_id"
@@ -1026,6 +1059,14 @@ class BackendLambdaStack(Stack):
             allow_list=True,
             list_prefix=lambda_list_prefixes["pension_report"],
             put_prefix="pension-reports",
+        )
+
+        # SES send permission for the pension report email (#5367).
+        pension_report_fn.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["ses:SendEmail"],
+                resources=["*"],
+            )
         )
 
         pension_report_schedule = (

--- a/frontend/src/pages/CreateAccountPage.tsx
+++ b/frontend/src/pages/CreateAccountPage.tsx
@@ -138,7 +138,15 @@ export default function CreateAccountPage() {
       });
       setSubmitted(true);
     } catch (err) {
-      console.error("Failed to submit account signup request", err);
+      const status = (err as Record<string, unknown> | null)?.status;
+      if (typeof status === "number") {
+        console.error(
+          `Failed to submit account signup request (HTTP ${status})`,
+          err,
+        );
+      } else {
+        console.error("Failed to submit account signup request", err);
+      }
       setError("Something went wrong submitting your request. Please try again.");
     } finally {
       setSubmitting(false);


### PR DESCRIPTION
## What

Closes #5367— the create-account flow was broken on the deployed CloudFront environment even after the API Gateway routing fix in #4785. The Lambda had no signup environment variables and no SES send permission.

## Changes

### 1. Add signup env vars to `backend_env` in CDK stack
`SIGNUP_ADMIN_EMAIL`, `SIGNUP_APPROVAL_BASE_URL`, and `SIGNUP_LOGIN_URL` are now read from CDK context or environment variables (following the existing `budget_alert_email` pattern) and conditionally injected into the Lambda environment.

### 2. Grant `ses:SendEmail` IAM permission
Both `BackendLambda` and `PensionReportLambda` now have `ses:SendEmail` permission via `add_to_role_policy`, scoped to `"*"` (SES does not support resource-level permission on `SendEmail`).

### 3. Update `.env.example`
Added `SIGNUP_ADMIN_EMAIL` and `SIGNUP_APPROVAL_BASE_URL` with documentation, alongside the existing `SIGNUP_LOGIN_URL`.

### 4. Improve frontend error logging
`CreateAccountPage.tsx` now checks for an HTTP `status` property on caught errors and includes it in `console.error` output for easier diagnosis, while keeping the user-facing message generic.

## Validation

- [x] 48 CDK synth tests pass
- [x] 7 frontend CreateAccountPage tests pass
- [x] Zero lint/diff noise

## Operator deploy notes

After merging, set these env vars or CDK context values before deploying:
- `SIGNUP_ADMIN_EMAIL` — the admin email that receives new-signup-request notifications
- `SIGNUP_APPROVAL_BASE_URL` — the backend base URL (API Gateway invoke URL or custom domain) for building approve/reject links in admin emails
- `SIGNUP_LOGIN_URL` — the frontend login page URL emailed to approved users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration support for account-signup approval emails, including administrator notifications and clickable approve/reject links.
  - Enabled email delivery permissions for signup and pension-report notifications.

- **Bug Fixes**
  - Improved protection of sensitive information by sanitising values in application logs.
  - Signup failures now record more specific HTTP status details for troubleshooting, while preserving the existing user-facing message.

- **Tests**
  - Added automated checks to help prevent unsafe values from being written to logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->