### PR TITLE
Fix: round pension forecast current age to whole number

### DIFF
--- a/frontend/src/pages/PensionForecast.tsx
+++ b/frontend/src/pages/PensionForecast.tsx
@@ -479,7 +479,9 @@ export default function PensionForecast() {
           <div className="space-y-3 text-sm text-slate-700">
             {currentAge !== null && dob && (
               <InfoLine
-                label={t("pensionForecast.currentAge", { age: currentAge })}
+                label={t("pensionForecast.currentAge", {
+                  age: Math.round(currentAge),
+                })}
                 value={t("pensionForecast.birthDate", { dob })}
               />
             )}

--- a/frontend/tests/unit/pages/PensionForecast.test.tsx
+++ b/frontend/tests/unit/pages/PensionForecast.test.tsx
@@ -94,6 +94,37 @@ describe("PensionForecast page", () => {
     expect(selects[0]).toBeInTheDocument();
   });
 
+  it("rounds a fractional current age to a whole number", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alex", full_name: "Alex Example", accounts: [] },
+    ]);
+    mockGetPensionForecast.mockResolvedValue({
+      forecast: [],
+      projected_pot_gbp: 0,
+      pension_pot_gbp: 0,
+      current_age: 42.3716632443,
+      retirement_age: 67,
+      dob: "1984-01-15",
+      earliest_retirement_age: null,
+      retirement_income_breakdown: null,
+      retirement_income_total_annual: null,
+      desired_income_annual: null,
+    });
+
+    const { default: PensionForecast } = await import("@/pages/PensionForecast");
+
+    renderWithI18n(<PensionForecast />);
+
+    const btn = await screen.findByRole("button", { name: /forecast/i });
+    await userEvent.click(btn);
+
+    await screen.findByText(/birth date: 1984-01-15/i);
+    expect(screen.getByText("Current age: 42")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/42\.3716632443/),
+    ).not.toBeInTheDocument();
+  });
+
   it("submits with selected owner", async () => {
     mockGetOwners.mockResolvedValue([
       { owner: "alex", full_name: "Alex Example", accounts: [] },


### PR DESCRIPTION
﻿## Summary

The Pension Forecast "Future You" results panel was displaying an unformatted decimal for the current age (e.g., 13.371663244353183 instead of 13). The backend computes current_age as a fractional-year float for retirement math, but the frontend rendered it raw without rounding.

**Fix:** Round current age to the nearest whole number when displaying it in the UI. The underlying fractional value remains unaffected for calculations.

**Testing:**
- Added unit test asserting fractional age displays as a whole number
- All 7 PensionForecast tests pass
- ESLint passes

Closes #5555

🤖 Generated with Claude Code
