### PR TITLE
Default enable_family_mvp to false

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -130,7 +130,7 @@ class Config:
     allowed_emails: Optional[List[str]] = None
     local_login_email: Optional[str] = None
     relative_view_enabled: Optional[bool] = None
-    enable_family_mvp: bool = True
+    enable_family_mvp: bool = False
     enable_compliance_workflows: bool = False
     enable_advanced_analytics: bool = False
     enable_reporting_extended: bool = False
@@ -454,7 +454,7 @@ def load_config() -> Config:
         enable_family_mvp=_coerce_bool_with_default(
             data.get("enable_family_mvp"),
             key="enable_family_mvp",
-            default=True,
+            default=False,
         ),
         enable_compliance_workflows=_coerce_bool_with_default(
             data.get("enable_compliance_workflows"),

--- a/config.lambda.yaml
+++ b/config.lambda.yaml
@@ -78,7 +78,7 @@ trading:
     max_volatility: null
 
 ui:
-  enable_family_mvp: true
+  enable_family_mvp: false
   enable_compliance_workflows: false
   enable_advanced_analytics: false
   enable_reporting_extended: false

--- a/config.yaml
+++ b/config.yaml
@@ -69,7 +69,7 @@ trading:
     min_sharpe: null
     max_volatility: null
 ui:
-  enable_family_mvp: true
+  enable_family_mvp: false
   enable_compliance_workflows: false
   enable_advanced_analytics: false
   enable_reporting_extended: false

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,7 +56,7 @@ def test_family_mvp_flags_default_when_missing(monkeypatch, tmp_path):
 
     cfg = reload_config()
     try:
-        assert cfg.enable_family_mvp is True
+        assert cfg.enable_family_mvp is False
         assert cfg.enable_compliance_workflows is False
         assert cfg.enable_advanced_analytics is False
         assert cfg.enable_reporting_extended is False
@@ -73,7 +73,7 @@ def test_family_mvp_flag_none_falls_back_to_default(monkeypatch, tmp_path):
 
     cfg = reload_config()
     try:
-        assert cfg.enable_family_mvp is True
+        assert cfg.enable_family_mvp is False
     finally:
         monkeypatch.undo()
         reload_config()


### PR DESCRIPTION
Closes #5881

## Summary
- Root `/` was unexpectedly redirecting to `/portfolio/<owner>` on every local and deployed environment because `enable_family_mvp` defaulted to `true` in both the code default (`backend/config.py`) and the checked-in `config.yaml` / `config.lambda.yaml`.
- Flips the default to `false` in all three places so `/` lands on the group dashboard (`?group=all`, URL kept clean) unless a deployment explicitly opts back in with `enable_family_mvp: true`.
- Updates `tests/test_config.py` assertions that previously pinned the old default.

## Test plan
- [x] `python -m pytest tests/test_config.py -q` — 31 passed
- [ ] Manually verify `/` on a local run lands on the group dashboard, not `/portfolio/<owner>`
- [ ] Verify deployed lambda config picks up `enable_family_mvp: false` after this merges/deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)