### PR TITLE
Extract shared MENU_INTERACTION_TIMEOUT_MS test utility

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,12 @@ The backend API must be running and reachable from the browser (local, LAN IP, o
 - `npm run dev` – start the Vite development server.
 - `npm test` – execute the test suite with Vitest and Testing Library.
   Test files should be named `*.test.ts`, `*.test.tsx`, or `*.test.js` to be picked up.
+  Tests that mount the full `Root` app around `Menu` and then wait on a
+  menu re-render (e.g. `findByRole('menuitem', ...)`) should pass
+  `MENU_INTERACTION_TIMEOUT_MS` from `tests/support/menuInteractionTimeout.ts`
+  as the query timeout instead of a bare number, since Testing Library's
+  1000ms default has been observed to be too tight for that heavier render
+  path under CI load (#5734).
 - `npm run build` – production build: runs `tsc -b` (full type-check) then
   `vite build`. This is the build used before any real deploy or CDK synth
   (`deploy-lambda.yml`, `cdk-dry-run.yml`, `iac-validation.yml`, and the

--- a/frontend/tests/support/menuInteractionTimeout.ts
+++ b/frontend/tests/support/menuInteractionTimeout.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared timeout for Testing Library queries that wait on the app's
+ * top-level Menu re-rendering (e.g. a toggle click opening a menu
+ * category and exposing its menuitems).
+ *
+ * Testing Library's default `findBy*`/`waitFor` timeout is 1000ms. Tests
+ * that mount the full Root app (AuthProvider + UserProvider + BrowserRouter)
+ * around Menu — rather than rendering Menu standalone — do more work per
+ * re-render, and under CI load that has been observed to occasionally
+ * exceed the default even though the menu genuinely opens (#5734). Use
+ * this constant instead of a bare `{ timeout: <number> }` so the value
+ * stays consistent and any future retuning only happens in one place.
+ */
+export const MENU_INTERACTION_TIMEOUT_MS = 3000;

--- a/frontend/tests/unit/logoutFlowCognito.test.tsx
+++ b/frontend/tests/unit/logoutFlowCognito.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from '@/i18n';
+import { MENU_INTERACTION_TIMEOUT_MS } from '../support/menuInteractionTimeout';
 
 // Full logout lifecycle in Cognito mode (issue #4802): click -> cognitoLogout()
 // called -> session cleared -> redirect to the Cognito hosted-UI logout
@@ -116,13 +117,10 @@ describe('Logout flow: Cognito mode (#4802)', () => {
       name: i18n.t('app.menuCategories.preferences'),
     });
     fireEvent.click(preferencesToggle);
-    // Timeout raised above the Testing Library default (1000ms): under CI
-    // load this re-render was observed to occasionally exceed the default
-    // and fail the assertion even though the menu genuinely opens (#5734).
     const logoutButton = await screen.findByRole(
       'menuitem',
       { name: i18n.t('app.logout') },
-      { timeout: 3000 }
+      { timeout: MENU_INTERACTION_TIMEOUT_MS }
     );
     fireEvent.click(logoutButton);
 
@@ -210,13 +208,10 @@ describe('Logout flow: Cognito mode (#4802)', () => {
       name: i18n.t('app.menuCategories.preferences'),
     });
     fireEvent.click(preferencesToggle);
-    // Timeout raised above the Testing Library default (1000ms): under CI
-    // load this re-render was observed to occasionally exceed the default
-    // and fail the assertion even though the menu genuinely opens (#5734).
     const logoutButton = await screen.findByRole(
       'menuitem',
       { name: i18n.t('app.logout') },
-      { timeout: 3000 }
+      { timeout: MENU_INTERACTION_TIMEOUT_MS }
     );
     fireEvent.click(logoutButton);
 

--- a/frontend/tests/unit/logoutFlowLocalDev.test.tsx
+++ b/frontend/tests/unit/logoutFlowLocalDev.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from '@/i18n';
+import { MENU_INTERACTION_TIMEOUT_MS } from '../support/menuInteractionTimeout';
 
 // Full logout lifecycle in local dev mode (issue #4802): click -> navigate('/')
 // -> redirect occurs, with no Cognito hosted-UI round trip. Exercises the real
@@ -97,9 +98,11 @@ describe('Logout flow: local dev mode (#4802)', () => {
       name: i18n.t('app.menuCategories.preferences'),
     });
     fireEvent.click(preferencesToggle);
-    const logoutButton = await screen.findByRole('menuitem', {
-      name: i18n.t('app.logout'),
-    });
+    const logoutButton = await screen.findByRole(
+      'menuitem',
+      { name: i18n.t('app.logout') },
+      { timeout: MENU_INTERACTION_TIMEOUT_MS }
+    );
     fireEvent.click(logoutButton);
 
     // navigate('/') was called: the browser location changes to '/'.
@@ -122,7 +125,11 @@ describe('Logout flow: local dev mode (#4802)', () => {
     });
     fireEvent.click(preferencesToggleAfterLogout);
     expect(
-      await screen.findByRole('menuitem', { name: i18n.t('app.logout') })
+      await screen.findByRole(
+        'menuitem',
+        { name: i18n.t('app.logout') },
+        { timeout: MENU_INTERACTION_TIMEOUT_MS }
+      )
     ).toBeInTheDocument();
   });
 
@@ -178,9 +185,11 @@ describe('Logout flow: local dev mode (#4802)', () => {
       name: i18n.t('app.menuCategories.preferences'),
     });
     fireEvent.click(preferencesToggle);
-    const logoutButton = await screen.findByRole('menuitem', {
-      name: i18n.t('app.logout'),
-    });
+    const logoutButton = await screen.findByRole(
+      'menuitem',
+      { name: i18n.t('app.logout') },
+      { timeout: MENU_INTERACTION_TIMEOUT_MS }
+    );
     fireEvent.click(logoutButton);
 
     // navigate('/') fires (there is no Cognito hosted-UI to redirect to).


### PR DESCRIPTION
## Summary
- #5734 hardened `logoutFlowCognito.test.tsx`'s `findByRole('menuitem', ...)` calls with a hardcoded `{ timeout: 3000 }` to fix a CI flake caused by the full `Root`-app mount's heavier re-render occasionally exceeding Testing Library's 1000ms default.
- `logoutFlowLocalDev.test.tsx` mounts the exact same full `Root` app and waits on the same menu re-render (three call sites) but was never given the same treatment, leaving it exposed to the identical flake.
- This PR extracts the raised timeout into a shared `MENU_INTERACTION_TIMEOUT_MS` constant in [`frontend/tests/support/menuInteractionTimeout.ts`](frontend/tests/support/menuInteractionTimeout.ts), applies it consistently across both files, and documents the convention in [`frontend/README.md`](frontend/README.md) so future menu-interaction tests reuse it instead of hardcoding a new number.

## Test plan
- [x] `npx vitest run tests/unit/logoutFlowCognito.test.tsx tests/unit/logoutFlowLocalDev.test.tsx` — 4/4 passed
- [x] `npx eslint` on all changed files — clean
- [x] `npx tsc -b` — clean

Closes #5739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
