### PR TITLE
ci: run only the test jobs a PR's changes can affect

### DIFF
--- a/.github/rulesets/default-branch-protection.json
+++ b/.github/rulesets/default-branch-protection.json
@@ -36,6 +36,12 @@
             "context": "CI / test"
           },
           {
+            "context": "CI / Frontend lint, type-check and unit tests"
+          },
+          {
+            "context": "CI / CDK infrastructure tests"
+          },
+          {
             "context": "CI / Validate backend/requirements.txt (dry-run)"
           },
           {

--- a/.github/workflows/_classify-change.yml
+++ b/.github/workflows/_classify-change.yml
@@ -1,0 +1,76 @@
+# Single source of truth for "which CI areas can this PR affect?".
+#
+# Called via `uses: ./.github/workflows/_classify-change.yml` so that ci.yml,
+# backend-integration.yml, frontend-tests.yml and iac-validation.yml all gate
+# on identical outputs. Before this existed the repo had four competing
+# mechanisms (a duplicated classify job, dorny/paths-filter, a hand-rolled
+# changed-files step, and workflow-level `paths:`), which could disagree.
+#
+# The classification rules -- and the fail-safe that widens an unrecognised
+# path to every area -- live in scripts/classify_change.py, not here.
+#
+# Callers MUST treat a missing output as "run the job": gate on
+# `needs.<id>.outputs.<area> != 'false'`, never on `== 'true'`. If this
+# workflow fails, its outputs are empty strings, and `!= 'false'` is the
+# polarity that then errs towards running the suite.
+name: Classify change
+
+on:
+  workflow_call:
+    outputs:
+      doc-only:
+        description: Whole diff is documentation/comments only.
+        value: ${{ jobs.classify.outputs.doc-only }}
+      backend:
+        description: Change can affect the Python backend or its test suite.
+        value: ${{ jobs.classify.outputs.backend }}
+      frontend:
+        description: Change can affect the frontend app or its test suite.
+        value: ${{ jobs.classify.outputs.frontend }}
+      cdk:
+        description: Change can affect CDK/IaC constructs.
+        value: ${{ jobs.classify.outputs.cdk }}
+      shell:
+        description: Change can affect shell scripts, containers or deploy tooling.
+        value: ${{ jobs.classify.outputs.shell }}
+      powershell:
+        description: Change can affect PowerShell scripts or their Pester suite.
+        value: ${{ jobs.classify.outputs.powershell }}
+
+permissions:
+  contents: read
+
+jobs:
+  classify:
+    name: Classify PR change (affected areas)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      doc-only: ${{ steps.classify.outputs.doc-only }}
+      backend: ${{ steps.classify.outputs.backend }}
+      frontend: ${{ steps.classify.outputs.frontend }}
+      cdk: ${{ steps.classify.outputs.cdk }}
+      shell: ${{ steps.classify.outputs.shell }}
+      powershell: ${{ steps.classify.outputs.powershell }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history: the classifier diffs base...head, and a shallow
+          # clone has no merge base to diff against.
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - name: Classify affected areas
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # No pip install: classify_change.py is stdlib-only by design.
+        run: |
+          python scripts/classify_change.py \
+            --event-name "$EVENT_NAME" \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -12,43 +12,20 @@ permissions:
   id-token: write
   
 jobs:
-  # Duplicated from ci.yml's classify-change job because workflow files can't
-  # share job outputs across files without a reusable workflow; the actual
-  # classification logic lives once in scripts/classify_change.py. Always
-  # runs (never gated itself) so integration-tests never loses its required
-  # status check to needs-skip-propagation; non-pull_request events (push,
-  # etc.) conservatively classify as not doc-only.
+  # Shared with ci.yml, frontend-tests.yml and iac-validation.yml. This job was
+  # previously a verbatim copy of ci.yml's classify-change because workflow
+  # files can't share job outputs across files -- a reusable workflow is
+  # exactly the mechanism that fixes that.
   classify-change:
-    name: Classify PR change (doc-only detection)
-    runs-on: ubuntu-latest
-    outputs:
-      doc-only: ${{ steps.classify.outputs.doc-only }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.12'
-      - name: Classify change as doc-only or not
-        id: classify
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          python scripts/classify_change.py \
-            --event-name "$EVENT_NAME" \
-            --base "$BASE_SHA" \
-            --head "$HEAD_SHA" \
-            --github-output "$GITHUB_OUTPUT"
+    uses: ./.github/workflows/_classify-change.yml
 
   integration-tests:
     needs: classify-change
     # !cancelled() (not the implicit default success()) so a classify-change
-    # failure still runs the full suite instead of silently skipping it --
-    # see scripts/classify_change.py's conservative fallback.
-    if: "!cancelled() && needs.classify-change.outputs.doc-only != 'true'"
+    # failure still runs the suite instead of silently skipping it, and
+    # `!= 'false'` (not `== 'true'`) so empty outputs from a failed classifier
+    # err towards running. See scripts/classify_change.py.
+    if: "!cancelled() && needs.classify-change.outputs.backend != 'false'"
     runs-on: ubuntu-latest
     env:
       AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,43 +7,29 @@ on:
 permissions:
   contents: read
 jobs:
-  # Classifies pull_request diffs as "doc-only" (comments/docstrings/*.md/docs/**
-  # only) so the heavyweight jobs below can skip on PRs like #5554 that add a
-  # code comment but touch no executable behaviour. Always runs (never gated
-  # itself) so jobs that `needs: classify-change` never lose their required
-  # status check to skip-propagation; non-pull_request events (push, etc.)
-  # conservatively classify as not doc-only. See scripts/classify_change.py.
+  # Single source of truth for which areas a PR can affect. Always runs (never
+  # gated itself) so jobs that `needs: classify-change` never lose their
+  # required status check to skip-propagation.
+  #
+  # Gated jobs below use `<area> != 'false'` rather than `== 'true'`: if the
+  # classifier fails its outputs are empty strings, and `!= 'false'` is the
+  # polarity that then errs towards running the suite. Pair it with
+  # `!cancelled()` (not the implicit default success()) so a classify-change
+  # failure doesn't skip-propagate. See scripts/classify_change.py.
   classify-change:
-    name: Classify PR change (doc-only detection)
-    runs-on: ubuntu-latest
-    outputs:
-      doc-only: ${{ steps.classify.outputs.doc-only }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.12'
-      - name: Classify change as doc-only or not
-        id: classify
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          python scripts/classify_change.py \
-            --event-name "$EVENT_NAME" \
-            --base "$BASE_SHA" \
-            --head "$HEAD_SHA" \
-            --github-output "$GITHUB_OUTPUT"
+    uses: ./.github/workflows/_classify-change.yml
 
+  # Repo-hygiene checks: cheap, apply to every PR, and gate nothing
+  # area-specific. Deliberately ungated --
+  # check_branch_protection_required_checks.py is what stops the ruleset
+  # drifting away from the jobs below, so it must run even on a change that
+  # affects no test area.
+  #
+  # Do NOT add a `name:` here and do not rename the job id. This job's check
+  # context is literally "CI / test" in
+  # .github/rulesets/default-branch-protection.json; renaming it would leave
+  # branch protection waiting forever for a context no workflow produces.
   test:
-    needs: classify-change
-    # !cancelled() (not the implicit default success()) so a classify-change
-    # failure still runs the full suite instead of silently skipping it --
-    # see scripts/classify_change.py's conservative fallback.
-    if: "!cancelled() && needs.classify-change.outputs.doc-only != 'true'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -58,6 +44,14 @@ jobs:
         run: pytest tests/test_review_common.py -v --no-cov
       - name: Check package-lock.json cross-OS platform coverage
         run: python scripts/check_lockfile_platform_coverage.py
+
+  frontend-checks:
+    name: Frontend lint, type-check and unit tests
+    needs: classify-change
+    if: "!cancelled() && needs.classify-change.outputs.frontend != 'false'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
@@ -73,10 +67,22 @@ jobs:
         working-directory: frontend
       - run: npm test -- --run
         working-directory: frontend
+
+  cdk-tests:
+    name: CDK infrastructure tests
+    needs: classify-change
+    if: "!cancelled() && needs.classify-change.outputs.cdk != 'false'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt -r requirements-dev.txt
       - name: Check cdk/tests/ exists and has tests
         run: |
           if [ ! -d "cdk/tests" ] || [ -z "$(ls -A cdk/tests/)" ]; then
-            echo "ERROR: cdk/tests/ is missing or empty. The test job requires at least one test file in cdk/tests/."
+            echo "ERROR: cdk/tests/ is missing or empty. This job requires at least one test file in cdk/tests/."
             exit 1
           fi
       - name: CDK infrastructure tests
@@ -84,6 +90,8 @@ jobs:
 
   shell-tests:
     name: Bash script tests (bats)
+    needs: classify-change
+    if: "!cancelled() && needs.classify-change.outputs.shell != 'false'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -101,6 +109,8 @@ jobs:
 
   powershell-tests:
     name: PowerShell script tests (Pester)
+    needs: classify-change
+    if: "!cancelled() && needs.classify-change.outputs.powershell != 'false'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -129,6 +139,8 @@ jobs:
   # gives. Keep both (issue #4467).
   validate-backend-deps:
     name: Validate backend/requirements.txt (dry-run)
+    needs: classify-change
+    if: "!cancelled() && needs.classify-change.outputs.backend != 'false'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -181,7 +193,7 @@ jobs:
   lambda-compat:
     name: Lambda-compat pytest (backend/requirements.txt)
     needs: classify-change
-    if: "!cancelled() && needs.classify-change.outputs.doc-only != 'true'"
+    if: "!cancelled() && needs.classify-change.outputs.backend != 'false'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -200,14 +212,16 @@ jobs:
         env:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
         # Run tests/ under Lambda-pinned deps to validate the backend works in
-        # the constrained Lambda runtime environment. The test job runs cdk/tests/
-        # instead, covering CDK infrastructure. This avoids duplication: tests/
-        # runs once (here), cdk/tests/ runs once (in test job), against their
-        # respective dependency sets.
+        # the constrained Lambda runtime environment. The cdk-tests job runs
+        # cdk/tests/ instead, covering CDK infrastructure. This avoids
+        # duplication: tests/ runs once (here), cdk/tests/ runs once (in
+        # cdk-tests), against their respective dependency sets.
         run: .venv-lambda/bin/pytest tests/
 
   lint-shell-scripts:
     name: Lint .github/scripts shell scripts (shellcheck)
+    needs: classify-change
+    if: "!cancelled() && needs.classify-change.outputs.shell != 'false'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -217,6 +231,8 @@ jobs:
         continue-on-error: true
         run: shellcheck .github/scripts/*.sh
 
+  # Deliberately ungated: this is the check that validates the gating itself,
+  # so it must run on every PR, including ones that touch only workflow YAML.
   lint-workflows:
     name: Lint GitHub Actions workflows
     runs-on: ubuntu-latest
@@ -238,7 +254,7 @@ jobs:
   python-compatibility:
     name: Python ${{ matrix.python-version }} compatibility smoke
     needs: classify-change
-    if: "!cancelled() && needs.classify-change.outputs.doc-only != 'true'"
+    if: "!cancelled() && needs.classify-change.outputs.backend != 'false'"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -261,26 +277,29 @@ jobs:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
         run: pytest --no-cov tests/test_backend_api.py::test_health tests/backend/common/test_data_provider_parity.py -q
 
-  detect-frontend-changes:
-    name: Detect frontend-relevant changes
-    runs-on: ubuntu-latest
-    outputs:
-      frontend: ${{ steps.filter.outputs.frontend }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
-        id: filter
-        with:
-          filters: |
-            frontend:
-              - 'frontend/**'
-              - 'package.json'
-              - 'package-lock.json'
-
   frontend-smoke:
     name: Frontend smoke tests (preview build)
-    needs: [test, detect-frontend-changes]
-    if: needs.detect-frontend-changes.outputs.frontend == 'true'
+    needs: [classify-change, frontend-checks]
+    # Three clauses, each load-bearing:
+    #   !cancelled()                     -- survive a classify-change failure
+    #                                       instead of skip-propagating, which
+    #                                       would report this required check as
+    #                                       skipped (i.e. passing) without ever
+    #                                       running the smoke tests.
+    #   frontend-checks.result != failure -- don't spend ~15 min on Playwright
+    #                                       when lint/type-check/vitest already
+    #                                       failed. `!cancelled()` replaces the
+    #                                       implicit success(), so this has to
+    #                                       be stated explicitly. A *skipped*
+    #                                       frontend-checks is fine: it means
+    #                                       frontend == 'false', and the third
+    #                                       clause skips this job too.
+    #   frontend != 'false'              -- the actual area gate, in fail-safe
+    #                                       polarity (empty output => run).
+    if: >-
+      !cancelled()
+      && needs.frontend-checks.result != 'failure'
+      && needs.classify-change.outputs.frontend != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -11,7 +11,17 @@ permissions:
   contents: read
 
 jobs:
+  # Shared with ci.yml, backend-integration.yml and iac-validation.yml.
+  classify-change:
+    uses: ./.github/workflows/_classify-change.yml
+
   frontend-tests:
+    needs: classify-change
+    # !cancelled() (not the implicit default success()) so a classify-change
+    # failure still runs the suite instead of silently skipping it, and
+    # `!= 'false'` (not `== 'true'`) so empty outputs from a failed classifier
+    # err towards running. See scripts/classify_change.py.
+    if: "!cancelled() && needs.classify-change.outputs.frontend != 'false'"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/iac-validation.yml
+++ b/.github/workflows/iac-validation.yml
@@ -11,62 +11,30 @@ permissions:
   contents: read
 
 jobs:
-  detect-iac-changes:
-    name: Detect IaC changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      iac_changed: ${{ steps.changed-files.outputs.iac_changed }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Check for IaC-relevant file changes
-        id: changed-files
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "$BASE_SHA" ] || ! git cat-file -e "$BASE_SHA^{commit}"; then
-            if git rev-parse --verify "$HEAD_SHA^" >/dev/null 2>&1; then
-              BASE_SHA="$(git rev-parse "$HEAD_SHA^")"
-            else
-              echo "iac_changed=true" >> "$GITHUB_OUTPUT"
-              echo "No comparable base commit found; running IaC validation defensively."
-              exit 0
-            fi
-          fi
-
-          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- cdk infra .github/workflows)"
-          if [ -n "$changed_files" ]; then
-            echo "iac_changed=true" >> "$GITHUB_OUTPUT"
-            echo "IaC validation will run for these files:"
-            echo "$changed_files"
-          else
-            echo "iac_changed=false" >> "$GITHUB_OUTPUT"
-            echo "No IaC-relevant changes detected."
-          fi
+  # Shared with ci.yml, backend-integration.yml and frontend-tests.yml. This
+  # replaces a hand-rolled `git diff --name-only -- cdk infra .github/workflows`
+  # step; the equivalent globs now live in AREA_PATH_RULES in
+  # scripts/classify_change.py, and .github/** still widens to every area, so
+  # a workflow edit keeps triggering CDK validation exactly as before.
+  classify-change:
+    uses: ./.github/workflows/_classify-change.yml
 
   cdk-validation:
     name: CDK validation
-    needs: detect-iac-changes
+    needs: classify-change
+    # A job-level gate replaces the per-step `if:` that used to be repeated on
+    # all eleven steps. cdk-validation is not a required status check, so
+    # skipping the job outright is safe here; ci.yml's required jobs keep the
+    # always-report shape instead. `!= 'false'` with `!cancelled()` keeps the
+    # fail-safe polarity: a classifier failure runs the validation.
+    if: "!cancelled() && needs.classify-change.outputs.cdk != 'false'"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Skip CDK validation for unrelated changes
-        if: needs.detect-iac-changes.outputs.iac_changed != 'true'
-        run: echo "No IaC-relevant changes detected; CDK validation is not required."
-
       - name: Checkout repository
-        if: needs.detect-iac-changes.outputs.iac_changed == 'true'
         uses: actions/checkout@v7
 
       - name: Set up Python
-        if: needs.detect-iac-changes.outputs.iac_changed == 'true'
         uses: actions/setup-python@v7
         with:
           python-version: '3.12'
@@ -74,13 +42,11 @@ jobs:
           cache-dependency-path: cdk/requirements.txt
 
       - name: Install Python dependencies
-        if: needs.detect-iac-changes.outputs.iac_changed == 'true'
         # Install only CDK packages and pytest; the full app stack is not needed for synth/test
         # and mixing requirements files causes aws-cdk-lib version conflicts.
         run: python -m pip install pytest -r cdk/requirements.txt
 
       - name: Set up Node.js
-        if: needs.detect-iac-changes.outputs.iac_changed == 'true'
         uses: actions/setup-node@v7
         with:
           node-version: '24'
@@ -90,28 +56,25 @@ jobs:
             frontend/package-lock.json
 
       - name: Install CDK CLI dependencies
-        if: needs.detect-iac-changes.outputs.iac_changed == 'true'
         run: npm ci
 
       - name: Install frontend dependencies
-        if: needs.detect-iac-changes.outputs.iac_changed == 'true'
         working-directory: frontend
         run: npm ci
 
       # StaticSiteStack stages frontend/dist during synth, so build assets before invoking CDK.
       - name: Build frontend assets for CDK synth
-        if: needs.detect-iac-changes.outputs.iac_changed == 'true'
         working-directory: frontend
         run: npm run build
 
       - name: Run CDK tests
-        if: needs.detect-iac-changes.outputs.iac_changed == 'true'
         # Clear addopts from pytest.ini so --cov=backend --cov-fail-under=90 is not inherited;
         # CDK tests don't cover backend/ and pytest-cov is not installed in this job.
+        # Not redundant with ci.yml's cdk-tests job: that one runs cdk/tests
+        # against the root requirements set, this one against cdk/requirements.txt.
         run: pytest cdk/tests -v --tb=short --override-ini="addopts="
 
       - name: Synthesize CDK app
-        if: needs.detect-iac-changes.outputs.iac_changed == 'true'
         working-directory: cdk
         env:
           JWT_SECRET: ci-cdk-validation-secret

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -8,27 +8,68 @@ For the broader product overview, see [docs/README.md](README.md). For repo-wide
 
 Before pushing, be aware that pull requests trigger automated AI code reviews via Claude and GPT workflows. These reviews are advisory and posted as PR comments. For details on how these workflows operate, failure handling, and debugging tips, see [docs/AI_REVIEW_WORKFLOWS.md](AI_REVIEW_WORKFLOWS.md).
 
-### CI fast path for doc-only PRs
+### CI runs only the areas a PR affects
 
-A `classify-change` job in `.github/workflows/ci.yml` and `.github/workflows/backend-integration.yml`
-inspects the PR's diff (via `scripts/classify_change.py`) and skips the heavyweight
-`test`, `lambda-compat`, `python-compatibility`, and `integration-tests` jobs
-when every changed line, across every changed file, is a blank line, a
-full-line comment (`#` in Python; `//`/`/* */` in TS/JS), or content inside a
-`*.md`/`docs/**`/`.github/ISSUE_TEMPLATE/**` file. `frontend-smoke` already
-skips on non-frontend PRs via its own path filter, and a doc-only PR that
-also doesn't touch `frontend/**` skips it too as a side effect of its
-`needs: test`.
+A PR does not run the whole test suite. The shared reusable workflow
+`.github/workflows/_classify-change.yml` runs `scripts/classify_change.py`
+once and publishes a flag per area; `ci.yml`, `backend-integration.yml`,
+`frontend-tests.yml` and `iac-validation.yml` all gate their jobs on those
+same flags, so they cannot disagree about what a PR touched.
 
-The classifier is deliberately conservative: any real code line, config file
-(`pytest.ini`, `mypy.ini`, `requirements*.txt`, workflow YAML, etc.),
-permission-bit change, or rename touching a non-doc path makes the whole PR
-non-doc-only, and the full suite runs as before. If classification itself
-fails for any reason, the full suite also runs — it never fails open into
-skipping tests. Lightweight checks (`super-linter`, `lint-workflows`,
-`pr-lint`, `issue-lint`, `empty-pr-check`, `validate-backend-deps`) always run
-regardless of classification. See [issue #5594](https://github.com/leonarduk/allotmint/issues/5594)
-for the full rationale.
+| Area | Gated jobs | Triggered by (see `AREA_PATH_RULES`) |
+| --- | --- | --- |
+| `backend` | `integration-tests`, `lambda-compat`, `python-compatibility`, `validate-backend-deps` | `backend/**`, `tests/**`, `data/**`, `requirements*.txt`, `pyproject.toml`, `pytest.ini`, `mypy.ini`, `config*.yaml`, `scripts/**.py` |
+| `frontend` | `frontend-checks`, `frontend-smoke`, `frontend-tests` | `frontend/**`, root `package.json`/`package-lock.json`, `backend/contracts_spa.py` |
+| `cdk` | `cdk-tests`, `cdk-validation` | `cdk/**`, `infra/**`, root `package.json`/`package-lock.json` |
+| `shell` | `shell-tests` (bats), `lint-shell-scripts` | `**/*.sh`, `scripts/bash/**`, `tests/bash/**`, `Dockerfile*`, `docker/**`, `docker-compose*.yml`, `deploy/**`, `Jenkinsfile*` |
+| `powershell` | `powershell-tests` (Pester) | `**/*.ps1`, `scripts/powershell/**`, `scripts/tests/**` |
+
+Some checks are deliberately **never** gated, because they are what verifies
+the gating: `test` (branch-protection and lockfile validation),
+`lint-workflows`, plus `super-linter`, `pr-lint`, `issue-lint` and
+`empty-pr-check`.
+
+**The classifier only ever widens.** It is designed so that being wrong costs
+wall-clock, never coverage:
+
+- **Doc-only PRs skip every area.** When every changed line is a blank line, a
+  full-line comment (`#` in Python; `//`/`/* */` in TS/JS), or content inside a
+  `*.md`/`docs/**`/`.github/ISSUE_TEMPLATE/**` file, all area flags are false.
+  Any real code line, config file, permission-bit change, or rename touching a
+  non-doc path makes the PR non-doc-only.
+- **An unrecognised path runs everything.** A file matching no rule in
+  `AREA_PATH_RULES` widens to every area, so adding a new top-level directory
+  cannot silently skip suites.
+- **CI's own machinery runs everything.** Any change under `.github/**`, or to
+  `classify_change.py` itself, sets every area — a change to the gating never
+  narrows the suite that validates it.
+- **Failure runs everything.** A `push` to `main`, a missing base SHA, or a
+  classifier crash all classify as "every area affected". Jobs gate on
+  `<area> != 'false'` (never `== 'true'`) so empty outputs from a failed
+  classifier run the job rather than skipping it.
+
+#### Adding or changing an area
+
+1. Add the path glob to `AREA_PATH_RULES` in `scripts/classify_change.py`.
+   Rules are **first-match-wins**, so a narrow rule must precede any broader
+   rule it sits inside (`tests/bash/**` before `tests/**`).
+2. For a genuinely new area, add it to `AREAS`, declare it as an output in
+   `.github/workflows/_classify-change.yml`, and gate the job with
+   `if: "!cancelled() && needs.classify-change.outputs.<area> != 'false'"`.
+3. If the gated job is a required check, update **both**
+   `.github/rulesets/default-branch-protection.json` and
+   `EXPECTED_REQUIRED_CHECKS` in
+   `scripts/check_branch_protection_required_checks.py` in the same PR — and
+   remember the ruleset JSON is a record of intent, so an admin must also apply
+   it in the repo's GitHub settings.
+4. `tests/scripts/test_classify_change.py` and
+   `tests/scripts/test_ci_area_gating.py` enforce the mapping and the gating
+   invariants; extend them alongside the change.
+
+See [issue #5594](https://github.com/leonarduk/allotmint/issues/5594) for the
+original doc-only fast path and
+[issue #5722](https://github.com/leonarduk/allotmint/issues/5722) for the
+generalisation to per-area gating.
 
 ## 1. Supported run modes at a glance
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -386,15 +386,21 @@ required.
 
 ## classify_change.py
 
-Used by the `classify-change` CI job (`.github/workflows/ci.yml`,
-`.github/workflows/backend-integration.yml`) to classify a pull request's
-diff as "doc-only" so the heavyweight test jobs can skip. See
-[docs/CONTRIBUTOR_RUNBOOK.md](../docs/CONTRIBUTOR_RUNBOOK.md#ci-fast-path-for-doc-only-prs)
-for the classification rules.
+The single source of truth for "which CI areas can this PR affect?". Called by
+the shared `.github/workflows/_classify-change.yml` reusable workflow, which
+`ci.yml`, `backend-integration.yml`, `frontend-tests.yml` and
+`iac-validation.yml` all reuse so they cannot disagree.
+
+Emits one `key=value` line per flag: `doc-only`, plus `backend`, `frontend`,
+`cdk`, `shell` and `powershell`. A doc-only diff sets every area to false.
 
 ```bash
 python scripts/classify_change.py --event-name pull_request --base <base-sha> --head <head-sha>
 ```
+
+The path-to-area map lives in `AREA_PATH_RULES` at the top of the script; see
+[docs/CONTRIBUTOR_RUNBOOK.md](../docs/CONTRIBUTOR_RUNBOOK.md#ci-runs-only-the-areas-a-pr-affects)
+for the rules, the fail-safe behaviour, and how to add a new area.
 
 ## n_review_issue.py
 

--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -18,11 +18,23 @@ RULESET_PATH = REPO_ROOT / ".github" / "rulesets" / "default-branch-protection.j
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
 EXPECTED_REQUIRED_CHECKS = {
-    # `test` runs cdk/tests/ (CDK infrastructure) against root deps; the
-    # backend `tests/` suite runs once, under Lambda-pinned deps, in
-    # `lambda-compat` below. Keeping each suite to a single dependency set
-    # avoids running `tests/` twice per PR (see PR #4464).
+    # `test` is the ungated repo-hygiene job (branch-protection validation,
+    # lockfile platform coverage, extract_verdict/review_common tests). Its
+    # context string is the bare job id, so the job must never gain a `name:`
+    # and must never be renamed -- see the comment on the job in ci.yml.
     "CI / test",
+    # Area-gated jobs. These skip on PRs that can't affect them, and GitHub
+    # reports a skipped job as a passing required check -- which is only safe
+    # because every gate is written `<area> != 'false'` with `!cancelled()`,
+    # so a classifier failure runs the job rather than skipping it. See
+    # scripts/classify_change.py and .github/workflows/_classify-change.yml.
+    "CI / Frontend lint, type-check and unit tests",
+    # cdk/tests/ against root deps; iac-validation.yml runs the same suite
+    # against cdk/requirements.txt. The backend `tests/` suite runs once,
+    # under Lambda-pinned deps, in `lambda-compat` below. Keeping each suite
+    # to a single dependency set avoids running `tests/` twice per PR
+    # (see PR #4464).
+    "CI / CDK infrastructure tests",
     "CI / Validate backend/requirements.txt (dry-run)",
     "CI / Lambda-compat pytest (backend/requirements.txt)",
     "CI / Frontend smoke tests (preview build)",

--- a/scripts/classify_change.py
+++ b/scripts/classify_change.py
@@ -1,25 +1,34 @@
-"""Classify a PR's diff as "doc-only" so CI can skip heavyweight test jobs.
+"""Classify a PR's diff so CI runs only the test jobs the change can affect.
 
-A change is doc-only when every changed line, across every changed file, is
-one of: a blank line, a full-line comment in a language we recognise, or a
-line inside a file matched by a documentation glob (``*.md``, ``docs/**``,
-etc.). Anything else -- including a single line of real code, a config file
-edit, a permission-bit change, or a rename that touches a non-doc path --
-makes the whole diff non-doc-only.
+Two classifications are produced from a single ``git diff``:
 
-The classifier is intentionally conservative: false negatives (running the
-full suite on a change that was actually doc-only) are fine, false positives
-(skipping the full suite on a change that touches real behaviour) are not.
-When in doubt, this module says "not doc-only".
+``doc-only``
+    True when every changed line, across every changed file, is one of: a
+    blank line, a full-line comment in a language we recognise, or a line
+    inside a file matched by a documentation glob (``*.md``, ``docs/**``,
+    etc.). Anything else -- including a single line of real code, a config
+    file edit, a permission-bit change, or a rename that touches a non-doc
+    path -- makes the whole diff non-doc-only.
+
+``backend`` / ``frontend`` / ``cdk`` / ``shell`` / ``powershell``
+    Per-area flags derived from the changed *paths* via ``AREA_PATH_RULES``
+    below. A doc-only diff sets every area to false, so CI jobs need to
+    consult one flag rather than a flag plus a doc-only override.
+
+The classifier is intentionally conservative: false negatives (running a
+suite that the change could not have broken) are cheap, false positives
+(skipping a suite that would have caught a regression) are not. When in
+doubt -- an unrecognised path, a failed diff, a non-``pull_request`` event --
+this module widens to "everything is affected".
 
 Usage::
 
     python scripts/classify_change.py --event-name pull_request \\
         --base <base-sha> --head <head-sha> [--github-output "$GITHUB_OUTPUT"]
 
-Prints ``doc-only=true`` or ``doc-only=false`` to stdout and, if
-``--github-output`` is given, appends the same line to that file so a GitHub
-Actions step can expose it via ``steps.<id>.outputs.doc-only``.
+Prints one ``key=value`` line per flag to stdout and, if ``--github-output``
+is given, appends the same lines to that file so a GitHub Actions step can
+expose them via ``steps.<id>.outputs.<key>``.
 
 This script intentionally uses only the Python standard library so it can
 run in CI before any pip install step.
@@ -50,6 +59,128 @@ SAFE_COMMENT_PREFIXES: dict[str, tuple[str, ...]] = {
 }
 
 _DIFF_HEADER_RE = re.compile(r"^diff --git a/(.+) b/(.+)$")
+
+# Every CI area a change can affect. Adding an area here is not enough on its
+# own -- it also needs a rule in AREA_PATH_RULES and a job gated on it.
+AREAS: tuple[str, ...] = ("backend", "frontend", "cdk", "shell", "powershell")
+
+_ALL_AREAS = frozenset(AREAS)
+_NO_AREAS: frozenset[str] = frozenset()
+
+# Ordered path -> area map. The FIRST rule whose glob matches a changed path
+# decides that path's areas; later rules are not consulted. Order therefore
+# matters: narrow rules must precede the broad ones they sit inside (e.g.
+# `tests/bash/**` before `tests/**`).
+#
+# Globs are matched case-insensitively against forward-slash repo-relative
+# paths. `**` matches across directory separators, `*` does not.
+#
+# A path matching NO rule falls back to "every area" -- see areas_for_path.
+# That fallback is what keeps a newly added top-level directory from silently
+# skipping every suite, so resist the urge to add a catch-all rule here.
+AREA_PATH_RULES: tuple[tuple[str, frozenset[str]], ...] = (
+    # -- Documentation: affects no executable area. ------------------------
+    ("docs/**", _NO_AREAS),
+    ("**/*.md", _NO_AREAS),
+    (".github/issue_template/**", _NO_AREAS),
+    (".github/pull_request_template*", _NO_AREAS),
+    ("license*", _NO_AREAS),
+    # -- CI's own machinery: widen to everything. --------------------------
+    # A workflow, composite action, ruleset or classifier edit can change the
+    # behaviour of any job, including this gating itself, so such a change
+    # must never narrow the suite that validates it.
+    ("scripts/classify_change.py", _ALL_AREAS),
+    ("scripts/check_branch_protection_required_checks.py", _ALL_AREAS),
+    (".github/**", _ALL_AREAS),
+    # -- Shell / container / deploy tooling. -------------------------------
+    ("scripts/bash/**", frozenset({"shell"})),
+    ("**/*.sh", frozenset({"shell"})),
+    ("**/*.bats", frozenset({"shell"})),
+    ("tests/bash/**", frozenset({"shell"})),
+    ("dockerfile*", frozenset({"shell"})),
+    ("**/dockerfile*", frozenset({"shell"})),
+    ("docker/**", frozenset({"shell"})),
+    ("docker-compose*.yml", frozenset({"shell"})),
+    ("deploy/**", frozenset({"shell"})),
+    ("jenkinsfile*", frozenset({"shell"})),
+    # -- PowerShell tooling (Pester suite lives in scripts/tests). ---------
+    ("scripts/powershell/**", frozenset({"powershell"})),
+    ("**/*.ps1", frozenset({"powershell"})),
+    ("scripts/tests/**", frozenset({"powershell"})),
+    # -- Frontend. ---------------------------------------------------------
+    ("frontend/**", frozenset({"frontend"})),
+    # The root package.json/lockfile installs the CDK CLI used by cdk synth
+    # (`../node_modules/.bin/cdk`) as well as the repo-level npm scripts, so a
+    # change there is both a frontend and a CDK concern.
+    ("package.json", frozenset({"frontend", "cdk"})),
+    ("package-lock.json", frozenset({"frontend", "cdk"})),
+    # -- Infrastructure. ---------------------------------------------------
+    # Deliberately does NOT include backend/** or frontend/**: cdk/tests are
+    # unit tests over CDK constructs, which application code cannot break.
+    # The full synth-against-real-assets path stays covered by cdk-dry-run.yml,
+    # whose own `paths:` filter still lists backend/** and frontend/**.
+    ("cdk/**", frozenset({"cdk"})),
+    ("infra/**", frozenset({"cdk"})),
+    # -- Backend. ----------------------------------------------------------
+    # The SPA contract version is asserted on both sides of the wire by
+    # scripts/check_contract_version_sync.py, so this one module is a
+    # frontend concern too.
+    ("backend/contracts_spa.py", frozenset({"backend", "frontend"})),
+    ("backend/**", frozenset({"backend"})),
+    ("tests/**", frozenset({"backend"})),
+    ("data/**", frozenset({"backend"})),
+    ("requirements*.txt", frozenset({"backend"})),
+    ("pyproject.toml", frozenset({"backend"})),
+    ("pytest.ini", frozenset({"backend"})),
+    ("mypy.ini", frozenset({"backend"})),
+    ("logging.ini", frozenset({"backend"})),
+    ("config*.yaml", frozenset({"backend"})),
+    ("makefile", frozenset({"backend"})),
+    # Remaining scripts/ entries are Python helpers covered by tests/scripts.
+    ("scripts/**", frozenset({"backend"})),
+)
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Compile a repo-path glob to a regex.
+
+    `**/` matches zero or more leading directories, `**` matches across
+    separators, `*` matches within a single path segment.
+    """
+    parts: list[str] = []
+    index = 0
+    while index < len(pattern):
+        if pattern.startswith("**/", index):
+            parts.append("(?:.*/)?")
+            index += 3
+        elif pattern.startswith("**", index):
+            parts.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            parts.append("[^/]*")
+            index += 1
+        else:
+            parts.append(re.escape(pattern[index]))
+            index += 1
+    return re.compile("^" + "".join(parts) + "$")
+
+
+_COMPILED_AREA_RULES: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = tuple(
+    (_glob_to_regex(pattern), areas) for pattern, areas in AREA_PATH_RULES
+)
+
+
+def areas_for_path(path: str) -> frozenset[str]:
+    """Return the CI areas a single changed *path* can affect.
+
+    Falls back to every area when no rule matches, so an unmapped path can
+    never cause a suite to be skipped.
+    """
+    normalised = path.lower()
+    for regex, areas in _COMPILED_AREA_RULES:
+        if regex.match(normalised):
+            return areas
+    return _ALL_AREAS
 
 
 class FileDiff:
@@ -145,6 +276,45 @@ def classify_diff(diff_text: str) -> bool:
     return all(classify_file(f) for f in files)
 
 
+def areas_for_diff(diff_text: str) -> frozenset[str]:
+    """Return the union of CI areas affected by *diff_text*.
+
+    Renames contribute both their old and new path, so moving a file out of
+    an area still runs that area's suite.
+    """
+    affected: set[str] = set()
+    for file_diff in parse_file_diffs(diff_text):
+        affected |= areas_for_path(file_diff.path)
+        if file_diff.old_path != file_diff.path:
+            affected |= areas_for_path(file_diff.old_path)
+    return frozenset(affected)
+
+
+def classify(event_name: str, base: str, head: str) -> tuple[bool, frozenset[str]]:
+    """Return ``(doc_only, affected_areas)`` for a change.
+
+    Only ``pull_request`` events get diff-based classification; every other
+    event (push, workflow_dispatch, ...) conservatively runs the full suite,
+    since a base/head diff isn't meaningful in the same way there. A diff
+    that cannot be computed widens to the full suite for the same reason.
+    """
+    if event_name != "pull_request" or not base or not head:
+        return False, _ALL_AREAS
+    try:
+        diff_text = get_diff_text(base, head)
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"WARNING: could not compute diff ({exc}); treating every area as affected",
+            file=sys.stderr,
+        )
+        return False, _ALL_AREAS
+    # A doc-only diff zeroes every area so gated jobs consult a single flag
+    # rather than an area flag plus a doc-only override.
+    if classify_diff(diff_text):
+        return True, _NO_AREAS
+    return False, areas_for_diff(diff_text)
+
+
 def get_diff_text(base: str, head: str) -> str:
     result = subprocess.run(
         ["git", "diff", "--no-color", "--unified=0", f"{base}...{head}"],
@@ -164,29 +334,23 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def format_output_lines(doc_only: bool, areas: frozenset[str]) -> list[str]:
+    """Render the classification as ``key=value`` lines, doc-only first."""
+    lines = [f"doc-only={'true' if doc_only else 'false'}"]
+    lines.extend(f"{area}={'true' if area in areas else 'false'}" for area in AREAS)
+    return lines
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    doc_only, areas = classify(args.event_name, args.base, args.head)
 
-    # Only pull_request events get diff-based classification; every other
-    # event (push, workflow_dispatch, ...) conservatively runs the full
-    # suite, since a base/head diff isn't meaningful in the same way there.
-    doc_only = False
-    if args.event_name == "pull_request" and args.base and args.head:
-        try:
-            diff_text = get_diff_text(args.base, args.head)
-        except subprocess.CalledProcessError as exc:
-            print(
-                f"WARNING: could not compute diff ({exc}); treating as not doc-only",
-                file=sys.stderr,
-            )
-        else:
-            doc_only = classify_diff(diff_text)
-
-    output_line = f"doc-only={'true' if doc_only else 'false'}"
-    print(output_line)
+    output_lines = format_output_lines(doc_only, areas)
+    for line in output_lines:
+        print(line)
     if args.github_output:
         with open(args.github_output, "a", encoding="utf-8") as fh:
-            fh.write(output_line + "\n")
+            fh.write("\n".join(output_lines) + "\n")
     return 0
 
 

--- a/tests/scripts/test_ci_area_gating.py
+++ b/tests/scripts/test_ci_area_gating.py
@@ -1,0 +1,171 @@
+"""Guard the invariants that make per-area CI gating safe.
+
+Gating jobs on "did this PR touch my area?" trades wall-clock for a new
+failure mode: a job that skips when it should have run reports as a *passing*
+required check, so the PR merges green with the regression uncaught. These
+tests pin the properties that make that impossible to introduce by accident.
+
+See scripts/classify_change.py and .github/workflows/_classify-change.yml.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+CLASSIFIER_WORKFLOW = WORKFLOWS / "_classify-change.yml"
+CLASSIFIER_WORKFLOW_REF = "./.github/workflows/_classify-change.yml"
+
+# Workflows that gate jobs on the shared classifier.
+GATED_WORKFLOWS = (
+    "ci.yml",
+    "backend-integration.yml",
+    "frontend-tests.yml",
+    "iac-validation.yml",
+)
+
+_SCRIPT = REPO_ROOT / "scripts" / "classify_change.py"
+_spec = importlib.util.spec_from_file_location("classify_change", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+AREAS: tuple[str, ...] = _mod.AREAS
+
+_OUTPUT_REF = re.compile(r"needs\.classify-change\.outputs\.([A-Za-z0-9_-]+)")
+
+
+def _load(name: str) -> dict:
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def _gated_jobs(workflow: dict) -> list[tuple[str, str]]:
+    """Return (job_id, if_expression) for jobs gated on a classifier output."""
+    gated: list[tuple[str, str]] = []
+    for job_id, job in workflow.get("jobs", {}).items():
+        if not isinstance(job, dict):
+            continue
+        condition = job.get("if")
+        if isinstance(condition, str) and "classify-change.outputs" in condition:
+            gated.append((job_id, condition))
+    return gated
+
+
+ALL_GATED_JOBS = [
+    pytest.param(name, job_id, condition, id=f"{name}:{job_id}")
+    for name in GATED_WORKFLOWS
+    for job_id, condition in _gated_jobs(_load(name))
+]
+
+
+def test_every_gated_workflow_actually_gates_something() -> None:
+    """A workflow listed here but gating nothing means this file has gone stale."""
+    for name in GATED_WORKFLOWS:
+        assert _gated_jobs(_load(name)), f"{name} references no classify-change output"
+
+
+@pytest.mark.parametrize(("workflow", "job_id", "condition"), ALL_GATED_JOBS)
+def test_gates_use_fail_safe_polarity(workflow: str, job_id: str, condition: str) -> None:
+    """`!= 'false'` runs the job when the classifier failed; `== 'true'` skips it.
+
+    A failed classifier produces empty outputs. Under `== 'true'` the job then
+    skips, GitHub reports the required check as passing, and the suite never
+    ran -- the exact fail-open this design forbids.
+    """
+    assert "!= 'false'" in condition, (
+        f"{workflow}:{job_id} must gate with \"<area> != 'false'\" so an empty "
+        f"classifier output runs the job. Found: {condition!r}"
+    )
+    assert "== 'true'" not in condition, (
+        f"{workflow}:{job_id} gates with \"== 'true'\", which silently skips the "
+        f"job (and passes its required check) whenever the classifier fails. "
+        f"Found: {condition!r}"
+    )
+
+
+@pytest.mark.parametrize(("workflow", "job_id", "condition"), ALL_GATED_JOBS)
+def test_gates_survive_a_classifier_failure(workflow: str, job_id: str, condition: str) -> None:
+    """Without `!cancelled()`, a failed `needs` skip-propagates to the gated job."""
+    assert "!cancelled()" in condition, (
+        f"{workflow}:{job_id} must include !cancelled() so a classify-change "
+        f"failure doesn't skip-propagate into a silently-passing check. "
+        f"Found: {condition!r}"
+    )
+
+
+@pytest.mark.parametrize(("workflow", "job_id", "condition"), ALL_GATED_JOBS)
+def test_gates_reference_a_real_classifier_output(workflow: str, job_id: str, condition: str) -> None:
+    """A typo'd area name yields an empty string, quietly disabling the gate."""
+    valid = {*AREAS, "doc-only"}
+    referenced = set(_OUTPUT_REF.findall(condition))
+    assert referenced, f"{workflow}:{job_id} has no parseable classifier output reference"
+    unknown = referenced - valid
+    assert not unknown, (
+        f"{workflow}:{job_id} references unknown classifier output(s) {sorted(unknown)}; "
+        f"valid outputs are {sorted(valid)}"
+    )
+
+
+@pytest.mark.parametrize("workflow", GATED_WORKFLOWS)
+def test_classification_comes_from_the_shared_reusable_workflow(workflow: str) -> None:
+    """One classifier, not four competing detection mechanisms."""
+    job = _load(workflow)["jobs"]["classify-change"]
+    assert job.get("uses") == CLASSIFIER_WORKFLOW_REF, (
+        f"{workflow} must classify via {CLASSIFIER_WORKFLOW_REF} rather than " f"its own copy of the detection logic"
+    )
+
+
+def test_reusable_workflow_exposes_every_area() -> None:
+    """An area with no output leaves its gate reading an empty string forever."""
+    workflow = yaml.safe_load(CLASSIFIER_WORKFLOW.read_text(encoding="utf-8"))
+    # PyYAML parses the `on:` key as the boolean True.
+    triggers = workflow.get(True) or workflow.get("on")
+    declared = set(triggers["workflow_call"]["outputs"])
+    assert declared == {*AREAS, "doc-only"}, (
+        f"_classify-change.yml declares outputs {sorted(declared)}, but "
+        f"classify_change.py emits {sorted({*AREAS, 'doc-only'})}"
+    )
+
+    job_outputs = set(workflow["jobs"]["classify"]["outputs"])
+    assert job_outputs == declared, (
+        "the classify job's outputs must match the workflow_call outputs, "
+        "otherwise a declared output is always empty"
+    )
+
+
+def test_hygiene_and_lint_jobs_stay_ungated() -> None:
+    """These validate the gating itself, so they must run on every PR."""
+    jobs = _load("ci.yml")["jobs"]
+    for job_id in ("test", "lint-workflows"):
+        assert "if" not in jobs[job_id], (
+            f"ci.yml:{job_id} must stay ungated -- it is part of what verifies "
+            f"that the other jobs' gating is correct"
+        )
+
+
+def test_required_test_job_keeps_its_context_name() -> None:
+    """ "CI / test" is a required context; a `name:` here would change it.
+
+    Branch protection matches on the rendered context string. Adding a `name:`
+    to this job renames the context, and the ruleset would then wait forever
+    for a check no workflow produces -- blocking every PR.
+    """
+    assert "name" not in _load("ci.yml")["jobs"]["test"], (
+        "ci.yml:test must not declare a `name:`; its required check context is "
+        "the bare job id 'CI / test' in .github/rulesets/default-branch-protection.json"
+    )
+
+
+def test_no_legacy_detection_mechanisms_remain() -> None:
+    """The point of the shared classifier is that these do not come back."""
+    for name in GATED_WORKFLOWS:
+        text = (WORKFLOWS / name).read_text(encoding="utf-8")
+        assert "dorny/paths-filter" not in text, (
+            f"{name} reintroduces dorny/paths-filter; gate on the shared " f"classifier instead so all workflows agree"
+        )
+        assert "detect-frontend-changes" not in text
+        assert "detect-iac-changes" not in text

--- a/tests/scripts/test_classify_change.py
+++ b/tests/scripts/test_classify_change.py
@@ -16,6 +16,10 @@ spec.loader.exec_module(_mod)  # type: ignore[union-attr]
 classify_diff = _mod.classify_diff
 is_doc_path = _mod.is_doc_path
 main = _mod.main
+areas_for_path = _mod.areas_for_path
+areas_for_diff = _mod.areas_for_diff
+classify = _mod.classify
+AREAS = _mod.AREAS
 
 
 # ---------------------------------------------------------------------------
@@ -268,7 +272,10 @@ class TestMain:
             ]
         )
         assert exit_code == 0
-        assert output_file.read_text(encoding="utf-8") == "doc-only=true\n"
+        written = output_file.read_text(encoding="utf-8").splitlines()
+        # An empty diff is doc-only, so every area flag must be false.
+        assert written[0] == "doc-only=true"
+        assert sorted(written[1:]) == sorted(f"{area}=false" for area in AREAS)
 
     def test_diff_failure_falls_back_to_not_doc_only(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -282,3 +289,281 @@ class TestMain:
         captured = capsys.readouterr()
         assert "doc-only=false" in captured.out
         assert "WARNING" in captured.err
+
+    def test_every_area_flag_is_emitted_exactly_once(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A missing output line would leave a gated job with an empty flag.
+
+        `!= 'false'` means that fails safe (the job runs), but silently, so
+        assert the full set is always present rather than relying on it.
+        """
+        monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: "")
+        exit_code = main(["--event-name", "pull_request", "--base", "a", "--head", "b"])
+        assert exit_code == 0
+        printed = capsys.readouterr().out.splitlines()
+        keys = [line.split("=", 1)[0] for line in printed]
+        assert keys == ["doc-only", *AREAS]
+
+
+# ---------------------------------------------------------------------------
+# areas_for_path
+# ---------------------------------------------------------------------------
+
+
+class TestAreasForPath:
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            # Backend
+            ("backend/app.py", {"backend"}),
+            ("backend/routes/accounts.py", {"backend"}),
+            ("tests/test_backend_api.py", {"backend"}),
+            ("tests/scripts/test_publish_pr.py", {"backend"}),
+            ("requirements.txt", {"backend"}),
+            ("requirements-dev.txt", {"backend"}),
+            ("mypy.ini", {"backend"}),
+            ("pyproject.toml", {"backend"}),
+            ("config.yaml", {"backend"}),
+            ("scripts/site_healthcheck.py", {"backend"}),
+            ("data/accounts/demo.json", {"backend"}),
+            # Frontend
+            ("frontend/src/main.tsx", {"frontend"}),
+            ("frontend/package-lock.json", {"frontend"}),
+            # CDK
+            ("cdk/stacks/api_stack.py", {"cdk"}),
+            ("cdk/tests/test_api_stack.py", {"cdk"}),
+            ("infra/lambda/handler.py", {"cdk"}),
+            # Shell / container / deploy
+            ("scripts/bash/run-local-api.sh", {"shell"}),
+            ("tests/bash/fetch-cloudwatch-logs.bats", {"shell"}),
+            ("Dockerfile", {"shell"}),
+            ("backend/Dockerfile.lambda", {"shell"}),
+            ("docker/nginx/nginx.conf", {"shell"}),
+            ("docker-compose.local.yml", {"shell"}),
+            ("deploy/Jenkinsfile-deploy", {"shell"}),
+            ("Jenkinsfile", {"shell"}),
+            # PowerShell
+            ("scripts/powershell/aider-issue.ps1", {"powershell"}),
+            ("scripts/developer_tools/m_implement_issue.ps1", {"powershell"}),
+            ("scripts/tests/aider-issue.Tests.ps1", {"powershell"}),
+        ],
+    )
+    def test_single_area_paths(self, path: str, expected: set[str]) -> None:
+        assert set(areas_for_path(path)) == expected
+
+    @pytest.mark.parametrize(
+        "path",
+        ["docs/DEPLOY.md", "README.md", "frontend/README.md", "LICENSE", ".github/ISSUE_TEMPLATE/bug_report.md"],
+    )
+    def test_documentation_paths_affect_no_area(self, path: str) -> None:
+        assert areas_for_path(path) == frozenset()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".github/workflows/ci.yml",
+            ".github/workflows/_classify-change.yml",
+            ".github/actions/setup-frontend-deps/action.yml",
+            ".github/rulesets/default-branch-protection.json",
+            # .github/scripts/*.sh are invoked by workflows, so they widen to
+            # everything under the `.github/**` rule rather than being treated
+            # as ordinary shell scripts.
+            ".github/scripts/extract_verdict.sh",
+            "scripts/classify_change.py",
+            "scripts/check_branch_protection_required_checks.py",
+        ],
+    )
+    def test_ci_machinery_widens_to_every_area(self, path: str) -> None:
+        """A change to the gating itself must never narrow the suite that validates it."""
+        assert set(areas_for_path(path)) == set(AREAS)
+
+    def test_unmapped_path_falls_back_to_every_area(self) -> None:
+        """The fail-safe: a new top-level directory can't silently skip everything."""
+        assert set(areas_for_path("some-brand-new-top-level-dir/thing.go")) == set(AREAS)
+
+    def test_root_package_files_are_frontend_and_cdk(self) -> None:
+        """Root npm installs the CDK CLI that `cdk synth` invokes, not just JS deps."""
+        assert set(areas_for_path("package.json")) == {"frontend", "cdk"}
+        assert set(areas_for_path("package-lock.json")) == {"frontend", "cdk"}
+
+    def test_contracts_spa_is_backend_and_frontend(self) -> None:
+        """check_contract_version_sync.py asserts this module against the SPA."""
+        assert set(areas_for_path("backend/contracts_spa.py")) == {"backend", "frontend"}
+
+    def test_narrow_rules_win_over_the_broader_rules_they_sit_inside(self) -> None:
+        # tests/bash/** and scripts/tests/** must not be swallowed by
+        # tests/** -> backend or scripts/** -> backend.
+        assert set(areas_for_path("tests/bash/deploy.bats")) == {"shell"}
+        assert set(areas_for_path("scripts/tests/thing.Tests.ps1")) == {"powershell"}
+        # ...while their general cases still land on backend.
+        assert set(areas_for_path("tests/test_app.py")) == {"backend"}
+        assert set(areas_for_path("scripts/check_contract_version_sync.py")) == {"backend"}
+
+    def test_matching_is_case_insensitive(self) -> None:
+        assert areas_for_path("Docs/Guide.MD") == frozenset()
+        assert set(areas_for_path("Frontend/src/App.tsx")) == {"frontend"}
+
+
+# ---------------------------------------------------------------------------
+# areas_for_diff
+# ---------------------------------------------------------------------------
+
+
+class TestAreasForDiff:
+    def test_multi_area_diff_unions_areas(self) -> None:
+        diff = """\
+diff --git a/backend/app.py b/backend/app.py
+index abc123..def456 100644
+--- a/backend/app.py
++++ b/backend/app.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+diff --git a/frontend/src/App.tsx b/frontend/src/App.tsx
+index abc123..def456 100644
+--- a/frontend/src/App.tsx
++++ b/frontend/src/App.tsx
+@@ -1 +1 @@
+-const a = 1
++const a = 2
+"""
+        assert set(areas_for_diff(diff)) == {"backend", "frontend"}
+
+    def test_rename_counts_both_old_and_new_paths(self) -> None:
+        """Moving a file out of an area must still run that area's suite."""
+        diff = """\
+diff --git a/backend/helper.py b/scripts/powershell/helper.ps1
+similarity index 90%
+rename from backend/helper.py
+rename to scripts/powershell/helper.ps1
+"""
+        assert set(areas_for_diff(diff)) == {"backend", "powershell"}
+
+    def test_empty_diff_affects_no_area(self) -> None:
+        assert areas_for_diff("") == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# classify (the doc-only + areas combination the workflows consume)
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    def test_non_pull_request_event_affects_every_area(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """push to main must keep running the full suite."""
+
+        def fail_if_called(base: str, head: str) -> str:
+            raise AssertionError("get_diff_text should not be called for push events")
+
+        monkeypatch.setattr(_mod, "get_diff_text", fail_if_called)
+        doc_only, areas = classify("push", "abc", "def")
+        assert doc_only is False
+        assert set(areas) == set(AREAS)
+
+    @pytest.mark.parametrize(("base", "head"), [("", "head-sha"), ("base-sha", ""), ("", "")])
+    def test_missing_sha_affects_every_area(self, monkeypatch: pytest.MonkeyPatch, base: str, head: str) -> None:
+        monkeypatch.setattr(
+            _mod,
+            "get_diff_text",
+            lambda b, h: (_ for _ in ()).throw(AssertionError("should not diff without both SHAs")),
+        )
+        _, areas = classify("pull_request", base, head)
+        assert set(areas) == set(AREAS)
+
+    def test_diff_failure_affects_every_area(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_called_process_error(base: str, head: str) -> str:
+            raise subprocess.CalledProcessError(1, ["git", "diff"])
+
+        monkeypatch.setattr(_mod, "get_diff_text", raise_called_process_error)
+        doc_only, areas = classify("pull_request", "abc", "def")
+        assert doc_only is False
+        assert set(areas) == set(AREAS)
+
+    def test_doc_only_diff_zeroes_every_area(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        diff = """\
+diff --git a/docs/RUNBOOK.md b/docs/RUNBOOK.md
+index abc123..def456 100644
+--- a/docs/RUNBOOK.md
++++ b/docs/RUNBOOK.md
+@@ -1,0 +2 @@
++Some prose.
+"""
+        monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
+        doc_only, areas = classify("pull_request", "abc", "def")
+        assert doc_only is True
+        assert areas == frozenset()
+
+    def test_comment_only_python_change_zeroes_areas_despite_backend_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """doc-only wins over the path map, so jobs gate on one flag only."""
+        diff = """\
+diff --git a/backend/app.py b/backend/app.py
+index abc123..def456 100644
+--- a/backend/app.py
++++ b/backend/app.py
+@@ -10,0 +11 @@ SOME_CONST = 5
++# Explanatory comment only.
+"""
+        monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
+        doc_only, areas = classify("pull_request", "abc", "def")
+        assert doc_only is True
+        assert areas == frozenset()
+
+    def test_backend_only_change_does_not_affect_frontend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        diff = """\
+diff --git a/backend/routes/accounts.py b/backend/routes/accounts.py
+index abc123..def456 100644
+--- a/backend/routes/accounts.py
++++ b/backend/routes/accounts.py
+@@ -1 +1 @@
+-LIMIT = 10
++LIMIT = 20
+"""
+        monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
+        doc_only, areas = classify("pull_request", "abc", "def")
+        assert doc_only is False
+        assert set(areas) == {"backend"}
+
+    def test_frontend_only_change_does_not_affect_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        diff = """\
+diff --git a/frontend/src/pages/Market.tsx b/frontend/src/pages/Market.tsx
+index abc123..def456 100644
+--- a/frontend/src/pages/Market.tsx
++++ b/frontend/src/pages/Market.tsx
+@@ -1 +1 @@
+-const a = 1
++const a = 2
+"""
+        monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
+        _, areas = classify("pull_request", "abc", "def")
+        assert set(areas) == {"frontend"}
+
+    def test_powershell_only_change_affects_only_powershell(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        diff = """\
+diff --git a/scripts/powershell/aider-issue.ps1 b/scripts/powershell/aider-issue.ps1
+index abc123..def456 100644
+--- a/scripts/powershell/aider-issue.ps1
++++ b/scripts/powershell/aider-issue.ps1
+@@ -1 +1 @@
+-$x = 1
++$x = 2
+"""
+        monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
+        _, areas = classify("pull_request", "abc", "def")
+        assert set(areas) == {"powershell"}
+
+    def test_workflow_change_affects_every_area(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        diff = """\
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index abc123..def456 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1 @@
+-  runs-on: ubuntu-latest
++  runs-on: ubuntu-24.04
+"""
+        monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
+        _, areas = classify("pull_request", "abc", "def")
+        assert set(areas) == set(AREAS)


### PR DESCRIPTION
## What

Generalises the doc-only CI fast path (#5594) into **per-area gating**: a PR now
runs the test suites its changes can actually break, instead of all of them.

Closes #5722

## How

**One classifier, not four.** `scripts/classify_change.py` now emits a flag per
area — `backend`, `frontend`, `cdk`, `shell`, `powershell` — alongside the
existing `doc-only`, derived from an ordered path→area map (`AREA_PATH_RULES`).
A doc-only diff zeroes every area, so gated jobs consult a single flag rather
than an area flag plus a doc-only override.

That classification is published once by a new reusable workflow,
`.github/workflows/_classify-change.yml`, which `ci.yml`,
`backend-integration.yml`, `frontend-tests.yml` and `iac-validation.yml` all
call. It replaces the four mechanisms that previously coexisted and could
disagree:

| Removed | Was in |
| --- | --- |
| `classify-change` job duplicated verbatim | `ci.yml` + `backend-integration.yml` |
| `dorny/paths-filter` (`detect-frontend-changes`) | `ci.yml` |
| hand-rolled `git diff --name-only -- cdk infra .github/workflows` (`detect-iac-changes`) | `iac-validation.yml` |

**`ci.yml`'s `test` job is split.** It was a grab-bag — branch-protection
validation, lockfile checks, frontend lint/type-check/vitest *and* CDK pytest —
so none of it could be gated independently. Frontend steps moved to
`frontend-checks`, CDK pytest to `cdk-tests`. `test` keeps its job id and stays
**ungated**: its context string is literally `CI / test` in the ruleset, and it
runs the branch-protection validation that keeps the ruleset honest.

`cdk-dry-run.yml` is deliberately untouched — its workflow-level `paths:` filter
(which includes `backend/**` and `frontend/**`) is what still covers the
backend→synth edge, so the `cdk` area could stay narrow.

## Fail-safe posture

Being wrong costs wall-clock, never coverage:

- **Unmapped path → every area.** A file matching no rule widens to everything,
  so a new top-level directory can't silently skip suites.
- **`.github/**` or classifier edit → every area.** A change to the gating never
  narrows the suite that validates it.
- **`push` to `main`, missing base SHA, or classifier crash → every area.**
- **Gate polarity is `<area> != 'false'`, never `== 'true'`, with
  `!cancelled()`.** A failed classifier produces *empty* outputs; under
  `== 'true'` the job would skip, GitHub would report the required check as
  passing, and the suite would never have run. This is the fail-open the whole
  design is built to prevent.

`frontend-smoke`'s condition has three load-bearing clauses (documented inline):
survive a classifier failure, don't spend ~15 min on Playwright when
`frontend-checks` already failed, and gate on the area in fail-safe polarity.

## Branch protection

`frontend-checks` and `cdk-tests` are new required contexts. Both
`.github/rulesets/default-branch-protection.json` and `EXPECTED_REQUIRED_CHECKS`
in `scripts/check_branch_protection_required_checks.py` are updated in this PR —
that script is itself a required check, so they must move together.

> [!IMPORTANT]
> The ruleset JSON is a **record of intent**. An admin still has to apply it in
> the repo's GitHub settings, or the two new contexts won't actually be enforced.

## Testing

- `tests/scripts/test_classify_change.py` — extended to 90 tests covering the
  path→area map, rename handling (old *and* new path count), case-insensitivity,
  first-match-wins ordering, and every fail-safe widening case.
- `tests/scripts/test_ci_area_gating.py` — **new**, 45 tests pinning the gating
  invariants themselves: correct polarity, `!cancelled()` present, output names
  that actually exist, hygiene/lint jobs stay ungated, `test` never gains a
  `name:`, and the legacy detectors don't come back.

```
316 passed  (tests/scripts/)
actionlint  exit 0
ruff/black  clean on changed files
python scripts/check_branch_protection_required_checks.py  ✓
```

## Expected effect

| PR touches | No longer runs |
| --- | --- |
| backend only | frontend install/lint/type-check/vitest, `frontend-tests`, Playwright smoke, CDK, bats, Pester |
| frontend only | backend pytest ×2 (integration + lambda-compat), mypy, python-compat, CDK, bats, Pester |
| `*.ps1` only | everything except Pester + ungated hygiene/lint |
| docs only | unchanged from today (#5594 behaviour preserved) |

`push` to `main` still runs the full suite unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improved Reliability**
  - Branch protection now requires frontend checks, unit tests and CDK infrastructure validation before changes can be merged.
  - CI checks are selected by the areas affected, while failures or uncertain classifications default to running relevant checks for safety.
  - Documentation-only changes can avoid unnecessary area-specific checks.

- **Documentation**
  - Updated contributor guidance to explain CI classification, path coverage, fail-safe behaviour and how to extend supported areas.

- **Testing**
  - Added comprehensive validation for CI gating, change classification and required status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->