### PR TITLE
Fix backend startup crash on trailing-dot LSE tickers

### DIFF
--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -33,9 +33,7 @@ def _resolve_instruments_dir() -> Path:
 
     fallback_dir = Path(__file__).resolve().parents[2] / "data" / "instruments"
     if fallback_dir.is_dir():
-        logger.debug(
-            "Configured instruments directory %s missing; falling back to %s", configured_dir, fallback_dir
-        )
+        logger.debug("Configured instruments directory %s missing; falling back to %s", configured_dir, fallback_dir)
         return fallback_dir
 
     logger.warning(
@@ -112,6 +110,7 @@ def _validate_part(value: str) -> str:
         raise ValueError("invalid ticker or exchange")
     return value
 
+
 def _s3_location() -> tuple[str, str] | None:
     bucket = os.getenv(METADATA_BUCKET_ENV)
     if not bucket:
@@ -141,6 +140,10 @@ def _instrument_path(ticker: str) -> Path:
     instruments_dir = _active_instruments_dir()
     sym, exch = (ticker.split(".", 1) + [None])[:2]
     sym = _validate_part(sym)
+    # A trailing dot with nothing after it (e.g. real LSE tickers like "BP.",
+    # "AV.", "SN.") splits into an empty string, not None -- treat that the
+    # same as no exchange at all rather than failing _validate_part's regex.
+    exch = exch or None
     if exch is not None:
         exch = _validate_part(exch)
     if sym == "CASH":
@@ -362,7 +365,9 @@ def _fetch_metadata_from_yahoo(symbol: str, exchange: str) -> Optional[Dict[str,
     except ValueError as exc:
         logger.debug(
             "Unsupported exchange for Yahoo metadata %s.%s: %s",
-            sanitise_log_value(symbol), sanitise_log_value(exchange), sanitise_log_value(exc),
+            sanitise_log_value(symbol),
+            sanitise_log_value(exchange),
+            sanitise_log_value(exc),
         )
         return None
 
@@ -373,7 +378,8 @@ def _fetch_metadata_from_yahoo(symbol: str, exchange: str) -> Optional[Dict[str,
     except Exception as exc:  # pragma: no cover - network/IO errors
         logger.warning(
             "Failed to initialise yfinance for %s: %s",
-            sanitise_log_value(yahoo_symbol), sanitise_log_value(exc),
+            sanitise_log_value(yahoo_symbol),
+            sanitise_log_value(exc),
         )
         return None
 
@@ -391,15 +397,12 @@ def _fetch_metadata_from_yahoo(symbol: str, exchange: str) -> Optional[Dict[str,
         except Exception as exc_attr:  # pragma: no cover - best effort fallback
             logger.debug(
                 "yfinance info attribute failed for %s: %s",
-                sanitise_log_value(full_ticker), sanitise_log_value(exc_attr),
+                sanitise_log_value(full_ticker),
+                sanitise_log_value(exc_attr),
             )
 
     name = _clean_str(
-        info.get("shortName")
-        or info.get("longName")
-        or info.get("displayName")
-        or info.get("name")
-        or full_ticker,
+        info.get("shortName") or info.get("longName") or info.get("displayName") or info.get("name") or full_ticker,
     )
 
     currency = _clean_str(info.get("currency"), upper=True)
@@ -476,7 +479,8 @@ def _auto_create_instrument_meta(ticker: str) -> Optional[Dict[str, Any]]:
     except Exception as exc:  # pragma: no cover - filesystem errors are rare
         logger.warning(
             "Failed to persist auto-created metadata for %s: %s",
-            sanitise_log_value(full), sanitise_log_value(exc),
+            sanitise_log_value(full),
+            sanitise_log_value(exc),
         )
     else:
         logger.info("Auto-created instrument metadata for %s from Yahoo Finance", sanitise_log_value(full))
@@ -496,6 +500,7 @@ def delete_instrument_meta(ticker: str, exchange: str) -> None:
         logger.warning("Permission denied deleting %s", path)
         return
     get_instrument_meta.cache_clear()
+
 
 # def save_instrument_meta(ticker: str, meta: Dict[str, Any]) -> None:
 #     """Write ``meta`` for ``ticker`` back to disk.
@@ -524,4 +529,3 @@ def list_instruments() -> List[Dict[str, Any]]:
         except Exception:
             logger.warning("Failed to load instrument metadata for %s", p)
     return instruments
-

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -38,6 +38,17 @@ def test_instrument_path_generates_expected_locations(monkeypatch, tmp_path) -> 
     assert instruments._instrument_path("cash.usd") == tmp_path / "Cash" / "USD.json"
 
 
+@pytest.mark.parametrize("ticker", ["BP.", "AV.", "SN.", "bp."])
+def test_instrument_path_treats_trailing_dot_as_no_exchange(monkeypatch, tmp_path, ticker: str) -> None:
+    """Real LSE tickers like "BP." split into an empty (not None) exchange
+    part; that must resolve the same as the bare symbol, not raise (#6266).
+    """
+    monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", tmp_path)
+
+    sym = ticker[:-1].upper()
+    assert instruments._instrument_path(ticker) == tmp_path / "Unknown" / f"{sym}.json"
+
+
 @pytest.mark.parametrize("ticker", ["bad$ticker", "abc.ba@d"])
 def test_instrument_path_rejects_invalid_symbols(monkeypatch, tmp_path, ticker: str) -> None:
     monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", tmp_path)
@@ -260,6 +271,7 @@ def test_instruments_dir_resolution(
         caplog.clear()
         with caplog.at_level("DEBUG"):
             if patch_module_path:
+
                 def fake_resolve(self, *args, **kwargs):  # type: ignore[override]
                     resolved = original_resolve(self, *args, **kwargs)
                     if resolved == module_path:
@@ -344,8 +356,7 @@ def test_save_instrument_meta_handles_read_only_filesystem(monkeypatch, tmp_path
 
     assert result is None
     assert any(
-        "Cannot write instrument metadata" in record.getMessage()
-        and record.levelname == "WARNING"
+        "Cannot write instrument metadata" in record.getMessage() and record.levelname == "WARNING"
         for record in caplog.records
     )
 
@@ -476,6 +487,7 @@ def test_auto_create_respects_offline_and_failure_cache(monkeypatch) -> None:
     assert calls == [("YYY", "L")]
     assert "YYY.L" in instruments._AUTO_CREATE_FAILURES
 
+
 @pytest.mark.xfail(reason="Query fallback mechanism needs investigation")
 def test_auto_create_respects_testing_guard(monkeypatch) -> None:
     monkeypatch.setattr(instruments, "_AUTO_CREATE_FAILURES", set())
@@ -490,6 +502,8 @@ def test_auto_create_respects_testing_guard(monkeypatch) -> None:
         assert instruments._auto_create_instrument_meta("TEST.L") is None
     finally:
         monkeypatch.delenv("TESTING", raising=False)
+
+
 def test_list_group_definitions_loads_json(monkeypatch, tmp_path) -> None:
     root = tmp_path / "instruments" / "groupings"
     root.mkdir(parents=True, exist_ok=True)
@@ -508,6 +522,8 @@ def test_list_group_definitions_loads_json(monkeypatch, tmp_path) -> None:
         assert "invalid" not in defs
     finally:
         instruments.list_group_definitions.cache_clear()
+
+
 @pytest.mark.parametrize(
     "value,upper,expected",
     [
@@ -565,4 +581,3 @@ def test_yahoo_suffix_for_exchange_unknown() -> None:
 )
 def test_build_yahoo_symbol(symbol, exchange, expected) -> None:
     assert instruments._build_yahoo_symbol(symbol, exchange) == expected
-

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -55,11 +55,11 @@ backend/common/instrument_api.py:415
 backend/common/instrument_groups.py:52
 backend/common/instrument_groups.py:55
 backend/common/instruments.py:36
-backend/common/instruments.py:41
-backend/common/instruments.py:84
-backend/common/instruments.py:88
-backend/common/instruments.py:496
-backend/common/instruments.py:525
+backend/common/instruments.py:39
+backend/common/instruments.py:82
+backend/common/instruments.py:86
+backend/common/instruments.py:500
+backend/common/instruments.py:530
 backend/common/portfolio.py:81
 backend/common/portfolio.py:115
 # raw/d_raw/amount_minor are logged with %r (repr), which already escapes


### PR DESCRIPTION
## Summary
- `_instrument_path()` in `backend/common/instruments.py` split a ticker on `.` expecting an absent exchange to be `None`, but a trailing dot with nothing after it (real LSE convention, e.g. `BP.`, `AV.`, `SN.`) produces an empty string instead, which `_validate_part`'s regex rejects.
- Since the ticker scan that hits this path runs unconditionally at backend import time (`instrument_api.py`), any owner having such a ticker crashed the *entire* backend on startup, not just their own page.
- Fix: treat an empty exchange part the same as no exchange at all.

Found and reported by the user while testing a different, unrelated fix (#6263/#6264) locally against real account data.

## Test plan
- [x] New regression test `test_instrument_path_treats_trailing_dot_as_no_exchange` covering `BP.`/`AV.`/`SN.`
- [x] `tests/backend/common/test_instruments.py` + `tests/test_instruments.py` -- 59 passed, 1 pre-existing xfail
- [x] Directly imported `backend.common.instrument_api` (the module that crashed at startup) against real account data -- now loads cleanly
- [x] `ruff check`, `black --check` clean

Closes #6266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tickers ending with a dot are now handled correctly when no exchange is specified.
  - These tickers use the default “Unknown” exchange location instead of being rejected.

- **Tests**
  - Added regression coverage to confirm trailing-dot tickers resolve to the expected location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->