### PR TITLE
Add JSON structured logging formatter alongside plain-text formatter

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -28,7 +28,7 @@ from backend.bootstrap import (
     register_routers,
 )
 from backend.config import reload_config
-from backend.logging_setup import sanitise_log_value
+from backend.logging_setup import sanitise_log_value, setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +40,8 @@ class CognitoTokenRequest(BaseModel):
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
+
+    setup_logging()
 
     cfg = load_runtime_config()
     runtime_paths = configure_runtime_paths(cfg)

--- a/backend/config.py
+++ b/backend/config.py
@@ -112,6 +112,7 @@ class Config:
     rate_limit_per_minute: int = 6000
     signup_rate_limit: str = "5/minute"
     log_config: Optional[str] = None
+    log_format: Optional[str] = None
     skip_snapshot_warm: Optional[bool] = None
     snapshot_warm_days: Optional[int] = None
 
@@ -290,6 +291,10 @@ def load_config() -> Config:
     if skip_snapshot_warm_env is not None:
         data["skip_snapshot_warm"] = skip_snapshot_warm_env
 
+    log_format_env = os.getenv("LOG_FORMAT")
+    if log_format_env is not None:
+        data["log_format"] = log_format_env
+
     telegram_token_env = os.getenv("TELEGRAM_BOT_TOKEN")
     if telegram_token_env is not None:
         data["telegram_bot_token"] = telegram_token_env
@@ -437,6 +442,7 @@ def load_config() -> Config:
         rate_limit_per_minute=data.get("rate_limit_per_minute", 60),
         signup_rate_limit=data.get("signup_rate_limit", "5/minute"),
         log_config=data.get("log_config"),
+        log_format=data.get("log_format"),
         skip_snapshot_warm=data.get("skip_snapshot_warm"),
         snapshot_warm_days=data.get("snapshot_warm_days"),
         ft_url_template=data.get("ft_url_template"),

--- a/backend/logging.ini
+++ b/backend/logging.ini
@@ -2,10 +2,10 @@
 keys=root,uvicorn,uvicorn.error,uvicorn.access
 
 [handlers]
-keys=consoleHandler,fileHandler,telegramHandler
+keys=consoleHandler,fileHandler,telegramHandler,jsonConsoleHandler
 
 [formatters]
-keys=standard
+keys=standard,json
 
 [filters]
 keys=redactToken
@@ -56,6 +56,17 @@ formatter=standard
 filters=redactToken
 args=()
 
+[handler_jsonConsoleHandler]
+class=StreamHandler
+level=INFO
+formatter=json
+filters=redactToken
+args=(sys.stdout,)
+
 [formatter_standard]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
 datefmt=%Y-%m-%d %H:%M:%S
+
+[formatter_json]
+class=backend.logging_setup.JSONFormatter
+format=%(levelname)s %(name)s %(message)s

--- a/backend/logging_setup.py
+++ b/backend/logging_setup.py
@@ -59,24 +59,24 @@ def _switch_console_handler_to_json(root_logger: logging.Logger) -> None:
 def setup_logging() -> None:
     """Configure application logging from configuration file.
 
-    If the root logger already has handlers, the function returns immediately
-    to avoid overriding existing logging configuration (e.g. when uvicorn
-    configures logging via ``--log-config``).
+    If the root logger already has handlers -- e.g. because uvicorn configured
+    logging itself via ``--log-config`` before importing the app -- the
+    ``fileConfig`` step is skipped to avoid overriding that configuration.
+    The ``LOG_FORMAT=json`` switch still applies in that case, since it acts
+    on whichever console handler is already installed.
     """
     root_logger = logging.getLogger()
-    if root_logger.handlers:
-        return
 
-    log_config = config.log_config
-    if not log_config:
-        return
+    if not root_logger.handlers:
+        log_config = config.log_config
+        if log_config:
+            config_path = Path(log_config)
+            if not config_path.is_absolute():
+                base = config.repo_root or Path.cwd()
+                config_path = base / config_path
 
-    config_path = Path(log_config)
-    if not config_path.is_absolute():
-        base = config.repo_root or Path.cwd()
-        config_path = base / config_path
+            if config_path.exists():
+                logging.config.fileConfig(config_path, disable_existing_loggers=False)
 
-    if config_path.exists():
-        logging.config.fileConfig(config_path, disable_existing_loggers=False)
-        if config.log_format == "json":
-            _switch_console_handler_to_json(root_logger)
+    if config.log_format == "json":
+        _switch_console_handler_to_json(root_logger)

