### PR TITLE
Add concurrency test for get_security_meta's lazy-init RLock

### DIFF
--- a/tests/backend/common/test_portfolio_utils.py
+++ b/tests/backend/common/test_portfolio_utils.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import sys
 import threading
+import time
 import types
 from datetime import UTC, datetime
 
@@ -933,20 +934,23 @@ def test_get_security_meta_thread_safe_first_call_builds_once(monkeypatch):
 
     calls: list[None] = []
     calls_lock = threading.Lock()
-    all_started = threading.Event()
-    started_count = [0]
-    started_count_lock = threading.Lock()
+    # A Barrier (unlike a counter+Event) blocks every worker from calling
+    # get_security_meta() until all 10 have arrived, so no thread's call can
+    # start before another's -- a real guarantee that all 10 race the
+    # unlocked `_SECURITIES is None` check together, rather than relying on
+    # scheduling luck.
+    start_barrier = threading.Barrier(10)
+    build_release = threading.Event()
     real_build = portfolio_utils._build_securities_from_portfolios
 
     def spy_build():
         with calls_lock:
             calls.append(None)
-        # Hold the lock briefly so any thread that hasn't yet reached its
-        # first (unlocked) `_SECURITIES is None` check has time to do so
-        # concurrently with this build, genuinely exercising the race that
-        # double-checked locking guards against, rather than the threads
-        # simply never overlapping.
-        all_started.wait(timeout=5)
+        # Keep the winning thread inside the lock until every other thread
+        # has had ample time (far more than a GIL switch interval) to run
+        # its own unlocked check and block on _SECURITIES_LOCK, so the race
+        # double-checked locking guards against is genuinely exercised.
+        build_release.wait(timeout=5)
         return real_build()
 
     monkeypatch.setattr(portfolio_utils, "_build_securities_from_portfolios", spy_build)
@@ -954,15 +958,14 @@ def test_get_security_meta_thread_safe_first_call_builds_once(monkeypatch):
     monkeypatch.setattr(portfolio_utils, "list_virtual_portfolios", lambda: [])
 
     def worker():
-        with started_count_lock:
-            started_count[0] += 1
-            if started_count[0] == 10:
-                all_started.set()
+        start_barrier.wait(timeout=5)
         portfolio_utils.get_security_meta("AAA.L")
 
     threads = [threading.Thread(target=worker) for _ in range(10)]
     for t in threads:
         t.start()
+    time.sleep(0.2)
+    build_release.set()
     for t in threads:
         t.join(timeout=5)
 

--- a/tests/backend/common/test_portfolio_utils.py
+++ b/tests/backend/common/test_portfolio_utils.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import sys
+import threading
 import types
 from datetime import UTC, datetime
 
@@ -914,3 +915,56 @@ def test_securities_are_not_built_at_import_time(monkeypatch):
 
     portfolio_utils.get_security_meta("BBB.L")
     assert calls == [None]  # second call reuses the already-built dict
+
+
+def test_get_security_meta_thread_safe_first_call_builds_once(monkeypatch):
+    """Concurrent first calls to get_security_meta() must build _SECURITIES
+    exactly once, not once per racing thread.
+
+    Regression guard mirroring issue #5104 (the ``_S3_HEAD_MISS_CACHE`` race)
+    for the analogous double-checked-locking lazy-init here: without
+    ``_SECURITIES_LOCK`` serialising the build, multiple threads could all
+    observe ``_SECURITIES is None`` before any of them finishes building it,
+    each redundantly calling ``_build_securities_from_portfolios()`` (which
+    itself issues S3 GetObject calls per ticker) and racing to overwrite the
+    module-level dict.
+    """
+    monkeypatch.setattr(portfolio_utils, "_SECURITIES", None)
+
+    calls: list[None] = []
+    calls_lock = threading.Lock()
+    all_started = threading.Event()
+    started_count = [0]
+    started_count_lock = threading.Lock()
+    real_build = portfolio_utils._build_securities_from_portfolios
+
+    def spy_build():
+        with calls_lock:
+            calls.append(None)
+        # Hold the lock briefly so any thread that hasn't yet reached its
+        # first (unlocked) `_SECURITIES is None` check has time to do so
+        # concurrently with this build, genuinely exercising the race that
+        # double-checked locking guards against, rather than the threads
+        # simply never overlapping.
+        all_started.wait(timeout=5)
+        return real_build()
+
+    monkeypatch.setattr(portfolio_utils, "_build_securities_from_portfolios", spy_build)
+    monkeypatch.setattr(portfolio_utils, "list_portfolios", lambda: [])
+    monkeypatch.setattr(portfolio_utils, "list_virtual_portfolios", lambda: [])
+
+    def worker():
+        with started_count_lock:
+            started_count[0] += 1
+            if started_count[0] == 10:
+                all_started.set()
+        portfolio_utils.get_security_meta("AAA.L")
+
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert len(calls) == 1
+    assert portfolio_utils._SECURITIES == {}

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -132,10 +132,10 @@ backend/reports.py:1630
 # DEFAULT_HEADLINE_MAX_AGE_HOURS is a module-level float constant (the
 # hardcoded 72-hour fallback), never attacker-controlled; the other arg on
 # each of these two calls is already wrapped in sanitise_log_value.
