### PR TITLE
Add read-only visual file explorer for the data admin area

### DIFF
--- a/backend/bootstrap/routers.py
+++ b/backend/bootstrap/routers.py
@@ -13,6 +13,7 @@ from backend.routes.analytics import router as analytics_router
 from backend.routes.approvals import router as approvals_router
 from backend.routes.compliance import router as compliance_router
 from backend.routes.config import router as config_router
+from backend.routes.data_explorer import router as data_explorer_router
 from backend.routes.data_quality import router as data_quality_router
 from backend.routes.events import router as events_router
 from backend.routes.goals import router as goals_router
@@ -65,6 +66,7 @@ def register_routers(app: FastAPI, cfg: Config) -> None:
     app.include_router(data_quality_router)
     app.include_router(timeseries_edit_router)
     app.include_router(timeseries_admin_router, dependencies=protected)
+    app.include_router(data_explorer_router, dependencies=protected)
     app.include_router(transactions_router)
     app.include_router(alert_settings_router, dependencies=protected)
     app.include_router(alerts_router, dependencies=protected)

--- a/backend/config.py
+++ b/backend/config.py
@@ -57,6 +57,7 @@ class TabsConfig:
     group: bool = True
     owner: bool = True
     dataadmin: bool = True
+    dataexplorer: bool = True
     virtual: bool = True
     support: bool = True
     settings: bool = True

