### PR TITLE
Run market_overview fetchers concurrently via asyncio.gather + run_in_executor

### DIFF
--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Market overview endpoint aggregating indexes, sectors and headlines."""
 
+import asyncio
 import logging
 import math
 import os
@@ -376,11 +377,21 @@ async def market_overview(
 ) -> Dict[str, Any]:
     """Return index levels, sector performance and latest headlines."""
 
-    indexes = _safe(_fetch_indexes, {})
     default_region = getattr(cfg, "default_sector_region", "US") or "US"
     region_value = region if isinstance(region, str) else None
     selected_region = (region_value or default_region).lower()
     fetcher = _fetch_uk_sectors if selected_region == "uk" else _fetch_sectors
-    sectors = _safe(fetcher, [])
-    headlines = _safe(_fetch_headlines, [])
+
+    # Each fetcher does blocking network I/O, so run them on the default
+    # executor's thread pool and await them together instead of one after
+    # another - total latency becomes roughly the slowest fetcher instead of
+    # the sum of all three. `_safe` still runs inside each thread, so an
+    # exception in one fetcher only replaces that fetcher's own result with
+    # its default and doesn't affect the others or fail the gather.
+    loop = asyncio.get_running_loop()
+    indexes, sectors, headlines = await asyncio.gather(
+        loop.run_in_executor(None, _safe, _fetch_indexes, {}),
+        loop.run_in_executor(None, _safe, fetcher, []),
+        loop.run_in_executor(None, _safe, _fetch_headlines, []),
+    )
     return {"indexes": indexes, "sectors": sectors, "headlines": headlines}

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -132,12 +132,12 @@ backend/reports.py:1630
 # DEFAULT_HEADLINE_MAX_AGE_HOURS is a module-level float constant (the
 # hardcoded 72-hour fallback), never attacker-controlled; the other arg on
 # each of these two calls is already wrapped in sanitise_log_value.
-backend/routes/market.py:71
-backend/routes/market.py:79
-backend/routes/market.py:162
-backend/routes/market.py:170
-backend/routes/market.py:179
-backend/routes/market.py:186
+backend/routes/market.py:72
+backend/routes/market.py:80
+backend/routes/market.py:163
+backend/routes/market.py:171
+backend/routes/market.py:180
+backend/routes/market.py:187
 backend/routes/signup.py:139
 backend/routes/signup.py:252
 backend/routes/support.py:69

--- a/tests/routes/test_market.py
+++ b/tests/routes/test_market.py
@@ -1,5 +1,6 @@
 """Tests for the market overview helpers and HTTP endpoint."""
 
+import time
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -325,7 +326,9 @@ def test_market_overview_default_region_handles_fetch_failures(monkeypatch):
     resp = client.get("/market/overview")
     assert resp.status_code == 200
     assert resp.json() == {"indexes": {}, "sectors": [], "headlines": []}
-    assert calls == ["indexes", "sectors", "headlines"]
+    # Fetchers run concurrently on separate threads, so call order isn't
+    # guaranteed - only that all three ran.
+    assert set(calls) == {"indexes", "sectors", "headlines"}
 
 
 def test_market_overview_uk_region_handles_fetch_errors(monkeypatch):
@@ -359,7 +362,42 @@ def test_market_overview_uk_region_handles_fetch_errors(monkeypatch):
     assert data["indexes"] == {"Dow Jones": {"value": 100.0, "change": 1.5}}
     assert data["sectors"] == []
     assert data["headlines"] == []
-    assert calls == ["uk", "headlines"]
+    # Fetchers run concurrently on separate threads, so call order isn't
+    # guaranteed - only that both ran.
+    assert set(calls) == {"uk", "headlines"}
+
+
+def test_market_overview_fetchers_run_concurrently(monkeypatch):
+    """The three fetchers must overlap in wall-clock time, not run one after
+    another - a purely sequential implementation would take >= 3x as long."""
+
+    delay = 0.2
+
+    def slow_indexes():
+        time.sleep(delay)
+        return {}
+
+    def slow_sectors():
+        time.sleep(delay)
+        return []
+
+    def slow_headlines():
+        time.sleep(delay)
+        return []
+
+    monkeypatch.setattr(market, "_fetch_indexes", slow_indexes)
+    monkeypatch.setattr(market, "_fetch_sectors", slow_sectors)
+    monkeypatch.setattr(market, "_fetch_headlines", slow_headlines)
+
+    client = _client()
+    start = time.monotonic()
+    resp = client.get("/market/overview")
+    elapsed = time.monotonic() - start
+
+    assert resp.status_code == 200
+    # Sequential execution would take roughly 3 * delay; concurrent execution
+    # should take roughly 1 * delay. Use 2x delay as a generous cutoff.
+    assert elapsed < delay * 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `market_overview` (`backend/routes/market.py`) was `async def` but called `_fetch_indexes`, the sectors fetcher, and `_fetch_headlines` sequentially, so total latency was the sum of all three blocking calls.
- Each fetcher now runs on the default executor's thread pool via `loop.run_in_executor` and all three are awaited together with `asyncio.gather`, cutting wall-clock latency to roughly the slowest single fetcher.
- `_safe` is unchanged and still runs inside each thread, so an exception in one fetcher only replaces that fetcher's result with its own default (`{}` / `[]`) and doesn't affect the other two or fail the whole gather.
- Fetcher function signatures (`_fetch_indexes`, `_fetch_sectors`, `_fetch_uk_sectors`, `_fetch_headlines`) are unchanged, per the issue's constraints.

## Test plan
- [x] `pytest tests/routes/test_market.py tests/backend/routes/test_market.py` — 37 passed
- [x] Added `test_market_overview_fetchers_run_concurrently`, which makes all three fetchers sleep 0.2s and asserts total response time stays well under the 0.6s a sequential implementation would take — verifies concurrency by timing, not just by reading the code
- [x] Updated `test_market_overview_default_region_handles_fetch_failures` and `test_market_overview_uk_region_handles_fetch_errors` to assert fetcher call sets instead of exact call order, since concurrent execution no longer guarantees ordering
- [x] `ruff check` clean on changed files
- [x] Response shape (`{"indexes": ..., "sectors": ..., "headlines": ...}`) unchanged; existing per-fetcher-exception tests confirm failures still fall back to defaults without crashing the endpoint

Closes #4680

🤖 Generated with [Claude Code](https://claude.com/claude-code)