### PR TITLE
Restore files dropped out-of-scope by the Tidy up commit (#6196)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ auth:
   disable_auth: true
   demo_identity: demo
   smoke_identity: demo
-  local_login_email: steveleonard11@gnail.com
+  local_login_email: ''
   allowed_emails: your-email@example.com
 server:
   app_env: local

--- a/scripts/qa/run_strict_qa_gate.sh
+++ b/scripts/qa/run_strict_qa_gate.sh
@@ -1,0 +1,717 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Strict gate runner for Issue #2581.
+# This script performs objective checks and writes durable evidence artifacts
+# suitable for attaching to the GitHub issue.
+
+API_BASE="${API_BASE:-http://localhost:8001}"
+OWNER="${OWNER:-}"
+GROUP_SLUG="${GROUP_SLUG:-}"
+RUN_DIR="${RUN_DIR:-artifacts/issue-2581/$(date -u +%Y%m%dT%H%M%SZ)}"
+SNAPSHOT_TIME_UTC="${SNAPSHOT_TIME_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+BROKER_SNAPSHOT_TIME_UTC="${BROKER_SNAPSHOT_TIME_UTC:-}"
+SYSTEM_FETCH_TIME_UTC="${SYSTEM_FETCH_TIME_UTC:-}"
+FRONTEND_SCREENSHOT_PATH="${FRONTEND_SCREENSHOT_PATH:-}"
+STARTUP_LOG_PATH="${STARTUP_LOG_PATH:-}"
+BROKER_SNAPSHOT_PATH="${BROKER_SNAPSHOT_PATH:-}"
+DEMO_PRODUCT_GATE_RESULT="${DEMO_PRODUCT_GATE_RESULT:-}"
+BROKER_SNAPSHOT_RUN_PATH="$RUN_DIR/broker_snapshot.json"
+
+mkdir -p "$RUN_DIR"
+
+failure_count=0
+run_verdict="PASS"
+
+declare -a failures=()
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+require_cmd curl
+require_cmd jq
+require_cmd python3
+
+if [[ -z "$OWNER" || -z "$GROUP_SLUG" ]]; then
+  die "OWNER and GROUP_SLUG are required"
+fi
+
+record_failure() {
+  local code="$1"
+  local step="$2"
+  local message="$3"
+  failure_count=$((failure_count + 1))
+  failures+=("$code|$step|$message")
+}
+
+write_env_lock() {
+  {
+    echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "git_commit=$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+    echo "python_version=$(python3 --version 2>&1)"
+    echo "api_base=$API_BASE"
+    echo "owner=$OWNER"
+    echo "group_slug=$GROUP_SLUG"
+    echo "snapshot_time_utc=$SNAPSHOT_TIME_UTC"
+    echo "broker_snapshot_time_utc=$BROKER_SNAPSHOT_TIME_UTC"
+    echo "system_fetch_time_utc=$SYSTEM_FETCH_TIME_UTC"
+  } >"$RUN_DIR/environment_lock.txt"
+
+  if command -v docker >/dev/null 2>&1; then
+    docker images --format '{{.Repository}}:{{.Tag}} {{.ID}}' >"$RUN_DIR/docker_images.txt" || true
+  else
+    echo "docker not found" >"$RUN_DIR/docker_images.txt"
+  fi
+}
+
+check_snapshot_window() {
+  python3 - "$SNAPSHOT_TIME_UTC" "$BROKER_SNAPSHOT_TIME_UTC" "$SYSTEM_FETCH_TIME_UTC" <<'PY'
+import datetime as dt
+import sys
+
+snapshot, broker, system = sys.argv[1:4]
+if not broker or not system:
+    print("MISSING")
+    sys.exit(2)
+
+def parse(ts):
+    return dt.datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=dt.timezone.utc)
+
+s = parse(snapshot)
+b = parse(broker)
+y = parse(system)
+
+max_drift = dt.timedelta(minutes=5)
+if abs(s - b) > max_drift or abs(s - y) > max_drift:
+    print("DRIFT")
+    sys.exit(1)
+
+print("OK")
+PY
+}
+
+# Fetch a URL, save the body to $out, record HTTP status.
+# On transport failure (curl non-zero exit) the function records a P1 failure
+# and continues — it does NOT abort the whole runner so that summary.json
+# is always produced.
+curl_json() {
+  local url="$1"
+  local out="$2"
+  local status
+  # Run curl in a subshell so its exit code does not propagate through set -e.
+  if ! status=$(curl -sS -o "$out" -w "%{http_code}" "$url" 2>"$out.stderr"); then
+    local curl_err
+    curl_err=$(cat "$out.stderr" 2>/dev/null || echo "unknown curl error")
+    record_failure "P1" "http" "curl transport error for $url: $curl_err"
+    echo "000" >"$out.status"
+    return
+  fi
+  echo "$status" >"$out.status"
+  if [[ "$status" != "200" ]]; then
+    record_failure "P1" "http" "Non-200 response from $url: $status"
+  fi
+}
+
+check_health_latency() {
+  local out="$RUN_DIR/backend_health.json"
+  local status latency combined
+  # Capture both status and latency; guard against transport errors.
+  if ! combined=$(curl -sS -o "$out" -w "%{http_code} %{time_total}" "$API_BASE/health" 2>"$RUN_DIR/backend_health.stderr"); then
+    record_failure "P1" "step1" "Backend /health unreachable: $(cat "$RUN_DIR/backend_health.stderr" 2>/dev/null)"
+    echo "000 999" >"$RUN_DIR/backend_health.timing"
+    return 1
+  fi
+  echo "$combined" >"$RUN_DIR/backend_health.timing"
+  # combined is "<http_status> <time_total>" e.g. "200 0.123456"
+  status=$(echo "$combined" | awk '{print $1}')
+  latency=$(echo "$combined" | awk '{print $2}')
+  if [[ "$status" != "200" ]]; then
+    record_failure "P1" "step1" "Backend /health returned HTTP $status"
+    return 1
+  fi
+  python3 - "$latency" <<'PY'
+import sys
+try:
+    lat = float(sys.argv[1])
+except ValueError:
+    print(f"Could not parse latency: {sys.argv[1]}", file=sys.stderr)
+    sys.exit(1)
+if lat >= 2.0:
+    sys.exit(1)
+PY
+}
+
+capture_step1_artifacts() {
+  local crash_pattern='(Traceback|Unhandled|Segmentation fault|Fatal|ERROR:|Exception)'
+
+  if [[ -n "$FRONTEND_SCREENSHOT_PATH" && -f "$FRONTEND_SCREENSHOT_PATH" ]]; then
+    cp "$FRONTEND_SCREENSHOT_PATH" "$RUN_DIR/frontend_screenshot.png"
+  else
+    : >"$RUN_DIR/frontend_screenshot.png.missing"
+    record_failure "P1" "step1" "Missing frontend screenshot evidence (set FRONTEND_SCREENSHOT_PATH)"
+  fi
+
+  if [[ -n "$STARTUP_LOG_PATH" && -f "$STARTUP_LOG_PATH" ]]; then
+    cp "$STARTUP_LOG_PATH" "$RUN_DIR/startup_log.txt"
+  else
+    : >"$RUN_DIR/startup_log.txt.missing"
+    record_failure "P1" "step1" "Missing startup log evidence (set STARTUP_LOG_PATH)"
+    return
+  fi
+
+  if grep -Eq "$crash_pattern" "$RUN_DIR/startup_log.txt"; then
+    record_failure "P1" "step1" "Startup log contains crash/error signatures"
+  fi
+}
+
+capture_broker_snapshot() {
+  if [[ -z "$BROKER_SNAPSHOT_PATH" ]]; then
+    if [[ -f "$BROKER_SNAPSHOT_RUN_PATH" ]]; then
+      return
+    fi
+    if [[ -f "$RUN_DIR/broker_snapshot.txt" ]]; then
+      cp "$RUN_DIR/broker_snapshot.txt" "$BROKER_SNAPSHOT_RUN_PATH"
+      record_failure "P2" "step2" "Using legacy broker_snapshot.txt fallback; migrate to broker_snapshot.json"
+      return
+    fi
+    record_failure "P1" "step2" "BROKER_SNAPSHOT_PATH is required unless RUN_DIR/broker_snapshot.json already exists"
+    : >"$BROKER_SNAPSHOT_RUN_PATH.missing"
+    return
+  fi
+
+  if [[ ! -f "$BROKER_SNAPSHOT_PATH" ]]; then
+    record_failure "P1" "step2" "BROKER_SNAPSHOT_PATH not found: $BROKER_SNAPSHOT_PATH"
+    : >"$BROKER_SNAPSHOT_RUN_PATH.missing"
+    return
+  fi
+
+  cp "$BROKER_SNAPSHOT_PATH" "$BROKER_SNAPSHOT_RUN_PATH"
+}
+
+broker_snapshot_is_json_object() {
+  python3 - "$BROKER_SNAPSHOT_RUN_PATH" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+if not isinstance(data, dict):
+    raise ValueError("Broker snapshot must be a JSON object")
+PY
+}
+
+check_portfolio_vs_broker_snapshot() {
+  python3 - "$RUN_DIR/portfolio_response.json" "$BROKER_SNAPSHOT_RUN_PATH" <<'PY'
+import json
+import sys
+from typing import Any
+
+portfolio_path, broker_path = sys.argv[1:3]
+with open(portfolio_path, "r", encoding="utf-8") as f:
+    portfolio = json.load(f)
+with open(broker_path, "r", encoding="utf-8") as f:
+    broker = json.load(f)
+
+if not isinstance(broker, dict):
+    raise ValueError("Broker snapshot must be a JSON object")
+
+def first_numeric(node: Any, keys: tuple[str, ...]):
+    if isinstance(node, dict):
+        for key in keys:
+            value = node.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return float(value)
+        for child in node.values():
+            found = first_numeric(child, keys)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for child in node:
+            found = first_numeric(child, keys)
+            if found is not None:
+                return found
+    return None
+
+def extract_holdings(node: Any):
+    holdings = []
+    if isinstance(node, dict):
+        symbol = node.get("ticker") or node.get("symbol") or node.get("instrument") or node.get("name")
+        value = first_numeric(node, ("market_value", "value", "position_value", "current_value", "amount"))
+        if isinstance(symbol, str) and value is not None:
+            holdings.append((symbol.strip().upper(), float(value)))
+        for child in node.values():
+            holdings.extend(extract_holdings(child))
+    elif isinstance(node, list):
+        for child in node:
+            holdings.extend(extract_holdings(child))
+    return holdings
+
+broker_total = first_numeric(broker, ("total_value", "portfolio_value", "total"))
+portfolio_total = first_numeric(portfolio, ("total_value", "portfolio_value", "total"))
+if broker_total is None or portfolio_total is None:
+    raise ValueError("Could not read total portfolio values from broker or portfolio payload")
+
+if broker_total <= 0 or portfolio_total <= 0:
+    raise ValueError("Broker/portfolio totals must be positive")
+
+delta_pct = abs(portfolio_total - broker_total) / broker_total * 100
+if delta_pct > 2:
+    raise ValueError(f"Portfolio total delta is {delta_pct:.3f}% (>2% P1 threshold)")
+
+broker_holdings = {}
+for symbol, value in extract_holdings(broker):
+    broker_holdings[symbol] = max(value, broker_holdings.get(symbol, 0.0))
+
+portfolio_holdings = extract_holdings(portfolio)
+portfolio_holdings = sorted(portfolio_holdings, key=lambda x: x[1], reverse=True)[:10]
+if not portfolio_holdings:
+    raise ValueError("No holdings found in portfolio payload for top-10 reconciliation")
+
+for symbol, value in portfolio_holdings:
+    broker_value = broker_holdings.get(symbol)
+    if broker_value is None:
+        raise ValueError(f"Missing broker holding for top position: {symbol}")
+    if broker_value <= 0:
+        raise ValueError(f"Invalid broker value for holding {symbol}")
+    position_delta = abs(value - broker_value) / broker_value * 100
+    if position_delta > 1:
+        raise ValueError(f"Holding {symbol} delta {position_delta:.3f}% exceeds 1% threshold")
+PY
+}
+
+check_no_null_or_negative_weights() {
+  local json_file="$1"
+  local label="$2"
+  python3 - "$json_file" "$label" <<'PY'
+import json, math, sys
+
+path, label = sys.argv[1:3]
+with open(path, 'r', encoding='utf-8') as f:
+    data = json.load(f)
+
+weights = []
+
+def walk(v):
+    if isinstance(v, dict):
+        for k, vv in v.items():
+            if vv is None:
+                raise ValueError(f"{label}: null value at key {k}")
+            if isinstance(vv, (int, float)) and not isinstance(vv, bool):
+                if not math.isfinite(vv):
+                    raise ValueError(f"{label}: non-finite number at key {k}")
+                if 'weight' in k.lower() or k in ('percentage', 'percent', 'value_pct'):
+                    weights.append(float(vv))
+            walk(vv)
+    elif isinstance(v, list):
+        for i in v:
+            walk(i)
+
+walk(data)
+if any(w < 0 for w in weights):
+    raise ValueError(f"{label}: negative weights found")
+if weights:
+    total = sum(weights)
+    if abs(total - 100.0) > 1.0:
+        raise ValueError(f"{label}: weight sum {total:.4f} outside 100±1")
+PY
+}
+
+check_var_structure() {
+  local json_file="$1"
+  python3 scripts/qa/var_payload_validator.py "$json_file"
+}
+
+check_audit_report_sections() {
+  local json_file="$1"
+  python3 - "$json_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+sections = data.get("sections")
+if not isinstance(sections, list):
+    raise ValueError("Report JSON missing 'sections' array")
+
+titles = []
+for section in sections:
+    if not isinstance(section, dict):
+        raise ValueError("Report JSON contains non-object section entry")
+    title = section.get("title")
+    if not isinstance(title, str) or not title.strip():
+        raise ValueError("Report JSON section missing non-empty title")
+    titles.append(title)
+
+required = [
+    "Portfolio overview",
+    "Sector allocation",
+    "Region allocation",
+    "Top holdings concentration",
+]
+for index, expected in enumerate(required):
+    if index >= len(titles) or titles[index] != expected:
+        raise ValueError(
+            f"Section {index + 1} must be '{expected}', got: {titles[index] if index < len(titles) else 'missing'}"
+        )
+
+allowed_optional = {"Portfolio risk", "Key Findings"}
+extras = titles[len(required):]
+for title in extras:
+    if title not in allowed_optional:
+        raise ValueError(f"Unexpected audit-report section title: {title}")
+
+if len(titles) < 4 or len(titles) > 6:
+    raise ValueError(f"Section count must be between 4 and 6 inclusive, got {len(titles)}")
+
+if "Key Findings" in titles and titles[-1] != "Key Findings":
+    raise ValueError("Key Findings must be the last section when present")
+
+if "Portfolio risk" in titles and titles.index("Portfolio risk") != 4:
+    raise ValueError("Portfolio risk must be section 5 when present")
+PY
+}
+
+check_pdf_total_and_var_reconciliation() {
+  python3 - \
+    "$RUN_DIR/audit_report.json" \
+    "$RUN_DIR/portfolio_response.json" \
+    "$RUN_DIR/var.json" <<'PY'
+import json
+import sys
+from typing import Any
+
+audit_path, portfolio_path, var_path = sys.argv[1:]
+with open(audit_path, "r", encoding="utf-8") as f:
+    audit = json.load(f)
+with open(portfolio_path, "r", encoding="utf-8") as f:
+    portfolio = json.load(f)
+with open(var_path, "r", encoding="utf-8") as f:
+    var_data = json.load(f)
+
+def first_numeric(node: Any, keys: tuple[str, ...]):
+    if isinstance(node, dict):
+        for key in keys:
+            value = node.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return float(value)
+        for child in node.values():
+            found = first_numeric(child, keys)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for child in node:
+            found = first_numeric(child, keys)
+            if found is not None:
+                return found
+    return None
+
+audit_total = first_numeric(audit, ("total_value", "portfolio_value", "total"))
+portfolio_total = first_numeric(portfolio, ("total_value", "portfolio_value", "total"))
+if audit_total is None or portfolio_total is None:
+    raise ValueError("Missing total value for audit/portfolio reconciliation")
+if abs(audit_total - portfolio_total) > 0.5:
+    raise ValueError("Audit total value does not reconcile with portfolio endpoint (±0.5 tolerance)")
+
+audit_var = first_numeric(audit, ("var", "var_pct", "value_at_risk"))
+endpoint_var = first_numeric(var_data, ("var", "var_pct", "value_at_risk"))
+if audit_var is None or endpoint_var is None:
+    raise ValueError("Missing VaR value for reconciliation")
+if abs(audit_var - endpoint_var) > 0.01:
+    raise ValueError("Audit VaR does not reconcile with /var endpoint (±0.01 tolerance)")
+PY
+}
+
+check_pdf_sector_region_reconciliation() {
+  python3 - \
+    "$RUN_DIR/audit_report.json" \
+    "$RUN_DIR/sectors.json" \
+    "$RUN_DIR/regions.json" <<'PY'
+import json
+import sys
+from typing import Any
+
+audit_path, sectors_path, regions_path = sys.argv[1:]
+with open(audit_path, "r", encoding="utf-8") as f:
+    audit = json.load(f)
+with open(sectors_path, "r", encoding="utf-8") as f:
+    sectors = json.load(f)
+with open(regions_path, "r", encoding="utf-8") as f:
+    regions = json.load(f)
+
+def first_numeric(node: Any, keys: tuple[str, ...]):
+    if isinstance(node, dict):
+        for key in keys:
+            value = node.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return float(value)
+        for child in node.values():
+            found = first_numeric(child, keys)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for child in node:
+            found = first_numeric(child, keys)
+            if found is not None:
+                return found
+    return None
+
+def extract_labeled_weight(node: Any):
+    if isinstance(node, list):
+        for entry in node:
+            if isinstance(entry, dict):
+                label = entry.get("name") or entry.get("label") or entry.get("sector") or entry.get("region")
+                weight = first_numeric(entry, ("weight", "percentage", "percent", "value_pct"))
+                if isinstance(label, str) and weight is not None:
+                    return label, float(weight)
+    if isinstance(node, dict):
+        for value in node.values():
+            result = extract_labeled_weight(value)
+            if result is not None:
+                return result
+    return None
+
+def value_from_section_title(report: Any, section_title: str):
+    if not isinstance(report, dict):
+        return None
+    sections = report.get("sections")
+    if not isinstance(sections, list):
+        return None
+    for section in sections:
+        if not isinstance(section, dict):
+            continue
+        title = section.get("title")
+        if title == section_title:
+            return first_numeric(section, ("weight", "percentage", "percent", "value_pct", "value"))
+    return None
+
+sector = extract_labeled_weight(sectors)
+region = extract_labeled_weight(regions)
+if sector is None or region is None:
+    raise ValueError("Could not identify representative sector/region weights")
+
+sector_label, sector_weight = sector
+region_label, region_weight = region
+audit_blob = json.dumps(audit)
+if sector_label not in audit_blob or region_label not in audit_blob:
+    raise ValueError("Audit report missing sector/region labels present in endpoints")
+
+audit_sector_weight = value_from_section_title(audit, "Sector allocation")
+audit_region_weight = value_from_section_title(audit, "Region allocation")
+if audit_sector_weight is None or abs(audit_sector_weight - sector_weight) > 1.0:
+    raise ValueError("Audit sector percentage does not reconcile within ±1")
+if audit_region_weight is None or abs(audit_region_weight - region_weight) > 1.0:
+    raise ValueError("Audit region percentage does not reconcile within ±1")
+PY
+}
+
+check_demo_watermark() {
+  if ! grep -aq "SAMPLE" "$RUN_DIR/demo_report.pdf"; then
+    record_failure "P1" "step6" "Demo PDF watermark 'SAMPLE' not detected"
+  fi
+}
+
+check_demo_product_gate() {
+  local normalized
+  normalized=$(echo "$DEMO_PRODUCT_GATE_RESULT" | tr '[:lower:]' '[:upper:]')
+  if [[ "$normalized" != "YES" ]]; then
+    record_failure "P1" "step6" "Step 6 product gate must be YES (set DEMO_PRODUCT_GATE_RESULT=YES)"
+  fi
+}
+
+write_summary() {
+  run_verdict="PASS"
+  if (( failure_count > 0 )); then
+    run_verdict="FAIL"
+  fi
+
+  {
+    echo "{"
+    echo "  \"timestamp_utc\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+    echo "  \"run_dir\": \"$RUN_DIR\","
+    echo "  \"verdict\": \"$run_verdict\","
+    echo "  \"failure_count\": $failure_count,"
+    echo "  \"failures\": ["
+    local first=1
+    for f in "${failures[@]}"; do
+      IFS='|' read -r code step message <<<"$f"
+      if [[ $first -eq 0 ]]; then
+        echo ","
+      fi
+      first=0
+      printf '    {"severity":"%s","step":"%s","message":%s}' "$code" "$step" "$(jq -Rn --arg m "$message" '$m')"
+    done
+    echo
+    echo "  ]"
+    echo "}"
+  } >"$RUN_DIR/summary.json"
+
+  echo "Wrote summary to $RUN_DIR/summary.json"
+}
+
+write_evidence_manifest() {
+  cat >"$RUN_DIR/evidence_manifest.txt" <<EOF
+Issue: #2581
+Run timestamp (UTC): $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Run directory: $RUN_DIR
+
+Required issue attachments
+- summary.json
+- summary_for_issue.md
+- environment_lock.txt
+- evidence_manifest.txt
+- audit_report.pdf
+- demo_report.pdf
+
+Required local durable evidence
+- backend_health.json
+- backend_health.timing
+- frontend_screenshot.png
+- startup_log.txt
+- portfolio_response.json
+- broker_snapshot.json
+- sectors.json
+- regions.json
+- var.json
+- docker_images.txt
+- transport/check logs (*.stderr, *.status, *.check.log)
+EOF
+}
+
+write_issue_summary_markdown() {
+  local failure_lines=""
+
+  if (( failure_count > 0 )); then
+    for f in "${failures[@]}"; do
+      IFS='|' read -r code step message <<<"$f"
+      failure_lines+="- [$code] **$step**: $message"$'\n'
+    done
+  else
+    failure_lines="- None"$'\n'
+  fi
+
+  cat >"$RUN_DIR/summary_for_issue.md" <<EOF
+## Issue #2581 strict run summary
+
+- **Verdict:** $run_verdict
+- **Run timestamp (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+- **Run directory:** \`$RUN_DIR\`
+- **Environment lock:** \`$RUN_DIR/environment_lock.txt\`
+- **Machine summary:** \`$RUN_DIR/summary.json\`
+- **Evidence manifest:** \`$RUN_DIR/evidence_manifest.txt\`
+
+### Failures
+$failure_lines
+### Required issue attachments
+- \`summary.json\`
+- \`summary_for_issue.md\`
+- \`environment_lock.txt\`
+- \`evidence_manifest.txt\`
+- \`audit_report.pdf\`
+- \`demo_report.pdf\`
+
+### Local-only (retain in run directory; attach when needed for review)
+- \`backend_health.json\`
+- \`backend_health.timing\`
+- \`frontend_screenshot.png\`
+- \`startup_log.txt\`
+- \`portfolio_response.json\`
+- \`broker_snapshot.json\`
+- \`sectors.json\`
+- \`regions.json\`
+- \`var.json\`
+- transport/check logs (\`*.stderr\`, \`*.check.log\`, \`*.status\`)
+EOF
+}
+
+main() {
+  write_env_lock
+
+  if ! check_snapshot_window >"$RUN_DIR/snapshot_window_check.txt" 2>&1; then
+    reason=$(cat "$RUN_DIR/snapshot_window_check.txt" 2>/dev/null || echo "unknown")
+    if [[ "$reason" == "MISSING" ]]; then
+      record_failure "P2" "global" "Missing broker/system snapshot timestamp"
+    else
+      record_failure "P1" "global" "Snapshot drift exceeds ±5 minutes"
+    fi
+  fi
+
+  # Step 1
+  if ! check_health_latency; then
+    record_failure "P1" "step1" "Backend /health latency >= 2s"
+  fi
+  capture_step1_artifacts
+
+  # Step 2
+  curl_json "$API_BASE/portfolio/$OWNER" "$RUN_DIR/portfolio_response.json"
+  capture_broker_snapshot
+  if [[ -f "$BROKER_SNAPSHOT_RUN_PATH" ]]; then
+    if broker_snapshot_is_json_object 2>>"$RUN_DIR/portfolio_vs_broker.check.log"; then
+      if ! check_portfolio_vs_broker_snapshot 2>>"$RUN_DIR/portfolio_vs_broker.check.log"; then
+        record_failure "P1" "step2" "Portfolio reconciliation against broker snapshot failed"
+      fi
+    else
+      record_failure "P2" "step2" "Broker snapshot is non-JSON; automated reconciliation skipped (manual review required)"
+    fi
+  fi
+
+  # Step 3
+  curl_json "$API_BASE/portfolio/$OWNER/sectors" "$RUN_DIR/sectors.json"
+  curl_json "$API_BASE/portfolio-group/$GROUP_SLUG/regions" "$RUN_DIR/regions.json"
+  if [[ -f "$RUN_DIR/sectors.json" ]] && ! check_no_null_or_negative_weights "$RUN_DIR/sectors.json" "sectors" 2>>"$RUN_DIR/sectors.check.log"; then
+    record_failure "P1" "step3" "Sector structure check failed"
+  fi
+  if [[ -f "$RUN_DIR/regions.json" ]] && ! check_no_null_or_negative_weights "$RUN_DIR/regions.json" "regions" 2>>"$RUN_DIR/regions.check.log"; then
+    record_failure "P1" "step3" "Region structure check failed"
+  fi
+
+  # Step 4
+  curl_json "$API_BASE/var/$OWNER" "$RUN_DIR/var.json"
+  if [[ -f "$RUN_DIR/var.json" ]] && ! check_var_structure "$RUN_DIR/var.json" 2>>"$RUN_DIR/var.check.log"; then
+    record_failure "P1" "step4" "VaR structural check failed"
+  fi
+
+  # Step 5
+  local code
+  code=$(curl -sS -o "$RUN_DIR/audit_report.pdf" -w "%{http_code}" "$API_BASE/reports/$OWNER/audit-report?format=pdf" 2>"$RUN_DIR/audit_report.stderr" || echo "000")
+  echo "$code" >"$RUN_DIR/audit_report.pdf.status"
+  if [[ "$code" != "200" ]]; then
+    record_failure "P1" "step5" "Audit PDF generation failed with status $code"
+  fi
+  curl_json "$API_BASE/reports/$OWNER/audit-report?format=json" "$RUN_DIR/audit_report.json"
+  if [[ -f "$RUN_DIR/audit_report.json" ]] && ! check_audit_report_sections "$RUN_DIR/audit_report.json" 2>>"$RUN_DIR/audit_report.check.log"; then
+    record_failure "P1" "step5" "Audit report section contract check failed"
+  fi
+  if [[ -f "$RUN_DIR/audit_report.json" ]] && ! check_pdf_total_and_var_reconciliation 2>>"$RUN_DIR/audit_reconciliation.check.log"; then
+    record_failure "P1" "step5" "Audit total/VaR reconciliation against endpoints failed"
+  fi
+  if [[ -f "$RUN_DIR/audit_report.json" ]] && ! check_pdf_sector_region_reconciliation 2>>"$RUN_DIR/audit_reconciliation.check.log"; then
+    record_failure "P1" "step5" "Audit JSON reconciliation against endpoints failed"
+  fi
+
+  # Step 6
+  local demo_code
+  demo_code=$(curl -sS -o "$RUN_DIR/demo_report.pdf" -w "%{http_code}" "$API_BASE/reports/demo-owner/audit-report?format=pdf&watermark=SAMPLE" 2>"$RUN_DIR/demo_report.stderr" || echo "000")
+  echo "$demo_code" >"$RUN_DIR/demo_report.pdf.status"
+  if [[ "$demo_code" != "200" ]]; then
+    record_failure "P1" "step6" "Demo PDF generation failed with status $demo_code"
+  fi
+  if [[ -f "$RUN_DIR/demo_report.pdf" ]]; then
+    check_demo_watermark
+  fi
+  check_demo_product_gate
+
+  write_summary
+  write_evidence_manifest
+  write_issue_summary_markdown
+  [[ "$run_verdict" == "PASS" ]]
+}
+
+main "$@"

--- a/scripts/qa/run_strict_qa_gate.sh
+++ b/scripts/qa/run_strict_qa_gate.sh
@@ -137,7 +137,7 @@ check_health_latency() {
     record_failure "P1" "step1" "Backend /health returned HTTP $status"
     return 1
   fi
-  python3 - "$latency" <<'PY'
+  if ! python3 - "$latency" <<'PY'
 import sys
 try:
     lat = float(sys.argv[1])
@@ -147,6 +147,10 @@ except ValueError:
 if lat >= 2.0:
     sys.exit(1)
 PY
+  then
+    record_failure "P1" "step1" "Backend /health latency >= 2s"
+    return 1
+  fi
 }
 
 capture_step1_artifacts() {
@@ -646,9 +650,7 @@ main() {
   fi
 
   # Step 1
-  if ! check_health_latency; then
-    record_failure "P1" "step1" "Backend /health latency >= 2s"
-  fi
+  check_health_latency || true
   capture_step1_artifacts
 
   # Step 2

--- a/scripts/qa/run_strict_qa_gate.sh
+++ b/scripts/qa/run_strict_qa_gate.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 # This script performs objective checks and writes durable evidence artifacts
 # suitable for attaching to the GitHub issue.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 API_BASE="${API_BASE:-http://localhost:8001}"
 OWNER="${OWNER:-}"
 GROUP_SLUG="${GROUP_SLUG:-}"
@@ -325,7 +327,7 @@ PY
 
 check_var_structure() {
   local json_file="$1"
-  python3 scripts/qa/var_payload_validator.py "$json_file"
+  python3 "$SCRIPT_DIR/var_payload_validator.py" "$json_file"
 }
 
 check_audit_report_sections() {

--- a/scripts/run-frontend-coverage.sh
+++ b/scripts/run-frontend-coverage.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 set -euo pipefail
 

--- a/scripts/run-frontend-coverage.sh
+++ b/scripts/run-frontend-coverage.sh
@@ -1,0 +1,48 @@
+
+#!/bin/bash
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# SYNOPSIS
+#   Installs frontend dependencies and runs the coverage test suite.
+# DESCRIPTION
+#   This script automates:
+#     1. Install NPM dependencies under the frontend workspace.
+#     2. Run the coverage script defined in package.json.
+# -----------------------------------------------------------------------------
+
+echo "Starting frontend coverage..."
+
+# Resolve repository root based on script location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+while [[ ! -f "$REPO_ROOT/package.json" && "$REPO_ROOT" != "/" ]]; do
+    REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+
+if [[ ! -f "$REPO_ROOT/package.json" ]]; then
+    echo "Unable to locate repository root from '$SCRIPT_DIR'."
+    exit 1
+fi
+
+FRONTEND_PATH="$REPO_ROOT/frontend"
+if [[ ! -d "$FRONTEND_PATH" ]]; then
+    echo "Frontend directory not found at '$FRONTEND_PATH'."
+    exit 1
+fi
+
+# Check npm availability
+if ! command -v npm &>/dev/null; then
+    echo "npm is required but was not found in PATH."
+    exit 1
+fi
+
+# Execute steps
+cd "$FRONTEND_PATH"
+echo "Installing frontend dependencies..."
+npm install
+
+echo "Running frontend coverage tests..."
+npm run coverage
+
+echo "Coverage completed successfully."

--- a/tests/scripts/test_issue_2581_strict_var_parser.py
+++ b/tests/scripts/test_issue_2581_strict_var_parser.py
@@ -126,6 +126,6 @@ def test_validate_var_payload_file_accepts_valid_payload(tmp_path) -> None:
 
 
 def test_strict_runner_delegates_to_shared_var_validator() -> None:
-    script_path = Path(__file__).resolve().parents[2] / "scripts" / "qa" / "run_issue_2581_strict.sh"
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "qa" / "run_strict_qa_gate.sh"
     script_text = script_path.read_text(encoding="utf-8")
     assert 'python3 scripts/qa/var_payload_validator.py "$json_file"' in script_text

--- a/tests/scripts/test_issue_2581_strict_var_parser.py
+++ b/tests/scripts/test_issue_2581_strict_var_parser.py
@@ -128,4 +128,4 @@ def test_validate_var_payload_file_accepts_valid_payload(tmp_path) -> None:
 def test_strict_runner_delegates_to_shared_var_validator() -> None:
     script_path = Path(__file__).resolve().parents[2] / "scripts" / "qa" / "run_strict_qa_gate.sh"
     script_text = script_path.read_text(encoding="utf-8")
-    assert 'python3 scripts/qa/var_payload_validator.py "$json_file"' in script_text
+    assert 'python3 "$SCRIPT_DIR/var_payload_validator.py" "$json_file"' in script_text


### PR DESCRIPTION
## What
Restores three things `f520f5a6` (#6196, "Tidy up") deleted or changed
outside its stated scope:

- `scripts/run-frontend-coverage.sh` — deleted entirely, even though its
  `.ps1` twin (`scripts/run-frontend-coverage.ps1`) still exists on `main`.
  Restored verbatim to match.
- The qa strict-gate script — deleted entirely, and covered by
  `tests/scripts/test_issue_2581_strict_var_parser.py`. Restored, but as
  `scripts/qa/run_strict_qa_gate.sh` instead of its old
  `run_issue_2581_strict.sh` name, which read as a temporary,
  issue-scoped file rather than the actively-maintained QA gate it is
  (see its git history: a dozen+ follow-up commits refining it well
  after issue #2581 closed). Updated the one test reference to the new
  path.
- `config.yaml`'s `auth.local_login_email` — changed from `''` to a
  typo'd real address (`steveleonard11@gnail.com`). Reverted.

## Why
Issue #6195 scoped the cleanup to `scripts/developer_tools` only, but
#6196's diff also touched these three unrelated files. All three
regressions are live on `main` right now and were failing 4 tests
(`test_strict_runner_delegates_to_shared_var_validator`,
`test_get_active_user_returns_none_when_disabled_without_token` x2,
`test_tax_allowances_route`) before this branch.

**This is not an implementation of #6195** (already closed) — it's a
corrective follow-up fixing #6196's own scope overreach against that
issue. It intentionally adds files back rather than removing directories,
which is the opposite of #6195's own acceptance criteria; that criteria
does not apply here.

## Note for reviewers
`origin/codex/implement-feature-from-issue-6197` (no PR open yet)
independently restored the qa script and reverted the config.yaml typo
in a commit bundled with unrelated feature work, under the *old*
`run_issue_2581_strict.sh` name. Once this PR merges, that branch's
owner should drop the now-redundant fix from their commit to avoid
reintroducing the old filename.

## AI review response
DeepSeek's first pass (REQUEST CHANGES) raised 5 points; verified each
against the actual code before acting:

- Fixed: `scripts/run-frontend-coverage.sh` had a stray blank line before
  its `#!/bin/bash` shebang (pre-existing in the original file, restored
  verbatim from `f520f5a6~1`). Removed.
- Fixed: `run_strict_qa_gate.sh` invoked its sibling
  `var_payload_validator.py` via a CWD-relative path, breaking when run
  from outside the repo root. Now resolves it via `SCRIPT_DIR`
  (`$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)`), matching the pattern
  already used in `run-frontend-coverage.sh`.
- Not actionable: the claim that `scripts/qa/var_payload_validator.py` is
  "not included in this diff" and might be missing — it was never deleted
  and exists on `main` today; confirmed via `test -f`.
- Not actionable: the claim that a `[[ -f ... ]]` check on the generated
  `audit_report.pdf` could pass on a corrupt file — no such check exists
  anywhere in the script for that file; it's gated only by the curl HTTP
  status, the same pattern used for every other artifact this script
  captures. DeepSeek's own cited line numbers didn't match the file's
  actual content, so this looks like a hallucinated finding.
- Deferred (flagged as follow-up, not fixed here): no functional test
  exists for the 717-line strict-gate script itself (it makes live HTTP
  calls against a running backend — mocking that is a real, separate
  undertaking, and it had no such coverage before it was ever deleted
  either).

## Testing
```
python -m pytest tests/scripts/test_issue_2581_strict_var_parser.py tests/test_auth_get_active_user.py tests/test_tax_route.py -q
```
44 passed. `black --check` / `ruff check` clean on the touched test file.
`bash -n` clean on both touched shell scripts.

## Checklist
- [x] Tests added/updated: N/A (restoring existing coverage, no new behavior)
- [x] Docs updated if needed: N/A (neither script was documented before deletion)
- [x] No breaking changes

See #6195 for the original (already-closed) cleanup issue this corrects scope creep from.