### PR TITLE
Log missing owners in alerts route (use raise_owner_not_found)

### DIFF
--- a/backend/routes/alerts.py
+++ b/backend/routes/alerts.py
@@ -1,14 +1,13 @@
+from pathlib import Path
 from typing import Dict
 
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from backend import alerts as alert_utils
-from pathlib import Path
-
 from backend.common import data_loader
 from backend.common.alerts import get_recent_alerts
-from backend.common.errors import OWNER_NOT_FOUND, OwnerNotFoundError
+from backend.common.errors import OwnerNotFoundError, raise_owner_not_found
 from backend.routes._accounts import resolve_accounts_root, resolve_owner_directory
 
 router = APIRouter(prefix="/alerts", tags=["alerts"])
@@ -38,7 +37,7 @@ def _validate_owner(user: str, request: Request) -> None:
             request.app.state.accounts_root = Path(fallback_root).expanduser().resolve(strict=False)
             return
 
-    raise OwnerNotFoundError(OWNER_NOT_FOUND, extra={"owner": user})
+    raise_owner_not_found(user)
 
 
 @router.get("/")

--- a/tests/backend/routes/test_alerts.py
+++ b/tests/backend/routes/test_alerts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, List
@@ -71,7 +72,9 @@ async def test_validate_owner_updates_request_state(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.anyio("asyncio")
-async def test_validate_owner_missing_everywhere(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_validate_owner_missing_everywhere(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     active_root = Path("/data/active")
     fallback_root = Path("/data/fallback")
     request = _make_request(active_root)
@@ -82,11 +85,14 @@ async def test_validate_owner_missing_everywhere(monkeypatch: pytest.MonkeyPatch
         fallback_succeeds=False,
     )
 
-    with pytest.raises(OwnerNotFoundError) as excinfo:
-        alerts._validate_owner("demo", request)
+    with caplog.at_level(logging.WARNING, logger="backend.common.errors"):
+        with pytest.raises(OwnerNotFoundError) as excinfo:
+            alerts._validate_owner("demo", request)
 
     assert excinfo.value.status_code == 404
     assert excinfo.value.detail == OWNER_NOT_FOUND
+    assert excinfo.value.extra == {"owner": "demo"}
+    assert "owner lookup: no owner found for owner=demo" in caplog.text
     assert call_roots == [active_root, fallback_root]
 
 


### PR DESCRIPTION
### Motivation

- Ensure missing-owner 404s in the alerts endpoints emit the same structured warning diagnostics used elsewhere.  
- Align the alerts route with the shared `log_owner_not_found` / `raise_owner_not_found` pattern introduced earlier to improve production observability.  
- Preserve existing API behaviour (status code, detail string) while adding diagnostic context for easier debugging.

### Description

- Replace the bare `OwnerNotFoundError` raise in `backend/routes/alerts.py` with the shared helper `raise_owner_not_found(user)` and add the required import.  
- Extend `tests/backend/routes/test_alerts.py` to assert the warning-level diagnostic log and that the raised `OwnerNotFoundError` preserves `extra` metadata.  
- No API contract changes were made: the HTTP 404 response, detail text, and exception type remain unchanged.  
- Closes #5678

### Testing

- Ran `pytest tests/backend/routes/test_alerts.py --no-cov` and observed `8 passed` for the targeted tests.  
- Ran style/format checks: `ruff`, `black --check`, and `isort --check-only` on the modified files and they all succeeded.  
- Ran `git diff --check` (whitespace/patch checks) and it reported no issues.  
- Note: an initial `pytest` invocation with repository-wide coverage triggered the repo's global coverage fail-under threshold (unrelated to these focused changes), so the targeted tests were validated with `--no-cov` and all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7975a3d60c83279569dac903dc8a36)