### PR TITLE
Point AI agents and aider at graphify's knowledge graph output

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@ Read `AGENTS.md` for full repository guidance. Use these short rules while gener
 - Be careful when changing `data/`, auth defaults, or smoke-test flows; these are tightly coupled to local development and demos.
 - Preserve bash/PowerShell parity when editing shared developer workflows.
 - For Codex browser-testing setup and POC commands, see `docs/CODEX_PLAYWRIGHT_MCP.md`.
+- Before deep-reading an unfamiliar area, check `graphify-out/.graphify_analysis.json` (`gods` hotspots, `communities` clusters) as a precomputed orientation aid — it's refreshed manually via `workflow_dispatch` on `.github/workflows/graphify.yml`, so treat it as a snapshot, not live truth. Never load `graphify-out/graph.json` (tens of MB) wholesale into context.
 
 ## Code quality invariants (non-negotiable)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,16 @@ This repository has a Python/FastAPI backend, a React/Vite frontend, AWS CDK inf
 - `docs/`: operational docs, smoke test notes, deployment notes, and user-facing setup details.
 - Contributor onboarding runbook: `docs/CONTRIBUTOR_RUNBOOK.md` for the supported local, auth-enabled, test, smoke, and deployment-oriented paths.
 
+### Codebase knowledge graph (graphify)
+
+Before reading a large, unfamiliar slice of the codebase file-by-file, check whether `graphify-out/` already has a head start:
+
+- `graphify-out/.graphify_analysis.json` — architectural summary: `gods` (high fan-in "god object" hotspots), `communities` (module clusters), `cohesion`, and `surprises` (semantic anomalies). Grep or `jq` specific fields instead of reading the whole file.
+- `graphify-out/manifest.json` — per-file AST/semantic hashes.
+- `graphify-out/graph.json` — the full dependency graph (tens of MB). **Never** load this wholesale into a context window; query specific nodes/edges instead.
+
+These files are refreshed **manually**, not continuously: a maintainer runs `.github/workflows/graphify.yml` via `workflow_dispatch`, which opens a PR into `main` with the regenerated output. Treat them as a helpful orientation aid — e.g. before a large refactor, check whether the files you're about to touch show up in `gods` or share a `communities` cluster — not as always-current ground truth; verify anything load-bearing against the actual source.
+
 ## 2. Entrypoints and runtime expectations
 
 ### Backend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This file gives Claude-style coding agents a fast, practical overview for workin
 - Local backend app: `backend.local_api.main:app`
 - Frontend app entry: `frontend/src/main.tsx`
 - Primary backend tests: top-level `tests/`
+- Codebase knowledge graph: `graphify-out/` (see High-signal warnings below)
 
 ## Most useful commands
 
@@ -39,6 +40,7 @@ npm run smoke:test:codex:poc
 - Never use `git commit -am`; always stage specific files explicitly. The `-a` flag will sweep in any lock file changes from local `npm ci` or `npm install` runs, which can strip platform-specific optional deps (e.g. Linux `@emnapi` entries) and break CI.
 - Be cautious around `data/`, auth toggles, and smoke-test identities; these often affect local demos and automated flows.
 - Preserve cross-platform workflow parity when touching scripts because the repo uses both bash and PowerShell helpers.
+- Before deep-reading an unfamiliar area, check `graphify-out/.graphify_analysis.json` for `gods` (fan-in hotspots) and `communities` (module clusters) — it's a precomputed orientation aid. It's refreshed **manually** via `workflow_dispatch` on `.github/workflows/graphify.yml`, so treat it as a snapshot, not live truth. Never load `graphify-out/graph.json` (tens of MB) wholesale into context — grep/`jq` specific entries instead.
 
 ## Branch, issue, and PR policy
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -191,11 +191,17 @@ The script:
    extracts any file paths already mentioned in the issue body
 3. If no file paths are found, asks a local Ollama model to suggest which
    repo files are relevant
