### PR TITLE
Fix Support page Logs panel 401s on AWS

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -194,7 +194,18 @@ export function createClient(
     (globalThis as any).google?.accounts?.id?.disableAutoSelect?.();
   }
 
-  async function fetchJson<T>(url: string, init: RequestInit = {}): Promise<T> {
+  // Builds and sends an authenticated request: resolves relative paths against
+  // the configured base, applies the CWE-918 client-side-request-forgery
+  // guards (origin + path-prefix checks), attaches the Cognito bearer token
+  // and CSRF header, and on a non-2xx response dispatches UNAUTHORIZED_EVENT
+  // for 401s and throws an Error carrying the backend's `detail` message when
+  // available. Returns the raw `Response` on success so callers can parse the
+  // body however is appropriate (JSON via fetchJson, plain text via
+  // fetchText, etc.) without duplicating this security-sensitive logic.
+  async function sendAuthenticated(
+    url: string,
+    init: RequestInit = {},
+  ): Promise<Response> {
     // Support relative paths by resolving against the provided base URL.
     const resolvedBase = resolveBase();
     // Validate the base eagerly so a mis-configured API_BASE surfaces as a clear error
@@ -267,10 +278,23 @@ export function createClient(
       (err as any).headers = res.headers;
       throw err;
     }
+    return res;
+  }
+
+  async function fetchJson<T>(url: string, init: RequestInit = {}): Promise<T> {
+    const res = await sendAuthenticated(url, init);
     return res.json() as Promise<T>;
   }
 
-  return { setAuthToken, getStoredAuthToken, login, logout, fetchJson };
+  // Same authenticated request/error handling as fetchJson, but parses the
+  // successful response body as text instead of JSON — needed for endpoints
+  // like GET /logs that return PlainTextResponse rather than JSON (#6111).
+  async function fetchText(url: string, init: RequestInit = {}): Promise<string> {
+    const res = await sendAuthenticated(url, init);
+    return res.text();
+  }
+
+  return { setAuthToken, getStoredAuthToken, login, logout, fetchJson, fetchText };
 }
 
 // Use a dynamic fetch that resolves to the current global fetch implementation
@@ -288,6 +312,7 @@ export const getStoredAuthToken = defaultClient.getStoredAuthToken;
 export const login = defaultClient.login;
 export const logout = defaultClient.logout;
 export const fetchJson = defaultClient.fetchJson;
+export const fetchText = defaultClient.fetchText;
 
 /* ------------------------------------------------------------------ */
 /* API wrappers                                                        */
@@ -1686,6 +1711,17 @@ export const checkPortfolioHealth = () =>
     `${API_BASE}/support/portfolio-health`,
     { method: "POST" },
   );
