### PR TITLE
Fix invalid currencies in group portfolios

### DIFF
--- a/backend/common/group_portfolio.py
+++ b/backend/common/group_portfolio.py
@@ -30,6 +30,14 @@ from backend.utils.pricing_dates import PricingDateCalculator
 logger = logging.getLogger("group_portfolio")
 
 
+def _normalise_account_currency(value: object) -> str:
+    """Return a non-empty account currency suitable for the SPA contract."""
+
+    if isinstance(value, str) and value.strip():
+        return value.strip().upper()
+    return "GBP"
+
+
 def _trade_counts_for_owner(owner: str, today: dt.date) -> tuple[int, int]:
     """Return (trades_this_month, trades_remaining) for an owner."""
 
@@ -152,6 +160,7 @@ def build_group_portfolio(slug: str, *, pricing_date: date | None = None) -> Dic
             owner = pf[OWNER]
             acct_copy = dict(acct)
             acct_copy[OWNER] = owner
+            acct_copy["currency"] = _normalise_account_currency(acct_copy.get("currency"))
 
             holdings = acct_copy.get(HOLDINGS, [])
             acct_copy[HOLDINGS] = [

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -696,8 +696,8 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   if (!slug) return <p>{t("group.select")}</p>;
   if (portfolioError)
     return (
-      <p style={{ color: "red" }}>
-        {t("common.error")}: {portfolioError.message}
+      <p role="alert" style={{ color: "red" }}>
+        {t("group.loadError")}
       </p>
     );
   if (loading || !portfolio) return <p>{t("common.loading")}</p>;

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -164,6 +164,7 @@
     "view": "Ansehen"
   },
   "group": {
+    "loadError": "Ihr Portfolio konnte nicht geladen werden. Bitte versuchen Sie es später erneut.",
     "atAGlance": "Auf einen Blick",
     "pricingAsOf": "Preisstand vom {{date}}",
     "pricingDatePickerLabel": "Preisstand ändern",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -194,6 +194,7 @@
     "view": "View"
   },
   "group": {
+    "loadError": "We couldn’t load your portfolio. Please try again later.",
     "atAGlance": "At a glance",
     "pricingAsOf": "Pricing as of {{date}}",
     "pricingDatePickerLabel": "Change pricing date",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -164,6 +164,7 @@
     "view": "Ver"
   },
   "group": {
+    "loadError": "No pudimos cargar tu cartera. Inténtalo de nuevo más tarde.",
     "atAGlance": "De un vistazo",
     "pricingAsOf": "Precios al {{date}}",
     "pricingDatePickerLabel": "Cambiar fecha de precios",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -164,6 +164,7 @@
     "view": "Voir"
   },
   "group": {
+    "loadError": "Nous n’avons pas pu charger votre portefeuille. Veuillez réessayer plus tard.",
     "atAGlance": "En un coup d'œil",
     "pricingAsOf": "Tarification au {{date}}",
     "pricingDatePickerLabel": "Changer la date de tarification",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -164,6 +164,7 @@
     "view": "Visualizza"
   },
   "group": {
+    "loadError": "Non è stato possibile caricare il portafoglio. Riprova più tardi.",
     "atAGlance": "A colpo d'occhio",
     "pricingAsOf": "Prezzi al {{date}}",
     "pricingDatePickerLabel": "Cambia data dei prezzi",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -164,6 +164,7 @@
     "view": "Ver"
   },
   "group": {
+    "loadError": "Não foi possível carregar seu portfólio. Tente novamente mais tarde.",
     "atAGlance": "Visão geral",
     "pricingAsOf": "Preços em {{date}}",
     "pricingDatePickerLabel": "Alterar data de preços",

--- a/frontend/tests/unit/components/GroupPortfolioView.test.tsx
+++ b/frontend/tests/unit/components/GroupPortfolioView.test.tsx
@@ -938,9 +938,8 @@ describe("GroupPortfolioView", () => {
     });
     vi.spyOn(global, "fetch").mockRejectedValueOnce(new Error("boom"));
     renderWithConfig(<GroupPortfolioView slug="all" owners={ownerFixtures} />);
-    await waitFor(() =>
-      screen.getByText(`${i18n.t("common.error")}: boom`)
-    );
+    await waitFor(() => screen.getByText(i18n.t("group.loadError")));
+    expect(screen.queryByText(/boom/)).not.toBeInTheDocument();
   });
 
   it.each(locales)("renders loading message in %s", async (lng) => {

--- a/tests/common/test_group_portfolio.py
+++ b/tests/common/test_group_portfolio.py
@@ -29,7 +29,10 @@ def test_list_groups_returns_expected_defaults():
 
 def test_list_groups_does_not_load_portfolio_contents():
     """Group discovery must not issue one data load per owner or account."""
-    owner_rows = [OwnerSummaryRecord(owner=f"owner-{index}", accounts=[f"account-{index}"]) for index in range(1_000)]
+    owner_rows = [
+        OwnerSummaryRecord(owner=f"owner-{index}", accounts=[f"account-{index}"])
+        for index in range(1_000)
+    ]
 
     started_at = time.perf_counter()
     with (
@@ -50,6 +53,7 @@ def test_build_group_portfolio_merges_accounts_and_totals():
             "owner": "Lucy",
             ACCOUNTS: [
                 {
+                    "currency": " usd ",
                     HOLDINGS: [
                         {"ticker": "AAA", "market_value_gbp": 100.0},
                         {"ticker": "BBB", "market_value_gbp": 50.0},
@@ -61,6 +65,7 @@ def test_build_group_portfolio_merges_accounts_and_totals():
             "owner": "Steve",
             ACCOUNTS: [
                 {
+                    "currency": None,
                     HOLDINGS: [
                         {"ticker": "CCC", "market_value_gbp": 200.0},
                     ]
@@ -92,8 +97,10 @@ def test_build_group_portfolio_merges_accounts_and_totals():
 
     first, second = result[ACCOUNTS]
     assert first[OWNER] == "Lucy"
+    assert first["currency"] == "USD"
     assert first["value_estimate_gbp"] == 150.0
     assert second[OWNER] == "Steve"
+    assert second["currency"] == "GBP"
     assert second["value_estimate_gbp"] == 200.0
 
     assert result["total_value_estimate_gbp"] == 350.0


### PR DESCRIPTION
Closes #6188 

#### Motivation

- The SPA contract requires every account in `/portfolio-group/*` to include a non-empty string `currency`, and invalid/missing values were causing frontend schema validation failures and raw JSON errors to be shown to users.
- The UI should present a friendly, localized error message instead of rendering raw validation details when the group portfolio fails to load.

### Description

- Add `_normalise_account_currency` to `backend/common/group_portfolio.py` and set `acct_copy["currency"]` during `build_group_portfolio` to trim/uppercase valid strings and default missing/blank values to `"GBP"`.
- Replace the raw error text in `GroupPortfolioView` with a localized load error by returning a role="alert" paragraph that shows `t("group.loadError")` instead of `portfolioError.message`.
- Add localized `group.loadError` strings to English, French, German, Spanish, Portuguese and Italian translation files.
- Extend backend and frontend unit tests to cover currency normalization and to assert that the UI no longer exposes raw technical error messages to end users.

### Testing

- Ran frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/components/GroupPortfolioView.test.tsx` and the suite passed (37 tests in the run passed). 
- Ran frontend lint (`npm --prefix frontend run lint -- --quiet`) and static checks (`python -m ruff check backend/common/group_portfolio.py tests/common/test_group_portfolio.py`) which succeeded and `git diff --check` produced no issues. 
- Attempted to run backend `pytest`, but full backend test initialization was blocked in this environment due to missing runtime dependencies (for example `boto3`), so end-to-end backend pytest was not executed here; the change is scoped and covered by the added unit-level test in `tests/common/test_group_portfolio.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7867f18c388327ace44e49d27e4548)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Portfolio loading failures now show a clear, translated message without exposing technical error details.
  * Portfolio currencies are standardised consistently, with missing or invalid values defaulting to GBP.
* **Translations**
  * Added portfolio loading error messages in English, German, Spanish, French, Italian and Portuguese.
* **Tests**
  * Expanded coverage for currency handling and localised error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->