-4. Prints the resulting file list, plus a trimmed prompt for confirmation
-   (title, `What`, `How`, `Constraints`, `Success`) -- `Why`, `Files
-   Affected`, and `Failure` are left out since they aren't actionable for
-   a coding LLM or are already covered by the file list
-5. On confirmation, adds the files to `aider` and hands off interactive
+4. If `graphify-out/.graphify_analysis.json` exists in the checkout, looks up
+   the resolved files against it and appends a short hint noting any that are
+   high fan-in "god object" hotspots or share a knowledge-graph community with
+   other symbols -- silently skipped if the file is absent (it's only
+   refreshed manually, see [Regenerating the graphify knowledge graph
+   locally](#regenerating-the-graphify-knowledge-graph-locally) below)
+5. Prints the resulting file list, plus a trimmed prompt for confirmation
+   (title, `What`, `How`, `Constraints`, `Success`, graphify hint) -- `Why`,
+   `Files Affected`, and `Failure` are left out since they aren't actionable
+   for a coding LLM or are already covered by the file list
+6. On confirmation, adds the files to `aider` and hands off interactive
    control to it
 
 Optional flags:
@@ -216,6 +222,27 @@ context window in `.aider.model.settings.yml`. Models smaller than ~14B
 parameters (e.g. 7B models on CPU-only hardware) are more likely to still hit
 this timeout on larger issues; if you're consistently timing out, either pick
 a larger/faster model or raise `timeout` in `.aider.conf.yml`.
+
+### Regenerating the graphify knowledge graph locally
+
+`graphify-out/graph.json`, `manifest.json`, and `.graphify_analysis.json` are
+committed to `main`, but only refreshed manually by running
+[`.github/workflows/graphify.yml`](../.github/workflows/graphify.yml) via
+`workflow_dispatch` -- they can lag behind the current tree. To regenerate
+them locally against your working copy instead of waiting on that workflow:
+
+```bash
+pip install graphifyy
+graphify .
+```
+
+This writes `graphify-out/graph.json`, `graphify-out/manifest.json`, and
+`graphify-out/.graphify_analysis.json` (the file `f_implement_issue_with_aider.py`
+reads for its hint). Add `--backend deepseek` to `graphify extract .` for the
+semantic "surprises" extraction pass too, which requires a `DEEPSEEK_API_KEY`.
+Do not commit a locally regenerated graph over the checked-in one outside of
+the workflow's own PR flow -- see `.github/workflows/graphify.yml` for how
+that's kept as a single, reviewable change.
 
 ## h_run_ci_checks.py
 

--- a/scripts/developer_tools/f_implement_issue_with_aider.py
+++ b/scripts/developer_tools/f_implement_issue_with_aider.py
@@ -88,8 +88,7 @@ def fetch_issue_from_github(
     except requests.RequestException as exc:
         print(f"ERROR: Failed to fetch issue #{issue_id}: {exc}", file=sys.stderr)
         print(
-            "Tip: If GitHub API is unreachable, use -f <file> to load a local "
-            "markdown file instead.",
+            "Tip: If GitHub API is unreachable, use -f <file> to load a local " "markdown file instead.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -301,9 +300,7 @@ Do not include test files or lock files. Be concise."""
             if isinstance(suggested, list):
                 # Filter to existing, safe (non-traversal) files
                 existing = [
-                    p
-                    for p in suggested
-                    if isinstance(p, str) and is_safe_relative_path(p) and Path(p).exists()
+                    p for p in suggested if isinstance(p, str) and is_safe_relative_path(p) and Path(p).exists()
                 ]
                 if verbose:
                     print(
@@ -357,10 +354,88 @@ def resolve_files_to_edit(
     return suggest_files_with_ollama(title, body, extracted_paths, endpoint, model, verbose)
 
 
+def _normalize_symbol_prefix(path: str) -> str:
+    """Convert a repo-relative file path to the underscore-joined id prefix
+    graphify uses for symbols defined in that file, e.g. "backend/app.py" ->
+    "backend_app"."""
+    stem = Path(path).with_suffix("")
+    return re.sub(r"[^a-z0-9]+", "_", str(stem).lower()).strip("_")
+
+
+def load_graphify_analysis(
+    analysis_path: str = "graphify-out/.graphify_analysis.json",
+    verbose: bool = False,
+) -> dict | None:
+    """Load graphify's precomputed knowledge-graph analysis, if present.
+
+    Returns None (never raises) when the file is missing or unreadable --
+    graphify-out/ is only refreshed manually via workflow_dispatch on
+    .github/workflows/graphify.yml, so it's a helpful-if-present snapshot,
+    not something every checkout is guaranteed to have.
+    """
+    path = Path(analysis_path)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        if verbose:
+            print(f"[DEBUG] Could not read graphify analysis: {exc}", file=sys.stderr)
+        return None
+
+
+def graphify_hint_for_files(files: list[str], analysis: dict | None) -> str:
+    """Build a short prompt hint from graphify's analysis for the given files:
+    whether any is a high fan-in "god object" hotspot, and which knowledge-graph
+    community it belongs to. Returns "" when there's nothing to say (no
+    analysis available, or none of the files are flagged) -- this is a hint,
+    not a required section of the prompt.
+    """
+    if not analysis:
+        return ""
+
+    gods = {g["id"]: g for g in analysis.get("gods", []) if isinstance(g, dict) and "id" in g}
+    communities = analysis.get("communities", {})
+
+    lines = []
+    for file in files:
+        prefix = _normalize_symbol_prefix(file)
+        if not prefix:
+            continue
+
+        for god_id, god in gods.items():
+            if god_id == prefix or god_id.startswith(f"{prefix}_"):
+                lines.append(
+                    f"- {file}: high fan-in hotspot ('{god.get('label', god_id)}', "
+                    f"degree {god.get('degree', '?')}) -- changes here have broad blast radius."
+                )
+
+        for community_id, members in communities.items():
+            if not isinstance(members, list):
+                continue
+            if any(m == prefix or m.startswith(f"{prefix}_") for m in members):
+                lines.append(
+                    f"- {file}: in knowledge-graph community {community_id} with "
+                    f"{len(members) - 1} other symbols -- check for related usages."
+                )
+                break
+
+    if not lines:
+        return ""
+
+    return "\n".join(
+        [
+            "\nGraphify knowledge-graph hints (precomputed, may be stale -- verify against the actual source):",
+            *lines,
+        ]
+    )
+
+
 def formulate_aider_prompt(
     issue_title: str,
     parsed_sections: dict[str, str],
     verbose: bool = False,
+    graphify_hint: str = "",
 ) -> str:
     """Formulate the prompt to pass to Aider based on parsed issue sections."""
     prompt_lines = [issue_title]
@@ -379,6 +454,9 @@ def formulate_aider_prompt(
             if content:
                 section_title = section.replace("_", " ").title()
                 prompt_lines.append(f"\n{section_title}:\n{content}")
+
+    if graphify_hint:
+        prompt_lines.append(graphify_hint)
 
     prompt = "\n".join(prompt_lines)
 
@@ -450,24 +528,19 @@ def run_aider(files: list[str], prompt: str, verbose: bool = False) -> None:
         print("ERROR: No files to add to Aider; aborting.", file=sys.stderr)
         sys.exit(1)
 
-    message_file = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".md", delete=False, encoding="utf-8"
-    )
+    message_file = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, encoding="utf-8")
     try:
         message_file.write(prompt)
         message_file.close()
         if verbose:
             print(f"[DEBUG] Applying initial prompt to {len(files)} files...", file=sys.stderr)
-        initial = _run_aider(
-            ["aider", "--edit-format", "whole", "--message-file", message_file.name, *files]
-        )
+        initial = _run_aider(["aider", "--edit-format", "whole", "--message-file", message_file.name, *files])
     finally:
         Path(message_file.name).unlink(missing_ok=True)
 
     if initial.returncode != 0:
         print(
-            f"ERROR: aider exited with status {initial.returncode} "
-            "while applying the initial prompt",
+            f"ERROR: aider exited with status {initial.returncode} " "while applying the initial prompt",
             file=sys.stderr,
         )
         sys.exit(initial.returncode)
@@ -532,17 +605,18 @@ def main(argv: list[str] | None = None) -> None:
     # Parse issue structure
     parsed = parse_issue_body(body, args.verbose)
 
-    files = resolve_files_to_edit(
-        title, body, endpoint, model, args.verbose, parsed.get("files_affected", "")
-    )
+    files = resolve_files_to_edit(title, body, endpoint, model, args.verbose, parsed.get("files_affected", ""))
     if not files:
         print(
             "WARNING: No files found or suggested. Proceeding with empty file list.",
             file=sys.stderr,
         )
 
-    # Formulate prompt
-    prompt = formulate_aider_prompt(title, parsed, args.verbose)
+    # Formulate prompt, folding in a short hint from graphify's precomputed
+    # knowledge graph (god-object hotspots / community membership) when
+    # graphify-out/ is present in this checkout.
+    graphify_hint = graphify_hint_for_files(files, load_graphify_analysis(verbose=args.verbose))
+    prompt = formulate_aider_prompt(title, parsed, args.verbose, graphify_hint)
 
     # Confirm with user
     if not confirm_with_user(files, prompt, args.no_confirm, args.verbose):

--- a/tests/scripts/test_implement_issue_with_aider.py
+++ b/tests/scripts/test_implement_issue_with_aider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -12,11 +13,14 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "developer_tools"))
 
 from f_implement_issue_with_aider import (  # noqa: E402
+    _normalize_symbol_prefix,
     confirm_with_user,
     extract_file_paths_from_issue,
     fetch_issue_from_github,
     formulate_aider_prompt,
+    graphify_hint_for_files,
     is_safe_relative_path,
+    load_graphify_analysis,
     load_issue_from_file,
     main,
     parse_issue_body,
@@ -233,6 +237,67 @@ class TestResolveFilesToEdit:
         mock_fetch.assert_not_called()
 
 
+class TestNormalizeSymbolPrefix:
+    def test_converts_path_to_underscore_prefix(self):
+        assert _normalize_symbol_prefix("backend/app.py") == "backend_app"
+
+    def test_strips_extension_and_lowercases(self):
+        assert _normalize_symbol_prefix("frontend/src/api.ts") == "frontend_src_api"
+
+    def test_collapses_non_alnum_runs(self):
+        assert _normalize_symbol_prefix("scripts/dev-tools/f_foo.py") == "scripts_dev_tools_f_foo"
+
+
+class TestLoadGraphifyAnalysis:
+    def test_returns_none_when_file_missing(self, tmp_path):
+        assert load_graphify_analysis(str(tmp_path / "nope.json")) is None
+
+    def test_returns_none_on_invalid_json(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json")
+        assert load_graphify_analysis(str(bad)) is None
+
+    def test_loads_valid_json(self, tmp_path):
+        analysis_file = tmp_path / "analysis.json"
+        analysis_file.write_text(json.dumps({"gods": [], "communities": {}}))
+        assert load_graphify_analysis(str(analysis_file)) == {"gods": [], "communities": {}}
+
+
+class TestGraphifyHintForFiles:
+    def test_returns_empty_string_when_analysis_is_none(self):
+        assert graphify_hint_for_files(["backend/app.py"], None) == ""
+
+    def test_returns_empty_string_when_analysis_has_no_matches(self):
+        analysis = {
+            "gods": [{"id": "unrelated_symbol", "label": "x()", "degree": 5}],
+            "communities": {},
+        }
+        assert graphify_hint_for_files(["backend/app.py"], analysis) == ""
+
+    def test_returns_empty_string_for_empty_analysis(self):
+        assert graphify_hint_for_files(["backend/app.py"], {}) == ""
+
+    def test_flags_god_object_hotspot(self):
+        analysis = {
+            "gods": [{"id": "backend_app_create_app", "label": "create_app()", "degree": 224}],
+            "communities": {},
+        }
+        hint = graphify_hint_for_files(["backend/app.py"], analysis)
+        assert "backend/app.py" in hint
+        assert "create_app()" in hint
+        assert "224" in hint
+
+    def test_flags_community_membership(self):
+        analysis = {
+            "gods": [],
+            "communities": {"5": ["frontend_src_api", "frontend_src_api_foo", "other_symbol"]},
+        }
+        hint = graphify_hint_for_files(["frontend/src/api.ts"], analysis)
+        assert "frontend/src/api.ts" in hint
+        assert "community 5" in hint
+        assert "2 other symbols" in hint
+
+
 class TestFormulateAiderPrompt:
     def test_includes_title_and_sections(self):
         sections = {"what": "Do the thing.", "how": "Do it this way."}
@@ -271,6 +336,14 @@ class TestFormulateAiderPrompt:
         assert "Failure:" not in prompt
         assert "It doesn't work." not in prompt
         assert "Success:" in prompt
+
+    def test_appends_graphify_hint_when_provided(self):
+        prompt = formulate_aider_prompt("Issue Title", {"what": "Do it."}, graphify_hint="\nGraphify hints:\n- foo")
+        assert prompt.endswith("Graphify hints:\n- foo")
+
+    def test_omits_graphify_hint_when_empty(self):
+        prompt = formulate_aider_prompt("Issue Title", {"what": "Do it."}, graphify_hint="")
+        assert "Graphify" not in prompt
 
 
 class TestFetchIssueFromGithub:
@@ -456,6 +529,7 @@ class TestMainOrdering:
     """The issue's constraint is to fail early if Ollama isn't running, before
     any other work -- these pin that ordering against a regression."""
 
+    @mock.patch("f_implement_issue_with_aider.load_graphify_analysis", return_value=None)
     @mock.patch("f_implement_issue_with_aider.os.chdir")
     @mock.patch("f_implement_issue_with_aider.get_repo_root", return_value="/repo/root")
     @mock.patch("f_implement_issue_with_aider.run_aider")
@@ -472,6 +546,7 @@ class TestMainOrdering:
         mock_run_aider,
         mock_get_repo_root,
         mock_chdir,
+        mock_load_graphify,
     ):
         calls = []
         mock_validate.side_effect = lambda endpoint: calls.append("ollama") or True
@@ -509,6 +584,7 @@ class TestMainOrdering:
         assert exc_info.value.code == 1
         mock_chdir.assert_not_called()
 
+    @mock.patch("f_implement_issue_with_aider.load_graphify_analysis", return_value=None)
     @mock.patch("f_implement_issue_with_aider.os.chdir")
     @mock.patch("f_implement_issue_with_aider.get_repo_root", return_value="/repo/root")
     @mock.patch("f_implement_issue_with_aider.run_aider")
@@ -523,6 +599,7 @@ class TestMainOrdering:
         mock_run_aider,
         mock_get_repo_root,
         mock_chdir,
+        mock_load_graphify,
     ):
         # Regression test: paths extracted from an issue body (and the files
         # ultimately handed to aider) are resolved relative to the process


### PR DESCRIPTION
## Summary
- `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` now each
  document `graphify-out/` (the knowledge graph generated by
  `.github/workflows/graphify.yml`) as an orientation aid for agents:
  what `.graphify_analysis.json`'s `gods`/`communities` mean, that the
  data is refreshed **manually** via `workflow_dispatch` (a snapshot, not
  live truth), and a warning never to load the full `graph.json` (tens of
  MB) wholesale into a context window.
- `scripts/developer_tools/f_implement_issue_with_aider.py` now looks up
  the files it's about to hand to aider against
  `graphify-out/.graphify_analysis.json` (when present) and appends a
  short hint noting any that are high fan-in "god object" hotspots or
  share a knowledge-graph community with other symbols. Degrades to a
  no-op when the file is absent — no crash, no required file.
- `scripts/README.md` documents this new prompt step and how to
  regenerate the graph locally (`pip install graphifyy && graphify .`)
  instead of waiting on the next ad-hoc workflow run.

## Test plan
- [x] `python -m pytest tests/scripts/test_implement_issue_with_aider.py -q`
      — 63 passed, including new coverage for
      `_normalize_symbol_prefix`, `load_graphify_analysis`, and
      `graphify_hint_for_files` (missing file, invalid JSON, god-object
      match, community match, no-match cases).
- [x] `ruff check --config backend/pyproject.toml` and
      `black --check --config backend/pyproject.toml` on the changed
      Python files — clean.
- [x] Reviewed the doc diffs — additive only, no command/behavior changes.

Closes #6136