### PR TITLE
Add advisory audit for architecture diagram staleness and reproducibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         run: pytest tests/test_review_common.py -v --no-cov
       - name: Check package-lock.json cross-OS platform coverage
         run: python scripts/check_lockfile_platform_coverage.py
+      - name: Audit architecture diagram reproducibility and references
+        run: python scripts/check_architecture_diagrams.py
 
   frontend-checks:
     name: Frontend lint, type-check and unit tests

--- a/scripts/check_architecture_diagrams.py
+++ b/scripts/check_architecture_diagrams.py
@@ -15,7 +15,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 # Build this value from fragments so the audit does not report its own source.
 LEGACY_DIAGRAM = "docs/" + "aws-architecture.svg"
+LEGACY_DIAGRAM_PATH = Path(LEGACY_DIAGRAM)
 SCRIPT_SUFFIXES = frozenset({".js", ".mjs", ".ps1", ".py", ".sh", ".ts"})
+# Formats that legitimately hold non-UTF-8 bytes; scanning them for a text
+# reference always fails, so they are skipped rather than reported as unreadable.
+BINARY_SUFFIXES = frozenset({".gif", ".ico", ".jpg", ".jpeg", ".parquet", ".pdf", ".png", ".svg"})
 
 
 def _normalise_name(value: str) -> str:
@@ -57,22 +61,43 @@ def find_unreproducible_diagrams(files: list[Path]) -> list[Path]:
     return [path for path in diagrams if not has_regenerator(path, files)]
 
 
-def find_stale_legacy_references(root: Path, files: list[Path]) -> list[Path]:
-    """Find non-README files that refer to the removed legacy AWS diagram."""
+def _legacy_reference_variants(path: Path) -> frozenset[str]:
+    """Return the substrings that indicate `path` references the legacy diagram.
+
+    A file living alongside the diagram (i.e. also under `docs/`) may link to
+    it with a sibling-relative path such as `aws-architecture.svg` or
+    `./aws-architecture.svg`, not just the repository-root spelling.
+    """
+    variants = {LEGACY_DIAGRAM, f"/{LEGACY_DIAGRAM}"}
+    if path.parent == LEGACY_DIAGRAM_PATH.parent:
+        variants.add(LEGACY_DIAGRAM_PATH.name)
+        variants.add(f"./{LEGACY_DIAGRAM_PATH.name}")
+    return frozenset(variants)
+
+
+def find_stale_legacy_references(root: Path, files: list[Path]) -> tuple[list[Path], list[Path]]:
+    """Find non-README files that refer to the removed legacy AWS diagram.
+
+    Returns a `(stale, unreadable)` pair: `unreadable` lists tracked candidate
+    files that could not be scanned, so an incomplete scan stays visible
+    instead of silently reporting zero warnings.
+    """
     if (root / LEGACY_DIAGRAM).exists():
-        return []
+        return [], []
 
     stale: list[Path] = []
+    unreadable: list[Path] = []
     for path in files:
-        if path.name.lower().startswith("readme") or path.suffix.lower() == ".svg":
+        if path.name.lower().startswith("readme") or path.suffix.lower() in BINARY_SUFFIXES:
             continue
         try:
             content = (root / path).read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
+            unreadable.append(path)
             continue
-        if LEGACY_DIAGRAM in content:
+        if any(variant in content for variant in _legacy_reference_variants(path)):
             stale.append(path)
-    return stale
+    return stale, unreadable
 
 
 def main() -> int:
@@ -88,11 +113,20 @@ def main() -> int:
             f"generate_{diagram.stem.replace('-', '_')} with a supported script suffix."
         )
 
-    for reference in find_stale_legacy_references(ROOT, files):
+    stale_references, unreadable_candidates = find_stale_legacy_references(ROOT, files)
+
+    for reference in stale_references:
         findings += 1
         print(
             f"::warning file={reference}::Stale reference to removed "
             f"{LEGACY_DIAGRAM}. Update or remove the reference."
+        )
+
+    for path in unreadable_candidates:
+        findings += 1
+        print(
+            f"::warning file={path}::Could not scan for a stale reference to "
+            f"{LEGACY_DIAGRAM}; the file is not valid UTF-8 text."
         )
 
     print(f"Architecture diagram audit complete ({findings} warning(s)).")

