### PR TITLE
Narrow backend-integration.yml suite for scripts/developer_tools/**-only changes

### DIFF
--- a/.github/workflows/_classify-change.yml
+++ b/.github/workflows/_classify-change.yml
@@ -33,6 +33,12 @@ on:
       shell:
         description: Change can affect shell scripts, containers or deploy tooling.
         value: ${{ jobs.classify.outputs.shell }}
+      backend-dev-tools-only:
+        description: >-
+          Backend area is affected, but only via scripts/developer_tools/** or
+          tests/scripts/** -- the backend job can run tests/scripts instead of
+          the full suite. Not an area gate; see scripts/classify_change.py.
+        value: ${{ jobs.classify.outputs.backend-dev-tools-only }}
 
 permissions:
   contents: read
@@ -48,6 +54,7 @@ jobs:
       frontend: ${{ steps.classify.outputs.frontend }}
       cdk: ${{ steps.classify.outputs.cdk }}
       shell: ${{ steps.classify.outputs.shell }}
+      backend-dev-tools-only: ${{ steps.classify.outputs.backend-dev-tools-only }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -31,6 +31,14 @@ jobs:
       AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       DATA_BUCKET: ${{ secrets.DATA_BUCKET }}
+      # 'true' only when every backend-affecting path is confined to
+      # scripts/developer_tools/** or tests/scripts/** (see #5823) -- those
+      # helpers have no import relationship to backend/, so the narrow
+      # tests/scripts suite gives equivalent coverage without paying for the
+      # full ~3500-test backend suite. `== 'true'` (not `!= 'false'`) is the
+      # correct polarity here: a missing/empty classifier output must run the
+      # FULL suite, not skip it, matching the job-level fail-safe above.
+      BACKEND_DEV_TOOLS_ONLY: ${{ needs.classify-change.outputs.backend-dev-tools-only == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -69,6 +77,11 @@ jobs:
           aws s3 sync "s3://$DATA_BUCKET/" data/
 
       - name: Type-check backend
+        # Skipped when the change is confined to scripts/developer_tools/** /
+        # tests/scripts/** (see BACKEND_DEV_TOOLS_ONLY above): those paths
+        # can't affect backend/, so a fresh mypy run over backend/ can't
+        # produce a different result than the last run that touched it.
+        if: env.BACKEND_DEV_TOOLS_ONLY != 'true'
         # --explicit-package-bases is required because of the root-level __init__.py
         # (added in #4840 so `backend.contracts_spa` imports resolve from the repo
         # root). Without it, mypy walks up from that __init__.py to infer a module
@@ -81,12 +94,14 @@ jobs:
           python -m mypy --version
           python -m mypy backend --config-file mypy.ini --show-error-codes --pretty --explicit-package-bases
       - name: Run provider parity tests
+        if: env.BACKEND_DEV_TOOLS_ONLY != 'true'
         env:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
         run: |
           pytest --no-cov tests/backend/common/test_data_provider_parity.py -q
 
       - name: Run tests
+        if: env.BACKEND_DEV_TOOLS_ONLY != 'true'
         env:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
         run: |
@@ -94,7 +109,17 @@ jobs:
           pytest tests --ignore=tests/live --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=80 -q
           pytest tests/test_backend_api.py::test_health tests/test_accounts_api.py --cov=backend --cov-append --cov-report=xml --cov-report=term --cov-fail-under=80 -q
 
+      # Narrow suite for a scripts/developer_tools/**-only change: equivalent
+      # coverage without paying for the full backend suite or its 80%
+      # backend/ coverage gate, which a dev-tools-only diff can't move.
+      - name: Run dev-tools test suite
+        if: env.BACKEND_DEV_TOOLS_ONLY == 'true'
+        env:
+          ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
+        run: pytest tests/scripts --no-cov -q
+
       - name: Upload backend coverage reports to Codecov
+        if: env.BACKEND_DEV_TOOLS_ONLY != 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         # fail_ci_if_error: false — Codecov v6 CLI has a GPG key verification
         # issue on GitHub-hosted runners; treat upload failures as non-fatal

--- a/scripts/classify_change.py
+++ b/scripts/classify_change.py
@@ -15,6 +15,13 @@ Two classifications are produced from a single ``git diff``:
     below. A doc-only diff sets every area to false, so CI jobs need to
     consult one flag rather than a flag plus a doc-only override.
 
+``backend-dev-tools-only``
+    True when the backend area is affected *and* every backend-affecting
+    path is confined to ``scripts/developer_tools/**`` or ``tests/scripts/**``
+    -- local-only dev-tools CLI helpers with no import relationship to
+    ``backend/``. Not an area gate on its own: it only tells the backend job
+    it can run ``tests/scripts`` instead of the full suite.
+
 The classifier is intentionally conservative: false negatives (running a
 suite that the change could not have broken) are cheap, false positives
 (skipping a suite that would have caught a regression) are not. When in
@@ -180,6 +187,44 @@ def areas_for_path(path: str) -> frozenset[str]:
     return _ALL_AREAS
 
 
+# Paths whose only backend-relevant coverage lives in `tests/scripts/`: the
+# local-only dev-tools CLI helpers (issue triage, PR review, aider
+# integration) and their tests, neither of which is imported by `backend/`.
+# When every backend-affecting path in a diff matches one of these globs,
+# `backend-integration.yml` can run `pytest tests/scripts` instead of the
+# full backend suite -- see issue #5823.
+_NARROW_BACKEND_GLOBS: tuple[str, ...] = (
+    "scripts/developer_tools/**",
+    "tests/scripts/**",
+)
+_COMPILED_NARROW_BACKEND_RULES: tuple[re.Pattern[str], ...] = tuple(
+    _glob_to_regex(pattern) for pattern in _NARROW_BACKEND_GLOBS
+)
+
+
+def _is_narrow_backend_path(path: str) -> bool:
+    normalised = path.lower()
+    return any(regex.match(normalised) for regex in _COMPILED_NARROW_BACKEND_RULES)
+
+
+def backend_dev_tools_only(diff_text: str) -> bool:
+    """Return True if every backend-affecting path is confined to dev-tools.
+
+    False whenever the backend area isn't touched at all -- callers must only
+    consult this after confirming the backend area flag is true, mirroring
+    how doc-only zeroes every area rather than this flag standing alone.
+    """
+    saw_backend_path = False
+    for file_diff in parse_file_diffs(diff_text):
+        for path in (file_diff.path, file_diff.old_path):
+            if "backend" not in areas_for_path(path):
+                continue
+            saw_backend_path = True
+            if not _is_narrow_backend_path(path):
+                return False
+    return saw_backend_path
+
+
 class FileDiff:
     """Mutable record of one file's entry in a unified `git diff`."""
 
@@ -287,16 +332,18 @@ def areas_for_diff(diff_text: str) -> frozenset[str]:
     return frozenset(affected)
 
 
-def classify(event_name: str, base: str, head: str) -> tuple[bool, frozenset[str]]:
-    """Return ``(doc_only, affected_areas)`` for a change.
+def classify(event_name: str, base: str, head: str) -> tuple[bool, frozenset[str], bool]:
+    """Return ``(doc_only, affected_areas, backend_dev_tools_only)`` for a change.
 
     Only ``pull_request`` events get diff-based classification; every other
     event (push, workflow_dispatch, ...) conservatively runs the full suite,
     since a base/head diff isn't meaningful in the same way there. A diff
-    that cannot be computed widens to the full suite for the same reason.
+    that cannot be computed widens to the full suite for the same reason --
+    both fall back to ``backend_dev_tools_only=False`` so the backend job
+    runs its full suite rather than the narrow one.
     """
     if event_name != "pull_request" or not base or not head:
-        return False, _ALL_AREAS
+        return False, _ALL_AREAS, False
     try:
         diff_text = get_diff_text(base, head)
     except subprocess.CalledProcessError as exc:
@@ -304,12 +351,14 @@ def classify(event_name: str, base: str, head: str) -> tuple[bool, frozenset[str
             f"WARNING: could not compute diff ({exc}); treating every area as affected",
             file=sys.stderr,
         )
-        return False, _ALL_AREAS
+        return False, _ALL_AREAS, False
     # A doc-only diff zeroes every area so gated jobs consult a single flag
     # rather than an area flag plus a doc-only override.
     if classify_diff(diff_text):
-        return True, _NO_AREAS
-    return False, areas_for_diff(diff_text)
+        return True, _NO_AREAS, False
+    areas = areas_for_diff(diff_text)
+    narrow = "backend" in areas and backend_dev_tools_only(diff_text)
+    return False, areas, narrow
 
 
 def get_diff_text(base: str, head: str) -> str:
@@ -331,18 +380,23 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def format_output_lines(doc_only: bool, areas: frozenset[str]) -> list[str]:
-    """Render the classification as ``key=value`` lines, doc-only first."""
+def format_output_lines(doc_only: bool, areas: frozenset[str], backend_dev_tools_only: bool) -> list[str]:
+    """Render the classification as ``key=value`` lines, doc-only first.
+
+    ``backend-dev-tools-only`` is not an area gate -- it never skips a job on
+    its own -- so it's appended last, after every area flag.
+    """
     lines = [f"doc-only={'true' if doc_only else 'false'}"]
     lines.extend(f"{area}={'true' if area in areas else 'false'}" for area in AREAS)
+    lines.append(f"backend-dev-tools-only={'true' if backend_dev_tools_only else 'false'}")
     return lines
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    doc_only, areas = classify(args.event_name, args.base, args.head)
+    doc_only, areas, backend_dev_tools_only = classify(args.event_name, args.base, args.head)
 
-    output_lines = format_output_lines(doc_only, areas)
+    output_lines = format_output_lines(doc_only, areas, backend_dev_tools_only)
     for line in output_lines:
         print(line)
     if args.github_output:

--- a/tests/scripts/test_ci_area_gating.py
+++ b/tests/scripts/test_ci_area_gating.py
@@ -125,9 +125,12 @@ def test_reusable_workflow_exposes_every_area() -> None:
     # PyYAML parses the `on:` key as the boolean True.
     triggers = workflow.get(True) or workflow.get("on")
     declared = set(triggers["workflow_call"]["outputs"])
-    assert declared == {*AREAS, "doc-only"}, (
-        f"_classify-change.yml declares outputs {sorted(declared)}, but "
-        f"classify_change.py emits {sorted({*AREAS, 'doc-only'})}"
+    # backend-dev-tools-only is not an area (see scripts/classify_change.py):
+    # it never gates a job on its own, so it's expected alongside the areas
+    # rather than folded into them.
+    expected = {*AREAS, "doc-only", "backend-dev-tools-only"}
+    assert declared == expected, (
+        f"_classify-change.yml declares outputs {sorted(declared)}, but " f"classify_change.py emits {sorted(expected)}"
     )
 
     job_outputs = set(workflow["jobs"]["classify"]["outputs"])

--- a/tests/scripts/test_classify_change.py
+++ b/tests/scripts/test_classify_change.py
@@ -18,6 +18,7 @@ is_doc_path = _mod.is_doc_path
 main = _mod.main
 areas_for_path = _mod.areas_for_path
 areas_for_diff = _mod.areas_for_diff
+backend_dev_tools_only = _mod.backend_dev_tools_only
 classify = _mod.classify
 AREAS = _mod.AREAS
 
@@ -273,9 +274,10 @@ class TestMain:
         )
         assert exit_code == 0
         written = output_file.read_text(encoding="utf-8").splitlines()
-        # An empty diff is doc-only, so every area flag must be false.
+        # An empty diff is doc-only, so every area flag (and the narrow
+        # dev-tools flag) must be false.
         assert written[0] == "doc-only=true"
-        assert sorted(written[1:]) == sorted(f"{area}=false" for area in AREAS)
+        assert sorted(written[1:]) == sorted([*(f"{area}=false" for area in AREAS), "backend-dev-tools-only=false"])
 
     def test_diff_failure_falls_back_to_not_doc_only(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -303,7 +305,7 @@ class TestMain:
         assert exit_code == 0
         printed = capsys.readouterr().out.splitlines()
         keys = [line.split("=", 1)[0] for line in printed]
-        assert keys == ["doc-only", *AREAS]
+        assert keys == ["doc-only", *AREAS, "backend-dev-tools-only"]
 
 
 # ---------------------------------------------------------------------------
@@ -443,6 +445,107 @@ rename to frontend/src/helper.ts
 
 
 # ---------------------------------------------------------------------------
+# backend_dev_tools_only
+# ---------------------------------------------------------------------------
+
+
+class TestBackendDevToolsOnly:
+    def test_dev_tools_script_change_is_narrow(self) -> None:
+        diff = """\
+diff --git a/scripts/developer_tools/n_review_issue.py b/scripts/developer_tools/n_review_issue.py
+index abc123..def456 100644
+--- a/scripts/developer_tools/n_review_issue.py
++++ b/scripts/developer_tools/n_review_issue.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+"""
+        assert backend_dev_tools_only(diff) is True
+
+    def test_dev_tools_test_change_is_narrow(self) -> None:
+        diff = """\
+diff --git a/tests/scripts/test_n_review_issue.py b/tests/scripts/test_n_review_issue.py
+index abc123..def456 100644
+--- a/tests/scripts/test_n_review_issue.py
++++ b/tests/scripts/test_n_review_issue.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+"""
+        assert backend_dev_tools_only(diff) is True
+
+    def test_other_scripts_change_is_not_narrow(self) -> None:
+        """A non-dev-tools scripts/** file still falls to the full backend suite."""
+        diff = """\
+diff --git a/scripts/check_portfolio_health.py b/scripts/check_portfolio_health.py
+index abc123..def456 100644
+--- a/scripts/check_portfolio_health.py
++++ b/scripts/check_portfolio_health.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+"""
+        assert backend_dev_tools_only(diff) is False
+
+    def test_backend_module_change_is_not_narrow(self) -> None:
+        diff = """\
+diff --git a/backend/app.py b/backend/app.py
+index abc123..def456 100644
+--- a/backend/app.py
++++ b/backend/app.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+"""
+        assert backend_dev_tools_only(diff) is False
+
+    def test_mixed_dev_tools_and_backend_change_is_not_narrow(self) -> None:
+        diff = """\
+diff --git a/scripts/developer_tools/n_review_issue.py b/scripts/developer_tools/n_review_issue.py
+index abc123..def456 100644
+--- a/scripts/developer_tools/n_review_issue.py
++++ b/scripts/developer_tools/n_review_issue.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+diff --git a/backend/app.py b/backend/app.py
+index abc123..def456 100644
+--- a/backend/app.py
++++ b/backend/app.py
+@@ -1 +1 @@
+-y = 1
++y = 2
+"""
+        assert backend_dev_tools_only(diff) is False
+
+    def test_rename_out_of_dev_tools_is_not_narrow(self) -> None:
+        """Moving a dev-tools script into backend/ must not narrow the suite."""
+        diff = """\
+diff --git a/scripts/developer_tools/n_review_issue.py b/backend/n_review_issue.py
+similarity index 100%
+rename from scripts/developer_tools/n_review_issue.py
+rename to backend/n_review_issue.py
+"""
+        assert backend_dev_tools_only(diff) is False
+
+    def test_frontend_only_diff_is_not_narrow(self) -> None:
+        """No backend path at all means the narrow flag doesn't apply."""
+        diff = """\
+diff --git a/frontend/src/App.tsx b/frontend/src/App.tsx
+index abc123..def456 100644
+--- a/frontend/src/App.tsx
++++ b/frontend/src/App.tsx
+@@ -1 +1 @@
+-const a = 1
++const a = 2
+"""
+        assert backend_dev_tools_only(diff) is False
+
+    def test_empty_diff_is_not_narrow(self) -> None:
+        assert backend_dev_tools_only("") is False
+
+
+# ---------------------------------------------------------------------------
 # classify (the doc-only + areas combination the workflows consume)
 # ---------------------------------------------------------------------------
 
@@ -455,9 +558,10 @@ class TestClassify:
             raise AssertionError("get_diff_text should not be called for push events")
 
         monkeypatch.setattr(_mod, "get_diff_text", fail_if_called)
-        doc_only, areas = classify("push", "abc", "def")
+        doc_only, areas, narrow = classify("push", "abc", "def")
         assert doc_only is False
         assert set(areas) == set(AREAS)
+        assert narrow is False
 
     @pytest.mark.parametrize(("base", "head"), [("", "head-sha"), ("base-sha", ""), ("", "")])
     def test_missing_sha_affects_every_area(self, monkeypatch: pytest.MonkeyPatch, base: str, head: str) -> None:
@@ -466,17 +570,19 @@ class TestClassify:
             "get_diff_text",
             lambda b, h: (_ for _ in ()).throw(AssertionError("should not diff without both SHAs")),
         )
-        _, areas = classify("pull_request", base, head)
+        _, areas, narrow = classify("pull_request", base, head)
         assert set(areas) == set(AREAS)
+        assert narrow is False
 
     def test_diff_failure_affects_every_area(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def raise_called_process_error(base: str, head: str) -> str:
             raise subprocess.CalledProcessError(1, ["git", "diff"])
 
         monkeypatch.setattr(_mod, "get_diff_text", raise_called_process_error)
-        doc_only, areas = classify("pull_request", "abc", "def")
+        doc_only, areas, narrow = classify("pull_request", "abc", "def")
         assert doc_only is False
         assert set(areas) == set(AREAS)
+        assert narrow is False
 
     def test_doc_only_diff_zeroes_every_area(self, monkeypatch: pytest.MonkeyPatch) -> None:
         diff = """\
@@ -488,9 +594,10 @@ index abc123..def456 100644
 +Some prose.
 """
         monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
-        doc_only, areas = classify("pull_request", "abc", "def")
+        doc_only, areas, narrow = classify("pull_request", "abc", "def")
         assert doc_only is True
         assert areas == frozenset()
+        assert narrow is False
 
     def test_comment_only_python_change_zeroes_areas_despite_backend_path(
         self, monkeypatch: pytest.MonkeyPatch
@@ -505,9 +612,10 @@ index abc123..def456 100644
 +# Explanatory comment only.
 """
         monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
-        doc_only, areas = classify("pull_request", "abc", "def")
+        doc_only, areas, narrow = classify("pull_request", "abc", "def")
         assert doc_only is True
         assert areas == frozenset()
+        assert narrow is False
 
     def test_backend_only_change_does_not_affect_frontend(self, monkeypatch: pytest.MonkeyPatch) -> None:
         diff = """\
@@ -520,9 +628,10 @@ index abc123..def456 100644
 +LIMIT = 20
 """
         monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
-        doc_only, areas = classify("pull_request", "abc", "def")
+        doc_only, areas, narrow = classify("pull_request", "abc", "def")
         assert doc_only is False
         assert set(areas) == {"backend"}
+        assert narrow is False
 
     def test_frontend_only_change_does_not_affect_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
         diff = """\
@@ -535,8 +644,9 @@ index abc123..def456 100644
 +const a = 2
 """
         monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
-        _, areas = classify("pull_request", "abc", "def")
+        _, areas, narrow = classify("pull_request", "abc", "def")
         assert set(areas) == {"frontend"}
+        assert narrow is False
 
     def test_powershell_only_change_falls_back_to_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """No dedicated area for .ps1 (no Pester suite); falls to scripts/** -> backend."""
@@ -550,8 +660,9 @@ index abc123..def456 100644
 +$x = 2
 """
         monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
-        _, areas = classify("pull_request", "abc", "def")
+        _, areas, narrow = classify("pull_request", "abc", "def")
         assert set(areas) == {"backend"}
+        assert narrow is False
 
     def test_workflow_change_affects_every_area(self, monkeypatch: pytest.MonkeyPatch) -> None:
         diff = """\
@@ -564,5 +675,45 @@ index abc123..def456 100644
 +  runs-on: ubuntu-24.04
 """
         monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
-        _, areas = classify("pull_request", "abc", "def")
+        _, areas, narrow = classify("pull_request", "abc", "def")
         assert set(areas) == set(AREAS)
+        assert narrow is False
+
+    def test_dev_tools_only_change_sets_narrow_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        diff = """\
+diff --git a/scripts/developer_tools/n_review_issue.py b/scripts/developer_tools/n_review_issue.py
+index abc123..def456 100644
+--- a/scripts/developer_tools/n_review_issue.py
++++ b/scripts/developer_tools/n_review_issue.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+"""
+        monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
+        doc_only, areas, narrow = classify("pull_request", "abc", "def")
+        assert doc_only is False
+        assert set(areas) == {"backend"}
+        assert narrow is True
+
+    def test_dev_tools_plus_backend_change_clears_narrow_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A dev-tools change alongside a real backend/ change must run the full suite."""
+        diff = """\
+diff --git a/scripts/developer_tools/n_review_issue.py b/scripts/developer_tools/n_review_issue.py
+index abc123..def456 100644
+--- a/scripts/developer_tools/n_review_issue.py
++++ b/scripts/developer_tools/n_review_issue.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+diff --git a/backend/app.py b/backend/app.py
+index abc123..def456 100644
+--- a/backend/app.py
++++ b/backend/app.py
+@@ -1 +1 @@
+-y = 1
++y = 2
+"""
+        monkeypatch.setattr(_mod, "get_diff_text", lambda base, head: diff)
+        _, areas, narrow = classify("pull_request", "abc", "def")
+        assert set(areas) == {"backend"}
+        assert narrow is False


### PR DESCRIPTION
## Summary

- `scripts/classify_change.py` now emits a `backend-dev-tools-only` flag: true when every backend-affecting path in a diff is confined to `scripts/developer_tools/**` or `tests/scripts/**` (the local-only dev-tools CLI helpers and their tests, which have no import relationship to `backend/`).
- `backend-integration.yml`'s `integration-tests` job consumes this flag and runs `pytest tests/scripts` instead of the full ~3500-test backend suite when it's true, and skips the mypy/provider-parity steps and Codecov upload, since `backend/` is guaranteed untouched.
- This is not a new required check — the existing `integration-tests` job just does less work on dev-tools-only PRs — so `check_branch_protection_required_checks.py` and the ruleset are unaffected (verified locally, still passes).

## Why

Per #5823: a two-line fix to a `scripts/developer_tools/**` helper currently triggers the same ~4-minute full backend suite as an actual `backend/` change, and picks up unrelated flakiness anywhere in that suite (as seen on #5809/#5817), despite `scripts/developer_tools/**` already having dedicated coverage under `tests/scripts/`.

## How

`backend_dev_tools_only()` walks every file in the diff, and for any path whose `areas_for_path()` includes `backend`, checks whether it also matches the narrow dev-tools globs. If **any** backend-affecting path falls outside those globs (e.g. an actual `backend/**` file, or another `scripts/**` helper like `scripts/check_portfolio_health.py`), the flag stays false and the full suite runs — so a PR mixing a real backend change with a dev-tools change still gets full coverage.

Closes #5823

## Test plan

- [x] `pytest tests/scripts -q --no-cov` — 367 passed, including new `TestBackendDevToolsOnly` and updated `TestClassify`/`TestMain` cases
- [x] `ruff check --config backend/pyproject.toml scripts/classify_change.py tests/scripts/test_classify_change.py tests/scripts/test_ci_area_gating.py` — clean
- [x] `black --check --config backend/pyproject.toml ...` — clean
- [x] `python scripts/check_branch_protection_required_checks.py` — still matches (no required-check drift)
- [x] YAML syntax validated for both edited workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
