### PR TITLE
Allocate unique local dev ports for backend/frontend (#5760)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ data/*
 !data/queries/
 !data/queries/**
 
+# Local dev instance port coordination (see #5760)
+/.local/
+
 # Logs
 backend.log
 /tests/.coverage

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -273,6 +273,26 @@ AllotMint depends heavily on realistic local/demo data.
 
 This path is preferred over outdated docs that still mention `uvicorn app:app`.
 
+### Running multiple local instances side by side
+
+`scripts/bash/run-local-api.sh` and `scripts/run-backend.ps1` pick the first
+free port starting at `server.uvicorn_port` (default `8000`) instead of
+failing if it's already bound, so a second checkout (e.g. a separate
+worktree or clone for a different set of changes) can run its own backend at
+the same time. The port actually chosen is logged to the terminal and
+written to `.local/ports/backend.port` (gitignored, one per checkout).
+
+`vite.config.ts` reads that file automatically when you start the frontend
+dev server (`npm --prefix frontend run dev`, or either `run-frontend`
+script) and points `VITE_ALLOTMINT_API_BASE` at the matching backend — the
+terminal and browser console both log which backend URL was picked. This
+only happens for the dev server; explicitly setting `VITE_ALLOTMINT_API_BASE`
+(env var or `.env`) always wins, and production builds/AWS deployments are
+unaffected since they don't run the dev server or read `.local/ports/`.
+
+The frontend dev server itself still uses Vite's own default port-clash
+handling (`5173`, incrementing if busy) — nothing extra to configure there.
+
 ### Minimal local env example
 
 ```bash

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -293,6 +293,17 @@ unaffected since they don't run the dev server or read `.local/ports/`.
 The frontend dev server itself still uses Vite's own default port-clash
 handling (`5173`, incrementing if busy) — nothing extra to configure there.
 
+**Scope**: one backend per checkout at a time. `.local/ports/backend.port`
+lives at the repo root, so two backends started from the *same* checkout
+still race for the same file (last one to finish starting wins) — run
+concurrent instances from separate worktrees/clones instead, each with its
+own `.local/`.
+
+Set `UVICORN_PORT_FIXED=1` to opt out and require the exact configured
+`server.uvicorn_port`, failing loudly instead of shifting to the next free
+port (e.g. if you specifically need the default port and want a clash to be
+an error rather than silently rebinding elsewhere).
+
 ### Minimal local env example
 
 ```bash

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -107,6 +107,12 @@ export let API_BASE: string = (() => {
   }
 })();
 
+// Surface which backend this instance is talking to, so it's obvious in the
+// browser console when running multiple local frontend/backend pairs (#5760).
+if (import.meta.env.DEV) {
+  console.info(`[allotmint] Connecting to backend at ${API_BASE}`);
+}
+
 export const getApiBase = () => API_BASE;
 
 export const setApiBase = (value: string | null | undefined) => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,15 +2,41 @@ import { defineConfig } from 'vitest/config'
 import type { PluginOption } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
+import fs from 'node:fs'
+
+// Local dev instances (e.g. separate worktrees/clones) each run their own
+// backend on a port chosen by scripts/bash/run-local-api.sh or
+// scripts/run-backend.ps1, recorded in .local/ports/backend.port at the
+// repo root. Pick that up automatically so `npm run dev` connects to the
+// right backend without manual VITE_ALLOTMINT_API_BASE wiring (see #5760).
+// Only applies to the dev server — production builds are unaffected.
+function readLocalBackendPort(): string | null {
+  const portFile = path.resolve(__dirname, '..', '.local', 'ports', 'backend.port')
+  try {
+    const port = fs.readFileSync(portFile, 'utf-8').trim()
+    return /^\d+$/.test(port) ? port : null
+  } catch {
+    return null
+  }
+}
 
 // https://vite.dev/config/
-export default defineConfig(() => {
+export default defineConfig(({ command }) => {
   const plugins: PluginOption[] = [
     ...react()
   ]
 
   // Prerender/PWA plugins were intentionally removed because this app now ships
   // as a standard SPA and infrastructure does not consume prerendered artifacts.
+
+  if (command === 'serve' && !process.env.VITE_ALLOTMINT_API_BASE) {
+    const backendPort = readLocalBackendPort()
+    if (backendPort) {
+      const apiBase = `http://localhost:${backendPort}`
+      process.env.VITE_ALLOTMINT_API_BASE = apiBase
+      console.log(`[vite] Connecting to local backend at ${apiBase} (from .local/ports/backend.port)`)
+    }
+  }
 
   const config = {
     plugins,

--- a/scripts/bash/lib/find_free_port.sh
+++ b/scripts/bash/lib/find_free_port.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Shared helper for local dev scripts: find the first free TCP port at or
+# after a starting port. Used to let multiple local backend/frontend
+# instances run concurrently without clashing (see #5760).
+
+# Returns 0 (true) if something is already listening on 127.0.0.1:$1.
+port_in_use() {
+  local port="$1"
+  (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null
+  local result=$?
+  exec 3>&- 2>/dev/null || true
+  return $result
+}
+
+# Prints the first free port at or after $1 (max 100 attempts), falling
+# back to the starting port if none is found.
+find_free_port() {
+  local port="$1"
+  local max_tries="${2:-100}"
+  local tries=0
+  while port_in_use "$port" && [[ $tries -lt $max_tries ]]; do
+    port=$((port + 1))
+    tries=$((tries + 1))
+  done
+  echo "$port"
+}

--- a/scripts/bash/lib/find_free_port.sh
+++ b/scripts/bash/lib/find_free_port.sh
@@ -4,12 +4,12 @@
 # instances run concurrently without clashing (see #5760).
 
 # Returns 0 (true) if something is already listening on 127.0.0.1:$1.
+# Uses fd 6 (not 3) and confines it to a subshell: bats-core reserves fd 3
+# for its own internal signaling, and closing it from the test process
+# (rather than a subshell) corrupts the harness for later tests.
 port_in_use() {
   local port="$1"
-  (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null
-  local result=$?
-  exec 3>&- 2>/dev/null || true
-  return $result
+  (exec 6<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null
 }
 
 # Prints the first free port at or after $1 (max 100 attempts), falling

--- a/scripts/bash/run-frontend.sh
+++ b/scripts/bash/run-frontend.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure the script runs from repository root
+# Ensure the script runs from the frontend directory regardless of caller cwd
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR/frontend"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT/frontend"
 
 # Install dependencies
 npm install

--- a/scripts/bash/run-local-api.sh
+++ b/scripts/bash/run-local-api.sh
@@ -50,9 +50,14 @@ if [[ -z "${UVICORN_PORT_FIXED:-}" ]]; then
   UVICORN_PORT="$RESOLVED_PORT"
 fi
 
+# Write via a temp file + rename so a concurrent reader (vite.config.ts)
+# never observes a partially written port number.
 PORT_FILE_DIR="$REPO_ROOT/.local/ports"
 mkdir -p "$PORT_FILE_DIR"
-echo "$UVICORN_PORT" > "$PORT_FILE_DIR/backend.port"
+PORT_FILE="$PORT_FILE_DIR/backend.port"
+TMP_PORT_FILE="$(mktemp "${PORT_FILE_DIR}/.backend.port.XXXXXX")"
+echo "$UVICORN_PORT" > "$TMP_PORT_FILE"
+mv -f "$TMP_PORT_FILE" "$PORT_FILE"
 echo "Backend will listen on http://localhost:$UVICORN_PORT (port recorded in .local/ports/backend.port)" >&2
 
 if [[ -n "${DATA_BUCKET:-}" ]]; then

--- a/scripts/bash/run-local-api.sh
+++ b/scripts/bash/run-local-api.sh
@@ -35,6 +35,26 @@ LOG_CONFIG=$(awk -F': ' '/^log_config:/ {print $2}' "$CONFIG_FILE" | tr -d '"')
 
 export ALLOTMINT_ENV="$APP_ENV"
 
+# shellcheck source=scripts/bash/lib/find_free_port.sh
+source "$SCRIPT_DIR/lib/find_free_port.sh"
+
+# Pick a free port starting from the configured one so multiple local
+# instances (e.g. separate worktrees/clones) can run side by side without
+# clashing (see #5760). Explicitly setting UVICORN_PORT in the environment
+# is treated as a hard requirement and is not shifted.
+if [[ -z "${UVICORN_PORT_FIXED:-}" ]]; then
+  RESOLVED_PORT=$(find_free_port "$UVICORN_PORT")
+  if [[ "$RESOLVED_PORT" != "$UVICORN_PORT" ]]; then
+    echo "Port $UVICORN_PORT is in use; using $RESOLVED_PORT instead" >&2
+  fi
+  UVICORN_PORT="$RESOLVED_PORT"
+fi
+
+PORT_FILE_DIR="$REPO_ROOT/.local/ports"
+mkdir -p "$PORT_FILE_DIR"
+echo "$UVICORN_PORT" > "$PORT_FILE_DIR/backend.port"
+echo "Backend will listen on http://localhost:$UVICORN_PORT (port recorded in .local/ports/backend.port)" >&2
+
 if [[ -n "${DATA_BUCKET:-}" ]]; then
   echo "Syncing data from s3://$DATA_BUCKET/" >&2
   aws s3 sync "s3://$DATA_BUCKET/" data/

--- a/scripts/run-backend.ps1
+++ b/scripts/run-backend.ps1
@@ -183,13 +183,14 @@ function Coalesce([object]$value, [object]$fallback) {
 }
 
 function Test-PortFree([int]$Port) {
+  $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $Port)
   try {
-    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $Port)
     $listener.Start()
-    $listener.Stop()
     return $true
   } catch {
     return $false
+  } finally {
+    $listener.Stop()
   }
 }
 
@@ -405,9 +406,14 @@ if (-not $env:UVICORN_PORT_FIXED) {
   }
 }
 
+# Write via a temp file + rename so a concurrent reader (vite.config.ts)
+# never observes a partially written port number.
 $portFileDir = Join-Path $REPO_ROOT '.local\ports'
 New-Item -ItemType Directory -Force -Path $portFileDir | Out-Null
-Set-Content -Path (Join-Path $portFileDir 'backend.port') -Value $port -NoNewline
+$portFile = Join-Path $portFileDir 'backend.port'
+$tmpPortFile = Join-Path $portFileDir ".backend.port.$PID.tmp"
+Set-Content -Path $tmpPortFile -Value $port -NoNewline
+Move-Item -Path $tmpPortFile -Destination $portFile -Force
 
 $logConfig = Get-ConfigValue $cfg @('paths','log_config') 'backend/logging.ini'
 $resolvedLogConfig = $null

--- a/scripts/run-backend.ps1
+++ b/scripts/run-backend.ps1
@@ -182,6 +182,29 @@ function Coalesce([object]$value, [object]$fallback) {
   return $fallback
 }
 
+function Test-PortFree([int]$Port) {
+  try {
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $Port)
+    $listener.Start()
+    $listener.Stop()
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+# Finds the first free port at or after $StartPort so multiple local
+# instances (e.g. separate worktrees/clones) can run side by side without
+# clashing (see #5760).
+function Find-FreePort([int]$StartPort, [int]$MaxTries = 100) {
+  $port = $StartPort
+  for ($i = 0; $i -lt $MaxTries; $i++) {
+    if (Test-PortFree $port) { return $port }
+    $port++
+  }
+  return $StartPort
+}
+
 function Read-YamlSimple([string]$path) {
   # Minimal YAML parser supporting nested hashtables via indentation (scalars only; ignores lists)
   $result = @{}
@@ -373,7 +396,19 @@ if (-not $uvicornAvailable) {
 # ───────────── env + defaults (PS 5.1) ────────
 $env:ALLOTMINT_ENV = Get-ConfigValue $cfg @('server','app_env') 'local'
 $env:DATA_ROOT = Coalesce $env:DATA_ROOT (Coalesce $cfg.paths.data_root 'data')
-$port      = Get-ConfigValue $cfg @('server','uvicorn_port') $Port
+$configuredPort = Get-ConfigValue $cfg @('server','uvicorn_port') $Port
+$port      = $configuredPort
+if (-not $env:UVICORN_PORT_FIXED) {
+  $port = Find-FreePort $configuredPort
+  if ($port -ne $configuredPort) {
+    Write-Host "Port $configuredPort is in use; using $port instead" -ForegroundColor Yellow
+  }
+}
+
+$portFileDir = Join-Path $REPO_ROOT '.local\ports'
+New-Item -ItemType Directory -Force -Path $portFileDir | Out-Null
+Set-Content -Path (Join-Path $portFileDir 'backend.port') -Value $port -NoNewline
+
 $logConfig = Get-ConfigValue $cfg @('paths','log_config') 'backend/logging.ini'
 $resolvedLogConfig = $null
 if (Test-Path $logConfig) {
@@ -405,7 +440,7 @@ if (-not $offline) {
 }
 
 # ───────────── start server ───────────────────
-Write-Host "Starting AllotMint Local API on http://localhost:$port ..." -ForegroundColor Green
+Write-Host "Starting AllotMint Local API on http://localhost:$port ... (recorded in .local/ports/backend.port)" -ForegroundColor Green
 
 $arguments = @(
   'backend.local_api.main:app',

--- a/tests/bash/find_free_port.bats
+++ b/tests/bash/find_free_port.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/bash/lib/find_free_port.sh, used by
+# scripts/bash/run-local-api.sh to give each local dev instance a
+# non-clashing backend port (see #5760).
+
+LIB="$BATS_TEST_DIRNAME/../../scripts/bash/lib/find_free_port.sh"
+
+setup() {
+  source "$LIB"
+}
+
+@test "find_free_port returns the starting port when it is free" {
+  # Extremely unlikely to be bound in a CI/test environment.
+  run find_free_port 59123
+  [ "$status" -eq 0 ]
+  [ "$output" = "59123" ]
+}
+
+@test "find_free_port skips a port that is already in use" {
+  command -v python3 >/dev/null || skip "python3 not available"
+
+  # A real accepting server, not a bare listen() backlog — a socket that
+  # never accept()s only tolerates one probe connection before refusing
+  # the rest, which would make this test flaky rather than the code buggy.
+  python3 -m http.server 59200 --bind 127.0.0.1 >/dev/null 2>&1 &
+  local server_pid=$!
+
+  for _ in $(seq 1 20); do
+    port_in_use 59200 && break
+    sleep 0.1
+  done
+
+  run find_free_port 59200
+  kill "$server_pid" 2>/dev/null || true
+  wait "$server_pid" 2>/dev/null || true
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "59201" ]
+}


### PR DESCRIPTION
## Summary

- `scripts/bash/run-local-api.sh` / `scripts/run-backend.ps1` now pick the first free port at or after the configured `server.uvicorn_port` (default `8000`) instead of always binding it, so a second local checkout (separate worktree/clone) can run its backend concurrently. The chosen port is logged and written to `.local/ports/backend.port` (gitignored, per checkout).
- `frontend/vite.config.ts` reads that file for the dev server (not production builds) and sets `VITE_ALLOTMINT_API_BASE` to match, unless the user already set it explicitly. Both the Vite terminal output and the browser console (`frontend/src/api.ts`) log which backend URL is in use.
- Fixed a pre-existing bug in `scripts/bash/run-frontend.sh` where it `cd`'d into a non-existent `scripts/bash/frontend` directory instead of the repo's `frontend/`.
- Added `scripts/bash/lib/find_free_port.sh` (shared bash helper) with bats coverage in `tests/bash/find_free_port.bats`.
- Documented the new behavior in `docs/CONTRIBUTOR_RUNBOOK.md`.

AWS deployment is unaffected: the port search only runs inside the local dev scripts, and the frontend logic only triggers for `vite`'s dev server (`command === 'serve'`), never for `vite build`.

## Test plan

- [x] `bash -n` syntax check on all modified/added shell scripts
- [x] Manually exercised `find_free_port`/`port_in_use` against a real listening server (busy port → next port; free port → itself)
- [x] Manually exercised `Find-FreePort`/`Test-PortFree` in PowerShell against a bound port
- [x] `npm --prefix frontend run lint` — clean
- [x] `npm --prefix frontend run test -- --run` — 655 tests passed
- [x] `npm --prefix frontend run build` — succeeds, confirms prod build path doesn't touch the new logic
- [x] Manually ran `npm run dev` with a fake `.local/ports/backend.port` and confirmed the frontend picked up and logged the matching backend URL
- [ ] CI: `shell-tests` (bats) will run `tests/bash/find_free_port.bats` on Linux

Closes #5760


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local backend development servers now automatically select an available port when the configured port is occupied.
  * The frontend automatically connects to the selected backend port during development.
  * Developers can still enforce a fixed backend port when required.
* **Documentation**
  * Added guidance for running multiple local backend instances across separate checkouts.
* **Bug Fixes**
  * Improved development startup from different working directories.
  * Added clearer reporting of the selected backend port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->