### PR TITLE
Add local/cloud LLM support to remaining developer_tools scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -273,11 +273,12 @@ bash scripts/bash/publish-pr.sh -m "Fix bug in auth" --no-ollama
 
 ## developer_tools/lib/commit_and_push.py
 
-Commit local changes and push to `origin`, using a local Ollama model to draft
-the commit message from the diff. This is a lighter-weight alternative to
-`publish_pr.py` for when you just want to commit and push -- e.g. an
-incremental push onto a branch that already has an open PR -- without also
-creating/updating a PR.
+Commit local changes and push to `origin`, using a local or cloud LLM (via
+`developer_tools/lib/llm_common.py`, same local/cloud switch as
+`n_review_issue.py`) to draft the commit message from the diff. This is a
+lighter-weight alternative to `publish_pr.py` for when you just want to commit
+and push -- e.g. an incremental push onto a branch that already has an open
+PR -- without also creating/updating a PR.
 
 ```bash
 python scripts/developer_tools/lib/commit_and_push.py
@@ -285,16 +286,17 @@ python scripts/developer_tools/lib/commit_and_push.py
 
 The script:
 1. Stages changed files (all changes by default, or specific files via `--files`)
-2. If Ollama is running locally, asks it to draft a commit message from the staged diff
-3. If Ollama is unavailable or `--no-ollama` is passed, falls back to a plain default message
+2. Asks the chosen model (`local` Ollama by default, or `cloud` DeepSeek via `--model-source cloud`) to draft a commit message from the staged diff
+3. If that model is unavailable or `--no-llm` is passed, falls back to a plain default message
 4. Appends a `Refs #<issue-id>` trailer with the issue ID extracted from the branch name (e.g. `fix/issue-4445-slug` -> `4445`), if one isn't already present in the message
 5. Commits, then pushes the branch to `origin` (skip with `--no-push`)
 
 Optional flags:
-- `-m/--message TEXT`: Commit message override (skips Ollama generation)
+- `-m/--message TEXT`: Commit message override (skips LLM generation)
 - `-f/--files FILE [FILE ...]`: Specific files to stage (default: all changed files)
-- `--no-ollama`: Skip Ollama and use a plain default commit message
-- `--model MODEL`: Ollama model name (default: env var `OLLAMA_MODEL` or `qwen2.5-coder:7b`)
+- `--no-llm` (alias `--no-ollama`): Skip the LLM and use a plain default commit message
+- `--model-source {local,cloud}`: Which model to use (default: `local`)
+- `--model MODEL`: Ollama model name, only used with `--model-source local` (default: env var `OLLAMA_MODEL` or `qwen2.5-coder:7b`)
 - `--no-push`: Commit only; skip pushing to `origin`
 
 On Windows, use the PowerShell wrapper:
@@ -308,7 +310,7 @@ bash scripts/bash/commit-and-push.sh -m "Fix bug in auth" --no-ollama
 ```
 
 **Requirements:**
-- Ollama is optional but recommended for better commit messages; without it (or with `--no-ollama`), a plain default message is used
+- A model is optional but recommended for better commit messages; without one reachable (or with `--no-llm`), a plain default message is used. `--model-source cloud` requires `DEEPSEEK_API_KEY`.
 
 ## m_dependabot_auto_merge.py
 
@@ -451,7 +453,12 @@ Review and refresh a single GitHub issue with a local or cloud LLM before work
 starts on it, so a stale or vague issue gets corrected instead of misread.
 Fetches the issue, asks the chosen model to bring the title/body up to date
 while preserving the original section structure, shows a diff of the proposed
-change, and only calls `gh issue edit` after you approve it.
+change, and only calls `gh issue edit` after you approve it. The local/cloud
+model switch lives in `developer_tools/lib/llm_common.py` and is shared by
+`b_create_issue.py`, `c_triage_issues.py`, `h_local_review.py`,
+`k_pr_review.py`, and `lib/commit_and_push.py` -- all of them accept
+`--model-source {local,cloud}` (or, for `b_create_issue.py`, an interactive
+prompt) to pick the same way.
 
 ```bash
 python scripts/developer_tools/o_review_issue.py 5695

--- a/scripts/developer_tools/b_create_issue.py
+++ b/scripts/developer_tools/b_create_issue.py
@@ -17,11 +17,11 @@ import requests
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from github_repo import get_repo_info
 from issue_review import parse_review_response
-from ollama_common import (
-    fetch_ollama_review,
-    get_ollama_endpoint,
-    get_ollama_model,
-    validate_ollama_connection,
+from llm_common import (
+    describe_model_source,
+    fetch_review,
+    prompt_for_model_source,
+    validate_model_source,
 )
 
 GITHUB_API_BASE = "https://api.github.com"
@@ -350,35 +350,26 @@ def build_review_prompt(title: str, body: str) -> str:
     )
 
 
-def offer_local_llm_review(title: str, body: str) -> tuple[str, str]:
-    """Optionally send the draft issue to a local Ollama model for review.
+def offer_llm_review(title: str, body: str) -> tuple[str, str]:
+    """Optionally send the draft issue to a local or cloud LLM for review.
 
     Returns the (possibly improved) title and body. Falls back to the
