### PR TITLE
Extract shared .flex-wrap-row class and replace duplicate inline flexWrap styles (Closes #5473)

### DIFF
--- a/frontend/src/MainApp.tsx
+++ b/frontend/src/MainApp.tsx
@@ -240,9 +240,8 @@ export default function MainApp() {
   return (
     <>
       <div
+        className="flex-wrap-row"
         style={{
-          display: "flex",
-          flexWrap: "wrap",
           justifyContent: "space-between",
           alignItems: "center",
         }}

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -32,9 +32,8 @@ export default function AppHeader({
   return (
     <>
       <div
+        className="flex-wrap-row"
         style={{
-          display: 'flex',
-          flexWrap: 'wrap',
           alignItems: 'center',
           gap: '0.5rem',
           margin: '1rem 0',

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -725,9 +725,8 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   return (
     <div style={{ marginTop: "1rem" }}>
       <div
+        className="flex-wrap-row"
         style={{
-          display: "flex",
-          flexWrap: "wrap",
           justifyContent: "space-between",
           alignItems: "flex-end",
           gap: "1rem",
@@ -821,9 +820,8 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
 
       {isAllPositions && enableAdvancedAnalytics && (
         <div
+          className="flex-wrap-row"
           style={{
-            display: "flex",
-            flexWrap: "wrap",
             gap: "2rem",
             marginBottom: "1rem",
             padding: "0.75rem 1rem",

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -506,9 +506,8 @@ export function InstrumentDetail({
         </div>
       )}
       <div
+        className="flex-wrap-row"
         style={{
-          display: "flex",
-          flexWrap: "wrap",
           justifyContent: "space-between",
           alignItems: "center",
           marginBottom: "0.2rem",

--- a/frontend/src/components/PerformanceDashboard.tsx
+++ b/frontend/src/components/PerformanceDashboard.tsx
@@ -209,9 +209,8 @@ export function PerformanceDashboard({ owner, asOf }: Props) {
         </div>
       </div>
       <div
+        className="flex-wrap-row"
         style={{
-          display: "flex",
-          flexWrap: "wrap",
           gap: "1rem",
           marginBottom: "1rem",
         }}

--- a/frontend/src/components/SummaryBar.tsx
+++ b/frontend/src/components/SummaryBar.tsx
@@ -13,9 +13,8 @@ export default function SummaryBar({ owners, owner, onOwnerChange, onRefresh }: 
   const { t } = useTranslation();
   return (
     <div
+      className="flex-wrap-row"
       style={{
-        display: "flex",
-        flexWrap: "wrap",
         justifyContent: "space-between",
         alignItems: "center",
         marginBottom: "1rem",

--- a/frontend/src/components/transactions/TransactionsTable.tsx
+++ b/frontend/src/components/transactions/TransactionsTable.tsx
@@ -87,7 +87,10 @@ export function TransactionsTable({
         <button type="button" onClick={onBulkDelete} disabled={!hasSelection}>
           Delete selected{hasSelection ? ` (${selectedCount})` : ""}
         </button>
-        <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: "0.5rem" }}>
+        <div
+          className="flex-wrap-row"
+          style={{ alignItems: "center", gap: "0.5rem" }}
+        >
           <span>{showingRangeLabel}</span>
           <button type="button" onClick={onPreviousPage} disabled={isFirstPage}>
             Previous

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -76,6 +76,11 @@ body {
     min-height: 100vh;
 }
 
+.flex-wrap-row {
+    display: flex;
+    flex-wrap: wrap;
+}
+
 /*
  * Native form controls do not consistently inherit the page colour scheme.
  * Browsers can retain dark-theme text while rendering a white control surface.


### PR DESCRIPTION
### Motivation

- Reduce duplicated inline `display: 'flex', flexWrap: 'wrap'` patterns by extracting a single shared style to make maintenance and naming consistent across the frontend. 
- The change consolidates the eight identical usages found across components introduced in prior PRs so future tweaks are centralized.

### Description

- Add a `.flex-wrap-row` global class in `frontend/src/index.css` with `display: flex; flex-wrap: wrap;`.
- Replace the inline `display: 'flex', flexWrap: 'wrap'` occurrences with `className="flex-wrap-row"` in `MainApp.tsx`, `AppHeader.tsx`, `GroupPortfolioView.tsx` (two sites), `InstrumentDetail.tsx`, `PerformanceDashboard.tsx`, `SummaryBar.tsx`, and `transactions/TransactionsTable.tsx` so container-specific inline properties (gaps, alignment, margins) remain unchanged.
- Work performed on branch `refactor/issue-5473-flex-wrap-row` and committed with message `Extract shared flex wrap row styles` (commit `e4f7a3d`).
- Closes #5473.

### Testing

- Ran `git diff --check` with no issues and `npm --prefix frontend run lint` which completed successfully.
- Ran type checks with `npm --prefix frontend run type-check` and a production build with `npm --prefix frontend run build`, both succeeding.
- Ran the frontend test suite; the full run reported one transient, unrelated failure in `tests/unit/logoutFlowCognito.test.tsx` while the aggregate run otherwise passed; re-running that test file (`npm --prefix frontend run test -- --run tests/unit/logoutFlowCognito.test.tsx`) passed (2/2 tests), indicating the failure was transient.
- Visual/behavioral changes: none intended or introduced because only the repeated `flex-wrap` declaration was extracted and component-specific styling was preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7752f325288327ab699b0c086fadb8)