### PR TITLE
Fix stale log-sanitization baseline for data_explorer.py

### DIFF
--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -132,10 +132,10 @@ backend/reports.py:1630
 # DEFAULT_HEADLINE_MAX_AGE_HOURS is a module-level float constant (the
 # hardcoded 72-hour fallback), never attacker-controlled; the other arg on
 # each of these two calls is already wrapped in sanitise_log_value.
-backend/routes/data_explorer.py:103
-backend/routes/data_explorer.py:167
-backend/routes/data_explorer.py:170
-backend/routes/data_explorer.py:182
+backend/routes/data_explorer.py:104
+backend/routes/data_explorer.py:168
+backend/routes/data_explorer.py:171
+backend/routes/data_explorer.py:183
 # these S3 branch calls follow the same pattern already grandfathered for
 # backend/common/accounts_store.py: bucket is a fixed env-configured name and
 # prefix/key are already wrapped in sanitise_log_value; the trailing `exc` is


### PR DESCRIPTION
## Summary
`tests/test_log_sanitization_audit.py::test_no_new_unwrapped_logger_calls` was failing on `main` (confirmed on commit `452321dec8fafdd2c797714ffb75755d80965e75`), blocking CI for every PR that merges main.

## Why
A prior commit added a docstring line to `backend/routes/data_explorer.py`, shifting the four grandfathered S3 `logger.warning` call sites down by one line (103→104, 167→168, 170→171, 182→183) without updating `tests/data/log_sanitization_baseline.txt`. The scanner (`scripts/build_tools/_scan_log_sanitisation.py`) matches on exact `file:line`, so the shift made the ratchet test see these as brand-new unwrapped calls.

I initially assumed the fix was to wrap the `bucket` argument in `sanitise_log_value(...)`, but the existing baseline comment already documents why that's unnecessary: `bucket` comes from `_s3_bucket()`, which reads a fixed env-configured name (`DATA_BUCKET_ENV`), not user input — only `prefix`/`key` carry attacker-controlled path segments, and those are already wrapped. So the actual bug is purely the stale baseline line numbers, not missing sanitization.

## Change
Updated the four `backend/routes/data_explorer.py` entries in `tests/data/log_sanitization_baseline.txt` to their current line numbers. No production code changed.

## Test plan
- [x] `pytest tests/test_log_sanitization_audit.py -v` — 2 passed
- [x] Confirmed `python scripts/build_tools/_scan_log_sanitisation.py` output for `data_explorer.py` now matches the baseline exactly

Closes #6094

🤖 Generated with [Claude Code](https://claude.com/claude-code)