### PR TITLE
[Issue #5263] Update local review to use qwen2.5-coder:14b

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.4.1.tgz",
       "integrity": "sha512-xqhOGLbTAYeOWK+IDUNSjQJAPapQjRHrIcgk9PYp52or9zFTaaMko31uNi16N6W+CRJ8VrRram6fOYILkBG2Hg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/scripts/dev_tools/ollama_common.py
+++ b/scripts/dev_tools/ollama_common.py
@@ -18,10 +18,10 @@ def get_ollama_endpoint() -> str:
 def get_ollama_model() -> str:
     """Return the Ollama model to use for reviews.
 
-    Defaults to 'neural-chat' (a lightweight coder model). Override with
+    Defaults to 'qwen2.5-coder:14b' (a lightweight coder model). Override with
     OLLAMA_MODEL environment variable.
     """
-    return os.environ.get("OLLAMA_MODEL", "neural-chat")
+    return os.environ.get("OLLAMA_MODEL", "qwen2.5-coder:14b")
 
 
 def list_available_models(endpoint: str) -> list[str]:

--- a/tests/test_local_review.py
+++ b/tests/test_local_review.py
@@ -119,7 +119,7 @@ class TestGenerateMarkdownReport:
             review=review,
             target_branch="main",
             current_branch="feature/test",
-            model="neural-chat",
+            model="qwen2.5-coder:14b",
             diff_size=1500,
             timestamp="2024-01-15T10:30:00+00:00",
         )
@@ -128,7 +128,7 @@ class TestGenerateMarkdownReport:
         assert "**Generated:** 2024-01-15T10:30:00+00:00" in report
         assert "**Current branch:** feature/test" in report
         assert "**Compared against:** main" in report
-        assert "**AI Model:** neural-chat" in report
+        assert "**AI Model:** qwen2.5-coder:14b" in report
         assert "**Diff size:** 1500 characters" in report
         assert "## Review" in report
         assert "APPROVE" in report

--- a/tests/test_ollama_common.py
+++ b/tests/test_ollama_common.py
@@ -37,9 +37,9 @@ class TestGetOllamaEndpoint:
 
 class TestGetOllamaModel:
     def test_default_model(self):
-        """Should return default neural-chat when env var not set."""
+        """Should return default qwen2.5-coder:14b when env var not set."""
         with mock.patch.dict(os.environ, {}, clear=True):
-            assert get_ollama_model() == "neural-chat"
+            assert get_ollama_model() == "qwen2.5-coder:14b"
 
     def test_custom_model(self):
         """Should return custom model from env var."""
@@ -51,14 +51,14 @@ class TestListAvailableModels:
     @mock.patch("urllib.request.urlopen")
     def test_successful_model_list(self, mock_urlopen):
         """Should return list of models from Ollama API."""
-        response_data = {"models": [{"name": "neural-chat"}, {"name": "mistral"}, {"name": "codellama"}]}
+        response_data = {"models": [{"name": "qwen2.5-coder:14b"}, {"name": "mistral"}, {"name": "codellama"}]}
         mock_response = mock.MagicMock()
         mock_response.read.return_value = json.dumps(response_data).encode()
         mock_response.__enter__.return_value = mock_response
         mock_urlopen.return_value = mock_response
 
         models = list_available_models("http://localhost:11434")
-        assert models == ["neural-chat", "mistral", "codellama"]
+        assert models == ["qwen2.5-coder:14b", "mistral", "codellama"]
 
     @mock.patch("urllib.request.urlopen")
     def test_ollama_unreachable(self, mock_urlopen):
@@ -85,7 +85,7 @@ class TestValidateOllamaConnection:
     @mock.patch("ollama_common.list_available_models")
     def test_valid_connection(self, mock_list_models):
         """Should return True when models are available."""
-        mock_list_models.return_value = ["neural-chat", "mistral"]
+        mock_list_models.return_value = ["qwen2.5-coder:14b", "mistral"]
         assert validate_ollama_connection("http://localhost:11434") is True
 
     @mock.patch("ollama_common.list_available_models")
@@ -122,7 +122,7 @@ class TestFetchOllamaReview:
         mock_response.__enter__.return_value = mock_response
         mock_urlopen.return_value = mock_response
 
-        review = fetch_ollama_review("http://localhost:11434", "neural-chat", "Test prompt")
+        review = fetch_ollama_review("http://localhost:11434", "qwen2.5-coder:14b", "Test prompt")
         assert "This PR looks good" in review
         assert "No issues found" in review
 
@@ -133,7 +133,7 @@ class TestFetchOllamaReview:
 
         mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
         with pytest.raises(SystemExit) as exc_info:
-            fetch_ollama_review("http://localhost:11434", "neural-chat", "Test prompt")
+            fetch_ollama_review("http://localhost:11434", "qwen2.5-coder:14b", "Test prompt")
         assert exc_info.value.code == 1
 
     @mock.patch("urllib.request.urlopen")
@@ -160,5 +160,5 @@ class TestFetchOllamaReview:
         mock_urlopen.return_value = mock_response
 
         with pytest.raises(SystemExit) as exc_info:
-            fetch_ollama_review("http://localhost:11434", "neural-chat", "Test prompt")
+            fetch_ollama_review("http://localhost:11434", "qwen2.5-coder:14b", "Test prompt")
         assert exc_info.value.code == 1


### PR DESCRIPTION
## What
Updated `local_Review.py` to use `qwen2.5-coder:14b` instead of `neural-chat`.

## Why
Since we do not have access to `neural-chat`, switching to `qwen2.5-coder:14b` is necessary to ensure the local review process continues smoothly without dependency issues.

## Testing
The changes were tested by running the `local_Review.py` script with `qwen2.5-coder:14b`. The script was verified to execute successfully and produce expected results, confirming that the update resolves the original issue.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #5263