### PR TITLE
Improve add position collapse accessibility

### DIFF
--- a/frontend/src/components/AddPositionForm.tsx
+++ b/frontend/src/components/AddPositionForm.tsx
@@ -11,9 +11,10 @@ type Props = {
   defaultAccount?: string;
   onAdded?: () => void;
   onCollapse?: () => void;
+  controlsId?: string;
 };
 
-export function AddPositionForm({ owner, accounts, defaultAccount, onAdded, onCollapse }: Props) {
+export function AddPositionForm({ owner, accounts, defaultAccount, onAdded, onCollapse, controlsId }: Props) {
   const { t } = useTranslation();
   const [account, setAccount] = useState(defaultAccount ?? accounts[0] ?? "");
   const [ticker, setTicker] = useState("");
@@ -80,6 +81,7 @@ export function AddPositionForm({ owner, accounts, defaultAccount, onAdded, onCo
 
   return (
     <form
+      id={controlsId}
       onSubmit={handleSubmit}
       aria-label={t("addPosition.title")}
       className="mb-6 rounded-lg border border-gray-800 bg-black/20 p-4"
@@ -91,9 +93,14 @@ export function AddPositionForm({ owner, accounts, defaultAccount, onAdded, onCo
             type="button"
             onClick={onCollapse}
             aria-label={t("addPosition.collapse")}
+            aria-expanded="true"
+            aria-controls={controlsId}
             className="rounded border border-gray-700 px-2 py-0.5 text-sm text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
           >
-            −
+            <svg aria-hidden="true" viewBox="0 0 12 12" className="mr-1 inline-block h-3 w-3">
+              <path d="M2 6h8" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+            {t("addPosition.collapseShort")}
           </button>
         )}
       </div>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -232,6 +232,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
   const [addPositionAccount, setAddPositionAccount] = useState<string | undefined>(undefined);
   const [addPositionExpanded, setAddPositionExpanded] = useState(false);
   const addPositionRef = useRef<HTMLDivElement>(null);
+  const addPositionFormId = "add-position-form";
   const { baseCurrency, familyMvpEnabled, enableAdvancedAnalytics = true } = useConfig();
 
   const accountKey = (acct: Account, idx: number) => `${acct.account_type}-${idx}`;
@@ -243,6 +244,23 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
   useEffect(() => {
     setPendingDate(data?.as_of ?? "");
   }, [data?.as_of]);
+
+  const handleAddPositionCollapse = useCallback(() => {
+    setAddPositionExpanded(false);
+    setAddPositionAccount(undefined);
+  }, []);
+
+  useEffect(() => {
+    if (!addPositionExpanded) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !event.defaultPrevented) {
+        handleAddPositionCollapse();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [addPositionExpanded, handleAddPositionCollapse]);
 
   const owner = data?.owner ?? null;
   const asOf = data?.as_of ?? null;
@@ -340,11 +358,6 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
     onPositionAdded?.();
   };
 
-  const handleAddPositionCollapse = () => {
-    setAddPositionExpanded(false);
-    setAddPositionAccount(undefined);
-  };
-
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
@@ -415,11 +428,14 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
                   defaultAccount={addPositionAccount}
                   onAdded={handlePositionAdded}
                   onCollapse={handleAddPositionCollapse}
+                  controlsId={addPositionFormId}
                 />
               ) : (
                 <button
                   type="button"
                   onClick={() => setAddPositionExpanded(true)}
+                  aria-expanded="false"
+                  aria-controls={addPositionFormId}
                   className="rounded border border-gray-700 px-3 py-1.5 text-sm text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
                 >
                   + {t("addPosition.title")}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -20,7 +20,8 @@
       "generic": "Position konnte nicht hinzugefügt werden."
     },
     "emptyAccountCta": "Erste Position hinzufügen",
-    "collapse": "Formular zum Hinzufügen einer Position einklappen"
+    "collapse": "Formular zum Hinzufügen einer Position einklappen",
+    "collapseShort": "Einklappen"
   },
   "alertSettings": {
     "description": "Konfigurieren Sie, wann Sie Benachrichtigungen erhalten. Die Alarme erscheinen auf der Alerts-Seite und als Push-Benachrichtigungen.",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -20,7 +20,8 @@
       "generic": "Failed to add position."
     },
     "emptyAccountCta": "Add your first position",
-    "collapse": "Collapse add position form"
+    "collapse": "Collapse add position form",
+    "collapseShort": "Collapse"
   },
   "alertSettings": {
     "description": "Configure when you'll receive alerts. Alerts appear on the Alerts page and in push notifications.",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -20,7 +20,8 @@
       "generic": "No se pudo añadir la posición."
     },
     "emptyAccountCta": "Añade tu primera posición",
-    "collapse": "Contraer formulario de añadir posición"
+    "collapse": "Contraer formulario de añadir posición",
+    "collapseShort": "Contraer"
   },
   "alertSettings": {
     "description": "Configura cuándo recibirás alertas. Las alertas aparecen en la página de alertas y en las notificaciones push.",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -20,7 +20,8 @@
       "generic": "Impossible d'ajouter la position."
     },
     "emptyAccountCta": "Ajouter votre première position",
-    "collapse": "Réduire le formulaire d'ajout de position"
+    "collapse": "Réduire le formulaire d'ajout de position",
+    "collapseShort": "Réduire"
   },
   "alertSettings": {
     "description": "Configurez quand vous recevrez des alertes. Les alertes apparaissent sur la page des alertes et dans les notifications push.",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -20,7 +20,8 @@
       "generic": "Impossibile aggiungere la posizione."
     },
     "emptyAccountCta": "Aggiungi la tua prima posizione",
