### PR TITLE
[Issue #5693] Harden .aider.conf.yml defaults to prevent unscoped edits

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,9 +1,13 @@
 model: "ollama/qwen2.5-coder:7b"
+edit-format: "diff"
 
 auto-commits: false
-yes-always: true
+yes-always: false
 
-auto-test: true
+# Disabled: a test failure was letting the model treat unrelated errors (e.g.
+# a conftest.py collision) as a new task and rewrite files outside the
+# requested scope. Run tests yourself after reviewing the diff instead.
+auto-test: false
 test-cmd: "pytest -q --ignore=tests/integration --ignore=tests/live"
 
 # litellm's default completion timeout is 600s, which a 14B local model can


### PR DESCRIPTION
## Summary
- The batching fix originally tracked by #5604 was already present on `main` (`stage_changes` already used a single batched `subprocess.run(["git", "add", "--", *files], check=True)` call) — this branch's earlier commit was a no-op stylistic swap and has been dropped.
- This PR now scopes to hardening `.aider.conf.yml`: `edit-format: diff`, `yes-always: false`, `auto-test: false`, so aider stops auto-committing unreviewed edits and stops chasing unrelated test failures into out-of-scope file changes.

Closes #5693

## Test plan
- [x] Verified `main`'s `stage_changes` already batches `git add` in a single call (no code change needed for #5604).
- [ ] Run a scoped aider session locally against the new config and confirm it proposes a diff for review instead of auto-committing, and does not auto-run tests.