### PR TITLE
Fix Tailwind responsive breakpoints not being generated at all (root cause of #5382)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 :root {
     font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -343,6 +343,65 @@ describe('Menu', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('toggles the mobile menu list via the hamburger button (#5382)', () => {
+    // The hamburger is the mobile-collapse control (hidden at sm: and above via
+    // Tailwind); jsdom can't evaluate the sm: media query, but it can verify the
+    // mobileMenuOpen state drives both the aria-expanded flag and the "hidden"/
+    // "flex" class swap on the menu list, which is what actually collapses it.
+    render(
+      <MemoryRouter>
+        <Menu />
+      </MemoryRouter>
+    );
+    const hamburger = screen.getByRole('button', { name: i18n.t('app.menu') });
+    const menuList = document.getElementById('app-main-menu');
+    expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+    expect(hamburger).toHaveAttribute('aria-controls', 'app-main-menu');
+    expect(menuList).toHaveClass('hidden');
+    expect(menuList).not.toHaveClass('flex');
+
+    fireEvent.click(hamburger);
+    expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: i18n.t('app.close') })).toBe(hamburger);
+    expect(menuList).toHaveClass('flex');
+    expect(menuList).not.toHaveClass('hidden');
+
+    fireEvent.click(hamburger);
+    expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+    expect(menuList).toHaveClass('hidden');
+  });
+
+  it('closes the mobile menu when Escape is pressed (#5382)', () => {
+    render(
+      <MemoryRouter>
+        <Menu />
+      </MemoryRouter>
+    );
+    const hamburger = screen.getByRole('button', { name: i18n.t('app.menu') });
+    fireEvent.click(hamburger);
+    expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('closes the mobile menu when clicking outside the nav (#5382)', () => {
+    render(
+      <div>
+        <MemoryRouter>
+          <Menu />
+        </MemoryRouter>
+        <div data-testid="outside">outside content</div>
+      </div>
+    );
+    const hamburger = screen.getByRole('button', { name: i18n.t('app.menu') });
+    fireEvent.click(hamburger);
+    expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it.each([
     ['MVP', true],
     ['non-MVP', false],

--- a/tests/snapshots/index.css
+++ b/tests/snapshots/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 :root {
     font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
## Summary
Fourth slice of #5382, but a different kind of fix from the first three (#5401, #5408, #5417) — this one is a build-config bug, and it's likely the **primary root cause** behind the original "doesn't look good on mobile" report.

While auditing the mobile hamburger menu (planned scope for this slice), I found the hamburger button was **visible at 1280px desktop width**, when `Menu.tsx` uses `sm:hidden` to hide it above 640px. Digging in:

- `frontend/src/index.css` used the deprecated `@tailwind base; @tailwind components; @tailwind utilities;` directive syntax.
- Tailwind v4 + `@tailwindcss/postcss` (the versions this repo is on) does not generate any responsive breakpoint CSS from that syntax.
- Confirmed by inspecting the actual served CSS in two ways:
  - **Dev server**: fetched `/src/index.css` and searched for `@media` rules — found only `hover`/`prefers-color-scheme` queries, zero `min-width`/`width >=` breakpoint rules.
  - **Production build**: ran `npm run build`, grepped `dist/styles.css` for any `sm\:`/`md\:`/`lg\:` prefixed selector — **zero matches**. The only media queries present (480px/768px/1024px) came from the hand-written `styles/responsive.css`, unrelated to Tailwind's utility generation.
- Switched `@tailwind base/components/utilities` to `@import "tailwindcss";` (the v4-recommended syntax) and rebuilt: `dist/styles.css` now contains `@media(min-width:40rem)` rules and matching `sm\:` selectors.

## What this means
Every `sm:`/`md:`/`lg:` class used anywhere in the app — `AddPositionForm`'s `sm:grid-cols-2 lg:grid-cols-4`, `TaxTools`'s `md:flex-row`, `AllocationCharts`'s `md:text-4xl`, and critically `Menu.tsx`'s `sm:hidden`/`sm:flex sm:flex-row` hamburger-vs-desktop-row toggle — has been a silent no-op since Tailwind v4 was adopted. This is a much bigger deal than the flexWrap fixes in the earlier three PRs and probably explains most of the original mobile complaint.

## Verification
- Live in-browser (local backend + frontend dev server against demo data):
  - At 1280px: hamburger button `display: none` (correct — was `inline-flex`/visible before the fix), menu list renders `flex-direction: row`.
  - At 375px: hamburger visible, menu list `display: none` until toggled; clicking it shows the category list stacked in a column with no page overflow; opening a category submenu renders in normal document flow (not absolute-positioned off-screen) and fits the viewport.
- Added test coverage for the hamburger's own open/close state (`Menu.test.tsx`) — the existing suite only tested the category-dropdown toggles, never the mobile-collapse hamburger itself (Escape-to-close and click-outside-to-close were also untested). 16/16 Menu tests pass.
- Full frontend suite: **95 test files / 640 tests, all passing** — this is a global CSS change so I ran the whole suite, not just targeted files.
- Confirmed `npm run build` succeeds and the built CSS contains the expected breakpoint rules.

## Scope
This doesn't close #5382 on its own, but combined with the earlier three PRs it should resolve the bulk of the reported mobile issues, since the responsive classes already written throughout the codebase should now actually activate. Worth a follow-up pass after this merges to spot-check pages that rely on `md:`/`lg:` grid/flex classes now that they'll visibly change layout for the first time.

Part of #5382.
