### PR TITLE
Coerce price/price_gbp to Decimal before comparison in import validation

### DIFF
--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -7,6 +7,7 @@ import re
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import date, datetime
+from decimal import Decimal
 from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple
@@ -811,7 +812,11 @@ def _tx_data_from_parsed(row: Transaction) -> Dict[str, Any]:
     tx_data = row.model_dump(mode="json", exclude={"owner", "account", "id"})
     price = tx_data.get("price")
     price_gbp = tx_data.get("price_gbp")
-    if price is not None and price_gbp is not None and price != price_gbp:
+    if (
+        price is not None
+        and price_gbp is not None
+        and Decimal(str(price)) != Decimal(str(price_gbp))
+    ):
         raise ValueError(f"Conflicting values for price ({price}) and price_gbp ({price_gbp})")
     if price_gbp is None:
         tx_data["price_gbp"] = price

--- a/tests/backend/routes/test_transactions.py
+++ b/tests/backend/routes/test_transactions.py
@@ -4,6 +4,7 @@ import contextlib
 import io
 import json
 from datetime import date
+from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -378,6 +379,36 @@ def test_tx_data_from_parsed_no_prices_set():
 
     assert tx_data["price_gbp"] is None
     assert "price" not in tx_data
+
+
+class _FakeParsedRow:
+    """Stand-in for a parsed ``Transaction`` whose ``price``/``price_gbp``
+    fields may carry mixed numeric types (e.g. ``Decimal`` vs ``float``),
+    which the ``Transaction`` model itself would normally coerce to
+    ``float`` -- used to exercise the type-safe comparison in isolation."""
+
+    def __init__(self, price, price_gbp):
+        self._price = price
+        self._price_gbp = price_gbp
+
+    def model_dump(self, mode="json", exclude=None):
+        return {"ticker": "AAA", "price": self._price, "price_gbp": self._price_gbp}
+
+
+def test_tx_data_from_parsed_allows_equal_decimal_and_float_price():
+    row = _FakeParsedRow(price=Decimal("10.50"), price_gbp=10.5)
+
+    tx_data = transactions_module._tx_data_from_parsed(row)
+
+    assert tx_data["price_gbp"] == 10.5
+    assert "price" not in tx_data
+
+
+def test_tx_data_from_parsed_raises_on_conflicting_decimal_and_float_price():
+    row = _FakeParsedRow(price=Decimal("10.50"), price_gbp=10.51)
+
+    with pytest.raises(ValueError, match="Conflicting values for price"):
+        transactions_module._tx_data_from_parsed(row)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `_tx_data_from_parsed` in [backend/routes/transactions.py](backend/routes/transactions.py) compared `price` and `price_gbp` with plain `!=`, which can produce false positives/negatives when the two values are backed by different numeric types (e.g. `Decimal` vs `float`).
- Both values are now coerced via `Decimal(str(value))` before comparison, and the raised error message still shows the original (uncoerced) values.
- Coalescing logic (falling back to `price` when `price_gbp` is absent) and the `None`/`None` no-op case are unchanged.

## Test plan
- [x] Added `test_tx_data_from_parsed_allows_equal_decimal_and_float_price` — `price=Decimal('10.50')`, `price_gbp=10.5` (float) is accepted.
- [x] Added `test_tx_data_from_parsed_raises_on_conflicting_decimal_and_float_price` — `price=Decimal('10.50')`, `price_gbp=10.51` still raises `ValueError`.
- [x] `pytest tests/backend/routes/test_transactions.py` — all 23 tests pass.
- [x] `ruff check --config backend/pyproject.toml` — no new issues.

Closes #5471

🤖 Generated with [Claude Code](https://claude.com/claude-code)