### PR TITLE
Fix SPA config contract test to validate the real /config response

### DIFF
--- a/backend/contracts_spa.py
+++ b/backend/contracts_spa.py
@@ -18,23 +18,51 @@ class AwsUiAuthContract(SpaContractBase):
 
 
 class ConfigTabsContract(SpaContractBase):
-    portfolio: bool
-    transactions: bool
-    goals: bool
-    tax: bool
-    alerts: bool
+    instrument: bool
     performance: bool
-    wizard: bool
-    ideas: bool
-    reports: bool
+    transactions: bool
+    screener: bool
+    query: bool
+    trading: bool
+    timeseries: bool
+    watchlist: bool
+    movers: bool
+    market: bool
+    allocation: bool
+    rebalance: bool
+    instrumentadmin: bool
+    group: bool
+    owner: bool
+    dataadmin: bool
+    dataquality: bool
+    dataexplorer: bool
+    virtual: bool
+    support: bool
     settings: bool
-    queries: bool
-    compliance: bool
+    alertsettings: bool
     trade_compliance: bool = Field(alias="trade-compliance")
+    trail: bool
+    taxtools: bool
+    profile: bool
     pension: bool
+    reports: bool
+    scenario: bool
+    logs: bool
+    research: bool
 
 
 class ConfigContract(SpaContractBase):
+    """Describes the subset of the real ``GET /config`` response the SPA relies on.
+
+    ``serialise_config()`` also exposes internal/backend-only settings (API
+    keys, rate limits, file paths, etc.) that the SPA never reads, so extra
+    top-level fields are ignored here. ``tabs`` is still validated strictly
+    via ``ConfigTabsContract`` since tab-name drift is what previously broke
+    the SPA (see #5871).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
     app_env: str
     google_auth_enabled: bool | None = None
     google_client_id: str | None = None

--- a/tests/backend/test_spa_response_contracts.py
+++ b/tests/backend/test_spa_response_contracts.py
@@ -6,12 +6,13 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pydantic import TypeAdapter
 
+from backend.config import Config as RealConfig
 from backend.contracts_spa import (
+    SPA_RESPONSE_CONTRACT_VERSION,
     ConfigContract,
     GroupSummaryContract,
     OwnerSummaryContract,
     PortfolioContract,
-    SPA_RESPONSE_CONTRACT_VERSION,
     TransactionContract,
 )
 from backend.routes import config as config_routes
@@ -32,37 +33,20 @@ def test_target_spa_endpoints_match_contracts(monkeypatch, tmp_path):
     app = _build_app(tmp_path)
     client = TestClient(app)
 
-    monkeypatch.setattr(
-        config_routes,
-        "serialise_config",
-        lambda _: {
-            "app_env": "local",
-            "google_auth_enabled": False,
-            "google_client_id": None,
-            "disable_auth": True,
-            "local_login_email": "demo@example.com",
-            "theme": "dark",
-            "relative_view_enabled": True,
-            "base_currency": "GBP",
-            "tabs": {
-                "portfolio": True,
-                "transactions": True,
-                "goals": True,
-                "tax": True,
-                "alerts": True,
-                "performance": True,
-                "wizard": True,
-                "ideas": True,
-                "reports": True,
-                "settings": True,
-                "queries": True,
-                "compliance": True,
-                "trade-compliance": True,
-                "pension": True,
-            },
-            "disabled_tabs": [],
-        },
+    # Exercise the real serialise_config() implementation against a real Config
+    # instance, rather than a hand-written fixture, so this test actually
+    # catches drift between TabsConfig/serialise_config and the SPA contracts.
+    real_config = RealConfig(
+        app_env="local",
+        google_auth_enabled=False,
+        google_client_id=None,
+        disable_auth=True,
+        local_login_email="demo@example.com",
+        theme="dark",
+        relative_view_enabled=True,
+        base_currency="GBP",
     )
+    monkeypatch.setattr(config_routes.config_module, "config", real_config)
 
     monkeypatch.setattr(
         portfolio_routes,


### PR DESCRIPTION
## Summary
- `test_target_spa_endpoints_match_contracts` previously monkeypatched `serialise_config()` with a hardcoded fixture whose tab names (`portfolio`, `goals`, `tax`, `wizard`, `ideas`, `queries`, `compliance`) don't exist in `TabsConfig`, so the test could never catch real drift.
- The test now builds a real `Config` instance and injects it as `backend.config.config`, so the router's real `serialise_config()` implementation is exercised end-to-end.
- `ConfigTabsContract` field names now match `TabsConfig`'s actual keys (`instrument`, `screener`, `query`, `dataquality`, `trade-compliance`, etc.) and stays strict (`extra="forbid"`) so future tab drift is caught.
- `ConfigContract` now ignores unrelated top-level fields that `serialise_config()` exposes (internal API keys, rate limits, file paths, etc.) since those aren't part of the SPA's contract — the SPA-relevant fields (`app_env`, `disable_auth`, `tabs`, etc.) are still validated.

## Verification
- Confirmed the updated test **fails** against the pre-fix `ConfigTabsContract` (missing keys like `instrument`/`dataquality`, extra_forbidden errors) — proving it now catches real drift.
- Confirmed the updated test **passes** with the corrected contract.

## Test plan
- [x] `python -m pytest tests/backend/test_spa_response_contracts.py -q --no-cov`
- [x] `python -m pytest tests/backend/test_tabs_config.py tests/backend/routes/test_config.py -q --no-cov`
- [x] `python -m ruff check backend/contracts_spa.py tests/backend/test_spa_response_contracts.py`
- [x] `python -m black --check backend/contracts_spa.py tests/backend/test_spa_response_contracts.py`

Closes #5874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
