### PR TITLE
Add diagnostics for missing-owner responses

### DIFF
--- a/backend/common/errors.py
+++ b/backend/common/errors.py
@@ -7,7 +7,10 @@ from typing import Any, Callable, TypeVar
 
 from fastapi import HTTPException
 
+from backend.logging_setup import sanitise_log_value
+
 OWNER_NOT_FOUND = "Owner not found"
+logger = logging.getLogger(__name__)
 
 
 class AppError(Exception):
@@ -92,9 +95,22 @@ class OwnerNotFoundError(ResourceNotFoundError):
         super().__init__(detail, extra=extra)
 
 
-def raise_owner_not_found() -> None:
-    """Helper for raising a canonical owner-not-found error."""
-    raise OwnerNotFoundError(OWNER_NOT_FOUND)
+def log_owner_not_found(owner: str | None = None, **diagnostics: Any) -> None:
+    """Log a missing-owner lookup with consistent diagnostic context."""
+    diagnostic_text = ", ".join(f"{key}={sanitise_log_value(value)}" for key, value in diagnostics.items())
+    suffix = f" ({diagnostic_text})" if diagnostic_text else ""
+    logger.warning(
+        "owner lookup: no owner found for owner=%s%s",
+        sanitise_log_value(owner),
+        sanitise_log_value(suffix),
+    )
+
+
+def raise_owner_not_found(owner: str | None = None, **diagnostics: Any) -> None:
+    """Log diagnostic context and raise the canonical owner-not-found error."""
+    log_owner_not_found(owner, **diagnostics)
+    extra = {"owner": owner, **diagnostics} if owner is not None else diagnostics
+    raise OwnerNotFoundError(OWNER_NOT_FOUND, extra=extra)
 
 
 F = TypeVar("F", bound=Callable[..., Any])

--- a/backend/routes/approvals.py
+++ b/backend/routes/approvals.py
@@ -55,7 +55,7 @@ def _resolve_owner_dir(root: Path, owner: str) -> Path:
         if fallback_dir:
             return fallback_dir
 
-    raise_owner_not_found()
+    raise_owner_not_found(owner)
 
 
 @router.get("/{owner}/approvals")

--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -45,7 +45,6 @@ def _known_owners(accounts_root) -> KnownOwnerSet:
         except Exception:
             return
 
-
         for alias in aliases:
             try:
                 demo_dir = fallback_root / alias
@@ -101,11 +100,7 @@ def _known_owners(accounts_root) -> KnownOwnerSet:
         return owners
 
     try:
-        root_path = (
-            Path(accounts_root)
-            if accounts_root
-            else data_loader.resolve_paths(None, None).accounts_root
-        )
+        root_path = Path(accounts_root) if accounts_root else data_loader.resolve_paths(None, None).accounts_root
     except Exception:
         owners.active_root_has_entries = active_root_has_entries
         return owners
@@ -134,11 +129,11 @@ async def compliance_for_owner(owner: str, request: Request):
     accounts_root = resolve_accounts_root(request)
     owner_dir = resolve_owner_directory(accounts_root, owner)
     if not owner_dir:
-        raise_owner_not_found()
+        raise_owner_not_found(owner)
     owner = owner_dir.name
     owners = _known_owners(accounts_root)
     if owners and owner.lower() not in owners:
-        raise_owner_not_found()
+        raise_owner_not_found(owner, total_owners_discovered=len(owners))
     try:
         # ``check_owner`` now returns additional fields such as
         # ``hold_countdowns`` and ``trades_remaining`` which are
@@ -146,7 +141,7 @@ async def compliance_for_owner(owner: str, request: Request):
         return compliance.check_owner(owner, accounts_root)
     except FileNotFoundError as exc:
         logger.warning("accounts for %s not found: %s", sanitise_log_value(owner), sanitise_log_value(exc))
-        raise_owner_not_found()
+        raise_owner_not_found(owner)
 
 
 @router.post("/compliance/validate")
@@ -165,23 +160,21 @@ async def validate_trade(request: Request):
     raw_owner = trade.get("owner")
     owner_value = " ".join(str(raw_owner or "").split()).strip()
     if not owner_value:
-        raise_owner_not_found()
+        raise_owner_not_found(owner_value)
 
     owners = _known_owners(accounts_root)