--- a/backend/logging_setup.py
+++ b/backend/logging_setup.py
@@ -4,11 +4,16 @@ This module provides :func:`setup_logging` which configures the root logger
 using the path specified in :mod:`backend.config`. It is safe to call multiple
  times; if logging is already configured the function does nothing.
 """
+
 from __future__ import annotations
 
 import logging
 import logging.config
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Dict
+
+from pythonjsonlogger.json import JsonFormatter
 
 from backend.config import config
 
@@ -20,6 +25,35 @@ def sanitise_log_value(value: object) -> str:
     via CWE-117 (log injection).
     """
     return str(value).replace("\r", "").replace("\n", "")
+
+
+class JSONFormatter(JsonFormatter):
+    """JSON formatter emitting ``timestamp``, ``level``, ``logger`` and ``message`` fields."""
+
+    def add_fields(
+        self,
+        log_record: Dict[str, Any],
+        record: logging.LogRecord,
+        message_dict: Dict[str, Any],
+    ) -> None:
+        super().add_fields(log_record, record, message_dict)
+        log_record["level"] = log_record.pop("levelname", record.levelname)
+        log_record["logger"] = log_record.pop("name", record.name)
+        log_record["timestamp"] = datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat()
+
+
+def _switch_console_handler_to_json(root_logger: logging.Logger) -> None:
+    """Switch the console handler's formatter to JSON output.
+
+    ``consoleHandler`` is a single instance shared by the root and uvicorn
+    loggers (``fileConfig`` builds one handler per ini key and reuses it
+    across every logger section that references it), so mutating its
+    formatter here switches every logger to JSON at once.
+    """
+    formatter = JSONFormatter("%(levelname)s %(name)s %(message)s")
+    for handler in root_logger.handlers:
+        if type(handler) is logging.StreamHandler:  # noqa: E721 (exclude FileHandler subclass)
+            handler.setFormatter(formatter)
 
 
 def setup_logging() -> None:
@@ -44,3 +78,5 @@ def setup_logging() -> None:
 
     if config_path.exists():
         logging.config.fileConfig(config_path, disable_existing_loggers=False)
+        if config.log_format == "json":
+            _switch_console_handler_to_json(root_logger)

