### PR TITLE
Narrow file finder to unambiguous, fresh matches

### DIFF
--- a/.github/scripts/create_followup_issues.py
+++ b/.github/scripts/create_followup_issues.py
@@ -14,7 +14,7 @@ from typing import Callable
 
 from llm_labels import extract_tier_label
 
-_FALLBACK_BODY_TEMPLATE = "Follow-up suggested by AI review of PR #{pr_number}."
+_PR_FOOTER_TEMPLATE = "_Follow-up suggested by AI review of PR #{pr_number}._"
 
 # Conversational preamble the model sometimes prepends before the real body,
 # e.g. "Here is a complete, actionable GitHub issue body based on your request."
@@ -111,17 +111,19 @@ Output ONLY the raw Markdown issue body. Do not wrap it in a code fence and do
 not add any preamble (e.g. "Here is the issue body") — start directly with the
 first heading. When you name a file, function, or line number, use only paths
 you can confirm from the review text above; if you are unsure, describe the
-location instead of guessing a concrete path.
-End with: _Follow-up from AI review of PR #{pr_number}._"""
+location instead of guessing a concrete path. Do not add a footer crediting the
+source PR -- that is appended separately."""
 
 
 def _call_anthropic(api_key: str, prompt: str) -> str:
     model = os.environ.get("ANTHROPIC_FOLLOWUP_MODEL", "claude-haiku-4-5-20251001")
-    payload = json.dumps({
-        "model": model,
-        "max_tokens": 1024,
-        "messages": [{"role": "user", "content": prompt}],
-    }).encode()
+    payload = json.dumps(
+        {
+            "model": model,
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+    ).encode()
     req = urllib.request.Request(
         "https://api.anthropic.com/v1/messages",
         data=payload,
@@ -136,16 +138,20 @@ def _call_anthropic(api_key: str, prompt: str) -> str:
     return data["content"][0]["text"].strip()
 
 
-def _openai_compatible_caller(url: str, model_env: str, default_model: str) -> Callable[[str, str], str]:
+def _openai_compatible_caller(
+    url: str, model_env: str, default_model: str
+) -> Callable[[str, str], str]:
     """Return a caller for OpenAI-compatible chat-completions APIs (OpenAI, DeepSeek)."""
 
     def _call(api_key: str, prompt: str) -> str:
-        payload = json.dumps({
-            "model": os.environ.get(model_env, default_model),
-            "max_tokens": 1024,
-            "temperature": 0.2,
-            "messages": [{"role": "user", "content": prompt}],
-        }).encode()
+        payload = json.dumps(
+            {
+                "model": os.environ.get(model_env, default_model),
+                "max_tokens": 1024,
+                "temperature": 0.2,
+                "messages": [{"role": "user", "content": prompt}],
+            }
+        ).encode()
         req = urllib.request.Request(
             url,
             data=payload,
@@ -166,60 +172,91 @@ _PROVIDERS: dict[str, tuple[str, Callable[[str, str], str]]] = {
     "claude": ("ANTHROPIC_API_KEY", _call_anthropic),
     "gpt": (
         "OPENAI_API_KEY",
-        _openai_compatible_caller("https://api.openai.com/v1/chat/completions", "OPENAI_FOLLOWUP_MODEL", "gpt-4o-mini"),
+        _openai_compatible_caller(
+            "https://api.openai.com/v1/chat/completions", "OPENAI_FOLLOWUP_MODEL", "gpt-4o-mini"
+        ),
     ),
     "deepseek": (
         "DEEPSEEK_API_KEY",
         _openai_compatible_caller(
-            "https://api.deepseek.com/v1/chat/completions", "DEEPSEEK_FOLLOWUP_MODEL", "deepseek-v4-flash"
+            "https://api.deepseek.com/v1/chat/completions",
+            "DEEPSEEK_FOLLOWUP_MODEL",
+            "deepseek-v4-flash",
         ),
     ),
 }
 
 
-def _generate_body_via_llm(title: str, pr_number: str, review_text: str) -> str:
+def _generate_body_via_llm(title: str, pr_number: str, review_text: str) -> str | None:
     """Call the configured LLM provider to generate a rich issue body.
 
     The provider is chosen via FOLLOWUP_LLM_PROVIDER (claude, gpt, or deepseek;
-    defaults to deepseek). Falls back to a minimal template if the provider is
-    unknown, its API key is unset, or the API call fails.
+    defaults to deepseek). Returns None if the provider is unknown, its API key is
+    unset, or the API call fails -- callers fall back to a minimal body.
     """
     # GitHub Actions sets unset `vars.*` to an empty string rather than omitting the
     # env var entirely, so `os.environ.get(..., default)` would not apply the default.
     provider = os.environ.get("FOLLOWUP_LLM_PROVIDER", "").strip().lower() or _DEFAULT_PROVIDER
     provider_config = _PROVIDERS.get(provider)
     if provider_config is None:
-        print(f"WARNING: unknown FOLLOWUP_LLM_PROVIDER '{provider}', using fallback body", file=sys.stderr)
-        return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
+        print(
+            f"WARNING: unknown FOLLOWUP_LLM_PROVIDER '{provider}', using fallback body",
+            file=sys.stderr,
+        )
+        return None
 
     api_key_env, call = provider_config
     api_key = os.environ.get(api_key_env, "")
     if not api_key:
-        return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
+        return None
 
     prompt = _build_prompt(title, pr_number, review_text)
     try:
         return _sanitize_body(call(api_key, prompt))
-    except (urllib.error.HTTPError, urllib.error.URLError, KeyError, IndexError, json.JSONDecodeError) as exc:
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        KeyError,
+        IndexError,
+        json.JSONDecodeError,
+    ) as exc:
         print(f"WARNING: failed to generate issue body via {provider}: {exc}", file=sys.stderr)
-        return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
+        return None
 
 
 def _build_body(title: str, pr_number: str, review_text: str | None) -> str:
-    if review_text:
-        return _generate_body_via_llm(title, pr_number, review_text)
-    return _FALLBACK_BODY_TEMPLATE.format(pr_number=pr_number)
+    """Build the issue body, always ending with a footer linking back to the source PR.
+
+    The prompt used to ask the model to end with a PR-linking footer itself, but that
+    was unreliable: long responses got truncated (max_tokens) before reaching it, and
+    models sometimes dropped it outright -- the #5845/#5846/#5847 batch of auto-filed
+    follow-ups all shipped with no visible link back to PR #5830, the review that
+    generated them. The footer is appended here unconditionally instead, so every
+    follow-up issue is traceable back to its source PR regardless of what the model
+    actually returned.
+    """
+    footer = _PR_FOOTER_TEMPLATE.format(pr_number=pr_number)
+    body = _generate_body_via_llm(title, pr_number, review_text) if review_text else None
+    if not body:
+        return footer
+    return f"{body}\n\n{footer}"
 
 
 def issue_exists(title: str) -> bool:
     """Return True if an ai-suggested issue with this exact title already exists."""
     result = subprocess.run(
         [
-            "gh", "issue", "list",
-            "--label", "ai-suggested",
-            "--search", title,
-            "--json", "title",
-            "--limit", "20",
+            "gh",
+            "issue",
+            "list",
+            "--label",
+            "ai-suggested",
+            "--search",
+            title,
+            "--json",
+            "title",
+            "--limit",
+            "20",
         ],
         capture_output=True,
         text=True,
@@ -234,9 +271,7 @@ def issue_exists(title: str) -> bool:
     return any(i.get("title", "").strip() == title.strip() for i in issues)
 
 
-def create_issues(
-    titles: list[str], pr_number: str, review_text: str | None = None
-) -> list[str]:
+def create_issues(titles: list[str], pr_number: str, review_text: str | None = None) -> list[str]:
     """Create each follow-up issue, returning titles that failed to create.
 
     A failure on one title (e.g. an unrecognized label) must not abort the
