### PR TITLE
Consolidate 9 documentation follow-up issues

### DIFF
--- a/backend/emails/signup_approved.py
+++ b/backend/emails/signup_approved.py
@@ -4,6 +4,9 @@ Reuses the SES pattern established in :mod:`backend.emails.weekly_report`
 (``boto3.client("ses")`` and the ``WEEKLY_REPORT_FROM`` sender). Sent to the
 requesting visitor after an admin approves their access request (#4352).
 
+New AWS accounts start with SES in sandbox mode, which only delivers to
+verified addresses -- see docs/ses-sandbox-setup.md before deploying this.
+
 The visitor-supplied name is HTML-escaped before being placed in the body so a
 hostile name cannot inject markup into the recipient's inbox.
 """

--- a/backend/emails/signup_request.py
+++ b/backend/emails/signup_request.py
@@ -4,6 +4,9 @@ Reuses the SES pattern established in :mod:`backend.emails.weekly_report`
 (``boto3.client("ses")`` and the ``WEEKLY_REPORT_FROM`` sender). The recipient
 is the admin address configured by the caller (``SIGNUP_ADMIN_EMAIL``).
 
+New AWS accounts start with SES in sandbox mode, which only delivers to
+verified addresses -- see docs/ses-sandbox-setup.md before deploying this.
+
 All visitor-supplied fields are HTML-escaped before being placed in the email
 body so a hostile name/note cannot inject markup into the admin's inbox.
 """

--- a/backend/routes/market.py
+++ b/backend/routes/market.py
@@ -86,6 +86,9 @@ def _get_headline_max_age() -> timedelta:
     return timedelta(hours=hours)
 
 
+# Read once at module import time: HEADLINE_MAX_AGE_HOURS is not re-read on
+# each request, so changing the env var requires restarting the process for
+# the new value to take effect.
 HEADLINE_MAX_AGE = _get_headline_max_age()
 
 

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -114,7 +114,7 @@ Copy `.env.example` to `.env` if you want a local file-backed setup, or export t
 | `APP_ENV` | Optional override | `APP_ENV=local` | Selects `local`, `production`, or `aws` runtime behavior. |
 | `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` | Optional | `123456:token` / `123456789` | Enables Telegram alert forwarding. |
 | `ALPHA_VANTAGE_KEY` | Optional unless using Alpha Vantage-backed features | `demo` | Enables Alpha Vantage integrations without storing the secret in git. |
-| `HEADLINE_MAX_AGE_HOURS` | Optional | `72` | Sets the maximum age of headlines shown in Market Overview. |
+| `HEADLINE_MAX_AGE_HOURS` | Optional | `72` | Sets the maximum age of headlines shown in Market Overview. Read once at startup; a running process must be restarted for a change to take effect. |
 | `TIMESERIES_CACHE_BASE` | Optional | `TIMESERIES_CACHE_BASE=./data/timeseries` | Overrides the configured timeseries cache directory. |
 
 ### Local auth-enabled mode

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -7,7 +7,7 @@ Copy `.env.example` to `.env` and supply the following values:
 | Variable | Purpose |
 | --- | --- |
 | `ALPHA_VANTAGE_KEY` | API key for market data |
-| `HEADLINE_MAX_AGE_HOURS` | Optional maximum age of Market Overview headlines; defaults to 72 hours |
+| `HEADLINE_MAX_AGE_HOURS` | Optional maximum age of Market Overview headlines; defaults to 72 hours. Read once at process/module startup -- changing it requires a restart to take effect |
 | `SNS_TOPIC_ARN` | Optional SNS topic for alerts |
 | `TELEGRAM_BOT_TOKEN` | Optional Telegram bot token for alerts |
 | `TELEGRAM_CHAT_ID` | Telegram chat for alerts |
@@ -22,6 +22,20 @@ Copy `.env.example` to `.env` and supply the following values:
 | `GOOGLE_CLIENT_ID` | OAuth client ID when Google sign-in is enabled |
 | `JWT_SECRET` | Secret used to sign and verify JWT tokens |
 | `BUDGET_ALERT_EMAIL` | Optional email recipient for the monthly AWS budget alert |
+| `SNAPSHOT_LOAD_TIMEOUT_SECONDS` | Optional per-call timeout (seconds) for the two cold-start snapshot warmup calls (S3 read + metadata scan) in `backend/bootstrap/startup.py`; defaults to `10` |
+
+## Feature flags
+
+The `ui:` block in `config.yaml` (and `config.lambda.yaml` for the deployed
+backend) controls opt-in UI features. All of the following default to
+`false` and must be explicitly set to `true` to enable:
+
+| Flag | Purpose |
+| --- | --- |
+| `enable_family_mvp` | Enables the family MVP feature. Defaults to `false` as of PR #5872 (previously defaulted to `true`) -- operators relying on the old default must now set this explicitly. |
+| `enable_compliance_workflows` | Enables compliance workflow features. |
+| `enable_advanced_analytics` | Enables advanced analytics features. |
+| `enable_reporting_extended` | Enables extended reporting features. |
 
 ## GitHub Actions secrets required for AWS deployment
 

--- a/docs/ses-sandbox-setup.md
+++ b/docs/ses-sandbox-setup.md
@@ -1,0 +1,37 @@
+# AWS SES Sandbox Setup for Signup Emails
+
+The signup flow (`backend/routes/signup.py`, `backend/emails/signup_request.py`,
+`backend/emails/signup_approved.py`) sends email via AWS SES. A new AWS
+account's SES access starts in **sandbox mode**, which only allows sending to
+verified identities. Deploying the signup flow without verifying the relevant
+addresses first causes SES to reject every email with a `MessageRejected`
+error, and the affected requests will silently never notify anyone.
+
+## Addresses that must be verified
+
+While the SES account is in sandbox mode, verify:
+
+- `SIGNUP_ADMIN_EMAIL` — receives the admin notification email for every new
+  signup request (sent by `send_signup_admin_email` in
+  `backend/emails/signup_request.py`).
+- Each visitor email address that will receive the "your login is ready"
+  email after approval (sent by `send_signup_approved_email` in
+  `backend/emails/signup_approved.py`). In sandbox mode this means every
+  visitor who signs up must also be a verified SES identity — acceptable for
+  testing with a handful of known addresses, but not for public production
+  traffic.
+
+## How to verify an address
+
+1. AWS Console → **SES** → **Verified identities** → **Create identity**.
+2. Choose **Email address**, enter the address, and confirm the verification
+   link sent to that inbox.
+3. Repeat for `SIGNUP_ADMIN_EMAIL` and any other addresses you need to test
+   with while still in sandbox mode.
+
+## Moving out of sandbox mode
+
+To send to arbitrary visitor addresses without verifying each one first,
+request SES production access (AWS Console → SES → Account dashboard →
+**Request production access**). This is out of scope for the signup flow's
+own code and is a one-time AWS account setup step.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -209,6 +209,14 @@ prepares aider's inputs and hands off control.
 **Requirements:** a running local Ollama server (the script fails fast with
 "Ollama serve must be running" if it isn't); `aider` on PATH.
 
+**Minimum model size:** `.aider.conf.yml` sets `timeout: 1800` (30 minutes)
+for aider's own completion calls, raised from litellm's 600s default because
+a 14B local model can exceed it once the repo-map and prompt fill the large
+context window in `.aider.model.settings.yml`. Models smaller than ~14B
+parameters (e.g. 7B models on CPU-only hardware) are more likely to still hit
+this timeout on larger issues; if you're consistently timing out, either pick
+a larger/faster model or raise `timeout` in `.aider.conf.yml`.
+
 ## h_run_ci_checks.py
 
 Run the credential-free integration and validation steps from the most relevant
@@ -486,6 +494,10 @@ refuses to propose the change rather than risk silently dropping details.
 
 **Requirements:** `gh` CLI authenticated against the target repo; either a
 running local Ollama server or a `DEEPSEEK_API_KEY`, depending on `--model`.
+`DEEPSEEK_API_KEY` is loaded from a `.env` file in the repo root (not the
+current working directory) -- running the script from
+`scripts/developer_tools/` picks this up automatically, or set the variable
+directly in your shell environment.
 
 ## p_add_issue_to_pr.py
 

--- a/scripts/build_tools/_scan_log_sanitisation.py
+++ b/scripts/build_tools/_scan_log_sanitisation.py
@@ -13,6 +13,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BACKEND_ROOT = REPO_ROOT / "backend"
 EXCLUDED_FILES = {BACKEND_ROOT / "logging_setup.py"}
+# Logging methods checked for unsanitised user-controlled values.
+# `debug` and `exception` were added to cover bare logger.* calls with
+# user-controlled values (see PR #5835), alongside the originally-checked
+# `info`/`warning`/`error`. To extend the lint to another logging method,
+# add it here and update tests/data/log_sanitization_baseline.txt accordingly.
 LOG_METHODS = {"warning", "error", "info", "debug", "exception"}
 
 

--- a/scripts/developer_tools/o_review_issue.py
+++ b/scripts/developer_tools/o_review_issue.py
@@ -35,6 +35,7 @@ from llm_common import (  # noqa: E402
 
 REPO_ROOT_ENV_FILE = Path(__file__).resolve().parent.parent.parent / ".env"
 
+
 def load_env_file(env_path: Path = REPO_ROOT_ENV_FILE) -> None:
     """Load local dev secrets (e.g. DEEPSEEK_API_KEY) from a repo-root .env file.
 
@@ -549,7 +550,14 @@ def prompt_for_disposition() -> tuple[str, str | None]:
 def main() -> int:
     """Run the interactive issue-review flow."""
     parser = argparse.ArgumentParser(
-        description="Review and refresh a GitHub issue using a local or cloud LLM"
+        description="Review and refresh a GitHub issue using a local or cloud LLM",
+        epilog=(
+            "For --model cloud, DEEPSEEK_API_KEY is loaded from a .env file in the "
+            "repo root (see load_env_file() above) -- running this script from "
+            "scripts/developer_tools/ picks it up automatically. A .env file in the "
+            "current working directory is not used. Set DEEPSEEK_API_KEY directly in "
+            "your shell environment instead if you don't want a repo-root .env file."
+        ),
     )
     parser.add_argument("issue_id", type=int, nargs="?", help="GitHub issue number to review")
     parser.add_argument("--model", choices=[LOCAL, CLOUD], help="Model source (skips the prompt)")

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -134,10 +134,10 @@ backend/reports.py:1630
 # each of these two calls is already wrapped in sanitise_log_value.
 backend/routes/market.py:72
 backend/routes/market.py:80
-backend/routes/market.py:163
-backend/routes/market.py:171
-backend/routes/market.py:180
-backend/routes/market.py:187
+backend/routes/market.py:166
+backend/routes/market.py:174
+backend/routes/market.py:183
+backend/routes/market.py:190
 backend/routes/signup.py:139
 backend/routes/signup.py:252
 backend/routes/support.py:69


### PR DESCRIPTION
## Summary

Bundles nine small, AI-review-flagged documentation follow-ups (tracked together in #5980) into a single PR instead of nine near-identical trivial ones.

- **#5373** — Add `docs/ses-sandbox-setup.md` explaining AWS SES sandbox verification requirements for `SIGNUP_ADMIN_EMAIL` and signup approval emails; referenced from `signup_request.py`/`signup_approved.py` via a docstring note.
- **#5433** — Document `SNAPSHOT_LOAD_TIMEOUT_SECONDS` in `docs/DEPLOY.md`'s env var table (actual current default is `10`, not `5` — raised by an earlier PR after the issue was filed).
- **#5535** — Add a "Minimum model size" note to `scripts/README.md` under `f_implement_issue_with_aider.py`, referencing the actual `.aider.conf.yml` `timeout: 1800` setting (the PowerShell script named in the original issue no longer exists — the tool was rewritten in Python).
- **#5593** — Verified `_SNAPSHOT_LOAD_TIMEOUT_SECONDS` does not exist in `backend/common/data_providers.py` (only in `backend/bootstrap/startup.py`, which already has the explanatory comment). No file change needed; noted on the issue.
- **#5616** — Verified the script is already correctly named `m_dependabot_auto_merge.py` and correctly documented in `scripts/README.md`. No `l_dependabot_auto_merge.py` reference exists. No change needed; noted on the issue.
- **#5632** — Documented that `HEADLINE_MAX_AGE_HOURS` is read once at module-import time in `backend/routes/market.py`, `docs/DEPLOY.md`, and `docs/CONTRIBUTOR_RUNBOOK.md`.
- **#5776** — Added a `.env`/`DEEPSEEK_API_KEY` note to `o_review_issue.py`'s `--help` epilog and to `scripts/README.md`.
- **#5837** — Added a rationale comment above `LOG_METHODS` in `scripts/build_tools/_scan_log_sanitisation.py` explaining `debug`/`exception` and how to extend it. (Required a matching line-number update in `tests/data/log_sanitization_baseline.txt` since the comment shifted later logger-call line numbers.)
- **#5875** — Added a new "Feature flags" section to `docs/DEPLOY.md` documenting all four `ui.*` flags, with `enable_family_mvp` called out as opt-in (defaults to `false` since PR #5872).

Documentation/comment changes only — no runtime logic, defaults, or test behavior changed (aside from the necessary baseline line-number shift for #5837).

## Test plan
- [x] `pytest tests/test_log_sanitization_audit.py tests/backend/routes/test_market.py -q` — 23 passed
- [x] `pytest tests/backend/routes/test_signup.py -q` — 29 passed
- [x] `pytest tests/scripts/ -k "review_issue or o_review" -q` — 66 passed
- [x] `black --check` / `ruff check` on all touched Python files — clean

Closes #5373, #5433, #5535, #5593, #5616, #5632, #5776, #5837, #5875, #5980
