### PR TITLE
Document: keep formatting-only changes separate from functional fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,7 @@ Read `AGENTS.md` for full repository guidance. Use these short rules while gener
 - Keep changes out of generated dependency folders such as `node_modules/`.
 - Be careful when changing `data/`, auth defaults, or smoke-test flows; these are tightly coupled to local development and demos.
 - Preserve bash/PowerShell parity when editing shared developer workflows.
+- Keep formatting-only changes (full-file `black`/`isort`/`prettier` runs) in their own commit, separate from functional fixes (#6268).
 - For Codex browser-testing setup and POC commands, see `docs/CODEX_PLAYWRIGHT_MCP.md`.
 - Before deep-reading an unfamiliar area, check `graphify-out/.graphify_analysis.json` (`gods` hotspots, `communities` clusters) as a precomputed orientation aid — it's refreshed manually via `workflow_dispatch` on `.github/workflows/graphify.yml`, so treat it as a snapshot, not live truth. Never load `graphify-out/graph.json` (tens of MB) wholesale into context.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ Never submit an issue that is missing any of these sections.
 - If you changed UI behavior, attach screenshots.
 - If you changed operational workflows, mention the exact commands used for validation.
 - **When rebasing a PR branch**: rebase onto the target and force-push to the **same branch name**. The PR updates automatically. Do not create a new branch or a new PR — that duplicates review state and creates noise.
+- **Keep formatting-only changes (a full-file `black`/`isort`/`prettier` run) in a separate commit from functional fixes.** Mixing them buries the real diff in cosmetic noise and breaks `git bisect`. (#6268)
 
 ## 10. Additional AI-facing files in this repo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ npm run smoke:test:codex:poc
 - Backend lint/format config currently targets Python 3.11 semantics even though some docs mention Python 3.12.
 - Avoid editing generated or vendored folders like `node_modules/`.
 - Never use `git commit -am`; always stage specific files explicitly. The `-a` flag will sweep in any lock file changes from local `npm ci` or `npm install` runs, which can strip platform-specific optional deps (e.g. Linux `@emnapi` entries) and break CI.
+- Keep formatting-only changes (a full-file `black`/`isort`/`prettier` run) in a separate commit from functional fixes — mixing them buries the real diff in cosmetic noise and breaks `git bisect` (#6268).
 - Be cautious around `data/`, auth toggles, and smoke-test identities; these often affect local demos and automated flows.
 - Preserve cross-platform workflow parity when touching scripts because the repo uses both bash and PowerShell helpers.
 - Before deep-reading an unfamiliar area, check `graphify-out/.graphify_analysis.json` for `gods` (fan-in hotspots) and `communities` (module clusters) — it's a precomputed orientation aid. It's refreshed **manually** via `workflow_dispatch` on `.github/workflows/graphify.yml`, so treat it as a snapshot, not live truth. Never load `graphify-out/graph.json` (tens of MB) wholesale into context — grep/`jq` specific entries instead.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -167,6 +167,14 @@ body (for example: `Closes #1234`).
 lock file changes from `npm ci` or `npm install` that strip platform-specific
 dependencies.
 
+**Keep formatting-only changes separate from functional changes**: running a
+full-file formatter (`black`, `isort`, `prettier`, etc.) as part of a
+functional fix can reformat unrelated lines in the same file, mixing
+cosmetic noise into a diff that's supposed to be about one behavior change.
+Put formatting-only changes in their own commit (or PR) instead of folding
+them into a functional commit — it keeps the diff reviewable and keeps
+`git bisect` pointing at a single logical change. (#6268)
+
 **Frontend optional dependency handling**: `frontend/package-lock.json` pins
 platform-specific optional packages (for example the Linux-only
 `@emnapi/core`/`@emnapi/runtime` entries under `@tailwindcss/oxide-wasm32-wasi`,


### PR DESCRIPTION
## Summary
- PR #6267 mixed a targeted functional fix (`_instrument_path`) with cosmetic reformatting from running `black`/`isort` on the whole file, making the diff noisier and harder to bisect than necessary.
- Adds a short guideline to all four AI-agent instruction files (`CLAUDE.md`, `AGENTS.md`, `docs/CONTRIBUTING.md`, `.github/copilot-instructions.md`) -- per `AGENTS.md`'s own note that repo facts should be mirrored across these files -- to keep formatting-only changes in their own commit going forward.

Docs-only change; no code, tests, or behavior affected.

Closes #6268

🤖 Generated with [Claude Code](https://claude.com/claude-code)