### PR TITLE
Add n_review_issue.py: review and refresh a GitHub issue with local/cloud LLM

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -384,6 +384,38 @@ Optional flags:
 Uses only `requests` and plain `git` -- no `gh` CLI or special GitHub scopes
 required.
 
+## n_review_issue.py
+
+Review and refresh a single GitHub issue with a local or cloud LLM before work
+starts on it, so a stale or vague issue gets corrected instead of misread.
+Fetches the issue, asks the chosen model to bring the title/body up to date
+while preserving the original section structure, shows a diff of the proposed
+change, and only calls `gh issue edit` after you approve it.
+
+```bash
+python scripts/developer_tools/n_review_issue.py 5695
+```
+
+Omit the issue number or `--model` to be prompted interactively:
+
+```bash
+python scripts/developer_tools/n_review_issue.py
+```
+
+Optional flags:
+- `--model {local,cloud}`: `local` uses Ollama (see `OLLAMA_ENDPOINT`/`OLLAMA_MODEL`
+  above); `cloud` uses DeepSeek and requires `DEEPSEEK_API_KEY` to be set.
+- `--yes`: skip the confirmation prompt and update the issue if changes are proposed.
+- `--dry-run`: show the proposed diff and confirmation flow, but never call
+  `gh issue edit`.
+- `--verbose`: print the raw model response.
+
+If the model's revised body is far shorter than the original, the script
+refuses to propose the change rather than risk silently dropping details.
+
+**Requirements:** `gh` CLI authenticated against the target repo; either a
+running local Ollama server or a `DEEPSEEK_API_KEY`, depending on `--model`.
+
 ## reconcile_drawdown.py
 
 Inspect max drawdowns and dump holding price data when the portfolio suffers a

