### PR TITLE
Reconcile branch protection ruleset with live GitHub settings

### DIFF
--- a/.github/rulesets/default-branch-protection.json
+++ b/.github/rulesets/default-branch-protection.json
@@ -1,10 +1,10 @@
 {
-  "name": "main deterministic PR gates",
+  "name": "Main",
   "target": "branch",
   "enforcement": "active",
   "conditions": {
     "ref_name": {
-      "include": ["refs/heads/main"],
+      "include": ["~DEFAULT_BRANCH"],
       "exclude": []
     }
   },
@@ -17,13 +17,16 @@
       "type": "non_fast_forward"
     },
     {
+      "type": "copilot_code_review"
+    },
+    {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 1,
-        "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": true,
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
         "require_last_push_approval": false,
-        "required_review_thread_resolution": true,
+        "required_review_thread_resolution": false,
         "allowed_merge_methods": ["merge", "squash", "rebase"]
       }
     },
@@ -31,42 +34,47 @@
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "CI / test"
+            "context": "test",
+            "integration_id": 15368
           },
           {
-            "context": "CI / Frontend lint, type-check and unit tests"
+            "context": "Frontend lint, type-check and unit tests",
+            "integration_id": 15368
           },
           {
-            "context": "CI / CDK infrastructure tests"
+            "context": "CDK infrastructure tests",
+            "integration_id": 15368
           },
           {
-            "context": "CI / Validate backend/requirements.txt (dry-run)"
+            "context": "Validate backend/requirements.txt (dry-run)",
+            "integration_id": 15368
           },
           {
-            "context": "Backend Integration Tests / integration-tests"
+            "context": "Lambda-compat pytest (backend/requirements.txt)",
+            "integration_id": 15368
           },
           {
-            "context": "Frontend Tests / frontend-tests"
+            "context": "Frontend smoke tests (preview build)",
+            "integration_id": 15368
           },
           {
-            "context": "CI / Frontend smoke tests (preview build)"
+            "context": "integration-tests",
+            "integration_id": 15368
           },
           {
-            "context": "PR Body Issue Reference Check / require-issue-reference"
+            "context": "require-issue-reference",
+            "integration_id": 15368
           },
           {
-            "context": "Dependency Review / dependency-review"
+            "context": "Check for merge conflicts with main",
+            "integration_id": 15368
           },
           {
-            "context": "CI / Lambda-compat pytest (backend/requirements.txt)"
-          },
-          {
-            "context": "ai-review / DeepSeek AI code review"
-          },
-          {
-            "context": "Merge Conflict Check / Check for merge conflicts with main"
+            "context": "ai-review / DeepSeek AI code review",
+            "integration_id": 15368
           }
         ]
       }

--- a/.github/workflows/branch-protection-drift.yml
+++ b/.github/workflows/branch-protection-drift.yml
@@ -1,0 +1,37 @@
+name: Branch Protection Drift
+
+# Compares live GitHub branch protection against
+# .github/rulesets/default-branch-protection.json.
+#
+# Deliberately NOT a PR check. Reading rulesets needs elevated access that the
+# default GITHUB_TOKEN does not have, and a PR from a fork must never receive a
+# PAT. Running on a schedule keeps the credential off the PR path while still
+# catching drift within a day. See issue #5728.
+
+on:
+  schedule:
+    # 07:15 UTC daily -- before the working day, after nightly Dependabot noise.
+    - cron: '15 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Compare live branch protection with checked-in ruleset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - run: pip install pyyaml
+      # BRANCH_PROTECTION_READ_TOKEN is a fine-grained PAT with read-only
+      # "Administration" repository permission -- the minimum that can read
+      # rulesets. It must never be granted write: this job only reports drift,
+      # and applying a ruleset stays a deliberate human action.
+      - name: Check for drift
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN || github.token }}
+        run: python scripts/check_live_branch_protection.py --repo "${{ github.repository }}"

--- a/.github/workflows/branch-protection-drift.yml
+++ b/.github/workflows/branch-protection-drift.yml
@@ -31,7 +31,17 @@ jobs:
       # "Administration" repository permission -- the minimum that can read
       # rulesets. It must never be granted write: this job only reports drift,
       # and applying a ruleset stays a deliberate human action.
+      #
+      # No fallback to github.token: it cannot read rulesets (they are
+      # admin-scoped), so a fallback would just fail with the same "API
+      # unavailable" exit code as a genuinely missing secret -- masking the
+      # real problem (secret never configured) as if it were transient.
       - name: Check for drift
         env:
-          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN || github.token }}
-        run: python scripts/check_live_branch_protection.py --repo "${{ github.repository }}"
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::BRANCH_PROTECTION_READ_TOKEN is not set. Add a fine-grained PAT with read-only Administration permission -- see docs/BRANCH_PROTECTION.md." >&2
+            exit 1
+          fi
+          python scripts/check_live_branch_protection.py --repo "${{ github.repository }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,12 @@ jobs:
   # drifting away from the jobs below, so it must run even on a change that
   # affects no test area.
   #
-  # Do NOT add a `name:` here and do not rename the job id. This job's check
-  # context is literally "CI / test" in
-  # .github/rulesets/default-branch-protection.json; renaming it would leave
-  # branch protection waiting forever for a context no workflow produces.
+  # Do NOT add a `name:` here and do not rename the job id. GitHub matches a
+  # required status check against the *check-run name*, which for a job without
+  # a `name:` is the bare job id -- so this job's context is literally "test"
+  # in .github/rulesets/default-branch-protection.json, not "CI / test".
+  # Renaming it (or adding a `name:`) would leave branch protection waiting
+  # forever for a context no workflow produces. See issue #5728.
   test:
     runs-on: ubuntu-latest
     steps:

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,42 +1,107 @@
 # Branch protection required checks
 
-The default branch (`main`) must be protected by the repository ruleset stored in
+The default branch (`main`) is gated by **one** mechanism: the repository
+ruleset stored in
 [`.github/rulesets/default-branch-protection.json`](../.github/rulesets/default-branch-protection.json).
-That ruleset is the source of truth for deterministic merge gates and should be
-kept in sync with GitHub repository settings.
+That file is the source of truth. Classic branch protection must not also set
+required status checks — two live mechanisms with two naming conventions is
+what caused issue #5728, where the checked-in ruleset enforced nothing at all.
+
+## Context naming — read this before editing the ruleset
+
+A required status check matches a GitHub Actions **check-run name**. That is
+**not** the `Workflow / Job` label the Actions UI shows. The rules are:
+
+| Job shape | Check-run name | Example |
+|---|---|---|
+| job with a `name:` | that `name:` | `CDK infrastructure tests` |
+| job without a `name:` | the job id | `test` |
+| job delegating via `uses:` | `<caller job id> / <called job name>` | `ai-review / DeepSeek AI code review` |
+
+Getting this wrong does not fail loudly — it leaves every PR pending forever on
+a check that never arrives. Verify any new context against a real check run
+before adding it:
+
+```bash
+gh api "repos/leonarduk/allotmint/commits/<pr-head-sha>/check-runs?per_page=100" --jq '.check_runs[].name'
+```
 
 ## Required deterministic checks
 
-Require these status checks before a pull request can merge into `main`:
+| Context | Produced by |
+|---|---|
+| `test` | `ci.yml` job `test` (ungated repo hygiene) |
+| `Frontend lint, type-check and unit tests` | `ci.yml` job `frontend-checks` |
+| `CDK infrastructure tests` | `ci.yml` job `cdk-tests` |
+| `Validate backend/requirements.txt (dry-run)` | `ci.yml` job `validate-backend-deps` |
+| `Lambda-compat pytest (backend/requirements.txt)` | `ci.yml` job `lambda-compat` |
+| `Frontend smoke tests (preview build)` | `ci.yml` job `frontend-smoke` |
+| `integration-tests` | `backend-integration.yml` |
+| `require-issue-reference` | `pr-lint.yml` |
+| `Check for merge conflicts with main` | `conflict-check.yml` |
+| `ai-review / DeepSeek AI code review` | `deepseek-pr-review.yml` via `_ai-pr-review.yml` |
 
