### PR TITLE
Fix: bootstrap allowed_emails so the deployment owner isn't locked out on AWS

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -506,6 +506,10 @@ jobs:
           CDK_OUTDIR: /tmp/cdk.out.${{ github.run_id }}.${{ github.run_attempt }}
           FRONTEND_ORIGIN: ${{ env.FRONTEND_ORIGIN }}
           CORS_ORIGINS: ${{ env.CORS_ORIGINS }}
+          # Optional (#6130): rotates the bootstrap owner allowlist without a
+          # code change. Falls back to config.lambda.yaml's baked-in default
+          # when this secret is not set.
+          ALLOWED_EMAILS: ${{ secrets.ALLOWED_EMAILS }}
         run: >
           npx cdk deploy BackendLambdaStack --require-approval never
           --parameters BackendLambdaStack:UiAuthUserPoolId="$UI_AUTH_USER_POOL_ID"

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -82,19 +82,40 @@ def _emails_for_person_meta(meta: Any) -> Set[str]:
     return emails
 
 
+def _configured_allowed_emails() -> Set[str]:
+    """Return the bootstrap allowlist from ``config.allowed_emails``.
+
+    Sourced from ``config.lambda.yaml``'s ``auth.allowed_emails`` (or the
+    ``ALLOWED_EMAILS`` env var, which overrides it -- see
+    :func:`backend.config.load_config`). Unlike the S3/local-provisioned
+    account emails below, this set is always available even before any owner
+    account has been created, so it lets a deployment's designated owner(s)
+    authenticate on a fresh deployment with zero provisioned accounts (#6130).
+    """
+
+    configured = getattr(config, "allowed_emails", None)
+    if not configured:
+        return set()
+    return {email.strip().lower() for email in configured if isinstance(email, str) and email.strip()}
+
+
 def _allowed_emails() -> Set[str]:
     """Return the set of configured account emails.
 
     Includes both each owner's own email and their configured viewer emails
     (see :func:`_emails_for_person_meta`), so identity resolution accepts the
     same callers ``ensure_owner_access`` would later authorize for that owner.
+    Also always includes :func:`_configured_allowed_emails`, the deployment's
+    bootstrap allowlist, so the owner(s) can authenticate even before any
+    account has been provisioned.
 
     When running in AWS, owner metadata is loaded from S3. If this request
-    fails, the exception is logged and an empty set is returned so that login
-    attempts are rejected cleanly.
+    fails, the exception is logged and the bootstrap allowlist alone is
+    returned (rather than clearing it) so the owner is not locked out by a
+    transient S3 error.
     """
 
-    emails: Set[str] = set()
+    emails: Set[str] = _configured_allowed_emails()
 
     if config.app_env == "aws":
         owners: Set[str] = set()
@@ -126,7 +147,7 @@ def _allowed_emails() -> Set[str]:
                         break
             except (BotoCoreError, ClientError):
                 logger.exception("Failed to list allowed emails from S3")
-                return set()
+                return emails
         for owner in owners:
             try:
                 meta = load_person_metadata(owner)
@@ -149,7 +170,7 @@ def _allowed_emails() -> Set[str]:
 
     if not root.exists():
         logger.warning("Accounts root %s does not exist", root)
-        return set()
+        return emails
 
     for owner_dir in root.iterdir():
         if not owner_dir.is_dir():

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -285,6 +285,11 @@ class BackendLambdaStack(Stack):
         signup_login_url = self.node.try_get_context("signup_login_url") or os.getenv(
             "SIGNUP_LOGIN_URL", ""
         )
+        # Bootstrap allowlist for backend.auth._allowed_emails() (#6130): lets a
+        # deployment's designated owner(s) authenticate before any account is
+        # provisioned in S3. Optional -- when unset, config.lambda.yaml's
+        # baked-in `auth.allowed_emails` default applies instead.
+        allowed_emails = self.node.try_get_context("allowed_emails") or os.getenv("ALLOWED_EMAILS", "")
         # SES sender identity used as the `Source` for signup/pension-report
         # emails (backend/emails/*.py's `_SENDER_EMAIL`, from `WEEKLY_REPORT_FROM`,
         # defaulting to "no-reply@allotmint.com"). Used below to scope the
