### PR TITLE
Fix flaky logoutFlowCognito menuitem race

### DIFF
--- a/frontend/tests/support/menuInteractionTimeout.ts
+++ b/frontend/tests/support/menuInteractionTimeout.ts
@@ -10,5 +10,13 @@
  * exceed the default even though the menu genuinely opens (#5734). Use
  * this constant instead of a bare `{ timeout: <number> }` so the value
  * stays consistent and any future retuning only happens in one place.
+ *
+ * A fixed 3000ms still occasionally proved too tight on contended CI
+ * runners even after #5734 (#6126), while the same test file reliably
+ * passes locally. Rather than blindly raising the value for every
+ * environment, scale it up only under CI (`process.env.CI`, set by GitHub
+ * Actions and honored elsewhere in this repo, e.g. `playwright.config.ts`)
+ * so local runs stay fast to fail while CI gets the extra headroom it
+ * actually needs.
  */
-export const MENU_INTERACTION_TIMEOUT_MS = 3000;
+export const MENU_INTERACTION_TIMEOUT_MS = process.env.CI ? 8000 : 3000;

--- a/frontend/tests/unit/logoutFlowCognito.test.tsx
+++ b/frontend/tests/unit/logoutFlowCognito.test.tsx
@@ -117,6 +117,13 @@ describe('Logout flow: Cognito mode (#4802)', () => {
       name: i18n.t('app.menuCategories.preferences'),
     });
     fireEvent.click(preferencesToggle);
+    // Wait for the category panel to actually report itself open before
+    // querying for the menuitem inside it, so a genuine "menu never
+    // opened" failure is distinguishable from a "menuitem not found"
+    // timeout instead of racing both in a single findByRole (#6126).
+    await waitFor(() =>
+      expect(preferencesToggle).toHaveAttribute('aria-expanded', 'true')
+    );
     const logoutButton = await screen.findByRole(
       'menuitem',
       { name: i18n.t('app.logout') },
@@ -208,6 +215,13 @@ describe('Logout flow: Cognito mode (#4802)', () => {
       name: i18n.t('app.menuCategories.preferences'),
     });
     fireEvent.click(preferencesToggle);
+    // Wait for the category panel to actually report itself open before
+    // querying for the menuitem inside it, so a genuine "menu never
+    // opened" failure is distinguishable from a "menuitem not found"
+    // timeout instead of racing both in a single findByRole (#6126).
+    await waitFor(() =>
+      expect(preferencesToggle).toHaveAttribute('aria-expanded', 'true')
+    );
     const logoutButton = await screen.findByRole(
       'menuitem',
       { name: i18n.t('app.logout') },


### PR DESCRIPTION
## Summary
- `MENU_INTERACTION_TIMEOUT_MS` (`frontend/tests/support/menuInteractionTimeout.ts`) now scales to 8000ms under `process.env.CI` (matching the convention already used in `playwright.config.ts`) instead of a flat 3000ms everywhere — local runs stay fast to fail, contended CI runners get real headroom.
- `logoutFlowCognito.test.tsx` now waits for the preferences panel's `aria-expanded` to flip to `"true"` before querying for the logout `menuitem`, so a genuine "menu never opened" failure is distinguishable from a menuitem-not-found timeout in CI logs going forward.

## Why
`tests/unit/logoutFlowCognito.test.tsx` intermittently failed in CI with `Unable to find role="menuitem" and name "Logout"` on a PR that only touched a workflow YAML file — no frontend regression. It's a required status check, so the flake blocks unrelated PRs. `MENU_INTERACTION_TIMEOUT_MS` had already been bumped once for this (#5734) and it recurred, so this scopes the increase to CI specifically rather than raising it again for every environment, and adds a clearer assertion boundary for next time.

## Test plan
- [x] `npx vitest --run tests/unit/logoutFlowCognito.test.tsx tests/unit/logoutFlowLocalDev.test.tsx` — 4/4 passed
- [x] `npx eslint tests/support/menuInteractionTimeout.ts tests/unit/logoutFlowCognito.test.tsx` — clean

Closes #6126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout flow test reliability by waiting for the preferences panel to open before locating the logout option.
  * Increased menu interaction timeouts in CI environments to reduce timing-related test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->