### PR TITLE
Add consolidated test coverage for 13 backlog test-suggestion issues

### DIFF
--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -868,6 +868,49 @@ def test_token_route_uses_http_none_authorizer(template):
         )
 
 
+def test_options_proxy_route_uses_http_none_authorizer(template):
+    """Positively assert that OPTIONS /{proxy+} — the CORS preflight route
+    that covers every Cognito-JWT-protected endpoint behind the catch-all
+    (e.g. GET /owners, GET /portfolio-group/{slug}) — is registered with
+    HttpNoneAuthorizer (AuthorizationType NONE), not just absent from the
+    Cognito-authorizer set.
+
+    This is the regression guard for issue #3945: browser CORS preflight
+    requests never carry an Authorization header, so if this route were
+    ever put behind the JWT authorizer, every authenticated endpoint would
+    start failing preflight with 401 before the real (GET/POST/etc.) request
+    was even sent — a failure mode that only shows up as a broken frontend,
+    not as an API Gateway error on the "real" route itself.
+
+    test_backend_api_routes_require_cognito_authorizer above already proves
+    OPTIONS /{proxy+} is unauthenticated via a negative check (it is part of
+    the UNAUTHENTICATED_ROUTES set). This test documents and enforces the
+    specific intended authorizer directly, mirroring
+    test_signup_routes_use_http_none_authorizer and
+    test_token_route_uses_http_none_authorizer above.
+    """
+    routes = template.find_resources("AWS::ApiGatewayV2::Route")
+    assert routes, "Expected at least one API Gateway route"
+
+    options_proxy_routes = {
+        resource["Properties"].get("RouteKey", logical_id): resource["Properties"]
+        for logical_id, resource in routes.items()
+        if resource["Properties"].get("RouteKey", "") == "OPTIONS /{proxy+}"
+    }
+    assert set(options_proxy_routes) == {"OPTIONS /{proxy+}"}
+
+    for route_key, properties in options_proxy_routes.items():
+        assert properties.get("AuthorizationType") == "NONE", (
+            f"Route {route_key} must use HttpNoneAuthorizer (AuthorizationType "
+            f"NONE) so CORS preflight requests are not rejected with 401 "
+            f"before the real request is sent (#3945), got "
+            f"{properties.get('AuthorizationType')!r}"
+        )
+        assert "AuthorizerId" not in properties, (
+            f"Route {route_key} must not reference an authorizer resource"
+        )
+
+
 # ---------------------------------------------------------------------------
 # CORS configuration (issue #4828)
 # ---------------------------------------------------------------------------

--- a/frontend/tests/unit/pages/CreateAccountPage.test.tsx
+++ b/frontend/tests/unit/pages/CreateAccountPage.test.tsx
@@ -164,4 +164,72 @@ describe("CreateAccountPage", () => {
       screen.getByRole("button", { name: /request account/i }),
     ).toBeInTheDocument();
   });
