### PR TITLE
Data Explorer: add S3 support, Support page link, clearer local auth 401

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -334,11 +334,20 @@ async def get_current_user(token: str | None = Depends(oauth2_scheme)) -> str:
         # no caller to authenticate. Raise explicitly rather than falling
         # through to _user_from_token(None), whose own "no token" rejection
         # happens to produce the same status code today but is not a
-        # substitute for this terminal case (#4795).
+        # substitute for this terminal case (#4795). The detail message is
+        # deliberately actionable (rather than a generic "Invalid
+        # authentication credentials") since this specific case is the
+        # out-of-the-box state of a fresh local checkout with disable_auth=true
+        # and no override picked yet — a bare 401 left first-time users with no
+        # indication that Support -> Local login override needed configuring
+        # (#6058).
         current_user.set(None)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authentication credentials",
+            detail=(
+                "No local login override is configured. Go to Support -> "
+                "Local login override and select a user to continue in local/demo mode."
+            ),
         )
     token_str = token if isinstance(token, str) else None
     return _user_from_token(token_str)

--- a/backend/routes/data_explorer.py
+++ b/backend/routes/data_explorer.py
@@ -1,9 +1,10 @@
-"""Read-only file explorer for the backend ``data/`` area.
+"""Read-only file explorer for the backend data area.
 
