### PR TITLE
Fix Alert Settings page header layout (#5736)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,11 +28,9 @@ import PortfolioDashboardSkeleton from './components/skeletons/PortfolioDashboar
 import TableSkeleton from './components/skeletons/TableSkeleton';
 import ChartSkeleton from './components/skeletons/ChartSkeleton';
 
-import { NotificationsDrawer } from './components/NotificationsDrawer';
 import { ComplianceWarnings } from './components/ComplianceWarnings';
 import { ScreenerQuery } from './pages/ScreenerQuery';
 import useFetchWithRetry from './hooks/useFetchWithRetry';
-import { LanguageSwitcher } from './components/LanguageSwitcher';
 import { TimeseriesEdit } from './pages/TimeseriesEdit';
 import Watchlist from './pages/Watchlist';
 import TopMovers from './pages/TopMovers';
@@ -47,11 +45,9 @@ import UserConfigPage from './pages/UserConfig';
 import BackendUnavailableCard from './components/BackendUnavailableCard';
 import Reports from './pages/Reports';
 import ReportTemplateCreator from './pages/ReportTemplateCreator';
-import UserAvatar from './components/UserAvatar';
 import AllocationCharts from './pages/AllocationCharts';
 import InstrumentAdmin from './pages/InstrumentAdmin';
-import Menu from './components/Menu';
-import { InstrumentSearchBarToggle } from './components/InstrumentSearchBar';
+import AppHeader from './components/AppHeader';
 import Rebalance from './pages/Rebalance';
 import PensionForecast from './pages/PensionForecast';
 import TaxTools from './pages/TaxTools';
@@ -216,7 +212,6 @@ export default function App({ onLogout }: AppProps) {
 
   const [backendUnavailable, setBackendUnavailable] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
-  const [notificationsOpen, setNotificationsOpen] = useState(false);
 
   const handleRetry = useCallback(() => {
     setRetryNonce((n) => n + 1);
@@ -555,22 +550,12 @@ export default function App({ onLogout }: AppProps) {
 
     return (
       <>
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            alignItems: 'center',
-            gap: '0.5rem',
-            margin: '1rem 0',
-          }}
+        <AppHeader
+          selectedOwner={selectedOwner}
+          selectedGroup={selectedGroup}
+          onLogout={handleLogout}
+          lastRefresh={lastRefresh}
         >
-          <LanguageSwitcher />
-          <Menu
-            selectedOwner={selectedOwner}
-            selectedGroup={selectedGroup}
-            onLogout={handleLogout}
-            style={{ margin: 0 }}
-          />
           {mode === 'owner' && (
             <div data-testid="portfolio-owner-selector">
               <OwnerSelector
@@ -580,38 +565,7 @@ export default function App({ onLogout }: AppProps) {
               />
             </div>
           )}
-          {lastRefresh && (
-            <span
-              style={{
-                background: '#eee',
-                borderRadius: '1rem',
-                padding: '0.25rem 0.5rem',
-                fontSize: '0.75rem',
-              }}
-              title={t('app.last') ?? undefined}
-            >
-              {new Date(lastRefresh).toLocaleString()}
-            </span>
-          )}
-          <InstrumentSearchBarToggle />
-          <button
-            aria-label="notifications"
-            onClick={() => setNotificationsOpen(true)}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              fontSize: '1.5rem',
-            }}
-          >
-            🔔
-          </button>
-          <UserAvatar />
-        </div>
-        <NotificationsDrawer
-          open={notificationsOpen}
-          onClose={() => setNotificationsOpen(false)}
-        />
+        </AppHeader>
 
         {/* INDIVIDUAL OWNER VIEW */}
         {mode === 'owner' && !selectedOwnerIsGroup && (

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,0 +1,85 @@
+import { useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LanguageSwitcher } from './LanguageSwitcher';
+import Menu from './Menu';
+import { InstrumentSearchBarToggle } from './InstrumentSearchBar';
+import { NotificationsDrawer } from './NotificationsDrawer';
+import UserAvatar from './UserAvatar';
+
+interface AppHeaderProps {
+  selectedOwner?: string;
+  selectedGroup?: string;
+  onLogout?: () => void;
+  lastRefresh?: string | null;
+  /** Extra header content, e.g. an owner selector, rendered between the nav and the refresh badge. */
+  children?: ReactNode;
+}
+
+/**
+ * Shared header row (language switcher, nav, notifications, search, avatar) used by
+ * every top-level page so standalone routes match the layout rendered inside App.tsx (#5736).
+ */
+export default function AppHeader({
+  selectedOwner,
+  selectedGroup,
+  onLogout,
+  lastRefresh,
+  children,
+}: AppHeaderProps) {
+  const { t } = useTranslation();
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+
+  return (
+    <>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: '0.5rem',
+          margin: '1rem 0',
+        }}
+      >
+        <LanguageSwitcher />
+        <Menu
+          selectedOwner={selectedOwner}
+          selectedGroup={selectedGroup}
+          onLogout={onLogout}
+          style={{ margin: 0 }}
+        />
+        {children}
+        {lastRefresh && (
+          <span
+            style={{
+              background: '#eee',
+              borderRadius: '1rem',
+              padding: '0.25rem 0.5rem',
+              fontSize: '0.75rem',
+            }}
+            title={t('app.last') ?? undefined}
+          >
+            {new Date(lastRefresh).toLocaleString()}
+          </span>
+        )}
+        <InstrumentSearchBarToggle />
+        <button
+          aria-label="notifications"
+          onClick={() => setNotificationsOpen(true)}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            fontSize: '1.5rem',
+          }}
+        >
+          🔔
+        </button>
+        <UserAvatar />
+      </div>
+      <NotificationsDrawer
+        open={notificationsOpen}
+        onClose={() => setNotificationsOpen(false)}
+      />
+    </>
+  );
+}

--- a/frontend/src/pages/AlertSettings.tsx
+++ b/frontend/src/pages/AlertSettings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import Menu from "../components/Menu";
+import AppHeader from "../components/AppHeader";
 import {
   getAlertThreshold,
   setAlertThreshold,
@@ -38,44 +38,48 @@ export default function AlertSettings() {
   }
 
   return (
-    <div style={{ maxWidth: 600, margin: "0 auto", padding: "1rem" }}>
-      <Menu />
-      <h1>{t("alertSettings.title")}</h1>
-      <p>{t("alertSettings.description")}</p>
-      {!owner && <p>{t("alertSettings.signInNotice")}</p>}
-      <div style={{ marginTop: "1rem" }}>
-        <label>
-          {t("alertSettings.threshold")}{" "}
-          <input
-            type="number"
-            value={threshold}
-            onChange={(e) =>
-              setThreshold(e.target.value === "" ? "" : Number(e.target.value))
-            }
-            style={{ width: "4rem" }}
-          />
-        </label>
-        <button
-          onClick={save}
-          style={{ marginLeft: "0.5rem" }}
-          disabled={!owner}
-        >
-          {t("alertSettings.save")}
-        </button>
-        {status === "saved" && (
-          <span style={{ marginLeft: "0.5rem" }}>
-            {t("alertSettings.status.saved")}
-          </span>
-        )}
-        {status === "error" && (
-          <span style={{ marginLeft: "0.5rem" }}>
-            {t("alertSettings.status.error")}
-          </span>
-        )}
-      </div>
-      <div style={{ marginTop: "2rem" }}>
-        <h2>{t("alertSettings.push.title")}</h2>
-        <p>{t("alertSettings.push.notSupported")}</p>
+    <div style={{ padding: "1rem" }}>
+      <AppHeader />
+      <div style={{ maxWidth: 600 }}>
+        <h1>{t("alertSettings.title")}</h1>
+        <p>{t("alertSettings.description")}</p>
+        {!owner && <p>{t("alertSettings.signInNotice")}</p>}
+        <div style={{ marginTop: "1rem" }}>
+          <label>
+            {t("alertSettings.threshold")}{" "}
+            <input
+              type="number"
+              value={threshold}
+              onChange={(e) =>
+                setThreshold(
+                  e.target.value === "" ? "" : Number(e.target.value),
+                )
+              }
+              style={{ width: "4rem" }}
+            />
+          </label>
+          <button
+            onClick={save}
+            style={{ marginLeft: "0.5rem" }}
+            disabled={!owner}
+          >
+            {t("alertSettings.save")}
+          </button>
+          {status === "saved" && (
+            <span style={{ marginLeft: "0.5rem" }}>
+              {t("alertSettings.status.saved")}
+            </span>
+          )}
+          {status === "error" && (
+            <span style={{ marginLeft: "0.5rem" }}>
+              {t("alertSettings.status.error")}
+            </span>
+          )}
+        </div>
+        <div style={{ marginTop: "2rem" }}>
+          <h2>{t("alertSettings.push.title")}</h2>
+          <p>{t("alertSettings.push.notSupported")}</p>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/AlertSettings.tsx
+++ b/frontend/src/pages/AlertSettings.tsx
@@ -6,10 +6,12 @@ import {
   setAlertThreshold,
 } from "../api";
 import { useUser } from "../UserContext";
+import { usePriceRefresh } from "../PriceRefreshContext";
 
 export default function AlertSettings() {
   const { t } = useTranslation();
   const { profile } = useUser();
+  const { lastRefresh } = usePriceRefresh();
   // Owner is determined from the authenticated user's profile
   const owner = profile?.email;
   const [threshold, setThreshold] = useState<number | "">("");
@@ -39,7 +41,7 @@ export default function AlertSettings() {
 
   return (
     <div style={{ padding: "1rem" }}>
-      <AppHeader />
+      <AppHeader lastRefresh={lastRefresh} />
       <div style={{ maxWidth: 600 }}>
         <h1>{t("alertSettings.title")}</h1>
         <p>{t("alertSettings.description")}</p>

--- a/frontend/tests/unit/pages/AlertSettings.test.tsx
+++ b/frontend/tests/unit/pages/AlertSettings.test.tsx
@@ -42,6 +42,13 @@ describe("AlertSettings navigation", () => {
     expect(
       screen.getByRole("heading", { name: en.alertSettings.push.title })
     ).toBeInTheDocument();
+
+    // Header parity (#5736): the shared AppHeader controls must be present,
+    // not just the bare nav.
+    expect(
+      screen.getByRole("button", { name: "notifications" }),
+    ).toBeInTheDocument();
+    expect(screen.getByAltText("user avatar")).toBeInTheDocument();
   });
 });
 

--- a/frontend/tests/unit/pages/AlertSettings.test.tsx
+++ b/frontend/tests/unit/pages/AlertSettings.test.tsx
@@ -9,6 +9,9 @@ import en from "@/locales/en/translation.json";
 vi.mock("@/api", () => ({
   getAlertThreshold: vi.fn().mockResolvedValue({ threshold: 5 }),
   setAlertThreshold: vi.fn().mockResolvedValue({}),
+  getAlerts: vi.fn().mockResolvedValue([]),
+  getNudges: vi.fn().mockResolvedValue([]),
+  searchInstruments: vi.fn().mockResolvedValue([]),
 }));
 
 describe("AlertSettings navigation", () => {


### PR DESCRIPTION
## Summary
- The Alert Settings page (`/alert-settings`) is registered as a standalone router route, so it renders outside App.tsx's shared header block. It compensated with a bare `<Menu />` wrapped in a `maxWidth: 600, margin: "0 auto"` container, which squeezed the nav onto two rows and shifted content ~200px right on typical viewports, and was missing the language switcher, search icon, notifications bell, and avatar.
- Extracted App.tsx's header row into a reusable `AppHeader` component ([frontend/src/components/AppHeader.tsx](frontend/src/components/AppHeader.tsx)) and used it in both `App.tsx` and `AlertSettings.tsx`, removing the narrow centered wrapper so the nav and content line up like every other page.

## Test plan
- [x] `npm run type-check` (frontend)
- [x] `npx eslint --format unix` on changed files
- [x] `npx vitest run` — full suite, 655 tests passing
- [x] Manually verified in a local dev server that `/alert-settings` and `/settings` render an identical single-row header with matching left offsets (no ~200px shift, nav stays on one row)

Closes #5736

🤖 Generated with [Claude Code](https://claude.com/claude-code)