### PR TITLE
Centralize Moneyhub configuration error handling

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -16,7 +16,7 @@ from json import JSONDecodeError
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.openapi.docs import get_swagger_ui_html
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel
 
 import backend.auth as auth
@@ -28,6 +28,7 @@ from backend.bootstrap import (
     register_routers,
 )
 from backend.config import reload_config
+from backend.integrations.moneyhub_api import MoneyhubNotConfiguredError
 from backend.logging_setup import sanitise_log_value, setup_logging
 
 logger = logging.getLogger(__name__)
@@ -36,6 +37,11 @@ logger = logging.getLogger(__name__)
 class CognitoTokenRequest(BaseModel):
     id_token: str
     client_id: str
+
+
+async def moneyhub_not_configured_handler(_request: Request, exc: MoneyhubNotConfiguredError) -> JSONResponse:
+    """Return a consistent service-unavailable response for Moneyhub routes."""
+    return JSONResponse(status_code=503, content={"detail": str(exc)})
 
 
 def create_app() -> FastAPI:
@@ -59,6 +65,7 @@ def create_app() -> FastAPI:
         docs_url=None,
         lifespan=lifespan,
     )
+    app.add_exception_handler(MoneyhubNotConfiguredError, moneyhub_not_configured_handler)
 
     admin_emails_raw = os.getenv("ADMIN_EMAILS", "")
     admin_set: frozenset[str] = (

--- a/backend/integrations/moneyhub_api.py
+++ b/backend/integrations/moneyhub_api.py
@@ -27,6 +27,10 @@ class MoneyhubAPIError(Exception):
     """Raised when a Moneyhub API call fails."""
 
 
+class MoneyhubNotConfiguredError(RuntimeError):
+    """Raised when the Moneyhub client cannot be created without credentials."""
+
+
 @dataclass
 class MoneyhubClient:
     """Adapter for the Moneyhub Open Banking transactions API.

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -26,7 +26,7 @@ from backend.common.authz import ensure_owner_access
 from backend.common.instruments import get_instrument_meta
 from backend.common.ticker_utils import normalise_filter_ticker
 from backend.config import config
-from backend.integrations.moneyhub_api import MoneyhubClient
+from backend.integrations.moneyhub_api import MoneyhubClient, MoneyhubNotConfiguredError
 from backend.routes._accounts import resolve_accounts_root
 from backend.utils import update_holdings_from_csv
 
@@ -66,10 +66,10 @@ def _get_moneyhub_client() -> MoneyhubClient:
     """Return the process-wide Moneyhub client, creating it on first use.
 
     Raises:
-        RuntimeError: if credentials are unset (and not in ``TESTING`` mode).
-            Callers that reach this from a request handler should catch it
-            and return a 503, since it means the optional Moneyhub feature
-            isn't configured -- not that the request itself is broken.
+        MoneyhubNotConfiguredError: if credentials are unset (and not in
+            ``TESTING`` mode). The application-wide exception handler turns
+            this into a 503 response for every request path that creates the
+            client.
     """
     global _moneyhub_client_instance
 
@@ -77,7 +77,7 @@ def _get_moneyhub_client() -> MoneyhubClient:
         client_id = os.environ.get("MONEYHUB_CLIENT_ID")
         client_secret = os.environ.get("MONEYHUB_CLIENT_SECRET")
         if (not client_id or not client_secret) and not os.getenv("TESTING"):
-            raise RuntimeError("MONEYHUB_CLIENT_ID and MONEYHUB_CLIENT_SECRET must be set")
+            raise MoneyhubNotConfiguredError("MONEYHUB_CLIENT_ID and MONEYHUB_CLIENT_SECRET must be set")
         _moneyhub_client_instance = MoneyhubClient(
             client_id=client_id or "",
             client_secret=client_secret or "",
@@ -908,10 +908,7 @@ async def import_moneyhub_transactions(
     from backend.importers import moneyhub_api as moneyhub_mapper
     from backend.integrations.moneyhub_api import MoneyhubAPIError
 
-    try:
-        client = _get_moneyhub_client()
-    except RuntimeError as exc:
-        raise HTTPException(status_code=503, detail=str(exc))
+    client = _get_moneyhub_client()
     try:
         access_token = moneyhub_tokens.get_valid_access_token(owner, client)
     except moneyhub_tokens.MoneyhubAuthError as exc:

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -15,9 +15,9 @@ backend/alerts.py:194
 backend/alerts.py:228
 backend/alerts.py:256
 backend/alerts.py:336
-backend/app.py:168
-backend/app.py:200
-backend/app.py:219
+backend/app.py:175
+backend/app.py:207
+backend/app.py:226
 backend/auth.py:126
 # accounts-root path comes from server config, not attacker-controlled input.
 backend/auth.py:172

--- a/tests/test_moneyhub_api_import.py
+++ b/tests/test_moneyhub_api_import.py
@@ -10,7 +10,11 @@ from backend.common.moneyhub_tokens import TokenSet
 from backend.common.url_validator import InvalidExternalURLError
 from backend.config import config
 from backend.importers import moneyhub_api as moneyhub_mapper
-from backend.integrations.moneyhub_api import MoneyhubAPIError, MoneyhubClient
+from backend.integrations.moneyhub_api import (
+    MoneyhubAPIError,
+    MoneyhubClient,
+    MoneyhubNotConfiguredError,
+)
 from backend.routes import transactions
 
 # ---------------------------------------------------------------------------
@@ -40,7 +44,8 @@ def test_get_moneyhub_client_requires_credentials(monkeypatch, missing_name):
     monkeypatch.delenv(missing_name)
 
     with pytest.raises(
-        RuntimeError, match="MONEYHUB_CLIENT_ID and MONEYHUB_CLIENT_SECRET must be set"
+        MoneyhubNotConfiguredError,
+        match="MONEYHUB_CLIENT_ID and MONEYHUB_CLIENT_SECRET must be set",
     ):
         transactions._get_moneyhub_client()
 
@@ -74,6 +79,28 @@ def test_moneyhub_import_route_returns_503_when_unconfigured(monkeypatch):
 
     assert response.status_code == 503
     assert "MONEYHUB_CLIENT_ID" in response.json()["detail"]
+
+
+def test_moneyhub_configuration_handler_applies_to_every_route(monkeypatch):
+    """Any request path creating the client receives the centralized 503 response."""
+    monkeypatch.setattr(transactions, "_moneyhub_client_instance", None)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("MONEYHUB_CLIENT_ID", raising=False)
+    monkeypatch.delenv("MONEYHUB_CLIENT_SECRET", raising=False)
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+
+    app = create_app()
+
+    @app.get("/_test/moneyhub-client")
+    async def create_moneyhub_client():
+        transactions._get_moneyhub_client()
+        return {"configured": True}
+
+    with TestClient(app) as client:
+        response = client.get("/_test/moneyhub-client")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "MONEYHUB_CLIENT_ID and MONEYHUB_CLIENT_SECRET must be set"}
 
 
 def test_refresh_access_token_posts_expected_payload(monkeypatch):
@@ -275,9 +302,7 @@ def test_load_token_set_returns_none_when_absent(token_storage):
 
 
 def test_save_and_load_token_set_round_trips(token_storage):
-    token_set = TokenSet(
-        access_token="a", refresh_token="r", expires_at=123.0, account_ids=["acc-1"]
-    )
+    token_set = TokenSet(access_token="a", refresh_token="r", expires_at=123.0, account_ids=["acc-1"])
     moneyhub_tokens.save_token_set("alice", token_set)
 
     loaded = moneyhub_tokens.load_token_set("alice")


### PR DESCRIPTION
Closes #5733 
### Motivation
- Missing Moneyhub client credentials were being signalled via ad-hoc `RuntimeError` handling in individual routes, which risked inconsistent 500 responses or duplicated guards across Moneyhub-backed paths. 
- The goal is to centralize the conversion of an unconfigured Moneyhub client into a consistent `503 {"detail": "..."}` service-unavailable response for every request that tries to create the client.

### Description
- Introduced a dedicated exception `MoneyhubNotConfiguredError` in `backend/integrations/moneyhub_api.py` to represent missing Moneyhub credentials. 
- Registered a FastAPI exception handler in `create_app()` (`backend/app.py`) that maps `MoneyhubNotConfiguredError` to `JSONResponse(status_code=503, content={"detail": ...})`. 
- Updated `_get_moneyhub_client()` in `backend/routes/transactions.py` to raise `MoneyhubNotConfiguredError` (preserving the existing `TESTING` guard) and removed the route-local `try/except` that previously converted `RuntimeError` to a 503. 
- Added/updated tests in `tests/test_moneyhub_api_import.py` to expect the new exception type and to verify the centralized handler applies from another request route.

### Testing
- Ran `PYENV_VERSION=3.11.15 python -m pytest tests/test_moneyhub_api_import.py -q --no-cov` and all tests in that file passed (30 passed, 1 warning). 
- Ran linting/format checks with `ruff`, `black` and `isort` against the changed files and they passed after applying formatting (`ruff` check passed; `black`/`isort` checks satisfied). 
- Verified the import route returns the same `503` shape and added a regression test that confirms the centralized handler produces `503 {"detail": "MONEYHUB_CLIENT_ID and MONEYHUB_CLIENT_SECRET must be set"}` from a separate test route.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7975b422a08327b6706a09cc9ea7be)