### PR TITLE
Test-coverage backlog: close 25 AI-review follow-up issues

### DIFF
--- a/.github/scripts/test_extract_verdict.py
+++ b/.github/scripts/test_extract_verdict.py
@@ -262,6 +262,16 @@ No review generated because the filtered diff was empty.
         review_text = "**SKIP** — no diff available"
         assert extract_verdict(review_text) == "SKIP"
 
+    def test_skip_with_trailing_prose_not_confused_with_skipped(self) -> None:
+        """**SKIP** followed by prose containing "SKIPPED" must still resolve to SKIP (#5758).
+
+        The word-boundary in _LINE_VERDICT_RE and the fixed-token match in
+        _BOLD_VERDICT_RE must not let a longer word like "SKIPPED" elsewhere
+        in the prose be mistaken for a bare "SKIP" verdict.
+        """
+        review_text = "**SKIP** because no diff\n\nThis run was SKIPPED due to an empty diff."
+        assert extract_verdict(review_text) == "SKIP"
+
     def test_backtick_wrapped_skip(self) -> None:
         """Test backtick-wrapped **`SKIP`** format."""
         review_text = "**`SKIP`** — empty diff"

--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -104,6 +104,11 @@ jobs:
         if: env.BACKEND_DEV_TOOLS_ONLY != 'true'
         env:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
+          # No Ollama server runs in CI. Pointing at an unreachable endpoint
+          # (rather than leaving it unset, which would default to
+          # localhost:11434) makes that explicit and catches any test that
+          # accidentally assumes a live Ollama server is reachable (#5816).
+          OLLAMA_ENDPOINT: 'http://127.0.0.1:1'
         run: |
           python -m coverage erase
           pytest tests --ignore=tests/live --cov=backend --cov-report=xml --cov-report=term --cov-fail-under=80 -q
@@ -116,6 +121,10 @@ jobs:
         if: env.BACKEND_DEV_TOOLS_ONLY == 'true'
         env:
           ALLOTMINT_SKIP_SNAPSHOT_WARM: 'true'
+          # See the OLLAMA_ENDPOINT comment on "Run tests" above (#5816) --
+          # this suite covers the ollama_common helpers, so it's the step
+          # most likely to accidentally depend on a live Ollama server.
+          OLLAMA_ENDPOINT: 'http://127.0.0.1:1'
         run: pytest tests/scripts --no-cov -q
 
       - name: Upload backend coverage reports to Codecov

--- a/cdk/tests/test_moneyhub_token_store.py
+++ b/cdk/tests/test_moneyhub_token_store.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
 from aws_cdk import App, Stack
 from aws_cdk import aws_iam as iam
 from aws_cdk.assertions import Match, Template
@@ -5,6 +10,8 @@ from stacks.moneyhub_token_store import (
     MONEYHUB_TOKEN_PARAMETER_PREFIX,
     MoneyhubTokenStore,
 )
+
+CDK_DIR = Path(__file__).resolve().parents[1]
 
 
 def test_grant_is_scoped_to_moneyhub_token_descendants() -> None:
@@ -52,3 +59,72 @@ def test_grant_is_scoped_to_moneyhub_token_descendants() -> None:
 
 def test_token_prefix_is_stable() -> None:
     assert MONEYHUB_TOKEN_PARAMETER_PREFIX == "/allotmint/moneyhub/tokens"
+
+
+def _fallback_string_literal(source_path: Path, assigned_name: str) -> str:
+    """Statically extract the fallback string literal assigned to ``assigned_name``.
+
+    Mirrors the helper in test_backend_lambda_stack_permissions.py: parses
+    with ``ast`` rather than importing the module, since the CDK test
+    environment does not install backend runtime dependencies.
+    """
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == assigned_name for t in node.targets):
+            continue
+        for sub in ast.walk(node.value):
+            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                return sub.value
+    raise AssertionError(f"Could not statically find a fallback literal for {assigned_name!r} in {source_path}")
+
+
+def test_token_prefix_matches_backend_moneyhub_tokens_uri_template() -> None:
+    """The CDK stack's MONEYHUB_TOKEN_PARAMETER_PREFIX must match the Python
+    backend's fallback URI template in backend.common.moneyhub_tokens, since
+    CDK's parameter ARN scoping and the backend's default storage URI must
+    agree on where per-owner token blobs live (see #5338, extending the
+    _COVERED_STACK_PREFIX_CONSTANTS pattern from PR #5318 to this stack)."""
+    moneyhub_tokens_path = CDK_DIR.parent / "backend" / "common" / "moneyhub_tokens.py"
+    backend_uri_template = _fallback_string_literal(moneyhub_tokens_path, "_DEFAULT_URI_TEMPLATE")
+
+    assert backend_uri_template == f"ssm://{MONEYHUB_TOKEN_PARAMETER_PREFIX}/{{owner}}", (
+        "backend.common.moneyhub_tokens._DEFAULT_URI_TEMPLATE "
+        f"('{backend_uri_template}') has drifted from CDK's "
+        f"MONEYHUB_TOKEN_PARAMETER_PREFIX ('{MONEYHUB_TOKEN_PARAMETER_PREFIX}')"
+    )
+
+
+# Every module-level *_PREFIX string constant in moneyhub_token_store.py that is
+# duplicated in a backend fallback literal must have a corresponding cross-check
+# test above (see #5338, extending the pattern audited for backend_lambda_stack.py
+# in PR #5318/#4933).
+_COVERED_STACK_PREFIX_CONSTANTS = frozenset({"MONEYHUB_TOKEN_PARAMETER_PREFIX"})
+
+
+def test_no_uncovered_duplicated_prefix_constants_in_moneyhub_token_store() -> None:
+    """Guards against a future *_PREFIX constant in moneyhub_token_store.py
+    being added without a matching cross-check test against its backend
+    duplicate (or an explicit acknowledgement that it isn't duplicated)."""
+    stack_path = CDK_DIR / "stacks" / "moneyhub_token_store.py"
+    tree = ast.parse(stack_path.read_text(encoding="utf-8"))
+
+    declared_prefix_constants = {
+        target.id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+        and target.id.endswith("_PREFIX")
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    }
+
+    assert declared_prefix_constants == _COVERED_STACK_PREFIX_CONSTANTS, (
+        "Module-level *_PREFIX string constants in moneyhub_token_store.py "
+        f"({sorted(declared_prefix_constants)}) no longer match the audited/covered "
+        f"set ({sorted(_COVERED_STACK_PREFIX_CONSTANTS)}). Add a cross-check test "
+        "for any new constant that duplicates a backend fallback literal, or "
+        "update _COVERED_STACK_PREFIX_CONSTANTS if it's confirmed out of scope."
+    )

