### PR TITLE
Add route-specific 5xx CloudWatch alarm for GET /portfolio-group/all

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -18,6 +18,7 @@ from aws_cdk import aws_apigatewayv2_authorizers as apigwv2_authorizers
 from aws_cdk import aws_apigatewayv2_integrations as apigwv2_integrations
 from aws_cdk import aws_budgets as budgets
 from aws_cdk import aws_cloudwatch as cloudwatch
+from aws_cdk import aws_cloudwatch_actions as cloudwatch_actions
 from aws_cdk import aws_cognito as cognito
 from aws_cdk import aws_events as events
 from aws_cdk import aws_events_targets as targets
@@ -25,6 +26,8 @@ from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as _lambda
 from aws_cdk import aws_logs as logs
 from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_sns as sns
+from aws_cdk import aws_sns_subscriptions as sns_subscriptions
 from constructs import Construct
 
 from stacks.exports import BACKEND_API_URL_EXPORT
@@ -1104,6 +1107,43 @@ class BackendLambdaStack(Stack):
             treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
         )
 
+        # HTTP API metrics are emitted per API/stage, not per route. Derive a
+        # route-specific metric from the structured access log so failures of
+        # this comparatively expensive aggregation endpoint are not hidden by
+        # otherwise healthy API traffic (issue #5523).
+        portfolio_group_5xx_metric = logs.MetricFilter(
+            self,
+            "PortfolioGroupAll5xxMetricFilter",
+            log_group=access_log_group,
+            filter_pattern=logs.FilterPattern.literal(
+                '{ ($.routeKey = "GET /portfolio-group/all") && ($.status = 5*) }'
+            ),
+            metric_namespace="AllotMint/BackendApi",
+            metric_name="PortfolioGroupAll5xx",
+            metric_value="1",
+            default_value=0,
+        )
+        operational_alerts_topic = sns.Topic(self, "OperationalAlertsTopic")
+        if budget_alert_email:
+            operational_alerts_topic.add_subscription(
+                sns_subscriptions.EmailSubscription(budget_alert_email)
+            )
+        portfolio_group_5xx_alarm = cloudwatch.Alarm(
+            self,
+            "PortfolioGroupAll5xxAlarm",
+            metric=portfolio_group_5xx_metric.metric(
+                statistic="Sum", period=Duration.minutes(1)
+            ),
+            threshold=0,
+            comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+            evaluation_periods=2,
+            datapoints_to_alarm=2,
+            treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
+        )
+        portfolio_group_5xx_alarm.add_alarm_action(
+            cloudwatch_actions.SnsAction(operational_alerts_topic)
+        )
+
         budget_notification = None
         if budget_alert_email:
             budget_notification = budgets.CfnBudget.NotificationWithSubscribersProperty(
@@ -1151,3 +1191,8 @@ class BackendLambdaStack(Stack):
             value=pension_report_log_group.log_group_name,
         )
         CfnOutput(self, "BackendLambdaErrorAlarmName", value=backend_error_alarm.alarm_name)
+        CfnOutput(
+            self,
+            "PortfolioGroupAll5xxAlarmName",
+            value=portfolio_group_5xx_alarm.alarm_name,
+        )

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -514,6 +514,56 @@ def test_backend_error_alarm_exists(template):
     )
 
 
+def test_portfolio_group_all_5xx_alarm_uses_route_specific_log_metric(template):
+    template.has_resource_properties(
+        "AWS::Logs::MetricFilter",
+        {
+            "FilterPattern": (
+                '{ ($.routeKey = "GET /portfolio-group/all") && ($.status = 5*) }'
+            ),
+            "MetricTransformations": [
+                {
+                    "DefaultValue": 0,
+                    "MetricName": "PortfolioGroupAll5xx",
+                    "MetricNamespace": "AllotMint/BackendApi",
+                    "MetricValue": "1",
+                }
+            ],
+        },
+    )
+    template.has_resource_properties(
+        "AWS::CloudWatch::Alarm",
+        {
+            "ComparisonOperator": "GreaterThanThreshold",
+            "DatapointsToAlarm": 2,
+            "EvaluationPeriods": 2,
+            "MetricName": "PortfolioGroupAll5xx",
+            "Namespace": "AllotMint/BackendApi",
+            "Period": 60,
+            "Statistic": "Sum",
+            "Threshold": 0,
+            "TreatMissingData": "notBreaching",
+        },
+    )
+
+
+def test_portfolio_group_all_5xx_alarm_notifies_operational_topic(template):
+    topics = template.find_resources("AWS::SNS::Topic")
+    assert len(topics) == 1
+    topic_logical_id = next(iter(topics))
+
+    alarms = template.find_resources("AWS::CloudWatch::Alarm")
+    route_alarms = [
+        alarm
+        for alarm in alarms.values()
+        if alarm.get("Properties", {}).get("MetricName") == "PortfolioGroupAll5xx"
+    ]
+    assert len(route_alarms) == 1
+    assert route_alarms[0]["Properties"]["AlarmActions"] == [
+        {"Ref": topic_logical_id}
+    ]
+
+
 def test_monthly_budget_exists(template):
     resources = template.find_resources("AWS::Budgets::Budget")
     assert resources, "Expected an AWS::Budgets::Budget resource"
@@ -1002,6 +1052,10 @@ def test_lambda_log_group_name_outputs_exist(template):
 
 def test_backend_lambda_error_alarm_output_exists(template):
     template.has_output("BackendLambdaErrorAlarmName", {})
+
+
+def test_portfolio_group_all_5xx_alarm_output_exists(template):
+    template.has_output("PortfolioGroupAll5xxAlarmName", {})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- The HTTP API-level 5xx metric masks route-specific regressions for the expensive `/portfolio-group/all` aggregation, so we need an endpoint-scoped alarm to detect regressions faster (issue #5523).

### Description

- Derive a route-specific metric from the backend API access log by adding a `logs.MetricFilter` that matches `GET /portfolio-group/all` 5xx responses and emits `AllotMint/BackendApi::PortfolioGroupAll5xx`.
- Create a CloudWatch `Alarm` that fires when the metric sum is > 0 for two consecutive one-minute periods and attach an SNS alarm action to a new `OperationalAlertsTopic`, subscribing `BUDGET_ALERT_EMAIL` when configured.
- Expose the alarm name as a CloudFormation output (`PortfolioGroupAll5xxAlarmName`) and add CDK unit tests covering the metric filter, alarm properties, SNS topic action, and the new output; also add the required `aws_cloudwatch_actions`/`aws_sns` imports.
- Closes #5523.

### Testing

- Ran the stack unit tests with `PYENV_VERSION=3.11.15 python -m pytest -o addopts='' cdk/tests/test_backend_lambda_stack.py -q`, and all tests passed (`52 passed`).
- Ran formatting and lint checks with `black` and `ruff`; files were reformatted by `black` and then `ruff` checks passed against the project `pyproject.toml` config.
- Verified `git diff --check` and template assertions in tests to ensure the new MetricFilter, Alarm, SNS topic, and CfnOutput are present and correctly configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a73544ec083279699ee0c1e4bb0e6)