### PR TITLE
[Issue #5457] Clean up temp file in `create_issue_via_gh()` error paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.4.2.tgz",
       "integrity": "sha512-fQPRb3JXRaU2pnufDUvqOjhsrYxDQeFRZyaj/sHydIUxD2NxOGHKMpmKUdI+U4OOmKuGZyvRpi7TSJU+7Bjbmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/scripts/developer_tools/b_create_issue.py
+++ b/scripts/developer_tools/b_create_issue.py
@@ -320,7 +320,9 @@ def create_issue_via_gh(
     except (OSError, subprocess.TimeoutExpired) as exc:
         print(f"gh CLI error: {exc}", file=sys.stderr)
         return None
-
+    finally:
+        if body_path and os.path.exists(body_path):
+            os.unlink(body_path)
 
 def derive_title_from_what(what: str) -> str | None:
     """Extract a candidate title from the first meaningful line of 'What'."""

--- a/scripts/developer_tools/b_create_issue.py
+++ b/scripts/developer_tools/b_create_issue.py
@@ -284,6 +284,7 @@ def create_issue_via_gh(
     # Write body to a temp file so the CLI can read it safely on all platforms.
     import tempfile
 
+    body_path: str | None = None
     try:
         with tempfile.NamedTemporaryFile(
             mode="w",

--- a/scripts/developer_tools/b_create_issue.py
+++ b/scripts/developer_tools/b_create_issue.py
@@ -309,7 +309,6 @@ def create_issue_via_gh(
             cmd.extend(["--label", label])
 
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-        os.unlink(body_path)
 
         if result.returncode != 0:
             print(f"gh CLI failed: {result.stderr.strip()}", file=sys.stderr)


### PR DESCRIPTION
## What
The `create_issue_via_gh()` function in `scripts/dev_tools/create_issue.py` creates a temporary file but fails to clean it up on error paths.

## Why
This change addresses a correctness and hygiene issue by ensuring that temporary files are always deleted after use, regardless of whether the operation succeeds or fails. This prevents the accumulation of leftover artifacts on disk, especially during development or CI usage.

## Testing
The changes were tested by introducing intentional errors in the `subprocess.run` call to simulate failure paths and verifying that the temp file is deleted in each case. Additionally, the success path was verified to ensure no behavioral changes.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #5457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when creating issues, ensuring temporary files are removed reliably even when the operation fails or exits early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->