### PR TITLE
Cover Moneyhub rows with empty dates

### DIFF
--- a/backend/importers/moneyhub.py
+++ b/backend/importers/moneyhub.py
@@ -51,7 +51,10 @@ def _composite_key(date: str | None, account: str, amount: float | None, descrip
 
     Returns ``None`` (no stable key) unless both ``date`` and ``amount`` are
     present, since those two fields carry the most identifying weight for a
-    bank/aggregator transaction row.
+    bank/aggregator transaction row. ``not date`` is ``True`` for both
+    ``None`` and an empty string, so a row with a blank ``Date`` column is
+    treated the same as a row missing the column's value entirely -- see
+    issue #5345.
     """
     if not date or amount is None:
         return None

--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -141,7 +141,8 @@ def test_moneyhub_to_float_invalid_inputs():
     assert moneyhub._to_float(None) is None
 
 
-def test_moneyhub_parse_empty_csv_returns_no_transactions():
+def test_moneyhub_parse_header_only_csv_returns_no_transactions():
+    """Header-only CSV (all required columns, zero data rows) parses to []."""
     csv_data = "Id,Owner,Account,Date,Amount,Description,Category\n"
     assert moneyhub.parse(csv_data.encode("utf-8")) == []
 

--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -146,6 +146,16 @@ def test_moneyhub_parse_empty_csv_returns_no_transactions():
     assert moneyhub.parse(csv_data.encode("utf-8")) == []
 
 
+def test_moneyhub_parse_row_with_empty_date_has_no_composite_key():
+    csv_data = "Owner,Account,Date,Amount,Description,Category\n" "alice,Current,,-42.50,Tesco Store,Groceries\n"
+
+    transactions = moneyhub.parse(csv_data.encode("utf-8"))
+
+    assert len(transactions) == 1
+    assert transactions[0].date == ""
+    assert transactions[0].external_id is None
+
+
 def test_moneyhub_parse_rejects_csv_with_unrecognised_columns():
     csv_data = "Foo,Bar\nx,y\n"
     with pytest.raises(ValueError, match="missing required columns"):


### PR DESCRIPTION
### Motivation
- Ensure `_composite_key` remains None-safe for Moneyhub rows whose `Date` field is empty by adding a parser-level regression test for an otherwise-valid CSV row, addressing the scenarios described in issue #5345.

### Description
- Add `test_moneyhub_parse_row_with_empty_date_has_no_composite_key` to `tests/test_transactions_import.py` which parses a Moneyhub CSV row with an empty `Date` and asserts the parsed row retains an empty `date` and has `external_id is None`, and include an auto-closing reference `Closes #5345`.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest --no-cov tests/test_transactions_import.py -q`, which passed all tests (24 passed).
- Ran formatting and lint checks with `python -m black --config backend/pyproject.toml tests/test_transactions_import.py` and `python -m ruff check --config backend/pyproject.toml tests/test_transactions_import.py`, which passed after formatting.
- A full `pytest` run with coverage succeeded on tests but the repository-wide coverage gate failed with `FAIL Required test coverage of 90% not reached; total coverage 27%`, which is unrelated to this focused, test-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a73e3fccc8327bc39838242dbf93c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified handling of transactions with an empty date during Moneyhub imports.
  * Transactions without a date no longer receive an external ID.

* **Tests**
  * Added regression coverage to verify empty-date transactions are imported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->