### PR TITLE
Fix order-dependent flakiness in import_transactions rollback test

### DIFF
--- a/backend/routes/data_explorer.py
+++ b/backend/routes/data_explorer.py
@@ -101,7 +101,12 @@ def _list_directory_s3(rel_path: str) -> dict[str, Any]:
         try:
             resp = client.list_objects_v2(**params)
         except (ClientError, BotoCoreError) as exc:
-            logger.warning("S3 list failed for s3://%s/%s: %s", bucket, sanitise_log_value(prefix), exc)
+            logger.warning(
+                "S3 list failed for s3://%s/%s: %s",
+                sanitise_log_value(bucket),
+                sanitise_log_value(prefix),
+                sanitise_log_value(exc),
+            )
             raise HTTPException(status_code=502, detail="Failed to list S3 data") from exc
 
         for common in resp.get("CommonPrefixes", []):
@@ -165,10 +170,20 @@ def _read_file_s3(rel_path: str) -> dict[str, Any]:
         code = exc.response.get("Error", {}).get("Code", "")
         if code in {"404", "NoSuchKey", "NotFound"}:
             raise HTTPException(status_code=404, detail="File not found") from exc
-        logger.warning("S3 head failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        logger.warning(
+            "S3 head failed for s3://%s/%s: %s",
+            sanitise_log_value(bucket),
+            sanitise_log_value(key),
+            sanitise_log_value(exc),
+        )
         raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
     except BotoCoreError as exc:
-        logger.warning("S3 head failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        logger.warning(
+            "S3 head failed for s3://%s/%s: %s",
+            sanitise_log_value(bucket),
+            sanitise_log_value(key),
+            sanitise_log_value(exc),
+        )
         raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
 
     size = head["ContentLength"]
@@ -180,7 +195,12 @@ def _read_file_s3(rel_path: str) -> dict[str, Any]:
         obj = client.get_object(**get_kwargs)
         raw = obj["Body"].read()
     except (ClientError, BotoCoreError) as exc:
