### PR TITLE
Holdings table: prioritize financial columns, single sparkline, and i18n trend header

### DIFF
--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -110,16 +110,21 @@ jobs:
           # review_diff's DEFAULT_GLOBS (Python/YAML/shell/etc.) omits the
           # frontend's TS/TSX/JS/JSX/JSON/CSS/HTML extensions, so a
           # frontend-only PR (e.g. #6279) produced an empty filtered diff and
-          # the AI review had nothing to look at. Pass allotmint's full stack
-          # explicitly so both backend and frontend changes are picked up.
+          # the AI review had nothing to look at. review_diff has no
+          # "extend defaults" flag -- any paths passed here fully replace
+          # DEFAULT_GLOBS -- so this list is DEFAULT_GLOBS (see
+          # cicaid_devtools/lib/review_diff.py) plus allotmint's frontend
+          # stack, kept as a superset so non-frontend PRs never regress to an
+          # empty diff again (#6280).
           DIFF=$(python3 -m cicaid_devtools.lib.review_diff \
             --base-ref "$BASE_REF" \
             --pr-title "$PR_TITLE" \
             --issue-body "$ISSUE_BODY" \
             -- \
-            "*.py" "*.ts" "*.tsx" "*.js" "*.jsx" "*.json" "*.css" "*.scss" "*.html" \
-            "*.toml" "*.md" "*.yml" "*.yaml" "*.sh" "*.cfg" "*.ini" "Dockerfile" \
-            "*.xml" "*.properties" "*.ps1" "*.txt")
+            "*.py" "*.toml" "*.md" "*.yml" "*.yaml" "*.sh" "*.cfg" "*.ini" \
+            "Dockerfile" "*.java" "*.xml" "*.properties" "*.ps1" "*.txt" \
+            "*.ts" "*.tsx" "*.js" "*.jsx" "*.mjs" "*.cjs" "*.json" "*.css" \
+            "*.scss" "*.html")
           DELIM="EOF_$(uuidgen | tr -d '-')"
           {
             echo "diff<<$DELIM"

--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -107,10 +107,19 @@ jobs:
           ISSUE_BODY: ${{ steps.issue.outputs.body }}
         run: |
           git fetch origin "$BASE_REF"
+          # review_diff's DEFAULT_GLOBS (Python/YAML/shell/etc.) omits the
+          # frontend's TS/TSX/JS/JSX/JSON/CSS/HTML extensions, so a
+          # frontend-only PR (e.g. #6279) produced an empty filtered diff and
+          # the AI review had nothing to look at. Pass allotmint's full stack
+          # explicitly so both backend and frontend changes are picked up.
           DIFF=$(python3 -m cicaid_devtools.lib.review_diff \
             --base-ref "$BASE_REF" \
             --pr-title "$PR_TITLE" \
-            --issue-body "$ISSUE_BODY")
+            --issue-body "$ISSUE_BODY" \
+            -- \
+            "*.py" "*.ts" "*.tsx" "*.js" "*.jsx" "*.json" "*.css" "*.scss" "*.html" \
+            "*.toml" "*.md" "*.yml" "*.yaml" "*.sh" "*.cfg" "*.ini" "Dockerfile" \
+            "*.xml" "*.properties" "*.ps1" "*.txt")
           DELIM="EOF_$(uuidgen | tr -d '-')"
           {
             echo "diff<<$DELIM"

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -14,7 +14,6 @@ import FilterBar, { useFilterReducer, type FilterState } from "./FilterBar";
 import EmptyState from "./EmptyState";
 import { useNavigate } from "react-router-dom";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ResponsiveContainer, LineChart, Line } from "recharts";
 import Sparkline from "./Sparkline";
 import { getGrowthStage } from "../utils/growthStage";
 import { preloadInstrumentHistory } from "../hooks/useInstrumentHistory";
