### PR TITLE
Add developer tools script to auto-merge passing Dependabot PRs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -254,6 +254,10 @@ Defaults to dry-run (prints what it would do). Pass `--yes` to actually merge
 and delete branches. Never touches non-Dependabot PRs or protected branches
 (`main`/`master`).
 
+Optional flags:
+- `--repo owner/name`: Operate on a different repository. Defaults to the
+  `origin` git remote, falling back to `leonarduk/allotmint`.
+
 **Requirements:**
 - `gh` CLI must be installed and authenticated with a token that can merge PRs
   and delete branches on the target repo (`repo` scope).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -233,6 +233,31 @@ bash scripts/bash/publish-pr.sh -m "Fix bug in auth" --no-ollama
 - `gh` CLI must be installed and authenticated
 - Ollama is optional but recommended for better PR descriptions
 
+## i_dependabot_auto_merge.py
+
+Auto-merge open Dependabot pull requests once their checks have all passed, then
+delete the branch. A PR that is green but only out-of-date with `main` (no real
+conflicts) is still merged.
+
+```bash
+python scripts/developer_tools/i_dependabot_auto_merge.py --dry-run
+python scripts/developer_tools/i_dependabot_auto_merge.py --yes
+```
+
+The script:
+1. Lists open PRs authored by `dependabot[bot]`
+2. Skips any PR whose checks haven't all completed successfully, or that has a
+   real merge conflict (`mergeable_state == dirty`)
+3. Merges (squash) and deletes the branch for every remaining PR
+
+Defaults to dry-run (prints what it would do). Pass `--yes` to actually merge
+and delete branches. Never touches non-Dependabot PRs or protected branches
+(`main`/`master`).
+
+**Requirements:**
+- `gh` CLI must be installed and authenticated with a token that can merge PRs
+  and delete branches on the target repo (`repo` scope).
+
 ## reconcile_drawdown.py
 
 Inspect max drawdowns and dump holding price data when the portfolio suffers a

