### PR TITLE
Warn when create_router() falls back to the unprotected signup router

### DIFF
--- a/backend/routes/signup.py
+++ b/backend/routes/signup.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import logging
 import os
+import warnings
 from copy import deepcopy
 from json import JSONDecodeError
 from pathlib import Path
@@ -295,6 +296,13 @@ def create_router(
     """
 
     if limiter is None or not rate_limit:
+        warnings.warn(
+            "create_router() returned the unprotected signup router with no "
+            "rate limiting on POST /signup/request -- pass both limiter and "
+            "rate_limit for a production mount.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
         return router
 
     limited = APIRouter(prefix="/signup", tags=["signup"])

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 import pytest
 from fastapi import FastAPI
@@ -510,6 +511,37 @@ def test_create_router_copies_are_independent_of_module_router():
     original_endpoint = module_route.endpoint
     limited_route.endpoint = lambda: None
     assert module_route.endpoint is original_endpoint
+
+
+def test_create_router_warns_when_returning_unprotected_router():
+    """create_router() must warn when it falls back to the unprotected router (#5334).
+
+    Called with no args (or a falsy rate_limit), it returns the module-level
+    `router` with no rate limiting at all. That's intentional for tests/direct
+    imports, but a production caller doing this by mistake would otherwise
+    fail silently -- a RuntimeWarning surfaces the misuse without breaking
+    anything (filterable by tests, doesn't raise on its own).
+    """
+
+    with pytest.warns(RuntimeWarning, match="unprotected signup router"):
+        result = signup_module.create_router()
+
+    assert result is signup_module.router
+
+    limiter = Limiter(key_func=get_remote_address, storage_uri="memory://")
+    with pytest.warns(RuntimeWarning, match="unprotected signup router"):
+        result = signup_module.create_router(limiter, rate_limit=None)
+
+    assert result is signup_module.router
+
+
+def test_create_router_does_not_warn_when_properly_configured():
+    """No warning when both limiter and rate_limit are supplied (the production path)."""
+
+    limiter = Limiter(key_func=get_remote_address, storage_uri="memory://")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        signup_module.create_router(limiter, "3/minute")
 
 
 def test_throttling_response_is_identical_for_all_emails(rate_limited_client, monkeypatch):


### PR DESCRIPTION
## What
Closes #5334

`create_router(limiter=None)` (its own default) silently returns the module-level, unprotected `router` with no rate limiting on `POST /signup/request`. A production caller that forgets to pass `limiter`/`rate_limit` would fail open with no indication anything was wrong.

## Approach chosen
Per the issue, this is a consolidated tracking issue with two candidate approaches; picked the **soft guard** (warning) rather than a hard error, since a hard-error approach depends on a robust "test environment" detector that doesn't currently exist and would risk false positives. A warning catches the misuse without needing that design work and can't break anything — it's filterable in tests, and doesn't change `create_router`'s signature or return type.

## Changes
- `backend/routes/signup.py`: `create_router` now emits a `RuntimeWarning` (via `warnings.warn(..., stacklevel=2)`) whenever it takes the `limiter is None or not rate_limit` branch and returns the unprotected `router`.
- The actual production mount (`backend/bootstrap/routers.py:76`, `create_signup_router(app.state.limiter, cfg.signup_rate_limit)`) always passes both, so this warning should never fire there.
- Added two tests to `tests/backend/routes/test_signup.py`:
  - `test_create_router_warns_when_returning_unprotected_router` — asserts the warning fires for both `create_router()` (no args) and `create_router(limiter, rate_limit=None)`.
  - `test_create_router_does_not_warn_when_properly_configured` — asserts no warning when both args are supplied (escalates `RuntimeWarning` to an error inside the test to prove it).

## Validation
- [x] `pytest tests/backend/routes/test_signup.py --no-cov` — 28/28 pass
- [x] `ruff check` / `black --check` on changed files — no new violations (pre-existing lint debt on untouched lines only)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>