### PR TITLE
Cover owner scaffold provisioning failures

### DIFF
--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -144,9 +144,7 @@ def test_resolve_owner_slug_stamps_identity_immediately_after_mkdir(tmp_path):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
 
-    winner = signup_provision._resolve_owner_slug(
-        "jane@example.com", accounts_root, "Jane Doe"
-    )
+    winner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
     assert winner == "jane"
 
     # The winner's person.json must carry the complete identity immediately.
@@ -163,8 +161,8 @@ def test_resolve_owner_slug_stamps_identity_immediately_after_mkdir(tmp_path):
     assert sorted(p.name for p in accounts_root.iterdir()) == ["jane"]
 
 
-def test_resolve_owner_slug_cleans_up_on_write_failure(tmp_path, monkeypatch):
-    """If the identity write fails after mkdir, the orphan directory is removed."""
+def test_resolve_owner_slug_cleans_up_on_identity_write_failure(tmp_path, monkeypatch):
+    """An identity-write failure removes the orphan and permits a retry."""
 
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
@@ -179,6 +177,10 @@ def test_resolve_owner_slug_cleans_up_on_write_failure(tmp_path, monkeypatch):
 
     # The directory created by mkdir must be cleaned up.
     assert not (accounts_root / "jane").exists()
+
+    monkeypatch.undo()
+    owner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
+    assert owner == "jane"
 
 
 def test_resolve_owner_slug_cleans_up_on_scaffold_failure(tmp_path, monkeypatch):
@@ -211,6 +213,27 @@ def test_resolve_owner_slug_cleans_up_on_scaffold_failure(tmp_path, monkeypatch)
     assert owner == "jane"
 
 
+def test_provision_owner_cleans_up_on_scaffold_failure(tmp_path, monkeypatch):
+    """The public provisioning flow propagates scaffold errors without debris."""
+
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+
+    def _failing_scaffold(*_args, **_kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(signup_provision, "ensure_owner_scaffold", _failing_scaffold)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+
+    assert not (accounts_root / "jane").exists()
+
+    monkeypatch.undo()
+    owner = signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+    assert owner == "jane"
+
+
 def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
@@ -219,9 +242,7 @@ def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     # Occupy both candidate slugs with a different email so none can be reused.
     for name in ("jane", "jane-2"):
         (accounts_root / name).mkdir()
-        (accounts_root / name / "person.json").write_text(
-            json.dumps({"email": "other@example.com"})
-        )
+        (accounts_root / name / "person.json").write_text(json.dumps({"email": "other@example.com"}))
 
     with pytest.raises(RuntimeError):
         signup_provision.provision_owner(_record("jane@example.com"), accounts_root)


### PR DESCRIPTION
### Motivation

- Increase test coverage for owner provisioning to cover identity-write failures inside `_resolve_owner_slug` and scaffold failures surfaced by the public `provision_owner` path as requested in issue #5344.
- Prevent orphaned owner directories after transient disk/write/scaffold errors and ensure retry behavior is exercised by the test suite.

### Description

- Updated `tests/backend/test_signup_provision.py` to rename/expand the existing identity-write failure test into `test_resolve_owner_slug_cleans_up_on_identity_write_failure` and assert cleanup and successful retry.
- Added `test_provision_owner_cleans_up_on_scaffold_failure` to verify `provision_owner` propagates scaffold errors, removes any orphaned directory, and allows a subsequent successful retry.
- All changes are test-only and do not modify production code or API surfaces.

### Testing

- Ran the module tests with `PYENV_VERSION=3.11.15 pytest -q --no-cov tests/backend/test_signup_provision.py`, which passed (`16 passed`).
- Ran style/format checks with `python -m ruff check --config backend/pyproject.toml tests/backend/test_signup_provision.py` and `python -m black --check --config backend/pyproject.toml tests/backend/test_signup_provision.py`, both succeeded.
- Added the tests without changing production behavior; note that repository-wide coverage gating prevents running a single-module coverage run without hitting the global fail-under threshold.

Closes #5344

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a731859a483278d78a6b8c23df1ca)