--- a/scripts/check_architecture_diagrams.py
+++ b/scripts/check_architecture_diagrams.py
@@ -1,0 +1,103 @@
+"""Warn when architecture diagrams cannot be reproduced or are referenced stale.
+
+The check is intentionally advisory: architecture documentation should not make
+an otherwise valid change fail CI.  Findings use GitHub workflow annotations so
+they remain visible in a pull request's log.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+# Build this value from fragments so the audit does not report its own source.
+LEGACY_DIAGRAM = "docs/" + "aws-architecture.svg"
+SCRIPT_SUFFIXES = frozenset({".js", ".mjs", ".ps1", ".py", ".sh", ".ts"})
+
+
+def _normalise_name(value: str) -> str:
+    """Return a filename fragment suitable for convention comparisons."""
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def tracked_files(root: Path) -> list[Path]:
+    """Return repository-relative files tracked by Git."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [Path(name) for name in result.stdout.split("\0") if name]
+
+
+def has_regenerator(diagram: Path, files: list[Path]) -> bool:
+    """Return whether a tracked script follows the diagram generator convention."""
+    diagram_name = _normalise_name(diagram.stem)
+    for path in files:
+        if path.suffix.lower() not in SCRIPT_SUFFIXES:
+            continue
+        script_name = _normalise_name(path.stem)
+        if "generate" in script_name and diagram_name in script_name:
+            return True
+    return False
+
+
+def find_unreproducible_diagrams(files: list[Path]) -> list[Path]:
+    """Find architecture SVGs without a conventionally named generator."""
+    diagrams = [
+        path
+        for path in files
+        if path.suffix.lower() == ".svg" and "architecture" in path.stem.lower()
+    ]
+    return [path for path in diagrams if not has_regenerator(path, files)]
+
+
+def find_stale_legacy_references(root: Path, files: list[Path]) -> list[Path]:
+    """Find non-README files that refer to the removed legacy AWS diagram."""
+    if (root / LEGACY_DIAGRAM).exists():
+        return []
+
+    stale: list[Path] = []
+    for path in files:
+        if path.name.lower().startswith("readme") or path.suffix.lower() == ".svg":
+            continue
+        try:
+            content = (root / path).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if LEGACY_DIAGRAM in content:
+            stale.append(path)
+    return stale
+
+
+def main() -> int:
+    """Run advisory architecture-documentation checks."""
+    files = tracked_files(ROOT)
+    findings = 0
+
+    for diagram in find_unreproducible_diagrams(files):
+        findings += 1
+        print(
+            f"::warning file={diagram}::Static architecture diagram has no "
+            "regeneration script. Add a script named "
+            f"generate_{diagram.stem.replace('-', '_')} with a supported script suffix."
+        )
+
+    for reference in find_stale_legacy_references(ROOT, files):
+        findings += 1
+        print(
+            f"::warning file={reference}::Stale reference to removed "
+            f"{LEGACY_DIAGRAM}. Update or remove the reference."
+        )
+
+    print(f"Architecture diagram audit complete ({findings} warning(s)).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_architecture_diagrams.py
+++ b/tests/test_check_architecture_diagrams.py
@@ -35,7 +35,10 @@ def test_stale_legacy_reference_is_reported_outside_readmes(tmp_path: Path) -> N
     (tmp_path / guide).write_text(f"See {LEGACY_DIAGRAM}", encoding="utf-8")
     (tmp_path / readme).write_text(f"See {LEGACY_DIAGRAM}", encoding="utf-8")
 
-    assert find_stale_legacy_references(tmp_path, [guide, readme]) == [guide]
+    stale, unreadable = find_stale_legacy_references(tmp_path, [guide, readme])
+
+    assert stale == [guide]
+    assert unreadable == []
 
 
 def test_legacy_reference_is_not_stale_while_diagram_exists(tmp_path: Path) -> None:
@@ -45,4 +48,51 @@ def test_legacy_reference_is_not_stale_while_diagram_exists(tmp_path: Path) -> N
     (tmp_path / diagram).write_text("<svg/>", encoding="utf-8")
     (tmp_path / guide).write_text(str(diagram), encoding="utf-8")
 
-    assert find_stale_legacy_references(tmp_path, [diagram, guide]) == []
+    stale, unreadable = find_stale_legacy_references(tmp_path, [diagram, guide])
+
+    assert stale == []
+    assert unreadable == []
+
+
+def test_sibling_relative_legacy_reference_is_detected(tmp_path: Path) -> None:
+    guide = Path("docs/deploy.md")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / guide).write_text("See ./aws-architecture.svg for context", encoding="utf-8")
+
+    stale, unreadable = find_stale_legacy_references(tmp_path, [guide])
+
+    assert stale == [guide]
+    assert unreadable == []
+
+
+def test_bare_filename_outside_docs_is_not_a_sibling_match(tmp_path: Path) -> None:
+    notes = Path("frontend/notes.md")
+    (tmp_path / "frontend").mkdir()
+    (tmp_path / notes).write_text("See aws-architecture.svg for context", encoding="utf-8")
+
+    stale, unreadable = find_stale_legacy_references(tmp_path, [notes])
+
+    assert stale == []
+    assert unreadable == []
+
+
+def test_unreadable_candidate_is_reported_not_silently_skipped(tmp_path: Path) -> None:
+    guide = Path("docs/deploy.md")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / guide).write_bytes(b"\xff\xfe\x00 not valid utf-8")
+
+    stale, unreadable = find_stale_legacy_references(tmp_path, [guide])
+
+    assert stale == []
+    assert unreadable == [guide]
+
+
+def test_known_binary_formats_are_skipped_without_being_reported(tmp_path: Path) -> None:
+    image = Path("docs/diagram.png")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / image).write_bytes(b"\x89PNG\r\n\x1a\n not valid utf-8")
+
+    stale, unreadable = find_stale_legacy_references(tmp_path, [image])
+
+    assert stale == []
+    assert unreadable == []

