### PR TITLE
Fix: include config file extensions in AI PR review diff filter

### DIFF
--- a/.github/scripts/prepare_review_diff.py
+++ b/.github/scripts/prepare_review_diff.py
@@ -8,7 +8,7 @@ import sys
 
 from review_common import MAX_DIFF_CHARS, format_truncation_log, prioritize_diff_blocks, truncate_diff
 
-DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml", "Makefile", "*.mk", "*.sh", "*.ps1", "*.txt", "*.html", "*CODEOWNERS*", ]
+DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml", "Makefile", "*.mk", "*.sh", "*.ps1", "*.txt", "*.html", "*.ini", "*.cfg", "*.toml", "*CODEOWNERS*", ]
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -464,6 +464,36 @@ def test_default_globs_include_codeowners_file(
     assert ".github/CODEOWNERS" in diff
 
 
+def test_default_globs_include_config_file_extensions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_script_module("prepare_review_diff_config_globs", "prepare_review_diff.py")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git(["init", "-b", "main"], repo)
+    _run_git(["config", "user.email", "test@example.com"], repo)
+    _run_git(["config", "user.name", "Test"], repo)
+
+    (repo / "README.md").write_text("hello\n")
+    _run_git(["add", "README.md"], repo)
+    _run_git(["commit", "-m", "init"], repo)
+    _run_git(["update-ref", "refs/remotes/origin/main", "HEAD"], repo)
+
+    (repo / "pytest.ini").write_text("[pytest]\ntestpaths = tests\n")
+    (repo / "mypy.cfg").write_text("[mypy]\nstrict = True\n")
+    (repo / "pyproject.toml").write_text("[tool.black]\nline-length = 100\n")
+    _run_git(["add", "pytest.ini", "mypy.cfg", "pyproject.toml"], repo)
+    _run_git(["commit", "-m", "add config files"], repo)
+
+    monkeypatch.chdir(repo)
+    diff = module.git_diff("main", module.DEFAULT_GLOBS)
+
+    assert "pytest.ini" in diff
+    assert "mypy.cfg" in diff
+    assert "pyproject.toml" in diff
+
+
 def _comment(
     login: str, body: str, created_at: str, user_type: str = "User", path: str | None = None
 ) -> dict:


### PR DESCRIPTION
## Summary
- `prepare_review_diff.py` filtered PR diffs to a fixed `DEFAULT_GLOBS` allowlist that omitted `*.ini`, `*.cfg`, and `*.toml`.
- A config-only PR (e.g. touching only `pytest.ini`) produced an empty filtered diff, so DeepSeek/GPT/Claude review was silently skipped in favor of a "filtered diff was empty" advisory comment instead of a real review.
- This is exactly how PR #5554 dropped the `--cov-fail-under=90` coverage gate without any AI review catching it.
- Added `*.ini`, `*.cfg`, `*.toml` to `DEFAULT_GLOBS`.

## Test plan
- [x] Added `test_default_globs_include_config_file_extensions` mirroring the existing CODEOWNERS coverage test
- [x] `pytest tests/test_ai_review_scripts.py` -- 45 passed
- [x] `ruff check --config backend/pyproject.toml tests/test_ai_review_scripts.py` -- clean
- [x] `black --check --config backend/pyproject.toml tests/test_ai_review_scripts.py` -- clean (pre-existing unrelated formatting drift left untouched)

Closes #5592

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files with `.ini`, `.cfg`, and `.toml` extensions are now included in default review diff filtering.

* **Tests**
  * Added coverage to verify that common configuration files are correctly included in filtered diffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->