### PR TITLE
Add script to retroactively link open PRs to issues

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -487,6 +487,37 @@ refuses to propose the change rather than risk silently dropping details.
 **Requirements:** `gh` CLI authenticated against the target repo; either a
 running local Ollama server or a `DEEPSEEK_API_KEY`, depending on `--model`.
 
+## p_add_issue_to_pr.py
+
+Retroactively link open PRs to an issue. Every PR is supposed to close an
+issue, but one opened by hand (or by an external contributor) can slip
+through without a `Closes #NNNN` reference. This script scans open PRs,
+skips any whose body already references an issue via a closing keyword
+(`Closes`/`Fixes`/`Resolves`, case-insensitive), and for the rest creates a
+new issue from the PR's own title/body/changed-files (using the standard
+`bug_report.md` template sections) before appending `Closes #<issue_id>` to
+the PR description.
+
+```bash
+python scripts/developer_tools/p_add_issue_to_pr.py
+```
+
+Defaults to dry-run, printing which PRs would get a new issue without
+creating or editing anything:
+
+```bash
+python scripts/developer_tools/p_add_issue_to_pr.py --yes
+```
+
+Optional flags:
+- `--repo owner/name`: target a repo other than the `origin` git remote.
+- `--pr NNNN`: only check/process a single PR instead of scanning all open PRs.
+- `--label LABEL`: label to apply to created issues (repeatable). Defaults to
+  `bug` and `Medium Value`.
+
+**Requirements:** `gh` CLI authenticated with a token that can create issues
+and edit PR descriptions on the target repo (repo scope covers this).
+
 ## reconcile_drawdown.py
 
 Inspect max drawdowns and dump holding price data when the portfolio suffers a

