### PR TITLE
Refuse to commit directly to main in j_commit_and_push.ps1

### DIFF
--- a/scripts/developer_tools/lib/commit_and_push.py
+++ b/scripts/developer_tools/lib/commit_and_push.py
@@ -26,6 +26,21 @@ from llm_common import (  # noqa: E402
 )
 from publish_pr import extract_issue_id, get_current_branch, push_to_remote  # noqa: E402
 
+MAIN_BRANCH = "main"
+
+
+def refuse_if_main_branch(branch: str) -> None:
+    """Exit with guidance if the current branch is the main branch."""
+    if branch != MAIN_BRANCH:
+        return
+    print(
+        f"ERROR: Refusing to commit directly to '{MAIN_BRANCH}'.\n"
+        "Create or switch to a feature/bugfix branch first, e.g.:\n"
+        "    git checkout -b fix/<issue-number>-short-description",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
 
 def get_git_root() -> str:
     """Get the root directory of the git repository."""
@@ -194,6 +209,7 @@ def main() -> int:
     os.chdir(get_git_root())
 
     branch = get_current_branch()
+    refuse_if_main_branch(branch)
     issue_id = extract_issue_id(branch)
 
     stage_changes(args.files)

--- a/tests/test_commit_and_push.py
+++ b/tests/test_commit_and_push.py
@@ -21,8 +21,19 @@ from commit_and_push import (  # noqa: E402
     get_staged_diff,
     has_staged_changes,
     main,
+    refuse_if_main_branch,
     stage_changes,
 )
+
+
+class TestRefuseIfMainBranch:
+    def test_raises_on_main(self):
+        with pytest.raises(SystemExit) as exc_info:
+            refuse_if_main_branch("main")
+        assert exc_info.value.code == 1
+
+    def test_allows_other_branches(self):
+        refuse_if_main_branch("fix/4445-thing")
 
 
 class TestGetGitRoot:
@@ -153,6 +164,35 @@ class TestCommitChanges:
 
 
 class TestMain:
+    @mock.patch("commit_and_push.push_to_remote")
+    @mock.patch("commit_and_push.commit_changes")
+    @mock.patch("commit_and_push.has_staged_changes")
+    @mock.patch("commit_and_push.stage_changes")
+    @mock.patch("commit_and_push.extract_issue_id")
+    @mock.patch("commit_and_push.get_current_branch")
+    @mock.patch("commit_and_push.get_git_root")
+    def test_refuses_to_commit_on_main_branch(
+        self,
+        mock_root,
+        mock_branch,
+        mock_extract,
+        mock_stage,
+        mock_has_staged,
+        mock_commit,
+        mock_push,
+    ):
+        mock_root.return_value = "/repo"
+        mock_branch.return_value = "main"
+
+        with mock.patch("sys.argv", ["commit_and_push.py"]), mock.patch("commit_and_push.os.chdir"):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        mock_stage.assert_not_called()
+        mock_commit.assert_not_called()
+        mock_push.assert_not_called()
+
     @mock.patch("commit_and_push.push_to_remote")
     @mock.patch("commit_and_push.commit_changes")
     @mock.patch("commit_and_push.has_staged_changes")


### PR DESCRIPTION
## Summary
- `commit_and_push.py` (invoked by `j_commit_and_push.ps1`) now refuses to commit when the current branch is `main`, printing guidance to create/switch to a feature or bugfix branch instead.
- All other branches are unaffected — staging, commit, and push continue as before.

## Test plan
- [x] `python -m pytest tests/test_commit_and_push.py -q --no-cov` — 29 passed, including new tests for `refuse_if_main_branch` and the `main()` refusal path.
- [x] `python -m black --check` / `python -m ruff check` on changed files.

Closes #5828
