### PR TITLE
Handle malformed Moneyhub token sets

### DIFF
--- a/backend/common/moneyhub_tokens.py
+++ b/backend/common/moneyhub_tokens.py
@@ -62,11 +62,22 @@ def _storage_uri(owner: str) -> str:
 
 
 def load_token_set(owner: str) -> Optional[TokenSet]:
-    """Return the stored token set for ``owner``, or ``None`` if absent."""
+    """Return the stored token set for ``owner``, or ``None`` if absent.
+
+    Raises:
+        MoneyhubAuthError: the stored token set is missing a required field.
+    """
     data = get_storage(_storage_uri(owner)).load()
     if not data:
         return None
-    return TokenSet.from_dict(data)
+    try:
+        return TokenSet.from_dict(data)
+    except KeyError as exc:
+        required_field = exc.args[0]
+        raise MoneyhubAuthError(
+            f"Stored Moneyhub token set for owner '{owner}' is missing "
+            f"required field '{required_field}'"
+        ) from exc
 
 
 def save_token_set(owner: str, token_set: TokenSet) -> None:

--- a/tests/test_moneyhub_api_import.py
+++ b/tests/test_moneyhub_api_import.py
@@ -284,6 +284,18 @@ def test_save_and_load_token_set_round_trips(token_storage):
     assert loaded == token_set
 
 
+def test_load_token_set_wraps_missing_required_field(token_storage):
+    storage_path = token_storage.format(owner="alice")
+    with open(storage_path, "w", encoding="utf-8") as stored_tokens:
+        stored_tokens.write('{"access_token": "a", "expires_at": 123.0}')
+
+    with pytest.raises(
+        moneyhub_tokens.MoneyhubAuthError,
+        match="owner 'alice'.*required field 'refresh_token'",
+    ):
+        moneyhub_tokens.load_token_set("alice")
+
+
 def test_get_valid_access_token_returns_cached_when_not_expired(token_storage):
     token_set = TokenSet(access_token="a", refresh_token="r", expires_at=time.time() + 3600)
     moneyhub_tokens.save_token_set("alice", token_set)


### PR DESCRIPTION
### Motivation

- Avoid leaking raw `KeyError` when persisted Moneyhub token JSON is malformed by translating it to the domain error used by the rest of the code (`MoneyhubAuthError`).
- Make diagnostics clearer by including the affected owner and the missing field in the error message.
- Add regression coverage to prevent a future accidental revert to the old behavior.

### Description

- Update `backend/common/moneyhub_tokens.load_token_set` to catch `KeyError` from `TokenSet.from_dict` and raise `MoneyhubAuthError` with a message containing the `owner` and the missing field.
- Add `tests/test_moneyhub_api_import.py::test_load_token_set_wraps_missing_required_field` to verify that a stored token JSON missing `refresh_token` raises `MoneyhubAuthError` with an appropriate message.
- Apply small formatting adjustments to satisfy the repository style checks (`ruff`/`black`).

### Testing

- Ran the focused test module with `PYENV_VERSION=3.11.15 python -m pytest --no-cov tests/test_moneyhub_api_import.py` and all tests in that module passed (30 passed).
- Ran static/format checks with `python -m ruff check --config backend/pyproject.toml backend/common/moneyhub_tokens.py tests/test_moneyhub_api_import.py` and `black --check` and they passed after formatting.
- A full `pytest` run with coverage failed due to the repository-wide coverage gate (`fail-under=90%`), which is expected when running an isolated module under the repo-wide coverage policy; the targeted unit tests themselves passed.

Closes #5702

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7978f0342483279b7215cd75e8b437)