### PR TITLE
[Issue #3905] refactor: decouple _SIZE_MARKER_TIERS from the public get_fallback_tier_label API so custom tier_map callers aren't silently affected by hardcoded local-model labels

### DIFF
--- a/.github/scripts/llm_labels.py
+++ b/.github/scripts/llm_labels.py
@@ -64,19 +64,31 @@ def extract_tier_label(body: str, tier_map: dict[str, str] | None = None) -> str
     return None
 
 
-def get_fallback_tier_label(model_name: str, tier_map: dict[str, str] | None = None) -> str:
+def get_fallback_tier_label(
+    model_name: str,
+    tier_map: dict[str, str] | None = None,
+    size_marker_map: dict[str, str] | None = None,
+) -> str:
     """Derive a tier label from a model name string (e.g. "claude-haiku-4-5-20251001").
 
     Used when a tier can't be extracted from issue body text but a model name
     is available. Returns ``_DEFAULT_TIER_LABEL`` if the model name doesn't
     name a known tier or size.
+
+    Size-marker matching is skipped by default for custom tier_map callers
+    unless they explicitly opt in via size_marker_map.
     """
     tier_map = LLM_TIER_MAP if tier_map is None else tier_map
     model_lower = model_name.lower()
     for tier, label in tier_map.items():
         if tier in model_lower:
             return label
-    for marker, label in _SIZE_MARKER_TIERS.items():
+
+    if size_marker_map is None:
+        size_marker_map = _SIZE_MARKER_TIERS
+
+    for marker, label in size_marker_map.items():
         if label in tier_map.values() and re.search(rf"\b{marker}\b", model_lower):
             return label
+
     return _DEFAULT_TIER_LABEL

--- a/.github/scripts/llm_labels.py
+++ b/.github/scripts/llm_labels.py
@@ -78,6 +78,7 @@ def get_fallback_tier_label(
     Size-marker matching is skipped by default for custom tier_map callers
     unless they explicitly opt in via size_marker_map.
     """
+    used_default_tier_map = tier_map is None
     tier_map = LLM_TIER_MAP if tier_map is None else tier_map
     model_lower = model_name.lower()
     for tier, label in tier_map.items():
@@ -85,7 +86,7 @@ def get_fallback_tier_label(
             return label
 
     if size_marker_map is None:
-        size_marker_map = _SIZE_MARKER_TIERS if tier_map is None else {}
+        size_marker_map = _SIZE_MARKER_TIERS if used_default_tier_map else {}
 
     for marker, label in size_marker_map.items():
         if label in tier_map.values() and re.search(rf"\b{marker}\b", model_lower):

--- a/.github/scripts/llm_labels.py
+++ b/.github/scripts/llm_labels.py
@@ -85,7 +85,7 @@ def get_fallback_tier_label(
             return label
 
     if size_marker_map is None:
-        size_marker_map = _SIZE_MARKER_TIERS
+        size_marker_map = _SIZE_MARKER_TIERS if tier_map is None else {}
 
     for marker, label in size_marker_map.items():
         if label in tier_map.values() and re.search(rf"\b{marker}\b", model_lower):

--- a/tests/test_llm_labels.py
+++ b/tests/test_llm_labels.py
@@ -95,14 +95,51 @@ def test_get_fallback_tier_label_with_custom_tier_map() -> None:
     # No match and no recognised tiers in the custom map -> default.
     assert mod.get_fallback_tier_label("unrelated-model", custom_map) == "sonnet"
 
+
 def test_get_fallback_tier_label_with_clashing_custom_tier_map() -> None:
     mod = load_module()
 
     custom_map = {"fast": "local-7b"}
 
+    custom_size_map = {
+        "7b": "test-7b",
+        "14b": "test-14b",
+    }
+
+    # Custom tier_map without size_marker_map opt-in: size markers are
+    # ignored entirely, so "local-7b" only matches via the literal tier_map.
     assert mod.get_fallback_tier_label("local-7b", custom_map) == "sonnet"
     assert mod.get_fallback_tier_label("local-7b", None) == "local-7b"
     assert mod.get_fallback_tier_label("local-7b") == "local-7b"
+
+    # Custom size_marker_map whose labels aren't in tier_map.values() ->
+    # no match, falls back to default.
+    assert mod.get_fallback_tier_label("test-7b", custom_map, custom_size_map) == "sonnet"
+
+
+def test_get_fallback_tier_label_with_custom_tier_map_and_explicit_size_marker_map() -> None:
+    """Document the opt-in: a custom tier_map + explicit size_marker_map can
+    match by size marker, as long as the size marker's label is one of the
+    custom tier_map's values."""
+    mod = load_module()
+
+    custom_map = {"fast": "fast-model", "slow": "slow-model"}
+    custom_size_map = {"7b": "fast-model", "14b": "slow-model"}
+
+    # Model name has no literal tier keyword, but matches a size marker whose
+    # label is recognised by the custom tier_map -> opt-in match succeeds.
+    assert (
+        mod.get_fallback_tier_label("qwen2.5-7b-instruct", custom_map, custom_size_map)
+        == "fast-model"
+    )
+    assert (
+        mod.get_fallback_tier_label("qwen2.5-14b-instruct", custom_map, custom_size_map)
+        == "slow-model"
+    )
+
+    # Without the size_marker_map opt-in, the same custom tier_map alone
+    # can't recognise size markers -> falls back to default.
+    assert mod.get_fallback_tier_label("qwen2.5-7b-instruct", custom_map) == "sonnet"
 
 
 def test_llm_tier_map_is_stable() -> None:

--- a/tests/test_llm_labels.py
+++ b/tests/test_llm_labels.py
@@ -88,13 +88,19 @@ def test_get_fallback_tier_label(model_name: str, expected_label: str) -> None:
 
 def test_get_fallback_tier_label_with_custom_tier_map() -> None:
     mod = load_module()
-    custom_map = {"fast": "fast-model", "slow": "slow-model", "local-7b": "test-7b"}
+    custom_map = {"fast": "fast-model", "slow": "slow-model"}
     assert mod.get_fallback_tier_label("the-fast-one", custom_map) == "fast-model"
     assert mod.get_fallback_tier_label("the-slow-one", custom_map) == "slow-model"
-    assert mod.get_fallback_tier_label("local-7b", custom_map) == "test-7b"
 
     # No match and no recognised tiers in the custom map -> default.
     assert mod.get_fallback_tier_label("unrelated-model", custom_map) == "sonnet"
+
+def test_get_fallback_tier_label_with_clashing_custom_tier_map() -> None:
+    mod = load_module()
+
+    custom_map = {"fast": "local-7b"}
+
+    assert mod.get_fallback_tier_label("local-7b", custom_map) == "sonnet"
     assert mod.get_fallback_tier_label("local-7b", None) == "local-7b"
     assert mod.get_fallback_tier_label("local-7b") == "local-7b"
 

--- a/tests/test_llm_labels.py
+++ b/tests/test_llm_labels.py
@@ -88,11 +88,15 @@ def test_get_fallback_tier_label(model_name: str, expected_label: str) -> None:
 
 def test_get_fallback_tier_label_with_custom_tier_map() -> None:
     mod = load_module()
-    custom_map = {"fast": "fast-model", "slow": "slow-model"}
+    custom_map = {"fast": "fast-model", "slow": "slow-model", "local-7b": "test-7b"}
     assert mod.get_fallback_tier_label("the-fast-one", custom_map) == "fast-model"
     assert mod.get_fallback_tier_label("the-slow-one", custom_map) == "slow-model"
+    assert mod.get_fallback_tier_label("local-7b", custom_map) == "test-7b"
+
     # No match and no recognised tiers in the custom map -> default.
     assert mod.get_fallback_tier_label("unrelated-model", custom_map) == "sonnet"
+    assert mod.get_fallback_tier_label("local-7b", None) == "local-7b"
+    assert mod.get_fallback_tier_label("local-7b") == "local-7b"
 
 
 def test_llm_tier_map_is_stable() -> None:


### PR DESCRIPTION
## What

Decoupled `_SIZE_MARKER_TIERS` from `get_fallback_tier_label` by adding an optional `size_marker_map` parameter, ensuring custom map callers are not silently affected by hardcoded size-marker labels.

## Why

- **Correctness:** Ensures custom `tier_map` callers' behavior is isolated from hardcoded size-markers.
- **Maintainability:** Prevents future changes to `_SIZE_MARKER_TIERS` from affecting custom-map users unintentionally.
- **API clarity:** Makes the size-marker behavior conditional and explicit in the function's docstring.

## Testing

Updated existing `tests/test_llm_labels.py::test_get_fallback_tier_label_with_custom_tier_map` to include a new test case that demonstrates the fixed isolation when using a custom map with colliding values. Ensured all tests pass locally before submitting.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #3905
Closes #5887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved automatic model labelling when model names include size markers.
* Preserved accurate tier labels when custom or default labelling rules are used.
* Improved recognition of local 7B models across fallback labelling scenarios.
* Prevented size markers from overriding custom tier mappings unless explicitly configured.

## Tests

* Expanded coverage for custom tier mappings, size-marker handling, and local model recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->