### PR TITLE
Add Playwright visual regression test for active nav state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
         run: npx playwright install --with-deps chromium
         working-directory: frontend
       - name: Run frontend smoke tests
-        run: npx playwright test --config playwright.config.ts tests/smoke.spec.ts
+        run: npx playwright test --config playwright.config.ts tests/smoke.spec.ts tests/navActiveState.spec.ts
         working-directory: frontend
       - name: Upload Playwright smoke-test artifacts
         if: failure()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "coverage": "vitest run --coverage",
     "test:jsdom": "vitest --environment=jsdom",
     "type-check": "tsc -b --noEmit",
-    "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts tests/cognito-auth-flow.spec.ts tests/responsive-layout.spec.ts",
+    "smoke:frontend": "npm run build:preview && playwright install chromium && playwright test --config playwright.config.ts tests/smoke.spec.ts tests/cognito-auth-flow.spec.ts tests/responsive-layout.spec.ts tests/navActiveState.spec.ts",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){require('husky').install();}\"",
     "deploy:aws": "powershell -ExecutionPolicy Bypass -File scripts/deploy-to-aws.ps1 -BucketName $env:S3_BUCKET -DistributionId $env:CLOUDFRONT_DISTRIBUTION_ID",
     "deploy:aws:linux": "bash scripts/deploy-to-aws.sh -b $S3_BUCKET ${CLOUDFRONT_DISTRIBUTION_ID:+-d $CLOUDFRONT_DISTRIBUTION_ID}",

