### PR TITLE
Wrap non-wrapping header/toolbar flex rows on narrow viewports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -558,6 +558,7 @@ export default function App({ onLogout }: AppProps) {
         <div
           style={{
             display: 'flex',
+            flexWrap: 'wrap',
             alignItems: 'center',
             gap: '0.5rem',
             margin: '1rem 0',

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -727,6 +727,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
       <div
         style={{
           display: "flex",
+          flexWrap: "wrap",
           justifyContent: "space-between",
           alignItems: "flex-end",
           gap: "1rem",
@@ -822,6 +823,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
         <div
           style={{
             display: "flex",
+            flexWrap: "wrap",
             gap: "2rem",
             marginBottom: "1rem",
             padding: "0.75rem 1rem",

--- a/frontend/src/components/SummaryBar.tsx
+++ b/frontend/src/components/SummaryBar.tsx
@@ -15,6 +15,7 @@ export default function SummaryBar({ owners, owner, onOwnerChange, onRefresh }: 
     <div
       style={{
         display: "flex",
+        flexWrap: "wrap",
         justifyContent: "space-between",
         alignItems: "center",
         marginBottom: "1rem",


### PR DESCRIPTION
## Summary
First slice of #5382 (Improve frontend layout responsiveness across mobile and tablet screen sizes). Three flex-row containers used `display: flex` without `flexWrap`, so their children overflowed the viewport horizontally on narrow screens instead of stacking:

- `App.tsx`: the top toolbar (language switcher, menu, owner selector, last-refresh badge, search toggle, notifications bell, avatar) rendered in every view.
- `GroupPortfolioView.tsx`: the group header/date-picker row, and the alpha/tracking-error/beta analytics strip.
- `SummaryBar.tsx`: the owner selector + refresh button bar used on Watchlist-style pages.

## Verification
Ran the local backend (`backend.local_api.main:app`) and frontend dev server against demo data, loaded the app in-browser, and measured `document.documentElement.scrollWidth` vs `window.innerWidth` at 375px, 768px, and 1280px — no horizontal overflow at any width after the fix. Confirmed via `git stash` that reverting the change was the mechanism under test (not a false positive from an already-narrow header).

- [x] `npx eslint` clean on the three changed files
- [x] `npx vitest run tests/unit/App.test.tsx tests/unit/App.familyMvpRedirect.test.tsx tests/unit/components/GroupPortfolioView.test.tsx` — 76/76 passing

## Scope
This does not close #5382 — it's the highest-visibility, lowest-risk slice (non-wrapping header rows). The issue's larger items (table stacking on mobile, menu-collapse audit, chart/form checks across remaining pages) are still open and better done as separate follow-up PRs rather than one large change.

Part of #5382.