@@ -298,7 +333,10 @@ def main() -> int:
 
     failed = create_issues(titles, pr_number, review_text)
     if failed:
-        print(f"ERROR: {len(failed)} of {len(titles)} follow-up issue(s) failed to create", file=sys.stderr)
+        print(
+            f"ERROR: {len(failed)} of {len(titles)} follow-up issue(s) failed to create",
+            file=sys.stderr,
+        )
         return 1
     return 0
 

--- a/.github/scripts/extract_followups.py
+++ b/.github/scripts/extract_followups.py
@@ -9,20 +9,37 @@ from pathlib import Path
 
 # Require at least 3 chars so trivial backtick tokens (`` `s` ``, `` `1` ``)
 # don't masquerade as a file/function/identifier reference.
-_REFERENCE_PATTERN = re.compile(r'`[^`]{3,}`')
+_REFERENCE_PATTERN = re.compile(r"`[^`]{3,}`")
 
 # Generic, low-value phrasing that gives an agent nothing concrete to act on.
 # A title is only rejected if it matches one of these AND has no backtick-quoted
 # file/function/identifier reference (see _is_low_specificity).
 _GENERIC_PHRASING_PATTERNS = [
     re.compile(
-        r'\bconsider adding (?:more )?(?:detailed|descriptive)?\s*'
-        r'(?:comments?|logging|documentation|tests?)\b.*\bfor clarity\b',
+        r"\bconsider adding (?:more )?(?:detailed|descriptive)?\s*"
+        r"(?:comments?|logging|documentation|tests?)\b.*\bfor clarity\b",
         re.IGNORECASE,
     ),
-    re.compile(r'\bimprove readability\b', re.IGNORECASE),
-    re.compile(r'\badd(?:ing)? more context\b', re.IGNORECASE),
+    re.compile(r"\bimprove readability\b", re.IGNORECASE),
+    re.compile(r"\badd(?:ing)? more context\b", re.IGNORECASE),
 ]
+
+# Quote pairs an AI reviewer wraps a suggested title in (straight and curly).
+_WRAPPING_QUOTE_PAIRS = [('"', '"'), ("'", "'"), ("“", "”"), ("‘", "’")]
+
+
+def _strip_wrapping_quotes(title: str) -> str:
+    """Strip a single matched pair of wrapping quote marks from a title.
+
+    The AI reviewer sometimes writes suggested titles wrapped in quotes (e.g.
+    `- "Add relevance scoring..."`); the bullet regex captures the line verbatim,
+    so without this the quotes end up baked into the created issue's title (#5846).
+    """
+    if len(title) >= 2 and any(
+        title[0] == open_q and title[-1] == close_q for open_q, close_q in _WRAPPING_QUOTE_PAIRS
+    ):
+        return title[1:-1].strip()
+    return title
 
 
 def _is_low_specificity(title: str) -> bool:
@@ -38,28 +55,29 @@ def extract_followups(review_text: str) -> list[str]:
     Looks for a heading matching '5. Suggested follow-up issues' and extracts
     bullet items (- or *) until the next heading or the verdict line.
     """
-    section_match = re.search(r'^#{1,6}\s+5\.\s+\S', review_text, re.MULTILINE)
+    section_match = re.search(r"^#{1,6}\s+5\.\s+\S", review_text, re.MULTILINE)
     if not section_match:
         return []
 
     section_start = section_match.end()
-    next_heading = re.search(r'^#{1,6}\s+\S', review_text[section_start:], re.MULTILINE)
+    next_heading = re.search(r"^#{1,6}\s+\S", review_text[section_start:], re.MULTILINE)
     if next_heading and next_heading.start() > 0:
         section_text = review_text[section_start : section_start + next_heading.start()]
     else:
         section_text = review_text[section_start:]
 
     # Stop before the verdict line in case it falls inside the section
-    verdict_match = re.search(r'^\*\*(APPROVE|REQUEST CHANGES)\*\*', section_text, re.MULTILINE)
+    verdict_match = re.search(r"^\*\*(APPROVE|REQUEST CHANGES)\*\*", section_text, re.MULTILINE)
     if verdict_match:
         section_text = section_text[: verdict_match.start()]
 
-    verdict_title_re = re.compile(r'^\*\*(APPROVE|REQUEST CHANGES)\*\*', re.IGNORECASE)
+    verdict_title_re = re.compile(r"^\*\*(APPROVE|REQUEST CHANGES)\*\*", re.IGNORECASE)
     titles = []
-    for m in re.finditer(r'^[-*]\s+(.+)', section_text, re.MULTILINE):
+    for m in re.finditer(r"^[-*]\s+(.+)", section_text, re.MULTILINE):
         title = m.group(1).strip()
         if not title or verdict_title_re.match(title):
             continue
+        title = _strip_wrapping_quotes(title)
         if _is_low_specificity(title):
             print(f"Skipping low-specificity follow-up: {title}", file=sys.stderr)
             continue

--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -165,8 +165,22 @@ def fetch_issue(owner: str, repo: str, number: int) -> dict:
     return json.loads(result.stdout)
 
 
-# Extensions searched for when an issue mentions a bare filename like 'foo.py'.
-CODE_FILE_EXTENSIONS = ("tsx", "ts", "py", "jsx", "js", "css", "md", "yaml", "yml", "json")
+# Extensions searched for when an issue mentions a bare filename like 'foo.py'. Includes
+# ps1/sh since this repo ships both PowerShell and bash developer_tools scripts.
+CODE_FILE_EXTENSIONS = (
+    "tsx",
+    "ts",
+    "py",
+    "jsx",
+    "js",
+    "css",
+    "md",
+    "yaml",
+    "yml",
+    "json",
+    "ps1",
+    "sh",
+)
 
 # Symbol names (functions/classes) must be at least this many characters to be worth a
 # repo-wide `git grep` -- short backticked tokens (`id`, `db`) are too noisy to search.

--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -117,6 +117,14 @@ The user reviewed a previous revision and gave this feedback -- incorporate it:
 {feedback}
 """
 
