### PR TITLE
Fix aider issue extractor missing files on non-templated issues

### DIFF
--- a/scripts/developer_tools/f_aider_issue_extractor.py
+++ b/scripts/developer_tools/f_aider_issue_extractor.py
@@ -143,9 +143,15 @@ def parse_issue_body(body: str, verbose: bool = False) -> dict[str, str]:
     """
     sections = {}
 
+    # Not every issue follows the "## Heading" template exactly -- issues
+    # filed before the template was standardized (or edited by hand) use a
+    # whole-line "**Heading**" bold style instead. Normalize those to ATX
+    # headers first so the single pattern below catches both.
+    normalized_body = re.sub(r"(?m)^\*\*([^\n*]+)\*\*\s*$", r"## \1", body)
+
     # Split by markdown headers (## Section)
     pattern = r"##\s*([^\n]+)\n(.*?)(?=##\s*|\Z)"
-    matches = re.finditer(pattern, body, re.DOTALL | re.IGNORECASE)
+    matches = re.finditer(pattern, normalized_body, re.DOTALL | re.IGNORECASE)
 
     for match in matches:
         section_title = match.group(1).strip().lower()
@@ -158,7 +164,7 @@ def parse_issue_body(body: str, verbose: bool = False) -> dict[str, str]:
             sections["why"] = section_content
         elif section_title == "how":
             sections["how"] = section_content
-        elif section_title in ("files affected", "files_affected"):
+        elif section_title in ("files affected", "files_affected", "files to change"):
             sections["files_affected"] = section_content
         elif section_title == "constraints":
             sections["constraints"] = section_content
@@ -206,8 +212,14 @@ def extract_file_paths_from_issue(
     """
     paths = []
 
-    # Match common path patterns: src/foo.ts, backend/app.py, etc.
-    pattern = r"(?:^|\s)([a-zA-Z0-9._/\-]+\.(?:ts|tsx|py|js|jsx|css|md|yml|yaml|json))"
+    # Match common path patterns: src/foo.ts, backend/app.py, etc. Paths are
+    # also allowed right after '[' or '(' so markdown link syntax like
+    # "[backend/app.py](https://...)" -- common in "Files Affected" sections
+    # generated from issue templates -- is recognized, not just bare paths.
+    # Longer extensions must be listed before their prefixes (tsx before ts,
+    # jsx before js) -- regex alternation takes the first match, so "ts"
+    # would otherwise win over "tsx" and truncate the captured path.
+    pattern = r"(?:^|[\s\[\(])([a-zA-Z0-9._/\-]+\.(?:tsx|ts|py|jsx|js|css|md|yaml|yml|json))"
     matches = re.finditer(pattern, issue_body, re.MULTILINE)
 
     for match in matches:

--- a/tests/test_aider_issue_extractor.py
+++ b/tests/test_aider_issue_extractor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 from unittest import mock
@@ -73,6 +74,14 @@ class TestParseIssueBody:
         sections = parse_issue_body(body)
         assert sections["files_affected"] == "backend/app.py\nfrontend/src/main.tsx"
 
+    def test_extracts_bold_headers_not_just_atx(self):
+        # Issues filed before the "## Heading" template was standardized (or
+        # edited by hand) use whole-line "**Heading**" bold style instead.
+        body = "**What**\nDo the thing.\n\n**Files to change**\nbackend/app.py\n"
+        sections = parse_issue_body(body)
+        assert sections["what"] == "Do the thing."
+        assert sections["files_affected"] == "backend/app.py"
+
 
 class TestIsSafeRelativePath:
     def test_rejects_parent_traversal(self):
@@ -107,6 +116,24 @@ class TestExtractFilePathsFromIssue:
         body = "See scripts/../scripts/developer_tools/f_aider_issue_extractor.py for details."
         assert extract_file_paths_from_issue(body) == []
 
+    def test_finds_path_inside_markdown_link(self):
+        real_file = "scripts/developer_tools/f_aider_issue_extractor.py"
+        body = f"- [{real_file}](https://github.com/owner/repo/blob/main/{real_file}) - details."
+        paths = extract_file_paths_from_issue(body)
+        assert paths == [real_file]
+
+    def test_does_not_truncate_tsx_extension_to_ts(self):
+        real_file = "frontend/src/components/Menu.tsx"
+        body = f"See {real_file} for details."
+        assert extract_file_paths_from_issue(body) == [real_file]
+
+    def test_does_not_truncate_jsx_extension_to_js(self):
+        # No .jsx fixture exists in-repo, so exercise the regex directly
+        # rather than depending on Path.exists() filtering.
+        pattern = r"(?:^|[\s\[\(])([a-zA-Z0-9._/\-]+\.(?:tsx|ts|py|jsx|js|css|md|yaml|yml|json))"
+        match = re.search(pattern, "See src/components/Foo.jsx for details.")
+        assert match.group(1) == "src/components/Foo.jsx"
+
 
 class TestResolveFilesToEdit:
     def test_prefers_files_affected_section_over_whole_body(self):
@@ -137,6 +164,28 @@ class TestResolveFilesToEdit:
         )
         assert result == []
         mock_fetch.assert_called_once()
+
+    @mock.patch("f_aider_issue_extractor.fetch_ollama_review")
+    def test_resolves_files_from_bold_header_markdown_link_issue_without_ollama(self, mock_fetch):
+        # Regression test for #5798: issues written before the "## Heading"
+        # template was standardized use bold "**Heading**" lines and list
+        # files as markdown links, e.g. "[path](url)". Previously this fell
+        # through to Ollama and produced an empty file list.
+        real_file = "scripts/developer_tools/f_aider_issue_extractor.py"
+        body = (
+            "**What**\nSomething is broken.\n\n"
+            "**Files to change**\n"
+            f"- [{real_file}](https://github.com/owner/repo/blob/main/{real_file})"
+            " - relevant logic here.\n\n"
+            "**Constraints**\nNone.\n"
+        )
+        sections = parse_issue_body(body)
+
+        result = resolve_files_to_edit(
+            "title", body, "http://x", "model", files_affected=sections.get("files_affected", "")
+        )
+        assert result == [real_file]
+        mock_fetch.assert_not_called()
 
 
 class TestFormulateAiderPrompt:


### PR DESCRIPTION
## Summary
- `parse_issue_body`/`extract_file_paths_from_issue` only recognized `## Heading` ATX headers and bare (non-linked) file paths. Issues filed before the template was standardized — like #5738, which was used to reproduce the bug reported in #5798 — use whole-line `**Heading**` bold headers and list files as markdown links (`[path](url)`). Neither matched, so extraction silently fell through to the Ollama fallback and often returned an empty file list, aborting the run exactly as described in #5798.
- While reproducing, also found a latent bug: the extension alternation tried `ts`/`js` before `tsx`/`jsx`, so `Menu.tsx` matched as `Menu.ts`, resolved to a nonexistent file, and got filtered out. Fixed the ordering.

## Test plan
- [x] `python -m pytest tests/test_aider_issue_extractor.py -q --no-cov` (42 passed, 5 new regression tests added)
- [x] `black --check` / `ruff check` on both changed files
- [x] Manually reproduced against issue #5738's real body (bold headers + markdown-link file list) before and after the fix

Closes #5798

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue parsing for bold section headings and “Files to Change” labels.
  * Enhanced file-path detection, including Markdown links and `.tsx` and `.jsx` files.
  * Improved compatibility with legacy issue formats without requiring Ollama.

* **Tests**
  * Added regression coverage for updated headings, linked file paths, and extension matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->