### PR TITLE
Harden market headline recency filtering

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 """Market overview endpoint aggregating indexes, sectors and headlines."""
 
 import logging
+import math
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Literal, Optional, TypedDict
 
@@ -47,12 +49,38 @@ US_SECTOR_ETFS = {
 
 logger = logging.getLogger(__name__)
 
+HEADLINE_MAX_AGE_HOURS_DEFAULT = 72.0
+
+
+def _headline_max_age() -> timedelta:
+    """Return the configured maximum headline age, or the safe default."""
+
+    raw_hours = os.getenv("HEADLINE_MAX_AGE_HOURS")
+    if raw_hours is None:
+        return timedelta(hours=HEADLINE_MAX_AGE_HOURS_DEFAULT)
+
+    try:
+        hours = float(raw_hours)
+    except ValueError:
+        hours = 0.0
+
+    if not math.isfinite(hours) or hours <= 0:
+        logger.warning(
+            "Invalid HEADLINE_MAX_AGE_HOURS=%r; using %.0f hours",
+            raw_hours,
+            HEADLINE_MAX_AGE_HOURS_DEFAULT,
+        )
+        hours = HEADLINE_MAX_AGE_HOURS_DEFAULT
+
+    return timedelta(hours=hours)
+
+
 # Headlines older than this are excluded from the Market Overview feed so the
 # page doesn't surface stale stories mixed in with recent ones.  Mirrors the
 # staleness-threshold pattern used for cache freshness in
 # ``backend.routes.news.NEWS_MAX_STALENESS``, but this applies to the
 # article's own publish date rather than the cache's age.
-HEADLINE_MAX_AGE = timedelta(hours=72)
+HEADLINE_MAX_AGE = _headline_max_age()
 
 
 class IndexPayload(TypedDict):
@@ -248,7 +276,7 @@ def _parse_published_at(value: Any) -> Optional[datetime]:
     if not isinstance(value, str) or not value:
         return None
 
-    cleaned = value[:-1] + "+00:00" if value.endswith("Z") else value
+    cleaned = value.replace("Z", "+00:00")
     try:
         dt = datetime.fromisoformat(cleaned)
     except ValueError:

--- a/tests/backend/routes/test_market.py
+++ b/tests/backend/routes/test_market.py
@@ -168,6 +168,30 @@ def _iso(dt: datetime) -> str:
     return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+@pytest.mark.parametrize("value", [None, "", 123])
+def test_parse_published_at_rejects_missing_or_non_string_values(value):
+    assert market_module._parse_published_at(value) is None
+
+
+def test_parse_published_at_accepts_utc_designator():
+    assert market_module._parse_published_at("2026-01-02T03:04:05Z") == datetime(
+        2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc
+    )
+
+
+def test_headline_max_age_uses_environment_hours(monkeypatch):
+    monkeypatch.setenv("HEADLINE_MAX_AGE_HOURS", "24")
+
+    assert market_module._headline_max_age() == timedelta(hours=24)
+
+
+@pytest.mark.parametrize("value", ["invalid", "0", "-1", "inf"])
+def test_headline_max_age_falls_back_for_invalid_environment_value(monkeypatch, value):
+    monkeypatch.setenv("HEADLINE_MAX_AGE_HOURS", value)
+
+    assert market_module._headline_max_age() == timedelta(hours=72)
+
+
 def test_sort_and_filter_headlines_excludes_old_and_sorts_newest_first():
     now = datetime.now(timezone.utc)
     old = {
@@ -189,6 +213,25 @@ def test_sort_and_filter_headlines_excludes_old_and_sorts_newest_first():
     result = market_module._sort_and_filter_headlines([old, middle, newest])
 
     assert result == [newest, middle]
+
+
+def test_sort_and_filter_headlines_excludes_undated_when_recent_items_exist():
+    now = datetime.now(timezone.utc)
+    recent = {
+        "headline": "Recent",
+        "url": "https://example.com/recent",
+        "published_at": _iso(now - timedelta(hours=1)),
+    }
+    old = {
+        "headline": "Old",
+        "url": "https://example.com/old",
+        "published_at": _iso(now - timedelta(days=10)),
+    }
+    undated = {"headline": "Undated", "url": "https://example.com/undated"}
+
+    result = market_module._sort_and_filter_headlines([undated, old, recent])
+
+    assert result == [recent]
 
 
 def test_sort_and_filter_headlines_falls_back_when_nothing_recent():


### PR DESCRIPTION
### Motivation

- Improve robustness of the Market Overview headline recency filter against malformed timestamps and runtime misconfiguration. 
- Make the maximum headline age configurable at deployment time while keeping the existing safe default behavior. 
- Add targeted tests to cover parser edge-cases and mixed dated/undated headline behavior so the feed is deterministic under sparse upstream data.

### Description

- Add environment-configurable headline age via `HEADLINE_MAX_AGE_HOURS` with a 72-hour default and validation that warns and falls back for invalid, non-finite, or non-positive values by introducing `_headline_max_age()` and using it for `HEADLINE_MAX_AGE` in `backend/routes/market.py`.
- Replace the fragile `value[:-1] + "+00:00"` timestamp fix with `value.replace("Z", "+00:00")` in `_parse_published_at` to correctly handle ISO-8601 UTC designator while still rejecting empty or non-string inputs.
- Add unit tests in `tests/backend/routes/test_market.py` to cover: missing/non-string `published_at` values, UTC `Z` parsing, environment-driven headline age, invalid environment values fallback, and mixed dated/undated headline filtering behavior.
- Minor logging and formatting adjustments to keep warnings readable and maintain consistent code style.
- Closes #5396

### Testing

- Ran static checks with `ruff` and formatting with `black` using the backend config, and the updated files pass style checks after formatting. 
- Executed the focused unit test file with `pytest tests/backend/routes/test_market.py -q --no-cov` and observed `19 passed` for the added/updated tests. 
- Running `pytest` with the repository-wide coverage config reported a coverage failure because overall repo coverage is below the configured `fail-under` threshold, but the new tests themselves passed; this is a repo-wide coverage policy signal rather than a regression in the new changes. 
- Verified `git diff --check` to ensure there are no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a7327af44832781c145a2e4e7e11b)