### PR TITLE
Fix: Support page tab toggles fail to save (missing dataquality field)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -57,6 +57,7 @@ class TabsConfig:
     group: bool = True
     owner: bool = True
     dataadmin: bool = True
+    dataquality: bool = True
     dataexplorer: bool = True
     virtual: bool = True
     support: bool = True

--- a/tests/backend/test_tabs_config.py
+++ b/tests/backend/test_tabs_config.py
@@ -21,6 +21,16 @@ def test_validate_tabs_accepts_new_keys():
     assert tabs.research is True
 
 
+def test_validate_tabs_accepts_dataquality():
+    # Regression test for #5871: the Support page's frontend route registry
+    # includes a "dataquality" tab (data-quality page) that must have a
+    # matching TabsConfig field, or saving the Support page's tab toggles
+    # fails with "Unknown tab 'dataquality'".
+    tabs = validate_tabs({"dataquality": False})
+    assert isinstance(tabs, TabsConfig)
+    assert tabs.dataquality is False
+
+
 def test_validate_tabs_rejects_unknown_key():
     with pytest.raises(ConfigValidationError):
         validate_tabs({"unknown": True})

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -102,8 +102,8 @@ backend/common/transaction_reconciliation.py:66
 backend/common/transaction_reconciliation.py:134
 backend/common/transaction_reconciliation.py:176
 backend/common/transaction_reconciliation.py:186
-backend/config.py:269
-backend/config.py:272
+backend/config.py:270
+backend/config.py:273
 backend/lambda_api/dividend_refresh.py:27
 backend/lambda_api/pension_report.py:206
 backend/lambda_api/pension_report.py:231


### PR DESCRIPTION
## Summary
- Root cause of #5871: the frontend Support page derives its tab-toggle checkboxes from every route with a `priority` in `frontend/src/routes/registry.ts`, which includes the `dataquality` (Data Quality) page — but `backend/config.py`'s `TabsConfig` dataclass had no matching field.
- `validate_tabs()` rejects any unknown key, so `PUT /config` raised `ConfigValidationError: Unknown tab 'dataquality'` (surfaced to the frontend as a 400/save error) whenever the Support page submitted the full tab set, which always includes `dataquality`.
- Fix: add `dataquality: bool = True` to `TabsConfig`, matching the frontend's `TabsConfig` interface (`frontend/src/ConfigContext.tsx`), which already declared `dataquality` on the TS side.

## Test plan
- [x] `python -m pytest tests/backend/test_tabs_config.py -q` — added a regression test asserting `dataquality` is accepted by `validate_tabs`.
- [x] `python -m pytest tests/backend -k config -q` — all config-route tests pass.
- [x] `python -m ruff check backend/config.py tests/backend/test_tabs_config.py` — clean.

Closes #5871

🤖 Generated with [Claude Code](https://claude.com/claude-code)