-backend/routes/data_explorer.py:103
-backend/routes/data_explorer.py:167
-backend/routes/data_explorer.py:170
-backend/routes/data_explorer.py:182
+backend/routes/data_explorer.py:104
+backend/routes/data_explorer.py:168
+backend/routes/data_explorer.py:171
+backend/routes/data_explorer.py:183
 # these S3 branch calls follow the same pattern already grandfathered for
 # backend/common/accounts_store.py: bucket is a fixed env-configured name and
 # prefix/key are already wrapped in sanitise_log_value; the trailing `exc` is


### PR DESCRIPTION
## Summary
Issue #5321 (folded into #6021) listed four S3-cache thread-safety follow-up items. Investigation found three were already implemented in prior work:
- `_s3_head_object()` (`backend/timeseries/cache.py:405-441`) already unifies the "miss → record in negative cache → return None" pattern shared by `_s3_object_mtime` and `_s3_cache_object_exists`.
- `_S3_CLIENT_CONFIG` (`backend/timeseries/cache.py:383-387`) already sets `connect_timeout=3s`/`read_timeout=5s`/2 retries on the shared S3 client, specifically to avoid a stalled HeadObject blocking a cold Lambda invocation.
- `_S3_HEAD_MISS_CACHE`'s TTL + `time.monotonic()` design (documented at `cache.py:330-336`) is already the intended answer to "clear on cold start vs warm invocations" — no explicit clear is needed since the TTL naturally resets across a freeze/thaw.

The one real gap: `_SECURITIES`'s double-checked-locking lazy-init in `backend/common/portfolio_utils.py:465-490` already uses an `RLock` (correctly, per its own comment, to allow reentrancy from `_build_securities_from_portfolios()` calling back into `list_portfolios()`), but had no test actually exercising concurrent first-call access — unlike the equivalent `_S3_HEAD_MISS_CACHE` lock, which has a dedicated 10-thread regression test for issue #5104.

This PR adds `test_get_security_meta_thread_safe_first_call_builds_once` in `tests/backend/common/test_portfolio_utils.py`, mirroring that existing pattern: 10 threads race to call `get_security_meta()` on a torn-down `_SECURITIES`, and the test asserts the build function fires exactly once.

## Verification
I sanity-checked the test actually catches a regression: running the same 10-thread race against a copy of `get_security_meta` with the lock removed produced 10 redundant builds (vs. 1 with the lock in place) — confirming the test isn't a false-positive-only check.

## Why
Addresses the remaining #5321 follow-up item from the consolidated backlog issue #6021.

## Test plan
- [x] `pytest tests/backend/common/test_portfolio_utils.py tests/test_timeseries_cache_base.py` — 59 passed
- [x] Manually verified the new test fails (10 builds instead of 1) against an unlocked version of `get_security_meta`
- [x] `ruff check` clean; `black --check` diff only touches pre-existing unrelated lines

Partial progress on #6021. Only `import_transactions` atomicity + API docs (#5464) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #6021
