### PR TITLE
Fix Portfolio.tsx loading state stuck on stale request completion

### DIFF
--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -110,7 +110,7 @@ export function Portfolio() {
         setError("Failed to load portfolio");
       })
       .finally(() => {
-        if (latestRequestRef.current === requestId) setLoading(false);
+        setLoading(false);
       });
   }, [activeOwner]);
 

--- a/frontend/tests/unit/pages/Portfolio.test.tsx
+++ b/frontend/tests/unit/pages/Portfolio.test.tsx
@@ -177,6 +177,59 @@ describe("Portfolio page", () => {
     expect(screen.getByText(/Approx Total:/).textContent).toMatch(/200/);
   });
 
+  it("clears the loading state when a stale request resolves while the newer request is still pending", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alice", accounts: [] },
+      { owner: "bob", accounts: [] },
+    ]);
+
+    const alice = deferred<Portfolio>();
+    const bob = deferred<Portfolio>();
+    mockGetPortfolio.mockImplementation((owner: string) =>
+      owner === "alice" ? alice.promise : bob.promise,
+    );
+
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/portfolio"]}>
+          <OwnerOnlyRouteProvider>
+            <Routes>
+              <Route path="/portfolio" element={<PortfolioPage />} />
+            </Routes>
+          </OwnerOnlyRouteProvider>
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    const ownerSelect = await screen.findByLabelText(/Owner/i);
+    await userEvent.selectOptions(ownerSelect, "alice");
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+
+    await userEvent.selectOptions(ownerSelect, "bob");
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
+
+    // The stale (alice) request resolves while the newer (bob) request is
+    // still pending -- e.g. bob's request never completes. Before the fix,
+    // alice's `finally` block would skip `setLoading(false)` because it's no
+    // longer the latest request, and since bob's `finally` never runs
+    // either, `loading` would stay stuck at `true` forever.
+    await act(async () => {
+      alice.resolve({
+        owner: "alice",
+        as_of: "2024-01-01",
+        trades_this_month: 0,
+        trades_remaining: 0,
+        total_value_estimate_gbp: 100,
+        accounts: [],
+      } as Portfolio);
+      await alice.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText(/^Loading…$/)).not.toBeInTheDocument();
+  });
+
   it("shows available owners excluding demo entries", async () => {
     mockGetOwners.mockResolvedValueOnce([
       { owner: "demo", accounts: [] },


### PR DESCRIPTION
## What
Closes #5297

The `finally` block in `Portfolio.tsx`'s `reloadPortfolio` only cleared `loading` when the completing request was still the latest one (`latestRequestRef.current === requestId`). If a stale request resolved/rejected while a newer request was still in flight and never completed, `loading` stayed stuck at `true` indefinitely.

## Changes
- `finally` now unconditionally calls `setLoading(false)`.
- The `latestRequestRef` staleness guard is kept in the `.then`/`.catch` handlers, so a stale response still can't overwrite newer data.
- Added a regression test: stale request resolves while the newer request is still pending — asserts the loading indicator clears.

## Validation
- [x] `npx vitest --run tests/unit/pages/Portfolio.test.tsx` — 4/4 pass
- [x] `npx eslint` on changed files — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>