### PR TITLE
Sort and filter Market Overview headlines by recency

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Market overview endpoint aggregating indexes, sectors and headlines."""
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Literal, Optional, TypedDict
 
 import requests
@@ -45,6 +46,13 @@ US_SECTOR_ETFS = {
 
 
 logger = logging.getLogger(__name__)
+
+# Headlines older than this are excluded from the Market Overview feed so the
+# page doesn't surface stale stories mixed in with recent ones.  Mirrors the
+# staleness-threshold pattern used for cache freshness in
+# ``backend.routes.news.NEWS_MAX_STALENESS``, but this applies to the
+# article's own publish date rather than the cache's age.
+HEADLINE_MAX_AGE = timedelta(hours=72)
 
 
 class IndexPayload(TypedDict):
@@ -234,14 +242,62 @@ def _fetch_uk_sectors() -> List[SectorPayload]:
     return out
 
 
+def _parse_published_at(value: Any) -> Optional[datetime]:
+    """Parse an ISO-8601 ``published_at`` string into a timezone-aware datetime."""
+
+    if not isinstance(value, str) or not value:
+        return None
+
+    cleaned = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _sort_and_filter_headlines(headlines: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Sort headlines newest-first and drop ones older than ``HEADLINE_MAX_AGE``.
+
+    Items whose ``published_at`` is missing or unparsable are treated as
+    undated: they're excluded from the primary (recency-filtered) result but
+    kept as a fallback, sorted after any dated items, so the page still shows
+    something when upstream providers return sparse or undated coverage
+    instead of going to an empty state.
+    """
+
+    now = datetime.now(timezone.utc)
+    dated: List[tuple[datetime, Dict[str, Any]]] = []
+    undated: List[Dict[str, Any]] = []
+
+    for item in headlines:
+        published = _parse_published_at(item.get("published_at"))
+        if published is None:
+            undated.append(item)
+        else:
+            dated.append((published, item))
+
+    dated.sort(key=lambda pair: pair[0], reverse=True)
+    recent = [item for published, item in dated if now - published <= HEADLINE_MAX_AGE]
+
+    if recent:
+        return recent
+
+    return [item for _, item in dated] + undated
+
+
 def _fetch_headlines() -> List[Dict[str, Any]]:
     """Fetch latest headlines for all known index symbols.
 
     Each index symbol is queried individually; results are aggregated and
-    de-duplicated by URL or headline.  Each item carries the ``stale`` flag
-    from ``get_cached_news`` so the frontend can flag headlines served from
-    an aged cache.  If all requests fail, an error is logged so callers have
-    some visibility into the failure.
+    de-duplicated by URL or headline, then sorted newest-first and filtered
+    to ``HEADLINE_MAX_AGE`` (see ``_sort_and_filter_headlines``).  Each item
+    carries the ``stale`` flag from ``get_cached_news`` so the frontend can
+    flag headlines served from an aged cache.  If all requests fail, an error
+    is logged so callers have some visibility into the failure.
     """
 
     logger = logging.getLogger(__name__)
@@ -271,7 +327,7 @@ def _fetch_headlines() -> List[Dict[str, Any]]:
     if not success:
         logger.error("Failed to fetch news for all index symbols")
 
-    return headlines
+    return _sort_and_filter_headlines(headlines)
 
 
 def _safe(func, default):

--- a/tests/backend/routes/test_market.py
+++ b/tests/backend/routes/test_market.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import List
 
 import pytest
@@ -38,12 +39,8 @@ def test_fetch_headlines_uses_cached_helper(monkeypatch):
     second = market_module._fetch_headlines()
 
     assert seen_fresh == set(symbols)
-    assert sorted(item["headline"] for item in first) == sorted(
-        f"{sym} fresh" for sym in symbols
-    )
-    assert sorted(item["headline"] for item in second) == sorted(
-        f"{sym} cached" for sym in symbols
-    )
+    assert sorted(item["headline"] for item in first) == sorted(f"{sym} fresh" for sym in symbols)
+    assert sorted(item["headline"] for item in second) == sorted(f"{sym} cached" for sym in symbols)
 
 
 def test_fetch_headlines_stops_on_quota_exhaustion(monkeypatch):
