### PR TITLE
Add collapse button to expanded Add Position form

### DIFF
--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -336,7 +336,13 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
 
   const handlePositionAdded = () => {
     setAddPositionExpanded(false);
+    setAddPositionAccount(undefined);
     onPositionAdded?.();
+  };
+
+  const handleCollapseAddPosition = () => {
+    setAddPositionExpanded(false);
+    setAddPositionAccount(undefined);
   };
 
   return (
@@ -403,12 +409,24 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
           {data.accounts.length > 0 && (
             <div ref={addPositionRef} className="mb-6">
               {addPositionExpanded ? (
-                <AddPositionForm
-                  owner={data.owner}
-                  accounts={data.accounts.map((acct) => acct.account_type)}
-                  defaultAccount={addPositionAccount}
-                  onAdded={handlePositionAdded}
-                />
+                <div>
+                  <div className="mb-2 flex justify-end">
+                    <button
+                      type="button"
+                      onClick={handleCollapseAddPosition}
+                      aria-label={t("addPosition.collapse")}
+                      className="rounded border border-gray-700 px-3 py-1.5 text-sm text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+                    >
+                      − {t("addPosition.title")}
+                    </button>
+                  </div>
+                  <AddPositionForm
+                    owner={data.owner}
+                    accounts={data.accounts.map((acct) => acct.account_type)}
+                    defaultAccount={addPositionAccount}
+                    onAdded={handlePositionAdded}
+                  />
+                </div>
               ) : (
                 <button
                   type="button"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -19,7 +19,8 @@
       "positiveNumber": "Enter a positive number.",
       "generic": "Failed to add position."
     },
-    "emptyAccountCta": "Add your first position"
+    "emptyAccountCta": "Add your first position",
+    "collapse": "Collapse add position form"
   },
   "alertSettings": {
     "description": "Configure when you'll receive alerts. Alerts appear on the Alerts page and in push notifications.",

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/api", () => ({
   getVarBreakdown: vi.fn().mockResolvedValue([]),
   createAccount: vi.fn(),
   importHoldingsCsv: vi.fn(),
+  createManualHolding: vi.fn(),
 }));
 
 vi.mock("@/components/PerformanceDashboard", () => ({
@@ -77,6 +78,22 @@ describe("PortfolioView", () => {
         render(<PortfolioView data={mockOwner} />);
 
         expect(screen.getByRole("button", { name: /add account/i })).toBeInTheDocument();
+    });
+
+    it("expands the Add Position form and can collapse it again", () => {
+        render(<PortfolioView data={mockOwner} />);
+
+        const addButton = screen.getByRole("button", { name: /^\+ add position$/i });
+        fireEvent.click(addButton);
+
+        expect(screen.getByRole("heading", { name: /add position/i })).toBeInTheDocument();
+        const collapseButton = screen.getByRole("button", { name: /collapse add position form/i });
+        expect(collapseButton).toBeInTheDocument();
+
+        fireEvent.click(collapseButton);
+
+        expect(screen.queryByRole("heading", { name: /add position/i })).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /^\+ add position$/i })).toBeInTheDocument();
     });
 
     it("opens the add-account form when 'Add account' is clicked", () => {


### PR DESCRIPTION
## What
Closes #5380

Once the Add Position form is expanded on the portfolio page, there was no way to collapse it back short of submitting a position or navigating away.

## Changes
- `PortfolioView.tsx`: render a "− Add position" collapse button above the expanded `AddPositionForm`, wired to a new `handleCollapseAddPosition` handler.
- Collapsing (and successfully adding a position) now resets `addPositionAccount` so re-expanding starts clean.
- Added `addPosition.collapse` translation key (English; other locales fall back to `en` per the app's `fallbackLng` config).
- Added a Vitest case covering expand → collapse.

## Validation
- [x] `npx vitest --run tests/unit/components/PortfolioView.test.tsx` — 14/14 pass
- [x] `npx eslint` on changed files — clean
- Manual browser verification was attempted but blocked by local dev-server/backend CORS-networking issues unrelated to this change; relying on the passing component tests above, which directly exercise the expand/collapse interaction.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>