### PR TITLE
Fix UnicodeDecodeError in o_review_issue.py on Windows

### DIFF
--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -141,6 +141,7 @@ def fetch_issue(owner: str, repo: str, number: int) -> dict:
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     if result.returncode != 0:
@@ -246,6 +247,7 @@ def update_issue(owner: str, repo: str, number: int, title: str, body: str, dry_
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=False,
         )
     finally:


### PR DESCRIPTION
## Summary
- `fetch_issue()` and `update_issue()` in `scripts/developer_tools/o_review_issue.py` called `subprocess.run(..., text=True)` without an explicit `encoding`, so Python fell back to the process locale (`cp1252` on Windows) to decode `gh`'s UTF-8 output.
- Any issue body containing a curly quote/em dash (e.g. #5808's repro, issue #3905) then crashed with `UnicodeDecodeError` in a background reader thread, leaving `result.stdout` as `None` and surfacing a confusing `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`.
- Added `encoding="utf-8"` to both `subprocess.run()` calls, matching the existing pattern in `c_triage_issues.py`, `b_create_issue.py`, and `m_dependabot_auto_merge.py`.

Closes #5808

## Test plan
- [ ] Run `python scripts/developer_tools/o_review_issue.py 3905` on Windows and confirm the issue fetches without raising `UnicodeDecodeError`/`TypeError`.
- [ ] `make lint` / relevant Python lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)