### PR TITLE
Strengthen owner-listing diagnostics coverage for issue #5486

### DIFF
--- a/tests/backend/common/test_portfolio_builder.py
+++ b/tests/backend/common/test_portfolio_builder.py
@@ -109,7 +109,13 @@ def test_build_owner_portfolio_requires_plot(monkeypatch, today):
         build_owner_portfolio("nope")
 
 
-def test_build_owner_portfolio_logs_total_plot_count_on_miss(monkeypatch, today, caplog):
+@pytest.mark.parametrize(
+    "discovered_plots",
+    [[], [OwnerSummaryRecord(owner="other", accounts=["account-one"])]],
+)
+def test_build_owner_portfolio_logs_total_plot_count_on_miss(
+    monkeypatch, today, caplog, discovered_plots
+):
     """Regression test for #5286.
 
     When an owner has no matching plot, log how many plots were discovered in
@@ -118,15 +124,14 @@ def test_build_owner_portfolio_logs_total_plot_count_on_miss(monkeypatch, today,
     (plots found == 0), without which a reported 404 for a real owner is
     unreproducible from logs alone.
     """
-    other_owner = OwnerSummaryRecord(owner="other", accounts=["account-one"])
-    monkeypatch.setattr("backend.common.portfolio.list_plots", lambda root=None: [other_owner])
+    monkeypatch.setattr("backend.common.portfolio.list_plots", lambda root=None: discovered_plots)
 
     with caplog.at_level(logging.WARNING, logger="backend.common.portfolio"):
         with pytest.raises(FileNotFoundError):
             build_owner_portfolio("nope")
 
-    assert any(
-        "no plot found for owner=nope" in record.getMessage()
-        and "total plots discovered=1" in record.getMessage()
-        for record in caplog.records
+    expected_message = (
+        "build_owner_portfolio: no plot found for owner=nope "
+        f"(total plots discovered={len(discovered_plots)})"
     )
+    assert expected_message in caplog.messages


### PR DESCRIPTION
### Motivation
- Ensure the diagnostic emitted by `build_owner_portfolio` can be relied on to distinguish a genuinely-missing owner from an empty/partial listing (a key step in investigating issue #5286). 
- The runtime diagnostic was already present, but the regression test only exercised the populated-listing case; the test must cover both empty and non-empty listing scenarios.

### Description
- Parameterize the existing regression test in `tests/backend/common/test_portfolio_builder.py` to exercise two cases: `discovered_plots = []` and `discovered_plots = [OwnerSummaryRecord(...)]`.
- Replace the single-case `monkeypatch` with `monkeypatch.setattr("backend.common.portfolio.list_plots", lambda root=None: discovered_plots)` and assert the complete diagnostic message including the discovered plot count.
- This change is test-only and does not modify runtime behavior in `backend/common/portfolio.py`.
- Closes #5486

### Testing
- Ran the modified test file with the virtualenv: `python -m pytest tests/backend/common/test_portfolio_builder.py -q --no-cov`, and all tests passed (`4 passed`).
- Ran `python -m pytest tests/backend/common/test_portfolio_builder.py -q` with the repo coverage enforcement enabled and observed a failure due to repository-wide coverage being below the project `fail-under=90` threshold (expected when running an isolated file against a heavy codebase); the test itself passed but the coverage gate failed.
- Ran code style checks with `black` and applied formatting; performed `git diff --check` to validate there are no diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a66fd4ef08327a97ed27d28b9153c)