### PR TITLE
Add sparkline trendlines to InstrumentTable

### DIFF
--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -36,9 +36,10 @@ import type { RowWithCost } from './instrumentTable/types';
 type Props = {
   rows: InstrumentSummary[];
   showGroupTotals?: boolean;
+  showSparklines?: boolean;
 };
 
-export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
+export function InstrumentTable({ rows, showGroupTotals = true, showSparklines = true }: Props) {
   const { t } = useTranslation();
   const { relativeViewEnabled, baseCurrency } = useConfig();
   const [groupDefinitions, setGroupDefinitions] = useState<InstrumentGroupDefinition[]>([]);
@@ -124,8 +125,12 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
   }
 
   const noFilteredRows = rowsWithCost.length === 0;
+  const showTrend = showSparklines && visibleColumns.trend;
+  const trendColumnLabels: [keyof typeof visibleColumns, string][] = showSparklines
+    ? [['trend', 'Trend']]
+    : [];
   const columnLabels: [keyof typeof visibleColumns, string][] = [
-    ['trend', 'Trend'],
+    ...trendColumnLabels,
     ['units', 'Units'],
     ['cost', 'Cost'],
     ['market', 'Market'],
@@ -235,7 +240,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
               {t('instrumentTable.columns.name')}
               {sortKey === 'name' ? (asc ? ' ▲' : ' ▼') : ''}
             </th>
-            {visibleColumns.trend && (
+            {showTrend && (
               <th className={`${tableStyles.cell} ${tableStyles.center}`}>
                 {t('instrumentTable.columns.trend', { defaultValue: 'Trend' })}
               </th>
@@ -377,7 +382,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
                       </span>
                     </button>
                   </th>
-                  {visibleColumns.trend && (
+                  {showTrend && (
                     <td className={`${tableStyles.cell} ${tableStyles.groupCell}`}>—</td>
                   )}
                   <td className={`${tableStyles.cell} ${tableStyles.groupCell}`}>—</td>
@@ -467,7 +472,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
                         </button>
                       </td>
                       <td className={tableStyles.cell}>{r.name}</td>
-                      {visibleColumns.trend && (
+                      {showTrend && (
                         <td className={`${tableStyles.cell} ${tableStyles.center}`}>
                           <Sparkline
                             ticker={r.ticker}
@@ -626,7 +631,8 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
         })}
         <tfoot>
           <tr>
-            <td className={`${tableStyles.cell} font-semibold`} colSpan={visibleColumns.trend ? 5 : 4}>
+            {/* colSpan covers always-visible columns (ticker, name, ccy, type) plus trend when shown */}
+            <td className={`${tableStyles.cell} font-semibold`} colSpan={showTrend ? 5 : 4}>
               {totalLabel}
             </td>
             {!relativeViewEnabled && visibleColumns.units && (

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -17,6 +17,7 @@ import {
   listInstrumentGroupingDefinitions,
 } from '../api';
 import { useNavigate } from 'react-router-dom';
+import Sparkline from './Sparkline';
 import { useInstrumentTableState } from './instrumentTable/useInstrumentTableState';
 import {
   cashFirstComparator,
@@ -124,6 +125,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
 
   const noFilteredRows = rowsWithCost.length === 0;
   const columnLabels: [keyof typeof visibleColumns, string][] = [
+    ['trend', 'Trend'],
     ['units', 'Units'],
     ['cost', 'Cost'],
     ['market', 'Market'],
@@ -233,6 +235,11 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
               {t('instrumentTable.columns.name')}
               {sortKey === 'name' ? (asc ? ' ▲' : ' ▼') : ''}
             </th>
+            {visibleColumns.trend && (
+              <th className={`${tableStyles.cell} ${tableStyles.center}`}>
+                {t('instrumentTable.columns.trend', { defaultValue: 'Trend' })}
+              </th>
+            )}
             <th
               className={`${tableStyles.cell} ${tableStyles.clickable}`}
               onClick={() => handleSort('currency')}
@@ -370,6 +377,9 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
                       </span>
                     </button>
                   </th>
+                  {visibleColumns.trend && (
+                    <td className={`${tableStyles.cell} ${tableStyles.groupCell}`}>—</td>
+                  )}
                   <td className={`${tableStyles.cell} ${tableStyles.groupCell}`}>—</td>
                   <td className={`${tableStyles.cell} ${tableStyles.groupCell}`}>—</td>
                   {!relativeViewEnabled && visibleColumns.units && (
@@ -457,6 +467,18 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
                         </button>
                       </td>
                       <td className={tableStyles.cell}>{r.name}</td>
+                      {visibleColumns.trend && (
+                        <td className={`${tableStyles.cell} ${tableStyles.center}`}>
+                          <Sparkline
+                            ticker={r.ticker}
+                            days={90}
+                            ariaLabel={t('instrumentTable.columns.sparklineAria', {
+                              ticker: r.ticker,
+                              defaultValue: `Price trend for ${r.ticker}`,
+                            })}
+                          />
+                        </td>
+                      )}
                       <td className={tableStyles.cell}>
                         {isSupportedFx(r.currency) ? (
                           <button
@@ -604,7 +626,7 @@ export function InstrumentTable({ rows, showGroupTotals = true }: Props) {
         })}
         <tfoot>
           <tr>
-            <td className={`${tableStyles.cell} font-semibold`} colSpan={4}>
+            <td className={`${tableStyles.cell} font-semibold`} colSpan={visibleColumns.trend ? 5 : 4}>
               {totalLabel}
             </td>
             {!relativeViewEnabled && visibleColumns.units && (

--- a/frontend/src/components/instrumentTable/types.ts
+++ b/frontend/src/components/instrumentTable/types.ts
@@ -31,4 +31,5 @@ export type VisibleColumns = {
   market: boolean;
   gain: boolean;
   gain_pct: boolean;
+  trend: boolean;
 };

--- a/frontend/src/components/instrumentTable/useInstrumentTableState.ts
+++ b/frontend/src/components/instrumentTable/useInstrumentTableState.ts
@@ -15,6 +15,7 @@ const DEFAULT_VISIBLE_COLUMNS: VisibleColumns = {
   market: true,
   gain: true,
   gain_pct: true,
+  trend: true,
 };
 
 export function useInstrumentTableState(

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -289,6 +289,7 @@
       "market": "Marktwert £",
       "name": "Name",
       "ticker": "Ticker",
+      "trend": "Trend",
       "type": "Typ",
       "units": "Einheiten"
     },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -340,6 +340,7 @@
       "market": "Market £",
       "name": "Name",
       "ticker": "Ticker",
+      "trend": "Trend",
       "type": "Type",
       "units": "Units"
     },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -289,6 +289,7 @@
       "market": "Valor de mercado £",
       "name": "Nombre",
       "ticker": "Ticker",
+      "trend": "Tendencia",
       "type": "Tipo",
       "units": "Unidades"
     },

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -289,6 +289,7 @@
       "market": "Valeur £",
       "name": "Nom",
       "ticker": "Ticker",
+      "trend": "Tendance",
       "type": "Type",
       "units": "Unités"
     },

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -289,6 +289,7 @@
       "market": "MERCATO £",
       "name": "Nome",
       "ticker": "Ticker",
+      "trend": "Trend",
       "type": "Tipo",
       "units": "Unità"
     },

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -289,6 +289,7 @@
       "market": "Valor de mercado £",
       "name": "Nome",
       "ticker": "Ticker",
+      "trend": "Tendência",
       "type": "Tipo",
       "units": "Unidades"
     },


### PR DESCRIPTION
## What

Adds sparkline price trendlines to each instrument row in the InstrumentTable component (used on `/?group=all` and the instrument plugin tab), matching the trendlines already present in HoldingsTable on owner portfolio pages.

## Changes

- **`InstrumentTable.tsx`**: Adds a toggleable "Trend" column between name and currency, rendering the existing shared `<Sparkline>` component with a 90-day window
- **`types.ts`**: Adds `trend: boolean` to `VisibleColumns`
- **`useInstrumentTableState.ts`**: Defaults trend column to visible
- **6 locale files**: Adds `"trend"` translation key (en: Trend, de: Trend, es: Tendencia, fr: Tendance, it: Trend, pt: Tendência)

## Design

No code duplication — uses the same `Sparkline` component already shared with `HoldingsTable`. The sparkline column is toggleable via the existing column visibility checkboxes, just like units/cost/market/gain columns.

## Validation

- All 644 Vitest tests pass (95 test files)
- TypeScript compilation clean (`tsc --noEmit`)
- Correct colSpan in group headers and totals row (dynamic 4/5 based on trend visibility)
- All 6 locale files updated

Closes #5449


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Trend column to the instrument table.
  * Displays 90-day trend sparklines for each instrument.
  * The Trend column is enabled by default and can be shown or hidden with other table columns.
  * Updated totals-row layout to accommodate the additional column.

* **Documentation**
  * Added Trend column translations for English, German, Spanish, French, Italian and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->