### PR TITLE
Add collapse button for expanded Add Position form

### DIFF
--- a/frontend/src/components/AddPositionForm.tsx
+++ b/frontend/src/components/AddPositionForm.tsx
@@ -10,9 +10,10 @@ type Props = {
   accounts: string[];
   defaultAccount?: string;
   onAdded?: () => void;
+  onCollapse?: () => void;
 };
 
-export function AddPositionForm({ owner, accounts, defaultAccount, onAdded }: Props) {
+export function AddPositionForm({ owner, accounts, defaultAccount, onAdded, onCollapse }: Props) {
   const { t } = useTranslation();
   const [account, setAccount] = useState(defaultAccount ?? accounts[0] ?? "");
   const [ticker, setTicker] = useState("");
@@ -83,7 +84,19 @@ export function AddPositionForm({ owner, accounts, defaultAccount, onAdded }: Pr
       aria-label={t("addPosition.title")}
       className="mb-6 rounded-lg border border-gray-800 bg-black/20 p-4"
     >
-      <h3 className="mb-3 text-base font-semibold text-white">{t("addPosition.title")}</h3>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-base font-semibold text-white">{t("addPosition.title")}</h3>
+        {onCollapse && (
+          <button
+            type="button"
+            onClick={onCollapse}
+            aria-label={t("addPosition.collapse")}
+            className="rounded border border-gray-700 px-2 py-0.5 text-sm text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+          >
+            −
+          </button>
+        )}
+      </div>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <label className="text-sm text-gray-300">
           {t("addPosition.account")}

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -408,6 +408,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
                   accounts={data.accounts.map((acct) => acct.account_type)}
                   defaultAccount={addPositionAccount}
                   onAdded={handlePositionAdded}
+                  onCollapse={() => setAddPositionExpanded(false)}
                 />
               ) : (
                 <button

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -336,7 +336,13 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
 
   const handlePositionAdded = () => {
     setAddPositionExpanded(false);
+    setAddPositionAccount(undefined);
     onPositionAdded?.();
+  };
+
+  const handleAddPositionCollapse = () => {
+    setAddPositionExpanded(false);
+    setAddPositionAccount(undefined);
   };
 
   return (
@@ -408,7 +414,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
                   accounts={data.accounts.map((acct) => acct.account_type)}
                   defaultAccount={addPositionAccount}
                   onAdded={handlePositionAdded}
-                  onCollapse={() => setAddPositionExpanded(false)}
+                  onCollapse={handleAddPositionCollapse}
                 />
               ) : (
                 <button

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -19,7 +19,8 @@
       "positiveNumber": "Geben Sie eine positive Zahl ein.",
       "generic": "Position konnte nicht hinzugefügt werden."
     },
-    "emptyAccountCta": "Erste Position hinzufügen"
+    "emptyAccountCta": "Erste Position hinzufügen",
+    "collapse": "Formular zum Hinzufügen einer Position einklappen"
   },
   "alertSettings": {
     "description": "Konfigurieren Sie, wann Sie Benachrichtigungen erhalten. Die Alarme erscheinen auf der Alerts-Seite und als Push-Benachrichtigungen.",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -19,7 +19,8 @@
       "positiveNumber": "Enter a positive number.",
       "generic": "Failed to add position."
     },
-    "emptyAccountCta": "Add your first position"
+    "emptyAccountCta": "Add your first position",
+    "collapse": "Collapse add position form"
   },
   "alertSettings": {
     "description": "Configure when you'll receive alerts. Alerts appear on the Alerts page and in push notifications.",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -19,7 +19,8 @@
       "positiveNumber": "Introduce un número positivo.",
       "generic": "No se pudo añadir la posición."
     },
-    "emptyAccountCta": "Añade tu primera posición"
+    "emptyAccountCta": "Añade tu primera posición",
+    "collapse": "Contraer formulario de añadir posición"
   },
   "alertSettings": {
     "description": "Configura cuándo recibirás alertas. Las alertas aparecen en la página de alertas y en las notificaciones push.",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -19,7 +19,8 @@
       "positiveNumber": "Saisissez un nombre positif.",
       "generic": "Impossible d'ajouter la position."
     },
