### PR TITLE
fix(smoke-test): send real authenticated traffic to BackendLambda

### DIFF
--- a/scripts/frontend-backend-smoke.ts
+++ b/scripts/frontend-backend-smoke.ts
@@ -1046,6 +1046,7 @@ export function fillPath(path: string, fixtures: SmokeFixtures, method?: string)
 export async function runSmoke(base: string) {
   const normalizedBase = base.replace(/\/+$/, '');
   const healthUrl = `${normalizedBase}/health`;
+  const authToken = process.env.SMOKE_AUTH_TOKEN?.trim() || process.env.TEST_ID_TOKEN?.trim() || null;
 
   try {
     await fetch(healthUrl, { method: 'GET' });
@@ -1129,6 +1130,39 @@ export async function runSmoke(base: string) {
     }
 
   }
+
+  await runAuthenticatedCheck(normalizedBase, authToken);
+}
+
+// The sweep above deliberately calls every route unauthenticated, so a 401 on a
+// protected route only proves the route + authorizer exist — it never sends real
+// authenticated traffic through the JWT authorizer to the backend integration.
+// This check does exactly that with a single read-only, idempotent request, so a
+// broken authorizer or integration (wrong audience, misconfigured Lambda
+// permission, etc.) is caught here instead of silently passing (#5366).
+async function runAuthenticatedCheck(normalizedBase: string, authToken: string | null): Promise<void> {
+  if (!authToken) {
+    console.warn(
+      'No SMOKE_AUTH_TOKEN/TEST_ID_TOKEN provided; skipping authenticated route check (#5366).',
+    );
+    return;
+  }
+
+  const authUrl = `${normalizedBase}/owners`;
+  let res: Awaited<ReturnType<typeof fetch>>;
+  try {
+    res = await fetch(authUrl, { headers: { Authorization: `Bearer ${authToken}` } });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Network error while calling authenticated GET /owners: ${reason}`);
+  }
+  if (!res.ok) {
+    throw new Error(
+      `Authenticated smoke check failed: GET /owners with a Bearer token -> ${res.status}. ` +
+        'The JWT authorizer or an integration may be broken.',
+    );
+  }
+  console.log(`✓ GET /owners (authenticated, ${res.status})`);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- `scripts/frontend-backend-smoke.ts` swept every backend route unauthenticated, so protected endpoints returning `401` were tagged as passing "route exists" checks — no real Cognito-authenticated request was ever made against the deployed `BackendLambda`.
- That's why `deploy-lambda.yml`'s "Verify authenticated invocations reached BackendLambda" step kept failing: it queries CloudWatch for real invocation traffic that the smoke suite never generated (confirmed via run [29680206986](https://github.com/leonarduk/allotmint/actions/runs/29680206986/job/88175824428) and repeated failures on v0.28.2/v0.26.x/v0.25.x/v0.24.4).
- Added a read-only `GET /owners` check at the end of `runSmoke()` using `SMOKE_AUTH_TOKEN`/`TEST_ID_TOKEN` (already threaded through the workflow env) with a real `Authorization: Bearer` header, so the CloudWatch check now has genuine authenticated traffic to observe. Skips gracefully (with a warning) when no token is available, e.g. local runs.

## Test plan
- [x] `tsx` import of the modified module succeeds (no syntax/type errors)
- [x] Ran the full unauthenticated sweep against a local backend (`disable_auth: true`) — pre-existing, unrelated 404 on `/instrument/admin/{exchange}/{ticker}` in local fixture data, not touched by this change
- [x] Verified `GET /owners` returns `200`/`ok` both with and without an `Authorization` header locally, confirming the new check's fetch logic
- [x] `tests/backend/test_smoke_endpoint_list.py` still passes (xfail, untouched — regex only reads the `smokeEndpoints` array, which this change doesn't modify)
- [ ] Confirm the "Verify authenticated invocations reached BackendLambda" step passes on the next `deploy-lambda` run with a real Cognito token

Closes #5366