+
+  it("logs the HTTP status code when the backend returns 502 for an SES failure (#5375)", async () => {
+    // backend.routes.signup returns 502 when send_signup_admin_email raises
+    // (SES MessageRejected/Throttling/config errors all collapse to this).
+    // api.ts's fetchJson attaches `.status` to the thrown error (see
+    // frontend/src/api.ts lines ~253-254), and CreateAccountPage's catch
+    // block (lines 141-149) branches on that to log the HTTP status.
+    const sesError = new Error("HTTP 502 - Bad Gateway (/signup/request)");
+    (sesError as unknown as { status: number }).status = 502;
+    vi.mocked(requestAccountSignup).mockRejectedValue(sesError);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <MemoryRouter>
+        <CreateAccountPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText(/full name/i), {
+      target: { value: "Ada Lovelace" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "ada@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /request account/i }));
+
+    expect(
+      await screen.findByText(/something went wrong/i),
+    ).toBeInTheDocument();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to submit account signup request (HTTP 502)",
+      sesError,
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("logs without an HTTP status when the failure has no status code", async () => {
+    const networkError = new Error("network down");
+    vi.mocked(requestAccountSignup).mockRejectedValue(networkError);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <MemoryRouter>
+        <CreateAccountPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText(/full name/i), {
+      target: { value: "Ada Lovelace" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "ada@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /request account/i }));
+
+    expect(
+      await screen.findByText(/something went wrong/i),
+    ).toBeInTheDocument();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to submit account signup request",
+      networkError,
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/frontend/tests/unit/pages/Portfolio.test.tsx
+++ b/frontend/tests/unit/pages/Portfolio.test.tsx
@@ -354,6 +354,57 @@ describe("Portfolio page", () => {
     expect((await screen.findByText(/Approx Total:/)).textContent).toMatch(/200/);
   });
 
+  it("shows the newer request's error when both stale and newer requests fail", async () => {
+    mockGetOwners.mockResolvedValue([
+      { owner: "alice", accounts: [] },
+      { owner: "bob", accounts: [] },
+    ]);
+
+    const alice = deferred<Portfolio>();
+    const bob = deferred<Portfolio>();
+    mockGetPortfolio.mockImplementation((owner: string) =>
+      owner === "alice" ? alice.promise : bob.promise,
+    );
+
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/portfolio"]}>
+          <OwnerOnlyRouteProvider>
+            <Routes>
+              <Route path="/portfolio" element={<PortfolioPage />} />
+            </Routes>
+          </OwnerOnlyRouteProvider>
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    const ownerSelect = await screen.findByLabelText(/Owner/i);
+    await userEvent.selectOptions(ownerSelect, "alice");
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+
+    await userEvent.selectOptions(ownerSelect, "bob");
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
+
+    // Both requests fail -- the stale (alice) request first, then the
+    // newer (bob) request. The stale failure must not surface, and once
+    // the newer request also fails, its error must be the one shown, with
+    // loading cleared.
+    await act(async () => {
+      alice.reject(new Error("stale alice failure"));
+      await expect(alice.promise).rejects.toThrow("stale alice failure");
+    });
+    expect(screen.queryByText("Failed to load portfolio")).not.toBeInTheDocument();
+
+    await act(async () => {
+      bob.reject(new Error("bob failed"));
+      await expect(bob.promise).rejects.toThrow("bob failed");
+    });
+
+    expect(await screen.findByText("Failed to load portfolio")).toBeInTheDocument();
+    expect(screen.queryByText(/^Loading…$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Approx Total:/)).not.toBeInTheDocument();
+  });
+
   it("shows available owners excluding demo entries", async () => {
     mockGetOwners.mockResolvedValueOnce([
       { owner: "demo", accounts: [] },

--- a/frontend/tests/unit/pages/UserConfig.test.tsx
+++ b/frontend/tests/unit/pages/UserConfig.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, waitFor } from "@testing-library/react";
+import { render, screen, act, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
@@ -6,6 +6,8 @@ const mockGetOwners = vi.hoisted(() => vi.fn());
 const mockGetUserConfig = vi.hoisted(() => vi.fn());
 const mockGetApprovals = vi.hoisted(() => vi.fn());
 const mockUpdateUserConfig = vi.hoisted(() => vi.fn());
+const mockAddApproval = vi.hoisted(() => vi.fn());
+const mockRemoveApproval = vi.hoisted(() => vi.fn());
 
 vi.mock("@/api", () => ({
   API_BASE: "",
@@ -13,8 +15,8 @@ vi.mock("@/api", () => ({
   getUserConfig: mockGetUserConfig,
   getApprovals: mockGetApprovals,
   updateUserConfig: mockUpdateUserConfig,
-  addApproval: vi.fn(),
-  removeApproval: vi.fn(),
+  addApproval: mockAddApproval,
+  removeApproval: mockRemoveApproval,
 }));
 
 import UserConfig from "@/pages/UserConfig";
@@ -210,6 +212,120 @@ describe("UserConfig page", () => {
     const select = await screen.findByRole("combobox");
     await act(async () => {
       await userEvent.selectOptions(select, "alex");
+    });
+
+    expect(await screen.findByText(/session has expired/i)).toBeInTheDocument();
+  });
+
+  it("shows a permission-specific message when adding an approval 403s (#5215)", async () => {
+    mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
+    mockGetUserConfig.mockResolvedValue({});
+    mockGetApprovals.mockResolvedValue({ approvals: [] });
+    const forbidden = new Error("HTTP 403 - Forbidden (/accounts/alex/approvals)");
+    (forbidden as any).status = 403;
+    mockAddApproval.mockRejectedValue(forbidden);
+
+    render(<UserConfig />);
+
+    const select = await screen.findByRole("combobox");
+    await act(async () => {
+      await userEvent.selectOptions(select, "alex");
+    });
+
+    const tickerInput = await screen.findByPlaceholderText("Ticker");
+    const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement;
+    await act(async () => {
+      await userEvent.type(tickerInput, "ABC");
+      fireEvent.change(dateInput, { target: { value: "2024-01-01" } });
+    });
+    const addButton = screen.getByRole("button", { name: /add/i });
+    await act(async () => {
+      await userEvent.click(addButton);
+    });
+
+    expect(
+      await screen.findByText(/don't have permission to view or manage approvals/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^Failed to add approval$/)).not.toBeInTheDocument();
+  });
+
+  it("shows a session-expiry message when adding an approval 401s (#5215)", async () => {
+    mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
+    mockGetUserConfig.mockResolvedValue({});
+    mockGetApprovals.mockResolvedValue({ approvals: [] });
+    const unauthorized = new Error("HTTP 401 - Unauthorized (/accounts/alex/approvals)");
+    (unauthorized as any).status = 401;
+    mockAddApproval.mockRejectedValue(unauthorized);
+
+    render(<UserConfig />);
+
+    const select = await screen.findByRole("combobox");
+    await act(async () => {
+      await userEvent.selectOptions(select, "alex");
+    });
+
+    const tickerInput = await screen.findByPlaceholderText("Ticker");
+    const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement;
+    await act(async () => {
+      await userEvent.type(tickerInput, "ABC");
+      fireEvent.change(dateInput, { target: { value: "2024-01-01" } });
+    });
+    const addButton = screen.getByRole("button", { name: /add/i });
+    await act(async () => {
+      await userEvent.click(addButton);
+    });
+
+    expect(await screen.findByText(/session has expired/i)).toBeInTheDocument();
+  });
+
+  it("shows a permission-specific message when removing an approval 403s (#5215)", async () => {
+    mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
+    mockGetUserConfig.mockResolvedValue({});
+    mockGetApprovals.mockResolvedValue({
+      approvals: [{ ticker: "ABC", approved_on: "2024-01-01" }],
+    });
+    const forbidden = new Error("HTTP 403 - Forbidden (/accounts/alex/approvals)");
+    (forbidden as any).status = 403;
+    mockRemoveApproval.mockRejectedValue(forbidden);
+
+    render(<UserConfig />);
+
+    const select = await screen.findByRole("combobox");
+    await act(async () => {
+      await userEvent.selectOptions(select, "alex");
+    });
+
+    const removeButton = await screen.findByRole("button", { name: /remove/i });
+    await act(async () => {
+      await userEvent.click(removeButton);
+    });
+
+    expect(
+      await screen.findByText(/don't have permission to view or manage approvals/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^Failed to remove approval$/)).not.toBeInTheDocument();
+  });
+
+  it("shows a session-expiry message when removing an approval 401s (#5215)", async () => {
+    mockGetOwners.mockResolvedValue([{ owner: "alex", accounts: [] }]);
+    mockGetUserConfig.mockResolvedValue({});
+    mockGetApprovals.mockResolvedValue({
+      approvals: [{ ticker: "ABC", approved_on: "2024-01-01" }],
+    });
+    const unauthorized = new Error("HTTP 401 - Unauthorized (/accounts/alex/approvals)");
+    (unauthorized as any).status = 401;
+    mockRemoveApproval.mockRejectedValue(unauthorized);
+
+    render(<UserConfig />);
+
+    const select = await screen.findByRole("combobox");
+    await act(async () => {
+      await userEvent.selectOptions(select, "alex");
+    });
+
+    const removeButton = await screen.findByRole("button", { name: /remove/i });
+    await act(async () => {
+      await userEvent.click(removeButton);
     });
 
     expect(await screen.findByText(/session has expired/i)).toBeInTheDocument();

--- a/tests/backend/routes/conftest.py
+++ b/tests/backend/routes/conftest.py
@@ -1,0 +1,27 @@
+"""Shared fixtures for tests under tests/backend/routes/."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def reset_warning_flag(monkeypatch: pytest.MonkeyPatch):
+    """Reset a module-level "warn once per process" flag before a test runs.
+
+    Some modules (e.g. ``backend.routes.transactions``) use a ``_warned_*``
+    module-level boolean to emit a given warning only once per process. Tests
+    that need to observe the warning must reset the flag first, since an
+    earlier test running in the same process may already have flipped it to
+    True -- otherwise the warning silently never fires and the assertion
+    becomes a false pass. This consolidates the previously-repeated inline
+    ``monkeypatch.setattr(module, "_warned_x", False)`` calls (issue #5343).
+
+    Usage:
+        def test_something(reset_warning_flag):
+            reset_warning_flag(transactions_module, "_warned_missing_data_bucket")
+    """
+
+    def _reset(module: object, attr_name: str) -> None:
+        monkeypatch.setattr(module, attr_name, False)
+
+    return _reset

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -2,6 +2,7 @@ import json
 import warnings
 
 import pytest
+from botocore.exceptions import ClientError, ParamValidationError
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from slowapi import Limiter
@@ -11,6 +12,31 @@ from slowapi.util import get_remote_address
 
 from backend.common import signup_requests
 from backend.routes import signup as signup_module
+
+
+def _ses_message_rejected() -> ClientError:
+    return ClientError(
+        {"Error": {"Code": "MessageRejected", "Message": "Email address is not verified"}},
+        "SendEmail",
+    )
+
+
+def _ses_throttling() -> ClientError:
+    return ClientError(
+        {"Error": {"Code": "Throttling", "Message": "Maximum sending rate exceeded"}},
+        "SendEmail",
+    )
+
+
+def _ses_generic_config_error() -> ParamValidationError:
+    return ParamValidationError(report="Invalid type for parameter Source")
+
+
+_SES_FAILURE_MODES = [
+    pytest.param(_ses_message_rejected, id="message-rejected"),
+    pytest.param(_ses_throttling, id="throttling"),
+    pytest.param(_ses_generic_config_error, id="generic-config"),
+]
 
 
 @pytest.fixture
@@ -130,6 +156,48 @@ def test_email_send_failure_is_not_swallowed(client, monkeypatch):
 
     resp = test_client.post("/signup/request", json={"name": "Jane", "email": "jane@example.com"})
     assert resp.status_code == 502
+
+
+@pytest.mark.parametrize("make_error", _SES_FAILURE_MODES)
+def test_email_send_ses_failure_returns_502_and_logs(client, monkeypatch, caplog, make_error):
+    """#5375: MessageRejected, throttling, and generic/config SES failures must
+    all surface as a 502 with the error logged (with the request id for
+    context), matching the generic-RuntimeError case above.
+
+    The pending-request record is written to disk *before* the admin email is
+    attempted (see ``_post_signup_request_impl``), so -- unlike the approval
+    flow -- an SES failure here does NOT roll back the persisted request; the
+    record legitimately remains on disk as still-pending. That is the actual,
+    intentional behaviour, not an oversight: the visitor's request is not
+    lost just because the admin notification failed to send.
+    """
+    test_client, tmp_path = client
+
+    def boom(admin_email, notification):
+        raise make_error()
+
+    monkeypatch.setattr(signup_module, "send_signup_admin_email", boom)
+
+    with caplog.at_level("ERROR"):
+        resp = test_client.post(
+            "/signup/request", json={"name": "Jane", "email": "jane@example.com"}
+        )
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "failed to notify administrator"
+
+    # Logged with request-id context, at ERROR level (logger.exception).
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert any("Failed to send signup admin email for request" in r.message for r in error_records)
+
+    # The pending request record was already persisted before the email
+    # attempt and is NOT rolled back -- this is the handler's actual current
+    # behaviour (see backend/routes/signup.py:_post_signup_request_impl).
+    store = tmp_path / "signup_requests"
+    files = list(store.glob("*.json"))
+    assert len(files) == 1
+    saved = json.loads(files[0].read_text())
+    assert saved["status"] == "pending"
 
 
 # ---------------------------------------------------------------------------
@@ -318,6 +386,50 @@ def test_approve_user_email_failure_is_not_swallowed(client, monkeypatch):
     request_id, token = _pending_request(tmp_path)
     resp = test_client.post(f"/signup/approve?id={request_id}&token={token}")
     assert resp.status_code == 502
+
+
+@pytest.mark.parametrize("make_error", _SES_FAILURE_MODES)
+def test_approve_user_email_ses_failure_returns_502_and_logs(client, monkeypatch, caplog, make_error):
+    """#5375: MessageRejected, throttling, and generic/config SES failures on
+    the approval-notification email must all surface as a 502 with the error
+    logged (with the request id for context).
+
+    By the time the user-notification email is attempted, the owner has
+    already been provisioned and the single-use token already consumed (see
+    ``approve_signup_request``'s docstring: 'the user has already been
+    provisioned by this point'). So an SES failure here intentionally does
+    NOT undo the provisioning or un-consume the token -- asserting otherwise
+    would contradict the handler's documented design.
+    """
+    test_client, tmp_path = client
+    store = _stub_store(monkeypatch)
+    monkeypatch.setenv("SIGNUP_LOGIN_URL", "https://allotmint.example/login")
+
+    def boom(user_email, name, login_url):
+        raise make_error()
+
+    monkeypatch.setattr(signup_module, "send_signup_approved_email", boom)
+
+    request_id, token = _pending_request(tmp_path)
+
+    with caplog.at_level("ERROR"):
+        resp = test_client.post(f"/signup/approve?id={request_id}&token={token}")
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "failed to notify user"
+
+    # Logged with request-id context, at ERROR level (logger.exception).
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert any("Failed to send login-ready email for request" in r.message for r in error_records)
+
+    # Provisioning and token consumption are NOT rolled back -- this is the
+    # handler's documented, intentional behaviour (email failure must not
+    # silently undo an already-granted account).
+    person = json.loads((tmp_path / "accounts" / "jane" / "person.json").read_text())
+    assert person["email"] == "jane@example.com"
+    assert store.ensured == ["jane"]
+    store_dir = signup_requests.signup_requests_dir(tmp_path)
+    assert json.loads((store_dir / f"{request_id}.json").read_text())["status"] == "approved"
 
 
 def test_get_approve_is_a_safe_confirmation_page(client, monkeypatch):

--- a/tests/backend/routes/test_transactions_writable_store.py
+++ b/tests/backend/routes/test_transactions_writable_store.py
@@ -66,11 +66,11 @@ def test_resolve_writable_store_uses_s3_in_aws(monkeypatch):
 
 
 def test_resolve_writable_store_falls_back_local_without_bucket(
-    monkeypatch, tmp_path, caplog
+    monkeypatch, tmp_path, caplog, reset_warning_flag
 ):
     monkeypatch.setattr(transactions_module.config, "app_env", "aws")
     monkeypatch.delenv(data_loader.DATA_BUCKET_ENV, raising=False)
-    monkeypatch.setattr(transactions_module, "_warned_missing_data_bucket", False)
+    reset_warning_flag(transactions_module, "_warned_missing_data_bucket")
 
     request = _make_request({"accounts_root": tmp_path})
     with caplog.at_level("WARNING", logger="transactions"):
@@ -97,11 +97,11 @@ def test_resolve_writable_store_no_warning_outside_aws(monkeypatch, tmp_path, ca
 
 
 def test_resolve_writable_store_warns_only_once_per_process(
-    monkeypatch, tmp_path, caplog
+    monkeypatch, tmp_path, caplog, reset_warning_flag
 ):
     monkeypatch.setattr(transactions_module.config, "app_env", "aws")
     monkeypatch.delenv(data_loader.DATA_BUCKET_ENV, raising=False)
-    monkeypatch.setattr(transactions_module, "_warned_missing_data_bucket", False)
+    reset_warning_flag(transactions_module, "_warned_missing_data_bucket")
 
     with caplog.at_level("WARNING", logger="transactions"):
         for _ in range(3):

--- a/tests/backend/test_signup_approved_email.py
+++ b/tests/backend/test_signup_approved_email.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError, ParamValidationError
+
+from backend.emails.signup_approved import (
+    render_signup_approved_email,
+    send_signup_approved_email,
+)
+
+
+def test_render_includes_greeting_and_login_link():
+    html = render_signup_approved_email("Jane Doe", "https://allotmint.example/login")
+    assert "Jane Doe" in html
+    assert "https://allotmint.example/login" in html
+    assert "<a href=" in html
+
+
+def test_render_escapes_hostile_name():
+    html = render_signup_approved_email("<script>alert(1)</script>", "https://allotmint.example/login")
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_handles_missing_login_url():
+    html = render_signup_approved_email("Jane", "")
+    assert "You can now log in to AllotMint." in html
+
+
+def test_send_signup_approved_email_invokes_ses():
+    with patch("boto3.client") as client_factory:
+        ses_client = MagicMock()
+        client_factory.return_value = ses_client
+        send_signup_approved_email("jane@example.com", "Jane Doe", "https://allotmint.example/login")
+
+    client_factory.assert_called_once()
+    assert client_factory.call_args.args[0] == "ses"
+    ses_client.send_email.assert_called_once()
+    _, kwargs = ses_client.send_email.call_args
+    assert kwargs["Destination"]["ToAddresses"] == ["jane@example.com"]
+    assert "login is ready" in kwargs["Message"]["Subject"]["Data"]
+
+
+# ---------------------------------------------------------------------------
+# SES failure modes (#5375) -- send_signup_approved_email must never swallow a
+# delivery failure; it propagates so the route can surface a 5xx rather than
+# reporting a false "approved and notified" success to the caller.
+# ---------------------------------------------------------------------------
+
+
+def _rejected_error() -> ClientError:
+    return ClientError(
+        {"Error": {"Code": "MessageRejected", "Message": "Email address is not verified"}},
+        "SendEmail",
+    )
+
+
+def _throttling_error() -> ClientError:
+    return ClientError(
+        {"Error": {"Code": "Throttling", "Message": "Maximum sending rate exceeded"}},
+        "SendEmail",
+    )
+
+
+def _config_error() -> ParamValidationError:
+    return ParamValidationError(report="Invalid type for parameter Source")
+
+
+@pytest.mark.parametrize(
+    "make_error",
+    [_rejected_error, _throttling_error, _config_error],
+    ids=["message-rejected", "throttling", "generic-config"],
+)
+def test_send_signup_approved_email_propagates_ses_failures(make_error):
+    """SES failures (rejection, throttling, and generic/config errors) must
+    propagate unmodified -- the caller (backend.routes.signup) relies on this
+    to turn the failure into a 502 rather than reporting a false success even
+    though the user was already provisioned by this point."""
+
+    with patch("boto3.client") as client_factory:
+        ses_client = MagicMock()
+        ses_client.send_email.side_effect = make_error()
+        client_factory.return_value = ses_client
+
+        with pytest.raises(type(make_error())):
+            send_signup_approved_email(
+                "jane@example.com", "Jane Doe", "https://allotmint.example/login"
+            )
+
+    ses_client.send_email.assert_called_once()

--- a/tests/backend/test_signup_request_email.py
+++ b/tests/backend/test_signup_request_email.py
@@ -1,5 +1,8 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+from botocore.exceptions import ClientError, ParamValidationError
+
 from backend.emails.signup_request import (
     SignupAdminNotification,
     render_signup_admin_email,
@@ -59,3 +62,50 @@ def test_send_signup_admin_email_invokes_ses():
     assert kwargs["Destination"]["ToAddresses"] == ["admin@example.com"]
     assert "Jane Doe" in kwargs["Message"]["Subject"]["Data"]
     assert "/signup/approve" in kwargs["Message"]["Body"]["Html"]["Data"]
+
+
+# ---------------------------------------------------------------------------
+# SES failure modes (#5375) -- send_signup_admin_email must never swallow a
+# delivery failure; it propagates so the route can surface a 5xx rather than
+# silently dropping the admin notification.
+# ---------------------------------------------------------------------------
+
+
+def _rejected_error() -> ClientError:
+    return ClientError(
+        {"Error": {"Code": "MessageRejected", "Message": "Email address is not verified"}},
+        "SendEmail",
+    )
+
+
+def _throttling_error() -> ClientError:
+    return ClientError(
+        {"Error": {"Code": "Throttling", "Message": "Maximum sending rate exceeded"}},
+        "SendEmail",
+    )
+
+
+def _config_error() -> ParamValidationError:
+    return ParamValidationError(report="Invalid type for parameter Source")
+
+
+@pytest.mark.parametrize(
+    "make_error",
+    [_rejected_error, _throttling_error, _config_error],
+    ids=["message-rejected", "throttling", "generic-config"],
+)
+def test_send_signup_admin_email_propagates_ses_failures(make_error):
+    """SES failures (rejection, throttling, and generic/config errors) must
+    propagate unmodified -- the caller (backend.routes.signup) relies on this
+    to turn the failure into a 502 rather than reporting a false success."""
+
+    notification = _notification()
+    with patch("boto3.client") as client_factory:
+        ses_client = MagicMock()
+        ses_client.send_email.side_effect = make_error()
+        client_factory.return_value = ses_client
+
+        with pytest.raises(type(make_error())):
+            send_signup_admin_email("admin@example.com", notification)
+
+    ses_client.send_email.assert_called_once()

--- a/tests/backend/test_startup_timed_phase.py
+++ b/tests/backend/test_startup_timed_phase.py
@@ -1,0 +1,138 @@
+"""Coverage for ``_timed_phase`` (backend/bootstrap/startup.py) and its
+interaction with ``sanitise_log_value`` / structured logging (issue #5343,
+tracked under the consolidated coverage issue #5974).
+
+``_timed_phase`` is the context manager cold-start warmup phases are wrapped
+in (see ``AppLifecycleService._warm_snapshot``). It must:
+
+* log the phase's duration even when the wrapped code raises, without
+  swallowing the exception (a bug here would hide startup failures behind a
+  generic 500 with no diagnostic signal);
+* attach ``phase``/``duration_ms`` as structured ``extra`` fields so a JSON
+  log formatter (not configured today, but anticipated by the docstring on
+  ``_timed_phase``) can serialize them without extra plumbing;
+* tolerate a ``None`` or non-string phase name via ``sanitise_log_value``
+  rather than raising while trying to log.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from backend.bootstrap.startup import _timed_phase
+from backend.logging_setup import sanitise_log_value
+
+_LOGGER_NAME = "backend.bootstrap.startup"
+
+
+def test_timed_phase_logs_duration_and_reraises_on_exception(
+    caplog: pytest.LogCaptureFixture,
+):
+    """A phase that raises must still get its duration logged, and the
+    exception must propagate (not be swallowed by the context manager)."""
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(ValueError, match="boom"):
+            with _timed_phase("exploding_phase"):
+                raise ValueError("boom")
+
+    phase_records = [
+        record for record in caplog.records if getattr(record, "phase", None) == "exploding_phase"
+    ]
+    assert len(phase_records) == 1, (
+        "Expected exactly one 'cold_start_phase' log for the failing phase, got: "
+        + str([r.message for r in caplog.records])
+    )
+    record = phase_records[0]
+    assert record.levelno == logging.INFO
+    assert "cold_start_phase" in record.message
+    assert isinstance(record.duration_ms, float)
+    assert record.duration_ms >= 0
+
+
+def test_timed_phase_handles_none_and_non_string_names(
+    caplog: pytest.LogCaptureFixture,
+):
+    """sanitise_log_value must coerce a None/non-string phase name to text
+    instead of raising while _timed_phase logs the completion message."""
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with _timed_phase(None):
+            pass
+        with _timed_phase(12345):
+            pass
+
+    # sanitise_log_value itself must not raise for these inputs.
+    assert sanitise_log_value(None) == "None"
+    assert sanitise_log_value(12345) == "12345"
+
+    phases = [getattr(record, "phase", "missing") for record in caplog.records]
+    assert None in phases
+    assert 12345 in phases
+    # No exception should have interrupted the two context managers above;
+    # both completions must have logged successfully.
+    assert len(caplog.records) == 2
+
+
+def test_timed_phase_exception_phase_name_is_sanitised(caplog: pytest.LogCaptureFixture):
+    """A phase name containing CRLF (log-injection attempt, CWE-117) must be
+    sanitised in the rendered message even when the wrapped code raises."""
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(RuntimeError):
+            with _timed_phase("bad\r\nname"):
+                raise RuntimeError("fail")
+
+    record = next(r for r in caplog.records if "phase=" in r.message)
+    assert "\r" not in record.message
+    assert "\n" not in record.message
+    # The raw (unsanitised) value is still present in `extra` for consumers
+    # that want the structured field rather than the rendered text.
+    assert record.phase == "bad\r\nname"
+
+
+def test_timed_phase_structured_logging_serializes_to_json():
+    """When a JSON formatter is attached, the `extra={"phase", "duration_ms"}`
+    fields _timed_phase supplies must serialize to valid JSON with the
+    expected keys -- this is the scenario the docstring on _timed_phase calls
+    out ("whenever a JSON log formatter is in place")."""
+
+    class JsonFormatter(logging.Formatter):
+        def format(self, record: logging.LogRecord) -> str:
+            payload = {
+                "message": record.getMessage(),
+                "level": record.levelname,
+                "logger": record.name,
+            }
+            if hasattr(record, "phase"):
+                payload["phase"] = record.phase
+            if hasattr(record, "duration_ms"):
+                payload["duration_ms"] = record.duration_ms
+            return json.dumps(payload)
+
+    captured: list[str] = []
+
+    class CapturingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(self.format(record))
+
+    logger = logging.getLogger(_LOGGER_NAME)
+    handler = CapturingHandler()
+    handler.setFormatter(JsonFormatter())
+    logger.addHandler(handler)
+    previous_level = logger.level
+    logger.setLevel(logging.INFO)
+    try:
+        with _timed_phase("json_formatted_phase"):
+            pass
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+    assert len(captured) == 1
+    payload = json.loads(captured[0])  # must be valid JSON
+    assert payload["phase"] == "json_formatted_phase"
+    assert isinstance(payload["duration_ms"], float)
+    assert payload["duration_ms"] >= 0
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == _LOGGER_NAME
+    assert "cold_start_phase" in payload["message"]

--- a/tests/bash/reconcile_changes_requested_label.bats
+++ b/tests/bash/reconcile_changes_requested_label.bats
@@ -93,6 +93,49 @@ HEADER
   grep -q -- "--remove-label Changes Requested" "$CALL_LOG"
 }
 
+@test "ENABLE_CLAUDE=false excludes Claude from the required set" {
+  export ENABLE_CLAUDE="false"
+  write_fake_gh "sha123" "true" \
+    "GPT AI code review=success" \
+    "DeepSeek AI code review=success"
+
+  run bash "$SCRIPT" 42
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"enabled reviewers: GPT AI code review DeepSeek AI code review"* ]]
+  [[ "$output" != *"Claude AI code review:"* ]]
+  grep -q -- "--remove-label Changes Requested" "$CALL_LOG"
+}
+
+@test "ENABLE_DEEPSEEK=false excludes DeepSeek from the required set" {
+  export ENABLE_DEEPSEEK="false"
+  write_fake_gh "sha123" "true" \
+    "Claude AI code review=success" \
+    "GPT AI code review=success"
+
+  run bash "$SCRIPT" 42
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"enabled reviewers: Claude AI code review GPT AI code review"* ]]
+  [[ "$output" != *"DeepSeek AI code review:"* ]]
+  grep -q -- "--remove-label Changes Requested" "$CALL_LOG"
+}
+
+@test "two disabled reviewers leaves only the remaining one's conclusion required" {
+  export ENABLE_CLAUDE="false"
+  export ENABLE_GPT="false"
+  # Only DeepSeek is enabled and it's still pending, so the label must stay.
+  write_fake_gh "sha123" "true" \
+    "DeepSeek AI code review=pending"
+
+  run bash "$SCRIPT" 42
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"enabled reviewers: DeepSeek AI code review"* ]]
+  [[ "$output" == *"leaving 'Changes Requested' label as-is"* ]]
+  ! grep -q -- "--remove-label" "$CALL_LOG"
+}
+
 @test "a disabled reviewer's pending check-run does not block label removal" {
   export ENABLE_GPT="false"
   # The GPT check-run doesn't exist at all (job skipped), which the fake gh

--- a/tests/common/test_holding_utils.py
+++ b/tests/common/test_holding_utils.py
@@ -47,6 +47,36 @@ def test_derived_cost_basis_close_px_caches_and_window(monkeypatch):
     assert calls[0][1] == dt.date(2024, 1, 10)  # end_date (Wednesday)
 
 
+def test_derived_cost_basis_close_px_nan_guard_returns_none_and_does_not_cache(monkeypatch):
+    """If the scaled close price resolves to NaN, the NaN guard must return
+    None instead of caching/propagating NaN (which would poison downstream
+    cost-basis arithmetic, e.g. ``units * NaN`` -> NaN)."""
+
+    calls = []
+
+    def fake_load(ticker, exchange, start_date, end_date):
+        calls.append((start_date, end_date))
+        return pd.DataFrame({"Date": [start_date], "Close": [float("nan")]})
+
+    monkeypatch.setattr(holding_utils, "load_meta_timeseries_range", fake_load)
+    # A scaling override that would otherwise turn a real price into a value;
+    # applied to NaN it should still be NaN, and the guard should catch it.
+    monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 0.5)
+
+    acq = dt.date(2024, 1, 8)  # Monday
+    cache: Dict[str, float] = {}
+    result = holding_utils._derived_cost_basis_close_px("ABC", "L", acq, cache)
+
+    assert result is None
+    # The NaN guard must not populate the cache with a NaN (or any) value for
+    # this key, so a subsequent lookup keeps trying rather than trusting a
+    # poisoned cached value.
+    key = f"ABC.L_{acq}"
+    assert key not in cache
+    # Confirms the guard actually executed the lookup rather than short-circuiting.
+    assert len(calls) == 1
+
+
 def test_load_latest_prices_resolution_scaling_and_missing(monkeypatch):
     def fake_resolve(full, result):
         return ("ABC", "L") if full == "ABC" else None

--- a/tests/common/test_portfolio_loader.py
+++ b/tests/common/test_portfolio_loader.py
@@ -75,6 +75,44 @@ def test_get_units_as_of_ignores_other_tickers() -> None:
     }
 
     assert get_units_as_of(tx_data, "ABC", "2024-06-01") == pytest.approx(100.0)
+
+
+def test_get_units_as_of_reflects_a_transfer_in_before_cutoff() -> None:
+    tx_data = {
+        "transactions": [
+            {"type": "BUY", "ticker": "ABC", "units": 100, "date": "2024-01-01"},
+            {"type": "TRANSFER_IN", "ticker": "ABC", "units": 50, "date": "2024-02-01"},
+        ]
+    }
+
+    assert get_units_as_of(tx_data, "ABC", "2024-01-15") == pytest.approx(100.0)
+    assert get_units_as_of(tx_data, "ABC", "2024-02-01") == pytest.approx(150.0)
+
+
+def test_get_units_as_of_reflects_a_transfer_out_before_cutoff() -> None:
+    tx_data = {
+        "transactions": [
+            {"type": "BUY", "ticker": "ABC", "units": 200, "date": "2024-01-01"},
+            {"type": "TRANSFER_OUT", "ticker": "ABC", "units": 75, "date": "2024-02-01"},
+        ]
+    }
+
+    assert get_units_as_of(tx_data, "ABC", "2024-01-15") == pytest.approx(200.0)
+    assert get_units_as_of(tx_data, "ABC", "2024-02-01") == pytest.approx(125.0)
+
+
+def test_get_units_as_of_reflects_a_removal_before_cutoff() -> None:
+    tx_data = {
+        "transactions": [
+            {"type": "BUY", "ticker": "ABC", "units": 200, "date": "2024-01-01"},
+            {"type": "REMOVAL", "ticker": "ABC", "units": 30, "date": "2024-02-01"},
+        ]
+    }
+
+    assert get_units_as_of(tx_data, "ABC", "2024-01-15") == pytest.approx(200.0)
+    assert get_units_as_of(tx_data, "ABC", "2024-02-01") == pytest.approx(170.0)
+
+
 def test_rebuild_account_holdings_treats_dividend_singular_like_dividends(tmp_path: Path) -> None:
     """Regression test for #4948: the sign table must recognise both
     ``DIVIDEND`` (written by backend/common/dividends.py) and the legacy

--- a/tests/common/test_prices.py
+++ b/tests/common/test_prices.py
@@ -488,3 +488,67 @@ def test_refresh_prices_partial_null_preserves_existing_prices(
     assert price_cache.get("BBB.L") == pytest.approx(20.0), (
         "_price_cache must contain preserved seed price for null-returning ticker"
     )
+
+
+def test_refresh_prices_filters_nan_zero_and_negative_prices(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end NaN/zero/negative guard: mock the underlying price fetches
+    (``_load_latest_prices`` / ``load_live_prices``) so ``get_price_snapshot``
+    runs for real, then verify ``refresh_prices``'s write-boundary filter
+    keeps only finite, strictly-positive prices — preserving any existing
+    seed value for tickers whose freshly-fetched price is NaN, zero, or
+    negative."""
+
+    tickers = ["NAN.L", "ZERO.L", "NEG.L", "OK.L"]
+    seed = {
+        "NAN.L": {"last_price": 10.0, "price_currency": "GBP"},
+        "ZERO.L": {"last_price": 20.0, "price_currency": "GBP"},
+        "NEG.L": {"last_price": 30.0, "price_currency": "GBP"},
+    }
+    output_path = tmp_path / "prices.json"
+    output_path.write_text(json.dumps(seed))
+
+    now = datetime.now(UTC)
+    # Live prices supply a NaN and a negative price directly; last-close
+    # fallback supplies a zero price for the ticker with no live entry.
+    monkeypatch.setattr(
+        prices,
+        "load_live_prices",
+        lambda t: {
+            "NAN.L": {"price": float("nan"), "timestamp": now},
+            "NEG.L": {"price": -5.0, "timestamp": now},
+            "OK.L": {"price": 12.0, "timestamp": now},
+        },
+    )
+    monkeypatch.setattr(
+        prices,
+        "_load_latest_prices",
+        lambda t: {"ZERO.L": 0.0},
+    )
+    monkeypatch.setattr(prices.instrument_api, "_resolve_full_ticker", lambda full, latest: None)
+    monkeypatch.setattr(prices, "_close_on", lambda *a, **k: None)
+    monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: tickers)
+    monkeypatch.setattr(prices, "refresh_snapshot_in_memory", Mock())
+    monkeypatch.setattr(prices, "check_price_alerts", Mock())
+    monkeypatch.setattr(prices.config, "prices_json", output_path)
+    monkeypatch.setattr(prices, "_price_cache", {})
+
+    result = prices.refresh_prices()
+
+    snapshot = result["snapshot"]
+    # get_price_snapshot's own NaN guard converts the NaN live price to None...
+    assert snapshot["NAN.L"]["last_price"] is None
+    # ...but zero and negative prices are not filtered at that layer, only
+    # at refresh_prices's write-boundary filter.
+    assert snapshot["ZERO.L"]["last_price"] == pytest.approx(0.0)
+    assert snapshot["NEG.L"]["last_price"] == pytest.approx(-5.0)
+    assert snapshot["OK.L"]["last_price"] == pytest.approx(12.0)
+
+    written = json.loads(output_path.read_text())
+    # NaN/zero/negative fetched prices must not overwrite the seed values.
+    assert written["NAN.L"]["last_price"] == pytest.approx(10.0)
+    assert written["ZERO.L"]["last_price"] == pytest.approx(20.0)
+    assert written["NEG.L"]["last_price"] == pytest.approx(30.0)
+    # A genuinely valid fresh price is persisted.
+    assert written["OK.L"]["last_price"] == pytest.approx(12.0)

--- a/tests/common/test_refresh_snapshot_in_memory.py
+++ b/tests/common/test_refresh_snapshot_in_memory.py
@@ -1,6 +1,10 @@
+import json
+import math
 from datetime import datetime, timezone
+from unittest.mock import Mock
 
 from backend.common import portfolio_utils as pu
+from backend.common import prices
 
 
 def test_refresh_snapshot_in_memory_updates_globals(monkeypatch):
@@ -32,4 +36,70 @@ def test_refresh_snapshot_in_memory_loads_when_none(monkeypatch):
 
     assert pu._PRICE_SNAPSHOT == expected
     assert pu._PRICE_SNAPSHOT_TS == ts
+
+
+def test_refresh_snapshot_in_memory_stores_exactly_what_it_is_given(monkeypatch):
+    """``refresh_snapshot_in_memory`` itself performs no NaN filtering — it is
+    a thin write-through to the module-level globals. The NaN guard lives
+    upstream (in ``refresh_prices``'s ``to_persist`` filter), so this
+    function must faithfully persist whatever dict it receives, including a
+    NaN, so that a regression in the upstream guard would be immediately
+    visible here (defense-in-depth: this test pins the "dumb writer"
+    contract that the upstream guard depends on)."""
+
+    monkeypatch.setattr(pu, "_PRICE_SNAPSHOT", {})
+    monkeypatch.setattr(pu, "_PRICE_SNAPSHOT_TS", None)
+
+    poisoned = {"NAN.L": {"last_price": float("nan")}}
+    ts = datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+    pu.refresh_snapshot_in_memory(poisoned, ts)
+
+    assert math.isnan(pu._PRICE_SNAPSHOT["NAN.L"]["last_price"])
+    assert pu._PRICE_SNAPSHOT_TS == ts
+
+
+def test_refresh_prices_write_boundary_guard_prevents_nan_reaching_in_memory_snapshot(
+    tmp_path, monkeypatch
+) -> None:
+    """Defense-in-depth: ``refresh_prices`` must never hand a NaN/zero/negative
+    price to ``refresh_snapshot_in_memory``. The ``to_persist`` filter at the
+    write boundary (backend/common/prices.py) is what protects the in-memory
+    snapshot from ever holding a non-finite or non-positive price, since
+    ``refresh_snapshot_in_memory`` itself does not filter (see the sibling
+    test above)."""
+
+    seed = {"NAN.L": {"last_price": 42.0, "price_currency": "GBP"}}
+    output_path = tmp_path / "prices.json"
+    output_path.write_text(json.dumps(seed))
+
+    snapshot = {
+        "NAN.L": {"last_price": float("nan"), "price_currency": "GBP", "is_stale": True},
+        "ZERO.L": {"last_price": 0.0, "price_currency": "GBP", "is_stale": True},
+        "NEG.L": {"last_price": -5.0, "price_currency": "GBP", "is_stale": True},
+        "OK.L": {"last_price": 12.0, "price_currency": "GBP", "is_stale": False},
+    }
+
+    monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: list(snapshot))
+    monkeypatch.setattr(prices, "get_price_snapshot", lambda _: snapshot)
+    monkeypatch.setattr(prices, "check_price_alerts", Mock())
+    monkeypatch.setattr(prices.config, "prices_json", output_path)
+    monkeypatch.setattr(prices, "_price_cache", {})
+
+    captured: list = []
+    monkeypatch.setattr(
+        prices, "refresh_snapshot_in_memory", lambda merged: captured.append(merged)
+    )
+
+    prices.refresh_prices()
+
+    assert len(captured) == 1
+    merged = captured[0]
+
+    # NaN/zero/negative prices must never reach the in-memory write boundary.
+    assert not math.isnan(merged["NAN.L"]["last_price"])
+    assert merged["NAN.L"]["last_price"] == 42.0  # preserved seed value
+    assert "ZERO.L" not in merged
+    assert "NEG.L" not in merged
+    assert merged["OK.L"]["last_price"] == 12.0
 

--- a/tests/scripts/test_deepseek_pr_review_workflow.py
+++ b/tests/scripts/test_deepseek_pr_review_workflow.py
@@ -127,3 +127,29 @@ def test_job_skips_for_dependabot() -> None:
 
 def test_job_skips_when_review_disabled_via_repo_var() -> None:
     assert _job_runs("alice", "synchronize", enable_var="false") is False
+
+
+def test_unlabeled_deep_review_required_with_other_label_present_reverts_to_defaults() -> None:
+    """Removing 'Deep Review Required' re-triggers the job even if an unrelated
+    label ('bug') is still present on the PR, and the model/token overrides
+    then resolve back to the script defaults.
+
+    The job's `if:` condition gates on `github.event.label.name` -- the single
+    label that was just added or removed by this specific event -- not on the
+    full set of labels currently on the PR (see the comment above `ai-review`'s
+    `if:` in deepseek-pr-review.yml). So an unrelated label coexisting on the
+    PR must not affect either the job's own re-run decision or the downstream
+    model selection once 'Deep Review Required' has actually been removed.
+    This exercises both the `if:` gate (_job_runs) and the `with:` ternaries
+    (_resolve_model_and_tokens) together for that combined scenario, which
+    neither test_job_re_evaluates_when_deep_review_required_label_removed nor
+    test_job_skips_when_unrelated_label_added_or_removed covers on its own.
+    """
+    assert _job_runs("alice", "unlabeled", label_name=REQUIRED_LABEL) is True
+
+    # After removal, the PR's remaining labels no longer include the required
+    # one -- only the unrelated "bug" label -- so contains(...) is false and
+    # the ternaries fall back to empty overrides (script defaults apply).
+    model, tokens = _resolve_model_and_tokens(["bug"])
+    assert model == ""
+    assert tokens == ""

--- a/tests/scripts/test_frontend_smoke_workflow.py
+++ b/tests/scripts/test_frontend_smoke_workflow.py
@@ -165,3 +165,58 @@ def test_deploy_lambda_step_order() -> None:
         "Build step must run before the first deploy step in the deploy job. "
         f"Found build at index {build_idx}, deploy at index {deploy_idx}."
     )
+
+
+def test_verify_smoke_tests_job_declared_after_its_dependency_chain() -> None:
+    """verify-smoke-tests must be declared after check-ci, deploy, and smoke-test.
+
+    PyYAML's safe_load preserves mapping key order for Python 3.7+, so the
+    `jobs` dict's iteration order mirrors the job declaration order in the
+    YAML file itself. This guards the human-readable top-to-bottom flow of
+    deploy-lambda.yml (check-ci -> deploy -> smoke-test -> verify-smoke-tests):
+    if verify-smoke-tests were accidentally moved above one of its
+    dependencies in the file, the `needs:` wiring would still be functionally
+    correct (GitHub Actions doesn't care about declaration order), but the
+    file would become confusing to read top-to-bottom and easy to
+    misunderstand during review. This is a structural/readability check
+    distinct from test_deploy_workflow_verify_smoke_tests_references_existing_job
+    above, which only checks the needs: reference is valid, not the file
+    ordering.
+    """
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    job_order = list(workflow["jobs"].keys())
+
+    expected_chain = ["check-ci", "deploy", "smoke-test", "verify-smoke-tests"]
+    for job_id in expected_chain:
+        assert job_id in job_order, f"Expected job {job_id!r} not found in deploy-lambda.yml"
+
+    actual_indices = [job_order.index(job_id) for job_id in expected_chain]
+    assert actual_indices == sorted(actual_indices), (
+        "Jobs in deploy-lambda.yml must be declared in dependency order "
+        f"(check-ci, deploy, smoke-test, verify-smoke-tests) for readability, "
+        f"but found declaration order {job_order}"
+    )
+
+
+def test_verify_smoke_tests_transitively_depends_on_deploy_and_check_ci() -> None:
+    """verify-smoke-tests's needs: chain must resolve all the way back to check-ci.
+
+    verify-smoke-tests directly needs only smoke-test (see
+    test_deploy_workflow_verify_smoke_tests_references_existing_job above),
+    but the gate is only meaningful if that chain is unbroken back to the
+    first job. If smoke-test's own needs: were ever changed to drop deploy
+    (or deploy's needs: dropped check-ci), verify-smoke-tests could pass
+    without the CI-gate or the actual deploy ever having run.
+    """
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+
+    def needs_of(job_id: str) -> list[str]:
+        needs = jobs[job_id].get("needs")
+        if needs is None:
+            return []
+        return [needs] if isinstance(needs, str) else list(needs)
+
+    assert "smoke-test" in needs_of("verify-smoke-tests")
+    assert "deploy" in needs_of("smoke-test")
+    assert "check-ci" in needs_of("deploy")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -121,6 +121,39 @@ def test_api_console_accessible_when_auth_disabled(monkeypatch):
     assert "text/html" in resp.headers["content-type"]
 
 
+def test_api_console_admin_allowlist_enforced_when_auth_disabled(monkeypatch):
+    """ADMIN_EMAILS must still be enforced when disable_auth=True and the
+    caller presents no valid token.
+
+    DISABLE_AUTH=true is set on the production Lambda (API Gateway handles
+    Cognito auth upstream), so this combination is the real production
+    configuration whenever ADMIN_EMAILS is also set. This test exercises the
+    dependency chain end-to-end (no dependency_overrides, matching
+    ``test_api_console_no_auth_local_dev``) with a missing/invalid bearer
+    token to confirm the admin allowlist gate is not silently bypassed just
+    because auth is disabled.
+    """
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+    monkeypatch.setattr(config, "disable_auth", True)
+    monkeypatch.setattr(config, "local_login_email", None)
+    monkeypatch.setenv("ADMIN_EMAILS", "admin@example.com")
+    with patch("backend.common.portfolio_utils.refresh_snapshot_async"):
+        app = create_app()
+        with TestClient(app, raise_server_exceptions=False) as client:
+            # No Authorization header at all: missing token.
+            resp_missing = client.get("/api-console")
+            # An invalid/garbage bearer token that cannot be decoded.
+            resp_invalid = client.get(
+                "/api-console",
+                headers={"Authorization": "Bearer not-a-real-token"},
+            )
+    # Neither request authenticates as an admin, so both must be rejected
+    # rather than falling through to the local-dev bypass.
+    assert resp_missing.status_code == 403
+    assert resp_invalid.status_code in (401, 403)
+
+
 @pytest.mark.parametrize("admin_emails,disable_auth,email,expected_status", [
     # allowlist configured: enforced regardless of disable_auth
     ("admin@example.com", False, "admin@example.com", 200),
@@ -326,3 +359,78 @@ def test_openapi_json_still_accessible(monkeypatch):
             resp = client.get("/openapi.json")
     assert resp.status_code == 200
     assert resp.json()["info"]["title"] == "Allotmint API"
+
+
+def test_health_returns_expected_body_without_auth_header(monkeypatch):
+    """GET /health must positively return its documented body with no
+    Authorization header at all, not merely avoid a 401.
+
+    Auth is deliberately left enabled (disable_auth=False) so this test
+    proves the route itself carries no auth dependency, rather than passing
+    only because auth checks were disabled for the whole app (#5329).
+    """
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setattr(config, "app_env", "test-env")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    with patch("backend.common.portfolio_utils.refresh_snapshot_async"):
+        app = create_app()
+        with TestClient(app) as client:
+            assert "Authorization" not in client.headers
+            resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "env": "test-env"}
+
+
+def test_config_get_returns_expected_body_without_auth_header(monkeypatch):
+    """GET /config must positively return the serialised configuration with
+    no Authorization header, since it is the frontend's pre-auth bootstrap
+    endpoint used to determine whether auth is required at all (#5329).
+    """
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+    monkeypatch.setattr(config, "disable_auth", False)
+    # google_auth_enabled/google_client_id are re-derived from the environment
+    # by load_runtime_config() on every create_app() call (they are not in
+    # backend/bootstrap/config.py's _OVERRIDE_ATTRS), so set them via env vars
+    # rather than monkeypatch.setattr(config, ...), which would be discarded.
+    monkeypatch.setenv("GOOGLE_AUTH_ENABLED", "true")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "client-123")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    with patch("backend.common.portfolio_utils.refresh_snapshot_async"):
+        app = create_app()
+        with TestClient(app) as client:
+            assert "Authorization" not in client.headers
+            resp = client.get("/config")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["disable_auth"] is False
+    assert body["google_auth_enabled"] is True
+    assert body["google_client_id"] == "client-123"
+
+
+def test_token_google_exchanges_token_without_auth_header(monkeypatch):
+    """POST /token/google must positively exchange a Google ID token for an
+    app JWT with no Authorization header present, since callers reach this
+    endpoint with no session of their own yet (#5329, see also #4240).
+
+    The Google verification itself is mocked out (as in
+    tests/test_google_auth.py::test_google_token_flow) so the test exercises
+    the route's response shape without depending on live Google network
+    calls.
+    """
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "snapshot_warm_days", 30)
+    monkeypatch.setattr(config, "disable_auth", False)
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setattr(auth, "verify_google_token", lambda token: "user@example.com")
+    with patch("backend.common.portfolio_utils.refresh_snapshot_async"):
+        app = create_app()
+        with TestClient(app) as client:
+            assert "Authorization" not in client.headers
+            resp = client.post("/token/google", json={"token": "google-id-token"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["token_type"] == "bearer"
+    assert isinstance(body["access_token"], str) and body["access_token"]

--- a/tests/test_extract_pr_comments.py
+++ b/tests/test_extract_pr_comments.py
@@ -142,6 +142,67 @@ def test_fetch_paginated_invalid_json_returns_truncated(mod):
     assert truncated is True
 
 
+# --- fetch_paginated(strict=True) tests ---
+
+
+def test_fetch_paginated_strict_first_page_failure_raises(mod):
+    """strict=True raises FetchPaginatedError when the very first page fails."""
+    with patch.object(mod, "run_gh_command", return_value=("", 1)):
+        with pytest.raises(mod.FetchPaginatedError, match="failed"):
+            mod.fetch_paginated("owner", "repo", "/some/endpoint", strict=True)
+
+
+def test_fetch_paginated_strict_partial_failure_raises_after_collecting_items(mod):
+    """strict=True raises even after some items were already collected."""
+    responses = [
+        (json.dumps([{"id": 1}]), 0),
+        ("", 1),
+    ]
+    with patch.object(mod, "run_gh_command", side_effect=responses):
+        with pytest.raises(mod.FetchPaginatedError, match="collecting 1 items"):
+            mod.fetch_paginated("owner", "repo", "/some/endpoint", strict=True)
+
+
+def test_fetch_paginated_strict_invalid_json_raises(mod):
+    """strict=True raises FetchPaginatedError on a JSON parse failure."""
+    responses = [
+        (json.dumps([{"id": 1}]), 0),
+        ("not json", 0),
+    ]
+    with patch.object(mod, "run_gh_command", side_effect=responses):
+        with pytest.raises(mod.FetchPaginatedError, match="Failed to parse JSON"):
+            mod.fetch_paginated("owner", "repo", "/some/endpoint", strict=True)
+
+
+def test_fetch_paginated_strict_exhausts_multiple_pages_before_failing(mod):
+    """strict=True still raises after several successful pages precede the failure,
+    i.e. the retry/page cap does not swallow an eventual failure."""
+    responses = [
+        (json.dumps([{"id": 1}]), 0),
+        (json.dumps([{"id": 2}]), 0),
+        (json.dumps([{"id": 3}]), 0),
+        ("", 1),
+    ]
+    with patch.object(mod, "run_gh_command", side_effect=responses):
+        with pytest.raises(mod.FetchPaginatedError, match="collecting 3 items"):
+            mod.fetch_paginated("owner", "repo", "/some/endpoint", strict=True)
+
+
+def test_fetch_paginated_strict_success_returns_items_untruncated(mod):
+    """strict=True does not affect the success path: items are returned normally."""
+    pages = [
+        json.dumps([{"id": 1}, {"id": 2}]),
+        json.dumps([]),
+    ]
+    with patch.object(mod, "run_gh_command", side_effect=[(p, 0) for p in pages]):
+        items, truncated = mod.fetch_paginated(
+            "owner", "repo", "/some/endpoint", strict=True
+        )
+
+    assert items == [{"id": 1}, {"id": 2}]
+    assert truncated is False
+
+
 # --- write_output() truncated-flag placement tests ---
 
 

--- a/tests/test_review_common.py
+++ b/tests/test_review_common.py
@@ -58,3 +58,43 @@ def test_emit_empty_diff_notice_parses_as_skip(
     notice = capsys.readouterr().out
 
     assert extract_verdict_mod.extract_verdict(notice) == "SKIP"
+
+
+@pytest.mark.parametrize("provider", ["Claude", "GPT", "DeepSeek"])
+def test_genuine_request_changes_verdict_fails_workflow(
+    review_common, extract_verdict_mod, capsys, tmp_path, provider
+) -> None:
+    """A real, non-empty REQUEST CHANGES review must still fail the workflow via extract_verdict.py.
+
+    Mirrors the actual `_ai-pr-review.yml` pipeline: `finalize_review` prints the model's review
+    text to stdout (which the workflow redirects into a file), and a *separate* step later runs
+    `extract_verdict.py` against that file to decide the job's exit code. This is distinct from
+    the empty-review path (`finalize_review` failing because the model returned nothing, or
+    extract_verdict.py's own "review output was empty" branch) covered by
+    `test_main_empty_file` in `tests/test_extract_verdict.py` and by
+    `test_emit_empty_diff_notice_parses_as_skip` above — here the review body is genuine and
+    non-empty, so `finalize_review` succeeds (exit 0) and the *verdict itself* is what must fail
+    the job.
+    """
+    review_text = (
+        "### 1. Acceptance criteria\n"
+        "Not fully met — see bug below.\n\n"
+        "### 2. Bugs and logic errors\n"
+        "Unhandled exception when the input list is empty (line 42).\n\n"
+        "**REQUEST CHANGES** — fix the empty-list edge case before merging"
+    )
+
+    # finalize_review succeeds and prints the review verbatim, exactly like the workflow step
+    # that writes the model's response to the review file the extractor later reads.
+    assert review_common.finalize_review(review_text, "ERROR: empty review") == 0
+    printed_review = capsys.readouterr().out
+
+    review_file = tmp_path / "review.md"
+    review_file.write_text(printed_review, encoding="utf-8")
+
+    result = extract_verdict_mod.main(str(review_file), provider)
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert f"[-] {provider} review: CHANGES REQUESTED" in captured.out
+    assert "review output was empty" not in captured.err

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -280,6 +280,91 @@ def test_s3_meta_cache_invalidates_when_last_modified_changes(monkeypatch):
     assert len(loads) == 2
 
 
+def test_load_meta_timeseries_rechecks_after_negative_cache_ttl_expires(monkeypatch):
+    """The negative cache consulted by ``_invalidate_meta_caches_if_stale``
+    (via ``_s3_object_mtime``) must expire after ``_S3_HEAD_MISS_TTL_SECONDS``
+    so a ticker whose data later appears in S3 is re-checked by
+    ``load_meta_timeseries`` instead of being treated as permanently missing.
+
+    This exercises the same negative-cache TTL as
+    ``test_has_cached_meta_timeseries_rechecks_after_negative_cache_ttl_expires``
+    but through the ``load_meta_timeseries`` / ``_invalidate_meta_caches_if_stale``
+    path rather than ``has_cached_meta_timeseries``.
+    """
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+    assert cache._S3_HEAD_MISS_TTL_SECONDS == 60.0
+
+    calls = []
+    missing = True
+    last_modified = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)
+
+    class FakeS3:
+        def head_object(self, *, Bucket, Key):
+            calls.append((Bucket, Key))
+            if missing:
+                raise cache.ClientError(
+                    {"Error": {"Code": "404", "Message": "Not Found"}},
+                    "HeadObject",
+                )
+            return {"LastModified": last_modified}
+
+    patch_s3_client(monkeypatch, cache, FakeS3())
+
+    loads = []
+
+    def fake_rolling_cache(*_args, **_kwargs):
+        loads.append(1)
+        return _frame(float(len(loads)))
+
+    monkeypatch.setattr(cache, "_rolling_cache", fake_rolling_cache)
+
+    current_time = [1000.0]
+    monkeypatch.setattr(cache.time, "monotonic", lambda: current_time[0])
+
+    # First call: confirmed missing, one live HeadObject call.
+    cache.load_meta_timeseries("MISSING", "L", 5)
+    assert len(calls) == 1
+
+    # Still within the negative-cache TTL: no new HeadObject call.
+    current_time[0] += 59
+    cache.load_meta_timeseries("MISSING", "L", 5)
+    assert len(calls) == 1
+
+    # TTL has elapsed and the object now exists: the stale "missing" verdict
+    # must not be trusted forever -- the next call must re-check S3.
+    current_time[0] += 2
+    missing = False
+    cache.load_meta_timeseries("MISSING", "L", 5)
+    assert len(calls) == 2
+
+
+def test_s3_client_is_singleton_across_calls(monkeypatch):
+    """``_s3_client`` is ``lru_cache``-wrapped so every caller shares one
+    boto3 S3 client instance instead of constructing a new one per call.
+    """
+    monkeypatch.setenv("TIMESERIES_CACHE_BASE", "s3://bucket/timeseries")
+    cache = import_cache()
+    cache._s3_client.cache_clear()
+
+    created = []
+
+    def fake_client(service):
+        assert service == "s3"
+        client = object()
+        created.append(client)
+        return client
+
+    monkeypatch.setattr(cache.boto3, "client", fake_client)
+
+    first = cache._s3_client()
+    second = cache._s3_client()
+    third = cache._s3_client()
+
+    assert first is second is third
+    assert len(created) == 1
+
+
 def test_local_meta_cache_still_invalidates_when_file_mtime_changes(monkeypatch, tmp_path):
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
     cache = import_cache()

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -455,6 +455,14 @@ def test_calculate_portfolio_impact_tolerates_bank_transaction_fields():
     assert transactions._calculate_portfolio_impact({"price_gbp": None, "units": None}) == 0.0
 
 
+def test_calculate_portfolio_impact_tolerates_price_only_none():
+    assert transactions._calculate_portfolio_impact({"price_gbp": None, "units": 10}) == 0.0
+
+
+def test_calculate_portfolio_impact_tolerates_units_only_none():
+    assert transactions._calculate_portfolio_impact({"price_gbp": 1.5, "units": None}) == 0.0
+
+
 def test_import_transactions_rolls_back_when_later_write_fails(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch)
     posted_before = list(transactions._POSTED_TRANSACTIONS)


### PR DESCRIPTION
## Summary

Consolidated, test-only PR implementing the 13 "suggest new tests" issues merged into #5974:

- **#5720** — test that a genuine REQUEST CHANGES verdict still fails the `_ai-pr-review.yml` path (`tests/test_review_common.py`)
- **#5625** — test for rapid successive owner switches with concurrent failures (`frontend/tests/unit/pages/Portfolio.test.tsx`)
- **#5446** — test for `require_admin` with `ADMIN_EMAILS` + `disable_auth=true` + invalid token (`tests/test_app.py`)
- **#5430** — 403/401 test coverage for `addApproval`/`removeApproval` (`frontend/tests/unit/pages/UserConfig.test.tsx`)
- **#5375** — SES email-failure integration tests for signup request/approval + frontend status-code logging (`tests/backend/test_signup_request_email.py`, new `tests/backend/test_signup_approved_email.py`, `tests/backend/routes/test_signup.py`, `frontend/tests/unit/pages/CreateAccountPage.test.tsx`)
- **#5343** — `_timed_phase` exception-path + structured-logging JSON tests, `reset_warning_flag` fixture (new `tests/backend/test_startup_timed_phase.py`, new `tests/backend/routes/conftest.py`, `tests/backend/routes/test_transactions_writable_store.py`)
- **#5329** — positive-assertion tests for `GET /config`, `GET /health`, `POST /token/google`, plus a CDK OPTIONS/200 regression test (`tests/test_app.py`, `cdk/tests/test_backend_lambda_stack.py`)
- **#5328** — NaN-guard regression tests for `_derived_cost_basis_close_px`, `refresh_snapshot_in_memory`, `refresh_prices` (`tests/common/test_holding_utils.py`, `tests/common/test_refresh_snapshot_in_memory.py`, `tests/common/test_prices.py`)
- **#5327** — `get_units_as_of` TRANSFER_IN/TRANSFER_OUT/REMOVAL coverage (`tests/common/test_portfolio_loader.py`)
- **#5325** — `fetch_paginated` `strict=True` retry-cap tests (`tests/test_extract_pr_comments.py`)
- **#5324** — `deploy-lambda.yml` step-order/job-dependency tests, `_job_runs` unlabeled-interaction test, Bats tests for `reconcile_changes_requested_label.sh` (`tests/scripts/test_frontend_smoke_workflow.py`, `tests/scripts/test_deepseek_pr_review_workflow.py`, `tests/bash/reconcile_changes_requested_label.bats`)
- **#5321** — S3 negative-cache TTL expiry + `_s3_client()` singleton tests (`tests/test_timeseries_cache_base.py`)
- **#5464** — `_calculate_portfolio_impact` None-tolerance tests (`tests/test_transactions_route.py`)

**Explicitly out of scope** (production-code hardening/refactor items bundled into some of the source tracking issues, left for separate follow-up PRs): `import_transactions` atomicity/rollback (#5464), NaN-helper unification (#5327), shared-helper extraction (#5321/#5329/#5324), `fetch_paginated` return-value alignment/dead-code removal (#5325).

## Test plan

- [x] `pytest tests --ignore=tests/live --cov=backend --cov-report=term --cov-fail-under=80 -q` → 3700 passed, 92.4% coverage
- [x] `pytest cdk/tests/ --no-cov -q` → 144 passed
- [x] `npx bats tests/bash/*.bats` → 18 passed
- [x] `npm --prefix frontend run test -- --run` → 663 passed (96 files) on rerun; one unrelated timing flake in `rootBootstrap.test.tsx` (a file untouched by this PR) self-resolved on retry
- [x] `npm --prefix frontend run lint` → clean
- [x] No production code changed (verified via diff — test files only)
- Note: `ruff`/`black --check` show pre-existing formatting drift across ~250 files unrelated to this PR (confirmed present on `main` before these changes); not addressed here as out of scope

Closes #5974
Closes #5720, #5625, #5446, #5430, #5375, #5343, #5329, #5328, #5327, #5325, #5324, #5321, #5464

🤖 Generated with [Claude Code](https://claude.com/claude-code)