--- a/scripts/developer_tools/i_dependabot_auto_merge.py
+++ b/scripts/developer_tools/i_dependabot_auto_merge.py
@@ -1,0 +1,213 @@
+"""CLI tool to auto-merge green Dependabot pull requests and delete their branches.
+
+Continues the a_/b_/.../h_ script chain in scripts/developer_tools/. Dependabot opens
+routine dependency-bump PRs; when CI has already passed there's no reason a human
+needs to click merge. This script finds open PRs authored by `dependabot[bot]`,
+merges the ones whose checks have all passed on the current head SHA, and deletes
+the branch afterward. A PR that is otherwise green but merely behind `main` (no
+real conflicts) is still merged -- being behind alone should never block it.
+
+Safety:
+  - Defaults to dry-run. Pass --yes to actually merge/delete anything.
+  - Only ever touches PRs authored by `dependabot[bot]`.
+  - Never merges a PR with failing/pending checks or real merge conflicts
+    (`mergeable_state == "dirty"`).
+  - Never deletes `main`/`master`, only the merged PR's own head branch.
+
+Requires the `gh` CLI to be authenticated with a token that can merge PRs and
+delete branches on the target repo (repo scope covers this).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+
+REPO_OWNER = "leonarduk"
+REPO_NAME = "allotmint"
+DEPENDABOT_LOGIN = "dependabot[bot]"
+PROTECTED_BRANCHES = {"main", "master"}
+GH_RETRY_ATTEMPTS = 3
+GH_RETRY_BACKOFF_SECONDS = 2
+
+# mergeable_state values that still permit a merge -- "behind" means only
+# out-of-date with the base branch, which the issue explicitly asks us to
+# merge anyway. "clean" is the ordinary green/no-conflict case.
+MERGEABLE_STATES_OK_TO_MERGE = {"clean", "behind"}
+
+
+@dataclass
+class PullRequest:
+    """A single open Dependabot pull request under consideration."""
+
+    number: int
+    title: str
+    head_ref_name: str
+    head_sha: str = ""
+    mergeable: str | None = None
+    mergeable_state: str = ""
+    checks: list[dict] = field(default_factory=list)
+
+
+def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a `gh` CLI command scoped to REPO_OWNER/REPO_NAME. Never raises.
+
+    Retries transient failures (network blips, GraphQL timeouts) up to
+    GH_RETRY_ATTEMPTS times with a linear backoff before returning the last
+    failing result to the caller.
+    """
+    result = None
+    for attempt in range(1, GH_RETRY_ATTEMPTS + 1):
+        result = subprocess.run(
+            ["gh", *args, "--repo", f"{REPO_OWNER}/{REPO_NAME}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        if result.returncode == 0:
+            return result
+        if attempt < GH_RETRY_ATTEMPTS:
+            wait_seconds = GH_RETRY_BACKOFF_SECONDS * attempt
+            print(
+                f"WARNING: gh {' '.join(args)} failed (attempt {attempt}/{GH_RETRY_ATTEMPTS}): "
+                f"{result.stderr.strip()} -- retrying in {wait_seconds}s",
+                file=sys.stderr,
+            )
+            time.sleep(wait_seconds)
+    return result
+
+
+def fetch_open_dependabot_prs() -> list[PullRequest]:
+    """List open PRs authored by dependabot[bot], with head ref/SHA and mergeable state."""
+    result = run_gh(
+        [
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--author",
+            DEPENDABOT_LOGIN,
+            "--json",
+            "number,title,headRefName,headRefOid,mergeable,mergeStateStatus,statusCheckRollup",
+            "--limit",
+            "200",
+        ]
+    )
+    if result.returncode != 0:
+        print(f"ERROR: gh pr list failed: {result.stderr}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: gh pr list returned non-JSON output: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    prs = []
+    for item in data:
+        prs.append(
+            PullRequest(
+                number=item["number"],
+                title=item["title"],
+                head_ref_name=item["headRefName"],
+                head_sha=item.get("headRefOid", ""),
+                mergeable=item.get("mergeable"),
+                mergeable_state=(item.get("mergeStateStatus") or "").lower(),
+                checks=item.get("statusCheckRollup") or [],
+            )
+        )
+    return prs
+
+
+def checks_have_passed(checks: list[dict]) -> bool:
+    """Return True only if there is at least one check and every check succeeded.
+
+    A PR with no checks at all is treated as not-yet-verified (returns False),
+    since that usually means CI hasn't reported in yet rather than "nothing to
+    check".
+    """
+    if not checks:
+        return False
+    for check in checks:
+        conclusion = (check.get("conclusion") or "").upper()
+        status = (check.get("status") or "").upper()
+        if status and status != "COMPLETED":
+            return False
+        if conclusion not in ("SUCCESS", "NEUTRAL", "SKIPPED"):
+            return False
+    return True
+
+
+def is_mergeable(pr: PullRequest) -> bool:
+    """Return True if the PR has no real conflicts (being merely behind main is fine)."""
+    if pr.mergeable is False:
+        return False
+    return pr.mergeable_state in MERGEABLE_STATES_OK_TO_MERGE or pr.mergeable_state == ""
+
+
+def merge_and_delete(pr: PullRequest, dry_run: bool) -> None:
+    """Merge a Dependabot PR (squash) and delete its head branch."""
+    prefix = "[DRY RUN] " if dry_run else ""
+    print(f"{prefix}Merging PR #{pr.number} ({pr.title}) and deleting branch '{pr.head_ref_name}'")
+    if dry_run:
+        return
+
+    if pr.head_ref_name in PROTECTED_BRANCHES:
+        print(
+            f"ERROR: refusing to delete protected branch '{pr.head_ref_name}' for PR #{pr.number}",
+            file=sys.stderr,
+        )
+        return
+
+    result = run_gh(["pr", "merge", str(pr.number), "--squash", "--delete-branch"])
+    if result.returncode != 0:
+        print(f"ERROR: failed to merge PR #{pr.number}: {result.stderr}", file=sys.stderr)
+
+
+def process_pr(pr: PullRequest, dry_run: bool) -> None:
+    """Decide whether a single Dependabot PR should be merged, and act on it."""
+    if not checks_have_passed(pr.checks):
+        print(f"SKIP: PR #{pr.number} ({pr.title}) -- checks not all passed")
+        return
+    if not is_mergeable(pr):
+        print(
+            f"SKIP: PR #{pr.number} ({pr.title}) -- not mergeable "
+            f"(mergeable={pr.mergeable}, state={pr.mergeable_state})"
+        )
+        return
+    merge_and_delete(pr, dry_run)
+
+
+def main() -> int:
+    """Run the Dependabot auto-merge flow."""
+    parser = argparse.ArgumentParser(
+        description="Auto-merge open Dependabot PRs whose checks have all passed"
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Actually merge and delete branches. Without this flag, runs in dry-run mode.",
+    )
+    args = parser.parse_args()
+    dry_run = not args.yes
+
+    print(f"INFO: Fetching open Dependabot PRs for {REPO_OWNER}/{REPO_NAME}...", file=sys.stderr)
+    prs = fetch_open_dependabot_prs()
+    print(f"INFO: {len(prs)} open Dependabot PR(s) found", file=sys.stderr)
+
+    if dry_run:
+        print("INFO: Running in dry-run mode. Pass --yes to actually merge/delete.", file=sys.stderr)
+
+    for pr in prs:
+        process_pr(pr, dry_run)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/developer_tools/i_dependabot_auto_merge.py
+++ b/scripts/developer_tools/i_dependabot_auto_merge.py
@@ -15,13 +15,16 @@ Safety:
   - Never deletes `main`/`master`, only the merged PR's own head branch.
 
 Requires the `gh` CLI to be authenticated with a token that can merge PRs and
-delete branches on the target repo (repo scope covers this).
+delete branches on the target repo (repo scope covers this). Defaults to
+operating on the `origin` git remote's repo; pass --repo owner/name to
+override.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import time
@@ -144,10 +147,16 @@ def checks_have_passed(checks: list[dict]) -> bool:
 
 
 def is_mergeable(pr: PullRequest) -> bool:
-    """Return True if the PR has no real conflicts (being merely behind main is fine)."""
-    if pr.mergeable is False:
+    """Return True if the PR has no real conflicts (being merely behind main is fine).
+
+    `mergeable` is `None` while GitHub is still computing mergeability, and
+    `mergeable_state` is empty in that case too -- both must be treated as
+    not-yet-mergeable rather than defaulting to "ok", since GitHub hasn't
+    confirmed the PR is conflict-free yet.
+    """
+    if pr.mergeable is not True:
         return False
-    return pr.mergeable_state in MERGEABLE_STATES_OK_TO_MERGE or pr.mergeable_state == ""
+    return pr.mergeable_state in MERGEABLE_STATES_OK_TO_MERGE
 
 
 def merge_and_delete(pr: PullRequest, dry_run: bool) -> None:
@@ -183,6 +192,34 @@ def process_pr(pr: PullRequest, dry_run: bool) -> None:
     merge_and_delete(pr, dry_run)
 
 
+def resolve_repo(explicit: str | None) -> tuple[str, str]:
+    """Resolve the (owner, repo) to operate on.
+
+    Precedence: an explicit `--repo owner/name` flag, then the `origin` git
+    remote, then the hardcoded REPO_OWNER/REPO_NAME fallback.
+    """
+    if explicit:
+        owner, _, name = explicit.partition("/")
+        if not owner or not name:
+            print(f"ERROR: --repo must be in 'owner/name' form, got '{explicit}'", file=sys.stderr)
+            raise SystemExit(1)
+        return owner, name
+
+    result = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if result.returncode == 0:
+        match = re.search(r"[:/]([^/:]+)/([^/]+?)(?:\.git)?$", result.stdout.strip())
+        if match:
+            return match.group(1), match.group(2)
+
+    return REPO_OWNER, REPO_NAME
+
+
 def main() -> int:
     """Run the Dependabot auto-merge flow."""
     parser = argparse.ArgumentParser(
@@ -193,8 +230,17 @@ def main() -> int:
         action="store_true",
         help="Actually merge and delete branches. Without this flag, runs in dry-run mode.",
     )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Repository to operate on as 'owner/name'. Defaults to the 'origin' git "
+        "remote, falling back to leonarduk/allotmint.",
+    )
     args = parser.parse_args()
     dry_run = not args.yes
+
+    global REPO_OWNER, REPO_NAME
+    REPO_OWNER, REPO_NAME = resolve_repo(args.repo)
 
     print(f"INFO: Fetching open Dependabot PRs for {REPO_OWNER}/{REPO_NAME}...", file=sys.stderr)
     prs = fetch_open_dependabot_prs()

--- a/tests/scripts/test_i_dependabot_auto_merge.py
+++ b/tests/scripts/test_i_dependabot_auto_merge.py
@@ -63,6 +63,14 @@ def test_is_mergeable_false_when_mergeable_flag_false():
     assert not i.is_mergeable(_pr(1, mergeable=False, mergeable_state="clean"))
 
 
+def test_is_mergeable_false_when_mergeable_is_none_and_state_empty():
+    assert not i.is_mergeable(_pr(1, mergeable=None, mergeable_state=""))
+
+
+def test_is_mergeable_false_when_state_unknown():
+    assert not i.is_mergeable(_pr(1, mergeable=True, mergeable_state="unknown"))
+
+
 def test_fetch_open_dependabot_prs_parses_payload(monkeypatch):
     payload = json.dumps(
         [
@@ -137,3 +145,38 @@ def test_merge_and_delete_refuses_protected_branch(monkeypatch):
     monkeypatch.setattr(i, "run_gh", lambda args: calls.append(args) or _FakeResult(0))
     i.merge_and_delete(_pr(1, head_ref_name="main"), dry_run=False)
     assert calls == []
+
+
+def test_resolve_repo_uses_explicit_flag(monkeypatch):
+    assert i.resolve_repo("someorg/somerepo") == ("someorg", "somerepo")
+
+
+def test_resolve_repo_rejects_malformed_explicit_flag():
+    try:
+        i.resolve_repo("not-a-valid-repo")
+        assert False, "expected SystemExit"
+    except SystemExit as exc:
+        assert exc.code == 1
+
+
+def test_resolve_repo_parses_https_git_remote(monkeypatch):
+    monkeypatch.setattr(
+        i.subprocess,
+        "run",
+        lambda *a, **k: _FakeResult(0, "https://github.com/someorg/somerepo.git\n"),
+    )
+    assert i.resolve_repo(None) == ("someorg", "somerepo")
+
+
+def test_resolve_repo_parses_ssh_git_remote(monkeypatch):
+    monkeypatch.setattr(
+        i.subprocess,
+        "run",
+        lambda *a, **k: _FakeResult(0, "git@github.com:someorg/somerepo.git\n"),
+    )
+    assert i.resolve_repo(None) == ("someorg", "somerepo")
+
+
+def test_resolve_repo_falls_back_when_remote_lookup_fails(monkeypatch):
+    monkeypatch.setattr(i.subprocess, "run", lambda *a, **k: _FakeResult(1, "", "no remote"))
+    assert i.resolve_repo(None) == (i.REPO_OWNER, i.REPO_NAME)

--- a/tests/scripts/test_i_dependabot_auto_merge.py
+++ b/tests/scripts/test_i_dependabot_auto_merge.py
@@ -1,0 +1,139 @@
+import json
+
+import scripts.developer_tools.i_dependabot_auto_merge as i
+
+
+def _pr(number, title="Bump foo", head_ref_name="dependabot/pip/foo-1.2.3",
+        mergeable=True, mergeable_state="clean", checks=None):
+    return i.PullRequest(
+        number=number,
+        title=title,
+        head_ref_name=head_ref_name,
+        mergeable=mergeable,
+        mergeable_state=mergeable_state,
+        checks=checks if checks is not None else [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+    )
+
+
+class _FakeResult:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_checks_have_passed_true_when_all_success():
+    checks = [
+        {"status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"status": "COMPLETED", "conclusion": "NEUTRAL"},
+    ]
+    assert i.checks_have_passed(checks)
+
+
+def test_checks_have_passed_false_when_empty():
+    assert not i.checks_have_passed([])
+
+
+def test_checks_have_passed_false_when_one_failing():
+    checks = [
+        {"status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"status": "COMPLETED", "conclusion": "FAILURE"},
+    ]
+    assert not i.checks_have_passed(checks)
+
+
+def test_checks_have_passed_false_when_pending():
+    checks = [{"status": "IN_PROGRESS", "conclusion": ""}]
+    assert not i.checks_have_passed(checks)
+
+
+def test_is_mergeable_true_when_clean():
+    assert i.is_mergeable(_pr(1, mergeable=True, mergeable_state="clean"))
+
+
+def test_is_mergeable_true_when_only_behind_main():
+    assert i.is_mergeable(_pr(1, mergeable=True, mergeable_state="behind"))
+
+
+def test_is_mergeable_false_when_dirty():
+    assert not i.is_mergeable(_pr(1, mergeable=True, mergeable_state="dirty"))
+
+
+def test_is_mergeable_false_when_mergeable_flag_false():
+    assert not i.is_mergeable(_pr(1, mergeable=False, mergeable_state="clean"))
+
+
+def test_fetch_open_dependabot_prs_parses_payload(monkeypatch):
+    payload = json.dumps(
+        [
+            {
+                "number": 42,
+                "title": "Bump requests from 2.0 to 2.1",
+                "headRefName": "dependabot/pip/requests-2.1",
+                "headRefOid": "abc123",
+                "mergeable": True,
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+            }
+        ]
+    )
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(0, payload))
+    prs = i.fetch_open_dependabot_prs()
+    assert len(prs) == 1
+    assert prs[0].number == 42
+    assert prs[0].head_ref_name == "dependabot/pip/requests-2.1"
+    assert prs[0].mergeable_state == "clean"
+
+
+def test_fetch_open_dependabot_prs_exits_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(1, "", "boom"))
+    try:
+        i.fetch_open_dependabot_prs()
+        assert False, "expected SystemExit"
+    except SystemExit as exc:
+        assert exc.code == 1
+
+
+def test_process_pr_skips_when_checks_not_passed(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "merge_and_delete", lambda pr, dry_run: calls.append(pr.number))
+    pr = _pr(1, checks=[{"status": "COMPLETED", "conclusion": "FAILURE"}])
+    i.process_pr(pr, dry_run=True)
+    assert calls == []
+
+
+def test_process_pr_skips_when_not_mergeable(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "merge_and_delete", lambda pr, dry_run: calls.append(pr.number))
+    pr = _pr(1, mergeable_state="dirty")
+    i.process_pr(pr, dry_run=True)
+    assert calls == []
+
+
+def test_process_pr_merges_when_green_and_only_behind(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "merge_and_delete", lambda pr, dry_run: calls.append(pr.number))
+    pr = _pr(1, mergeable_state="behind")
+    i.process_pr(pr, dry_run=True)
+    assert calls == [1]
+
+
+def test_merge_and_delete_dry_run_does_not_call_gh(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "run_gh", lambda args: calls.append(args))
+    i.merge_and_delete(_pr(1), dry_run=True)
+    assert calls == []
+
+
+def test_merge_and_delete_calls_gh_pr_merge(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "run_gh", lambda args: calls.append(args) or _FakeResult(0))
+    i.merge_and_delete(_pr(1, head_ref_name="dependabot/pip/foo-1.2.3"), dry_run=False)
+    assert calls == [["pr", "merge", "1", "--squash", "--delete-branch"]]
+
+
+def test_merge_and_delete_refuses_protected_branch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "run_gh", lambda args: calls.append(args) or _FakeResult(0))
+    i.merge_and_delete(_pr(1, head_ref_name="main"), dry_run=False)
+    assert calls == []


### PR DESCRIPTION
## What / Why

Adds `scripts/developer_tools/i_dependabot_auto_merge.py`, continuing the `a_`–`h_` script chain in `scripts/developer_tools/`. Dependabot opens routine dependency-bump PRs; when CI has already passed there's no reason a human needs to click merge manually. This is toil the new script removes.

Closes #5580

The script:
1. Lists open PRs authored by `dependabot[bot]` via `gh pr list`
2. Skips any PR whose checks haven't all completed successfully
3. Skips any PR with a real merge conflict (`mergeable_state == "dirty"`)
4. Merges (squash) and deletes the branch for every remaining PR — including a PR that is green but merely behind `main` (`mergeable_state == "behind"`), per the issue's explicit requirement that being behind alone should not block a merge

Safety:
- Defaults to dry-run; requires `--yes` to actually merge/delete anything
- Only ever acts on PRs authored by `dependabot[bot]`
- Refuses to delete `main`/`master` even if somehow targeted

## How I validated this

- [x] Relevant tests updated/added and passing (`pytest tests/scripts/test_i_dependabot_auto_merge.py`)
- [x] Lint passing (`ruff check --config backend/pyproject.toml tests/scripts/test_i_dependabot_auto_merge.py` — clean; `black` flags formatting on both the new script and the pre-existing `h_triage_issues.py`, since `scripts/developer_tools/` isn't in `make format`'s scope)
- [ ] Manually verified the change — not run against live GitHub in this session (no PRs currently need merging); relies on unit tests covering `checks_have_passed`, `is_mergeable`, `process_pr`, and `merge_and_delete` behavior instead
- [x] No prior-state/version claims made in this description

## Notes for reviewers

- Requires a `gh`-authenticated token with merge + delete-branch permissions to actually run for real; usage documented in `scripts/README.md`.
- `scripts/developer_tools/` is not covered by the repo's `make format`/`make lint` targets (those only run against `backend` and `tests`), so the new script follows the existing style of `h_triage_issues.py` rather than being reformatted to strict Black rules.


---
_Generated by [Claude Code](https://claude.ai/code/session_014Fr3VE32zJjLDrvUY4QjaS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to identify eligible Dependabot pull requests and merge them using squash merges.
  * Pull requests are only processed after checks pass and merge conflicts are ruled out.
  * Includes safeguards for protected branches and defaults to dry-run mode.

* **Documentation**
  * Added usage instructions, command examples, confirmation options, and required GitHub CLI permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->