### PR TITLE
Fix page-wide horizontal overflow on the Portfolio page below xl width

### DIFF
--- a/frontend/src/components/AccountBlock.tsx
+++ b/frontend/src/components/AccountBlock.tsx
@@ -36,7 +36,7 @@ export function AccountBlock({
   const { baseCurrency } = useConfig();
 
   return (
-    <div className="mb-4 p-2 md:mb-8 md:p-4">
+    <div className="mb-4 min-w-0 p-2 md:mb-8 md:p-4">
       <h2 className="mt-0">
         {onToggle && (
           <input

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -284,7 +284,7 @@ export function HoldingsTable({
         </>
       )}
       {sortedRows.length ? (
-        <div ref={tableContainerRef} className="overflow-x-auto md:overflow-visible">
+        <div ref={tableContainerRef} className="overflow-x-auto">
           <table className={`${tableStyles.table} mb-4 w-full`}>
         <thead ref={tableHeaderRef}>
           <tr>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -347,7 +347,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
         <section className="rounded-lg border border-gray-800 bg-gray-900/70 p-4 md:p-6">
           {!familyMvpEnabled && (
             <form


### PR DESCRIPTION
## Summary
Found during a post-merge visual sweep of #5382, following #5424 (which fixed Tailwind's responsive breakpoints from being silently non-functional). This is a **critical, live-breaking bug on the app's most-used page** that was invisible until #5424 made the responsive classes involved actually work.

Three stacked CSS issues, all masked before #5424:

1. **`HoldingsTable.tsx`**: the table's scroll wrapper was `overflow-x-auto md:overflow-visible`. The `md:` override removed scroll containment at ≥768px, assuming desktop has "enough room" — false for a ~20-column table (~2000px wide). Removed the override; every other scrollable table in the codebase (`Watchlist`, `TaxTools`, `ScenarioTester`, `TimeseriesEdit`, `VirtualPortfolio`, `PensionForecast`) just uses plain `overflow-x-auto` with no such escape hatch — `HoldingsTable` was the only outlier.
2. **`PortfolioView.tsx`**: the two-column layout grid only declared `grid-template-columns` via `xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]`, with no base `grid-cols-1`. Below `xl` (1280px), the single implicit grid track had no width constraint at all and grew to fit its widest child instead of the viewport — classic CSS Grid "no explicit track sizing" trap.
3. **`AccountBlock.tsx`**: its root div is a flex child (inside `PortfolioView`'s `<div className="flex items-start">`), and flex items default to `min-width: auto`, letting the item grow past its flex container to fit the wide table underneath rather than shrinking. Added `min-w-0`.

All three had to be fixed together — each one alone still left the table forcing the page wider. Diagnosed by walking the ancestor chain from `<table>` up to the page root, checking `scrollWidth`/`clientWidth` at each level to find where the width constraint was being lost.

## Verification
Live in-browser (local backend + frontend dev server against demo data), navigated to `/portfolio/demo-owner`:

- **Before fix**: `document.documentElement.scrollWidth` = 2067px at a 768px viewport — the whole page scrolled horizontally, not just the table.
- **After fix**: `scrollWidth` matches `innerWidth` exactly at 375px, 768px, and 1280px — no page-level overflow at any of the three key breakpoints.
- Confirmed the two-column layout still correctly activates at ≥1280px (`getComputedStyle(grid).gridTemplateColumns` shows two real tracks, not one).
- Full frontend suite: **95 test files / 644 tests, all passing** (ran the whole suite since this touches shared layout components used across every portfolio view).
- ESLint clean on all three changed files.

## Scope
This fixes the single highest-value page found so far. A broader visual sweep of the remaining pages (`Watchlist`, `TaxTools`, `ScenarioTester`, `Reports`, `PensionForecast`, etc.) for similar newly-exposed regressions from #5424 is still worth doing as a follow-up — this PR doesn't claim to have covered all of them.

Part of #5382.
