### PR TITLE
Add holdings CSV reconciliation preview (frontend)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1815,6 +1815,84 @@ export interface ImportHoldingsCsvResponse {
   path: string;
 }
 
+export interface ReconciledHolding {
+  ticker: string;
+  units: number;
+  value_gbp: number;
+}
+
+export interface ReconciledQuantityChange {
+  ticker: string;
+  stored_units: number;
+  imported_units: number;
+  delta: number;
+}
+
+export interface ReconciledValueChange {
+  ticker: string;
+  stored_value_gbp: number;
+  imported_value_gbp: number;
+  delta_gbp: number;
+}
+
+export interface ReconcileHoldingsCsvResponse {
+  added: ReconciledHolding[];
+  removed: ReconciledHolding[];
+  quantity_changed: ReconciledQuantityChange[];
+  value_changed: ReconciledValueChange[];
+  cash_balance: {
+    stored_gbp: number;
+    imported_gbp: number;
+    delta_gbp: number;
+  };
+}
+
+const createHoldingsCsvFormData = (
+  owner: string,
+  account: string,
+  provider: string,
+  file: File,
+) => {
+  const formData = new FormData();
+  formData.append("owner", owner);
+  formData.append("account", account);
+  formData.append("provider", provider);
+  formData.append("file", file);
+  return formData;
+};
+
+/** Preview how a CSV differs from stored holdings without applying changes. */
+export const reconcileHoldingsCsv = async (
+  owner: string,
+  account: string,
+  provider: string,
+  file: File,
+): Promise<ReconcileHoldingsCsvResponse> => {
+  const headers = new Headers();
+  const token = getStoredAuthToken();
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const csrf = defaultGetCsrfToken();
+  if (csrf) headers.set("X-CSRFToken", csrf);
+
+  const res = await dynamicFetch(`${API_BASE}/holdings/reconcile`, {
+    method: "POST",
+    headers,
+    credentials: "include",
+    body: createHoldingsCsvFormData(owner, account, provider, file),
+  });
+  if (!res.ok) {
+    let detail = `HTTP ${res.status} - ${res.statusText}`;
+    try {
+      const body = await res.json();
+      if (typeof body?.detail === "string") detail = body.detail;
+    } catch {
+      // response body was not JSON; fall back to the status text above
+    }
+    throw new Error(detail);
+  }
+  return res.json() as Promise<ReconcileHoldingsCsvResponse>;
+};
+
 /**
  * Upload a CSV export of holdings/transactions for `owner`/`account` and have
  * the backend parse it with the given `provider` and persist the result.
@@ -1825,11 +1903,7 @@ export const importHoldingsCsv = async (
   provider: string,
   file: File,
 ): Promise<ImportHoldingsCsvResponse> => {
-  const formData = new FormData();
-  formData.append("owner", owner);
-  formData.append("account", account);
-  formData.append("provider", provider);
-  formData.append("file", file);
+  const formData = createHoldingsCsvFormData(owner, account, provider, file);
 
   const headers = new Headers();
   const token = getStoredAuthToken();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1862,70 +1862,28 @@ const createHoldingsCsvFormData = (
 };
 
 /** Preview how a CSV differs from stored holdings without applying changes. */