--- a/tests/test_check_architecture_diagrams.py
+++ b/tests/test_check_architecture_diagrams.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from scripts.check_architecture_diagrams import (
+    LEGACY_DIAGRAM,
+    find_stale_legacy_references,
+    find_unreproducible_diagrams,
+)
+
+
+def test_architecture_svg_without_generator_is_reported() -> None:
+    files = [Path("docs/cloud-architecture.svg")]
+
+    assert find_unreproducible_diagrams(files) == files
+
+
+def test_matching_generator_makes_architecture_svg_reproducible() -> None:
+    files = [
+        Path("docs/cloud-architecture.svg"),
+        Path("scripts/generate_cloud_architecture.py"),
+    ]
+
+    assert find_unreproducible_diagrams(files) == []
+
+
+def test_non_architecture_svg_does_not_require_generator() -> None:
+    files = [Path("frontend/public/logo.svg")]
+
+    assert find_unreproducible_diagrams(files) == []
+
+
+def test_stale_legacy_reference_is_reported_outside_readmes(tmp_path: Path) -> None:
+    guide = Path("docs/deploy.md")
+    readme = Path("docs/README.md")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / guide).write_text(f"See {LEGACY_DIAGRAM}", encoding="utf-8")
+    (tmp_path / readme).write_text(f"See {LEGACY_DIAGRAM}", encoding="utf-8")
+
+    assert find_stale_legacy_references(tmp_path, [guide, readme]) == [guide]
+
+
+def test_legacy_reference_is_not_stale_while_diagram_exists(tmp_path: Path) -> None:
+    diagram = Path(LEGACY_DIAGRAM)
+    guide = Path("docs/deploy.md")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / diagram).write_text("<svg/>", encoding="utf-8")
+    (tmp_path / guide).write_text(str(diagram), encoding="utf-8")
+
+    assert find_stale_legacy_references(tmp_path, [diagram, guide]) == []


### PR DESCRIPTION
### Motivation
- Provide an automated, advisory check to detect static architecture diagrams that cannot be regenerated and stale references to a removed legacy diagram so documentation drift is visible in PRs without failing unrelated changes.

### Description
- Add `scripts/check_architecture_diagrams.py` which scans Git-tracked files, warns about SVGs with "architecture" in their name that lack a conventionally named generator script, and warns about non-README references to the legacy `docs/aws-architecture.svg` when that file is absent.
- Add unit tests in `tests/test_check_architecture_diagrams.py` that cover unreproducible diagrams, matching generator detection, non-architecture SVGs, stale legacy references excluding READMEs, and the case where the legacy diagram still exists.
- Integrate the audit into the CI `test` job by running `python scripts/check_architecture_diagrams.py` as an advisory step in `.github/workflows/ci.yml` so findings surface as GitHub Actions annotations.
- The check is intentionally non-blocking: it emits `::warning` annotations rather than failing CI to avoid breaking unrelated changes.

### Testing
- Ran the new unit tests with `pytest tests/test_check_architecture_diagrams.py` and all tests passed (5 passed).
- Ran style checks with `ruff` and `black --check` on the new files and they succeeded.
- Executed the audit script with `python scripts/check_architecture_diagrams.py` which completed and emitted zero warnings in the final repository state.

Closes #5331

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7752dc7fb88327a39a8050b6583e16)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated checks to identify architecture diagrams that may not be reproducible.
  * Added warnings for references to removed legacy diagrams and unreadable diagram files.
  * Checks continue successfully while highlighting issues for review.

* **Tests**
  * Added coverage for diagram validation, legacy references, relative paths, documentation exclusions, unreadable files, and binary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->