-    "collapse": "Comprimi il modulo di aggiunta posizione"
+    "collapse": "Comprimi il modulo di aggiunta posizione",
+    "collapseShort": "Comprimi"
   },
   "alertSettings": {
     "description": "Configura quando riceverai avvisi. Gli avvisi compaiono nella pagina degli avvisi e nelle notifiche push.",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -20,7 +20,8 @@
       "generic": "Não foi possível adicionar a posição."
     },
     "emptyAccountCta": "Adicione a sua primeira posição",
-    "collapse": "Recolher formulário de adicionar posição"
+    "collapse": "Recolher formulário de adicionar posição",
+    "collapseShort": "Recolher"
   },
   "alertSettings": {
     "description": "Configure quando receber alertas. Os alertas aparecem na página de alertas e nas notificações push.",

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -161,6 +161,29 @@ describe("PortfolioView", () => {
         expect(within(screen.getByRole("form", { name: /^add position$/i })).getByLabelText(/account/i)).toHaveValue("ISA");
     });
 
+    it("exposes the add-position expansion state and collapses on Escape", () => {
+        render(<PortfolioView data={mockOwner} />);
+
+        const expandButton = screen.getByRole("button", { name: /\+ add position/i });
+        expect(expandButton).toHaveAttribute("aria-expanded", "false");
+        expect(expandButton).toHaveAttribute("aria-controls", "add-position-form");
+
+        fireEvent.click(expandButton);
+        const collapseButton = screen.getByRole("button", { name: /collapse add position form/i });
+        expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+        expect(collapseButton).toHaveAttribute("aria-controls", "add-position-form");
+        expect(screen.getByRole("form", { name: /^add position$/i })).toHaveAttribute("id", "add-position-form");
+        expect(collapseButton).toHaveTextContent("Collapse");
+        expect(collapseButton.querySelector("svg")).toBeInTheDocument();
+
+        fireEvent.keyDown(document, { key: "Enter" });
+        expect(screen.getByRole("form", { name: /^add position$/i })).toBeInTheDocument();
+
+        fireEvent.keyDown(document, { key: "Escape" });
+        expect(screen.queryByRole("form", { name: /^add position$/i })).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /\+ add position/i })).toHaveAttribute("aria-expanded", "false");
+    });
+
     it("hides the CSV import form when no accounts exist", () => {
         const emptyOwner: Portfolio = { ...mockOwner, accounts: [] };
 


### PR DESCRIPTION
### Motivation
- Expose the add-position toggle state to assistive technology by linking the expand/collapse controls to the controlled form region.
- Provide a clearer visible collapse affordance (short visible text + icon) while preserving the full `aria-label` for screen readers.
- Let keyboard users dismiss the open add-position form with `Escape` and ensure the listener is active only while the form is expanded.

### Description
- Added a `controlsId` prop and `id` on the add-position form so it can be referenced from the toggle controls.
- Added `aria-expanded` and `aria-controls` attributes to the expand and collapse buttons and wired them to the form id.
- Implemented an expanded-only `Escape` key handler in `PortfolioView` that invokes the same collapse handler and unregisters itself on collapse/unmount.
- Replaced the Unicode minus glyph with an inline SVG and a short localized visible label while retaining the original full `aria-label` text.
- Added `collapseShort` keys to locale files and updated unit test coverage in `frontend/tests/unit/components/PortfolioView.test.tsx` to validate expansion semantics, icon/label presence, and Escape-to-collapse behavior.
- Small test and formatting edits to reflect the new attributes and strings (files modified: `AddPositionForm.tsx`, `PortfolioView.tsx`, locale JSONs, and the portfolio view tests).

### Testing
- Ran the frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/components/AddPositionForm.test.tsx tests/unit/components/PortfolioView.test.tsx`; all tests passed (`22 tests passed`).
- Ran lint with `npm --prefix frontend run lint -- --quiet`; succeeded.
- Ran TypeScript check with `npm --prefix frontend run type-check`; succeeded.
- Ran `npm --prefix frontend run build:preview`; build completed successfully.
- Verified locale JSONs with `jq empty` and ran `git diff --check`; no issues reported.
- Attempted an automated Playwright screenshot run, but browser installation failed due to the Playwright CDN returning HTTP 403 in this environment, so a screenshot could not be produced (Playwright install failed). 

Closes #5472

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a7336bb70832799de72bd7070da2f)