### PR TITLE
Cover owner provisioning scaffold failures

### DIFF
--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -144,9 +144,7 @@ def test_resolve_owner_slug_stamps_identity_immediately_after_mkdir(tmp_path):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
 
-    winner = signup_provision._resolve_owner_slug(
-        "jane@example.com", accounts_root, "Jane Doe"
-    )
+    winner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
     assert winner == "jane"
 
     # The winner's person.json must carry the complete identity immediately.
@@ -211,6 +209,29 @@ def test_resolve_owner_slug_cleans_up_on_scaffold_failure(tmp_path, monkeypatch)
     assert owner == "jane"
 
 
+def test_provision_owner_cleans_up_on_scaffold_failure(tmp_path, monkeypatch):
+    """A scaffold failure must propagate through the public provisioning API."""
+
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+    store_calls = []
+
+    class FakeStore:
+        def ensure_owner(self, owner):
+            store_calls.append(owner)
+
+    def _failing_scaffold(*_args, **_kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(signup_provision, "ensure_owner_scaffold", _failing_scaffold)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        signup_provision.provision_owner(_record("jane@example.com"), accounts_root, store=FakeStore())
+
+    assert not (accounts_root / "jane").exists()
+    assert store_calls == []
+
+
 def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
@@ -219,9 +240,7 @@ def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     # Occupy both candidate slugs with a different email so none can be reused.
     for name in ("jane", "jane-2"):
         (accounts_root / name).mkdir()
-        (accounts_root / name / "person.json").write_text(
-            json.dumps({"email": "other@example.com"})
-        )
+        (accounts_root / name / "person.json").write_text(json.dumps({"email": "other@example.com"}))
 
     with pytest.raises(RuntimeError):
         signup_provision.provision_owner(_record("jane@example.com"), accounts_root)


### PR DESCRIPTION
### Motivation
- Ensure the public `provision_owner` API propagates scaffold errors, cleans up any partially-created owner directory, and does not call the backing store after a scaffold failure, closing the test-coverage gap tracked in the issue.

### Description
- Added `test_provision_owner_cleans_up_on_scaffold_failure` to `tests/backend/test_signup_provision.py` which monkeypatches `ensure_owner_scaffold` to raise and asserts `provision_owner` propagates the `OSError`, removes the created directory, and does not call `store.ensure_owner`.
- Minor formatting cleanup in `tests/backend/test_signup_provision.py` (Black reformat) as part of the change.
- Changes were committed on branch `fix/issue-5344` and a PR prepared that references `Closes #5344`.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/backend/test_signup_provision.py -q --no-cov` and got `16 passed` for the file-level tests.
- Ran formatting and lint checks with `black` and `ruff` against `tests/backend/test_signup_provision.py`, which succeeded (file reformatted by Black then checks passed).
- A prior repository-wide coverage run (`pytest --cov`) failed due to overall project coverage being below the CI threshold (unrelated to this test-only change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a710fdda0832785450519597ce6ee)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added regression coverage for signup provisioning failures, ensuring newly created owner directories are cleaned up when setup cannot be completed.
  * Confirmed that the original provisioning error is preserved and no account record is created after the failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->