### PR TITLE
Fix near-invisible active nav tab text (WCAG AA contrast)

### DIFF
--- a/.github/scripts/prepare_review_diff.py
+++ b/.github/scripts/prepare_review_diff.py
@@ -8,7 +8,7 @@ import sys
 
 from review_common import MAX_DIFF_CHARS, format_truncation_log, prioritize_diff_blocks, truncate_diff
 
-DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml", "Makefile", "*.mk", "*.sh", "*.ps1", "*.txt", "*.html", "*.ini", "*.cfg", "*.toml", "*CODEOWNERS*", ]
+DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.js", "*.json", "*.md", "*.yaml", "*.yml", "Makefile", "*.mk", "*.sh", "*.ps1", "*.txt", "*.html", "*.css", "*.ini", "*.cfg", "*.toml", "*CODEOWNERS*", ]
 
 
 def parse_args() -> argparse.Namespace:

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -193,10 +193,10 @@ export default function Menu({
                 type="button"
                 aria-expanded={isOpen}
                 aria-controls={panelId}
-                className={`flex min-h-11 w-full items-center justify-between gap-2 rounded px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring sm:min-w-[8rem] sm:w-auto ${
+                className={`flex min-h-11 w-full items-center justify-between gap-2 rounded border-b-2 px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus-visible:ring sm:min-w-[8rem] sm:w-auto ${
                   isOpen || containsActiveTab
-                    ? 'bg-gray-100 text-gray-900'
-                    : 'bg-transparent text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                    ? 'border-blue-600 bg-gray-100 text-gray-900'
+                    : 'border-transparent bg-transparent text-gray-600 hover:bg-gray-100 hover:text-gray-900'
                 }`}
                 onClick={() =>
                   setOpenCategory((current) =>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -96,52 +96,54 @@ h1 {
     line-height: 1.1;
 }
 
-button {
-    border-radius: 8px;
-    border: 1px solid transparent;
-    padding: 0.6em 1.2em;
-    font-size: 1em;
-    font-weight: 500;
-    font-family: inherit;
-    background-color: #1a1a1a;
-    cursor: pointer;
-    transition: border-color 0.25s;
-}
-
-button:hover {
-    border-color: #646cff;
-}
-
-button:focus,
-button:focus-visible {
-    outline: 4px auto -webkit-focus-ring-color;
-}
-
-:root[data-theme='light'] button {
-    background-color: #f9f9f9;
-}
-
-@media (prefers-color-scheme: light) {
-    :root:not([data-theme]) {
-        color: #213547;
-        background-color: #ffffff;
-
-        --drawer-bg: #ffffff;
-        --drawer-color: #213547;
-        --drawer-border-color: #ccc;
-        --drawer-muted-color: #666;
-        --surface-card-bg: #f5f5f5;
-        --surface-card-color: #213547;
-        --surface-card-border: #e0e0e0;
-        --surface-muted-color: #555555;
+@layer base {
+    button {
+        border-radius: 8px;
+        border: 1px solid transparent;
+        padding: 0.6em 1.2em;
+        font-size: 1em;
+        font-weight: 500;
+        font-family: inherit;
+        background-color: #1a1a1a;
+        cursor: pointer;
+        transition: border-color 0.25s;
     }
 
-    :root:not([data-theme]) a:hover {
-        color: #747bff;
+    button:hover {
+        border-color: #646cff;
     }
 
-    :root:not([data-theme]) button {
+    button:focus,
+    button:focus-visible {
+        outline: 4px auto -webkit-focus-ring-color;
+    }
+
+    :root[data-theme='light'] button {
         background-color: #f9f9f9;
+    }
+
+    @media (prefers-color-scheme: light) {
+        :root:not([data-theme]) {
+            color: #213547;
+            background-color: #ffffff;
+
+            --drawer-bg: #ffffff;
+            --drawer-color: #213547;
+            --drawer-border-color: #ccc;
+            --drawer-muted-color: #666;
+            --surface-card-bg: #f5f5f5;
+            --surface-card-color: #213547;
+            --surface-card-border: #e0e0e0;
+            --surface-muted-color: #555555;
+        }
+
+        :root:not([data-theme]) a:hover {
+            color: #747bff;
+        }
+
+        :root:not([data-theme]) button {
+            background-color: #f9f9f9;
+        }
     }
 }
 

--- a/tests/snapshots/index.css
+++ b/tests/snapshots/index.css
@@ -96,52 +96,54 @@ h1 {
     line-height: 1.1;
 }
 
-button {
-    border-radius: 8px;
-    border: 1px solid transparent;
-    padding: 0.6em 1.2em;
-    font-size: 1em;
-    font-weight: 500;
-    font-family: inherit;
-    background-color: #1a1a1a;
-    cursor: pointer;
-    transition: border-color 0.25s;
-}
-
-button:hover {
-    border-color: #646cff;
-}
-
-button:focus,
-button:focus-visible {
-    outline: 4px auto -webkit-focus-ring-color;
-}
-
-:root[data-theme='light'] button {
-    background-color: #f9f9f9;
-}
-
-@media (prefers-color-scheme: light) {
-    :root:not([data-theme]) {
-        color: #213547;
-        background-color: #ffffff;
-
-        --drawer-bg: #ffffff;
-        --drawer-color: #213547;
-        --drawer-border-color: #ccc;
-        --drawer-muted-color: #666;
-        --surface-card-bg: #f5f5f5;
-        --surface-card-color: #213547;
-        --surface-card-border: #e0e0e0;
-        --surface-muted-color: #555555;
+@layer base {
+    button {
+        border-radius: 8px;
+        border: 1px solid transparent;
+        padding: 0.6em 1.2em;
+        font-size: 1em;
+        font-weight: 500;
+        font-family: inherit;
+        background-color: #1a1a1a;
+        cursor: pointer;
+        transition: border-color 0.25s;
     }
 
-    :root:not([data-theme]) a:hover {
-        color: #747bff;
+    button:hover {
+        border-color: #646cff;
     }
 
-    :root:not([data-theme]) button {
+    button:focus,
+    button:focus-visible {
+        outline: 4px auto -webkit-focus-ring-color;
+    }
+
+    :root[data-theme='light'] button {
         background-color: #f9f9f9;
+    }
+
+    @media (prefers-color-scheme: light) {
+        :root:not([data-theme]) {
+            color: #213547;
+            background-color: #ffffff;
+
+            --drawer-bg: #ffffff;
+            --drawer-color: #213547;
+            --drawer-border-color: #ccc;
+            --drawer-muted-color: #666;
+            --surface-card-bg: #f5f5f5;
+            --surface-card-color: #213547;
+            --surface-card-border: #e0e0e0;
+            --surface-muted-color: #555555;
+        }
+
+        :root:not([data-theme]) a:hover {
+            color: #747bff;
+        }
+
+        :root:not([data-theme]) button {
+            background-color: #f9f9f9;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Wrap the global `button { background-color: #1a1a1a; ... }` reset in `index.css` inside `@layer base` so it participates in Tailwind v4's cascade layers instead of silently outranking every utility class on `<button>` elements.
- This fixes the active top-nav category button (Dashboard/Insights/Requirements/Settings), which previously rendered `text-gray-900` (dark navy) on top of the unlayered `#1a1a1a` near-black background instead of the intended `bg-gray-100` light background.
- Add a `border-b-2 border-blue-600` indicator on the active/open nav category button so the active state is distinguishable by more than text color alone, per the issue's constraint.

## Root cause
Tailwind v4 (`@import "tailwindcss";`) emits its utility classes inside named CSS cascade layers. The plain, unlayered `button { ... }` rule in `index.css` was treated as being in an implicit layer that outranks all named layers regardless of selector specificity — so `bg-gray-100` on the active `Menu.tsx` trigger button lost to `#1a1a1a` every time.

## Test plan
- [x] `npm --prefix frontend run test -- --run tests/unit/components/Menu.test.tsx` — 17 passed
- [x] `npm --prefix frontend run lint` — clean
- [ ] Manual visual check in browser (light + dark theme) that the active nav tab is legible

Closes #5735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated menu category buttons with a bottom border to clearly indicate active or open categories.
  * Preserved the existing grey background and text styling for active categories.
  * Maintained consistent button and light-colour-scheme styling across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->