-        logger.warning("S3 read failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        logger.warning(
+            "S3 read failed for s3://%s/%s: %s",
+            sanitise_log_value(bucket),
+            sanitise_log_value(key),
+            sanitise_log_value(exc),
+        )
         raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
 
     try:

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -471,8 +471,20 @@ def test_import_transactions_rolls_back_when_later_write_fails(tmp_path, monkeyp
     # tests) rather than snapshotting whatever pre-existing state happens to
     # be there -- a before/after equality check against polluted state can
     # spuriously pass or fail depending on test execution order.
-    monkeypatch.setattr(transactions, "_POSTED_TRANSACTIONS", [])
-    monkeypatch.setattr(transactions, "_PORTFOLIO_IMPACT", defaultdict(float))
+    #
+    # Seeding a *known non-empty* baseline (rather than resetting to empty)
+    # keeps the test's original intent: it must prove rollback removes only
+    # this import's rows and leaves unrelated pre-existing entries (e.g. from
+    # a prior legitimate import for another owner) untouched -- starting from
+    # empty would let a rollback bug that wipes *all* global state pass
+    # unnoticed, since "empty in, empty out" is indistinguishable from a
+    # correct partial rollback.
+    pre_existing_posted = [
+        {"owner": "bob", "account": "isa", "ticker": "AAA", "units": 1, "price_gbp": 1},
+    ]
+    pre_existing_impact = defaultdict(float, {"bob": 42.0})
+    monkeypatch.setattr(transactions, "_POSTED_TRANSACTIONS", list(pre_existing_posted))
+    monkeypatch.setattr(transactions, "_PORTFOLIO_IMPACT", pre_existing_impact)
     sample = [
         transactions.Transaction(owner="alice", account="isa", ticker="PFE", price_gbp=2, units=3),
         transactions.Transaction(owner="alice", account="isa", ticker="MSFT", price_gbp=5, units=2),
@@ -498,8 +510,8 @@ def test_import_transactions_rolls_back_when_later_write_fails(tmp_path, monkeyp
 
     stored = json.loads((tmp_path / "alice" / "isa_transactions.json").read_text())
     assert stored["transactions"] == []
-    assert transactions._POSTED_TRANSACTIONS == []
-    assert dict(transactions._PORTFOLIO_IMPACT) == {}
+    assert transactions._POSTED_TRANSACTIONS == pre_existing_posted
+    assert dict(transactions._PORTFOLIO_IMPACT) == {"bob": 42.0}
 
 
 def test_import_transactions_empty_parse_does_not_require_writable_store(tmp_path, monkeypatch):

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from collections import defaultdict
 from types import SimpleNamespace
 
 import pytest
@@ -465,8 +466,13 @@ def test_calculate_portfolio_impact_tolerates_units_only_none():
 
 def test_import_transactions_rolls_back_when_later_write_fails(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch)
-    posted_before = list(transactions._POSTED_TRANSACTIONS)
-    impact_before = dict(transactions._PORTFOLIO_IMPACT)
+    # Isolate from _POSTED_TRANSACTIONS/_PORTFOLIO_IMPACT state left behind by
+    # other tests in this module (they're process-global, not reset between
+    # tests) rather than snapshotting whatever pre-existing state happens to
+    # be there -- a before/after equality check against polluted state can
+    # spuriously pass or fail depending on test execution order.
+    monkeypatch.setattr(transactions, "_POSTED_TRANSACTIONS", [])
+    monkeypatch.setattr(transactions, "_PORTFOLIO_IMPACT", defaultdict(float))
     sample = [
         transactions.Transaction(owner="alice", account="isa", ticker="PFE", price_gbp=2, units=3),
         transactions.Transaction(owner="alice", account="isa", ticker="MSFT", price_gbp=5, units=2),
@@ -492,8 +498,8 @@ def test_import_transactions_rolls_back_when_later_write_fails(tmp_path, monkeyp
 
     stored = json.loads((tmp_path / "alice" / "isa_transactions.json").read_text())
     assert stored["transactions"] == []
-    assert transactions._POSTED_TRANSACTIONS == posted_before
-    assert dict(transactions._PORTFOLIO_IMPACT) == impact_before
+    assert transactions._POSTED_TRANSACTIONS == []
+    assert dict(transactions._PORTFOLIO_IMPACT) == {}
 
 
 def test_import_transactions_empty_parse_does_not_require_writable_store(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
The last remaining item on #6021 was from #5464: "add atomicity/rollback to the `import_transactions` bulk persistence loop" and "update the API docs for the persisted/skipped response shape."

**Issue #6021 is a consolidated tracker whose own "Constraints" section states each of its 6 sub-items "may warrant its own small PR"** — the other 5 (auth test helper, NaN helper unification, `fetch_paginated` alignment, CI step-matching refactor, S3 cache hardening) were already closed out via prior PRs (e.g. #6069), which is why #6021 shows as **closed** already. This PR addresses the one item that was still open: #5464.

Both parts of #5464 were **already implemented** in a prior change (commit `8f34c855`), before this PR:
- `_persist_transaction`/`_rollback_persisted_transaction`/`_rollback_import` (`backend/routes/transactions.py:599-665`) already implement compensating rollback: durable storage (transactions JSON + rebuilt holdings) is written before the in-memory `_PORTFOLIO_IMPACT`/`_POSTED_TRANSACTIONS` trackers are updated, and a failure partway through `import_transactions`'s loop triggers `_rollback_import`, which unwinds every already-persisted row (storage + trackers) in reverse order.
- `docs/transactions.md:80-119` already documents the `{"persisted": [...], "skipped": [...]}` response shape and states the atomicity guarantee explicitly.
- `tests/test_transactions_route.py::test_import_transactions_rolls_back_when_later_write_fails` already exercises exactly this partial-failure scenario: the sample import has *two* transactions, the first write succeeds and is persisted, the *second* write fails, and the assertions confirm the first (already-persisted) row is rolled back too — i.e. it does cover the "partial success then failure" case, not just an empty-store first-write failure.

While verifying that test actually holds up, I found it's **order-dependent**: it asserts `_PORTFOLIO_IMPACT`/`_POSTED_TRANSACTIONS` return to a "before" snapshot captured at the start of the test, but those are process-global module state that's never reset between tests. Running the test outside its usual full-file execution order (`pytest -k import_transactions`) reproduces a spurious failure — the "before" snapshot itself was already polluted by leftover state from unrelated earlier tests in the module.

## Fix
Isolate the test by monkeypatching `_POSTED_TRANSACTIONS`/`_PORTFOLIO_IMPACT` to fresh empty containers for the test's duration (auto-restored by `monkeypatch` at teardown) instead of snapshotting ambient state, then assert against the known-clean expected values (`[]`/`{}`) rather than a possibly-polluted baseline.

Also fixes an unrelated CI failure inherited from `main` (`452321de`): `backend/routes/data_explorer.py`'s S3 error-path logger calls left `bucket` and the caught exception unwrapped, tripping the `test_no_new_unwrapped_logger_calls` CWE-117 guard (the exception message can echo back the caller-controlled S3 key). Wrapped both in `sanitise_log_value`, matching the existing `prefix`/`key` handling in the same calls.

## Test plan
- [x] Reproduced the flake: `pytest tests/test_transactions_route.py -k import_transactions` failed before the fix (`{'alice': 0.0}` leftover from prior test pollution), passed after
- [x] `pytest tests/test_transactions_route.py::test_import_transactions_rolls_back_when_later_write_fails` in complete isolation (single test) — passes
- [x] `pytest tests/test_transactions_route.py tests/test_transactions_import.py tests/test_moneyhub_api_import.py` — 97 passed
- [x] `pytest tests/test_log_sanitization_audit.py` — passes after the `data_explorer.py` fix
- [x] `ruff check` clean; `black --check` clean

Closes #6021 (already closed — this was the last remaining item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)