### PR TITLE
Cover Moneyhub CSV rows with missing dates

### DIFF
--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -94,10 +94,7 @@ def test_degiro_to_float_invalid_inputs():
 
 
 def test_degiro_parse_handles_bad_data():
-    csv_data = (
-        "owner,account,date,ticker,type,price,units\n"
-        "bob,ISA,2024-05-02,MSFT,BUY,,oops\n"
-    )
+    csv_data = "owner,account,date,ticker,type,price,units\n" "bob,ISA,2024-05-02,MSFT,BUY,,oops\n"
     txs = degiro.parse(csv_data.encode("utf-8"))
     assert len(txs) == 1
     tx = txs[0]
@@ -141,9 +138,19 @@ def test_moneyhub_to_float_invalid_inputs():
     assert moneyhub._to_float(None) is None
 
 
-def test_moneyhub_parse_empty_csv_returns_no_transactions():
+def test_moneyhub_parse_header_only_csv_returns_no_transactions():
     csv_data = "Id,Owner,Account,Date,Amount,Description,Category\n"
     assert moneyhub.parse(csv_data.encode("utf-8")) == []
+
+
+def test_moneyhub_parse_empty_date_leaves_composite_key_unset():
+    csv_data = "Owner,Account,Date,Amount,Description,Category\n" "alice,Current,,-42.50,Tesco Store,Groceries\n"
+
+    txs = moneyhub.parse(csv_data.encode("utf-8"))
+
+    assert len(txs) == 1
+    assert txs[0].date == ""
+    assert txs[0].external_id is None
 
 
 def test_moneyhub_parse_rejects_csv_with_unrecognised_columns():


### PR DESCRIPTION
### Motivation

- Issue #5345 consolidates concerns about `_composite_key` handling when the `date` field is missing or empty and requests test coverage for header-only and empty-date CSV rows.
- Add focused regression tests to prove the parser treats an empty `date` as absent for dedupe-key generation without changing parsing behaviour.

### Description

- Renamed the existing header-only test to `test_moneyhub_parse_header_only_csv_returns_no_transactions` to make its intent explicit.
- Added `test_moneyhub_parse_empty_date_leaves_composite_key_unset` which parses a valid Moneyhub-style row with an empty `Date` and asserts the row is returned with `date == ""` and `external_id is None` (no synthetic composite key produced). 
- This change only adds/renames tests under `tests/test_transactions_import.py` and does not modify production code; Closes #5345.

### Testing

- Ran the targeted test file with `PYENV_VERSION=3.11.15 python -m pytest --no-cov tests/test_transactions_import.py -q` which passed (`24 passed`).
- Ran formatter and lint checks with `python -m black --check --config backend/pyproject.toml tests/test_transactions_import.py` and `python -m ruff check --config backend/pyproject.toml tests/test_transactions_import.py`, both of which passed after formatting.
- Running the full test suite with coverage (`pytest`) in this environment surfaced the repository-wide coverage guard (fail-under=90%) and reported failure due to low total coverage, but the focused tests and tooling checks for the modified file succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a6f12f8c48327a931df2459f04d35)