### PR TITLE
Fix Settings owner dropdown not reflecting the active owner

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -734,7 +734,7 @@ export default function App({ onLogout }: AppProps) {
         {mode === 'alerts' && <Alerts />}
         {mode === 'taxtools' && <TaxTools />}
         {mode === 'support' && <Support />}
-        {mode === 'settings' && <UserConfigPage />}
+        {mode === 'settings' && <UserConfigPage selectedOwner={selectedOwner} />}
         {mode === 'scenario' && <ScenarioTester />}
         {mode === 'research' && (
           <Suspense fallback={<ChartSkeleton height={400} label={t('app.loading')} />}>

--- a/frontend/src/pages/UserConfig.tsx
+++ b/frontend/src/pages/UserConfig.tsx
@@ -30,7 +30,11 @@ function approvalsErrorMessage(err: unknown, fallback: string): string {
   return fallback;
 }
 
-export default function UserConfigPage() {
+type UserConfigPageProps = {
+  selectedOwner?: string;
+};
+
+export default function UserConfigPage({ selectedOwner = '' }: UserConfigPageProps) {
   const { t } = useTranslation();
   const { user } = useAuth();
   const { theme } = useConfig();
@@ -58,8 +62,14 @@ export default function UserConfigPage() {
 
   useEffect(() => {
     if (!owners.length) return;
-    setOwner((current) => current || findOwnerForUser(owners, user)?.owner || '');
-  }, [owners, user]);
+    setOwner((current) => {
+      if (current) return current;
+      if (selectedOwner && owners.some((o) => o.owner === selectedOwner)) {
+        return selectedOwner;
+      }
+      return findOwnerForUser(owners, user)?.owner || '';
+    });
+  }, [owners, user, selectedOwner]);
 
   useEffect(() => {
     if (owner) {

--- a/frontend/tests/unit/pages/UserConfig.test.tsx
+++ b/frontend/tests/unit/pages/UserConfig.test.tsx
@@ -85,6 +85,54 @@ describe("UserConfig page", () => {
     expect(mockGetUserConfig).not.toHaveBeenCalledWith("alex");
   });
 
+  it("defaults the owner dropdown to the app-wide active owner (#5553)", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alex", accounts: [], email: "alex@example.com" },
+      { owner: "jamie", accounts: [], email: "jamie@example.com" },
+    ]);
+    mockGetUserConfig.mockResolvedValue({});
+    mockGetApprovals.mockResolvedValue({ approvals: [] });
+
+    render(
+      <AuthContext.Provider
+        value={{ user: { email: "jamie@example.com" }, setUser: vi.fn() }}
+      >
+        <UserConfig selectedOwner="alex" />
+      </AuthContext.Provider>,
+    );
+
+    const select = await screen.findByRole("combobox");
+    await screen.findByDisplayValue("alex");
+    expect((select as HTMLSelectElement).value).toBe("alex");
+    // The globally active owner (e.g. shown in the top nav) must win over the
+    // logged-in user's mapped owner so Settings reflects what the rest of the
+    // app is already showing, instead of silently switching to a different
+    // account.
+    await waitFor(() => expect(mockGetUserConfig).toHaveBeenCalledWith("alex"));
+    expect(mockGetUserConfig).not.toHaveBeenCalledWith("jamie");
+  });
+
+  it("falls back to the logged-in user's owner when the active owner isn't in the authorized list (#5553)", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alex", accounts: [], email: "alex@example.com" },
+      { owner: "jamie", accounts: [], email: "jamie@example.com" },
+    ]);
+    mockGetUserConfig.mockResolvedValue({});
+    mockGetApprovals.mockResolvedValue({ approvals: [] });
+
+    render(
+      <AuthContext.Provider
+        value={{ user: { email: "jamie@example.com" }, setUser: vi.fn() }}
+      >
+        <UserConfig selectedOwner="not-a-real-owner" />
+      </AuthContext.Provider>,
+    );
+
+    const select = await screen.findByRole("combobox");
+    await screen.findByDisplayValue("jamie");
+    expect((select as HTMLSelectElement).value).toBe("jamie");
+  });
+
   it("leaves the owner dropdown unselected when there is no logged-in user", async () => {
     mockGetOwners.mockResolvedValue([
       { owner: "alex", accounts: [], email: "alex@example.com" },


### PR DESCRIPTION
﻿## Summary
- The "Select owner" dropdown on the User Settings page (`/settings`) computed its own owner selection purely from `findOwnerForUser(owners, user)`, ignoring the app-wide active owner (`selectedOwner` in `App.tsx`) that drives the top-nav `OwnerSelector`. If the active owner didn't match the logged-in user's own mapped owner, the dropdown showed the empty "Select owner" placeholder instead of the actual active owner.
- `UserConfigPage` now accepts a `selectedOwner` prop and prefers it (when it's a valid, authorized owner) over the user-identity match, falling back to the previous behavior otherwise.

## Test plan
- [x] `npx vitest run tests/unit/pages/UserConfig.test.tsx` - all 10 tests pass, including 2 new tests for this fix
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/pages/UserConfig.tsx src/App.tsx tests/unit/pages/UserConfig.test.tsx`

Closes #5553

Generated with Claude Code