### PR TITLE
Require owner authorization for Moneyhub transaction import

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -11,15 +11,17 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple
 
-from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from pydantic import BaseModel, ConfigDict, Field
 
 from backend import importers
+from backend.auth import get_active_user
 from backend.common import compliance, data_loader, moneyhub_tokens
 from backend.common.accounts_store import (
     LocalAccountsStore,
     S3AccountsStore,
 )
+from backend.common.authz import ensure_owner_access
 from backend.common.instruments import get_instrument_meta
 from backend.common.ticker_utils import normalise_filter_ticker
 from backend.config import config
@@ -893,7 +895,9 @@ async def import_transactions(
 
 @router.post("/transactions/import/moneyhub")
 async def import_moneyhub_transactions(
-    request: Request, owner: str = Form(...)
+    request: Request,
+    owner: str = Form(...),
+    identity: str | None = Depends(get_active_user),
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Pull ``owner``'s transactions from the live Moneyhub API, persist the new ones, and report the rest.
 
@@ -904,8 +908,15 @@ async def import_moneyhub_transactions(
     owner to have already completed the Moneyhub consent flow and have a
     token set stored; there is no self-service way for this endpoint to
     initiate that consent itself.
+
+    ``owner`` is only a valid import target when the caller is authorized
+    for it -- :func:`ensure_owner_access` (the same check used by
+    ``/accounts/{owner}/approvals`` and ``/user-config/{owner}``) raises a
+    403 otherwise, so this endpoint can no longer be triggered for an
+    arbitrary owner by anyone who can guess the name (#5704).
     """
     owner = _validate_component(owner, "owner")
+    ensure_owner_access(identity, owner, resolve_accounts_root(request))
 
     from backend.importers import moneyhub_api as moneyhub_mapper
     from backend.integrations.moneyhub_api import MoneyhubAPIError

--- a/tests/test_moneyhub_api_import.py
+++ b/tests/test_moneyhub_api_import.py
@@ -418,3 +418,36 @@ def test_import_moneyhub_route_surfaces_upstream_failure(tmp_path, monkeypatch):
 
     resp = client.post("/transactions/import/moneyhub", data={"owner": "alice"})
     assert resp.status_code == 502
+
+
+def _make_auth_enabled_client(tmp_path, monkeypatch):
+    """Build a client with authentication (and thus owner scoping) enabled.
+
+    Mirrors ``_auth_enabled_client`` in ``tests/test_user_config_route.py``:
+    ``disable_auth`` must be off before ``create_app()`` for both the
+    router-level auth dependency and :func:`ensure_owner_access` to be live.
+    """
+
+    monkeypatch.setattr(config, "disable_auth", False)
+    client = _make_client(tmp_path, monkeypatch)
+    token = client.post("/token", json={"id_token": "good"}).json()["access_token"]
+    client.headers.update({"Authorization": f"Bearer {token}"})
+    return client
+
+
+def test_import_moneyhub_route_requires_owner_authorization(tmp_path, monkeypatch):
+    """A logged-in user may only trigger a Moneyhub import for an authorized owner (#5704)."""
+
+    def fake_meta(owner, root=None):
+        return {"email": "user@example.com"} if owner == "alice" else {}
+
+    monkeypatch.setattr("backend.common.authz.load_person_meta", fake_meta)
+    client = _make_auth_enabled_client(tmp_path, monkeypatch)
+
+    # Authorized owner: falls through to the normal consent check (no token stored yet).
+    resp = client.post("/transactions/import/moneyhub", data={"owner": "alice"})
+    assert resp.status_code == 424
+
+    # Unauthorized owner: rejected before any Moneyhub call is attempted.
+    resp = client.post("/transactions/import/moneyhub", data={"owner": "bob"})
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- The `POST /transactions/import/moneyhub` endpoint relied solely on the `owner` form field to authorize the caller, so anyone who could guess an owner name could trigger Moneyhub token refresh and transaction fetching/persistence for that owner.
- Adds the same `get_active_user` + `ensure_owner_access` check already used by `/accounts/{owner}/approvals` and `/user-config/{owner}` (`backend/common/authz.py`), so the authenticated caller must own/be a viewer of the target `owner` before the import proceeds. No-ops when `disable_auth` is set (local/demo mode), matching every other owner-scoped route.
- `owner` is still read from the form field and used as the import target, but it's now a validated target rather than the sole authorization mechanism.

## Test plan
- [x] Added `test_import_moneyhub_route_requires_owner_authorization` in `tests/test_moneyhub_api_import.py`, verifying an authorized owner still reaches the normal 424 (no consent stored) response and an unauthorized owner gets 403 before any Moneyhub call.
- [x] `python -m pytest tests/test_moneyhub_api_import.py -q --no-cov` — 29 passed
- [x] `python -m pytest tests/ -k "transactions or moneyhub" -q --no-cov` — 181 passed
- [x] Full suite: `python -m pytest tests/ -q --no-cov` — 3595 passed, 6 skipped, 16 xfailed, 1 xpassed
- [x] `python -m ruff check backend/routes/transactions.py tests/test_moneyhub_api_import.py` — clean
- [x] `python -m black --check` / `python -m isort --check-only` — clean

Closes #5704

🤖 Generated with [Claude Code](https://claude.com/claude-code)