### PR TITLE
Include viewer emails in _allowed_emails identity resolution

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -59,8 +59,35 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token", auto_error=False)
 current_user: ContextVar[str | None] = ContextVar("current_user", default=None)
 
 
+def _emails_for_person_meta(meta: Any) -> Set[str]:
+    """Return the lower-cased owner email plus any viewer emails from ``meta``.
+
+    Mirrors :func:`backend.common.authz._allowed_identities`, which grants
+    per-owner access to both the owner's own email and its ``viewers`` list.
+    ``_allowed_emails`` must recognise the same set at login/identity-resolution
+    time, otherwise a legitimate viewer (allowed by ``ensure_owner_access``)
+    would be rejected earlier with a 403 "Unauthorized email" before ever
+    reaching that per-owner check (#5215).
+    """
+
+    if meta is None:
+        return set()
+    emails: Set[str] = set()
+    email = getattr(meta, "email", None)
+    if isinstance(email, str) and email.strip():
+        emails.add(email.strip().lower())
+    viewers = getattr(meta, "viewers", None)
+    if isinstance(viewers, list):
+        emails.update(viewer.strip().lower() for viewer in viewers if isinstance(viewer, str) and viewer.strip())
+    return emails
+
+
 def _allowed_emails() -> Set[str]:
     """Return the set of configured account emails.
+
+    Includes both each owner's own email and their configured viewer emails
+    (see :func:`_emails_for_person_meta`), so identity resolution accepts the
+    same callers ``ensure_owner_access`` would later authorize for that owner.
 
     When running in AWS, owner metadata is loaded from S3. If this request
     fails, the exception is logged and an empty set is returned so that login
@@ -105,9 +132,7 @@ def _allowed_emails() -> Set[str]:
                 meta = load_person_metadata(owner)
             except Exception:
                 meta = None
-            email = meta.email if meta else None
-            if email:
-                emails.add(email.lower())
+            emails |= _emails_for_person_meta(meta)
         return emails
 
     # Determine the accounts root from configuration. Prefer the explicitly
@@ -133,9 +158,7 @@ def _allowed_emails() -> Set[str]:
             meta = load_person_metadata(owner_dir.name, data_root=root)
         except Exception:
             meta = None
-        email = meta.email if meta else None
-        if email:
-            emails.add(email.lower())
+        emails |= _emails_for_person_meta(meta)
     return emails
 
 

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -19,7 +19,13 @@ backend/app.py:166
 backend/app.py:198
 backend/app.py:217
 backend/auth.py:126
+# accounts-root path comes from server config, not attacker-controlled input.
+backend/auth.py:151
 backend/auth.py:537
+# provider is always a hardcoded literal ("Google"/"Cognito") passed by the
+# caller, never attacker-controlled; email/token on the same call are already
+# wrapped in sanitise_log_value.
+backend/auth.py:560
 backend/bootstrap/isolation.py:89
 backend/bootstrap/startup.py:92
 backend/common/accounts_store.py:244

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from fastapi import HTTPException
 
@@ -50,3 +52,45 @@ def test_verify_google_token_rejects_unverified_email(monkeypatch, tmp_path):
     with pytest.raises(HTTPException) as exc:
         auth.verify_google_token("dummy")
     assert exc.value.status_code == 401
+
+
+def test_emails_for_person_meta_includes_owner_email_and_viewers():
+    from backend.common.account_models import PersonMetadata
+
+    person = PersonMetadata(
+        owner="alice",
+        email="Alice@Example.com",
+        viewers=["Bob@Example.com", "carol@example.com", "  "],
+    )
+
+    assert auth._emails_for_person_meta(person) == {
+        "alice@example.com",
+        "bob@example.com",
+        "carol@example.com",
+    }
+
+
+def test_emails_for_person_meta_handles_none():
+    assert auth._emails_for_person_meta(None) == set()
+
+
+def test_allowed_emails_includes_viewer_emails(monkeypatch, tmp_path):
+    """A viewer granted access via person.json must be able to authenticate.
+
+    Regression test for #5215: ``ensure_owner_access``/``identity_can_access_owner``
+    already grant a listed viewer access to an owner's data, but
+    ``_allowed_emails`` (consulted earlier, at identity-resolution time) only
+    looked at each owner's own ``email`` field -- so a legitimate viewer was
+    rejected with a 403 "Unauthorized email" before that per-owner check was
+    ever reached.
+    """
+
+    monkeypatch.setattr(config, "app_env", "local")
+    root = tmp_path / "accounts"
+    owner_dir = root / "alice"
+    owner_dir.mkdir(parents=True)
+    person = {"owner": "alice", "email": "alice@example.com", "viewers": ["bob@example.com"]}
+    (owner_dir / "person.json").write_text(json.dumps(person), encoding="utf-8")
+    monkeypatch.setattr(config, "accounts_root", root)
+
+    assert auth._allowed_emails() == {"alice@example.com", "bob@example.com"}


### PR DESCRIPTION
## Summary

Investigation of #5215 (403 on `/accounts/{owner}/approvals`). The previously-suspected causes were already ruled out by prior investigation (comment on #5215, PR #5425):
- A 403 cannot trigger the frontend's `sessionExpired`/session-wall flow — `fetchJson` only dispatches `UNAUTHORIZED_EVENT` on HTTP 401, never 403.
- `ensure_owner_access` is a no-op whenever `config.disable_auth` is true (which it is in the deployed Lambda — API Gateway enforces the Cognito JWT before the Lambda runs), so it can't be the source of an unexpected prod 403 either.

Tracing the actual auth path (`get_active_user` → `_resolve_identity_when_auth_disabled`, which *does* run in prod since it's independent of `ensure_owner_access`) found a real, reproducible bug: `_allowed_emails()` only collected each owner's own `person.json` `email` field, never their `viewers` list. `ensure_owner_access`/`identity_can_access_owner` (`backend/common/authz.py`) already treat a listed viewer as authorized for that owner — but identity resolution runs *before* that per-owner check and used a narrower, inconsistent allow-list. A legitimate viewer signing in via Cognito or Google would authenticate fine at the IdP, then get bounced with a 403 "Unauthorized email" by the backend before ever reaching the endpoint's owner-scoping check.

## Change

- Added `_emails_for_person_meta()` in `backend/auth.py`, mirroring `authz._allowed_identities` (owner's own email + viewers list, lower-cased, blanks stripped).
- `_allowed_emails()` (both the S3/AWS branch and the local-accounts-root branch) now unions this per-owner set instead of only the owner's own email.

## Test plan
- [x] New unit tests: `_emails_for_person_meta` (owner + viewers, `None` input), and `_allowed_emails` against a real `person.json` with a `viewers` entry (`tests/test_auth_utils.py`)
- [x] `pytest tests/test_auth.py tests/test_auth_aws.py tests/test_auth_get_active_user.py tests/test_auth_utils.py tests/backend/test_auth.py tests/backend/test_auth_module.py tests/backend/common/test_authz.py tests/routes/test_approvals.py tests/backend/test_approvals_route.py tests/common/test_approvals.py tests/backend/common/test_approvals.py tests/backend/routes/test_signup.py` — 164 passed

Closes #5215

🤖 Generated with [Claude Code](https://claude.com/claude-code)