### PR TITLE
Test owner provisioning scaffold failures

### DIFF
--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -144,9 +144,7 @@ def test_resolve_owner_slug_stamps_identity_immediately_after_mkdir(tmp_path):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
 
-    winner = signup_provision._resolve_owner_slug(
-        "jane@example.com", accounts_root, "Jane Doe"
-    )
+    winner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
     assert winner == "jane"
 
     # The winner's person.json must carry the complete identity immediately.
@@ -209,6 +207,31 @@ def test_resolve_owner_slug_cleans_up_on_scaffold_failure(tmp_path, monkeypatch)
     monkeypatch.undo()
     owner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
     assert owner == "jane"
+
+
+def test_provision_owner_propagates_scaffold_failure_without_calling_store(tmp_path, monkeypatch):
+    """The public provisioning path must not hide or continue after scaffold failure."""
+
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+    store_calls = []
+
+    class FakeStore:
+        def ensure_owner(self, owner):
+            store_calls.append(owner)
+
+    def _failing_scaffold(*_args, **_kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(signup_provision, "ensure_owner_scaffold", _failing_scaffold)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        signup_provision.provision_owner(
+            _record("jane@example.com"), accounts_root, store=FakeStore()
+        )
+
+    assert not (accounts_root / "jane").exists()
+    assert store_calls == []
 
 
 def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation
- Add regression coverage to ensure the public `provision_owner` path propagates scaffold-time failures and does not continue to invoke writable-store logic or leave a partially-created owner directory.

### Description
- Add `test_provision_owner_propagates_scaffold_failure_without_calling_store` to `tests/backend/test_signup_provision.py` which monkeypatches `ensure_owner_scaffold` to raise `OSError`, asserts the created directory is removed, and verifies a supplied store's `ensure_owner` is not called; Closes #5344.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest -q --no-cov tests/backend/test_signup_provision.py` (16 passed), `PYENV_VERSION=3.11.15 python -m ruff check tests/backend/test_signup_provision.py` (passed), `PYENV_VERSION=3.11.15 python -m black --check tests/backend/test_signup_provision.py` (passed after formatting), and `git diff --check` (no issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a70d560bc8327a9e4d4a694186bce)