+# Section headings in an issue *body* may use any level from '##' to '######' -- some
+# issues (and some model rewrites) use a deeper level than the template's canonical
+# '##' for subsections (#5820: an issue with '### Why', '### How', etc. throughout had
+# every one of those sections misreported as "missing" because the check only matched
+# a literal '##'). Every pattern here that scans an existing body tolerates '#{2,6}';
+# newly *inserted* headings still always emit canonical '##'.
+_SECTION_HEADING = r"#{2,6}"
+
 
 def load_template_sections(template_path: Path = BUG_REPORT_TEMPLATE_PATH) -> list[str]:
     """Extract the ordered '## Section' headings from a GitHub issue template.
@@ -133,8 +141,8 @@ def load_template_sections(template_path: Path = BUG_REPORT_TEMPLATE_PATH) -> li
 
 
 def missing_sections(body: str, sections: list[str]) -> list[str]:
-    """Return the required sections that have no '## <Section>' heading in body."""
-    present = set(re.findall(r"^##\s+(.+?)\s*$", body, re.MULTILINE))
+    """Return the required sections that have no heading (any level) in body."""
+    present = set(re.findall(rf"^{_SECTION_HEADING}\s+(.+?)\s*$", body, re.MULTILINE))
     return [section for section in sections if section not in present]
 
 
@@ -211,7 +219,10 @@ def strip_files_affected_section(text: str) -> str:
     hints are only ever resolved from the issue's substantive prose, not its own
     previous output.
     """
