### PR TITLE
Cover Moneyhub rows with empty transaction dates

### DIFF
--- a/tests/test_transactions_import.py
+++ b/tests/test_transactions_import.py
@@ -146,6 +146,16 @@ def test_moneyhub_parse_empty_csv_returns_no_transactions():
     assert moneyhub.parse(csv_data.encode("utf-8")) == []
 
 
+def test_moneyhub_parse_row_with_empty_date_has_no_composite_key():
+    csv_data = "Owner,Account,Date,Amount,Description,Category\nalice,Current,,-42.50,Tesco Store,Groceries\n"
+
+    transactions = moneyhub.parse(csv_data.encode("utf-8"))
+
+    assert len(transactions) == 1
+    assert transactions[0].external_id is None
+    assert transactions[0].date == ""
+
+
 def test_moneyhub_parse_rejects_csv_with_unrecognised_columns():
     csv_data = "Foo,Bar\nx,y\n"
     with pytest.raises(ValueError, match="missing required columns"):


### PR DESCRIPTION
### Motivation
- Add regression coverage to ensure the Moneyhub CSV importer handles an otherwise-valid row with an empty `Date` field without producing a synthetic composite id or raising an exception.

### Description
- Added `test_moneyhub_parse_row_with_empty_date_has_no_composite_key` to `tests/test_transactions_import.py`, which parses a Moneyhub CSV row with an empty `Date` and asserts the row is parsed, `external_id` is `None`, and `date` remains empty; no production code changes were made (Closes #5345).

### Testing
- Ran focused validation: `PYENV_VERSION=3.11.15 pytest -q --no-cov tests/test_transactions_import.py` (24 tests passed), `PYENV_VERSION=3.11.15 python -m ruff check --config backend/pyproject.toml tests/test_transactions_import.py` (passed), and `PYENV_VERSION=3.11.15 python -m black --config backend/pyproject.toml --check backend/importers/moneyhub.py tests/test_transactions_import.py` (passed); running the full test suite with coverage fails the repository-wide coverage gate (`fail-under=90`) because overall coverage is 27%, but the targeted tests for this change passed; validation used Python 3.11.15 because the repo-pinned 3.11.14 was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a72d97ad88327a066426ed8053caa)