-Lets an admin browse the directory tree rooted at ``config.data_root`` and
-preview small text files, for debugging what's actually on disk (cached
-timeseries, account files, etc.) without shell access to the environment.
-Never writes, deletes, or renames anything.
+Lets an admin browse the directory tree rooted at ``config.data_root`` (local
+filesystem) or under ``DATA_BUCKET`` (S3, when ``config.app_env == "aws"``)
+and preview small text files, for debugging what's actually on disk/in S3
+(cached timeseries, account files, etc.) without shell access to the
+environment. Never writes, deletes, or renames anything.
 """
 
 from __future__ import annotations
@@ -14,9 +15,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from botocore.exceptions import BotoCoreError, ClientError
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from backend.auth import get_current_user
+from backend.common.data_providers import DATA_BUCKET_ENV
 from backend.config import config
 from backend.logging_setup import sanitise_log_value
 
@@ -32,6 +35,24 @@ MAX_PREVIEW_BYTES = 200_000
 PREVIEWABLE_EXTENSIONS = {".json", ".csv", ".txt", ".log", ".yaml", ".yml", ".md"}
 
 
+def _reject_unsafe_relative_path(rel_path: str) -> str:
+    """Normalise ``rel_path`` to a clean, root-relative path, or reject it.
+
+    Shared by both the local-filesystem and S3 branches: rejects absolute
+    paths, Windows drive prefixes, and any ``..`` segment before the path is
+    ever joined onto a root/prefix.
+    """
+
+    normalised = (rel_path or "").strip().replace("\\", "/")
+    if normalised.startswith("/") or (len(normalised) > 1 and normalised[1] == ":"):
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    segments = [seg for seg in normalised.split("/") if seg not in ("", ".")]
+    if any(seg == ".." for seg in segments):
+        raise HTTPException(status_code=400, detail="Invalid path")
+    return "/".join(segments)
+
+
 def _data_root() -> Path:
     root = config.data_root
     if root is None:
@@ -42,14 +63,138 @@ def _data_root() -> Path:
 def _resolve_within_root(root: Path, rel_path: str) -> Path:
     """Resolve ``rel_path`` under ``root``, rejecting any attempt to escape it."""
 
-    normalised = (rel_path or "").strip().replace("\\", "/")
-    if normalised.startswith("/") or (len(normalised) > 1 and normalised[1] == ":"):
-        raise HTTPException(status_code=400, detail="Invalid path")
-
+    normalised = _reject_unsafe_relative_path(rel_path)
     candidate = (root / normalised).resolve()
     if candidate != root and root not in candidate.parents:
         raise HTTPException(status_code=400, detail="Invalid path")
     return candidate
+
+
+def _s3_bucket() -> str:
+    bucket = os.getenv(DATA_BUCKET_ENV)
+    if not bucket:
+        raise HTTPException(status_code=501, detail=f"{DATA_BUCKET_ENV} is not configured")
+    return bucket
+
+
+def _s3_client() -> Any:
+    import boto3  # type: ignore
+
+    return boto3.client("s3")
+
+
+def _list_directory_s3(rel_path: str) -> dict[str, Any]:
+    bucket = _s3_bucket()
+    prefix = _reject_unsafe_relative_path(rel_path)
+    prefix = f"{prefix}/" if prefix else ""
+
+    client = _s3_client()
+    entries: list[dict[str, Any]] = []
+    seen_dirs: set[str] = set()
+    found_any = False
+    token: str | None = None
+    while True:
+        params: dict[str, Any] = {"Bucket": bucket, "Prefix": prefix, "Delimiter": "/"}
+        if token:
+            params["ContinuationToken"] = token
+        try:
+            resp = client.list_objects_v2(**params)
+        except (ClientError, BotoCoreError) as exc:
+            logger.warning("S3 list failed for s3://%s/%s: %s", bucket, sanitise_log_value(prefix), exc)
+            raise HTTPException(status_code=502, detail="Failed to list S3 data") from exc
+
+        for common in resp.get("CommonPrefixes", []):
+            key = common.get("Prefix", "")
+            name = key[len(prefix) :].rstrip("/")
+            if not name or name in seen_dirs:
+                continue
+            seen_dirs.add(name)
+            found_any = True
+            entries.append(
+                {
+                    "name": name,
+                    "path": key.rstrip("/"),
+                    "type": "dir",
+                    "size": None,
+                    "modified": None,
+                }
+            )
+
+        for obj in resp.get("Contents", []):
+            key = obj.get("Key", "")
+            name = key[len(prefix) :]
+            if not name or "/" in name:
+                continue
+            found_any = True
+            last_modified = obj.get("LastModified")
+            entries.append(
+                {
+                    "name": name,
+                    "path": key,
+                    "type": "file",
+                    "size": obj.get("Size"),
+                    "modified": (last_modified.astimezone(timezone.utc).isoformat() if last_modified else None),
+                }
+            )
+
+        if resp.get("IsTruncated"):
+            token = resp.get("NextContinuationToken")
+        else:
+            break
+
+    if not found_any and prefix:
+        raise HTTPException(status_code=404, detail="Path not found")
+
+    entries.sort(key=lambda e: (e["type"] != "dir", e["name"].lower()))
+    return {"path": prefix.rstrip("/"), "entries": entries}
+
+
+def _read_file_s3(rel_path: str) -> dict[str, Any]:
+    bucket = _s3_bucket()
+    key = _reject_unsafe_relative_path(rel_path)
+    if not key:
+        raise HTTPException(status_code=400, detail="Invalid path")
+    if Path(key).suffix.lower() not in PREVIEWABLE_EXTENSIONS:
+        raise HTTPException(status_code=415, detail="File type is not previewable")
+
+    client = _s3_client()
+    try:
+        head = client.head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in {"404", "NoSuchKey", "NotFound"}:
+            raise HTTPException(status_code=404, detail="File not found") from exc
+        logger.warning("S3 head failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
+    except BotoCoreError as exc:
+        logger.warning("S3 head failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
+
+    size = head["ContentLength"]
+    truncated = size > MAX_PREVIEW_BYTES
+    get_kwargs: dict[str, Any] = {"Bucket": bucket, "Key": key}
+    if truncated:
+        get_kwargs["Range"] = f"bytes=0-{MAX_PREVIEW_BYTES - 1}"
+    try:
+        obj = client.get_object(**get_kwargs)
+        raw = obj["Body"].read()
+    except (ClientError, BotoCoreError) as exc:
+        logger.warning("S3 read failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
+
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(status_code=415, detail="File is not valid UTF-8 text") from exc
+
+    modified = head.get("LastModified")
+    return {
+        "path": key,
+        "size": size,
+        "modified": modified.astimezone(timezone.utc).isoformat() if modified else None,
+        "truncated": truncated,
+        "content": content,
+    }
 
 
 def _iso_mtime(stat_result: os.stat_result) -> str:
@@ -60,13 +205,10 @@ def _iso_mtime(stat_result: os.stat_result) -> str:
 async def list_directory(path: str = Query("")) -> dict[str, Any]:
     """List the immediate contents of a directory under the data root."""
 
-    root = _data_root()
     if config.app_env == "aws":
-        raise HTTPException(
-            status_code=501,
-            detail="Data explorer is only available against a local filesystem, not S3",
-        )
+        return _list_directory_s3(path)
 
+    root = _data_root()
     target = _resolve_within_root(root, path)
     if not target.exists():
         raise HTTPException(status_code=404, detail="Path not found")
@@ -100,13 +242,10 @@ async def list_directory(path: str = Query("")) -> dict[str, Any]:
 async def read_file(path: str = Query(...)) -> dict[str, Any]:
     """Return a text preview of a single file under the data root."""
 
-    root = _data_root()
     if config.app_env == "aws":
-        raise HTTPException(
-            status_code=501,
-            detail="Data explorer is only available against a local filesystem, not S3",
-        )
+        return _read_file_s3(path)
 
+    root = _data_root()
     target = _resolve_within_root(root, path)
     if not target.exists() or not target.is_file():
         raise HTTPException(status_code=404, detail="File not found")

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -250,7 +250,19 @@ export function createClient(
       if (res.status === 401 && typeof window !== "undefined") {
         window.dispatchEvent(new Event(UNAUTHORIZED_EVENT));
       }
-      const err = new Error(`HTTP ${res.status} - ${res.statusText} (${safeUrl})`);
+      // Prefer the backend's `detail` message (e.g. actionable 401 guidance)
+      // over the generic status text, so admin screens can surface it as-is
+      // instead of a bare "HTTP 401 - Unauthorized" (#6058).
+      let message = `HTTP ${res.status} - ${res.statusText} (${safeUrl})`;
+      try {
+        const body = await res.json();
+        if (typeof body?.detail === "string" && body.detail.trim()) {
+          message = body.detail;
+        }
+      } catch {
+        // response body was not JSON; fall back to the generic message above
+      }
+      const err = new Error(message);
       (err as any).status = res.status;
       (err as any).headers = res.headers;
       throw err;

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -532,6 +532,11 @@
       "tabsEnabled": "Tabs aktiviert",
       "title": "Konfiguration"
     },
+    "dataExplorer": {
+      "title": "Data Explorer",
+      "description": "Browse the backend data area (local files, or S3 in the AWS deployment) to inspect account, price, and timeseries data.",
+      "link": "Open Data Explorer"
+    },
     "environment": "Umgebung",
     "health": {
       "copyReport": "Bericht kopieren",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -642,6 +642,11 @@
       "tabsEnabled": "Tabs Enabled",
       "title": "Configuration"
     },
+    "dataExplorer": {
+      "title": "Data Explorer",
+      "description": "Browse the backend data area (local files, or S3 in the AWS deployment) to inspect account, price, and timeseries data.",
+      "link": "Open Data Explorer"
+    },
     "environment": "Environment",
     "health": {
       "copyReport": "Copy report",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -463,6 +463,11 @@
       "tabsEnabled": "Pestañas habilitadas",
       "title": "Configuración"
     },
+    "dataExplorer": {
+      "title": "Data Explorer",
+      "description": "Browse the backend data area (local files, or S3 in the AWS deployment) to inspect account, price, and timeseries data.",
+      "link": "Open Data Explorer"
+    },
     "environment": "Entorno",
     "health": {
       "copyReport": "Copiar informe",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -464,6 +464,11 @@
       "tabsEnabled": "Onglets activés",
       "title": "Configuration"
     },
+    "dataExplorer": {
+      "title": "Data Explorer",
+      "description": "Browse the backend data area (local files, or S3 in the AWS deployment) to inspect account, price, and timeseries data.",
+      "link": "Open Data Explorer"
+    },
     "environment": "Environnement",
     "health": {
       "copyReport": "Copier le rapport",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -464,6 +464,11 @@
       "tabsEnabled": "Schede abilitate",
       "title": "Configurazione"
     },
+    "dataExplorer": {
+      "title": "Data Explorer",
+      "description": "Browse the backend data area (local files, or S3 in the AWS deployment) to inspect account, price, and timeseries data.",
+      "link": "Open Data Explorer"
+    },
     "environment": "Ambiente",
     "health": {
       "copyReport": "Copia rapporto",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -463,6 +463,11 @@
       "tabsEnabled": "Abas ativadas",
       "title": "Configuração"
     },
+    "dataExplorer": {
+      "title": "Data Explorer",
+      "description": "Browse the backend data area (local files, or S3 in the AWS deployment) to inspect account, price, and timeseries data.",
+      "link": "Open Data Explorer"
+    },
     "environment": "Ambiente",
     "health": {
       "copyReport": "Copiar relatório",

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -423,6 +423,21 @@ export default function Support() {
         )}
       </SectionCard>
 
+      <SectionCard title={t("support.dataExplorer.title", "Data Explorer")}>
+        <p className="mb-2 text-sm text-gray-600">
+          {t(
+            "support.dataExplorer.description",
+            "Browse the backend data area (local files, or S3 in the AWS deployment) to inspect account, price, and timeseries data.",
+          )}
+        </p>
+        <Link
+          to="/data-explorer"
+          className="inline-block rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+        >
+          {t("support.dataExplorer.link", "Open Data Explorer")}
+        </Link>
+      </SectionCard>
+
       <SectionCard title={t("support.environment")} items={envEntries}>
         <table className="w-full table-auto text-sm">
           <tbody>

--- a/frontend/tests/unit/api.test.ts
+++ b/frontend/tests/unit/api.test.ts
@@ -77,6 +77,36 @@ describe("unauthorized event (issue #4674)", () => {
       window.removeEventListener(UNAUTHORIZED_EVENT, handler);
     }
   });
+
+  it("surfaces the backend's `detail` message instead of a bare status (issue #6058)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: () =>
+        Promise.resolve({
+          detail:
+            "No local login override is configured. Go to Support -> Local login override and select a user to continue in local/demo mode.",
+        }),
+    });
+    // @ts-expect-error: replacing global fetch with mock
+    global.fetch = mockFetch;
+    await expect(fetchJson("/data-explorer/tree")).rejects.toThrow(
+      "Go to Support -> Local login override",
+    );
+  });
+
+  it("falls back to the generic status message when the error body isn't JSON", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      json: () => Promise.reject(new Error("not json")),
+    });
+    // @ts-expect-error: replacing global fetch with mock
+    global.fetch = mockFetch;
+    await expect(fetchJson("/owners")).rejects.toThrow("HTTP 500");
+  });
 });
 
 describe("login", () => {

--- a/frontend/tests/unit/pages/Support.test.tsx
+++ b/frontend/tests/unit/pages/Support.test.tsx
@@ -77,6 +77,15 @@ describe("Support page", () => {
     expect(await screen.findByText(en.support.environment)).toBeInTheDocument();
   });
 
+  it("links to the Data Explorer (issue #6058)", async () => {
+    render(<Support />, { wrapper: MemoryRouter });
+    await expandSection(en.support.dataExplorer.title);
+    const link = await screen.findByRole("link", {
+      name: en.support.dataExplorer.link,
+    });
+    expect(link).toHaveAttribute("href", "/data-explorer");
+  });
+
   it("shows owner selector", async () => {
     render(<Support />, { wrapper: MemoryRouter });
     await expandSection(en.support.notifications.title);

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -25,7 +25,7 @@ backend/auth.py:537
 # provider is always a hardcoded literal ("Google"/"Cognito") passed by the
 # caller, never attacker-controlled; email/token on the same call are already
 # wrapped in sanitise_log_value.
-backend/auth.py:560
+backend/auth.py:569
 backend/bootstrap/isolation.py:89
 backend/bootstrap/startup.py:92
 backend/common/accounts_store.py:244
@@ -132,6 +132,15 @@ backend/reports.py:1630
 # DEFAULT_HEADLINE_MAX_AGE_HOURS is a module-level float constant (the
 # hardcoded 72-hour fallback), never attacker-controlled; the other arg on
 # each of these two calls is already wrapped in sanitise_log_value.
+backend/routes/data_explorer.py:103
+backend/routes/data_explorer.py:167
+backend/routes/data_explorer.py:170
+backend/routes/data_explorer.py:182
+# these S3 branch calls follow the same pattern already grandfathered for
+# backend/common/accounts_store.py: bucket is a fixed env-configured name and
+# prefix/key are already wrapped in sanitise_log_value; the trailing `exc` is
+# a botocore ClientError/BotoCoreError whose str() carries no attacker-
+# controlled request path (the key/prefix that could is already wrapped).
 backend/routes/market.py:72
 backend/routes/market.py:80
 backend/routes/market.py:164

--- a/tests/routes/test_data_explorer.py
+++ b/tests/routes/test_data_explorer.py
@@ -1,6 +1,9 @@
 import asyncio
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 from fastapi import HTTPException
 
 from backend.config import config
@@ -79,13 +82,224 @@ def test_list_directory_rejects_traversal(monkeypatch, tmp_path, traversal):
     assert exc.value.status_code == 400
 
 
-def test_list_directory_aws_not_supported(monkeypatch, tmp_path):
+def test_list_directory_aws_missing_bucket_501(monkeypatch):
     monkeypatch.setattr(config, "app_env", "aws")
-    monkeypatch.setattr(config, "data_root", tmp_path)
+    monkeypatch.delenv("DATA_BUCKET", raising=False)
 
     with pytest.raises(HTTPException) as exc:
         _run(data_explorer.list_directory(""))
     assert exc.value.status_code == 501
+
+
+def test_list_directory_aws_lists_dirs_and_files(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+    mock_client = MagicMock()
+    mock_client.list_objects_v2.return_value = {
+        "CommonPrefixes": [{"Prefix": "timeseries/"}],
+        "Contents": [
+            {
+                "Key": "accounts.json",
+                "Size": 2,
+                "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
+            }
+        ],
+        "IsTruncated": False,
+    }
+
+    with patch("boto3.client", return_value=mock_client):
+        result = _run(data_explorer.list_directory(""))
+
+    assert result["path"] == ""
+    names = [(e["name"], e["type"]) for e in result["entries"]]
+    assert names == [("timeseries", "dir"), ("accounts.json", "file")]
+    file_entry = next(e for e in result["entries"] if e["name"] == "accounts.json")
+    assert file_entry["size"] == 2
+    assert file_entry["path"] == "accounts.json"
+    mock_client.list_objects_v2.assert_called_once_with(Bucket="test-bucket", Prefix="", Delimiter="/")
+
+
+def test_list_directory_aws_subdir_uses_prefixed_key(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+    mock_client = MagicMock()
+    mock_client.list_objects_v2.return_value = {
+        "CommonPrefixes": [],
+        "Contents": [
+            {
+                "Key": "timeseries/meta/ABC_L.parquet",
+                "Size": 10,
+                "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
+            }
+        ],
+        "IsTruncated": False,
+    }
+
+    with patch("boto3.client", return_value=mock_client):
+        result = _run(data_explorer.list_directory("timeseries/meta"))
+
+    assert result["path"] == "timeseries/meta"
+    assert result["entries"][0]["path"] == "timeseries/meta/ABC_L.parquet"
+    mock_client.list_objects_v2.assert_called_once_with(Bucket="test-bucket", Prefix="timeseries/meta/", Delimiter="/")
+
+
+def test_list_directory_aws_paginates(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+    mock_client = MagicMock()
+    mock_client.list_objects_v2.side_effect = [
+        {
+            "CommonPrefixes": [],
+            "Contents": [
+                {
+                    "Key": "a.json",
+                    "Size": 1,
+                    "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
+                }
+            ],
+            "IsTruncated": True,
+            "NextContinuationToken": "token-1",
+        },
+        {
+            "CommonPrefixes": [],
+            "Contents": [
+                {
+                    "Key": "b.json",
+                    "Size": 2,
+                    "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
+                }
+            ],
+            "IsTruncated": False,
+        },
+    ]
+
+    with patch("boto3.client", return_value=mock_client):
+        result = _run(data_explorer.list_directory(""))
+
+    names = [e["name"] for e in result["entries"]]
+    assert names == ["a.json", "b.json"]
+    assert mock_client.list_objects_v2.call_count == 2
+    second_call_kwargs = mock_client.list_objects_v2.call_args_list[1].kwargs
+    assert second_call_kwargs["ContinuationToken"] == "token-1"
+
+
+def test_list_directory_aws_empty_subdir_404(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+    mock_client = MagicMock()
+    mock_client.list_objects_v2.return_value = {
+        "CommonPrefixes": [],
+        "Contents": [],
+        "IsTruncated": False,
+    }
+
+    with patch("boto3.client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc:
+            _run(data_explorer.list_directory("does-not-exist"))
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "traversal",
+    [
+        "../",
+        "../../etc/passwd",
+        "/etc/passwd",
+        "timeseries/../../etc",
+    ],
+)
+def test_list_directory_aws_rejects_traversal(monkeypatch, traversal):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.list_directory(traversal))
+    assert exc.value.status_code == 400
+
+
+def test_list_directory_aws_list_failure_502(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+    mock_client = MagicMock()
+    mock_client.list_objects_v2.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "denied"}}, "ListObjectsV2"
+    )
+
+    with patch("boto3.client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc:
+            _run(data_explorer.list_directory(""))
+    assert exc.value.status_code == 502
+
+
+def test_read_file_aws_preview(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+    mock_client = MagicMock()
+    mock_client.head_object.return_value = {
+        "ContentLength": 11,
+        "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
+    }
+    mock_client.get_object.return_value = {"Body": MagicMock(read=lambda: b"hello world")}
+
+    with patch("boto3.client", return_value=mock_client):
+        result = _run(data_explorer.read_file("notes.txt"))
+
+    assert result["content"] == "hello world"
+    assert result["truncated"] is False
+    assert result["path"] == "notes.txt"
+    mock_client.get_object.assert_called_once_with(Bucket="test-bucket", Key="notes.txt")
+
+
+def test_read_file_aws_truncates_large_files(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+    big_content = "x" * (data_explorer.MAX_PREVIEW_BYTES + 100)
+    mock_client = MagicMock()
+    mock_client.head_object.return_value = {
+        "ContentLength": len(big_content),
+        "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
+    }
+    mock_client.get_object.return_value = {
+        "Body": MagicMock(read=lambda: big_content[: data_explorer.MAX_PREVIEW_BYTES].encode("utf-8"))
+    }
+
+    with patch("boto3.client", return_value=mock_client):
+        result = _run(data_explorer.read_file("big.log"))
+
+    assert result["truncated"] is True
+    assert len(result["content"]) == data_explorer.MAX_PREVIEW_BYTES
+    range_header = f"bytes=0-{data_explorer.MAX_PREVIEW_BYTES - 1}"
+    mock_client.get_object.assert_called_once_with(Bucket="test-bucket", Key="big.log", Range=range_header)
+
+
+def test_read_file_aws_rejects_unsupported_extension(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.read_file("cache.parquet"))
+    assert exc.value.status_code == 415
+
+
+def test_read_file_aws_missing_404(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+    mock_client = MagicMock()
+    mock_client.head_object.side_effect = ClientError({"Error": {"Code": "404", "Message": "not found"}}, "HeadObject")
+
+    with patch("boto3.client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc:
+            _run(data_explorer.read_file("missing.txt"))
+    assert exc.value.status_code == 404
+
+
+def test_read_file_aws_rejects_traversal(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("DATA_BUCKET", "test-bucket")
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.read_file("../secret.txt"))
+    assert exc.value.status_code == 400
 
 
 def test_read_file_preview(monkeypatch, tmp_path):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -381,6 +381,11 @@ async def test_get_current_user_disabled_without_identity(monkeypatch):
 
     assert exc_info.value.status_code == 401
     assert auth.current_user.get() is None
+    # The message must be actionable (points to the Support page fix) rather
+    # than a bare/generic 401, since this is the out-of-the-box state of a
+    # fresh local checkout (#6058).
+    assert "Support" in exc_info.value.detail
+    assert "Local login override" in exc_info.value.detail
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #6058. Three gaps in the Data Explorer follow-up to #5579 / #5582:

- **Gap 1 (AWS/S3)**: `backend/routes/data_explorer.py` now lists/reads real objects under `DATA_BUCKET` when `config.app_env == "aws"` instead of always returning 501. Reuses the `boto3.client("s3")` + pagination pattern already used in `timeseries_admin.py`, with the same read-only, path-validated, size-capped, admin-gated contract as the local filesystem branch (falls back to 501 only if `DATA_BUCKET` itself isn't configured).
- **Gap 2 (discoverability)**: Added a "Data Explorer" section to the Support page (`frontend/src/pages/Support.tsx`) linking to `/data-explorer`, with translations added across all 6 locales.
- **Gap 3 (local auth UX)**: When `disable_auth` is true and no local login override is configured, `backend/auth.py` now raises a 401 with an actionable message ("Go to Support -> Local login override...") instead of a bare "Invalid authentication credentials". `frontend/src/api.ts`'s `fetchJson` now surfaces that backend `detail` message instead of a generic "HTTP 401 - Unauthorized" string.

## Test plan

- [x] `pytest tests/routes/test_data_explorer.py tests/test_auth.py -q` — new S3-branch tests (listing, pagination, traversal rejection, unsupported extension, 404/502 handling) and updated auth fallback-message test
- [x] Full backend suite (`pytest tests/`) — no new failures beyond a pre-existing local-environment artifact (a stray `backend/.venv` directory scanned by `test_log_sanitization_audit`), confirmed present on unmodified `origin/main` too via `git stash`
- [x] `npx vitest run` (frontend) — all 666 tests pass, including new Support page link test and api.ts detail-surfacing tests
- [x] `npx eslint` / `npx tsc --noEmit` — clean
- [x] `black` / `isort` / `ruff` (backend config, line-length 120) on touched backend files — clean
- [x] `tests/data/log_sanitization_baseline.txt` updated for the new S3-branch logger calls, following the same grandfathering pattern already used for `accounts_store.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)