### PR TITLE
docs: note the CI area gate in pre-deploy-check.ps1

### DIFF
--- a/scripts/powershell/pre-deploy-check.ps1
+++ b/scripts/powershell/pre-deploy-check.ps1
@@ -7,6 +7,11 @@
 #
 # $ErrorActionPreference = 'Continue' is set explicitly to document intent: every check
 # must run and accumulate its own PASS/FAIL rather than aborting on the first error.
+#
+# CI note: editing this file sets the `powershell` area in
+# scripts/classify_change.py, which runs the Pester suite under scripts/tests.
+# The backend, frontend and CDK jobs deliberately skip for a PowerShell-only
+# change -- see docs/CONTRIBUTOR_RUNBOOK.md "CI runs only the areas a PR affects".
 $ErrorActionPreference = 'Continue'
 
 # Always run from the repository root regardless of where the script is invoked from.


### PR DESCRIPTION
## What

Adds a short CI note to `scripts/powershell/pre-deploy-check.ps1` recording that editing it sets the `powershell` area, so backend/frontend/CDK jobs skipping on a PowerShell-only PR reads as intended behaviour rather than a broken pipeline.

## Why

Doubles as the empirical verification for #5728.

Classic branch protection on `main` now requires five contexts. This PR is PowerShell-only, so the classifier reports `powershell=true` and everything else `false`, which means **three of the five required contexts skip**:

| Required context | Expected on this PR |
|---|---|
| `test` | runs (ungated) |
| `ai-review / DeepSeek AI code review` | runs |
| `integration-tests` | **skipped** |
| `Frontend lint, type-check and unit tests` | **skipped** |
| `CDK infrastructure tests` | **skipped** |

If GitHub treats a skipped check run as satisfying a required status check, this PR reaches `mergeStateStatus: CLEAN`. If it does not, it reports `BLOCKED` — which would mean the area gating introduced in #5723 has made `main` unmergeable for any PR that doesn't touch every area, and the fix would be an aggregate gate job.

Refs #5728

🤖 Generated with [Claude Code](https://claude.com/claude-code)