### PR TITLE
Reject conflicting price/price_gbp values in transaction import

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -711,8 +711,12 @@ def _tx_data_from_parsed(row: Transaction) -> Dict[str, Any]:
     """
 
     tx_data = row.model_dump(mode="json", exclude={"owner", "account", "id"})
-    if tx_data.get("price_gbp") is None:
-        tx_data["price_gbp"] = tx_data.get("price")
+    price = tx_data.get("price")
+    price_gbp = tx_data.get("price_gbp")
+    if price is not None and price_gbp is not None and price != price_gbp:
+        raise ValueError(f"Conflicting values for price ({price}) and price_gbp ({price_gbp})")
+    if price_gbp is None:
+        tx_data["price_gbp"] = price
     tx_data.pop("price", None)
     if not tx_data.get("reason"):
         tx_data["reason"] = tx_data.get("reason_to_buy")

--- a/tests/backend/routes/test_transactions.py
+++ b/tests/backend/routes/test_transactions.py
@@ -326,6 +326,60 @@ def test_format_transaction_response_omits_missing_instrument_name(monkeypatch):
     }
 
 
+def _make_transaction(**overrides):
+    fields = {
+        "owner": "alice",
+        "account": "primary",
+        "ticker": "AAA",
+        "units": 10,
+    }
+    fields.update(overrides)
+    return transactions_module.Transaction(**fields)
+
+
+def test_tx_data_from_parsed_raises_on_conflicting_price_and_price_gbp():
+    row = _make_transaction(price=10.5, price_gbp=11.0)
+
+    with pytest.raises(ValueError, match="Conflicting values for price"):
+        transactions_module._tx_data_from_parsed(row)
+
+
+def test_tx_data_from_parsed_allows_matching_price_and_price_gbp():
+    row = _make_transaction(price=10.5, price_gbp=10.5)
+
+    tx_data = transactions_module._tx_data_from_parsed(row)
+
+    assert tx_data["price_gbp"] == 10.5
+    assert "price" not in tx_data
+
+
+def test_tx_data_from_parsed_coalesces_price_only():
+    row = _make_transaction(price=10.5, price_gbp=None)
+
+    tx_data = transactions_module._tx_data_from_parsed(row)
+
+    assert tx_data["price_gbp"] == 10.5
+    assert "price" not in tx_data
+
+
+def test_tx_data_from_parsed_keeps_price_gbp_only():
+    row = _make_transaction(price=None, price_gbp=9.9)
+
+    tx_data = transactions_module._tx_data_from_parsed(row)
+
+    assert tx_data["price_gbp"] == 9.9
+    assert "price" not in tx_data
+
+
+def test_tx_data_from_parsed_no_prices_set():
+    row = _make_transaction(price=None, price_gbp=None)
+
+    tx_data = transactions_module._tx_data_from_parsed(row)
+
+    assert tx_data["price_gbp"] is None
+    assert "price" not in tx_data
+
+
 @pytest.mark.asyncio
 async def test_create_transaction_records_valid_payload(monkeypatch, tmp_path):
     accounts_dir = tmp_path / "accounts"


### PR DESCRIPTION
## Summary
- `_tx_data_from_parsed` coalesced `price` into `price_gbp` silently, so an importer emitting both fields with different values would lose data with no warning.
- Now raises `ValueError` when `price` and `price_gbp` are both present and differ; behavior is unchanged when only one is present or both match.

## Test plan
- [x] `pytest tests/backend/routes/test_transactions.py -k tx_data_from_parsed`
- [x] `pytest tests/test_transactions_import.py tests/backend/routes/test_transactions.py tests/test_transactions_route.py tests/backend/routes/test_transactions_writable_store.py tests/test_transaction_post_updates_portfolio.py`

Closes #5419

🤖 Generated with [Claude Code](https://claude.com/claude-code)