### PR TITLE
Fix empty-diff AI review notice being reported as CHANGES REQUESTED

### DIFF
--- a/.github/scripts/review_common.py
+++ b/.github/scripts/review_common.py
@@ -162,10 +162,17 @@ are only non-blocking observations, use APPROVE and put them in section 5."""
 
 
 def emit_empty_diff_notice(provider_name: str) -> int:
-    """Exit cleanly when the filtered diff is empty instead of making a no-context API call."""
+    """Exit cleanly when the filtered diff is empty instead of making a no-context API call.
+
+    Ends with a bold **APPROVE** line so `extract_verdict.py` treats this the same as a real
+    "nothing to flag" review instead of "no valid verdict found" (which the workflow's
+    `check_approval` step otherwise reports as `CHANGES REQUESTED` — see #5715). There is
+    nothing to request changes on when no diff was reviewed at all.
+    """
     print(
         f"No {provider_name} review generated because the filtered diff was empty. "
-        "The workflow can still post this advisory note without failing."
+        "The workflow can still post this advisory note without failing.\n\n"
+        "**APPROVE** — nothing to review"
     )
     return 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
       - run: python scripts/check_branch_protection_required_checks.py
       - name: Run extract_verdict tests
         run: pytest tests/test_extract_verdict.py -v --no-cov
+      - name: Run review_common tests
+        run: pytest tests/test_review_common.py -v --no-cov
       - name: Check package-lock.json cross-OS platform coverage
         run: python scripts/check_lockfile_platform_coverage.py
       - uses: actions/setup-node@v7

--- a/tests/test_review_common.py
+++ b/tests/test_review_common.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".github" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def load_module(name: str):
+    spec = importlib.util.spec_from_file_location(f"{name}_test", SCRIPTS_DIR / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # review_common.py's ReviewContext is a dataclass with `from __future__ import
+    # annotations` (string annotations); dataclasses resolves those via
+    # sys.modules[cls.__module__], which requires the module to be registered there
+    # before exec_module runs the class body.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def review_common():
+    return load_module("review_common")
+
+
+@pytest.fixture(scope="module")
+def extract_verdict_mod():
+    return load_module("extract_verdict")
+
+
+@pytest.mark.parametrize("provider", ["Claude", "GPT", "DeepSeek"])
+def test_emit_empty_diff_notice_returns_success(review_common, provider) -> None:
+    assert review_common.emit_empty_diff_notice(provider) == 0
+
+
+@pytest.mark.parametrize("provider", ["Claude", "GPT", "DeepSeek"])
+def test_emit_empty_diff_notice_parses_as_approve(
+    review_common, extract_verdict_mod, capsys, provider
+) -> None:
+    """The empty-diff advisory notice must read as APPROVE, not "no verdict found".
+
+    Regression test for #5715: extract_verdict.py previously treated this notice as
+    having no valid verdict, which the workflow's fail step reported as
+    "CHANGES REQUESTED" even though nothing was actually reviewed.
+    """
+    review_common.emit_empty_diff_notice(provider)
+    notice = capsys.readouterr().out
+
+    assert extract_verdict_mod.extract_verdict(notice) == "APPROVE"


### PR DESCRIPTION
### Motivation

Closes #5715

`review_common.emit_empty_diff_notice()` prints an advisory-only notice ("filtered diff was empty... can still post this advisory note without failing") and returns exit code 0, but the text contains no `**APPROVE**`/`**REQUEST CHANGES**` marker. `extract_verdict.py` then reads that as "no valid verdict found," and the calling `_ai-pr-review.yml` job's final step reports it as `CHANGES REQUESTED` and fails — even though nothing was reviewed and no changes were actually requested.

Since `ai-review / DeepSeek AI code review` is a required branch-protection check on `main`, this blocked [PR #5618](https://github.com/leonarduk/allotmint/pull/5618) (a CSS-only change) and required an admin-merge bypass. `claude_review.py`/`gpt_review.py` share the same `emit_empty_diff_notice()` helper, so they're exposed to the identical bug — it just isn't visible today because both are disabled (`ENABLE_CLAUDE_REVIEW`/`ENABLE_GPT_REVIEW = false`) and neither check is currently required.

### Description

- `emit_empty_diff_notice()` now appends a bold `**APPROVE**` line to the advisory text, so `extract_verdict.py` (unchanged) parses it as a genuine approval instead of "no valid verdict." There is nothing to request changes on when no diff was ever reviewed.
- Added `tests/test_review_common.py`, mirroring the existing `tests/test_extract_verdict.py` pattern, with a regression test asserting the notice parses as `APPROVE` for all three providers.
- Wired the new test into `.github/workflows/ci.yml` alongside the existing `extract_verdict` test step.

### Testing

- `pytest tests/test_review_common.py tests/test_extract_verdict.py -v --no-cov` — 19 passed.
- Verified the diff introduces no new `black`/`ruff` violations on the changed lines (pre-existing lint findings elsewhere in `review_common.py` are untouched, out of scope).