### PR TITLE
Prepare secure Moneyhub token storage

### DIFF
--- a/backend/common/storage.py
+++ b/backend/common/storage.py
@@ -143,7 +143,11 @@ def get_storage(uri: str, *, param_type: str = "SecureString") -> JSONStorage:
 
     if scheme in {"ssm", "ssm-param", "parameter"}:
         name = parsed.netloc + parsed.path
-        name = name.lstrip("/")
+        # Preserve the leading slash for hierarchical names written as
+        # ``ssm:///allotmint/...``. The two-slash legacy form
+        # ``ssm://parameter/name`` has a netloc and remains relative.
+        if parsed.netloc:
+            name = name.lstrip("/")
         return ParameterStoreJSONStorage(name=name, type=param_type)
 
     # default to file-based storage

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -28,6 +28,7 @@ from aws_cdk import aws_s3 as s3
 from constructs import Construct
 
 from stacks.exports import BACKEND_API_URL_EXPORT
+from stacks.moneyhub_token_store import MoneyhubTokenStore
 
 # S3 prefix (relative to the data bucket) under which per-owner writable account
 # documents are persisted. Kept in sync with
@@ -442,6 +443,13 @@ class BackendLambdaStack(Stack):
             memory_size=1024,
         )
         backend_fn.add_environment("APP_ENV", env)
+
+        moneyhub_token_store = MoneyhubTokenStore(self, "MoneyhubTokenStore")
+        moneyhub_token_store.grant_read_write(backend_fn)
+        backend_fn.add_environment(
+            "MONEYHUB_TOKEN_PARAMETER_PREFIX",
+            moneyhub_token_store.parameter_prefix,
+        )
 
         # BackendLambda: read + put + list for API data paths. Add an explicit
         # timeseries cache grant below so the synthesized IAM policy always covers

--- a/cdk/stacks/moneyhub_token_store.py
+++ b/cdk/stacks/moneyhub_token_store.py
@@ -1,0 +1,35 @@
+"""Least-privilege access to Moneyhub OAuth token parameters."""
+
+from aws_cdk import Stack
+from aws_cdk import aws_iam as iam
+from constructs import Construct
+
+MONEYHUB_TOKEN_PARAMETER_PREFIX = "/allotmint/moneyhub/tokens"
+
+
+class MoneyhubTokenStore(Construct):
+    """Represent the per-owner SecureString namespace used by Moneyhub.
+
+    Parameters are created lazily by the application because an owner is not
+    known when the stack is deployed. This construct deliberately grants only
+    the two SSM operations used by ``ParameterStoreJSONStorage`` and scopes
+    them to descendants of the token prefix.
+    """
+
+    def __init__(self, scope: Construct, construct_id: str) -> None:
+        super().__init__(scope, construct_id)
+        self.parameter_prefix = MONEYHUB_TOKEN_PARAMETER_PREFIX
+        self.parameter_arn = Stack.of(self).format_arn(
+            service="ssm",
+            resource="parameter",
+            resource_name=f"{self.parameter_prefix.lstrip('/')}/*",
+        )
+
+    def grant_read_write(self, grantee: iam.IGrantable) -> iam.Grant:
+        """Allow ``grantee`` to load and persist per-owner token blobs."""
+
+        return iam.Grant.add_to_principal(
+            grantee=grantee,
+            actions=["ssm:GetParameter", "ssm:PutParameter"],
+            resource_arns=[self.parameter_arn],
+        )

--- a/cdk/tests/test_moneyhub_token_store.py
+++ b/cdk/tests/test_moneyhub_token_store.py
@@ -1,0 +1,54 @@
+from aws_cdk import App, Stack
+from aws_cdk import aws_iam as iam
+from aws_cdk.assertions import Match, Template
+from stacks.moneyhub_token_store import (
+    MONEYHUB_TOKEN_PARAMETER_PREFIX,
+    MoneyhubTokenStore,
+)
+
+
+def test_grant_is_scoped_to_moneyhub_token_descendants() -> None:
+    app = App()
+    stack = Stack(app, "TestStack")
+    role = iam.Role(
+        stack,
+        "Role",
+        assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+    )
+    token_store = MoneyhubTokenStore(stack, "TokenStore")
+
+    token_store.grant_read_write(role)
+
+    Template.from_stack(stack).has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": {
+                "Statement": Match.array_with(
+                    [
+                        {
+                            "Action": ["ssm:GetParameter", "ssm:PutParameter"],
+                            "Effect": "Allow",
+                            "Resource": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "arn:",
+                                        {"Ref": "AWS::Partition"},
+                                        ":ssm:",
+                                        {"Ref": "AWS::Region"},
+                                        ":",
+                                        {"Ref": "AWS::AccountId"},
+                                        ":parameter/allotmint/moneyhub/tokens/*",
+                                    ],
+                                ]
+                            },
+                        }
+                    ]
+                )
+            }
+        },
+    )
+
+
+def test_token_prefix_is_stable() -> None:
+    assert MONEYHUB_TOKEN_PARAMETER_PREFIX == "/allotmint/moneyhub/tokens"

