### PR TITLE
Fix /api-console requiring auth when disable_auth=true (#5434)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -70,12 +70,14 @@ def create_app() -> FastAPI:
             "Set ADMIN_EMAILS to a comma-separated list of admin emails."
         )
 
-    async def require_admin(current_user: str = Depends(auth.get_current_user)) -> str:
+    async def require_admin(
+        current_user: str | None = Depends(auth.get_active_user),
+    ) -> str | None:
         if admin_set:
             # Allowlist is configured: always enforce it regardless of disable_auth.
             # DISABLE_AUTH=true is set on the Lambda because API Gateway handles Cognito
             # auth — it must NOT be used to bypass the admin restriction here.
-            if current_user.lower() not in admin_set:
+            if current_user is None or current_user.lower() not in admin_set:
                 raise HTTPException(status_code=403, detail="Admin access required")
         elif not cfg.disable_auth:
             # No allowlist in a production-like environment: deny all to avoid silent
@@ -225,7 +227,7 @@ def create_app() -> FastAPI:
 
     @app.get("/whoami")
     async def whoami(
-        _: str = Depends(require_admin),
+        _: str | None = Depends(require_admin),
         token: str | None = Depends(auth.oauth2_scheme),
     ):
         """Auth-boundary debug view of the bearer token the backend received.

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -15,9 +15,9 @@ backend/alerts.py:336
 backend/alerts.py:49
 backend/alerts.py:55
 backend/alerts.py:93
-backend/app.py:164
-backend/app.py:196
-backend/app.py:215
+backend/app.py:166
+backend/app.py:198
+backend/app.py:217
 backend/auth.py:126
 backend/auth.py:537
 backend/bootstrap/isolation.py:89

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -87,6 +87,25 @@ def test_docs_url_is_removed(monkeypatch):
     assert resp.status_code == 404
 
 
+def test_api_console_no_auth_local_dev(monkeypatch):
+    """GET /api-console returns 200 (HTML) in local dev without any dependency overrides.
+
+    When disable_auth=True and no ADMIN_EMAILS is configured, the admin gate
+    should allow unauthenticated visitors through — no token, no
+    local_login_email, no dependency_overrides required.
+    """
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+    monkeypatch.setattr(config, "disable_auth", True)
+    monkeypatch.delenv("ADMIN_EMAILS", raising=False)
+    with patch("backend.common.portfolio_utils.refresh_snapshot_async"):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/api-console")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
 def test_api_console_accessible_when_auth_disabled(monkeypatch):
     # When auth is disabled the admin check is bypassed; use dependency_overrides
     # so get_current_user returns a user without a real JWT token.


### PR DESCRIPTION
## What changed

Changed \equire_admin\ to use \uth.get_active_user\ instead of \uth.get_current_user\, so the local-dev bypass can be reached when auth is disabled and no \ADMIN_EMAILS\ is configured.

## Why

\get_current_user\ raises HTTP 401 before the admin allowlist check runs, even when \disable_auth=true\. \get_active_user\ returns \None\ in that case, allowing the existing local-dev fallthrough to work correctly.

## What was validated

- All 23 existing tests in \	ests/test_app.py\ pass
- New test \	est_api_console_no_auth_local_dev\ verifies the fix works without any dependency overrides (no token, no \local_login_email\, no \ADMIN_EMAILS\)
- Admin allowlist enforcement unchanged (\ADMIN_EMAILS\ still gates access)
- Production behavior unchanged (\disable_auth=false\ still requires valid auth)

## Risk

Low. The only behavioral change is that \equire_admin\ now defers to \get_active_user\ (which handles the disabled-auth case) instead of \get_current_user\ (which unconditionally requires a token). The admin allowlist logic is preserved, with the addition of an explicit \None\ check for the \current_user\ value.

Closes #5434