### PR TITLE
Add encoding="utf-8" to remaining developer_tools subprocess.run(text=True) calls

### DIFF
--- a/scripts/developer_tools/d_work_on_issue.py
+++ b/scripts/developer_tools/d_work_on_issue.py
@@ -53,6 +53,7 @@ def get_main_branch_sha(owner: str, repo: str) -> str:
             ["git", "rev-parse", "origin/main"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=False,
         )
         if result.returncode == 0:
@@ -61,6 +62,7 @@ def get_main_branch_sha(owner: str, repo: str) -> str:
             ["git", "rev-parse", "origin/master"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         return result.stdout.strip()

--- a/scripts/developer_tools/i_local_review.py
+++ b/scripts/developer_tools/i_local_review.py
@@ -36,6 +36,7 @@ def get_git_root() -> str:
             ["git", "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         return result.stdout.strip()
@@ -51,6 +52,7 @@ def get_current_branch() -> str:
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         return result.stdout.strip()
@@ -73,6 +75,7 @@ def get_local_diff(target_branch: str = "main") -> str:
             ["git", "diff", f"{target_branch}...HEAD"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         diff = result.stdout
@@ -82,6 +85,7 @@ def get_local_diff(target_branch: str = "main") -> str:
             ["git", "diff", "HEAD"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         if result.stdout:
@@ -92,6 +96,7 @@ def get_local_diff(target_branch: str = "main") -> str:
             ["git", "ls-files", "--others", "--exclude-standard"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         untracked = result.stdout.strip()

--- a/scripts/developer_tools/l_pr_review.py
+++ b/scripts/developer_tools/l_pr_review.py
@@ -42,6 +42,7 @@ def get_repo_info() -> tuple[str, str]:
             ["git", "config", "--get", "remote.origin.url"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         url = result.stdout.strip()
@@ -77,6 +78,7 @@ def fetch_pr_details(owner: str, repo: str, pr_id: int) -> dict:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         return json.loads(result.stdout)
@@ -95,6 +97,7 @@ def fetch_pr_diff(owner: str, repo: str, pr_id: int) -> str:
             ["gh", "pr", "diff", str(pr_id), "--repo", f"{owner}/{repo}"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         )
         return filter_binary_files(result.stdout)
@@ -135,6 +138,7 @@ def extract_issue_body(pr_body: str, owner: str, repo: str) -> str:
                     ],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
                     check=True,
                 )
                 issue = json.loads(result.stdout)


### PR DESCRIPTION
## Summary
- Follow-up to #5809 (`o_review_issue.py`). The same missing-encoding pattern existed in three other scripts, where `subprocess.run(..., text=True)` decodes `git`/`gh` output using the process locale instead of UTF-8:
  - `l_pr_review.py`: `git config --get remote.origin.url`, `gh pr view --json title,body,baseRefName`, `gh pr diff`, and the nested `gh issue view --json body` call -- the PR/issue body calls are highest risk since they routinely carry non-ASCII text.
  - `i_local_review.py`: `git rev-parse --show-toplevel`, `git rev-parse --abbrev-ref HEAD`, both `git diff` calls, and `git ls-files --others` -- diff content can include non-ASCII bytes.
  - `d_work_on_issue.py`: both `git rev-parse origin/main` / `origin/master` calls -- lower risk (ref names are ASCII) but fixed for consistency.
- Added `encoding="utf-8"` to all 11 calls, matching the pattern already used in `c_triage_issues.py`, `b_create_issue.py`, `m_dependabot_auto_merge.py`, and `o_review_issue.py`.
- Confirmed `h_run_ci_checks.py` and `e_work_on_pr.py` don't decode captured text output the same way and don't need this fix.

Closes #5812

## Test plan
- [ ] `python -m py_compile` passes on all three files (done locally).
- [ ] Run `l_pr_review.py` against a PR whose body/diff contains non-ASCII characters (e.g. curly quotes) on Windows and confirm no `UnicodeDecodeError`.
- [ ] `make lint` / relevant Python lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)