@@ -192,12 +191,37 @@ export function HoldingsTable({
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const tableHeaderRef = useRef<HTMLTableSectionElement>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
+  const [hasMoreColumns, setHasMoreColumns] = useState(false);
 
   useEffect(() => {
     if (tableHeaderRef.current) {
       setHeaderHeight(tableHeaderRef.current.getBoundingClientRect().height);
     }
   }, []);
+
+  useEffect(() => {
+    const container = tableContainerRef.current;
+    if (!container) return;
+
+    const updateOverflowCue = () => {
+      const remainingScroll =
+        container.scrollWidth - container.clientWidth - container.scrollLeft;
+      setHasMoreColumns(remainingScroll > 1);
+    };
+
+    updateOverflowCue();
+    container.addEventListener("scroll", updateOverflowCue, { passive: true });
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(updateOverflowCue);
+    resizeObserver?.observe(container);
+
+    return () => {
+      container.removeEventListener("scroll", updateOverflowCue);
+      resizeObserver?.disconnect();
+    };
+  }, [sortedRows.length, relativeViewEnabled, visibleColumns]);
 
   const rowVirtualizer = useVirtualizer({
     count: sortedRows.length,
@@ -284,7 +308,10 @@ export function HoldingsTable({
         </>
       )}
       {sortedRows.length ? (
-        <div ref={tableContainerRef} className="overflow-x-auto">
+        <div
+          ref={tableContainerRef}
+          className={`${tableStyles.scrollContainer} ${hasMoreColumns ? tableStyles.hasMoreColumns : ""}`}
+        >
           <table className={`${tableStyles.table} mb-4 w-full`}>
         <thead ref={tableHeaderRef}>
           <tr>
@@ -302,15 +329,6 @@ export function HoldingsTable({
                 onChange={(e) => handleFilterChange("name", e.target.value)}
               />
             </th>
-            <th className={tableStyles.cell}></th>
-            <th className={tableStyles.cell}></th>
-            <th className={tableStyles.cell}>
-              <input
-                placeholder={t("holdingsTable.filters.type")}
-                value={filters.instrument_type}
-                onChange={(e) => handleFilterChange("instrument_type", e.target.value)}
-              />
-            </th>
             {!relativeViewEnabled && visibleColumns.units && (
               <th className={`${tableStyles.cell} ${tableStyles.right}`}>
                 <input
@@ -319,10 +337,6 @@ export function HoldingsTable({
                   onChange={(e) => handleFilterChange("units", e.target.value)}
                 />
               </th>
-            )}
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
-            {!relativeViewEnabled && visibleColumns.cost && (
-              <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
             )}
             {!relativeViewEnabled && visibleColumns.market && (
               <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
@@ -339,6 +353,10 @@ export function HoldingsTable({
                 />
               </th>
             )}
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+            {!relativeViewEnabled && visibleColumns.cost && (
+              <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+            )}
             {showForward7d && (
               <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
             )}
@@ -346,6 +364,15 @@ export function HoldingsTable({
               <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
             )}
             <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
+            <th className={tableStyles.cell}></th>
+            <th className={tableStyles.cell}></th>
+            <th className={tableStyles.cell}>
+              <input
+                placeholder={t("holdingsTable.filters.type")}
+                value={filters.instrument_type}
+                onChange={(e) => handleFilterChange("instrument_type", e.target.value)}
+              />
+            </th>
             <th className={tableStyles.cell}></th>
             <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
             <th className={tableStyles.cell}></th>
@@ -372,20 +399,8 @@ export function HoldingsTable({
             <th className={`${tableStyles.cell} ${tableStyles.clickable}`} onClick={() => handleSort("name")}>
               {t("holdingsTable.columns.name")}{sortKey === "name" ? (asc ? " ▲" : " ▼") : ""}
             </th>
-            <th className={tableStyles.cell}>{t("holdingsTable.columns.trend")} ({sparkRange}d)</th>
-            <th className={tableStyles.cell}>{t("instrumentTable.columns.ccy")}</th>
-            <th className={tableStyles.cell}>{t("instrumentTable.columns.type")}</th>
             {!relativeViewEnabled && visibleColumns.units && (
               <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("holdingsTable.columns.units")}</th>
-            )}
-            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("holdingsTable.columns.price")}</th>
-            {!relativeViewEnabled && visibleColumns.cost && (
-              <th
-                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
-                onClick={() => handleSort("cost")}
-              >
-                {t("holdingsTable.columns.cost")}{sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
-              </th>
             )}
             {!relativeViewEnabled && visibleColumns.market && (
               <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("holdingsTable.columns.market")}</th>
@@ -404,6 +419,15 @@ export function HoldingsTable({
                 onClick={() => handleSort("gain_pct")}
               >
                 {t("holdingsTable.columns.gainPct")}{sortKey === "gain_pct" ? (asc ? " ▲" : " ▼") : ""}
+              </th>
+            )}
+            <th className={`${tableStyles.cell} ${tableStyles.right}`}>{t("holdingsTable.columns.price")}</th>
+            {!relativeViewEnabled && visibleColumns.cost && (
+              <th
+                className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
+                onClick={() => handleSort("cost")}
+              >
+                {t("holdingsTable.columns.cost")}{sortKey === "cost" ? (asc ? " ▲" : " ▼") : ""}
               </th>
             )}
             {showForward7d && (
@@ -430,6 +454,11 @@ export function HoldingsTable({
             >
               {t("holdingsTable.columns.weightPct")}{sortKey === "weight_pct" ? (asc ? " ▲" : " ▼") : ""}
             </th>
+            <th className={`${tableStyles.cell} ${tableStyles.trend}`}>
+              {t("holdingsTable.trendHeader", { range: sparkRange })}
+            </th>
+            <th className={tableStyles.cell}>{t("instrumentTable.columns.ccy")}</th>
+            <th className={tableStyles.cell}>{t("instrumentTable.columns.type")}</th>
             <th className={tableStyles.cell}>{t("holdingsTable.columns.acquired")}</th>
             <th
               className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
@@ -458,14 +487,6 @@ export function HoldingsTable({
               event.stopPropagation();
               onSelectInstrument?.(h.ticker, h.name ?? h.ticker);
             };
-            const sparkData =
-              (globalThis as any).sparks?.[h.ticker]?.[String(sparkRange)] ?? [];
-            const sparkColor =
-              sparkData.length > 1
-                ? sparkData[sparkData.length - 1].close_gbp > sparkData[0].close_gbp
-                  ? "lightgreen"
-                  : "red"
-                : "#8884d8";
             return (
               <tr key={h.ticker + h.acquired_date}>
                 <td className={tableStyles.cell}>
@@ -477,54 +498,25 @@ export function HoldingsTable({
                     {h.ticker}
                   </button>
                 </td>
-                <td className={tableStyles.cell}>{h.name}</td>
-                <td className={`${tableStyles.cell} w-20`}>
-                  <Sparkline
-                    ticker={h.ticker}
-                    days={sparkRange}
-                    ariaLabel={t('holdingsTable.sparklineAria', { ticker: h.ticker })}
-                  />
-                  {sparkData.length ? (
-                    <ResponsiveContainer width="100%" height={40}>
-                      <LineChart
-                        data={sparkData}
-                        margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
-                        role="img"
-                        aria-label={t('holdingsTable.historyAria', { ticker: h.ticker })}
-                        tabIndex={0}
-                      >
-                        <Line
-                          type="monotone"
-                          dataKey="close_gbp"
-                          stroke={sparkColor}
-                          dot={false}
-                          strokeWidth={1}
-                        />
-                      </LineChart>
-                    </ResponsiveContainer>
-                  ) : null}
-                </td>
-                <td className={tableStyles.cell}>
-                  {isSupportedFx(h.currency) ? (
-                    <button
-                      type="button"
-                      onClick={() =>
-                        onSelectInstrument?.(`${h.currency!}GBP.FX`, h.currency!)
-                      }
-                      className="link-button"
-                    >
-                      {h.currency}
-                    </button>
-                  ) : (
-                    h.currency ?? "—"
-                  )}
-                </td>
-                <td className={tableStyles.cell}>
-                  {translateInstrumentType(t, h.instrument_type)}
-                </td>
+                <td className={`${tableStyles.cell} ${tableStyles.name}`}>{h.name}</td>
                 {!relativeViewEnabled && visibleColumns.units && (
                   <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                     {new Intl.NumberFormat(i18n.language).format(h.units ?? 0)}
+                  </td>
+                )}
+                {!relativeViewEnabled && visibleColumns.market && (
+                  <td className={`${tableStyles.cell} ${tableStyles.right}`}>
+                    {money(h.market, h.market_value_currency || baseCurrency)}
+                  </td>
+                )}
+                {!relativeViewEnabled && visibleColumns.gain && (
+                  <td className={`${tableStyles.cell} ${tableStyles.right} ${getPerformanceClass(h.gain)}`}>
+                    {money(h.gain, h.gain_currency || baseCurrency)}
+                  </td>
+                )}
+                {visibleColumns.gain_pct && (
+                  <td className={`${tableStyles.cell} ${tableStyles.right} ${getPerformanceClass(h.gain_pct)}`}>
+                    {percent(h.gain_pct, 1)}
                   </td>
                 )}
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
@@ -564,25 +556,6 @@ export function HoldingsTable({
                     )}
                   </td>
                 )}
-                {!relativeViewEnabled && visibleColumns.market && (
-                  <td className={`${tableStyles.cell} ${tableStyles.right}`}>
-                    {money(h.market, h.market_value_currency || baseCurrency)}
-                  </td>
-                )}
-                {!relativeViewEnabled && visibleColumns.gain && (
-                  <td
-                    className={`${tableStyles.cell} ${tableStyles.right} ${getPerformanceClass(h.gain)}`}
-                  >
-                    {money(h.gain, h.gain_currency || baseCurrency)}
-                  </td>
-                )}
-                {visibleColumns.gain_pct && (
-                  <td
-                    className={`${tableStyles.cell} ${tableStyles.right} ${getPerformanceClass(h.gain_pct)}`}
-                  >
-                    {percent(h.gain_pct, 1)}
-                  </td>
-                )}
                 {showForward7d && (
                   <td
                     className={`${tableStyles.cell} ${tableStyles.right} ${getPerformanceClass(h.forward_7d_change_pct)}`}
@@ -599,6 +572,29 @@ export function HoldingsTable({
                 )}
                 <td className={`${tableStyles.cell} ${tableStyles.right}`}>
                   {percent(h.weight_pct ?? 0, 1)}
+                </td>
+                <td className={`${tableStyles.cell} ${tableStyles.trend}`}>
+                  <Sparkline
+                    ticker={h.ticker}
+                    days={sparkRange}
+                    ariaLabel={t("holdingsTable.sparklineAria", { ticker: h.ticker })}
+                  />
+                </td>
+                <td className={tableStyles.cell}>
+                  {isSupportedFx(h.currency) ? (
+                    <button
+                      type="button"
+                      onClick={() => onSelectInstrument?.(`${h.currency!}GBP.FX`, h.currency!)}
+                      className="link-button"
+                    >
+                      {h.currency}
+                    </button>
+                  ) : (
+                    h.currency ?? "—"
+                  )}
+                </td>
+                <td className={tableStyles.cell}>
+                  {translateInstrumentType(t, h.instrument_type)}
                 </td>
                 <td className={tableStyles.cell}>
                   {h.acquired_date && !isNaN(Date.parse(h.acquired_date))
@@ -640,17 +636,11 @@ export function HoldingsTable({
         </tbody>
         <tfoot>
           <tr>
-            <td className={`${tableStyles.cell} font-semibold`} colSpan={5}>
+            <td className={`${tableStyles.cell} font-semibold`} colSpan={2}>
               {t("holdingsTable.totalRowLabel")}
             </td>
             {!relativeViewEnabled && visibleColumns.units && (
               <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>—</td>
-            )}
-            <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>—</td>
-            {!relativeViewEnabled && visibleColumns.cost && (
-              <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
-                {money(totals.cost, baseCurrency)}
-              </td>
             )}
             {!relativeViewEnabled && visibleColumns.market && (
               <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
@@ -671,6 +661,12 @@ export function HoldingsTable({
                 {percent(totalGainPct, 1)}
               </td>
             )}
+            <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>—</td>
+            {!relativeViewEnabled && visibleColumns.cost && (
+              <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
+                {money(totals.cost, baseCurrency)}
+              </td>
+            )}
             {showForward7d && (
               <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>—</td>
             )}
@@ -680,10 +676,9 @@ export function HoldingsTable({
             <td className={`${tableStyles.cell} ${tableStyles.right} font-semibold`}>
               {percent(totals.weight, 1)}
             </td>
-            <td className={tableStyles.cell}></td>
-            <td className={`${tableStyles.cell} ${tableStyles.right}`}></td>
-            <td className={tableStyles.cell}></td>
-            <td className={`${tableStyles.cell} ${tableStyles.center}`}></td>
+            {Array.from({ length: 7 }, (_, index) => (
+              <td key={index} className={tableStyles.cell}></td>
+            ))}
           </tr>
         </tfoot>
         </table>

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -221,7 +221,7 @@ export function HoldingsTable({
       container.removeEventListener("scroll", updateOverflowCue);
       resizeObserver?.disconnect();
     };
-  }, [sortedRows.length, relativeViewEnabled, visibleColumns]);
+  }, [sortedRows.length, relativeViewEnabled, visibleColumns, showForward7d, showForward30d]);
 
   const rowVirtualizer = useVirtualizer({
     count: sortedRows.length,
@@ -577,6 +577,7 @@ export function HoldingsTable({
                   <Sparkline
                     ticker={h.ticker}
                     days={sparkRange}
+                    width={80}
                     ariaLabel={t("holdingsTable.sparklineAria", { ticker: h.ticker })}
                   />
                 </td>

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -218,6 +218,7 @@
     "rangeOption": "{{count}}T",
     "source": "Quelle:",
     "totalRowLabel": "Gesamt",
+    "trendHeader": "Trend ({{range}}T)",
     "view": "Ansicht:",
     "viewPresets": {
       "all": "Alle"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -248,6 +248,7 @@
     "rangeOption": "{{count}}d",
     "source": "Source:",
     "totalRowLabel": "Total",
+    "trendHeader": "Trend ({{range}}d)",
     "view": "View:",
     "viewPresets": {
       "all": "All"

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -218,6 +218,7 @@
     "rangeOption": "{{count}}d",
     "source": "Fuente:",
     "totalRowLabel": "Total",
+    "trendHeader": "Tendencia ({{range}}d)",
     "view": "Vista:",
     "viewPresets": {
       "all": "Todos"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -218,6 +218,7 @@
     "rangeOption": "{{count}}j",
     "source": "Source :",
     "totalRowLabel": "Total",
+    "trendHeader": "Tendance ({{range}}j)",
     "view": "Vue :",
     "viewPresets": {
       "all": "Tous"

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -218,6 +218,7 @@
     "rangeOption": "{{Count}} d",
     "source": "Fonte:",
     "totalRowLabel": "Totale",
+    "trendHeader": "Tendenza ({{range}}d)",
     "view": "Visualizzazione:",
     "viewPresets": {
       "all": "Tutto"

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -218,6 +218,7 @@
     "rangeOption": "{{count}}d",
     "source": "Fonte:",
     "totalRowLabel": "Total",
+    "trendHeader": "Tendência ({{range}}d)",
     "view": "Visão:",
     "viewPresets": {
       "all": "Todos"

--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -3,6 +3,16 @@
   border-collapse: collapse;
 }
 
+.scrollContainer {
+  overflow-x: auto;
+  scrollbar-color: rgba(71, 85, 105, 0.8) rgba(148, 163, 184, 0.2);
+  scrollbar-gutter: stable;
+}
+
+.hasMoreColumns {
+  box-shadow: inset -14px 0 12px -14px rgba(15, 23, 42, 0.85);
+}
+
 .table thead th {
   position: sticky;
   top: 0;
@@ -12,6 +22,19 @@
 
 .cell {
   padding: 4px 6px;
+}
+
+.name {
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trend {
+  width: 5rem;
+  min-width: 5rem;
+  max-width: 5rem;
 }
 
 .right {

--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -120,11 +120,13 @@
 }
 
 @media (max-width: 768px) {
+  .scrollContainer {
+    -webkit-overflow-scrolling: touch;
+  }
+
   .table {
     display: block;
     max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   .table thead,

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -182,7 +182,7 @@ describe("HoldingsTable", () => {
         renderWithConfig(<HoldingsTable holdings={holdings} />);
 
         await screen.findByText("AAA");
-        expect(screen.getAllByTestId("sparkline-empty")).toHaveLength(holdings.length);
+        expect(screen.getAllByTestId(/^sparkline/)).toHaveLength(holdings.length);
     });
 
     it("shows days to go if not eligible", async () => {

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -157,6 +157,34 @@ describe("HoldingsTable", () => {
         expect(screen.getByRole('columnheader', { name: /Gain %/ })).toBeInTheDocument();
     });
 
+    it("prioritizes financial columns and localizes the trend range", async () => {
+        renderWithConfig(<HoldingsTable holdings={holdings} />);
+
+        const headerRows = await screen.findAllByRole("row");
+        const headers = within(headerRows[1])
+            .getAllByRole("columnheader")
+            .map((header) => header.textContent);
+
+        expect(headers.slice(0, 8)).toEqual([
+            "Ticker ▲",
+            "Name",
+            "Units",
+            "Mkt £",
+            "Gain £",
+            "Gain %",
+            "Px £",
+            "Cost £",
+        ]);
+        expect(screen.getByRole("columnheader", { name: "Trend (30d)" })).toBeInTheDocument();
+    });
+
+    it("renders one sparkline per holding", async () => {
+        renderWithConfig(<HoldingsTable holdings={holdings} />);
+
+        await screen.findByText("AAA");
+        expect(screen.getAllByTestId("sparkline-empty")).toHaveLength(holdings.length);
+    });
+
     it("shows days to go if not eligible", async () => {
         render(<HoldingsTable holdings={holdings}/>);
         const row = (await screen.findByText("Test Holding")).closest("tr");

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -178,6 +178,39 @@ describe("HoldingsTable", () => {
         expect(screen.getByRole("columnheader", { name: "Trend (30d)" })).toBeInTheDocument();
     });
 
+    it("keeps footer columns aligned with the header in relative view", async () => {
+        const TestProviderRelative = ({ children }: { children: React.ReactNode }) => (
+            <configContext.Provider
+              value={{
+                ...defaultConfig,
+                relativeViewEnabled: true,
+                setRelativeViewEnabled: () => {},
+                refreshConfig: async () => {},
+                setBaseCurrency: () => {},
+              }}
+            >
+                {children}
+            </configContext.Provider>
+        );
+        render(
+            <TestProviderRelative>
+                <HoldingsTable holdings={holdings} />
+            </TestProviderRelative>,
+        );
+
+        const rows = await screen.findAllByRole("row");
+        const headerColumnCount = within(rows[1]).getAllByRole("columnheader").length;
+
+        const table = screen.getByRole("table");
+        const footerRow = table.querySelector("tfoot tr") as HTMLTableRowElement;
+        const footerColumnCount = Array.from(footerRow.children).reduce(
+            (sum, cell) => sum + (Number(cell.getAttribute("colspan")) || 1),
+            0,
+        );
+
+        expect(footerColumnCount).toBe(headerColumnCount);
+    });
+
     it("renders one sparkline per holding", async () => {
         renderWithConfig(<HoldingsTable holdings={holdings} />);
 

--- a/frontend/tests/unit/components/responsiveRender.test.tsx
+++ b/frontend/tests/unit/components/responsiveRender.test.tsx
@@ -6,6 +6,7 @@ import { AccountBlock } from "@/components/AccountBlock";
 import { HoldingsTable } from "@/components/HoldingsTable";
 import { configContext, type AppConfig } from "@/ConfigContext";
 import type { Portfolio, Account, Holding } from "@/types";
+import tableStyles from "@/styles/table.module.css";
 
 vi.mock("@/components/ValueAtRisk", () => ({
   ValueAtRisk: () => <div />,
@@ -133,8 +134,8 @@ describe("mobile viewport rendering", () => {
       await act(async () => {
         ({ container } = renderWithConfig(<HoldingsTable holdings={holdings} />));
       });
-      const wrapper = container.querySelector("div.overflow-x-auto");
-      await waitFor(() => expect(wrapper).toHaveClass("overflow-x-auto"));
+      const wrapper = container.querySelector(`div.${tableStyles.scrollContainer}`);
+      await waitFor(() => expect(wrapper).toHaveClass(tableStyles.scrollContainer));
       expect(container.querySelector("table")).toHaveClass("mb-4");
     });
   });


### PR DESCRIPTION
Closes #6276 
Closes #5444 
Closes #6280 

### Motivation
- The holdings table placed secondary columns (Trend, CCY, Type) before core financial columns, making Units/Market/Gain hard to see on load. 
- The Trend cell rendered two charts which increased width and render cost and contributed to layout crowding. 
- There was no visible affordance when the table overflowed horizontally, causing users to miss important data. 
- The trend header format was constructed in JSX rather than the locale system, preventing clean i18n interpolation.

### Description
- Reordered columns in `frontend/src/components/HoldingsTable.tsx` so `Ticker`/`Name` are followed by `Units`, `Market`, `Gain`, `Gain %`, `Price`, and `Cost` while preserving existing sorting, filtering, relative-view, and column-visibility behavior. 
- Removed the duplicate Recharts `LineChart` and now render a single `Sparkline` per row, reducing render work and column width. 
- Added overflow detection and a visual right-edge shadow affordance via a `hasMoreColumns` state, `ResizeObserver`, and styles in `frontend/src/styles/table.module.css` to indicate horizontal overflow. 
- Constrained long `Name` and `Trend` cells with CSS (`.name`, `.trend`) to prevent secondary content from crowding numeric columns. 
- Extracted the trend header into the English locale at `frontend/src/locales/en/translation.json` as `holdingsTable.trendHeader` and use `t('holdingsTable.trendHeader', { range: sparkRange })` in the table header. 
- Added unit tests in `frontend/tests/unit/components/HoldingsTable.test.tsx` covering column order, localized trend header, and single-sparkline rendering. 
- This change implements and closes the behavior/formatting requests in `#6276` and `#5444`.

### Review follow-ups (CodeRabbit / Codex)
- Recalculate the overflow cue when `showForward7d`/`showForward30d` change, not just `visibleColumns`.
- Constrain the `Sparkline` width to the Trend column's 5rem cell instead of the 100px default.
- Assert the total sparkline count in the new test instead of only counting empty-state sparklines.
- Add `holdingsTable.trendHeader` to the de/es/fr/it/pt locales so switching language doesn't silently fall back to English.
- Make `.scrollContainer` the sole horizontal scroller at all breakpoints so the overflow-cue shadow also works on mobile, where `.table` previously became its own competing scroller.
- Fixes #6280: the AI review workflows' diff filter (`cicaid_devtools.lib.review_diff`'s `DEFAULT_GLOBS`) had no TS/TSX/JS/JSX/JSON/CSS/HTML entries, so this frontend-only PR produced an empty filtered diff for DeepSeek/Claude/GPT review. `.github/workflows/_ai-pr-review.yml` now passes allotmint's full path-glob list explicitly.

### Testing
- Ran lint with `npm --prefix frontend run lint` and it completed successfully. 
- Ran the frontend suite with `npm --prefix frontend run test -- --run` and the tests passed. 
- Ran the focused unit file with `npm --prefix frontend run test -- --run tests/unit/components/HoldingsTable.test.tsx` and all `19` tests passed. 
- Built the frontend with `npm --prefix frontend run build` and the production build succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a210a12588327960b919cdbc2dafd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the holdings table layout and column ordering.
  * Added a 30-day trend heading and retained inline trend visualisations.
  * Added visual cues when additional columns are available horizontally.
  * Improved long holding-name display and table scrolling.

* **Bug Fixes**
  * Corrected totals alignment across the revised table layout.

* **Tests**
  * Added coverage for column ordering, trend labels and empty trend charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->