### PR TITLE
Fix run-backend.ps1 crash: add missing jinja2 to root requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ frozendict~=2.4.7
 h11~=0.16.0
 httpx~=0.28.1
 idna~=3.16
+jinja2~=3.1.6
 jmespath~=1.1.0
 lxml~=6.1.1
 mangum~=0.21.0

--- a/tests/test_requirements_consistency.py
+++ b/tests/test_requirements_consistency.py
@@ -1,0 +1,57 @@
+"""Regression tests keeping root and backend requirements files in sync (issue #6016).
+
+`scripts/run-backend.ps1` and `scripts/bash/run-local-api.sh` install dependencies
+from the root `requirements.txt`, not `backend/requirements.txt`. If a package that
+`backend/` actually imports is only pinned in `backend/requirements.txt`, a fresh
+local venv built from the root file will be missing it and the backend will crash
+at import time (e.g. `ModuleNotFoundError: No module named 'jinja2'`).
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT_REQUIREMENTS = Path(__file__).resolve().parents[1] / "requirements.txt"
+BACKEND_REQUIREMENTS = Path(__file__).resolve().parents[1] / "backend" / "requirements.txt"
+
+# Packages that are legitimately backend-only build/deploy tooling and are not
+# imported by backend/**/*.py at runtime, so they don't need to be mirrored
+# into the root requirements.txt used by the local dev server.
+BACKEND_ONLY_ALLOWLIST = {"setuptools"}
+
+_PACKAGE_NAME_RE = re.compile(r"^([A-Za-z0-9_.\-]+)")
+
+
+def _parse_package_names(path: Path) -> set[str]:
+    names = set()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        match = _PACKAGE_NAME_RE.match(line)
+        if match:
+            names.add(match.group(1).lower())
+    return names
+
+
+class RequirementsConsistencyTests(unittest.TestCase):
+    def test_backend_requirements_are_mirrored_in_root_requirements(self) -> None:
+        root_packages = _parse_package_names(ROOT_REQUIREMENTS)
+        backend_packages = _parse_package_names(BACKEND_REQUIREMENTS)
+
+        missing = backend_packages - root_packages - BACKEND_ONLY_ALLOWLIST
+
+        self.assertFalse(
+            missing,
+            f"Package(s) {sorted(missing)} are pinned in backend/requirements.txt "
+            "but missing from the root requirements.txt. scripts/run-backend.ps1 "
+            "installs only from the root file, so a fresh local venv would be "
+            "missing these and the backend would crash at import time "
+            "(see issue #6016). Add them to requirements.txt, or add them to "
+            "BACKEND_ONLY_ALLOWLIST in this test if they are genuinely "
+            "backend-deploy-only tooling that backend/**/*.py never imports.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `scripts/run-backend.ps1` installs dependencies from the root `requirements.txt`, but `jinja2` (imported directly by `backend/routes/instrument.py`, `backend/timeseries/timeseries_api.py`, and the email report modules) was only pinned in `backend/requirements.txt`. A fresh `.venv` therefore crashed at startup with `ModuleNotFoundError: No module named 'jinja2'`.
- Adds `jinja2~=3.1.6` to the root `requirements.txt`, matching the version already pinned in `backend/requirements.txt`.
- Adds a regression test (`tests/test_requirements_consistency.py`) that fails the suite if `backend/requirements.txt` and the root `requirements.txt` drift apart again on packages `backend/` actually imports.

Closes #6016

## Test plan
- [x] `python -m pytest tests/test_requirements_consistency.py --no-cov -q` passes on this branch and fails on `main` (reproduced by stashing the fix).
- [x] `python -c "from backend.app import create_app; create_app()"` succeeds (previously raised `ModuleNotFoundError: No module named 'jinja2'` in a venv built solely from the root requirements file).
- [x] `black --check` / `isort --check-only` / `ruff check` pass on the new test file.