--- a/backend/routes/data_explorer.py
+++ b/backend/routes/data_explorer.py
@@ -1,0 +1,138 @@
+"""Read-only file explorer for the backend ``data/`` area.
+
+Lets an admin browse the directory tree rooted at ``config.data_root`` and
+preview small text files, for debugging what's actually on disk (cached
+timeseries, account files, etc.) without shell access to the environment.
+Never writes, deletes, or renames anything.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from backend.auth import get_current_user
+from backend.config import config
+from backend.logging_setup import sanitise_log_value
+
+router = APIRouter(prefix="/data-explorer", tags=["data-explorer"], dependencies=[Depends(get_current_user)])
+logger = logging.getLogger("routes.data_explorer")
+
+# Preview is capped well below typical request/response body limits so a
+# multi-GB cache file can't be read into memory or hang the request.
+MAX_PREVIEW_BYTES = 200_000
+
+# Only a small allowlist of known-text extensions is ever previewed; anything
+# else (parquet, binary caches, etc.) is rejected rather than streamed raw.
+PREVIEWABLE_EXTENSIONS = {".json", ".csv", ".txt", ".log", ".yaml", ".yml", ".md"}
+
+
+def _data_root() -> Path:
+    root = config.data_root
+    if root is None:
+        raise HTTPException(status_code=501, detail="Data root is not configured")
+    return root.resolve()
+
+
+def _resolve_within_root(root: Path, rel_path: str) -> Path:
+    """Resolve ``rel_path`` under ``root``, rejecting any attempt to escape it."""
+
+    normalised = (rel_path or "").strip().replace("\\", "/")
+    if normalised.startswith("/") or (len(normalised) > 1 and normalised[1] == ":"):
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    candidate = (root / normalised).resolve()
+    if candidate != root and root not in candidate.parents:
+        raise HTTPException(status_code=400, detail="Invalid path")
+    return candidate
+
+
+def _iso_mtime(stat_result: os.stat_result) -> str:
+    return datetime.fromtimestamp(stat_result.st_mtime, tz=timezone.utc).isoformat()
+
+
+@router.get("/tree")
+async def list_directory(path: str = Query("")) -> dict[str, Any]:
+    """List the immediate contents of a directory under the data root."""
+
+    root = _data_root()
+    if config.app_env == "aws":
+        raise HTTPException(
+            status_code=501,
+            detail="Data explorer is only available against a local filesystem, not S3",
+        )
+
+    target = _resolve_within_root(root, path)
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="Path not found")
+    if not target.is_dir():
+        raise HTTPException(status_code=400, detail="Path is not a directory")
+
+    entries: list[dict[str, Any]] = []
+    for child in sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
+        try:
+            stat_result = child.stat()
+        except OSError:
+            logger.warning("Failed to stat %s", sanitise_log_value(child))
+            continue
+        entries.append(
+            {
+                "name": child.name,
+                "path": child.relative_to(root).as_posix(),
+                "type": "dir" if child.is_dir() else "file",
+                "size": None if child.is_dir() else stat_result.st_size,
+                "modified": _iso_mtime(stat_result),
+            }
+        )
+
+    return {
+        "path": "" if target == root else target.relative_to(root).as_posix(),
+        "entries": entries,
+    }
+
+
+@router.get("/file")
+async def read_file(path: str = Query(...)) -> dict[str, Any]:
+    """Return a text preview of a single file under the data root."""
+
+    root = _data_root()
+    if config.app_env == "aws":
+        raise HTTPException(
+            status_code=501,
+            detail="Data explorer is only available against a local filesystem, not S3",
+        )
+
+    target = _resolve_within_root(root, path)
+    if not target.exists() or not target.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    if target.suffix.lower() not in PREVIEWABLE_EXTENSIONS:
+        raise HTTPException(status_code=415, detail="File type is not previewable")
+
+    stat_result = target.stat()
+    try:
+        with target.open("rb") as fh:
+            raw = fh.read(MAX_PREVIEW_BYTES + 1)
+    except OSError as exc:
+        logger.warning("Failed to read %s: %s", sanitise_log_value(target), sanitise_log_value(exc))
+        raise HTTPException(status_code=500, detail="Failed to read file") from exc
+
+    truncated = len(raw) > MAX_PREVIEW_BYTES
+    if truncated:
+        raw = raw[:MAX_PREVIEW_BYTES]
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(status_code=415, detail="File is not valid UTF-8 text") from exc
+
+    return {
+        "path": target.relative_to(root).as_posix(),
+        "size": stat_result.st_size,
+        "modified": _iso_mtime(stat_result),
+        "truncated": truncated,
+        "content": content,
+    }

--- a/config.yaml
+++ b/config.yaml
@@ -91,6 +91,7 @@ ui:
     rebalance: true
     instrumentadmin: true
     dataadmin: true
+    dataexplorer: true
     virtual: true
     support: true
     settings: true

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -26,6 +26,7 @@ export interface TabsConfig {
   movers: boolean;
   instrumentadmin: boolean;
   dataadmin: boolean;
+  dataexplorer: boolean;
   virtual: boolean;
   research: boolean;
   support: boolean;
@@ -88,6 +89,7 @@ const defaultTabs: TabsConfig = {
   movers: true,
   instrumentadmin: true,
   dataadmin: true,
+  dataexplorer: true,
   virtual: true,
   research: true,
   support: true,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -50,6 +50,8 @@ import type {
   AnalyticsFunnelSummary,
   AnalyticsSource,
   DataQualityTimeseriesResponse,
+  DataExplorerDirectory,
+  DataExplorerFile,
 } from "./types";
 import {
   configContractSchema,
@@ -945,6 +947,17 @@ export const rebuildTimeseriesCache = (ticker: string, exchange: string) =>
   fetchJson<{ status: string; rows: number }>(
     `${API_BASE}/timeseries/admin/${encodeURIComponent(ticker)}/${encodeURIComponent(exchange)}/rebuild_cache`,
     { method: "POST" },
+  );
+
+// Data explorer (read-only browsing of the backend data/ area)
+export const listDataExplorerDirectory = (path: string = "") =>
+  fetchJson<DataExplorerDirectory>(
+    `${API_BASE}/data-explorer/tree?path=${encodeURIComponent(path)}`,
+  );
+
+export const getDataExplorerFile = (path: string) =>
+  fetchJson<DataExplorerFile>(
+    `${API_BASE}/data-explorer/file?path=${encodeURIComponent(path)}`,
   );
 
 // Instrument metadata admin

--- a/frontend/src/components/DataExplorerTree.tsx
+++ b/frontend/src/components/DataExplorerTree.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import { listDataExplorerDirectory } from "../api";
+import type { DataExplorerEntry } from "../types";
+
+function formatSize(size: number | null): string {
+  if (size === null) return "";
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+interface TreeNodeProps {
+  path: string;
+  name: string;
+  depth: number;
+  defaultExpanded?: boolean;
+  selectedPath: string | null;
+  onSelectFile: (path: string) => void;
+}
+
+function TreeNode({
+  path,
+  name,
+  depth,
+  defaultExpanded = false,
+  selectedPath,
+  onSelectFile,
+}: TreeNodeProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [entries, setEntries] = useState<DataExplorerEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!expanded || entries !== null) return;
+    let cancelled = false;
+    setLoading(true);
+    listDataExplorerDirectory(path)
+      .then((res) => {
+        if (cancelled) return;
+        setEntries(res.entries);
+        setError(null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // `loading` is intentionally excluded: it's set inside this effect, and
+    // including it re-runs the effect on the very next render (loading
+    // false -> true), whose cleanup then marks the in-flight request
+    // `cancelled` before it ever resolves.
+  }, [expanded, entries, path]);
+
+  return (
+    <li style={{ listStyle: "none" }}>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        style={{
+          paddingLeft: `${depth * 1}rem`,
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          fontWeight: "bold",
+          textAlign: "left",
+          width: "100%",
+        }}
+      >
+        <span aria-hidden="true">{expanded ? "▼" : "▶"} </span>
+        {name}
+      </button>
+      {expanded && (
+        <ul style={{ paddingLeft: 0, margin: 0 }}>
+          {loading && (
+            <li style={{ paddingLeft: `${(depth + 1) * 1}rem` }}>Loading…</li>
+          )}
+          {error && (
+            <li style={{ paddingLeft: `${(depth + 1) * 1}rem`, color: "red" }}>
+              {error}
+            </li>
+          )}
+          {entries?.map((entry) =>
+            entry.type === "dir" ? (
+              <TreeNode
+                key={entry.path}
+                path={entry.path}
+                name={entry.name}
+                depth={depth + 1}
+                selectedPath={selectedPath}
+                onSelectFile={onSelectFile}
+              />
+            ) : (
+              <li key={entry.path} style={{ listStyle: "none" }}>
+                <button
+                  type="button"
+                  onClick={() => onSelectFile(entry.path)}
+                  style={{
+                    paddingLeft: `${(depth + 1) * 1}rem`,
+                    background:
+                      selectedPath === entry.path ? "#e0e8ff" : "none",
+                    border: "none",
+                    cursor: "pointer",
+                    textAlign: "left",
+                    width: "100%",
+                  }}
+                >
+                  {entry.name}{" "}
+                  <span style={{ color: "#888", fontSize: "0.85em" }}>
+                    {formatSize(entry.size)}
+                  </span>
+                </button>
+              </li>
+            ),
+          )}
+          {entries !== null && entries.length === 0 && !loading && !error && (
+            <li
+              style={{ paddingLeft: `${(depth + 1) * 1}rem`, color: "#888" }}
+            >
+              (empty)
+            </li>
+          )}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+interface DataExplorerTreeProps {
+  selectedPath: string | null;
+  onSelectFile: (path: string) => void;
+}
+
+export default function DataExplorerTree({
+  selectedPath,
+  onSelectFile,
+}: DataExplorerTreeProps) {
+  return (
+    <ul style={{ paddingLeft: 0, margin: 0 }}>
+      <TreeNode
+        path=""
+        name="data"
+        depth={0}
+        defaultExpanded
+        selectedPath={selectedPath}
+        onSelectFile={onSelectFile}
+      />
+    </ul>
+  );
+}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -72,6 +72,7 @@
       "allocation": "Allokation",
       "compliance": "Compliance-Warnungen",
       "dataadmin": "Datenverwaltung",
+      "dataexplorer": "Datei-Explorer",
       "dataquality": "Datenqualität",
       "group": "Gruppe",
       "instrument": "Instrument",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -66,6 +66,7 @@
       "allocation": "Allocation",
       "compliance": "Compliance Warnings",
       "dataadmin": "Data Admin",
+      "dataexplorer": "Data Explorer",
       "dataquality": "Data Quality",
       "group": "Group",
       "instrument": "Instrument",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -72,6 +72,7 @@
       "allocation": "Asignación",
       "compliance": "Alertas de cumplimiento",
       "dataadmin": "Administración de datos",
+      "dataexplorer": "Explorador de archivos",
       "dataquality": "Calidad de datos",
       "group": "Grupo",
       "instrument": "Instrumento",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -72,6 +72,7 @@
       "allocation": "Allocation",
       "compliance": "Alertes de conformité",
       "dataadmin": "Administration des données",
+      "dataexplorer": "Explorateur de fichiers",
       "dataquality": "Qualité des données",
       "group": "Groupe",
       "instrument": "Instrument",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -72,6 +72,7 @@
       "allocation": "Allocazione",
       "compliance": "Avvisi di conformità",
       "dataadmin": "Amministrazione dati",
+      "dataexplorer": "Esplora file",
       "dataquality": "Qualità dei dati",
       "group": "Gruppo",
       "instrument": "Strumento",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -72,6 +72,7 @@
       "allocation": "Alocação",
       "compliance": "Alertas de conformidade",
       "dataadmin": "Administração de dados",
+      "dataexplorer": "Explorador de arquivos",
       "dataquality": "Qualidade dos dados",
       "group": "Grupo",
       "instrument": "Instrumento",

--- a/frontend/src/modes.ts
+++ b/frontend/src/modes.ts
@@ -14,6 +14,7 @@ export type Mode =
   | "movers"
   | "instrumentadmin"
   | "dataadmin"
+  | "dataexplorer"
   | "virtual"
   | "settings"
   | "research"
@@ -45,6 +46,7 @@ export const MODES: Mode[] = [
   "rebalance",
   "instrumentadmin",
   "dataadmin",
+  "dataexplorer",
   "virtual",
   "research",
   "reports",

--- a/frontend/src/pages/DataExplorer.tsx
+++ b/frontend/src/pages/DataExplorer.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getDataExplorerFile } from "../api";
+import DataExplorerTree from "../components/DataExplorerTree";
+import type { DataExplorerFile } from "../types";
+
+export default function DataExplorer() {
+  const { t } = useTranslation();
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [file, setFile] = useState<DataExplorerFile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSelectFile = (path: string) => {
+    setSelectedPath(path);
+    setFile(null);
+    setError(null);
+    setLoading(true);
+    getDataExplorerFile(path)
+      .then((res) => setFile(res))
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <div className="container mx-auto p-4 max-w-6xl">
+      <h2 className="mb-4 text-xl md:text-2xl">
+        {t("app.modes.dataexplorer")}
+      </h2>
+      <div style={{ display: "flex", gap: "1rem", alignItems: "flex-start" }}>
+        <div
+          style={{
+            width: "35%",
+            minWidth: "250px",
+            border: "1px solid #ddd",
+            borderRadius: "4px",
+            padding: "0.5rem",
+            maxHeight: "70vh",
+            overflow: "auto",
+          }}
+        >
+          <DataExplorerTree
+            selectedPath={selectedPath}
+            onSelectFile={handleSelectFile}
+          />
+        </div>
+        <div
+          style={{
+            flex: 1,
+            border: "1px solid #ddd",
+            borderRadius: "4px",
+            padding: "0.5rem",
+            minHeight: "10rem",
+          }}
+        >
+          {!selectedPath && <p>Select a file to preview its contents.</p>}
+          {loading && <p>{t("common.loading")}</p>}
+          {error && <p style={{ color: "red" }}>{error}</p>}
+          {file && (
+            <div>
+              <p>
+                <strong>{file.path}</strong> — {file.size} bytes — last
+                modified {file.modified}
+              </p>
+              {file.truncated && (
+                <p style={{ color: "#a66" }}>
+                  Preview truncated; showing only the first part of the file.
+                </p>
+              )}
+              <pre
+                style={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  maxHeight: "60vh",
+                  overflow: "auto",
+                }}
+              >
+                {file.content}
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/registry.ts
+++ b/frontend/src/routes/registry.ts
@@ -196,6 +196,16 @@ export const ROUTE_REGISTRY: RouteRegistryEntry[] = [
     lazyComponent: lazyPage(() => import('../pages/DataQuality')),
   },
   {
+    mode: 'dataexplorer',
+    routeSegment: 'data-explorer',
+    section: 'support',
+    menuCategory: 'operations',
+    priority: 92,
+    defaultPath: () => '/data-explorer',
+    routePath: '/data-explorer',
+    lazyComponent: lazyPage(() => import('../pages/DataExplorer')),
+  },
+  {
     mode: 'reports',
     routeSegment: 'reports',
     section: 'user',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -422,6 +422,27 @@ export interface TimeseriesSummary {
   main_source?: string | null;
 }
 
+export interface DataExplorerEntry {
+  name: string;
+  path: string;
+  type: "dir" | "file";
+  size: number | null;
+  modified: string;
+}
+
+export interface DataExplorerDirectory {
+  path: string;
+  entries: DataExplorerEntry[];
+}
+
+export interface DataExplorerFile {
+  path: string;
+  size: number;
+  modified: string;
+  truncated: boolean;
+  content: string;
+}
+
 export interface InstrumentMetadata {
   ticker: string;
   exchange?: string | null;

--- a/frontend/tests/unit/pages/DataExplorer.test.tsx
+++ b/frontend/tests/unit/pages/DataExplorer.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockListDataExplorerDirectory = vi.hoisted(() => vi.fn());
+const mockGetDataExplorerFile = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api", async () => {
+  const actual = await vi.importActual<typeof import("@/api")>("@/api");
+  return {
+    ...actual,
+    listDataExplorerDirectory: mockListDataExplorerDirectory,
+    getDataExplorerFile: mockGetDataExplorerFile,
+  };
+});
+
+import DataExplorer from "@/pages/DataExplorer";
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+});
+
+describe("DataExplorer page", () => {
+  it("lists the root directory and expands a subdirectory", async () => {
+    mockListDataExplorerDirectory.mockImplementation((path: string) => {
+      if (path === "") {
+        return Promise.resolve({
+          path: "",
+          entries: [
+            { name: "timeseries", path: "timeseries", type: "dir", size: null, modified: "2026-01-01T00:00:00Z" },
+            { name: "accounts.json", path: "accounts.json", type: "file", size: 42, modified: "2026-01-01T00:00:00Z" },
+          ],
+        });
+      }
+      if (path === "timeseries") {
+        return Promise.resolve({
+          path: "timeseries",
+          entries: [
+            { name: "meta.json", path: "timeseries/meta.json", type: "file", size: 10, modified: "2026-01-01T00:00:00Z" },
+          ],
+        });
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`));
+    });
+
+    render(<DataExplorer />);
+
+    expect(await screen.findByText("accounts.json")).toBeInTheDocument();
+    expect(await screen.findByText("timeseries")).toBeInTheDocument();
+    expect(screen.queryByText("meta.json")).not.toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(screen.getByText("timeseries"));
+    });
+
+    expect(await screen.findByText("meta.json")).toBeInTheDocument();
+  });
+
+  it("previews a selected file's contents", async () => {
+    mockListDataExplorerDirectory.mockResolvedValue({
+      path: "",
+      entries: [
+        { name: "notes.txt", path: "notes.txt", type: "file", size: 11, modified: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    mockGetDataExplorerFile.mockResolvedValue({
+      path: "notes.txt",
+      size: 11,
+      modified: "2026-01-01T00:00:00Z",
+      truncated: false,
+      content: "hello world",
+    });
+
+    render(<DataExplorer />);
+
+    const fileButton = await screen.findByText("notes.txt");
+    await act(async () => {
+      await userEvent.click(fileButton);
+    });
+
+    expect(await screen.findByText("hello world")).toBeInTheDocument();
+    expect(mockGetDataExplorerFile).toHaveBeenCalledWith("notes.txt");
+  });
+
+  it("shows an error when the file preview request fails", async () => {
+    mockListDataExplorerDirectory.mockResolvedValue({
+      path: "",
+      entries: [
+        { name: "cache.parquet", path: "cache.parquet", type: "file", size: 99, modified: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    mockGetDataExplorerFile.mockRejectedValue(new Error("File type is not previewable"));
+
+    render(<DataExplorer />);
+
+    const fileButton = await screen.findByText("cache.parquet");
+    await act(async () => {
+      await userEvent.click(fileButton);
+    });
+
+    expect(await screen.findByText("File type is not previewable")).toBeInTheDocument();
+  });
+});

--- a/tests/routes/test_data_explorer.py
+++ b/tests/routes/test_data_explorer.py
@@ -1,0 +1,140 @@
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from backend.config import config
+from backend.routes import data_explorer
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_list_directory_root(monkeypatch, tmp_path):
+    (tmp_path / "timeseries").mkdir()
+    (tmp_path / "accounts.json").write_text("{}")
+
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    result = _run(data_explorer.list_directory(""))
+
+    assert result["path"] == ""
+    names = [(e["name"], e["type"]) for e in result["entries"]]
+    assert names == [("timeseries", "dir"), ("accounts.json", "file")]
+    file_entry = next(e for e in result["entries"] if e["name"] == "accounts.json")
+    assert file_entry["size"] == 2
+    assert file_entry["path"] == "accounts.json"
+
+
+def test_list_directory_subdir(monkeypatch, tmp_path):
+    sub = tmp_path / "timeseries" / "meta"
+    sub.mkdir(parents=True)
+    (sub / "ABC_L.parquet").write_bytes(b"\x00\x01")
+
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    result = _run(data_explorer.list_directory("timeseries/meta"))
+
+    assert result["path"] == "timeseries/meta"
+    assert result["entries"][0]["path"] == "timeseries/meta/ABC_L.parquet"
+
+
+def test_list_directory_missing_path_404(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.list_directory("does-not-exist"))
+    assert exc.value.status_code == 404
+
+
+def test_list_directory_rejects_file_path(monkeypatch, tmp_path):
+    (tmp_path / "a.txt").write_text("hi")
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.list_directory("a.txt"))
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "traversal",
+    [
+        "../",
+        "../../etc/passwd",
+        "/etc/passwd",
+        "timeseries/../../etc",
+    ],
+)
+def test_list_directory_rejects_traversal(monkeypatch, tmp_path, traversal):
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.list_directory(traversal))
+    assert exc.value.status_code == 400
+
+
+def test_list_directory_aws_not_supported(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.list_directory(""))
+    assert exc.value.status_code == 501
+
+
+def test_read_file_preview(monkeypatch, tmp_path):
+    (tmp_path / "notes.txt").write_text("hello world")
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    result = _run(data_explorer.read_file("notes.txt"))
+
+    assert result["content"] == "hello world"
+    assert result["truncated"] is False
+    assert result["path"] == "notes.txt"
+
+
+def test_read_file_truncates_large_files(monkeypatch, tmp_path):
+    big_content = "x" * (data_explorer.MAX_PREVIEW_BYTES + 100)
+    (tmp_path / "big.log").write_text(big_content)
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    result = _run(data_explorer.read_file("big.log"))
+
+    assert result["truncated"] is True
+    assert len(result["content"]) == data_explorer.MAX_PREVIEW_BYTES
+
+
+def test_read_file_rejects_unsupported_extension(monkeypatch, tmp_path):
+    (tmp_path / "cache.parquet").write_bytes(b"\x00\x01\x02")
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.read_file("cache.parquet"))
+    assert exc.value.status_code == 415
+
+
+def test_read_file_missing_404(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.read_file("missing.txt"))
+    assert exc.value.status_code == 404
+
+
+def test_read_file_rejects_traversal(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.read_file("../secret.txt"))
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary

- Adds a new read-only admin screen (`/data-explorer`) that browses the backend `data/` directory tree and previews small text files, so debugging cached/account data no longer requires shell access to the environment.
- Backend: new `GET /data-explorer/tree` and `GET /data-explorer/file` endpoints (`backend/routes/data_explorer.py`), gated behind the same auth dependency as `DataAdmin`/`InstrumentAdmin`. All requested paths are strictly resolved under `config.data_root` and rejected if they'd escape it (absolute paths, `..`, Windows drive prefixes). Only a small allowlist of text extensions (`.json`, `.csv`, `.txt`, `.log`, `.yaml`, `.yml`, `.md`) is previewable, capped at 200KB, and the endpoint is disabled (501) when `app_env == "aws"` since there is no local filesystem to browse there.
- Frontend: new `DataExplorer` page + `DataExplorerTree` component (lazily-expanding folder tree, click-to-preview file panel), wired into the existing route registry/tabs/mode system alongside `DataAdmin`/`DataQuality`, with nav labels added to all locales.

Closes #5579

## Test plan

- [x] `pytest tests/routes/test_data_explorer.py -q` — traversal rejection, directory listing, file preview/truncation/unsupported-type cases, AWS-mode 501
- [x] Full backend suite (`pytest tests/`) — no new failures (pre-existing network/mangum-only failures unrelated to this change)
- [x] `npx vitest run` (frontend) — all 648 tests pass, including new `DataExplorer.test.tsx`
- [x] `npx eslint` / `npx tsc --noEmit` — clean
- [x] `black`/`ruff`/`isort` on touched backend files — clean
- [x] `tests/test_log_sanitization_audit.py` — clean (new logger calls wrapped in `sanitise_log_value`)


---
_Generated by [Claude Code](https://claude.ai/code/session_016iEZeCe9RfdB67W2soDR8H)_