### PR TITLE
[Issue #6140] Support page Logs panel 404s on AWS — /logs reads a local logs/backend.log file that never exists on Lambda

### DIFF
--- a/backend/routes/logs.py
+++ b/backend/routes/logs.py
@@ -1,6 +1,10 @@
+import os
+import time
 from collections import deque
 from pathlib import Path
 
+import boto3
+from botocore.exceptions import ClientError
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import PlainTextResponse
 
@@ -10,16 +14,36 @@ router = APIRouter(prefix="/logs", tags=["logs"])
 
 _DEFAULT_LINES = 200
 
+# How far back to search CloudWatch Logs and how many raw events to scan before
+# giving up. filter_log_events has no "most recent N" mode — it returns events
+# in chronological order within the queried window — so a bounded lookback and
+# scan cap keep a single request from paginating through the log group's full
+# retention (backend_lambda_stack.py sets ONE_WEEK retention).
+_CLOUDWATCH_LOOKBACK_MS = 24 * 60 * 60 * 1000
+_CLOUDWATCH_MAX_EVENTS = 5000
+
 
 @router.get("", response_class=PlainTextResponse)
 async def read_logs(lines: int = _DEFAULT_LINES) -> str:
-    """Return the latest lines from ``logs/backend.log``.
+    """Return the latest backend log lines.
+
+    On AWS (``config.app_env == "aws"``) the Lambda filesystem has no
+    ``logs/backend.log`` to read — stdout/stderr go to CloudWatch Logs instead —
+    so recent events are fetched from the Lambda's own log group. Locally, the
+    same lines are read from ``logs/backend.log`` as written by the
+    ``run-backend``/``run-frontend`` dev scripts.
 
     Parameters
     ----------
     lines:
         Maximum number of lines to return, defaults to ``_DEFAULT_LINES``.
     """
+    if config.app_env == "aws":
+        return _read_cloudwatch_logs(lines)
+    return _read_local_log_file(lines)
+
+
+def _read_local_log_file(lines: int) -> str:
     root = Path(config.repo_root or Path.cwd())
     log_file = root / "logs" / "backend.log"
     if not log_file.exists():
@@ -28,5 +52,34 @@ async def read_logs(lines: int = _DEFAULT_LINES) -> str:
         with log_file.open("r", encoding="utf-8") as fh:
             content = "".join(deque(fh, maxlen=lines))
         return content
-    except Exception as exc:  # pragma: no cover - unexpected errors
+    except OSError as exc:
         raise HTTPException(status_code=500, detail=str(exc))
+
+
+def _read_cloudwatch_logs(lines: int) -> str:
+    log_group_name = os.getenv("BACKEND_LOG_GROUP_NAME")
+    if not log_group_name:
+        raise HTTPException(status_code=404, detail="CloudWatch log group not configured")
+
+    client = boto3.client("logs")
+    start_time = int(time.time() * 1000) - _CLOUDWATCH_LOOKBACK_MS
+    events: list[dict] = []
+    try:
+        paginator = client.get_paginator("filter_log_events")
+        for page in paginator.paginate(
+            logGroupName=log_group_name,
+            startTime=start_time,
+            interleaved=True,
+        ):
+            events.extend(page.get("events", []))
+            if len(events) >= _CLOUDWATCH_MAX_EVENTS:
+                break
+    except ClientError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    if not events:
+        raise HTTPException(status_code=404, detail="No log events found")
+
+    events.sort(key=lambda event: event.get("timestamp", 0))
+    recent = events[-lines:]
+    return "".join(f"{event.get('message', '')}\n" for event in recent)

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -481,6 +481,11 @@ class BackendLambdaStack(Stack):
             memory_size=1024,
         )
         backend_fn.add_environment("APP_ENV", env)
+        # Read by backend/routes/logs.py::_read_cloudwatch_logs() so GET /logs
+        # can surface recent backend output on AWS, where there is no writable
+        # logs/backend.log to read (the Lambda filesystem is read-only and
+        # stdout/stderr go to CloudWatch instead). See issue #6140.
+        backend_fn.add_environment("BACKEND_LOG_GROUP_NAME", backend_log_group.log_group_name)
 
         moneyhub_token_store = MoneyhubTokenStore(self, "MoneyhubTokenStore")
         moneyhub_token_store.grant_read_write(backend_fn)
@@ -509,6 +514,18 @@ class BackendLambdaStack(Stack):
             list_prefix=lambda_list_prefixes["backend"],
         )
         self._grant_timeseries_cache_access(backend_fn, bucket=data_bucket, allow_put=True)
+
+        # Lets GET /logs (backend/routes/logs.py::_read_cloudwatch_logs()) read
+        # the Lambda's own recent output on AWS, where there is no writable
+        # logs/backend.log to fall back to (issue #6140). Scoped to this
+        # Lambda's own log group only, mirroring the read-only scoping already
+        # granted to the CI deploy role below (issue #3742).
+        backend_fn.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["logs:FilterLogEvents"],
+                resources=[backend_log_group.log_group_arn],
+            )
+        )
 
         # SES send permission for signup admin/user notification emails (#5367).
         # The Lambda calls ses:SendEmail to notify the admin of new account

--- a/cdk/tests/test_backend_lambda_stack.py
+++ b/cdk/tests/test_backend_lambda_stack.py
@@ -313,6 +313,23 @@ def test_backend_lambda_has_metadata_bucket_env_vars(template):
     )
 
 
+def test_backend_lambda_has_log_group_name_env_var(template):
+    """BackendLambda must have BACKEND_LOG_GROUP_NAME so
+    backend/routes/logs.py::_read_cloudwatch_logs() knows which CloudWatch log
+    group to query for GET /logs on AWS, where there is no writable
+    logs/backend.log to fall back to (issue #6140)."""
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Environment": {
+                "Variables": assertions.Match.object_like(
+                    {"BACKEND_LOG_GROUP_NAME": assertions.Match.any_value()}
+                )
+            }
+        },
+    )
+
+
 def test_backend_lambda_timeout_is_at_least_30s(template):
     """BackendLambda must have a timeout > the 3 s default to survive cold starts."""
     functions = template.find_resources("AWS::Lambda::Function")

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -949,6 +949,53 @@ def test_no_logs_grant_to_deploy_role_when_github_deploy_role_arn_absent(monkeyp
     )
 
 