@@ -63,10 +60,7 @@ def test_fetch_headlines_stops_on_quota_exhaustion(monkeypatch):
 
     assert calls == symbols[: symbols.index(stop_after) + 1]
     assert all(stop_after not in item["headline"] for item in headlines)
-    assert all(
-        item["headline"].endswith("fresh")
-        for item in headlines
-    )
+    assert all(item["headline"].endswith("fresh") for item in headlines)
 
 
 @pytest.mark.asyncio
@@ -168,6 +162,58 @@ def test_fetch_uk_sectors_nested_values(monkeypatch):
         {"sector": "Financials", "change": -1.1, "source": "lse"},
         {"sector": "Utilities", "change": 0.5, "source": "lse"},
     ]
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def test_sort_and_filter_headlines_excludes_old_and_sorts_newest_first():
+    now = datetime.now(timezone.utc)
+    old = {
+        "headline": "Old",
+        "url": "https://example.com/old",
+        "published_at": _iso(now - timedelta(days=10)),
+    }
+    middle = {
+        "headline": "Middle",
+        "url": "https://example.com/middle",
+        "published_at": _iso(now - timedelta(hours=10)),
+    }
+    newest = {
+        "headline": "Newest",
+        "url": "https://example.com/newest",
+        "published_at": _iso(now - timedelta(hours=1)),
+    }
+
+    result = market_module._sort_and_filter_headlines([old, middle, newest])
+
+    assert result == [newest, middle]
+
+
+def test_sort_and_filter_headlines_falls_back_when_nothing_recent():
+    now = datetime.now(timezone.utc)
+    old = {
+        "headline": "Old",
+        "url": "https://example.com/old",
+        "published_at": _iso(now - timedelta(days=30)),
+    }
+    older = {
+        "headline": "Older",
+        "url": "https://example.com/older",
+        "published_at": _iso(now - timedelta(days=60)),
+    }
+    undated = {"headline": "Undated", "url": "https://example.com/undated"}
+
+    result = market_module._sort_and_filter_headlines([older, old, undated])
+
+    assert result == [old, older, undated]
+
+
+def test_sort_and_filter_headlines_keeps_undated_when_no_dated_items():
+    undated = [{"headline": "A", "url": "https://example.com/a"}]
+
+    assert market_module._sort_and_filter_headlines(undated) == undated
 
 
 def test_fetch_uk_sectors_skips_invalid_entries(monkeypatch):

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -102,10 +102,10 @@ backend/reports.py:462
 backend/reports.py:468
 backend/reports.py:522
 backend/reports.py:809
-backend/routes/market.py:121
 backend/routes/market.py:129
-backend/routes/market.py:138
-backend/routes/market.py:145
+backend/routes/market.py:137
+backend/routes/market.py:146
+backend/routes/market.py:153
 backend/routes/timeseries_admin.py:110
 backend/routes/timeseries_admin.py:88
 backend/timeseries/cache.py:114


### PR DESCRIPTION
## Summary
- `_fetch_headlines()` in `backend/routes/market.py` previously concatenated news across the 5 index symbols with no ordering or age cutoff, so old stories could appear on `/market` alongside recent ones.
- Added `_sort_and_filter_headlines()`: parses `published_at`, sorts newest-first, and drops items older than `HEADLINE_MAX_AGE` (72h). Falls back to showing whatever is available (dated newest-first, then undated) when nothing is within the window, so the feed doesn't collapse to empty on sparse upstream coverage.
- Existing cache-staleness `stale` flag behavior is untouched — this is an additive filter on article recency, not a replacement.

Closes #5381

## Test plan
- [x] `python -m pytest tests/backend/routes/test_market.py -q --no-cov` — 9 passed, including 3 new tests covering sort/filter/fallback behavior
- [x] `python -m ruff check --config backend/pyproject.toml backend/routes/market.py tests/backend/routes/test_market.py`
- [x] `python -m black --check backend/routes/market.py tests/backend/routes/test_market.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)