### PR TITLE
Allow extract_value_label() to match same-line **Value**: **X Value**

### DIFF
--- a/.github/scripts/llm_labels.py
+++ b/.github/scripts/llm_labels.py
@@ -116,10 +116,15 @@ DEFAULT_VALUE_LABEL = "Low Value"
 
 
 def _build_value_pattern(value_map: dict[str, str]) -> re.Pattern[str]:
-    """Build a regex matching a "**Value**" section naming one of value_map's keys."""
+    """Build a regex matching a "**Value**" section naming one of value_map's keys.
+
+    Accepts both the value label on the line following "**Value**" (e.g.
+    "**Value**\\n**High Value**") and on the same line (e.g.
+    "**Value**: **High Value**").
+    """
     words = "|".join(re.escape(word) for word in value_map)
     return re.compile(
-        rf"\*\*Value\*\*[^\n]*\n[^\n]*\*\*({words})\s+Value\b",
+        rf"\*\*Value\*\*(?:[^\n]*\n)?[^\n]*\*\*({words})\s+Value\b",
         re.IGNORECASE,
     )
 

--- a/tests/test_llm_labels.py
+++ b/tests/test_llm_labels.py
@@ -160,6 +160,9 @@ def test_llm_tier_map_is_stable() -> None:
         ("**Value**\n**Medium Value** — reliability improvement", "Medium Value"),
         ("**Value**\n**High Value** — security fix", "High Value"),
         ("**value**\n**HIGH VALUE** — case insensitive", "High Value"),
+        ("**Value**: **High Value**", "High Value"),
+        ("**Value**: **Medium Value** — some text", "Medium Value"),
+        ("**Value** **Low Value** — same line, no colon", "Low Value"),
         ("This is a High Value issue.", "High Value"),
         ("This is a Medium Value issue.", "Medium Value"),
         ("This is a Low Value issue.", "Low Value"),
@@ -175,6 +178,21 @@ def test_extract_value_label(body: str, expected_label: str | None) -> None:
 def test_extract_value_label_prefers_value_section_over_bare_mention() -> None:
     mod = load_module()
     body = "Mentions Low Value in passing.\n\n**Value**\n**High Value** — security fix"
+    assert mod.extract_value_label(body) == "High Value"
+
+
+def test_extract_value_label_prefers_same_line_value_section_over_bare_mention() -> None:
+    mod = load_module()
+    body = "Mentions Low Value in passing.\n\n**Value**: **High Value** — security fix"
+    assert mod.extract_value_label(body) == "High Value"
+
+
+def test_extract_value_label_does_not_match_bare_mention_as_section() -> None:
+    mod = load_module()
+    # A bare "**High Value**" elsewhere in the body, with no "**Value**"
+    # heading anywhere, must fall through to the bare-mention path rather
+    # than being mistaken for a "**Value**" section match.
+    body = "Some notes.\n\nThis looks like a **High Value** fix."
     assert mod.extract_value_label(body) == "High Value"
 
 


### PR DESCRIPTION
## Summary
- `_build_value_pattern()` required the value label on the line *after* `**Value**`, so the inline `**Value**: **High Value**` format silently returned `None` and fell back to `Low Value`.
- Regex now accepts both the next-line layout and the same-line layout (with or without a colon), while still requiring the label to be a `**<word> Value**` token under the `**Value**` heading (bare mentions elsewhere still only match via the existing fallback path).

## Test plan
- [x] Added parametrized cases: `**Value**: **High Value**`, `**Value**: **Medium Value** — some text`, `**Value** **Low Value**` (no colon)
- [x] Added regression tests confirming section match still wins over an earlier bare mention (both next-line and same-line variants), and that a bare mention with no `**Value**` heading still falls through correctly
- [x] `python -m pytest tests/test_llm_labels.py -q --no-cov` — 46 passed
- [x] `python -m ruff check` / `python -m black --check` on changed files — clean

Closes #5920

🤖 Generated with [Claude Code](https://claude.com/claude-code)