### PR TITLE
Fix duplicate account option keys (AddPositionForm & CsvImportForm)

### DIFF
--- a/frontend/src/components/AddPositionForm.tsx
+++ b/frontend/src/components/AddPositionForm.tsx
@@ -119,8 +119,8 @@ export function AddPositionForm({
             onChange={(e) => setAccount(e.target.value)}
             className="mt-1 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
           >
-            {accounts.map((acct) => (
-              <option key={acct} value={acct}>
+            {accounts.map((acct, index) => (
+              <option key={`${acct}-${index}`} value={acct}>
                 {acct}
               </option>
             ))}

--- a/frontend/src/components/CsvImportForm.tsx
+++ b/frontend/src/components/CsvImportForm.tsx
@@ -235,8 +235,8 @@ export function CsvImportForm({ owner, accountTypes, onImported }: Props) {
             onChange={handleAccountChange}
             className="rounded border border-gray-700 bg-gray-800 p-1 text-white"
           >
-            {accountTypes.map((type) => (
-              <option key={type} value={type}>
+            {accountTypes.map((type, index) => (
+              <option key={`${type}-${index}`} value={type}>
                 {type}
               </option>
             ))}

--- a/frontend/tests/unit/components/AddPositionForm.test.tsx
+++ b/frontend/tests/unit/components/AddPositionForm.test.tsx
@@ -108,6 +108,22 @@ describe("AddPositionForm", () => {
     expect(screen.queryByRole("button", { name: "Collapse add position form" })).toBeNull();
   });
 
+  it("renders duplicate account types without a React key warning", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <AddPositionForm owner="alice" accounts={["ISA", "ISA", "SIPP"]} />,
+    );
+
+    expect(
+      screen.getByLabelText("Account").querySelectorAll("option"),
+    ).toHaveLength(3);
+    expect(consoleError.mock.calls.flat().join(" ")).not.toContain("same key");
+    consoleError.mockRestore();
+  });
+
   it("calls onCollapse when the collapse button is clicked", async () => {
     const onCollapse = vi.fn();
     render(<AddPositionForm owner="alice" accounts={["ISA"]} onCollapse={onCollapse} />);

--- a/frontend/tests/unit/components/CsvImportForm.test.tsx
+++ b/frontend/tests/unit/components/CsvImportForm.test.tsx
@@ -38,6 +38,20 @@ describe('CsvImportForm', () => {
     expect(reconcile).toBeEnabled();
   });
 
+  it('renders duplicate account types without a React key warning', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    render(
+      <CsvImportForm owner="alice" accountTypes={['ISA', 'ISA', 'SIPP']} />
+    );
+
+    expect(screen.getAllByRole('option', { name: /ISA|SIPP/ })).toHaveLength(3);
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('same key');
+    consoleError.mockRestore();
+  });
+
   it('previews a readable reconciliation without importing', async () => {
     vi.mocked(reconcileHoldingsCsv).mockResolvedValue({
       added: [{ ticker: 'NEW.L', units: 5, value_gbp: 10 }],


### PR DESCRIPTION
### Motivation
- Dropdown option lists used the account type string as the React `key`, which produced duplicate-key warnings when an owner has multiple accounts of the same type.
- The form `value` semantics must remain unchanged while removing the React warning and preventing fragile render behavior.

### Description
- Use the array index alongside the account type to generate unique React keys for account `<option>` elements in `AddPositionForm` (`frontend/src/components/AddPositionForm.tsx`).
- Apply the same unique-key strategy to the account selector in `CsvImportForm` (`frontend/src/components/CsvImportForm.tsx`).
- Add regression unit tests that render duplicate account types and assert no React duplicate-key warning is emitted in both `AddPositionForm.test.tsx` and `CsvImportForm.test.tsx`.
- Keep the `<option>` `value` and visible labels unchanged so submission behavior is identical; include `Closes #6290` in the PR metadata.

### Testing
- Ran the targeted frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/components/AddPositionForm.test.tsx tests/unit/components/CsvImportForm.test.tsx`, which completed successfully (all tests passed).
- Ran linter with `npm --prefix frontend run lint -- --max-warnings=0`, which succeeded without warnings.
- Ran TypeScript checks with `npm --prefix frontend run type-check`, which succeeded with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a410a5fa88327967261f2bcb78dc2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account selection lists so duplicate account types display correctly without warnings.
  * Ensured all available account options remain selectable during position entry and CSV imports.

* **Tests**
  * Added coverage confirming duplicate account types render correctly in both forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->