### PR TITLE
Trim aider prompt to What/How/Constraints/Success

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -191,7 +191,10 @@ The script:
    extracts any file paths already mentioned in the issue body
 3. If no file paths are found, asks a local Ollama model to suggest which
    repo files are relevant
-4. Prints the resulting file list and formulated prompt for confirmation
+4. Prints the resulting file list, plus a trimmed prompt for confirmation
+   (title, `What`, `How`, `Constraints`, `Success`) -- `Why`, `Files
+   Affected`, and `Failure` are left out since they aren't actionable for
+   a coding LLM or are already covered by the file list
 5. On confirmation, adds the files to `aider` and hands off interactive
    control to it
 

--- a/scripts/developer_tools/f_aider_issue_extractor.py
+++ b/scripts/developer_tools/f_aider_issue_extractor.py
@@ -12,7 +12,7 @@ import tempfile
 from pathlib import Path
 
 import requests
-from lib.github_repo import get_repo_info
+from lib.github_repo import get_repo_info, get_repo_root
 from lib.ollama_common import (
     fetch_ollama_review,
     get_ollama_endpoint,
@@ -468,6 +468,11 @@ def main(argv: list[str] | None = None) -> None:
     """Main entry point."""
     args = parse_args(argv)
 
+    # Resolve a local issue file against the caller's original cwd before
+    # the chdir below moves us to the repo root.
+    if args.issue_file:
+        args.issue_file = str(Path(args.issue_file).resolve())
+
     # Fail early if Ollama isn't running, before any GitHub/file I/O -- per
     # the issue's constraint, nothing else here is useful without it.
     endpoint = get_ollama_endpoint()
@@ -480,6 +485,17 @@ def main(argv: list[str] | None = None) -> None:
     if not validate_ollama_connection(endpoint):
         print("ERROR: Ollama serve must be running", file=sys.stderr)
         print(f"ERROR: Could not connect to {endpoint}", file=sys.stderr)
+        sys.exit(1)
+
+    # Extracted/suggested file paths and the final `aider` invocation are
+    # both resolved relative to the process cwd, so chdir to the repo root
+    # to make this work regardless of where the script was invoked from
+    # (e.g. from scripts/developer_tools/, where a repo-relative path like
+    # "frontend/src/main.tsx" would otherwise never resolve).
+    try:
+        os.chdir(get_repo_root())
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
 
     # Get repo info (for GitHub fetching)

--- a/scripts/developer_tools/f_aider_issue_extractor.py
+++ b/scripts/developer_tools/f_aider_issue_extractor.py
@@ -354,8 +354,12 @@ def formulate_aider_prompt(
     if verbose:
         print("[DEBUG] Formulating Aider prompt...", file=sys.stderr)
 
-    # Add structured sections
-    for section in ["what", "why", "how", "files_affected", "constraints", "success", "failure"]:
+    # Add structured sections. "why", "files_affected", and "failure" are
+    # deliberately excluded: motivation isn't actionable for a coding LLM,
+    # the affected files are already loaded into aider's context separately
+    # (repeating them here just adds noise), and "failure" is the inverse of
+    # "success" -- keeping both doesn't add information.
+    for section in ["what", "how", "constraints", "success"]:
         if section in parsed_sections:
             content = parsed_sections[section].strip()
             if content:

--- a/scripts/developer_tools/lib/github_repo.py
+++ b/scripts/developer_tools/lib/github_repo.py
@@ -22,3 +22,17 @@ def get_repo_info() -> tuple[str, str]:
     if match:
         return match.group(1), match.group(2)
     raise ValueError("Could not determine GitHub repo from git remote origin")
+
+
+def get_repo_root() -> str:
+    """Return the absolute path to the current git repository's root."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f"Could not determine repo root from git: {exc}") from exc
+    return result.stdout.strip()

--- a/tests/test_aider_issue_extractor.py
+++ b/tests/test_aider_issue_extractor.py
@@ -404,13 +404,22 @@ class TestMainOrdering:
     """The issue's constraint is to fail early if Ollama isn't running, before
     any other work -- these pin that ordering against a regression."""
 
+    @mock.patch("f_aider_issue_extractor.os.chdir")
+    @mock.patch("f_aider_issue_extractor.get_repo_root", return_value="/repo/root")
     @mock.patch("f_aider_issue_extractor.run_aider")
     @mock.patch("f_aider_issue_extractor.resolve_files_to_edit")
     @mock.patch("f_aider_issue_extractor.fetch_issue_from_github")
     @mock.patch("f_aider_issue_extractor.get_repo_info")
     @mock.patch("f_aider_issue_extractor.validate_ollama_connection")
     def test_ollama_checked_before_github_fetch(
-        self, mock_validate, mock_repo_info, mock_fetch, mock_resolve, mock_run_aider
+        self,
+        mock_validate,
+        mock_repo_info,
+        mock_fetch,
+        mock_resolve,
+        mock_run_aider,
+        mock_get_repo_root,
+        mock_chdir,
     ):
         calls = []
         mock_validate.side_effect = lambda endpoint: calls.append("ollama") or True
@@ -425,6 +434,7 @@ class TestMainOrdering:
 
         assert calls == ["ollama", "github"]
         mock_run_aider.assert_called_once()
+        mock_chdir.assert_called_once_with("/repo/root")
 
     @mock.patch("f_aider_issue_extractor.fetch_issue_from_github")
     @mock.patch("f_aider_issue_extractor.get_repo_info")
@@ -438,3 +448,37 @@ class TestMainOrdering:
         assert exc_info.value.code == 1
         mock_repo_info.assert_not_called()
         mock_fetch.assert_not_called()
+
+    @mock.patch("f_aider_issue_extractor.os.chdir")
+    @mock.patch("f_aider_issue_extractor.get_repo_root", side_effect=ValueError("not a git repo"))
+    @mock.patch("f_aider_issue_extractor.validate_ollama_connection", return_value=True)
+    def test_exits_cleanly_when_repo_root_cannot_be_determined(
+        self, mock_validate, mock_get_repo_root, mock_chdir
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["-i", "42"])
+
+        assert exc_info.value.code == 1
+        mock_chdir.assert_not_called()
+
+    @mock.patch("f_aider_issue_extractor.os.chdir")
+    @mock.patch("f_aider_issue_extractor.get_repo_root", return_value="/repo/root")
+    @mock.patch("f_aider_issue_extractor.run_aider")
+    @mock.patch("f_aider_issue_extractor.resolve_files_to_edit")
+    @mock.patch("f_aider_issue_extractor.get_repo_info", return_value=("owner", "repo"))
+    def test_chdirs_to_repo_root_before_resolving_files(
+        self, mock_repo_info, mock_resolve, mock_run_aider, mock_get_repo_root, mock_chdir
+    ):
+        # Regression test: paths extracted from an issue body (and the files
+        # ultimately handed to aider) are resolved relative to the process
+        # cwd. Without chdir'ing to the repo root first, running this script
+        # from e.g. scripts/developer_tools/ makes every real repo-relative
+        # path look nonexistent.
+        calls = []
+        mock_chdir.side_effect = lambda path: calls.append("chdir")
+        mock_resolve.side_effect = lambda *a, **k: calls.append("resolve") or ["file.py"]
+
+        main(["-f", str(Path(__file__)), "--no-confirm"])
+
+        assert calls == ["chdir", "resolve"]
+        mock_get_repo_root.assert_called_once()

--- a/tests/test_aider_issue_extractor.py
+++ b/tests/test_aider_issue_extractor.py
@@ -190,21 +190,42 @@ class TestResolveFilesToEdit:
 
 class TestFormulateAiderPrompt:
     def test_includes_title_and_sections(self):
-        sections = {"what": "Do the thing.", "why": "Because it matters."}
+        sections = {"what": "Do the thing.", "how": "Do it this way."}
         prompt = formulate_aider_prompt("Issue Title", sections)
         assert prompt.startswith("Issue Title")
         assert "What:" in prompt
         assert "Do the thing." in prompt
-        assert "Why:" in prompt
+        assert "How:" in prompt
+        assert "Do it this way." in prompt
 
     def test_omits_missing_sections(self):
         prompt = formulate_aider_prompt("Issue Title", {"what": "Only this."})
-        assert "Why:" not in prompt
         assert "How:" not in prompt
+        assert "Constraints:" not in prompt
+        assert "Success:" not in prompt
 
     def test_skips_blank_sections(self):
         prompt = formulate_aider_prompt("Issue Title", {"what": "   "})
         assert "What:" not in prompt
+
+    def test_excludes_why_files_affected_and_failure(self):
+        # These sections are deliberately dropped: "why" isn't actionable,
+        # "files_affected" duplicates the file list already loaded into
+        # aider's context, and "failure" is just the inverse of "success".
+        sections = {
+            "what": "Do the thing.",
+            "why": "Because reasons.",
+            "files_affected": "backend/app.py",
+            "success": "It works.",
+            "failure": "It doesn't work.",
+        }
+        prompt = formulate_aider_prompt("Issue Title", sections)
+        assert "Why:" not in prompt
+        assert "Files Affected:" not in prompt
+        assert "backend/app.py" not in prompt
+        assert "Failure:" not in prompt
+        assert "It doesn't work." not in prompt
+        assert "Success:" in prompt
 
 
 class TestFetchIssueFromGithub:


### PR DESCRIPTION
## Summary
Follow-up to #5799, addressing the rest of #5798's failure modes seen after that PR merged.

- The formulated Aider prompt repeated the "Files Affected" section text even though those files are already loaded into aider's context separately, and included "Why" (motivation, not actionable for a coding LLM) and "Failure looks like" (just the inverse of "Success looks like"). Trims the prompt down to Title + What + How + Constraints + Success.
- Extracted/suggested file paths and the final `aider` invocation are resolved relative to the process cwd. Running the script from `scripts/developer_tools/` (as reported against #5798) made every real repo-relative path look nonexistent, reproducing the same "no files found" failure even though extraction itself was working correctly. Adds `get_repo_root()` to `lib/github_repo.py` and `chdir`s to it early in `main()`, so the script works regardless of invocation directory.

Relates to #5798

## Test plan
- [x] `python -m pytest tests/test_aider_issue_extractor.py -q --no-cov` (45 passed)
- [x] `black --check` / `ruff check` on all changed files
- [x] Manually ran `-i 5738` from both the repo root and from `scripts/developer_tools/` and confirmed both correctly find the 2 files and print the trimmed prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)