### PR TITLE
[Issue #5916] Rename `used_default_tier_map` to `is_default_tier_map` for clarity in `.github/scripts/llm_labels.py`

### DIFF
--- a/.github/scripts/llm_labels.py
+++ b/.github/scripts/llm_labels.py
@@ -84,7 +84,7 @@ def get_fallback_tier_label(
     Size-marker matching is skipped by default for custom tier_map callers
     unless they explicitly opt in via size_marker_map.
     """
-    used_default_tier_map = tier_map is None
+    is_default_tier_map = tier_map is None
     tier_map = LLM_TIER_MAP if tier_map is None else tier_map
     model_lower = model_name.lower()
     for tier, label in tier_map.items():
@@ -92,7 +92,7 @@ def get_fallback_tier_label(
             return label
 
     if size_marker_map is None:
-        size_marker_map = _SIZE_MARKER_TIERS if used_default_tier_map else {}
+        size_marker_map = _SIZE_MARKER_TIERS if is_default_tier_map else {}
 
     for marker, label in size_marker_map.items():
         if label in tier_map.values() and re.search(rf"\b{marker}\b", model_lower):


### PR DESCRIPTION
## What
Renamed the local variable `used_default_tier_map` to `is_default_tier_map` in `.github/scripts/llm_labels.py` within the `get_fallback_tier_label()` function for improved clarity.

## Why
The current name is misleading; it should accurately reflect that the variable indicates whether the default tier map is being used before any custom logic. This improves code readability and reduces confusion for maintainers.

## Testing
Ran all existing tests to ensure no behavioral changes were introduced. The `git diff` shows only the rename operation, with no other modifications or logic changes.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #5916