### PR TITLE
Scope ses:SendEmail IAM permission to sender identity, not wildcard

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -258,6 +258,16 @@ class BackendLambdaStack(Stack):
         signup_login_url = self.node.try_get_context("signup_login_url") or os.getenv(
             "SIGNUP_LOGIN_URL", ""
         )
+        # SES sender identity used as the `Source` for signup/pension-report
+        # emails (backend/emails/*.py's `_SENDER_EMAIL`, from `WEEKLY_REPORT_FROM`,
+        # defaulting to "no-reply@allotmint.com"). Used below to scope the
+        # `ses:SendEmail` IAM grants to this identity instead of `"*"` (#5372).
+        ses_sender_email = self.node.try_get_context("ses_sender_email") or os.getenv(
+            "WEEKLY_REPORT_FROM", "no-reply@allotmint.com"
+        )
+        ses_send_email_resources = [
+            f"arn:aws:ses:{self.region}:{self.account}:identity/{ses_sender_email}"
+        ]
         # Cadence for the pension report Lambda's EventBridge rule (issue #2758).
         # "weekly" -> every Monday; "monthly" -> the 1st of the month. Configurable
         # via CDK context or env var rather than hardcoded in the rule itself.
@@ -461,7 +471,7 @@ class BackendLambdaStack(Stack):
         backend_fn.add_to_role_policy(
             iam.PolicyStatement(
                 actions=["ses:SendEmail"],
-                resources=["*"],
+                resources=ses_send_email_resources,
             )
         )
 
@@ -1065,7 +1075,7 @@ class BackendLambdaStack(Stack):
         pension_report_fn.add_to_role_policy(
             iam.PolicyStatement(
                 actions=["ses:SendEmail"],
-                resources=["*"],
+                resources=ses_send_email_resources,
             )
         )
 

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -518,6 +518,28 @@ def test_pension_report_lambda_put_object_scoped_to_pension_reports_prefix() -> 
         ), f"Expected s3:PutObject resource scoped to pension-reports/*, got {resource!r}"
 
 
+def test_ses_send_email_scoped_to_sender_identity_not_wildcard() -> None:
+    """BackendLambda and PensionReportLambda's ses:SendEmail must not be `"*"`.
+
+    Both Lambdas only ever send from the WEEKLY_REPORT_FROM sender identity
+    (backend/emails/*.py's `_SENDER_EMAIL`, default "no-reply@allotmint.com").
+    A wildcard resource would let a compromised Lambda send email as any
+    verified SES identity in the account (issue #5372).
+    """
+    template = _stack_template()
+
+    for fragment in ("BackendLambda", "PensionReportLambda"):
+        role = _role_logical_id_for_lambda(template, fragment)
+        send_email_resources = _resources_for_s3_action(template, role, "ses:SendEmail")
+
+        assert send_email_resources, f"Expected {fragment} to have an ses:SendEmail grant"
+        for resource in send_email_resources:
+            assert resource != "*", f"{fragment}'s ses:SendEmail must not be scoped to '*'"
+            assert (
+                "identity/no-reply@allotmint.com" in resource
+            ), f"Expected ses:SendEmail scoped to the sender identity, got {resource!r}"
+
+
 def test_lambda_roles_do_not_have_s3_delete_permissions() -> None:
     template = _stack_template()
 


### PR DESCRIPTION
## What
Closes #5372

`BackendLambda` and `PensionReportLambda` both had `ses:SendEmail` scoped to `resources=["*"]`, letting a compromised Lambda send email as any verified SES identity in the account.

## Changes
- `cdk/stacks/backend_lambda_stack.py`: derive `ses_sender_email` from CDK context (`ses_sender_email`) or `WEEKLY_REPORT_FROM` env var, defaulting to `no-reply@allotmint.com` — matching the existing runtime default in `backend/emails/*.py`'s `_SENDER_EMAIL` (all four email senders — signup_request, signup_approved, pension_report, weekly_report — use the same `_SENDER_EMAIL`, so one identity ARN covers both Lambdas).
- Build the SES identity ARN (`arn:aws:ses:{region}:{account}:identity/{sender}`) and use it as `resources=` for both Lambdas' `ses:SendEmail` policy statements instead of `"*"`.
- No Lambda function code changes — IAM policy only, per the issue's constraints.
- Added `test_ses_send_email_scoped_to_sender_identity_not_wildcard` to `cdk/tests/test_backend_lambda_stack_permissions.py`, asserting neither Lambda's grant is `"*"` and both resolve to the sender identity ARN.

## Validation
- [x] `pytest cdk/tests/test_backend_lambda_stack_permissions.py cdk/tests/test_backend_lambda_stack.py --no-cov` — 73/73 pass
- [x] `ruff check` / `black --check` on changed files — no new violations (pre-existing lint debt on untouched lines only)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>