+
+/**
+ * Fetch recent backend log output for the Support page's Logs panel.
+ *
+ * Routed through the authenticated {@link fetchText} path (not a raw
+ * `fetch`) so it attaches the Cognito bearer token — otherwise API Gateway's
+ * Cognito authorizer rejects the request with 401 before it ever reaches the
+ * Lambda on AWS deployments (#6111). `GET /logs` returns `PlainTextResponse`,
+ * so this uses fetchText rather than fetchJson.
+ */
+export const getLogs = () => fetchText(`${API_BASE}/logs`);
 
 // ───────────── Account signup ─────────────
 export interface AccountSignupRequest {

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -7,6 +7,7 @@ import {
   getOwners,
   updateConfig,
   checkPortfolioHealth,
+  getLogs,
   type Finding,
   refreshPrices,
 } from "../api";
@@ -245,9 +246,7 @@ export default function Support() {
     setLogsLoading(true);
     setLogsError(null);
     try {
-      const res = await fetch(`${API_BASE}/logs`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const text = await res.text();
+      const text = await getLogs();
       setLogs(text);
     } catch {
       setLogs("");

--- a/frontend/tests/unit/api.test.ts
+++ b/frontend/tests/unit/api.test.ts
@@ -4,6 +4,8 @@ import {
   API_BASE,
   createClient,
   fetchJson,
+  fetchText,
+  getLogs,
   setAuthToken,
   setApiBase,
   login,
@@ -106,6 +108,57 @@ describe("unauthorized event (issue #4674)", () => {
     // @ts-expect-error: replacing global fetch with mock
     global.fetch = mockFetch;
     await expect(fetchJson("/owners")).rejects.toThrow("HTTP 500");
+  });
+});
+
+describe("fetchText / getLogs (issue #6111)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setAuthToken(null);
+    setApiBase(DEFAULT_API_BASE);
+  });
+
+  it("parses the response body as text rather than JSON", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, text: () => Promise.resolve("log line one\nlog line two") });
+    // @ts-expect-error: replacing global fetch with mock
+    global.fetch = mockFetch;
+    const text = await fetchText("/logs");
+    expect(text).toBe("log line one\nlog line two");
+  });
+
+  it("attaches the Authorization header, same as fetchJson", async () => {
+    setAuthToken("logs-token");
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
+    // @ts-expect-error: replacing global fetch with mock
+    global.fetch = mockFetch;
+    await getLogs();
+    const args = mockFetch.mock.calls[0];
+    expect(args[0]).toBe(`${API_BASE}/logs`);
+    const headers = args[1].headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer logs-token");
+  });
+
+  it("dispatches UNAUTHORIZED_EVENT and rejects with the backend detail on a 401", async () => {
+    const handler = vi.fn();
+    window.addEventListener(UNAUTHORIZED_EVENT, handler);
+    try {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: () => Promise.resolve({ detail: "Session expired" }),
+      });
+      // @ts-expect-error: replacing global fetch with mock
+      global.fetch = mockFetch;
+      await expect(fetchText("/logs")).rejects.toThrow("Session expired");
+      expect(handler).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(UNAUTHORIZED_EVENT, handler);
+    }
   });
 });
 

--- a/frontend/tests/unit/pages/Support.test.tsx
+++ b/frontend/tests/unit/pages/Support.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/api", async () => {
 
 import Support from "@/pages/Support";
 import en from "@/locales/en/translation.json";