-    discovered_for_active_root = getattr(
-        owners, "active_root_has_entries", bool(owners)
-    )
+    discovered_for_active_root = getattr(owners, "active_root_has_entries", bool(owners))
     owner_dir = resolve_owner_directory(accounts_root, owner_value)
     scaffold_missing = owner_dir is None
 
     if owner_dir:
         canonical_owner = owner_dir.name
         if discovered_for_active_root and canonical_owner.lower() not in owners:
-            raise_owner_not_found()
+            raise_owner_not_found(canonical_owner, total_owners_discovered=len(owners))
         trade["owner"] = canonical_owner
     else:
         if discovered_for_active_root:
-            raise_owner_not_found()
+            raise_owner_not_found(owner_value, total_owners_discovered=len(owners))
         trade["owner"] = owner_value
     try:
         result = compliance.check_trade(
@@ -190,7 +183,7 @@ async def validate_trade(request: Request):
             scaffold_missing=scaffold_missing,
         )
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(str(trade["owner"]))
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/backend/routes/metrics.py
+++ b/backend/routes/metrics.py
@@ -18,4 +18,4 @@ async def get_metrics(owner: str):
             metrics = compute_and_store_metrics(owner)
         return metrics
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner)

--- a/backend/routes/nudges.py
+++ b/backend/routes/nudges.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 from backend import nudges as nudge_utils
 from backend.common import data_loader
-from backend.common.errors import OWNER_NOT_FOUND
+from backend.common.errors import OWNER_NOT_FOUND, log_owner_not_found
 
 router = APIRouter(prefix="/nudges", tags=["nudges"])
 
@@ -21,6 +21,7 @@ def _validate_owner(
     except data_loader.ProviderUnavailable as exc:
         raise HTTPException(status_code=503, detail="Account data provider unavailable") from exc
     if user not in owners and not allow_unknown:
+        log_owner_not_found(user, total_plots_discovered=len(owners))
         raise HTTPException(status_code=404, detail=OWNER_NOT_FOUND)
 
 

--- a/backend/routes/performance.py
+++ b/backend/routes/performance.py
@@ -8,7 +8,7 @@ import re
 from fastapi import APIRouter, HTTPException
 
 from backend.common import portfolio_utils
-from backend.common.errors import handle_owner_not_found, log_owner_not_found, raise_owner_not_found
+from backend.common.errors import handle_owner_not_found, raise_owner_not_found
 from backend.utils.pricing_dates import PricingDateCalculator
 
 router = APIRouter(tags=["performance"])
@@ -219,6 +219,7 @@ async def group_max_drawdown(slug: str, days: int = 365):
 
 
 @router.get("/performance/{owner}")
+@handle_owner_not_found
 async def performance(
     owner: str,
     days: int = 365,
@@ -239,8 +240,7 @@ async def performance(
             pricing_date=_resolve_as_of(as_of),
         )
     except FileNotFoundError:
-        log_owner_not_found(owner)
-        raise HTTPException(status_code=404, detail="Owner not found")
+        raise_owner_not_found(owner)
     return {"owner": owner, **result}
 
 

--- a/backend/routes/performance.py
+++ b/backend/routes/performance.py
@@ -8,7 +8,7 @@ import re
 from fastapi import APIRouter, HTTPException
 
 from backend.common import portfolio_utils
-from backend.common.errors import handle_owner_not_found, raise_owner_not_found
+from backend.common.errors import handle_owner_not_found, log_owner_not_found, raise_owner_not_found
 from backend.utils.pricing_dates import PricingDateCalculator
 
 router = APIRouter(tags=["performance"])
@@ -79,7 +79,7 @@ async def owner_alpha(
         response.update(breakdown)
         return response
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner, benchmark=benchmark)
 
 
 @router.get("/performance/{owner}/tracking-error")
@@ -105,7 +105,7 @@ async def owner_tracking_error(
         response.update(breakdown)
         return response
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner, benchmark=benchmark)
 
 
 @router.get("/performance/{owner}/max-drawdown")
@@ -124,7 +124,7 @@ async def owner_max_drawdown(owner: str, days: int = 365, as_of: str | None = No
         response.update(breakdown)
         return response
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner)
 
 
 @router.get("/performance/{owner}/twr")
@@ -133,12 +133,10 @@ async def owner_twr(owner: str, days: int = 365, as_of: str | None = None):
     """Return time-weighted return for ``owner``."""
     owner = _validate_owner_slug(owner, "owner")
     try:
-        val = portfolio_utils.compute_time_weighted_return(
-            owner, days, pricing_date=_resolve_as_of(as_of)
-        )
+        val = portfolio_utils.compute_time_weighted_return(owner, days, pricing_date=_resolve_as_of(as_of))
         return {"owner": owner, "time_weighted_return": val}
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner)
 
 
 @router.get("/performance/{owner}/xirr")
@@ -147,12 +145,10 @@ async def owner_xirr(owner: str, days: int = 365, as_of: str | None = None):
     """Return XIRR for ``owner``."""
     owner = _validate_owner_slug(owner, "owner")
     try:
-        val = portfolio_utils.compute_xirr(
-            owner, days, pricing_date=_resolve_as_of(as_of)
-        )
+        val = portfolio_utils.compute_xirr(owner, days, pricing_date=_resolve_as_of(as_of))
         return {"owner": owner, "xirr": val}
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner)
 
 
 @router.get("/performance/{owner}/holdings")
