### PR TITLE
Harden bulk transaction import persistence

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -546,10 +546,6 @@ def _persist_transaction(
     already skips any transaction entry without a ticker.
     """
 
-    impact = _calculate_portfolio_impact(tx_data)
-    _PORTFOLIO_IMPACT[owner] += impact
-    _POSTED_TRANSACTIONS.append({"owner": owner, "account": account, **tx_data})
-
     store.ensure_owner(owner)
     with _locked_transactions_data(owner, account, store) as (data, _file):
         transactions = data.setdefault("transactions", [])
@@ -558,10 +554,49 @@ def _persist_transaction(
         data["account_type"] = account
         new_index = len(transactions) - 1
 
-    _rebuild_portfolio(owner, account, store)
+    try:
+        _rebuild_portfolio(owner, account, store)
+    except Exception:
+        with _locked_transactions_data(owner, account, store) as (data, _file):
+            data.setdefault("transactions", []).pop(new_index)
+        raise
+
+    impact = _calculate_portfolio_impact(tx_data)
+    _PORTFOLIO_IMPACT[owner] += impact
+    _POSTED_TRANSACTIONS.append({"owner": owner, "account": account, **tx_data})
 
     tx_id = _build_transaction_id(owner, account, new_index)
     return _format_transaction_response(owner, account, tx_data, tx_id)
+
+
+def _rollback_persisted_transaction(store: "AccountsStore", persisted: Mapping[str, Any]) -> Tuple[str, str]:
+    """Remove one transaction previously returned by ``_persist_transaction``."""
+    owner, account, index = _parse_transaction_id(str(persisted["id"]))
+    with _locked_transactions_data(owner, account, store) as (data, _file):
+        stored = data.setdefault("transactions", [])
+        if index >= len(stored):
+            raise RuntimeError(f"Cannot roll back missing transaction {persisted['id']}")
+        removed = stored.pop(index)
+
+    posted = {"owner": owner, "account": account, **removed}
+    for posted_index in range(len(_POSTED_TRANSACTIONS) - 1, -1, -1):
+        if _POSTED_TRANSACTIONS[posted_index] == posted:
+            _POSTED_TRANSACTIONS.pop(posted_index)
+            break
+    else:
+        raise RuntimeError(f"Cannot roll back untracked transaction {persisted['id']}")
+
+    _PORTFOLIO_IMPACT[owner] -= _calculate_portfolio_impact(removed)
+    if not _PORTFOLIO_IMPACT[owner]:
+        del _PORTFOLIO_IMPACT[owner]
+    return owner, account
+
+
+def _rollback_import(store: "AccountsStore", persisted: List[Dict[str, Any]]) -> None:
+    """Compensate all writes from a failed bulk import in reverse order."""
+    affected = {_rollback_persisted_transaction(store, row) for row in reversed(persisted)}
+    for owner, account in affected:
+        _rebuild_portfolio(owner, account, store)
 
 
 @router.post("/transactions", status_code=201)
@@ -784,7 +819,11 @@ async def import_transactions(
             continue
 
         tx_data = _tx_data_from_parsed(row)
-        persisted.append(_persist_transaction(store, row_owner, row_account, tx_data))
+        try:
+            persisted.append(_persist_transaction(store, row_owner, row_account, tx_data))
+        except Exception:
+            _rollback_import(store, persisted)
+            raise
 
     return {"persisted": persisted, "skipped": skipped}
 

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -76,3 +76,44 @@ adjustment. Fetch it again using `GET /portfolio/alex` to verify:
 # later
 curl https://api.example.com/portfolio/alex
 ```
+
+## Bulk import
+
+```
+POST /transactions/import
+Content-Type: multipart/form-data
+```
+
+Upload the provider export in the `file` field and identify its format with
+the `provider` field. The optional `owner` and `account` fields provide a
+destination when rows in the export do not contain one. Rows without a
+resolvable destination, or with an invalid owner or account, are returned in
+`skipped` with a `skip_reason`.
+
+The response is an object containing separate arrays for transactions written
+and rows skipped; it is not a flat array:
+
+```json
+{
+  "persisted": [
+    {
+      "id": "alex:isa:0",
+      "owner": "alex",
+      "account": "isa",
+      "ticker": "PFE",
+      "price_gbp": 17.0,
+      "units": 10
+    }
+  ],
+  "skipped": [
+    {
+      "ticker": "MSFT",
+      "skip_reason": "missing owner/account"
+    }
+  ]
+}
+```
+
+Persistence is atomic for the accepted rows in one request. If any write
+fails, transactions already written by that import are removed and affected
+portfolios are rebuilt before the error is returned.

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -451,6 +451,43 @@ def test_import_transactions_success(tmp_path, monkeypatch):
     assert captured == {"provider": "degiro", "data": b"content"}
 
 
+def test_calculate_portfolio_impact_tolerates_bank_transaction_fields():
+    assert transactions._calculate_portfolio_impact({"price_gbp": None, "units": None}) == 0.0
+
+
+def test_import_transactions_rolls_back_when_later_write_fails(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    posted_before = list(transactions._POSTED_TRANSACTIONS)
+    impact_before = dict(transactions._PORTFOLIO_IMPACT)
+    sample = [
+        transactions.Transaction(owner="alice", account="isa", ticker="PFE", price_gbp=2, units=3),
+        transactions.Transaction(owner="alice", account="isa", ticker="MSFT", price_gbp=5, units=2),
+    ]
+    monkeypatch.setattr(transactions.importers, "parse", lambda provider, data: sample)
+    real_persist = transactions._persist_transaction
+    calls = 0
+
+    def fail_second_write(store, owner, account, tx_data):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("simulated persistence failure")
+        return real_persist(store, owner, account, tx_data)
+
+    monkeypatch.setattr(transactions, "_persist_transaction", fail_second_write)
+    with pytest.raises(OSError, match="simulated persistence failure"):
+        client.post(
+            "/transactions/import",
+            data={"provider": "degiro"},
+            files={"file": ("tx.csv", b"content", "text/csv")},
+        )
+
+    stored = json.loads((tmp_path / "alice" / "isa_transactions.json").read_text())
+    assert stored["transactions"] == []
+    assert transactions._POSTED_TRANSACTIONS == posted_before
+    assert dict(transactions._PORTFOLIO_IMPACT) == impact_before
+
+
 def test_import_transactions_empty_parse_does_not_require_writable_store(tmp_path, monkeypatch):
     """An empty parse result (e.g. the "test" provider used by smoke tests,
     which always returns []) must not 400 for a request with no writable


### PR DESCRIPTION
### Motivation
- Prevent partial bulk-import failures from leaving on-disk transaction files, in-memory `_POSTED_TRANSACTIONS`, or `_PORTFOLIO_IMPACT` inconsistent.
- Ensure single-write persistence only updates in-memory tracking after durable persistence and portfolio rebuild succeed.
- Clarify the `POST /transactions/import` contract and add tests for tolerant impact calculation and rollback behavior.

### Description
- Add rollback helpers (`_rollback_persisted_transaction`, `_rollback_import`) and update `import_transactions` to remove previously persisted rows and rebuild affected portfolios if a later write fails.
- Change `_persist_transaction` to defer updating `_POSTED_TRANSACTIONS` and `_PORTFOLIO_IMPACT` until after the portfolio rebuild succeeds and remove the inserted transaction on rebuild failure.
- Add tests covering bank-style transactions where `price_gbp`/`units` can be `None` and a regression test that simulates a failure partway through a bulk import to assert rollback behavior.
- Update `docs/transactions.md` with the multipart `POST /transactions/import` contract and the structured `{ "persisted": [...], "skipped": [...] }` response shape; include `Closes #5464`.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/test_transactions_route.py -q --no-cov` and all 42 tests in that module passed.
- Ran lint/format checks (`ruff` and `black`) against the modified files and the checks passed on the touched files.
- Ran repository checks (`git diff --check`) and the changed files pass style/format validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a73fef99c83278419dd99204ae8ea)