### PR TITLE
Fix graphify: commit one flat result folder, not date subfolders

### DIFF
--- a/.github/workflows/graphify.yml
+++ b/.github/workflows/graphify.yml
@@ -55,6 +55,12 @@ jobs:
       # main is protected (PR required), so the generated graph can't be
       # pushed directly. Open a PR instead; a human merges it like any other
       # change. Skips cleanly if a run produces no diff against main.
+      #
+      # graphify also writes a cache/ dir (gitignored, see #6131) and a
+      # dated snapshot subfolder (graphify-out/<date>/) duplicating the
+      # same files. We only want one flat folder of current results, not
+      # split by date/tag, so the top-level result files are added
+      # explicitly instead of the whole directory.
       - name: Open PR with graphify output
         env:
           GH_TOKEN: ${{ github.token }}
@@ -63,15 +69,22 @@ jobs:
           OUTPUT_DIR="graphify-out"
           BRANCH="graphify-update-${{ github.run_id }}"
 
-          if [ ! -d "$OUTPUT_DIR" ]; then
-            echo "No $OUTPUT_DIR directory found, skipping PR."
+          RESULT_FILES=()
+          for f in graph.json manifest.json .graphify_analysis.json; do
+            if [ -f "$OUTPUT_DIR/$f" ]; then
+              RESULT_FILES+=("$OUTPUT_DIR/$f")
+            fi
+          done
+
+          if [ ${#RESULT_FILES[@]} -eq 0 ]; then
+            echo "No graphify result files found in $OUTPUT_DIR, skipping PR."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add "$OUTPUT_DIR"
+          git add "${RESULT_FILES[@]}"
           if git diff --cached --quiet; then
             echo "No changes to persist, skipping PR."
             exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,10 @@ jenkins_home/
 # blobs, not meaningful output) — only graph.json/manifest.json etc. from
 # graphify-out/ should ever be committed, see #6119.
 graphify-out/cache/
+# graphify also writes a dated snapshot subfolder duplicating the same
+# files (graphify-out/2026-08-05/, etc). We only want one flat folder of
+# current results, not split by date, see #6131.
+graphify-out/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/
 
 # Offline issue sync
 issues/


### PR DESCRIPTION
## Summary
Follow-up to #6132, which merged before this second commit was pushed to
that branch — see the reopening comment on #6131 for why this is a separate
PR.

- graphify writes a `graphify-out/<date>/` subfolder that duplicates
  `graph.json`/`manifest.json`/`.graphify_analysis.json` alongside the
  top-level copies of the same files. Committing the whole directory (as
  the workflow did before #6132) staged both copies.
- The "Open PR with graphify output" step now explicitly `git add`s only
  the three top-level result files instead of the whole `graphify-out/`
  directory, so the dated subfolder is never staged.
- Added a gitignore pattern for date-named subfolders under `graphify-out/`
  as a backstop, in case the `git add` step is ever changed back to a
  directory add.

Net effect: a graphify PR now contains exactly one flat folder of current
results (`graph.json`, `manifest.json`, `.graphify_analysis.json`) — no
per-date or per-tag subfolders.

## Test plan
- [x] Validated the workflow YAML parses
- [x] Simulated the new file-selection logic locally against a mock
      `graphify-out/` layout (root files + dated subfolder + cache/) —
      confirmed only the 3 canonical files get staged, dated subfolder and
      cache/ are left alone
- [ ] On merge, manually dispatch graphify and confirm the resulting PR
      contains only the 3 top-level result files, no dated subfolder

Closes #6131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated Graphify reporting by including only relevant analysis outputs in generated pull requests.
  - Prevented empty pull requests from being created when no analysis results are available.
  - Excluded dated snapshots and cache files from source control to keep repository changes focused and manageable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->