### PR TITLE
Add cross-OS package-lock.json platform coverage check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - run: python scripts/check_branch_protection_required_checks.py
       - name: Run extract_verdict tests
         run: pytest tests/test_extract_verdict.py -v --no-cov
+      - name: Check package-lock.json cross-OS platform coverage
+        run: python scripts/check_lockfile_platform_coverage.py
       - uses: actions/setup-node@v7
         with:
           node-version: '24'

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -176,6 +176,11 @@ incorrect `peer: true` annotations, which then makes Linux CI fail with
 `EUSAGE` even though the change looks unrelated. Before committing any
 `frontend/package-lock.json` diff, review it for removed `@emnapi/*` or other
 `optionalDependencies`/`peer` entries and restore them if present.
+CI runs `python scripts/check_lockfile_platform_coverage.py` (see the `test`
+job in `.github/workflows/ci.yml`) to catch a lockfile that lost coverage for
+`linux`, `win32`, or `darwin` before it reaches a Linux `npm ci` step; run it
+locally after regenerating either `package-lock.json` or
+`frontend/package-lock.json` to check the same thing before pushing.
 
 ## Automated code reviews
 

--- a/scripts/check_lockfile_platform_coverage.py
+++ b/scripts/check_lockfile_platform_coverage.py
@@ -1,0 +1,91 @@
+"""Check that npm lockfiles retain optional dependencies for every OS platform.
+
+Usage::
+
+    python scripts/check_lockfile_platform_coverage.py
+
+Exits 0 on success, 1 if a lockfile is missing optional-dependency entries for
+one of the required platforms.
+
+Background: several npm dependencies (esbuild, @emnapi/*, etc.) ship
+platform-specific optional packages tagged with an "os" field in
+package-lock.json (e.g. "linux", "win32", "darwin"). GitHub Actions installs
+these lockfiles with `npm ci` on ubuntu-latest (see
+.github/actions/setup-frontend-deps/action.yml), so the "linux" entries must
+always be present. Regenerating a lockfile with `npm install` on Windows can
+silently prune optional entries for platforms other than the one npm ran on,
+which then breaks `npm ci` in CI. This script fails fast, in CI or locally,
+before that broken lockfile reaches Linux CI.
+
+This script intentionally uses only the Python standard library so it can run
+in CI before any pip install step.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Every lockfile that ships optional platform-specific packages must retain
+# entries for at least these three OSes: "linux" is required because CI runs
+# `npm ci` on ubuntu-latest; "win32" and "darwin" are required because
+# contributors develop locally on Windows and macOS.
+REQUIRED_PLATFORMS = frozenset({"linux", "win32", "darwin"})
+
+LOCKFILES = (
+    ROOT / "package-lock.json",
+    ROOT / "frontend" / "package-lock.json",
+)
+
+
+def platforms_in_lockfile(lockfile: Path) -> set[str]:
+    """Return the union of "os" values across optional packages in *lockfile*."""
+    data = json.loads(lockfile.read_text(encoding="utf-8"))
+    platforms: set[str] = set()
+    for pkg in data.get("packages", {}).values():
+        if isinstance(pkg, dict) and pkg.get("optional") and "os" in pkg:
+            platforms.update(pkg["os"])
+    return platforms
+
+
+def main() -> int:
+    failures: list[str] = []
+    for lockfile in LOCKFILES:
+        if not lockfile.exists():
+            continue
+        platforms = platforms_in_lockfile(lockfile)
+        if not platforms:
+            # No platform-restricted optional packages at all in this
+            # lockfile; nothing to check.
+            continue
+        missing = REQUIRED_PLATFORMS - platforms
+        if missing:
+            try:
+                rel = lockfile.relative_to(ROOT)
+            except ValueError:
+                rel = lockfile
+            failures.append(
+                f"{rel}: missing optional-dependency entries for "
+                f"{sorted(missing)} (found {sorted(platforms)}). This "
+                "usually means the lockfile was regenerated with `npm "
+                "install` on a single OS, which can prune platform-specific "
+                "optional packages for other platforms. Regenerate with "
+                "`npm install` (not `npm ci`) and diff against the previous "
+                "lockfile to confirm the other platforms' entries are still "
+                "present, or restore them from the previous commit."
+            )
+
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+
+    print(f"Lockfile platform coverage OK ({len(LOCKFILES)} lockfiles checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_lockfile_platform_coverage.py
+++ b/tests/scripts/test_check_lockfile_platform_coverage.py
@@ -1,0 +1,144 @@
+"""Unit tests for scripts/check_lockfile_platform_coverage.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_lockfile_platform_coverage.py"
+spec = importlib.util.spec_from_file_location("check_lockfile_platform_coverage", _SCRIPT)
+_mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+platforms_in_lockfile = _mod.platforms_in_lockfile
+main = _mod.main
+
+
+def _write_lockfile(path: Path, packages: dict) -> None:
+    path.write_text(json.dumps({"packages": packages}), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# platforms_in_lockfile
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformsInLockfile:
+    def test_collects_os_values_from_optional_packages(self, tmp_path: Path) -> None:
+        f = tmp_path / "package-lock.json"
+        _write_lockfile(
+            f,
+            {
+                "node_modules/@esbuild/linux-x64": {
+                    "optional": True,
+                    "os": ["linux"],
+                },
+                "node_modules/@esbuild/win32-x64": {
+                    "optional": True,
+                    "os": ["win32"],
+                },
+            },
+        )
+        assert platforms_in_lockfile(f) == {"linux", "win32"}
+
+    def test_ignores_non_optional_packages(self, tmp_path: Path) -> None:
+        f = tmp_path / "package-lock.json"
+        _write_lockfile(
+            f,
+            {
+                "node_modules/react": {"version": "19.0.0"},
+                "node_modules/@esbuild/linux-x64": {
+                    "optional": True,
+                    "os": ["linux"],
+                },
+            },
+        )
+        assert platforms_in_lockfile(f) == {"linux"}
+
+    def test_no_platform_restricted_packages_returns_empty_set(self, tmp_path: Path) -> None:
+        f = tmp_path / "package-lock.json"
+        _write_lockfile(f, {"node_modules/react": {"version": "19.0.0"}})
+        assert platforms_in_lockfile(f) == set()
+
+
+# ---------------------------------------------------------------------------
+# main() end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def _patch_lockfiles(self, monkeypatch: pytest.MonkeyPatch, *lockfiles: Path) -> None:
+        monkeypatch.setattr(_mod, "LOCKFILES", tuple(lockfiles))
+
+    def test_full_platform_coverage_returns_0(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        f = tmp_path / "package-lock.json"
+        _write_lockfile(
+            f,
+            {
+                "node_modules/@esbuild/linux-x64": {"optional": True, "os": ["linux"]},
+                "node_modules/@esbuild/win32-x64": {"optional": True, "os": ["win32"]},
+                "node_modules/@esbuild/darwin-x64": {"optional": True, "os": ["darwin"]},
+            },
+        )
+        self._patch_lockfiles(monkeypatch, f)
+        assert main() == 0
+        assert "OK" in capsys.readouterr().out
+
+    def test_missing_linux_platform_returns_1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        f = tmp_path / "package-lock.json"
+        _write_lockfile(
+            f,
+            {
+                "node_modules/@esbuild/win32-x64": {"optional": True, "os": ["win32"]},
+                "node_modules/@esbuild/darwin-x64": {"optional": True, "os": ["darwin"]},
+            },
+        )
+        self._patch_lockfiles(monkeypatch, f)
+        assert main() == 1
+        err = capsys.readouterr().err
+        assert "ERROR" in err
+        assert "linux" in err
+
+    def test_no_platform_restricted_packages_is_not_a_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        f = tmp_path / "package-lock.json"
+        _write_lockfile(f, {"node_modules/react": {"version": "19.0.0"}})
+        self._patch_lockfiles(monkeypatch, f)
+        assert main() == 0
+
+    def test_missing_lockfile_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._patch_lockfiles(monkeypatch, tmp_path / "nonexistent-lock.json")
+        assert main() == 0
+
+    def test_multiple_lockfiles_report_all_failures(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        good = tmp_path / "good-lock.json"
+        bad = tmp_path / "bad-lock.json"
+        _write_lockfile(
+            good,
+            {
+                "node_modules/@esbuild/linux-x64": {"optional": True, "os": ["linux"]},
+                "node_modules/@esbuild/win32-x64": {"optional": True, "os": ["win32"]},
+                "node_modules/@esbuild/darwin-x64": {"optional": True, "os": ["darwin"]},
+            },
+        )
+        _write_lockfile(
+            bad,
+            {
+                "node_modules/@esbuild/win32-x64": {"optional": True, "os": ["win32"]},
+            },
+        )
+        self._patch_lockfiles(monkeypatch, good, bad)
+        assert main() == 1
+        err = capsys.readouterr().err
+        assert str(bad.name) in err


### PR DESCRIPTION
## What
Adds `scripts/check_lockfile_platform_coverage.py`, which asserts that `package-lock.json` and `frontend/package-lock.json` retain optional-dependency entries for `linux`, `win32`, and `darwin`, and wires it into the `test` job in `.github/workflows/ci.yml`.

## Why
`.github/actions/setup-frontend-deps/action.yml` runs `npm ci` for both lockfiles on `ubuntu-latest`. Several dependencies (esbuild, `@emnapi/*`, etc.) ship OS-specific optional packages tagged with an `"os"` field in the lockfile. Regenerating a lockfile with `npm install` on Windows (or macOS) can silently prune the optional entries for other platforms, including the Linux ones CI needs — this is exactly the failure mode `docs/CONTRIBUTING.md` already warns about manually reviewing for ("Frontend optional dependency handling"). Currently that check is manual/best-effort; this makes it automatic and fails fast with an actionable message instead of surfacing as a confusing `npm ci`/`EUSAGE` failure deep in CI.

## How
- New script walks each lockfile's `packages` map, collects the union of `"os"` values across `optional: true` entries, and fails if `linux`, `win32`, or `darwin` is missing from that union (skips lockfiles with no platform-restricted optional packages at all).
- Added as a `test` job step in `ci.yml`, right after the existing pre-flight checks, before `npm ci` runs.
- Updated `docs/CONTRIBUTING.md`'s existing "Frontend optional dependency handling" section to point at the new automated check instead of only describing manual review.
- Added unit tests in `tests/scripts/test_check_lockfile_platform_coverage.py` covering the collection logic and `main()`'s pass/fail/multi-lockfile behavior.

## Constraints
No changes to the actual committed lockfiles — both already have full platform coverage today; this only guards against future regressions.

## Test plan
- [x] `python -m pytest tests/scripts/test_check_lockfile_platform_coverage.py --no-cov` — 8 passed
- [x] `python scripts/check_lockfile_platform_coverage.py` — passes against current `package-lock.json` / `frontend/package-lock.json`
- [x] `python -m black --check` / `python -m ruff check` on new files — clean
- [x] `actionlint .github/workflows/ci.yml` — clean
- [ ] CI run on this PR (GitHub Actions)

Closes #5608