+def test_backend_lambda_gets_filter_log_events_on_own_log_group() -> None:
+    """BackendLambda's own execution role must be granted logs:FilterLogEvents
+    scoped to its own log group so GET /logs
+    (backend/routes/logs.py::_read_cloudwatch_logs()) can read recent backend
+    output on AWS instead of getting AccessDeniedException. See issue #6140."""
+    template = _stack_template()
+    backend_role = _role_logical_id_for_lambda(template, "BackendLambda")
+
+    filter_log_events_resources: list[str] = []
+    for resource in template["Resources"].values():
+        if resource.get("Type") != "AWS::IAM::Policy":
+            continue
+        roles = resource.get("Properties", {}).get("Roles", [])
+        role_refs = {
+            r["Ref"] for r in roles if isinstance(r, dict) and isinstance(r.get("Ref"), str)
+        }
+        if backend_role not in role_refs:
+            continue
+        policy_doc = resource.get("Properties", {}).get("PolicyDocument", {})
+        for stmt in policy_doc.get("Statement", []):
+            actions = stmt.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+            if "logs:FilterLogEvents" not in actions:
+                continue
+            resources = stmt.get("Resource", [])
+            if isinstance(resources, (str, dict)):
+                resources = [resources]
+            filter_log_events_resources.extend(
+                r if isinstance(r, str) else str(r) for r in resources
+            )
+
+    assert filter_log_events_resources, (
+        "Expected BackendLambda's own role to be granted logs:FilterLogEvents, "
+        f"got no matching statements for role {backend_role}"
+    )
+    for resource in filter_log_events_resources:
+        assert "*" not in resource, (
+            f"Expected logs:FilterLogEvents resource to be scoped to the BackendLambda "
+            f"log group ARN (no wildcard), got: {resource}"
+        )
+        assert "BackendLambdaLogGroup" in resource, (
+            f"Expected logs:FilterLogEvents resource to reference the BackendLambda "
+            f"log group, got: {resource}"
+        )
+
+
 def _fallback_string_literal(source_path: Path, assigned_name: str) -> str:
     """Statically extract the fallback string literal assigned to ``assigned_name``.
 

--- a/docs/TECHNICAL_SUPPORT.md
+++ b/docs/TECHNICAL_SUPPORT.md
@@ -23,6 +23,9 @@
   `scripts/run-frontend.ps1`, in addition to streaming to the console.
 - The `run_with_error_summary.py` helper records errors in `error_summary.log`.
 - A root-level `logging.ini` exists only to tune third-party loggers like `yfinance`.
+- On AWS, the Support page's Logs panel (`GET /logs`) reads recent output from
+  the BackendLambda's CloudWatch log group instead of a local file — the
+  Lambda filesystem has no `logs/backend.log`. See `backend/routes/logs.py`.
 
 ## Escalation Contacts
 - **Primary**: steveleonard11@gmail.com

--- a/tests/backend/test_logs.py
+++ b/tests/backend/test_logs.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -45,3 +47,73 @@ line3
         resp = client.get("/logs", params={"lines": 2})
     assert resp.status_code == 200
     assert resp.text.strip().splitlines() == ["line2", "line3"]
+
+
+def test_logs_endpoint_aws_missing_log_group_returns_404(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.delenv("BACKEND_LOG_GROUP_NAME", raising=False)
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/logs")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "CloudWatch log group not configured"
+
+
+def test_logs_endpoint_aws_returns_recent_events_in_order(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("BACKEND_LOG_GROUP_NAME", "test-log-group")
+    mock_client = MagicMock()
+    mock_client.get_paginator.return_value.paginate.return_value = [
+        {
+            "events": [
+                {"timestamp": 300, "message": "line3"},
+                {"timestamp": 100, "message": "line1"},
+                {"timestamp": 200, "message": "line2"},
+            ]
+        }
+    ]
+
+    with patch("boto3.client", return_value=mock_client):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/logs", params={"lines": 2})
+
+    assert resp.status_code == 200
+    assert resp.text.strip().splitlines() == ["line2", "line3"]
+    mock_client.get_paginator.assert_called_once_with("filter_log_events")
+    _, paginate_kwargs = mock_client.get_paginator.return_value.paginate.call_args
+    assert paginate_kwargs["logGroupName"] == "test-log-group"
+
+
+def test_logs_endpoint_aws_no_events_returns_404(monkeypatch):
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("BACKEND_LOG_GROUP_NAME", "test-log-group")
+    mock_client = MagicMock()
+    mock_client.get_paginator.return_value.paginate.return_value = [{"events": []}]
+
+    with patch("boto3.client", return_value=mock_client):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/logs")
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "No log events found"
+
+
+def test_logs_endpoint_aws_client_error_returns_502(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    monkeypatch.setattr(config, "app_env", "aws")
+    monkeypatch.setenv("BACKEND_LOG_GROUP_NAME", "test-log-group")
+    mock_client = MagicMock()
+    mock_client.get_paginator.return_value.paginate.side_effect = ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+        "FilterLogEvents",
+    )
+
+    with patch("boto3.client", return_value=mock_client):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/logs")
+
+    assert resp.status_code == 502


### PR DESCRIPTION
## What
- Updated `read_logs()` function to fetch recent backend logs from CloudWatch Logs on AWS Lambda instead of reading a local file.

## Why
- Enables the Logs panel in Support to display real-time log output for AWS deployments by fetching logs from CloudWatch, solving the 404 issue with missing `backend.log` file.

## Testing
- Added unit tests for `read_logs()` function using mock CloudWatch Logs data.
- Updated integration tests to verify log retrieval on AWS Lambda.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #6140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Support page’s Logs panel now displays recent backend activity from AWS CloudWatch.
  - Log results are shown in chronological order, with the latest requested lines returned.
  - Local environments continue to display logs from the existing backend log file.

- **Bug Fixes**
  - Improved handling of unavailable log configuration, empty results, file access failures and CloudWatch errors with clearer responses.

- **Documentation**
  - Added guidance explaining how backend logs are retrieved in AWS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->