@@ -164,7 +160,7 @@ async def owner_holdings(owner: str, date: str):
         rows = portfolio_utils.portfolio_value_breakdown(owner, date)
         return {"owner": owner, "date": date, "holdings": rows}
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -175,9 +171,7 @@ async def group_alpha(slug: str, benchmark: str = "VWRL.L", days: int = 365):
     slug = _validate_owner_slug(slug, "slug")
     benchmark = _validate_benchmark(benchmark)
     try:
-        result = portfolio_utils.compute_group_alpha_vs_benchmark(
-            slug, benchmark, days, include_breakdown=True
-        )
+        result = portfolio_utils.compute_group_alpha_vs_benchmark(slug, benchmark, days, include_breakdown=True)
         if isinstance(result, tuple):
             val, breakdown = result
         else:
@@ -195,9 +189,7 @@ async def group_tracking_error(slug: str, benchmark: str = "VWRL.L", days: int =
     slug = _validate_owner_slug(slug, "slug")
     benchmark = _validate_benchmark(benchmark)
     try:
-        result = portfolio_utils.compute_group_tracking_error(
-            slug, benchmark, days, include_breakdown=True
-        )
+        result = portfolio_utils.compute_group_tracking_error(slug, benchmark, days, include_breakdown=True)
         if isinstance(result, tuple):
             val, breakdown = result
         else:
@@ -214,9 +206,7 @@ async def group_max_drawdown(slug: str, days: int = 365):
     """Return max drawdown for a group portfolio."""
     slug = _validate_owner_slug(slug, "slug")
     try:
-        result = portfolio_utils.compute_group_max_drawdown(
-            slug, days, include_breakdown=True
-        )
+        result = portfolio_utils.compute_group_max_drawdown(slug, days, include_breakdown=True)
         if isinstance(result, tuple):
             val, breakdown = result
         else:
@@ -249,6 +239,7 @@ async def performance(
             pricing_date=_resolve_as_of(as_of),
         )
     except FileNotFoundError:
+        log_owner_not_found(owner)
         raise HTTPException(status_code=404, detail="Owner not found")
     return {"owner": owner, **result}
 
@@ -263,4 +254,4 @@ async def compare_returns(owner: str, days: int = 365):
         cash_apy = portfolio_utils.compute_cash_apy(owner, days)
         return {"owner": owner, "cagr": cagr, "cash_apy": cash_apy}
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner)

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -34,6 +34,7 @@ from backend.common import (
 )
 from backend.common import portfolio as portfolio_mod
 from backend.common.account_models import OwnerSummaryRecord, PersonMetadata
+from backend.common.errors import log_owner_not_found
 from backend.config import config, demo_identity
 from backend.logging_setup import sanitise_log_value
 from backend.routes._accounts import resolve_accounts_root, resolve_owner_directory
