### PR TITLE
Fix stylesheet snapshot drift from #6159

### DIFF
--- a/tests/snapshots/index.css
+++ b/tests/snapshots/index.css
@@ -76,6 +76,11 @@ body {
     min-height: 100vh;
 }
 
+.flex-wrap-row {
+    display: flex;
+    flex-wrap: wrap;
+}
+
 /*
  * Native form controls do not consistently inherit the page colour scheme.
  * Browsers can retain dark-theme text while rendering a white control surface.


### PR DESCRIPTION
## Summary
- #6159 (Extract shared flex wrap row styles) added a `.flex-wrap-row` rule to `frontend/src/index.css` but didn't regenerate `tests/snapshots/index.css`, so `test_stylesheet_snapshot` has been failing on `main` since that merge.
- Updates the snapshot to match the current stylesheet exactly. No stylesheet behavior changes.
- Identified while triaging CI failures on PR #6153, which was blocked by this unrelated drift.

## Test plan
- [x] `pytest tests/test_styles_snapshot.py -v --no-cov` passes locally
- [x] `diff frontend/src/index.css tests/snapshots/index.css` — no differences