### PR TITLE
Improve add position collapse accessibility

### DIFF
--- a/frontend/src/components/AddPositionForm.tsx
+++ b/frontend/src/components/AddPositionForm.tsx
@@ -11,9 +11,17 @@ type Props = {
   defaultAccount?: string;
   onAdded?: () => void;
   onCollapse?: () => void;
+  controlsId?: string;
 };
 
-export function AddPositionForm({ owner, accounts, defaultAccount, onAdded, onCollapse }: Props) {
+export function AddPositionForm({
+  owner,
+  accounts,
+  defaultAccount,
+  onAdded,
+  onCollapse,
+  controlsId,
+}: Props) {
   const { t } = useTranslation();
   const [account, setAccount] = useState(defaultAccount ?? accounts[0] ?? "");
   const [ticker, setTicker] = useState("");
@@ -80,6 +88,7 @@ export function AddPositionForm({ owner, accounts, defaultAccount, onAdded, onCo
 
   return (
     <form
+      id={controlsId}
       onSubmit={handleSubmit}
       aria-label={t("addPosition.title")}
       className="mb-6 rounded-lg border border-gray-800 bg-black/20 p-4"
@@ -91,9 +100,14 @@ export function AddPositionForm({ owner, accounts, defaultAccount, onAdded, onCo
             type="button"
             onClick={onCollapse}
             aria-label={t("addPosition.collapse")}
-            className="rounded border border-gray-700 px-2 py-0.5 text-sm text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+            aria-expanded="true"
+            aria-controls={controlsId}
+            className="inline-flex items-center gap-1.5 rounded border border-gray-700 px-2 py-0.5 text-sm text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
           >
-            −
+            <svg aria-hidden="true" viewBox="0 0 12 12" className="h-3 w-3" fill="none">
+              <path d="M2 6h8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+            {t("addPosition.collapseShort")}
           </button>
         )}
       </div>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -45,6 +45,8 @@ const CSV_HEADERS = [
   "gain_pct",
 ];
 
+const ADD_POSITION_FORM_ID = "add-position-form";
+
 const sanitizeFilenamePart = (value: string): string =>
   value.replaceAll(/[^a-zA-Z0-9_-]/g, "_");
 
@@ -244,6 +246,21 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
     setPendingDate(data?.as_of ?? "");
   }, [data?.as_of]);
 
+  const handleAddPositionCollapse = useCallback(() => {
+    setAddPositionExpanded(false);
+    setAddPositionAccount(undefined);
+  }, []);
+
+  useEffect(() => {
+    if (!addPositionExpanded) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") handleAddPositionCollapse();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [addPositionExpanded, handleAddPositionCollapse]);
+
   const owner = data?.owner ?? null;
   const asOf = data?.as_of ?? null;
 
@@ -340,11 +357,6 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
     onPositionAdded?.();
   };
 
-  const handleAddPositionCollapse = () => {
-    setAddPositionExpanded(false);
-    setAddPositionAccount(undefined);
-  };
-
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
@@ -415,11 +427,14 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
                   defaultAccount={addPositionAccount}
                   onAdded={handlePositionAdded}
                   onCollapse={handleAddPositionCollapse}
+                  controlsId={ADD_POSITION_FORM_ID}
                 />
               ) : (
                 <button
                   type="button"
                   onClick={() => setAddPositionExpanded(true)}
+                  aria-expanded="false"
+                  aria-controls={ADD_POSITION_FORM_ID}
                   className="rounded border border-gray-700 px-3 py-1.5 text-sm text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
                 >
                   + {t("addPosition.title")}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -20,7 +20,8 @@
       "generic": "Position konnte nicht hinzugefügt werden."
     },
     "emptyAccountCta": "Erste Position hinzufügen",
-    "collapse": "Formular zum Hinzufügen einer Position einklappen"
+    "collapse": "Formular zum Hinzufügen einer Position einklappen",
+    "collapseShort": "Einklappen"
   },
   "alertSettings": {
     "description": "Konfigurieren Sie, wann Sie Benachrichtigungen erhalten. Die Alarme erscheinen auf der Alerts-Seite und als Push-Benachrichtigungen.",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -20,7 +20,8 @@
       "generic": "Failed to add position."
     },
     "emptyAccountCta": "Add your first position",
-    "collapse": "Collapse add position form"
+    "collapse": "Collapse add position form",
+    "collapseShort": "Collapse"
   },
   "alertSettings": {
     "description": "Configure when you'll receive alerts. Alerts appear on the Alerts page and in push notifications.",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -20,7 +20,8 @@
       "generic": "No se pudo añadir la posición."
     },
     "emptyAccountCta": "Añade tu primera posición",
-    "collapse": "Contraer formulario de añadir posición"
+    "collapse": "Contraer formulario de añadir posición",
+    "collapseShort": "Contraer"
   },
   "alertSettings": {
     "description": "Configura cuándo recibirás alertas. Las alertas aparecen en la página de alertas y en las notificaciones push.",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -20,7 +20,8 @@
       "generic": "Impossible d'ajouter la position."
     },
     "emptyAccountCta": "Ajouter votre première position",
