### PR TITLE
Only retry transient gh errors in triage script

### DIFF
--- a/scripts/developer_tools/c_triage_issues.py
+++ b/scripts/developer_tools/c_triage_issues.py
@@ -43,6 +43,14 @@ REPO_NAME = "allotmint"
 CONSOLIDATOR_MILESTONE = "Backend Hardening & Test Coverage"
 GH_RETRY_ATTEMPTS = 3
 GH_RETRY_BACKOFF_SECONDS = 2
+TRANSIENT_ERROR_PATTERNS = (
+    "timeout",
+    "timed out",
+    "eof",
+    "connection reset by peer",
+    "tls handshake",
+    "ssl",
+)
 
 SCOPE_APART_PATTERN = re.compile(
     r"(?:tracked separately as|out of scope:?)\s*#(\d+)", re.IGNORECASE
@@ -63,12 +71,24 @@ class Issue:
     body: str = ""
 
 
+def is_transient_gh_error(stderr: str) -> bool:
+    """Return True if `stderr` looks like a network-level (retryable) failure.
+
+    Application-level errors (bad arguments, auth failures, 404s, etc.) don't
+    match any of these patterns and are treated as permanent.
+    """
+    lowered = stderr.lower()
+    return any(pattern in lowered for pattern in TRANSIENT_ERROR_PATTERNS)
+
+
 def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
     """Run a `gh` CLI command scoped to REPO_OWNER/REPO_NAME. Never raises.
 
     Retries transient failures (network blips, GraphQL timeouts) up to
     GH_RETRY_ATTEMPTS times with a linear backoff before returning the last
-    failing result to the caller.
+    failing result to the caller. Permanent (application-level) errors, as
+    identified by `is_transient_gh_error`, are returned immediately without
+    retrying.
     """
     result = None
     for attempt in range(1, GH_RETRY_ATTEMPTS + 1):
@@ -80,6 +100,13 @@ def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
             check=False,
         )
         if result.returncode == 0:
+            return result
+        if not is_transient_gh_error(result.stderr):
+            print(
+                f"ERROR: gh {' '.join(args)} failed with a permanent error, not retrying: "
+                f"{result.stderr.strip()}",
+                file=sys.stderr,
+            )
             return result
         if attempt < GH_RETRY_ATTEMPTS:
             wait_seconds = GH_RETRY_BACKOFF_SECONDS * attempt

--- a/tests/scripts/test_c_triage_issues.py
+++ b/tests/scripts/test_c_triage_issues.py
@@ -135,10 +135,42 @@ def test_run_gh_retries_transient_failure_then_succeeds(monkeypatch):
 def test_run_gh_gives_up_after_max_retries(monkeypatch):
     sleeps = []
     monkeypatch.setattr(h.time, "sleep", lambda seconds: sleeps.append(seconds))
-    monkeypatch.setattr(h.subprocess, "run", lambda args, **kwargs: _FakeResult(1, "", "boom"))
+    monkeypatch.setattr(
+        h.subprocess, "run", lambda args, **kwargs: _FakeResult(1, "", "connection reset by peer")
+    )
     result = h.run_gh(["issue", "list"])
     assert result.returncode == 1
     assert len(sleeps) == h.GH_RETRY_ATTEMPTS - 1
+
+
+def test_run_gh_does_not_retry_permanent_error(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(h.time, "sleep", lambda seconds: sleeps.append(seconds))
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return _FakeResult(1, "", "issue not found (404)")
+
+    monkeypatch.setattr(h.subprocess, "run", fake_run)
+    result = h.run_gh(["issue", "close", "999"])
+    assert result.returncode == 1
+    assert len(calls) == 1
+    assert sleeps == []
+
+
+def test_is_transient_gh_error_matches_known_network_patterns():
+    assert h.is_transient_gh_error("Post: context deadline exceeded (Client.Timeout)")
+    assert h.is_transient_gh_error("net/http: TLS handshake timeout")
+    assert h.is_transient_gh_error("unexpected EOF")
+    assert h.is_transient_gh_error("read: connection reset by peer")
+    assert h.is_transient_gh_error("x509: certificate signed by unknown authority: SSL error")
+
+
+def test_is_transient_gh_error_rejects_permanent_errors():
+    assert not h.is_transient_gh_error("HTTP 404: Not Found")
+    assert not h.is_transient_gh_error("could not determine base repo: authentication failed")
+    assert not h.is_transient_gh_error("unknown flag: --bogus")
 
 
 def test_close_issue_dry_run_does_not_call_gh(monkeypatch):


### PR DESCRIPTION
## Summary
- `run_gh()` in `scripts/developer_tools/c_triage_issues.py` previously retried on **any** non-zero exit code from `gh`, including permanent application-level errors (bad arguments, auth failures, 404s), wasting up to 6s of backoff and masking real bugs.
- Added `is_transient_gh_error()`, which checks `stderr` against a set of known network-level failure substrings (timeout, EOF, connection reset, TLS handshake, SSL). Only errors matching these patterns are retried; everything else fails immediately with a clear `ERROR:` log line.

## Test plan
- [x] `python -m pytest tests/scripts/test_c_triage_issues.py -q` — all 31 tests pass, including new coverage for `is_transient_gh_error` (transient vs. permanent patterns) and `run_gh` short-circuiting on a permanent error without sleeping/retrying.
- [x] Updated the existing max-retries test to use a genuinely transient stderr message so it still exercises the retry path under the new logic.

Closes #5548

🤖 Generated with [Claude Code](https://claude.com/claude-code)
