### PR TITLE
Wrap more non-wrapping header/metrics flex rows on narrow viewports

### DIFF
--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -242,6 +242,7 @@ export default function MainApp() {
       <div
         style={{
           display: "flex",
+          flexWrap: "wrap",
           justifyContent: "space-between",
           alignItems: "center",
         }}

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -508,6 +508,7 @@ export function InstrumentDetail({
       <div
         style={{
           display: "flex",
+          flexWrap: "wrap",
           justifyContent: "space-between",
           alignItems: "center",
           marginBottom: "0.2rem",

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -211,6 +211,7 @@ export function PerformanceDashboard({ owner, asOf }: Props) {
       <div
         style={{
           display: "flex",
+          flexWrap: "wrap",
           gap: "1rem",
           marginBottom: "1rem",
         }}

--- a/frontend/src/components/transactions/TransactionsTable.tsx
+++ b/frontend/src/components/transactions/TransactionsTable.tsx
@@ -87,7 +87,7 @@ export function TransactionsTable({
         <button type="button" onClick={onBulkDelete} disabled={!hasSelection}>
           Delete selected{hasSelection ? ` (${selectedCount})` : ""}
         </button>
-        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: "0.5rem" }}>
           <span>{showingRangeLabel}</span>
           <button type="button" onClick={onPreviousPage} disabled={isFirstPage}>
             Previous


### PR DESCRIPTION
## Summary
Second slice of #5382 (first slice: #5401, merged). Same root cause, different components: `display: flex` rows without `flexWrap` can overflow the viewport horizontally on narrow screens instead of stacking.

- `PerformanceDashboard.tsx`: the alpha vs benchmark / tracking error / max drawdown metrics row.
- `InstrumentDetail.tsx`: the title + relative-view-toggle header row.
- `TransactionsTable.tsx`: the pagination controls (range label, Previous, page indicator, Next).
- `MainApp.tsx`: the legacy top toolbar (language switcher + refresh/notifications buttons) — same shape as the fix already applied to `App.tsx` in #5401; kept in sync since `MainApp.tsx` has its own test coverage (`MainApp.demo.test.tsx`) and shares the bug.

## Verification
Ran the local backend + frontend dev server against demo data and checked the performance view at 375px width in-browser.

- Confirmed via `git stash`/`pop` that `flexWrap` is applied and no horizontal page overflow occurs.
- Note: with the current demo dataset's exact values, the metrics row's children summed to ~311px + gaps ≈ 375px — right at the edge, not overflowing either way. The fix is still correct and matches the same defensive pattern applied elsewhere in #5401: longer numbers (e.g. 3-digit percentages) or other-locale translations push this over on a 375px device, and the two other rows (transactions pagination, instrument detail header) are less borderline and would visibly overflow without this.
- `npx eslint` clean on all four changed files.
- `npx vitest run` on the corresponding suites (`InstrumentDetail`, `PerformanceDashboard`, `MainApp.demo`, `TransactionsPage`, `transactionTable`) — 34/34 passing.

## Scope
Still doesn't close #5382 — remaining work: table-to-card collapse on very narrow widths, a fuller menu-collapse audit, and per-page chart/form checks (AllocationCharts, TaxTools, AddPositionForm, UserConfig).

Part of #5382.
