### PR TITLE
Add Support page integration test for dataquality tab save flow

### DIFF
--- a/frontend/tests/unit/pages/Support.test.tsx
+++ b/frontend/tests/unit/pages/Support.test.tsx
@@ -251,6 +251,81 @@ describe("Support page", () => {
     ).not.toBeChecked();
   });
 
+  it("saves the dataquality tab toggle and persists it after save", async () => {
+    mockGetConfig.mockResolvedValueOnce({
+      flag: true,
+      theme: "system",
+      tabs: {
+        group: true,
+        owner: true,
+        instrument: true,
+        trading: true,
+        support: true,
+        reports: true,
+        allocation: true,
+        scenario: true,
+        market: true,
+        rebalance: true,
+        pension: true,
+        dataquality: false,
+      },
+    });
+    mockGetConfig.mockResolvedValueOnce({
+      flag: true,
+      theme: "system",
+      tabs: {
+        group: true,
+        owner: true,
+        instrument: true,
+        trading: true,
+        support: true,
+        reports: true,
+        allocation: true,
+        scenario: true,
+        market: true,
+        rebalance: true,
+        pension: true,
+        dataquality: true,
+      },
+    });
+    mockUpdateConfig.mockResolvedValue(undefined);
+
+    render(<Support />, { wrapper: MemoryRouter });
+    await expandSection(en.support.config.title);
+
+    const dataquality = await screen.findByRole("checkbox", {
+      name: /^dataquality$/i,
+    });
+    expect(dataquality).not.toBeChecked();
+
+    await act(async () => {
+      await userEvent.click(dataquality);
+    });
+    expect(dataquality).toBeChecked();
+
+    const saveButton = screen.getByRole("button", {
+      name: en.support.config.save,
+    });
+    await act(async () => {
+      await userEvent.click(saveButton);
+    });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ui: expect.objectContaining({
+          tabs: expect.objectContaining({ dataquality: true }),
+        }),
+      }),
+    );
+
+    expect(
+      await screen.findByText(en.support.status.saved),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("checkbox", { name: /^dataquality$/i }),
+    ).toBeChecked();
+  });
+
   it("separates switches from other parameters", async () => {
     render(<Support />, { wrapper: MemoryRouter });
     await expandSection(en.support.config.title);


### PR DESCRIPTION
## Summary
- Adds a frontend integration test to `frontend/tests/unit/pages/Support.test.tsx` covering the full save flow for the Support page tab toggles, including the `dataquality` tab.
- The test toggles `dataquality` on, saves, asserts the outgoing `updateConfig` payload includes `ui.tabs.dataquality: true`, and asserts the UI reflects a successful save with the persisted checkbox state.
- Follows the existing test conventions in the file (same mocking/setup pattern as the neighboring `persists tab selections after save` test).

Closes #5877

## Test plan
- [x] `npm --prefix frontend run test -- --run tests/unit/pages/Support.test.tsx` — 15 passed
- [x] `npx eslint tests/unit/pages/Support.test.tsx` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)