### PR TITLE
Extract value-label inference from workflow YAML to shared script

### DIFF
--- a/.github/scripts/llm_labels.py
+++ b/.github/scripts/llm_labels.py
@@ -140,3 +140,26 @@ def extract_value_label(body: str, value_map: dict[str, str] | None = None) -> s
         if re.search(rf"\b{re.escape(word)}\s+Value\b", body, re.IGNORECASE):
             return label
     return None
+
+
+def _cli(argv: list[str]) -> int:
+    """CLI entry point so bash workflow steps can reuse the extraction logic
+    above instead of re-implementing it with their own regexes.
+
+    Usage: ``echo "$ISSUE_BODY" | python3 llm_labels.py value-label``
+    Prints the extracted label, falling back to ``DEFAULT_VALUE_LABEL``.
+    """
+    import sys
+
+    if len(argv) != 1 or argv[0] != "value-label":
+        print("usage: llm_labels.py value-label < issue_body", file=sys.stderr)
+        return 2
+    body = sys.stdin.read()
+    print(extract_value_label(body) or DEFAULT_VALUE_LABEL)
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    raise SystemExit(_cli(sys.argv[1:]))

--- a/.github/workflows/label-ai-issues.yml
+++ b/.github/workflows/label-ai-issues.yml
@@ -15,6 +15,8 @@ jobs:
       issues: write
 
     steps:
+      - uses: actions/checkout@v7
+
       - name: Check for existing tier label and apply fallback
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,21 +84,11 @@ jobs:
             fi
           done
 
-          # Infer value from the issue body.  Precedence: explicit **Value**
-          # section first, then any bare "<word> Value" mention.
-          body_lower=$(echo "$ISSUE_BODY" | tr '[:upper:]' '[:lower:]')
-          value_label=""
-          if echo "$body_lower" | grep -qE '\*\*value\*\*.*high value|\bhigh value\b'; then
-            value_label="High Value"
-          elif echo "$body_lower" | grep -qE '\*\*value\*\*.*medium value|\bmedium value\b'; then
-            value_label="Medium Value"
-          elif echo "$body_lower" | grep -qE '\*\*value\*\*.*low value|\blow value\b'; then
-            value_label="Low Value"
-          else
-            # Default: Low Value — ai-suggested issues have historically
-            # skewed low-value, matching the manual triage pass on 2026-08-02.
-            value_label="Low Value"
-          fi
+          # Infer value from the issue body using the shared extraction logic
+          # in .github/scripts/llm_labels.py (also used by
+          # create_followup_issues.py), so both paths stay in sync instead of
+          # duplicating the regex here.
+          value_label=$(echo "$ISSUE_BODY" | python3 .github/scripts/llm_labels.py value-label)
 
           echo "Applying value label: $value_label"
           gh issue edit "$ISSUE_NUMBER" \

--- a/tests/test_llm_labels.py
+++ b/tests/test_llm_labels.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -199,3 +200,36 @@ def test_value_label_map_is_stable() -> None:
         "high": "High Value",
     }
     assert mod.DEFAULT_VALUE_LABEL == "Low Value"
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_label"),
+    [
+        ("**Value**\n**High Value** — security fix", "High Value"),
+        ("This is a Medium Value issue.", "Medium Value"),
+        ("No value mentioned", "Low Value"),
+        ("", "Low Value"),
+    ],
+)
+def test_cli_value_label(body: str, expected_label: str) -> None:
+    """The workflow YAML shells out to this CLI instead of re-implementing
+    the extraction regex in bash; verify that path end-to-end."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / "llm_labels.py"), "value-label"],
+        input=body,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == expected_label
+
+
+def test_cli_rejects_unknown_command() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / "llm_labels.py"), "bogus"],
+        input="",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "usage" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- `label-ai-issues.yml`'s value-label step re-implemented the value-inference regex in bash, duplicating logic already implemented in `.github/scripts/llm_labels.py` (`extract_value_label`, already used by `create_followup_issues.py`).
- Added a small CLI to `llm_labels.py` (`python3 llm_labels.py value-label < issue_body`) so the bash workflow step can call the shared Python function instead of duplicating the regex.
- Added an `actions/checkout` step to the workflow (previously absent) so the script is available to run.
- Added subprocess-level tests covering the new CLI path.

## Test plan
- [x] `python -m pytest tests/test_llm_labels.py tests/test_create_followup_issues.py -q --no-cov`
- [x] `python -m black --check .github/scripts/llm_labels.py tests/test_llm_labels.py`
- [x] `python -m ruff check .github/scripts/llm_labels.py tests/test_llm_labels.py`
- [x] YAML parses (`yaml.safe_load`)

Closes #5932

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic value-label assignment for issues by using consistent label extraction.
  * Issues without a recognised value label now receive the default **Low Value** label.
  * Updated labelling workflow behaviour to ensure issue content is available before processing.

* **Reliability**
  * Added validation for unsupported labelling commands, with clear usage feedback.
  * Expanded automated coverage for label extraction, defaults, empty input, and invalid commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->