-    "emptyAccountCta": "Ajouter votre première position"
+    "emptyAccountCta": "Ajouter votre première position",
+    "collapse": "Réduire le formulaire d'ajout de position"
   },
   "alertSettings": {
     "description": "Configurez quand vous recevrez des alertes. Les alertes apparaissent sur la page des alertes et dans les notifications push.",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -19,7 +19,8 @@
       "positiveNumber": "Inserisci un numero positivo.",
       "generic": "Impossibile aggiungere la posizione."
     },
-    "emptyAccountCta": "Aggiungi la tua prima posizione"
+    "emptyAccountCta": "Aggiungi la tua prima posizione",
+    "collapse": "Comprimi il modulo di aggiunta posizione"
   },
   "alertSettings": {
     "description": "Configura quando riceverai avvisi. Gli avvisi compaiono nella pagina degli avvisi e nelle notifiche push.",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -19,7 +19,8 @@
       "positiveNumber": "Introduza um número positivo.",
       "generic": "Não foi possível adicionar a posição."
     },
-    "emptyAccountCta": "Adicione a sua primeira posição"
+    "emptyAccountCta": "Adicione a sua primeira posição",
+    "collapse": "Recolher formulário de adicionar posição"
   },
   "alertSettings": {
     "description": "Configure quando receber alertas. Os alertas aparecem na página de alertas e nas notificações push.",

--- a/frontend/tests/unit/components/AddPositionForm.test.tsx
+++ b/frontend/tests/unit/components/AddPositionForm.test.tsx
@@ -101,4 +101,19 @@ describe("AddPositionForm", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("HTTP 400 - Bad Request");
   });
+
+  it("does not render a collapse button when onCollapse is not provided", () => {
+    render(<AddPositionForm owner="alice" accounts={["ISA"]} />);
+
+    expect(screen.queryByRole("button", { name: "Collapse add position form" })).toBeNull();
+  });
+
+  it("calls onCollapse when the collapse button is clicked", async () => {
+    const onCollapse = vi.fn();
+    render(<AddPositionForm owner="alice" accounts={["ISA"]} onCollapse={onCollapse} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Collapse add position form" }));
+
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { PortfolioView } from "@/components/PortfolioView";
 import type { Portfolio } from "@/types";
@@ -145,6 +145,20 @@ describe("PortfolioView", () => {
         fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
 
         await waitFor(() => expect(onPositionAdded).toHaveBeenCalledTimes(1));
+    });
+
+    it("resets the pre-selected account when the add-position form is collapsed and reopened", () => {
+        Element.prototype.scrollIntoView = vi.fn();
+        render(<PortfolioView data={mockOwner} />);
+
+        fireEvent.click(screen.getAllByRole("button", { name: /add your first position/i })[1]);
+        const addPositionForm = screen.getByRole("form", { name: /^add position$/i });
+        expect(within(addPositionForm).getByLabelText(/account/i)).toHaveValue("SIPP");
+
+        fireEvent.click(screen.getByRole("button", { name: /collapse add position form/i }));
+        fireEvent.click(screen.getByRole("button", { name: /\+ add position/i }));
+
+        expect(within(screen.getByRole("form", { name: /^add position$/i })).getByLabelText(/account/i)).toHaveValue("ISA");
     });
 
     it("hides the CSV import form when no accounts exist", () => {


### PR DESCRIPTION
## Summary
- Add an `onCollapse` prop to `AddPositionForm` that renders a "−" button next to the "Add position" heading when supplied.
- Wire it up in `PortfolioView` so clicking it sets `addPositionExpanded` back to `false`, restoring the "+ Add position" button.
- Add `addPosition.collapse` translation key across all locales (en, de, es, fr, it, pt).

## Test plan
- [x] `npm --prefix frontend run test -- --run` — 635 tests pass
- [x] `npm --prefix frontend run lint` — clean
- [x] Manually verified in browser at `/portfolio/alex`: clicking "+ Add position" expands the form with a visible collapse button; clicking it collapses the form back to the "+ Add position" button.

Closes #5380
