### PR TITLE
Add rebase workflow rule: force-push to same branch, not new PR/branch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,6 +13,7 @@ Read `AGENTS.md` for full repository guidance. Use these short rules while gener
 - Prefer `bash scripts/bash/run-local-api.sh` for the local backend instead of outdated `uvicorn app:app` examples.
 - Verify command names against actual `package.json`, `Makefile`, and scripts before updating docs.
 - If your change implements an issue, include an auto-closing PR reference (for example: `Closes #1234`).
+- When rebasing a PR, force-push to the same branch — don't create a new one.
 - Keep changes out of generated dependency folders such as `node_modules/`.
 - Be careful when changing `data/`, auth defaults, or smoke-test flows; these are tightly coupled to local development and demos.
 - Preserve bash/PowerShell parity when editing shared developer workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ Before finishing:
 - If work implements a GitHub issue, include an auto-closing reference in the PR body (for example: `Closes #1234`).
 - If you changed UI behavior, attach screenshots.
 - If you changed operational workflows, mention the exact commands used for validation.
+- **When rebasing a PR branch**: rebase onto the target and force-push to the **same branch name**. The PR updates automatically. Do not create a new branch or a new PR — that duplicates review state and creates noise.
 
 ## 9. Additional AI-facing files in this repo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,12 @@ npm run smoke:test:codex:poc
 
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#branch-and-pr-policy) for the
 canonical branch/PR rules (never commit to `main`, worktree-first for dirty
-checkouts, required PR steps, branch naming, `Closes #NNNN` linking).
+checkouts, required PR steps, branch naming, `Closes #NNNN` linking). Agents
+must treat branch creation as a first step, not a release step at the end.
+
+**When rebasing a PR branch**: rebase onto the target and force-push to the
+**same branch name**. The PR updates automatically. Do not create a new branch
+or a new PR — that duplicates review state and creates noise.
 
 ## Preferred workflow
 


### PR DESCRIPTION
## What changed

Added a short rule to all three AI-facing files stating that when rebasing a PR, agents must force-push to the same branch — not create a new one.

## Why

Prevents duplicated PRs and lost review state when rebasing (closes #5377).

## Files

- \AGENTS.md\ — §8 Commit and PR expectations
- \CLAUDE.md\ — Branch and PR policy section
- \.github/copilot-instructions.md\ — near other PR guidance

## Risk

None — docs only.