### PR TITLE
Cover Moneyhub rows with empty dates

### DIFF
--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -94,10 +94,7 @@ def test_degiro_to_float_invalid_inputs():
 
 
 def test_degiro_parse_handles_bad_data():
-    csv_data = (
-        "owner,account,date,ticker,type,price,units\n"
-        "bob,ISA,2024-05-02,MSFT,BUY,,oops\n"
-    )
+    csv_data = "owner,account,date,ticker,type,price,units\n" "bob,ISA,2024-05-02,MSFT,BUY,,oops\n"
     txs = degiro.parse(csv_data.encode("utf-8"))
     assert len(txs) == 1
     tx = txs[0]
@@ -144,6 +141,16 @@ def test_moneyhub_to_float_invalid_inputs():
 def test_moneyhub_parse_empty_csv_returns_no_transactions():
     csv_data = "Id,Owner,Account,Date,Amount,Description,Category\n"
     assert moneyhub.parse(csv_data.encode("utf-8")) == []
+
+
+def test_moneyhub_parse_row_with_empty_date_has_no_composite_key():
+    csv_data = "Id,Owner,Account,Date,Amount,Description,Category\n" ",alice,Current,,-42.50,Tesco Store,Groceries\n"
+
+    txs = moneyhub.parse(csv_data.encode("utf-8"))
+
+    assert len(txs) == 1
+    assert txs[0].date == ""
+    assert txs[0].external_id is None
 
 
 def test_moneyhub_parse_rejects_csv_with_unrecognised_columns():


### PR DESCRIPTION
### Motivation
- Add a parser-level regression test for Moneyhub CSV rows whose `Date` field is empty so the existing `_composite_key` date None-safety is exercised and protected against regressions (issue #5345).

### Description
- Added `test_moneyhub_parse_row_with_empty_date_has_no_composite_key` to `tests/test_transactions_import.py` which parses an otherwise-valid Moneyhub CSV row with an empty `Date` and asserts the row parses and `external_id` is `None`.
- No production code changes were required because `backend/importers/moneyhub.py::_composite_key` already returns `None` when `date` or `amount` is missing.
- Changes committed on branch `fix/issue-5345-composite-key-none-safety` with commit message `Cover Moneyhub rows with empty dates` and this PR will `Closes #5345`.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest --no-cov tests/test_transactions_import.py -q` and all tests in that file passed (24 passed, 1 warning).
- Ran `python -m black --config backend/pyproject.toml --check backend/importers/moneyhub.py tests/test_transactions_import.py` and `python -m ruff check --config backend/pyproject.toml backend/importers/moneyhub.py tests/test_transactions_import.py`, both of which passed.
- Ran `git diff --check` with no whitespace/patch issues detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a72874c9c8327bb5e81b337f89d1a)