### PR TITLE
Optimize /groups owner discovery to avoid N+1 data loads

### DIFF
--- a/backend/common/group_portfolio.py
+++ b/backend/common/group_portfolio.py
@@ -10,9 +10,11 @@ Virtual "group portfolio" builder.
 
 import datetime as dt
 import logging
+import time
 from datetime import date
 from typing import Any, Dict, List
 
+from backend.common import data_loader
 from backend.common import portfolio as owner_portfolio
 from backend.common.approvals import load_approvals
 from backend.common.constants import (
@@ -62,9 +64,10 @@ def list_groups() -> List[Dict[str, Any]]:
     - "adults"   - lucy + steve
     - "children" - alex + joe
     """
-    from backend.common.portfolio_loader import list_portfolios  # local import avoids cycles
-
-    owners = sorted({pf.get("owner") for pf in list_portfolios() if pf.get("owner")})
+    started_at = time.perf_counter()
+    owner_rows = data_loader.list_plots()
+    owners = sorted({row.owner for row in owner_rows})
+    owner_discovery_ms = (time.perf_counter() - started_at) * 1000
 
     groups = [
         {
@@ -96,6 +99,16 @@ def list_groups() -> List[Dict[str, Any]]:
             }
         )
 
+    logger.info(
+        "group_portfolio.list_groups_complete",
+        extra={
+            "event": "group_portfolio.list_groups_complete",
+            "owner_count": len(owners),
+            "group_count": len(groups),
+            "owner_discovery_ms": round(owner_discovery_ms, 2),
+            "duration_ms": round((time.perf_counter() - started_at) * 1000, 2),
+        },
+    )
     return groups
 
 

--- a/tests/common/test_group_portfolio.py
+++ b/tests/common/test_group_portfolio.py
@@ -1,17 +1,19 @@
+import time
 from unittest.mock import patch
 
-from backend.common.constants import ACCOUNTS, HOLDINGS, OWNER
 from backend.common import group_portfolio
+from backend.common.account_models import OwnerSummaryRecord
+from backend.common.constants import ACCOUNTS, HOLDINGS, OWNER
 
 
 def test_list_groups_returns_expected_defaults():
-    mock_portfolios = [
-        {"owner": "Lucy"},
-        {"owner": "Steve"},
-        {"owner": "Alex"},
-        {"owner": "Joe"},
+    owner_rows = [
+        OwnerSummaryRecord(owner="Lucy"),
+        OwnerSummaryRecord(owner="Steve"),
+        OwnerSummaryRecord(owner="Alex"),
+        OwnerSummaryRecord(owner="Joe"),
     ]
-    with patch("backend.common.portfolio_loader.list_portfolios", return_value=mock_portfolios):
+    with patch("backend.common.group_portfolio.data_loader.list_plots", return_value=owner_rows):
         groups = group_portfolio.list_groups()
 
     assert groups == [
@@ -23,6 +25,23 @@ def test_list_groups_returns_expected_defaults():
         {"slug": "adults", "name": "Adults", "members": ["Lucy", "Steve"]},
         {"slug": "children", "name": "Children", "members": ["Alex", "Joe"]},
     ]
+
+
+def test_list_groups_does_not_load_portfolio_contents():
+    """Group discovery must not issue one data load per owner or account."""
+    owner_rows = [OwnerSummaryRecord(owner=f"owner-{index}", accounts=[f"account-{index}"]) for index in range(1_000)]
+
+    started_at = time.perf_counter()
+    with (
+        patch("backend.common.group_portfolio.data_loader.list_plots", return_value=owner_rows),
+        patch("backend.common.portfolio_loader.list_portfolios") as list_portfolios,
+    ):
+        groups = group_portfolio.list_groups()
+    elapsed = time.perf_counter() - started_at
+
+    list_portfolios.assert_not_called()
+    assert len(groups[0]["members"]) == len(owner_rows)
+    assert elapsed < 2
 
 
 def test_build_group_portfolio_merges_accounts_and_totals():
@@ -53,6 +72,10 @@ def test_build_group_portfolio_merges_accounts_and_totals():
 
     patches = [
         patch("backend.common.portfolio_loader.list_portfolios", return_value=mock_portfolios),
+        patch(
+            "backend.common.group_portfolio.data_loader.list_plots",
+            return_value=[OwnerSummaryRecord(owner=row["owner"]) for row in mock_portfolios],
+        ),
         patch("backend.common.group_portfolio.load_approvals", return_value={}),
         patch("backend.common.group_portfolio.load_user_config", return_value={}),
         patch(
@@ -60,7 +83,7 @@ def test_build_group_portfolio_merges_accounts_and_totals():
             side_effect=lambda h, *_args, **_kwargs: h,
         ),
     ]
-    with patches[0], patches[1], patches[2], patches[3]:
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
         result = group_portfolio.build_group_portfolio("adults")
 
     assert result["slug"] == "adults"


### PR DESCRIPTION
### Motivation
- `/groups` was triggering an N+1 data-loading pattern by calling `list_portfolios()` and then reading per-owner account/person documents, which can produce large S3 read latency (reported ~13.2s).
- The endpoint only needs owner identifiers, so owner discovery should use a lightweight summary API to avoid expensive per-owner reads.

### Description
- Replace the heavy `list_portfolios()` owner discovery with `data_loader.list_plots()` in `backend/common/group_portfolio.py` so groups are built from lightweight `OwnerSummaryRecord` rows instead of full portfolio documents.
- Emit structured profiling telemetry (`group_portfolio.list_groups_complete`) with `owner_count`, `group_count`, `owner_discovery_ms`, and total `duration_ms` to aid production diagnosis.
- Add a regression test `tests/common/test_group_portfolio.py::test_list_groups_does_not_load_portfolio_contents` that verifies `list_groups()` does not call full `portfolio_loader.list_portfolios()` and completes under a 2s budget for 1,000 owners, and update existing group tests to patch the new discovery path.
- No API contract changes were made to `/groups` responses or error handling.

### Testing
- Ran `pytest --no-cov tests/common/test_group_portfolio.py tests/test_main.py -q`, which completed with all tests passing (25 passed).
- Ran targeted lint/format checks against modified files with `ruff` and `black` and the changed files passed those checks.
- Attempted the full `make lint` run but it is blocked by pre-existing, unrelated Ruff violations elsewhere in the repository; the PR's modified files remain clean under targeted checks.

Closes #5493

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a66e854f48327ba49374020658b1d)