### PR TITLE
Reuse and validate the Moneyhub API client

### DIFF
--- a/backend/bootstrap/startup.py
+++ b/backend/bootstrap/startup.py
@@ -60,6 +60,12 @@ class AppLifecycleService:
         self.temp_dirs = temp_dirs or []
 
     async def startup(self, app: FastAPI) -> None:
+        # Keep Moneyhub optional for local/test deployments, but fail fast on
+        # partial credentials instead of waiting for the first import request.
+        from backend.routes.transactions import validate_moneyhub_configuration
+
+        validate_moneyhub_configuration()
+
         if not self.cfg.skip_snapshot_warm:
             await self._warm_snapshot(app)
 

--- a/backend/common/moneyhub_tokens.py
+++ b/backend/common/moneyhub_tokens.py
@@ -1,0 +1,106 @@
+"""Per-owner Moneyhub OAuth token storage.
+
+Follows the secret storage decision in
+``docs/moneyhub-integration.md``: each owner's token set (access token,
+refresh token, expiry, connected account ids) is one JSON blob under an
+``ssm://`` parameter -- ``/allotmint/moneyhub/tokens/{owner}`` by default,
+loaded through the existing pluggable :func:`backend.common.storage.get_storage`
+abstraction rather than a new secret-loading mechanism. Refresh happens
+lazily on read (check expiry, refresh if needed, write back), consistent
+with the rest of the backend having no background workers.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from backend.common.storage import get_storage
+from backend.integrations.moneyhub_api import MoneyhubAPIError, MoneyhubClient
+
+_DEFAULT_URI_TEMPLATE = "ssm:///allotmint/moneyhub/tokens/{owner}"
+
+
+class MoneyhubAuthError(Exception):
+    """Raised when an owner has no stored Moneyhub consent to import against."""
+
+
+@dataclass
+class TokenSet:
+    access_token: str
+    refresh_token: str
+    expires_at: float
+    account_ids: List[str] = field(default_factory=list)
+
+    def is_expired(self, *, skew_seconds: int = 60) -> bool:
+        """True once ``expires_at`` is within ``skew_seconds`` of now."""
+        return time.time() >= (self.expires_at - skew_seconds)
+
+    def to_dict(self) -> dict:
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "expires_at": self.expires_at,
+            "account_ids": self.account_ids,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TokenSet":
+        return cls(
+            access_token=data["access_token"],
+            refresh_token=data["refresh_token"],
+            expires_at=data["expires_at"],
+            account_ids=list(data.get("account_ids") or []),
+        )
+
+
+def _storage_uri(owner: str) -> str:
+    template = os.environ.get("MONEYHUB_TOKENS_STORAGE_URI", _DEFAULT_URI_TEMPLATE)
+    return template.format(owner=owner)
+
+
+def load_token_set(owner: str) -> Optional[TokenSet]:
+    """Return the stored token set for ``owner``, or ``None`` if absent."""
+    data = get_storage(_storage_uri(owner)).load()
+    if not data:
+        return None
+    return TokenSet.from_dict(data)
+
+
+def save_token_set(owner: str, token_set: TokenSet) -> None:
+    """Persist ``token_set`` for ``owner``."""
+    get_storage(_storage_uri(owner)).save(token_set.to_dict())
+
+
+def get_valid_access_token(owner: str, client: MoneyhubClient) -> str:
+    """Return a usable access token for ``owner``, refreshing if needed.
+
+    Raises:
+        MoneyhubAuthError: no token set is stored for ``owner`` (they have
+            not completed the Moneyhub consent flow), or the stored refresh
+            token has been rejected by Moneyhub.
+    """
+    token_set = load_token_set(owner)
+    if token_set is None:
+        raise MoneyhubAuthError(f"No Moneyhub consent stored for owner '{owner}'")
+
+    if not token_set.is_expired():
+        return token_set.access_token
+
+    try:
+        refreshed = client.refresh_access_token(token_set.refresh_token)
+    except MoneyhubAPIError as exc:
+        raise MoneyhubAuthError(
+            f"Moneyhub token refresh failed for owner '{owner}': {exc}"
+        ) from exc
+
+    new_token_set = TokenSet(
+        access_token=refreshed["access_token"],
+        refresh_token=refreshed.get("refresh_token", token_set.refresh_token),
+        expires_at=time.time() + refreshed.get("expires_in", 3600),
+        account_ids=token_set.account_ids,
+    )
+    save_token_set(owner, new_token_set)
+    return new_token_set.access_token

--- a/backend/importers/moneyhub_api.py
+++ b/backend/importers/moneyhub_api.py
@@ -1,0 +1,87 @@
+"""Maps raw Moneyhub Open Banking API transaction records to AllotMint's ``Transaction``.
+
+Field mapping follows the plan in ``docs/moneyhub-integration.md``. Moneyhub
+is a cash/bank-account aggregator (Open Banking AISP data), not a brokerage
+feed, so these map onto AllotMint's cash-movement transactions
+(``kind="account"``) rather than share trades -- there is no
+ticker/price/shares source field to populate.
+
+This is distinct from :mod:`backend.importers.moneyhub`, which parses manual
+Moneyhub CSV exports (#3426); this module maps the live API's JSON response
+shape (#3425) instead. Both feed the same ``Transaction`` model and the same
+shared :func:`backend.importers.dedupe_against_existing` helper.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+
+from backend.routes.transactions import Transaction
+
+# Per the design doc's open question: Moneyhub returns transactions in
+# various lifecycle states. "pending" transactions are excluded here because
+# they later settle under a different, "posted" Moneyhub id -- importing
+# both would double-count the same real-world movement.
+_EXCLUDED_STATUSES = frozenset({"pending"})
+
+
+def _amount_minor(amount: Mapping[str, Any] | None) -> Optional[float]:
+    """Convert Moneyhub's decimal major-unit amount to minor units (pence/cents)."""
+    if not amount:
+        return None
+    value = amount.get("amount")
+    if value is None:
+        return None
+    try:
+        return round(float(value) * 100)
+    except (TypeError, ValueError):
+        return None
+
+
+def _currency(amount: Mapping[str, Any] | None) -> Optional[str]:
+    if not amount:
+        return None
+    return amount.get("currency")
+
+
+def map_transactions(
+    raw: List[Dict[str, Any]],
+    owner: str,
+    *,
+    account_id_map: Optional[Mapping[str, str]] = None,
+) -> List[Transaction]:
+    """Map raw Moneyhub transaction records into ``Transaction`` rows for ``owner``.
+
+    ``account_id_map`` translates Moneyhub's own ``accountId`` values into
+    AllotMint account slugs (per the design doc, no automatic correspondence
+    exists between the two, so this is a one-time manual link per connected
+    account); unmapped account ids fall through unchanged so callers can see
+    what still needs linking rather than silently dropping the row.
+    """
+    account_id_map = account_id_map or {}
+    transactions: List[Transaction] = []
+
+    for item in raw:
+        if (item.get("status") or "").lower() in _EXCLUDED_STATUSES:
+            continue
+
+        raw_account_id = item.get("accountId") or ""
+        account = account_id_map.get(raw_account_id, raw_account_id)
+        raw_id = item.get("id")
+
+        transactions.append(
+            Transaction(
+                external_id=f"moneyhub:{raw_id}" if raw_id else None,
+                owner=owner,
+                account=account,
+                date=item.get("date"),
+                type=item.get("category"),
+                kind="account",
+                amount_minor=_amount_minor(item.get("amount")),
+                currency=_currency(item.get("amount")),
+                comments=item.get("description"),
+                synthetic=False,
+            )
+        )
+
+    return transactions

--- a/backend/integrations/moneyhub_api.py
+++ b/backend/integrations/moneyhub_api.py
@@ -1,0 +1,105 @@
+"""OAuth2 client for the Moneyhub Open Banking API.
+
+Implements the access method and auth flow decided in
+``docs/moneyhub-integration.md`` (issue #2749): the official Moneyhub API
+(OAuth2/OIDC, ``transactions:read`` scope), never scraping
+``client.moneyhub.co.uk``. This module is a thin, stateless HTTP wrapper --
+it does not know how tokens are stored; see
+:mod:`backend.common.moneyhub_tokens` for the per-owner token persistence
+that sits above it.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from backend.common.url_validator import validate_external_url
+
+log = logging.getLogger("integrations.moneyhub")
+
+
+class MoneyhubAPIError(Exception):
+    """Raised when a Moneyhub API call fails."""
+
+
+@dataclass
+class MoneyhubClient:
+    """Adapter for the Moneyhub Open Banking transactions API.
+
+    Only the subset needed to refresh a token and pull transactions is
+    implemented -- registering the OAuth2 client and completing the initial
+    user-consent authorization-code exchange is a one-off, human-driven step
+    (see ``docs/moneyhub-integration.md#handoff-to-a-human``), not something
+    this adapter automates.
+    """
+
+    client_id: str
+    client_secret: str
+    base_url: str = "https://api.moneyhub.co.uk"
+    timeout: int = 10
+
+    def _headers(self, access_token: str) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {access_token}"}
+
+    def refresh_access_token(self, refresh_token: str) -> Dict[str, Any]:
+        """Exchange ``refresh_token`` for a new access/refresh token pair.
+
+        Returns the raw token response (``access_token``, ``refresh_token``,
+        ``expires_in``, ...) for the caller to persist -- this adapter has no
+        opinion on storage, see :mod:`backend.common.moneyhub_tokens`.
+        """
+        url = f"{self.base_url}/oidc/token"
+        validate_external_url(url)
+        try:
+            resp = requests.post(
+                url,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                timeout=self.timeout,
+                allow_redirects=False,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as exc:
+            raise MoneyhubAPIError(f"Token refresh failed: {exc}") from exc
+
+    def fetch_transactions(self, access_token: str, *, account_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Fetch raw transaction records for the consented accounts.
+
+        ``account_id`` narrows the pull to a single connected account;
+        omitted, Moneyhub returns transactions across every account the
+        owner has consented to share. Field mapping into AllotMint's
+        ``Transaction`` model happens separately -- see
+        :mod:`backend.importers.moneyhub_api`.
+        """
+        url = f"{self.base_url}/transactions"
+        validate_external_url(url)
+        params: Dict[str, str] = {}
+        if account_id:
+            params["accountId"] = account_id
+
+        try:
+            resp = requests.get(
+                url,
+                params=params,
+                headers=self._headers(access_token),
+                timeout=self.timeout,
+                allow_redirects=False,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except requests.RequestException as exc:
+            raise MoneyhubAPIError(f"Transaction fetch failed: {exc}") from exc
+
+        transactions = payload.get("data", payload.get("transactions", [])) if isinstance(payload, dict) else payload
+        if not isinstance(transactions, list) or not all(isinstance(item, dict) for item in transactions):
+            raise MoneyhubAPIError("Transaction fetch returned an invalid payload")
+        return transactions

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, File, Form, HTTPException, Query, Request, Upload
 from pydantic import BaseModel, ConfigDict, Field
 
 from backend import importers
-from backend.common import compliance, data_loader
+from backend.common import compliance, data_loader, moneyhub_tokens
 from backend.common.accounts_store import (
     LocalAccountsStore,
     S3AccountsStore,
@@ -23,11 +23,14 @@ from backend.common.accounts_store import (
 from backend.common.instruments import get_instrument_meta
 from backend.common.ticker_utils import normalise_filter_ticker
 from backend.config import config
+from backend.integrations.moneyhub_api import MoneyhubAPIError, MoneyhubClient
 from backend.routes._accounts import resolve_accounts_root
 from backend.utils import update_holdings_from_csv
 
 router = APIRouter(tags=["transactions"])
 log = logging.getLogger("transactions")
+
+_moneyhub_client_instance: MoneyhubClient | None = None
 
 # resolve_writable_store() has always lived in this module (never in
 # data_loader.py); this flag dedupes its missing-DATA_BUCKET warning to
@@ -785,6 +788,87 @@ async def import_transactions(
 
         tx_data = _tx_data_from_parsed(row)
         persisted.append(_persist_transaction(store, row_owner, row_account, tx_data))
+
+    return {"persisted": persisted, "skipped": skipped}
+
+
+def _get_moneyhub_client() -> MoneyhubClient:
+    """Return the process-wide Moneyhub client, creating it on first use."""
+    global _moneyhub_client_instance
+
+    if _moneyhub_client_instance is None:
+        client_id = os.environ.get("MONEYHUB_CLIENT_ID")
+        client_secret = os.environ.get("MONEYHUB_CLIENT_SECRET")
+        if not client_id or not client_secret:
+            raise RuntimeError("MONEYHUB_CLIENT_ID and MONEYHUB_CLIENT_SECRET must be set")
+        _moneyhub_client_instance = MoneyhubClient(
+            client_id=client_id,
+            client_secret=client_secret,
+            base_url=os.environ.get("MONEYHUB_BASE_URL", "https://api.moneyhub.co.uk"),
+        )
+
+    return _moneyhub_client_instance
+
+
+def validate_moneyhub_configuration() -> None:
+    """Validate credentials at startup when the optional integration is configured."""
+    if os.environ.get("MONEYHUB_CLIENT_ID") or os.environ.get("MONEYHUB_CLIENT_SECRET"):
+        _get_moneyhub_client()
+
+
+@router.post("/transactions/import/moneyhub")
+async def import_moneyhub_transactions(request: Request, owner: str = Form(...)) -> Dict[str, List[Dict[str, Any]]]:
+    """Pull ``owner``'s transactions from the live Moneyhub API, persist the new ones, and report the rest.
+
+    Unlike :func:`import_transactions` (file upload), this pulls directly
+    from Moneyhub using the owner's stored OAuth consent (see
+    :mod:`backend.common.moneyhub_tokens`) -- the access method and auth
+    flow decided in ``docs/moneyhub-integration.md`` (#2749). Requires the
+    owner to have already completed the Moneyhub consent flow and have a
+    token set stored; there is no self-service way for this endpoint to
+    initiate that consent itself.
+    """
+    owner = _validate_component(owner, "owner")
+
+    from backend.importers import moneyhub_api as moneyhub_mapper
+
+    client = _get_moneyhub_client()
+    try:
+        access_token = moneyhub_tokens.get_valid_access_token(owner, client)
+    except moneyhub_tokens.MoneyhubAuthError as exc:
+        raise HTTPException(status_code=424, detail=str(exc))
+
+    try:
+        raw = client.fetch_transactions(access_token)
+    except MoneyhubAPIError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    parsed = moneyhub_mapper.map_transactions(raw, owner)
+    if not parsed:
+        return {"persisted": [], "skipped": []}
+
+    store = _require_writable_store(request)
+
+    if any(t.external_id for t in parsed):
+        existing = _load_all_transactions(store)
+        parsed = importers.dedupe_against_existing(parsed, existing)
+
+    persisted: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, Any]] = []
+
+    for row in parsed:
+        row_account = row.account
+        if not row_account:
+            skipped.append({**row.model_dump(mode="json"), "skip_reason": "missing account"})
+            continue
+        try:
+            row_account = _validate_component(row_account, "account")
+        except HTTPException as exc:
+            skipped.append({**row.model_dump(mode="json"), "skip_reason": str(exc.detail)})
+            continue
+
+        tx_data = _tx_data_from_parsed(row)
+        persisted.append(_persist_transaction(store, owner, row_account, tx_data))
 
     return {"persisted": persisted, "skipped": skipped}
 

--- a/docs/moneyhub-integration.md
+++ b/docs/moneyhub-integration.md
@@ -169,3 +169,35 @@ To close out the remaining success criteria in #2749:
 3. Store the sandbox credentials via `ssm://` per [Secret storage
    decision](#secret-storage-decision) (SecureString) and hand the parameter
    name to the agent implementing #3425.
+
+## #3425 implementation status
+
+The importer infrastructure described above has been built against the
+field-mapping plan and auth flow decided here, ahead of real sandbox access
+(tracked in #3425):
+
+- [`backend/integrations/moneyhub_api.py`](../backend/integrations/moneyhub_api.py) —
+  stateless OAuth2 HTTP client (`refresh_access_token`, `fetch_transactions`)
+  against `https://api.moneyhub.co.uk`.
+- [`backend/common/moneyhub_tokens.py`](../backend/common/moneyhub_tokens.py) —
+  per-owner token storage via the `ssm://` scheme
+  (`/allotmint/moneyhub/tokens/{owner}` by default, overridable via
+  `MONEYHUB_TOKENS_STORAGE_URI` for tests/local dev), with lazy refresh-on-read.
+- [`backend/importers/moneyhub_api.py`](../backend/importers/moneyhub_api.py) —
+  maps raw API transaction records onto `Transaction` (`kind="account"`,
+  `external_id` prefixed `moneyhub:`, pending transactions excluded), reusing
+  the same `dedupe_against_existing` helper #3426's CSV importer uses.
+- `POST /transactions/import/moneyhub` (`backend/routes/transactions.py`) —
+  pulls an owner's transactions live and persists new ones through the same
+  `_persist_transaction` path as the file-upload importer.
+
+**Still blocked on the human prerequisite above**: this was built against
+the documented-but-unconfirmed Moneyhub schema (`id`, `accountId`, `date`,
+`amount.amount`/`amount.currency`, `description`, `category`, `status`), and
+tests mock the HTTP layer rather than hitting a real sandbox. Once real
+sandbox credentials and a sample response exist, verify the field names and
+the cash-vs-trade-data question above, and adjust the mapping in
+`backend/importers/moneyhub_api.py` if they differ. The CDK `StringParameter`
+construct and IAM grant for the `/allotmint/moneyhub/*` namespace, and the
+account-id linking table (Moneyhub `accountId` → AllotMint account slug),
+remain open follow-up work.

--- a/tests/test_moneyhub_api_import.py
+++ b/tests/test_moneyhub_api_import.py
@@ -1,0 +1,404 @@
+import time
+
+import pytest
+import requests
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.common import moneyhub_tokens
+from backend.common.moneyhub_tokens import TokenSet
+from backend.common.url_validator import InvalidExternalURLError
+from backend.config import config
+from backend.importers import moneyhub_api as moneyhub_mapper
+from backend.integrations.moneyhub_api import MoneyhubAPIError, MoneyhubClient
+from backend.routes import transactions as transactions_route
+
+# ---------------------------------------------------------------------------
+# backend.integrations.moneyhub_api.MoneyhubClient
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_moneyhub_client(monkeypatch):
+    monkeypatch.setattr(transactions_route, "_moneyhub_client_instance", None)
+
+
+def test_get_moneyhub_client_is_lazy_and_reused(monkeypatch):
+    monkeypatch.setenv("MONEYHUB_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MONEYHUB_CLIENT_SECRET", "client-secret")
+
+    first = transactions_route._get_moneyhub_client()
+    second = transactions_route._get_moneyhub_client()
+
+    assert first is second
+    assert first.client_id == "client-id"
+    assert first.client_secret == "client-secret"
+
+
+@pytest.mark.parametrize("missing", ["MONEYHUB_CLIENT_ID", "MONEYHUB_CLIENT_SECRET"])
+def test_get_moneyhub_client_requires_credentials(monkeypatch, missing):
+    monkeypatch.setenv("MONEYHUB_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MONEYHUB_CLIENT_SECRET", "client-secret")
+    monkeypatch.delenv(missing)
+
+    with pytest.raises(RuntimeError, match="MONEYHUB_CLIENT_ID and MONEYHUB_CLIENT_SECRET must be set"):
+        transactions_route._get_moneyhub_client()
+
+
+def test_startup_validation_rejects_partial_configuration(monkeypatch):
+    monkeypatch.setenv("MONEYHUB_CLIENT_ID", "client-id")
+    monkeypatch.delenv("MONEYHUB_CLIENT_SECRET", raising=False)
+
+    with pytest.raises(RuntimeError, match="MONEYHUB_CLIENT_ID and MONEYHUB_CLIENT_SECRET must be set"):
+        transactions_route.validate_moneyhub_configuration()
+
+
+def test_startup_validation_allows_unconfigured_optional_integration(monkeypatch):
+    monkeypatch.delenv("MONEYHUB_CLIENT_ID", raising=False)
+    monkeypatch.delenv("MONEYHUB_CLIENT_SECRET", raising=False)
+
+    transactions_route.validate_moneyhub_configuration()
+
+
+def test_refresh_access_token_posts_expected_payload(monkeypatch):
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+    called = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"access_token": "new-token", "refresh_token": "new-refresh", "expires_in": 3600}
+
+    def fake_post(url, data=None, timeout=None, **kwargs):
+        called["url"] = url
+        called["data"] = data
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    result = client.refresh_access_token("old-refresh")
+
+    assert result["access_token"] == "new-token"
+    assert called["url"] == "https://api.moneyhub.co.uk/oidc/token"
+    assert called["data"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": "old-refresh",
+        "client_id": "id",
+        "client_secret": "secret",
+    }
+
+
+def test_refresh_access_token_wraps_network_error(monkeypatch):
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+
+    def fake_post(*args, **kwargs):
+        raise requests.RequestException("network error")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    with pytest.raises(MoneyhubAPIError, match="Token refresh failed"):
+        client.refresh_access_token("old-refresh")
+
+
+def test_fetch_transactions_returns_data_list(monkeypatch):
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+    called = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": [{"id": "tx-1"}, {"id": "tx-2"}]}
+
+    def fake_get(url, params=None, headers=None, timeout=None, **kwargs):
+        called["url"] = url
+        called["params"] = params
+        called["headers"] = headers
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    txs = client.fetch_transactions("access-token", account_id="acc-1")
+
+    assert [t["id"] for t in txs] == ["tx-1", "tx-2"]
+    assert called["params"] == {"accountId": "acc-1"}
+    assert called["headers"] == {"Authorization": "Bearer access-token"}
+
+
+def test_fetch_transactions_returns_bare_list_payload(monkeypatch):
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return [{"id": "tx-1"}]
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: FakeResponse())
+    txs = client.fetch_transactions("access-token")
+    assert txs == [{"id": "tx-1"}]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"data": None},
+        {"data": "not-a-list"},
+        {"data": [{"id": "tx-1"}, "not-an-object"]},
+    ],
+)
+def test_fetch_transactions_rejects_invalid_payload(monkeypatch, payload):
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: FakeResponse())
+
+    with pytest.raises(MoneyhubAPIError, match="invalid payload"):
+        client.fetch_transactions("access-token")
+
+
+def test_fetch_transactions_wraps_network_error(monkeypatch):
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+
+    def fake_get(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    with pytest.raises(MoneyhubAPIError, match="Transaction fetch failed"):
+        client.fetch_transactions("access-token")
+
+
+def test_client_rejects_private_base_url():
+    client = MoneyhubClient(client_id="id", client_secret="secret", base_url="https://127.0.0.1")
+    with pytest.raises(InvalidExternalURLError):
+        client.fetch_transactions("access-token")
+
+
+# ---------------------------------------------------------------------------
+# backend.importers.moneyhub_api.map_transactions
+# ---------------------------------------------------------------------------
+
+
+def test_map_transactions_maps_fields():
+    raw = [
+        {
+            "id": "tx-1",
+            "accountId": "mh-acc-1",
+            "date": "2024-05-01",
+            "amount": {"amount": -42.50, "currency": "GBP"},
+            "description": "Tesco Store",
+            "category": "Groceries",
+            "status": "posted",
+        }
+    ]
+    txs = moneyhub_mapper.map_transactions(raw, "alice", account_id_map={"mh-acc-1": "Current"})
+
+    assert len(txs) == 1
+    tx = txs[0]
+    assert tx.external_id == "moneyhub:tx-1"
+    assert tx.owner == "alice"
+    assert tx.account == "Current"
+    assert tx.date == "2024-05-01"
+    assert tx.amount_minor == -4250
+    assert tx.currency == "GBP"
+    assert tx.comments == "Tesco Store"
+    assert tx.type == "Groceries"
+    assert tx.kind == "account"
+    assert tx.synthetic is False
+
+
+def test_map_transactions_excludes_pending():
+    raw = [
+        {"id": "tx-1", "accountId": "a", "amount": {"amount": 1.0}, "status": "pending"},
+        {"id": "tx-2", "accountId": "a", "amount": {"amount": 2.0}, "status": "posted"},
+    ]
+    txs = moneyhub_mapper.map_transactions(raw, "alice")
+    assert [t.external_id for t in txs] == ["moneyhub:tx-2"]
+
+
+def test_map_transactions_unmapped_account_id_falls_through():
+    raw = [{"id": "tx-1", "accountId": "mh-unknown", "amount": {"amount": 1.0}}]
+    txs = moneyhub_mapper.map_transactions(raw, "alice")
+    assert txs[0].account == "mh-unknown"
+
+
+def test_map_transactions_missing_amount_is_none():
+    raw = [{"id": "tx-1", "accountId": "a"}]
+    txs = moneyhub_mapper.map_transactions(raw, "alice")
+    assert txs[0].amount_minor is None
+    assert txs[0].currency is None
+
+
+def test_map_transactions_non_numeric_amount_is_none():
+    raw = [{"id": "tx-1", "accountId": "a", "amount": {"amount": "not-a-number"}}]
+    txs = moneyhub_mapper.map_transactions(raw, "alice")
+    assert txs[0].amount_minor is None
+
+
+# ---------------------------------------------------------------------------
+# backend.common.moneyhub_tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def token_storage(tmp_path, monkeypatch):
+    template = str(tmp_path / "{owner}.json")
+    monkeypatch.setenv("MONEYHUB_TOKENS_STORAGE_URI", f"file://{template}")
+    return template
+
+
+def test_load_token_set_returns_none_when_absent(token_storage):
+    assert moneyhub_tokens.load_token_set("alice") is None
+
+
+def test_save_and_load_token_set_round_trips(token_storage):
+    token_set = TokenSet(access_token="a", refresh_token="r", expires_at=123.0, account_ids=["acc-1"])
+    moneyhub_tokens.save_token_set("alice", token_set)
+
+    loaded = moneyhub_tokens.load_token_set("alice")
+    assert loaded == token_set
+
+
+def test_get_valid_access_token_returns_cached_when_not_expired(token_storage):
+    token_set = TokenSet(access_token="a", refresh_token="r", expires_at=time.time() + 3600)
+    moneyhub_tokens.save_token_set("alice", token_set)
+
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+    assert moneyhub_tokens.get_valid_access_token("alice", client) == "a"
+
+
+def test_get_valid_access_token_refreshes_when_expired(token_storage, monkeypatch):
+    token_set = TokenSet(access_token="stale", refresh_token="r", expires_at=time.time() - 10)
+    moneyhub_tokens.save_token_set("alice", token_set)
+
+    def fake_post(url, data=None, timeout=None, **kwargs):
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"access_token": "fresh", "refresh_token": "r2", "expires_in": 3600}
+
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+    token = moneyhub_tokens.get_valid_access_token("alice", client)
+
+    assert token == "fresh"
+    reloaded = moneyhub_tokens.load_token_set("alice")
+    assert reloaded.access_token == "fresh"
+    assert reloaded.refresh_token == "r2"
+
+
+def test_get_valid_access_token_raises_when_no_token_stored(token_storage):
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+    with pytest.raises(moneyhub_tokens.MoneyhubAuthError, match="No Moneyhub consent"):
+        moneyhub_tokens.get_valid_access_token("alice", client)
+
+
+def test_get_valid_access_token_raises_on_refresh_failure(token_storage, monkeypatch):
+    token_set = TokenSet(access_token="stale", refresh_token="r", expires_at=time.time() - 10)
+    moneyhub_tokens.save_token_set("alice", token_set)
+
+    def fake_post(*args, **kwargs):
+        raise requests.RequestException("rejected")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    client = MoneyhubClient(client_id="id", client_secret="secret")
+    with pytest.raises(moneyhub_tokens.MoneyhubAuthError, match="token refresh failed"):
+        moneyhub_tokens.get_valid_access_token("alice", client)
+
+
+# ---------------------------------------------------------------------------
+# /transactions/import/moneyhub route
+# ---------------------------------------------------------------------------
+
+
+def _make_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "accounts_root", tmp_path)
+    monkeypatch.setenv("MONEYHUB_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("MONEYHUB_CLIENT_SECRET", "test-client-secret")
+    template = str(tmp_path / "tokens" / "{owner}.json")
+    monkeypatch.setenv("MONEYHUB_TOKENS_STORAGE_URI", f"file://{template}")
+    app = create_app()
+    return TestClient(app)
+
+
+def test_import_moneyhub_route_requires_consent(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    resp = client.post("/transactions/import/moneyhub", data={"owner": "alice"})
+    assert resp.status_code == 424
+
+
+def test_import_moneyhub_route_persists_and_dedupes_on_reimport(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    token_set = TokenSet(access_token="a", refresh_token="r", expires_at=time.time() + 3600)
+    moneyhub_tokens.save_token_set("alice", token_set)
+
+    raw_transactions = [
+        {
+            "id": "tx-1",
+            "accountId": "Current",
+            "date": "2024-05-01",
+            "amount": {"amount": -42.50, "currency": "GBP"},
+            "description": "Tesco Store",
+            "category": "Groceries",
+            "status": "posted",
+        },
+        {
+            "id": "tx-2",
+            "accountId": "Current",
+            "date": "2024-05-02",
+            "amount": {"amount": 1500.00, "currency": "GBP"},
+            "description": "Salary",
+            "category": "Income",
+            "status": "posted",
+        },
+    ]
+
+    def fake_get(url, params=None, headers=None, timeout=None, **kwargs):
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"data": raw_transactions}
+
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    resp = client.post("/transactions/import/moneyhub", data={"owner": "alice"})
+    assert resp.status_code == 200
+    first = resp.json()
+    assert first["skipped"] == []
+    assert {t["external_id"] for t in first["persisted"]} == {"moneyhub:tx-1", "moneyhub:tx-2"}
+    assert all(t["owner"] == "alice" for t in first["persisted"])
+    assert all(t["account"] == "Current" for t in first["persisted"])
+
+    # Re-importing must not create duplicates.
+    resp = client.post("/transactions/import/moneyhub", data={"owner": "alice"})
+    assert resp.status_code == 200
+    assert resp.json() == {"persisted": [], "skipped": []}
+
+
+def test_import_moneyhub_route_surfaces_upstream_failure(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    token_set = TokenSet(access_token="a", refresh_token="r", expires_at=time.time() + 3600)
+    moneyhub_tokens.save_token_set("alice", token_set)
+
+    def fake_get(*args, **kwargs):
+        raise requests.RequestException("upstream down")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    resp = client.post("/transactions/import/moneyhub", data={"owner": "alice"})
+    assert resp.status_code == 502


### PR DESCRIPTION
### Motivation

- Avoid creating a new `MoneyhubClient` on every request to improve performance and match the repo's client-initialisation pattern. 
- Surface missing or partial `MONEYHUB_CLIENT_ID`/`MONEYHUB_CLIENT_SECRET` configuration early with a clear error instead of confusing downstream auth failures. 
- Keep the Moneyhub integration optional for deployments that do not configure it while failing fast for partial/incorrect setups.

### Description

- Introduced a process-wide, lazily-initialised Moneyhub client via `_get_moneyhub_client()` and a module-level `_moneyhub_client_instance` in `backend/routes/transactions.py`. 
- Added `validate_moneyhub_configuration()` and invoked it during application startup from `backend/bootstrap/startup.py` to detect partial credential configuration at startup. 
- Updated the Moneyhub import route `POST /transactions/import/moneyhub` to use the shared client and to propagate clear HTTP errors for missing consent or upstream API failures. 
- Added focused test coverage in `tests/test_moneyhub_api_import.py` to exercise lazy initialisation, singleton reuse, missing credentials, optional-unconfigured behaviour, and the route-level behavior when test credentials are provided.

### Testing

- Ran format/lint checks with `black` and `ruff` against the modified files and fixed formatting; the checks passed. 
- Ran the Moneyhub-focused pytest file with `PYENV_VERSION=3.11.15 python -m pytest --no-cov tests/test_moneyhub_api_import.py -q` and all tests in that file passed (`28 passed`). 
- Verified repository hygiene with `git diff --check` which reported no issues.

Closes #5479

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a6f4b0cd883278dca40b9dde0928d)