### PR TITLE
Add Files Affected section to issue templates and scripts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,6 +29,11 @@ messages, screenshots, or logs where relevant. -->
 
 **Environment:** (backend/frontend/CDK, browser, OS, commit/branch)
 
+## Files Affected
+
+<!-- List the specific file paths (from the repo root) that need to be
+changed, added, or deleted to fix this. Use one path per line. -->
+
 ## Constraints
 
 <!-- Anything the fix must not break, e.g. "must not change the public API

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,6 +19,11 @@ assignees: ""
 <!-- Outline the intended approach at a high level. Link to affected files or
 areas of the codebase if known. -->
 
+## Files Affected
+
+<!-- List the specific file paths (from the repo root) that need to be
+changed, added, or deleted to implement this. Use one path per line. -->
+
 ## Constraints
 
 <!-- Anything the implementation must respect, e.g. "no application code

--- a/scripts/developer_tools/b_create_issue.py
+++ b/scripts/developer_tools/b_create_issue.py
@@ -34,6 +34,10 @@ SECTIONS_FEATURE = [
     ("Why", "Why is this needed? What problem does it solve, or what value does it add?"),
     ("How", "Outline the intended approach at a high level."),
     (
+        "Files Affected",
+        "Specific file paths (from the repo root) to change, add, or delete. One per line.",
+    ),
+    (
         "Constraints",
         (
             "Anything the implementation must respect"
@@ -55,6 +59,10 @@ SECTIONS_BUG = [
     ("What", "What is broken? Describe the observed behavior."),
     ("Why", "Why does this matter? What's the user/dev impact?"),
     ("How", "Steps to reproduce, and (if known) what the fix likely involves."),
+    (
+        "Files Affected",
+        "Specific file paths (from the repo root) to change, add, or delete. One per line.",
+    ),
     ("Constraints", "Anything the fix must not break."),
     ("LLM tier", "Suggested AI agent tier: haiku / sonnet / opus"),
     (
@@ -170,6 +178,10 @@ def format_feature_body(sections: dict[str, str]) -> str:
         "",
         sections.get("How", ""),
         "",
+        "## Files Affected",
+        "",
+        sections.get("Files Affected", "Unknown"),
+        "",
         "## Constraints",
         "",
         sections.get("Constraints", "None"),
@@ -203,6 +215,10 @@ def format_bug_body(sections: dict[str, str]) -> str:
         "## How",
         "",
         sections.get("How", ""),
+        "",
+        "## Files Affected",
+        "",
+        sections.get("Files Affected", "Unknown"),
         "",
         "## Constraints",
         "",
@@ -470,6 +486,8 @@ def main() -> None:
             default = "-"
         elif label == "Constraints":
             default = "None"
+        elif label == "Files Affected":
+            default = "Unknown"
 
         value = prompt(label, hint, default=default)
         sections[label] = value

--- a/scripts/developer_tools/f_aider_issue_extractor.py
+++ b/scripts/developer_tools/f_aider_issue_extractor.py
@@ -158,6 +158,8 @@ def parse_issue_body(body: str, verbose: bool = False) -> dict[str, str]:
             sections["why"] = section_content
         elif section_title == "how":
             sections["how"] = section_content
+        elif section_title in ("files affected", "files_affected"):
+            sections["files_affected"] = section_content
         elif section_title == "constraints":
             sections["constraints"] = section_content
         elif section_title in ("llm tier", "llm_tier"):
@@ -300,12 +302,21 @@ def resolve_files_to_edit(
     endpoint: str,
     model: str,
     verbose: bool = False,
+    files_affected: str = "",
 ) -> list[str]:
     """Return the files to hand to aider.
 
-    Prefers file paths already mentioned in the issue body; falls back to
-    asking Ollama to suggest files only when none are found there.
+    Prefers file paths listed in the issue's "Files Affected" section, then
+    falls back to any file paths mentioned elsewhere in the issue body, and
+    only asks Ollama to suggest files when none are found in either place.
     """
+    if files_affected:
+        section_paths = extract_file_paths_from_issue(files_affected, verbose)
+        if section_paths:
+            if verbose:
+                print(f"[DEBUG] Using Files Affected paths: {section_paths}", file=sys.stderr)
+            return section_paths
+
     extracted_paths = extract_file_paths_from_issue(body, verbose)
     if extracted_paths:
         if verbose:
@@ -332,7 +343,7 @@ def formulate_aider_prompt(
         print("[DEBUG] Formulating Aider prompt...", file=sys.stderr)
 
     # Add structured sections
-    for section in ["what", "why", "how", "constraints", "success", "failure"]:
+    for section in ["what", "why", "how", "files_affected", "constraints", "success", "failure"]:
         if section in parsed_sections:
             content = parsed_sections[section].strip()
             if content:
@@ -473,7 +484,9 @@ def main(argv: list[str] | None = None) -> None:
     # Parse issue structure
     parsed = parse_issue_body(body, args.verbose)
 
-    files = resolve_files_to_edit(title, body, endpoint, model, args.verbose)
+    files = resolve_files_to_edit(
+        title, body, endpoint, model, args.verbose, parsed.get("files_affected", "")
+    )
     if not files:
         print(
             "WARNING: No files found or suggested. Proceeding with empty file list.",

--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -69,6 +69,7 @@ FALLBACK_TEMPLATE_SECTIONS = [
     "What",
     "Why",
     "How",
+    "Files Affected",
     "Constraints",
     "LLM tier",
     "Success looks like",

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -143,6 +143,7 @@ def test_load_template_sections_reads_real_bug_report_template():
         "What",
         "Why",
         "How",
+        "Files Affected",
         "Constraints",
         "LLM tier",
         "Success looks like",

--- a/tests/test_aider_issue_extractor.py
+++ b/tests/test_aider_issue_extractor.py
@@ -19,6 +19,7 @@ from f_aider_issue_extractor import (  # noqa: E402
     load_issue_from_file,
     main,
     parse_issue_body,
+    resolve_files_to_edit,
     run_aider,
     suggest_files_with_ollama,
 )
@@ -67,6 +68,11 @@ class TestParseIssueBody:
         body = "## Random Heading\n\nSome content.\n"
         assert parse_issue_body(body) == {}
 
+    def test_extracts_files_affected_section(self):
+        body = "## Files Affected\n\nbackend/app.py\nfrontend/src/main.tsx\n"
+        sections = parse_issue_body(body)
+        assert sections["files_affected"] == "backend/app.py\nfrontend/src/main.tsx"
+
 
 class TestIsSafeRelativePath:
     def test_rejects_parent_traversal(self):
@@ -100,6 +106,37 @@ class TestExtractFilePathsFromIssue:
         # rejected before the existence check ever runs.
         body = "See scripts/../scripts/developer_tools/f_aider_issue_extractor.py for details."
         assert extract_file_paths_from_issue(body) == []
+
+
+class TestResolveFilesToEdit:
+    def test_prefers_files_affected_section_over_whole_body(self):
+        real_file = "scripts/developer_tools/f_aider_issue_extractor.py"
+        other_file = "scripts/developer_tools/b_create_issue.py"
+        body = f"See {other_file} for background."
+
+        result = resolve_files_to_edit("title", body, "http://x", "model", files_affected=real_file)
+        assert result == [real_file]
+
+    @mock.patch("f_aider_issue_extractor.fetch_ollama_review")
+    def test_falls_back_to_body_when_files_affected_has_no_real_paths(self, mock_fetch):
+        real_file = "scripts/developer_tools/f_aider_issue_extractor.py"
+        body = f"See {real_file} for details."
+
+        result = resolve_files_to_edit(
+            "title", body, "http://x", "model", files_affected="totally/made/up/path.py"
+        )
+        assert result == [real_file]
+        mock_fetch.assert_not_called()
+
+    @mock.patch("f_aider_issue_extractor.fetch_ollama_review")
+    def test_asks_ollama_when_nothing_found_anywhere(self, mock_fetch):
+        mock_fetch.return_value = "[]"
+
+        result = resolve_files_to_edit(
+            "title", "no files here", "http://x", "model", files_affected="also none here"
+        )
+        assert result == []
+        mock_fetch.assert_called_once()
 
 
 class TestFormulateAiderPrompt:

--- a/tests/test_create_issue.py
+++ b/tests/test_create_issue.py
@@ -10,6 +10,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_too
 
 from b_create_issue import (  # noqa: E402
     build_review_prompt,
+    format_bug_body,
+    format_feature_body,
     offer_local_llm_review,
     parse_review_response,
 )
@@ -42,6 +44,26 @@ class TestParseReviewResponse:
         title, body = parse_review_response(response, "orig title", "orig body")
         assert title == "orig title"
         assert body == "orig body"
+
+
+class TestFormatBody:
+    def test_feature_body_includes_files_affected_section(self):
+        body = format_feature_body({"Files Affected": "backend/app.py"})
+        assert "## Files Affected" in body
+        assert "backend/app.py" in body
+
+    def test_feature_body_defaults_files_affected_to_unknown(self):
+        body = format_feature_body({})
+        assert "## Files Affected\n\nUnknown" in body
+
+    def test_bug_body_includes_files_affected_section(self):
+        body = format_bug_body({"Files Affected": "frontend/src/main.tsx"})
+        assert "## Files Affected" in body
+        assert "frontend/src/main.tsx" in body
+
+    def test_bug_body_defaults_files_affected_to_unknown(self):
+        body = format_bug_body({})
+        assert "## Files Affected\n\nUnknown" in body
 
 
 class TestOfferLocalLlmReview:


### PR DESCRIPTION
## Summary
- Add a `## Files Affected` section to both `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md` so issues explicitly list the file paths that need to change.
- `scripts/developer_tools/b_create_issue.py` now prompts for and includes this section (defaulting to "Unknown") when creating issues via the CLI.
- `scripts/developer_tools/o_review_issue.py` picks it up automatically since it derives required sections from the bug report template; its fallback list was updated to match.
- `scripts/developer_tools/f_aider_issue_extractor.py` now parses the "Files Affected" section and prioritizes paths listed there over a whole-body regex scan, falling back to Ollama suggestion only when nothing is found in either place.

## Test plan
- [x] `pytest tests/test_aider_issue_extractor.py tests/test_create_issue.py tests/scripts/test_o_review_issue.py -q --no-cov` — 78 passed
- [x] `ruff check` on touched files — clean
- [x] `black --check` on touched files — clean (formatted one test file)

Closes #5780

🤖 Generated with [Claude Code](https://claude.com/claude-code)