### PR TITLE
Move developer_tools test files into tests/scripts/

### DIFF
--- a/tests/scripts/test_commit_and_push.py
+++ b/tests/scripts/test_commit_and_push.py
@@ -9,8 +9,8 @@ from unittest import mock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools" / "lib"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools" / "lib"))
 
 from commit_and_push import (  # noqa: E402
     build_commit_prompt,

--- a/tests/scripts/test_create_issue.py
+++ b/tests/scripts/test_create_issue.py
@@ -6,8 +6,8 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools" / "lib"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools" / "lib"))
 
 from b_create_issue import (  # noqa: E402
     build_review_prompt,

--- a/tests/scripts/test_implement_issue_with_aider.py
+++ b/tests/scripts/test_implement_issue_with_aider.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools"))
 
 from f_implement_issue_with_aider import (  # noqa: E402
     confirm_with_user,

--- a/tests/scripts/test_local_review.py
+++ b/tests/scripts/test_local_review.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools"))
 
 from i_local_review import (
     generate_markdown_report,

--- a/tests/scripts/test_ollama_common.py
+++ b/tests/scripts/test_ollama_common.py
@@ -12,7 +12,7 @@ import pytest
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools" / "lib"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools" / "lib"))
 from ollama_common import (
     extract_ollama_review,
     fetch_ollama_review,

--- a/tests/scripts/test_pr_review.py
+++ b/tests/scripts/test_pr_review.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools"))
 from l_pr_review import extract_issue_body, fetch_pr_details, fetch_pr_diff, get_repo_info
 
 

--- a/tests/scripts/test_sync_issues.py
+++ b/tests/scripts/test_sync_issues.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools"))
 import a_sync_issues  # noqa: E402
 
 

--- a/tests/scripts/test_work_on_issue.py
+++ b/tests/scripts/test_work_on_issue.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "developer_tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools"))
 from d_work_on_issue import fetch_issue, main, slugify
 
 


### PR DESCRIPTION
## Summary
- `tests/test_commit_and_push.py`, `test_create_issue.py`, `test_implement_issue_with_aider.py`, `test_local_review.py`, `test_ollama_common.py`, `test_pr_review.py`, `test_sync_issues.py`, and `test_work_on_issue.py` all test scripts under `scripts/developer_tools/` but lived at the top level of `tests/`, outside the `tests/scripts/**` glob that `scripts/classify_change.py`'s `backend-dev-tools-only` check (#5825) uses to narrow `backend-integration.yml` to `pytest tests/scripts` instead of the full ~3500-test backend suite.
- Moved all 8 files into `tests/scripts/`, adjusting each file's `sys.path.insert` call for the extra directory level. No import-style or test-logic changes.
- The dev-tools-only CI build step (`pytest tests/scripts --no-cov -q`) already exists in `backend-integration.yml` from #5825, so this closes the coverage gap without needing further workflow changes.

## Test plan
- [x] `pytest tests/scripts --no-cov -q` — 522 passed
- [x] `pytest tests --collect-only -q` — 3580 tests collected, no import errors
- [x] `pytest tests/scripts/test_classify_change.py tests/scripts/test_ci_area_gating.py --no-cov -q` — 141 passed

Closes #5842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
