### PR TITLE
Link Data Explorer and Support logs fixes to umbrella issue #6109

### DIFF
--- a/backend/routes/data_explorer.py
+++ b/backend/routes/data_explorer.py
@@ -37,7 +37,8 @@ PREVIEWABLE_EXTENSIONS = {".json", ".csv", ".txt", ".log", ".yaml", ".yml", ".md
 
 # Friendly message shown to the user in place of the (technically accurate but
 # unhelpful-looking) 415 for a file type that isn't in PREVIEWABLE_EXTENSIONS,
-# e.g. clicking a binary VCS object like `.git/index`.
+# e.g. clicking a binary VCS object like `.git/index` (umbrella issue #6109;
+# local-explorer follow-up #6112).
 NOT_PREVIEWABLE_DETAIL = "This file type can't be previewed here (binary or unsupported format)."
 
 # VCS/IDE housekeeping folders that belong to the tooling around the data

--- a/cdk/stacks/backend_lambda_stack.py
+++ b/cdk/stacks/backend_lambda_stack.py
@@ -365,7 +365,8 @@ class BackendLambdaStack(Stack):
                 # "" entry is handled specially by _grant_bucket_access,
                 # which adds only the exact "" condition value (no "/*"
                 # wildcard), so it grants root-level listing only — not
-                # recursive or bucket-wide access.
+                # recursive or bucket-wide access (umbrella issue #6109;
+                # root-listing follow-up #6110).
                 "",
             ),
             # price_refresh needs accounts/ to call list_objects_v2 via

--- a/cdk/tests/test_backend_lambda_stack_permissions.py
+++ b/cdk/tests/test_backend_lambda_stack_permissions.py
@@ -33,7 +33,7 @@ BACKEND_LIST_PREFIXES = (
     WRITABLE_ACCOUNTS_PREFIX,
     # Root/empty prefix: the Data Explorer's root tree view calls
     # list_objects_v2(Prefix="", Delimiter="/"), which needs an explicit ""
-    # entry in the StringLike condition (issue #6110).
+    # entry in the StringLike condition (umbrella issue #6109; #6110).
     "",
 )
 # accounts/ is required because refresh_prices() → list_all_unique_tickers() →

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -288,7 +288,8 @@ export function createClient(
 
   // Same authenticated request/error handling as fetchJson, but parses the
   // successful response body as text instead of JSON — needed for endpoints
-  // like GET /logs that return PlainTextResponse rather than JSON (#6111).
+  // like GET /logs that return PlainTextResponse rather than JSON
+  // (umbrella issue #6109; authenticated-logs follow-up #6111).
   async function fetchText(url: string, init: RequestInit = {}): Promise<string> {
     const res = await sendAuthenticated(url, init);
     return res.text();

--- a/tests/routes/test_data_explorer.py
+++ b/tests/routes/test_data_explorer.py
@@ -358,7 +358,8 @@ def test_read_file_rejects_unsupported_extension(monkeypatch, tmp_path):
 
 
 def test_read_file_rejects_binary_file_with_no_extension_friendly_message(monkeypatch, tmp_path):
-    # Regression for #6112: a file like `.git/index` has no recognised
+    # Regression for umbrella issue #6109 / follow-up #6112: a file like
+    # `.git/index` has no recognised
     # extension at all, but the 415 detail should still read as a friendly
     # in-app message rather than a bare technical string.
     git_dir = tmp_path / ".git"


### PR DESCRIPTION
### Motivation
- Tie together and document the previously landed fixes for the Data Explorer root S3 listing, authenticated plain-text Support logs, and local explorer dotfolder/binary-preview behavior by linking them back to the umbrella report `#6109` so the change history and tests reference the original issue.

### Description
- Non-functional bookkeeping: updated comment text and test docstrings to reference umbrella issue `#6109` and related follow-ups in `backend/routes/data_explorer.py`, `cdk/stacks/backend_lambda_stack.py`, `cdk/tests/test_backend_lambda_stack_permissions.py`, `frontend/src/api.ts`, and `tests/routes/test_data_explorer.py` without changing runtime behavior.

### Testing
- Ran the frontend unit suite with `npm --prefix frontend run test -- --run tests/unit/api.test.ts tests/unit/pages/Support.test.tsx tests/unit/pages/DataExplorer.test.tsx` and all 56 tests passed. 
- Validated the focused backend tests with `PYENV_VERSION=3.11.15 python -m pytest tests/routes/test_data_explorer.py -q --no-cov` (30 passed) and `PYENV_VERSION=3.11.15 python -m pytest cdk/tests/test_backend_lambda_stack_permissions.py -q --no-cov` (26 passed). 
- Note: running the two pytest modules together under the repository-wide coverage run triggered the global coverage `fail-under=90` threshold; the focused tests themselves passed when executed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77521ab6288327b493ffd42f1363d1)