-    pattern = re.compile(r"^##\s+Files Affected\s*\n.*?(?=^##\s+|\Z)", re.MULTILINE | re.DOTALL)
+    pattern = re.compile(
+        rf"^{_SECTION_HEADING}\s+Files Affected\s*\n.*?(?=^{_SECTION_HEADING}\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
     return pattern.sub("", text)
 
 
@@ -297,7 +308,10 @@ def apply_known_file_paths(
     paths = sorted({path for matches in file_hints.values() for path in matches})
     replacement = "\n".join(f"- `{path}`" for path in paths) if paths else "Unknown"
 
-    pattern = re.compile(r"(^##\s+Files Affected\s*\n)(.*?)(?=^##\s+|\Z)", re.MULTILINE | re.DOTALL)
+    pattern = re.compile(
+        rf"(^{_SECTION_HEADING}\s+Files Affected\s*\n)(.*?)(?=^{_SECTION_HEADING}\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
     if pattern.search(body):
         return pattern.sub(lambda m: m.group(1) + replacement + "\n\n", body, count=1)
 
@@ -305,7 +319,9 @@ def apply_known_file_paths(
     sections = sections if sections is not None else load_template_sections()
     if "Files Affected" in sections:
         for later_section in sections[sections.index("Files Affected") + 1 :]:
-            match = re.search(rf"^##\s+{re.escape(later_section)}\s*$", body, re.MULTILINE)
+            match = re.search(
+                rf"^{_SECTION_HEADING}\s+{re.escape(later_section)}\s*$", body, re.MULTILINE
+            )
             if match:
                 return body[: match.start()] + section_block + body[match.start() :]
     return body.rstrip("\n") + "\n\n" + section_block.rstrip("\n") + "\n"
@@ -445,15 +461,21 @@ def files_affected_is_unresolved(body: str) -> bool:
     """Return True when the '## Files Affected' section has no confirmed path.
 
     apply_known_file_paths() always writes either real resolved paths or the literal
-    "Unknown" into this section, so an empty/"Unknown" section means the file finder
-    found nothing it could confirm against the repo -- this issue can't be reliably
-    auto-implemented until a human identifies the correct file(s).
+    "Unknown" into this section (inserting it if the model dropped it entirely), so
+    in the normal main() flow this is always called on a body that already has the
+    section. But the heading being missing altogether is itself an unresolved state
+    (#5845) -- treating it as resolved (the old behavior) would let a malformed or
+    pre-template body silently skip the unresolved-files CLI warning and issue
+    comment if this were ever called before apply_known_file_paths, or on a body
+    that bypassed it.
     """
     match = re.search(
-        r"^##\s+Files Affected\s*\n(.*?)(?=^##\s+|\Z)", body, re.MULTILINE | re.DOTALL
+        rf"^{_SECTION_HEADING}\s+Files Affected\s*\n(.*?)(?=^{_SECTION_HEADING}\s+|\Z)",
+        body,
+        re.MULTILINE | re.DOTALL,
     )
     if not match:
-        return False
+        return True
     content = match.group(1).strip()
     return content == "" or content.lower() == "unknown"
 
@@ -626,8 +648,11 @@ def main() -> int:
 
     if not update_issue(owner, repo, issue_id, new_title, new_body, args.dry_run):
         return 1
+    # A failure here is reported (post_unresolved_files_comment prints its own ERROR) but
+    # is not fatal: the issue's title/body update above already succeeded, and a failed
+    # advisory comment shouldn't make a successful update report as an overall failure (#5847).
     if unresolved_files:
-        return 0 if post_unresolved_files_comment(owner, repo, issue_id, args.dry_run) else 1
+        post_unresolved_files_comment(owner, repo, issue_id, args.dry_run)
     return 0
 
 

--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -276,23 +276,21 @@ def format_file_hints(hints: dict[str, list[str]]) -> str:
 
 
 def apply_known_file_paths(body: str, file_hints: dict[str, list[str]]) -> str:
-    """Overwrite the '## Files Affected' section with paths resolved by find_repo_file_hints().
+    """Always rewrite the '## Files Affected' section deterministically, never the model's text.
 
-    Small local models are unreliable at copying exact paths back out of the prompt's hint
-    block -- they tend to play it safe and write "Unknown" rather than risk echoing it wrong.
-    Once we've resolved real paths ourselves, write them into the section directly instead of
-    trusting the model to transcribe them.
+    Both local and cloud models will guess a plausible, real, but wrong file (#5632: `backend/
+    app.py` exists, but isn't where the issue's symbol is defined) rather than admit they don't
+    know -- the "write Unknown if unresolved" instruction in the prompt is advisory, not
+    enforced. So the model's own "Files Affected" text is never trusted here: this always
+    replaces it with paths confidently resolved by find_repo_file_hints(), or with the literal
+    "Unknown" when nothing resolved, so an unverified guess can never survive into the issue.
     """
-    if not file_hints:
-        return body
     paths = sorted({path for matches in file_hints.values() for path in matches})
-    if not paths:
-        return body
-    bullet_list = "\n".join(f"- `{path}`" for path in paths)
+    replacement = "\n".join(f"- `{path}`" for path in paths) if paths else "Unknown"
     pattern = re.compile(r"(^##\s+Files Affected\s*\n)(.*?)(?=^##\s+|\Z)", re.MULTILINE | re.DOTALL)
     if not pattern.search(body):
         return body
-    return pattern.sub(lambda m: m.group(1) + bullet_list + "\n\n", body, count=1)
+    return pattern.sub(lambda m: m.group(1) + replacement + "\n\n", body, count=1)
 
 
 def build_review_prompt(

--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -275,7 +275,11 @@ def format_file_hints(hints: dict[str, list[str]]) -> str:
     return FILE_HINTS_SECTION_TEMPLATE.format(hints="\n".join(lines))
 
 
-def apply_known_file_paths(body: str, file_hints: dict[str, list[str]]) -> str:
+def apply_known_file_paths(
+    body: str,
+    file_hints: dict[str, list[str]],
+    sections: list[str] | None = None,
+) -> str:
     """Always rewrite the '## Files Affected' section deterministically, never the model's text.
 
     Both local and cloud models will guess a plausible, real, but wrong file (#5632: `backend/
@@ -284,13 +288,27 @@ def apply_known_file_paths(body: str, file_hints: dict[str, list[str]]) -> str:
     enforced. So the model's own "Files Affected" text is never trusted here: this always
     replaces it with paths confidently resolved by find_repo_file_hints(), or with the literal
     "Unknown" when nothing resolved, so an unverified guess can never survive into the issue.
+
+    A model will also sometimes drop the section heading entirely rather than leave it empty
+    (#5650) -- in that case it's inserted at its canonical position (from `sections`, the
+    template's section order) ahead of whichever required section comes next, or appended to
+    the end of the body if no later section is present either.
     """
     paths = sorted({path for matches in file_hints.values() for path in matches})
     replacement = "\n".join(f"- `{path}`" for path in paths) if paths else "Unknown"
+
     pattern = re.compile(r"(^##\s+Files Affected\s*\n)(.*?)(?=^##\s+|\Z)", re.MULTILINE | re.DOTALL)
-    if not pattern.search(body):
-        return body
-    return pattern.sub(lambda m: m.group(1) + replacement + "\n\n", body, count=1)
+    if pattern.search(body):
+        return pattern.sub(lambda m: m.group(1) + replacement + "\n\n", body, count=1)
+
+    section_block = f"## Files Affected\n{replacement}\n\n"
+    sections = sections if sections is not None else load_template_sections()
+    if "Files Affected" in sections:
+        for later_section in sections[sections.index("Files Affected") + 1 :]:
+            match = re.search(rf"^##\s+{re.escape(later_section)}\s*$", body, re.MULTILINE)
+            if match:
+                return body[: match.start()] + section_block + body[match.start() :]
+    return body.rstrip("\n") + "\n\n" + section_block.rstrip("\n") + "\n"
 
 
 def build_review_prompt(
@@ -592,7 +610,7 @@ def main() -> int:
                 file=sys.stderr,
             )
 
-        if new_title == title and new_body == body:
+        if new_title == title and new_body.rstrip() == body.rstrip():
             return 0
 
         if args.yes:

--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -188,6 +188,19 @@ def list_repo_files(repo_root: Path) -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
+def strip_files_affected_section(text: str) -> str:
+    """Remove any existing '## Files Affected' section from issue text.
+
+    A prior review pass may have written incorrect, stale, or overly broad paths into
+    this section. Searching that text for "mentions" to re-confirm would let a bad
+    entry re-justify itself on every future re-review (#5829) -- so file/symbol
+    hints are only ever resolved from the issue's substantive prose, not its own
+    previous output.
+    """
+    pattern = re.compile(r"^##\s+Files Affected\s*\n.*?(?=^##\s+|\Z)", re.MULTILINE | re.DOTALL)
+    return pattern.sub("", text)
+
+
 def find_repo_file_hints(text: str, repo_root: Path) -> dict[str, list[str]]:
     """Resolve filenames/symbols mentioned in issue text to real repo-relative paths.
 
@@ -196,7 +209,15 @@ def find_repo_file_hints(text: str, repo_root: Path) -> dict[str, list[str]]:
     any file it's asked to cite. This grounds the prompt by searching the actual
     checkout for tracked files matching a bare filename, or containing a def/class
     matching a backticked symbol name, mentioned in the issue.
+
+    A name is only resolved when it maps to exactly one file. A name that matches
+    several files (a common filename reused across directories, a symbol name
+    defined in more than one module) is ambiguous rather than wrong, but including
+    every candidate is what caused the file finder to flood "Files Affected" with
+    irrelevant matches (#5829) -- so ambiguous names are left unresolved rather than
+    guessed.
     """
+    text = strip_files_affected_section(text)
     hints: dict[str, list[str]] = {}
 
     repo_files = list_repo_files(repo_root)
@@ -210,7 +231,7 @@ def find_repo_file_hints(text: str, repo_root: Path) -> dict[str, list[str]]:
         if filename in hints:
             continue
         matches = files_by_basename.get(filename)
-        if matches:
+        if matches and len(matches) == 1:
             hints[filename] = matches
 
     for match in re.finditer(r"`([A-Za-z_][A-Za-z0-9_]*)`", text):
@@ -226,7 +247,7 @@ def find_repo_file_hints(text: str, repo_root: Path) -> dict[str, list[str]]:
             check=False,
         )
         matches = [line.strip() for line in result.stdout.splitlines() if line.strip()]
-        if matches:
+        if len(matches) == 1:
             hints[symbol] = matches
 
     return hints
@@ -236,10 +257,7 @@ def format_file_hints(hints: dict[str, list[str]]) -> str:
     """Render resolved file hints as a bullet list for the review prompt, or "" if empty."""
     if not hints:
         return ""
-    lines = []
-    for name, paths in hints.items():
-        joined = ", ".join(f"`{path}`" for path in paths[:5])
-        lines.append(f"- `{name}` -> {joined}")
+    lines = [f"- `{name}` -> `{paths[0]}`" for name, paths in hints.items()]
     return FILE_HINTS_SECTION_TEMPLATE.format(hints="\n".join(lines))
 
 

--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -414,6 +414,64 @@ def update_issue(owner: str, repo: str, number: int, title: str, body: str, dry_
     return True
 
 
+UNRESOLVED_FILES_COMMENT = (
+    "\U0001f916 Automated issue review: this tool could not confidently locate any file in "
+    "the repository matching the symbols/files referenced in this issue. The referenced code "
+    "may have been renamed, moved, or removed since the issue was filed. `Files Affected` has "
+    'been left as "Unknown" -- please investigate and confirm the correct file(s) before this '
+    "issue is implemented."
+)
+
+
+def files_affected_is_unresolved(body: str) -> bool:
+    """Return True when the '## Files Affected' section has no confirmed path.
+
+    apply_known_file_paths() always writes either real resolved paths or the literal
+    "Unknown" into this section, so an empty/"Unknown" section means the file finder
+    found nothing it could confirm against the repo -- this issue can't be reliably
+    auto-implemented until a human identifies the correct file(s).
+    """
+    match = re.search(
+        r"^##\s+Files Affected\s*\n(.*?)(?=^##\s+|\Z)", body, re.MULTILINE | re.DOTALL
+    )
+    if not match:
+        return False
+    content = match.group(1).strip()
+    return content == "" or content.lower() == "unknown"
+
+
+def post_unresolved_files_comment(owner: str, repo: str, number: int, dry_run: bool) -> bool:
+    """Post a comment flagging that Files Affected couldn't be resolved. Returns success."""
+    if dry_run:
+        print(f"[DRY RUN] Would comment on issue #{number} that Files Affected is unresolved.")
+        return True
+
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(number),
+            "--repo",
+            f"{owner}/{repo}",
+            "--body",
+            UNRESOLVED_FILES_COMMENT,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if result.returncode != 0:
+        print(
+            f"ERROR: Failed to comment on issue #{number}: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    print(f"[OK] Commented on issue #{number} about unresolved files.")
+    return True
+
+
 def prompt_for_issue_number() -> int:
     """Interactively prompt for an issue number."""
     try:
@@ -525,6 +583,15 @@ def main() -> int:
                 file=sys.stderr,
             )
 
+        unresolved_files = files_affected_is_unresolved(new_body)
+        if unresolved_files:
+            print(
+                f"WARNING: Could not confidently identify which files issue #{issue_id} "
+                "affects; it cannot be reliably auto-implemented until a human investigates. "
+                "A comment noting this will be added to the issue.",
+                file=sys.stderr,
+            )
+
         if new_title == title and new_body == body:
             return 0
 
@@ -539,7 +606,11 @@ def main() -> int:
             return 0
         print("INFO: Re-reviewing with your feedback...", file=sys.stderr)
 
-    return 0 if update_issue(owner, repo, issue_id, new_title, new_body, args.dry_run) else 1
+    if not update_issue(owner, repo, issue_id, new_title, new_body, args.dry_run):
+        return 1
+    if unresolved_files:
+        return 0 if post_unresolved_files_comment(owner, repo, issue_id, args.dry_run) else 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -253,15 +253,64 @@ def test_find_repo_file_hints_ignores_short_symbols(git_repo):
     assert n.find_repo_file_hints("Fix `id` please.", git_repo) == {}
 
 
+def test_find_repo_file_hints_skips_ambiguous_filename(git_repo):
+    # Two files share the basename 'config.py' -- neither is confidently "the" match.
+    other_dir = git_repo / "other"
+    other_dir.mkdir()
+    (other_dir / "config.py").write_text("VALUE = 1\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=git_repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "add duplicate basename"], cwd=git_repo, check=True
+    )
+    (git_repo / "config.py").write_text("VALUE = 2\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=git_repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add root config.py"], cwd=git_repo, check=True)
+    assert n.find_repo_file_hints("See config.py for details.", git_repo) == {}
+
+
+def test_find_repo_file_hints_skips_ambiguous_symbol(git_repo):
+    # The same symbol name is defined in two different files -- ambiguous, so unresolved.
+    other_dir = git_repo / "other"
+    other_dir.mkdir()
+    (other_dir / "helpers.py").write_text(
+        "def widget_test_stub_symbol():\n    pass\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "add", "-A"], cwd=git_repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add duplicate symbol"], cwd=git_repo, check=True)
+    hints = n.find_repo_file_hints("Fix `widget_test_stub_symbol` retry handling.", git_repo)
+    assert hints == {}
+
+
+def test_find_repo_file_hints_ignores_stale_files_affected_section(git_repo):
+    # A prior pass's (possibly wrong) Files Affected entry shouldn't re-confirm itself just
+    # because the filename it names happens to exist in the repo.
+    text = "## What\nsome unrelated bug.\n\n## Files Affected\n- `README.md`\n"
+    assert n.find_repo_file_hints(text, git_repo) == {}
+
+
+def test_strip_files_affected_section_removes_only_that_section():
+    text = "## What\nsome text\n\n## Files Affected\n- `a.py`\n- `b.py`\n\n## Constraints\nnone\n"
+    result = n.strip_files_affected_section(text)
+    assert "a.py" not in result
+    assert "b.py" not in result
+    assert "## What\nsome text" in result
+    assert "## Constraints\nnone" in result
+
+
+def test_strip_files_affected_section_noop_when_section_absent():
+    text = "## What\nsome text\n\n## Constraints\nnone\n"
+    assert n.strip_files_affected_section(text) == text
+
+
 def test_format_file_hints_empty():
     assert n.format_file_hints({}) == ""
 
 
 def test_format_file_hints_renders_bullet_list():
-    text = n.format_file_hints({"foo": ["a/foo.py"], "bar": ["b/bar.py", "c/bar.py"]})
+    text = n.format_file_hints({"foo": ["a/foo.py"], "bar": ["b/bar.py"]})
     assert "Known repository file locations" in text
     assert "- `foo` -> `a/foo.py`" in text
-    assert "- `bar` -> `b/bar.py`, `c/bar.py`" in text
+    assert "- `bar` -> `b/bar.py`" in text
 
 
 def test_build_review_prompt_includes_file_hints_section():

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -360,9 +360,13 @@ def test_apply_known_file_paths_dedupes_and_sorts_multiple_matches():
     assert files_section.index("a/foo.py") < files_section.index("b/foo.py")
 
 
-def test_apply_known_file_paths_noop_without_hints():
-    body = "## Files Affected\n- `fetch_paginated.py`\n"
-    assert n.apply_known_file_paths(body, {}) == body
+def test_apply_known_file_paths_forces_unknown_without_hints():
+    # A model-guessed path is never trusted, even if it looks plausible -- without a
+    # confidently resolved hint, the section is forced to "Unknown" rather than left alone.
+    body = "## Files Affected\n- `backend/app.py`\n\n## Constraints\nnone\n"
+    result = n.apply_known_file_paths(body, {})
+    assert "backend/app.py" not in result
+    assert "## Files Affected\nUnknown" in result
 
 
 def test_apply_known_file_paths_noop_when_section_missing():

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -408,10 +408,31 @@ def test_apply_known_file_paths_forces_unknown_without_hints():
     assert "## Files Affected\nUnknown" in result
 
 
-def test_apply_known_file_paths_noop_when_section_missing():
+def test_apply_known_file_paths_inserts_section_before_next_canonical_section():
+    # The model dropped the 'Files Affected' heading entirely (#5650) -- it must still be
+    # inserted, in its canonical template position, not silently skipped.
+    body = "## What\ntext\n\n## Constraints\nsome constraint\n"
+    hints = {"foo": ["a/foo.py"]}
+    sections = ["What", "Files Affected", "Constraints"]
+    result = n.apply_known_file_paths(body, hints, sections=sections)
+    assert "## Files Affected\n- `a/foo.py`\n\n## Constraints\nsome constraint" in result
+    assert result.index("## Files Affected") < result.index("## Constraints")
+
+
+def test_apply_known_file_paths_appends_section_when_no_later_section_present():
     body = "## What\nno files affected section here\n"
     hints = {"foo": ["a/foo.py"]}
-    assert n.apply_known_file_paths(body, hints) == body
+    sections = ["What", "Files Affected"]
+    result = n.apply_known_file_paths(body, hints, sections=sections)
+    assert result.rstrip("\n").endswith("## Files Affected\n- `a/foo.py`")
+    assert "## What\nno files affected section here" in result
+
+
+def test_apply_known_file_paths_inserts_unknown_when_section_missing_and_no_hints():
+    body = "## What\ntext\n\n## Constraints\nnone\n"
+    sections = ["What", "Files Affected", "Constraints"]
+    result = n.apply_known_file_paths(body, {}, sections=sections)
+    assert "## Files Affected\nUnknown\n\n## Constraints\nnone" in result
 
 
 def test_apply_known_file_paths_handles_last_section_in_body():

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -182,6 +182,13 @@ def test_missing_sections_empty_when_all_present():
     assert n.missing_sections(body, ["What", "Why"]) == []
 
 
+def test_missing_sections_recognizes_deeper_heading_levels():
+    # An issue using '###' throughout (#5820) must not have every one of those
+    # sections misreported as missing just because they aren't '##'.
+    body = "## What\ntext\n\n### Why\nreason\n\n#### How\nsteps\n"
+    assert n.missing_sections(body, ["What", "Why", "How", "Constraints"]) == ["Constraints"]
+
+
 def test_build_review_prompt_has_no_feedback_section_by_default():
     prompt = n.build_review_prompt("title", "## What\nbody")
     assert "The user reviewed a previous revision" not in prompt
@@ -235,8 +242,14 @@ def test_files_affected_is_unresolved_false_when_paths_present():
     assert not n.files_affected_is_unresolved(body)
 
 
-def test_files_affected_is_unresolved_false_when_section_missing():
-    assert not n.files_affected_is_unresolved("## What\nno such section\n")
+def test_files_affected_is_unresolved_true_when_section_missing():
+    # A missing heading is itself an unresolved state (#5845), not a pass-through.
+    assert n.files_affected_is_unresolved("## What\nno such section\n")
+
+
+def test_files_affected_is_unresolved_recognizes_deeper_heading_level():
+    body = "### Files Affected\n- `real/path.py`\n"
+    assert not n.files_affected_is_unresolved(body)
 
 
 def test_post_unresolved_files_comment_dry_run_skips_gh_call(monkeypatch):
@@ -352,6 +365,13 @@ def test_strip_files_affected_section_noop_when_section_absent():
     assert n.strip_files_affected_section(text) == text
 
 
+def test_strip_files_affected_section_recognizes_deeper_heading_level():
+    text = "## What\nsome text\n\n### Files Affected\n- `a.py`\n\n### Constraints\nnone\n"
+    result = n.strip_files_affected_section(text)
+    assert "a.py" not in result
+    assert "### Constraints\nnone" in result
+
+
 def test_format_file_hints_empty():
     assert n.format_file_hints({}) == ""
 
@@ -384,6 +404,16 @@ def test_apply_known_file_paths_replaces_model_guess():
     result = n.apply_known_file_paths(body, hints)
     assert "- `scripts/build_tools/extract_pr_comments.py`" in result
     assert "fetch_paginated.py" not in result
+
+
+def test_apply_known_file_paths_recognizes_deeper_heading_level():
+    # #5820: a body using '###' throughout must still have its Files Affected
+    # section found and replaced, not treated as missing and duplicated at '##'.
+    body = "### What\nsome text\n\n### Files Affected\n- `old.py`\n\n### Constraints\nnone\n"
+    hints = {"old": ["real/old.py"]}
+    result = n.apply_known_file_paths(body, hints)
+    assert result.count("Files Affected") == 1
+    assert "### Files Affected\n- `real/old.py`" in result
     assert "## Constraints\nnone" in result
 
 

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -241,6 +241,17 @@ def test_find_repo_file_hints_resolves_bare_filename(git_repo):
     assert hints == {"README.md": ["README.md"]}
 
 
+def test_find_repo_file_hints_resolves_powershell_and_bash_scripts(git_repo):
+    (git_repo / "deploy.ps1").write_text("Write-Host 'hi'\n", encoding="utf-8")
+    (git_repo / "deploy.sh").write_text("echo hi\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=git_repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add scripts"], cwd=git_repo, check=True)
+    hints = n.find_repo_file_hints(
+        "The script `deploy.ps1` and `deploy.sh` both need work.", git_repo
+    )
+    assert hints == {"deploy.ps1": ["deploy.ps1"], "deploy.sh": ["deploy.sh"]}
+
+
 def test_find_repo_file_hints_ignores_unknown_names(git_repo):
     text = "Update `totally_missing_symbol` in nonexistent.py."
     assert n.find_repo_file_hints(text, git_repo) == {}

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -220,6 +220,45 @@ def test_prompt_for_disposition_aborts_on_eof(monkeypatch):
     assert n.prompt_for_disposition() == ("abort", None)
 
 
+def test_files_affected_is_unresolved_true_for_unknown():
+    body = "## What\ntext\n\n## Files Affected\nUnknown\n\n## Constraints\nnone\n"
+    assert n.files_affected_is_unresolved(body)
+
+
+def test_files_affected_is_unresolved_true_for_empty_section():
+    body = "## What\ntext\n\n## Files Affected\n\n## Constraints\nnone\n"
+    assert n.files_affected_is_unresolved(body)
+
+
+def test_files_affected_is_unresolved_false_when_paths_present():
+    body = "## Files Affected\n- `real/path.py`\n"
+    assert not n.files_affected_is_unresolved(body)
+
+
+def test_files_affected_is_unresolved_false_when_section_missing():
+    assert not n.files_affected_is_unresolved("## What\nno such section\n")
+
+
+def test_post_unresolved_files_comment_dry_run_skips_gh_call(monkeypatch):
+    def fail_if_called(*a, **k):
+        raise AssertionError("gh should not be called in dry-run mode")
+
+    monkeypatch.setattr(n.subprocess, "run", fail_if_called)
+    assert n.post_unresolved_files_comment("owner", "repo", 1, dry_run=True) is True
+
+
+def test_post_unresolved_files_comment_success(monkeypatch):
+    monkeypatch.setattr(n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=0))
+    assert n.post_unresolved_files_comment("owner", "repo", 1, dry_run=False) is True
+
+
+def test_post_unresolved_files_comment_reports_failure(monkeypatch):
+    monkeypatch.setattr(
+        n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=1, stderr="boom")
+    )
+    assert n.post_unresolved_files_comment("owner", "repo", 1, dry_run=False) is False
+
+
 def test_list_repo_files_returns_tracked_paths(git_repo):
     files = n.list_repo_files(git_repo)
     assert "README.md" in files

--- a/tests/test_create_followup_issues.py
+++ b/tests/test_create_followup_issues.py
@@ -59,7 +59,13 @@ def test_generate_body_calls_deepseek_by_default_and_returns_content(
     monkeypatch.delenv("FOLLOWUP_LLM_PROVIDER", raising=False)
     monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
     fake_payload = {
-        "choices": [{"message": {"content": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}}]
+        "choices": [
+            {
+                "message": {
+                    "content": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"
+                }
+            }
+        ]
     }
     monkeypatch.setattr(
         mod.urllib.request,
@@ -83,7 +89,13 @@ def test_generate_body_treats_empty_provider_env_as_default(
     monkeypatch.setenv("FOLLOWUP_LLM_PROVIDER", "")
     monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
     fake_payload = {
-        "choices": [{"message": {"content": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}}]
+        "choices": [
+            {
+                "message": {
+                    "content": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"
+                }
+            }
+        ]
     }
     monkeypatch.setattr(
         mod.urllib.request,
@@ -101,7 +113,9 @@ def test_generate_body_calls_claude_when_selected(
     mod = load_module()
     monkeypatch.setenv("FOLLOWUP_LLM_PROVIDER", "claude")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
-    fake_payload = {"content": [{"text": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}]}
+    fake_payload = {
+        "content": [{"text": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}]
+    }
     monkeypatch.setattr(
         mod.urllib.request,
         "urlopen",
@@ -119,7 +133,13 @@ def test_generate_body_calls_gpt_when_selected(
     monkeypatch.setenv("FOLLOWUP_LLM_PROVIDER", "gpt")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     fake_payload = {
-        "choices": [{"message": {"content": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"}}]
+        "choices": [
+            {
+                "message": {
+                    "content": "## What\nFix the thing\n\n_Follow-up from AI review of PR #42._"
+                }
+            }
+        ]
     }
     monkeypatch.setattr(
         mod.urllib.request,
@@ -131,18 +151,17 @@ def test_generate_body_calls_gpt_when_selected(
     assert "Follow-up" in body
 
 
-def test_generate_body_falls_back_on_unknown_provider(
+def test_generate_body_returns_none_on_unknown_provider(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     mod = load_module()
     monkeypatch.setenv("FOLLOWUP_LLM_PROVIDER", "bogus")
-    body = mod._generate_body_via_llm("Fix the thing", "42", "Review text here")
-    assert "PR #42" in body
+    assert mod._generate_body_via_llm("Fix the thing", "42", "Review text here") is None
     assert "unknown FOLLOWUP_LLM_PROVIDER 'bogus'" in capsys.readouterr().err
 
 
-def test_generate_body_falls_back_on_api_error(
+def test_generate_body_returns_none_on_api_error(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -156,9 +175,36 @@ def test_generate_body_falls_back_on_api_error(
         )
 
     monkeypatch.setattr(mod.urllib.request, "urlopen", raise_error)
-    body = mod._generate_body_via_llm("Fix the thing", "42", "Review text here")
-    assert "PR #42" in body
+    assert mod._generate_body_via_llm("Fix the thing", "42", "Review text here") is None
     assert "failed to generate" in capsys.readouterr().err
+
+
+def test_build_body_appends_pr_footer_when_provider_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = load_module()
+    monkeypatch.setenv("FOLLOWUP_LLM_PROVIDER", "bogus")
+    body = mod._build_body("Fix the thing", "42", "Review text here")
+    assert "PR #42" in body
+    assert "Follow-up" in body
+
+
+def test_build_body_appends_pr_footer_even_when_model_omits_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The prompt asks the model not to add its own footer, and models are
+    unreliable about following instructions like this anyway (#5845/#5846/#5847
+    all shipped with no PR link) -- the footer must be guaranteed in code."""
+    mod = load_module()
+    monkeypatch.delenv("FOLLOWUP_LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    fake_payload = {"choices": [{"message": {"content": "## What\nFix the thing."}}]}
+    monkeypatch.setattr(
+        mod.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse(fake_payload)
+    )
+    body = mod._build_body("Fix the thing", "42", "Review text here")
+    assert body.startswith("## What\nFix the thing.")
+    assert body.endswith("_Follow-up suggested by AI review of PR #42._")
 
 
 @pytest.mark.parametrize(
@@ -248,12 +294,14 @@ def test_main_missing_review_file_falls_back(
     followups.write_text(json.dumps([]))
 
     monkeypatch.setattr(
-        sys, "argv", [
+        sys,
+        "argv",
+        [
             "create_followup_issues.py",
             str(followups),
             "7",
             "/nonexistent/review.md",
-        ]
+        ],
     )
     result = mod.main()
     assert result == 0

--- a/tests/test_extract_followups.py
+++ b/tests/test_extract_followups.py
@@ -156,6 +156,45 @@ def test_add_more_context_without_reference_is_dropped() -> None:
     assert extract_followups(review) == ["Add unit tests for the new helper"]
 
 
+def test_wrapping_double_quotes_are_stripped() -> None:
+    """A title wrapped in quotes by the reviewer (#5846) shouldn't carry them
+    verbatim into the created issue's title."""
+    review = """\
+## 5. Suggested follow-up issues
+
+- "Add relevance scoring to file finder to prioritize production code over test files"
+
+**APPROVE**
+"""
+    assert extract_followups(review) == [
+        "Add relevance scoring to file finder to prioritize production code over test files"
+    ]
+
+
+def test_wrapping_single_quotes_are_stripped() -> None:
+    review = """\
+## 5. Suggested follow-up issues
+
+- 'Refactor the auth module'
+
+**APPROVE**
+"""
+    assert extract_followups(review) == ["Refactor the auth module"]
+
+
+def test_internal_quote_is_not_stripped() -> None:
+    """Only a matched wrapping pair is stripped -- a quote that isn't wrapping
+    the whole title (or is unmatched) is left alone."""
+    review = """\
+## 5. Suggested follow-up issues
+
+- Rename the "old" variable to something clearer
+
+**APPROVE**
+"""
+    assert extract_followups(review) == ['Rename the "old" variable to something clearer']
+
+
 def test_trivial_backtick_token_does_not_bypass_filter() -> None:
     """A short, meaningless backtick token (e.g. a variable name like `s`) should
     not count as a concrete reference and bypass the specificity filter."""


### PR DESCRIPTION
## Summary
- `find_repo_file_hints()` now only resolves a filename/symbol when it maps to exactly one file; ambiguous matches (a filename or symbol name that exists in multiple places) are left unresolved instead of dumping every candidate into the prompt.
- Added `strip_files_affected_section()` so hint resolution ignores an issue's own previous `## Files Affected` section, preventing a stale/wrong entry from re-confirming itself on every subsequent re-review.
- `apply_known_file_paths()` now always deterministically rewrites `## Files Affected` (real paths or literal `Unknown`) instead of ever trusting the model's own free-text guess, and inserts the section at its canonical position if the model dropped the heading entirely instead of silently no-op'ing.
- When nothing resolves, the CLI now prints a clear warning and posts a comment on the GitHub issue itself flagging it for manual investigation (`files_affected_is_unresolved()` / `post_unresolved_files_comment()`).
- Every regex matching a `## <Section>` heading in an issue body now tolerates any heading depth (`#{2,6}`), not just a literal `##` -- an issue using `###` throughout was having every one of those sections misreported as missing.
- `extract_followups.py` now strips a wrapping pair of quote marks from a reviewer-suggested title, so quotes no longer end up baked into an auto-filed issue's title.
- `create_followup_issues.py` now appends the "source PR" footer in code, unconditionally, instead of relying on the LLM to include it -- that was unreliable (truncation, models dropping it) and every auto-filed follow-up from this branch's own review shipped without a visible link back to its source PR.

## Why
Closes #5829 -- the file finder used when reviewing issues was including too many/irrelevant files, adding noise and manual cleanup work.
Closes #5845, Closes #5847 -- real follow-up bugs found by DeepSeek's own review of this branch.
#5846 (relevance scoring / ranking ambiguous candidates instead of just rejecting them) is left open as a legitimate distinct enhancement, not covered by this PR.

## Test plan
- [x] `pytest tests/scripts/test_o_review_issue.py tests/test_extract_followups.py tests/test_create_followup_issues.py -q` -- 106 tests pass
- [x] `ruff check` / `black --check` clean (pre-existing lint debt in `.github/scripts/create_followup_issues.py` and `tests/test_extract_followups.py` left untouched, out of scope)
- [x] Manually verified against the real repo checkout: a stale `Files Affected` mention no longer reappears, a genuine backticked symbol reference still resolves correctly, a `.ps1` filename now resolves, a totally unresolved symbol correctly falls back to "Unknown" instead of a plausible-but-wrong guess, and a `###`-heading issue no longer reports its existing sections as missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Repository file detection now recognises PowerShell and shell script files.
  - File and symbol references are resolved more accurately, with ambiguous matches excluded.
  - Affected-file listings are refreshed consistently, preventing outdated entries from being retained.
  - When no affected files can be identified, the listing now clearly shows "Unknown".
- **Tests**
  - Added coverage for script paths, ambiguous matches, stale entries, and missing file hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->