--- a/docs/moneyhub-integration.md
+++ b/docs/moneyhub-integration.md
@@ -106,16 +106,13 @@ has a working pluggable JSON storage abstraction selected by URI scheme:
 refresh token, expiry, connected account IDs) as one JSON blob per owner
 under an `ssm://` parameter, e.g. `ssm:///allotmint/moneyhub/tokens/{owner}`,
 loaded through `get_storage()` exactly like the alerts module already does.
-Two changes needed on top of the existing abstraction (out of scope for this
-spike, listed for #3425):
+The storage and deployment groundwork is now in place:
 
-- `ParameterStoreJSONStorage` should use `Type="SecureString"` (not
-  `String`) when persisting token material — the current alerts use case
-  doesn't carry secrets, so this wasn't needed before.
-- A CDK `StringParameter`/`Secret` construct and IAM grant so the Lambda
-  execution role can read/write the `/allotmint/moneyhub/*` parameter
-  namespace — there is no existing CDK precedent for this in `cdk/stacks/`,
-  so it is new construct work, not a copy of an existing pattern.
+- `ParameterStoreJSONStorage` persists `SecureString` values by default and
+  decrypts them on read.
+- `MoneyhubTokenStore` grants the backend Lambda only `ssm:GetParameter` and
+  `ssm:PutParameter` beneath `/allotmint/moneyhub/tokens/*`. Parameters remain
+  application-created because owner IDs are not known at deployment time.
 
 Token refresh should happen lazily on read (check expiry, refresh if
 needed, write back the updated blob) rather than a separate scheduled job,

--- a/tests/backend/common/test_storage.py
+++ b/tests/backend/common/test_storage.py
@@ -168,6 +168,12 @@ def test_get_storage_ssm_defaults_to_secure_string() -> None:
     assert storage.type == "SecureString"
 
 
+def test_get_storage_preserves_hierarchical_parameter_name() -> None:
+    storage = get_storage("ssm:///allotmint/moneyhub/tokens/owner-id")
+
+    assert storage.name == "/allotmint/moneyhub/tokens/owner-id"
+
+
 def test_get_storage_ssm_explicit_string_type() -> None:
     storage = get_storage("ssm://parameter/name", param_type="String")
     assert storage.type == "String"


### PR DESCRIPTION
### Motivation

- Moneyhub OAuth token sets contain secret material and must be stored encrypted per owner with least-privilege runtime access before the Moneyhub importer work can proceed.
- The backend already has an SSM-backed JSON storage abstraction, but hierarchical `ssm:///...` names and a CDK construct + IAM grant for the per-owner token namespace were missing.

### Description

- Preserve leading slashes when parsing `ssm:///...` URIs in `get_storage()` so hierarchical parameter names like `ssm:///allotmint/moneyhub/tokens/{owner}` are preserved (backend/common/storage.py).
- Add `MoneyhubTokenStore` CDK construct that exposes the token namespace prefix `/allotmint/moneyhub/tokens` and grants only `ssm:GetParameter` and `ssm:PutParameter` scoped to `parameter/allotmint/moneyhub/tokens/*` (cdk/stacks/moneyhub_token_store.py).
- Wire the construct into the backend stack by granting the backend Lambda the scoped SSM permissions and exposing `MONEYHUB_TOKEN_PARAMETER_PREFIX` to the runtime (cdk/stacks/backend_lambda_stack.py).
- Add unit/tests: synthesized IAM policy assertions for the token store (cdk/tests/test_moneyhub_token_store.py) and a regression test for hierarchical SSM names (tests/backend/common/test_storage.py), and update docs to reflect the completed SecureString + CDK groundwork (docs/moneyhub-integration.md).
- Closes #5340

### Testing

- Ran `pytest` for storage unit tests: `PYENV_VERSION=3.11.15 python -m pytest -c /dev/null tests/backend/common/test_storage.py -q` — 14 passed.
- Ran CDK stack assertions: `PYENV_VERSION=3.11.15 python -m pytest -c /dev/null cdk/tests/test_moneyhub_token_store.py cdk/tests/test_backend_lambda_stack.py cdk/tests/test_backend_lambda_stack_permissions.py -q` — 75 passed.
- Ran formatting and static-analysis: `black --check` and `ruff` on changed modules — checks passed (files formatted/fixed where needed).
- Performed `git diff --check` and repository sanity checks; no diffs or check failures remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a7279db74832797c9aaee82eb7306)