### PR TITLE
Fix unreadable active nav tab (WCAG AA contrast)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -96,29 +96,44 @@ h1 {
     line-height: 1.1;
 }
 
-button {
-    border-radius: 8px;
-    border: 1px solid transparent;
-    padding: 0.6em 1.2em;
-    font-size: 1em;
-    font-weight: 500;
-    font-family: inherit;
-    background-color: #1a1a1a;
-    cursor: pointer;
-    transition: border-color 0.25s;
-}
+/*
+ * Layered so Tailwind utility classes (emitted into the `utilities` layer)
+ * can override this default without a specificity fight. An unlayered
+ * `button { ... }` rule outranks every named layer regardless of
+ * specificity, which previously made bg-* utilities on <button> silently
+ * lose to this #1a1a1a default (#5735).
+ */
+@layer base {
+    button {
+        border-radius: 8px;
+        border: 1px solid transparent;
+        padding: 0.6em 1.2em;
+        font-size: 1em;
+        font-weight: 500;
+        font-family: inherit;
+        background-color: #1a1a1a;
+        cursor: pointer;
+        transition: border-color 0.25s;
+    }
 
-button:hover {
-    border-color: #646cff;
-}
+    button:hover {
+        border-color: #646cff;
+    }
 
-button:focus,
-button:focus-visible {
-    outline: 4px auto -webkit-focus-ring-color;
-}
+    button:focus,
+    button:focus-visible {
+        outline: 4px auto -webkit-focus-ring-color;
+    }
 
-:root[data-theme='light'] button {
-    background-color: #f9f9f9;
+    :root[data-theme='light'] button {
+        background-color: #f9f9f9;
+    }
+
+    @media (prefers-color-scheme: light) {
+        :root:not([data-theme]) button {
+            background-color: #f9f9f9;
+        }
+    }
 }
 
 @media (prefers-color-scheme: light) {
@@ -138,10 +153,6 @@ button:focus-visible {
 
     :root:not([data-theme]) a:hover {
         color: #747bff;
-    }
-
-    :root:not([data-theme]) button {
-        background-color: #f9f9f9;
     }
 }
 


### PR DESCRIPTION
## Summary
- The active top-nav category button (`bg-gray-100 text-gray-900` in [Menu.tsx](frontend/src/components/Menu.tsx)) was rendering dark navy text on a near-black background, well under WCAG AA contrast.
- Root cause: the global `button { background-color: #1a1a1a; ... }` rule in [frontend/src/index.css](frontend/src/index.css) was **unlayered**, so per the CSS Cascade Layers spec it outranked every named Tailwind layer (including `utilities`) regardless of selector specificity — silently defeating `bg-gray-100` on any `<button>`.
- Fix: wrap the global button reset (and its light-theme overrides) in `@layer base`, so Tailwind utility classes on buttons now win as intended.

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run build` — passes, CSS compiles correctly
- [x] `npm run test -- --run` — all 655 tests pass (96 files)
- [x] Verified in a live dev server via injected DOM check: a plain `<button>` still renders `background-color: rgb(26, 26, 26)` (#1a1a1a, unchanged — no regression), while a button with `bg-gray-100 text-gray-900` now correctly renders a light gray background with dark navy text (high contrast, WCAG AA satisfied).
- [x] Active tab is already visually distinct via background (not just text color), satisfying the issue's constraint.

Closes #5735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button styling so custom utility styles take precedence consistently.
  * Ensured light-mode button appearance is applied correctly based on the user’s display preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->