### PR TITLE
Fix require-issue-reference to exempt Dependabot PRs by author, not actor

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   require-issue-reference:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Validate pull request body includes issue reference


### PR DESCRIPTION
## What / Why

`.github/workflows/pr-lint.yml`'s `require-issue-reference` job is meant to skip Dependabot PRs, via `if: github.actor != 'dependabot[bot]'`. But `github.actor` is whoever triggered *this specific workflow run*, not the PR's author. For a `pull_request` `synchronize` event, that's whoever pushed the new commit — not necessarily Dependabot.

When anything else pushes to a Dependabot branch (a maintainer clicking "Update branch" in the UI, `gh pr update-branch` run by a human or a script — including `scripts/developer_tools/i_dependabot_auto_merge.py`'s `update-branch` `--behind-strategy`), the resulting `synchronize` event has `actor` set to that pusher. The `if` condition then evaluates to "run the check", and it fails because Dependabot's PR body never contains an issue reference like `Closes #123`.

Confirmed live on PR #5571 (`Update boto3 requirement from >=1.43.40 to >=1.43.57 in /backend`, opened by `dependabot[bot]`): the head commit `"Merge branch 'main' into dependabot/pip/backend/boto3-gte-1.43.56"` was authored by a human maintainer updating the branch. That push's `synchronize` event had `actor: leonarduk`, so `require-issue-reference` ran for real and failed with:

> Pull request body must include an issue reference such as Closes #123, Fixes #123, Resolves #123, Refs #123, or Relates to #123.

(job run: https://github.com/leonarduk/allotmint/actions/runs/30387611011/job/90370738406)

Closes #5589

## How I validated this

- [x] Relevant tests updated/added and passing — no test suite covers this workflow file; validated by parsing the YAML (`python3 -c "import yaml; yaml.safe_load(...)"` — valid) and confirming `github.event.pull_request.user.login` is a standard, documented GitHub Actions context field that stays constant across every event on a given PR, unlike `github.actor`.
- [x] Lint passing — the repo's own "Lint GitHub Actions workflows" CI job will validate this file on the PR.
- [ ] Manually verified the change — not re-run against a live Dependabot PR sync event in this session (would require pushing a commit to an existing Dependabot branch); root-caused and reasoned from the actual failing run's logs/actor field instead.
- [x] No prior-state/version claims made in this description beyond what's cited above (verified against current file content and the linked live failure, not assumed).

## Notes for reviewers

- One-line change: `github.actor != 'dependabot[bot]'` → `github.event.pull_request.user.login != 'dependabot[bot]'`.
- Doesn't touch the check's actual logic (the `grep` pattern and accepted keywords), so genuinely human-authored PRs without an issue reference still fail as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_014Fr3VE32zJjLDrvUY4QjaS)_