--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -425,6 +425,12 @@ describe('Menu', () => {
 
     fireEvent.mouseDown(hamburger);
     expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+
+    // Clicking the <nav> wrapper itself -- the element mobileMenuRef directly
+    // references -- is the most direct test of the containment boundary (#5490).
+    const nav = document.querySelector('nav');
+    fireEvent.mouseDown(nav as HTMLElement);
+    expect(hamburger).toHaveAttribute('aria-expanded', 'true');
   });
 
   it.each([

--- a/tests/backend/common/test_authz.py
+++ b/tests/backend/common/test_authz.py
@@ -55,6 +55,18 @@ def test_ensure_owner_access_noop_when_auth_disabled(monkeypatch):
     assert calls["count"] == 0
 
 
+def test_ensure_owner_access_no_log_when_disable_auth(monkeypatch, caplog):
+    """The disable_auth early return must precede the denial log (#5431)."""
+
+    monkeypatch.setattr(config, "disable_auth", True)
+    monkeypatch.setattr(authz, "load_person_meta", lambda owner, root=None: {})
+
+    with caplog.at_level("WARNING", logger="backend.common.authz"):
+        authz.ensure_owner_access(None, "alice")
+
+    assert caplog.records == []
+
+
 def test_ensure_owner_access_allows_authorized(monkeypatch):
     monkeypatch.setattr(config, "disable_auth", False)
     monkeypatch.setattr(authz, "load_person_meta", lambda owner, root=None: {"email": "alice@example.com"})
@@ -98,9 +110,7 @@ def test_ensure_owner_access_denial_is_logged(monkeypatch, caplog):
     assert "identity_present=False" in message
 
 
-def test_ensure_owner_access_denial_log_reports_identity_present_when_unauthorized(
-    monkeypatch, caplog
-):
+def test_ensure_owner_access_denial_log_reports_identity_present_when_unauthorized(monkeypatch, caplog):
     """A present-but-unauthorized identity is distinguished from no identity
     at all in the log, since they're different failure modes (wrong account
     vs. genuinely anonymous caller).

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -368,9 +368,7 @@ def test_get_approve_expired_token_renders_error_page(client, monkeypatch):
 
     store_dir = signup_requests.signup_requests_dir(tmp_path)
     long_ago = datetime.now(timezone.utc) - timedelta(days=8)
-    record, token = signup_requests.create_signup_request(
-        "Jane Doe", "jane@example.com", "", store_dir, now=long_ago
-    )
+    record, token = signup_requests.create_signup_request("Jane Doe", "jane@example.com", "", store_dir, now=long_ago)
 
     resp = test_client.get(f"/signup/approve?id={record.id}&token={token}")
     assert resp.status_code == 400
@@ -533,6 +531,23 @@ def test_create_router_warns_when_returning_unprotected_router():
         result = signup_module.create_router(limiter, rate_limit=None)
 
     assert result is signup_module.router
+
+
+def test_create_router_warning_points_to_caller_not_signup_module():
+    """The warning's stacklevel must attribute it to the caller (#5407).
+
+    stacklevel=2 skips the warn() call's own frame (inside signup.py) and
+    reports the immediate caller's frame instead, so developers are pointed
+    at their own misconfigured call site rather than library internals.
+    """
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", RuntimeWarning)
+        signup_module.create_router()
+
+    assert len(caught) == 1
+    assert caught[0].filename != signup_module.__file__
+    assert caught[0].filename == __file__
 
 
 def test_create_router_does_not_warn_when_properly_configured():

--- a/tests/backend/test_app_bootstrap.py
+++ b/tests/backend/test_app_bootstrap.py
@@ -14,9 +14,7 @@ from backend.bootstrap.startup import AppLifecycleService
 from backend.config import config
 
 
-def test_create_app_test_isolation_copies_accounts_root(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
+def test_create_app_test_isolation_copies_accounts_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     repo_root = tmp_path / "repo"
     accounts_root = repo_root / "data" / "accounts"
     owner_dir = accounts_root / "alice"
@@ -65,12 +63,8 @@ async def test_lifecycle_service_warms_snapshot_and_registers_background_task(
         "backend.common.instrument_api.update_latest_prices_from_snapshot",
         InstrumentApi.update_latest_prices_from_snapshot,
     )
-    monkeypatch.setattr(
-        "backend.common.instrument_api.prime_latest_prices", InstrumentApi.prime_latest_prices
-    )
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.refresh_snapshot_async", lambda days: snapshot_task
-    )
+    monkeypatch.setattr("backend.common.instrument_api.prime_latest_prices", InstrumentApi.prime_latest_prices)
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_async", lambda days: snapshot_task)
 
     config.skip_snapshot_warm = False
     config.snapshot_warm_days = 5
@@ -103,16 +97,10 @@ async def test_lifecycle_service_warmup_logs_timed_phases(
     snapshot_task = asyncio.Future()
 
     monkeypatch.setattr("backend.common.portfolio_utils._load_snapshot", lambda: ({"ABC": 1}, "ts"))
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.refresh_snapshot_in_memory", lambda snapshot, ts: None
-    )
-    monkeypatch.setattr(
-        "backend.common.instrument_api.update_latest_prices_from_snapshot", lambda snapshot: None
-    )
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_in_memory", lambda snapshot, ts: None)
+    monkeypatch.setattr("backend.common.instrument_api.update_latest_prices_from_snapshot", lambda snapshot: None)
     monkeypatch.setattr("backend.common.instrument_api.prime_latest_prices", lambda: None)
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.refresh_snapshot_async", lambda days: snapshot_task
-    )
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_async", lambda days: snapshot_task)
 
     config.skip_snapshot_warm = False
     config.snapshot_warm_days = 5
@@ -124,11 +112,7 @@ async def test_lifecycle_service_warmup_logs_timed_phases(
         prime_task = next(t for t in app.state.background_tasks if t is not snapshot_task)
         await prime_task
 
-    phases = {
-        record.phase
-        for record in caplog.records
-        if getattr(record, "phase", None) is not None
-    }
+    phases = {record.phase for record in caplog.records if getattr(record, "phase", None) is not None}
     assert phases == {"snapshot_load", "metadata_update_from_snapshot", "price_history_fetch"}
     for record in caplog.records:
         if getattr(record, "phase", None) is not None:
@@ -150,9 +134,7 @@ async def test_prime_latest_prices_background_is_an_instance_method(
     )
 
     service = AppLifecycleService(cfg=config)
-    assert not isinstance(
-        type(service).__dict__["_prime_latest_prices_background"], staticmethod
-    )
+    assert not isinstance(type(service).__dict__["_prime_latest_prices_background"], staticmethod)
 
     await service._prime_latest_prices_background()
 
@@ -160,9 +142,7 @@ async def test_prime_latest_prices_background_is_an_instance_method(
 
 
 @pytest.mark.asyncio
-async def test_lifecycle_service_shutdown_cancels_tasks_and_temp_dirs(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
+async def test_lifecycle_service_shutdown_cancels_tasks_and_temp_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     cleanup_called = {"page_cache": False}
     temp_dir = tmp_path / "isolated"
     temp_dir.mkdir()
@@ -171,9 +151,7 @@ async def test_lifecycle_service_shutdown_cancels_tasks_and_temp_dirs(
     async def cancel_refresh_tasks():
         cleanup_called["page_cache"] = True
 
-    monkeypatch.setattr(
-        "backend.bootstrap.startup.page_cache.cancel_refresh_tasks", cancel_refresh_tasks
-    )
+    monkeypatch.setattr("backend.bootstrap.startup.page_cache.cancel_refresh_tasks", cancel_refresh_tasks)
 
     service = AppLifecycleService(cfg=config, temp_dirs=[temp_dir])
     app = app_module.create_app()
@@ -230,9 +208,7 @@ async def test_lifecycle_service_startup_survives_prime_latest_prices_failure(
 
     assert any(
         "Failed to prime latest prices" in r.message for r in caplog.records
-    ), "Expected 'Failed to prime latest prices' log but got: " + str(
-        [r.message for r in caplog.records]
-    )
+    ), "Expected 'Failed to prime latest prices' log but got: " + str([r.message for r in caplog.records])
 
 
 @pytest.mark.asyncio
@@ -276,9 +252,7 @@ async def test_lifecycle_service_snapshot_load_is_time_bounded(
     assert warmed == {"snapshot": {}, "ts": None}
     assert any(
         "Snapshot load timed out" in r.message for r in caplog.records
-    ), "Expected a snapshot-load timeout warning but got: " + str(
-        [r.message for r in caplog.records]
-    )
+    ), "Expected a snapshot-load timeout warning but got: " + str([r.message for r in caplog.records])
 
 
 @pytest.mark.asyncio
@@ -312,9 +286,54 @@ async def test_lifecycle_service_metadata_update_is_time_bounded(
 
     assert any(
         "timed out" in r.message for r in caplog.records
-    ), "Expected a metadata-update timeout warning but got: " + str(
-        [r.message for r in caplog.records]
+    ), "Expected a metadata-update timeout warning but got: " + str([r.message for r in caplog.records])
+
+
+@pytest.mark.asyncio
+async def test_snapshot_load_timeout_value_is_respected(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """The timeout must fire at the configured value, not just eventually (#5432).
+
+    A regression that changed _SNAPSHOT_LOAD_TIMEOUT_SECONDS handling (e.g. by
+    ignoring it or hardcoding a different value) would still pass the existing
+    "is_time_bounded" tests as long as *a* timeout eventually occurs. This test
+    measures elapsed wall-clock time to pin down the actual configured value.
+    """
+    configured_timeout = 0.3
+    monkeypatch.setattr("backend.bootstrap.startup._SNAPSHOT_LOAD_TIMEOUT_SECONDS", configured_timeout)
+
+    def _hang():
+        time.sleep(100)
+        return ({"ABC": 1}, "ts")
+
+    monkeypatch.setattr("backend.common.portfolio_utils._load_snapshot", _hang)
+    monkeypatch.setattr(
+        "backend.common.portfolio_utils.refresh_snapshot_in_memory",
+        lambda snapshot, ts: None,
     )
+    monkeypatch.setattr(
+        "backend.common.instrument_api.update_latest_prices_from_snapshot",
+        lambda snapshot: None,
+    )
+    monkeypatch.setattr("backend.common.instrument_api.prime_latest_prices", lambda: None)
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_async", lambda days: None)
+    monkeypatch.setattr(config, "skip_snapshot_warm", False, raising=False)
+
+    service = AppLifecycleService(cfg=config)
+    app = app_module.create_app()
+
+    start = time.monotonic()
+    with caplog.at_level(logging.WARNING):
+        await asyncio.wait_for(service.startup(app), timeout=5.0)
+    elapsed = time.monotonic() - start
+
+    # Generous tolerance to avoid CI flakiness while still catching gross
+    # deviations (e.g. the timeout being ignored or set to a different value).
+    assert (
+        configured_timeout <= elapsed < configured_timeout + 2.0
+    ), f"expected timeout around {configured_timeout}s, took {elapsed}s"
 
 
 def test_create_app_skips_snapshot_warm_when_disabled(monkeypatch: pytest.MonkeyPatch):
@@ -337,12 +356,8 @@ def test_create_app_skips_snapshot_warm_when_disabled(monkeypatch: pytest.Monkey
     def track_refresh(days):
         refresh_called_with.append(days)
 
-    monkeypatch.setattr(
-        "backend.bootstrap.startup.AppLifecycleService._warm_snapshot", unexpected_warm
-    )
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.refresh_snapshot_async", track_refresh
-    )
+    monkeypatch.setattr("backend.bootstrap.startup.AppLifecycleService._warm_snapshot", unexpected_warm)
+    monkeypatch.setattr("backend.common.portfolio_utils.refresh_snapshot_async", track_refresh)
 
     monkeypatch.setattr(config, "snapshot_warm_days", 7, raising=False)
     app = app_module.create_app()
@@ -352,6 +367,6 @@ def test_create_app_skips_snapshot_warm_when_disabled(monkeypatch: pytest.Monkey
     # The blocking warm-up must NOT have run.
     assert warm_called is False
     # The background async refresh MUST still fire unconditionally.
-    assert refresh_called_with == [7], (
-        "refresh_snapshot_async should always be called even when skip_snapshot_warm=True"
-    )
+    assert refresh_called_with == [
+        7
+    ], "refresh_snapshot_async should always be called even when skip_snapshot_warm=True"

--- a/tests/backend/test_signup_requests.py
+++ b/tests/backend/test_signup_requests.py
@@ -233,6 +233,11 @@ def test_enforce_cap_serializes_concurrent_callers(tmp_path, monkeypatch):
     # linked issue rather than for the assertions this test makes.
     thread_b.start()
     time.sleep(0.05)
+    # Make the contention scenario explicit (#5840): thread B must still be
+    # blocked on _PERSIST_LOCK at this point, not finished or idle -- if the
+    # lock were missing, thread B could race straight through and finish
+    # before thread A is ever released below.
+    assert thread_b.is_alive(), "thread B finished before thread A released the lock"
     thread_a_may_proceed.set()
 
     thread_a.join(timeout=5)

--- a/tests/backend/test_spa_response_contracts.py
+++ b/tests/backend/test_spa_response_contracts.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import List
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from backend.config import Config as RealConfig
 from backend.contracts_spa import (
@@ -159,3 +160,14 @@ def test_target_spa_endpoints_match_contracts(monkeypatch, tmp_path):
     TypeAdapter(List[GroupSummaryContract]).validate_python(groups_payload)
     PortfolioContract.model_validate(portfolio_payload)
     TypeAdapter(List[TransactionContract]).validate_python(transactions_payload)
+
+    # Negative case (#5952): prove the strict tabs contract actually rejects
+    # drift, rather than just passing on the current, correct real payload.
+    # Without this, the contract test could be silently neutered (e.g. by an
+    # accidental extra="ignore" on ConfigTabsContract) and nothing above
+    # would catch it.
+    tampered_config_payload = dict(config_payload)
+    tampered_config_payload["tabs"] = dict(config_payload["tabs"])
+    tampered_config_payload["tabs"]["not_a_real_tab"] = True
+    with pytest.raises(ValidationError):
+        ConfigContract.model_validate(tampered_config_payload)

--- a/tests/scripts/test_classify_change.py
+++ b/tests/scripts/test_classify_change.py
@@ -528,6 +528,26 @@ rename to backend/n_review_issue.py
 """
         assert backend_dev_tools_only(diff) is False
 
+    def test_dev_tools_and_dev_tools_tests_together_is_narrow(self) -> None:
+        """A diff touching both narrow globs (and nothing else) stays narrow (#5826)."""
+        diff = """\
+diff --git a/scripts/developer_tools/n_review_issue.py b/scripts/developer_tools/n_review_issue.py
+index abc123..def456 100644
+--- a/scripts/developer_tools/n_review_issue.py
++++ b/scripts/developer_tools/n_review_issue.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+diff --git a/tests/scripts/test_n_review_issue.py b/tests/scripts/test_n_review_issue.py
+index abc123..def456 100644
+--- a/tests/scripts/test_n_review_issue.py
++++ b/tests/scripts/test_n_review_issue.py
+@@ -1 +1 @@
+-x = 1
++x = 2
+"""
+        assert backend_dev_tools_only(diff) is True
+
     def test_frontend_only_diff_is_not_narrow(self) -> None:
         """No backend path at all means the narrow flag doesn't apply."""
         diff = """\

--- a/tests/scripts/test_commit_and_push.py
+++ b/tests/scripts/test_commit_and_push.py
@@ -32,6 +32,14 @@ class TestRefuseIfMainBranch:
             refuse_if_main_branch("main")
         assert exc_info.value.code == 1
 
+    def test_raises_on_main_with_expected_message(self, capsys):
+        """Pin the exact guidance text so a future edit can't silently regress it (#5834)."""
+        with pytest.raises(SystemExit):
+            refuse_if_main_branch("main")
+        err = capsys.readouterr().err
+        assert "Refusing to commit directly to 'main'" in err
+        assert "git checkout -b fix/<issue-number>-short-description" in err
+
     def test_allows_other_branches(self):
         refuse_if_main_branch("fix/4445-thing")
 

--- a/tests/scripts/test_implement_issue_with_aider.py
+++ b/tests/scripts/test_implement_issue_with_aider.py
@@ -92,9 +92,7 @@ class TestIsSafeRelativePath:
         assert is_safe_relative_path("/etc/passwd") is False
 
     def test_accepts_plain_relative_path(self):
-        assert (
-            is_safe_relative_path("scripts/developer_tools/f_implement_issue_with_aider.py") is True
-        )
+        assert is_safe_relative_path("scripts/developer_tools/f_implement_issue_with_aider.py") is True
 
 
 class TestExtractFilePathsFromIssue:
@@ -152,6 +150,23 @@ class TestExtractFilePathsFromIssue:
         body = f"## Files Affected\n- `{file_a}`\n- `{file_b}`\n"
         assert set(extract_file_paths_from_issue(body)) == {file_a, file_b}
 
+    def test_backtick_wrapped_path_with_space_is_not_matched(self):
+        """Paths containing a space are outside the supported character class (#5852).
+
+        The path regex's character class ([a-zA-Z0-9._/\\-]+) deliberately
+        excludes whitespace, so a backtick-wrapped path with an embedded
+        space (e.g. from a file genuinely named with a space) is not
+        extracted. This pins down that known, intentional limitation rather
+        than leaving it undocumented.
+        """
+        body = "## Files Affected\n- `scripts/my script/f_implement_issue_with_aider.py`\n"
+        assert extract_file_paths_from_issue(body) == []
+
+    def test_backtick_wrapped_path_with_special_characters_is_not_matched(self):
+        """Paths with characters outside [a-zA-Z0-9._/-] are not extracted (#5852)."""
+        body = "## Files Affected\n- `scripts/weird(name)/f_implement_issue_with_aider.py`\n"
+        assert extract_file_paths_from_issue(body) == []
+
 
 class TestResolveFilesToEdit:
     def test_prefers_files_affected_section_over_whole_body(self):
@@ -167,9 +182,7 @@ class TestResolveFilesToEdit:
         real_file = "scripts/developer_tools/f_implement_issue_with_aider.py"
         body = f"See {real_file} for details."
 
-        result = resolve_files_to_edit(
-            "title", body, "http://x", "model", files_affected="totally/made/up/path.py"
-        )
+        result = resolve_files_to_edit("title", body, "http://x", "model", files_affected="totally/made/up/path.py")
         assert result == [real_file]
         mock_fetch.assert_not_called()
 
@@ -177,9 +190,7 @@ class TestResolveFilesToEdit:
     def test_asks_ollama_when_nothing_found_anywhere(self, mock_fetch):
         mock_fetch.return_value = "[]"
 
-        result = resolve_files_to_edit(
-            "title", "no files here", "http://x", "model", files_affected="also none here"
-        )
+        result = resolve_files_to_edit("title", "no files here", "http://x", "model", files_affected="also none here")
         assert result == []
         mock_fetch.assert_called_once()
 
@@ -480,9 +491,7 @@ class TestMainOrdering:
     @mock.patch("f_implement_issue_with_aider.fetch_issue_from_github")
     @mock.patch("f_implement_issue_with_aider.get_repo_info")
     @mock.patch("f_implement_issue_with_aider.validate_ollama_connection", return_value=False)
-    def test_exits_before_any_github_io_when_ollama_down(
-        self, mock_validate, mock_repo_info, mock_fetch
-    ):
+    def test_exits_before_any_github_io_when_ollama_down(self, mock_validate, mock_repo_info, mock_fetch):
         with pytest.raises(SystemExit) as exc_info:
             main(["-i", "42"])
 
@@ -491,13 +500,9 @@ class TestMainOrdering:
         mock_fetch.assert_not_called()
 
     @mock.patch("f_implement_issue_with_aider.os.chdir")
-    @mock.patch(
-        "f_implement_issue_with_aider.get_repo_root", side_effect=ValueError("not a git repo")
-    )
+    @mock.patch("f_implement_issue_with_aider.get_repo_root", side_effect=ValueError("not a git repo"))
     @mock.patch("f_implement_issue_with_aider.validate_ollama_connection", return_value=True)
-    def test_exits_cleanly_when_repo_root_cannot_be_determined(
-        self, mock_validate, mock_get_repo_root, mock_chdir
-    ):
+    def test_exits_cleanly_when_repo_root_cannot_be_determined(self, mock_validate, mock_get_repo_root, mock_chdir):
         with pytest.raises(SystemExit) as exc_info:
             main(["-i", "42"])
 

--- a/tests/scripts/test_o_review_issue.py
+++ b/tests/scripts/test_o_review_issue.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -90,6 +91,27 @@ def test_load_env_file_sets_missing_vars(monkeypatch, tmp_path):
     assert os.environ["DEEPSEEK_API_KEY"] == "from-env-file"
 
 
+def test_load_env_file_noop_when_dotenv_package_unavailable(monkeypatch, tmp_path):
+    """load_env_file must be a documented no-op when python-dotenv isn't installed (#5775).
+
+    python-dotenv is a dev-only dependency; some CI jobs only install
+    backend/requirements.txt. Setting sys.modules["dotenv"] = None forces the
+    `from dotenv import load_dotenv` import inside load_env_file to raise
+    ImportError, exercising that except branch regardless of whether dotenv
+    actually happens to be installed in the test environment.
+    """
+    import sys
+
+    monkeypatch.setitem(sys.modules, "dotenv", None)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text("DEEPSEEK_API_KEY=from-env-file\n", encoding="utf-8")
+
+    n.load_env_file(env_file)  # must not raise
+
+    assert "DEEPSEEK_API_KEY" not in os.environ
+
+
 def test_load_env_file_missing_file_is_a_noop(monkeypatch, tmp_path):
     monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     n.load_env_file(tmp_path / "does_not_exist.env")
@@ -115,17 +137,37 @@ def test_run_review_returns_none_on_empty_response(monkeypatch):
 
 def test_fetch_issue_parses_gh_json(monkeypatch):
     payload = json.dumps({"number": 42, "title": "T", "body": "B", "state": "OPEN", "url": "u"})
-    monkeypatch.setattr(
-        n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=0, stdout=payload)
-    )
+    monkeypatch.setattr(n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=0, stdout=payload))
     issue = n.fetch_issue("owner", "repo", 42)
     assert issue == {"number": 42, "title": "T", "body": "B", "state": "OPEN", "url": "u"}
 
 
+def test_fetch_issue_parses_non_ascii_gh_json(monkeypatch):
+    """fetch_issue must handle non-ASCII issue text and request utf-8 decoding (#5811, #5819).
+
+    Windows consoles often default to a legacy codepage (e.g. cp1252) rather
+    than UTF-8, which would mangle or crash on non-ASCII gh output unless the
+    subprocess call explicitly requests utf-8 decoding.
+    """
+    title = "Fix “curly quotes” \U0001f41b in café"
+    body = "Résumé: 日本語 — emoji \U0001f680"
+    payload = json.dumps({"number": 7, "title": title, "body": body, "state": "OPEN", "url": "u"})
+    captured_kwargs = {}
+
+    def fake_run(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return _FakeResult(returncode=0, stdout=payload)
+
+    monkeypatch.setattr(n.subprocess, "run", fake_run)
+    issue = n.fetch_issue("owner", "repo", 7)
+
+    assert issue["title"] == title
+    assert issue["body"] == body
+    assert captured_kwargs.get("encoding") == "utf-8"
+
+
 def test_fetch_issue_exits_on_gh_failure(monkeypatch):
-    monkeypatch.setattr(
-        n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=1, stderr="not found")
-    )
+    monkeypatch.setattr(n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=1, stderr="not found"))
     try:
         n.fetch_issue("owner", "repo", 42)
         raise AssertionError("expected SystemExit")
