### PR TITLE
[Issue #5791] Add a warning when `--model` is passed with `--model-source cloud` in `lib/commit_and_push.py`

### DIFF
--- a/scripts/developer_tools/lib/commit_and_push.py
+++ b/scripts/developer_tools/lib/commit_and_push.py
@@ -208,6 +208,14 @@ def main() -> int:
     if args.model and args.model_source == LOCAL:
         os.environ["OLLAMA_MODEL"] = args.model
 
+    # Add warning for --model with --model-source cloud
+    if args.model and args.model_source != LOCAL:
+        print(
+            "Warning: --model is only supported with --model-source local; "
+            "ignoring --model for cloud model source.",
+            file=sys.stderr,
+        )
+
     os.chdir(get_git_root())
 
     branch = get_current_branch()


### PR DESCRIPTION
## What

Added a warning when `--model` is passed with `--model-source cloud` in `lib/commit_and_push.py`.

## Why

This change ensures that users are aware when the `--model` flag is ignored for cloud model sources, preventing confusion and potential issues in automated workflows. It also enhances maintainability by making it clear which flags interact differently based on the source.

## Testing

The changes were tested locally by running various combinations of command-line arguments to ensure the warning is displayed correctly when applicable and that existing functionality remains unaffected.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #5791