### PR TITLE
Add Moneyhub token storage infrastructure

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -28,6 +28,7 @@ from aws_cdk import aws_s3 as s3
 from constructs import Construct
 
 from stacks.exports import BACKEND_API_URL_EXPORT
+from stacks.moneyhub_token_store import MoneyhubTokenStore
 
 # S3 prefix (relative to the data bucket) under which per-owner writable account
 # documents are persisted. Kept in sync with
@@ -442,6 +443,15 @@ class BackendLambdaStack(Stack):
             memory_size=1024,
         )
         backend_fn.add_environment("APP_ENV", env)
+
+        # Moneyhub OAuth token sets are created lazily as per-owner SecureString
+        # parameters. Scope the API Lambda to that namespace only; the scheduled
+        # Lambdas do not participate in Moneyhub consent or token refresh.
+        moneyhub_token_store = MoneyhubTokenStore(self, "MoneyhubTokenStore")
+        moneyhub_token_store.grant_read_write(backend_fn)
+        backend_fn.add_environment(
+            "MONEYHUB_TOKEN_STORAGE_BASE", moneyhub_token_store.storage_uri
+        )
 
         # BackendLambda: read + put + list for API data paths. Add an explicit
         # timeseries cache grant below so the synthesized IAM policy always covers

--- a/cdk/stacks/moneyhub_token_store.py
+++ b/cdk/stacks/moneyhub_token_store.py
@@ -1,0 +1,38 @@
+"""Infrastructure contract for per-owner Moneyhub OAuth token storage."""
+
+from aws_cdk import ArnFormat, Stack
+from aws_cdk import aws_iam as iam
+from constructs import Construct
+
+
+class MoneyhubTokenStore(Construct):
+    """Grant access to the SecureString parameters in the Moneyhub namespace.
+
+    Token parameters are created lazily by the application because there is one
+    JSON document per owner. CloudFormation cannot provision an open-ended set
+    of owners and ``AWS::SSM::Parameter`` does not support ``SecureString``, so
+    this construct deliberately owns the namespace IAM contract rather than a
+    placeholder plaintext parameter.
+    """
+
+    PARAMETER_PATH = "/allotmint/moneyhub/tokens"
+
+    def __init__(self, scope: Construct, construct_id: str) -> None:
+        super().__init__(scope, construct_id)
+        self.parameter_path = self.PARAMETER_PATH
+        self.storage_uri = f"ssm://{self.parameter_path}"
+        self.parameter_arn = Stack.of(self).format_arn(
+            service="ssm",
+            resource="parameter",
+            resource_name=f"{self.parameter_path.lstrip('/')}/*",
+            arn_format=ArnFormat.SLASH_RESOURCE_NAME,
+        )
+
+    def grant_read_write(self, grantee: iam.IGrantable) -> iam.Grant:
+        """Allow ``grantee`` to decrypt, read, and update owner token sets."""
+
+        return iam.Grant.add_to_principal(
+            grantee=grantee,
+            actions=["ssm:GetParameter", "ssm:PutParameter"],
+            resource_arns=[self.parameter_arn],
+        )

--- a/cdk/tests/test_moneyhub_token_store.py
+++ b/cdk/tests/test_moneyhub_token_store.py
@@ -1,0 +1,56 @@
+"""Tests for the Moneyhub token-storage infrastructure contract."""
+
+import os
+
+from aws_cdk import App
+from aws_cdk.assertions import Match, Template
+from stacks.backend_lambda_stack import BackendLambdaStack
+
+
+def _template() -> Template:
+    os.environ.setdefault("JWT_SECRET", "test-secret")
+    os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client-id")
+    app = App(context={"data_bucket": "unit-test-data-bucket", "app_env": "aws"})
+    return Template.from_stack(BackendLambdaStack(app, "MoneyhubTokenStoreTest"))
+
+
+def test_backend_lambda_receives_moneyhub_token_namespace() -> None:
+    _template().has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Environment": {
+                "Variables": Match.object_like({"MONEYHUB_TOKEN_STORAGE_BASE": ("ssm:///allotmint/moneyhub/tokens")})
+            }
+        },
+    )
+
+
+def test_backend_lambda_can_only_read_and_write_moneyhub_token_parameters() -> None:
+    template = _template()
+    template.has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": {
+                "Statement": Match.array_with(
+                    [
+                        Match.object_like(
+                            {
+                                "Action": ["ssm:GetParameter", "ssm:PutParameter"],
+                                "Effect": "Allow",
+                                "Resource": {
+                                    "Fn::Join": Match.array_with(
+                                        [
+                                            Match.array_with(
+                                                [Match.string_like_regexp("parameter/allotmint/moneyhub/tokens/\\\\*")]
+                                            )
+                                        ]
+                                    )
+                                },
+                            }
+                        )
+                    ]
+                )
+            }
+        },
+    )
+    assert template.find_resources("AWS::SSM::Parameter") == {}

