### PR TITLE
Dedupe repo-info and review-response parsing in issue scripts

### DIFF
--- a/scripts/developer_tools/b_create_issue.py
+++ b/scripts/developer_tools/b_create_issue.py
@@ -15,6 +15,8 @@ from pathlib import Path
 import requests
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from github_repo import get_repo_info
+from issue_review import parse_review_response
 from ollama_common import (
     fetch_ollama_review,
     get_ollama_endpoint,
@@ -64,30 +66,6 @@ SECTIONS_BUG = [
         "What regressions or gaps would mean the fix failed. Start each line with '-'.",
     ),
 ]
-
-
-def get_repo_info() -> tuple[str, str]:
-    """Extract owner and repo from git remote origin."""
-    try:
-        result = subprocess.run(
-            ["git", "config", "--get", "remote.origin.url"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        url = result.stdout.strip()
-        if url.startswith("git@"):
-            match = re.search(r"github\.com[:/]([^/]+)/(.+?)(?:\.git)?$", url)
-        else:
-            match = re.search(r"github\.com/([^/]+)/(.+?)(?:\.git)?$", url)
-        if match:
-            repo = match.group(2)
-            if repo.endswith(".git"):
-                repo = repo[:-4]
-            return match.group(1), repo
-    except subprocess.CalledProcessError as exc:
-        raise ValueError(f"Could not determine GitHub repo from git remote origin: {exc}") from exc
-    raise ValueError("Could not determine GitHub repo from git remote origin")
 
 
 def get_github_token() -> str:
@@ -324,6 +302,7 @@ def create_issue_via_gh(
         if body_path and os.path.exists(body_path):
             os.unlink(body_path)
 
+
 def derive_title_from_what(what: str) -> str | None:
     """Extract a candidate title from the first meaningful line of 'What'."""
     if not what:
@@ -353,20 +332,6 @@ def build_review_prompt(title: str, body: str) -> str:
         f"Original title: {title}\n\n"
         f"Original body:\n{body}\n"
     )
-
-
-def parse_review_response(
-    response: str, fallback_title: str, fallback_body: str
-) -> tuple[str, str]:
-    """Parse the LLM's TITLE/BODY response, falling back to the originals on any mismatch."""
-    match = re.search(r"TITLE:\s*(.*?)\s*\nBODY:\s*\n?(.*)", response, re.DOTALL)
-    if not match:
-        return fallback_title, fallback_body
-    title = match.group(1).strip()
-    body = match.group(2).strip()
-    if not title or not body:
-        return fallback_title, fallback_body
-    return title, body
 
 
 def offer_local_llm_review(title: str, body: str) -> tuple[str, str]:

--- a/scripts/developer_tools/lib/issue_review.py
+++ b/scripts/developer_tools/lib/issue_review.py
@@ -1,0 +1,24 @@
+"""Shared helpers for parsing LLM issue-review responses.
+
+Used by both b_create_issue.py (drafting a new issue) and n_review_issue.py
+(refreshing an existing one), which send differently-worded prompts to the
+model but expect the same TITLE:/BODY: response format back.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def parse_review_response(
+    response: str, fallback_title: str, fallback_body: str
+) -> tuple[str, str]:
+    """Parse the model's TITLE/BODY response, falling back to the originals on any mismatch."""
+    match = re.search(r"TITLE:\s*(.*?)\s*\nBODY:\s*\n?(.*)", response, re.DOTALL)
+    if not match:
+        return fallback_title, fallback_body
+    title = match.group(1).strip()
+    body = match.group(2).strip()
+    if not title or not body:
+        return fallback_title, fallback_body
+    return title, body

--- a/scripts/developer_tools/n_review_issue.py
+++ b/scripts/developer_tools/n_review_issue.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / ".github" / "script
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from deepseek_review import fetch_deepseek_review  # noqa: E402
 from github_repo import get_repo_info  # noqa: E402
+from issue_review import parse_review_response  # noqa: E402
 from ollama_common import (  # noqa: E402
     fetch_ollama_review,
     get_ollama_endpoint,
@@ -146,20 +147,6 @@ def build_review_prompt(title: str, body: str, feedback: str | None = None) -> s
     return REVIEW_PROMPT_TEMPLATE.format(
         title=title, body=body, sections=sections, feedback_section=feedback_section
     )
-
-
-def parse_review_response(
-    response: str, fallback_title: str, fallback_body: str
-) -> tuple[str, str]:
-    """Parse the model's TITLE/BODY response, falling back to the originals on any mismatch."""
-    match = re.search(r"TITLE:\s*(.*?)\s*\nBODY:\s*\n?(.*)", response, re.DOTALL)
-    if not match:
-        return fallback_title, fallback_body
-    title = match.group(1).strip()
-    body = match.group(2).strip()
-    if not title or not body:
-        return fallback_title, fallback_body
-    return title, body
 
 
 def run_review(


### PR DESCRIPTION
## Summary
- `b_create_issue.py` had its own copy of `get_repo_info`, duplicating `lib/github_repo.py`'s implementation (already used by `n_review_issue.py`) — now both import the shared helper.
- `parse_review_response` was byte-for-byte identical in both `b_create_issue.py` and `n_review_issue.py` — extracted to a new `lib/issue_review.py` and imported by both.
- No behavior, CLI, or user-experience changes to either script.

## Test plan
- [x] `pytest tests/test_create_issue.py tests/scripts/test_n_review_issue.py tests/test_work_on_issue.py tests/test_pr_review.py tests/test_publish_pr.py` — 64 passed
- [x] `ruff check`, `black --check` on changed files
- [x] Manually imported both scripts and confirmed `get_repo_info`/`parse_review_response` are the same shared function object
- [x] `n_review_issue.py --help` still works as before

Closes #5759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue review response handling by consistently extracting titles and descriptions.
  * Added fallback handling when responses are incomplete or do not follow the expected format.
  * Standardised issue creation and review workflows for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->