### PR TITLE
Limit issue-review feedback retries to prevent infinite loops

### DIFF
--- a/scripts/developer_tools/__init__.py
+++ b/scripts/developer_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility entry points for repository-specific developer tooling."""

--- a/scripts/developer_tools/n_review_issue.py
+++ b/scripts/developer_tools/n_review_issue.py
@@ -1,0 +1,52 @@
+"""Run cicaid's issue reviewer with a bounded interactive feedback loop.
+
+The implementation of the review workflow lives in ``cicaid-devtools``.  This
+small compatibility entry point applies AllotMint's feedback-round safety
+limit without duplicating that shared workflow.
+"""
+
+from collections.abc import Callable
+
+from cicaid_devtools import review_issue
+
+MAX_FEEDBACK_RETRIES = 5
+
+Disposition = tuple[str, str | None]
+
+
+def limited_disposition_prompt(
+    prompt: Callable[[], Disposition],
+) -> Callable[[], Disposition]:
+    """Wrap *prompt* so no more than the allowed feedback rounds are accepted."""
+    feedback_retries = 0
+
+    def prompt_with_limit() -> Disposition:
+        nonlocal feedback_retries
+        action, feedback = prompt()
+        if action != "retry":
+            return action, feedback
+
+        if feedback_retries >= MAX_FEEDBACK_RETRIES:
+            review_issue.logger.error(
+                "Maximum feedback retries reached; aborting without applying the review."
+            )
+            return "abort", None
+
+        feedback_retries += 1
+        return action, feedback
+
+    return prompt_with_limit
+
+
+def main() -> int:
+    """Run the shared issue-review command with bounded feedback retries."""
+    original_prompt = review_issue.prompt_for_disposition
+    review_issue.prompt_for_disposition = limited_disposition_prompt(original_prompt)
+    try:
+        return review_issue.main()
+    finally:
+        review_issue.prompt_for_disposition = original_prompt
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_n_review_issue.py
+++ b/tests/scripts/test_n_review_issue.py
@@ -1,0 +1,40 @@
+"""Tests for the bounded issue-review feedback compatibility entry point."""
+
+from unittest.mock import Mock
+
+from scripts.developer_tools import n_review_issue
+
+
+def test_limited_disposition_prompt_aborts_after_maximum_feedback(monkeypatch) -> None:
+    prompt = Mock(return_value=("retry", "try again"))
+    log_error = Mock()
+    monkeypatch.setattr(n_review_issue.review_issue.logger, "error", log_error)
+    limited_prompt = n_review_issue.limited_disposition_prompt(prompt)
+
+    for _ in range(n_review_issue.MAX_FEEDBACK_RETRIES):
+        assert limited_prompt() == ("retry", "try again")
+
+    assert limited_prompt() == ("abort", None)
+    assert prompt.call_count == n_review_issue.MAX_FEEDBACK_RETRIES + 1
+    log_error.assert_called_once_with(
+        "Maximum feedback retries reached; aborting without applying the review."
+    )
+
+
+def test_limited_disposition_prompt_preserves_apply_and_abort() -> None:
+    prompt = Mock(side_effect=[("apply", None), ("abort", None)])
+    limited_prompt = n_review_issue.limited_disposition_prompt(prompt)
+
+    assert limited_prompt() == ("apply", None)
+    assert limited_prompt() == ("abort", None)
+
+
+def test_main_restores_shared_prompt(monkeypatch) -> None:
+    original_prompt = n_review_issue.review_issue.prompt_for_disposition
+    shared_main = Mock(return_value=0)
+    monkeypatch.setattr(n_review_issue.review_issue, "main", shared_main)
+
+    assert n_review_issue.main() == 0
+
+    shared_main.assert_called_once_with()
+    assert n_review_issue.review_issue.prompt_for_disposition is original_prompt


### PR DESCRIPTION
### Motivation

- Prevent the issue-review workflow from running indefinitely when the user (or an automated input stream) repeatedly supplies non-apply/non-abort feedback to the model. 
- Keep the authoritative review logic in the shared `cicaid-devtools` package while applying a repository-specific safety guard. 

### Description

- Add `scripts/developer_tools/n_review_issue.py`, a small compatibility entry point that delegates to `cicaid_devtools.review_issue` and enforces `MAX_FEEDBACK_RETRIES = 5`.
- Implement `limited_disposition_prompt` to wrap `review_issue.prompt_for_disposition`, causing the flow to log an error and return an abort when the retry limit is exceeded, and restore the original prompt after execution.
- Add unit tests in `tests/scripts/test_n_review_issue.py` that cover the retry-limit exit path, preservation of apply/abort dispositions, and restoration of the shared prompt.
- Closes #5751.

### Testing

- Ran the new unit tests with `PYENV_VERSION=3.11.15 python -m pytest tests/scripts/test_n_review_issue.py --no-cov -q`, which reported `3 passed`.
- Ran static checks with `python -m ruff check scripts/developer_tools/n_review_issue.py tests/scripts/test_n_review_issue.py` and `python -m black --check scripts/developer_tools/n_review_issue.py tests/scripts/test_n_review_issue.py`, both of which passed.
- Performed `git diff --check` to ensure no whitespace/index errors, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7975c355ec8327b82667192761f8d7)