### PR TITLE
Automate local CI and integration checks

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -195,6 +195,32 @@ If aider makes no commits (e.g. the local model replies with prose instead of
 edits), the script fails rather than pushing an empty branch or opening a
 content-free PR.
 
+## f_run_ci_checks.py
+
+Run the credential-free integration and validation steps from the most relevant
+GitHub Actions workflows before pushing. With no arguments, the script presents
+an interactive menu:
+
+```bash
+python scripts/developer_tools/f_run_ci_checks.py
+```
+
+For automation or non-interactive shells, select one or more groups explicitly:
+
+```bash
+python scripts/developer_tools/f_run_ci_checks.py --list
+python scripts/developer_tools/f_run_ci_checks.py --check backend --check frontend
+python scripts/developer_tools/f_run_ci_checks.py --all --keep-going
+python scripts/developer_tools/f_run_ci_checks.py --all --dry-run
+```
+
+The groups mirror backend integration, frontend, infrastructure/workflow-lint,
+and developer-script jobs. The runner assumes their dependencies are already
+installed, runs from the repository root regardless of the caller's current
+directory, stops at the first failure by default, and propagates a failing exit
+status. Cloud deployment and other secret-dependent jobs are intentionally not
+offered as local checks.
+
 ## publish_pr.py
 
 Automate PR publishing: commit changes, push to remote, and create a PR with auto-filled body sections. Optionally uses Ollama to generate thoughtful PR descriptions.

