### PR TITLE
Filter .git/.idea from local Data Explorer tree; friendlier 415 message

### DIFF
--- a/backend/routes/data_explorer.py
+++ b/backend/routes/data_explorer.py
@@ -35,6 +35,18 @@ MAX_PREVIEW_BYTES = 200_000
 # else (parquet, binary caches, etc.) is rejected rather than streamed raw.
 PREVIEWABLE_EXTENSIONS = {".json", ".csv", ".txt", ".log", ".yaml", ".yml", ".md"}
 
+# Friendly message shown to the user in place of the (technically accurate but
+# unhelpful-looking) 415 for a file type that isn't in PREVIEWABLE_EXTENSIONS,
+# e.g. clicking a binary VCS object like `.git/index`.
+NOT_PREVIEWABLE_DETAIL = "This file type can't be previewed here (binary or unsupported format)."
+
+# VCS/IDE housekeeping folders that belong to the tooling around the data
+# repo, not the data itself. Excluded from the local tree listing so they
+# don't clutter (or get clicked into) alongside real data folders. Kept as a
+# narrow, named set rather than "skip anything starting with a dot" since
+# legitimate dotfiles/dotfolders could exist in the data repo.
+EXCLUDED_LOCAL_DIR_NAMES = {".git", ".idea"}
+
 
 def _reject_unsafe_relative_path(rel_path: str) -> str:
     """Normalise ``rel_path`` to a clean, root-relative path, or reject it.
@@ -161,7 +173,7 @@ def _read_file_s3(rel_path: str) -> dict[str, Any]:
     if not key:
         raise HTTPException(status_code=400, detail="Invalid path")
     if Path(key).suffix.lower() not in PREVIEWABLE_EXTENSIONS:
-        raise HTTPException(status_code=415, detail="File type is not previewable")
+        raise HTTPException(status_code=415, detail=NOT_PREVIEWABLE_DETAIL)
 
     client = _s3_client()
     try:
@@ -238,6 +250,8 @@ async def list_directory(path: str = Query("")) -> dict[str, Any]:
 
     entries: list[dict[str, Any]] = []
     for child in sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
+        if child.is_dir() and child.name in EXCLUDED_LOCAL_DIR_NAMES:
+            continue
         try:
             stat_result = child.stat()
         except OSError:
@@ -283,7 +297,7 @@ async def read_file(path: str = Query(...)) -> dict[str, Any]:
     if not target.exists() or not target.is_file():
         raise HTTPException(status_code=404, detail="File not found")
     if target.suffix.lower() not in PREVIEWABLE_EXTENSIONS:
-        raise HTTPException(status_code=415, detail="File type is not previewable")
+        raise HTTPException(status_code=415, detail=NOT_PREVIEWABLE_DETAIL)
 
     stat_result = target.stat()
     try:

--- a/frontend/tests/unit/pages/DataExplorer.test.tsx
+++ b/frontend/tests/unit/pages/DataExplorer.test.tsx
@@ -91,7 +91,9 @@ describe("DataExplorer page", () => {
         { name: "cache.parquet", path: "cache.parquet", type: "file", size: 99, modified: "2026-01-01T00:00:00Z" },
       ],
     });
-    mockGetDataExplorerFile.mockRejectedValue(new Error("File type is not previewable"));
+    mockGetDataExplorerFile.mockRejectedValue(
+      new Error("This file type can't be previewed here (binary or unsupported format)."),
+    );
 
     render(<DataExplorer />);
 
@@ -100,6 +102,8 @@ describe("DataExplorer page", () => {
       await userEvent.click(fileButton);
     });
 
-    expect(await screen.findByText("File type is not previewable")).toBeInTheDocument();
+    expect(
+      await screen.findByText("This file type can't be previewed here (binary or unsupported format)."),
+    ).toBeInTheDocument();
   });
 });

--- a/tests/routes/test_data_explorer.py
+++ b/tests/routes/test_data_explorer.py
@@ -45,6 +45,25 @@ def test_list_directory_subdir(monkeypatch, tmp_path):
     assert result["entries"][0]["path"] == "timeseries/meta/ABC_L.parquet"
 
 
+def test_list_directory_excludes_git_and_idea_dirs(monkeypatch, tmp_path):
+    (tmp_path / "timeseries").mkdir()
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "index").write_bytes(b"\x00\x01")
+    (tmp_path / ".idea").mkdir()
+    (tmp_path / ".idea" / "workspace.xml").write_text("<xml/>")
+    (tmp_path / "accounts.json").write_text("{}")
+
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    result = _run(data_explorer.list_directory(""))
+
+    names = [e["name"] for e in result["entries"]]
+    assert ".git" not in names
+    assert ".idea" not in names
+    assert set(names) == {"timeseries", "accounts.json"}
+
+
 def test_list_directory_missing_path_404(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "app_env", "local")
     monkeypatch.setattr(config, "data_root", tmp_path)
@@ -279,6 +298,7 @@ def test_read_file_aws_rejects_unsupported_extension(monkeypatch):
     with pytest.raises(HTTPException) as exc:
         _run(data_explorer.read_file("cache.parquet"))
     assert exc.value.status_code == 415
+    assert exc.value.detail == data_explorer.NOT_PREVIEWABLE_DETAIL
 
 
 def test_read_file_aws_missing_404(monkeypatch):
@@ -334,6 +354,23 @@ def test_read_file_rejects_unsupported_extension(monkeypatch, tmp_path):
     with pytest.raises(HTTPException) as exc:
         _run(data_explorer.read_file("cache.parquet"))
     assert exc.value.status_code == 415
+    assert exc.value.detail == data_explorer.NOT_PREVIEWABLE_DETAIL
+
+
+def test_read_file_rejects_binary_file_with_no_extension_friendly_message(monkeypatch, tmp_path):
+    # Regression for #6112: a file like `.git/index` has no recognised
+    # extension at all, but the 415 detail should still read as a friendly
+    # in-app message rather than a bare technical string.
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "index").write_bytes(b"\x00\x01\x02\x03")
+    monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "data_root", tmp_path)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(data_explorer.read_file(".git/index"))
+    assert exc.value.status_code == 415
+    assert exc.value.detail == data_explorer.NOT_PREVIEWABLE_DETAIL
 
 
 def test_read_file_missing_404(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- `list_directory`'s local-filesystem branch in `backend/routes/data_explorer.py` iterated every child of a directory unconditionally, so `.git` and `.idea` folders belonging to the sibling `allotmint-data` repo used as `data_root` were listed in the tree alongside real data folders. Clicking a binary entry inside them (e.g. `.git/index`) returned an unhandled backend HTTP 415 detail string, surfaced verbatim in the UI.
- Added a small, named `EXCLUDED_LOCAL_DIR_NAMES = {".git", ".idea"}` set and skip those directories when walking the local tree, instead of a blanket "skip anything starting with a dot" — that would risk hiding legitimate dotfiles/dotfolders that might exist in the data repo.
- Replaced the terse `"File type is not previewable"` 415 detail (used by both the local and S3 `read_file` branches, for consistency) with a friendlier `NOT_PREVIEWABLE_DETAIL = "This file type can't be previewed here (binary or unsupported format)."`. The frontend's `fetchJson` in `frontend/src/api.ts` already prefers the backend's `detail` string over a generic `HTTP 415 - ...` message (added in #6058), and `DataExplorer.tsx`'s existing red `<p>{error}</p>` block already renders it — so improving the backend wording alone satisfies the "friendly message" requirement without introducing a new error-display pattern.

## Test plan

- [x] `python -m pytest tests/routes/test_data_explorer.py -v` — 30/30 passed, including new tests for `.git`/`.idea` exclusion and the friendly 415 message (both extension-based and extensionless files like `.git/index`).
- [x] `isort` / `black` / `ruff check` on the changed backend files (backend/pyproject.toml config) — clean.
- [x] `npm --prefix frontend run lint` — clean.
- [x] `npm --prefix frontend run test -- --run DataExplorer` — 3/3 passed (updated the existing 415 test to expect the new friendly wording).

Closes #6112