### PR TITLE
Add issue-template creation rules to agent-facing docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,6 +13,7 @@ Read `AGENTS.md` for full repository guidance. Use these short rules while gener
 - Prefer `bash scripts/bash/run-local-api.sh` for the local backend instead of outdated `uvicorn app:app` examples.
 - Verify command names against actual `package.json`, `Makefile`, and scripts before updating docs.
 - If your change implements an issue, include an auto-closing PR reference (for example: `Closes #1234`).
+- When creating an issue, always use the template format from `.github/ISSUE_TEMPLATE/` and include all required sections: What, Why, How, Constraints, LLM tier, Success looks like, Failure looks like.
 - When rebasing a PR, force-push to the same branch — don't create a new one.
 - Keep changes out of generated dependency folders such as `node_modules/`.
 - Be careful when changing `data/`, auth defaults, or smoke-test flows; these are tightly coupled to local development and demos.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,25 @@ Before finishing:
 3. Update nearby docs when behavior or workflow meaningfully changes.
 4. Summarize any environment limitations clearly.
 
-## 8. Commit and PR expectations
+## 8. Issue creation
+
+When creating a GitHub issue, always use the repo template format defined in
+`.github/ISSUE_TEMPLATE/bug_report.md` or `.github/ISSUE_TEMPLATE/feature_request.md`.
+The required sections are:
+
+- **What** — what is broken or what should be built
+- **Why** — impact on users or developers
+- **How** — steps to reproduce (bug) or high-level approach (feature); include
+  expected vs actual behavior and environment for bugs
+- **Constraints** — guardrails the fix must respect (backwards compat, API
+  shape, platform parity, etc.)
+- **LLM tier** — suggested AI agent tier: haiku / sonnet / opus
+- **Success looks like** — checklist of acceptance criteria
+- **Failure looks like** — what regressions or gaps would mean the fix failed
+
+Never submit an issue that is missing any of these sections.
+
+## 9. Commit and PR expectations
 
 - Use focused, imperative commit messages, e.g. `Refresh AI contributor guidance`.
 - In PR descriptions, include:
@@ -126,7 +144,7 @@ Before finishing:
 - If you changed operational workflows, mention the exact commands used for validation.
 - **When rebasing a PR branch**: rebase onto the target and force-push to the **same branch name**. The PR updates automatically. Do not create a new branch or a new PR — that duplicates review state and creates noise.
 
-## 9. Additional AI-facing files in this repo
+## 10. Additional AI-facing files in this repo
 
 To support tool-specific agents, keep these files aligned when the repo guidance changes:
 - `AGENTS.md` — primary source of truth for agent workflow.
@@ -135,7 +153,7 @@ To support tool-specific agents, keep these files aligned when the repo guidance
 
 When updating one of these, consider whether the same repo facts or command changes should be mirrored in the others.
 
-## 10. Code quality invariants (non-negotiable)
+## 11. Code quality invariants (non-negotiable)
 
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#code-quality-invariants-non-negotiable)
 for the canonical rules (function length, zero lint warnings, no silent error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,12 +40,17 @@ npm run smoke:test:codex:poc
 - Be cautious around `data/`, auth toggles, and smoke-test identities; these often affect local demos and automated flows.
 - Preserve cross-platform workflow parity when touching scripts because the repo uses both bash and PowerShell helpers.
 
-## Branch and PR policy
+## Branch, issue, and PR policy
 
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#branch-and-pr-policy) for the
 canonical branch/PR rules (never commit to `main`, worktree-first for dirty
 checkouts, required PR steps, branch naming, `Closes #NNNN` linking). Agents
 must treat branch creation as a first step, not a release step at the end.
+
+**Issue creation**: Always use the template format from
+`.github/ISSUE_TEMPLATE/bug_report.md` or `.github/ISSUE_TEMPLATE/feature_request.md`
+and include every required section: What, Why, How, Constraints, LLM tier,
+Success looks like, Failure looks like.
 
 **When rebasing a PR branch**: rebase onto the target and force-push to the
 **same branch name**. The PR updates automatically. Do not create a new branch


### PR DESCRIPTION

## What changed

Added mandatory issue-template formatting rules to all three agent-facing instruction files so AI agents always produce issues that match the repo templates (`.github/ISSUE_TEMPLATE/bug_report.md` / `feature_request.md`).

## Why

Issue #5434 was initially created without the required template sections (What, Why, How, Constraints, LLM tier, Success looks like, Failure looks like). The AGENTS.md had no rule for this, so agents had no prompt-level guidance to use the template format.

## What I validated

- Verified `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md` both use the same seven-section format
- Confirmed the updated sections are numbered consistently in AGENTS.md (8 → Issue creation, 9 → Commit/PR, 10 → AI-facing files, 11 → Code quality)
- CLAUDE.md and copilot-instructions.md both updated with concise references to the same rule

## Files changed

- `AGENTS.md` — new Section 8: Issue creation with mandatory section list; renumbered sections 9–11
- `CLAUDE.md` — renamed "Branch and PR policy" → "Branch, issue, and PR policy"; added issue creation rule
- `.github/copilot-instructions.md` — added one-line rule requiring template format for all issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring issue reports to use the repository’s standard templates.
  * Defined the required sections for new bug reports and feature requests.
  * Updated contributor guidance to reflect the new issue-creation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->