### PR TITLE
Add diagnostic logging for ensure_owner_access denials (#5215)

### DIFF
--- a/backend/common/authz.py
+++ b/backend/common/authz.py
@@ -17,12 +17,16 @@ restricted.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Mapping, Optional, Set
 
 from backend.common.data_loader import load_person_meta
 from backend.common.errors import PermissionDeniedError
 from backend.config import config
+from backend.logging_setup import sanitise_log_value
+
+logger = logging.getLogger(__name__)
 
 _FORBIDDEN_DETAIL = "Not authorized for this owner"
 
@@ -62,6 +66,12 @@ def ensure_owner_access(
     No-op when authentication is disabled (local/demo mode). Otherwise the
     owner's person metadata is consulted and the caller must match the owner
     id, the owner's email, or a listed viewer.
+
+    Denials are logged (owner, whether an identity was present at all, and
+    the allowed-identity set size) purely for diagnostics -- issue #5215
+    reports a 403 here that couldn't be reproduced or root-caused from code
+    alone; the next real occurrence should be traceable from these logs
+    rather than requiring another blind investigation.
     """
 
     if config.disable_auth:
@@ -69,4 +79,10 @@ def ensure_owner_access(
 
     meta = load_person_meta(owner, accounts_root)
     if not identity_can_access_owner(identity, owner, meta):
+        logger.warning(
+            "ensure_owner_access denied: owner=%s identity_present=%s allowed_count=%s",
+            sanitise_log_value(owner),
+            identity is not None,
+            len(_allowed_identities(owner, meta)),
+        )
         raise PermissionDeniedError(_FORBIDDEN_DETAIL, safe_detail=_FORBIDDEN_DETAIL)

--- a/tests/backend/common/test_authz.py
+++ b/tests/backend/common/test_authz.py
@@ -76,3 +76,40 @@ def test_ensure_owner_access_rejects_missing_identity(monkeypatch):
 
     with pytest.raises(PermissionDeniedError):
         authz.ensure_owner_access(None, "alice")
+
+
+def test_ensure_owner_access_denial_is_logged(monkeypatch, caplog):
+    """A denial must be logged with enough context to diagnose the next real
+    occurrence of issue #5215 (a 403 on /accounts/{owner}/approvals that
+    couldn't be reproduced or root-caused from code alone) without needing
+    another blind investigation. The raw identity is deliberately not logged
+    (only whether one was present), since it may be a real user's email.
+    """
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setattr(authz, "load_person_meta", lambda owner, root=None: {})
+
+    with caplog.at_level("WARNING", logger="backend.common.authz"):
+        with pytest.raises(PermissionDeniedError):
+            authz.ensure_owner_access(None, "alice")
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "alice" in message
+    assert "identity_present=False" in message
+
+
+def test_ensure_owner_access_denial_log_reports_identity_present_when_unauthorized(
+    monkeypatch, caplog
+):
+    """A present-but-unauthorized identity is distinguished from no identity
+    at all in the log, since they're different failure modes (wrong account
+    vs. genuinely anonymous caller).
+    """
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setattr(authz, "load_person_meta", lambda owner, root=None: {})
+
+    with caplog.at_level("WARNING", logger="backend.common.authz"):
+        with pytest.raises(PermissionDeniedError):
+            authz.ensure_owner_access("bob", "alice")
+
+    assert "identity_present=True" in caplog.records[0].getMessage()

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -31,6 +31,9 @@ backend/common/alerts.py:78
 backend/common/approvals.py:40
 backend/common/approvals.py:45
 backend/common/approvals.py:92
+# issue #5215 diagnostic: identity is not None (always bool) and len(...)
+# (always int) can't carry attacker-controlled input.
+backend/common/authz.py:82
 backend/common/compliance.py:198
 backend/common/compliance.py:236
 backend/common/compliance.py:265


### PR DESCRIPTION
## What
Partially addresses #5215 — does **not** close it, since the actual root cause of the reported 403 remains unconfirmed. This is diagnostic instrumentation, not a behavioral fix.

## Investigation summary
Issue #5215 reports a 403 on `GET /accounts/{owner}/approvals` that "silently expires anonymous/demo mode sessions." Traced through the relevant code paths:

1. **A 403 from this endpoint cannot touch global auth/session state today.** `fetchJson` in `frontend/src/api.ts` only dispatches `UNAUTHORIZED_EVENT` (the only thing that sets `sessionExpired`/shows the sign-in wall in `main.tsx`) on `status === 401`. `UserConfig.tsx`'s `getApprovals` catch just sets a local `approvalsError` string. This matches PR #5193's own investigation, which I independently re-verified still holds.
2. **The most plausible code-level lead was a dead end.** `_resolve_identity_when_auth_disabled` (`backend/auth.py`) rejects a present-but-unrecognized token email with a 403 instead of falling back to the local/demo identity. I initially proposed changing this, but `tests/test_auth.py::test_get_current_user_rejects_unrecognized_email_claim` explicitly pins this as *intentional*, tied to issue #4750: "An unprovisioned email must be rejected, not mapped to the local/demo identity." Changing it would regress a deliberate security control, not fix a bug.
3. **`ensure_owner_access`** (shared by this endpoint and `/user-config/{owner}`) no-ops entirely when `disable_auth` is true, and otherwise requires the identity to match the owner/email/viewers list — this reads as intentional per-owner access control, not an obvious defect.

Given PR #5193's own author already hit this same wall ("I could not fully reconstruct the exact mechanism... the backend identity/token logs... would be the next place to look"), guessing at a further fix risks introducing a new problem to address an unconfirmed one.

## Change
- `backend/common/authz.py`: `ensure_owner_access` now logs a `WARNING` on every denial — the owner, whether an identity was present at all (not the raw identity, which may be a real email), and the size of the allowed-identity set. This is the one 403 site directly implicated by the issue that had no logging at all (the other candidate site, `_resolve_identity_when_auth_disabled`, already logs the rejected email on its 403 path).
- Added test coverage confirming the log fires and distinguishes "no identity" from "wrong identity."

## Next step
When this 403 recurs in production, the log line will show whether the caller had any identity at all — which narrows the next investigation to either the frontend (is a request going out with a stale/absent token where a real one was expected?) or the backend's identity resolution, instead of starting from zero again.

## Validation
- [x] `pytest tests/backend/common/test_authz.py tests/backend/common/test_approvals.py tests/backend/test_approvals_route.py tests/common/test_approvals.py tests/routes/test_approvals.py tests/test_auth.py --no-cov` — 74/74 pass
- [x] `ruff check` / `black --check` on changed files — no new violations (pre-existing lint debt on untouched lines only)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>