-- `CI / test`
-- `Backend Integration Tests / integration-tests`
-- `Frontend Tests / frontend-tests`
-- `PR Body Issue Reference Check / require-issue-reference`
-- `Dependency Review / dependency-review`
+If a workflow or job is renamed, update the ruleset, `EXPECTED_REQUIRED_CHECKS`
+in `scripts/check_branch_protection_required_checks.py`, and this document in
+the same pull request.
 
-These names intentionally use the exact `Workflow name / job name` contexts that
-GitHub branch protection expects. If a workflow or job is renamed, update the
-ruleset and this document in the same pull request.
+### Skipped jobs count as passing
+
+Every area-gated job above skips on PRs that cannot affect it, and GitHub
+reports a skipped job as a *passing* required check. That is only safe because
+each gate is written `<area> != 'false'` paired with `!cancelled()`, so a
+classifier failure runs the suite rather than skipping it. Do not "simplify"
+a gate to `== 'true'` — that turns the gate fail-open. See
+`scripts/classify_change.py` and `.github/workflows/_classify-change.yml`.
+
+## Excluded: disabled workflows
+
+`frontend-tests.yml` and `dependency-review.yml` are **disabled** in GitHub
+(`gh workflow list --all` reports `disabled_manually`) and were removed from
+the required list in #5728. A disabled workflow never reports, so requiring one
+blocks every PR permanently. `frontend-tests.yml`'s vitest+coverage run is
+already covered by CI's `Frontend lint, type-check and unit tests`.
+
+Re-enabling either one is a deliberate change that must also fix why it was
+failing, and must remove the file from `DISABLED_WORKFLOW_FILES` in
+`scripts/check_branch_protection_required_checks.py`.
+
+## Review policy
+
+The ruleset requires **0** approving reviews, with no code-owner review, no
+stale-review dismissal and no review-thread resolution. This matches what the
+repository has actually enforced and is deliberate: a solo-maintained repo
+cannot satisfy a 1-approval gate on its own PRs. AI review jobs are advisory
+(below); the deterministic checks above are the real gate.
 
 ## Applying the ruleset
 
-Repository administrators can apply the checked-in ruleset with the GitHub CLI.
-Create it when it does not exist:
+Requires repo admin — the default `GITHUB_TOKEN` cannot write rulesets, so this
+is a human action that CI cannot perform.
 
 ```bash
-gh api --method POST repos/leonarduk/allotmint/rulesets \
-  --input .github/rulesets/default-branch-protection.json
+RULESET_ID=$(gh api repos/leonarduk/allotmint/rulesets --jq '.[] | select(.name == "Main") | .id')
+gh api --method PUT "repos/leonarduk/allotmint/rulesets/${RULESET_ID}" --input .github/rulesets/default-branch-protection.json
 ```
 
-Update it when GitHub already has a ruleset with the same name:
+Create it if no ruleset with that name exists:
 
 ```bash
-RULESET_ID=$(gh api repos/leonarduk/allotmint/rulesets \
-  --jq '.[] | select(.name == "main deterministic PR gates") | .id')
-gh api --method PUT "repos/leonarduk/allotmint/rulesets/${RULESET_ID}" \
-  --input .github/rulesets/default-branch-protection.json
+gh api --method POST repos/leonarduk/allotmint/rulesets --input .github/rulesets/default-branch-protection.json
 ```
+
+Then, on an open PR, confirm the ruleset is genuinely the gate — the PR's merge
+box should list the contexts above as required, and merge should be blocked
+while one of them is red. Only once that is confirmed, drop the duplicate
+required-checks entry from classic protection (this removes *only* the
+required-checks portion; the rest of classic protection is untouched):
+
+```bash
+gh api --method DELETE repos/leonarduk/allotmint/branches/main/protection/required_status_checks
+```
+
+Do not run that command first. Leaving `main` briefly ungated is worse than the
+drift.
 
 ## Advisory checks
 
@@ -44,8 +109,11 @@ AI review jobs are useful review aids, but they depend on external model
 availability and API quotas. Keep these jobs non-blocking and do not add them to
 the required-check ruleset:
 
-- `GPT PR Review / GPT AI code review`
-- `Claude PR Review / Claude AI code review`
+- `ai-review / GPT AI code review`
+- `ai-review / Claude AI code review`
+
+`ai-review / DeepSeek AI code review` is the deliberate exception and *is*
+required.
 
 ## Merge conflict check-run
 
