### PR TITLE
Cover owner provisioning scaffold failures

### DIFF
--- a/tests/backend/test_signup_provision.py
+++ b/tests/backend/test_signup_provision.py
@@ -144,9 +144,7 @@ def test_resolve_owner_slug_stamps_identity_immediately_after_mkdir(tmp_path):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
 
-    winner = signup_provision._resolve_owner_slug(
-        "jane@example.com", accounts_root, "Jane Doe"
-    )
+    winner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
     assert winner == "jane"
 
     # The winner's person.json must carry the complete identity immediately.
@@ -163,8 +161,8 @@ def test_resolve_owner_slug_stamps_identity_immediately_after_mkdir(tmp_path):
     assert sorted(p.name for p in accounts_root.iterdir()) == ["jane"]
 
 
-def test_resolve_owner_slug_cleans_up_on_write_failure(tmp_path, monkeypatch):
-    """If the identity write fails after mkdir, the orphan directory is removed."""
+def test_resolve_owner_slug_cleans_up_on_identity_write_failure(tmp_path, monkeypatch):
+    """An identity-write failure removes the orphan and permits a retry."""
 
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
@@ -179,6 +177,11 @@ def test_resolve_owner_slug_cleans_up_on_write_failure(tmp_path, monkeypatch):
 
     # The directory created by mkdir must be cleaned up.
     assert not (accounts_root / "jane").exists()
+
+    # Once the transient write failure clears, the original slug is available.
+    monkeypatch.undo()
+    owner = signup_provision._resolve_owner_slug("jane@example.com", accounts_root, "Jane Doe")
+    assert owner == "jane"
 
 
 def test_resolve_owner_slug_cleans_up_on_scaffold_failure(tmp_path, monkeypatch):
@@ -211,6 +214,28 @@ def test_resolve_owner_slug_cleans_up_on_scaffold_failure(tmp_path, monkeypatch)
     assert owner == "jane"
 
 
+def test_provision_owner_cleans_up_on_scaffold_failure(tmp_path, monkeypatch):
+    """The public provisioning path propagates failure without leaving an owner."""
+
+    accounts_root = tmp_path / "accounts"
+    accounts_root.mkdir()
+
+    def _failing_scaffold(*_args, **_kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(signup_provision, "ensure_owner_scaffold", _failing_scaffold)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+
+    assert not (accounts_root / "jane").exists()
+
+    # The outer call remains retryable after the transient failure clears.
+    monkeypatch.undo()
+    owner = signup_provision.provision_owner(_record("jane@example.com"), accounts_root)
+    assert owner == "jane"
+
+
 def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     accounts_root = tmp_path / "accounts"
     accounts_root.mkdir()
@@ -219,9 +244,8 @@ def test_resolve_owner_slug_raises_when_exhausted(tmp_path, monkeypatch):
     # Occupy both candidate slugs with a different email so none can be reused.
     for name in ("jane", "jane-2"):
         (accounts_root / name).mkdir()
-        (accounts_root / name / "person.json").write_text(
-            json.dumps({"email": "other@example.com"})
-        )
+        person_path = accounts_root / name / "person.json"
+        person_path.write_text(json.dumps({"email": "other@example.com"}))
 
     with pytest.raises(RuntimeError):
         signup_provision.provision_owner(_record("jane@example.com"), accounts_root)


### PR DESCRIPTION
### Motivation

- Add missing regression coverage for failures during owner provisioning so transient filesystem errors cannot leave orphan owner directories or consume slugs. 
- Provide tests at both the internal `_resolve_owner_slug` level (identity-write failure) and the public `provision_owner` boundary (scaffold failure) to reduce regression risk. 

### Description

- Updated `tests/backend/test_signup_provision.py` to rename and expand the identity-write failure test into `test_resolve_owner_slug_cleans_up_on_identity_write_failure` which verifies cleanup and retry. 
- Added `test_provision_owner_cleans_up_on_scaffold_failure` to verify `provision_owner` propagates scaffold failures, removes any orphan directory, and remains retryable after the transient error clears. 
- Small test hygiene change: factor out `person_path` when creating `person.json` fixtures and applied `black` formatting; no production code was modified. 

### Testing

- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/backend/test_signup_provision.py -q --no-cov` and all tests in that module passed (`16 passed`).
- Ran `PYENV_VERSION=3.11.15 python -m ruff check tests/backend/test_signup_provision.py` and the linter passed. 
- Applied `black` (`PYENV_VERSION=3.11.15 python -m black --config backend/pyproject.toml tests/backend/test_signup_provision.py`) to reformat the file and re-checked that formatting and `git diff --check` produced no issues. 
- Note: a full-repo coverage run earlier reported the repository-wide coverage threshold failure (total coverage 24% vs `fail-under=90`), which is unrelated to these test-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a726a937c832780de667ddda38838)