--- a/backend/logging_setup.py
+++ b/backend/logging_setup.py
@@ -52,7 +52,7 @@ def _switch_console_handler_to_json(root_logger: logging.Logger) -> None:
     """
     formatter = JSONFormatter("%(levelname)s %(name)s %(message)s")
     for handler in root_logger.handlers:
-        if type(handler) is logging.StreamHandler:  # noqa: E721 (exclude FileHandler subclass)
+        if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler):
             handler.setFormatter(formatter)
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -47,3 +47,4 @@ PyJWT~=2.13.0
 python-multipart~=0.0.32
 google-auth~=2.56.2
 redis~=8.1.0
+python-json-logger~=3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ pycparser~=3.0
 pyjwt~=2.13.0
 pydantic~=2.13.4
 pysocks~=1.7.1
+python-json-logger~=3.3.0
 python-multipart~=0.0.28
 python-dateutil~=2.9.0post0
 pytz~=2025.2

--- a/tests/backend/test_app_bootstrap.py
+++ b/tests/backend/test_app_bootstrap.py
@@ -14,9 +14,19 @@ from backend.bootstrap.startup import AppLifecycleService
 from backend.config import config
 
 
-def test_create_app_test_isolation_copies_accounts_root(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
+def test_create_app_configures_logging(monkeypatch: pytest.MonkeyPatch):
+    """create_app() must call setup_logging() so LOG_FORMAT=json actually
+    takes effect for the real entrypoints (issue #4681) -- previously
+    setup_logging() existed but was never invoked by production code."""
+    called = []
+    monkeypatch.setattr(app_module, "setup_logging", lambda: called.append(True))
+
+    app_module.create_app()
+
+    assert called == [True]
+
+
+def test_create_app_test_isolation_copies_accounts_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     repo_root = tmp_path / "repo"
     accounts_root = repo_root / "data" / "accounts"
     owner_dir = accounts_root / "alice"
@@ -65,12 +75,8 @@ async def test_lifecycle_service_warms_snapshot_and_registers_background_task(
         "backend.common.instrument_api.update_latest_prices_from_snapshot",
         InstrumentApi.update_latest_prices_from_snapshot,
     )
-    monkeypatch.setattr(
-        "backend.common.instrument_api.prime_latest_prices", InstrumentApi.prime_latest_prices
-    )
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.refresh_snapshot_async", lambda days: snapshot_task
-    )
+    monkeypatch.setattr("backend.common.instrument_api.prime_latest_prices", InstrumentApi.prime_latest_prices)
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_async", lambda days: snapshot_task)
 
     config.skip_snapshot_warm = False
     config.snapshot_warm_days = 5
@@ -103,16 +109,10 @@ async def test_lifecycle_service_warmup_logs_timed_phases(
     snapshot_task = asyncio.Future()
 
     monkeypatch.setattr("backend.common.portfolio_utils._load_snapshot", lambda: ({"ABC": 1}, "ts"))
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.refresh_snapshot_in_memory", lambda snapshot, ts: None
-    )
-    monkeypatch.setattr(
-        "backend.common.instrument_api.update_latest_prices_from_snapshot", lambda snapshot: None
-    )
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_in_memory", lambda snapshot, ts: None)
+    monkeypatch.setattr("backend.common.instrument_api.update_latest_prices_from_snapshot", lambda snapshot: None)
     monkeypatch.setattr("backend.common.instrument_api.prime_latest_prices", lambda: None)
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.refresh_snapshot_async", lambda days: snapshot_task
-    )
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_async", lambda days: snapshot_task)
 
     config.skip_snapshot_warm = False
     config.snapshot_warm_days = 5
@@ -124,11 +124,7 @@ async def test_lifecycle_service_warmup_logs_timed_phases(
         prime_task = next(t for t in app.state.background_tasks if t is not snapshot_task)
         await prime_task
 
-    phases = {
-        record.phase
-        for record in caplog.records
-        if getattr(record, "phase", None) is not None
-    }
+    phases = {record.phase for record in caplog.records if getattr(record, "phase", None) is not None}
     assert phases == {"snapshot_load", "metadata_update_from_snapshot", "price_history_fetch"}
     for record in caplog.records:
         if getattr(record, "phase", None) is not None:
@@ -150,9 +146,7 @@ async def test_prime_latest_prices_background_is_an_instance_method(
     )
 
     service = AppLifecycleService(cfg=config)
-    assert not isinstance(
-        type(service).__dict__["_prime_latest_prices_background"], staticmethod
-    )
+    assert not isinstance(type(service).__dict__["_prime_latest_prices_background"], staticmethod)
 
     await service._prime_latest_prices_background()
 
@@ -160,9 +154,7 @@ async def test_prime_latest_prices_background_is_an_instance_method(
 
 
 @pytest.mark.asyncio
-async def test_lifecycle_service_shutdown_cancels_tasks_and_temp_dirs(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
+async def test_lifecycle_service_shutdown_cancels_tasks_and_temp_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     cleanup_called = {"page_cache": False}
     temp_dir = tmp_path / "isolated"
     temp_dir.mkdir()
@@ -171,9 +163,7 @@ async def test_lifecycle_service_shutdown_cancels_tasks_and_temp_dirs(
     async def cancel_refresh_tasks():
         cleanup_called["page_cache"] = True
 
-    monkeypatch.setattr(
-        "backend.bootstrap.startup.page_cache.cancel_refresh_tasks", cancel_refresh_tasks
-    )
+    monkeypatch.setattr("backend.bootstrap.startup.page_cache.cancel_refresh_tasks", cancel_refresh_tasks)
 
     service = AppLifecycleService(cfg=config, temp_dirs=[temp_dir])
     app = app_module.create_app()
@@ -230,9 +220,7 @@ async def test_lifecycle_service_startup_survives_prime_latest_prices_failure(
 
     assert any(
         "Failed to prime latest prices" in r.message for r in caplog.records
-    ), "Expected 'Failed to prime latest prices' log but got: " + str(
-        [r.message for r in caplog.records]
-    )
+    ), "Expected 'Failed to prime latest prices' log but got: " + str([r.message for r in caplog.records])
 
 
 @pytest.mark.asyncio
@@ -276,9 +264,7 @@ async def test_lifecycle_service_snapshot_load_is_time_bounded(
     assert warmed == {"snapshot": {}, "ts": None}
     assert any(
         "Snapshot load timed out" in r.message for r in caplog.records
-    ), "Expected a snapshot-load timeout warning but got: " + str(
-        [r.message for r in caplog.records]
-    )
+    ), "Expected a snapshot-load timeout warning but got: " + str([r.message for r in caplog.records])
 
 
 @pytest.mark.asyncio
@@ -312,9 +298,7 @@ async def test_lifecycle_service_metadata_update_is_time_bounded(
 
     assert any(
         "timed out" in r.message for r in caplog.records
-    ), "Expected a metadata-update timeout warning but got: " + str(
-        [r.message for r in caplog.records]
-    )
+    ), "Expected a metadata-update timeout warning but got: " + str([r.message for r in caplog.records])
 
 
 def test_create_app_skips_snapshot_warm_when_disabled(monkeypatch: pytest.MonkeyPatch):
@@ -337,12 +321,8 @@ def test_create_app_skips_snapshot_warm_when_disabled(monkeypatch: pytest.Monkey
     def track_refresh(days):
         refresh_called_with.append(days)
 
-    monkeypatch.setattr(
-        "backend.bootstrap.startup.AppLifecycleService._warm_snapshot", unexpected_warm
-    )
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.refresh_snapshot_async", track_refresh
-    )
+    monkeypatch.setattr("backend.bootstrap.startup.AppLifecycleService._warm_snapshot", unexpected_warm)
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_async", track_refresh)
 
     monkeypatch.setattr(config, "snapshot_warm_days", 7, raising=False)
     app = app_module.create_app()
@@ -352,6 +332,6 @@ def test_create_app_skips_snapshot_warm_when_disabled(monkeypatch: pytest.Monkey
     # The blocking warm-up must NOT have run.
     assert warm_called is False
     # The background async refresh MUST still fire unconditionally.
-    assert refresh_called_with == [7], (
-        "refresh_snapshot_async should always be called even when skip_snapshot_warm=True"
-    )
+    assert refresh_called_with == [
+        7
+    ], "refresh_snapshot_async should always be called even when skip_snapshot_warm=True"

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -15,9 +15,9 @@ backend/alerts.py:194
 backend/alerts.py:228
 backend/alerts.py:256
 backend/alerts.py:336
-backend/app.py:166
-backend/app.py:198
-backend/app.py:217
+backend/app.py:168
+backend/app.py:200
+backend/app.py:219
 backend/auth.py:126
 # accounts-root path comes from server config, not attacker-controlled input.
 backend/auth.py:151

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -104,8 +104,8 @@ backend/common/transaction_reconciliation.py:66
 backend/common/transaction_reconciliation.py:134
 backend/common/transaction_reconciliation.py:176
 backend/common/transaction_reconciliation.py:186
-backend/config.py:270
-backend/config.py:273
+backend/config.py:271
+backend/config.py:274
 backend/lambda_api/dividend_refresh.py:27
 backend/lambda_api/pension_report.py:206
 backend/lambda_api/pension_report.py:231

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -36,9 +36,7 @@ def test_setup_logging_relative_path(monkeypatch):
 
     try:
         logging_setup.setup_logging()
-        file_config_mock.assert_called_once_with(
-            Path("/repo/logging.ini"), disable_existing_loggers=False
-        )
+        file_config_mock.assert_called_once_with(Path("/repo/logging.ini"), disable_existing_loggers=False)
     finally:
         root_logger.handlers = original_handlers
 

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -82,6 +82,52 @@ def test_switch_console_handler_to_json_mutates_shared_handler():
     assert isinstance(other_logger.handlers[0].formatter, logging_setup.JSONFormatter)
 
 
+def test_switch_console_handler_to_json_covers_stream_handler_subclasses():
+    """A StreamHandler subclass (e.g. one uvicorn or another library installs)
+    must still be switched -- an exact `type(handler) is StreamHandler` check
+    would silently skip it."""
+
+    class CustomStreamHandler(logging.StreamHandler):
+        pass
+
+    root_logger = logging.getLogger("test.json.subclass")
+    custom_handler = CustomStreamHandler()
+    root_logger.handlers = [custom_handler]
+
+    logging_setup._switch_console_handler_to_json(root_logger)
+
+    assert isinstance(custom_handler.formatter, logging_setup.JSONFormatter)
+
+
+def test_switch_console_handler_to_json_leaves_file_handler_untouched(tmp_path):
+    """FileHandler is a StreamHandler subclass; it must not be switched to JSON."""
+    root_logger = logging.getLogger("test.json.filehandler")
+    plain_formatter = logging.Formatter("%(message)s")
+    file_handler = logging.FileHandler(tmp_path / "test.log")
+    file_handler.setFormatter(plain_formatter)
+    root_logger.handlers = [file_handler]
+
+    try:
+        logging_setup._switch_console_handler_to_json(root_logger)
+        assert file_handler.formatter is plain_formatter
+    finally:
+        file_handler.close()
+
+
+def test_switch_console_handler_to_json_preserves_existing_filters():
+    """RedactTokenFilter (attached via logging.ini's filters=redactToken) must
+    still apply after the formatter is swapped to JSON."""
+    root_logger = logging.getLogger("test.json.filters")
+    handler = logging.StreamHandler()
+    marker_filter = logging.Filter(name="redactToken")
+    handler.addFilter(marker_filter)
+    root_logger.handlers = [handler]
+
+    logging_setup._switch_console_handler_to_json(root_logger)
+
+    assert marker_filter in root_logger.handlers[0].filters
+
+
 def test_setup_logging_switches_to_json_when_configured(monkeypatch):
     root_logger = logging.getLogger()
     original_handlers = root_logger.handlers[:]
@@ -101,5 +147,58 @@ def test_setup_logging_switches_to_json_when_configured(monkeypatch):
     try:
         logging_setup.setup_logging()
         assert isinstance(stream_handler.formatter, logging_setup.JSONFormatter)
+    finally:
+        root_logger.handlers = original_handlers
+
+
+def test_setup_logging_leaves_plain_text_formatter_when_log_format_unset(monkeypatch):
+    """LOG_FORMAT unset (or anything other than "json") must not touch the
+    formatter fileConfig installed -- today's plain-text-only behaviour."""
+    root_logger = logging.getLogger()
+    original_handlers = root_logger.handlers[:]
+    root_logger.handlers = []
+
+    monkeypatch.setattr(logging_setup.config, "log_config", "logging.ini")
+    monkeypatch.setattr(logging_setup.config, "log_format", None)
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+
+    stream_handler = logging.StreamHandler()
+    plain_formatter = logging.Formatter("%(message)s")
+    stream_handler.setFormatter(plain_formatter)
+
+    def fake_file_config(*args, **kwargs):
+        root_logger.handlers = [stream_handler]
+
+    monkeypatch.setattr(logging.config, "fileConfig", fake_file_config)
+
+    try:
+        logging_setup.setup_logging()
+        assert stream_handler.formatter is plain_formatter
+    finally:
+        root_logger.handlers = original_handlers
+
+
+def test_setup_logging_switches_to_json_when_uvicorn_preconfigured_logging(monkeypatch):
+    """When uvicorn's own --log-config already populated root_logger.handlers
+    (its Config.configure_logging() runs before the app is imported), fileConfig
+    must be skipped but the JSON switch must still apply to the handler uvicorn
+    installed (issue #4681 follow-up: setup_logging() previously wasn't wired
+    into any real entrypoint, so this path never ran in production)."""
+    root_logger = logging.getLogger()
+    original_handlers = root_logger.handlers[:]
+
+    uvicorn_installed_handler = logging.StreamHandler()
+    root_logger.handlers = [uvicorn_installed_handler]
+
+    monkeypatch.setattr(logging_setup.config, "log_config", "logging.ini")
+    monkeypatch.setattr(logging_setup.config, "log_format", "json")
+
+    file_config_mock = MagicMock()
+    monkeypatch.setattr(logging.config, "fileConfig", file_config_mock)
+
+    try:
+        logging_setup.setup_logging()
+        file_config_mock.assert_not_called()
+        assert isinstance(uvicorn_installed_handler.formatter, logging_setup.JSONFormatter)
     finally:
         root_logger.handlers = original_handlers

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,9 +1,9 @@
+import json
 import logging
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import backend.logging_setup as logging_setup
-
 
 
 def test_setup_logging_noop_when_root_logger_has_handlers(monkeypatch):
@@ -36,6 +36,72 @@ def test_setup_logging_relative_path(monkeypatch):
 
     try:
         logging_setup.setup_logging()
-        file_config_mock.assert_called_once_with(Path("/repo/logging.ini"), disable_existing_loggers=False)
+        file_config_mock.assert_called_once_with(
+            Path("/repo/logging.ini"), disable_existing_loggers=False
+        )
+    finally:
+        root_logger.handlers = original_handlers
+
+
+def test_json_formatter_emits_required_fields():
+    formatter = logging_setup.JSONFormatter("%(levelname)s %(name)s %(message)s")
+    record = logging.LogRecord(
+        name="my.logger",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=1,
+        msg="hello %s",
+        args=("world",),
+        exc_info=None,
+    )
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["level"] == "WARNING"
+    assert payload["logger"] == "my.logger"
+    assert payload["message"] == "hello world"
+    assert "levelname" not in payload
+    assert "name" not in payload
+    # timestamp must be ISO 8601 parseable
+    from datetime import datetime
+
+    datetime.fromisoformat(payload["timestamp"])
+
+
+def test_switch_console_handler_to_json_mutates_shared_handler():
+    root_logger = logging.getLogger("test.json.root")
+    other_logger = logging.getLogger("test.json.uvicorn")
+    shared_handler = logging.StreamHandler()
+    shared_handler.setFormatter(logging.Formatter("%(message)s"))
+    root_logger.handlers = [shared_handler]
+    other_logger.handlers = [shared_handler]
+
+    logging_setup._switch_console_handler_to_json(root_logger)
+
+    assert isinstance(root_logger.handlers[0].formatter, logging_setup.JSONFormatter)
+    # Same handler instance is shared, so the other logger sees the switch too.
+    assert other_logger.handlers[0] is root_logger.handlers[0]
+    assert isinstance(other_logger.handlers[0].formatter, logging_setup.JSONFormatter)
+
+
+def test_setup_logging_switches_to_json_when_configured(monkeypatch):
+    root_logger = logging.getLogger()
+    original_handlers = root_logger.handlers[:]
+    root_logger.handlers = []
+
+    monkeypatch.setattr(logging_setup.config, "log_config", "logging.ini")
+    monkeypatch.setattr(logging_setup.config, "log_format", "json")
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+
+    stream_handler = logging.StreamHandler()
+
+    def fake_file_config(*args, **kwargs):
+        root_logger.handlers = [stream_handler]
+
+    monkeypatch.setattr(logging.config, "fileConfig", fake_file_config)
+
+    try:
+        logging_setup.setup_logging()
+        assert isinstance(stream_handler.formatter, logging_setup.JSONFormatter)
     finally:
         root_logger.handlers = original_handlers


### PR DESCRIPTION
## Summary
- Add `python-json-logger` dependency and a `JSONFormatter` class in `backend/logging_setup.py` (extends `pythonjsonlogger.json.JsonFormatter`, overrides `add_fields` to normalise `level`/`logger` and emit an ISO 8601 `timestamp`)
- Add `[formatter_json]` / `[handler_jsonConsoleHandler]` sections to `backend/logging.ini` (with `filters=redactToken`, matching `consoleHandler`)
- Add `Config.log_format` (read from `LOG_FORMAT` env var in `backend/config.py`, following the existing convention for other env-derived fields)
- `setup_logging()` swaps the shared `consoleHandler`'s formatter to JSON *after* `fileConfig()` runs when `LOG_FORMAT=json`. Since `consoleHandler` is a single instance shared by the root and uvicorn loggers (`fileConfig` builds one handler per ini key and reuses it), mutating its formatter switches every logger to JSON exclusively — no double-printing, and `RedactTokenFilter` (already attached to that handler) still applies unchanged.
- Unset `LOG_FORMAT` leaves today's plain-text-only behaviour untouched.

## Test plan
- [x] `LOG_FORMAT=json python -c "..."` (via `setup_logging()`) emits valid JSON lines with `timestamp`, `level`, `logger`, `message` fields
- [x] Unset `LOG_FORMAT` → plain-text output unchanged
- [x] Added unit tests in `tests/test_logging_setup.py` covering `JSONFormatter` field output, the handler-swap helper, and `setup_logging()` end-to-end with `LOG_FORMAT=json`
- [x] `pytest tests/test_logging_setup.py` and related config tests pass
- [x] `ruff check --config backend/pyproject.toml` / `black --check --config backend/pyproject.toml` pass on all changed files (pre-existing unrelated lint failures elsewhere in `tests/` are unchanged from `main`)

Closes #4681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional JSON-formatted console logging, configurable through the `LOG_FORMAT` setting.
  * JSON log entries now include consistent severity, logger name and UTC timestamp fields.
  * Existing console logging remains in plain text when JSON formatting is not enabled.
  * Sensitive token data is redacted from JSON logs.

* **Bug Fixes**
  * Application logging is now initialised consistently during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->