### PR TITLE
Add negative test for Menu's click-outside handler

### DIFF
--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -386,6 +386,10 @@ describe('Menu', () => {
   });
 
   it('closes the mobile menu when clicking outside the nav (#5382)', () => {
+    // Menu's click-outside handler checks mobileMenuRef.current.contains(event.target)
+    // via a plain document-level mousedown listener (no composedPath()). Firing the
+    // event on a real sibling element outside the <nav ref={mobileMenuRef}> exercises
+    // that exact containment check rather than assuming it (#5440).
     render(
       <div>
         <MemoryRouter>
@@ -400,6 +404,27 @@ describe('Menu', () => {
 
     fireEvent.mouseDown(screen.getByTestId('outside'));
     expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('does not close the mobile menu when clicking inside the nav (#5440)', () => {
+    // Negative case for the click-outside handler: mobileMenuRef wraps both the
+    // hamburger button and the <ul id="app-main-menu"> menu list, so a mousedown
+    // anywhere inside either must NOT collapse the menu.
+    render(
+      <MemoryRouter>
+        <Menu />
+      </MemoryRouter>
+    );
+    const hamburger = screen.getByRole('button', { name: i18n.t('app.menu') });
+    fireEvent.click(hamburger);
+    expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+
+    const menuList = document.getElementById('app-main-menu');
+    fireEvent.mouseDown(menuList as HTMLElement);
+    expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.mouseDown(hamburger);
+    expect(hamburger).toHaveAttribute('aria-expanded', 'true');
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- Audited the actual click-outside handler in `frontend/src/components/Menu.tsx`: a plain document-level `mousedown` listener checking `mobileMenuRef.current.contains(event.target)` — no `composedPath()`. The ref sits on the `<nav>` element, wrapping **both** the hamburger button and the `#app-main-menu` list.
- The existing outside-click test (`fireEvent.mouseDown` on a real sibling element) already exercises this exact containment check via real event bubbling — it was not a false positive as the AI review speculated.
- The actual gap: no test asserted that clicking *inside* the nav (the menu list or the hamburger button itself) leaves the menu open. Added that negative test, plus a comment documenting the verified containment strategy so the assumption is explicit if the handler implementation changes later.

## Test plan
- [x] `npx vitest run tests/unit/components/Menu.test.tsx` — 17 passed (including the 2 new assertions in the negative test)
- [x] `eslint` on the changed file — clean

Closes #5440

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile menu click handling so interactions inside the menu, including the hamburger button and menu items, do not unintentionally close it.
  * Clicking outside the navigation continues to close the mobile menu as expected.

* **Tests**
  * Expanded coverage for inside and outside click scenarios to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->