--- a/scripts/developer_tools/n_review_issue.py
+++ b/scripts/developer_tools/n_review_issue.py
@@ -1,0 +1,317 @@
+"""CLI tool to review and refresh a single GitHub issue using a local or cloud LLM.
+
+Continues the a_/b_/c_/.../m_ script chain in scripts/developer_tools/. Fetches one
+issue by number, asks the chosen model (local Ollama or cloud DeepSeek) to bring the
+title/body up to date, shows a diff of the proposed change, and only calls `gh issue
+edit` after the user approves it. Never touches the issue if the model's answer looks
+like it dropped content from the original.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Add .github/scripts (for deepseek_review) and the local lib/ dir (for
+# ollama_common/github_repo) to sys.path so this works both as an importable
+# module and when invoked directly, where the repo root is not on sys.path.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / ".github" / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from deepseek_review import fetch_deepseek_review  # noqa: E402
+from github_repo import get_repo_info  # noqa: E402
+from ollama_common import (  # noqa: E402
+    fetch_ollama_review,
+    get_ollama_endpoint,
+    get_ollama_model,
+    validate_ollama_connection,
+)
+
+LOCAL = "local"
+CLOUD = "cloud"
+
+# Below this fraction of the original body length, treat the model's answer as having
+# dropped content rather than genuinely trimmed stale text, and refuse to show it as a
+# safe-to-approve diff.
+MIN_BODY_LENGTH_RATIO = 0.5
+
+REVIEW_PROMPT_TEMPLATE = """You are reviewing an existing GitHub issue from the allotmint repo \
+for staleness before it is worked on. The issue may describe files, behaviour, or context that \
+has since changed.
+
+Update the title and body so they are accurate and current. Preserve the original section \
+structure (e.g. '## What', '## Why', '## How', '## Constraints', '## LLM tier', \
+'## Success looks like', '## Failure looks like') if present, and keep every concrete detail \
+that is still accurate. Never delete information outright -- if something is now uncertain, \
+flag it inline instead of removing it. Do not invent new requirements or acceptance criteria \
+that aren't implied by the original text.
+
+If the issue is already accurate and needs no changes, return it unchanged.
+
+Respond with exactly two parts, in this format and nothing else:
+TITLE: <title>
+BODY:
+<body>
+
+Original title: {title}
+
+Original body:
+{body}
+"""
+
+
+def fetch_issue(owner: str, repo: str, number: int) -> dict:
+    """Fetch an issue's title/body/state via the `gh` CLI."""
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            f"{owner}/{repo}",
+            "--json",
+            "number,title,body,state,url",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(f"ERROR: Failed to fetch issue #{number}: {result.stderr.strip()}", file=sys.stderr)
+        raise SystemExit(1)
+
+    import json
+
+    return json.loads(result.stdout)
+
+
+def build_review_prompt(title: str, body: str) -> str:
+    """Build the prompt sent to the model to review and refresh the issue."""
+    return REVIEW_PROMPT_TEMPLATE.format(title=title, body=body)
+
+
+def parse_review_response(
+    response: str, fallback_title: str, fallback_body: str
+) -> tuple[str, str]:
+    """Parse the model's TITLE/BODY response, falling back to the originals on any mismatch."""
+    match = re.search(r"TITLE:\s*(.*?)\s*\nBODY:\s*\n?(.*)", response, re.DOTALL)
+    if not match:
+        return fallback_title, fallback_body
+    title = match.group(1).strip()
+    body = match.group(2).strip()
+    if not title or not body:
+        return fallback_title, fallback_body
+    return title, body
+
+
+def run_review(model_source: str, title: str, body: str, verbose: bool = False) -> str | None:
+    """Call the chosen model with the review prompt. Returns None on any failure."""
+    prompt = build_review_prompt(title, body)
+
+    if model_source == LOCAL:
+        endpoint = get_ollama_endpoint()
+        if not validate_ollama_connection(endpoint):
+            print(
+                f"ERROR: Ollama is not reachable at {endpoint}. "
+                "Start Ollama or set OLLAMA_ENDPOINT.",
+                file=sys.stderr,
+            )
+            return None
+        model = get_ollama_model()
+        print(f"INFO: Reviewing with local model '{model}' at {endpoint}...", file=sys.stderr)
+        response = fetch_ollama_review(endpoint, model, prompt)
+    else:
+        api_key = os.environ.get("DEEPSEEK_API_KEY", "")
+        if not api_key:
+            print(
+                "ERROR: DEEPSEEK_API_KEY is not set; cannot use the cloud model.", file=sys.stderr
+            )
+            return None
+        print("INFO: Reviewing with cloud model (DeepSeek)...", file=sys.stderr)
+        response = fetch_deepseek_review(api_key, prompt)
+
+    if verbose:
+        print(f"[VERBOSE] Model response:\n{response}", file=sys.stderr)
+    if not response.strip():
+        print("ERROR: Model returned an empty response.", file=sys.stderr)
+        return None
+    return response
+
+
+def looks_like_content_loss(original_body: str, revised_body: str) -> bool:
+    """Return True when the revision is suspiciously shorter than the original.
+
+    A model that garbles or drops sections of the issue tends to produce a much
+    shorter body; this is a cheap guard, not a semantic check, so it only blocks
+    approval and always leaves the final call to the user.
+    """
+    if not original_body.strip():
+        return False
+    return len(revised_body) < len(original_body) * MIN_BODY_LENGTH_RATIO
+
+
+def print_diff(old_title: str, old_body: str, new_title: str, new_body: str) -> None:
+    """Print a unified diff of the proposed title/body change."""
+    old_lines = [f"Title: {old_title}\n", "\n", *[f"{line}\n" for line in old_body.splitlines()]]
+    new_lines = [f"Title: {new_title}\n", "\n", *[f"{line}\n" for line in new_body.splitlines()]]
+    diff = difflib.unified_diff(old_lines, new_lines, fromfile="current", tofile="proposed")
+    diff_text = "".join(diff)
+    if not diff_text.strip():
+        print("No changes proposed -- the issue already looks accurate.")
+        return
+    print()
+    print("=" * 60)
+    print("Proposed changes:")
+    print("=" * 60)
+    print(diff_text)
+    print("=" * 60)
+
+
+def update_issue(owner: str, repo: str, number: int, title: str, body: str, dry_run: bool) -> bool:
+    """Update the issue's title/body on GitHub via `gh issue edit`. Returns success."""
+    if dry_run:
+        print(f"[DRY RUN] Would update issue #{number} with the title/body above.")
+        return True
+
+    body_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", encoding="utf-8", delete=False
+        ) as tf:
+            tf.write(body)
+            body_path = tf.name
+
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "edit",
+                str(number),
+                "--repo",
+                f"{owner}/{repo}",
+                "--title",
+                title,
+                "--body-file",
+                body_path,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        if body_path and os.path.exists(body_path):
+            os.unlink(body_path)
+
+    if result.returncode != 0:
+        print(f"ERROR: Failed to update issue #{number}: {result.stderr.strip()}", file=sys.stderr)
+        return False
+    print(f"[OK] Updated issue #{number}.")
+    return True
+
+
+def prompt_for_issue_number() -> int:
+    """Interactively prompt for an issue number."""
+    try:
+        raw = input("Issue number to review: ").strip()
+    except EOFError:
+        raw = ""
+    try:
+        return int(raw)
+    except ValueError:
+        print(f"Invalid issue number: {raw!r}", file=sys.stderr)
+        raise SystemExit(1) from None
+
+
+def prompt_for_model_source() -> str:
+    """Interactively prompt for which model to use."""
+    print()
+    print("Model source:")
+    print("  [l] Local (Ollama)")
+    print("  [c] Cloud (DeepSeek)")
+    try:
+        choice = input("> ").strip().lower()
+    except EOFError:
+        choice = "l"
+    return CLOUD if choice in ("c", "cloud") else LOCAL
+
+
+def main() -> int:
+    """Run the interactive issue-review flow."""
+    parser = argparse.ArgumentParser(
+        description="Review and refresh a GitHub issue using a local or cloud LLM"
+    )
+    parser.add_argument("issue_id", type=int, nargs="?", help="GitHub issue number to review")
+    parser.add_argument("--model", choices=[LOCAL, CLOUD], help="Model source (skips the prompt)")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt and update the issue if changes are proposed",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the proposed diff and confirmation flow, but never call `gh issue edit`",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print the raw model response",
+    )
+    args = parser.parse_args()
+
+    try:
+        owner, repo = get_repo_info()
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    issue_id = args.issue_id if args.issue_id is not None else prompt_for_issue_number()
+    model_source = args.model or prompt_for_model_source()
+
+    print(f"INFO: Fetching issue #{issue_id} from {owner}/{repo}...", file=sys.stderr)
+    issue = fetch_issue(owner, repo, issue_id)
+    title = issue.get("title", "")
+    body = issue.get("body") or ""
+    if issue.get("state") == "CLOSED":
+        print(f"WARNING: Issue #{issue_id} is closed.", file=sys.stderr)
+
+    response = run_review(model_source, title, body, args.verbose)
+    if response is None:
+        return 1
+
+    new_title, new_body = parse_review_response(response, title, body)
+
+    if looks_like_content_loss(body, new_body):
+        print(
+            "ERROR: The revised body is far shorter than the original issue; refusing to "
+            "propose a change that may have dropped details. Re-run with --verbose to inspect "
+            "the raw model response.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print_diff(title, body, new_title, new_body)
+
+    if new_title == title and new_body == body:
+        return 0
+
+    if not args.yes:
+        try:
+            confirm = input("Apply this update to the issue? [Y/n] ").strip().lower()
+        except EOFError:
+            confirm = "n"
+        if confirm not in ("", "y", "yes"):
+            print("Aborted; issue left unchanged.", file=sys.stderr)
+            return 0
+
+    return 0 if update_issue(owner, repo, issue_id, new_title, new_body, args.dry_run) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_n_review_issue.py
+++ b/tests/scripts/test_n_review_issue.py
@@ -1,0 +1,115 @@
+import json
+
+import scripts.developer_tools.n_review_issue as n
+
+
+class _FakeResult:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_parse_review_response_extracts_title_and_body():
+    response = "TITLE: Fixed title\nBODY:\n## What\nUpdated content\n"
+    title, body = n.parse_review_response(response, "old title", "old body")
+    assert title == "Fixed title"
+    assert body == "## What\nUpdated content"
+
+
+def test_parse_review_response_falls_back_on_malformed_response():
+    response = "I refuse to answer in the requested format."
+    title, body = n.parse_review_response(response, "old title", "old body")
+    assert (title, body) == ("old title", "old body")
+
+
+def test_parse_review_response_falls_back_on_empty_body():
+    response = "TITLE: New title\nBODY:\n"
+    title, body = n.parse_review_response(response, "old title", "old body")
+    assert (title, body) == ("old title", "old body")
+
+
+def test_looks_like_content_loss_true_when_much_shorter():
+    original = "## What\n" + ("detail line\n" * 50)
+    revised = "## What\nshort"
+    assert n.looks_like_content_loss(original, revised)
+
+
+def test_looks_like_content_loss_false_when_similar_length():
+    original = "## What\nsome detail here"
+    revised = "## What\nsome updated detail here"
+    assert not n.looks_like_content_loss(original, revised)
+
+
+def test_looks_like_content_loss_false_when_original_is_empty():
+    assert not n.looks_like_content_loss("", "")
+
+
+def test_run_review_local_returns_none_when_ollama_unreachable(monkeypatch):
+    monkeypatch.setattr(n, "validate_ollama_connection", lambda endpoint: False)
+    assert n.run_review(n.LOCAL, "title", "body") is None
+
+
+def test_run_review_local_returns_response(monkeypatch):
+    monkeypatch.setattr(n, "validate_ollama_connection", lambda endpoint: True)
+    monkeypatch.setattr(
+        n, "fetch_ollama_review", lambda endpoint, model, prompt: "TITLE: t\nBODY:\nb"
+    )
+    assert n.run_review(n.LOCAL, "title", "body") == "TITLE: t\nBODY:\nb"
+
+
+def test_run_review_cloud_returns_none_without_api_key(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    assert n.run_review(n.CLOUD, "title", "body") is None
+
+
+def test_run_review_cloud_returns_response(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "fake-key")
+    monkeypatch.setattr(n, "fetch_deepseek_review", lambda api_key, prompt: "TITLE: t\nBODY:\nb")
+    assert n.run_review(n.CLOUD, "title", "body") == "TITLE: t\nBODY:\nb"
+
+
+def test_run_review_returns_none_on_empty_response(monkeypatch):
+    monkeypatch.setattr(n, "validate_ollama_connection", lambda endpoint: True)
+    monkeypatch.setattr(n, "fetch_ollama_review", lambda endpoint, model, prompt: "   ")
+    assert n.run_review(n.LOCAL, "title", "body") is None
+
+
+def test_fetch_issue_parses_gh_json(monkeypatch):
+    payload = json.dumps({"number": 42, "title": "T", "body": "B", "state": "OPEN", "url": "u"})
+    monkeypatch.setattr(
+        n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=0, stdout=payload)
+    )
+    issue = n.fetch_issue("owner", "repo", 42)
+    assert issue == {"number": 42, "title": "T", "body": "B", "state": "OPEN", "url": "u"}
+
+
+def test_fetch_issue_exits_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(
+        n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=1, stderr="not found")
+    )
+    try:
+        n.fetch_issue("owner", "repo", 42)
+        raise AssertionError("expected SystemExit")
+    except SystemExit as exc:
+        assert exc.code == 1
+
+
+def test_update_issue_dry_run_skips_gh_call(monkeypatch):
+    def fail_if_called(*a, **k):
+        raise AssertionError("gh should not be called in dry-run mode")
+
+    monkeypatch.setattr(n.subprocess, "run", fail_if_called)
+    assert n.update_issue("owner", "repo", 1, "title", "body", dry_run=True) is True
+
+
+def test_update_issue_reports_failure(monkeypatch):
+    monkeypatch.setattr(
+        n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=1, stderr="boom")
+    )
+    assert n.update_issue("owner", "repo", 1, "title", "body", dry_run=False) is False
+
+
+def test_update_issue_success(monkeypatch):
+    monkeypatch.setattr(n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=0))
+    assert n.update_issue("owner", "repo", 1, "title", "body", dry_run=False) is True