--- a/scripts/developer_tools/f_run_ci_checks.py
+++ b/scripts/developer_tools/f_run_ci_checks.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Run the useful, credential-free parts of AllotMint GitHub Actions locally."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Check:
+    """A local check and the workflow that it mirrors."""
+
+    name: str
+    description: str
+    workflow: str
+    commands: tuple[str, ...]
+
+
+CHECKS = (
+    Check(
+        "backend",
+        "Backend integration tests, coverage, type checks, and contract sync",
+        ".github/workflows/backend-integration.yml",
+        (
+            "python scripts/check_contract_version_sync.py",
+            "python -m mypy backend --config-file mypy.ini --show-error-codes --pretty --explicit-package-bases",
+            "pytest --no-cov tests/backend/common/test_data_provider_parity.py -q",
+            "pytest tests --ignore=tests/live --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=80 -q",
+        ),
+    ),
+    Check(
+        "frontend",
+        "Frontend lint, type checking, unit tests, and dependency audit",
+        ".github/workflows/frontend-tests.yml and .github/workflows/ci.yml",
+        (
+            "npm --prefix frontend run lint",
+            "npm --prefix frontend run type-check",
+            "npm --prefix frontend test -- --run --coverage",
+            "npm --prefix frontend audit --audit-level=high",
+        ),
+    ),
+    Check(
+        "infrastructure",
+        "CDK tests and GitHub Actions workflow lint",
+        ".github/workflows/ci.yml and .github/workflows/cdk-dry-run.yml",
+        (
+            "pytest cdk/tests/ --no-cov",
+            "actionlint",
+        ),
+    ),
+    Check(
+        "scripts",
+        "Bash and PowerShell developer script tests",
+        ".github/workflows/ci.yml",
+        (
+            "npx --yes bats@1.13.0 tests/bash/*.bats",
+            'pwsh -NoProfile -Command "Import-Module Pester -RequiredVersion '
+            '5.6.1 -Force; Invoke-Pester -Path scripts/tests -CI"',
+        ),
+    ),
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    choices = tuple(check.name for check in CHECKS)
+    selection = parser.add_mutually_exclusive_group()
+    selection.add_argument("--check", action="append", choices=choices, help="check to run; repeatable")
+    selection.add_argument("--all", action="store_true", help="run every check")
+    selection.add_argument("--list", action="store_true", help="list checks and commands")
+    parser.add_argument("--dry-run", action="store_true", help="print commands without running them")
+    parser.add_argument("--keep-going", action="store_true", help="continue after a failed command")
+    return parser.parse_args(argv)
+
+
+def print_checks() -> None:
+    """Print the available checks and their exact commands."""
+    for index, check in enumerate(CHECKS, start=1):
+        print(f"{index}. {check.name}: {check.description}")
+        print(f"   Mirrors: {check.workflow}")
+        for command in check.commands:
+            print(f"   $ {command}")
+
+
+def prompt_for_checks() -> list[Check]:
+    """Ask an interactive user which checks to run."""
+    print_checks()
+    answer = input("Select checks by number (comma-separated), or 'all': ").strip().lower()
+    if answer == "all":
+        return list(CHECKS)
+    try:
+        indexes = [int(value.strip()) for value in answer.split(",")]
+        if not indexes or any(index < 1 or index > len(CHECKS) for index in indexes):
+            raise ValueError
+    except ValueError as exc:
+        raise SystemExit("Invalid selection; use listed numbers or 'all'.") from exc
+    return [CHECKS[index - 1] for index in dict.fromkeys(indexes)]
+
+
+def select_checks(args: argparse.Namespace) -> list[Check]:
+    """Resolve flags or the interactive menu to checks."""
+    if args.all:
+        return list(CHECKS)
+    if args.check:
+        selected = set(args.check)
+        return [check for check in CHECKS if check.name in selected]
+    if not sys.stdin.isatty():
+        raise SystemExit("No check selected. Use --check NAME, --all, or --list.")
+    return prompt_for_checks()
+
+
+def run_checks(checks: list[Check], root: Path, dry_run: bool, keep_going: bool) -> int:
+    """Run selected commands, returning a process-style status code."""
+    failures = 0
+    for check in checks:
+        print(f"\n== {check.name}: {check.description} ==", flush=True)
+        for command in check.commands:
+            print(f"$ {command}", flush=True)
+            if dry_run:
+                continue
+            result = subprocess.run(command, cwd=root, shell=True, check=False)
+            if result.returncode:
+                failures += 1
+                print(f"FAILED ({result.returncode}): {command}", file=sys.stderr)
+                if not keep_going:
+                    return result.returncode
+    return 1 if failures else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Provide the CLI entry point."""
+    args = parse_args(argv)
+    if args.list:
+        print_checks()
+        return 0
+    root = Path(__file__).resolve().parents[2]
+    return run_checks(select_checks(args), root, args.dry_run, args.keep_going)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_run_ci_checks.py
+++ b/tests/scripts/test_run_ci_checks.py
@@ -1,0 +1,48 @@
+"""Tests for the local GitHub Actions check runner."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.developer_tools import f_run_ci_checks
+
+
+def test_select_checks_preserves_catalog_order() -> None:
+    args = f_run_ci_checks.parse_args(["--check", "scripts", "--check", "backend"])
+
+    selected = f_run_ci_checks.select_checks(args)
+
+    assert [check.name for check in selected] == ["backend", "scripts"]
+
+
+def test_noninteractive_invocation_requires_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = f_run_ci_checks.parse_args([])
+    monkeypatch.setattr(f_run_ci_checks.sys.stdin, "isatty", lambda: False)
+
+    with pytest.raises(SystemExit, match="No check selected"):
+        f_run_ci_checks.select_checks(args)
+
+
+def test_dry_run_does_not_start_processes(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unexpected_run(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("dry-run started a process")
+
+    monkeypatch.setattr(f_run_ci_checks.subprocess, "run", unexpected_run)
+
+    assert f_run_ci_checks.run_checks([f_run_ci_checks.CHECKS[0]], Path.cwd(), True, False) == 0
+
+
+def test_keep_going_runs_remaining_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    return_codes = iter((2, 0))
+    calls: list[str] = []
+
+    def fake_run(command: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, next(return_codes))
+
+    check = f_run_ci_checks.Check("sample", "Sample", "workflow.yml", ("first", "second"))
+    monkeypatch.setattr(f_run_ci_checks.subprocess, "run", fake_run)
+
+    assert f_run_ci_checks.run_checks([check], Path.cwd(), False, True) == 1
+    assert calls == ["first", "second"]


### PR DESCRIPTION
### Motivation

- Provide a single, discoverable CLI to reproduce the credential-free parts of the repository's GitHub Actions locally so developers can validate important checks before pushing.

### Description

- Add `scripts/developer_tools/f_run_ci_checks.py`, a small CLI that maps common workflow groups (backend, frontend, infrastructure, scripts) to the exact local commands and supports `--check`, `--all`, `--list`, `--dry-run`, and `--keep-going` modes and interactive selection.
- Add unit tests `tests/scripts/test_run_ci_checks.py` to validate selection ordering, non-interactive invocation handling, dry-run safety, and keep-going behavior.
- Document the new runner in `scripts/README.md` and make the runner executable from the repository root so commands run in a predictable environment.
- The runner is intentionally scoped to credential-free checks and excludes cloud/deploy steps; the PR includes an auto-closing reference `Closes #5528`.

### Testing

- Ran unit tests: `pytest tests/scripts/test_run_ci_checks.py --confcutdir=tests/scripts -c /dev/null -q`, which returned `4 passed`.
- Ran linters/format checks: `ruff` and `black --check` against the new files and they passed after formatting changes.
- Exercised the CLI smoke paths: `python scripts/developer_tools/f_run_ci_checks.py --list` and `python scripts/developer_tools/f_run_ci_checks.py --all --dry-run`, both completed successfully.
- Verified no whitespace/issues with `git diff --check` and committed the changes on branch `fix/issue-5528`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a664acaa88327ba629b963f954615)