### PR TITLE
Add httpMethod to backend API access logs

### DIFF
--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -56,6 +56,7 @@ ACCESS_LOG_FORMAT = json.dumps(
         "requestId": "$context.requestId",
         "routeKey": "$context.routeKey",
         "path": "$context.path",
+        "httpMethod": "$context.httpMethod",
         "status": "$context.status",
         "errorMessage": "$context.error.message",
         "authorizerError": "$context.authorizer.error",


### PR DESCRIPTION
### Motivation

- Issue #5523 asked for a CloudWatch alarm on `GET /portfolio-group/all` 5xx errors. That issue is already closed (completed) — the monitoring goal was independently satisfied by the broader `PortfolioGroup5xxAlarm` (issue #5494), which now covers every `/portfolio-group/*` sub-path with its own SNS topic.
- This PR originally duplicated that alarm with a narrower, endpoint-specific version (its own `MetricFilter`, `Alarm`, and an `OperationalAlertsTopic` construct). Rebasing onto `main` surfaced the overlap — including a construct-ID collision on `OperationalAlertsTopic` — so the duplicate alarm/metric-filter/SNS-topic-import/CfnOutput were dropped rather than merged. See the [PR discussion](https://github.com/leonarduk/allotmint/pull/6152#issuecomment-5227773469) for the full resolution.

### Description

- Adds `httpMethod` (`$context.httpMethod`) to the structured API Gateway access log format (`ACCESS_LOG_FORMAT`) in `cdk/stacks/backend_lambda_stack.py`, alongside the existing `path` field. This lets future log-based metric filters discriminate by HTTP method, not just path.

### Testing

- CDK synthesis unit tests (`cdk/tests/test_backend_lambda_stack.py`): 54 passed.

Relates to #5523