### PR TITLE
Extract shared auth-route assertion helper; document truncated in OpenAPI schema

### DIFF
--- a/backend/routes/data_explorer.py
+++ b/backend/routes/data_explorer.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 
 from backend.auth import get_current_user
 from backend.config import config
@@ -54,6 +55,16 @@ def _resolve_within_root(root: Path, rel_path: str) -> Path:
 
 def _iso_mtime(stat_result: os.stat_result) -> str:
     return datetime.fromtimestamp(stat_result.st_mtime, tz=timezone.utc).isoformat()
+
+
+class FileReadResponse(BaseModel):
+    """Response body for GET /data-explorer/file."""
+
+    path: str
+    size: int = Field(description="Full file size in bytes (may exceed len(content) if truncated)")
+    modified: str
+    truncated: bool = Field(description="True if the file exceeded MAX_PREVIEW_BYTES and content was cut off")
+    content: str
 
 
 @router.get("/tree")
@@ -96,7 +107,7 @@ async def list_directory(path: str = Query("")) -> dict[str, Any]:
     }
 
 
-@router.get("/file")
+@router.get("/file", response_model=FileReadResponse)
 async def read_file(path: str = Query(...)) -> dict[str, Any]:
     """Return a text preview of a single file under the data root."""
 

--- a/backend/routes/data_quality.py
+++ b/backend/routes/data_quality.py
@@ -7,9 +7,11 @@ independently of any frontend. Never fetches new data or mutates the cache.
 
 import logging
 import re
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
 
 from backend.logging_setup import sanitise_log_value
 from backend.timeseries.cache import (
@@ -41,7 +43,22 @@ def _validate_symbol(value: str, *, kind: str) -> str:
     return upper
 
 
-@router.get("/timeseries")
+class TimeseriesQualityResponse(BaseModel):
+    """Response body for GET /data-quality/timeseries.
+
+    ``positions`` items are ``TimeseriesQuality`` TypedDicts (see
+    backend/timeseries/quality.py); left as ``dict`` here rather than fully
+    typed so this schema doesn't drift out of sync with that TypedDict.
+    """
+
+    count: int = Field(description="Number of ticker/exchange pairs included in ``positions``")
+    positions: list[dict[str, Any]] = Field(description="Per-ticker data quality metrics")
+    truncated: bool = Field(
+        description="True if max_results cut off the pair list before all cached tickers were processed"
+    )
+
+
+@router.get("/timeseries", response_model=TimeseriesQualityResponse)
 async def get_timeseries_quality(
     ticker: str | None = Query(None, description="Filter to a single ticker (must be provided with exchange)"),
     exchange: str | None = Query(None, description="Filter to a single exchange (must be provided with ticker)"),

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -706,6 +706,26 @@ def _route_authorizer_map(template: dict) -> dict[str, dict]:
     }
 
 
+def _assert_routes_use_none_authorizer(routes: dict[str, dict]) -> None:
+    """Positively assert every route in ``routes`` uses HttpNoneAuthorizer.
+
+    Shared assertion body for test_signup_routes_use_http_none_authorizer,
+    test_token_route_uses_http_none_authorizer, and
+    test_options_proxy_route_uses_http_none_authorizer, which all check the
+    same two properties (AuthorizationType == "NONE", no AuthorizerId) rather
+    than only relying on the negative check in
+    test_backend_api_routes_require_cognito_authorizer (#5329 follow-up).
+    """
+    for route_key, properties in routes.items():
+        assert properties.get("AuthorizationType") == "NONE", (
+            f"Route {route_key} must use HttpNoneAuthorizer (AuthorizationType "
+            f"NONE), got {properties.get('AuthorizationType')!r}"
+        )
+        assert "AuthorizerId" not in properties, (
+            f"Route {route_key} must not reference an authorizer resource"
+        )
+
+
 def test_backend_api_routes_require_cognito_authorizer(template):
     """All API Gateway routes must require Cognito JWT authorization except
     /health, GET /config, POST /token, POST /token/google, the public
@@ -827,14 +847,7 @@ def test_signup_routes_use_http_none_authorizer(template):
         f"Unexpected /signup/* route set: {set(signup_routes)}"
     )
 
-    for route_key, properties in signup_routes.items():
-        assert properties.get("AuthorizationType") == "NONE", (
-            f"Route {route_key} must use HttpNoneAuthorizer (AuthorizationType "
-            f"NONE), got {properties.get('AuthorizationType')!r}"
-        )
-        assert "AuthorizerId" not in properties, (
-            f"Route {route_key} must not reference an authorizer resource"
-        )
+    _assert_routes_use_none_authorizer(signup_routes)
 
 
 def test_token_route_uses_http_none_authorizer(template):
@@ -848,24 +861,17 @@ def test_token_route_uses_http_none_authorizer(template):
     mirroring test_signup_routes_use_http_none_authorizer (audit follow-up
     from #4798, issue #4800).
     """
-    routes = template.find_resources("AWS::ApiGatewayV2::Route")
-    assert routes, "Expected at least one API Gateway route"
+    route_authorizer_map = _route_authorizer_map(template)
+    assert route_authorizer_map, "Expected at least one API Gateway route"
 
     token_routes = {
-        resource["Properties"].get("RouteKey", logical_id): resource["Properties"]
-        for logical_id, resource in routes.items()
-        if resource["Properties"].get("RouteKey", "") == "POST /token"
+        route_key: properties
+        for route_key, properties in route_authorizer_map.items()
+        if route_key == "POST /token"
     }
     assert set(token_routes) == {"POST /token"}
 
-    for route_key, properties in token_routes.items():
-        assert properties.get("AuthorizationType") == "NONE", (
-            f"Route {route_key} must use HttpNoneAuthorizer (AuthorizationType "
-            f"NONE), got {properties.get('AuthorizationType')!r}"
-        )
-        assert "AuthorizerId" not in properties, (
-            f"Route {route_key} must not reference an authorizer resource"
-        )
+    _assert_routes_use_none_authorizer(token_routes)
 
 
 def test_options_proxy_route_uses_http_none_authorizer(template):
@@ -889,26 +895,17 @@ def test_options_proxy_route_uses_http_none_authorizer(template):
     test_signup_routes_use_http_none_authorizer and
     test_token_route_uses_http_none_authorizer above.
     """
-    routes = template.find_resources("AWS::ApiGatewayV2::Route")
-    assert routes, "Expected at least one API Gateway route"
+    route_authorizer_map = _route_authorizer_map(template)
+    assert route_authorizer_map, "Expected at least one API Gateway route"
 
     options_proxy_routes = {
-        resource["Properties"].get("RouteKey", logical_id): resource["Properties"]
-        for logical_id, resource in routes.items()
-        if resource["Properties"].get("RouteKey", "") == "OPTIONS /{proxy+}"
+        route_key: properties
+        for route_key, properties in route_authorizer_map.items()
+        if route_key == "OPTIONS /{proxy+}"
     }
     assert set(options_proxy_routes) == {"OPTIONS /{proxy+}"}
 
-    for route_key, properties in options_proxy_routes.items():
-        assert properties.get("AuthorizationType") == "NONE", (
-            f"Route {route_key} must use HttpNoneAuthorizer (AuthorizationType "
-            f"NONE) so CORS preflight requests are not rejected with 401 "
-            f"before the real request is sent (#3945), got "
-            f"{properties.get('AuthorizationType')!r}"
-        )
-        assert "AuthorizerId" not in properties, (
-            f"Route {route_key} must not reference an authorizer resource"
-        )
+    _assert_routes_use_none_authorizer(options_proxy_routes)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **CDK tests**: extract `_assert_routes_use_none_authorizer(routes)` in `cdk/tests/test_backend_lambda_stack.py`, collapsing the duplicated `AuthorizationType == "NONE"` / `no AuthorizerId` positive-assertion pattern from three tests (`test_signup_routes_use_http_none_authorizer`, `test_token_route_uses_http_none_authorizer`, `test_options_proxy_route_uses_http_none_authorizer`) into one function. Also switched the latter two to reuse the existing `_route_authorizer_map(template)` helper instead of duplicating the `template.find_resources(...)` route-map construction inline.
- **OpenAPI schema**: `GET /data-explorer/file` and `GET /data-quality/timeseries` previously returned bare dicts / a raw `JSONResponse`, so FastAPI emitted no documented response schema at all — `truncated` (and every other field) was invisible in the OpenAPI docs. Added `FileReadResponse` and `TimeseriesQualityResponse` Pydantic models with `response_model=` wired on each route, with `truncated: bool = Field(description=...)` documenting what it means for each endpoint.
  - `data_quality.py` keeps returning `JSONResponse(...)` directly (unchanged runtime behavior — FastAPI does not re-serialize/validate when a `Response` subclass is returned) but the `response_model=` is still used to generate the documented schema.
  - `data_explorer.py`'s `read_file` return type is fully covered by the 5-field model (`path`, `size`, `modified`, `truncated`, `content`), so this one *does* go through model validation/serialization — no behavior change since the returned dict already matched exactly.
  - `positions` in `TimeseriesQualityResponse` is left as `list[dict[str, Any]]` rather than a fully-typed nested model, deliberately, so the schema doesn't need to track `backend/timeseries/quality.py`'s `TimeseriesQuality` TypedDict shape 1:1 and risk drifting/breaking on unrelated changes there.

## Why
Addresses the two follow-up items filed against #5329 (auth routes: positive-assertion test audit) and bundled into the consolidated backlog issue #6021.

Refs #6021.

## Test plan
- [x] `pytest tests/routes/test_data_explorer.py tests/routes/test_data_quality.py` — 24 passed
- [x] `pytest cdk/tests/test_backend_lambda_stack.py` — 53 passed
- [x] Verified via `app.openapi()` that `truncated` (and sibling fields) now appear with descriptions in `components.schemas.FileReadResponse` / `TimeseriesQualityResponse`
- [x] `ruff check` / `black --check` clean on all touched files

Partial progress on #6021 (2 of 7 bundled items now addressed, including the prior NaN-guard PR #6065).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved API response descriptions for file previews, including file metadata, truncation status and content.
  * Improved API response descriptions for time-series quality results, including record counts, positions and truncation status.

* **Tests**
  * Strengthened checks confirming that selected public routes do not require authorisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->