@@ -72,21 +140,31 @@ in the "Checks" tab of long-lived PRs; see the inline comments in
 `conflict-check.yml` for the full investigation history (issue #3738, PR
 #3731).
 
-This check-run is currently advisory (not in the required-checks list above).
-If it is ever added to the ruleset, update this document and the ruleset in
-the same pull request.
-
 ## CodeQL
 
-CodeQL should be added to the required-check set only after a CodeQL workflow is
-configured in this repository and its exact check context is known. Until then,
-it is intentionally absent from the ruleset to avoid documenting a required
-check that GitHub cannot evaluate.
+CodeQL should be added to the required-check set only after its exact check
+context is confirmed against a real check run. Until then, it is intentionally
+absent from the ruleset to avoid documenting a required check that GitHub
+cannot evaluate.
 
 ## Drift detection
 
-`python scripts/check_branch_protection_required_checks.py` verifies that the
-ruleset contains exactly the deterministic checks above, that those checks match
-current workflow/job names, and that advisory AI review jobs remain non-blocking.
-The `CI / test` job runs this script so workflow renames cannot silently weaken
-branch protection.
+Two checkers, because one cannot do both jobs:
+
+| Script | Runs | Sees | Catches |
+|---|---|---|---|
+| `scripts/check_branch_protection_required_checks.py` | the `test` job, every PR | repo files only | a job renamed out from under a required context; a context pointing at a workflow listed as disabled |
+| `scripts/check_live_branch_protection.py` | `branch-protection-drift.yml`, daily | GitHub API (read-only) | the ruleset never being applied, targeting no branches, or having its required checks removed; classic protection re-acquiring required checks; a workflow disabled in the UI |
+
+The live checker needs elevated read access (rulesets are admin-scoped), so it
+runs on a schedule with the `BRANCH_PROTECTION_READ_TOKEN` secret — a
+fine-grained PAT with read-only **Administration** permission — rather than on
+every PR, where a fork PR must never receive a credential. It exits `2` rather
+than `0` when it cannot reach the API, so an expired token fails loudly instead
+of looking like a clean result.
+
+Run it locally with an admin `gh` login:
+
+```bash
+python scripts/check_live_branch_protection.py
+```

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -59,9 +59,12 @@ wall-clock, never coverage:
 3. If the gated job is a required check, update **both**
    `.github/rulesets/default-branch-protection.json` and
    `EXPECTED_REQUIRED_CHECKS` in
-   `scripts/check_branch_protection_required_checks.py` in the same PR — and
-   remember the ruleset JSON is a record of intent, so an admin must also apply
-   it in the repo's GitHub settings.
+   `scripts/check_branch_protection_required_checks.py` in the same PR. Use the
+   job's check-run name (its `name:`, or its job id if it has none) — not the
+   `Workflow / Job` label. An admin must then apply the ruleset in the repo's
+   GitHub settings; until they do, the daily
+   `.github/workflows/branch-protection-drift.yml` run will fail, which is the
+   intended reminder.
 4. `tests/scripts/test_classify_change.py` and
    `tests/scripts/test_ci_area_gating.py` enforce the mapping and the gating
    invariants; extend them alongside the change.
@@ -95,7 +98,7 @@ Notes:
 
 - **JWT namespace conflict**: the `jwt` package (v1.x, from PyPI) and `PyJWT` (listed in `requirements.txt` as `pyjwt`) both install into the `jwt` module namespace. If the standalone `jwt` package is present in your environment it will shadow `PyJWT`, causing `AttributeError: module 'jwt' has no attribute 'encode'` in tests. Fix by running `pip uninstall jwt` before `pip install -r requirements.txt`.
 - Python formatting/lint configuration lives in `backend/pyproject.toml`, while pytest and coverage defaults live in the root `pyproject.toml`.
-- Branch protection required-check policy lives in `docs/BRANCH_PROTECTION.md` and is validated by `python scripts/check_branch_protection_required_checks.py`.
+- Branch protection required-check policy lives in `docs/BRANCH_PROTECTION.md`. It is validated on every PR by `python scripts/check_branch_protection_required_checks.py` (repo files only) and daily against live GitHub settings by `python scripts/check_live_branch_protection.py`. Required contexts are check-run names (`test`), **not** the `Workflow / Job` labels the Actions UI shows.
 - The frontend already has its own `package.json`; use `npm --prefix frontend ...` from the repo root unless you intentionally `cd frontend`.
 
 ## 3. Environment variables you are most likely to need

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -402,6 +402,38 @@ The path-to-area map lives in `AREA_PATH_RULES` at the top of the script; see
 [docs/CONTRIBUTOR_RUNBOOK.md](../docs/CONTRIBUTOR_RUNBOOK.md#ci-runs-only-the-areas-a-pr-affects)
 for the rules, the fail-safe behaviour, and how to add a new area.
 
+## check_branch_protection_required_checks.py
+
+Offline guard on the merge gate. Reads only repo files, so it runs in `ci.yml`'s
+`test` job on every PR with the default token. Fails when
+`.github/rulesets/default-branch-protection.json` drifts from
+`EXPECTED_REQUIRED_CHECKS`, when a required context matches no workflow job, or
+when one maps to a workflow listed in `DISABLED_WORKFLOW_FILES`.
+
+```bash
+python scripts/check_branch_protection_required_checks.py
+```
+
+## check_live_branch_protection.py
+
+The companion that talks to GitHub. Read-only; fails when the *live* ruleset
+diverges from the checked-in JSON, when classic branch protection also requires
+status checks, or when a required context maps to a workflow GitHub reports as
+disabled. Exits `2` (not `0`) if the API cannot be reached, so a missing or
+expired token never looks like a clean result.
+
+Reading rulesets needs admin-scoped access, so this runs on a schedule
+(`.github/workflows/branch-protection-drift.yml`) rather than on PRs. Locally it
+uses your `gh` login:
+
+```bash
+python scripts/check_live_branch_protection.py --repo leonarduk/allotmint
+```
+
+See [docs/BRANCH_PROTECTION.md](../docs/BRANCH_PROTECTION.md) for the context
+naming rules — required contexts are check-run names (`test`), not the
+`Workflow / Job` labels the Actions UI displays.
+
 ## n_review_issue.py
 
 Review and refresh a single GitHub issue with a local or cloud LLM before work

--- a/scripts/check_branch_protection_required_checks.py
+++ b/scripts/check_branch_protection_required_checks.py
@@ -3,6 +3,26 @@
 
 This protects the documented branch protection gate from silently drifting away
 from the deterministic GitHub Actions workflows that are expected to block PRs.
+
+This script is *offline*: it only reads files in the repository, so it can run
+on every PR with the default read-only `GITHUB_TOKEN`. It cannot see what
+GitHub actually enforces -- that comparison lives in
+`scripts/check_live_branch_protection.py`, which needs API access and runs on a
+schedule. Both are needed: this one catches "a job was renamed", the live one
+catches "the ruleset was never applied".
+
+## Context naming
+
+A required status check matches a GitHub Actions **check-run name**, which is:
+
+* the job's `name:` if it has one, otherwise its job id -- e.g. `test`,
+  `CDK infrastructure tests`; **not** the `Workflow / Job` form shown in the
+  Actions UI; and
+* `<caller job id> / <called job name>` for a job that delegates to a reusable
+  workflow via `uses:` -- e.g. `ai-review / DeepSeek AI code review`.
+
+Getting this wrong is not a cosmetic error: a required context that no
+check-run ever produces leaves every PR pending forever. See issue #5728.
 """
 
 from __future__ import annotations
@@ -22,28 +42,40 @@ EXPECTED_REQUIRED_CHECKS = {
     # lockfile platform coverage, extract_verdict/review_common tests). Its
     # context string is the bare job id, so the job must never gain a `name:`
     # and must never be renamed -- see the comment on the job in ci.yml.
-    "CI / test",
+    "test",
     # Area-gated jobs. These skip on PRs that can't affect them, and GitHub
     # reports a skipped job as a passing required check -- which is only safe
     # because every gate is written `<area> != 'false'` with `!cancelled()`,
     # so a classifier failure runs the job rather than skipping it. See
     # scripts/classify_change.py and .github/workflows/_classify-change.yml.
-    "CI / Frontend lint, type-check and unit tests",
+    "Frontend lint, type-check and unit tests",
     # cdk/tests/ against root deps; iac-validation.yml runs the same suite
     # against cdk/requirements.txt. The backend `tests/` suite runs once,
     # under Lambda-pinned deps, in `lambda-compat` below. Keeping each suite
     # to a single dependency set avoids running `tests/` twice per PR
     # (see PR #4464).
-    "CI / CDK infrastructure tests",
-    "CI / Validate backend/requirements.txt (dry-run)",
-    "CI / Lambda-compat pytest (backend/requirements.txt)",
-    "CI / Frontend smoke tests (preview build)",
-    "Backend Integration Tests / integration-tests",
-    "Frontend Tests / frontend-tests",
-    "Merge Conflict Check / Check for merge conflicts with main",
-    "PR Body Issue Reference Check / require-issue-reference",
-    "Dependency Review / dependency-review",
+    "CDK infrastructure tests",
+    "Validate backend/requirements.txt (dry-run)",
+    "Lambda-compat pytest (backend/requirements.txt)",
+    "Frontend smoke tests (preview build)",
+    "integration-tests",
+    "require-issue-reference",
+    "Check for merge conflicts with main",
+    # Reusable-workflow job: the check-run name is `<caller job id> / <called
+    # job name>`, which is why this one alone carries a `/`.
     "ai-review / DeepSeek AI code review",
+}
+
+# Workflows that are disabled in GitHub (`gh workflow list --all` reports
+# `disabled_manually`). A disabled workflow never reports a check-run, so any
+# context it would produce must stay out of the required set or every PR is
+# blocked forever. Removed from the required list in #5728; re-enabling one is
+# a deliberate change that must also fix why it was failing.
+DISABLED_WORKFLOW_FILES = {
+    "frontend-tests.yml",
+    "dependency-review.yml",
+    "siteplan.yml",
+    "super-linter.yml",
 }
 
 
@@ -90,10 +122,20 @@ def resolve_called_workflow_job_names(workflow_path: Path, with_inputs: dict) ->
     return names
 
 
-def workflow_check_contexts() -> set[str]:
+def workflow_check_contexts(exclude_files: set[str] | None = None) -> set[str]:
+    """Return every check-run name the repository's workflows can produce.
+
+    `exclude_files` names workflow files to skip; it defaults to
+    `DISABLED_WORKFLOW_FILES` so a required context can never resolve to a job
+    that will never run. Pass an empty set to see every context, disabled
+    included.
+    """
+    skip = DISABLED_WORKFLOW_FILES if exclude_files is None else exclude_files
     contexts: set[str] = set()
 
     for workflow_path in WORKFLOWS_DIR.glob("*.yml"):
+        if workflow_path.name in skip:
+            continue
         try:
             workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
         except yaml.YAMLError as exc:
@@ -101,9 +143,8 @@ def workflow_check_contexts() -> set[str]:
             continue
         if not isinstance(workflow, dict):
             continue
-        workflow_name = workflow.get("name")
         jobs = workflow.get("jobs")
-        if not isinstance(workflow_name, str) or not isinstance(jobs, dict):
+        if not isinstance(jobs, dict):
             continue
         for job_id, job in jobs.items():
             uses = job.get("uses") if isinstance(job, dict) else None
@@ -116,7 +157,7 @@ def workflow_check_contexts() -> set[str]:
                 continue
             job_name = job.get("name") if isinstance(job, dict) else None
             display_name = job_name if isinstance(job_name, str) else job_id
-            contexts.add(f"{workflow_name} / {display_name}")
+            contexts.add(display_name)
 
     return contexts
 
@@ -134,9 +175,17 @@ def main() -> int:
         if unexpected:
             errors.append(f"Ruleset has unexpected required checks: {unexpected}")
 
-    missing_workflows = sorted(required_contexts - available_contexts)
+    missing_workflows = set(required_contexts) - available_contexts
     if missing_workflows:
-        errors.append(f"Required checks do not match workflow/job names: {missing_workflows}")
+        disabled_contexts = workflow_check_contexts(exclude_files=set()) - available_contexts
+        blocked = sorted(missing_workflows & disabled_contexts)
+        unknown = sorted(missing_workflows - disabled_contexts)
+        if blocked:
+            errors.append(
+                "Required checks map to disabled workflows and can never report: " f"{blocked}"
+            )
+        if unknown:
+            errors.append(f"Required checks do not match workflow/job names: {unknown}")
 
     if errors:
         for error in errors:

--- a/scripts/check_live_branch_protection.py
+++ b/scripts/check_live_branch_protection.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Compare live GitHub branch protection against the checked-in ruleset.
+
+`scripts/check_branch_protection_required_checks.py` only reads files in the
+repository, so it passes cleanly even when GitHub enforces something entirely
+different -- which is exactly what happened in issue #5728: the checked-in
+ruleset declared 12 required contexts while the live ruleset declared none, and
+the real gate was a *classic* branch protection entry with different context
+names.
+
+This script closes that hole. It reads (never writes) the GitHub API and fails
+when live settings diverge from `.github/rulesets/default-branch-protection.json`:
+
+1. a ruleset with the checked-in `name` exists, is `active`, and targets the
+   same refs;
+2. its `pull_request` parameters and rule types match the checked-in ones;
+3. its required status check contexts match the checked-in ones exactly;
+4. classic branch protection does **not** also require status checks (two live
+   mechanisms is the drift's root cause);
+5. no required context maps to a disabled workflow, which would block every PR
+   on a check-run that never arrives.
+
+Read-only by design: applying a ruleset needs repo admin, which the default
+`GITHUB_TOKEN` does not have. Reading rulesets also needs elevated access, so
+this runs on a schedule with a PAT rather than on every PR.
+
+Usage:
+    python scripts/check_live_branch_protection.py [--repo owner/name]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+# Importable both as `python scripts/check_live_branch_protection.py` (script
+# dir already on sys.path) and via importlib from tests (it is not).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_branch_protection_required_checks import (  # noqa: E402
+    DISABLED_WORKFLOW_FILES,
+    RULESET_PATH,
+    WORKFLOWS_DIR,
+    workflow_check_contexts,
+)
+
+DEFAULT_REPO = "leonarduk/allotmint"
+
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_UNAVAILABLE = 2
+
+# `pull_request` rule parameters that GitHub returns but that the checked-in
+# JSON does not need to declare. Compared only when present in both.
+_OPTIONAL_PR_PARAMETERS = frozenset({"required_reviewers", "automatic_copilot_code_review_enabled"})
+
+
+class ApiUnavailable(RuntimeError):
+    """Raised when the GitHub API could not be queried at all."""
+
+
+Fetch = Callable[[str], Any]
+
+
+def gh_api(path: str) -> Any:
+    """Fetch `path` from the GitHub API via the `gh` CLI.
+
+    Raises ApiUnavailable when `gh` is missing or the token lacks access;
+    returns None for a 404 (the resource legitimately does not exist).
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", path],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment dependent
+        raise ApiUnavailable("the `gh` CLI is not installed") from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "404" in stderr or "Not Found" in stderr:
+            return None
+        raise ApiUnavailable(f"`gh api {path}` failed: {stderr}")
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ApiUnavailable(f"`gh api {path}` returned non-JSON output") from exc
+
+
+def load_checked_in_ruleset() -> dict[str, Any]:
+    return json.loads(RULESET_PATH.read_text(encoding="utf-8"))
+
+
+def rules_by_type(ruleset: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    rules: dict[str, dict[str, Any]] = {}
+    for rule in ruleset.get("rules", []):
+        if isinstance(rule, dict) and isinstance(rule.get("type"), str):
+            rules[rule["type"]] = rule
+    return rules
+
+
+def required_contexts(ruleset: dict[str, Any]) -> set[str]:
+    rule = rules_by_type(ruleset).get("required_status_checks")
+    if not rule:
+        return set()
+    checks = rule.get("parameters", {}).get("required_status_checks", [])
+    return {
+        c["context"] for c in checks if isinstance(c, dict) and isinstance(c.get("context"), str)
+    }
+
+
+def find_live_ruleset(fetch: Fetch, repo: str, name: str) -> dict[str, Any]:
+    listing = fetch(f"repos/{repo}/rulesets")
+    if not isinstance(listing, list):
+        raise ApiUnavailable(f"repos/{repo}/rulesets did not return a list")
+    matches = [r for r in listing if isinstance(r, dict) and r.get("name") == name]
+    if not matches:
+        available = sorted(str(r.get("name")) for r in listing if isinstance(r, dict))
+        raise LookupError(
+            f"no live ruleset named {name!r}; GitHub has: {available or '(none)'}. "
+            f"Apply {RULESET_PATH.name} -- see docs/BRANCH_PROTECTION.md."
+        )
+    detail = fetch(f"repos/{repo}/rulesets/{matches[0]['id']}")
+    if not isinstance(detail, dict):
+        raise ApiUnavailable(f"could not read ruleset {matches[0]['id']}")
+    return detail
+
+
+def compare_conditions(expected: dict[str, Any], live: dict[str, Any]) -> list[str]:
+    expected_ref = expected.get("conditions", {}).get("ref_name", {})
+    live_ref = live.get("conditions", {}).get("ref_name", {})
+    errors: list[str] = []
+    for key in ("include", "exclude"):
+        want = sorted(expected_ref.get(key, []) or [])
+        got = sorted(live_ref.get(key, []) or [])
+        if want != got:
+            errors.append(f"ruleset conditions.ref_name.{key}: checked-in {want}, live {got}")
+    return errors
+
+
+def compare_rule_types(expected: dict[str, Any], live: dict[str, Any]) -> list[str]:
+    want = set(rules_by_type(expected))
+    got = set(rules_by_type(live))
+    errors: list[str] = []
+    if want - got:
+        errors.append(f"ruleset is missing rule types that are checked in: {sorted(want - got)}")
+    if got - want:
+        errors.append(f"live ruleset has rule types that are not checked in: {sorted(got - want)}")
+    return errors
+
+
+def compare_pull_request_parameters(expected: dict[str, Any], live: dict[str, Any]) -> list[str]:
+    want = rules_by_type(expected).get("pull_request", {}).get("parameters", {})
+    got = rules_by_type(live).get("pull_request", {}).get("parameters", {})
+    errors: list[str] = []
+    for key, want_value in sorted(want.items()):
+        if key in _OPTIONAL_PR_PARAMETERS or key not in got:
+            continue
+        got_value = got[key]
+        if isinstance(want_value, list) and isinstance(got_value, list):
+            if sorted(want_value) != sorted(got_value):
+                errors.append(
+                    f"pull_request.{key}: checked-in {sorted(want_value)}, live {sorted(got_value)}"
+                )
+        elif want_value != got_value:
+            errors.append(f"pull_request.{key}: checked-in {want_value!r}, live {got_value!r}")
+    return errors
+
+
+def compare_required_checks(expected: dict[str, Any], live: dict[str, Any]) -> list[str]:
+    want = required_contexts(expected)
+    got = required_contexts(live)
+    errors: list[str] = []
+    if want - got:
+        errors.append(f"live ruleset does not require checked-in contexts: {sorted(want - got)}")
+    if got - want:
+        errors.append(
+            f"live ruleset requires contexts that are not checked in: {sorted(got - want)}"
+        )
+
+    want_strict = (
+        rules_by_type(expected)
+        .get("required_status_checks", {})
+        .get("parameters", {})
+        .get("strict_required_status_checks_policy")
+    )
+    got_strict = (
+        rules_by_type(live)
+        .get("required_status_checks", {})
+        .get("parameters", {})
+        .get("strict_required_status_checks_policy")
+    )
+    if want_strict is not None and got_strict is not None and want_strict != got_strict:
+        errors.append(
+            f"strict_required_status_checks_policy: checked-in {want_strict}, live {got_strict}"
+        )
+    return errors
+
+
+def check_classic_protection(fetch: Fetch, repo: str, branch: str) -> list[str]:
+    """Classic protection must not also require status checks."""
+    protection = fetch(f"repos/{repo}/branches/{branch}/protection")
+    if not isinstance(protection, dict):
+        return []
+    contexts = protection.get("required_status_checks", {}).get("contexts") or []
+    if contexts:
+        return [
+            "classic branch protection also requires status checks "
+            f"{sorted(contexts)} on {branch}; two live mechanisms is the drift "
+            "this check exists to prevent. Remove the classic required-checks "
+            "entry once the ruleset is confirmed working."
+        ]
+    return []
+
+
+def disabled_workflow_names(fetch: Fetch, repo: str) -> set[str]:
+    """Return the file names of workflows GitHub reports as disabled.
+
+    Restricted to files that still exist in this checkout: GitHub keeps
+    listing workflows from deleted branches, and those cannot produce a
+    context anyone could require here.
+    """
+    payload = fetch(f"repos/{repo}/actions/workflows?per_page=100")
+    if not isinstance(payload, dict):
+        raise ApiUnavailable(f"could not list workflows for {repo}")
+    present = {path.name for path in WORKFLOWS_DIR.glob("*.yml")}
+    disabled: set[str] = set()
+    for workflow in payload.get("workflows", []):
+        if not isinstance(workflow, dict):
+            continue
+        if workflow.get("state") in {"disabled_manually", "disabled_inactivity"}:
+            name = Path(str(workflow.get("path", ""))).name
+            if name in present:
+                disabled.add(name)
+    return disabled
+
+
+def check_contexts_are_producible(fetch: Fetch, repo: str, contexts: set[str]) -> list[str]:
+    """Fail when a required context can never be reported.
+
+    Uses GitHub's own view of which workflows are disabled rather than the
+    hard-coded `DISABLED_WORKFLOW_FILES` list, so disabling a workflow in the
+    UI is caught without a code change.
+    """
+    disabled_files = disabled_workflow_names(fetch, repo)
+    producible = workflow_check_contexts(exclude_files=disabled_files)
+    everything = workflow_check_contexts(exclude_files=set())
+
+    errors: list[str] = []
+    if stale := sorted(disabled_files - DISABLED_WORKFLOW_FILES):
+        errors.append(
+            "workflows are disabled in GitHub but not listed in "
+            f"DISABLED_WORKFLOW_FILES: {stale}"
+        )
+    if blocked := sorted(contexts & (everything - producible)):
+        errors.append(
+            f"required contexts map to disabled workflows and can never report: {blocked}"
+        )
+    if unknown := sorted(contexts - everything):
+        errors.append(f"required contexts match no workflow job in this repo: {unknown}")
+    return errors
+
+
+def run(fetch: Fetch, repo: str) -> tuple[int, list[str]]:
+    expected = load_checked_in_ruleset()
+    try:
+        live = find_live_ruleset(fetch, repo, expected["name"])
+    except LookupError as exc:
+        return EXIT_DRIFT, [str(exc)]
+
+    errors: list[str] = []
+    if live.get("enforcement") != expected.get("enforcement"):
+        errors.append(
+            f"ruleset enforcement: checked-in {expected.get('enforcement')!r}, "
+            f"live {live.get('enforcement')!r}"
+        )
+    errors += compare_conditions(expected, live)
+    errors += compare_rule_types(expected, live)
+    errors += compare_pull_request_parameters(expected, live)
+    errors += compare_required_checks(expected, live)
+    errors += check_classic_protection(fetch, repo, "main")
+    errors += check_contexts_are_producible(fetch, repo, required_contexts(expected))
+
+    return (EXIT_DRIFT if errors else EXIT_OK), errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="owner/name (default: %(default)s)")
+    args = parser.parse_args(argv)
+
+    try:
+        exit_code, errors = run(gh_api, args.repo)
+    except ApiUnavailable as exc:
+        print(f"Could not query GitHub: {exc}", file=sys.stderr)
+        print(
+            "Reading rulesets requires admin access; supply a PAT via GH_TOKEN.",
+            file=sys.stderr,
+        )
+        return EXIT_UNAVAILABLE
+
+    for error in errors:
+        print(f"Branch protection drift: {error}", file=sys.stderr)
+    if exit_code == EXIT_OK:
+        print(f"Live branch protection on {args.repo} matches {RULESET_PATH.name}.")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_live_branch_protection.py
+++ b/scripts/check_live_branch_protection.py
@@ -107,14 +107,21 @@ def rules_by_type(ruleset: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return rules
 
 
-def required_contexts(ruleset: dict[str, Any]) -> set[str]:
+def required_checks(ruleset: dict[str, Any]) -> dict[str, Any]:
+    """Map required context -> integration_id (None if unset)."""
     rule = rules_by_type(ruleset).get("required_status_checks")
     if not rule:
-        return set()
+        return {}
     checks = rule.get("parameters", {}).get("required_status_checks", [])
     return {
-        c["context"] for c in checks if isinstance(c, dict) and isinstance(c.get("context"), str)
+        c["context"]: c.get("integration_id")
+        for c in checks
+        if isinstance(c, dict) and isinstance(c.get("context"), str)
     }
+
+
+def required_contexts(ruleset: dict[str, Any]) -> set[str]:
+    return set(required_checks(ruleset))
 
 
 def find_live_ruleset(fetch: Fetch, repo: str, name: str) -> dict[str, Any]:
@@ -176,8 +183,10 @@ def compare_pull_request_parameters(expected: dict[str, Any], live: dict[str, An
 
 
 def compare_required_checks(expected: dict[str, Any], live: dict[str, Any]) -> list[str]:
-    want = required_contexts(expected)
-    got = required_contexts(live)
+    want_checks = required_checks(expected)
+    got_checks = required_checks(live)
+    want = set(want_checks)
+    got = set(got_checks)
     errors: list[str] = []
     if want - got:
         errors.append(f"live ruleset does not require checked-in contexts: {sorted(want - got)}")
@@ -185,6 +194,16 @@ def compare_required_checks(expected: dict[str, Any], live: dict[str, Any]) -> l
         errors.append(
             f"live ruleset requires contexts that are not checked in: {sorted(got - want)}"
         )
+
+    # A required context can silently switch which GitHub App produces it --
+    # e.g. a job migrating from a first-party Action to a third-party App --
+    # without the context string itself changing. integration_id catches that.
+    for context in sorted(want & got):
+        want_id, got_id = want_checks[context], got_checks[context]
+        if want_id is not None and got_id is not None and want_id != got_id:
+            errors.append(
+                f"required check {context!r} integration_id: checked-in {want_id}, live {got_id}"
+            )
 
     want_strict = (
         rules_by_type(expected)

--- a/scripts/classify_change.py
+++ b/scripts/classify_change.py
@@ -91,6 +91,7 @@ AREA_PATH_RULES: tuple[tuple[str, frozenset[str]], ...] = (
     # must never narrow the suite that validates it.
     ("scripts/classify_change.py", _ALL_AREAS),
     ("scripts/check_branch_protection_required_checks.py", _ALL_AREAS),
+    ("scripts/check_live_branch_protection.py", _ALL_AREAS),
     (".github/**", _ALL_AREAS),
     # -- Shell / container / deploy tooling. -------------------------------
     ("scripts/bash/**", frozenset({"shell"})),

--- a/tests/scripts/test_check_branch_protection_required_checks.py
+++ b/tests/scripts/test_check_branch_protection_required_checks.py
@@ -1,0 +1,167 @@
+"""Unit tests for scripts/check_branch_protection_required_checks.py.
+
+These pin down the *context naming convention*, which is the part that is easy
+to get wrong and expensive when wrong: a required context that no check-run
+produces leaves every PR pending forever. Issue #5728 was caused by the ruleset
+using the `Workflow / Job` form the Actions UI displays rather than the
+check-run name GitHub actually matches on.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_branch_protection_required_checks.py"
+_spec = importlib.util.spec_from_file_location("check_branch_protection_required_checks", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# The real repository must be self-consistent
+# ---------------------------------------------------------------------------
+
+
+def test_repository_passes_its_own_check() -> None:
+    assert _mod.main() == 0
+
+
+def test_ruleset_matches_expected_required_checks() -> None:
+    assert _mod.load_ruleset_contexts() == _mod.EXPECTED_REQUIRED_CHECKS
+
+
+def test_every_required_context_is_produced_by_an_enabled_workflow() -> None:
+    unproducible = _mod.EXPECTED_REQUIRED_CHECKS - _mod.workflow_check_contexts()
+    assert not unproducible, (
+        f"required contexts {sorted(unproducible)} match no enabled workflow job; "
+        f"branch protection would wait for them forever"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Context naming convention
+# ---------------------------------------------------------------------------
+
+
+def test_normal_job_contexts_are_bare_names_not_workflow_slash_job() -> None:
+    """`test`, not `CI / test`. This is the #5728 regression guard."""
+    contexts = _mod.workflow_check_contexts()
+    assert "test" in contexts
+    assert "CI / test" not in contexts
+    assert "Frontend lint, type-check and unit tests" in contexts
+    assert "CI / Frontend lint, type-check and unit tests" not in contexts
+
+
+def test_reusable_workflow_contexts_use_caller_job_id_prefix() -> None:
+    """A `uses:` job reports `<caller job id> / <called job name>`."""
+    assert "ai-review / DeepSeek AI code review" in _mod.workflow_check_contexts()
+
+
+def test_only_reusable_workflow_contexts_contain_a_separator() -> None:
+    """A ` / ` in a required context is a strong signal of the old wrong form.
+
+    Matched on `" / "` with surrounding spaces, so a bare `/` inside a job name
+    (`Validate backend/requirements.txt (dry-run)`) is not a false positive.
+    """
+    slashed = {c for c in _mod.EXPECTED_REQUIRED_CHECKS if " / " in c}
+    assert slashed == {"ai-review / DeepSeek AI code review"}, (
+        "a required context containing '/' must be a reusable-workflow job; "
+        "otherwise it is almost certainly the 'Workflow / Job' UI label, which "
+        "GitHub never reports as a check-run name"
+    )
+
+
+def test_job_id_used_when_job_has_no_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workflows = tmp_path / "workflows"
+    workflows.mkdir()
+    (workflows / "sample.yml").write_text(
+        "name: Sample\njobs:\n  bare-id: {runs-on: ubuntu-latest}\n"
+        "  named: {name: Pretty Name, runs-on: ubuntu-latest}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_mod, "WORKFLOWS_DIR", workflows)
+    assert _mod.workflow_check_contexts(exclude_files=set()) == {"bare-id", "Pretty Name"}
+
+
+# ---------------------------------------------------------------------------
+# Disabled workflows
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_workflows_produce_no_available_contexts() -> None:
+    enabled = _mod.workflow_check_contexts()
+    everything = _mod.workflow_check_contexts(exclude_files=set())
+    # frontend-tests.yml and dependency-review.yml are disabled in GitHub; the
+    # contexts they would produce must not be visible as "available".
+    assert "frontend-tests" in everything - enabled
+    assert "dependency-review" in everything - enabled
+
+
+def test_no_required_context_comes_from_a_disabled_workflow() -> None:
+    everything = _mod.workflow_check_contexts(exclude_files=set())
+    disabled_only = everything - _mod.workflow_check_contexts()
+    assert not (_mod.EXPECTED_REQUIRED_CHECKS & disabled_only)
+
+
+def test_disabled_workflow_files_all_exist() -> None:
+    """A stale entry here would silently hide a live context from the check."""
+    for name in _mod.DISABLED_WORKFLOW_FILES:
+        assert (_mod.WORKFLOWS_DIR / name).exists(), f"{name} is listed as disabled but is gone"
+
+
+# ---------------------------------------------------------------------------
+# Failure detection
+# ---------------------------------------------------------------------------
+
+
+def _write_ruleset(path: Path, contexts: list[str]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "name": "Main",
+                "rules": [
+                    {
+                        "type": "required_status_checks",
+                        "parameters": {
+                            "required_status_checks": [{"context": c} for c in contexts]
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_unexpected_context_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ruleset = tmp_path / "ruleset.json"
+    _write_ruleset(ruleset, [*_mod.EXPECTED_REQUIRED_CHECKS, "surprise"])
+    monkeypatch.setattr(_mod, "RULESET_PATH", ruleset)
+    assert _mod.main() == 1
+
+
+def test_missing_context_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ruleset = tmp_path / "ruleset.json"
+    _write_ruleset(ruleset, sorted(_mod.EXPECTED_REQUIRED_CHECKS)[1:])
+    monkeypatch.setattr(_mod, "RULESET_PATH", ruleset)
+    assert _mod.main() == 1
+
+
+def test_context_from_disabled_workflow_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Re-adding `dependency-review` must fail with a message naming the cause."""
+    ruleset = tmp_path / "ruleset.json"
+    contexts = [*_mod.EXPECTED_REQUIRED_CHECKS, "dependency-review"]
+    _write_ruleset(ruleset, contexts)
+    monkeypatch.setattr(_mod, "RULESET_PATH", ruleset)
+    monkeypatch.setattr(
+        _mod, "EXPECTED_REQUIRED_CHECKS", _mod.EXPECTED_REQUIRED_CHECKS | {"dependency-review"}
+    )
+    assert _mod.main() == 1
+    assert "disabled workflows" in capsys.readouterr().err

--- a/tests/scripts/test_check_live_branch_protection.py
+++ b/tests/scripts/test_check_live_branch_protection.py
@@ -1,0 +1,248 @@
+"""Unit tests for scripts/check_live_branch_protection.py.
+
+The script's whole job is to notice when GitHub enforces something other than
+`.github/rulesets/default-branch-protection.json`, so every test here builds a
+live payload that differs from the checked-in one in exactly one way and
+asserts the difference is reported. Issue #5728 existed because the previous
+checker could not see any of this.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_live_branch_protection.py"
+_spec = importlib.util.spec_from_file_location("check_live_branch_protection", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+REPO = "leonarduk/allotmint"
+RULESET_ID = 7292508
+
+
+def _checked_in() -> dict[str, Any]:
+    return json.loads(_mod.RULESET_PATH.read_text(encoding="utf-8"))
+
+
+def _live_from_checked_in() -> dict[str, Any]:
+    """A live ruleset payload that agrees with the checked-in file."""
+    live = copy.deepcopy(_checked_in())
+    live["id"] = RULESET_ID
+    return live
+
+
+def _fetch_factory(
+    *,
+    ruleset: dict[str, Any] | None = None,
+    rulesets_list: list[dict[str, Any]] | None = None,
+    classic_contexts: list[str] | None = None,
+    disabled_workflows: list[str] | None = None,
+):
+    """Build a `fetch` stub covering every endpoint the script calls."""
+    live = _live_from_checked_in() if ruleset is None else ruleset
+    listing = (
+        [{"id": RULESET_ID, "name": live.get("name")}] if rulesets_list is None else rulesets_list
+    )
+    default_names = sorted(_mod.DISABLED_WORKFLOW_FILES)
+    names = default_names if disabled_workflows is None else disabled_workflows
+    workflows = [
+        {"path": f".github/workflows/{name}", "state": "disabled_manually"} for name in names
+    ]
+
+    def fetch(path: str) -> Any:
+        if path == f"repos/{REPO}/rulesets":
+            return listing
+        if path == f"repos/{REPO}/rulesets/{RULESET_ID}":
+            return live
+        if path == f"repos/{REPO}/branches/main/protection":
+            if classic_contexts is None:
+                return None
+            return {"required_status_checks": {"contexts": classic_contexts}}
+        if path.startswith(f"repos/{REPO}/actions/workflows"):
+            return {"workflows": workflows}
+        raise AssertionError(f"unexpected API path: {path}")
+
+    return fetch
+
+
+def _errors(**kwargs) -> list[str]:
+    exit_code, errors = _mod.run(_fetch_factory(**kwargs), REPO)
+    assert (exit_code == _mod.EXIT_OK) == (not errors)
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# The happy path
+# ---------------------------------------------------------------------------
+
+
+def test_no_drift_when_live_matches_checked_in() -> None:
+    assert _errors() == []
+
+
+# ---------------------------------------------------------------------------
+# Ruleset-level drift
+# ---------------------------------------------------------------------------
+
+
+def test_missing_ruleset_is_drift() -> None:
+    errors = _errors(rulesets_list=[{"id": 1, "name": "something else"}])
+    assert any("no live ruleset named" in e for e in errors)
+
+
+def test_inactive_enforcement_is_drift() -> None:
+    live = _live_from_checked_in()
+    live["enforcement"] = "evaluate"
+    assert any("enforcement" in e for e in _errors(ruleset=live))
+
+
+def test_ruleset_targeting_no_branches_is_drift() -> None:
+    """The exact live state found in #5728: `include` was empty."""
+    live = _live_from_checked_in()
+    live["conditions"]["ref_name"]["include"] = []
+    errors = _errors(ruleset=live)
+    assert any("conditions.ref_name.include" in e for e in errors)
+
+
+def test_missing_required_status_checks_rule_is_drift() -> None:
+    """Also #5728: the live ruleset had no required_status_checks rule at all."""
+    live = _live_from_checked_in()
+    live["rules"] = [r for r in live["rules"] if r["type"] != "required_status_checks"]
+    errors = _errors(ruleset=live)
+    assert any("missing rule types" in e for e in errors)
+    assert any("does not require checked-in contexts" in e for e in errors)
+
+
+def test_extra_live_rule_type_is_drift() -> None:
+    live = _live_from_checked_in()
+    live["rules"].append({"type": "required_linear_history"})
+    assert any("not checked in" in e for e in _errors(ruleset=live))
+
+
+def test_review_policy_drift_is_reported() -> None:
+    live = _live_from_checked_in()
+    for rule in live["rules"]:
+        if rule["type"] == "pull_request":
+            rule["parameters"]["required_approving_review_count"] = 2
+    errors = _errors(ruleset=live)
+    assert any("pull_request.required_approving_review_count" in e for e in errors)
+
+
+def test_pull_request_parameters_absent_from_live_are_ignored() -> None:
+    """GitHub may omit parameters; only shared keys are compared."""
+    live = _live_from_checked_in()
+    for rule in live["rules"]:
+        if rule["type"] == "pull_request":
+            rule["parameters"].pop("require_last_push_approval")
+    assert _errors(ruleset=live) == []
+
+
+def test_allowed_merge_methods_compared_order_insensitively() -> None:
+    live = _live_from_checked_in()
+    for rule in live["rules"]:
+        if rule["type"] == "pull_request":
+            rule["parameters"]["allowed_merge_methods"] = ["squash", "rebase", "merge"]
+    assert _errors(ruleset=live) == []
+
+
+# ---------------------------------------------------------------------------
+# Required-context drift -- the failure mode that blocks every PR
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_context_naming_convention_is_drift() -> None:
+    """`CI / test` instead of `test` is the trap #5728 warns about."""
+    live = _live_from_checked_in()
+    for rule in live["rules"]:
+        if rule["type"] == "required_status_checks":
+            for check in rule["parameters"]["required_status_checks"]:
+                if check["context"] == "test":
+                    check["context"] = "CI / test"
+    errors = _errors(ruleset=live)
+    assert any("does not require checked-in contexts" in e and "'test'" in e for e in errors)
+    assert any("not checked in" in e and "CI / test" in e for e in errors)
+
+
+def test_dropped_context_is_drift() -> None:
+    live = _live_from_checked_in()
+    for rule in live["rules"]:
+        if rule["type"] == "required_status_checks":
+            rule["parameters"]["required_status_checks"] = [
+                c for c in rule["parameters"]["required_status_checks"] if c["context"] != "test"
+            ]
+    assert any("does not require checked-in contexts" in e for e in _errors(ruleset=live))
+
+
+def test_strict_policy_drift_is_reported() -> None:
+    live = _live_from_checked_in()
+    for rule in live["rules"]:
+        if rule["type"] == "required_status_checks":
+            rule["parameters"]["strict_required_status_checks_policy"] = False
+    assert any("strict_required_status_checks_policy" in e for e in _errors(ruleset=live))
+
+
+# ---------------------------------------------------------------------------
+# The other two live mechanisms
+# ---------------------------------------------------------------------------
+
+
+def test_classic_protection_with_required_checks_is_drift() -> None:
+    errors = _errors(classic_contexts=["test", "integration-tests"])
+    assert any("classic branch protection also requires status checks" in e for e in errors)
+
+
+def test_classic_protection_without_required_checks_is_fine() -> None:
+    assert _errors(classic_contexts=[]) == []
+
+
+def test_required_context_from_newly_disabled_workflow_is_drift() -> None:
+    """Disabling `conflict-check.yml` in the UI must be caught immediately."""
+    disabled = sorted(_mod.DISABLED_WORKFLOW_FILES | {"conflict-check.yml"})
+    errors = _errors(disabled_workflows=disabled)
+    assert any("not listed in DISABLED_WORKFLOW_FILES" in e for e in errors)
+    assert any(
+        "can never report" in e and "Check for merge conflicts with main" in e for e in errors
+    )
+
+
+def test_context_matching_no_workflow_is_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    live = _live_from_checked_in()
+    for rule in live["rules"]:
+        if rule["type"] == "required_status_checks":
+            rule["parameters"]["required_status_checks"].append({"context": "does-not-exist"})
+    monkeypatch.setattr(_mod, "load_checked_in_ruleset", lambda: live)
+    _, errors = _mod.run(_fetch_factory(ruleset=live), REPO)
+    assert any("match no workflow job" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# API availability
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_api_exits_two_rather_than_reporting_no_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A permission failure must never be mistaken for a clean result.
+
+    Exit 2 is distinct from exit 1 so the scheduled workflow's failure message
+    distinguishes "the token expired" from "someone changed the gate".
+    """
+
+    def fetch(_path: str) -> Any:
+        raise _mod.ApiUnavailable("token lacks Administration: read")
+
+    monkeypatch.setattr(_mod, "gh_api", fetch)
+    assert _mod.main(["--repo", REPO]) == _mod.EXIT_UNAVAILABLE
+
+
+def test_clean_run_exits_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_mod, "gh_api", _fetch_factory())
+    assert _mod.main(["--repo", REPO]) == _mod.EXIT_OK

--- a/tests/scripts/test_check_live_branch_protection.py
+++ b/tests/scripts/test_check_live_branch_protection.py
@@ -170,6 +170,38 @@ def test_wrong_context_naming_convention_is_drift() -> None:
     assert any("not checked in" in e and "CI / test" in e for e in errors)
 
 
+def test_integration_id_mismatch_is_drift() -> None:
+    """A context whose producing App changes without the string changing."""
+    live = _live_from_checked_in()
+    for rule in live["rules"]:
+        if rule["type"] == "required_status_checks":
+            for check in rule["parameters"]["required_status_checks"]:
+                if check["context"] == "test":
+                    check["integration_id"] = 99999
+    errors = _errors(ruleset=live)
+    assert any("integration_id" in e and "'test'" in e for e in errors)
+
+
+def test_integration_id_absent_from_checked_in_is_not_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Checked-in entries with no integration_id opt out of this comparison."""
+    expected = _checked_in()
+    for rule in expected["rules"]:
+        if rule["type"] == "required_status_checks":
+            for check in rule["parameters"]["required_status_checks"]:
+                check.pop("integration_id", None)
+    live = _live_from_checked_in()
+    for rule in live["rules"]:
+        if rule["type"] == "required_status_checks":
+            for check in rule["parameters"]["required_status_checks"]:
+                check["integration_id"] = 1
+
+    monkeypatch.setattr(_mod, "load_checked_in_ruleset", lambda: expected)
+    _, errors = _mod.run(_fetch_factory(ruleset=live), REPO)
+    assert not any("integration_id" in e for e in errors)
+
+
 def test_dropped_context_is_drift() -> None:
     live = _live_from_checked_in()
     for rule in live["rules"]:

--- a/tests/scripts/test_ci_area_gating.py
+++ b/tests/scripts/test_ci_area_gating.py
@@ -148,15 +148,17 @@ def test_hygiene_and_lint_jobs_stay_ungated() -> None:
 
 
 def test_required_test_job_keeps_its_context_name() -> None:
-    """ "CI / test" is a required context; a `name:` here would change it.
+    """`test` is a required context; a `name:` here would change it.
 
-    Branch protection matches on the rendered context string. Adding a `name:`
-    to this job renames the context, and the ruleset would then wait forever
-    for a check no workflow produces -- blocking every PR.
+    Branch protection matches on the check-run name, which for an Actions job
+    is its `name:` or, absent that, its job id -- *not* the `Workflow / Job`
+    form the UI displays. Adding a `name:` to this job renames the context, and
+    the ruleset would then wait forever for a check no workflow produces --
+    blocking every PR. See issue #5728.
     """
     assert "name" not in _load("ci.yml")["jobs"]["test"], (
         "ci.yml:test must not declare a `name:`; its required check context is "
-        "the bare job id 'CI / test' in .github/rulesets/default-branch-protection.json"
+        "the bare job id 'test' in .github/rulesets/default-branch-protection.json"
     )
 
 


### PR DESCRIPTION
## Summary

- Rewrites `.github/rulesets/default-branch-protection.json` to match what GitHub actually matches required checks against: bare check-run names (`test`, not `CI / test`), the live ruleset's `name` (`Main`), `~DEFAULT_BRANCH` targeting (the live ruleset's `ref_name.include` was empty — the ruleset applied to *nothing*), and 0 required approvals (matching what the repo has actually enforced; requiring 1 approval blocks a solo maintainer's own PRs).
- Drops the two required contexts that pointed at manually-disabled workflows (`frontend-tests.yml`, `dependency-review.yml`) from both the JSON and `EXPECTED_REQUIRED_CHECKS` — a disabled workflow never reports, so requiring one blocks every PR forever.
- Adds `scripts/check_live_branch_protection.py`, a read-only checker that compares *live* GitHub ruleset/branch-protection state against the checked-in JSON — the gap the issue identifies, since the existing `check_branch_protection_required_checks.py` only ever compared files against files. It flags: the ruleset never being applied, wrong context naming, review-policy drift, classic protection re-acquiring required checks, and any required context that maps to a workflow GitHub reports as disabled.
- Runs the new checker daily via `.github/workflows/branch-protection-drift.yml` (not on every PR — reading rulesets needs admin-scoped access that must never reach a fork PR).
- Updates `docs/BRANCH_PROTECTION.md`, `docs/CONTRIBUTOR_RUNBOOK.md`, and `scripts/README.md` to document the context-naming rule and the two-checker split.

## What I verified against live GitHub before writing anything

```
gh api repos/leonarduk/allotmint/rulesets/7292508          # ref_name.include: [], no required_status_checks rule
gh api repos/leonarduk/allotmint/branches/main/protection  # 5 bare-name contexts, 0 required approvals
gh api repos/leonarduk/allotmint/commits/<open-PR-head>/check-runs  # confirmed every context name against a real run
gh workflow list --all                                      # frontend-tests.yml, dependency-review.yml: disabled_manually
```

## Decisions (confirmed with the repo owner before implementing)

- **Ruleset wins** over classic branch protection — matches the issue's stated direction. This PR does **not** apply the ruleset or touch classic protection live; both require repo admin and are called out as a human follow-up in `docs/BRANCH_PROTECTION.md`.
- **0 required approvals** — matches current live behavior; this is a solo-maintained repo.
- **Disabled workflows dropped from required list**, not re-enabled — `frontend-tests.yml`'s vitest+coverage run is already covered by `CI / Frontend lint, type-check and unit tests`; re-enabling `dependency-review.yml` is left as separate follow-up work since it lost its supply-chain scan coverage.

## Follow-up required (needs repo admin, cannot be done in PR CI)

1. Apply the reconciled JSON: `gh api --method PUT repos/leonarduk/allotmint/rulesets/7292508 --input .github/rulesets/default-branch-protection.json`
2. Confirm on an open PR that the contexts are genuinely enforced (merge blocked while one is red) before touching classic protection.
3. Only then: `gh api --method DELETE repos/leonarduk/allotmint/branches/main/protection/required_status_checks`
4. Add a fine-grained PAT with read-only Administration permission as the `BRANCH_PROTECTION_READ_TOKEN` secret so the new scheduled workflow can read rulesets (falls back to `github.token`, which cannot).

## Test plan

- [x] `python scripts/check_branch_protection_required_checks.py` passes against the reconciled JSON
- [x] `python scripts/check_live_branch_protection.py` run against the *current* live (unreconciled) settings correctly reports every drift described in the issue (empty ref_name.include, missing required_status_checks rule, missing contexts, classic protection duplication)
- [x] New unit tests for both checkers (31 tests) covering the wrong-naming-convention trap, disabled-workflow detection, and API-unavailable handling
- [x] `actionlint .github/workflows/branch-protection-drift.yml` passes
- [x] `pytest tests/ -q` — 2409 passed (1 pre-existing failure in `test_log_sanitization_audit.py`, unrelated, reproduces on `main`)
- [ ] Repo admin applies the ruleset and confirms a red required check actually blocks merge on a live PR

Closes #5728

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated monitoring to detect differences between configured and live branch protection.
  - Introduced clearer enforcement for required checks and Copilot code review.

- **Bug Fixes**
  - Improved validation of required checks, workflow changes and disabled workflows.
  - Detects conflicting or unavailable branch-protection settings with clear outcomes.

- **Documentation**
  - Expanded guidance for branch protection, contributor procedures and validation tools.
  - Clarified check naming, review policies and troubleshooting steps.

- **Tests**
  - Added comprehensive coverage for configuration drift and required-check validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->