-    originals if the user declines, Ollama is unreachable, or the response
-    can't be parsed.
+    originals if the user declines, the chosen model is unreachable, or the
+    response can't be parsed.
     """
     try:
-        use_llm = (
-            input("\nUse local LLM (ollama) to review and improve this issue? [Y/n] ")
-            .strip()
-            .lower()
-        )
+        use_llm = input("\nUse an LLM to review and improve this issue? [Y/n] ").strip().lower()
     except EOFError:
         use_llm = ""
     if use_llm not in ("y", "yes", ""):
         return title, body
 
-    endpoint = get_ollama_endpoint()
-    model = get_ollama_model()
-
-    if not validate_ollama_connection(endpoint):
-        print(
-            f"WARNING: Could not reach Ollama at {endpoint}; skipping LLM review.", file=sys.stderr
-        )
+    model_source = prompt_for_model_source()
+    if not validate_model_source(model_source):
         return title, body
 
-    print(f"Reviewing with {model} at {endpoint}...")
-    response = fetch_ollama_review(endpoint, model, build_review_prompt(title, body))
+    print(f"Reviewing with {describe_model_source(model_source)}...")
+    response = fetch_review(model_source, build_review_prompt(title, body))
     if not response.strip():
         print("WARNING: LLM review returned no content; keeping original issue.", file=sys.stderr)
         return title, body
@@ -517,8 +508,8 @@ def main() -> None:
     else:
         body = format_feature_body(sections)
 
-    # Optionally improve with a local LLM before creating
-    title, body = offer_local_llm_review(title, body)
+    # Optionally improve with an LLM before creating
+    title, body = offer_llm_review(title, body)
 
     # Confirm and create
     confirm_and_create(owner, repo, title, body, labels, token)

--- a/scripts/developer_tools/c_triage_issues.py
+++ b/scripts/developer_tools/c_triage_issues.py
@@ -1,10 +1,11 @@
-"""CLI tool to triage unmilestoned open issues using a local Ollama model.
+"""CLI tool to triage unmilestoned open issues using a local or cloud LLM.
 
 Continues the a_/b_/c_/.../o_ script chain in scripts/developer_tools/. Replaces the
-hosted "allotmint-issue-triage" scheduled cloud-agent task: a local model (driven via
-lib/ollama_common.py, same pattern as i_local_review.py/l_pr_review.py) classifies
-open, unmilestoned issues and this script drives the resulting `gh issue` calls
-directly, so the routine no longer needs a hosted-Claude scheduled session.
+hosted "allotmint-issue-triage" scheduled cloud-agent task: a model (local Ollama or
+cloud DeepSeek, driven via lib/llm_common.py, same pattern as
+i_local_review.py/l_pr_review.py/o_review_issue.py) classifies open, unmilestoned
+issues and this script drives the resulting `gh issue` calls directly, so the routine
+no longer needs a hosted-Claude scheduled session.
 
 Rules ported from the scheduled-task prompt:
   - Only issues with no milestone are ever touched; already-milestoned issues are
@@ -30,11 +31,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from ollama_common import (  # noqa: E402
-    fetch_ollama_review,
-    get_ollama_endpoint,
-    get_ollama_model,
-    validate_ollama_connection,
+from llm_common import (  # noqa: E402
+    add_model_source_arg,
+    describe_model_source,
+    fetch_review,
+    validate_model_source,
 )
 
 REPO_OWNER = "leonarduk"
@@ -43,9 +44,13 @@ CONSOLIDATOR_MILESTONE = "Backend Hardening & Test Coverage"
 GH_RETRY_ATTEMPTS = 3
 GH_RETRY_BACKOFF_SECONDS = 2
 
-SCOPE_APART_PATTERN = re.compile(r"(?:tracked separately as|out of scope:?)\s*#(\d+)", re.IGNORECASE)
+SCOPE_APART_PATTERN = re.compile(
+    r"(?:tracked separately as|out of scope:?)\s*#(\d+)", re.IGNORECASE
+)
 ISSUE_REF_PATTERN = re.compile(r"#(\d+)")
-CLASSIFICATION_LINE_PATTERN = re.compile(r"#(\d+):\s*(DUPLICATE|FOLD|STANDALONE|NEW_FEATURE)", re.IGNORECASE)
+CLASSIFICATION_LINE_PATTERN = re.compile(
+    r"#(\d+):\s*(DUPLICATE|FOLD|STANDALONE|NEW_FEATURE)", re.IGNORECASE
+)
 
 
 @dataclass
@@ -116,8 +121,14 @@ def fetch_unmilestoned_open_issues(verbose: bool = False) -> list[Issue]:
         if item.get("milestone") is not None:
             continue
         labels = [label["name"] for label in item.get("labels", [])]
-        issues.append(Issue(number=item["number"], title=item["title"],
-                            labels=labels, body=item.get("body") or ""))
+        issues.append(
+            Issue(
+                number=item["number"],
+                title=item["title"],
+                labels=labels,
+                body=item.get("body") or "",
+            )
+        )
 
     return issues
 
@@ -209,14 +220,17 @@ def build_group_classification_prompt(group: list[Issue]) -> str:
 
 def parse_classifications(response: str) -> dict[int, str]:
     """Parse the model's '#N: CLASSIFICATION' lines into a {number: classification} map."""
-    return {int(m.group(1)): m.group(2).upper() for m in CLASSIFICATION_LINE_PATTERN.finditer(response)}
+    return {
+        int(m.group(1)): m.group(2).upper() for m in CLASSIFICATION_LINE_PATTERN.finditer(response)
+    }
 
 
-def classify_single_issue(issue: Issue, model: str, endpoint: str, verbose: bool = False) -> str:
+def classify_single_issue(issue: Issue, model_source: str, verbose: bool = False) -> str:
     """Classify a standalone issue as NEW_FEATURE or BACKLOG."""
-    prompt = SINGLE_CLASSIFY_PROMPT_TEMPLATE.format(number=issue.number, title=issue.title,
-                                                    body=issue.body.strip())
-    response = fetch_ollama_review(endpoint, model, prompt)
+    prompt = SINGLE_CLASSIFY_PROMPT_TEMPLATE.format(
+        number=issue.number, title=issue.title, body=issue.body.strip()
+    )
+    response = fetch_review(model_source, prompt)
     if verbose:
         print(f"[VERBOSE] Model response for issue #{issue.number}: {response}", file=sys.stderr)
     return "NEW_FEATURE" if "NEW_FEATURE" in response.upper() else "BACKLOG"
@@ -294,11 +308,12 @@ def create_consolidator_issue(title: str, folded: list[Issue], dry_run: bool) ->
     return int(match.group(1)) if match else None
 
 
-def triage_group(group: list[Issue], model: str, endpoint: str, dry_run: bool,
-                 verbose: bool = False) -> set[int]:
+def triage_group(
+    group: list[Issue], model_source: str, dry_run: bool, verbose: bool = False
+) -> set[int]:
     """Classify and act on one candidate group. Returns the issue numbers it handled."""
     prompt = build_group_classification_prompt(group)
-    response = fetch_ollama_review(endpoint, model, prompt)
+    response = fetch_review(model_source, prompt)
     if verbose:
         print(f"[VERBOSE] Model response for group {group}: {response}", file=sys.stderr)
     classifications = parse_classifications(response)
