### PR TITLE
Fix pandas mypy call-overload errors in quality.py and risk.py

### DIFF
--- a/backend/common/risk.py
+++ b/backend/common/risk.py
@@ -244,7 +244,7 @@ def compute_portfolio_var_breakdown(
             closes = pd.to_numeric(ts["Close"], errors="coerce")
             date_col = pd.to_datetime(ts["Date"], errors="coerce")
             instrument_returns = pd.Series(closes.values, index=date_col).dropna()
-            instrument_returns = instrument_returns[~instrument_returns.index.isna()].sort_index()
+            instrument_returns = instrument_returns[instrument_returns.index.notna()].sort_index()
             if not instrument_returns.empty:
                 if horizon_days <= 1:
                     shock_returns = instrument_returns.pct_change()

--- a/backend/timeseries/quality.py
+++ b/backend/timeseries/quality.py
@@ -117,14 +117,14 @@ def find_outliers(
     rolling_std = close.rolling(window=window, min_periods=min_periods).std()
 
     outliers: list[Outlier] = []
-    for idx, value in close.items():
-        mean = rolling_mean[idx]
-        std = rolling_std[idx]
+    for pos, value in enumerate(close):
+        mean = rolling_mean.iloc[pos]
+        std = rolling_std.iloc[pos]
         if pd.isna(value) or pd.isna(mean) or pd.isna(std) or std == 0:
             continue
         z_score = abs(value - mean) / std
         if z_score > sigma:
-            row_date = pd.to_datetime(sorted_df["Date"][idx]).date()
+            row_date = pd.to_datetime(sorted_df["Date"].iloc[pos]).date()
             outliers.append(Outlier(date=row_date.isoformat(), value=float(value), z_score=float(z_score)))
     return outliers
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ ruff~=0.16.0
 pytest-asyncio~=1.4.0
 jsonschema~=4.23.0
 mypy~=2.3.0
+pandas-stubs==2.3.3.251201


### PR DESCRIPTION
## Summary
- `mypy backend` fails locally with `[call-overload]`/`[operator]` errors in `backend/timeseries/quality.py` (indexing a `Series` by a bare `Hashable` label from `.items()`) and `backend/common/risk.py` (inverting an `Index[bool]` with `~`)
- Reproduces identically on `main`, so unrelated to any specific branch
- Fixed by iterating `find_outliers` positionally (`enumerate` + `.iloc`) instead of label-indexing, and building the NaT mask via `Index.notna()` instead of `~Index.isna()`
- No behavior change — verified with existing tests and a full `mypy backend` run (clean)

Closes #5684

## Test plan
- [x] `python -m mypy backend --config-file mypy.ini --show-error-codes --pretty --explicit-package-bases` — clean
- [x] `pytest tests --ignore=tests/live -k "quality or risk or var" -q` — 166 passed, 3 skipped
- [x] `black --check`, `ruff check`, `isort --check-only` on both changed files