### PR TITLE
Fix UnicodeEncodeError writing issue body in d_work_on_issue.py

### DIFF
--- a/scripts/developer_tools/d_work_on_issue.py
+++ b/scripts/developer_tools/d_work_on_issue.py
@@ -179,7 +179,7 @@ def main() -> None:
     # Write issue to markdown file (preserve original content without reformatting)
     issue_file = Path(f".issue-{args.issue_id}.md")
     content = f"{title}\n\n{body}\n"
-    issue_file.write_text(content)
+    issue_file.write_text(content, encoding="utf-8")
     print(f"Wrote issue to {issue_file}")
     print(f"\n[OK] Ready to work on issue #{args.issue_id}")
 

--- a/tests/scripts/test_work_on_issue.py
+++ b/tests/scripts/test_work_on_issue.py
@@ -59,7 +59,9 @@ def _run_main(monkeypatch, tmp_path, cli_args, sleep_mock):
         lambda owner, repo, issue_id, token: {"title": "Some Issue Title", "body": "body text"},
     )
     monkeypatch.setattr("d_work_on_issue.get_main_branch_sha", lambda owner, repo: "deadbeef")
-    monkeypatch.setattr("d_work_on_issue.create_branch", lambda owner, repo, branch_name, sha, token: None)
+    monkeypatch.setattr(
+        "d_work_on_issue.create_branch", lambda owner, repo, branch_name, sha, token: None
+    )
 
     run_calls: list[list[str]] = []
 
@@ -102,3 +104,34 @@ class TestFetchDelay:
         _run_main(monkeypatch, tmp_path, ["4445"], sleep_mock)
 
         sleep_mock.assert_called_once()
+
+
+class TestIssueFileEncoding:
+    def test_writes_unicode_body_as_utf8(self, monkeypatch, tmp_path):
+        """GitHub issue bodies commonly contain non-ASCII punctuation (e.g. non-breaking
+        hyphens); writing with the platform default encoding fails with UnicodeEncodeError
+        on Windows (cp1252) unless UTF-8 is specified explicitly."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["d_work_on_issue.py", "4445"])
+        monkeypatch.setattr("d_work_on_issue.time.sleep", mock.MagicMock())
+        monkeypatch.setattr("d_work_on_issue.get_repo_info", lambda: ("leonarduk", "allotmint"))
+        unicode_body = "multi‑domain project — see notes"
+        issue_response = {"title": "Some Issue Title", "body": unicode_body}
+        monkeypatch.setattr(
+            "d_work_on_issue.fetch_issue",
+            lambda owner, repo, issue_id, token: issue_response,
+        )
+        monkeypatch.setattr("d_work_on_issue.get_main_branch_sha", lambda owner, repo: "deadbeef")
+        monkeypatch.setattr(
+            "d_work_on_issue.create_branch",
+            lambda owner, repo, branch_name, sha, token: None,
+        )
+        monkeypatch.setattr(
+            "d_work_on_issue.subprocess.run",
+            lambda cmd, **kwargs: mock.MagicMock(returncode=0, stdout=""),
+        )
+
+        main()
+
+        issue_file = tmp_path / ".issue-4445.md"
+        assert issue_file.read_text(encoding="utf-8") == f"Some Issue Title\n\n{unicode_body}\n"


### PR DESCRIPTION
## Summary
- `Path.write_text()` in `d_work_on_issue.py` used the platform default encoding, which crashes with `UnicodeEncodeError` on Windows (cp1252) for any issue body containing non-breaking hyphens, smart quotes, or em/en dashes — after the branch has already been created and checked out remotely.
- Fixed by writing `.issue-N.md` with explicit `encoding="utf-8"`.
- Added a regression test asserting a Unicode issue body round-trips correctly.

Closes #6050

## Test plan
- [x] `python -m pytest tests/scripts/test_work_on_issue.py -q` — 10 passed
- [x] `python -m ruff check` / `python -m black --check` on both changed files — no new violations introduced (pre-existing unrelated E501s left untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)