### PR TITLE
Sanitise exception tracebacks in error logs

### DIFF
--- a/backend/common/data_loader.py
+++ b/backend/common/data_loader.py
@@ -13,6 +13,8 @@ from pathlib import Path, PureWindowsPath
 from threading import RLock
 from typing import Any, Dict, List, Optional, Tuple
 
+from pydantic import ValidationError
+
 from backend.common.account_models import AccountRecord, OwnerSummaryRecord, PersonMetadata
 from backend.common.data_providers import (
     DATA_BUCKET_ENV,
@@ -28,8 +30,7 @@ from backend.common.path_utils import safe_join
 from backend.common.virtual_portfolio import VirtualPortfolio
 from backend.config import config
 from backend.config import demo_identity as get_demo_identity
-from backend.logging_setup import sanitise_log_value
-from pydantic import ValidationError
+from backend.logging_setup import sanitise_exception_traceback, sanitise_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -1061,8 +1062,9 @@ def load_account(
             if not os.getenv(DATA_BUCKET_ENV):
                 raise MissingData(str(exc)) from exc
             logger.warning(
-                "Failed to load account data: %s; falling back to local file",
+                "Failed to load account data: %s; falling back to local file; traceback: %s",
                 sanitise_log_value(str(exc)),
+                sanitise_exception_traceback(exc),
                 extra={
                     "event": "data_loader.account_provider_unavailable",
                     "owner": sanitise_log_value(owner),
@@ -1070,7 +1072,6 @@ def load_account(
                     "fallback_to_local": bool(local_root),
                     "provider": "s3",
                 },
-                exc_info=True,
             )
             if not local_root:
                 raise

--- a/backend/lambda_api/dividend_refresh.py
+++ b/backend/lambda_api/dividend_refresh.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 
 from backend.common.dividends import refresh_dividends
-from backend.logging_setup import sanitise_log_value
+from backend.logging_setup import sanitise_exception_traceback, sanitise_log_value
 
 logger = logging.getLogger("dividends")
 
@@ -25,5 +25,9 @@ def lambda_handler(event, context):
     try:
         return refresh_dividends()
     except Exception as exc:
-        logger.error("Dividend refresh failed: %s", sanitise_log_value(exc), exc_info=True)
+        logger.error(
+            "Dividend refresh failed: %s; traceback: %s",
+            sanitise_log_value(exc),
+            sanitise_exception_traceback(exc),
+        )
         return {"error": str(exc), "dividends_created": 0}

--- a/backend/lambda_api/pension_report.py
+++ b/backend/lambda_api/pension_report.py
@@ -47,7 +47,7 @@ from backend.common.pension_snapshots import (
 from backend.common.portfolio_loader import list_portfolios
 from backend.common.storage import get_storage
 from backend.emails.pension_report import PensionReport, send_pension_report_email
-from backend.logging_setup import sanitise_log_value
+from backend.logging_setup import sanitise_exception_traceback, sanitise_log_value
 
 logger = logging.getLogger("pension_report")
 
@@ -203,7 +203,11 @@ def lambda_handler(event, context):
         target_owners = _load_recipient_owners()
         portfolios = list_portfolios()
     except Exception as exc:
-        logger.error("Pension report failed to initialise: %s", sanitise_log_value(exc), exc_info=True)
+        logger.error(
+            "Pension report failed to initialise: %s; traceback: %s",
+            sanitise_log_value(exc),
+            sanitise_exception_traceback(exc),
+        )
         publish_sns_alert(
             {
                 "message": f"Pension report Lambda failed to start: {exc}",
@@ -229,10 +233,10 @@ def lambda_handler(event, context):
             sent += 1
         except Exception as exc:
             logger.error(
-                "Pension report failed for owner %s: %s",
+                "Pension report failed for owner %s: %s; traceback: %s",
                 sanitise_log_value(owner),
                 sanitise_log_value(exc),
-                exc_info=True,
+                sanitise_exception_traceback(exc),
             )
             errors.append(f"{owner}: {exc}")
 

--- a/backend/lambda_api/price_refresh.py
+++ b/backend/lambda_api/price_refresh.py
@@ -25,7 +25,7 @@ from datetime import UTC, datetime
 from backend.common.portfolio_utils import DATA_BUCKET_ENV, PRICES_S3_KEY
 from backend.common.prices import refresh_prices
 from backend.config import config
-from backend.logging_setup import sanitise_log_value
+from backend.logging_setup import sanitise_exception_traceback, sanitise_log_value
 
 try:  # trading agent is optional; skip if missing
     import trading_agent  # type: ignore
@@ -77,9 +77,9 @@ def lambda_handler(event, context):
         result = refresh_prices()
     except Exception as exc:
         logger.error(
-            "Price refresh failed; seeding empty snapshot to suppress cold-start warnings: %s",
+            "Price refresh failed; seeding empty snapshot to suppress cold-start warnings: %s; traceback: %s",
             sanitise_log_value(exc),
-            exc_info=True,
+            sanitise_exception_traceback(exc),
         )
         try:
             _seed_empty_snapshot()

--- a/backend/logging_setup.py
+++ b/backend/logging_setup.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import logging.config
+import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
@@ -25,6 +26,11 @@ def sanitise_log_value(value: object) -> str:
     via CWE-117 (log injection).
     """
     return str(value).replace("\r", "").replace("\n", "")
+
+
+def sanitise_exception_traceback(exc: BaseException) -> str:
+    """Return ``exc`` and its traceback as one log-safe line."""
+    return sanitise_log_value("".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
 
 
 class JSONFormatter(JsonFormatter):

--- a/backend/routes/portfolio.py
+++ b/backend/routes/portfolio.py
@@ -36,7 +36,7 @@ from backend.common import portfolio as portfolio_mod
 from backend.common.account_models import OwnerSummaryRecord, PersonMetadata
 from backend.common.errors import log_owner_not_found
 from backend.config import config, demo_identity
-from backend.logging_setup import sanitise_log_value
+from backend.logging_setup import sanitise_exception_traceback, sanitise_log_value
 from backend.routes._accounts import resolve_accounts_root, resolve_owner_directory
 from backend.utils.pricing_dates import PricingDateCalculator
 from backend.utils.timeseries_helpers import resolve_date_range
@@ -852,24 +852,24 @@ async def get_account(owner: str, account: str, request: Request):
         data = data_loader.load_account_record(owner, account, root).model_dump(exclude_unset=True)
     except data_loader.ProviderUnavailable as exc:
         log.warning(
-            "portfolio.account_provider_unavailable",
+            "portfolio.account_provider_unavailable; traceback: %s",
+            sanitise_exception_traceback(exc),
             extra={
                 "event": "portfolio.account_provider_unavailable",
                 "owner": sanitise_log_value(owner),
                 "account": sanitise_log_value(account),
             },
-            exc_info=True,
         )
         raise HTTPException(status_code=503, detail="Account data provider unavailable") from exc
     except data_loader.InvalidPayload as exc:
         log.warning(
-            "portfolio.account_invalid_payload",
+            "portfolio.account_invalid_payload; traceback: %s",
+            sanitise_exception_traceback(exc),
             extra={
                 "event": "portfolio.account_invalid_payload",
                 "owner": sanitise_log_value(owner),
                 "account": sanitise_log_value(account),
             },
-            exc_info=True,
         )
         raise HTTPException(status_code=502, detail="Account data payload is invalid") from exc
     except FileNotFoundError:

--- a/scripts/build_tools/_scan_log_sanitisation.py
+++ b/scripts/build_tools/_scan_log_sanitisation.py
@@ -32,9 +32,9 @@ def _is_safe_arg(node: ast.expr) -> bool:
         return False
     if isinstance(node, ast.Call):
         func = node.func
-        if isinstance(func, ast.Name) and func.id == "sanitise_log_value":
+        if isinstance(func, ast.Name) and func.id in {"sanitise_log_value", "sanitise_exception_traceback"}:
             return True
-        if isinstance(func, ast.Attribute) and func.attr == "sanitise_log_value":
+        if isinstance(func, ast.Attribute) and func.attr in {"sanitise_log_value", "sanitise_exception_traceback"}:
             return True
     return False
 

--- a/tests/test_log_injection_sanitisation.py
+++ b/tests/test_log_injection_sanitisation.py
@@ -101,6 +101,21 @@ def test_sanitise_log_value_strips_newline_from_exception():
     assert "evil" in sanitised
 
 
+def test_sanitise_exception_traceback_strips_newlines():
+    """Formatted tracebacks must not allow an exception to forge log lines."""
+    from backend.logging_setup import sanitise_exception_traceback
+
+    try:
+        raise RuntimeError("provider failed\r\nforged warning")
+    except RuntimeError as exc:
+        sanitised = sanitise_exception_traceback(exc)
+
+    assert "\r" not in sanitised
+    assert "\n" not in sanitised
+    assert "RuntimeError: provider failedforged warning" in sanitised
+    assert "Traceback (most recent call last)" in sanitised
+
+
 def test_sanitise_log_value_or_sentinel_precedence():
     """
     Regression: `sanitise_log_value(x or '<empty>')` correctly substitutes

--- a/tests/test_log_sanitization_audit.py
+++ b/tests/test_log_sanitization_audit.py
@@ -110,18 +110,38 @@ def test_warning_and_error_exception_messages_are_sanitised() -> None:
                 and bool(self.exception_names)
             )
             if is_relevant_log:
-                for argument in node.args[1:]:
-                    uses_exception = any(
-                        isinstance(child, ast.Name) and child.id in self.exception_names for child in ast.walk(argument)
-                    )
-                    is_sanitised = any(
-                        isinstance(child, ast.Call)
-                        and isinstance(child.func, ast.Name)
-                        and child.func.id in {"sanitise_log_value", "_sanitize_for_log"}
-                        for child in ast.walk(argument)
-                    )
-                    if uses_exception and not is_sanitised:
+                sanitiser_names = {
+                    "sanitise_log_value",
+                    "sanitise_exception_traceback",
+                    "_sanitize_for_log",
+                }
+
+                class UnsafeExceptionReference(ast.NodeVisitor):
+                    found = False
+
+                    def visit_Call(self, child: ast.Call) -> None:  # noqa: N802
+                        if isinstance(child.func, ast.Name) and child.func.id in sanitiser_names:
+                            return
+                        self.generic_visit(child)
+
+                    def visit_Name(self, child: ast.Name) -> None:  # noqa: N802
+                        if child.id in self_exception_names:
+                            self.found = True
+
+                self_exception_names = self.exception_names
+                for argument in node.args:
+                    reference = UnsafeExceptionReference()
+                    reference.visit(argument)
+                    if reference.found:
                         violations.append(f"{self.relative_path}:{node.lineno}")
+
+                raw_traceback = any(
+                    keyword.arg == "exc_info"
+                    and not (isinstance(keyword.value, ast.Constant) and keyword.value.value is False)
+                    for keyword in node.keywords
+                )
+                if raw_traceback:
+                    violations.append(f"{self.relative_path}:{node.lineno}")
             self.generic_visit(node)
 
     for source_path in sorted((REPO_ROOT / "backend").rglob("*.py")):


### PR DESCRIPTION
### Motivation

- Prevent CWE-117 log injection by ensuring formatted tracebacks and exception-derived text logged at `warning`/`error` levels cannot contain CR/LF sequences. 
- Preserve diagnostic context while preventing forged log lines from appearing in console/Telegram/plain-text formatters.

### Description

- Add `sanitise_exception_traceback(exc: BaseException) -> str` to `backend/logging_setup.py` which formats the exception+traceback and strips `\r`/`\n` into a single safe line. 
- Replace unsafe `exc_info=True` usage in Lambda handlers and other error paths with explicit sanitized traceback arguments; representative changes are in `backend/lambda_api/dividend_refresh.py`, `backend/lambda_api/pension_report.py`, and `backend/lambda_api/price_refresh.py`. 
- Strengthen the static AST audit in `tests/test_log_sanitization_audit.py` to inspect format arguments, detect embedded exception references and raw `exc_info` usage, and accept the new `sanitise_exception_traceback` helper. 
- Update the scanner in `scripts/build_tools/_scan_log_sanitisation.py` to recognise `sanitise_exception_traceback` as a valid sanitiser, and adjust a few backend call-sites (`backend/common/data_loader.py`, `backend/routes/portfolio.py`, etc.) to emit the sanitized traceback argument. 
- Add a behavioral unit test `test_sanitise_exception_traceback_strips_newlines` to `tests/test_log_injection_sanitisation.py` to verify that formatted tracebacks are reduced to a single safe line at runtime.

### Testing

- Ran the static and behavioral suites with `python -m pytest tests/test_log_sanitization_audit.py tests/test_log_injection_sanitisation.py -q --no-cov` and all tests passed (`19 passed`).
- Ran lint/format checks with `python -m ruff check --config backend/pyproject.toml ...` on the changed files and the check completed without errors.
- Verified there are no whitespace/patch issues with `git diff --check` and the working diff was clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a798aead8148327aa3d64a31c98d427)