### PR TITLE
Fix portfolio-group 5xx alarm to match on actual request path

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -55,6 +55,7 @@ ACCESS_LOG_FORMAT = json.dumps(
     {
         "requestId": "$context.requestId",
         "routeKey": "$context.routeKey",
+        "path": "$context.path",
         "status": "$context.status",
         "errorMessage": "$context.error.message",
         "authorizerError": "$context.authorizer.error",
@@ -1115,19 +1116,27 @@ class BackendLambdaStack(Stack):
             treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
         )
 
-        # HTTP API metrics are emitted per API/stage, not per route. Derive a
-        # route-specific metric from the structured access log so failures of
-        # this comparatively expensive aggregation endpoint are not hidden by
-        # otherwise healthy API traffic (issue #5523).
+        # HTTP API metrics are emitted per API/stage, not per route. All
+        # portfolio-group endpoints (/portfolio-group/{slug} and its
+        # /instruments, /sectors, /regions, /exposure, /movers,
+        # /instrument/{ticker} sub-resources - see backend/routes/portfolio.py)
+        # are registered only via the ANY /{proxy+} catch-all, so
+        # $context.routeKey for those requests is always the literal string
+        # "ANY /{proxy+}", never the specific method+path. A metric filter
+        # keyed on routeKey can therefore never match real portfolio-group
+        # traffic; $context.path (the actual request path, logged above)
+        # is used instead so failures of this comparatively expensive
+        # aggregation endpoint family are not hidden by otherwise healthy API
+        # traffic (issue #5494, follow-up from #5491).
         portfolio_group_5xx_metric = logs.MetricFilter(
             self,
-            "PortfolioGroupAll5xxMetricFilter",
+            "PortfolioGroup5xxMetricFilter",
             log_group=access_log_group,
             filter_pattern=logs.FilterPattern.literal(
-                '{ ($.routeKey = "GET /portfolio-group/all") && ($.status = 5*) }'
+                '{ ($.path = "/portfolio-group*") && ($.status = 5*) }'
             ),
             metric_namespace="AllotMint/BackendApi",
-            metric_name="PortfolioGroupAll5xx",
+            metric_name="PortfolioGroup5xx",
             metric_value="1",
             default_value=0,
         )
@@ -1138,7 +1147,7 @@ class BackendLambdaStack(Stack):
             )
         portfolio_group_5xx_alarm = cloudwatch.Alarm(
             self,
-            "PortfolioGroupAll5xxAlarm",
+            "PortfolioGroup5xxAlarm",
             metric=portfolio_group_5xx_metric.metric(
                 statistic="Sum", period=Duration.minutes(1)
             ),
@@ -1201,6 +1210,6 @@ class BackendLambdaStack(Stack):
         CfnOutput(self, "BackendLambdaErrorAlarmName", value=backend_error_alarm.alarm_name)
         CfnOutput(
             self,
-            "PortfolioGroupAll5xxAlarmName",
+            "PortfolioGroup5xxAlarmName",
             value=portfolio_group_5xx_alarm.alarm_name,
         )

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -514,17 +514,17 @@ def test_backend_error_alarm_exists(template):
     )
 
 
