### PR TITLE
Test Moneyhub imports with empty dates

### DIFF
--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -146,6 +146,19 @@ def test_moneyhub_parse_empty_csv_returns_no_transactions():
     assert moneyhub.parse(csv_data.encode("utf-8")) == []
 
 
+def test_moneyhub_parse_row_with_empty_date_has_no_composite_key():
+    csv_data = (
+        "Owner,Account,Date,Amount,Description,Category\n"
+        "alice,Current,,-42.50,Tesco Store,Groceries\n"
+    )
+
+    transactions = moneyhub.parse(csv_data.encode("utf-8"))
+
+    assert len(transactions) == 1
+    assert transactions[0].date == ""
+    assert transactions[0].external_id is None
+
+
 def test_moneyhub_parse_rejects_csv_with_unrecognised_columns():
     csv_data = "Foo,Bar\nx,y\n"
     with pytest.raises(ValueError, match="missing required columns"):


### PR DESCRIPTION
### Motivation
- Add parser-level regression coverage to ensure a Moneyhub CSV row with an empty `Date` field is parsed without error and does not receive a synthetic composite `external_id` (the `_composite_key` contract requires a date and should return `None` when missing). 

### Description
- Added `test_moneyhub_parse_row_with_empty_date_has_no_composite_key` to `tests/test_transactions_import.py` which parses a one-row Moneyhub CSV with an empty `Date` and asserts the parsed transaction's `date` is `""` and `external_id` is `None`; no production code was modified. 

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/test_transactions_import.py -q --no-cov` (24 passed) and `PYENV_VERSION=3.11.15 python -m ruff check --config backend/pyproject.toml tests/test_transactions_import.py` which both succeeded, and `git diff --check` which reported no issues; running the focused tests with repository coverage enabled fails the repo-wide `fail-under=90` threshold (expected and unrelated to this focused test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a6f260fb88327889b18ce0ce1e02f)