### PR TITLE
[Issue #6048] Add Graphify Knowledge Graph Generation to Release CI/CD Pipeline

### DIFF
--- a/.github/workflows/graphify-release.yml
+++ b/.github/workflows/graphify-release.yml
@@ -1,0 +1,47 @@
+name: Graphify Knowledge Graph
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  graphify:
+    name: Build knowledge graph
+    runs-on: ubuntu-latest
+    continue-on-error: true  # Must never block a release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install Graphify
+        run: |
+          pip install graphifyy==0.9.32
+          pip show graphifyy 2>/dev/null | head -2 || true
+
+      - name: Build knowledge graph
+        run: graphify .
+
+      - name: Semantic extraction (DeepSeek)
+        if: ${{ secrets.DEEPSEEK_API_KEY != '' }}
+        continue-on-error: true
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: graphify extract . --backend deepseek
+
+      - name: Upload graphify output
+        uses: actions/upload-artifact@v7
+        with:
+          name: graphify-${{ github.ref_name }}
+          path: graphify-out/
+          retention-days: 90

--- a/.github/workflows/graphify-release.yml
+++ b/.github/workflows/graphify-release.yml
@@ -6,7 +6,9 @@ on:
 
 permissions:
   contents: read
-  actions: write
+
+env:
+  HAS_DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY != '' }}
 
 jobs:
   graphify:
@@ -25,15 +27,13 @@ jobs:
           python-version: '3.12'
 
       - name: Install Graphify
-        run: |
-          pip install graphifyy==0.9.32
-          pip show graphifyy 2>/dev/null | head -2 || true
+        run: pip install graphifyy==0.9.32
 
       - name: Build knowledge graph
         run: graphify .
 
       - name: Semantic extraction (DeepSeek)
-        if: ${{ secrets.DEEPSEEK_API_KEY != '' }}
+        if: env.HAS_DEEPSEEK_API_KEY == 'true'
         continue-on-error: true
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}


### PR DESCRIPTION
## What
Introduce a new CI/CD workflow that automatically runs **Graphify** during each release build to compile a knowledge graph of the AllotMint codebase.

## Why
This change is necessary for maintaining an up-to-date structural map of the AllotMint project, which spans multiple domains and technologies. Graphify helps identify architectural drift, god nodes, community clusters, and other insights that improve debugging, onboarding, and AI-assisted development.

## Testing
The changes were tested by creating a mock GitHub Actions workflow and verifying that it installs Graphify, runs the knowledge graph compilation, and uploads the `graphify-out/` directory as a release artifact without blocking the release process.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #6048