### PR TITLE
Add developer_tools script to commit local changes via local LLM and push

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -233,6 +233,45 @@ bash scripts/bash/publish-pr.sh -m "Fix bug in auth" --no-ollama
 - `gh` CLI must be installed and authenticated
 - Ollama is optional but recommended for better PR descriptions
 
+## j_commit_and_push.py
+
+Commit local changes and push to `origin`, using a local Ollama model to draft
+the commit message from the diff. This is a lighter-weight alternative to
+`publish_pr.py` for when you just want to commit and push -- e.g. an
+incremental push onto a branch that already has an open PR -- without also
+creating/updating a PR.
+
+```bash
+python scripts/developer_tools/j_commit_and_push.py
+```
+
+The script:
+1. Stages changed files (all changes by default, or specific files via `--files`)
+2. If Ollama is running locally, asks it to draft a commit message from the staged diff
+3. If Ollama is unavailable or `--no-ollama` is passed, falls back to a plain default message
+4. Appends a `Refs #<issue-id>` trailer with the issue ID extracted from the branch name (e.g. `fix/issue-4445-slug` -> `4445`), if one isn't already present in the message
+5. Commits, then pushes the branch to `origin` (skip with `--no-push`)
+
+Optional flags:
+- `-m/--message TEXT`: Commit message override (skips Ollama generation)
+- `-f/--files FILE [FILE ...]`: Specific files to stage (default: all changed files)
+- `--no-ollama`: Skip Ollama and use a plain default commit message
+- `--model MODEL`: Ollama model name (default: env var `OLLAMA_MODEL` or `qwen2.5-coder:14b`)
+- `--no-push`: Commit only; skip pushing to `origin`
+
+On Windows, use the PowerShell wrapper:
+```powershell
+./scripts/developer_tools/j_commit_and_push.ps1 -Message "Fix bug in auth" -NoOllama
+```
+
+Or on Linux/Mac:
+```bash
+bash scripts/bash/commit-and-push.sh -m "Fix bug in auth" --no-ollama
+```
+
+**Requirements:**
+- Ollama is optional but recommended for better commit messages; without it (or with `--no-ollama`), a plain default message is used
+
 ## i_dependabot_auto_merge.py
 
 Auto-merge open Dependabot pull requests once their checks have all passed, then

--- a/scripts/bash/commit-and-push.sh
+++ b/scripts/bash/commit-and-push.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Commit local changes (with an Ollama-drafted message) and push to origin.
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 if [ -z "$REPO_ROOT" ]; then
     echo "Error: not in a git repository" >&2
     exit 1

--- a/scripts/bash/commit-and-push.sh
+++ b/scripts/bash/commit-and-push.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Commit local changes (with an Ollama-drafted message) and push to origin.
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+if [ -z "$REPO_ROOT" ]; then
+    echo "Error: not in a git repository" >&2
+    exit 1
+fi
+
+# Pass all arguments to the Python script
+python "$REPO_ROOT/scripts/developer_tools/j_commit_and_push.py" "$@"
+exit $?

--- a/scripts/developer_tools/j_commit_and_push.ps1
+++ b/scripts/developer_tools/j_commit_and_push.ps1
@@ -1,0 +1,45 @@
+param(
+    [string]$Message = $null,
+    [string[]]$Files = $null,
+    [switch]$NoOllama = $false,
+    [string]$Model = $null,
+    [switch]$NoPush = $false
+)
+
+# Ensure we're in the repo root
+$repoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) {
+    Write-Error "Not in a git repository"
+    exit 1
+}
+
+# Build arguments for the Python script
+$pythonArgs = @()
+
+if ($Message) {
+    $pythonArgs += "--message", $Message
+}
+
+if ($Files -and $Files.Count -gt 0) {
+    $pythonArgs += "--files"
+    $pythonArgs += $Files
+}
+
+if ($NoOllama) {
+    $pythonArgs += "--no-ollama"
+}
+
+if ($Model) {
+    $pythonArgs += "--model", $Model
+}
+
+if ($NoPush) {
+    $pythonArgs += "--no-push"
+}
+
+# Run the Python script
+# Nest Join-Path calls so this also works on Windows PowerShell 5.1, whose
+# Join-Path lacks the -AdditionalChildPath parameter (PowerShell 6+ only).
+$scriptPath = Join-Path (Join-Path $repoRoot "scripts") (Join-Path "developer_tools" "j_commit_and_push.py")
+python $scriptPath @pythonArgs
+exit $LASTEXITCODE