--- a/scripts/developer_tools/p_add_issue_to_pr.py
+++ b/scripts/developer_tools/p_add_issue_to_pr.py
@@ -1,0 +1,348 @@
+"""CLI tool to retroactively link open PRs to a GitHub issue.
+
+Continues the a_/b_/.../o_ script chain in scripts/developer_tools/. Every PR
+is supposed to close an issue (see docs/CONTRIBUTING.md), but a PR opened by
+hand, or by an external contributor, can slip through without a
+"Closes #NNNN" reference. This script finds open PRs whose body doesn't
+reference an issue, creates a matching issue from the PR's own title/body
+(using the standard bug_report.md template sections), and appends the closing
+syntax to the PR description so GitHub links the two and closes the issue
+automatically once the PR merges.
+
+Safety:
+  - Defaults to dry-run: prints what would be created/edited without doing
+    it. Pass --yes to actually create issues and edit PR descriptions.
+  - Never touches a PR whose body already references an issue via
+    Closes/Close/Closed/Fixes/Fix/Fixed/Resolves/Resolve/Resolved
+    (case-insensitive) -- those are left alone.
+
+Requires the `gh` CLI to be authenticated with a token that can create
+issues and edit PR descriptions on the target repo (repo scope covers this).
+Defaults to operating on the `origin` git remote's repo; pass --repo
+owner/name to override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from github_repo import get_repo_info
+
+GH_TIMEOUT_SECONDS = 60
+DEFAULT_VALUE_LABEL = "Medium Value"
+
+ISSUE_REF_PATTERN = re.compile(
+    r"\b(closes?|closed|fix(?:es|ed)?|resolves?|resolved)\s*:?\s*#(\d+)",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class PullRequest:
+    """A single open pull request under consideration."""
+
+    number: int
+    title: str
+    body: str
+    files: list[str] = field(default_factory=list)
+
+
+def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a single `gh` CLI command. Never raises."""
+    cmd = ["gh", *args]
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            cmd, returncode=124, stdout="", stderr=f"gh {' '.join(args)} timed out"
+        )
+
+
+def has_linked_issue(pr_body: str) -> bool:
+    """Return True if the PR body already references an issue via a closing keyword."""
+    return bool(ISSUE_REF_PATTERN.search(pr_body or ""))
+
+
+def fetch_open_prs(owner: str, repo: str) -> list[PullRequest]:
+    """List open PRs (title, body, changed files) for the given repo."""
+    result = run_gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            f"{owner}/{repo}",
+            "--state",
+            "open",
+            "--json",
+            "number,title,body,files",
+            "--limit",
+            "200",
+        ]
+    )
+    if result.returncode != 0:
+        print(f"ERROR: gh pr list failed: {result.stderr}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: gh pr list returned non-JSON output: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    prs = []
+    for item in data:
+        files = [f["path"] for f in (item.get("files") or []) if f.get("path")]
+        prs.append(
+            PullRequest(
+                number=item["number"],
+                title=item["title"],
+                body=item.get("body") or "",
+                files=files,
+            )
+        )
+    return prs
+
+
+def build_issue_body(pr: PullRequest) -> str:
+    """Build a bug_report.md-shaped issue body describing a retroactive link to `pr`."""
+    what = pr.body.strip() or f"See PR #{pr.number} for details."
+    files_affected = "\n".join(pr.files) if pr.files else f"See PR #{pr.number} diff."
+    parts = [
+        "## What",
+        "",
+        f"This issue was retroactively created to link PR #{pr.number}, which had "
+        "no linked issue.",
+        "",
+        what,
+        "",
+        "## Why",
+        "",
+        "To ensure every pull request is associated with an issue before merging, "
+        "for traceability and documentation.",
+        "",
+        "## How",
+        "",
+        f"Already implemented in PR #{pr.number}. See the PR diff for the change.",
+        "",
+        "## Files Affected",
+        "",
+        files_affected,
+        "",
+        "## Constraints",
+        "",
+        "None",
+        "",
+        "## LLM tier",
+        "",
+        "sonnet",
+        "",
+        "## Value",
+        "",
+        DEFAULT_VALUE_LABEL,
+        "",
+        "## Success looks like",
+        "",
+        f"- [ ] PR #{pr.number} is merged",
+        "",
+        "## Failure looks like",
+        "",
+        f"- PR #{pr.number} is closed without merging",
+    ]
+    return "\n".join(parts)
+
+
+def create_issue(owner: str, repo: str, title: str, body: str, labels: list[str]) -> int | None:
+    """Create an issue via the `gh` CLI. Returns the new issue number, or None on failure."""
+    body_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", encoding="utf-8", delete=False
+        ) as tf:
+            tf.write(body)
+            body_path = tf.name
+
+        args = [
+            "issue",
+            "create",
+            "--repo",
+            f"{owner}/{repo}",
+            "--title",
+            title,
+            "--body-file",
+            body_path,
+        ]
+        for label in labels:
+            args += ["--label", label]
+
+        result = run_gh(args)
+        if result.returncode != 0:
+            print(f"ERROR: gh issue create failed: {result.stderr.strip()}", file=sys.stderr)
+            return None
+
+        match = re.search(r"/issues/(\d+)", result.stdout)
+        if not match:
+            print(
+                f"ERROR: could not parse issue number from gh output: {result.stdout!r}",
+                file=sys.stderr,
+            )
+            return None
+        return int(match.group(1))
+    finally:
+        if body_path and Path(body_path).exists():
+            Path(body_path).unlink()
+
+
+def update_pr_body(owner: str, repo: str, pr: PullRequest, issue_number: int) -> bool:
+    """Append a `Closes #NNNN` line to the PR body via the `gh` CLI."""
+    new_body = pr.body.rstrip()
+    new_body += f"\n\nCloses #{issue_number}" if new_body else f"Closes #{issue_number}"
+
+    body_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", encoding="utf-8", delete=False
+        ) as tf:
+            tf.write(new_body)
+            body_path = tf.name
+
+        result = run_gh(
+            [
+                "pr",
+                "edit",
+                str(pr.number),
+                "--repo",
+                f"{owner}/{repo}",
+                "--body-file",
+                body_path,
+            ]
+        )
+        if result.returncode != 0:
+            print(
+                f"ERROR: gh pr edit failed for PR #{pr.number}: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            return False
+        return True
+    finally:
+        if body_path and Path(body_path).exists():
+            Path(body_path).unlink()
+
+
+def process_pr(owner: str, repo: str, pr: PullRequest, dry_run: bool, labels: list[str]) -> bool:
+    """Link a single unlinked PR to a newly created issue.
+
+    Returns False only when a create/edit was attempted and failed; skipping
+    an already-linked PR is not treated as a failure.
+    """
+    if has_linked_issue(pr.body):
+        print(f"SKIP: PR #{pr.number} ({pr.title}) -- already references an issue")
+        return True
+
+    prefix = "[DRY RUN] " if dry_run else ""
+    print(f"{prefix}PR #{pr.number} ({pr.title}) has no linked issue -- creating one")
+    if dry_run:
+        return True
+
+    issue_body = build_issue_body(pr)
+    issue_number = create_issue(owner, repo, pr.title, issue_body, labels)
+    if issue_number is None:
+        return False
+    print(f"  Created issue #{issue_number}")
+
+    if not update_pr_body(owner, repo, pr, issue_number):
+        return False
+    print(f"  Updated PR #{pr.number} body with 'Closes #{issue_number}'")
+    return True
+
+
+def resolve_repo(explicit: str | None) -> tuple[str, str]:
+    """Resolve the (owner, repo) to operate on: an explicit --repo, else the origin remote."""
+    if explicit:
+        owner, _, name = explicit.partition("/")
+        if not owner or not name:
+            print(f"ERROR: --repo must be in 'owner/name' form, got '{explicit}'", file=sys.stderr)
+            raise SystemExit(1)
+        return owner, name
+
+    try:
+        return get_repo_info()
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+def main() -> int:
+    """Run the retroactive issue-linking flow."""
+    parser = argparse.ArgumentParser(
+        description="Create and link issues for open PRs that don't reference one"
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Actually create issues and edit PR descriptions. Without this flag, "
+        "runs in dry-run mode.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Repository to operate on as 'owner/name'. Defaults to the 'origin' git remote.",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="Only process this single PR number instead of scanning all open PRs.",
+    )
+    parser.add_argument(
+        "--label",
+        action="append",
+        default=None,
+        help="Label to apply to created issues (repeatable). Defaults to 'bug' and "
+        f"'{DEFAULT_VALUE_LABEL}'.",
+    )
+    args = parser.parse_args()
+    dry_run = not args.yes
+    labels = args.label or ["bug", DEFAULT_VALUE_LABEL]
+
+    owner, repo = resolve_repo(args.repo)
+
+    print(f"INFO: Fetching open PRs for {owner}/{repo}...", file=sys.stderr)
+    prs = fetch_open_prs(owner, repo)
+    if args.pr is not None:
+        prs = [pr for pr in prs if pr.number == args.pr]
+        if not prs:
+            print(f"ERROR: PR #{args.pr} not found among open PRs", file=sys.stderr)
+            return 1
+    print(f"INFO: {len(prs)} open PR(s) to check", file=sys.stderr)
+
+    if dry_run:
+        print(
+            "INFO: Running in dry-run mode. Pass --yes to actually create/edit anything.",
+            file=sys.stderr,
+        )
+
+    had_failures = False
+    for pr in prs:
+        if not process_pr(owner, repo, pr, dry_run, labels):
+            had_failures = True
+
+    return 1 if had_failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_p_add_issue_to_pr.py
+++ b/tests/scripts/test_p_add_issue_to_pr.py
@@ -1,0 +1,200 @@
+import json
+
+import pytest
+
+import scripts.developer_tools.p_add_issue_to_pr as i
+
+
+def _pr(number=42, title="Fix flaky login test", body="", files=None):
+    return i.PullRequest(number=number, title=title, body=body, files=files or [])
+
+
+class _FakeResult:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Closes #123",
+        "closes #123",
+        "This closes: #123",
+        "Fixes #99",
+        "fix #99",
+        "Fixed #99",
+        "Resolves #7",
+        "resolve #7",
+        "Resolved #7",
+        "See also #1, but this one Closed #123 for real",
+    ],
+)
+def test_has_linked_issue_true(body):
+    assert i.has_linked_issue(body)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "",
+        "No issue reference here.",
+        "See #123 for context.",
+        "Related to #123.",
+    ],
+)
+def test_has_linked_issue_false(body):
+    assert not i.has_linked_issue(body)
+
+
+def test_fetch_open_prs_parses_payload(monkeypatch):
+    payload = json.dumps(
+        [
+            {
+                "number": 42,
+                "title": "Fix flaky login test",
+                "body": "No linked issue.",
+                "files": [{"path": "tests/test_login.py"}, {"path": ""}],
+            }
+        ]
+    )
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(0, payload))
+    prs = i.fetch_open_prs("owner", "repo")
+    assert len(prs) == 1
+    assert prs[0].number == 42
+    assert prs[0].title == "Fix flaky login test"
+    assert prs[0].files == ["tests/test_login.py"]
+
+
+def test_fetch_open_prs_exits_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(1, "", "boom"))
+    with pytest.raises(SystemExit) as exc_info:
+        i.fetch_open_prs("owner", "repo")
+    assert exc_info.value.code == 1
+
+
+def test_build_issue_body_includes_key_sections():
+    pr = _pr(body="Some PR description.", files=["a.py", "b.py"])
+    body = i.build_issue_body(pr)
+    assert "PR #42" in body
+    assert "Some PR description." in body
+    assert "a.py\nb.py" in body
+    assert "## Value" in body
+    assert i.DEFAULT_VALUE_LABEL in body
+    assert "- [ ] PR #42 is merged" in body
+
+
+def test_build_issue_body_falls_back_when_no_files_or_body():
+    pr = _pr(body="", files=[])
+    body = i.build_issue_body(pr)
+    assert "See PR #42" in body
+
+
+def test_create_issue_parses_issue_number(monkeypatch):
+    monkeypatch.setattr(
+        i, "run_gh", lambda args: _FakeResult(0, "https://github.com/o/r/issues/55\n")
+    )
+    assert i.create_issue("o", "r", "Title", "Body", ["bug"]) == 55
+
+
+def test_create_issue_returns_none_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(1, "", "boom"))
+    assert i.create_issue("o", "r", "Title", "Body", ["bug"]) is None
+
+
+def test_create_issue_returns_none_when_url_unparseable(monkeypatch):
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(0, "not a url"))
+    assert i.create_issue("o", "r", "Title", "Body", ["bug"]) is None
+
+
+def test_update_pr_body_appends_closes_line(monkeypatch):
+    captured = {}
+
+    def fake_run_gh(args):
+        body_file = args[args.index("--body-file") + 1]
+        with open(body_file, encoding="utf-8") as f:
+            captured["body"] = f.read()
+        return _FakeResult(0)
+
+    monkeypatch.setattr(i, "run_gh", fake_run_gh)
+    pr = _pr(body="Existing description.")
+    assert i.update_pr_body("o", "r", pr, 55) is True
+    assert captured["body"] == "Existing description.\n\nCloses #55"
+
+
+def test_update_pr_body_handles_empty_body(monkeypatch):
+    captured = {}
+
+    def fake_run_gh(args):
+        body_file = args[args.index("--body-file") + 1]
+        with open(body_file, encoding="utf-8") as f:
+            captured["body"] = f.read()
+        return _FakeResult(0)
+
+    monkeypatch.setattr(i, "run_gh", fake_run_gh)
+    pr = _pr(body="")
+    assert i.update_pr_body("o", "r", pr, 55) is True
+    assert captured["body"] == "Closes #55"
+
+
+def test_update_pr_body_returns_false_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(1, "", "boom"))
+    pr = _pr(body="Existing description.")
+    assert i.update_pr_body("o", "r", pr, 55) is False
+
+
+def test_process_pr_skips_when_already_linked(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "create_issue", lambda *a, **k: calls.append("create") or 1)
+    pr = _pr(body="Closes #1")
+    assert i.process_pr("o", "r", pr, dry_run=False, labels=["bug"]) is True
+    assert calls == []
+
+
+def test_process_pr_dry_run_does_not_create_or_edit(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "create_issue", lambda *a, **k: calls.append("create") or 1)
+    monkeypatch.setattr(i, "update_pr_body", lambda *a, **k: calls.append("edit") or True)
+    pr = _pr(body="No issue here.")
+    assert i.process_pr("o", "r", pr, dry_run=True, labels=["bug"]) is True
+    assert calls == []
+
+
+def test_process_pr_creates_issue_and_updates_pr(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "create_issue", lambda *a, **k: calls.append("create") or 55)
+    monkeypatch.setattr(i, "update_pr_body", lambda *a, **k: calls.append("edit") or True)
+    pr = _pr(body="No issue here.")
+    assert i.process_pr("o", "r", pr, dry_run=False, labels=["bug"]) is True
+    assert calls == ["create", "edit"]
+
+
+def test_process_pr_fails_when_create_issue_fails(monkeypatch):
+    monkeypatch.setattr(i, "create_issue", lambda *a, **k: None)
+    edit_calls = []
+    monkeypatch.setattr(i, "update_pr_body", lambda *a, **k: edit_calls.append(1) or True)
+    pr = _pr(body="No issue here.")
+    assert i.process_pr("o", "r", pr, dry_run=False, labels=["bug"]) is False
+    assert edit_calls == []
+
+
+def test_process_pr_fails_when_update_pr_body_fails(monkeypatch):
+    monkeypatch.setattr(i, "create_issue", lambda *a, **k: 55)
+    monkeypatch.setattr(i, "update_pr_body", lambda *a, **k: False)
+    pr = _pr(body="No issue here.")
+    assert i.process_pr("o", "r", pr, dry_run=False, labels=["bug"]) is False
+
+
+def test_resolve_repo_uses_explicit_flag():
+    assert i.resolve_repo("someowner/somerepo") == ("someowner", "somerepo")
+
+
+def test_resolve_repo_rejects_malformed_flag():
+    with pytest.raises(SystemExit):
+        i.resolve_repo("not-a-valid-repo")
+
+
+def test_resolve_repo_falls_back_to_git_remote(monkeypatch):
+    monkeypatch.setattr(i, "get_repo_info", lambda: ("gitowner", "gitrepo"))
+    assert i.resolve_repo(None) == ("gitowner", "gitrepo")


### PR DESCRIPTION
## Summary
- Add `scripts/developer_tools/p_add_issue_to_pr.py`, a CLI that scans open PRs, skips any that already reference an issue via a closing keyword (`Closes`/`Fixes`/`Resolves #N`, case-insensitive), and for the rest creates a matching issue (using the `bug_report.md` template sections, including the `Value` label) and appends `Closes #<id>` to the PR description.
- Defaults to dry-run (prints what it would do); pass `--yes` to actually create issues and edit PRs. Supports `--repo`, `--pr`, and `--label` overrides.
- Add 32 unit tests in `tests/scripts/test_p_add_issue_to_pr.py` covering the linked-issue regex, PR fetching, issue-body construction, `gh` create/edit calls, and per-PR orchestration.
- Document the new script in `scripts/README.md`.

## Test plan
- [x] `python -m pytest tests/scripts/test_p_add_issue_to_pr.py -q` — 32 passed
- [x] `python -m pytest tests/scripts/ -q` — 583 passed (full scripts suite, no regressions)
- [x] `black --check` / `isort --check-only` / `ruff check` clean on new files

Closes #5883

🤖 Generated with [Claude Code](https://claude.com/claude-code)