### PR TITLE
Wrap InstrumentAdmin and DataAdmin tables in overflow-x-auto

### DIFF
--- a/frontend/src/pages/DataAdmin.tsx
+++ b/frontend/src/pages/DataAdmin.tsx
@@ -61,6 +61,7 @@ export default function DataAdmin() {
   return (
     <div className="container mx-auto p-4 max-w-5xl">
       <h2 className="mb-4 text-xl md:text-2xl">{t("app.modes.dataadmin")}</h2>
+      <div className="overflow-x-auto">
       <table className="w-full border-collapse">
         <thead>
           <tr>
@@ -126,6 +127,7 @@ export default function DataAdmin() {
           })}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/InstrumentAdmin.tsx
+++ b/frontend/src/pages/InstrumentAdmin.tsx
@@ -184,6 +184,7 @@ export default function InstrumentAdmin() {
       >
         {t("instrumentadmin.add")}
       </button>
+      <div className="overflow-x-auto">
       <table className="w-full border-collapse">
         <thead>
           <tr>
@@ -244,6 +245,7 @@ export default function InstrumentAdmin() {
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This completes a full-app visual sweep of #5382, following on from #5465 (which fixed the Portfolio page). Checked every remaining reachable page — Watchlist, TaxTools, ScenarioTester, Reports, Transactions, PensionForecast, Rebalance, TimeseriesEdit, VirtualPortfolio, InstrumentAdmin, DataAdmin, Settings, Support, AllocationCharts, and the Menu — at 375px, 768px, and 1280px.

**Clean, no changes needed**: Watchlist, TaxTools, ScenarioTester, Reports, Transactions, PensionForecast, Rebalance, TimeseriesEdit, VirtualPortfolio, Settings, Support, AllocationCharts, Menu.

**Broken, fixed here**: `InstrumentAdmin.tsx` and `DataAdmin.tsx`. Both had a plain `<table className="w-full border-collapse">` with **no scroll wrapper at all** — unlike every other table in the codebase (`HoldingsTable`, `Watchlist`, `TaxTools`, `ScenarioTester`, `TimeseriesEdit`, `VirtualPortfolio`, `PensionForecast`), which all wrap their table in `<div className="overflow-x-auto">`. This is a pre-existing bug, unrelated to #5424 (Tailwind breakpoints) or #5465 (Portfolio grid) — these two tables never had any responsive handling to begin with, so it wasn't newly exposed, just found during this sweep.

- `InstrumentAdmin.tsx`: 7-column editable ticker table (ticker, exchange, name, region, sector, grouping, actions), each cell an `<input>`.
- `DataAdmin.tsx`: 9-column table (ticker, exchange, name, earliest/latest date, completeness %, sources, actions), each row with 3 action buttons.

## Verification
Live in-browser (local backend + frontend dev server against demo data):

- **Before fix**: at both 375px and 768px, `document.documentElement.scrollWidth` was ~1184px for `/instrumentadmin` — the whole page scrolled horizontally. Notably, the Browser tool's own resize even refused to shrink the viewport below the table's forced content width on this page, which I initially suspected was a tooling glitch — it turned out to be a real symptom of the overflow, since the same resize worked cleanly once the fix was applied.
- **After fix**: `scrollWidth` matches `innerWidth` exactly at 375px, 768px, and 1280px for both pages.
- Re-verified `AllocationCharts` and `Menu` post-#5424/#5465 too: hamburger correctly hides at ≥640px and the menu renders as a horizontal row at 1280px; no regressions.
- Full frontend suite: **95 test files / 644 tests, all passing**.
- ESLint clean on both changed files.

## Scope
This is likely the last piece of the mobile-responsiveness sweep for #5382 — every reachable page has now been checked at all three key breakpoints, following #5401, #5408, #5417, #5424, and #5465. Not marking this as closing #5382 since I can't personally verify every edge case (different locales, extreme content lengths, real device testing) — leaving that call to whoever reviews the full set of PRs.

Relates to #5382.