### PR TITLE
Add script to retroactively link open PRs to a GitHub issue

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -487,6 +487,35 @@ refuses to propose the change rather than risk silently dropping details.
 **Requirements:** `gh` CLI authenticated against the target repo; either a
 running local Ollama server or a `DEEPSEEK_API_KEY`, depending on `--model`.
 
+## n_add_issue_to_pr.py
+
+Retroactively link open PRs to a GitHub issue. Every PR is supposed to close
+an issue, but one opened without going through `d_work_on_issue.py` /
+`k_publish-pr.ps1` can slip through without a `Closes #NNNN` reference. This
+script finds open PRs whose body doesn't reference an issue via a
+Closes/Fixes/Resolves keyword, creates a matching issue from the PR's own
+title/body, and appends `Closes #<new-issue>` to the PR description so
+merging it auto-closes the new issue.
+
+```bash
+python scripts/developer_tools/n_add_issue_to_pr.py
+python scripts/developer_tools/n_add_issue_to_pr.py --yes
+python scripts/developer_tools/n_add_issue_to_pr.py --pr 1234 --yes
+```
+
+Defaults to dry-run (prints what it would do). Pass `--yes` to actually
+create issues and edit PRs. Never touches a PR whose body already references
+an issue.
+
+Optional flags:
+- `--repo owner/name`: Operate on a different repository. Defaults to the
+  `origin` git remote, falling back to `leonarduk/allotmint`.
+- `--pr NNNN`: Operate on a single PR instead of scanning all open PRs.
+- `--limit N`: Maximum number of open PRs to fetch when scanning (default 200).
+
+**Requirements:** `gh` CLI must be installed and authenticated with a token
+that can create issues and edit PRs on the target repo.
+
 ## reconcile_drawdown.py
 
 Inspect max drawdowns and dump holding price data when the portfolio suffers a

