### PR TITLE
Fix follow-up issue creation aborting the batch on one bad label

### DIFF
--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -236,7 +236,14 @@ def issue_exists(title: str) -> bool:
 
 def create_issues(
     titles: list[str], pr_number: str, review_text: str | None = None
-) -> None:
+) -> list[str]:
+    """Create each follow-up issue, returning titles that failed to create.
+
+    A failure on one title (e.g. an unrecognized label) must not abort the
+    remaining titles in the batch — a single bad `gh issue create` call
+    previously raised uncaught and silently dropped every follow-up after it.
+    """
+    failed: list[str] = []
     for title in titles:
         if not title.strip():
             continue
@@ -250,10 +257,15 @@ def create_issues(
         if llm_label:
             labels.append(llm_label)
         label_args = [arg for label in labels for arg in ("--label", label)]
-        subprocess.run(
-            ["gh", "issue", "create", "--title", title, "--body", body, *label_args],
-            check=True,
-        )
+        try:
+            subprocess.run(
+                ["gh", "issue", "create", "--title", title, "--body", body, *label_args],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            print(f"ERROR: failed to create issue '{title}': {exc}", file=sys.stderr)
+            failed.append(title)
+    return failed
 
 
 def main() -> int:
@@ -284,7 +296,10 @@ def main() -> int:
                 file=sys.stderr,
             )
 
-    create_issues(titles, pr_number, review_text)
+    failed = create_issues(titles, pr_number, review_text)
+    if failed:
+        print(f"ERROR: {len(failed)} of {len(titles)} follow-up issue(s) failed to create", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -234,6 +234,12 @@ jobs:
           create_label_if_missing "haiku" "C5DEF5" "Suitable for Claude Haiku (simple/mechanical task)"
           create_label_if_missing "sonnet" "BFD4F2" "Suitable for Claude Sonnet (moderate reasoning)"
           create_label_if_missing "opus" "0052CC" "Suitable for Claude Opus (complex design/architecture)"
+          # local-7b/local-14b are also valid tiers in create_followup_issues.py's prompt
+          # (llm_labels.LLM_TIER_MAP) even though this workflow's own review prompts don't
+          # request them; missing either label makes `gh issue create --label local-7b` fail
+          # outright and previously crashed the whole follow-up batch (see #5556).
+          create_label_if_missing "local-7b" "0e8a16" "Doable by a local LLM (qwen2.5-coder:7b)"
+          create_label_if_missing "local-14b" "1d76db" "Doable by a local LLM (qwen2.5-coder:14b); too hard for 7b"
 
           # Extract titles to a file, then create issues via Python subprocess (no shell injection)
           python3 .github/scripts/extract_followups.py /tmp/${{ inputs.provider_id }}_review_body.md \

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -350,6 +350,55 @@ def test_create_issues_applies_llm_label(
     assert "ai-suggested" in created[0]
 
 
+def test_create_issues_continues_after_one_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failing `gh issue create` (e.g. an unrecognized label) must not abort
+    the batch — subsequent titles still get attempted, and the failed title
+    is returned so callers can surface it."""
+    mod = load_module()
+    attempted: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        title = cmd[cmd.index("--title") + 1]
+        attempted.append(title)
+        if title == "Bad title":
+            raise mod.subprocess.CalledProcessError(1, cmd)
+        return None
+
+    monkeypatch.setattr(mod, "issue_exists", lambda title: False)
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    failed = mod.create_issues(["Bad title", "Good title"], "5", None)
+
+    assert attempted == ["Bad title", "Good title"]
+    assert failed == ["Bad title"]
+    assert "failed to create issue 'Bad title'" in capsys.readouterr().err
+
+
+def test_main_returns_nonzero_when_issue_creation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mod = load_module()
+
+    followups = tmp_path / "followups.json"
+    followups.write_text(json.dumps(["Bad title"]))
+    review = tmp_path / "review.md"
+    review.write_text("Some review text")
+
+    monkeypatch.setattr(mod, "create_issues", lambda *args, **kwargs: ["Bad title"])
+    monkeypatch.setattr(
+        sys, "argv", ["create_followup_issues.py", str(followups), "7", str(review)]
+    )
+
+    result = mod.main()
+    assert result == 1
+    assert "1 of 1 follow-up issue(s) failed to create" in capsys.readouterr().err
+
+
 def test_create_issues_applies_no_llm_label_when_body_has_no_tier(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- `create_issues()` now isolates failures per title instead of letting one bad `gh issue create` (`subprocess.run(check=True)`) abort every remaining follow-up in the batch — it collects failed titles and returns them.
- `main()` now returns 1 (surfacing the failure in CI) when any follow-up issue fails to create, instead of always returning 0.
- `_ai-pr-review.yml` now pre-creates the `local-7b`/`local-14b` labels alongside the existing tier labels — `create_followup_issues.py`'s prompt already recommends those two tiers, but the labels never existed, so any `local-7b`/`local-14b` recommendation would 422 and (per the bug above) wipe out the rest of the batch.

This mirrors a fix already made in the sibling `ai-systems-lab` repo (see its `_ai-pr-review.yml` comments referencing its PR #6 CI run) that never made it back into allotmint, even though allotmint's own prompt already asks for the same two tiers.

Closes #5556

## Test plan
- [x] `pytest tests/test_create_followup_issues.py tests/test_extract_followups.py` — 39 passed, including two new tests: one failing `gh issue create` no longer blocks subsequent titles, and `main()` returns 1 when any issue fails to create.
- [x] YAML validated with `yaml.safe_load` on `_ai-pr-review.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)