-    "collapse": "Réduire le formulaire d'ajout de position"
+    "collapse": "Réduire le formulaire d'ajout de position",
+    "collapseShort": "Réduire"
   },
   "alertSettings": {
     "description": "Configurez quand vous recevrez des alertes. Les alertes apparaissent sur la page des alertes et dans les notifications push.",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -20,7 +20,8 @@
       "generic": "Impossibile aggiungere la posizione."
     },
     "emptyAccountCta": "Aggiungi la tua prima posizione",
-    "collapse": "Comprimi il modulo di aggiunta posizione"
+    "collapse": "Comprimi il modulo di aggiunta posizione",
+    "collapseShort": "Comprimi"
   },
   "alertSettings": {
     "description": "Configura quando riceverai avvisi. Gli avvisi compaiono nella pagina degli avvisi e nelle notifiche push.",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -20,7 +20,8 @@
       "generic": "Não foi possível adicionar a posição."
     },
     "emptyAccountCta": "Adicione a sua primeira posição",
-    "collapse": "Recolher formulário de adicionar posição"
+    "collapse": "Recolher formulário de adicionar posição",
+    "collapseShort": "Recolher"
   },
   "alertSettings": {
     "description": "Configure quando receber alertas. Os alertas aparecem na página de alertas e nas notificações push.",

--- a/frontend/tests/unit/components/AddPositionForm.test.tsx
+++ b/frontend/tests/unit/components/AddPositionForm.test.tsx
@@ -116,4 +116,24 @@ describe("AddPositionForm", () => {
 
     expect(onCollapse).toHaveBeenCalledTimes(1);
   });
+
+  it("labels the collapse control and exposes its expanded state", () => {
+    render(
+      <AddPositionForm
+        owner="alice"
+        accounts={["ISA"]}
+        onCollapse={vi.fn()}
+        controlsId="add-position-form"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Collapse add position form" });
+    expect(button).toHaveTextContent("Collapse");
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(button).toHaveAttribute("aria-controls", "add-position-form");
+    expect(screen.getByRole("form", { name: "Add position" })).toHaveAttribute(
+      "id",
+      "add-position-form",
+    );
+  });
 });

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -161,6 +161,27 @@ describe("PortfolioView", () => {
         expect(within(screen.getByRole("form", { name: /^add position$/i })).getByLabelText(/account/i)).toHaveValue("ISA");
     });
 
+    it("collapses the add-position form on Escape and ignores other keys", () => {
+        render(<PortfolioView data={mockOwner} />);
+        const addButton = screen.getByRole("button", { name: /\+ add position/i });
+        expect(addButton).toHaveAttribute("aria-expanded", "false");
+
+        fireEvent.click(addButton);
+        expect(screen.getByRole("button", { name: /collapse add position form/i })).toHaveAttribute(
+            "aria-expanded",
+            "true",
+        );
+
+        fireEvent.keyDown(document, { key: "Enter" });
+        expect(screen.getByRole("form", { name: /^add position$/i })).toBeInTheDocument();
+
+        fireEvent.keyDown(document, { key: "Escape" });
+        expect(screen.queryByRole("form", { name: /^add position$/i })).not.toBeInTheDocument();
+
+        fireEvent.keyDown(document, { key: "Escape" });
+        expect(screen.getByRole("button", { name: /\+ add position/i })).toBeInTheDocument();
+    });
+
     it("hides the CSV import form when no accounts exist", () => {
         const emptyOwner: Portfolio = { ...mockOwner, accounts: [] };
 


### PR DESCRIPTION
### Motivation

- The add-position toggle needed proper ARIA state, a concise visible label, consistent iconography, and keyboard behaviour to meet accessibility expectations and avoid multiple small follow-ups. 

### Description

- Expose the toggle relationship and state by adding `controlsId` prop, an `id` on the form, and `aria-expanded`/`aria-controls` on the open/collapse buttons in `AddPositionForm` and `PortfolioView`.
- Replace the Unicode minus glyph with an inline SVG and surface a short localized visible label (`collapseShort`) while preserving the full accessible name (`collapse`) in translations for en/de/es/fr/it/pt.
- Add an `Escape` key listener (registered only while the add-position form is expanded) that invokes the same collapse callback and is removed on collapse/unmount to avoid leaks or interference.
- Add unit tests that assert the button label, ARIA state, `aria-controls` relationship, Escape behaviour, and that unrelated keys are ignored.

Closes #5472

### Testing

- Ran the focused frontend tests with `npm --prefix frontend run test -- --run tests/unit/components/AddPositionForm.test.tsx tests/unit/components/PortfolioView.test.tsx`, and all tests passed (2 files, 23 tests).
- Ran type checking with `npm --prefix frontend run type-check` and lint with `npm --prefix frontend run lint`, both completed successfully.
- Verified diff sanity with `git diff --check` and committed changes on branch `fix/issue-5472`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a729687188327a69d9114e68d78a7)