### PR TITLE
Resolve conflicts and merge main into developer-tools reorg (PR #5613)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -173,7 +173,7 @@ The script:
 Optional flags:
 - `--token TOKEN`: GitHub personal access token (also reads `GITHUB_TOKEN` env var). Required for branch creation (unauthenticated requests will fail with 401/403).
 
-## e_implement_issue_using_local_llm.ps1
+## developer_tools/e_implement_issue_using_local_llm.ps1
 
 Automates implementing a GitHub issue end-to-end with a local LLM: fetches the
 issue, creates/resets an `issue-<N>` branch, runs [aider](https://aider.chat)
@@ -233,7 +233,7 @@ bash scripts/bash/publish-pr.sh -m "Fix bug in auth" --no-ollama
 - `gh` CLI must be installed and authenticated
 - Ollama is optional but recommended for better PR descriptions
 
-## commit_and_push.py
+## developer_tools/lib/commit_and_push.py
 
 Commit local changes and push to `origin`, using a local Ollama model to draft
 the commit message from the diff. This is a lighter-weight alternative to
@@ -272,7 +272,7 @@ bash scripts/bash/commit-and-push.sh -m "Fix bug in auth" --no-ollama
 **Requirements:**
 - Ollama is optional but recommended for better commit messages; without it (or with `--no-ollama`), a plain default message is used
 
-## i_dependabot_auto_merge.py
+## l_dependabot_auto_merge.py
 
 Auto-merge open Dependabot pull requests once their checks have all passed, then
 delete the branch. A PR that is green but only out-of-date with `main` (no real

--- a/scripts/developer_tools/d_work_on_issue.py
+++ b/scripts/developer_tools/d_work_on_issue.py
@@ -12,33 +12,7 @@ import time
 from pathlib import Path
 
 import requests
-
-
-def get_repo_info() -> tuple[str, str]:
-    """Extract owner and repo from git remote origin."""
-    try:
-        result = subprocess.run(
-            ["git", "config", "--get", "remote.origin.url"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        url = result.stdout.strip()
-        # Handle both https and ssh URLs
-        if url.startswith("git@"):
-            # git@github.com:owner/repo.git
-            match = re.search(r"github\.com[:/]([^/]+)/(.+?)(?:\.git)?$", url)
-        else:
-            # https://github.com/owner/repo.git
-            match = re.search(r"github\.com/([^/]+)/(.+?)(?:\.git)?$", url)
-        if match:
-            repo = match.group(2)
-            if repo.endswith(".git"):
-                repo = repo[:-4]
-            return match.group(1), repo
-    except subprocess.CalledProcessError as exc:
-        raise ValueError(f"Could not determine GitHub repo from git remote origin: {exc}") from exc
-    raise ValueError("Could not determine GitHub repo from git remote origin")
+from lib.github_repo import get_repo_info
 
 
 def slugify(text: str) -> str:
@@ -57,11 +31,14 @@ def slugify(text: str) -> str:
     return slug
 
 
-def fetch_issue(owner: str, repo: str, issue_id: int) -> dict:
+def fetch_issue(owner: str, repo: str, issue_id: int, token: str | None = None) -> dict:
     """Fetch issue details from GitHub API."""
     url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_id}"
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
     try:
-        resp = requests.get(url, timeout=10)
+        resp = requests.get(url, headers=headers, timeout=10)
         resp.raise_for_status()
     except requests.RequestException as exc:
         print(f"Failed to fetch issue #{issue_id}: {exc}", file=sys.stderr)
@@ -114,6 +91,7 @@ def create_branch(owner: str, repo: str, branch_name: str, sha: str, token: str 
 
 
 def main() -> None:
+    """Create and check out a remote branch for the requested issue."""
     parser = argparse.ArgumentParser(description="Create a GitHub issue checkout branch")
     parser.add_argument("issue_id", type=int, help="GitHub issue ID")
     parser.add_argument(
@@ -146,9 +124,11 @@ def main() -> None:
         print(f"Failed to fetch from origin: {exc}", file=sys.stderr)
         sys.exit(1)
 
+    token = args.token or os.getenv("GITHUB_TOKEN")
+
     # Fetch issue
     print(f"Fetching issue #{args.issue_id}...")
-    issue = fetch_issue(owner, repo, args.issue_id)
+    issue = fetch_issue(owner, repo, args.issue_id, token)
     title = issue.get("title", "")
     body = issue.get("body") or ""
     if not title:
@@ -166,7 +146,7 @@ def main() -> None:
 
     # Create branch in remote
     print("Creating branch in remote...")
-    create_branch(owner, repo, branch_name, sha, args.token or os.getenv("GITHUB_TOKEN"))
+    create_branch(owner, repo, branch_name, sha, token)
 
     # Small delay to avoid a race where the branch ref isn't visible yet
     time.sleep(1)

--- a/scripts/developer_tools/e_implement_issue_using_local_llm.ps1
+++ b/scripts/developer_tools/e_implement_issue_using_local_llm.ps1
@@ -79,8 +79,8 @@ if (-not $defaultBranch) {
     $defaultBranch = 'main'
 }
 
-# Accept either a full URL or a bare issue number
-if ($Issue -match '(\d+)$') {
+# Accept only a bare issue number or a canonical GitHub issue URL.
+if ($Issue -match '^(\d+)$' -or $Issue -match '^https://github\.com/[^/\s]+/[^/\s]+/issues/(\d+)$') {
     $number = $Matches[1]
 } else {
     Write-Error "Expected an issue number or URL, e.g. 123 or https://github.com/leonarduk/allotmint/issues/123"
@@ -137,7 +137,11 @@ if (-not $baseSha) {
 # non-interactively, process the reply, then exit). Routing the issue body through
 # a file keeps attacker-controlled content off the command line entirely.
 $promptFile = [System.IO.Path]::GetTempFileName()
-Set-Content -Path $promptFile -Value "GitHub issue #${number}: $title`n`n$issueBody" -Encoding UTF8
+[System.IO.File]::WriteAllText(
+    $promptFile,
+    "GitHub issue #${number}: $title`n`n$issueBody",
+    (New-Object System.Text.UTF8Encoding($false))
+)
 
 # Discover files the issue references that actually exist on disk and add them
 # to aider's editable context. Without explicit targets, weaker local models
@@ -330,7 +334,7 @@ $issueBody
 ## Changes
 $diffStat
 
-🤖 Implemented via [aider](https://aider.chat) with local Ollama model
+Implemented via [aider](https://aider.chat) with local Ollama model
 "@
 
 # Build the PR title with + to avoid re-evaluating backticks or $(...) in $title

--- a/scripts/developer_tools/k_work_on_pr.py
+++ b/scripts/developer_tools/k_work_on_pr.py
@@ -4,33 +4,15 @@ from __future__ import annotations
 
 import argparse
 import os
-import re
 import subprocess
 import sys
 
 import requests
-
-
-def get_repo_info() -> tuple[str, str]:
-    """Extract owner and repo from git remote origin."""
-    try:
-        result = subprocess.run(
-            ["git", "config", "--get", "remote.origin.url"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        url = result.stdout.strip()
-        # Handles both https and ssh (git@github.com:owner/repo.git) URLs
-        match = re.search(r"github\.com[:/]([^/]+)/(.+?)(?:\.git)?/?$", url)
-        if match:
-            return match.group(1), match.group(2)
-    except subprocess.CalledProcessError as exc:
-        raise ValueError(f"Could not determine GitHub repo from git remote origin: {exc}") from exc
-    raise ValueError("Could not determine GitHub repo from git remote origin")
+from lib.github_repo import get_repo_info
 
 
 def _auth_headers(token: str | None) -> dict:
+    """Build GitHub API headers, including authentication when available."""
     headers = {"Accept": "application/vnd.github.v3+json"}
     if token:
         headers["Authorization"] = f"token {token}"
@@ -123,9 +105,11 @@ def checkout_pr_branch(pr: dict) -> None:
         except subprocess.CalledProcessError as exc:
             print(f"Failed to fetch {branch_name} from fork {fork_full_name}: {exc}", file=sys.stderr)
             sys.exit(1)
-        _checkout_local_branch(local_branch, remote_ref)
-        # The remote is only needed to fetch the fork's branch; drop it once checked out.
-        subprocess.run(["git", "remote", "remove", remote_name], capture_output=True, check=False)
+        try:
+            _checkout_local_branch(local_branch, remote_ref)
+        finally:
+            # The remote is temporary and must also be removed after a failed checkout.
+            subprocess.run(["git", "remote", "remove", remote_name], capture_output=True, check=False)
         return
 
     print(f"Fetching branch {branch_name} from origin...")
@@ -158,6 +142,7 @@ def _checkout_local_branch(local_branch: str, remote_ref: str) -> None:
 
 
 def main() -> None:
+    """Fetch a selected pull request and check out its head branch."""
     parser = argparse.ArgumentParser(description="Check out the branch for an open GitHub pull request")
     parser.add_argument(
         "pr_number",

--- a/scripts/developer_tools/lib/commit_and_push.py
+++ b/scripts/developer_tools/lib/commit_and_push.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-sys.path.insert(0, str(Path(__file__).parent / "lib"))
+sys.path.insert(0, str(Path(__file__).parent))
 
 from ollama_common import (  # noqa: E402
     fetch_ollama_review,
@@ -69,12 +69,16 @@ def has_staged_changes() -> bool:
 
 def get_staged_diff() -> str:
     """Return the diff of staged changes."""
-    result = subprocess.run(
-        ["git", "diff", "--cached"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: Failed to read staged changes: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
     return result.stdout
 
 
@@ -172,6 +176,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
+    """Stage, commit, and optionally push changes based on CLI arguments."""
     args = build_arg_parser().parse_args()
 
     os.chdir(get_git_root())

--- a/scripts/developer_tools/lib/github_repo.py
+++ b/scripts/developer_tools/lib/github_repo.py
@@ -1,0 +1,24 @@
+"""Helpers for identifying the GitHub repository in the current checkout."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+
+def get_repo_info() -> tuple[str, str]:
+    """Extract the GitHub owner and repository name from ``origin``."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f"Could not determine GitHub repo from git remote origin: {exc}") from exc
+
+    match = re.search(r"github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?/?$", result.stdout.strip())
+    if match:
+        return match.group(1), match.group(2)
+    raise ValueError("Could not determine GitHub repo from git remote origin")

--- a/tests/test_commit_and_push.py
+++ b/tests/test_commit_and_push.py
@@ -1,4 +1,4 @@
-"""Unit tests for commit_and_push script."""
+"""Unit tests for the commit_and_push helper."""
 
 from __future__ import annotations
 
@@ -90,6 +90,14 @@ class TestGetStagedDiff:
     def test_returns_diff_output(self, mock_run):
         mock_run.return_value = mock.MagicMock(stdout="diff --git a/x b/x\n")
         assert get_staged_diff() == "diff --git a/x b/x\n"
+
+    @mock.patch("commit_and_push.subprocess.run")
+    def test_failure_exits_cleanly(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+
+        with pytest.raises(SystemExit) as exc_info:
+            get_staged_diff()
+        assert exc_info.value.code == 1
 
 
 class TestBuildCommitPrompt:

--- a/tests/test_local_review.py
+++ b/tests/test_local_review.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
 
 from g_local_review import (

--- a/tests/test_work_on_issue.py
+++ b/tests/test_work_on_issue.py
@@ -9,7 +9,7 @@ from unittest import mock
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
-from d_work_on_issue import main, slugify
+from d_work_on_issue import fetch_issue, main, slugify
 
 
 class TestSlugify:
@@ -30,6 +30,24 @@ class TestSlugify:
         assert slugify("\U0001f680") != slugify("\U0001f389")
 
 
+def test_fetch_issue_authenticates_with_token(monkeypatch):
+    """The issue lookup must support private repositories."""
+    response = mock.MagicMock()
+    response.json.return_value = {"title": "Private issue"}
+    get = mock.MagicMock(return_value=response)
+    monkeypatch.setattr("d_work_on_issue.requests.get", get)
+
+    assert fetch_issue("owner", "repo", 42, "secret") == {"title": "Private issue"}
+    get.assert_called_once_with(
+        "https://api.github.com/repos/owner/repo/issues/42",
+        headers={
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": "token secret",
+        },
+        timeout=10,
+    )
+
+
 def _run_main(monkeypatch, tmp_path, cli_args, sleep_mock):
     """Run main() with every external side effect mocked, return the resolved branch name."""
     monkeypatch.chdir(tmp_path)
@@ -38,7 +56,7 @@ def _run_main(monkeypatch, tmp_path, cli_args, sleep_mock):
     monkeypatch.setattr("d_work_on_issue.get_repo_info", lambda: ("leonarduk", "allotmint"))
     monkeypatch.setattr(
         "d_work_on_issue.fetch_issue",
-        lambda owner, repo, issue_id: {"title": "Some Issue Title", "body": "body text"},
+        lambda owner, repo, issue_id, token: {"title": "Some Issue Title", "body": "body text"},
     )
     monkeypatch.setattr("d_work_on_issue.get_main_branch_sha", lambda owner, repo: "deadbeef")
     monkeypatch.setattr("d_work_on_issue.create_branch", lambda owner, repo, branch_name, sha, token: None)


### PR DESCRIPTION
### Motivation

- PR changes to reorganize `scripts/developer_tools` had become unmergeable after overlapping commits landed on `main`, so the branch was brought up-to-date and conflicts resolved. 
- Preserve the refactor that moves shared helpers into `lib/` and keep token-aware/private-repo behavior for issue/PR helpers. 

### Description

- Merged `main` into the PR branch and resolved conflicts in `scripts/README.md`, `tests/test_commit_and_push.py`, and `tests/test_work_on_issue.py` while retaining the reorganized paths and docs headings. 
- Added `scripts/developer_tools/lib/github_repo.py` and switched `d_work_on_issue.py` and `k_work_on_pr.py` to use `get_repo_info` from that shared helper. 
- Updated `d_work_on_issue.py` to accept/forward an optional `--token` (or `GITHUB_TOKEN`) to `fetch_issue` and `create_branch`, and made `fetch_issue` include auth headers when a token is provided. 
- Hardened `scripts/developer_tools/lib/commit_and_push.py` by adjusting `sys.path` to import relocated modules, adding `get_staged_diff()` error handling (exits cleanly on `CalledProcessError`), and clarifying `main()` docstring. 
- Updated tests to reflect relocated imports, added a regression test that `fetch_issue` uses auth headers, and added a failure-path test for `get_staged_diff()`. 

### Testing

- Ran unit tests: `PYENV_VERSION=3.11.15 python -m pytest -q --no-cov tests/test_commit_and_push.py tests/test_work_on_issue.py tests/test_local_review.py tests/test_pr_review.py tests/scripts/test_check_lockfile_platform_coverage.py` — all tests passed (`67 passed`).
- Ran static checks: `PYENV_VERSION=3.11.15 python -m ruff check --config backend/pyproject.toml scripts/developer_tools tests/test_commit_and_push.py tests/test_work_on_issue.py tests/test_local_review.py tests/test_pr_review.py tests/scripts/test_check_lockfile_platform_coverage.py` — passed after automated fixes.
- Ran `git diff --cached --check` before committing — no whitespace/diff issues found.
- Note: push to update the remote branch failed in this environment due to missing GitHub credentials (`could not read Username for 'https://github.com'`); the conflict-resolution commit is on the local branch and needs to be pushed from an environment with appropriate credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a5b736a0c83279ab97eea37f5dbe9)