### PR TITLE
Fix unsanitised logger calls in data_explorer.py (unblocks CI on main)

### DIFF
--- a/backend/routes/data_explorer.py
+++ b/backend/routes/data_explorer.py
@@ -101,7 +101,12 @@ def _list_directory_s3(rel_path: str) -> dict[str, Any]:
         try:
             resp = client.list_objects_v2(**params)
         except (ClientError, BotoCoreError) as exc:
-            logger.warning("S3 list failed for s3://%s/%s: %s", bucket, sanitise_log_value(prefix), exc)
+            logger.warning(
+                "S3 list failed for s3://%s/%s: %s",
+                sanitise_log_value(bucket),
+                sanitise_log_value(prefix),
+                sanitise_log_value(exc),
+            )
             raise HTTPException(status_code=502, detail="Failed to list S3 data") from exc
 
         for common in resp.get("CommonPrefixes", []):
@@ -165,10 +170,20 @@ def _read_file_s3(rel_path: str) -> dict[str, Any]:
         code = exc.response.get("Error", {}).get("Code", "")
         if code in {"404", "NoSuchKey", "NotFound"}:
             raise HTTPException(status_code=404, detail="File not found") from exc
-        logger.warning("S3 head failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        logger.warning(
+            "S3 head failed for s3://%s/%s: %s",
+            sanitise_log_value(bucket),
+            sanitise_log_value(key),
+            sanitise_log_value(exc),
+        )
         raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
     except BotoCoreError as exc:
-        logger.warning("S3 head failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        logger.warning(
+            "S3 head failed for s3://%s/%s: %s",
+            sanitise_log_value(bucket),
+            sanitise_log_value(key),
+            sanitise_log_value(exc),
+        )
         raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
 
     size = head["ContentLength"]
@@ -180,7 +195,12 @@ def _read_file_s3(rel_path: str) -> dict[str, Any]:
         obj = client.get_object(**get_kwargs)
         raw = obj["Body"].read()
     except (ClientError, BotoCoreError) as exc:
-        logger.warning("S3 read failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        logger.warning(
+            "S3 read failed for s3://%s/%s: %s",
+            sanitise_log_value(bucket),
+            sanitise_log_value(key),
+            sanitise_log_value(exc),
+        )
         raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
 
     try:


### PR DESCRIPTION
## Summary
`tests/test_log_sanitization_audit.py::test_no_new_unwrapped_logger_calls` is currently failing on `main` (surfaced while getting #6087 to a mergeable state — that PR doesn't touch this file, but inherits the failure since it's a required check on every PR). Four `logger.warning(...)` calls in `backend/routes/data_explorer.py`'s S3 branch pass the `bucket` name and caught `exc` object directly instead of wrapping them in `sanitise_log_value(...)`, unlike the rest of the file (e.g. the local-filesystem branch already does this at line 273).

## Why
This is a required CI gate, so a red result on `main` blocks every PR into the repo, not just ones that touch logging.

## Changes
- Wrapped `bucket` and `exc` in `sanitise_log_value(...)` in the four flagged `logger.warning(...)` calls in `_list_directory_s3` and `_read_file_s3`, matching the existing convention used elsewhere in the same file.

## Test plan
- [x] `python scripts/build_tools/_scan_log_sanitisation.py` — no longer lists any `backend/routes/data_explorer.py` lines
- [x] `pytest tests/test_log_sanitization_audit.py tests/routes/test_data_explorer.py` — 30 passed
- [x] `ruff check backend/routes/data_explorer.py` — clean
- [x] `black --check backend/routes/data_explorer.py` — clean

Closes #6095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
