### PR TITLE
Wrap toggle-button and control rows on the Allocation and Watchlist pages

### DIFF
--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -199,13 +199,13 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
 
   return (
     <div className="container mx-auto p-4">
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
         <h1 className="text-2xl md:text-4xl">
           {t("app.modes.allocation", { defaultValue: "Allocation" })}
         </h1>
         <RelativeViewToggle />
       </div>
-      <div className="mb-4 flex gap-2">
+      <div className="mb-4 flex flex-wrap gap-2">
         <button onClick={() => setView("asset")} disabled={view === "asset"}>
           {t("allocation.instrumentTypes", { defaultValue: "Instrument Types" })}
         </button>

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -146,7 +146,7 @@ export function Watchlist() {
           onChange={(e) => setSymbols(e.target.value)}
         />
       </div>
-      <div className="mb-2 flex items-center gap-2">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
         <label className="flex items-center gap-1">
           {t("watchlist.refreshFrequency", { defaultValue: "Auto-refresh" })}
           <select


### PR DESCRIPTION
## Summary
Third slice of #5382 (first two slices: #5401, #5408, both merged). Audited the remaining pages named in the issue (`AllocationCharts`, `TaxTools`, plus a broader sweep of `src/pages` for `flex` classes missing `flex-wrap`) — most pages already follow the repo's Tailwind responsive conventions (`flex-col md:flex-row`, `flex-wrap`), but two spots didn't:

- `AllocationCharts.tsx`: the title + relative-view-toggle row, and the asset/sector/region view-switch button row.
- `Watchlist.tsx`: the auto-refresh control row.

## Verification
Ran the local backend + frontend dev server against demo data, opened the Allocation view at 375px width.

- Without the fix (checked via `git stash`), the three view-switch buttons (`Instrument Types` / `Industries` / `Regions`) sit in a `flex` row with default `flex-shrink`, so **they don't cause page overflow — they get visually compressed** instead (shrunk below their natural ~166px/112px/98px widths onto one line).
- With the fix, `read_page`/computed-style inspection confirms `flexWrap: wrap` and the buttons render at full natural width across two lines (row height 84px vs squeezed single-line before).
- So this fix is about button/label readability on narrow screens rather than a horizontal-scroll bug like the earlier two slices — worth calling out explicitly since the earlier PRs were framed around overflow.
- `npx eslint` clean on both changed files.
- `npx vitest run` on `AllocationCharts.test.tsx` and `Watchlist.test.tsx` — 19/19 passing.

## Scope
Still doesn't close #5382. Swept the remaining named pages (`TaxTools`, `AddPositionForm`, `UserConfig`) and most of `src/pages` — they already handle mobile reasonably (responsive grid/flex classes, `w-full` inputs). Remaining open items: table-to-card collapse for very narrow widths (currently horizontal-scroll, which is an acceptable but not ideal pattern), and a dedicated menu-collapse audit (the hamburger menu already works via Tailwind `sm:hidden`, but hasn't been screenshot-verified end-to-end).

Part of #5382.
