### PR TITLE
Document Moneyhub credential storage exception

### DIFF
--- a/docs/moneyhub-integration.md
+++ b/docs/moneyhub-integration.md
@@ -73,6 +73,22 @@ per owner, not one for the whole app).
 
 ## Secret storage decision
 
+### Known client-credential exception
+
+The live API implementation currently being developed reads
+`MONEYHUB_CLIENT_ID` and `MONEYHUB_CLIENT_SECRET` directly from the process
+environment. It does **not** resolve those two client credentials from SSM.
+This is a known deviation from issue #2749's SSM requirement, tracked in
+issue #5481; changing credential resolution is outside the scope of that
+documentation update.
+
+This exception applies only to the Moneyhub OAuth client's registration
+credentials. After an owner completes authentication, that owner's access and
+refresh tokens use the `ssm://` storage described below. The current mainline
+code supports manual Moneyhub CSV imports only; this note documents the
+credential contract of the pending live API integration so it is not mistaken
+for the token-storage contract.
+
 Follow the existing `ssm://` pattern in
 [`backend/common/storage.py`](../backend/common/storage.py) rather than
 inventing a new secret-loading mechanism — this repo's `cdk/` has no


### PR DESCRIPTION
### Motivation

Closes #5481 

- Make explicit that `MONEYHUB_CLIENT_ID` and `MONEYHUB_CLIENT_SECRET` are read from process environment variables (not SSM) so maintainers and automated tooling do not assume an `ssm://` pattern for these client credentials.
- Clarify that this exception only applies to the OAuth client registration credentials while per-owner access and refresh tokens continue to use `ssm://` storage, and that changing credential resolution is out of scope.

### Description

- Add a "Known client-credential exception" note to `docs/moneyhub-integration.md` under the "Secret storage decision" section explaining the env-var vs SSM gap and referencing issue `#2749` and tracking issue `#5481`.
- The change is documentation-only and does not alter any runtime behavior or code paths; token-storage semantics remain unchanged.
- Closes `#5481`.

### Testing

- Ran repository checks including `git diff --check`, `git status --short --branch`, and reviewed the doc diff via `git show --stat` to validate the committed documentation change.
- No unit/integration tests were required or modified because this is a docs-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a671272ec8327bb0b5e9128bd1ec8)