### PR TITLE
Load DEEPSEEK_API_KEY from repo-root .env in o_review_issue.py

### DIFF
--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -33,6 +33,24 @@ from ollama_common import (  # noqa: E402
     validate_ollama_connection,
 )
 
+REPO_ROOT_ENV_FILE = Path(__file__).parent.parent.parent / ".env"
+
+
+def load_env_file(env_path: Path = REPO_ROOT_ENV_FILE) -> None:
+    """Load local dev secrets (e.g. DEEPSEEK_API_KEY) from a repo-root .env file.
+
+    CI sets these as real env vars instead, so a missing .env or missing
+    python-dotenv is fine -- this only helps local, interactive runs.
+    """
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return
+    load_dotenv(env_path)
+
+
+load_env_file()
+
 LOCAL = "local"
 CLOUD = "cloud"
 

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import scripts.developer_tools.o_review_issue as n
 
@@ -56,6 +57,22 @@ def test_run_review_local_returns_response(monkeypatch):
         n, "fetch_ollama_review", lambda endpoint, model, prompt: "TITLE: t\nBODY:\nb"
     )
     assert n.run_review(n.LOCAL, "title", "body") == "TITLE: t\nBODY:\nb"
+
+
+def test_load_env_file_sets_missing_vars(monkeypatch, tmp_path):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text("DEEPSEEK_API_KEY=from-env-file\n", encoding="utf-8")
+    n.load_env_file(env_file)
+    # Register with monkeypatch so it's still tracked for auto-cleanup after the test.
+    monkeypatch.setenv("DEEPSEEK_API_KEY", os.environ["DEEPSEEK_API_KEY"])
+    assert os.environ["DEEPSEEK_API_KEY"] == "from-env-file"
+
+
+def test_load_env_file_missing_file_is_a_noop(monkeypatch, tmp_path):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    n.load_env_file(tmp_path / "does_not_exist.env")
+    assert "DEEPSEEK_API_KEY" not in os.environ
 
 
 def test_run_review_cloud_returns_none_without_api_key(monkeypatch):

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+import pytest
+
 import scripts.developer_tools.o_review_issue as n
 
 
@@ -60,6 +62,9 @@ def test_run_review_local_returns_response(monkeypatch):
 
 
 def test_load_env_file_sets_missing_vars(monkeypatch, tmp_path):
+    # python-dotenv is a dev-only dependency (requirements-dev.txt); some CI jobs
+    # install only backend/requirements.txt, where load_env_file is a documented no-op.
+    pytest.importorskip("dotenv")
     monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     env_file = tmp_path / ".env"
     env_file.write_text("DEEPSEEK_API_KEY=from-env-file\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- `o_review_issue.py`'s cloud (DeepSeek) path only read `os.environ`, so a key present in the repo's `.env` file was silently ignored unless the shell had it exported manually — matching the exact repro in the issue.
- Adds `load_env_file()`, called at import time, which loads `python-dotenv` (already a dev dependency, used the same way in `scripts/site_snapshot.py`) against the repo-root `.env` and is a no-op if the package or file is missing (CI sets real env vars instead).

## Test plan
- [x] `python -m pytest tests/scripts/test_o_review_issue.py -q` — 28 passed (2 new tests covering `load_env_file`)
- [x] `python -m ruff check` / `python -m black --check` on both changed files
- [x] Manually verified `DEEPSEEK_API_KEY` from the repo's local `.env` is now visible in `os.environ` after importing the module

Closes #5773

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically loading environment settings from a repository `.env` file during local development.
  * Missing optional configuration support is handled gracefully.

* **Tests**
  * Added coverage for loading settings from existing `.env` files and safely ignoring missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->