### PR TITLE
Sanitize bucket arg in data_explorer.py S3 error logging

### DIFF
--- a/backend/routes/data_explorer.py
+++ b/backend/routes/data_explorer.py
@@ -101,7 +101,9 @@ def _list_directory_s3(rel_path: str) -> dict[str, Any]:
         try:
             resp = client.list_objects_v2(**params)
         except (ClientError, BotoCoreError) as exc:
-            logger.warning("S3 list failed for s3://%s/%s: %s", bucket, sanitise_log_value(prefix), exc)
+            logger.warning(
+                "S3 list failed for s3://%s/%s: %s", sanitise_log_value(bucket), sanitise_log_value(prefix), exc
+            )
             raise HTTPException(status_code=502, detail="Failed to list S3 data") from exc
 
         for common in resp.get("CommonPrefixes", []):
@@ -165,10 +167,10 @@ def _read_file_s3(rel_path: str) -> dict[str, Any]:
         code = exc.response.get("Error", {}).get("Code", "")
         if code in {"404", "NoSuchKey", "NotFound"}:
             raise HTTPException(status_code=404, detail="File not found") from exc
-        logger.warning("S3 head failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        logger.warning("S3 head failed for s3://%s/%s: %s", sanitise_log_value(bucket), sanitise_log_value(key), exc)
         raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
     except BotoCoreError as exc:
-        logger.warning("S3 head failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        logger.warning("S3 head failed for s3://%s/%s: %s", sanitise_log_value(bucket), sanitise_log_value(key), exc)
         raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
 
     size = head["ContentLength"]
@@ -180,7 +182,7 @@ def _read_file_s3(rel_path: str) -> dict[str, Any]:
         obj = client.get_object(**get_kwargs)
         raw = obj["Body"].read()
     except (ClientError, BotoCoreError) as exc:
-        logger.warning("S3 read failed for s3://%s/%s: %s", bucket, sanitise_log_value(key), exc)
+        logger.warning("S3 read failed for s3://%s/%s: %s", sanitise_log_value(bucket), sanitise_log_value(key), exc)
         raise HTTPException(status_code=502, detail="Failed to read file from S3") from exc
 
     try:

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -132,15 +132,15 @@ backend/reports.py:1630
 # DEFAULT_HEADLINE_MAX_AGE_HOURS is a module-level float constant (the
 # hardcoded 72-hour fallback), never attacker-controlled; the other arg on
 # each of these two calls is already wrapped in sanitise_log_value.
-backend/routes/data_explorer.py:103
-backend/routes/data_explorer.py:167
+backend/routes/data_explorer.py:104
 backend/routes/data_explorer.py:170
-backend/routes/data_explorer.py:182
+backend/routes/data_explorer.py:173
+backend/routes/data_explorer.py:185
 # these S3 branch calls follow the same pattern already grandfathered for
-# backend/common/accounts_store.py: bucket is a fixed env-configured name and
-# prefix/key are already wrapped in sanitise_log_value; the trailing `exc` is
-# a botocore ClientError/BotoCoreError whose str() carries no attacker-
-# controlled request path (the key/prefix that could is already wrapped).
+# backend/common/accounts_store.py: bucket and prefix/key are already wrapped
+# in sanitise_log_value; the trailing `exc` is a botocore ClientError/
+# BotoCoreError whose str() carries no attacker-controlled request path (the
+# key/prefix that could is already wrapped).
 backend/routes/market.py:72
 backend/routes/market.py:80
 backend/routes/market.py:164


### PR DESCRIPTION
Closes #6101

## Summary
- `tests/test_log_sanitization_audit.py::test_no_new_unwrapped_logger_calls` fails on `main` (452321d) — the ratchet flags 4 unwrapped `bucket` arguments passed to `logger.warning(...)` in `backend/routes/data_explorer.py`, alongside an already-sanitised `prefix`/`key` in the same calls.
- Wraps `bucket` in `sanitise_log_value(...)` at all four S3 error-logging call sites in `_list_directory_s3` and `_read_file_s3`, matching the existing `prefix`/`key` pattern (CWE-117 log-injection guard).
- Updates the corresponding entries in `tests/data/log_sanitization_baseline.txt` to the new line numbers produced by the fix (the trailing `exc` argument remains grandfathered, same rationale as the neighboring `accounts_store.py` entries).

## Test plan
- [x] `pytest tests/test_log_sanitization_audit.py -v --no-cov` — both tests pass
- [x] `ruff check backend/routes/data_explorer.py` — clean
- [x] `isort --check-only backend/routes/data_explorer.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)