--- a/frontend/tests/navActiveState.spec.ts
+++ b/frontend/tests/navActiveState.spec.ts
@@ -1,0 +1,158 @@
+import { expect, test, type Page } from '@playwright/test';
+import {
+  applyAuth as applyAuthToken,
+  DEFAULT_CONFIG_BODY,
+  DEFAULT_GROUPS_BODY,
+  DEFAULT_OWNERS_BODY,
+  getActiveRouteMarker,
+} from './support/smokeFixtures';
+
+// Regression coverage for #5735 / PR #5741: an unlayered `button` reset in
+// index.css previously outranked Tailwind's utilities layer, so the active
+// nav category button rendered dark text on a near-black background in both
+// themes. These tests assert the actual computed styles (not just class
+// names) so a future change to the cascade layer or Menu.tsx that
+// reintroduces the regression fails loudly here rather than only being
+// caught by eyeballing a screenshot.
+
+const baseUrl = process.env.SMOKE_URL ?? 'http://localhost:5173';
+const authToken =
+  process.env.SMOKE_AUTH_TOKEN ?? process.env.TEST_ID_TOKEN ?? null;
+const marketPath = new URL('/market', baseUrl).toString();
+
+const applyAuth = (page: Page) => applyAuthToken(page, authToken);
+
+// getComputedStyle can return colors in whatever notation the CSS declared
+// them in (Tailwind v4 emits oklch()), so normalise via a 1x1 canvas — the
+// canvas 2D context always reports back-converted sRGB regardless of the
+// input color space/function.
+const toRgbString = (page: Page, color: string): Promise<string> =>
+  page.evaluate((value) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const ctx = canvas.getContext('2d')!;
+    ctx.fillStyle = value;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+    return `rgb(${r}, ${g}, ${b})`;
+  }, color);
+
+// Reads the computed background/text/border colors that Tailwind's
+// `bg-gray-100 text-gray-900 border-blue-600` utility classes resolve to in
+// the current theme, via a throwaway off-screen element — avoids hard-coding
+// palette values that would drift if Tailwind's color space/version changes.
+const referenceActiveClassColors = (page: Page) =>
+  page.evaluate(() => {
+    const el = document.createElement('div');
+    el.className = 'bg-gray-100 text-gray-900 border-blue-600 border-b-2';
+    el.style.position = 'absolute';
+    el.style.visibility = 'hidden';
+    document.body.appendChild(el);
+    const computed = getComputedStyle(el);
+    const result = {
+      backgroundColor: computed.backgroundColor,
+      color: computed.color,
+      borderBottomColor: computed.borderBottomColor,
+    };
+    el.remove();
+    return result;
+  });
+
+const mockIdentityCatalogue = async (page: Page, theme: 'light' | 'dark') => {
+  await page.route('**/config', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ...DEFAULT_CONFIG_BODY, theme }),
+    });
+  });
+  await page.route('**/owners', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(DEFAULT_OWNERS_BODY),
+    });
+  });
+  await page.route('**/groups', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(DEFAULT_GROUPS_BODY),
+    });
+  });
+};
+
+// Relative luminance / contrast ratio per the WCAG 2.x formula, computed
+// from `rgb(r, g, b)` strings as returned by getComputedStyle.
+const relativeLuminance = (rgb: string): number => {
+  const [r, g, b] = rgb
+    .match(/[\d.]+/g)!
+    .slice(0, 3)
+    .map(Number)
+    .map((channel) => {
+      const c = channel / 255;
+      return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const contrastRatio = (foreground: string, background: string): number => {
+  const l1 = relativeLuminance(foreground);
+  const l2 = relativeLuminance(background);
+  const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+test.describe('nav active state contrast (#5754)', () => {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`the active dashboard nav trigger is styled and legible in the ${theme} theme`, async ({
+      page,
+    }) => {
+      await applyAuth(page);
+      await mockIdentityCatalogue(page, theme);
+
+      await page.goto(marketPath);
+
+      const marker = getActiveRouteMarker(page);
+      await expect(marker).toHaveAttribute('data-mode', 'market');
+
+      // "market" belongs to the "dashboard" menu category, so its trigger
+      // button is active (containsActiveTab) without opening the dropdown.
+      const trigger = page.locator('#menu-trigger-dashboard');
+      await expect(trigger).toBeVisible();
+
+      const rawStyles = await trigger.evaluate((el) => {
+        const computed = getComputedStyle(el);
+        return {
+          backgroundColor: computed.backgroundColor,
+          color: computed.color,
+          borderBottomColor: computed.borderBottomColor,
+          borderBottomWidth: computed.borderBottomWidth,
+        };
+      });
+
+      const [backgroundColor, color, borderBottomColor] = await Promise.all([
+        toRgbString(page, rawStyles.backgroundColor),
+        toRgbString(page, rawStyles.color),
+        toRgbString(page, rawStyles.borderBottomColor),
+      ]);
+
+      const expected = await referenceActiveClassColors(page);
+      const [expectedBg, expectedColor, expectedBorder] = await Promise.all([
+        toRgbString(page, expected.backgroundColor),
+        toRgbString(page, expected.color),
+        toRgbString(page, expected.borderBottomColor),
+      ]);
+
+      expect(backgroundColor).toBe(expectedBg);
+      expect(color).toBe(expectedColor);
+      expect(borderBottomColor).toBe(expectedBorder);
+      expect(rawStyles.borderBottomWidth).toBe('2px');
+
+      // WCAG AA for normal-weight text requires a contrast ratio >= 4.5:1.
+      const ratio = contrastRatio(color, backgroundColor);
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `frontend/tests/navActiveState.spec.ts`, a Playwright test asserting the active dashboard nav trigger's computed `background-color`, `color`, and `border-bottom-color`/`border-bottom-width` in both light and dark themes, plus a WCAG AA contrast-ratio check between text and background.
- Colors are asserted against a live-rendered reference element carrying the same Tailwind utility classes (`bg-gray-100 text-gray-900 border-blue-600 border-b-2`) rather than hard-coded hex/oklch values, and normalized to RGB via an offscreen canvas so the test is resilient to Tailwind's color-space/version changes.
- Wires the new spec into `.github/workflows/ci.yml`'s frontend smoke-test step and into the `smoke:frontend` npm script, so it runs in CI on every PR.

Guards against the near-invisible active-tab regression from #5735 (fixed in PR #5741) reoccurring silently — verified locally that the test passes with the current `Menu.tsx`/`index.css` and fails when the active-state classes are reverted to the pre-fix styling.

## Test plan
- [x] `npx playwright test tests/navActiveState.spec.ts` passes against the current build (light + dark)
- [x] Confirmed the test fails when `Menu.tsx`'s active-state classes are reverted to the pre-#5741 styling, then restored and re-verified passing
- [x] `npx eslint --max-warnings=0 tests/navActiveState.spec.ts` clean
- [x] `npx tsc -b --noEmit` clean
- [x] `npx prettier --check` clean

Closes #5754

🤖 Generated with [Claude Code](https://claude.com/claude-code)