@@ -142,10 +184,26 @@ def test_update_issue_dry_run_skips_gh_call(monkeypatch):
 
 
 def test_update_issue_reports_failure(monkeypatch):
-    monkeypatch.setattr(
-        n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=1, stderr="boom")
-    )
+    monkeypatch.setattr(n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=1, stderr="boom"))
     assert n.update_issue("owner", "repo", 1, "title", "body", dry_run=False) is False
+
+
+def test_update_issue_writes_non_ascii_body_as_utf8(monkeypatch, tmp_path):
+    """update_issue's body-file temp write must round-trip non-ASCII text (#5811, #5819)."""
+    title = "Fix “curly quotes” \U0001f41b in café"
+    body = "Résumé: 日本語 — emoji \U0001f680"
+    written_paths = []
+
+    def fake_run(args, **kwargs):
+        body_path = args[args.index("--body-file") + 1]
+        written_paths.append(body_path)
+        assert Path(body_path).read_text(encoding="utf-8") == body
+        assert title in args
+        return _FakeResult(returncode=0)
+
+    monkeypatch.setattr(n.subprocess, "run", fake_run)
+    assert n.update_issue("owner", "repo", 1, title, body, dry_run=False) is True
+    assert written_paths
 
 
 def test_update_issue_success(monkeypatch):
