### PR TITLE
Harden market headline recency filtering

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 """Market overview endpoint aggregating indexes, sectors and headlines."""
 
 import logging
+import math
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Literal, Optional, TypedDict
 
@@ -52,7 +54,37 @@ logger = logging.getLogger(__name__)
 # staleness-threshold pattern used for cache freshness in
 # ``backend.routes.news.NEWS_MAX_STALENESS``, but this applies to the
 # article's own publish date rather than the cache's age.
-HEADLINE_MAX_AGE = timedelta(hours=72)
+DEFAULT_HEADLINE_MAX_AGE_HOURS = 72.0
+
+
+def _headline_max_age() -> timedelta:
+    """Return the configured headline age limit, or the safe default."""
+
+    value = os.getenv("HEADLINE_MAX_AGE_HOURS")
+    if value is None:
+        return timedelta(hours=DEFAULT_HEADLINE_MAX_AGE_HOURS)
+
+    try:
+        hours = float(value)
+    except ValueError:
+        logger.warning(
+            "Invalid HEADLINE_MAX_AGE_HOURS=%r; using the %.0f-hour default",
+            value,
+            DEFAULT_HEADLINE_MAX_AGE_HOURS,
+        )
+        return timedelta(hours=DEFAULT_HEADLINE_MAX_AGE_HOURS)
+
+    if not math.isfinite(hours) or hours <= 0:
+        logger.warning(
+            "HEADLINE_MAX_AGE_HOURS must be positive; using the %.0f-hour default",
+            DEFAULT_HEADLINE_MAX_AGE_HOURS,
+        )
+        return timedelta(hours=DEFAULT_HEADLINE_MAX_AGE_HOURS)
+
+    return timedelta(hours=hours)
+
+
+HEADLINE_MAX_AGE = _headline_max_age()
 
 
 class IndexPayload(TypedDict):
@@ -248,7 +280,7 @@ def _parse_published_at(value: Any) -> Optional[datetime]:
     if not isinstance(value, str) or not value:
         return None
 
-    cleaned = value[:-1] + "+00:00" if value.endswith("Z") else value
+    cleaned = value.replace("Z", "+00:00") if value.endswith("Z") else value
     try:
         dt = datetime.fromisoformat(cleaned)
     except ValueError:

--- a/tests/backend/routes/test_market.py
+++ b/tests/backend/routes/test_market.py
@@ -168,6 +168,30 @@ def _iso(dt: datetime) -> str:
     return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+@pytest.mark.parametrize("value", [None, "", 123])
+def test_parse_published_at_rejects_missing_or_non_string_values(value):
+    assert market_module._parse_published_at(value) is None
+
+
+def test_parse_published_at_accepts_utc_designator():
+    assert market_module._parse_published_at("2026-07-19T12:30:00Z") == datetime(
+        2026, 7, 19, 12, 30, tzinfo=timezone.utc
+    )
+
+
+def test_headline_max_age_uses_environment(monkeypatch):
+    monkeypatch.setenv("HEADLINE_MAX_AGE_HOURS", "24")
+
+    assert market_module._headline_max_age() == timedelta(hours=24)
+
+
+@pytest.mark.parametrize("value", ["invalid", "0", "-1", "nan", "inf"])
+def test_headline_max_age_falls_back_for_invalid_values(monkeypatch, value):
+    monkeypatch.setenv("HEADLINE_MAX_AGE_HOURS", value)
+
+    assert market_module._headline_max_age() == timedelta(hours=72)
+
+
 def test_sort_and_filter_headlines_excludes_old_and_sorts_newest_first():
     now = datetime.now(timezone.utc)
     old = {
@@ -189,6 +213,25 @@ def test_sort_and_filter_headlines_excludes_old_and_sorts_newest_first():
     result = market_module._sort_and_filter_headlines([old, middle, newest])
 
     assert result == [newest, middle]
+
+
+def test_sort_and_filter_headlines_excludes_undated_when_recent_items_exist():
+    now = datetime.now(timezone.utc)
+    recent = {
+        "headline": "Recent",
+        "url": "https://example.com/recent",
+        "published_at": _iso(now - timedelta(hours=1)),
+    }
+    old = {
+        "headline": "Old",
+        "url": "https://example.com/old",
+        "published_at": _iso(now - timedelta(days=10)),
+    }
+    undated = {"headline": "Undated", "url": "https://example.com/undated"}
+
+    result = market_module._sort_and_filter_headlines([undated, old, recent])
+
+    assert result == [recent]
 
 
 def test_sort_and_filter_headlines_falls_back_when_nothing_recent():


### PR DESCRIPTION
### Motivation

- Make the Market Overview headline recency filter robust and configurable so deployments can tune the recency window without code changes.
- Fix a fragile ISO-8601 parsing slice and add explicit behavior around missing/invalid `published_at` inputs so undated/stale items are handled predictably.

### Description

- Add `HEADLINE_MAX_AGE_HOURS` environment configuration with a safe 72-hour default and a `_headline_max_age()` helper that validates non-numeric, non-finite, and non-positive values and logs fallbacks (`backend/routes/market.py`).
- Replace the fragile `value[:-1] + "+00:00"` parsing with `value.replace("Z", "+00:00")` in `_parse_published_at` to avoid incorrect slicing on edge inputs (`backend/routes/market.py`).
- Update `_sort_and_filter_headlines` semantics via tests to ensure recent dated items are preferred and undated items are excluded when recent dated items exist, while still falling back to undated items when no dated items are recent (`tests/backend/routes/test_market.py`).
- Add unit tests for `_parse_published_at` edge cases and for the headline max-age configuration and recency behavior (`tests/backend/routes/test_market.py`).
- Files changed: `backend/routes/market.py`, `tests/backend/routes/test_market.py`.

### Testing

- Ran the focused test module with `PYENV_VERSION=3.11.15 python -m pytest tests/backend/routes/test_market.py -q --no-cov`, and `20 passed` was reported for the new/updated tests.
- Ran linters and formatters for the touched files with `PYENV_VERSION=3.11.15 ruff check --config backend/pyproject.toml backend/routes/market.py tests/backend/routes/test_market.py` and `black --config backend/pyproject.toml` formatting, and the checks passed for the changed files after formatting.
- Verified `git diff --check` returned no issues for the modified files and local sanity checks completed successfully.
- Note: a repository-wide `make lint` run surfaced unrelated, pre-existing Ruff findings and a global coverage gate that are outside the scope of this change; the focused module tests and file-level lint/format checks shown above passed.

Closes #5396

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a7318c1c08327a37cafd563612719)