-def test_portfolio_group_all_5xx_alarm_uses_route_specific_log_metric(template):
+def test_portfolio_group_5xx_alarm_uses_path_specific_log_metric(template):
     template.has_resource_properties(
         "AWS::Logs::MetricFilter",
         {
             "FilterPattern": (
-                '{ ($.routeKey = "GET /portfolio-group/all") && ($.status = 5*) }'
+                '{ ($.path = "/portfolio-group*") && ($.status = 5*) }'
             ),
             "MetricTransformations": [
                 {
                     "DefaultValue": 0,
-                    "MetricName": "PortfolioGroupAll5xx",
+                    "MetricName": "PortfolioGroup5xx",
                     "MetricNamespace": "AllotMint/BackendApi",
                     "MetricValue": "1",
                 }
@@ -537,7 +537,7 @@ def test_portfolio_group_all_5xx_alarm_uses_route_specific_log_metric(template):
             "ComparisonOperator": "GreaterThanThreshold",
             "DatapointsToAlarm": 2,
             "EvaluationPeriods": 2,
-            "MetricName": "PortfolioGroupAll5xx",
+            "MetricName": "PortfolioGroup5xx",
             "Namespace": "AllotMint/BackendApi",
             "Period": 60,
             "Statistic": "Sum",
@@ -547,7 +547,7 @@ def test_portfolio_group_all_5xx_alarm_uses_route_specific_log_metric(template):
     )
 
 
-def test_portfolio_group_all_5xx_alarm_notifies_operational_topic(template):
+def test_portfolio_group_5xx_alarm_notifies_operational_topic(template):
     topics = template.find_resources("AWS::SNS::Topic")
     assert len(topics) == 1
     topic_logical_id = next(iter(topics))
@@ -556,7 +556,7 @@ def test_portfolio_group_all_5xx_alarm_notifies_operational_topic(template):
     route_alarms = [
         alarm
         for alarm in alarms.values()
-        if alarm.get("Properties", {}).get("MetricName") == "PortfolioGroupAll5xx"
+        if alarm.get("Properties", {}).get("MetricName") == "PortfolioGroup5xx"
     ]
     assert len(route_alarms) == 1
     assert route_alarms[0]["Properties"]["AlarmActions"] == [
@@ -1001,6 +1001,11 @@ def test_backend_api_stage_has_access_logging(template):
     )
     assert "$context.status" in fmt, "Access log format must include $context.status"
     assert "$context.routeKey" in fmt, "Access log format must include $context.routeKey"
+    assert "$context.path" in fmt, (
+        "Access log format must include $context.path: portfolio-group routes "
+        "are only registered via the ANY /{proxy+} catch-all, so routeKey alone "
+        "cannot distinguish them for the PortfolioGroup5xx metric filter"
+    )
     assert "$context.identity.sourceIp" in fmt, (
         "Access log format must include $context.identity.sourceIp for debugging context"
     )
@@ -1097,8 +1102,8 @@ def test_backend_lambda_error_alarm_output_exists(template):
     template.has_output("BackendLambdaErrorAlarmName", {})
 
 
-def test_portfolio_group_all_5xx_alarm_output_exists(template):
-    template.has_output("PortfolioGroupAll5xxAlarmName", {})
+def test_portfolio_group_5xx_alarm_output_exists(template):
+    template.has_output("PortfolioGroup5xxAlarmName", {})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Issue #5494 asked for a CloudWatch alarm monitoring 5xx errors on the portfolio-group endpoints. A prior PR (#5660) had already added a `PortfolioGroupAll5xxAlarm`, but its `AWS::Logs::MetricFilter` filtered on `$.routeKey = "GET /portfolio-group/all"`.

All portfolio-group endpoints (`/portfolio-group/{slug}` and its `/instruments`, `/sectors`, `/regions`, `/exposure`, `/movers`, `/instrument/{ticker}` sub-resources — see `backend/routes/portfolio.py`) are registered only via the `ANY /{proxy+}` catch-all route in `cdk/stacks/backend_lambda_stack.py`. `$context.routeKey` for those requests is always the literal string `"ANY /{proxy+}"`, never the specific method+path — so the existing filter could never match real traffic and the alarm was effectively dead.

## Changes
- Added `$context.path` to the API Gateway access log format (`ACCESS_LOG_FORMAT`) alongside the existing `$context.routeKey`.
- Changed the metric filter to match on `$.path = "/portfolio-group*"` (with `$.status = 5*`), which also broadens coverage from just `/portfolio-group/all` to the whole portfolio-group endpoint family, matching the issue's intent ("portfolio-group endpoints", plural).
- Renamed the alarm/metric filter resources and CloudFormation output from `PortfolioGroupAll5xx*` to `PortfolioGroup5xx*` to reflect the broadened scope.
- Reuses the existing `operational_alerts_topic` SNS topic for notifications (unchanged).
- Updated `cdk/tests/test_backend_lambda_stack.py` to assert the new filter pattern, metric name, and output name, and added an assertion that the access log format includes `$context.path`.

Closes #5494

## Test plan
- [x] `python -m pytest cdk/tests/ -q --no-cov` — 146 passed
- [x] `python -m pytest cdk/tests/test_backend_lambda_stack.py -q` — 53 passed (coverage gate failure is expected/pre-existing when running a single test file in isolation)
- [ ] Manual verification post-deploy: trigger a 5xx on a `/portfolio-group/*` route and confirm the alarm fires and the SNS notification is delivered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API access logs now record the request path to provide better visibility into API usage and aid in debugging.

* **Improvements**
  * Portfolio-group 5xx error monitoring has been expanded to track all endpoints under the `/portfolio-group` path, providing broader visibility into potential issues across the entire portfolio-group service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->