--- a/scripts/developer_tools/n_add_issue_to_pr.py
+++ b/scripts/developer_tools/n_add_issue_to_pr.py
@@ -1,0 +1,369 @@
+"""CLI tool to retroactively link open PRs to a GitHub issue.
+
+Continues the a_/b_/.../m_ script chain in scripts/developer_tools/. Every PR
+is supposed to close an issue (see docs/CONTRIBUTING.md's branch/PR policy),
+but a PR opened without going through d_work_on_issue.py/k_publish-pr.ps1 can
+slip through without a "Closes #NNNN" reference. This script finds open PRs
+whose body doesn't reference an issue, creates a matching issue from the PR's
+own title/body, and appends "Closes #<new-issue>" to the PR description so
+merging it auto-closes the new issue.
+
+Safety:
+  - Defaults to dry-run. Pass --yes to actually create issues and edit PRs.
+  - Never touches a PR whose body already references an issue via
+    Closes/Fixes/Resolves #NNNN (case-insensitive).
+  - Only ever creates a new issue and appends to a PR's existing body; never
+    deletes or overwrites existing PR body content.
+
+Requires the `gh` CLI to be authenticated with a token that can create issues
+and edit PRs on the target repo. Defaults to operating on the `origin` git
+remote's repo; pass --repo owner/name to override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_OWNER = "leonarduk"
+REPO_NAME = "allotmint"
+GH_RETRY_ATTEMPTS = 3
+GH_RETRY_BACKOFF_SECONDS = 2
+GH_TIMEOUT_SECONDS = 60
+
+# Matches "Closes #123", "fixes: #45", "Resolved #7", etc. -- the same set of
+# GitHub auto-close keywords recognised in a PR description, case-insensitive.
+ISSUE_REF_PATTERN = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)", re.IGNORECASE
+)
+
+
+@dataclass
+class PullRequest:
+    """A single open pull request under consideration."""
+
+    number: int
+    title: str
+    body: str
+    author: str = ""
+
+
+def _run_gh_once(
+    args: list[str], timeout: int = GH_TIMEOUT_SECONDS
+) -> subprocess.CompletedProcess[str]:
+    """Run a single `gh` CLI command scoped to REPO_OWNER/REPO_NAME. Never raises.
+
+    A timed-out process is reported as a failing CompletedProcess rather than
+    propagating subprocess.TimeoutExpired, so callers can uniformly check
+    `result.returncode`.
+    """
+    cmd = ["gh", *args, "--repo", f"{REPO_OWNER}/{REPO_NAME}"]
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            cmd, returncode=124, stdout="", stderr=f"gh {' '.join(args)} timed out after {timeout}s"
+        )
+
+
+def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a `gh` CLI command scoped to REPO_OWNER/REPO_NAME. Never raises.
+
+    Retries transient failures (network blips, GraphQL timeouts) up to
+    GH_RETRY_ATTEMPTS times with a linear backoff. Only safe for idempotent
+    (read-only) commands -- use `_run_gh_once` directly for non-idempotent
+    operations like creating an issue or editing a PR, where a retry after a
+    lost response could re-invoke the action.
+    """
+    result = None
+    for attempt in range(1, GH_RETRY_ATTEMPTS + 1):
+        result = _run_gh_once(args)
+        if result.returncode == 0:
+            return result
+        if attempt < GH_RETRY_ATTEMPTS:
+            wait_seconds = GH_RETRY_BACKOFF_SECONDS * attempt
+            print(
+                f"WARNING: gh {' '.join(args)} failed (attempt {attempt}/{GH_RETRY_ATTEMPTS}): "
+                f"{result.stderr.strip()} -- retrying in {wait_seconds}s",
+                file=sys.stderr,
+            )
+            time.sleep(wait_seconds)
+    return result
+
+
+def fetch_open_prs(limit: int = 200) -> list[PullRequest]:
+    """List open PRs with their number/title/body/author."""
+    result = run_gh(
+        [
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,body,author",
+            "--limit",
+            str(limit),
+        ]
+    )
+    if result.returncode != 0:
+        print(f"ERROR: gh pr list failed: {result.stderr}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: gh pr list returned non-JSON output: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    prs = []
+    for item in data:
+        prs.append(
+            PullRequest(
+                number=item["number"],
+                title=item["title"],
+                body=item.get("body") or "",
+                author=(item.get("author") or {}).get("login", ""),
+            )
+        )
+    return prs
+
+
+def fetch_pr(number: int) -> PullRequest:
+    """Fetch a single PR by number."""
+    result = run_gh(["pr", "view", str(number), "--json", "number,title,body,author"])
+    if result.returncode != 0:
+        print(f"ERROR: gh pr view {number} failed: {result.stderr}", file=sys.stderr)
+        raise SystemExit(1)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: gh pr view {number} returned non-JSON output: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    return PullRequest(
+        number=data["number"],
+        title=data["title"],
+        body=data.get("body") or "",
+        author=(data.get("author") or {}).get("login", ""),
+    )
+
+
+def has_linked_issue(body: str) -> bool:
+    """Return True if the PR body already references an issue via a close keyword."""
+    return bool(ISSUE_REF_PATTERN.search(body or ""))
+
+
+def build_issue_body(pr: PullRequest) -> str:
+    """Build a structured issue body from a PR's own title/body."""
+    pr_body = (pr.body or "").strip()
+    how = pr_body if pr_body else "See PR for implementation details."
+    parts = [
+        "## What",
+        "",
+        pr.title,
+        "",
+        "## Why",
+        "",
+        f"Opened as PR #{pr.number} without an associated issue; this issue was "
+        "created retroactively for traceability.",
+        "",
+        "## How",
+        "",
+        how,
+        "",
+        "## Files Affected",
+        "",
+        f"See PR #{pr.number} for the file list.",
+        "",
+        "## Constraints",
+        "",
+        "None",
+        "",
+        "## LLM tier",
+        "",
+        "sonnet",
+        "",
+        "## Success looks like",
+        "",
+        f"- [ ] PR #{pr.number} is merged with this issue linked and closed",
+        "",
+        "## Failure looks like",
+        "",
+        "- PR merges without this issue being closed",
+    ]
+    return "\n".join(parts)
+
+
+def create_issue(pr: PullRequest, dry_run: bool) -> int | None:
+    """Create an issue for a PR that lacks one. Returns the new issue number, or None on failure."""
+    prefix = "[DRY RUN] " if dry_run else ""
+    print(f"{prefix}Creating issue for PR #{pr.number}: {pr.title}")
+    if dry_run:
+        return None
+
+    body = build_issue_body(pr)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", encoding="utf-8", delete=False) as tf:
+        tf.write(body)
+        body_path = tf.name
+    try:
+        result = _run_gh_once(["issue", "create", "--title", pr.title, "--body-file", body_path])
+    finally:
+        Path(body_path).unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        print(
+            f"ERROR: failed to create issue for PR #{pr.number}: {result.stderr}", file=sys.stderr
+        )
+        return None
+
+    url = result.stdout.strip()
+    match = re.search(r"/issues/(\d+)", url)
+    if not match:
+        print(f"ERROR: could not parse issue number from gh output: {url!r}", file=sys.stderr)
+        return None
+    issue_number = int(match.group(1))
+    print(f"[OK] Created issue #{issue_number}: {url}")
+    return issue_number
+
+
+def link_issue_to_pr(pr: PullRequest, issue_number: int, dry_run: bool) -> bool:
+    """Append a 'Closes #NNNN' line to the PR body so merging auto-closes the issue."""
+    prefix = "[DRY RUN] " if dry_run else ""
+    print(f"{prefix}Linking PR #{pr.number} to issue #{issue_number}")
+    if dry_run:
+        return True
+
+    closing_line = f"Closes #{issue_number}"
+    new_body = f"{pr.body.rstrip()}\n\n{closing_line}\n" if pr.body.strip() else f"{closing_line}\n"
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", encoding="utf-8", delete=False) as tf:
+        tf.write(new_body)
+        body_path = tf.name
+    try:
+        result = _run_gh_once(["pr", "edit", str(pr.number), "--body-file", body_path])
+    finally:
+        Path(body_path).unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        print(f"ERROR: failed to update PR #{pr.number}: {result.stderr}", file=sys.stderr)
+        return False
+    print(f"[OK] PR #{pr.number} now closes #{issue_number}")
+    return True
+
+
+def process_pr(pr: PullRequest, dry_run: bool) -> bool:
+    """Create and link an issue for a single PR, if it doesn't already have one.
+
+    Returns False only when a create/link step was attempted and failed;
+    skipping an already-linked PR is not treated as a failure.
+    """
+    if has_linked_issue(pr.body):
+        print(f"SKIP: PR #{pr.number} ({pr.title}) already references an issue")
+        return True
+
+    issue_number = create_issue(pr, dry_run)
+    if dry_run:
+        return True
+    if issue_number is None:
+        return False
+    return link_issue_to_pr(pr, issue_number, dry_run)
+
+
+def resolve_repo(explicit: str | None) -> tuple[str, str]:
+    """Resolve the (owner, repo) to operate on.
+
+    Precedence: an explicit `--repo owner/name` flag, then the `origin` git
+    remote, then the hardcoded REPO_OWNER/REPO_NAME fallback.
+    """
+    if explicit:
+        owner, _, name = explicit.partition("/")
+        if not owner or not name:
+            print(f"ERROR: --repo must be in 'owner/name' form, got '{explicit}'", file=sys.stderr)
+            raise SystemExit(1)
+        return owner, name
+
+    result = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if result.returncode == 0:
+        match = re.search(r"[:/]([^/:]+)/([^/]+?)(?:\.git)?$", result.stdout.strip())
+        if match:
+            return match.group(1), match.group(2)
+
+    return REPO_OWNER, REPO_NAME
+
+
+def main() -> int:
+    """Run the retroactive issue-linking flow."""
+    parser = argparse.ArgumentParser(
+        description="Create and link issues for open PRs that don't reference one"
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Actually create issues and edit PRs. Without this flag, runs in dry-run mode.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Repository to operate on as 'owner/name'. Defaults to the 'origin' git "
+        "remote, falling back to leonarduk/allotmint.",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="Operate on a single PR number instead of scanning all open PRs.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Maximum number of open PRs to fetch when scanning (default 200).",
+    )
+    args = parser.parse_args()
+    dry_run = not args.yes
+
+    global REPO_OWNER, REPO_NAME
+    REPO_OWNER, REPO_NAME = resolve_repo(args.repo)
+
+    print(f"INFO: Operating on {REPO_OWNER}/{REPO_NAME}", file=sys.stderr)
+    if args.pr:
+        prs = [fetch_pr(args.pr)]
+    else:
+        prs = fetch_open_prs(args.limit)
+        print(f"INFO: {len(prs)} open PR(s) found", file=sys.stderr)
+
+    unlinked = [pr for pr in prs if not has_linked_issue(pr.body)]
+    print(f"INFO: {len(unlinked)} PR(s) without a linked issue", file=sys.stderr)
+
+    if dry_run:
+        print("INFO: Running in dry-run mode. Pass --yes to actually create/link.", file=sys.stderr)
+
+    had_failures = False
+    for pr in prs:
+        if not process_pr(pr, dry_run):
+            had_failures = True
+
+    return 1 if had_failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_n_add_issue_to_pr.py
+++ b/tests/scripts/test_n_add_issue_to_pr.py
@@ -1,0 +1,242 @@
+import json
+
+import pytest
+
+import scripts.developer_tools.n_add_issue_to_pr as i
+
+
+def _pr(number, title="Fix the thing", body="", author="someone"):
+    return i.PullRequest(number=number, title=title, body=body, author=author)
+
+
+class _FakeResult:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Closes #123",
+        "closes #123",
+        "Fixes #45",
+        "fixed #45",
+        "Resolves #7",
+        "resolved: #7",
+        "Some text.\n\nCloses #99\n",
+    ],
+)
+def test_has_linked_issue_true_for_close_keywords(body):
+    assert i.has_linked_issue(body)
+
+
+@pytest.mark.parametrize(
+    "body",
+    ["", "No issue reference here.", "See #123 for context.", "Related to #5"],
+)
+def test_has_linked_issue_false_without_close_keyword(body):
+    assert not i.has_linked_issue(body)
+
+
+def test_build_issue_body_includes_pr_number_and_title():
+    pr = _pr(42, title="Add widget support", body="Some implementation notes.")
+    body = i.build_issue_body(pr)
+    assert "Add widget support" in body
+    assert "PR #42" in body
+    assert "Some implementation notes." in body
+
+
+def test_build_issue_body_falls_back_when_pr_body_empty():
+    pr = _pr(42, title="Add widget support", body="")
+    body = i.build_issue_body(pr)
+    assert "See PR for implementation details." in body
+
+
+def test_fetch_open_prs_parses_payload(monkeypatch):
+    payload = json.dumps(
+        [
+            {
+                "number": 7,
+                "title": "Do a thing",
+                "body": "No issue link",
+                "author": {"login": "alice"},
+            }
+        ]
+    )
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(0, payload))
+    prs = i.fetch_open_prs()
+    assert len(prs) == 1
+    assert prs[0].number == 7
+    assert prs[0].title == "Do a thing"
+    assert prs[0].author == "alice"
+
+
+def test_fetch_open_prs_exits_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(1, "", "boom"))
+    with pytest.raises(SystemExit) as exc_info:
+        i.fetch_open_prs()
+    assert exc_info.value.code == 1
+
+
+def test_fetch_pr_parses_payload(monkeypatch):
+    payload = json.dumps(
+        {"number": 9, "title": "Single PR", "body": "body text", "author": {"login": "bob"}}
+    )
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(0, payload))
+    pr = i.fetch_pr(9)
+    assert pr.number == 9
+    assert pr.author == "bob"
+
+
+def test_fetch_pr_exits_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(i, "run_gh", lambda args: _FakeResult(1, "", "boom"))
+    with pytest.raises(SystemExit):
+        i.fetch_pr(9)
+
+
+def test_create_issue_dry_run_does_not_call_gh(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "_run_gh_once", lambda args: calls.append(args))
+    result = i.create_issue(_pr(1), dry_run=True)
+    assert result is None
+    assert calls == []
+
+
+def test_create_issue_parses_issue_number_from_url(monkeypatch):
+    monkeypatch.setattr(
+        i, "_run_gh_once", lambda args: _FakeResult(0, "https://github.com/o/r/issues/555\n")
+    )
+    result = i.create_issue(_pr(1), dry_run=False)
+    assert result == 555
+
+
+def test_create_issue_returns_none_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(i, "_run_gh_once", lambda args: _FakeResult(1, "", "boom"))
+    assert i.create_issue(_pr(1), dry_run=False) is None
+
+
+def test_create_issue_returns_none_on_unparseable_url(monkeypatch):
+    monkeypatch.setattr(i, "_run_gh_once", lambda args: _FakeResult(0, "not a url"))
+    assert i.create_issue(_pr(1), dry_run=False) is None
+
+
+def test_create_issue_does_not_retry(monkeypatch):
+    """Issue creation must not go through the retrying run_gh -- it isn't idempotent."""
+    calls = []
+    monkeypatch.setattr(i, "run_gh", lambda args: calls.append(args) or _FakeResult(0))
+    monkeypatch.setattr(
+        i, "_run_gh_once", lambda args: _FakeResult(0, "https://github.com/o/r/issues/1\n")
+    )
+    i.create_issue(_pr(1), dry_run=False)
+    assert calls == []
+
+
+def test_link_issue_to_pr_dry_run_does_not_call_gh(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "_run_gh_once", lambda args: calls.append(args))
+    assert i.link_issue_to_pr(_pr(1), 42, dry_run=True) is True
+    assert calls == []
+
+
+def test_link_issue_to_pr_calls_gh_pr_edit(monkeypatch):
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+        return _FakeResult(0)
+
+    monkeypatch.setattr(i, "_run_gh_once", fake_run)
+    assert i.link_issue_to_pr(_pr(3, body="Existing description"), 42, dry_run=False) is True
+    assert calls[0][:3] == ["pr", "edit", "3"]
+    assert "--body-file" in calls[0]
+
+
+def test_link_issue_to_pr_returns_false_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(i, "_run_gh_once", lambda args: _FakeResult(1, "", "boom"))
+    assert i.link_issue_to_pr(_pr(1), 42, dry_run=False) is False
+
+
+def test_process_pr_skips_when_already_linked(monkeypatch):
+    calls = []
+    monkeypatch.setattr(i, "create_issue", lambda pr, dry_run: calls.append(pr.number) or 1)
+    pr = _pr(1, body="Closes #5")
+    assert i.process_pr(pr, dry_run=True) is True
+    assert calls == []
+
+
+def test_process_pr_creates_and_links_when_unlinked(monkeypatch):
+    monkeypatch.setattr(i, "create_issue", lambda pr, dry_run: 77)
+    link_calls = []
+    monkeypatch.setattr(
+        i,
+        "link_issue_to_pr",
+        lambda pr, issue_number, dry_run: link_calls.append((pr.number, issue_number)) or True,
+    )
+    pr = _pr(3, body="")
+    assert i.process_pr(pr, dry_run=False) is True
+    assert link_calls == [(3, 77)]
+
+
+def test_process_pr_dry_run_does_not_link(monkeypatch):
+    monkeypatch.setattr(i, "create_issue", lambda pr, dry_run: None)
+    link_calls = []
+    monkeypatch.setattr(
+        i, "link_issue_to_pr", lambda pr, issue_number, dry_run: link_calls.append(1) or True
+    )
+    pr = _pr(3, body="")
+    assert i.process_pr(pr, dry_run=True) is True
+    assert link_calls == []
+
+
+def test_process_pr_fails_when_issue_creation_fails(monkeypatch):
+    monkeypatch.setattr(i, "create_issue", lambda pr, dry_run: None)
+    pr = _pr(3, body="")
+    assert i.process_pr(pr, dry_run=False) is False
+
+
+def test_resolve_repo_uses_explicit_flag():
+    assert i.resolve_repo("someorg/somerepo") == ("someorg", "somerepo")
+
+
+def test_resolve_repo_rejects_malformed_explicit_flag():
+    with pytest.raises(SystemExit) as exc_info:
+        i.resolve_repo("not-a-valid-repo")
+    assert exc_info.value.code == 1
+
+
+def test_resolve_repo_parses_https_git_remote(monkeypatch):
+    monkeypatch.setattr(
+        i.subprocess,
+        "run",
+        lambda *a, **k: _FakeResult(0, "https://github.com/someorg/somerepo.git\n"),
+    )
+    assert i.resolve_repo(None) == ("someorg", "somerepo")
+
+
+def test_resolve_repo_parses_ssh_git_remote(monkeypatch):
+    monkeypatch.setattr(
+        i.subprocess,
+        "run",
+        lambda *a, **k: _FakeResult(0, "git@github.com:someorg/somerepo.git\n"),
+    )
+    assert i.resolve_repo(None) == ("someorg", "somerepo")
+
+
+def test_resolve_repo_falls_back_when_remote_lookup_fails(monkeypatch):
+    monkeypatch.setattr(i.subprocess, "run", lambda *a, **k: _FakeResult(1, "", "no remote"))
+    assert i.resolve_repo(None) == (i.REPO_OWNER, i.REPO_NAME)
+
+
+def test_run_gh_returns_failing_result_on_timeout(monkeypatch):
+    import subprocess
+
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["gh"], timeout=60)
+
+    monkeypatch.setattr(i.subprocess, "run", _raise_timeout)
+    monkeypatch.setattr(i.time, "sleep", lambda seconds: None)
+    result = i.run_gh(["pr", "list"])
+    assert result.returncode != 0
+    assert "timed out" in result.stderr


### PR DESCRIPTION
## Summary
- Adds `scripts/developer_tools/n_add_issue_to_pr.py`, which scans open PRs for a missing `Closes/Fixes/Resolves #NNNN` reference, creates a matching issue from the PR's own title/body, and appends the closing syntax to the PR description so merging auto-closes it.
- Defaults to dry-run; `--yes` performs the actual create/edit. Supports `--repo`, `--pr <number>`, and `--limit`.
- Documents the script in `scripts/README.md` alongside the other `developer_tools` scripts.

## Test plan
- [x] `python -m pytest tests/scripts/test_n_add_issue_to_pr.py -q` (35 passed)
- [x] `python -m ruff check scripts/developer_tools/n_add_issue_to_pr.py tests/scripts/test_n_add_issue_to_pr.py`
- [x] `python -m black --check scripts/developer_tools/n_add_issue_to_pr.py tests/scripts/test_n_add_issue_to_pr.py`

Closes #5883

🤖 Generated with [Claude Code](https://claude.com/claude-code)