@@ -65,16 +66,8 @@ def _coerce_owner_summary_entry(entry: OwnerSummaryRecord | Dict[str, Any] | Non
     return OwnerSummaryRecord.model_construct(
         owner=str(payload.get("owner", "")),
         accounts=list(accounts) if isinstance(accounts, list) else [],
-        full_name=(
-            raw_full_name.strip()
-            if isinstance(raw_full_name, str) and raw_full_name.strip()
-            else None
-        ),
-        email=(
-            raw_email.strip()
-            if isinstance(raw_email, str) and raw_email.strip()
-            else None
-        ),
+        full_name=(raw_full_name.strip() if isinstance(raw_full_name, str) and raw_full_name.strip() else None),
+        email=(raw_email.strip() if isinstance(raw_email, str) and raw_email.strip() else None),
         has_transactions_artifact=bool(payload.get("has_transactions_artifact", False)),
     )
 
@@ -466,9 +459,7 @@ def _build_demo_summary(accounts_root: Path) -> Dict[str, Any]:
     return fallback
 
 
-def _list_owner_summaries(
-    request: Request, current_user: Optional[str] = None
-) -> List[OwnerSummary]:
+def _list_owner_summaries(request: Request, current_user: Optional[str] = None) -> List[OwnerSummary]:
     """Return owner summaries enriched with conventional account entries."""
 
     accounts_root = resolve_accounts_root(request, allow_missing=True)
@@ -506,9 +497,7 @@ if config.disable_auth:
 else:
 
     @router.get("/owners", response_model=List[OwnerSummary])
-    async def owners(
-        request: Request, current_user: str = Depends(get_current_user)
-    ) -> List[OwnerSummary]:
+    async def owners(request: Request, current_user: str = Depends(get_current_user)) -> List[OwnerSummary]:
         """List available owners including demo defaults when necessary."""
 
         return _list_owner_summaries(request, current_user)
@@ -531,10 +520,9 @@ async def portfolio(owner: str, request: Request, as_of: str | None = None):
     pricing_date = _resolve_pricing_date(as_of)
 
     try:
-        return portfolio_mod.build_owner_portfolio(
-            owner, accounts_root, pricing_date=pricing_date
-        )
+        return portfolio_mod.build_owner_portfolio(owner, accounts_root, pricing_date=pricing_date)
     except FileNotFoundError:
+        log_owner_not_found(owner)
         raise HTTPException(status_code=404, detail="Owner not found")
 
 
@@ -547,10 +535,9 @@ async def portfolio_sectors(owner: str, request: Request, as_of: str | None = No
     pricing_date = _resolve_pricing_date(as_of)
 
     try:
-        portfolio_data = portfolio_mod.build_owner_portfolio(
-            owner, accounts_root, pricing_date=pricing_date
-        )
+        portfolio_data = portfolio_mod.build_owner_portfolio(owner, accounts_root, pricing_date=pricing_date)
     except FileNotFoundError:
+        log_owner_not_found(owner)
         raise HTTPException(status_code=404, detail="Owner not found")
 
     return portfolio_utils.aggregate_by_sector(portfolio_data)
@@ -572,6 +559,7 @@ async def portfolio_var(
         var = risk.compute_portfolio_var(owner, days=days, confidence=confidence, include_cash=not exclude_cash)
         sharpe = risk.compute_sharpe_ratio(owner, days=days)
     except FileNotFoundError:
+        log_owner_not_found(owner)
         raise HTTPException(status_code=404, detail="Owner not found")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -615,6 +603,7 @@ async def portfolio_var_breakdown(
             horizon_days=horizon_days,
         )
     except FileNotFoundError:
+        log_owner_not_found(owner)
         raise HTTPException(status_code=404, detail="Owner not found")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -644,6 +633,7 @@ async def portfolio_var_recompute(
     try:
         var = risk.compute_portfolio_var(owner, days=days, confidence=confidence)
     except FileNotFoundError:
+        log_owner_not_found(owner)
         raise HTTPException(status_code=404, detail="Owner not found")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -668,11 +658,7 @@ def _normalise_filter_values(values: Optional[Sequence[str]]) -> set[str] | None
         return None
     if isinstance(values, str):
         values = [values]
-    normalised = {
-        str(value).strip().lower()
-        for value in values
-        if value is not None and str(value).strip()
-    }
+    normalised = {str(value).strip().lower() for value in values if value is not None and str(value).strip()}
     return normalised or None
 
 
@@ -727,9 +713,7 @@ async def group_instruments(
     portfolio_for_aggregation: Dict[str, Any]
     if filters:
         filtered_accounts = [
-            account
-            for account in gp.get("accounts", [])
-            if _account_matches_filters(account, filters)
+            account for account in gp.get("accounts", []) if _account_matches_filters(account, filters)
         ]
         portfolio_for_aggregation = {**gp, "accounts": filtered_accounts}
     else:
@@ -835,7 +819,8 @@ async def group_movers(
     except Exception as e:
         log.warning(
             "Failed to load instrument summaries for group %s: %s",
-            sanitise_log_value(slug), sanitise_log_value(e),
+            sanitise_log_value(slug),
+            sanitise_log_value(e),
         )
         raise HTTPException(status_code=404, detail="Group not found")
 
@@ -962,15 +947,11 @@ async def instrument_detail(
     control only the price-series window.  A position exists or it doesn't;
     there is no historical positions API here.
     """
-    resolved_start, resolved_end = resolve_date_range(
-        365, start_date=start_date, end_date=end_date
-    )
+    resolved_start, resolved_end = resolve_date_range(365, start_date=start_date, end_date=end_date)
     if resolved_start > resolved_end:
         raise HTTPException(status_code=400, detail="start_date must not be after end_date")
     try:
-        series = instrument_api.timeseries_for_ticker(
-            ticker, start_date=resolved_start, end_date=resolved_end
-        )
+        series = instrument_api.timeseries_for_ticker(ticker, start_date=resolved_start, end_date=resolved_end)
         prices_list = series.get("prices", [])
         positions_list = instrument_api.positions_for_ticker(slug, ticker)
     except Exception:

--- a/backend/routes/reports.py
+++ b/backend/routes/reports.py
@@ -6,8 +6,10 @@ from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
+from backend.common.errors import log_owner_not_found
 from backend.reports import (
     DEFAULT_TEMPLATE_ID,
+    _parse_date,
     build_report_document,
     create_user_template,
     delete_user_template,
@@ -16,7 +18,6 @@ from backend.reports import (
     report_to_csv,
     report_to_pdf,
     update_user_template,
-    _parse_date,
 )
 
 router = APIRouter(tags=["reports"])
@@ -72,9 +73,7 @@ async def create_template(payload: TemplateCreatePayload) -> dict:
 
 
 @router.put("/reports/templates/{template_id}")
-async def update_template(
-    template_id: str, payload: TemplateUpdatePayload
-) -> dict:
+async def update_template(template_id: str, payload: TemplateUpdatePayload) -> dict:
     try:
         template = update_user_template(template_id, payload.model_dump())
     except FileNotFoundError:
@@ -115,6 +114,7 @@ async def owner_report(
             build_kwargs["watermark"] = watermark_text
         document = build_report_document(DEFAULT_TEMPLATE_ID, owner, **build_kwargs)
     except FileNotFoundError:
+        log_owner_not_found(owner, template_id=DEFAULT_TEMPLATE_ID)
         raise HTTPException(status_code=404, detail="Owner not found")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -155,6 +155,7 @@ async def owner_template_report(
             build_kwargs["watermark"] = watermark_text
         document = build_report_document(template_id, owner, **build_kwargs)
     except FileNotFoundError:
+        log_owner_not_found(owner, template_id=template_id)
         raise HTTPException(status_code=404, detail="Owner not found")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -164,17 +165,13 @@ async def owner_template_report(
         return Response(
             content,
             media_type="text/csv",
-            headers={
-                "Content-Disposition": f"attachment; filename={owner}_{template_id}.csv"
-            },
+            headers={"Content-Disposition": f"attachment; filename={owner}_{template_id}.csv"},
         )
     if format.lower() == "pdf":
         content = report_to_pdf(document)
         return Response(
             content,
             media_type="application/pdf",
-            headers={
-                "Content-Disposition": f"attachment; filename={owner}_{template_id}.pdf"
-            },
+            headers={"Content-Disposition": f"attachment; filename={owner}_{template_id}.pdf"},
         )
     return document.to_dict()

--- a/backend/routes/user_config.py
+++ b/backend/routes/user_config.py
@@ -16,7 +16,7 @@ async def get_user_config(owner: str, request: Request, identity: str | None = D
     try:
         cfg = load_user_config(owner, accounts_root)
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner)
     return cfg.to_dict()
 
 
@@ -30,7 +30,7 @@ async def update_user_config(owner: str, request: Request, identity: str | None 
         cfg = load_user_config(owner, accounts_root)
         return cfg.to_dict()
     except FileNotFoundError:
-        raise_owner_not_found()
+        raise_owner_not_found(owner)
 
 
 router.get("/{owner}")(get_user_config)

--- a/tests/backend/routes/test_metrics.py
+++ b/tests/backend/routes/test_metrics.py
@@ -51,7 +51,8 @@ async def test_get_metrics_raises_http_not_found(monkeypatch):
 
     stub = {"called": False}
 
-    def stub_raise_owner_not_found():
+    def stub_raise_owner_not_found(owner=None, **_diagnostics):
+        assert owner == "alex"
         stub["called"] = True
         raise OwnerNotFoundError
 

--- a/tests/common/test_errors.py
+++ b/tests/common/test_errors.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 import pytest
+
 from backend.common.errors import (
     OWNER_NOT_FOUND,
     OwnerNotFoundError,
@@ -14,10 +15,16 @@ from backend.common.errors import (
 )
 
 
-def test_raise_owner_not_found():
-    with pytest.raises(OwnerNotFoundError) as excinfo:
-        raise_owner_not_found()
+def test_raise_owner_not_found(caplog):
+    with caplog.at_level(logging.WARNING, logger="backend.common.errors"):
+        with pytest.raises(OwnerNotFoundError) as excinfo:
+            raise_owner_not_found("missing-owner", total_plots_discovered=3)
     assert str(excinfo.value) == OWNER_NOT_FOUND
+    assert excinfo.value.extra == {
+        "owner": "missing-owner",
+        "total_plots_discovered": 3,
+    }
+    assert "owner lookup: no owner found for owner=missing-owner " "(total_plots_discovered=3)" in caplog.text
 
 
 def test_handle_owner_not_found_sync():


### PR DESCRIPTION
### Motivation
- Improve observability for endpoints that return generic 404s for missing owners by logging contextual diagnostics so operators can distinguish genuinely-missing owners from empty/partial data discovery. 
- Reuse the existing logging/sanitisation infrastructure and preserve API semantics and status codes. 
- Follow the pattern established in the existing `build_owner_portfolio` diagnostic logging to keep messages consistent.

### Description
- Add a shared sanitised diagnostic logger `log_owner_not_found` and an enriched `raise_owner_not_found` helper in `backend/common/errors.py` that records `owner` plus optional context keys and attaches them to the raised `OwnerNotFoundError` as structured `extra` metadata. 
- Emit diagnostics (using `log_owner_not_found` or `raise_owner_not_found`) at owner-related 404 paths across these route modules: `backend/routes/performance.py`, `backend/routes/portfolio.py`, `backend/routes/reports.py`, `backend/routes/compliance.py`, `backend/routes/metrics.py`, `backend/routes/nudges.py`, `backend/routes/approvals.py`, and `backend/routes/user_config.py`. 
- Ensure all logged values are passed through `sanitise_log_value` and keep HTTP response behaviour unchanged (endpoints still return `404` / same exceptions). 
- Add a focused unit test `tests/common/test_errors.py` to validate logging output and structured `extra` data on `OwnerNotFoundError`. 
- Closes #5524

### Testing
- Ran the targeted pytest command `PYENV_VERSION=3.11.15 python -m pytest -q --no-cov tests/common/test_errors.py tests/test_performance_route.py tests/test_reports_route.py tests/test_compliance_route.py tests/test_user_config_route.py tests/test_portfolio_route_regression.py tests/test_push_subscription_route.py` and observed all tests pass (`72 passed`).
- Ran style and safety checks: `ruff` fixes, `black` formatting, and `python scripts/build_tools/check_new_log_sanitisation.py` on changed files, all of which passed for the modified files. 
- Ran `git diff --check` to ensure no leftover whitespace/errors, which passed. 
- Note: `make lint` for the full repo reports pre-existing lint issues outside the scope of this change; the PR only modifies and verified lint/format/sanitisation for the files touched.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a73688b20832784f05cc9d7e20506)