### PR TITLE
Cover Moneyhub CSV rows with empty dates

### DIFF
--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -131,8 +131,12 @@ def test_moneyhub_parse_uses_id_column_when_present():
 
 def test_moneyhub_composite_key_requires_date_and_amount():
     assert moneyhub._composite_key(None, "Current", -42.50, "Tesco") is None
+    assert moneyhub._composite_key("", "Current", -42.50, "Tesco") is None
     assert moneyhub._composite_key("2024-05-01", "Current", None, "Tesco") is None
-    assert moneyhub._composite_key("2024-05-01", "Current", -42.50, "Tesco") == "2024-05-01|Current|-42.50|tesco"
+    assert (
+        moneyhub._composite_key("2024-05-01", "Current", -42.50, "Tesco")
+        == "2024-05-01|Current|-42.50|tesco"
+    )
 
 
 def test_moneyhub_to_float_invalid_inputs():
@@ -144,6 +148,19 @@ def test_moneyhub_to_float_invalid_inputs():
 def test_moneyhub_parse_empty_csv_returns_no_transactions():
     csv_data = "Id,Owner,Account,Date,Amount,Description,Category\n"
     assert moneyhub.parse(csv_data.encode("utf-8")) == []
+
+
+def test_moneyhub_parse_row_with_empty_date_has_no_composite_key():
+    csv_data = (
+        "Owner,Account,Date,Amount,Description,Category\n"
+        "alice,Current,,-42.50,Tesco Store,Groceries\n"
+    )
+
+    transactions = moneyhub.parse(csv_data.encode("utf-8"))
+
+    assert len(transactions) == 1
+    assert transactions[0].date == ""
+    assert transactions[0].external_id is None
 
 
 def test_moneyhub_parse_rejects_csv_with_unrecognised_columns():
@@ -177,7 +194,10 @@ def test_moneyhub_parse_header_matching_is_case_insensitive_for_id(id_header):
 
 
 def test_moneyhub_parse_header_matching_is_case_insensitive_for_required_columns():
-    csv_data = "OWNER,ACCOUNT,DATE,AMOUNT,description,category\nalice,Current,2024-05-01,-42.50,Tesco,Groceries\n"
+    csv_data = (
+        "OWNER,ACCOUNT,DATE,AMOUNT,description,category\n"
+        "alice,Current,2024-05-01,-42.50,Tesco,Groceries\n"
+    )
     txs = moneyhub.parse(csv_data.encode("utf-8"))
     assert len(txs) == 1
     assert txs[0].owner == "alice"


### PR DESCRIPTION
### Motivation

- Issue #5345 consolidated reports that Moneyhub importer behavior around missing or empty `date` fields lacked explicit regression coverage.
- The code already guards against `None` for `date`, but empty-string CSV fields were not directly covered by tests.

### Description

- Added an assertion that `_composite_key` returns `None` when `date` is an empty string in `tests/test_transactions_import.py`.
- Added `test_moneyhub_parse_row_with_empty_date_has_no_composite_key` to verify a Moneyhub CSV row with an empty `Date` field parses without producing a synthetic `external_id`.
- Reformatted two long test string/assertion lines in the same test module so the file passes `ruff` linting.
- This PR is test-only and does not change importer implementation logic; it closes the test-coverage gap for empty-date rows. (Closes #5345)

### Testing

- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/test_transactions_import.py -q --no-cov` and all tests in that module passed (`24 passed`).
- Ran `ruff` on the modified test file and it passed with no errors.
- Ran repository-level pytest with coverage for the single module which succeeded locally for the module, but a full-suite coverage check reported the project-wide coverage is below the repo `fail-under=90` threshold (expected when running an isolated module); this does not indicate a regression in the change.
- Ran `git diff --check` to ensure no whitespace or diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a71d603cc8327848bca90e0a1e784)