### PR TITLE
[Issue #5778] Consider using `Path.resolve()` for `REPO_ROOT_ENV_FILE` to handle symlinked script locations

### DIFF
--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -33,8 +33,7 @@ from llm_common import (  # noqa: E402
     validate_model_source,
 )
 
-REPO_ROOT_ENV_FILE = Path(__file__).parent.parent.parent / ".env"
-
+REPO_ROOT_ENV_FILE = Path(__file__).resolve().parent.parent.parent / ".env"
 
 def load_env_file(env_path: Path = REPO_ROOT_ENV_FILE) -> None:
     """Load local dev secrets (e.g. DEEPSEEK_API_KEY) from a repo-root .env file.


### PR DESCRIPTION
## What
Updated `REPO_ROOT_ENV_FILE` in [scripts/developer_tools/o_review_issue.py](scripts/developer_tools/o_review_issue.py) to use `Path(__file__).resolve().parent.parent.parent / ".env"`, ensuring it correctly points to the `.env` file even when the script is invoked through a symlinked path.

## Why
Using `Path.resolve()` resolves any symlinks in `__file__` before navigating up three parent directories, preventing issues where the script might point at the wrong directory.

## Testing
- `python -m pytest tests/scripts/test_o_review_issue.py`: Passes all tests related to loading environment variables.
- `make lint` / `ruff` on the file shows no new warnings.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #5778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading environment settings, regardless of the directory from which the tool is run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->