### PR TITLE
Add thread-safe singleton pattern for S3 client caching

### DIFF
--- a/backend/common/data_providers.py
+++ b/backend/common/data_providers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -90,6 +91,8 @@ class LocalDataProvider:
 
 
 class S3DataProvider:
+    _client_lock = threading.Lock()
+
     def __init__(self, bucket: Optional[str] = None) -> None:
         self.bucket = bucket or os.getenv(DATA_BUCKET_ENV)
         if not self.bucket:
@@ -103,19 +106,26 @@ class S3DataProvider:
         client per call adds ~100-200ms of cold-start overhead each time
         (credential resolution, endpoint discovery). Reusing a single
         client eliminates this overhead on every account/person-meta load.
+
+        Uses double-checked locking so concurrent callers on the same
+        instance (e.g. Lambda execution environment reuse) can't both pass
+        the initial None check and race to create duplicate clients.
         """
         if self._cached_client is not None:
             return self._cached_client
-        try:
-            import boto3  # type: ignore
-        except Exception as exc:  # pragma: no cover - import failure is environment-specific
-            raise ProviderUnavailable("boto3 is not available") from exc
-        try:
-            client = boto3.client("s3")
-        except Exception as exc:  # pragma: no cover - client creation is environment-specific
-            raise ProviderUnavailable("Unable to create S3 client") from exc
-        self._cached_client = client
-        return client
+        with self._client_lock:
+            if self._cached_client is not None:
+                return self._cached_client
+            try:
+                import boto3  # type: ignore
+            except Exception as exc:  # pragma: no cover - import failure is environment-specific
+                raise ProviderUnavailable("boto3 is not available") from exc
+            try:
+                client = boto3.client("s3")
+            except Exception as exc:  # pragma: no cover - client creation is environment-specific
+                raise ProviderUnavailable("Unable to create S3 client") from exc
+            self._cached_client = client
+            return client
 
     def load_account(self, owner: str, account: str) -> AccountObject:
         key = f"{PLOTS_PREFIX}{owner}/{account}.json"

--- a/tests/backend/common/test_data_providers.py
+++ b/tests/backend/common/test_data_providers.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -10,6 +12,7 @@ from backend.common.data_providers import (
     InvalidPayload,
     LocalDataProvider,
     MissingData,
+    S3DataProvider,
 )
 
 
@@ -103,3 +106,51 @@ def test_load_person_meta_valid(accounts_root: Path, provider: LocalDataProvider
     obj = provider.load_person_meta("carol", accounts_root)
     assert obj.owner == "carol"
     assert obj.metadata.get("full_name") == "Carol"
+
+
+# ---------------------------------------------------------------------------
+# S3DataProvider._client — thread-safe caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def s3_provider(monkeypatch: pytest.MonkeyPatch) -> S3DataProvider:
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+    return S3DataProvider()
+
+
+def test_client_returns_cached_instance_on_subsequent_calls(s3_provider: S3DataProvider) -> None:
+    with patch("boto3.client") as mock_boto_client:
+        mock_boto_client.return_value = object()
+        first = s3_provider._client()
+        second = s3_provider._client()
+    assert first is second
+    mock_boto_client.assert_called_once_with("s3")
+
+
+def test_client_creation_is_thread_safe_under_concurrent_calls(s3_provider: S3DataProvider) -> None:
+    created_clients = []
+
+    def _slow_client(*_args, **_kwargs):
+        # Simulate the latency of real client construction so concurrent
+        # threads are likely to race inside _client() without the lock.
+        threading.Event().wait(0.01)
+        client = object()
+        created_clients.append(client)
+        return client
+
+    with patch("boto3.client", side_effect=_slow_client) as mock_boto_client:
+        results: list[object] = [None] * 20  # type: ignore[list-item]
+
+        def _call(index: int) -> None:
+            results[index] = s3_provider._client()
+
+        threads = [threading.Thread(target=_call, args=(i,)) for i in range(len(results))]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert mock_boto_client.call_count == 1
+    assert len(created_clients) == 1
+    assert all(result is created_clients[0] for result in results)


### PR DESCRIPTION
## Summary
- `S3DataProvider._client()` now uses double-checked locking with a class-level `threading.Lock` instead of the non-atomic hasattr/None check, so concurrent calls on the same instance (e.g. Lambda execution environment reuse) can't race into creating duplicate boto3 clients.
- Added unit tests: cached-instance reuse across calls, and a concurrency test spawning 20 threads against a slow mocked `boto3.client` to verify only one client is ever created.

## Test plan
- [x] `python -m pytest tests/backend/common/test_data_providers.py tests/backend/common/test_data_loader.py -q --no-cov` — 62 passed, 1 skipped, 1 xfailed
- [x] Verified no new lint/format issues introduced (pre-existing ruff/black findings in this file are unrelated to the diff)

Closes #5520