### PR TITLE
Portfolio: add tabbed account view and single scoped holdings table (Closes #6277)

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -20,8 +20,14 @@ import { preloadInstrumentHistory } from "../hooks/useInstrumentHistory";
 
 const VIEW_PRESET_STORAGE_KEY = "holdingsTableViewPreset";
 
+type HoldingsTableRow = Holding & {
+  source_account?: string;
+  row_key?: string;
+};
+
 type Props = {
-  holdings: Holding[];
+  holdings: HoldingsTableRow[];
+  showAccount?: boolean;
   onSelectInstrument?: (ticker: string, name: string) => void;
   showForward7d?: boolean;
   showForward30d?: boolean;
@@ -31,6 +37,7 @@ type Props = {
 
 export function HoldingsTable({
   holdings,
+  showAccount = false,
   onSelectInstrument,
   showForward7d = false,
   showForward30d = false,
@@ -315,6 +322,7 @@ export function HoldingsTable({
           <table className={`${tableStyles.table} mb-4 w-full`}>
         <thead ref={tableHeaderRef}>
           <tr>
+            {showAccount && <th className={tableStyles.cell}></th>}
             <th className={tableStyles.cell}>
               <input
                 placeholder={t("holdingsTable.filters.ticker")}
@@ -389,6 +397,9 @@ export function HoldingsTable({
             </th>
           </tr>
           <tr>
+            {showAccount && (
+              <th className={tableStyles.cell}>Account</th>
+            )}
             <th
               className={`${tableStyles.cell} ${tableStyles.clickable}`}
               onClick={() => handleSort("ticker")}
@@ -475,7 +486,7 @@ export function HoldingsTable({
           {paddingTop > 0 && (
             <tr style={{ height: paddingTop }}>
               <td
-                colSpan={21 + (showForward7d ? 1 : 0) + (showForward30d ? 1 : 0)}
+                colSpan={21 + (showAccount ? 1 : 0) + (showForward7d ? 1 : 0) + (showForward30d ? 1 : 0)}
                 className="p-0 border-0"
               />
             </tr>
@@ -488,7 +499,10 @@ export function HoldingsTable({
               onSelectInstrument?.(h.ticker, h.name ?? h.ticker);
             };
             return (
-              <tr key={h.ticker + h.acquired_date}>
+              <tr key={h.row_key ?? h.ticker + h.acquired_date}>
+                {showAccount && (
+                  <td className={tableStyles.cell}>{h.source_account}</td>
+                )}
                 <td className={tableStyles.cell}>
                   <button
                     type="button"
@@ -629,7 +643,7 @@ export function HoldingsTable({
           {paddingBottom > 0 && (
             <tr style={{ height: paddingBottom }}>
               <td
-                colSpan={21 + (showForward7d ? 1 : 0) + (showForward30d ? 1 : 0)}
+                colSpan={21 + (showAccount ? 1 : 0) + (showForward7d ? 1 : 0) + (showForward30d ? 1 : 0)}
                 className="p-0 border-0"
               />
             </tr>
@@ -637,7 +651,7 @@ export function HoldingsTable({
         </tbody>
         <tfoot>
           <tr>
-            <td className={`${tableStyles.cell} font-semibold`} colSpan={2}>
+            <td className={`${tableStyles.cell} font-semibold`} colSpan={showAccount ? 3 : 2}>
               {t("holdingsTable.totalRowLabel")}
             </td>
             {!relativeViewEnabled && visibleColumns.units && (

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -3,7 +3,8 @@ import type { FormEvent } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import type { Portfolio, Account, SectorContribution } from "../types";
-import { AccountBlock } from "./AccountBlock";
+import { HoldingsTable } from "./HoldingsTable";
+import { InstrumentDetail } from "./InstrumentDetail";
 import { AddAccountForm } from "./AddAccountForm";
 import { AddPositionForm } from "./AddPositionForm";
 import { EmptyState } from "./EmptyState";
@@ -13,7 +14,6 @@ import { money } from "../lib/money";
 import { formatDateISO } from "../lib/date";
 import { useConfig } from "../ConfigContext";
 import { complianceForOwner, getOwnerSectorContributions } from "../api";
-import { getGrowthStage } from "../utils/growthStage";
 import lazyWithDelay from "../utils/lazyWithDelay";
 import PortfolioDashboardSkeleton from "./skeletons/PortfolioDashboardSkeleton";
 import TextSkeleton from "./skeletons/TextSkeleton";
@@ -227,7 +227,11 @@ type Props = {
  */
 export function PortfolioView({ data, loading, error, onDateChange, onAccountAdded, onPositionAdded }: Props) {
   const { t } = useTranslation();
-  const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
+  const [activeAccount, setActiveAccount] = useState("all");
+  const [selectedInstrument, setSelectedInstrument] = useState<{
+    ticker: string;
+    name: string;
+  } | null>(null);
   const [hasWarnings, setHasWarnings] = useState(false);
   const [pendingDate, setPendingDate] = useState<string>("");
   const [showAddAccount, setShowAddAccount] = useState(false);
@@ -239,8 +243,13 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
   const accountKey = (acct: Account, idx: number) => `${acct.account_type}-${idx}`;
 
   useEffect(() => {
-    setSelectedAccounts(data ? data.accounts.map(accountKey) : []);
-  }, [data]);
+    if (
+      activeAccount !== "all" &&
+      !data?.accounts.some((account, index) => accountKey(account, index) === activeAccount)
+    ) {
+      setActiveAccount("all");
+    }
+  }, [activeAccount, data]);
 
   useEffect(() => {
     setPendingDate(data?.as_of ?? "");
@@ -303,18 +312,26 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
   if (error) return <div className="text-error">{error}</div>; // bubble errors
   if (!data) return <div>Select an owner.</div>; // nothing chosen yet
 
-  const allKeys = data.accounts.map(accountKey);
-  const activeSet = new Set(
-    selectedAccounts.length ? selectedAccounts : allKeys
+  const activeAccountIndex = data.accounts.findIndex(
+    (account, index) => accountKey(account, index) === activeAccount,
   );
-
-  const totalValue = data.accounts.reduce(
-    (sum, acct, idx) =>
-      activeSet.has(accountKey(acct, idx))
-        ? sum + acct.value_estimate_gbp
-        : sum,
-    0
+  const scopedAccounts =
+    activeAccount === "all" || activeAccountIndex < 0
+      ? data.accounts
+      : [data.accounts[activeAccountIndex]];
+  const totalValue = scopedAccounts.reduce(
+    (sum, account) => sum + account.value_estimate_gbp,
+    0,
   );
+  const scopedHoldings = scopedAccounts.flatMap((account) => {
+    const originalIndex = data.accounts.indexOf(account);
+    const sourceKey = accountKey(account, originalIndex);
+    return account.holdings.map((holding, holdingIndex) => ({
+      ...holding,
+      source_account: account.account_type,
+      row_key: `${sourceKey}-${holdingIndex}`,
+    }));
+  });
 
   const asOfDate = data.as_of ? new Date(data.as_of) : null;
   const todayIso = formatDateISO(new Date());
@@ -345,7 +362,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
     onAccountAdded?.();
   };
 
-  const handleAddPositionRequest = (accountType: string) => {
+  const handleAddPositionRequest = (accountType?: string) => {
     setAddPositionAccount(accountType);
     setAddPositionExpanded(true);
     addPositionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -432,7 +449,13 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
               ) : (
                 <button
                   type="button"
-                  onClick={() => setAddPositionExpanded(true)}
+                  onClick={() =>
+                    handleAddPositionRequest(
+                      activeAccountIndex >= 0
+                        ? data.accounts[activeAccountIndex].account_type
+                        : undefined,
+                    )
+                  }
                   aria-expanded="false"
                   aria-controls={ADD_POSITION_FORM_ID}
                   className="rounded border border-gray-700 px-3 py-1.5 text-sm text-white hover:border-gray-500 hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
@@ -502,45 +525,61 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
               )}
             </>
           )}
-          <div className="space-y-4">
-            {data.accounts.map((acct, idx) => {
-              const key = accountKey(acct, idx);
-              const checked = activeSet.has(key);
-              const order: Record<string, number> = {
-                seed: 0,
-                growing: 1,
-                harvest: 2,
-              };
-              const stageInfo = acct.holdings.reduce(
-                (prev, h) => {
-                  const s = getGrowthStage({ daysHeld: h.days_held });
-                  return order[s.stage] > order[prev.stage] ? s : prev;
-                },
-                getGrowthStage({})
-              );
-              return (
-                <div key={key} className="flex items-start">
-                  <span className="mr-2" title={stageInfo.message}>
-                    {stageInfo.icon}
-                  </span>
-                  <AccountBlock
-                    account={acct}
-                    selected={checked}
-                    onToggle={() =>
-                      setSelectedAccounts((prev) =>
-                        prev.includes(key)
-                          ? prev.filter((k) => k !== key)
-                          : [...prev, key]
-                      )
-                    }
-                    showForward7d={showForward7d}
-                    showForward30d={showForward30d}
-                    onAddPosition={() => handleAddPositionRequest(acct.account_type)}
-                  />
-                </div>
-              );
-            })}
-          </div>
+          {data.accounts.length > 0 && (
+            <section aria-label="Portfolio holdings" className="min-w-0">
+              <div
+                role="tablist"
+                aria-label="Portfolio accounts"
+                className="mb-4 flex max-w-full gap-1 overflow-x-auto border-b border-gray-700"
+              >
+                {[
+                  { key: "all", label: "All accounts" },
+                  ...data.accounts.map((account, index) => ({
+                    key: accountKey(account, index),
+                    label: account.account_type,
+                  })),
+                ].map((tab) => (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    role="tab"
+                    aria-selected={activeAccount === tab.key}
+                    onClick={() => setActiveAccount(tab.key)}
+                    className={`shrink-0 border-b-2 px-3 py-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400 ${
+                      activeAccount === tab.key
+                        ? "border-blue-400 font-semibold text-white"
+                        : "border-transparent text-gray-400 hover:text-white"
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+              <HoldingsTable
+                holdings={scopedHoldings}
+                showAccount={activeAccount === "all"}
+                onSelectInstrument={(ticker, name) =>
+                  setSelectedInstrument({ ticker, name })
+                }
+                showForward7d={showForward7d}
+                showForward30d={showForward30d}
+                onAddPosition={() =>
+                  handleAddPositionRequest(
+                    activeAccountIndex >= 0
+                      ? data.accounts[activeAccountIndex].account_type
+                      : undefined,
+                  )
+                }
+              />
+              {selectedInstrument && (
+                <InstrumentDetail
+                  ticker={selectedInstrument.ticker}
+                  name={selectedInstrument.name}
+                  onClose={() => setSelectedInstrument(null)}
+                />
+              )}
+            </section>
+          )}
           <div className="mb-6 mt-4">
             {data.accounts.length === 0 ? (
               <EmptyState

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -242,7 +242,15 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
 
   const accountKey = (acct: Account, idx: number) => `${acct.account_type}-${idx}`;
 
+  const lastOwnerRef = useRef<string | null>(null);
+
   useEffect(() => {
+    const owner = data?.owner ?? null;
+    if (owner !== lastOwnerRef.current) {
+      lastOwnerRef.current = owner;
+      setActiveAccount("all");
+      return;
+    }
     if (
       activeAccount !== "all" &&
       !data?.accounts.some((account, index) => accountKey(account, index) === activeAccount)

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -81,6 +81,37 @@ describe("PortfolioView", () => {
         expect(screen.getByText("SIPP holding")).toBeInTheDocument();
     });
 
+    it("resets the active account tab to 'all' when the owner changes even if the new owner has a colliding account key", () => {
+        const otherOwner: Portfolio = {
+            owner: "jane",
+            as_of: "2025-07-29",
+            trades_this_month: 0,
+            trades_remaining: 20,
+            total_value_estimate_gbp: 500,
+            accounts: [
+                {
+                    account_type: "ISA",
+                    currency: "GBP",
+                    value_estimate_gbp: 500,
+                    last_updated: "2025-07-24",
+                    holdings: [
+                        { ticker: "OTHER", name: "Jane ISA holding", units: 1, market_value_gbp: 500 },
+                    ],
+                },
+            ],
+        };
+
+        const { rerender } = render(<PortfolioView data={mockOwner} />);
+        fireEvent.click(screen.getByRole("tab", { name: "ISA" }));
+        expect(screen.getByRole("tab", { name: "ISA" })).toHaveAttribute("aria-selected", "true");
+
+        rerender(<PortfolioView data={otherOwner} />);
+
+        expect(screen.getByRole("tab", { name: "All accounts" })).toHaveAttribute("aria-selected", "true");
+        const total = screen.getByText(/Approx Total:/);
+        expect(total).toHaveTextContent("£500.00");
+    });
+
     it("preserves table filter state while switching account tabs", () => {
         render(<PortfolioView data={mockOwner} />);
 

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -33,45 +33,62 @@ describe("PortfolioView", () => {
                 currency: "GBP",
                 value_estimate_gbp: 0,
                 last_updated: "2025-07-24",
-                holdings: [],
+                holdings: [
+                    { ticker: "SHARED", name: "ISA holding", units: 1, market_value_gbp: 10 },
+                ],
             },
             {
                 account_type: "SIPP",
                 currency: "GBP",
                 value_estimate_gbp: 14925,
                 last_updated: "2025-07-15",
-                holdings: [],
+                holdings: [
+                    { ticker: "SHARED", name: "SIPP holding", units: 2, market_value_gbp: 20 },
+                ],
             },
         ],
     };
 
-    it("renders account blocks", () => {
+    it("renders one tabbed holdings view and identifies source accounts", () => {
         render(<PortfolioView data={mockOwner}/>);
 
-        // Match headings like "ISA (GBP)"
-        const isaBlock = screen.getByText((_, el) => {
-            if (!el) return false;
-            const isHeading = el.tagName.toLowerCase() === "h2";
-            const startsWithIsa = el.textContent?.trim().startsWith("ISA") ?? false;
-            return isHeading && startsWithIsa;
-        });
-
-        expect(isaBlock).toBeInTheDocument();
-
-        expect(screen.getByText(/SIPP.*GBP/)).toBeInTheDocument();
-
+        expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+            "All accounts",
+            "ISA",
+            "SIPP",
+        ]);
+        expect(screen.getByRole("columnheader", { name: "Account" })).toBeInTheDocument();
+        expect(screen.getAllByText("SHARED")).toHaveLength(2);
+        expect(screen.getByText("ISA holding")).toBeInTheDocument();
+        expect(screen.getByText("SIPP holding")).toBeInTheDocument();
     });
 
-    it("updates total when accounts are toggled", () => {
+    it("updates holdings and total when the active account tab changes", () => {
         render(<PortfolioView data={mockOwner}/>);
 
         const total = screen.getByText(/Approx Total:/);
         expect(total).toHaveTextContent("£14,925.00");
 
-        const sippCheckbox = screen.getByRole("checkbox", {name: /sipp/i});
-        fireEvent.click(sippCheckbox);
+        fireEvent.click(screen.getByRole("tab", { name: "ISA" }));
 
         expect(total).toHaveTextContent("£0.00");
+        expect(screen.getByText("ISA holding")).toBeInTheDocument();
+        expect(screen.queryByText("SIPP holding")).not.toBeInTheDocument();
+        expect(screen.queryByRole("columnheader", { name: "Account" })).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("tab", { name: "SIPP" }));
+        expect(total).toHaveTextContent("£14,925.00");
+        expect(screen.getByText("SIPP holding")).toBeInTheDocument();
+    });
+
+    it("preserves table filter state while switching account tabs", () => {
+        render(<PortfolioView data={mockOwner} />);
+
+        const tickerFilter = screen.getAllByPlaceholderText("Ticker")[0];
+        fireEvent.change(tickerFilter, { target: { value: "SHAR" } });
+        fireEvent.click(screen.getByRole("tab", { name: "ISA" }));
+
+        expect(screen.getAllByPlaceholderText("Ticker")[0]).toHaveValue("SHAR");
     });
 
     it("shows an 'Add account' button for an owner with accounts", () => {
@@ -148,18 +165,19 @@ describe("PortfolioView", () => {
         await waitFor(() => expect(onPositionAdded).toHaveBeenCalledTimes(1));
     });
 
-    it("resets the pre-selected account when the add-position form is collapsed and reopened", () => {
+    it("preserves the active account when the add-position form is collapsed and reopened", () => {
         Element.prototype.scrollIntoView = vi.fn();
         render(<PortfolioView data={mockOwner} />);
 
-        fireEvent.click(screen.getAllByRole("button", { name: /add your first position/i })[1]);
+        fireEvent.click(screen.getByRole("tab", { name: "SIPP" }));
+        fireEvent.click(screen.getByRole("button", { name: /\+ add position/i }));
         const addPositionForm = screen.getByRole("form", { name: /^add position$/i });
         expect(within(addPositionForm).getByLabelText(/account/i)).toHaveValue("SIPP");
 
         fireEvent.click(screen.getByRole("button", { name: /collapse add position form/i }));
         fireEvent.click(screen.getByRole("button", { name: /\+ add position/i }));
 
-        expect(within(screen.getByRole("form", { name: /^add position$/i })).getByLabelText(/account/i)).toHaveValue("ISA");
+        expect(within(screen.getByRole("form", { name: /^add position$/i })).getByLabelText(/account/i)).toHaveValue("SIPP");
     });
 
     it("collapses the add-position form on Escape and ignores other keys", () => {


### PR DESCRIPTION
### Motivation

- The portfolio page rendered each account as a full stacked dashboard with duplicated controls and tables, which is noisy for owners with multiple accounts.  
- The intent is to present one coherent holdings table with a tab strip for "All" + per-account scopes while preserving existing filter/sort/column behavior.

### Description

- Replace stacked `AccountBlock` rendering with a tab strip in `frontend/src/components/PortfolioView.tsx` and render a single `HoldingsTable` scoped to the active tab.  
- Update `HoldingsTable` to accept a `showAccount` flag and stable `row_key`/`source_account` on rows so combined views show the source account and rows keep stable identities.  
- Preserve the mounted table instance while switching tabs so filters, sorting, range, presets, and column-visibility state do not reset.  
- Add/adjust unit tests in `frontend/tests/unit/components/PortfolioView.test.tsx` to cover tab rendering, combined row source labels, tab-scoped totals/holdings, filter persistence, and add-position account selection.  
- Implementation constraints: no data model changes; view-only additions (`source_account`, `row_key`) are injected for rendering only.

### Testing

- Ran frontend lint: `npm --prefix frontend run lint -- --quiet` — passed.  
- Ran targeted frontend unit tests: `npm --prefix frontend run test -- --run tests/unit/components/PortfolioView.test.tsx tests/unit/components/HoldingsTable.test.tsx` — all tests passed (36 tests).  
- Ran type-check: `npm --prefix frontend run type-check` — passed.  
- Attempted to capture a Playwright screenshot of the new UI, but Playwright browser download failed in this environment (CDN returned HTTP 403), and a local backend screenshot attempt was blocked by missing `uvicorn` in the environment; these are environmental issues and not regressions in the change.

Closes #6277

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a2cffc7e48327a34668b9d6fa7f30)