### PR TITLE
Move aider-issue.ps1 into developer_tools/ and fix run timeouts

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -5,3 +5,10 @@ yes-always: true
 
 auto-test: true
 test-cmd: "pytest -q --ignore=tests/integration --ignore=tests/live"
+
+# litellm's default completion timeout is 600s, which a 14B local model can
+# exceed on modest hardware once the repo-map + prompt fill the large context
+# window configured in .aider.model.settings.yml. Without this, aider aborts
+# mid-generation with a Timeout error before producing any edits, which looks
+# like the whole run "hung" rather than the API call being cut short.
+timeout: 1800

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install Pester
         shell: pwsh
         run: Install-Module -Name Pester -RequiredVersion 5.6.1 -Force -SkipPublisherCheck -Scope CurrentUser
-      - name: Run Pester tests for scripts/aider-issue.ps1
+      - name: Run Pester tests for scripts/developer_tools/implement_issue.ps1
         shell: pwsh
         run: |
           Import-Module Pester -RequiredVersion 5.6.1 -Force

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -172,6 +172,29 @@ The script:
 
 Optional flags:
 - `--token TOKEN`: GitHub personal access token (also reads `GITHUB_TOKEN` env var). Required for branch creation (unauthenticated requests will fail with 401/403).
+
+## developer_tools/implement_issue.ps1
+
+Automates implementing a GitHub issue end-to-end with a local LLM: fetches the
+issue, creates/resets an `issue-<N>` branch, runs [aider](https://aider.chat)
+against a local Ollama model (configured in `.aider.conf.yml`) to generate the
+code changes, then pushes the branch and opens a draft PR.
+
+```powershell
+./scripts/developer_tools/implement_issue.ps1 -Issue 123
+```
+
+Requires `gh` and `aider` on PATH, and a running local Ollama server serving
+the model configured in `.aider.conf.yml`.
+
+Optional flags:
+- `-Force`: bypass the pre-flight check for an unresolved merge/rebase/cherry-pick conflict left over from a prior interrupted run.
+- `-TimeoutMinutes N` (default `40`): wall-clock cap on the aider run. This is separate from the `timeout` setting in `.aider.conf.yml`, which only bounds a single LLM API call — a 14B local model on modest hardware can need the API-call timeout raised too if it consistently runs long.
+
+If aider makes no commits (e.g. the local model replies with prose instead of
+edits), the script fails rather than pushing an empty branch or opening a
+content-free PR.
+
 ## publish_pr.py
 
 Automate PR publishing: commit changes, push to remote, and create a PR with auto-filled body sections. Optionally uses Ollama to generate thoughtful PR descriptions.

--- a/scripts/developer_tools/implement_issue.ps1
+++ b/scripts/developer_tools/implement_issue.ps1
@@ -255,16 +255,25 @@ $fileArgs = @($referencedFiles | ForEach-Object { '--file', $_ })
 Write-Host "[4/6] Running aider on issue #$number (wall-clock cap: ${TimeoutMinutes}m)..."
 
 # Run via System.Diagnostics.Process (not Start-Process/the call operator) so
-# each argument travels as its own ArgumentList entry - no shell re-quoting to
-# get wrong - while still letting us bound total wall-clock time with
-# WaitForExit(timeout). UseShellExecute=$false with no output redirection
-# means aider's output streams straight to this console, same as a direct call.
+# we can bound total wall-clock time with WaitForExit(timeout).
+# UseShellExecute=$false with no output redirection means aider's output
+# streams straight to this console, same as a direct call.
+#
+# Build a single command-line string for .Arguments rather than populating
+# .ArgumentList: on Windows PowerShell 5.1 (the default `powershell.exe`,
+# distinct from pwsh/PowerShell 7), ProcessStartInfo.ArgumentList comes back
+# $null instead of an initialized collection, so every .Add() below is a
+# silent no-op - aider then launches with zero arguments (no --yes-always,
+# no --message-file) and sits at its interactive prompt instead of running
+# non-interactively. .Arguments (a plain string) has worked the same way on
+# both PowerShell hosts since .NET 1.1.
+$allAiderArgs = @($fileArgs) + @('--yes-always', '--message-file', $promptFile)
+$aiderArgString = ($allAiderArgs | ForEach-Object {
+        if ($_ -match '[\s"]') { '"' + ($_ -replace '"', '""') + '"' } else { $_ }
+    }) -join ' '
+
 $aiderPath = (Get-Command aider -ErrorAction Stop).Source
-$psi = [System.Diagnostics.ProcessStartInfo]::new($aiderPath)
-foreach ($a in $fileArgs) { $psi.ArgumentList.Add($a) }
-$psi.ArgumentList.Add('--yes-always')
-$psi.ArgumentList.Add('--message-file')
-$psi.ArgumentList.Add($promptFile)
+$psi = [System.Diagnostics.ProcessStartInfo]::new($aiderPath, $aiderArgString)
 $psi.UseShellExecute = $false
 
 $aiderProc = [System.Diagnostics.Process]::Start($psi)

--- a/scripts/developer_tools/implement_issue.ps1
+++ b/scripts/developer_tools/implement_issue.ps1
@@ -3,7 +3,14 @@ param(
     # Bypass the active-operation check below (MERGE_HEAD/CHERRY_PICK_HEAD/
     # rebase-merge/rebase-apply) for emergency recovery from a stale git state.
     # Does not affect the unmerged-path detection or reset logic that follows.
-    [switch]$Force
+    [switch]$Force,
+    # Wall-clock cap on the aider run itself, independent of the `timeout`
+    # setting in .aider.conf.yml (which only bounds a single LLM API call).
+    # A stuck git lock, editor prompt, or other non-API hang would otherwise
+    # leave the script running indefinitely with no way to tell "still
+    # working" from "hung". Defaults a bit above the 1800s (30min) API
+    # timeout so a normal slow-but-successful run isn't cut off first.
+    [int]$TimeoutMinutes = 40
 )
 
 # Pre-flight: require gh and aider on PATH
@@ -245,10 +252,37 @@ if ($referencedFiles.Count -gt 0) {
 # option. An empty array splats to nothing, leaving aider to work from repo-map.
 $fileArgs = @($referencedFiles | ForEach-Object { '--file', $_ })
 
-Write-Host "[4/6] Running aider on issue #$number..."
-aider @fileArgs --yes-always --message-file $promptFile
+Write-Host "[4/6] Running aider on issue #$number (wall-clock cap: ${TimeoutMinutes}m)..."
+
+# Run via System.Diagnostics.Process (not Start-Process/the call operator) so
+# each argument travels as its own ArgumentList entry - no shell re-quoting to
+# get wrong - while still letting us bound total wall-clock time with
+# WaitForExit(timeout). UseShellExecute=$false with no output redirection
+# means aider's output streams straight to this console, same as a direct call.
+$aiderPath = (Get-Command aider -ErrorAction Stop).Source
+$psi = [System.Diagnostics.ProcessStartInfo]::new($aiderPath)
+foreach ($a in $fileArgs) { $psi.ArgumentList.Add($a) }
+$psi.ArgumentList.Add('--yes-always')
+$psi.ArgumentList.Add('--message-file')
+$psi.ArgumentList.Add($promptFile)
+$psi.UseShellExecute = $false
+
+$aiderProc = [System.Diagnostics.Process]::Start($psi)
+$finishedInTime = $aiderProc.WaitForExit([int]($TimeoutMinutes * 60 * 1000))
+if (-not $finishedInTime) {
+    Write-Error "aider did not finish within $TimeoutMinutes minute(s) (PID $($aiderProc.Id)) - killing it. This is a wall-clock safety net distinct from the API-call timeout in .aider.conf.yml; a run can still stall on something other than the LLM call (e.g. a git lock or an interactive prompt aider is waiting on). Re-run with -TimeoutMinutes for a larger issue on slower hardware, or investigate why aider stalled."
+    try { $aiderProc.Kill($true) } catch {
+        Write-Warning "Failed to kill stalled aider process (PID $($aiderProc.Id)): $_. You may need to terminate it manually."
+    }
+    Remove-Item $promptFile -ErrorAction SilentlyContinue
+    exit 1
+}
+$aiderExitCode = $aiderProc.ExitCode
 Remove-Item $promptFile -ErrorAction SilentlyContinue
-if ($LASTEXITCODE -ne 0) { exit 1 }
+if ($aiderExitCode -ne 0) {
+    Write-Error "aider exited with code $aiderExitCode."
+    exit 1
+}
 
 # Abort if aider made no commits - avoids pushing an empty branch and opening
 # a content-free PR. The most common cause is the model replying with prose

--- a/scripts/tests/implement_issue.Tests.ps1
+++ b/scripts/tests/implement_issue.Tests.ps1
@@ -1,34 +1,34 @@
-# Unit tests for the file discovery logic in ../aider-issue.ps1
+# Unit tests for the file discovery logic in ../developer_tools/implement_issue.ps1
 # (direct path matching + basename fallback via `git ls-files`, added by PR #4293).
 #
-# aider-issue.ps1 is a top-level script with real side effects (git checkout,
+# implement_issue.ps1 is a top-level script with real side effects (git checkout,
 # git reset --hard, git push, gh pr create) and no extracted function to call
 # in isolation, so these tests extract the discovery snippet verbatim from the
 # source file's text and dot-source it with git/Test-Path mocked. This runs the
 # exact shipped code (not a re-implementation), so a regression in the real
 # script fails these tests, while `git`/the filesystem are never touched.
 #
-# Constraint: this file must never modify aider-issue.ps1 (tests only).
+# Constraint: this file must never modify implement_issue.ps1 (tests only).
 
 BeforeAll {
-    $script:ScriptUnderTest = (Resolve-Path (Join-Path $PSScriptRoot '..' 'aider-issue.ps1')).Path
+    $script:ScriptUnderTest = (Resolve-Path (Join-Path $PSScriptRoot '..' 'developer_tools' 'implement_issue.ps1')).Path
     $raw = Get-Content -LiteralPath $script:ScriptUnderTest -Raw
 
     # Start marker: first line of the candidate-path regex setup.
     # End marker: the line combining identifier/direct/basename matches into $referencedFiles.
-    # If aider-issue.ps1 is restructured, these IndexOf calls stop finding the
+    # If implement_issue.ps1 is restructured, these IndexOf calls stop finding the
     # markers and the throw below fails loudly instead of silently testing stale text.
     $startToken = '$pathPattern'
     $endToken = '$referencedFiles = @(('
 
     $startIndex = $raw.IndexOf($startToken)
     if ($startIndex -lt 0) {
-        throw "Could not locate start marker '$startToken' in aider-issue.ps1 - the file discovery logic may have moved. Update the extraction markers in this test file."
+        throw "Could not locate start marker '$startToken' in implement_issue.ps1 - the file discovery logic may have moved. Update the extraction markers in this test file."
     }
 
     $endAnchor = $raw.IndexOf($endToken)
     if ($endAnchor -lt 0) {
-        throw "Could not locate end marker '$endToken' in aider-issue.ps1 - the file discovery logic may have moved. Update the extraction markers in this test file."
+        throw "Could not locate end marker '$endToken' in implement_issue.ps1 - the file discovery logic may have moved. Update the extraction markers in this test file."
     }
 
     $eol = $raw.IndexOf("`n", $endAnchor)
@@ -37,7 +37,7 @@ BeforeAll {
     $script:DiscoverySnippet = $raw.Substring($startIndex, $eol - $startIndex)
 }
 
-Describe 'aider-issue.ps1 file discovery logic' {
+Describe 'implement_issue.ps1 file discovery logic' {
 
     BeforeEach {
         # $title/$issueBody/$repoRoot are read by the dot-sourced snippet below;


### PR DESCRIPTION
## Summary

Closes #5529: adds a script in `developer_tools/` that automates implementing a GitHub issue using a local LLM.

Rather than write a new script from scratch, this relocates the existing (already fairly mature/hardened) `scripts/aider-issue.ps1` to `scripts/developer_tools/implement_issue.ps1`, since it already does everything the issue asks for: fetches the issue, creates/resets a branch, runs `aider` against a local Ollama model to generate the implementation, pushes, and opens a draft PR.

While testing this, the reporter noted the script "kept timing out before completing any issues" even though Ollama itself was fine. Root cause: litellm's default completion timeout is 600s, which a 14B local model can exceed once the large context window configured in `.aider.model.settings.yml` fills up — aider was aborting mid-generation with a timeout before producing any edits, which looked like a hang rather than a cut-off API call.

## Changes

- `.aider.conf.yml`: add `timeout: 1800` to raise the per-API-call timeout well above litellm's 600s default.
- `scripts/aider-issue.ps1` → `scripts/developer_tools/implement_issue.ps1` (git mv), with a new `-TimeoutMinutes` (default 40) wall-clock guard around the `aider` process itself — a safety net distinct from the API-call timeout, for the case where a run stalls on something other than the LLM call (e.g. a stuck git lock).
- `scripts/tests/aider-issue.Tests.ps1` → `scripts/tests/implement_issue.Tests.ps1`, updated to point at the new script path (still extracts and dot-sources the real file-discovery code, unchanged).
- `.github/workflows/ci.yml`: update the Pester step name to the new path.
- `scripts/README.md`: document the new script location and the two timeout knobs.

## Test plan

- [x] `scripts/tests/implement_issue.Tests.ps1` passes locally under Pester 5.6.1 (7/7, unchanged file-discovery logic, just repointed at the new file).
- [x] `implement_issue.ps1` parses cleanly (`Parser]::ParseFile`, no errors).
- [ ] CI Pester job (`powershell-tests`) green on this branch.
- [ ] Manual smoke test against a real issue with `aider`/Ollama running locally (not run here — needs a local Ollama instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable time limit for automated issue implementation runs, with clear handling when the limit is exceeded.
  * Added documentation for the end-to-end issue implementation workflow, prerequisites, and optional controls.

* **Bug Fixes**
  * Increased the default AI completion timeout to support longer-running local model tasks.

* **Tests**
  * Updated automated checks to validate the current issue implementation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->