### PR TITLE
Fix: redact secret fields from GET/PUT /config response

### DIFF
--- a/backend/contracts_spa.py
+++ b/backend/contracts_spa.py
@@ -54,11 +54,19 @@ class ConfigTabsContract(SpaContractBase):
 class ConfigContract(SpaContractBase):
     """Describes the subset of the real ``GET /config`` response the SPA relies on.
 
-    ``serialise_config()`` also exposes internal/backend-only settings (API
-    keys, rate limits, file paths, etc.) that the SPA never reads, so extra
-    top-level fields are ignored here. ``tabs`` is still validated strictly
-    via ``ConfigTabsContract`` since tab-name drift is what previously broke
-    the SPA (see #5871).
+    ``serialise_config()`` also exposes internal/backend-only settings (rate
+    limits, file paths, etc.) that the SPA never reads, so extra top-level
+    fields are ignored here. ``tabs`` is still validated strictly via
+    ``ConfigTabsContract`` since tab-name drift is what previously broke the
+    SPA (see #5871).
+
+    NOTE: ``extra="ignore"`` here is a validation convenience, not a security
+    boundary — it only relaxes what this *test-time* contract checks, it does
+    not redact anything from the real HTTP response. Secrets (API keys,
+    tokens, SNS ARNs) must never reach ``serialise_config()``'s return value
+    in the first place; they are stripped explicitly in
+    ``backend.routes.config._SECRET_CONFIG_FIELDS`` before this contract is
+    ever applied (see #5953).
     """
 
     model_config = ConfigDict(extra="ignore")

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -22,6 +22,17 @@ from backend.logging_setup import sanitise_log_value
 _TRUE_STRINGS = {"1", "true", "yes"}
 _FALSE_STRINGS = {"0", "false", "no"}
 
+# Secret/credential fields on backend.config.Config that must never leave the
+# process in an HTTP response body. GET /config returns the full serialised
+# Config to the SPA, so these are redacted before serialise_config() returns.
+_SECRET_CONFIG_FIELDS = (
+    "telegram_bot_token",
+    "alpha_vantage_key",
+    "yahoo_news_key",
+    "google_news_key",
+    "sns_topic_arn",
+)
+
 
 def _normalise_google_auth_flag(value: Any) -> bool | None | Any:
     if isinstance(value, bool) or value is None:
@@ -60,6 +71,8 @@ def serialise_config(cfg: config_module.Config) -> ConfigContract:
     Save config to pydantic ConfigContract
     """
     data = asdict(cfg)
+    for secret_field in _SECRET_CONFIG_FIELDS:
+        data.pop(secret_field, None)
     tabs = data.get("tabs")
     if isinstance(tabs, dict):
         serialised_tabs = {

--- a/tests/backend/routes/test_config.py
+++ b/tests/backend/routes/test_config.py
@@ -75,6 +75,22 @@ async def test_read_config_exposes_auth_enabled_bootstrap_fields(monkeypatch: py
     assert result["local_login_email"] is None
 
 
+async def test_read_config_redacts_secret_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_config = routes_config.config_module.Config(
+        sns_topic_arn="arn:aws:sns:eu-west-1:123456789012:alerts",
+        telegram_bot_token="123456:ABC-DEF-super-secret-token",
+        alpha_vantage_key="alpha-vantage-secret-key",
+        yahoo_news_key="yahoo-news-secret-key",
+        google_news_key="google-news-secret-key",
+    )
+    monkeypatch.setattr(routes_config.config_module, "config", dummy_config)
+
+    result = await routes_config.read_config()
+
+    for secret_field in routes_config._SECRET_CONFIG_FIELDS:
+        assert secret_field not in result
+
+
 async def test_read_config_exposes_auth_disabled_local_login_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy_config = routes_config.config_module.Config(
         google_auth_enabled=False,

--- a/tests/backend/test_spa_response_contracts.py
+++ b/tests/backend/test_spa_response_contracts.py
@@ -149,6 +149,8 @@ def test_target_spa_endpoints_match_contracts(monkeypatch, tmp_path):
     )
 
     config_payload = client.get("/config").json()
+    for secret_field in config_routes._SECRET_CONFIG_FIELDS:
+        assert secret_field not in config_payload
     owners_payload = client.get("/owners").json()
     groups_payload = client.get("/groups").json()
     portfolio_payload = client.get("/portfolio/alice").json()


### PR DESCRIPTION
## Summary
- `serialise_config()` in [backend/routes/config.py](backend/routes/config.py) ran `asdict()` on the full `Config` dataclass and returned it directly as the `GET /config` (and `PUT /config`) response body — leaking `telegram_bot_token`, `alpha_vantage_key`, `yahoo_news_key`, `google_news_key`, and `sns_topic_arn` in plaintext to any client able to call the endpoint.
- `ConfigContract`'s `extra="ignore"` in [backend/contracts_spa.py](backend/contracts_spa.py) is a test-time validation relaxation only — it is not wired in as the route's `response_model` and does nothing to filter the real response, so it never actually redacted these fields. Updated its docstring to make that explicit and point at the real fix.
- Fix: `serialise_config()` now explicitly pops the known secret fields (`backend.routes.config._SECRET_CONFIG_FIELDS`) before returning, covering both `GET /config` and `PUT /config` (both call `serialise_config()`).
- Confirmed via `frontend/src` grep that none of these fields are consumed by the SPA.

## Test plan
- [x] `tests/backend/routes/test_config.py::test_read_config_redacts_secret_fields` — new test asserting the secret keys are absent from `read_config()`'s output
- [x] `tests/backend/test_spa_response_contracts.py::test_target_spa_endpoints_match_contracts` — extended to assert the secret keys are absent from the real `/config` HTTP response
- [x] `python -m pytest tests/ -k config` — 109 passed
- [x] `ruff check` / `black --check` on touched files — no new violations introduced

Closes #5953