### PR TITLE
Fix test_chdirs_to_repo_root_before_resolving_files failing without Ollama (#5810)

### DIFF
--- a/tests/test_aider_issue_extractor.py
+++ b/tests/test_aider_issue_extractor.py
@@ -466,14 +466,27 @@ class TestMainOrdering:
     @mock.patch("f_aider_issue_extractor.run_aider")
     @mock.patch("f_aider_issue_extractor.resolve_files_to_edit")
     @mock.patch("f_aider_issue_extractor.get_repo_info", return_value=("owner", "repo"))
+    @mock.patch("f_aider_issue_extractor.validate_ollama_connection", return_value=True)
     def test_chdirs_to_repo_root_before_resolving_files(
-        self, mock_repo_info, mock_resolve, mock_run_aider, mock_get_repo_root, mock_chdir
+        self,
+        mock_validate,
+        mock_repo_info,
+        mock_resolve,
+        mock_run_aider,
+        mock_get_repo_root,
+        mock_chdir,
     ):
         # Regression test: paths extracted from an issue body (and the files
         # ultimately handed to aider) are resolved relative to the process
         # cwd. Without chdir'ing to the repo root first, running this script
         # from e.g. scripts/developer_tools/ makes every real repo-relative
         # path look nonexistent.
+        #
+        # validate_ollama_connection is mocked (not exercised elsewhere in
+        # this test) purely so main() doesn't sys.exit(1) on the real
+        # connectivity check before ever reaching the chdir this test is
+        # actually verifying (#5810) -- environments without Ollama running
+        # would otherwise fail here for an unrelated reason.
         calls = []
         mock_chdir.side_effect = lambda path: calls.append("chdir")
         mock_resolve.side_effect = lambda *a, **k: calls.append("resolve") or ["file.py"]


### PR DESCRIPTION
## Summary

- `test_chdirs_to_repo_root_before_resolving_files` (added in #5802) mocked every dependency of `main()` except `validate_ollama_connection`. `main()` calls that check *before* `os.chdir(get_repo_root())`, so on any runner without Ollama reachable at `localhost:11434` (every CI runner), it exits at `sys.exit(1)` before ever reaching the chdir the test is supposed to verify — failing with an uncaught `SystemExit: 1` on every run, on `main` and on every PR branched from it.
- Added `@mock.patch("f_aider_issue_extractor.validate_ollama_connection", return_value=True)`, matching the pattern already used by `test_ollama_checked_before_github_fetch` in the same class.
- Left `test_ollama_checked_before_github_fetch` and `test_exits_before_any_github_io_when_ollama_down` untouched — they intentionally exercise Ollama-check behavior.

## Test plan

- [x] `pytest tests/test_aider_issue_extractor.py -v` — 45 passed
- [x] `pytest tests/test_aider_issue_extractor.py::TestMainOrdering::test_chdirs_to_repo_root_before_resolving_files -v --no-cov` — passes in isolation
- [x] `black --check` / `ruff check` on the changed file — clean

Closes #5810