### PR DESCRIPTION
## Summary
- Adds `scripts/developer_tools/n_review_issue.py`, an interactive CLI that fetches a GitHub issue, asks a local (Ollama) or cloud (DeepSeek) model to bring the title/body up to date while preserving the original section structure, shows a diff of the proposed change, and only calls `gh issue edit` after the user approves.
- Guards against content loss: refuses to propose a revision whose body is far shorter than the original rather than risk silently dropping details.
- Documents the script in `scripts/README.md` alongside the rest of the `developer_tools` chain.

Note: issue #5695 literally asked for this script to live in a `developer_tools` **repository**, but no such repo exists under this account. Per user direction, this was implemented as `scripts/developer_tools/n_review_issue.py` in this repo instead, consistent with how every other issue-scoped script here lives in its own repo.

## Test plan
- [x] `pytest tests/scripts/test_n_review_issue.py -v` — 16/16 passing
- [x] `ruff check` / `black --check` clean on both new files
- [x] Manually ran `python scripts/developer_tools/n_review_issue.py 5695 --model local --dry-run` against the real issue: fetched #5695, got a live Ollama review, displayed a correct diff, and reported `[DRY RUN] Would update issue #5695` without calling `gh issue edit`

Closes #5695

🤖 Generated with [Claude Code](https://claude.com/claude-code)