### PR TITLE
Cover owner provisioning scaffold failures

### DIFF
--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -144,9 +144,7 @@ def test_resolve_owner_slug_stamps_identity_immediately_after_mkdir(tmp_path):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
 
-    winner = signup_provision._resolve_owner_slug(
-        "jane@example.com", accounts_root, "Jane Doe"
-    )
+    winner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
     assert winner == "jane"
 
     # The winner's person.json must carry the complete identity immediately.
@@ -163,8 +161,8 @@ def test_resolve_owner_slug_stamps_identity_immediately_after_mkdir(tmp_path):
     assert sorted(p.name for p in accounts_root.iterdir()) == ["jane"]
 
 
-def test_resolve_owner_slug_cleans_up_on_write_failure(tmp_path, monkeypatch):
-    """If the identity write fails after mkdir, the orphan directory is removed."""
+def test_resolve_owner_slug_cleans_up_on_identity_write_failure(tmp_path, monkeypatch):
+    """If the identity write fails after mkdir, cleanup permits a retry."""
 
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
@@ -179,6 +177,11 @@ def test_resolve_owner_slug_cleans_up_on_write_failure(tmp_path, monkeypatch):
 
     # The directory created by mkdir must be cleaned up.
     assert not (accounts_root / "jane").exists()
+
+    # Once the transient write failure clears, the same slug can be reclaimed.
+    monkeypatch.undo()
+    owner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
+    assert owner == "jane"
 
 
 def test_resolve_owner_slug_cleans_up_on_scaffold_failure(tmp_path, monkeypatch):
@@ -211,6 +214,27 @@ def test_resolve_owner_slug_cleans_up_on_scaffold_failure(tmp_path, monkeypatch)
     assert owner == "jane"
 
 
+def test_provision_owner_cleans_up_on_scaffold_failure(tmp_path, monkeypatch):
+    """A scaffold failure propagates through provisioning without side effects."""
+
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+
+    def _failing_scaffold(*_args, **_kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(signup_provision, "ensure_owner_scaffold", _failing_scaffold)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+
+    assert not (accounts_root / "jane").exists()
+
+    monkeypatch.undo()
+    owner = signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+    assert owner == "jane"
+
+
 def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
@@ -219,9 +243,7 @@ def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     # Occupy both candidate slugs with a different email so none can be reused.
     for name in ("jane", "jane-2"):
         (accounts_root / name).mkdir()
-        (accounts_root / name / "person.json").write_text(
-            json.dumps({"email": "other@example.com"})
-        )
+        (accounts_root / name / "person.json").write_text(json.dumps({"email": "other@example.com"}))
 
     with pytest.raises(RuntimeError):
         signup_provision.provision_owner(_record("jane@example.com"), accounts_root)


### PR DESCRIPTION
### Motivation

- Close gaps in failure-path test coverage for owner provisioning by exercising identity-write and scaffold-failure paths flagged in issue #5344. 
- Ensure `_resolve_owner_slug` and the public `provision_owner` contract clean up orphan directories and allow successful retries after transient errors. 

### Description

- Added/updated tests in `tests/backend/test_signup_provision.py` to cover an identity-write failure: `test_resolve_owner_slug_cleans_up_on_identity_write_failure` verifies the created directory is removed and the original slug can be reclaimed after the transient failure clears. 
- Added `test_provision_owner_cleans_up_on_scaffold_failure` to exercise scaffold failures at the public `provision_owner` level, asserting exception propagation, orphan-directory cleanup, and successful retry. 
- This is a test-only change and does not modify production code behavior. 
- Closes #5344

### Testing

- Ran the focused unit file with `PYENV_VERSION=3.11.15 python -m pytest tests/backend/test_signup_provision.py -q --no-cov`, and all tests in that module passed. 
- Formatting and lint checks with `python -m black --check --config backend/pyproject.toml tests/backend/test_signup_provision.py` and `python -m ruff check --config backend/pyproject.toml tests/backend/test_signup_provision.py` passed. 
- Running the full pytest invocation that enforces repository coverage failed the global coverage gate (repo-wide `fail-under=90`), but the new tests themselves passed; this is expected when running an isolated test file against the repo-level coverage threshold.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a72a425d883278ed37ecd946bbe10)