@@ -469,6 +474,8 @@ class BackendLambdaStack(Stack):
             backend_env["SIGNUP_APPROVAL_BASE_URL"] = signup_approval_base_url
         if signup_login_url:
             backend_env["SIGNUP_LOGIN_URL"] = signup_login_url
+        if allowed_emails:
+            backend_env["ALLOWED_EMAILS"] = allowed_emails
 
         backend_log_group = self._lambda_log_group(self, "BackendLambdaLogGroup")
         backend_fn = _lambda.DockerImageFunction(

--- a/config.lambda.yaml
+++ b/config.lambda.yaml
@@ -22,7 +22,13 @@ auth:
   demo_identity: demo
   smoke_identity: demo
   local_login_email: ""
-  allowed_emails: []
+  # Bootstrap allowlist consulted by `_allowed_emails()` (backend/auth.py) in
+  # addition to any owner accounts already provisioned in S3. Without this,
+  # a fresh deployment with no S3 accounts yet has no one who can pass
+  # `_allowed_emails()` -- including its own owner (#6130). Overridden by the
+  # ALLOWED_EMAILS env var if set (see backend/config.py).
+  allowed_emails:
+    - steveleonard11@gmail.com
 
 server:
   app_env: aws                      # overridden by APP_ENV env var

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -184,6 +184,11 @@ to use the tool (#6130).
   allowlist alone is still honoured rather than rejecting everyone, so a
   transient error can't lock the owner out.
 
+This deployment's owner is pre-seeded directly in `config.lambda.yaml`, but
+that's a one-time step for *this* repo, not a requirement going forward: a
+future deployment (or rotating this one's owner) only needs the
+`ALLOWED_EMAILS` GitHub Actions secret set, no code change.
+
 Two distinct paths can create an owner's data directory:
 
 ### Admin-provisioned (signup-approval flow)

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -158,6 +158,32 @@ bearer token is never logged.
 
 ## Account creation
 
+### Bootstrapping the first owner account (AWS)
+
+On a fresh AWS deployment there are no owner accounts in S3 yet, so
+`_allowed_emails()` (`backend/auth.py`) — consulted by `get_current_user` /
+`_resolve_identity_when_auth_disabled` on every protected route, including
+Cognito-authenticated ones — has nothing to admit. Historically this meant
+even the deployment's own owner got a 403 `"Unauthorized email"`, with no way
+to bootstrap in: the signup-approval flow below requires already being able
+to use the tool (#6130).
+
+`_allowed_emails()` now always includes a **bootstrap allowlist** sourced from
+`config.allowed_emails`, in addition to whatever is provisioned in S3/locally:
+
+- `config.lambda.yaml`'s `auth.allowed_emails` ships with the deployment
+  owner's email pre-seeded, so it works out of the box.
+- Setting the `ALLOWED_EMAILS` env var (comma-separated emails) overrides the
+  yaml value entirely — set it as the `ALLOWED_EMAILS` GitHub Actions secret
+  to rotate the owner list without a code change; `cdk/stacks/backend_lambda_stack.py`
+  passes it through to the Lambda when present.
+- This is a fix, not a broadening: it is still an explicit, small allowlist —
+  it does not open access to arbitrary Cognito users, and per-owner data
+  access is still gated separately by `ensure_owner_access`.
+- If the S3 owner listing fails (e.g. a transient AWS error), the bootstrap
+  allowlist alone is still honoured rather than rejecting everyone, so a
+  transient error can't lock the owner out.
+
 Two distinct paths can create an owner's data directory:
 
 ### Admin-provisioned (signup-approval flow)

--- a/docs/CONTRIBUTOR_RUNBOOK.md
+++ b/docs/CONTRIBUTOR_RUNBOOK.md
@@ -185,6 +185,7 @@ See `docs/DEPLOY.md` ("Critical: `GITHUB_DEPLOY_ROLE_ARN` environment variable f
 | --- | --- | --- |
 | `SMOKE_TEST_USERNAME` | Username for authenticated smoke test runs | `SMOKE_TEST_USERNAME=test-user@example.com` |
 | `SMOKE_TEST_PASSWORD` | Password for authenticated smoke test runs | `SMOKE_TEST_PASSWORD=<secure-password>` |
+| `ALLOWED_EMAILS` | Rotates the bootstrap owner allowlist without a code change (see [docs/AUTH.md](AUTH.md#bootstrapping-the-first-owner-account-aws)) | `ALLOWED_EMAILS=owner@example.com` |
 
 **Validating deployment configuration:**
 

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -20,12 +20,12 @@ backend/app.py:200
 backend/app.py:219
 backend/auth.py:126
 # accounts-root path comes from server config, not attacker-controlled input.
-backend/auth.py:151
+backend/auth.py:172
 backend/auth.py:537
 # provider is always a hardcoded literal ("Google"/"Cognito") passed by the
 # caller, never attacker-controlled; email/token on the same call are already
 # wrapped in sanitise_log_value.
-backend/auth.py:569
+backend/auth.py:590
 backend/bootstrap/isolation.py:89
 backend/bootstrap/startup.py:92
 backend/common/accounts_store.py:244

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -164,6 +164,36 @@ def test_allowed_emails_bootstrap_allowlist_when_no_accounts_provisioned(monkeyp
     assert auth._allowed_emails() == {"owner@example.com"}
 
 
+def test_configured_allowed_emails_normalizes_list(monkeypatch):
+    """``config.allowed_emails`` (already a ``list[str]``, however sourced --
+    config.lambda.yaml's yaml list or the ALLOWED_EMAILS env var, both parsed
+    by ``_parse_str_list`` in backend/config.py) must become a lower-cased,
+    whitespace-trimmed set, not be iterated character-by-character (#6130).
+
+    Deliberately does not exercise ``reload_config()``: config.py's parsing of
+    ALLOWED_EMAILS into a list is already covered by
+    tests/test_config.py::test_allowed_emails_env_override, and re-entering
+    ``reload_config()`` here would trip its unrelated "preserve a
+    monkeypatched allowed_emails across reload" bookkeeping (backend/config.py
+    ``_allowed_emails_overridden``) whenever an earlier test in this file has
+    already monkeypatched ``config.allowed_emails`` directly -- this test's
+    job is only ``_configured_allowed_emails()``'s own aggregation logic.
+    """
+
+    monkeypatch.setattr(
+        auth.config,
+        "allowed_emails",
+        [" Owner@Example.com", "Second@Example.com ", "", "   "],
+        raising=False,
+    )
+    assert auth._configured_allowed_emails() == {"owner@example.com", "second@example.com"}
+
+
+def test_configured_allowed_emails_empty_when_unset(monkeypatch):
+    monkeypatch.setattr(auth.config, "allowed_emails", None, raising=False)
+    assert auth._configured_allowed_emails() == set()
+
+
 def test_create_and_decode_token_round_trip():
     token = auth.create_access_token("user@example.com")
     assert auth.decode_token(token) == "user@example.com"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -60,6 +60,7 @@ def test_allowed_emails_local_relative_root(monkeypatch, tmp_path):
     (accounts / "notes.txt").write_text("ignore")
 
     monkeypatch.setattr(auth.config, "app_env", "local", raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", None, raising=False)
     monkeypatch.setattr(auth.config, "accounts_root", "accounts", raising=False)
     monkeypatch.setattr(auth.config, "repo_root", repo_root, raising=False)
 
@@ -86,6 +87,7 @@ def test_allowed_emails_local_fallback_handles_errors(monkeypatch, tmp_path):
     (fallback_root / "bob").mkdir()
 
     monkeypatch.setattr(auth.config, "app_env", "local", raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", None, raising=False)
     monkeypatch.setattr(auth.config, "accounts_root", None, raising=False)
     monkeypatch.setattr(auth.config, "repo_root", repo_root, raising=False)
 
@@ -109,6 +111,7 @@ def test_allowed_emails_local_fallback_handles_errors(monkeypatch, tmp_path):
 
 def test_allowed_emails_aws_s3_error(monkeypatch, caplog):
     monkeypatch.setattr(auth.config, "app_env", "aws", raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", None, raising=False)
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
 
     class FakeS3:
@@ -126,6 +129,39 @@ def test_allowed_emails_aws_s3_error(monkeypatch, caplog):
 
     assert emails == set()
     assert any("Failed to list allowed emails from S3" in record.message for record in caplog.records)
+
+
+def test_allowed_emails_bootstrap_allowlist_survives_s3_error(monkeypatch, caplog):
+    """The configured bootstrap owner must still get in even if S3 fails (#6130).
+
+    A transient S3 error must not lock out the deployment's configured owner
+    email(s) -- only the S3-provisioned portion of the set is lost.
+    """
+
+    monkeypatch.setattr(auth.config, "app_env", "aws", raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", ["Owner@Example.com"], raising=False)
+    monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
+
+    class FakeS3:
+        def list_objects_v2(self, **kwargs):  # noqa: ARG002 - kwargs for API parity
+            raise auth.BotoCoreError()
+
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=lambda name: FakeS3()))
+
+    with caplog.at_level("ERROR"):
+        emails = auth._allowed_emails()
+
+    assert emails == {"owner@example.com"}
+
+
+def test_allowed_emails_bootstrap_allowlist_when_no_accounts_provisioned(monkeypatch):
+    """A fresh AWS deployment with zero S3 accounts must still admit the configured owner (#6130)."""
+
+    monkeypatch.setattr(auth.config, "app_env", "aws", raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", ["owner@example.com"], raising=False)
+    monkeypatch.delenv(dl.DATA_BUCKET_ENV, raising=False)
+
+    assert auth._allowed_emails() == {"owner@example.com"}
 
 
 def test_create_and_decode_token_round_trip():

--- a/tests/test_auth_aws.py
+++ b/tests/test_auth_aws.py
@@ -10,6 +10,7 @@ from backend.common.account_models import PersonMetadata
 
 def test_allowed_emails_from_s3(monkeypatch):
     monkeypatch.setattr(auth.config, "app_env", "aws", raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", None, raising=False)
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
 
     def fake_client(name):
@@ -51,6 +52,7 @@ def test_allowed_emails_from_s3(monkeypatch):
 
 def test_allowed_emails_logs_s3_error(monkeypatch, caplog):
     monkeypatch.setattr(auth.config, "app_env", "aws", raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", None, raising=False)
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
 
     class FakeS3:
@@ -72,6 +74,7 @@ def test_allowed_emails_logs_s3_error(monkeypatch, caplog):
 
 def test_allowed_emails_s3_handles_pagination(monkeypatch):
     monkeypatch.setattr(auth.config, "app_env", "aws", raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", None, raising=False)
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
 
     calls: list[dict[str, object]] = []
@@ -110,6 +113,7 @@ def test_allowed_emails_s3_handles_pagination(monkeypatch):
 
 def test_allowed_emails_s3_filters_invalid_entries(monkeypatch):
     monkeypatch.setattr(auth.config, "app_env", "aws", raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", None, raising=False)
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
 
     class FakeS3:

--- a/tests/test_auth_get_active_user.py
+++ b/tests/test_auth_get_active_user.py
@@ -261,6 +261,7 @@ def test_allowed_emails_missing_accounts_root(
 ) -> None:
     monkeypatch.setattr(auth.config, "disable_auth", False, raising=False)
     monkeypatch.setattr(auth.config, "app_env", None, raising=False)
+    monkeypatch.setattr(auth.config, "allowed_emails", None, raising=False)
 
     missing_root = tmp_path / "missing"
     monkeypatch.setattr(auth.config, "accounts_root", missing_root, raising=False)

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -86,6 +86,7 @@ def test_allowed_emails_includes_viewer_emails(monkeypatch, tmp_path):
     """
 
     monkeypatch.setattr(config, "app_env", "local")
+    monkeypatch.setattr(config, "allowed_emails", None, raising=False)
     root = tmp_path / "accounts"
     owner_dir = root / "alice"
     owner_dir.mkdir(parents=True)
@@ -106,6 +107,7 @@ def test_allowed_emails_includes_viewer_emails_from_s3(monkeypatch):
     """
 
     monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setattr(config, "allowed_emails", None, raising=False)
     monkeypatch.setenv("DATA_BUCKET", "test-bucket")
 
     class _FakeS3Client:


### PR DESCRIPTION
## Summary

- \`_allowed_emails()\` (`backend/auth.py`) only ever admitted emails found in already-provisioned S3 `person.json` files, so a fresh AWS deployment with zero accounts had no one who could pass it — not even its own owner. It now always merges in a bootstrap allowlist from `config.allowed_emails` (config-file `auth.allowed_emails`, overridable via the `ALLOWED_EMAILS` env var), and that bootstrap allowlist now survives an S3 listing failure instead of being cleared to an empty set.
- `config.lambda.yaml` ships with `steveleonard11@gmail.com` pre-seeded as the bootstrap owner, so this unblocks the deployment with no extra manual step beyond merging/redeploying.
- `cdk/stacks/backend_lambda_stack.py` and `.github/workflows/deploy-lambda.yml` optionally pass through an `ALLOWED_EMAILS` context/secret so the owner list can be rotated later without a code change (mirrors the existing `SIGNUP_ADMIN_EMAIL` pattern).
- `docs/AUTH.md` documents the new "Bootstrapping the first owner account (AWS)" flow; `docs/CONTRIBUTOR_RUNBOOK.md` lists the new optional `ALLOWED_EMAILS` deploy variable.
- Updated `tests/test_auth.py`, `tests/test_auth_aws.py`, `tests/test_auth_utils.py`, `tests/test_auth_get_active_user.py` to isolate `config.allowed_emails` where they test the S3/local-provisioning path alone, and added two new tests covering the bootstrap-allowlist-survives-S3-error and zero-accounts-provisioned cases. Also updated `tests/data/log_sanitization_baseline.txt` for two line-number shifts caused by the new function (no new unsanitised logger calls were introduced).

This does not weaken auth for any other user: the merged set is still an explicit, small allowlist, and per-owner data access is still separately gated by `ensure_owner_access`.

Closes #6130

## Test plan

- [x] `pytest tests/` — 3798 passed, 6 skipped, 16 xfailed, 1 xpassed
- [x] `pytest cdk/tests/test_backend_lambda_stack.py cdk/tests/test_backend_lambda_stack_permissions.py` — 78 passed
- [x] `ruff check --config backend/pyproject.toml` / `black --check --config backend/pyproject.toml` on changed backend/test files — clean
- [ ] Manually verify `steveleonard11@gmail.com` can open `/data-explorer` on the AWS deployment after this is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable bootstrap email allowlists for authentication during fresh deployments.
  * Deployment settings can override the default allowlist using `ALLOWED_EMAILS`.
  * Bootstrap addresses remain usable when no accounts exist or account discovery is unavailable.

* **Documentation**
  * Added guidance covering first-owner bootstrapping, overrides and access controls.
  * Documented the new deployment setting and example usage.

* **Tests**
  * Expanded coverage for bootstrap access, S3 failures and unprovisioned accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->