### PR TITLE
Collapse Add Position form by default with expand toggle

### DIFF
--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -230,6 +230,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
   const [pendingDate, setPendingDate] = useState<string>("");
   const [showAddAccount, setShowAddAccount] = useState(false);
   const [addPositionAccount, setAddPositionAccount] = useState<string | undefined>(undefined);
+  const [addPositionExpanded, setAddPositionExpanded] = useState(false);
   const addPositionRef = useRef<HTMLDivElement>(null);
   const { baseCurrency, familyMvpEnabled, enableAdvancedAnalytics = true } = useConfig();
 
@@ -329,7 +330,13 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
 
   const handleAddPositionRequest = (accountType: string) => {
     setAddPositionAccount(accountType);
+    setAddPositionExpanded(true);
     addPositionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const handlePositionAdded = () => {
+    setAddPositionExpanded(false);
+    onPositionAdded?.();
   };
 
   return (
@@ -395,12 +402,22 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
           )}
           {data.accounts.length > 0 && (
             <div ref={addPositionRef} className="mb-6">
-              <AddPositionForm
-                owner={data.owner}
-                accounts={data.accounts.map((acct) => acct.account_type)}
-                defaultAccount={addPositionAccount}
-                onAdded={onPositionAdded}
-              />
+              {addPositionExpanded ? (
+                <AddPositionForm
+                  owner={data.owner}
+                  accounts={data.accounts.map((acct) => acct.account_type)}
+                  defaultAccount={addPositionAccount}
+                  onAdded={handlePositionAdded}
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setAddPositionExpanded(true)}
+                  className="rounded border border-gray-700 px-3 py-1.5 text-sm text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+                >
+                  + {t("addPosition.title")}
+                </button>
+              )}
             </div>
           )}
           {data.accounts.length > 0 && (


### PR DESCRIPTION
## What changed

The Add Position form on portfolio detail pages now starts **collapsed** and shows a compact \+ Add position\ button. The full form only expands when the user clicks the button (or when the empty-account CTA in the holdings table triggers it). After a successful submission the form collapses again.

## Why

The always-visible form took significant vertical space and pushed the actual holdings content down the page unnecessarily (closes #5368).

## What was validated

- TypeScript compilation passes (725 modules transformed)
- The \handleAddPositionRequest\ flow (used by AccountBlock empty-state CTA) now expands the form automatically
- The form collapses after a successful position add via \handlePositionAdded\

## Risk

Low — the change is a pure UI state toggle in \PortfolioView.tsx\. The \AddPositionForm\ component itself is unchanged.