--- a/scripts/developer_tools/j_commit_and_push.py
+++ b/scripts/developer_tools/j_commit_and_push.py
@@ -1,0 +1,198 @@
+"""CLI tool to commit local changes and push, using a local LLM for the commit message.
+
+Stages local changes, asks a local Ollama model to draft a commit message
+from the diff (falling back to a plain default message when Ollama is
+unavailable or `--no-ollama` is passed), makes sure the message references
+the issue ID found in the current branch name, commits, and pushes the
+branch to `origin`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+from ollama_common import (  # noqa: E402
+    fetch_ollama_review,
+    get_ollama_endpoint,
+    get_ollama_model,
+    validate_ollama_connection,
+)
+from publish_pr import extract_issue_id, get_current_branch, push_to_remote  # noqa: E402
+
+
+def get_git_root() -> str:
+    """Get the root directory of the git repository."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: Not a git repository or git command failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+def stage_changes(files: Optional[list[str]]) -> None:
+    """Stage the given files, or all changes (tracked and untracked) if none given."""
+    if files:
+        for f in files:
+            subprocess.run(["git", "add", f], check=True)
+    else:
+        subprocess.run(["git", "add", "-A"], check=True)
+
+
+def has_staged_changes() -> bool:
+    """Return True if there are staged changes ready to commit."""
+    result = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
+    return result.returncode != 0
+
+
+def get_staged_diff() -> str:
+    """Return the diff of staged changes."""
+    result = subprocess.run(
+        ["git", "diff", "--cached"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def build_commit_prompt(diff: str, issue_id: Optional[int]) -> str:
+    """Build the Ollama prompt used to draft a commit message from a diff."""
+    issue_line = (
+        f"Reference issue #{issue_id} in the message (e.g. a trailing 'Refs #{issue_id}' line)."
+        if issue_id
+        else "No issue is linked to this branch; do not invent an issue reference."
+    )
+    return f"""Write a git commit message for the following diff.
+
+Rules:
+- Subject line under 72 characters, imperative mood (e.g. "Fix", "Add", "Update").
+- Optionally follow with a blank line and a short body explaining why, if useful.
+- {issue_line}
+- Output only the commit message, no preamble or code fences.
+
+Diff:
+{diff}
+"""
+
+
+def generate_commit_message(diff: str, issue_id: Optional[int], model: str, endpoint: str) -> Optional[str]:
+    """Ask Ollama to draft a commit message. Returns None on failure or empty diff."""
+    if not diff.strip():
+        return None
+    prompt = build_commit_prompt(diff, issue_id)
+    try:
+        message = fetch_ollama_review(endpoint, model, prompt)
+    except SystemExit:
+        return None
+    return message.strip() or None
+
+
+def ensure_issue_reference(message: str, issue_id: Optional[int]) -> str:
+    """Append a 'Refs #<issue_id>' trailer if the message doesn't already mention it."""
+    if issue_id is None:
+        return message
+    marker = f"#{issue_id}"
+    if marker in message:
+        return message
+    return f"{message}\n\nRefs {marker}"
+
+
+def commit_changes(message: str) -> bool:
+    """Commit staged changes with the given message."""
+    try:
+        subprocess.run(["git", "commit", "-m", message], check=True)
+        return True
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: Failed to commit: {exc}", file=sys.stderr)
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Commit local changes (with an Ollama-drafted message) and push to origin"
+    )
+    parser.add_argument(
+        "--message",
+        "-m",
+        default=None,
+        help="Commit message override (skips Ollama generation)",
+    )
+    parser.add_argument(
+        "--files",
+        "-f",
+        nargs="+",
+        default=None,
+        help="Specific files to stage (default: all changed files)",
+    )
+    parser.add_argument(
+        "--no-ollama",
+        action="store_true",
+        help="Skip Ollama and use a plain default commit message",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Ollama model name (default: OLLAMA_MODEL env var or 'qwen2.5-coder:14b')",
+    )
+    parser.add_argument(
+        "--no-push",
+        action="store_true",
+        help="Commit only; skip pushing the branch to origin",
+    )
+    args = parser.parse_args()
+
+    os.chdir(get_git_root())
+
+    branch = get_current_branch()
+    issue_id = extract_issue_id(branch)
+
+    stage_changes(args.files)
+
+    if not has_staged_changes():
+        print("No staged changes to commit.", file=sys.stderr)
+        return 0
+
+    message = args.message
+    if not message and not args.no_ollama:
+        endpoint = get_ollama_endpoint()
+        if validate_ollama_connection(endpoint):
+            model = args.model or get_ollama_model()
+            print(f"INFO: Generating commit message with Ollama model '{model}'...", file=sys.stderr)
+            diff = get_staged_diff()
+            message = generate_commit_message(diff, issue_id, model, endpoint)
+        else:
+            print(f"WARNING: Ollama not reachable at {endpoint}. Using a default message.", file=sys.stderr)
+
+    if not message:
+        message = f"Work on issue #{issue_id}" if issue_id else "Commit local changes"
+
+    message = ensure_issue_reference(message, issue_id)
+
+    if not commit_changes(message):
+        return 1
+    print(f"Committed: {message.splitlines()[0]}")
+
+    if args.no_push:
+        return 0
+
+    if not push_to_remote(branch):
+        return 1
+    print(f"Pushed branch '{branch}' to origin.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/developer_tools/j_commit_and_push.py
+++ b/scripts/developer_tools/j_commit_and_push.py
@@ -44,17 +44,27 @@ def get_git_root() -> str:
 
 def stage_changes(files: Optional[list[str]]) -> None:
     """Stage the given files, or all changes (tracked and untracked) if none given."""
-    if files:
-        for f in files:
-            subprocess.run(["git", "add", f], check=True)
-    else:
-        subprocess.run(["git", "add", "-A"], check=True)
+    try:
+        if files:
+            subprocess.run(["git", "add", "--", *files], check=True)
+        else:
+            subprocess.run(["git", "add", "-A"], check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: Failed to stage changes: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
 
 
 def has_staged_changes() -> bool:
-    """Return True if there are staged changes ready to commit."""
+    """Return True if there are staged changes ready to commit.
+
+    `git diff --cached --quiet` exits 0 (no diff) or 1 (has diff); any other
+    code means the command itself failed and must not be read as "changes".
+    """
     result = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
-    return result.returncode != 0
+    if result.returncode not in (0, 1):
+        print(f"ERROR: 'git diff --cached --quiet' failed with exit code {result.returncode}", file=sys.stderr)
+        raise SystemExit(1)
+    return result.returncode == 1
 
 
 def get_staged_diff() -> str:
@@ -68,6 +78,9 @@ def get_staged_diff() -> str:
     return result.stdout
 
 
+MAX_DIFF_CHARS = 20_000
+
+
 def build_commit_prompt(diff: str, issue_id: Optional[int]) -> str:
     """Build the Ollama prompt used to draft a commit message from a diff."""
     issue_line = (
@@ -75,6 +88,8 @@ def build_commit_prompt(diff: str, issue_id: Optional[int]) -> str:
         if issue_id
         else "No issue is linked to this branch; do not invent an issue reference."
     )
+    if len(diff) > MAX_DIFF_CHARS:
+        diff = diff[:MAX_DIFF_CHARS] + "\n... (diff truncated)"
     return f"""Write a git commit message for the following diff.
 
 Rules:
@@ -120,7 +135,8 @@ def commit_changes(message: str) -> bool:
         return False
 
 
-def main() -> int:
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(
         description="Commit local changes (with an Ollama-drafted message) and push to origin"
     )
@@ -152,7 +168,11 @@ def main() -> int:
         action="store_true",
         help="Commit only; skip pushing the branch to origin",
     )
-    args = parser.parse_args()
+    return parser
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
 
     os.chdir(get_git_root())
 

--- a/tests/test_commit_and_push.py
+++ b/tests/test_commit_and_push.py
@@ -1,0 +1,255 @@
+"""Unit tests for j_commit_and_push script."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools" / "lib"))
+
+from j_commit_and_push import (  # noqa: E402
+    build_commit_prompt,
+    commit_changes,
+    ensure_issue_reference,
+    generate_commit_message,
+    get_git_root,
+    get_staged_diff,
+    has_staged_changes,
+    main,
+    stage_changes,
+)
+
+
+class TestGetGitRoot:
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_successful_fetch(self, mock_run):
+        mock_result = mock.MagicMock()
+        mock_result.stdout = "/path/to/repo\n"
+        mock_run.return_value = mock_result
+
+        assert get_git_root() == "/path/to/repo"
+
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_not_a_git_repo(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(128, "git")
+
+        with pytest.raises(SystemExit) as exc_info:
+            get_git_root()
+        assert exc_info.value.code == 1
+
+
+class TestStageChanges:
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_stages_specific_files(self, mock_run):
+        stage_changes(["a.py", "b.py"])
+
+        calls = [c.args[0] for c in mock_run.call_args_list]
+        assert calls == [["git", "add", "a.py"], ["git", "add", "b.py"]]
+
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_stages_all_when_no_files_given(self, mock_run):
+        stage_changes(None)
+
+        mock_run.assert_called_once_with(["git", "add", "-A"], check=True)
+
+
+class TestHasStagedChanges:
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_true_when_diff_nonzero_exit(self, mock_run):
+        mock_run.return_value = mock.MagicMock(returncode=1)
+        assert has_staged_changes() is True
+
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_false_when_no_diff(self, mock_run):
+        mock_run.return_value = mock.MagicMock(returncode=0)
+        assert has_staged_changes() is False
+
+
+class TestGetStagedDiff:
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_returns_diff_output(self, mock_run):
+        mock_run.return_value = mock.MagicMock(stdout="diff --git a/x b/x\n")
+        assert get_staged_diff() == "diff --git a/x b/x\n"
+
+
+class TestBuildCommitPrompt:
+    def test_includes_issue_reference_when_present(self):
+        prompt = build_commit_prompt("diff --git a/x b/x", 4445)
+        assert "#4445" in prompt
+        assert "diff --git a/x b/x" in prompt
+
+    def test_no_issue_reference_when_absent(self):
+        prompt = build_commit_prompt("diff --git a/x b/x", None)
+        assert "No issue is linked" in prompt
+
+
+class TestGenerateCommitMessage:
+    def test_empty_diff_returns_none(self):
+        assert generate_commit_message("", 4445, "model", "http://localhost:11434") is None
+
+    @mock.patch("j_commit_and_push.fetch_ollama_review")
+    def test_returns_stripped_message(self, mock_fetch):
+        mock_fetch.return_value = "  Fix the thing  \n"
+        result = generate_commit_message("diff", 4445, "model", "http://localhost:11434")
+        assert result == "Fix the thing"
+
+    @mock.patch("j_commit_and_push.fetch_ollama_review")
+    def test_ollama_failure_returns_none(self, mock_fetch):
+        mock_fetch.side_effect = SystemExit(1)
+        assert generate_commit_message("diff", 4445, "model", "http://localhost:11434") is None
+
+
+class TestEnsureIssueReference:
+    def test_appends_ref_when_missing(self):
+        result = ensure_issue_reference("Fix the thing", 4445)
+        assert result == "Fix the thing\n\nRefs #4445"
+
+    def test_no_change_when_already_present(self):
+        message = "Fix the thing\n\nRefs #4445"
+        assert ensure_issue_reference(message, 4445) == message
+
+    def test_no_change_when_no_issue_id(self):
+        assert ensure_issue_reference("Fix the thing", None) == "Fix the thing"
+
+
+class TestCommitChanges:
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_success(self, mock_run):
+        mock_run.return_value = mock.MagicMock()
+        assert commit_changes("Fix the thing") is True
+
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_failure(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+        assert commit_changes("Fix the thing") is False
+
+
+class TestMain:
+    @mock.patch("j_commit_and_push.push_to_remote")
+    @mock.patch("j_commit_and_push.commit_changes")
+    @mock.patch("j_commit_and_push.has_staged_changes")
+    @mock.patch("j_commit_and_push.stage_changes")
+    @mock.patch("j_commit_and_push.extract_issue_id")
+    @mock.patch("j_commit_and_push.get_current_branch")
+    @mock.patch("j_commit_and_push.get_git_root")
+    def test_no_changes_to_commit(
+        self,
+        mock_root,
+        mock_branch,
+        mock_extract,
+        mock_stage,
+        mock_has_staged,
+        mock_commit,
+        mock_push,
+    ):
+        mock_root.return_value = "/repo"
+        mock_branch.return_value = "fix/issue-4445-thing"
+        mock_extract.return_value = 4445
+        mock_has_staged.return_value = False
+
+        with mock.patch("sys.argv", ["j_commit_and_push.py"]), mock.patch("j_commit_and_push.os.chdir"):
+            result = main()
+
+        assert result == 0
+        mock_commit.assert_not_called()
+        mock_push.assert_not_called()
+
+    @mock.patch("j_commit_and_push.push_to_remote")
+    @mock.patch("j_commit_and_push.commit_changes")
+    @mock.patch("j_commit_and_push.has_staged_changes")
+    @mock.patch("j_commit_and_push.stage_changes")
+    @mock.patch("j_commit_and_push.extract_issue_id")
+    @mock.patch("j_commit_and_push.get_current_branch")
+    @mock.patch("j_commit_and_push.get_git_root")
+    def test_commits_and_pushes_with_explicit_message(
+        self,
+        mock_root,
+        mock_branch,
+        mock_extract,
+        mock_stage,
+        mock_has_staged,
+        mock_commit,
+        mock_push,
+    ):
+        mock_root.return_value = "/repo"
+        mock_branch.return_value = "fix/issue-4445-thing"
+        mock_extract.return_value = 4445
+        mock_has_staged.return_value = True
+        mock_commit.return_value = True
+        mock_push.return_value = True
+
+        argv = ["j_commit_and_push.py", "--message", "Fix the thing", "--no-ollama"]
+        with mock.patch("sys.argv", argv), mock.patch("j_commit_and_push.os.chdir"):
+            result = main()
+
+        assert result == 0
+        mock_commit.assert_called_once()
+        committed_message = mock_commit.call_args.args[0]
+        assert "Fix the thing" in committed_message
+        assert "#4445" in committed_message
+        mock_push.assert_called_once_with("fix/issue-4445-thing")
+
+    @mock.patch("j_commit_and_push.push_to_remote")
+    @mock.patch("j_commit_and_push.commit_changes")
+    @mock.patch("j_commit_and_push.has_staged_changes")
+    @mock.patch("j_commit_and_push.stage_changes")
+    @mock.patch("j_commit_and_push.extract_issue_id")
+    @mock.patch("j_commit_and_push.get_current_branch")
+    @mock.patch("j_commit_and_push.get_git_root")
+    def test_no_push_flag_skips_push(
+        self,
+        mock_root,
+        mock_branch,
+        mock_extract,
+        mock_stage,
+        mock_has_staged,
+        mock_commit,
+        mock_push,
+    ):
+        mock_root.return_value = "/repo"
+        mock_branch.return_value = "chore/misc"
+        mock_extract.return_value = None
+        mock_has_staged.return_value = True
+        mock_commit.return_value = True
+
+        argv = ["j_commit_and_push.py", "--message", "Tidy up", "--no-ollama", "--no-push"]
+        with mock.patch("sys.argv", argv), mock.patch("j_commit_and_push.os.chdir"):
+            result = main()
+
+        assert result == 0
+        mock_push.assert_not_called()
+
+    @mock.patch("j_commit_and_push.push_to_remote")
+    @mock.patch("j_commit_and_push.commit_changes")
+    @mock.patch("j_commit_and_push.has_staged_changes")
+    @mock.patch("j_commit_and_push.stage_changes")
+    @mock.patch("j_commit_and_push.extract_issue_id")
+    @mock.patch("j_commit_and_push.get_current_branch")
+    @mock.patch("j_commit_and_push.get_git_root")
+    def test_commit_failure_exits_nonzero(
+        self,
+        mock_root,
+        mock_branch,
+        mock_extract,
+        mock_stage,
+        mock_has_staged,
+        mock_commit,
+        mock_push,
+    ):
+        mock_root.return_value = "/repo"
+        mock_branch.return_value = "chore/misc"
+        mock_extract.return_value = None
+        mock_has_staged.return_value = True
+        mock_commit.return_value = False
+
+        argv = ["j_commit_and_push.py", "--message", "Tidy up", "--no-ollama"]
+        with mock.patch("sys.argv", argv), mock.patch("j_commit_and_push.os.chdir"):
+            result = main()
+
+        assert result == 1
+        mock_push.assert_not_called()

--- a/tests/test_commit_and_push.py
+++ b/tests/test_commit_and_push.py
@@ -48,8 +48,7 @@ class TestStageChanges:
     def test_stages_specific_files(self, mock_run):
         stage_changes(["a.py", "b.py"])
 
-        calls = [c.args[0] for c in mock_run.call_args_list]
-        assert calls == [["git", "add", "a.py"], ["git", "add", "b.py"]]
+        mock_run.assert_called_once_with(["git", "add", "--", "a.py", "b.py"], check=True)
 
     @mock.patch("j_commit_and_push.subprocess.run")
     def test_stages_all_when_no_files_given(self, mock_run):
@@ -57,10 +56,18 @@ class TestStageChanges:
 
         mock_run.assert_called_once_with(["git", "add", "-A"], check=True)
 
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_failure_exits_cleanly(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+
+        with pytest.raises(SystemExit) as exc_info:
+            stage_changes(["missing.py"])
+        assert exc_info.value.code == 1
+
 
 class TestHasStagedChanges:
     @mock.patch("j_commit_and_push.subprocess.run")
-    def test_true_when_diff_nonzero_exit(self, mock_run):
+    def test_true_when_diff_exit_code_one(self, mock_run):
         mock_run.return_value = mock.MagicMock(returncode=1)
         assert has_staged_changes() is True
 
@@ -68,6 +75,14 @@ class TestHasStagedChanges:
     def test_false_when_no_diff(self, mock_run):
         mock_run.return_value = mock.MagicMock(returncode=0)
         assert has_staged_changes() is False
+
+    @mock.patch("j_commit_and_push.subprocess.run")
+    def test_git_error_raises_instead_of_reporting_changes(self, mock_run):
+        mock_run.return_value = mock.MagicMock(returncode=128)
+
+        with pytest.raises(SystemExit) as exc_info:
+            has_staged_changes()
+        assert exc_info.value.code == 1
 
 
 class TestGetStagedDiff:
@@ -201,6 +216,45 @@ class TestMain:
     @mock.patch("j_commit_and_push.extract_issue_id")
     @mock.patch("j_commit_and_push.get_current_branch")
     @mock.patch("j_commit_and_push.get_git_root")
+    def test_forwards_selected_files_to_staging(
+        self,
+        mock_root,
+        mock_branch,
+        mock_extract,
+        mock_stage,
+        mock_has_staged,
+        mock_commit,
+        mock_push,
+    ):
+        mock_root.return_value = "/repo"
+        mock_branch.return_value = "fix/issue-4445-thing"
+        mock_extract.return_value = 4445
+        mock_has_staged.return_value = True
+        mock_commit.return_value = True
+        mock_push.return_value = True
+
+        argv = [
+            "j_commit_and_push.py",
+            "--message",
+            "Fix the thing",
+            "--no-ollama",
+            "--files",
+            "a.py",
+            "b.py",
+        ]
+        with mock.patch("sys.argv", argv), mock.patch("j_commit_and_push.os.chdir"):
+            result = main()
+
+        assert result == 0
+        mock_stage.assert_called_once_with(["a.py", "b.py"])
+
+    @mock.patch("j_commit_and_push.push_to_remote")
+    @mock.patch("j_commit_and_push.commit_changes")
+    @mock.patch("j_commit_and_push.has_staged_changes")
+    @mock.patch("j_commit_and_push.stage_changes")
+    @mock.patch("j_commit_and_push.extract_issue_id")
+    @mock.patch("j_commit_and_push.get_current_branch")
+    @mock.patch("j_commit_and_push.get_git_root")
     def test_no_push_flag_skips_push(
         self,
         mock_root,
@@ -253,3 +307,34 @@ class TestMain:
 
         assert result == 1
         mock_push.assert_not_called()
+
+    @mock.patch("j_commit_and_push.push_to_remote")
+    @mock.patch("j_commit_and_push.commit_changes")
+    @mock.patch("j_commit_and_push.has_staged_changes")
+    @mock.patch("j_commit_and_push.stage_changes")
+    @mock.patch("j_commit_and_push.extract_issue_id")
+    @mock.patch("j_commit_and_push.get_current_branch")
+    @mock.patch("j_commit_and_push.get_git_root")
+    def test_push_failure_exits_nonzero(
+        self,
+        mock_root,
+        mock_branch,
+        mock_extract,
+        mock_stage,
+        mock_has_staged,
+        mock_commit,
+        mock_push,
+    ):
+        mock_root.return_value = "/repo"
+        mock_branch.return_value = "chore/misc"
+        mock_extract.return_value = None
+        mock_has_staged.return_value = True
+        mock_commit.return_value = True
+        mock_push.return_value = False
+
+        argv = ["j_commit_and_push.py", "--message", "Tidy up", "--no-ollama"]
+        with mock.patch("sys.argv", argv), mock.patch("j_commit_and_push.os.chdir"):
+            result = main()
+
+        assert result == 1
+        mock_push.assert_called_once_with("chore/misc")


### PR DESCRIPTION
## What

Adds `scripts/developer_tools/j_commit_and_push.py`, a standalone CLI script that:
1. Stages local changes (all changes by default, or specific files via `--files`)
2. Uses a local Ollama model to draft a commit message from the staged diff (falling back to a plain default message if Ollama is unreachable or `--no-ollama` is passed)
3. Appends a `Refs #<issue-id>` trailer, with the issue ID parsed from the current branch name, if it's not already present in the message
4. Commits, then pushes the branch to `origin` (skippable with `--no-push`)

Also adds:
- `scripts/developer_tools/j_commit_and_push.ps1` — PowerShell wrapper
- `scripts/bash/commit-and-push.sh` — bash wrapper
- `tests/test_commit_and_push.py` — unit tests
- A `scripts/README.md` section documenting the new script

## Why

This is a lighter-weight alternative to `publish_pr.py` for when a PR already exists (or isn't wanted yet) and you just need to commit and push -- e.g. an incremental WIP push onto an already-open PR branch -- without going through the full PR-creation flow.

Closes #5597

## How

- Reuses `extract_issue_id`, `get_current_branch`, and `push_to_remote` from `scripts/developer_tools/lib/publish_pr.py` instead of duplicating that logic.
- Reuses `get_ollama_endpoint`, `get_ollama_model`, `validate_ollama_connection`, and `fetch_ollama_review` from `scripts/developer_tools/lib/ollama_common.py`.
- CLI flags mirror `publish_pr.py`'s existing conventions (`-m/--message`, `-f/--files`, `--no-ollama`, `--model`) plus a new `--no-push` for commit-only runs.

## Constraints respected

- Does not modify `publish_pr.py`'s PR-creation behavior.
- Fails with a clear error and non-zero exit code on `git commit`/`git push` failure rather than swallowing errors.
- Exits early (code 0, no push) when there's nothing staged to commit.
- Uses the existing `OLLAMA_ENDPOINT`/`OLLAMA_MODEL` env var conventions rather than inventing new ones.

## Test plan

- [x] `ruff check --config backend/pyproject.toml scripts/developer_tools/j_commit_and_push.py tests/test_commit_and_push.py` — passes
- [x] `black --check --config backend/pyproject.toml scripts/developer_tools/j_commit_and_push.py tests/test_commit_and_push.py` — passes
- [x] `pytest tests/test_commit_and_push.py` — 21 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01A9CKkj78Z38zcEMMPzd5hb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cross-platform tool for staging, committing and optionally pushing local changes.
  * Supports custom commit messages, selected files, optional local AI-generated messages and push controls.
  * Automatically adds issue references to commit messages when available.
  * Added Bash and PowerShell launchers.

* **Documentation**
  * Documented usage, command-line options, platform wrappers and local AI requirements.

* **Tests**
  * Added comprehensive coverage for repository detection, staging, message generation, commits and pushing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->