### PR TITLE
Add Dependabot auto-merge for frontend dev-dependency patch bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
       - "chore"
 
   # Frontend npm workspace: React/Vite app dependencies in frontend/.
+  # Patch-level bumps of direct dev dependencies from this entry are
+  # auto-merged by .github/workflows/dependabot-auto-merge.yml once required
+  # status checks pass; production deps and minor/major bumps still need a
+  # manual review. See issue #5540.
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,43 @@
+name: Dependabot Auto-Merge
+
+# Auto-merges Dependabot pull requests that bump a frontend *dev* dependency
+# by a patch version only. Everything else -- production dependencies, minor
+# or major bumps, non-frontend ecosystems -- is left for manual review.
+#
+# `gh pr merge --auto` only *enables* auto-merge: GitHub still waits for the
+# branch's required status checks (see .github/rulesets/default-branch-protection.json)
+# before the merge actually happens, so this does not bypass CI.
+#
+# Repo setting "Allow auto-merge" must be enabled for this to take effect --
+# see docs/CONTRIBUTING.md.
+#
+# See issue #5540 -- follow-up from PR #5538 (manual "tar" patch bump).
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for frontend dev-dependency patch bumps
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          steps.metadata.outputs.dependency-type == 'direct:development' &&
+          startsWith(github.event.pull_request.head.ref, 'dependabot/npm_and_yarn/frontend/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -140,6 +140,19 @@ in the "Checks" tab of long-lived PRs; see the inline comments in
 `conflict-check.yml` for the full investigation history (issue #3738, PR
 #3731).
 
+## Dependabot auto-merge
+
+`.github/workflows/dependabot-auto-merge.yml` calls `gh pr merge --auto` for
+Dependabot PRs that bump a frontend *dev* dependency by a patch version only
+(`dependabot/fetch-metadata` reports `update-type: version-update:semver-patch`
+and `dependency-type: direct:development`, and the head ref matches
+`dependabot/npm_and_yarn/frontend/*`). `--auto` only enables auto-merge --
+GitHub still waits for every required status check above before merging, so
+this does not weaken the gate. Production dependency bumps and minor/major
+updates are unaffected and still require manual review. The repo's
+"Allow auto-merge" setting (`allow_auto_merge`) must stay enabled for this to
+have any effect. See issue #5540.
+
 ## CodeQL
 
 CodeQL should be added to the required-check set only after its exact check


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependabot-auto-merge.yml`: uses `dependabot/fetch-metadata` to detect Dependabot PRs that bump a **frontend, direct, dev** dependency by a **patch** version only, and calls `gh pr merge --auto --squash` on them. `--auto` only enables auto-merge — required status checks (see `docs/BRANCH_PROTECTION.md`) still gate the actual merge, so this doesn't bypass CI.
- Enabled the repo's `allow_auto_merge` setting via the API — required for `gh pr merge --auto` to have any effect, previously `false`.
- Documented the mechanism in `docs/BRANCH_PROTECTION.md`.

Production dependencies, minor/major bumps, and non-frontend ecosystems are untouched and still require manual review, per the issue's constraints.

Closes #5540

## Test plan
- [x] Validated the new workflow YAML parses (`yaml.safe_load`)
- [x] Confirmed `allow_auto_merge` is now `true` via `gh api repos/leonarduk/allotmint`
- [ ] Verify end-to-end against a real Dependabot PR for a frontend dev dependency patch bump (next weekly Dependabot run)
