### PR TITLE
Document O(n) cost, add perf guard, clarify zero-check in get_units_as_of

### DIFF
--- a/backend/common/dividends.py
+++ b/backend/common/dividends.py
@@ -233,7 +233,7 @@ def refresh_dividends() -> Dict[str, Any]:
                     if key in existing_keys:
                         continue
                     units_as_of_ex_date = get_units_as_of(data, ticker, decl["ex_date"])
-                    if not units_as_of_ex_date:
+                    if units_as_of_ex_date == 0.0:
                         continue
                     amount_minor = _amount_minor_gbp(ticker, decl["amount_per_share"], units_as_of_ex_date)
                     if amount_minor is None or amount_minor <= 0:

--- a/backend/common/portfolio_loader.py
+++ b/backend/common/portfolio_loader.py
@@ -288,6 +288,11 @@ def get_units_as_of(tx_data: dict[str, Any], ticker: str, as_of: str) -> float:
     Used by :mod:`backend.common.dividends` to size a dividend by the units
     actually held on its ex-date rather than the (possibly since-changed)
     current holding (#4947).
+
+    O(n) in the number of transactions in ``tx_data`` — it does a single
+    linear scan with no indexing or early exit, so callers computing this
+    for many tickers/dates over the same ``tx_data`` incur O(n) per call
+    rather than amortising the scan.
     """
     TYPE_SIGN = {
         "BUY": 1,

--- a/tests/common/test_portfolio_loader.py
+++ b/tests/common/test_portfolio_loader.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from pathlib import Path
 
 import pytest
@@ -111,6 +112,35 @@ def test_get_units_as_of_reflects_a_removal_before_cutoff() -> None:
 
     assert get_units_as_of(tx_data, "ABC", "2024-01-15") == pytest.approx(200.0)
     assert get_units_as_of(tx_data, "ABC", "2024-02-01") == pytest.approx(170.0)
+
+
+def test_get_units_as_of_large_transaction_log_performance() -> None:
+    """Guard against accidental superlinear blowup in the O(n) scan (#5327).
+
+    get_units_as_of does a single linear pass with no indexing, so cost
+    should scale ~linearly with transaction count. 20k transactions (mixed
+    tickers, half of them irrelevant) should still complete in well under a
+    second on any CI runner; a generous 5s ceiling flags a real regression
+    (e.g. an accidental O(n^2) reintroduction) without being flaky.
+    """
+    transaction_count = 20_000
+    tx_data = {
+        "transactions": [
+            {
+                "type": "BUY" if i % 2 == 0 else "SELL",
+                "ticker": "ABC" if i % 3 == 0 else "XYZ",
+                "units": 10,
+                "date": f"{2000 + (i % 24):04d}-01-01",
+            }
+            for i in range(transaction_count)
+        ]
+    }
+
+    start = time.perf_counter()
+    get_units_as_of(tx_data, "ABC", "2030-01-01")
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 5.0, f"get_units_as_of took {elapsed:.2f}s for {transaction_count} transactions"
 
 
 def test_rebuild_account_holdings_treats_dividend_singular_like_dividends(tmp_path: Path) -> None:

--- a/tests/common/test_portfolio_loader.py
+++ b/tests/common/test_portfolio_loader.py
@@ -137,9 +137,15 @@ def test_get_units_as_of_large_transaction_log_performance() -> None:
     }
 
     start = time.perf_counter()
-    get_units_as_of(tx_data, "ABC", "2030-01-01")
+    result = get_units_as_of(tx_data, "ABC", "2030-01-01")
     elapsed = time.perf_counter() - start
 
+    # ABC transactions occur where i % 3 == 0 (6,667 of the 20k). Of those,
+    # i % 6 == 0 are BUYs (3,334) and i % 6 == 3 are SELLs (3,333), each of
+    # 10 units, so the net is (3334 - 3333) * 10 = 10.0. Asserting this
+    # confirms the timed call actually performed the full scan rather than
+    # short-circuiting.
+    assert result == pytest.approx(10.0)
     assert elapsed < 5.0, f"get_units_as_of took {elapsed:.2f}s for {transaction_count} transactions"
 
 


### PR DESCRIPTION
## Summary
- `backend/common/portfolio_loader.py`: added a docstring note to `get_units_as_of` documenting that it's an O(n) linear scan with no indexing/early-exit, so callers doing repeated calls over the same `tx_data` (as `backend/common/dividends.py` does, once per dividend declaration) know the cost doesn't amortise.
- `tests/common/test_portfolio_loader.py`: added `test_get_units_as_of_large_transaction_log_performance`, a plain timed-assertion test over 20k synthetic transactions with a generous 5s ceiling — no new test dependency (there's no existing `pytest-benchmark`/marker convention in this repo), just a regression guard against an accidental superlinear reintroduction. Runs in a few ms in practice.
- `backend/common/dividends.py`: changed `if not units_as_of_ex_date:` to `if units_as_of_ex_date == 0.0:` — behaviorally identical (the only falsy float is 0.0) but makes the actual intent ("skip if no units were held") explicit rather than relying on Python truthiness.

## Why
Addresses the three remaining follow-up items filed against #5327, bundled into the consolidated backlog issue #6021 (the NaN-guard item from the same issue was already done in PR #6065).

## Test plan
- [x] `pytest tests/common/test_portfolio_loader.py -v` — 14 passed, including the new benchmark test
- [x] `pytest tests/common tests/test_dividends.py tests/test_dividend_refresh_lambda.py` — 262 passed
- [x] `ruff check` clean on all touched files; `black --check` diffs only touch pre-existing unrelated lines (verified none overlap my additions)

Partial progress on #6021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Refs #6021 (partial progress on the consolidated backlog issue; does not close it).