### PR TITLE
Add test coverage for log_owner_not_found across its call sites

### DIFF
--- a/tests/backend/routes/test_nudges.py
+++ b/tests/backend/routes/test_nudges.py
@@ -1,0 +1,41 @@
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from backend.routes import nudges
+
+
+def _fake_request(accounts_root: Path) -> SimpleNamespace:
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(accounts_root=accounts_root)))
+
+
+def test_validate_owner_logs_and_raises_404_when_unknown_and_disallowed(monkeypatch, caplog, tmp_path):
+    """``_validate_owner(allow_unknown=False)`` must call ``log_owner_not_found``
+    and raise a 404 when the owner isn't among the discovered plots (#5717).
+    Every route in this module currently calls ``_validate_owner`` with
+    ``allow_unknown=True``, so this branch is otherwise dead from the router's
+    perspective and needs direct coverage."""
+    monkeypatch.setattr(nudges.data_loader, "list_plots", lambda root: [])
+
+    with caplog.at_level(logging.WARNING, logger="backend.common.errors"):
+        with pytest.raises(HTTPException) as excinfo:
+            nudges._validate_owner("ghost", _fake_request(tmp_path), allow_unknown=False)
+
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.detail == nudges.OWNER_NOT_FOUND
+    assert "owner lookup: no owner found for owner=ghost" in caplog.text
+    assert "total_plots_discovered=0" in caplog.text
+
+
+def test_validate_owner_does_not_raise_when_unknown_and_allowed(monkeypatch, caplog, tmp_path):
+    """The live routes pass ``allow_unknown=True``, so an unknown owner must
+    pass through silently -- no log, no exception."""
+    monkeypatch.setattr(nudges.data_loader, "list_plots", lambda root: [])
+
+    with caplog.at_level(logging.WARNING, logger="backend.common.errors"):
+        nudges._validate_owner("ghost", _fake_request(tmp_path), allow_unknown=True)
+
+    assert caplog.text == ""

--- a/tests/common/test_errors.py
+++ b/tests/common/test_errors.py
@@ -3,6 +3,7 @@ import logging
 
 import pytest
 
+from backend.common import errors as errors_module
 from backend.common.errors import (
     OWNER_NOT_FOUND,
     OwnerNotFoundError,
@@ -10,9 +11,44 @@ from backend.common.errors import (
     ValidationFailure,
     handle_app_error,
     handle_owner_not_found,
+    log_owner_not_found,
     raise_owner_not_found,
     to_http_exception,
 )
+
+
+def test_log_owner_not_found_strips_newlines_but_keeps_quotes_in_diagnostics(caplog):
+    """Special characters (quotes, newlines) in a diagnostic value must not
+    break or truncate the log line: newlines are stripped by
+    ``sanitise_log_value`` (CWE-117 log injection defence), but quotes are
+    left untouched -- they aren't part of what that helper sanitises (#5884)."""
+    with caplog.at_level(logging.WARNING, logger="backend.common.errors"):
+        log_owner_not_found("ghost", note='has "quotes" and\nnewlines\r\nhere')
+
+    assert 'owner lookup: no owner found for owner=ghost (note=has "quotes" andnewlineshere)' in caplog.text
+
+
+def test_log_owner_not_found_sanitises_each_value_exactly_once(monkeypatch, caplog):
+    """Regression for #5879/#5880: the assembled ``suffix`` string must not be
+    passed through ``sanitise_log_value`` a second time on top of the
+    per-diagnostic-value sanitisation already applied when building it."""
+    call_count = 0
+    real_sanitise = errors_module.sanitise_log_value
+
+    def counting_sanitise(value):
+        nonlocal call_count
+        call_count += 1
+        return real_sanitise(value)
+
+    monkeypatch.setattr(errors_module, "sanitise_log_value", counting_sanitise)
+
+    with caplog.at_level(logging.WARNING, logger="backend.common.errors"):
+        log_owner_not_found("ghost", diag_a="x", diag_b="y")
+
+    # once for `owner`, once per diagnostic value -- never once more for the
+    # assembled suffix string as a whole.
+    assert call_count == 3
+    assert "owner lookup: no owner found for owner=ghost (diag_a=x, diag_b=y)" in caplog.text
 
 
 def test_raise_owner_not_found(caplog):

--- a/tests/test_portfolio_route_regression.py
+++ b/tests/test_portfolio_route_regression.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
@@ -14,3 +16,22 @@ def test_portfolio_unknown_owner_does_not_create_directory(tmp_path):
         assert resp.status_code == 404
 
     assert not missing_owner.exists()
+
+
+def test_portfolio_unknown_owner_logs_owner_not_found_warning(tmp_path, caplog):
+    """GET /portfolio/{owner} for an unknown owner must both 404 and emit the
+    log_owner_not_found warning from its FileNotFoundError handler (#5712,
+    #5690): a full request through the real app, not a call to the handler
+    function directly, so the actual routing/exception-handling wiring is
+    exercised end to end."""
+    app = create_app()
+    accounts_root = tmp_path / "accounts"
+    app.state.accounts_root = accounts_root
+
+    with caplog.at_level(logging.WARNING, logger="backend.common.errors"):
+        with TestClient(app) as client:
+            resp = client.get("/portfolio/ghost")
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Owner not found"
+    assert "owner lookup: no owner found for owner=ghost" in caplog.text


### PR DESCRIPTION
## Summary

Part of the #6022 consolidated backlog. Tackles the `log_owner_not_found` test cluster.

- Closes #5884, closes #5880, closes #5717, closes #5712, closes #5690

`log_owner_not_found` (`backend/common/errors.py:98`) had exactly one existing test (`test_raise_owner_not_found`, exercised indirectly through `raise_owner_not_found`, with only a plain owner string). This PR adds direct, targeted coverage:

- **`tests/common/test_errors.py`**
  - Special characters (quotes/newlines) in a diagnostic value: newlines are stripped by `sanitise_log_value` (CWE-117 defence), quotes are left as-is (#5884).
  - Regression test asserting `sanitise_log_value` is called exactly once per value (owner + each diagnostic) — never a second time on the assembled `suffix` string. This is the behaviour the `#5879 - don't double sanitize` exemption in `tests/data/log_sanitization_baseline.txt` depends on (#5880).
- **`tests/backend/routes/test_nudges.py`** (new file)
  - `_validate_owner(allow_unknown=False)` logs via `log_owner_not_found` and raises a 404 when the owner isn't among the discovered plots. Both live routes in `nudges.py` (`/subscribe`, `/snooze`) currently call `_validate_owner` with `allow_unknown=True`, so this branch was previously unreachable from the router and untested (#5717).
- **`tests/test_portfolio_route_regression.py`**
  - End-to-end `TestClient` request to `GET /portfolio/{unknown-owner}` through the real app, asserting both the 404 response and the `log_owner_not_found` warning log line — exercises the actual routing/exception-handling wiring, not just the handler function in isolation (#5712, #5690).

## Test plan

- [x] `pytest tests/common/test_errors.py tests/backend/routes/test_nudges.py tests/test_portfolio_route_regression.py` — all pass
- [x] Full `pytest tests/` run — 3737 passed, 6 skipped, 16 xfailed, 1 xpassed, no regressions
- [x] `isort`/`black`/`ruff` clean via `--config backend/pyproject.toml` (the config `make format`/`make lint` use for `tests/` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
