### PR TITLE
Harden logoutFlowCognito test timeout to fix CI flake

### DIFF
--- a/frontend/tests/unit/logoutFlowCognito.test.tsx
+++ b/frontend/tests/unit/logoutFlowCognito.test.tsx
@@ -116,9 +116,14 @@ describe('Logout flow: Cognito mode (#4802)', () => {
       name: i18n.t('app.menuCategories.preferences'),
     });
     fireEvent.click(preferencesToggle);
-    const logoutButton = await screen.findByRole('menuitem', {
-      name: i18n.t('app.logout'),
-    });
+    // Timeout raised above the Testing Library default (1000ms): under CI
+    // load this re-render was observed to occasionally exceed the default
+    // and fail the assertion even though the menu genuinely opens (#5734).
+    const logoutButton = await screen.findByRole(
+      'menuitem',
+      { name: i18n.t('app.logout') },
+      { timeout: 3000 }
+    );
     fireEvent.click(logoutButton);
 
     // cognitoLogout() was called: the hosted-UI logout endpoint is reached
@@ -205,9 +210,14 @@ describe('Logout flow: Cognito mode (#4802)', () => {
       name: i18n.t('app.menuCategories.preferences'),
     });
     fireEvent.click(preferencesToggle);
-    const logoutButton = await screen.findByRole('menuitem', {
-      name: i18n.t('app.logout'),
-    });
+    // Timeout raised above the Testing Library default (1000ms): under CI
+    // load this re-render was observed to occasionally exceed the default
+    // and fail the assertion even though the menu genuinely opens (#5734).
+    const logoutButton = await screen.findByRole(
+      'menuitem',
+      { name: i18n.t('app.logout') },
+      { timeout: 3000 }
+    );
     fireEvent.click(logoutButton);
 
     // cognitoLogout's throw is caught: the app keeps rendering instead of


### PR DESCRIPTION
## Summary
- Fixes #5734: `tests/unit/logoutFlowCognito.test.tsx` intermittently failed in CI (run [30667935393](https://github.com/leonarduk/allotmint/actions/runs/30667935393)) with `Unable to find role="menuitem" and name "Logout"`, which cascaded into the tagged-commit deploy-verification workflow failing its `ci.yml` gate ([30668854436](https://github.com/leonarduk/allotmint/actions/runs/30668854436)).
- The test passed reliably in local runs (single file and full suite, repeated), consistent with a CI-load-only timing race rather than a real regression in `Menu`'s preferences-category logic.
- Raises the `findByRole('menuitem', ...)` timeout for the "Logout" item from Testing Library's default 1000ms to 3000ms in both tests in the file.

## Test plan
- [x] `npx vitest run tests/unit/logoutFlowCognito.test.tsx` — 2/2 passed
- [x] `npx eslint tests/unit/logoutFlowCognito.test.tsx` — clean
- [x] `npx tsc -b` — clean

Closes #5734