### PR TITLE
Fix DeepSeek PR reviews failing silently

### DIFF
--- a/.github/scripts/deepseek_review.py
+++ b/.github/scripts/deepseek_review.py
@@ -9,9 +9,16 @@ handling stay identical across all three reviewers.
 from __future__ import annotations
 
 import os
+import sys
 from typing import Any
 
-from review_common import build_prompt, emit_empty_diff_notice, fetch_review, finalize_review, load_review_context
+from review_common import (
+    build_prompt,
+    emit_empty_diff_notice,
+    fetch_review,
+    finalize_review,
+    load_review_context,
+)
 
 DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-flash"
 DEFAULT_MAX_TOKENS = 4096
@@ -44,14 +51,36 @@ def extract_deepseek_review(data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     `{"choices": [{"message": {"content": "<string>"}}]}` — unlike Anthropic's
     content-block format, DeepSeek never returns `content` as a list, so no
     list-handling branch is needed here.
+
+    Thinking-capable models (e.g. `deepseek-v4-flash`, `deepseek-reasoner`)
+    also return a `reasoning_content` field holding the chain-of-thought. If
+    `max_tokens` is exhausted before the model finishes reasoning, `content`
+    comes back empty even though the response itself is large — this used to
+    fail with no clue why (#5697). `fetch_deepseek_review` disables thinking
+    mode to avoid this, but if a response still comes back with reasoning and
+    no content, surface that explicitly instead of a bare empty-review error.
     """
     choices = data.get("choices", [])
     if not choices:
         return "", {}
 
-    message = choices[0].get("message", {})
+    choice = choices[0]
+    message = choice.get("message", {})
     content = message.get("content", "")
     review = content.strip() if isinstance(content, str) else ""
+
+    if not review:
+        reasoning = message.get("reasoning_content") or ""
+        finish_reason = choice.get("finish_reason")
+        if reasoning:
+            print(
+                "WARNING: DeepSeek response contained only reasoning_content "
+                f"({len(reasoning)} chars, finish_reason={finish_reason!r}) and no "
+                "final content — the model likely ran out of max_tokens while "
+                "thinking. Consider raising DEEPSEEK_MAX_TOKENS.",
+                file=sys.stderr,
+            )
+
     return review, {}
 
 
@@ -62,12 +91,25 @@ def fetch_deepseek_review(api_key: str, prompt: str) -> str:
     surfaced with a non-zero exit code so the advisory workflow can post a
     skip/failure notice instead of silently succeeding.
     """
-    payload = {
-        "model": get_deepseek_model(),
+    model = get_deepseek_model()
+    payload: dict[str, Any] = {
+        "model": model,
         "messages": [{"role": "user", "content": prompt}],
         "max_tokens": get_max_tokens(),
         "temperature": 0.2,
     }
+    if model != "deepseek-reasoner":
+        # Thinking-capable models (the default deepseek-v4-flash) default to
+        # thinking mode "on" with high effort, which can burn the entire
+        # max_tokens budget on reasoning_content and leave `content` empty
+        # (see #5697 — reviews were failing with a 200 response and no visible
+        # reason). PR review is a straightforward advisory task that doesn't
+        # need chain-of-thought, so disable it for a reliable final answer
+        # within budget. Skip this for deepseek-reasoner (opted into via the
+        # "Deep Review Required" label with a larger token budget) since
+        # reasoning is that model's whole purpose and disabling isn't
+        # documented as supported for it.
+        payload["thinking"] = {"type": "disabled"}
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
@@ -89,7 +131,13 @@ def main() -> int:
     if not context.diff.strip():
         return emit_empty_diff_notice("DeepSeek")
 
-    prompt = build_prompt(context.pr_title, context.diff, context.issue_body, context.discussion, context.verified_facts)
+    prompt = build_prompt(
+        context.pr_title,
+        context.diff,
+        context.issue_body,
+        context.discussion,
+        context.verified_facts,
+    )
     review = fetch_deepseek_review(context.api_key, prompt)
     return finalize_review(review, "ERROR: DeepSeek API returned an empty review")
 

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -67,6 +67,88 @@ def test_deepseek_review_uses_current_default_model_and_allows_override(
     assert module.get_deepseek_model() == "deepseek-v4-flash"
 
 
+def test_deepseek_review_disables_thinking_mode_for_default_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for #5697: flash-tier reviews must disable thinking mode.
+
+    Thinking-capable DeepSeek models default to thinking mode "on", which can
+    burn the whole max_tokens budget on reasoning_content and leave `content`
+    empty — the review then fails with a 200 response and no visible cause.
+    Sending `thinking: {type: disabled}` for the default (non-reasoner) model
+    avoids that.
+    """
+    module = load_script_module("deepseek_review_thinking_flash", "deepseek_review.py")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    monkeypatch.setenv("PR_TITLE", "Add thing")
+    monkeypatch.setenv("ISSUE_BODY", "Do thing")
+    monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
+    monkeypatch.delenv("DEEPSEEK_MODEL", raising=False)
+
+    captured_payloads: list[dict[str, object]] = []
+
+    def fake_urlopen(request, *args, **kwargs):
+        captured_payloads.append(json.loads(request.data.decode()))
+        return FakeResponse({"choices": [{"message": {"content": "Looks good\n**APPROVE**"}}]})
+
+    monkeypatch.setattr(review_common.urllib.request, "urlopen", fake_urlopen)
+
+    assert module.main() == 0
+    assert captured_payloads[0]["thinking"] == {"type": "disabled"}
+
+
+def test_deepseek_review_leaves_thinking_mode_enabled_for_reasoner_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """deepseek-reasoner is opted into deliberately for deep reviews; don't disable reasoning."""
+    module = load_script_module("deepseek_review_thinking_reasoner", "deepseek_review.py")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    monkeypatch.setenv("PR_TITLE", "Add thing")
+    monkeypatch.setenv("ISSUE_BODY", "Do thing")
+    monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
+    monkeypatch.setenv("DEEPSEEK_MODEL", "deepseek-reasoner")
+
+    captured_payloads: list[dict[str, object]] = []
+
+    def fake_urlopen(request, *args, **kwargs):
+        captured_payloads.append(json.loads(request.data.decode()))
+        return FakeResponse({"choices": [{"message": {"content": "Looks good\n**APPROVE**"}}]})
+
+    monkeypatch.setattr(review_common.urllib.request, "urlopen", fake_urlopen)
+
+    assert module.main() == 0
+    assert "thinking" not in captured_payloads[0]
+
+
+def test_deepseek_review_warns_when_only_reasoning_content_returned(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If a response still comes back reasoning-only, the failure must explain why (#5697)."""
+    module = load_script_module("deepseek_review_reasoning_only", "deepseek_review.py")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    monkeypatch.setenv("PR_TITLE", "Add thing")
+    monkeypatch.setenv("ISSUE_BODY", "Do thing")
+    monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
+    payload = {
+        "choices": [
+            {
+                "message": {"content": "", "reasoning_content": "thinking very hard..."},
+                "finish_reason": "length",
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        review_common.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(payload)
+    )
+
+    assert module.main() == 1
+    err = capsys.readouterr().err
+    assert "reasoning_content" in err
+    assert "finish_reason='length'" in err
+    assert "ERROR: DeepSeek API returned an empty review" in err
+
+
 @pytest.mark.parametrize(
     ("module_name", "file_name", "api_env"),
     [


### PR DESCRIPTION
## Summary
- Every DeepSeek review call returned HTTP 200 with a sizeable body but empty `content`, so the workflow only posted a generic "review failed to complete" comment — no indication of why (#5697).
- Root cause: the default model (`deepseek-v4-flash`) has thinking mode enabled by default, and it was consuming the entire `max_tokens` budget on `reasoning_content` before any final answer was produced (confirmed against every recent failing `deepseek-pr-review.yml` run — all show `status=200` with a non-trivial body and an empty extracted review).
- Fix: disable thinking mode (`"thinking": {"type": "disabled"}`) for the default flash-tier model, which doesn't need chain-of-thought for an advisory code review. `deepseek-reasoner` (opted into via the "Deep Review Required" label, with a larger 16000-token budget) is left untouched since reasoning is its whole purpose.
- Added a diagnostic warning in `extract_deepseek_review` that surfaces `reasoning_content` length and `finish_reason` on future empty-content responses, so this class of failure is never silent again.

## Test plan
- [x] `python -m pytest tests/test_ai_review_scripts.py -q --no-cov` (48 passed)
- [x] `python -m black --check .github/scripts/deepseek_review.py tests/test_ai_review_scripts.py`
- [x] `python -m ruff check .github/scripts/deepseek_review.py tests/test_ai_review_scripts.py` (no new findings)
- [x] Added regression tests: default model disables thinking, `deepseek-reasoner` keeps thinking enabled, and empty-content-with-reasoning responses produce an actionable stderr warning

Closes #5697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of AI responses when reasoning is returned without a final answer.
  * Added diagnostic details, including reasoning length and completion status, to aid troubleshooting.
  * Ensured advanced thinking is enabled only for supported reasoning models.

* **Tests**
  * Added regression coverage for standard and reasoning model behaviour, including incomplete responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->