### PR TITLE
Add responsive layout regression coverage

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "coverage": "vitest run --coverage",
     "test:jsdom": "vitest --environment=jsdom",
     "type-check": "tsc -b --noEmit",
-    "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts tests/cognito-auth-flow.spec.ts",
+    "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts tests/cognito-auth-flow.spec.ts tests/responsive-layout.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",
     "deploy:aws:linux": "bash scripts/deploy-to-aws.sh -b $S3_BUCKET ${CLOUDFRONT_DISTRIBUTION_ID:+-d $CLOUDFRONT_DISTRIBUTION_ID}",

--- a/frontend/tests/responsive-layout.spec.ts
+++ b/frontend/tests/responsive-layout.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { setupCoreMocks } from './support/smokeFixtures';
+
+const baseUrl = process.env.SMOKE_URL ?? 'http://localhost:5173';
+const viewports = [
+  { name: 'sm', width: 640 },
+  { name: 'md', width: 768 },
+  { name: 'lg', width: 1024 },
+  { name: 'xl', width: 1280 },
+] as const;
+
+const portfolio = {
+  owner: 'demo-owner',
+  as_of: '2026-07-29',
+  trades_this_month: 0,
+  trades_remaining: 10,
+  total_value_estimate_gbp: 1000,
+  accounts: [
+    {
+      account_type: 'ISA',
+      currency: 'GBP',
+      value_estimate_gbp: 1000,
+      holdings: [],
+    },
+  ],
+};
+
+const openPage = async (page: Page, path: string) => {
+  await setupCoreMocks(page);
+  await page.route('**/portfolio/demo-owner*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(portfolio),
+    });
+  });
+  await page.route('**/timeseries*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          ticker: 'RESPONSIVE-LAYOUT-LONG-TICKER',
+          exchange: 'LONDON',
+          name: 'Responsive layout regression fixture',
+          earliest: '2025-01-01',
+          latest: '2026-07-29',
+          completeness: 100,
+          latest_source: 'Deterministic fixture',
+          main_source: 'Deterministic fixture',
+        },
+      ]),
+    });
+  });
+  await page.route('**/instrument/admin', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          ticker: 'RESPONSIVE-LAYOUT-LONG-TICKER',
+          exchange: 'LONDON',
+          name: 'Responsive layout regression fixture',
+          region: 'United Kingdom',
+          sector: 'Technology',
+          grouping: 'Equity',
+        },
+      ]),
+    });
+  });
+  await page.route('**/quotes*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    });
+  });
+
+  await page.goto(new URL(path, baseUrl).toString());
+};
+
+const expectNoPageOverflow = async (page: Page) => {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.documentElement.scrollWidth <= window.innerWidth
+      )
+    )
+    .toBe(true);
+};
+
+const expectWrappingRow = async (row: Locator) => {
+  await expect(row).toBeVisible();
+  await expect(row).toHaveCSS('flex-wrap', 'wrap');
+  await expect(row).toHaveClass(/\bgap-2\b/);
+};
+
+for (const viewport of viewports) {
+  test.describe(`${viewport.name} (${viewport.width}px)`, () => {
+    test.use({ viewport: { width: viewport.width, height: 900 } });
+
+    test('keeps the portfolio grid responsive without page overflow', async ({
+      page,
+    }) => {
+      await openPage(page, '/portfolio/demo-owner');
+
+      const grid = page
+        .getByText('Approx Total:', { exact: false })
+        .locator('xpath=../..');
+      await expect(grid).toBeVisible();
+      await expect(grid).toHaveCSS(
+        'grid-template-columns',
+        viewport.width < 1280
+          ? /^\d+(?:\.\d+)?px$/
+          : /^\d+(?:\.\d+)?px \d+(?:\.\d+)?px$/
+      );
+      await expectNoPageOverflow(page);
+    });
+
+    test('contains both admin tables in horizontal scroll regions', async ({
+      page,
+    }) => {
+      for (const path of ['/instrumentadmin', '/dataadmin']) {
+        await openPage(page, path);
+
+        const table = page.locator('table');
+        const wrapper = table.locator('..');
+        await expect(table).toBeVisible();
+        await expect(wrapper).toHaveClass(/\boverflow-x-auto\b/);
+        await expect(wrapper).toHaveCSS('overflow-x', 'auto');
+        if (viewport.width <= 768) {
+          await expect
+            .poll(() =>
+              wrapper.evaluate(
+                (element) => element.scrollWidth > element.clientWidth
+              )
+            )
+            .toBe(true);
+        }
+        await expectNoPageOverflow(page);
+      }
+    });
+
+    test('allows allocation and watchlist control rows to wrap', async ({
+      page,
+    }) => {
+      await openPage(page, '/allocation');
+      await expectWrappingRow(
+        page.getByRole('button', { name: 'Instrument Types' }).locator('..')
+      );
+      await expectNoPageOverflow(page);
+
+      await openPage(page, '/watchlist');
+      await expectWrappingRow(
+        page.getByRole('button', { name: 'Refresh' }).locator('..')
+      );
+      await expectNoPageOverflow(page);
+    });
+  });
+}


### PR DESCRIPTION
### Motivation
- Add deterministic end-to-end coverage for recent CSS-only responsive fixes so regressions on Portfolio, Admin tables, Allocation, and Watchlist pages are caught by CI. 
- Reuse the existing Playwright smoke infra and deterministic API mocks to avoid flaky, network-dependent tests.

### Description
- Added a Playwright spec `frontend/tests/responsive-layout.spec.ts` that runs the Portfolio, InstrumentAdmin, DataAdmin, Allocation, and Watchlist pages across `sm` (640px), `md` (768px), `lg` (1024px), and `xl` (1280px) breakpoints and asserts layout behavior with DOM/CSS checks and no page-level horizontal overflow. 
- The spec seeds deterministic mocks for `/config`, `/owners`, `/groups`, `/portfolio/demo-owner`, `/timeseries`, `/instrument/admin`, and `/quotes` so tests do not rely on live data or timing. 
- Asserts include computed `grid-template-columns` for the portfolio grid, presence of `overflow-x-auto` for admin-table wrappers and actual horizontal-scroll behaviour at narrow widths, and `flex-wrap`/`gap-2` behavior for allocation/watchlist control rows. 
- Wired the new spec into the frontend smoke command by updating `frontend/package.json` so CI will run it as part of `smoke:frontend`. 
- Commit created on branch `test/issue-5474-responsive-layout-regressions`. 
- Closes #5474.

### Testing
- Ran lint: `npm --prefix frontend run lint -- --max-warnings=0` (passed).
- Ran type-check: `npm --prefix frontend run type-check` (passed).
- Built preview: `npm --prefix frontend run build:preview` (passed).
- Ran Prettier checks: `npx prettier --check tests/responsive-layout.spec.ts package.json` (passed).
- Attempted to run Playwright locally: `npx playwright install chromium` / `npx playwright test --config playwright.config.ts tests/responsive-layout.spec.ts`, but the environment blocked Chromium download (Playwright CDN returned HTTP 403), so the browser-based tests could not complete locally; CI should run the full Playwright suite (the smoke command installs browsers in CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a737f0de48327975415b6c5638d94)