### PR TITLE
Allow compliance lookup for provider-discovered owners (fix #6187)

### DIFF
--- a/backend/routes/compliance.py
+++ b/backend/routes/compliance.py
@@ -127,18 +127,28 @@ def _known_owners(accounts_root) -> KnownOwnerSet:
 async def compliance_for_owner(owner: str, request: Request):
     """Return compliance warnings and status for an owner."""
     accounts_root = resolve_accounts_root(request)
+    owners = _known_owners(accounts_root)
     owner_dir = resolve_owner_directory(accounts_root, owner)
     if not owner_dir:
-        raise_owner_not_found(owner)
-    owner = owner_dir.name
-    owners = _known_owners(accounts_root)
+        # AWS owners are discovered from S3 by ``list_plots`` and need not
+        # have a directory in Lambda's local filesystem.  Treat the provider
+        # listing as authoritative and evaluate an empty transaction history
+        # when no local compliance files are present.
+        if owner.lower() not in owners:
+            raise_owner_not_found(owner, total_owners_discovered=len(owners))
+    else:
+        owner = owner_dir.name
     if owners and owner.lower() not in owners:
         raise_owner_not_found(owner, total_owners_discovered=len(owners))
     try:
         # ``check_owner`` now returns additional fields such as
         # ``hold_countdowns`` and ``trades_remaining`` which are
         # forwarded directly to the client.
-        return compliance.check_owner(owner, accounts_root)
+        return compliance.check_owner(
+            owner,
+            accounts_root,
+            scaffold_missing=owner_dir is None,
+        )
     except FileNotFoundError as exc:
         logger.warning("accounts for %s not found: %s", sanitise_log_value(owner), sanitise_log_value(exc))
         raise_owner_not_found(owner)

--- a/tests/backend/routes/test_compliance.py
+++ b/tests/backend/routes/test_compliance.py
@@ -192,11 +192,49 @@ async def test_compliance_for_owner_missing_directory(tmp_path, monkeypatch, fas
         "resolve_owner_directory",
         lambda root, owner: None,
     )
+    monkeypatch.setattr(compliance_module, "_known_owners", lambda root: set())
 
     with pytest.raises(OwnerNotFoundError) as excinfo:
         await compliance_module.compliance_for_owner("alice", request)
 
     assert excinfo.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_compliance_for_remote_owner_without_local_directory(
+    tmp_path, monkeypatch, fastapi_request
+):
+    app, request = fastapi_request
+    accounts_root = tmp_path / "accounts"
+
+    monkeypatch.setattr(
+        compliance_module,
+        "resolve_accounts_root",
+        lambda req: accounts_root,
+    )
+    monkeypatch.setattr(
+        compliance_module,
+        "resolve_owner_directory",
+        lambda root, owner: None,
+    )
+    monkeypatch.setattr(
+        compliance_module,
+        "_known_owners",
+        lambda root: {"alice"},
+    )
+
+    calls = []
+
+    def check_owner(owner, root, *, scaffold_missing=False):
+        calls.append((owner, root, scaffold_missing))
+        return {"owner": owner, "warnings": []}
+
+    monkeypatch.setattr(compliance_module.compliance, "check_owner", check_owner)
+
+    result = await compliance_module.compliance_for_owner("alice", request)
+
+    assert result == {"owner": "alice", "warnings": []}
+    assert calls == [("alice", accounts_root, True)]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #6187 
### Motivation

- The `/compliance/{owner}` endpoint previously required a local on-disk owner directory which caused valid, provider-discovered owners (e.g. from S3) to return `404 Owner not found` in deployed AWS environments.

### Description

- Update `backend/routes/compliance.py` to consult the provider-backed owner listing (`_known_owners`) before rejecting when no local directory exists and treat provider-discovered owners as authoritative when present. 
- When the owner has no local directory but is present in the provider listing, call `compliance.check_owner(..., scaffold_missing=True)` so compliance is evaluated against an empty transaction history without mutating the shared dataset. 
- Add a regression test in `tests/backend/routes/test_compliance.py` that verifies a provider-discovered owner with no local directory returns compliance results and that unknown owners still raise a 404.

### Testing

- Ran the focused backend tests for the changed module with `python -m pytest tests/backend/routes/test_compliance.py -q --no-cov`, which passed (`29 passed`).
- Static checks `python -m ruff check backend/routes/compliance.py` and `python -m black --check backend/routes/compliance.py` passed.
- A full-repository coverage run shows the repo-wide coverage threshold exceeded the configured fail-under (the focused tests passed; the repo coverage guard is unrelated to the change itself).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a786a5ff3f88327a5b1265f3ae4fe29)