+import { setAuthToken, UNAUTHORIZED_EVENT } from "@/api";
 
 async function expandSection(title: string) {
   const heading = await screen.findByRole("heading", { name: title });
@@ -39,6 +40,7 @@ async function expandSection(title: string) {
 beforeEach(() => {
   (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
   vi.clearAllMocks();
+  setAuthToken(null);
   mockFetch.mockResolvedValue({ ok: true, text: async () => "log entry" });
   vi.stubGlobal("fetch", mockFetch);
   mockGetConfig.mockResolvedValue({
@@ -411,8 +413,28 @@ describe("Support page", () => {
   it("loads logs and renders them", async () => {
     render(<Support />, { wrapper: MemoryRouter });
     await expandSection(en.support.logs.title);
-    expect(mockFetch).toHaveBeenCalledWith("/logs");
+    const call = mockFetch.mock.calls.find(([url]) =>
+      String(url).endsWith("/logs"),
+    );
+    expect(call).toBeDefined();
     expect(await screen.findByText("log entry")).toBeInTheDocument();
+  });
+
+  it("sends the Authorization header when loading logs (issue #6111)", async () => {
+    setAuthToken("test-logs-token");
+    try {
+      render(<Support />, { wrapper: MemoryRouter });
+      await expandSection(en.support.logs.title);
+      await screen.findByText("log entry");
+      const call = mockFetch.mock.calls.find(([url]) =>
+        String(url).endsWith("/logs"),
+      );
+      expect(call).toBeDefined();
+      const headers = call?.[1]?.headers as Headers;
+      expect(headers.get("Authorization")).toBe("Bearer test-logs-token");
+    } finally {
+      setAuthToken(null);
+    }
   });
 
   it("shows error message when logs fetch fails", async () => {
@@ -421,6 +443,26 @@ describe("Support page", () => {
     await expandSection(en.support.logs.title);
     expect(await screen.findByText(en.support.logs.error)).toBeInTheDocument();
     expect(screen.getByText(en.support.logs.empty)).toBeInTheDocument();
+  });
+
+  it("surfaces a 401 on the logs endpoint as an error state, not silently (issue #6111)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: () => Promise.resolve({ detail: "Session expired" }),
+    });
+    const handler = vi.fn();
+    window.addEventListener(UNAUTHORIZED_EVENT, handler);
+    try {
+      render(<Support />, { wrapper: MemoryRouter });
+      await expandSection(en.support.logs.title);
+      expect(await screen.findByText(en.support.logs.error)).toBeInTheDocument();
+      expect(screen.getByText(en.support.logs.empty)).toBeInTheDocument();
+      expect(handler).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(UNAUTHORIZED_EVENT, handler);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- `Support.tsx`'s `loadLogs()` called a raw `fetch(\`${API_BASE}/logs\`)`, bypassing the authenticated client in `api.ts`. On AWS, API Gateway's Cognito JWT authorizer rejects unauthenticated requests to `/logs` with 401 before the Lambda ever runs — it only appeared to work on localhost because auth is disabled there by default.
- `GET /logs` returns `PlainTextResponse` (`backend/routes/logs.py`), so `loadLogs()` can't just be swapped to `fetchJson`, which unconditionally calls `res.json()`.

## Approach

- In `frontend/src/api.ts`, extracted the shared request-building logic from `fetchJson` (relative-path resolution, the CWE-918 origin/path-prefix CSRF-forgery guards, Cognito bearer + CSRF headers, 401 → `UNAUTHORIZED_EVENT` dispatch, and preferring the backend's `detail` message on errors) into a new `sendAuthenticated()` helper that returns the raw `Response`.
- `fetchJson<T>()` now calls `sendAuthenticated()` and parses the body with `res.json()`.
- Added `fetchText()`, which calls `sendAuthenticated()` and parses the body with `res.text()` — used for endpoints like `/logs` that return plain text.
- Added a `getLogs()` wrapper (`fetchText(\`${API_BASE}/logs\`)`) alongside the other Support-tools wrappers, and rewired `Support.tsx`'s `loadLogs()` to call it instead of raw `fetch`.
- This avoids duplicating the security-sensitive URL-validation/CSRF-guard logic between the JSON and text paths — both now share `sendAuthenticated()`.
- Did **not** touch the CDK route allowlist (`cdk/stacks/backend_lambda_stack.py`) — `/logs` stays behind Cognito auth via the catch-all route, per the issue's constraints. The fix is entirely client-side.

## Test plan

- [x] `npm --prefix frontend run lint` passes
- [x] `npm --prefix frontend run test -- --run tests/unit/api.test.ts tests/unit/pages/Support.test.tsx` — 53/53 passing, including new coverage:
  - `fetchText`/`getLogs` parse the response body as text, attach the `Authorization` header, and dispatch `UNAUTHORIZED_EVENT` + surface the backend `detail` message on a 401 (`frontend/tests/unit/api.test.ts`)
  - `Support.tsx`'s Logs panel sends the `Authorization` header when loading logs, and surfaces a 401 as an error state (not silently swallowed) rather than leaving the panel blank (`frontend/tests/unit/pages/Support.test.tsx`)
- [x] Confirmed the pre-existing failures seen in a full `npm --prefix frontend run test -- --run` run (in `App.test.tsx`, `MainApp.demo.test.tsx`, `urlUtils.test.ts`, `PensionForecast.test.tsx`) are unrelated flaky/order-dependent tests — they pass in isolation and pass on `origin/main` before this change, and none touch `api.ts` or `Support.tsx`.

Closes #6111