### PR TITLE
Cover portfolio owner-switch request races

### DIFF
--- a/frontend/tests/unit/pages/Portfolio.test.tsx
+++ b/frontend/tests/unit/pages/Portfolio.test.tsx
@@ -36,10 +36,12 @@ function OwnerOnlyRouteProvider({ children }: { children: React.ReactNode }) {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 vi.mock("@/api");
@@ -177,6 +179,112 @@ describe("Portfolio page", () => {
     expect(screen.getByText(/Approx Total:/).textContent).toMatch(/200/);
   });
 
+  it("keeps the newer request error when the stale request resolves later", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alice", accounts: [] },
+      { owner: "bob", accounts: [] },
+    ]);
+
+    const alice = deferred<Portfolio>();
+    const bob = deferred<Portfolio>();
+    mockGetPortfolio.mockImplementation((owner: string) =>
+      owner === "alice" ? alice.promise : bob.promise,
+    );
+
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/portfolio"]}>
+          <OwnerOnlyRouteProvider>
+            <Routes>
+              <Route path="/portfolio" element={<PortfolioPage />} />
+            </Routes>
+          </OwnerOnlyRouteProvider>
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    const ownerSelect = await screen.findByLabelText(/Owner/i);
+    await userEvent.selectOptions(ownerSelect, "alice");
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+    await userEvent.selectOptions(ownerSelect, "bob");
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
+
+    await act(async () => {
+      bob.reject(new Error("bob failed"));
+      await expect(bob.promise).rejects.toThrow("bob failed");
+    });
+    expect(await screen.findByText("Failed to load portfolio")).toBeInTheDocument();
+
+    await act(async () => {
+      alice.resolve({
+        owner: "alice",
+        as_of: "2024-01-01",
+        trades_this_month: 0,
+        trades_remaining: 0,
+        total_value_estimate_gbp: 100,
+        accounts: [],
+      } as Portfolio);
+      await alice.promise;
+    });
+
+    expect(screen.getByText("Failed to load portfolio")).toBeInTheDocument();
+    expect(screen.queryByText(/Approx Total:/)).not.toBeInTheDocument();
+  });
+
+  it("ignores a stale request error while the newer owner request is pending", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alice", accounts: [] },
+      { owner: "bob", accounts: [] },
+    ]);
+
+    const alice = deferred<Portfolio>();
+    const bob = deferred<Portfolio>();
+    mockGetPortfolio.mockImplementation((owner: string) =>
+      owner === "alice" ? alice.promise : bob.promise,
+    );
+
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/portfolio"]}>
+          <OwnerOnlyRouteProvider>
+            <Routes>
+              <Route path="/portfolio" element={<PortfolioPage />} />
+            </Routes>
+          </OwnerOnlyRouteProvider>
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    const ownerSelect = await screen.findByLabelText(/Owner/i);
+    await userEvent.selectOptions(ownerSelect, "alice");
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+    await userEvent.selectOptions(ownerSelect, "bob");
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
+
+    await act(async () => {
+      alice.reject(new Error("stale alice failure"));
+      await expect(alice.promise).rejects.toThrow("stale alice failure");
+    });
+    expect(screen.queryByText("Failed to load portfolio")).not.toBeInTheDocument();
+
+    await act(async () => {
+      bob.resolve({
+        owner: "bob",
+        as_of: "2024-01-01",
+        trades_this_month: 0,
+        trades_remaining: 0,
+        total_value_estimate_gbp: 200,
+        accounts: [
+          { account_type: "isa", currency: "GBP", value_estimate_gbp: 200, holdings: [] },
+        ],
+      } as Portfolio);
+      await bob.promise;
+    });
+
+    expect((await screen.findByText(/Approx Total:/)).textContent).toMatch(/200/);
+    expect(screen.queryByText("Failed to load portfolio")).not.toBeInTheDocument();
+  });
+
   it("clears the loading state when a stale request resolves while the newer request is still pending", async () => {
     mockGetOwners.mockResolvedValue([
       { owner: "alice", accounts: [] },
@@ -228,6 +336,22 @@ describe("Portfolio page", () => {
     });
 
     expect(screen.queryByText(/^Loading…$/)).not.toBeInTheDocument();
+
+    await act(async () => {
+      bob.resolve({
+        owner: "bob",
+        as_of: "2024-01-01",
+        trades_this_month: 0,
+        trades_remaining: 0,
+        total_value_estimate_gbp: 200,
+        accounts: [
+          { account_type: "isa", currency: "GBP", value_estimate_gbp: 200, holdings: [] },
+        ],
+      } as Portfolio);
+      await bob.promise;
+    });
+
+    expect((await screen.findByText(/Approx Total:/)).textContent).toMatch(/200/);
   });
 
   it("shows available owners excluding demo entries", async () => {


### PR DESCRIPTION
### Motivation

Closes #5341 

- Prevent regressions where stale frontend requests or their errors overwrite the current owner's UI state when multiple portfolio requests are in flight, as tracked by issue #5341.

### Description

- Extended the test helper `deferred()` in `frontend/tests/unit/pages/Portfolio.test.tsx` to return a `reject` function so tests can simulate request failures. 
- Added tests that assert a newer owner request's error remains visible when a stale request resolves later, and that stale request errors are ignored while a newer request is pending. 
- Strengthened the existing stale-first-completion test to verify the newer owner's data is ultimately rendered (by providing portfolio account fixtures with value). 
- These are test-only changes implementing the coverage requested for the owner-switch race scenarios and will auto-close issue #5341.

### Testing

- Ran the unit test file with `npm --prefix frontend run test -- --run tests/unit/pages/Portfolio.test.tsx` and all 6 tests passed. 
- Ran lint with `npm --prefix frontend run lint -- --quiet` and it succeeded without reported issues. 
- The modified test file is `frontend/tests/unit/pages/Portfolio.test.tsx` and the changes are limited to test helpers and new test cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a67ae20a48327aa852fa0c25c82a9)