### PR TITLE
Enforce bidirectional requirements consistency

### DIFF
--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -6,9 +6,11 @@ pytest~=9.1.1
 pytest-cov~=7.1.0
 pytest-asyncio~=1.4.0
 # jsonschema is used by tests/contracts/test_api_response_contracts.py for API
-# contract validation; it is not a Lambda runtime dep but is needed to run the
-# full backend test suite in the lambda-compat job.
-jsonschema~=4.26.0
+# contract validation. It's no longer pinned here: backend/requirements.txt
+# mirrors it from the root requirements.txt (see tests/test_requirements_consistency.py),
+# and pinning a second, different range here made this file's combined
+# `pip install -r backend/requirements.txt -r backend/requirements-test.txt`
+# unresolvable (jsonschema~=4.23.0 vs ~=4.26.0).
 # cicaid-devtools is imported by tests/test_ai_review_scripts.py and
 # tests/test_review_common.py. Not a Lambda runtime dep — test-only.
 cicaid-devtools @ https://github.com/leonarduk/cicaid/releases/download/v0.5.2/cicaid_devtools-0.5.2-py3-none-any.whl

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -58,7 +58,7 @@ google-auth-oauthlib~=1.4.0
 jmespath~=1.1.0
 jsonschema~=4.23.0
 multitasking~=0.0.13
-pillow>=12.3.0,<13.0
+pillow>=12.3.0,<13.0  # transitive dep of reportlab~=5.0.0 (image support); already pulled into the Lambda build regardless
 platformdirs~=4.11.0
 pyasn1>=0.6.3
 pycparser~=3.0
@@ -68,6 +68,6 @@ tzdata~=2026.3
 urllib3~=2.7.0
 websocket-client~=1.9.0
 websockets~=16.0.0
-win_inet_pton~=1.1.0; sys_platform == "win32"
+win_inet_pton~=1.1.0; sys_platform == "win32"  # mirrors requirements.txt; marker makes this a no-op on Linux Lambda
 wsproto~=1.3.2
 zipp>=4.1.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -48,3 +48,26 @@ python-multipart~=0.0.32
 google-auth~=2.56.2
 redis~=8.1.0
 python-json-logger~=4.1.0
+annotated-types~=0.8.0
+anyio~=4.14.0
+botocore~=1.43.62
+curl-cffi>=0.15,<0.16  # yfinance~=1.5.1 requires curl_cffi>=0.15
+frozendict~=2.4.7
+google-auth-httplib2~=0.4.0
+google-auth-oauthlib~=1.4.0
+jmespath~=1.1.0
+jsonschema~=4.23.0
+multitasking~=0.0.13
+pillow>=12.3.0,<13.0
+platformdirs~=4.11.0
+pyasn1>=0.6.3
+pycparser~=3.0
+six~=1.17.0
+trio-websocket~=0.12.2
+tzdata~=2026.3
+urllib3~=2.7.0
+websocket-client~=1.9.0
+websockets~=16.0.0
+win_inet_pton~=1.1.0; sys_platform == "win32"
+wsproto~=1.3.2
+zipp>=4.1.0

--- a/tests/test_requirements_consistency.py
+++ b/tests/test_requirements_consistency.py
@@ -19,6 +19,11 @@ BACKEND_REQUIREMENTS = Path(__file__).resolve().parents[1] / "backend" / "requir
 # into the root requirements.txt used by the local dev server.
 BACKEND_ONLY_ALLOWLIST = {"setuptools"}
 
+# Keep exemptions explicit and narrowly limited to packages that are genuinely
+# needed only by local tooling. Runtime dependencies belong in both files so
+# local development and Lambda/Docker deployments install the same package set.
+ROOT_ONLY_ALLOWLIST: set[str] = set()
+
 _PACKAGE_NAME_RE = re.compile(r"^([A-Za-z0-9_.\-]+)")
 
 
@@ -50,6 +55,22 @@ class RequirementsConsistencyTests(unittest.TestCase):
             "(see issue #6016). Add them to requirements.txt, or add them to "
             "BACKEND_ONLY_ALLOWLIST in this test if they are genuinely "
             "backend-deploy-only tooling that backend/**/*.py never imports.",
+        )
+
+    def test_root_requirements_are_mirrored_in_backend_requirements(self) -> None:
+        root_packages = _parse_package_names(ROOT_REQUIREMENTS)
+        backend_packages = _parse_package_names(BACKEND_REQUIREMENTS)
+
+        missing = root_packages - backend_packages - ROOT_ONLY_ALLOWLIST
+
+        self.assertFalse(
+            missing,
+            f"Package(s) {sorted(missing)} are pinned in requirements.txt but "
+            "missing from backend/requirements.txt. Lambda/Docker deployments "
+            "install only the backend file and must not silently omit packages "
+            "available to the local backend (see issue #6020). Add them to "
+            "backend/requirements.txt, or add them to ROOT_ONLY_ALLOWLIST in "
+            "this test if they are genuinely local-only tooling.",
         )
 
 


### PR DESCRIPTION
### Motivation

- Ensure the backend runtime manifest used for Lambda/Docker deployments does not silently omit packages that exist in the root `requirements.txt`, by adding the inverse consistency check to the existing validation.

### Description

- Add a new test `test_root_requirements_are_mirrored_in_backend_requirements` and a `ROOT_ONLY_ALLOWLIST` to `tests/test_requirements_consistency.py` that asserts every package in the root `requirements.txt` is also present in `backend/requirements.txt` unless explicitly exempted.
- Synchronise `backend/requirements.txt` by adding the missing runtime packages found in the root manifest so Lambda/Docker installs match local development package presence.
- The check enforces package presence only (not identical version pins), and keeps a narrow allowlist for genuine local-only tooling.
- Closes #6020

### Testing

- Ran `PYENV_VERSION=3.11.15 python tests/test_requirements_consistency.py` and both tests in that module passed.
- Ran `PYENV_VERSION=3.11.15 python -m ruff check tests/test_requirements_consistency.py` which passed.
- Ran `PYENV_VERSION=3.11.15 python -m pip install --dry-run -r backend/requirements.txt` to validate the backend manifest is resolvable which succeeded.
- Note: a full `pytest` run initially failed to import the repo bootstrap in this environment due to a missing `PyYAML` package, but the standalone test execution above validated the new checks successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7976d1b3588327b2642504ddf4a4f7)