@@ -267,9 +325,7 @@ def test_post_unresolved_files_comment_success(monkeypatch):
 
 
 def test_post_unresolved_files_comment_reports_failure(monkeypatch):
-    monkeypatch.setattr(
-        n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=1, stderr="boom")
-    )
+    monkeypatch.setattr(n.subprocess, "run", lambda *a, **k: _FakeResult(returncode=1, stderr="boom"))
     assert n.post_unresolved_files_comment("owner", "repo", 1, dry_run=False) is False
 
 
@@ -299,9 +355,7 @@ def test_find_repo_file_hints_resolves_powershell_and_bash_scripts(git_repo):
     (git_repo / "deploy.sh").write_text("echo hi\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "add scripts"], cwd=git_repo, check=True)
-    hints = n.find_repo_file_hints(
-        "The script `deploy.ps1` and `deploy.sh` both need work.", git_repo
-    )
+    hints = n.find_repo_file_hints("The script `deploy.ps1` and `deploy.sh` both need work.", git_repo)
     assert hints == {"deploy.ps1": ["deploy.ps1"], "deploy.sh": ["deploy.sh"]}
 
 
@@ -323,9 +377,7 @@ def test_find_repo_file_hints_skips_ambiguous_filename(git_repo):
     other_dir.mkdir()
     (other_dir / "config.py").write_text("VALUE = 1\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=git_repo, check=True)
-    subprocess.run(
-        ["git", "commit", "-q", "-m", "add duplicate basename"], cwd=git_repo, check=True
-    )
+    subprocess.run(["git", "commit", "-q", "-m", "add duplicate basename"], cwd=git_repo, check=True)
     (git_repo / "config.py").write_text("VALUE = 2\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "add root config.py"], cwd=git_repo, check=True)
@@ -336,11 +388,27 @@ def test_find_repo_file_hints_skips_ambiguous_symbol(git_repo):
     # The same symbol name is defined in two different files -- ambiguous, so unresolved.
     other_dir = git_repo / "other"
     other_dir.mkdir()
-    (other_dir / "helpers.py").write_text(
-        "def widget_test_stub_symbol():\n    pass\n", encoding="utf-8"
-    )
+    (other_dir / "helpers.py").write_text("def widget_test_stub_symbol():\n    pass\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "add duplicate symbol"], cwd=git_repo, check=True)
+    hints = n.find_repo_file_hints("Fix `widget_test_stub_symbol` retry handling.", git_repo)
+    assert hints == {}
+
+
+def test_find_repo_file_hints_skips_symbol_defined_in_three_files(git_repo):
+    """A symbol defined in 3+ files is just as ambiguous as 2 (#5854)."""
+    other_dir = git_repo / "other"
+    other_dir.mkdir()
+    (other_dir / "helpers.py").write_text("def widget_test_stub_symbol():\n    pass\n", encoding="utf-8")
+    third_dir = git_repo / "third"
+    third_dir.mkdir()
+    (third_dir / "more_helpers.py").write_text("def widget_test_stub_symbol():\n    pass\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=git_repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "add second and third duplicate symbol"],
+        cwd=git_repo,
+        check=True,
+    )
     hints = n.find_repo_file_hints("Fix `widget_test_stub_symbol` retry handling.", git_repo)
     assert hints == {}
 
@@ -385,9 +453,7 @@ def test_format_file_hints_renders_bullet_list():
 
 
 def test_build_review_prompt_includes_file_hints_section():
-    prompt = n.build_review_prompt(
-        "title", "## What\nbody", file_hints={"fetch_paginated": ["scripts/foo.py"]}
-    )
+    prompt = n.build_review_prompt("title", "## What\nbody", file_hints={"fetch_paginated": ["scripts/foo.py"]})
     assert "Known repository file locations" in prompt
     assert "`fetch_paginated` -> `scripts/foo.py`" in prompt
 
@@ -398,9 +464,7 @@ def test_build_review_prompt_no_file_hints_section_by_default():
 
 
 def test_apply_known_file_paths_replaces_model_guess():
-    body = (
-        "## What\nsome text\n\n## Files Affected\n- `fetch_paginated.py`\n\n## Constraints\nnone\n"
-    )
+    body = "## What\nsome text\n\n## Files Affected\n- `fetch_paginated.py`\n\n## Constraints\nnone\n"
     hints = {"fetch_paginated": ["scripts/build_tools/extract_pr_comments.py"]}
     result = n.apply_known_file_paths(body, hints)
     assert "- `scripts/build_tools/extract_pr_comments.py`" in result

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -94,3 +94,42 @@ def test_allowed_emails_includes_viewer_emails(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "accounts_root", root)
 
     assert auth._allowed_emails() == {"alice@example.com", "bob@example.com"}
+
+
+def test_allowed_emails_includes_viewer_emails_from_s3(monkeypatch):
+    """The S3 code path (app_env == 'aws') must include viewer emails too (#5476).
+
+    The S3 branch reuses ``_emails_for_person_meta`` (already unit-tested
+    above), but nothing previously exercised the full S3 path in
+    ``_allowed_emails`` -- listing owners via ``list_objects_v2`` and merging
+    in their viewer emails.
+    """
+
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+
+    class _FakeS3Client:
+        def list_objects_v2(self, **params):
+            assert params["Bucket"] == "test-bucket"
+            return {
+                "Contents": [
+                    {"Key": "accounts/alice/portfolio.json"},
+                    {"Key": "accounts/alice/other.json"},
+                ],
+                "IsTruncated": False,
+            }
+
+    import boto3
+
+    monkeypatch.setattr(boto3, "client", lambda service: _FakeS3Client())
+
+    from backend.common.account_models import PersonMetadata
+
+    person = PersonMetadata(
+        owner="alice",
+        email="Alice@Example.com",
+        viewers=["Bob@Example.com", "  ", 42],  # noqa: PLR2004 (mixed case, whitespace, invalid)
+    )
+    monkeypatch.setattr(auth, "load_person_metadata", lambda owner: person)
+
+    assert auth._allowed_emails() == {"alice@example.com", "bob@example.com"}

--- a/tests/test_extract_pr_comments.py
+++ b/tests/test_extract_pr_comments.py
@@ -14,9 +14,7 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 
 def load_extract_pr_comments():
-    spec = importlib.util.spec_from_file_location(
-        "extract_pr_comments_test", SCRIPTS_DIR / "extract_pr_comments.py"
-    )
+    spec = importlib.util.spec_from_file_location("extract_pr_comments_test", SCRIPTS_DIR / "extract_pr_comments.py")
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -82,7 +80,7 @@ def test_format_top_level_comment_with_missing_user_key(mod):
 
 
 def test_format_inline_comment_with_valid_user(mod):
-    """A valid 'user' dict still extracts the login."""
+    """A valid 'user' dict still extracts the login, and path/line are propagated (#5322)."""
     comment = {
         "id": 5,
         "user": {"login": "octocat"},
@@ -93,6 +91,31 @@ def test_format_inline_comment_with_valid_user(mod):
     }
     result = mod.format_inline_comment(comment, {})
     assert result["author"] == "octocat"
+    assert result["path"] == "app.py"
+    assert result["line"] == 10
+
+
+def test_format_top_level_comment_with_valid_user(mod):
+    """format_top_level_comment's full output shape for a normal comment (#5322).
+
+    The existing None-user/missing-user tests only cover the author field;
+    nothing previously asserted the full mapping (id, type, created_at, body)
+    for the ordinary case, unlike format_inline_comment's valid-user test.
+    """
+    comment = {
+        "id": 6,
+        "user": {"login": "octocat"},
+        "created_at": "2026-06-18T17:00:00Z",
+        "body": "LGTM.",
+    }
+    result = mod.format_top_level_comment(comment)
+    assert result == {
+        "id": 6,
+        "author": "octocat",
+        "type": "top-level",
+        "created_at": "2026-06-18T17:00:00Z",
+        "body": "LGTM.",
+    }
 
 
 # --- fetch_paginated() truncation tests ---
@@ -185,3 +208,40 @@ def test_process_comments_propagates_truncated(mod):
 
     assert comments == []
     assert truncated is True
+
+
+def test_process_comments_deduplicates_by_id(mod):
+    """Two comments sharing an id must collapse to one, keeping the first-seen (#5322).
+
+    Nothing previously exercised process_comments' own dedup-by-id step
+    directly -- the existing truncation test only passes empty comment lists.
+    """
+    since = mod.parse_iso_datetime("2020-01-01T00:00:00Z")
+    duplicate_inline = [
+        {
+            "id": 42,
+            "user": {"login": "octocat"},
+            "path": "app.py",
+            "line": 1,
+            "created_at": "2026-06-18T17:00:00Z",
+            "body": "first",
+        },
+        {
+            "id": 42,
+            "user": {"login": "octocat"},
+            "path": "app.py",
+            "line": 1,
+            "created_at": "2026-06-18T17:00:01Z",
+            "body": "duplicate, should be dropped",
+        },
+    ]
+    with (
+        patch.object(mod, "fetch_reviews", return_value=({}, False)),
+        patch.object(mod, "fetch_inline_comments", return_value=(duplicate_inline, False)),
+        patch.object(mod, "fetch_top_level_comments", return_value=([], False)),
+    ):
+        comments, truncated = mod.process_comments("owner", "repo", 1, since, False)
+
+    assert len(comments) == 1
+    assert comments[0]["body"] == "first"
+    assert truncated is False

--- a/tests/test_log_injection_sanitisation.py
+++ b/tests/test_log_injection_sanitisation.py
@@ -21,6 +21,7 @@ passed to logging.getLogger() in each module (not __name__):
   portfolio_utils          → portfolio_utils.py
   data_loader              → data_loader.py (logger = logging.getLogger(__name__))
 """
+
 import logging
 from pathlib import Path
 from unittest.mock import patch
@@ -30,6 +31,7 @@ from fastapi.testclient import TestClient
 
 # ── helper ───────────────────────────────────────────────────────────────────
 
+
 def _has_raw_newline(record: logging.LogRecord) -> bool:
     """Return True if the formatted log message contains a bare newline/CR."""
     msg = record.getMessage()
@@ -38,12 +40,22 @@ def _has_raw_newline(record: logging.LogRecord) -> bool:
 
 # ── sanitise_log_value unit tests ────────────────────────────────────────────
 
+
 def test_sanitise_log_value_strips_newline():
     from backend.logging_setup import sanitise_log_value
 
     assert "\n" not in sanitise_log_value("ticker\ninjected")
     assert "\r" not in sanitise_log_value("ticker\rinjected")
     assert "\n" not in sanitise_log_value("a\r\nb")
+
+
+def test_sanitise_log_value_passes_clean_input_unchanged():
+    """Values with no newline/CR characters must pass through unmodified."""
+    from backend.logging_setup import sanitise_log_value
+
+    assert sanitise_log_value("normal_key") == "normal_key"
+    assert sanitise_log_value("John Doe") == "John Doe"
+    assert sanitise_log_value("owner-123") == "owner-123"
 
 
 def test_sanitise_log_value_handles_non_string_types():
@@ -108,6 +120,7 @@ def test_sanitise_log_value_or_sentinel_precedence():
 
 # ── fetch_alphavantage_timeseries ─────────────────────────────────────────────
 
+
 def test_alphavantage_skipped_ticker_log_no_injection(caplog):
     """Injected newline in ticker/exchange must not appear in the log message."""
     from datetime import date
@@ -123,6 +136,7 @@ def test_alphavantage_skipped_ticker_log_no_injection(caplog):
             from backend.timeseries.fetch_alphavantage_timeseries import (
                 fetch_alphavantage_timeseries_range,
             )
+
             fetch_alphavantage_timeseries_range(
                 malicious_ticker,
                 malicious_exchange,
@@ -130,16 +144,13 @@ def test_alphavantage_skipped_ticker_log_no_injection(caplog):
                 date(2024, 1, 31),
             )
 
-    assert caplog.records, (
-        "Expected at least one log record from alphavantage_timeseries logger"
-    )
+    assert caplog.records, "Expected at least one log record from alphavantage_timeseries logger"
     for record in caplog.records:
-        assert not _has_raw_newline(record), (
-            f"Raw newline in log record: {record.getMessage()!r}"
-        )
+        assert not _has_raw_newline(record), f"Raw newline in log record: {record.getMessage()!r}"
 
 
 # ── fetch_meta_timeseries ─────────────────────────────────────────────────────
+
 
 def test_meta_timeseries_invalid_ticker_pattern_log_no_injection(caplog):
     """
@@ -153,14 +164,13 @@ def test_meta_timeseries_invalid_ticker_pattern_log_no_injection(caplog):
         import pandas as pd
 
         from backend.timeseries.fetch_meta_timeseries import fetch_meta_timeseries
+
         result = fetch_meta_timeseries(malicious_ticker)
 
     assert isinstance(result, pd.DataFrame)
     assert caplog.records, "Expected at least one warning record from meta_timeseries logger"
     for record in caplog.records:
-        assert not _has_raw_newline(record), (
-            f"Raw newline in log record: {record.getMessage()!r}"
-        )
+        assert not _has_raw_newline(record), f"Raw newline in log record: {record.getMessage()!r}"
 
 
 def test_meta_timeseries_cache_exchange_mismatch_sentinel():
@@ -180,6 +190,7 @@ def test_meta_timeseries_cache_exchange_mismatch_sentinel():
 
 
 # ── portfolio_loader ──────────────────────────────────────────────────────────
+
 
 def test_portfolio_loader_missing_tx_file_no_injection(caplog, tmp_path):
     """
@@ -201,9 +212,7 @@ def test_portfolio_loader_missing_tx_file_no_injection(caplog, tmp_path):
     assert result == {}
     assert caplog.records, "Expected at least one error record from portfolio_loader"
     for record in caplog.records:
-        assert not _has_raw_newline(record), (
-            f"Raw newline in log record: {record.getMessage()!r}"
-        )
+        assert not _has_raw_newline(record), f"Raw newline in log record: {record.getMessage()!r}"
     # Content is preserved (newline stripped, not content).
     logged_msg = caplog.records[0].getMessage()
     assert "savings" in logged_msg
@@ -213,9 +222,11 @@ def test_portfolio_loader_missing_tx_file_no_injection(caplog, tmp_path):
 
 # ── routes/portfolio — TestClient integration test ───────────────────────────
 
+
 def _portfolio_test_client(tmp_path):
     """Build a minimal FastAPI app wired to the portfolio router."""
     from backend.routes import portfolio as portfolio_module
+
     app = FastAPI()
     app.include_router(portfolio_module.router)
     app.state.accounts_root = tmp_path
@@ -249,12 +260,8 @@ def test_get_account_provider_unavailable_no_log_injection(caplog, monkeypatch, 
     for record in caplog.records:
         owner_val = str(record.__dict__.get("owner", ""))
         account_val = str(record.__dict__.get("account", ""))
-        assert "\n" not in owner_val and "\r" not in owner_val, (
-            f"Raw newline in extra['owner']: {owner_val!r}"
-        )
-        assert "\n" not in account_val and "\r" not in account_val, (
-            f"Raw newline in extra['account']: {account_val!r}"
-        )
+        assert "\n" not in owner_val and "\r" not in owner_val, f"Raw newline in extra['owner']: {owner_val!r}"
+        assert "\n" not in account_val and "\r" not in account_val, f"Raw newline in extra['account']: {account_val!r}"
 
 
 def test_get_account_invalid_payload_no_log_injection(caplog, monkeypatch, tmp_path):
@@ -279,12 +286,11 @@ def test_get_account_invalid_payload_no_log_injection(caplog, monkeypatch, tmp_p
     for record in caplog.records:
         for field in ("owner", "account"):
             val = str(record.__dict__.get(field, ""))
-            assert "\n" not in val and "\r" not in val, (
-                f"Raw newline in extra['{field}']: {val!r}"
-            )
+            assert "\n" not in val and "\r" not in val, f"Raw newline in extra['{field}']: {val!r}"
 
 
 # ── data_loader ───────────────────────────────────────────────────────────────
+
 
 def test_data_loader_extra_dict_current_user_sanitised():
     """
@@ -334,6 +340,7 @@ def test_data_loader_person_meta_owner_sanitised():
 
 # ── portfolio_utils ───────────────────────────────────────────────────────────
 
+
 def test_portfolio_utils_ticker_log_no_injection(caplog):
     """
     portfolio_utils logs ticker/exchange in a warning when non-numeric closes
@@ -359,6 +366,4 @@ def test_portfolio_utils_ticker_log_no_injection(caplog):
 
     assert caplog.records, "Expected a warning record from portfolio_utils logger"
     for record in caplog.records:
-        assert not _has_raw_newline(record), (
-            f"Raw newline in log record: {record.getMessage()!r}"
-        )
+        assert not _has_raw_newline(record), f"Raw newline in log record: {record.getMessage()!r}"

--- a/tests/test_log_sanitization_audit.py
+++ b/tests/test_log_sanitization_audit.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from scripts.build_tools import _scan_log_sanitisation
 from scripts.build_tools._scan_log_sanitisation import find_unwrapped_log_calls
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -43,3 +44,41 @@ def test_no_new_unwrapped_logger_calls() -> None:
         "tests/data/log_sanitization_baseline.txt with a comment explaining "
         "why the value can't carry attacker-controlled input."
     )
+
+
+def test_find_unwrapped_log_calls_flags_multi_line_debug_and_exception_calls(monkeypatch, tmp_path) -> None:
+    """Multi-line logger.debug/exception calls with unsanitised args must be detected (#5836).
+
+    LOG_METHODS already includes "debug" and "exception", but no test
+    previously fed synthetic source through the scanner to confirm a call
+    whose arguments span several lines is still flagged with the correct
+    node.lineno (the line the call *starts* on).
+    """
+    fake_backend = tmp_path / "backend"
+    fake_backend.mkdir()
+    source = (
+        "import logging\n"
+        "\n"
+        "logger = logging.getLogger(__name__)\n"
+        "\n"
+        "\n"
+        "def handler(owner):\n"
+        "    logger.debug(\n"
+        "        'owner lookup failed for %s',\n"
+        "        owner,\n"
+        "    )\n"
+        "    logger.exception(\n"
+        "        'unexpected error for %s',\n"
+        "        owner,\n"
+        "    )\n"
+    )
+    (fake_backend / "multiline_example.py").write_text(source, encoding="utf-8")
+
+    monkeypatch.setattr(_scan_log_sanitisation, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(_scan_log_sanitisation, "BACKEND_ROOT", fake_backend)
+    monkeypatch.setattr(_scan_log_sanitisation, "EXCLUDED_FILES", set())
+
+    results = find_unwrapped_log_calls()
+
+    assert ("backend/multiline_example.py", 7) in results
+    assert ("backend/multiline_example.py", 11) in results


### PR DESCRIPTION
## Summary

Consolidates 25 small "consider adding a test" / hardening AI-review follow-up issues into one change, tracked by #5961.

For each issue, the actual code was checked against the issue's stated gap first — several had already been closed by prior work in this repo, so those are confirmed rather than duplicated:

- **New tests added**: #5338, #5364, #5407, #5431, #5432, #5476, #5490, #5679, #5758, #5775, #5811/#5819 (same file), #5826, #5834, #5836, #5840, #5852, #5854, #5952, plus #5322's `format_top_level_comment`/dedup-by-id coverage.
- **CI hardening**: #5816 — `OLLAMA_ENDPOINT` is now explicitly pointed at an unreachable address in the backend test jobs, so no test can silently rely on a live Ollama server.
- **Already satisfied, confirmed only**: #5700, #5841 — existing tests already covered the described gap.
- **No longer applicable**: #5534 — the target PowerShell script (`implement_issue.ps1`) and its Pester test suite were deleted in a prior refactor (#5764) in favor of the Python-based aider flow; nothing left to test.
- **Deferred (not implemented)**: #5766 — a screenshot-based visual regression test needs a baseline image generated in the same environment CI runs in (Linux); generating one locally on Windows risked landing a test that fails on the very first CI run due to font/rendering differences. Flagging as a separate follow-up rather than shipping something flaky.
- **#5322's out-of-scope items** (Related #N support, `--continue-on-error` flag, importlib→PYTHONPATH refactor, streaming vs in-memory) are genuine features/refactors beyond test coverage — left as-is per that issue's own "pick off individually" framing.

## Test plan
- [x] `pytest` on every modified backend test file (373 tests, all passing)
- [x] `.github/scripts/test_extract_verdict.py` (35 tests)
- [x] `cdk/tests/test_moneyhub_token_store.py` + `test_backend_lambda_stack_permissions.py` (28 tests)
- [x] `frontend` Vitest — `Menu.test.tsx` (17 tests)
- [x] `black`/`ruff` clean on all touched Python files
- [x] YAML syntax validated for the workflow change

Closes #5338, #5364, #5407, #5431, #5432, #5476, #5490, #5534, #5679, #5700, #5758, #5775, #5811, #5816, #5819, #5826, #5834, #5836, #5840, #5841, #5852, #5854, #5952, #5322, #5961

Not closed: #5766 (deferred — see above; left open as a standalone follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regression coverage for authentication, signup approvals, startup timeouts, menu interactions and configuration validation.
  * Added checks for correct verdict extraction, comment handling, log sanitisation and non-ASCII content.
  * Strengthened coverage for concurrency, token configuration, access control and developer-tool behaviour.
* **Chores**
  * Improved test-environment isolation to prevent accidental connections to local services.
  * Enhanced safeguards around branch protection and malformed or ambiguous input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->