### PR TITLE
Wire persistence into POST /transactions/import

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -532,6 +532,38 @@ def _validate_component(value: str, field: str) -> str:
     return value
 
 
+def _persist_transaction(
+    store: "AccountsStore", owner: str, account: str, tx_data: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Append ``tx_data`` to owner/account's transaction log and rebuild the portfolio.
+
+    Shared by :func:`create_transaction` (single, request-validated write) and
+    :func:`import_transactions` (bulk write from a parsed import, #4965) so
+    both go through the exact same append/impact/rebuild path rather than
+    duplicating it. Portfolio impact is computed tolerantly (0.0 when
+    ``price_gbp``/``units`` are absent) since imported bank-style rows (e.g.
+    Moneyhub) carry no ticker/price/units at all -- ``rebuild_account_holdings``
+    already skips any transaction entry without a ticker.
+    """
+
+    impact = _calculate_portfolio_impact(tx_data)
+    _PORTFOLIO_IMPACT[owner] += impact
+    _POSTED_TRANSACTIONS.append({"owner": owner, "account": account, **tx_data})
+
+    store.ensure_owner(owner)
+    with _locked_transactions_data(owner, account, store) as (data, _file):
+        transactions = data.setdefault("transactions", [])
+        transactions.append(tx_data)
+        data["owner"] = owner
+        data["account_type"] = account
+        new_index = len(transactions) - 1
+
+    _rebuild_portfolio(owner, account, store)
+
+    tx_id = _build_transaction_id(owner, account, new_index)
+    return _format_transaction_response(owner, account, tx_data, tx_id)
+
+
 @router.post("/transactions", status_code=201)
 async def create_transaction(request: Request, tx: TransactionCreate) -> dict:
     """Store a new transaction and return it.
@@ -555,22 +587,8 @@ async def create_transaction(request: Request, tx: TransactionCreate) -> dict:
     units_val = tx_data.get("units")
     if price is None or units_val is None:
         raise HTTPException(status_code=400, detail="price_gbp and units are required")
-    impact = float(price) * float(units_val)
-    _PORTFOLIO_IMPACT[owner] += impact
-    _POSTED_TRANSACTIONS.append({"owner": owner, "account": account, **tx_data})
 
-    store.ensure_owner(owner)
-    with _locked_transactions_data(owner, account, store) as (data, _file):
-        transactions = data.setdefault("transactions", [])
-        transactions.append(tx_data)
-        data["owner"] = owner
-        data["account_type"] = account
-        new_index = len(transactions) - 1
-
-    _rebuild_portfolio(owner, account, store)
-
-    tx_id = _build_transaction_id(owner, account, new_index)
-    return _format_transaction_response(owner, account, tx_data, tx_id)
+    return _persist_transaction(store, owner, account, tx_data)
 
 
 @router.put("/transactions/{tx_id}")
@@ -681,16 +699,46 @@ async def delete_transaction(request: Request, tx_id: str) -> dict:
     return {"status": "deleted"}
 
 
-@router.post("/transactions/import", response_model=List[Transaction])
+def _tx_data_from_parsed(row: Transaction) -> Dict[str, Any]:
+    """Normalise a parsed import ``Transaction`` into the persisted-record shape.
+
+    Importers set ``price``/``reason_to_buy`` (degiro/hargreaves) while the
+    persisted shape (matching ``TransactionCreate``) uses
+    ``price_gbp``/``reason`` -- coalesce rather than storing both. Bank-style
+    rows (Moneyhub) carry no ticker/price/units at all; those fields persist
+    as ``None``, which ``_calculate_portfolio_impact`` and
+    ``rebuild_account_holdings`` already treat as "no security impact" (#4965).
+    """
+
+    tx_data = row.model_dump(mode="json", exclude={"owner", "account", "id"})
+    if tx_data.get("price_gbp") is None:
+        tx_data["price_gbp"] = tx_data.get("price")
+    tx_data.pop("price", None)
+    if not tx_data.get("reason"):
+        tx_data["reason"] = tx_data.get("reason_to_buy")
+    tx_data.pop("reason_to_buy", None)
+    return tx_data
+
+
+@router.post("/transactions/import")
 async def import_transactions(
-    request: Request, provider: str = Form(...), file: UploadFile = File(...)
-) -> List[Transaction]:
-    """Parse a transaction export and return transactions not already imported.
+    request: Request,
+    provider: str = Form(...),
+    file: UploadFile = File(...),
+    owner: str | None = Form(default=None),
+    account: str | None = Form(default=None),
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Parse a transaction export, persist rows not already imported, and report the rest.
 
     Candidates carrying a stable ``external_id`` (e.g. Moneyhub's per-row
     ``Id``) are filtered against previously persisted transactions so
-    re-importing the same export file does not surface duplicates to the
-    caller.
+    re-importing the same export file does not persist duplicates.
+
+    ``owner``/``account`` are optional fallbacks used only when a parsed row
+    doesn't carry its own (e.g. Hargreaves exports never set owner/account —
+    the caller must supply the destination explicitly). Rows for which no
+    owner/account can be resolved are reported in ``skipped`` rather than
+    persisted or silently dropped.
     """
 
     data = await file.read()
@@ -701,16 +749,40 @@ async def import_transactions(
     except Exception as exc:  # pragma: no cover - parsing errors
         raise HTTPException(status_code=400, detail=f"Failed to parse file: {exc}")
 
-    if not any(t.external_id for t in parsed):
-        # No candidate carries a stable key (e.g. degiro/hargreaves never set
-        # external_id), so dedupe would be a no-op. Skip the store lookup
-        # entirely rather than paying for it on every import regardless of
-        # provider.
-        return parsed
+    if not parsed:
+        # Nothing to persist or dedupe against -- skip resolving a writable
+        # store entirely so an empty parse (e.g. the "test" provider used by
+        # smoke tests, which always returns []) never 400s for callers with
+        # no writable account root.
+        return {"persisted": [], "skipped": []}
 
-    store, _ = resolve_writable_store(request)
-    existing = _load_all_transactions(store)
-    return importers.dedupe_against_existing(parsed, existing)
+    store = _require_writable_store(request)
+
+    if any(t.external_id for t in parsed):
+        existing = _load_all_transactions(store)
+        parsed = importers.dedupe_against_existing(parsed, existing)
+
+    persisted: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, Any]] = []
+
+    for row in parsed:
+        row_owner = row.owner or owner
+        row_account = row.account or account
+        if not row_owner or not row_account:
+            skipped.append({**row.model_dump(mode="json"), "skip_reason": "missing owner/account"})
+            continue
+
+        try:
+            row_owner = _validate_component(row_owner, "owner")
+            row_account = _validate_component(row_account, "account")
+        except HTTPException as exc:
+            skipped.append({**row.model_dump(mode="json"), "skip_reason": str(exc.detail)})
+            continue
+
+        tx_data = _tx_data_from_parsed(row)
+        persisted.append(_persist_transaction(store, row_owner, row_account, tx_data))
+
+    return {"persisted": persisted, "skipped": skipped}
 
 
 @router.post("/holdings/import")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -137,13 +137,24 @@ Use the PowerShell wrapper for convenience:
 
 ## import_transactions.py
 
-Upload a local transaction export to the running backend for parsing:
+Upload a local transaction export to the running backend for parsing and persistence:
 
 ```
 python scripts/import_transactions.py degiro path/to/transactions.csv
 ```
 
-Use `--api` to point at a different backend URL. Parsed transactions are printed as JSON.
+Use `--api` to point at a different backend URL. Rows already imported (matched by the
+source provider's stable id, where available) are deduped and never re-persisted.
+
+Degiro and Moneyhub exports carry an owner/account per row; Hargreaves exports don't, so
+pass `--owner`/`--account` as a fallback destination for rows that lack their own:
+
+```
+python scripts/import_transactions.py hargreaves path/to/export.csv --owner alice --account isa
+```
+
+Rows with no resolvable owner/account (no fallback given, and the row doesn't carry its
+own) are reported as skipped rather than persisted or silently dropped.
 
 ## work_on_issue.py
 

--- a/scripts/import_transactions.py
+++ b/scripts/import_transactions.py
@@ -16,19 +16,41 @@ def main() -> None:
     parser.add_argument(
         "--api", default="http://localhost:8000", help="Base URL of the backend API"
     )
+    parser.add_argument(
+        "--owner",
+        default=None,
+        help=(
+            "Fallback owner for rows that don't carry their own (e.g. "
+            "Hargreaves exports never set owner/account; degiro/moneyhub "
+            "usually do). Rows with no resolvable owner/account are reported "
+            "under 'skipped' rather than persisted (#4965)."
+        ),
+    )
+    parser.add_argument(
+        "--account", default=None, help="Fallback account for rows that don't carry their own."
+    )
     args = parser.parse_args()
 
     url = f"{args.api.rstrip('/')}/transactions/import"
     with args.file.open("rb") as fh:
         files = {"file": (args.file.name, fh)}
         data = {"provider": args.provider}
+        if args.owner:
+            data["owner"] = args.owner
+        if args.account:
+            data["account"] = args.account
         resp = requests.post(url, data=data, files=files, timeout=30)
     try:
         resp.raise_for_status()
     except requests.HTTPError as exc:  # pragma: no cover - network errors
         print(f"Request failed: {exc}", file=sys.stderr)
         sys.exit(1)
-    print(resp.json())
+    result = resp.json()
+    print(f"Persisted {len(result['persisted'])} transaction(s).")
+    if result["skipped"]:
+        print(f"Skipped {len(result['skipped'])} row(s):", file=sys.stderr)
+        for row in result["skipped"]:
+            print(f"  {row.get('skip_reason')}: {row}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 import pytest
@@ -32,8 +31,60 @@ def test_import_transactions_csv(tmp_path, monkeypatch):
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data[0]["ticker"] == "PFE"
-    assert data[0]["owner"] == "alice"
+    assert data["skipped"] == []
+    assert len(data["persisted"]) == 1
+    persisted = data["persisted"][0]
+    assert persisted["ticker"] == "PFE"
+    assert persisted["owner"] == "alice"
+    assert persisted["price_gbp"] == 10.5
+    assert persisted["units"] == 2
+    assert persisted["reason"] == "diversify"
+    assert persisted["id"] == "alice:ISA:0"
+
+
+def test_import_transactions_hargreaves_uses_owner_account_fallback(tmp_path, monkeypatch):
+    """Hargreaves rows never carry owner/account of their own (hargreaves.parse()
+    always sets them to ""), so the caller must supply a destination
+    explicitly via the ``owner``/``account`` form fields (#4965).
+    """
+    client = _make_client(tmp_path, monkeypatch)
+    csv_data = "Code,Units held,Price (pence),Cost (£)\nPFE,2,1050,21.00\n"
+
+    resp = client.post(
+        "/transactions/import",
+        data={"provider": "hargreaves", "owner": "alice", "account": "ISA"},
+        files={"file": ("tx.csv", csv_data, "text/csv")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["skipped"] == []
+    assert len(data["persisted"]) == 1
+    persisted = data["persisted"][0]
+    assert persisted["owner"] == "alice"
+    assert persisted["account"] == "ISA"
+    assert persisted["ticker"] == "PFE"
+    assert persisted["price_gbp"] == pytest.approx(10.5)
+    assert persisted["units"] == 2
+
+
+def test_import_transactions_skips_rows_with_no_resolvable_owner_account(tmp_path, monkeypatch):
+    """A row with no owner/account of its own, and no fallback supplied, must
+    be reported as skipped rather than persisted or silently dropped (#4965).
+    """
+    client = _make_client(tmp_path, monkeypatch)
+    csv_data = "Code,Units held,Price (pence),Cost (£)\nPFE,2,1050,21.00\n"
+
+    resp = client.post(
+        "/transactions/import",
+        data={"provider": "hargreaves"},
+        files={"file": ("tx.csv", csv_data, "text/csv")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["persisted"] == []
+    assert len(data["skipped"]) == 1
+    assert data["skipped"][0]["skip_reason"] == "missing owner/account"
+    assert data["skipped"][0]["ticker"] == "PFE"
 
 
 def test_degiro_to_float_invalid_inputs():
@@ -161,12 +212,20 @@ def test_dedupe_against_existing_treats_missing_external_id_as_always_new():
     assert result == [candidate]
 
 
-def test_import_transactions_moneyhub_dedupes_on_reimport(tmp_path, monkeypatch):
+def test_import_transactions_moneyhub_persists_and_dedupes_on_reimport(tmp_path, monkeypatch):
+    """Import -> persist -> re-import must show zero duplicates end-to-end (#4965).
+
+    Unlike the old version of this test, nothing is hand-written to the
+    accounts store to simulate a prior import: both rounds go through the
+    real ``/transactions/import`` persistence path, so a regression in that
+    path (e.g. dedupe checking the wrong store) would actually be caught.
+    """
     client = _make_client(tmp_path, monkeypatch)
     key_row1 = "2024-05-01|Current|-42.50|tesco store"
     key_row2 = "2024-05-02|Current|1500.00|salary"
 
-    # First import: nothing persisted yet, so both rows come back as new.
+    # First import: nothing persisted yet, so both bank-style rows (no
+    # ticker/price/units -- Moneyhub) are persisted as-is.
     resp = client.post(
         "/transactions/import",
         data={"provider": "moneyhub"},
@@ -174,29 +233,17 @@ def test_import_transactions_moneyhub_dedupes_on_reimport(tmp_path, monkeypatch)
     )
     assert resp.status_code == 200
     first = resp.json()
-    assert {t["external_id"] for t in first} == {key_row1, key_row2}
+    assert first["skipped"] == []
+    assert {t["external_id"] for t in first["persisted"]} == {key_row1, key_row2}
+    assert all(t["owner"] == "alice" for t in first["persisted"])
 
-    # Persist one of the two rows directly, mimicking what a caller would do
-    # after reviewing the parsed-but-not-yet-saved import result.
-    owner_dir = tmp_path / "alice"
-    owner_dir.mkdir(parents=True)
-    (owner_dir / "Current_transactions.json").write_text(
-        json.dumps(
-            {
-                "owner": "alice",
-                "account_type": "Current",
-                "transactions": [{"external_id": key_row1, "comments": "Tesco Store"}],
-            }
-        )
-    )
-
-    # Re-importing the same export should no longer surface the already
-    # persisted row, only the still-new one.
+    # Re-importing the same export must persist nothing further: both rows
+    # are already in storage, so dedupe filters them out before persistence
+    # is ever attempted.
     resp = client.post(
         "/transactions/import",
         data={"provider": "moneyhub"},
         files={"file": ("tx.csv", MONEYHUB_SAMPLE.read_bytes(), "text/csv")},
     )
     assert resp.status_code == 200
-    second = resp.json()
-    assert {t["external_id"] for t in second} == {key_row2}
+    assert resp.json() == {"persisted": [], "skipped": []}

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -441,8 +441,32 @@ def test_import_transactions_success(tmp_path, monkeypatch):
     resp = client.post("/transactions/import", data={"provider": "degiro"}, files=files)
 
     assert resp.status_code == 200
-    assert resp.json() == [tx.model_dump() for tx in sample]
+    data = resp.json()
+    assert data["skipped"] == []
+    assert len(data["persisted"]) == 1
+    assert data["persisted"][0]["owner"] == "alice"
+    assert data["persisted"][0]["account"] == "isa"
+    assert data["persisted"][0]["ticker"] == "PFE"
+    assert data["persisted"][0]["id"] == "alice:isa:0"
     assert captured == {"provider": "degiro", "data": b"content"}
+
+
+def test_import_transactions_empty_parse_does_not_require_writable_store(tmp_path, monkeypatch):
+    """An empty parse result (e.g. the "test" provider used by smoke tests,
+    which always returns []) must not 400 for a request with no writable
+    account root -- there's nothing to persist or dedupe against, so no
+    store should even be resolved (#4965, follow-up to #5366's smoke-test
+    auth fix: this endpoint is on the smoke sweep and must keep responding
+    200 regardless of the caller's write permissions).
+    """
+    client = _make_client(tmp_path, monkeypatch, accounts_root="")
+    monkeypatch.setattr(transactions.importers, "parse", lambda provider, data: [])
+
+    files = {"file": ("tx.csv", b"content", "text/csv")}
+    resp = client.post("/transactions/import", data={"provider": "test"}, files=files)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"persisted": [], "skipped": []}
 
 
 def test_import_transactions_unknown_provider(tmp_path, monkeypatch):


### PR DESCRIPTION
## What
Closes #4965

`POST /transactions/import` (used by degiro, hargreaves, and moneyhub) parsed an uploaded export and returned the resulting transactions, but never persisted them. #3426 added Moneyhub import + return-time dedupe, but that dedupe only filtered what was *returned* — it did nothing for callers who never persisted the result, which was every caller (only `scripts/import_transactions.py` existed, and it just printed the JSON).

## Design decision
The issue's "How" flagged that `POST /transactions` requires `ticker`, `price_gbp > 0`, `units > 0` — which doesn't fit bank-style rows like Moneyhub's (amount + description, no ticker/units/price), and asked whether that needs a new transaction-model variant.

It doesn't: `rebuild_account_holdings` already does `ticker = (t.get("ticker") or "").upper()` and only processes an entry `if ttype in TYPE_SIGN and ticker` — it silently skips any transaction with no ticker. So bank-style rows can be appended to the same transaction log, in the same shape, with no holdings impact, using the existing tolerant helpers (`_calculate_portfolio_impact` already returns `0.0` on missing/invalid price/units). No new schema needed.

## Changes
- **`backend/routes/transactions.py`**:
  - Extracted `_persist_transaction()` from `create_transaction()`'s body (append + portfolio-impact + rebuild), shared by both the single-transaction endpoint and the new bulk import path.
  - `import_transactions()` now persists every parsed+deduped row whose owner/account can be resolved — from the row itself (degiro/moneyhub embed it per-row) or new optional `owner`/`account` form fields (Hargreaves rows never carry their own — `hargreaves.py` always sets `owner=""`, `account=""`). Unresolvable rows land in a new `skipped` list with a reason instead of being persisted or silently dropped.
  - `_tx_data_from_parsed()` coalesces the importers' `price`/`reason_to_buy` fields into the persisted `price_gbp`/`reason` shape.
  - An empty parse result (the `"test"` provider used by the smoke-test sweep always returns `[]`) skips resolving a writable store entirely, so a caller with no write access still gets `200` rather than a new `400` — this endpoint is in the smoke sweep (`scripts/frontend-backend-smoke.ts`) and must keep responding.
  - Response shape changed from a plain array to `{"persisted": [...], "skipped": [...]}`.
- **`scripts/import_transactions.py`**: added `--owner`/`--account` fallback flags; prints persisted/skipped counts (with reasons) instead of the raw parsed list.
- **Tests**: updated `test_import_transactions_csv`/`test_import_transactions_success` for the new response shape; added coverage for the Hargreaves owner/account fallback, the missing-owner/account skip path, and the empty-parse/no-store-required path. Rewrote `test_import_transactions_moneyhub_dedupes_on_reimport` (now `..._persists_and_dedupes_on_reimport`) to prove zero duplicates through two real `/transactions/import` calls end-to-end, instead of hand-writing a fixture file to fake a prior import — per the issue's explicit ask.
- **`scripts/README.md`**: documented the new flags and persistence behavior.

## Validation
- [x] `pytest tests/test_transactions_import.py tests/test_transactions_route.py --no-cov` — 63/63 pass
- [x] `pytest tests/ --no-cov` (full backend suite) — 3061 passed, 6 skipped, 16 xfailed, 1 xpassed (1 unrelated pre-existing failure in `test_review_comment.py`, a WSL/bash environment issue, deselected)
- [x] `ruff check` / `black --check` on changed files — no new violations (pre-existing lint debt on untouched lines only, confirmed against `origin/main`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Transaction imports now report separate lists of successfully persisted and skipped records.
  - Owner and account fallback values can be supplied for imports missing this information.
  - Skipped rows include a clear reason, such as missing owner or account details.
  - Re-importing transactions with stable source IDs now avoids creating duplicates.
  - The import command-line tool summarises results and reports skipped rows clearly.
- **Bug Fixes**
  - Imported transaction fields are now consistently mapped and saved, including prices, reasons, and generated IDs.
  - Empty imports complete successfully without requiring a writable transaction store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->