-export const reconcileHoldingsCsv = async (
+export const reconcileHoldingsCsv = (
   owner: string,
   account: string,
   provider: string,
   file: File,
-): Promise<ReconcileHoldingsCsvResponse> => {
-  const headers = new Headers();
-  const token = getStoredAuthToken();
-  if (token) headers.set("Authorization", `Bearer ${token}`);
-  const csrf = defaultGetCsrfToken();
-  if (csrf) headers.set("X-CSRFToken", csrf);
-
-  const res = await dynamicFetch(`${API_BASE}/holdings/reconcile`, {
+): Promise<ReconcileHoldingsCsvResponse> =>
+  fetchJson<ReconcileHoldingsCsvResponse>(`${API_BASE}/holdings/reconcile`, {
     method: "POST",
-    headers,
-    credentials: "include",
     body: createHoldingsCsvFormData(owner, account, provider, file),
   });
-  if (!res.ok) {
-    let detail = `HTTP ${res.status} - ${res.statusText}`;
-    try {
-      const body = await res.json();
-      if (typeof body?.detail === "string") detail = body.detail;
-    } catch {
-      // response body was not JSON; fall back to the status text above
-    }
-    throw new Error(detail);
-  }
-  return res.json() as Promise<ReconcileHoldingsCsvResponse>;
-};
 
 /**
  * Upload a CSV export of holdings/transactions for `owner`/`account` and have
  * the backend parse it with the given `provider` and persist the result.
  */
-export const importHoldingsCsv = async (
+export const importHoldingsCsv = (
   owner: string,
   account: string,
   provider: string,
   file: File,
-): Promise<ImportHoldingsCsvResponse> => {
-  const formData = createHoldingsCsvFormData(owner, account, provider, file);
-
-  const headers = new Headers();
-  const token = getStoredAuthToken();
-  if (token) headers.set("Authorization", `Bearer ${token}`);
-  const csrf = defaultGetCsrfToken();
-  if (csrf) headers.set("X-CSRFToken", csrf);
-
-  const res = await dynamicFetch(`${API_BASE}/holdings/import`, {
+): Promise<ImportHoldingsCsvResponse> =>
+  fetchJson<ImportHoldingsCsvResponse>(`${API_BASE}/holdings/import`, {
     method: "POST",
-    headers,
-    credentials: "include",
-    body: formData,
+    body: createHoldingsCsvFormData(owner, account, provider, file),
   });
-  if (!res.ok) {
-    let detail = `HTTP ${res.status} - ${res.statusText}`;
-    try {
-      const body = await res.json();
-      if (typeof body?.detail === "string") detail = body.detail;
-    } catch {
-      // response body was not JSON; fall back to the status text above
-    }
-    throw new Error(detail);
-  }
-  return res.json() as Promise<ImportHoldingsCsvResponse>;
-};

--- a/frontend/src/components/CsvImportForm.tsx
+++ b/frontend/src/components/CsvImportForm.tsx
@@ -1,4 +1,10 @@
-import { useId, useState, type ChangeEvent, type FormEvent } from 'react';
+import {
+  useId,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from 'react';
 import {
   importHoldingsCsv,
   reconcileHoldingsCsv,
@@ -138,10 +144,29 @@ export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
   const [file, setFile] = useState<File | null>(null);
   const [status, setStatus] = useState<Status>({ kind: 'idle' });
   const formId = useId();
+  // Bumped whenever account/provider/file change so a reconcile/import
+  // response that resolves after the inputs moved on can detect it's stale
+  // and avoid overwriting the newer selection with an old preview.
+  const requestIdRef = useRef(0);
+
+  const invalidatePreview = () => {
+    requestIdRef.current += 1;
+    setStatus({ kind: 'idle' });
+  };
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     setFile(e.target.files?.[0] ?? null);
-    setStatus({ kind: 'idle' });
+    invalidatePreview();
+  };
+
+  const handleAccountChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    setAccount(e.target.value);
+    invalidatePreview();
+  };
+
+  const handleProviderChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    setProvider(e.target.value);
+    invalidatePreview();
   };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -150,6 +175,8 @@ export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
     const action = (e.nativeEvent as SubmitEvent).submitter?.getAttribute(
       'value'
     );
+    const requestId = ++requestIdRef.current;
+    const isStale = () => requestIdRef.current !== requestId;
 
     if (action === 'reconcile') {
       setStatus({ kind: 'submitting', action: 'reconcile' });
@@ -160,8 +187,10 @@ export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
           provider,
           file
         );
+        if (isStale()) return;
         setStatus({ kind: 'reconciled', result });
       } catch (err) {
+        if (isStale()) return;
         setStatus({ kind: 'error', message: extractErrorMessage(err) });
       }
       return;
@@ -170,10 +199,15 @@ export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
     setStatus({ kind: 'submitting', action: 'import' });
     try {
       const result = await importHoldingsCsv(owner, account, provider, file);
+      // The write already happened on the backend, so the parent must
+      // refresh regardless of whether this request is still current —
+      // only the local status/file reset below is conditional on that.
+      onImported?.();
+      if (isStale()) return;
       setStatus({ kind: 'imported', path: result.path });
       setFile(null);
-      onImported?.();
     } catch (err) {
+      if (isStale()) return;
       setStatus({ kind: 'error', message: extractErrorMessage(err) });
     }
   };
@@ -197,7 +231,7 @@ export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
           <select
             id={`${formId}-account`}
             value={account}
-            onChange={(e) => setAccount(e.target.value)}
+            onChange={handleAccountChange}
             className="rounded border border-gray-700 bg-gray-800 p-1 text-white"
           >
             {accountTypes.map((type) => (
@@ -217,7 +251,7 @@ export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
           <select
             id={`${formId}-provider`}
             value={provider}
-            onChange={(e) => setProvider(e.target.value)}
+            onChange={handleProviderChange}
             className="rounded border border-gray-700 bg-gray-800 p-1 text-white"
           >
             <option value="">Select provider…</option>

--- a/frontend/src/components/CsvImportForm.tsx
+++ b/frontend/src/components/CsvImportForm.tsx
@@ -1,10 +1,14 @@
-import { useId, useState, type ChangeEvent, type FormEvent } from "react";
-import { importHoldingsCsv } from "../api";
+import { useId, useState, type ChangeEvent, type FormEvent } from 'react';
+import {
+  importHoldingsCsv,
+  reconcileHoldingsCsv,
+  type ReconcileHoldingsCsvResponse,
+} from '../api';
 
 /** Provider keys supported by `backend/importers`, excluding the `test` stub. */
 const PROVIDERS = [
-  { value: "degiro", label: "DEGIRO" },
-  { value: "hargreaves", label: "Hargreaves Lansdown" },
+  { value: 'degiro', label: 'DEGIRO' },
+  { value: 'hargreaves', label: 'Hargreaves Lansdown' },
 ];
 
 type Props = {
@@ -14,44 +18,167 @@ type Props = {
 };
 
 type Status =
-  | { kind: "idle" }
-  | { kind: "submitting" }
-  | { kind: "success"; path: string }
-  | { kind: "error"; message: string };
+  | { kind: 'idle' }
+  | { kind: 'submitting'; action: 'import' | 'reconcile' }
+  | { kind: 'imported'; path: string }
+  | { kind: 'reconciled'; result: ReconcileHoldingsCsvResponse }
+  | { kind: 'error'; message: string };
 
 const extractErrorMessage = (err: unknown): string => {
   if (err instanceof Error) return err.message;
-  return "Failed to import file. Please try again.";
+  return 'Failed to process file. Please try again.';
 };
 
-/** Form for uploading a CSV of holdings/transactions to `POST /holdings/import`. */
+const formatNumber = (value: number) => value.toLocaleString('en-GB');
+const formatGbp = (value: number) =>
+  value.toLocaleString('en-GB', { style: 'currency', currency: 'GBP' });
+const formatDelta = (value: number, formatter = formatNumber) =>
+  `${value > 0 ? '+' : ''}${formatter(value)}`;
+
+type DiffSectionProps = {
+  title: string;
+  emptyMessage: string;
+  rows: Array<{ ticker: string; detail: string }>;
+};
+
+function DiffSection({ title, emptyMessage, rows }: DiffSectionProps) {
+  return (
+    <section>
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-300">
+        {title}
+      </h4>
+      {rows.length === 0 ? (
+        <p className="mt-1 text-sm text-gray-500">{emptyMessage}</p>
+      ) : (
+        <ul className="mt-1 divide-y divide-gray-800 rounded border border-gray-800">
+          {rows.map(({ ticker, detail }) => (
+            <li
+              key={ticker}
+              className="flex justify-between gap-3 px-2 py-1 text-sm"
+            >
+              <span className="font-medium text-white">{ticker}</span>
+              <span className="text-right text-gray-300">{detail}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ReconciliationPreview({
+  result,
+}: {
+  result: ReconcileHoldingsCsvResponse;
+}) {
+  const cash = result.cash_balance;
+  return (
+    <div
+      role="status"
+      aria-label="Reconciliation preview"
+      className="mt-3 space-y-3 border-t border-gray-800 pt-3"
+    >
+      <div>
+        <h3 className="font-semibold text-blue-300">Reconciliation preview</h3>
+        <p className="text-sm text-gray-400">
+          Preview only — no stored holdings were changed.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <DiffSection
+          title="Added"
+          emptyMessage="No holdings to add."
+          rows={result.added.map((item) => ({
+            ticker: item.ticker,
+            detail: `${formatNumber(item.units)} units · ${formatGbp(item.value_gbp)}`,
+          }))}
+        />
+        <DiffSection
+          title="Removed"
+          emptyMessage="No holdings to remove."
+          rows={result.removed.map((item) => ({
+            ticker: item.ticker,
+            detail: `${formatNumber(item.units)} units · ${formatGbp(item.value_gbp)}`,
+          }))}
+        />
+        <DiffSection
+          title="Quantity changed"
+          emptyMessage="No quantity changes."
+          rows={result.quantity_changed.map((item) => ({
+            ticker: item.ticker,
+            detail: `${formatNumber(item.stored_units)} → ${formatNumber(item.imported_units)} (${formatDelta(item.delta)})`,
+          }))}
+        />
+        <DiffSection
+          title="Value changed"
+          emptyMessage="No value changes."
+          rows={result.value_changed.map((item) => ({
+            ticker: item.ticker,
+            detail: `${formatGbp(item.stored_value_gbp)} → ${formatGbp(item.imported_value_gbp)} (${formatDelta(item.delta_gbp, formatGbp)})`,
+          }))}
+        />
+      </div>
+      <section className="rounded border border-gray-800 p-2 text-sm">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-300">
+          Cash balance
+        </h4>
+        <p className="mt-1 text-gray-300">
+          {formatGbp(cash.stored_gbp)} → {formatGbp(cash.imported_gbp)} (
+          {formatDelta(cash.delta_gbp, formatGbp)})
+        </p>
+      </section>
+    </div>
+  );
+}
+
+/** Upload and safely preview or import a CSV of holdings/transactions. */
 export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
-  const [account, setAccount] = useState(accountTypes[0] ?? "");
-  const [provider, setProvider] = useState("");
+  const [account, setAccount] = useState(accountTypes[0] ?? '');
+  const [provider, setProvider] = useState('');
   const [file, setFile] = useState<File | null>(null);
-  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
   const formId = useId();
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     setFile(e.target.files?.[0] ?? null);
+    setStatus({ kind: 'idle' });
   };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!account || !provider || !file) return;
+    const action = (e.nativeEvent as SubmitEvent).submitter?.getAttribute(
+      'value'
+    );
 
-    setStatus({ kind: "submitting" });
+    if (action === 'reconcile') {
+      setStatus({ kind: 'submitting', action: 'reconcile' });
+      try {
+        const result = await reconcileHoldingsCsv(
+          owner,
+          account,
+          provider,
+          file
+        );
+        setStatus({ kind: 'reconciled', result });
+      } catch (err) {
+        setStatus({ kind: 'error', message: extractErrorMessage(err) });
+      }
+      return;
+    }
+
+    setStatus({ kind: 'submitting', action: 'import' });
     try {
       const result = await importHoldingsCsv(owner, account, provider, file);
-      setStatus({ kind: "success", path: result.path });
+      setStatus({ kind: 'imported', path: result.path });
       setFile(null);
       onImported?.();
     } catch (err) {
-      setStatus({ kind: "error", message: extractErrorMessage(err) });
+      setStatus({ kind: 'error', message: extractErrorMessage(err) });
     }
   };
 
-  const submitting = status.kind === "submitting";
+  const submitting = status.kind === 'submitting';
   const canSubmit = Boolean(account && provider && file) && !submitting;
 
   return (
@@ -102,7 +229,10 @@ export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
           </select>
         </div>
         <div>
-          <label htmlFor={`${formId}-file`} className="block text-xs text-gray-400">
+          <label
+            htmlFor={`${formId}-file`}
+            className="block text-xs text-gray-400"
+          >
             CSV file
           </label>
           <input
@@ -115,18 +245,34 @@ export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
         </div>
         <button
           type="submit"
+          value="reconcile"
+          disabled={!canSubmit}
+          className="rounded border border-blue-600 px-3 py-1 text-blue-200 hover:bg-blue-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {status.kind === 'submitting' && status.action === 'reconcile'
+            ? 'Reconciling…'
+            : 'Reconcile (preview)'}
+        </button>
+        <button
+          type="submit"
+          value="import"
           disabled={!canSubmit}
           className="rounded border border-gray-700 px-3 py-1 text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {submitting ? "Importing…" : "Import"}
+          {status.kind === 'submitting' && status.action === 'import'
+            ? 'Importing…'
+            : 'Import'}
         </button>
       </form>
-      {status.kind === "success" && (
+      {status.kind === 'imported' && (
         <p role="status" className="mt-2 text-sm text-green-400">
           Imported successfully. Saved to {status.path}.
         </p>
       )}
-      {status.kind === "error" && (
+      {status.kind === 'reconciled' && (
+        <ReconciliationPreview result={status.result} />
+      )}
+      {status.kind === 'error' && (
         <p role="alert" className="mt-2 text-sm text-red-500">
           {status.message}
         </p>

--- a/frontend/src/components/CsvImportForm.tsx
+++ b/frontend/src/components/CsvImportForm.tsx
@@ -35,7 +35,11 @@ const extractErrorMessage = (err: unknown): string => {
   return 'Failed to process file. Please try again.';
 };
 
-const formatNumber = (value: number) => value.toLocaleString('en-GB');
+// `toLocaleString` defaults to a maximum of 3 fraction digits, which would
+// silently round a genuine fractional-share delta (the backend compares
+// units down to a 1e-9 threshold) down to a misleading "no change".
+const formatNumber = (value: number) =>
+  value.toLocaleString('en-GB', { maximumFractionDigits: 6 });
 const formatGbp = (value: number) =>
   value.toLocaleString('en-GB', { style: 'currency', currency: 'GBP' });
 const formatDelta = (value: number, formatter = formatNumber) =>

--- a/frontend/tests/unit/api.test.ts
+++ b/frontend/tests/unit/api.test.ts
@@ -16,7 +16,42 @@ import {
   getPensionForecast,
   getConfig,
   UNAUTHORIZED_EVENT,
+  reconcileHoldingsCsv,
 } from "@/api";
+
+describe("holdings CSV reconciliation", () => {
+  it("posts multipart fields to the read-only reconciliation endpoint", async () => {
+    const response = {
+      added: [],
+      removed: [],
+      quantity_changed: [],
+      value_changed: [],
+      cash_balance: { stored_gbp: 1, imported_gbp: 2, delta_gbp: 1 },
+    };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(response),
+    });
+    global.fetch = mockFetch;
+    const file = new File(["ticker,units"], "holdings.csv", {
+      type: "text/csv",
+    });
+
+    await expect(
+      reconcileHoldingsCsv("alice", "ISA", "degiro", file),
+    ).resolves.toEqual(response);
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${DEFAULT_API_BASE}/holdings/reconcile`);
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    const body = init.body as FormData;
+    expect(body.get("owner")).toBe("alice");
+    expect(body.get("account")).toBe("ISA");
+    expect(body.get("provider")).toBe("degiro");
+    expect(body.get("file")).toBe(file);
+  });
+});
 
 describe("auth token handling", () => {
   beforeEach(() => {

--- a/frontend/tests/unit/api.test.ts
+++ b/frontend/tests/unit/api.test.ts
@@ -17,9 +17,20 @@ import {
   getConfig,
   UNAUTHORIZED_EVENT,
   reconcileHoldingsCsv,
+  importHoldingsCsv,
 } from "@/api";
 
+const csvFile = new File(["ticker,units"], "holdings.csv", {
+  type: "text/csv",
+});
+
 describe("holdings CSV reconciliation", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setAuthToken(null);
+    setApiBase(DEFAULT_API_BASE);
+  });
+
   it("posts multipart fields to the read-only reconciliation endpoint", async () => {
     const response = {
       added: [],
@@ -33,12 +44,9 @@ describe("holdings CSV reconciliation", () => {
       json: () => Promise.resolve(response),
     });
     global.fetch = mockFetch;
-    const file = new File(["ticker,units"], "holdings.csv", {
-      type: "text/csv",
-    });
 
     await expect(
-      reconcileHoldingsCsv("alice", "ISA", "degiro", file),
+      reconcileHoldingsCsv("alice", "ISA", "degiro", csvFile),
     ).resolves.toEqual(response);
 
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
@@ -49,7 +57,104 @@ describe("holdings CSV reconciliation", () => {
     expect(body.get("owner")).toBe("alice");
     expect(body.get("account")).toBe("ISA");
     expect(body.get("provider")).toBe("degiro");
-    expect(body.get("file")).toBe(file);
+    expect(body.get("file")).toBe(csvFile);
+    // No explicit Content-Type: the browser must set the multipart boundary itself.
+    const headers = init.headers as Headers;
+    expect(headers.has("Content-Type")).toBe(false);
+  });
+
+  it("routes through the authenticated client, attaching the bearer token", async () => {
+    setAuthToken("token123");
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          added: [],
+          removed: [],
+          quantity_changed: [],
+          value_changed: [],
+          cash_balance: { stored_gbp: 0, imported_gbp: 0, delta_gbp: 0 },
+        }),
+    });
+    global.fetch = mockFetch;
+
+    await reconcileHoldingsCsv("alice", "ISA", "degiro", csvFile);
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer token123");
+  });
+
+  it("dispatches UNAUTHORIZED_EVENT and rejects on a 401 response", async () => {
+    const handler = vi.fn();
+    window.addEventListener(UNAUTHORIZED_EVENT, handler);
+    try {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: () => Promise.resolve({ detail: "Session expired" }),
+      });
+      global.fetch = mockFetch;
+
+      await expect(
+        reconcileHoldingsCsv("alice", "ISA", "degiro", csvFile),
+      ).rejects.toThrow("Session expired");
+      expect(handler).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(UNAUTHORIZED_EVENT, handler);
+    }
+  });
+});
+
+describe("holdings CSV import", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setAuthToken(null);
+    setApiBase(DEFAULT_API_BASE);
+  });
+
+  it("posts multipart fields to the import endpoint", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ path: "/data/accounts/alice/ISA.json" }),
+    });
+    global.fetch = mockFetch;
+
+    await expect(
+      importHoldingsCsv("alice", "ISA", "degiro", csvFile),
+    ).resolves.toEqual({ path: "/data/accounts/alice/ISA.json" });
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${DEFAULT_API_BASE}/holdings/import`);
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    const body = init.body as FormData;
+    expect(body.get("owner")).toBe("alice");
+    expect(body.get("account")).toBe("ISA");
+    expect(body.get("provider")).toBe("degiro");
+    expect(body.get("file")).toBe(csvFile);
+  });
+
+  it("dispatches UNAUTHORIZED_EVENT and rejects on a 401 response", async () => {
+    const handler = vi.fn();
+    window.addEventListener(UNAUTHORIZED_EVENT, handler);
+    try {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: () => Promise.resolve({ detail: "Session expired" }),
+      });
+      global.fetch = mockFetch;
+
+      await expect(
+        importHoldingsCsv("alice", "ISA", "degiro", csvFile),
+      ).rejects.toThrow("Session expired");
+      expect(handler).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(UNAUTHORIZED_EVENT, handler);
+    }
   });
 });
 

--- a/frontend/tests/unit/components/CsvImportForm.test.tsx
+++ b/frontend/tests/unit/components/CsvImportForm.test.tsx
@@ -81,6 +81,34 @@ describe('CsvImportForm', () => {
     expect(preview).toHaveTextContent('£100.00 → £110.00 (+£10.00)');
   });
 
+  it('preserves a small fractional unit delta instead of showing "+0"', async () => {
+    vi.mocked(reconcileHoldingsCsv).mockResolvedValue({
+      added: [],
+      removed: [],
+      quantity_changed: [
+        {
+          ticker: 'FRAC.L',
+          stored_units: 1.0001,
+          imported_units: 1.0002,
+          delta: 0.0001,
+        },
+      ],
+      value_changed: [],
+      cash_balance: { stored_gbp: 0, imported_gbp: 0, delta_gbp: 0 },
+    });
+
+    render(<CsvImportForm owner="alice" accountTypes={['ISA']} />);
+    await userEvent.selectOptions(screen.getByLabelText('Provider'), 'degiro');
+    await userEvent.upload(screen.getByLabelText('CSV file'), csvFile);
+    await userEvent.click(screen.getByRole('button', { name: /Reconcile/ }));
+
+    const preview = await screen.findByRole('status', {
+      name: 'Reconciliation preview',
+    });
+    expect(preview).toHaveTextContent('1.0001 → 1.0002 (+0.0001)');
+    expect(preview).not.toHaveTextContent('(+0)');
+  });
+
   it('clears a completed preview when the account changes', async () => {
     vi.mocked(reconcileHoldingsCsv).mockResolvedValue({
       added: [{ ticker: 'NEW.L', units: 5, value_gbp: 10 }],

--- a/frontend/tests/unit/components/CsvImportForm.test.tsx
+++ b/frontend/tests/unit/components/CsvImportForm.test.tsx
@@ -1,73 +1,124 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { CsvImportForm } from "@/components/CsvImportForm";
-import { importHoldingsCsv } from "@/api";
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CsvImportForm } from '@/components/CsvImportForm';
+import { importHoldingsCsv, reconcileHoldingsCsv } from '@/api';
 
-vi.mock("@/api", () => ({
+vi.mock('@/api', () => ({
   importHoldingsCsv: vi.fn(),
+  reconcileHoldingsCsv: vi.fn(),
 }));
 
-describe("CsvImportForm", () => {
+describe('CsvImportForm', () => {
   beforeEach(() => {
     vi.mocked(importHoldingsCsv).mockReset();
+    vi.mocked(reconcileHoldingsCsv).mockReset();
   });
 
-  const csvFile = new File(["a,b\n1,2"], "holdings.csv", { type: "text/csv" });
+  const csvFile = new File(['a,b\n1,2'], 'holdings.csv', { type: 'text/csv' });
 
-  it("disables submit until a provider and file are chosen", async () => {
-    render(<CsvImportForm owner="alice" accountTypes={["ISA", "SIPP"]} />);
+  it('disables submit until a provider and file are chosen', async () => {
+    render(<CsvImportForm owner="alice" accountTypes={['ISA', 'SIPP']} />);
 
-    const submit = screen.getByRole("button", { name: "Import" });
+    const submit = screen.getByRole('button', { name: 'Import' });
+    const reconcile = screen.getByRole('button', { name: /Reconcile/ });
+    expect(submit).toBeDisabled();
+    expect(reconcile).toBeDisabled();
+
+    await userEvent.selectOptions(screen.getByLabelText('Provider'), 'degiro');
     expect(submit).toBeDisabled();
 
-    await userEvent.selectOptions(screen.getByLabelText("Provider"), "degiro");
-    expect(submit).toBeDisabled();
-
-    const fileInput = screen.getByLabelText("CSV file");
+    const fileInput = screen.getByLabelText('CSV file');
     await userEvent.upload(fileInput, csvFile);
     expect(submit).toBeEnabled();
+    expect(reconcile).toBeEnabled();
   });
 
-  it("submits the selected account, provider and file as multipart data", async () => {
-    vi.mocked(importHoldingsCsv).mockResolvedValue({
-      path: "/data/accounts/alice/ISA.json",
+  it('previews a readable reconciliation without importing', async () => {
+    vi.mocked(reconcileHoldingsCsv).mockResolvedValue({
+      added: [{ ticker: 'NEW.L', units: 5, value_gbp: 10 }],
+      removed: [{ ticker: 'OLD.L', units: 2, value_gbp: 6 }],
+      quantity_changed: [
+        { ticker: 'AAA.L', stored_units: 8, imported_units: 10, delta: 2 },
+      ],
+      value_changed: [
+        {
+          ticker: 'AAA.L',
+          stored_value_gbp: 11.2,
+          imported_value_gbp: 15,
+          delta_gbp: 3.8,
+        },
+      ],
+      cash_balance: { stored_gbp: 100, imported_gbp: 110, delta_gbp: 10 },
     });
 
-    render(<CsvImportForm owner="alice" accountTypes={["ISA", "SIPP"]} />);
+    render(<CsvImportForm owner="alice" accountTypes={['ISA']} />);
+    await userEvent.selectOptions(
+      screen.getByLabelText('Provider'),
+      'hargreaves'
+    );
+    await userEvent.upload(screen.getByLabelText('CSV file'), csvFile);
+    await userEvent.click(screen.getByRole('button', { name: /Reconcile/ }));
 
-    await userEvent.selectOptions(screen.getByLabelText("Account"), "SIPP");
-    await userEvent.selectOptions(screen.getByLabelText("Provider"), "hargreaves");
-    await userEvent.upload(screen.getByLabelText("CSV file"), csvFile);
-    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+    expect(reconcileHoldingsCsv).toHaveBeenCalledWith(
+      'alice',
+      'ISA',
+      'hargreaves',
+      csvFile
+    );
+    expect(importHoldingsCsv).not.toHaveBeenCalled();
+    const preview = await screen.findByRole('status', {
+      name: 'Reconciliation preview',
+    });
+    expect(preview).toHaveTextContent('Preview only');
+    expect(preview).toHaveTextContent('NEW.L');
+    expect(preview).toHaveTextContent('OLD.L');
+    expect(preview).toHaveTextContent('AAA.L');
+    expect(preview).toHaveTextContent('£100.00 → £110.00 (+£10.00)');
+  });
+
+  it('submits the selected account, provider and file as multipart data', async () => {
+    vi.mocked(importHoldingsCsv).mockResolvedValue({
+      path: '/data/accounts/alice/ISA.json',
+    });
+
+    render(<CsvImportForm owner="alice" accountTypes={['ISA', 'SIPP']} />);
+
+    await userEvent.selectOptions(screen.getByLabelText('Account'), 'SIPP');
+    await userEvent.selectOptions(
+      screen.getByLabelText('Provider'),
+      'hargreaves'
+    );
+    await userEvent.upload(screen.getByLabelText('CSV file'), csvFile);
+    await userEvent.click(screen.getByRole('button', { name: 'Import' }));
 
     expect(importHoldingsCsv).toHaveBeenCalledWith(
-      "alice",
-      "SIPP",
-      "hargreaves",
-      csvFile,
+      'alice',
+      'SIPP',
+      'hargreaves',
+      csvFile
     );
     expect(
-      await screen.findByText(/Imported successfully/),
+      await screen.findByText(/Imported successfully/)
     ).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "/data/accounts/alice/ISA.json",
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/data/accounts/alice/ISA.json'
     );
   });
 
-  it("shows the backend error message for an unknown provider", async () => {
+  it('shows the backend error message for an unknown provider', async () => {
     vi.mocked(importHoldingsCsv).mockRejectedValue(
-      new Error("Unknown provider: bogus"),
+      new Error('Unknown provider: bogus')
     );
 
-    render(<CsvImportForm owner="alice" accountTypes={["ISA"]} />);
+    render(<CsvImportForm owner="alice" accountTypes={['ISA']} />);
 
-    await userEvent.selectOptions(screen.getByLabelText("Provider"), "degiro");
-    await userEvent.upload(screen.getByLabelText("CSV file"), csvFile);
-    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+    await userEvent.selectOptions(screen.getByLabelText('Provider'), 'degiro');
+    await userEvent.upload(screen.getByLabelText('CSV file'), csvFile);
+    await userEvent.click(screen.getByRole('button', { name: 'Import' }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Unknown provider: bogus",
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Unknown provider: bogus'
     );
   });
 });

--- a/frontend/tests/unit/components/CsvImportForm.test.tsx
+++ b/frontend/tests/unit/components/CsvImportForm.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CsvImportForm } from '@/components/CsvImportForm';
-import { importHoldingsCsv, reconcileHoldingsCsv } from '@/api';
+import {
+  importHoldingsCsv,
+  reconcileHoldingsCsv,
+  type ReconcileHoldingsCsvResponse,
+} from '@/api';
 
 vi.mock('@/api', () => ({
   importHoldingsCsv: vi.fn(),
@@ -75,6 +79,62 @@ describe('CsvImportForm', () => {
     expect(preview).toHaveTextContent('OLD.L');
     expect(preview).toHaveTextContent('AAA.L');
     expect(preview).toHaveTextContent('£100.00 → £110.00 (+£10.00)');
+  });
+
+  it('clears a completed preview when the account changes', async () => {
+    vi.mocked(reconcileHoldingsCsv).mockResolvedValue({
+      added: [{ ticker: 'NEW.L', units: 5, value_gbp: 10 }],
+      removed: [],
+      quantity_changed: [],
+      value_changed: [],
+      cash_balance: { stored_gbp: 0, imported_gbp: 0, delta_gbp: 0 },
+    });
+
+    render(<CsvImportForm owner="alice" accountTypes={['ISA', 'SIPP']} />);
+    await userEvent.selectOptions(screen.getByLabelText('Provider'), 'degiro');
+    await userEvent.upload(screen.getByLabelText('CSV file'), csvFile);
+    await userEvent.click(screen.getByRole('button', { name: /Reconcile/ }));
+    await screen.findByRole('status', { name: 'Reconciliation preview' });
+
+    await userEvent.selectOptions(screen.getByLabelText('Account'), 'SIPP');
+
+    expect(
+      screen.queryByRole('status', { name: 'Reconciliation preview' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('ignores a reconcile response that resolves after the account changed', async () => {
+    let resolveReconcile:
+      | ((value: ReconcileHoldingsCsvResponse) => void)
+      | undefined;
+    vi.mocked(reconcileHoldingsCsv).mockReturnValue(
+      new Promise((resolve) => {
+        resolveReconcile = resolve;
+      })
+    );
+
+    render(<CsvImportForm owner="alice" accountTypes={['ISA', 'SIPP']} />);
+    await userEvent.selectOptions(screen.getByLabelText('Provider'), 'degiro');
+    await userEvent.upload(screen.getByLabelText('CSV file'), csvFile);
+    await userEvent.click(screen.getByRole('button', { name: /Reconcile/ }));
+
+    // The account changes while the reconcile request for "ISA" is still in flight.
+    await userEvent.selectOptions(screen.getByLabelText('Account'), 'SIPP');
+
+    await act(async () => {
+      resolveReconcile?.({
+        added: [{ ticker: 'STALE.L', units: 1, value_gbp: 1 }],
+        removed: [],
+        quantity_changed: [],
+        value_changed: [],
+        cash_balance: { stored_gbp: 0, imported_gbp: 0, delta_gbp: 0 },
+      });
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.queryByRole('status', { name: 'Reconciliation preview' })
+    ).not.toBeInTheDocument();
   });
 
   it('submits the selected account, provider and file as multipart data', async () => {

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/api", () => ({
   getVarBreakdown: vi.fn().mockResolvedValue([]),
   createAccount: vi.fn(),
   importHoldingsCsv: vi.fn(),
+  reconcileHoldingsCsv: vi.fn(),
 }));
 
 vi.mock("@/components/PerformanceDashboard", () => ({


### PR DESCRIPTION
### Motivation
- The backend exposes a read-only `POST /holdings/reconcile` endpoint but the frontend provided no way for users to preview CSV diffs before calling the destructive import, forcing curl-based workflows. 
- Provide a clear, non-destructive UI path so users can inspect Added/Removed/Quantity/Value/Cash deltas before performing `POST /holdings/import`.

### Description
- Added typed response models and a `reconcileHoldingsCsv` API wrapper that posts multipart form data to `POST /holdings/reconcile`, and factored form-data creation into `createHoldingsCsvFormData` so the import and reconcile flows share the same construction. (file: `frontend/src/api.ts`).
- Updated `CsvImportForm` to add a distinct "Reconcile (preview)" button alongside the existing Import action and separate submitting states so previewing never falls through to import. (file: `frontend/src/components/CsvImportForm.tsx`).
- Rendered a readable reconciliation preview with sections for Added, Removed, Quantity changed, Value changed and Cash balance and a clear message that no stored holdings were mutated. (file: `frontend/src/components/CsvImportForm.tsx`).
- Added/updated unit tests and mocks to cover the new API wrapper and UI behavior (`frontend/tests/unit/api.test.ts`, `frontend/tests/unit/components/CsvImportForm.test.tsx`, `frontend/tests/unit/components/PortfolioView.test.tsx`).
- Closes #6200

### Testing
- Ran the focused unit tests with `npm --prefix frontend run test -- --run tests/unit/components/CsvImportForm.test.tsx tests/unit/api.test.ts tests/unit/components/PortfolioView.test.tsx` and all included tests passed (58 tests passed).
- Ran lint and type checks with `npm --prefix frontend run lint` and `npm --prefix frontend run type-check`, which completed without errors.
- Ran `git diff --check` to ensure no whitespace/check issues and committed the changes; attempts to capture a Playwright screenshot failed because the Playwright CDN returned HTTP 403 when installing Chromium in this environment (no browser screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7976f562808327a883b8680f94212e)