### PR TITLE
Sort news headlines most-recent-first

### DIFF
--- a/backend/routes/news.py
+++ b/backend/routes/news.py
@@ -145,7 +145,20 @@ def _trim_payload(payload: Any) -> List[Dict[str, str]]:
         )
         if news_item is not None:
             trimmed.append(news_item)
-    return trimmed
+    return _sort_by_published_at_desc(trimmed)
+
+
+def _sort_by_published_at_desc(items: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Return ``items`` ordered most-recent-first by ``published_at``.
+
+    ``published_at`` values are already normalised to ISO-8601 UTC strings by
+    ``_isoformat``, so lexicographic ordering matches chronological ordering.
+    Items missing ``published_at`` sort last rather than being dropped, since
+    upstream sources (notably the Yahoo/Google fallbacks) don't always return
+    results in date order.
+    """
+
+    return sorted(items, key=lambda item: item.get("published_at") or "", reverse=True)
 
 
 def _lookup_instrument_name(ticker: str) -> Optional[str]:

--- a/frontend/src/pages/InstrumentResearch.tsx
+++ b/frontend/src/pages/InstrumentResearch.tsx
@@ -83,6 +83,10 @@ function addInstrumentTypeOption(options: string[], value: string) {
   );
 }
 
+function sortNewsByPublishedAtDesc(items: NewsItem[]): NewsItem[] {
+  return [...items].sort((a, b) => (b.published_at ?? "").localeCompare(a.published_at ?? ""));
+}
+
 type DisplayPrice = {
   close: number;
   currency: string;
@@ -663,7 +667,7 @@ export default function InstrumentResearch({ ticker }: InstrumentResearchProps) 
       setNewsError(null);
       try {
         const items = await getNews(tkr, newsCtrl.signal);
-        setNews(items);
+        setNews(sortNewsByPublishedAtDesc(items));
       } catch (err) {
         const error = err as { name?: string } | null | undefined;
         if (error?.name === "AbortError") {

--- a/frontend/tests/unit/pages/InstrumentResearch.test.tsx
+++ b/frontend/tests/unit/pages/InstrumentResearch.test.tsx
@@ -396,6 +396,40 @@ describe("InstrumentResearch page", () => {
     expect(await screen.findByText("No news available")).toBeInTheDocument();
   });
 
+  it("orders news most-recent first regardless of API response order", async () => {
+    mockGetNews.mockResolvedValueOnce([
+      {
+        headline: "Oldest headline",
+        url: "https://example.com/oldest",
+        published_at: "2023-01-01T00:00:00Z",
+      },
+      {
+        headline: "Newest headline",
+        url: "https://example.com/newest",
+        published_at: "2023-08-25T16:00:00Z",
+      },
+      {
+        headline: "Middle headline",
+        url: "https://example.com/middle",
+        published_at: "2023-05-01T00:00:00Z",
+      },
+    ]);
+
+    renderPage();
+
+    const newsTab = screen.getByRole("button", { name: /News/i });
+    await userEvent.click(newsTab);
+
+    const links = await screen.findAllByRole("link", {
+      name: /(Oldest|Newest|Middle) headline/,
+    });
+    expect(links.map((link) => link.textContent)).toEqual([
+      "Newest headline",
+      "Middle headline",
+      "Oldest headline",
+    ]);
+  });
+
   it("renders news metadata when available", async () => {
     mockGetNews.mockResolvedValueOnce([
       {

--- a/tests/routes/test_news_helpers.py
+++ b/tests/routes/test_news_helpers.py
@@ -127,6 +127,29 @@ def test_trim_payload_filters_invalid_entries():
     assert news_module._trim_payload({"unexpected": "mapping"}) == []
 
 
+def test_trim_payload_sorts_by_published_at_descending():
+    payload = [
+        {"headline": "Oldest", "url": "https://example.com/1", "published_at": "2024-01-01T00:00:00Z"},
+        {"headline": "Newest", "url": "https://example.com/2", "published_at": "2024-06-01T12:00:00Z"},
+        {"headline": "Middle", "url": "https://example.com/3", "published_at": "2024-03-15T09:30:00Z"},
+    ]
+
+    assert [item["headline"] for item in news_module._trim_payload(payload)] == [
+        "Newest",
+        "Middle",
+        "Oldest",
+    ]
+
+
+def test_trim_payload_sorts_missing_published_at_last():
+    payload = [
+        {"headline": "NoDate", "url": "https://example.com/1"},
+        {"headline": "Dated", "url": "https://example.com/2", "published_at": "2024-01-01T00:00:00Z"},
+    ]
+
+    assert [item["headline"] for item in news_module._trim_payload(payload)] == ["Dated", "NoDate"]
+
+
 def test_isoformat_normalises_to_utc_seconds():
     naive = datetime(2024, 1, 2, 3, 4, 5)
     aware = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone(timedelta(hours=2)))


### PR DESCRIPTION
## Summary
- Fixes #5421 — the News tab on instrument research (e.g. `/research/PFE.N`) listed headlines in whatever order the upstream source returned them, not sorted by date.
- `backend/routes/news.py`: `_trim_payload()` now sorts items by `published_at` descending (missing timestamps sort last), so every response path — fresh fetch, cache, and quota-exhausted fallback to cache — is consistently ordered.
- `frontend/src/pages/InstrumentResearch.tsx`: added a defensive client-side sort (`sortNewsByPublishedAtDesc`) applied when news is fetched, in case a stale cached payload predates the backend fix.

## Test plan
- [x] `python -m pytest tests/routes/test_news_helpers.py tests/routes/test_news.py tests/backend/test_news_route.py tests/test_news_route.py -q --no-cov` — 62 passed
- [x] `npx vitest run tests/unit/pages/InstrumentResearch.test.tsx` — 21 passed (includes new sort-order test)
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint` — clean

Closes #5421

🤖 Generated with [Claude Code](https://claude.com/claude-code)