@@ -325,18 +340,21 @@ def triage_group(group: list[Issue], model: str, endpoint: str, dry_run: bool,
         title = f"Consolidated follow-ups: {fold_candidates[0].title}"
         consolidator_number = create_consolidator_issue(title, fold_candidates, dry_run)
         for issue in fold_candidates:
-            reference = f"#{consolidator_number}" if consolidator_number else "a new consolidator issue"
+            reference = (
+                f"#{consolidator_number}" if consolidator_number else "a new consolidator issue"
+            )
             close_issue(issue.number, f"Folded into {reference}.", dry_run)
             handled.add(issue.number)
 
     return handled
 
 
-def triage_remaining(issues: list[Issue], model: str, endpoint: str, dry_run: bool,
-                     verbose: bool = False) -> None:
+def triage_remaining(
+    issues: list[Issue], model_source: str, dry_run: bool, verbose: bool = False
+) -> None:
     """Classify every issue not already handled by group triage, then act on it."""
     for issue in issues:
-        classification = classify_single_issue(issue, model, endpoint, verbose)
+        classification = classify_single_issue(issue, model_source, verbose)
         if classification == "NEW_FEATURE":
             comment_new_feature(issue.number, dry_run)
         else:
@@ -345,7 +363,9 @@ def triage_remaining(issues: list[Issue], model: str, endpoint: str, dry_run: bo
 
 def main() -> int:
     """Run the issue-triage flow."""
-    parser = argparse.ArgumentParser(description="Triage open, unmilestoned issues using a local Ollama model")
+    parser = argparse.ArgumentParser(
+        description="Triage open, unmilestoned issues using a local or cloud LLM"
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -362,16 +382,11 @@ def main() -> int:
         default=None,
         help="Only consider the first N unmilestoned issues (useful for testing)",
     )
+    add_model_source_arg(parser)
     args = parser.parse_args()
 
-    endpoint = get_ollama_endpoint()
-    if not validate_ollama_connection(endpoint):
-        print(
-            f"ERROR: Ollama is not reachable at {endpoint}. Please start Ollama or set OLLAMA_ENDPOINT.",
-            file=sys.stderr,
-        )
+    if not validate_model_source(args.model_source):
         return 1
-    model = get_ollama_model()
 
     print(
         f"INFO: Fetching unmilestoned open issues from {REPO_OWNER}/{REPO_NAME}...",
@@ -382,15 +397,15 @@ def main() -> int:
         issues = issues[: args.limit]
     print(f"INFO: {len(issues)} unmilestoned open issues found", file=sys.stderr)
 
-    print(f"INFO: Using Ollama model '{model}' at {endpoint}", file=sys.stderr)
+    print(f"INFO: Using {describe_model_source(args.model_source)}", file=sys.stderr)
 
     groups = find_candidate_groups(issues)
     handled: set[int] = set()
     for group in groups:
-        handled |= triage_group(group, model, endpoint, args.dry_run, args.verbose)
+        handled |= triage_group(group, args.model_source, args.dry_run, args.verbose)
 
     remaining = [issue for issue in issues if issue.number not in handled]
-    triage_remaining(remaining, model, endpoint, args.dry_run, args.verbose)
+    triage_remaining(remaining, args.model_source, args.dry_run, args.verbose)
 
     return 0
 

--- a/scripts/developer_tools/i_local_review.py
+++ b/scripts/developer_tools/i_local_review.py
@@ -1,8 +1,9 @@
-"""CLI tool to review uncommitted local changes using Ollama.
+"""CLI tool to review uncommitted local changes using a local or cloud LLM.
 
 Compares the current working directory (including uncommitted changes)
 against the target branch (default: main) and generates a markdown report
-with the Ollama review.
+with the review from the chosen model (local Ollama or cloud DeepSeek, via
+lib/llm_common.py).
 """
 
 from __future__ import annotations
@@ -14,16 +15,16 @@ import sys
 from pathlib import Path
 
 # Add .github/scripts (for review_common) and the local lib/ dir (for
-# ollama_common) to sys.path so this works both as an importable module and
+# llm_common) to sys.path so this works both as an importable module and
 # when invoked directly (e.g. `python scripts/developer_tools/i_local_review.py`),
 # where the repo root is not on sys.path and `scripts` is not importable.
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / ".github" / "scripts"))
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from ollama_common import (
-    fetch_ollama_review,
-    get_ollama_endpoint,
-    get_ollama_model,
-    validate_ollama_connection,
+from llm_common import (
+    add_model_source_arg,
+    describe_model_source,
+    fetch_review,
+    validate_model_source,
 )
 from review_common import build_prompt, truncate_diff
 
@@ -144,7 +145,8 @@ def save_report(content: str, output_path: str) -> str:
 def main() -> int:
     """Run the local review flow."""
     parser = argparse.ArgumentParser(
-        description="Review uncommitted local changes using Ollama and generate a markdown report"
+        description="Review uncommitted local changes using a local or cloud LLM "
+        "and generate a markdown report"
     )
     parser.add_argument(
         "--branch",
@@ -161,19 +163,12 @@ def main() -> int:
         action="store_true",
         help="Print review to stdout instead of saving to file",
     )
+    add_model_source_arg(parser)
     args = parser.parse_args()
 
-    # Validate Ollama is reachable
-    endpoint = get_ollama_endpoint()
-    if not validate_ollama_connection(endpoint):
-        print(
-            f"ERROR: Ollama is not reachable at {endpoint}. "
-            "Please start Ollama or set OLLAMA_ENDPOINT.",
-            file=sys.stderr,
-        )
+    if not validate_model_source(args.model_source):
         return 1
 
-    model = get_ollama_model()
     current_branch = get_current_branch()
 
     # Get local diff
@@ -194,7 +189,7 @@ def main() -> int:
         return 0
 
     # Build prompt and fetch review
-    print(f"INFO: Using Ollama model '{model}'", file=sys.stderr)
+    print(f"INFO: Using {describe_model_source(args.model_source)}", file=sys.stderr)
     prompt = build_prompt(
         pr_title=f"Local changes on {current_branch}",
         diff=diff,
@@ -202,10 +197,10 @@ def main() -> int:
         discussion="",
         verified_facts="",
     )
-    review = fetch_ollama_review(endpoint, model, prompt)
+    review = fetch_review(args.model_source, prompt)
 
     if not review.strip():
-        print("ERROR: Ollama returned an empty review", file=sys.stderr)
+        print("ERROR: Model returned an empty review", file=sys.stderr)
         return 1
 
     # Generate timestamp for report
@@ -216,7 +211,7 @@ def main() -> int:
         review=review,
         target_branch=args.branch,
         current_branch=current_branch,
-        model=model,
+        model=describe_model_source(args.model_source),
         diff_size=len(diff),
         timestamp=timestamp,
     )

--- a/scripts/developer_tools/j_commit_and_push.ps1
+++ b/scripts/developer_tools/j_commit_and_push.ps1
@@ -3,6 +3,8 @@ param(
     [string[]]$Files = $null,
     [switch]$NoOllama = $false,
     [string]$Model = $null,
+    [ValidateSet('local', 'cloud')]
+    [string]$ModelSource = $null,
     [switch]$NoPush = $false
 )
 
@@ -31,6 +33,10 @@ if ($NoOllama) {
 
 if ($Model) {
     $pythonArgs += "--model", $Model
+}
+
+if ($ModelSource) {
+    $pythonArgs += "--model-source", $ModelSource
 }
 
 if ($NoPush) {

--- a/scripts/developer_tools/l_pr_review.py
+++ b/scripts/developer_tools/l_pr_review.py
@@ -1,7 +1,8 @@
-"""CLI tool to review a GitHub PR using local Ollama.
+"""CLI tool to review a GitHub PR using a local or cloud LLM.
 
-Takes a PR ID and calls Ollama to generate an advisory review, reusing the
-shared review_common infrastructure. Requires gh CLI for fetching PR details.
+Takes a PR ID and calls the chosen model (local Ollama or cloud DeepSeek,
+via lib/llm_common.py) to generate an advisory review, reusing the shared
+review_common infrastructure. Requires gh CLI for fetching PR details.
 """
 
 from __future__ import annotations
@@ -14,16 +15,16 @@ import sys
 from pathlib import Path
 
 # Add .github/scripts (for review_common) and the local lib/ dir (for
-# ollama_common) to sys.path so this works both as an importable module and
+# llm_common) to sys.path so this works both as an importable module and
 # when invoked directly (e.g. `python scripts/developer_tools/l_pr_review.py`),
 # where the repo root is not on sys.path and `scripts` is not importable.
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / ".github" / "scripts"))
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from ollama_common import (
-    fetch_ollama_review,
-    get_ollama_endpoint,
-    get_ollama_model,
-    validate_ollama_connection,
+from llm_common import (
+    add_model_source_arg,
+    describe_model_source,
+    fetch_review,
+    validate_model_source,
 )
 from review_common import (
     build_prompt,
@@ -146,25 +147,17 @@ def extract_issue_body(pr_body: str, owner: str, repo: str) -> str:
 
 def main() -> int:
     """Run the PR review flow."""
-    parser = argparse.ArgumentParser(description="Review a GitHub PR using local Ollama")
+    parser = argparse.ArgumentParser(description="Review a GitHub PR using a local or cloud LLM")
     parser.add_argument("pr_id", type=int, help="GitHub PR ID to review")
     parser.add_argument(
         "--repo",
         help="GitHub repository (owner/repo format). Auto-detected from git remote if not provided.",  # noqa: E501
     )
+    add_model_source_arg(parser)
     args = parser.parse_args()
 
-    # Validate Ollama is reachable
-    endpoint = get_ollama_endpoint()
-    if not validate_ollama_connection(endpoint):
-        print(
-            f"ERROR: Ollama is not reachable at {endpoint}. "
-            "Please start Ollama or set OLLAMA_ENDPOINT.",
-            file=sys.stderr,
-        )
+    if not validate_model_source(args.model_source):
         return 1
-
-    model = get_ollama_model()
 
     # Get repo info
     try:
@@ -201,14 +194,14 @@ def main() -> int:
         )
 
     if not diff.strip():
-        return emit_empty_diff_notice("Ollama")
+        return emit_empty_diff_notice(args.model_source)
 
     # Build prompt and fetch review
     prompt = build_prompt(pr_title, diff, issue_body, discussion="", verified_facts="")
-    print(f"INFO: Using Ollama model '{model}'", file=sys.stderr)
-    review = fetch_ollama_review(endpoint, model, prompt)
+    print(f"INFO: Using {describe_model_source(args.model_source)}", file=sys.stderr)
+    review = fetch_review(args.model_source, prompt)
 
-    return finalize_review(review, "ERROR: Ollama returned an empty review")
+    return finalize_review(review, "ERROR: Model returned an empty review")
 
 
 if __name__ == "__main__":

--- a/scripts/developer_tools/lib/commit_and_push.py
+++ b/scripts/developer_tools/lib/commit_and_push.py
@@ -1,10 +1,10 @@
-"""CLI tool to commit local changes and push, using a local LLM for the commit message.
+"""CLI tool to commit local changes and push, using an LLM for the commit message.
 
-Stages local changes, asks a local Ollama model to draft a commit message
-from the diff (falling back to a plain default message when Ollama is
-unavailable or `--no-ollama` is passed), makes sure the message references
-the issue ID found in the current branch name, commits, and pushes the
-branch to `origin`.
+Stages local changes, asks the chosen model (local Ollama or cloud DeepSeek,
+via llm_common.py) to draft a commit message from the diff (falling back to a
+plain default message when that model is unavailable or `--no-llm` is
+passed), makes sure the message references the issue ID found in the current
+branch name, commits, and pushes the branch to `origin`.
 """
 
 from __future__ import annotations
@@ -14,15 +14,15 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from ollama_common import (  # noqa: E402
-    fetch_ollama_review,
-    get_ollama_endpoint,
-    get_ollama_model,
-    validate_ollama_connection,
+from llm_common import (  # noqa: E402
+    LOCAL,
+    add_model_source_arg,
+    describe_model_source,
+    fetch_review,
+    validate_model_source,
 )
 from publish_pr import extract_issue_id, get_current_branch, push_to_remote  # noqa: E402
 
@@ -42,7 +42,7 @@ def get_git_root() -> str:
         raise SystemExit(1) from exc
 
 
-def stage_changes(files: Optional[list[str]]) -> None:
+def stage_changes(files: list[str] | None) -> None:
     """Stage the given files, or all changes (tracked and untracked) if none given."""
     try:
         if files:
@@ -62,7 +62,10 @@ def has_staged_changes() -> bool:
     """
     result = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
     if result.returncode not in (0, 1):
-        print(f"ERROR: 'git diff --cached --quiet' failed with exit code {result.returncode}", file=sys.stderr)
+        print(
+            f"ERROR: 'git diff --cached --quiet' failed with exit code {result.returncode}",
+            file=sys.stderr,
+        )
         raise SystemExit(1)
     return result.returncode == 1
 
@@ -85,8 +88,8 @@ def get_staged_diff() -> str:
 MAX_DIFF_CHARS = 20_000
 
 
-def build_commit_prompt(diff: str, issue_id: Optional[int]) -> str:
-    """Build the Ollama prompt used to draft a commit message from a diff."""
+def build_commit_prompt(diff: str, issue_id: int | None) -> str:
+    """Build the prompt used to draft a commit message from a diff."""
     issue_line = (
         f"Reference issue #{issue_id} in the message (e.g. a trailing 'Refs #{issue_id}' line)."
         if issue_id
@@ -107,19 +110,19 @@ Diff:
 """
 
 
-def generate_commit_message(diff: str, issue_id: Optional[int], model: str, endpoint: str) -> Optional[str]:
-    """Ask Ollama to draft a commit message. Returns None on failure or empty diff."""
+def generate_commit_message(diff: str, issue_id: int | None, model_source: str) -> str | None:
+    """Ask the chosen model to draft a commit message. Returns None on failure or empty diff."""
     if not diff.strip():
         return None
     prompt = build_commit_prompt(diff, issue_id)
     try:
-        message = fetch_ollama_review(endpoint, model, prompt)
+        message = fetch_review(model_source, prompt)
     except SystemExit:
         return None
     return message.strip() or None
 
 
-def ensure_issue_reference(message: str, issue_id: Optional[int]) -> str:
+def ensure_issue_reference(message: str, issue_id: int | None) -> str:
     """Append a 'Refs #<issue_id>' trailer if the message doesn't already mention it."""
     if issue_id is None:
         return message
@@ -142,13 +145,13 @@ def commit_changes(message: str) -> bool:
 def build_arg_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(
-        description="Commit local changes (with an Ollama-drafted message) and push to origin"
+        description="Commit local changes (with an LLM-drafted message) and push to origin"
     )
     parser.add_argument(
         "--message",
         "-m",
         default=None,
-        help="Commit message override (skips Ollama generation)",
+        help="Commit message override (skips LLM generation)",
     )
     parser.add_argument(
         "--files",
@@ -158,15 +161,21 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Specific files to stage (default: all changed files)",
     )
     parser.add_argument(
+        "--no-llm",
         "--no-ollama",
+        dest="no_llm",
         action="store_true",
-        help="Skip Ollama and use a plain default commit message",
+        help="Skip the LLM and use a plain default commit message",
     )
     parser.add_argument(
         "--model",
         default=None,
-        help="Ollama model name (default: OLLAMA_MODEL env var or 'qwen2.5-coder:7b')",
+        help=(
+            "Ollama model name, only used when --model-source=local "
+            "(default: OLLAMA_MODEL env var or 'qwen2.5-coder:7b')"
+        ),
     )
+    add_model_source_arg(parser)
     parser.add_argument(
         "--no-push",
         action="store_true",
@@ -178,6 +187,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
 def main() -> int:
     """Stage, commit, and optionally push changes based on CLI arguments."""
     args = build_arg_parser().parse_args()
+
+    if args.model and args.model_source == LOCAL:
+        os.environ["OLLAMA_MODEL"] = args.model
 
     os.chdir(get_git_root())
 
@@ -191,15 +203,17 @@ def main() -> int:
         return 0
 
     message = args.message
-    if not message and not args.no_ollama:
-        endpoint = get_ollama_endpoint()
-        if validate_ollama_connection(endpoint):
-            model = args.model or get_ollama_model()
-            print(f"INFO: Generating commit message with Ollama model '{model}'...", file=sys.stderr)
+    if not message and not args.no_llm:
+        if validate_model_source(args.model_source):
+            print(
+                f"INFO: Generating commit message with "
+                f"{describe_model_source(args.model_source)}...",
+                file=sys.stderr,
+            )
             diff = get_staged_diff()
-            message = generate_commit_message(diff, issue_id, model, endpoint)
+            message = generate_commit_message(diff, issue_id, args.model_source)
         else:
-            print(f"WARNING: Ollama not reachable at {endpoint}. Using a default message.", file=sys.stderr)
+            print("WARNING: Model unavailable. Using a default message.", file=sys.stderr)
 
     if not message:
         message = f"Work on issue #{issue_id}" if issue_id else "Commit local changes"

--- a/scripts/developer_tools/lib/llm_common.py
+++ b/scripts/developer_tools/lib/llm_common.py
@@ -1,0 +1,105 @@
+"""Shared local/cloud model dispatch for developer_tools scripts.
+
+n_review_issue.py (#5721) introduced a LOCAL/CLOUD model-source switch that let
+a script fall back to a cloud model (DeepSeek) when a heavier review benefits
+from it. This module centralizes that switch -- the argparse wiring, the
+interactive prompt, connection/credential validation, and the actual
+dispatch -- so every other developer_tools script that calls an LLM (issue
+creation, issue triage, local/PR review, commit-message generation) can offer
+the same choice without re-implementing it (#5768).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Add .github/scripts (for deepseek_review) to sys.path so this works both as
+# an importable module and when a caller script is invoked directly, where the
+# repo root is not on sys.path. ollama_common is a sibling in this same lib/
+# dir, so it needs no path insertion.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / ".github" / "scripts"))
+from deepseek_review import fetch_deepseek_review  # noqa: E402
+from ollama_common import (  # noqa: E402
+    fetch_ollama_review,
+    get_ollama_endpoint,
+    get_ollama_model,
+    validate_ollama_connection,
+)
+
+LOCAL = "local"
+CLOUD = "cloud"
+MODEL_SOURCES = (LOCAL, CLOUD)
+
+
+def add_model_source_arg(parser, default: str = LOCAL) -> None:
+    """Add a ``--model-source {local,cloud}`` option to an argparse parser."""
+    parser.add_argument(
+        "--model-source",
+        choices=MODEL_SOURCES,
+        default=default,
+        help=("Which LLM to use: 'local' (Ollama) or 'cloud' (DeepSeek). " f"Default: {default}."),
+    )
+
+
+def prompt_for_model_source() -> str:
+    """Interactively prompt for which model source to use."""
+    print()
+    print("Model source:")
+    print("  [l] Local (Ollama)")
+    print("  [c] Cloud (DeepSeek)")
+    try:
+        choice = input("> ").strip().lower()
+    except EOFError:
+        choice = "l"
+    return CLOUD if choice in ("c", "cloud") else LOCAL
+
+
+def describe_model_source(model_source: str) -> str:
+    """Human-readable description of the chosen model, for INFO logs."""
+    if model_source == LOCAL:
+        return f"local model '{get_ollama_model()}' at {get_ollama_endpoint()}"
+    return "cloud model (DeepSeek)"
+
+
+def validate_model_source(model_source: str) -> bool:
+    """Return True if the chosen model source is actually usable right now.
+
+    Prints an actionable error to stderr and returns False otherwise, so
+    callers can bail out with a single `if not validate_model_source(...)`.
+    """
+    if model_source == LOCAL:
+        endpoint = get_ollama_endpoint()
+        if not validate_ollama_connection(endpoint):
+            print(
+                f"ERROR: Ollama is not reachable at {endpoint}. "
+                "Start Ollama or set OLLAMA_ENDPOINT.",
+                file=sys.stderr,
+            )
+            return False
+        return True
+
+    if not os.environ.get("DEEPSEEK_API_KEY"):
+        print(
+            "ERROR: DEEPSEEK_API_KEY is not set; cannot use the cloud model.",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def fetch_review(model_source: str, prompt: str) -> str:
+    """Dispatch a prompt to the chosen model source and return its response.
+
+    Mirrors `fetch_ollama_review`'s contract: returns "" on an empty/failed
+    response rather than raising, so callers keep a single failure check
+    regardless of which model source is active.
+    """
+    if model_source == LOCAL:
+        endpoint = get_ollama_endpoint()
+        model = get_ollama_model()
+        return fetch_ollama_review(endpoint, model, prompt)
+
+    api_key = os.environ.get("DEEPSEEK_API_KEY", "")
+    return fetch_deepseek_review(api_key, prompt)

--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -18,19 +18,19 @@ import sys
 import tempfile
 from pathlib import Path
 
-# Add .github/scripts (for deepseek_review) and the local lib/ dir (for
-# ollama_common/github_repo) to sys.path so this works both as an importable
-# module and when invoked directly, where the repo root is not on sys.path.
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / ".github" / "scripts"))
+# Add the local lib/ dir (for github_repo/llm_common) to sys.path so this
+# works both as an importable module and when invoked directly, where the
+# repo root is not on sys.path.
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from deepseek_review import fetch_deepseek_review  # noqa: E402
 from github_repo import get_repo_info  # noqa: E402
 from issue_review import parse_review_response  # noqa: E402
-from ollama_common import (  # noqa: E402
-    fetch_ollama_review,
-    get_ollama_endpoint,
-    get_ollama_model,
-    validate_ollama_connection,
+from llm_common import (  # noqa: E402
+    CLOUD,
+    LOCAL,
+    describe_model_source,
+    fetch_review,
+    prompt_for_model_source,
+    validate_model_source,
 )
 
 REPO_ROOT_ENV_FILE = Path(__file__).parent.parent.parent / ".env"
@@ -50,9 +50,6 @@ def load_env_file(env_path: Path = REPO_ROOT_ENV_FILE) -> None:
 
 
 load_env_file()
-
-LOCAL = "local"
-CLOUD = "cloud"
 
 # Below this fraction of the original body length, treat the model's answer as having
 # dropped content rather than genuinely trimmed stale text, and refuse to show it as a
@@ -178,27 +175,10 @@ def run_review(
     """Call the chosen model with the review prompt. Returns None on any failure."""
     prompt = build_review_prompt(title, body, feedback=feedback)
 
-    if model_source == LOCAL:
-        endpoint = get_ollama_endpoint()
-        if not validate_ollama_connection(endpoint):
-            print(
-                f"ERROR: Ollama is not reachable at {endpoint}. "
-                "Start Ollama or set OLLAMA_ENDPOINT.",
-                file=sys.stderr,
-            )
-            return None
-        model = get_ollama_model()
-        print(f"INFO: Reviewing with local model '{model}' at {endpoint}...", file=sys.stderr)
-        response = fetch_ollama_review(endpoint, model, prompt)
-    else:
-        api_key = os.environ.get("DEEPSEEK_API_KEY", "")
-        if not api_key:
-            print(
-                "ERROR: DEEPSEEK_API_KEY is not set; cannot use the cloud model.", file=sys.stderr
-            )
-            return None
-        print("INFO: Reviewing with cloud model (DeepSeek)...", file=sys.stderr)
-        response = fetch_deepseek_review(api_key, prompt)
+    if not validate_model_source(model_source):
+        return None
+    print(f"INFO: Reviewing with {describe_model_source(model_source)}...", file=sys.stderr)
+    response = fetch_review(model_source, prompt)
 
     if verbose:
         print(f"[VERBOSE] Model response:\n{response}", file=sys.stderr)
@@ -311,19 +291,6 @@ def prompt_for_disposition() -> tuple[str, str | None]:
     if lowered in ("n", "no"):
         return "abort", None
     return "retry", raw
-
-
-def prompt_for_model_source() -> str:
-    """Interactively prompt for which model to use."""
-    print()
-    print("Model source:")
-    print("  [l] Local (Ollama)")
-    print("  [c] Cloud (DeepSeek)")
-    try:
-        choice = input("> ").strip().lower()
-    except EOFError:
-        choice = "l"
-    return CLOUD if choice in ("c", "cloud") else LOCAL
 
 
 def main() -> int:

--- a/tests/scripts/test_c_triage_issues.py
+++ b/tests/scripts/test_c_triage_issues.py
@@ -65,15 +65,15 @@ def test_parse_classifications_reads_number_and_label():
 
 
 def test_classify_single_issue_detects_new_feature(monkeypatch):
-    monkeypatch.setattr(h, "fetch_ollama_review", lambda endpoint, model, prompt: "NEW_FEATURE")
+    monkeypatch.setattr(h, "fetch_review", lambda model_source, prompt: "NEW_FEATURE")
     issue = _issue(1, "Add dark mode toggle")
-    assert h.classify_single_issue(issue, "model", "endpoint") == "NEW_FEATURE"
+    assert h.classify_single_issue(issue, "local") == "NEW_FEATURE"
 
 
 def test_classify_single_issue_defaults_to_backlog(monkeypatch):
-    monkeypatch.setattr(h, "fetch_ollama_review", lambda endpoint, model, prompt: "BACKLOG")
+    monkeypatch.setattr(h, "fetch_review", lambda model_source, prompt: "BACKLOG")
     issue = _issue(1, "Add missing test coverage")
-    assert h.classify_single_issue(issue, "model", "endpoint") == "BACKLOG"
+    assert h.classify_single_issue(issue, "local") == "BACKLOG"
 
 
 def test_fetch_unmilestoned_open_issues_filters_milestoned(monkeypatch):
@@ -196,70 +196,80 @@ def test_create_consolidator_issue_returns_none_on_failure(monkeypatch):
 
 
 def test_triage_group_closes_duplicate_keeping_lowest_number(monkeypatch):
-    monkeypatch.setattr(h, "fetch_ollama_review", lambda endpoint, model, prompt: "#2: DUPLICATE")
+    monkeypatch.setattr(h, "fetch_review", lambda model_source, prompt: "#2: DUPLICATE")
     closed = []
     monkeypatch.setattr(h, "close_issue", lambda number, comment, dry_run: closed.append(number))
     group = [_issue(1, "First"), _issue(2, "Second")]
-    handled = h.triage_group(group, "model", "endpoint", dry_run=True, verbose=True)
+    handled = h.triage_group(group, "local", dry_run=True, verbose=True)
     assert closed == [2]
     assert handled == {2}
 
 
 def test_triage_group_does_not_close_canonical_even_if_flagged_duplicate(monkeypatch):
-    monkeypatch.setattr(h, "fetch_ollama_review", lambda endpoint, model, prompt: "#1: DUPLICATE\n#2: DUPLICATE")
+    monkeypatch.setattr(
+        h, "fetch_review", lambda model_source, prompt: "#1: DUPLICATE\n#2: DUPLICATE"
+    )
     closed = []
     monkeypatch.setattr(h, "close_issue", lambda number, comment, dry_run: closed.append(number))
     group = [_issue(1, "First"), _issue(2, "Second")]
-    handled = h.triage_group(group, "model", "endpoint", dry_run=True, verbose=True)
+    handled = h.triage_group(group, "local", dry_run=True, verbose=True)
     assert closed == [2]
     assert handled == {2}
 
 
 def test_triage_group_folds_multiple_fold_candidates_into_consolidator(monkeypatch):
-    monkeypatch.setattr(h, "fetch_ollama_review", lambda endpoint, model, prompt: "#1: FOLD\n#2: FOLD")
+    monkeypatch.setattr(h, "fetch_review", lambda model_source, prompt: "#1: FOLD\n#2: FOLD")
     monkeypatch.setattr(h, "create_consolidator_issue", lambda title, folded, dry_run: 999)
     closed = []
     monkeypatch.setattr(h, "close_issue", lambda number, comment, dry_run: closed.append(number))
     group = [_issue(1, "First"), _issue(2, "Second")]
-    handled = h.triage_group(group, "model", "endpoint", dry_run=True, verbose=True)
+    handled = h.triage_group(group, "local", dry_run=True, verbose=True)
     assert closed == [1, 2]
     assert handled == {1, 2}
 
 
 def test_triage_group_single_fold_candidate_is_left_unhandled(monkeypatch):
-    monkeypatch.setattr(h, "fetch_ollama_review", lambda endpoint, model, prompt: "#1: FOLD")
+    monkeypatch.setattr(h, "fetch_review", lambda model_source, prompt: "#1: FOLD")
     created = []
-    monkeypatch.setattr(h, "create_consolidator_issue", lambda title, folded, dry_run: created.append(1))
+    monkeypatch.setattr(
+        h, "create_consolidator_issue", lambda title, folded, dry_run: created.append(1)
+    )
     group = [_issue(1, "First")]
-    handled = h.triage_group(group, "model", "endpoint", dry_run=True, verbose=True)
+    handled = h.triage_group(group, "local", dry_run=True, verbose=True)
     assert created == []
     assert handled == set()
 
 
 def test_triage_group_new_feature_is_commented_and_handled(monkeypatch):
-    monkeypatch.setattr(h, "fetch_ollama_review", lambda endpoint, model, prompt: "#1: NEW_FEATURE")
+    monkeypatch.setattr(h, "fetch_review", lambda model_source, prompt: "#1: NEW_FEATURE")
     commented = []
     monkeypatch.setattr(h, "comment_new_feature", lambda number, dry_run: commented.append(number))
     group = [_issue(1, "Add a feature"), _issue(2, "Nit")]
-    handled = h.triage_group(group, "model", "endpoint", dry_run=True, verbose=True)
+    handled = h.triage_group(group, "local", dry_run=True, verbose=True)
     assert commented == [1]
     assert 1 in handled
 
 
 def test_triage_remaining_assigns_milestone_to_backlog_issues(monkeypatch):
-    monkeypatch.setattr(h, "classify_single_issue", lambda issue, model, endpoint, verbose: "BACKLOG")
+    monkeypatch.setattr(h, "classify_single_issue", lambda issue, model_source, verbose: "BACKLOG")
     assigned = []
-    monkeypatch.setattr(h, "assign_milestone", lambda number, milestone, dry_run: assigned.append(number))
-    h.triage_remaining([_issue(1, "Nit")], "model", "endpoint", dry_run=True, verbose=True)
+    monkeypatch.setattr(
+        h, "assign_milestone", lambda number, milestone, dry_run: assigned.append(number)
+    )
+    h.triage_remaining([_issue(1, "Nit")], "local", dry_run=True, verbose=True)
     assert assigned == [1]
 
 
 def test_triage_remaining_skips_milestone_for_new_feature(monkeypatch):
-    monkeypatch.setattr(h, "classify_single_issue", lambda issue, model, endpoint, verbose: "NEW_FEATURE")
+    monkeypatch.setattr(
+        h, "classify_single_issue", lambda issue, model_source, verbose: "NEW_FEATURE"
+    )
     commented = []
     assigned = []
-    monkeypatch.setattr(h, "assign_milestone", lambda number, milestone, dry_run: assigned.append(number))
+    monkeypatch.setattr(
+        h, "assign_milestone", lambda number, milestone, dry_run: assigned.append(number)
+    )
     monkeypatch.setattr(h, "comment_new_feature", lambda number, dry_run: commented.append(number))
-    h.triage_remaining([_issue(1, "Add a feature")], "model", "endpoint", dry_run=True, verbose=True)
+    h.triage_remaining([_issue(1, "Add a feature")], "local", dry_run=True, verbose=True)
     assert assigned == []
     assert commented == [1]

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -49,15 +49,13 @@ def test_looks_like_content_loss_false_when_original_is_empty():
 
 
 def test_run_review_local_returns_none_when_ollama_unreachable(monkeypatch):
-    monkeypatch.setattr(n, "validate_ollama_connection", lambda endpoint: False)
+    monkeypatch.setattr(n, "validate_model_source", lambda model_source: False)
     assert n.run_review(n.LOCAL, "title", "body") is None
 
 
 def test_run_review_local_returns_response(monkeypatch):
-    monkeypatch.setattr(n, "validate_ollama_connection", lambda endpoint: True)
-    monkeypatch.setattr(
-        n, "fetch_ollama_review", lambda endpoint, model, prompt: "TITLE: t\nBODY:\nb"
-    )
+    monkeypatch.setattr(n, "validate_model_source", lambda model_source: True)
+    monkeypatch.setattr(n, "fetch_review", lambda model_source, prompt: "TITLE: t\nBODY:\nb")
     assert n.run_review(n.LOCAL, "title", "body") == "TITLE: t\nBODY:\nb"
 
 
@@ -87,13 +85,13 @@ def test_run_review_cloud_returns_none_without_api_key(monkeypatch):
 
 def test_run_review_cloud_returns_response(monkeypatch):
     monkeypatch.setenv("DEEPSEEK_API_KEY", "fake-key")
-    monkeypatch.setattr(n, "fetch_deepseek_review", lambda api_key, prompt: "TITLE: t\nBODY:\nb")
+    monkeypatch.setattr(n, "fetch_review", lambda model_source, prompt: "TITLE: t\nBODY:\nb")
     assert n.run_review(n.CLOUD, "title", "body") == "TITLE: t\nBODY:\nb"
 
 
 def test_run_review_returns_none_on_empty_response(monkeypatch):
-    monkeypatch.setattr(n, "validate_ollama_connection", lambda endpoint: True)
-    monkeypatch.setattr(n, "fetch_ollama_review", lambda endpoint, model, prompt: "   ")
+    monkeypatch.setattr(n, "validate_model_source", lambda model_source: True)
+    monkeypatch.setattr(n, "fetch_review", lambda model_source, prompt: "   ")
     assert n.run_review(n.LOCAL, "title", "body") is None
 
 

--- a/tests/test_commit_and_push.py
+++ b/tests/test_commit_and_push.py
@@ -113,18 +113,18 @@ class TestBuildCommitPrompt:
 
 class TestGenerateCommitMessage:
     def test_empty_diff_returns_none(self):
-        assert generate_commit_message("", 4445, "model", "http://localhost:11434") is None
+        assert generate_commit_message("", 4445, "local") is None
 
-    @mock.patch("commit_and_push.fetch_ollama_review")
+    @mock.patch("commit_and_push.fetch_review")
     def test_returns_stripped_message(self, mock_fetch):
         mock_fetch.return_value = "  Fix the thing  \n"
-        result = generate_commit_message("diff", 4445, "model", "http://localhost:11434")
+        result = generate_commit_message("diff", 4445, "local")
         assert result == "Fix the thing"
 
-    @mock.patch("commit_and_push.fetch_ollama_review")
-    def test_ollama_failure_returns_none(self, mock_fetch):
+    @mock.patch("commit_and_push.fetch_review")
+    def test_model_failure_returns_none(self, mock_fetch):
         mock_fetch.side_effect = SystemExit(1)
-        assert generate_commit_message("diff", 4445, "model", "http://localhost:11434") is None
+        assert generate_commit_message("diff", 4445, "local") is None
 
 
 class TestEnsureIssueReference:

--- a/tests/test_create_issue.py
+++ b/tests/test_create_issue.py
@@ -1,4 +1,4 @@
-"""Unit tests for the local-LLM review step in scripts/developer_tools/b_create_issue.py."""
+"""Unit tests for the LLM review step in scripts/developer_tools/b_create_issue.py."""
 
 from __future__ import annotations
 
@@ -7,12 +7,13 @@ from pathlib import Path
 from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools" / "lib"))
 
 from b_create_issue import (  # noqa: E402
     build_review_prompt,
     format_bug_body,
     format_feature_body,
-    offer_local_llm_review,
+    offer_llm_review,
     parse_review_response,
 )
 
@@ -66,44 +67,54 @@ class TestFormatBody:
         assert "## Files Affected\n\nUnknown" in body
 
 
-class TestOfferLocalLlmReview:
+class TestOfferLlmReview:
     @mock.patch("builtins.input", return_value="n")
     def test_declines_llm_review(self, _mock_input):
-        title, body = offer_local_llm_review("orig title", "orig body")
+        title, body = offer_llm_review("orig title", "orig body")
         assert (title, body) == ("orig title", "orig body")
 
-    @mock.patch("b_create_issue.validate_ollama_connection", return_value=False)
+    @mock.patch("b_create_issue.validate_model_source", return_value=False)
+    @mock.patch("b_create_issue.prompt_for_model_source", return_value="local")
     @mock.patch("builtins.input", return_value="y")
-    def test_falls_back_when_ollama_unreachable(self, _mock_input, _mock_validate):
-        title, body = offer_local_llm_review("orig title", "orig body")
+    def test_falls_back_when_model_unreachable(
+        self, _mock_input, _mock_prompt_source, _mock_validate
+    ):
+        title, body = offer_llm_review("orig title", "orig body")
         assert (title, body) == ("orig title", "orig body")
 
-    @mock.patch("b_create_issue.fetch_ollama_review", return_value="")
-    @mock.patch("b_create_issue.validate_ollama_connection", return_value=True)
+    @mock.patch("b_create_issue.fetch_review", return_value="")
+    @mock.patch("b_create_issue.validate_model_source", return_value=True)
+    @mock.patch("b_create_issue.prompt_for_model_source", return_value="local")
     @mock.patch("builtins.input", return_value="y")
-    def test_falls_back_on_empty_llm_response(self, _mock_input, _mock_validate, _mock_fetch):
-        title, body = offer_local_llm_review("orig title", "orig body")
+    def test_falls_back_on_empty_llm_response(
+        self, _mock_input, _mock_prompt_source, _mock_validate, _mock_fetch
+    ):
+        title, body = offer_llm_review("orig title", "orig body")
         assert (title, body) == ("orig title", "orig body")
 
     @mock.patch(
-        "b_create_issue.fetch_ollama_review",
+        "b_create_issue.fetch_review",
         return_value="TITLE: New title\nBODY:\n## What\n\nNew body\n",
     )
-    @mock.patch("b_create_issue.validate_ollama_connection", return_value=True)
+    @mock.patch("b_create_issue.validate_model_source", return_value=True)
+    @mock.patch("b_create_issue.prompt_for_model_source", return_value="local")
     @mock.patch("builtins.input", side_effect=["y", "y"])
-    def test_applies_accepted_suggestion(self, _mock_input, _mock_validate, _mock_fetch):
-        title, body = offer_local_llm_review("orig title", "orig body")
+    def test_applies_accepted_suggestion(
+        self, _mock_input, _mock_prompt_source, _mock_validate, _mock_fetch
+    ):
+        title, body = offer_llm_review("orig title", "orig body")
         assert title == "New title"
         assert "New body" in body
 
     @mock.patch(
-        "b_create_issue.fetch_ollama_review",
+        "b_create_issue.fetch_review",
         return_value="TITLE: New title\nBODY:\n## What\n\nNew body\n",
     )
-    @mock.patch("b_create_issue.validate_ollama_connection", return_value=True)
+    @mock.patch("b_create_issue.validate_model_source", return_value=True)
+    @mock.patch("b_create_issue.prompt_for_model_source", return_value="local")
     @mock.patch("builtins.input", side_effect=["y", "n"])
     def test_keeps_original_when_suggestion_rejected(
-        self, _mock_input, _mock_validate, _mock_fetch
+        self, _mock_input, _mock_prompt_source, _mock_validate, _mock_fetch
     ):
-        title, body = offer_local_llm_review("orig title", "orig body")
+        title, body = offer_llm_review("orig title", "orig body")
         assert (title, body) == ("orig title", "orig body")


### PR DESCRIPTION
## Summary
- `n_review_issue.py` already had a LOCAL/CLOUD (Ollama/DeepSeek) model-source switch. Extracted it into a new shared `scripts/developer_tools/lib/llm_common.py` module (argparse wiring, interactive prompt, connection/credential validation, and dispatch) so the same choice is available everywhere without duplicating the logic.
- Wired `--model-source {local,cloud}` into `b_create_issue.py` (interactive prompt), `c_triage_issues.py`, `h_local_review.py`, `k_pr_review.py`, and `lib/commit_and_push.py`.
- Preserved backwards compatibility: `commit_and_push.py`'s existing `--no-ollama` and `--model` flags still work (`--no-ollama` is now an alias for `--no-llm`; `--model` still overrides the Ollama model name when `--model-source=local`).
- Updated `scripts/README.md` for the affected sections.
- Updated existing unit tests (`test_n_review_issue.py`, `test_c_triage_issues.py`, `test_create_issue.py`, `test_commit_and_push.py`) to patch the new shared functions instead of the old per-script Ollama-only ones.

## Why
Some triage/review/commit-message tasks benefit from a more powerful cloud model, but previously only `n_review_issue.py` offered that option -- the rest were hardcoded to local Ollama. Issue #5768 asked for this without introducing code duplication.

Closes #5768

## Test plan
- [x] `python -m pytest tests/ -q --no-cov` -- 3448 passed, 6 skipped, 16 xfailed, 1 xpassed (no new failures)
- [x] `python -m ruff check` / `python -m black --check` on all changed files -- clean
- [x] Manually ran `--help` on each updated script to confirm `--model-source` wires up correctly
- [x] Verified `llm_common.validate_model_source`/`describe_model_source` behave correctly for both `local` and `cloud`