--- a/docs/moneyhub-integration.md
+++ b/docs/moneyhub-integration.md
@@ -98,24 +98,20 @@ has a working pluggable JSON storage abstraction selected by URI scheme:
 - `file://` — local file (tests/dev)
 - `s3://bucket/key.json` — S3 object
 - `ssm://parameter-name` — SSM Parameter Store, via
-  `ParameterStoreJSONStorage` (`backend/common/storage.py:86-112`), which
-  calls `boto3.client("ssm").get_parameter(..., WithDecryption=True)` on
-  read and `put_parameter(..., Type="String", Overwrite=True)` on write.
+  `ParameterStoreJSONStorage` (`backend/common/storage.py`), which calls
+  `boto3.client("ssm").get_parameter(..., WithDecryption=True)` on read and
+  defaults writes to `put_parameter(..., Type="SecureString", Overwrite=True)`.
 
 **Decision:** store each owner's Moneyhub OAuth token set (access token,
 refresh token, expiry, connected account IDs) as one JSON blob per owner
 under an `ssm://` parameter, e.g. `ssm:///allotmint/moneyhub/tokens/{owner}`,
 loaded through `get_storage()` exactly like the alerts module already does.
-Two changes needed on top of the existing abstraction (out of scope for this
-spike, listed for #3425):
-
-- `ParameterStoreJSONStorage` should use `Type="SecureString"` (not
-  `String`) when persisting token material — the current alerts use case
-  doesn't carry secrets, so this wasn't needed before.
-- A CDK `StringParameter`/`Secret` construct and IAM grant so the Lambda
-  execution role can read/write the `/allotmint/moneyhub/*` parameter
-  namespace — there is no existing CDK precedent for this in `cdk/stacks/`,
-  so it is new construct work, not a copy of an existing pattern.
+The storage abstraction now defaults to `SecureString`. The
+`MoneyhubTokenStore` CDK construct grants only the backend Lambda read/write
+access to `/allotmint/moneyhub/tokens/*` and exposes the namespace through
+`MONEYHUB_TOKEN_STORAGE_BASE`. It intentionally does not create a placeholder
+parameter: owner parameters are dynamic, and CloudFormation's
+`AWS::SSM::Parameter` resource cannot create `SecureString` values.
 
 Token refresh should happen lazily on read (check expiry, refresh if
 needed, write back the updated blob) rather than a separate scheduled job,


### PR DESCRIPTION
### Motivation

- Implement the infrastructure groundwork from issue #5340 so Moneyhub owner OAuth token sets are stored securely and accessible to the backend Lambda. 
- Ensure tokens are persisted as SSM `SecureString` parameters (one JSON blob per owner) and that the CDK stack grants least-privilege access to that namespace. 

### Description

- Added a new CDK construct `MoneyhubTokenStore` in `cdk/stacks/moneyhub_token_store.py` that models the `/allotmint/moneyhub/tokens/*` namespace ARN and exposes a `grant_read_write()` helper. 
- Wired the construct into the backend stack by granting the API Lambda `ssm:GetParameter` and `ssm:PutParameter` only for that namespace and exposing the namespace as the `MONEYHUB_TOKEN_STORAGE_BASE` environment variable in `cdk/stacks/backend_lambda_stack.py`. 
- Added synthesis/unit tests in `cdk/tests/test_moneyhub_token_store.py` asserting the Lambda environment variable, the least-privilege IAM policy, and that no plaintext `AWS::SSM::Parameter` resources are created. 
- Updated `docs/moneyhub-integration.md` to reflect that the storage abstraction defaults to `SecureString` and to document the new `MoneyhubTokenStore` contract. 
- Design note: the construct intentionally does not create `AWS::SSM::Parameter` resources because per-owner `SecureString` parameters are created dynamically by the application and cannot be modelled as an open-ended set in CloudFormation. 

Closes #5340

### Testing

- Ran the CDK unit/synthesis test suite with `PYENV_VERSION=3.11.15 python -m pytest -o addopts='' cdk/tests -q` and received `140 passed`. 
- Ran the new test file with `PYENV_VERSION=3.11.15 python -m pytest -o addopts='' cdk/tests/test_moneyhub_token_store.py -q` and it passed (`2 passed`). 
- Ran static checks: `ruff` (auto-fixed import ordering) and `black --check` against the new files and confirmed formatting/lint pass. 
- An attempt to run `tests/backend/common/test_storage.py` failed to collect due to a missing runtime dependency (`PyYAML`) in the execution environment and is unrelated to the introduced CDK changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a73c2aff88327ae86a5364deefebd)