### PR TITLE
Cover Moneyhub imports with empty dates

### DIFF
--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -146,6 +146,19 @@ def test_moneyhub_parse_empty_csv_returns_no_transactions():
     assert moneyhub.parse(csv_data.encode("utf-8")) == []
 
 
+def test_moneyhub_parse_row_with_empty_date_has_no_composite_key():
+    csv_data = (
+        "Owner,Account,Date,Amount,Description,Category\n"
+        "alice,Current,,-42.50,Tesco Store,Groceries\n"
+    )
+
+    transactions = moneyhub.parse(csv_data.encode("utf-8"))
+
+    assert len(transactions) == 1
+    assert transactions[0].date == ""
+    assert transactions[0].external_id is None
+
+
 def test_moneyhub_parse_rejects_csv_with_unrecognised_columns():
     csv_data = "Foo,Bar\nx,y\n"
     with pytest.raises(ValueError, match="missing required columns"):


### PR DESCRIPTION
### Motivation
- Ensure Moneyhub CSV parsing handles rows with an empty `Date` field without producing an unstable synthetic `external_id` and to add regression coverage requested in the consolidated issue (Closes #5345).

### Description
- Add `test_moneyhub_parse_row_with_empty_date_has_no_composite_key` to `tests/test_transactions_import.py` which parses a single-row CSV with an empty `Date` and asserts the transaction is returned and `external_id` is `None`; no production code was modified.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/test_transactions_import.py -q --no-cov` which executed the focused suite and reported `24 passed`.
- A focused pytest run with repository coverage enabled ran the same tests but exited non-zero because the single-file run cannot meet the repo-wide `fail-under=90` coverage threshold (repository coverage check failed). 
- `black --check tests/test_transactions_import.py` and `ruff check tests/test_transactions_import.py` were run and reported pre-existing formatting/line-length issues outside this change (no new lint failures introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a70d119708327ae4ebea49024559f)