### PR TITLE
Resolve foreign holdings to native tickers and avoid mis-suffixing (Closes #6296)

### DIFF
--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -33,11 +33,17 @@ def _resolve_instruments_dir() -> Path:
 
     fallback_dir = Path(__file__).resolve().parents[2] / "data" / "instruments"
     if fallback_dir.is_dir():
-        logger.debug("Configured instruments directory %s missing; falling back to %s", configured_dir, fallback_dir)
+        logger.debug(
+            "Configured instruments directory %s missing; falling back to %s",
+            configured_dir,
+            fallback_dir,
+        )
         return fallback_dir
 
     logger.warning(
-        "Configured instruments directory %s missing and fallback %s not found", configured_dir, fallback_dir
+        "Configured instruments directory %s missing and fallback %s not found",
+        configured_dir,
+        fallback_dir,
     )
     return configured_dir
 
@@ -58,6 +64,10 @@ METADATA_BUCKET_ENV = "METADATA_BUCKET"
 METADATA_PREFIX_ENV = "METADATA_PREFIX"
 
 _AUTO_CREATE_FAILURES: set[str] = set()
+
+# Keep the canonical exchange names used by the bundled instrument catalogue.
+# ``N`` represents Yahoo symbols that do not need a market suffix.
+RESOLUTION_EXCHANGES = ("L", "N", "DE", "TO", "AX", "F")
 
 
 @lru_cache(maxsize=1)
@@ -195,13 +205,17 @@ def get_instrument_meta(ticker: str) -> Dict[str, Any]:
         # route — that callers must invoke deliberately, not on every read.
         return {}
     except json.JSONDecodeError as exc:
-        logger.warning("Invalid instrument JSON %s: %s", sanitise_log_value(path), sanitise_log_value(exc))
+        logger.warning(
+            "Invalid instrument JSON %s: %s", sanitise_log_value(path), sanitise_log_value(exc)
+        )
         return {}
     except ValueError:
         logger.warning("Invalid ticker format: %s", sanitise_log_value(ticker))
         return {}
     except Exception:
-        logger.exception("Unexpected error loading instrument metadata for %s", sanitise_log_value(ticker))
+        logger.exception(
+            "Unexpected error loading instrument metadata for %s", sanitise_log_value(ticker)
+        )
         raise
 
 
@@ -389,7 +403,11 @@ def _fetch_metadata_from_yahoo(symbol: str, exchange: str) -> Optional[Dict[str,
         if isinstance(fetched, dict):
             info = fetched
     except Exception as exc:  # pragma: no cover - best effort fallback
-        logger.debug("yfinance get_info failed for %s: %s", sanitise_log_value(full_ticker), sanitise_log_value(exc))
+        logger.debug(
+            "yfinance get_info failed for %s: %s",
+            sanitise_log_value(full_ticker),
+            sanitise_log_value(exc),
+        )
         try:
             fetched_attr = getattr(stock, "info", None)
             if isinstance(fetched_attr, dict):
@@ -402,7 +420,11 @@ def _fetch_metadata_from_yahoo(symbol: str, exchange: str) -> Optional[Dict[str,
             )
 
     name = _clean_str(
-        info.get("shortName") or info.get("longName") or info.get("displayName") or info.get("name") or full_ticker,
+        info.get("shortName")
+        or info.get("longName")
+        or info.get("displayName")
+        or info.get("name")
+        or full_ticker,
     )
 
     currency = _clean_str(info.get("currency"), upper=True)
@@ -483,9 +505,74 @@ def _auto_create_instrument_meta(ticker: str) -> Optional[Dict[str, Any]]:
             sanitise_log_value(exc),
         )
     else:
-        logger.info("Auto-created instrument metadata for %s from Yahoo Finance", sanitise_log_value(full))
+        logger.info(
+            "Auto-created instrument metadata for %s from Yahoo Finance", sanitise_log_value(full)
+        )
 
     return payload
+
+
+def _has_informative_metadata(meta: Dict[str, Any]) -> bool:
+    """Return whether metadata contains more than identity/placeholder fields."""
+
+    informative_keys = {key for key, value in meta.items() if value not in (None, "")}
+    return not informative_keys <= {"ticker", "exchange", "name"}
+
+
+def find_known_instrument_ticker(
+    symbol: str, exchanges: tuple[str, ...] = RESOLUTION_EXCHANGES
+) -> Optional[str]:
+    """Return the first already-catalogued market ticker for a bare symbol.
+
+    This helper performs disk/S3 reads only.  It is therefore safe on the CSV
+    import path and lets an explicit resolution performed once benefit all
+    subsequent imports without adding network latency.
+    """
+
+    canonical = (symbol or "").strip().upper()
+    if not canonical or "." in canonical:
+        return canonical or None
+    for exchange in exchanges:
+        candidate = f"{canonical}.{exchange}"
+        if _has_informative_metadata(get_instrument_meta(candidate)):
+            return candidate
+    return None
+
+
+def is_sedol(value: str) -> bool:
+    """Return whether ``value`` has the shape and checksum of a SEDOL code."""
+
+    canonical = (value or "").strip().upper()
+    if not re.fullmatch(r"[0-9B-DF-HJ-NP-TV-Z]{7}", canonical):
+        return False
+    weights = (1, 3, 1, 7, 3, 9, 1)
+    values = (int(char) if char.isdigit() else ord(char) - ord("A") + 10 for char in canonical)
+    return sum(value * weight for value, weight in zip(values, weights)) % 10 == 0
+
+
+def resolve_instrument_ticker(
+    symbol: str, exchanges: tuple[str, ...] = RESOLUTION_EXCHANGES
+) -> Optional[str]:
+    """Explicitly resolve and persist a bare symbol's exchange via Yahoo.
+
+    Existing informative metadata wins in exchange-priority order.  Missing
+    candidates are fetched deliberately through the existing guarded
+    auto-create path.  SEDOL identifiers are not equity tickers and are left
+    for manual mapping to an appropriate fund data source.
+    """
+
+    canonical = (symbol or "").strip().upper()
+    if not canonical or "." in canonical or is_sedol(canonical):
+        return None
+    known = find_known_instrument_ticker(canonical, exchanges)
+    if known:
+        return known
+    for exchange in exchanges:
+        candidate = f"{canonical}.{exchange}"
+        created = _auto_create_instrument_meta(candidate)
+        if created and _has_informative_metadata(created):
+            return candidate
+    return None
 
 
 def delete_instrument_meta(ticker: str, exchange: str) -> None:

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -67,7 +67,7 @@ _AUTO_CREATE_FAILURES: set[str] = set()
 
 # Keep the canonical exchange names used by the bundled instrument catalogue.
 # ``N`` represents Yahoo symbols that do not need a market suffix.
-RESOLUTION_EXCHANGES = ("L", "N", "DE", "TO", "AX", "F")
+RESOLUTION_EXCHANGES = ("L", "N", "PARIS", "DE", "TO", "AX", "F")
 
 
 @lru_cache(maxsize=1)
@@ -169,6 +169,71 @@ def _instrument_key(ticker: str, prefix: str) -> str:
     return f"{prefix}{rel}"
 
 
+def _ticker_from_catalogue_key(key: str, prefix: str) -> Optional[str]:
+    """Return the ticker represented by an instrument catalogue object key."""
+
+    relative = key.removeprefix(prefix)
+    path = Path(relative)
+    if len(path.parts) != 2 or path.suffix.lower() != ".json":
+        return None
+    exchange, filename = path.parts
+    if exchange in {"Cash", "Unknown", "groupings"}:
+        return None
+    try:
+        return f"{_validate_part(Path(filename).stem)}.{_validate_part(exchange)}"
+    except ValueError:
+        return None
+
+
+@lru_cache(maxsize=1)
+def _catalogued_instrument_tickers() -> frozenset[str]:
+    """Build a process-wide ticker index from local files and one S3 listing.
+
+    Looking up each possible exchange with ``get_object`` makes imports scale
+    with holdings multiplied by exchanges.  An object listing lets misses be
+    rejected locally and limits known S3 instruments to one metadata read.
+    """
+
+    tickers: set[str] = set()
+    instruments_dir = _active_instruments_dir()
+    try:
+        paths = instruments_dir.glob("*/*.json")
+        for path in paths:
+            ticker = _ticker_from_catalogue_key(path.relative_to(instruments_dir).as_posix(), "")
+            if ticker:
+                tickers.add(ticker)
+    except OSError as exc:
+        logger.warning("Failed to index local instrument catalogue: %s", sanitise_log_value(exc))
+
+    s3_loc = _s3_location()
+    if not s3_loc:
+        return frozenset(tickers)
+
+    bucket, prefix = s3_loc
+    continuation_token: Optional[str] = None
+    try:
+        while True:
+            request: Dict[str, Any] = {"Bucket": bucket, "Prefix": prefix}
+            if continuation_token:
+                request["ContinuationToken"] = continuation_token
+            response = _s3_client().list_objects_v2(**request)
+            for item in response.get("Contents", []):
+                ticker = _ticker_from_catalogue_key(str(item.get("Key", "")), prefix)
+                if ticker:
+                    tickers.add(ticker)
+            continuation_token = response.get("NextContinuationToken")
+            if not response.get("IsTruncated") or not continuation_token:
+                break
+    except Exception as exc:
+        logger.warning(
+            "Failed to index S3 instrument catalogue s3://%s/%s: %s",
+            sanitise_log_value(bucket),
+            sanitise_log_value(prefix),
+            sanitise_log_value(exc),
+        )
+    return frozenset(tickers)
+
+
 @lru_cache(maxsize=2048)
 def get_instrument_meta(ticker: str) -> Dict[str, Any]:
     """Return metadata for ``ticker`` from disk or S3.
@@ -205,17 +270,13 @@ def get_instrument_meta(ticker: str) -> Dict[str, Any]:
         # route — that callers must invoke deliberately, not on every read.
         return {}
     except json.JSONDecodeError as exc:
-        logger.warning(
-            "Invalid instrument JSON %s: %s", sanitise_log_value(path), sanitise_log_value(exc)
-        )
+        logger.warning("Invalid instrument JSON %s: %s", sanitise_log_value(path), sanitise_log_value(exc))
         return {}
     except ValueError:
         logger.warning("Invalid ticker format: %s", sanitise_log_value(ticker))
         return {}
     except Exception:
-        logger.exception(
-            "Unexpected error loading instrument metadata for %s", sanitise_log_value(ticker)
-        )
+        logger.exception("Unexpected error loading instrument metadata for %s", sanitise_log_value(ticker))
         raise
 
 
@@ -286,6 +347,7 @@ def save_instrument_meta(
             )
 
     get_instrument_meta.cache_clear()
+    _catalogued_instrument_tickers.cache_clear()
     return path
 
 
@@ -420,11 +482,7 @@ def _fetch_metadata_from_yahoo(symbol: str, exchange: str) -> Optional[Dict[str,
             )
 
     name = _clean_str(
-        info.get("shortName")
-        or info.get("longName")
-        or info.get("displayName")
-        or info.get("name")
-        or full_ticker,
+        info.get("shortName") or info.get("longName") or info.get("displayName") or info.get("name") or full_ticker,
     )
 
     currency = _clean_str(info.get("currency"), upper=True)
@@ -505,9 +563,7 @@ def _auto_create_instrument_meta(ticker: str) -> Optional[Dict[str, Any]]:
             sanitise_log_value(exc),
         )
     else:
-        logger.info(
-            "Auto-created instrument metadata for %s from Yahoo Finance", sanitise_log_value(full)
-        )
+        logger.info("Auto-created instrument metadata for %s from Yahoo Finance", sanitise_log_value(full))
 
     return payload
 
@@ -519,9 +575,7 @@ def _has_informative_metadata(meta: Dict[str, Any]) -> bool:
     return not informative_keys <= {"ticker", "exchange", "name"}
 
 
-def find_known_instrument_ticker(
-    symbol: str, exchanges: tuple[str, ...] = RESOLUTION_EXCHANGES
-) -> Optional[str]:
+def find_known_instrument_ticker(symbol: str, exchanges: tuple[str, ...] = RESOLUTION_EXCHANGES) -> Optional[str]:
     """Return the first already-catalogued market ticker for a bare symbol.
 
     This helper performs disk/S3 reads only.  It is therefore safe on the CSV
@@ -532,9 +586,10 @@ def find_known_instrument_ticker(
     canonical = (symbol or "").strip().upper()
     if not canonical or "." in canonical:
         return canonical or None
+    catalogued = _catalogued_instrument_tickers()
     for exchange in exchanges:
         candidate = f"{canonical}.{exchange}"
-        if _has_informative_metadata(get_instrument_meta(candidate)):
+        if candidate in catalogued and _has_informative_metadata(get_instrument_meta(candidate)):
             return candidate
     return None
 
@@ -550,9 +605,7 @@ def is_sedol(value: str) -> bool:
     return sum(value * weight for value, weight in zip(values, weights)) % 10 == 0
 
 
-def resolve_instrument_ticker(
-    symbol: str, exchanges: tuple[str, ...] = RESOLUTION_EXCHANGES
-) -> Optional[str]:
+def resolve_instrument_ticker(symbol: str, exchanges: tuple[str, ...] = RESOLUTION_EXCHANGES) -> Optional[str]:
     """Explicitly resolve and persist a bare symbol's exchange via Yahoo.
 
     Existing informative metadata wins in exchange-priority order.  Missing
@@ -587,6 +640,7 @@ def delete_instrument_meta(ticker: str, exchange: str) -> None:
         logger.warning("Permission denied deleting %s", path)
         return
     get_instrument_meta.cache_clear()
+    _catalogued_instrument_tickers.cache_clear()
 
 
 # def save_instrument_meta(ticker: str, meta: Dict[str, Any]) -> None:

--- a/backend/routes/instrument_admin.py
+++ b/backend/routes/instrument_admin.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from backend.config import config
+
 from backend.common import instrument_groups
 from backend.common.instruments import (
     _ORIGINAL_FETCH_METADATA,
@@ -14,10 +14,13 @@ from backend.common.instruments import (
     delete_instrument_meta,
     get_instrument_meta,
     instrument_meta_path,
+    is_sedol,
     list_group_definitions,
-    save_instrument_meta,
     list_instruments,
+    resolve_instrument_ticker,
+    save_instrument_meta,
 )
+from backend.config import config
 
 router = APIRouter(
     prefix="/instrument",
@@ -67,12 +70,31 @@ async def create_group(body: dict[str, Any]) -> dict[str, Any]:
     status = "exists" if existed else "created"
     return {"status": status, "group": canonical, "groups": groups}
 
+
+@router.post("/admin/resolve/{ticker}")
+async def resolve_instrument(ticker: str) -> dict[str, str]:
+    """Resolve a bare broker symbol and persist its discovered metadata."""
+
+    canonical = ticker.strip().upper()
+    if is_sedol(canonical):
+        return {"status": "manual_mapping_required", "ticker": canonical, "reason": "sedol"}
+    try:
+        resolved = resolve_instrument_ticker(canonical)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not resolved:
+        raise HTTPException(status_code=404, detail="No supported exchange resolved this ticker")
+    return {"status": "resolved", "ticker": resolved}
+
+
 @router.get("/admin/groupings")
 async def list_instrument_groupings() -> list[dict[str, Any]]:
     """Return shared instrument grouping definitions."""
 
     catalogue = list_group_definitions()
-    return sorted((dict(entry) for entry in catalogue.values()), key=lambda item: item.get("id", ""))
+    return sorted(
+        (dict(entry) for entry in catalogue.values()), key=lambda item: item.get("id", "")
+    )
 
 
 @router.get("/admin/{exchange}/{ticker}")
@@ -160,10 +182,7 @@ async def refresh_instrument(
     if not exists:
         raise HTTPException(status_code=404, detail="Instrument not found")
 
-    if (
-        config.offline_mode
-        and _fetch_metadata_from_yahoo is _ORIGINAL_FETCH_METADATA
-    ):
+    if config.offline_mode and _fetch_metadata_from_yahoo is _ORIGINAL_FETCH_METADATA:
         raise HTTPException(status_code=503, detail="Metadata refresh disabled in offline mode")
 
     preview = True
@@ -283,4 +302,3 @@ async def clear_group(exchange: str, ticker: str) -> dict[str, Any]:
     if changed:
         save_instrument_meta(ticker, exchange, meta)
     return {"status": "cleared"}
-

--- a/backend/utils/update_holdings_from_csv.py
+++ b/backend/utils/update_holdings_from_csv.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, List, Mapping
 
 from backend import importers
+from backend.common.instruments import find_known_instrument_ticker, is_sedol
 from backend.common.path_utils import safe_join
 from backend.config import config
 from backend.logging_setup import sanitise_log_value
@@ -34,6 +35,15 @@ def _normalise_ticker(ticker: object, provider: str) -> str:
     if value in {"CASH", "GBP", "CASH GBP", "CASH.GBP"}:
         return "CASH.GBP"
     if provider.lower() == "hargreaves" and value and "." not in value:
+        if is_sedol(value):
+            logger.warning(
+                "Holding code %s is a SEDOL and needs manual instrument mapping",
+                sanitise_log_value(value),
+            )
+            return value
+        known_ticker = find_known_instrument_ticker(value)
+        if known_ticker:
+            return known_ticker
         return f"{value}.L"
     return value
 
@@ -46,7 +56,9 @@ def _number(value: object) -> float:
 
 def _normalise_holding(holding: Mapping[str, object], provider: str) -> dict[str, float | str]:
     units = _number(holding.get("units"))
-    price = _number(holding.get("current_price_gbp", holding.get("price_gbp", holding.get("price"))))
+    price = _number(
+        holding.get("current_price_gbp", holding.get("price_gbp", holding.get("price")))
+    )
     explicit_value = holding.get("value_gbp", holding.get("market_value_gbp"))
     value = _number(explicit_value) if explicit_value is not None else units * price
     ticker = _normalise_ticker(holding.get("ticker"), provider)
@@ -55,7 +67,9 @@ def _normalise_holding(holding: Mapping[str, object], provider: str) -> dict[str
     return {"ticker": ticker, "units": units, "value_gbp": value}
 
 
-def _index_holdings(holdings: List[Mapping[str, object]], provider: str) -> dict[str, dict[str, float | str]]:
+def _index_holdings(
+    holdings: List[Mapping[str, object]], provider: str
+) -> dict[str, dict[str, float | str]]:
     indexed: dict[str, dict[str, float | str]] = {}
     for raw in holdings:
         normalised = _normalise_holding(raw, provider)
@@ -124,7 +138,9 @@ def reconcile_from_csv(
     }
 
 
-def _aggregate_for_storage(raw_holdings: List[Mapping[str, object]], provider: str) -> List[dict[str, object]]:
+def _aggregate_for_storage(
+    raw_holdings: List[Mapping[str, object]], provider: str
+) -> List[dict[str, object]]:
     """Collapse per-row parsed holdings into one entry per ticker.
 
     Reuses :func:`_index_holdings` (the same aggregation reconcile relies on)
@@ -139,7 +155,9 @@ def _aggregate_for_storage(raw_holdings: List[Mapping[str, object]], provider: s
         ticker = _normalise_ticker(raw.get("ticker"), provider)
         if ticker not in indexed:
             continue
-        cost_basis_gbp[ticker] = cost_basis_gbp.get(ticker, 0.0) + _number(raw.get("cost_basis_gbp"))
+        cost_basis_gbp[ticker] = cost_basis_gbp.get(ticker, 0.0) + _number(
+            raw.get("cost_basis_gbp")
+        )
 
     return [
         {
@@ -183,7 +201,9 @@ def update_from_csv(
         try:
             loaded = json.loads(acct_path.read_text())
         except (OSError, json.JSONDecodeError):
-            logger.warning("Failed to read existing holdings at %s; overwriting", sanitise_log_value(acct_path))
+            logger.warning(
+                "Failed to read existing holdings at %s; overwriting", sanitise_log_value(acct_path)
+            )
         else:
             if isinstance(loaded, dict):
                 existing = loaded

--- a/scripts/python/reconcile_holding_tickers.py
+++ b/scripts/python/reconcile_holding_tickers.py
@@ -1,0 +1,59 @@
+"""Explicitly resolve mistickered holdings and rewrite account documents."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from backend.common.instruments import is_sedol, resolve_instrument_ticker  # noqa: E402
+
+
+def reconcile_file(path: Path) -> dict[str, list[str]]:
+    """Resolve unresolved ``.L`` holdings in one account document."""
+
+    payload: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    changed: list[str] = []
+    manual: list[str] = []
+    for holding in payload.get("holdings", []):
+        ticker = str(holding.get("ticker", "")).strip().upper()
+        symbol, separator, exchange = ticker.partition(".")
+        if is_sedol(symbol):
+            manual.append(symbol)
+            if separator:
+                holding["ticker"] = symbol
+                changed.append(f"{ticker} -> {symbol}")
+            continue
+        if exchange != "L":
+            continue
+        resolved = resolve_instrument_ticker(symbol)
+        if resolved and resolved != ticker:
+            holding["ticker"] = resolved
+            changed.append(f"{ticker} -> {resolved}")
+    if changed:
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return {"changed": changed, "manual_mapping_required": manual}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "accounts_root", type=Path, help="Directory containing owner/account JSON files"
+    )
+    args = parser.parse_args()
+    report = {
+        str(path): result
+        for path in sorted(args.accounts_root.glob("*/*.json"))
+        if any((result := reconcile_file(path)).values())
+    }
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -39,7 +39,9 @@ def test_instrument_path_generates_expected_locations(monkeypatch, tmp_path) -> 
 
 
 @pytest.mark.parametrize("ticker", ["BP.", "AV.", "SN.", "bp."])
-def test_instrument_path_treats_trailing_dot_as_no_exchange(monkeypatch, tmp_path, ticker: str) -> None:
+def test_instrument_path_treats_trailing_dot_as_no_exchange(
+    monkeypatch, tmp_path, ticker: str
+) -> None:
     """Real LSE tickers like "BP." split into an empty (not None) exchange
     part; that must resolve the same as the bare symbol, not raise (#6266).
     """
@@ -122,7 +124,9 @@ def test_get_instrument_meta_falls_back_to_local_on_s3_error(monkeypatch, tmp_pa
     assert "falling back to local file" in caplog.text
 
 
-def test_save_instrument_meta_writes_uploads_and_clears_cache(monkeypatch, tmp_path, caplog) -> None:
+def test_save_instrument_meta_writes_uploads_and_clears_cache(
+    monkeypatch, tmp_path, caplog
+) -> None:
     monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", tmp_path)
     monkeypatch.setenv(instruments.METADATA_BUCKET_ENV, "bucket")
     monkeypatch.setenv(instruments.METADATA_PREFIX_ENV, "prefix")
@@ -396,7 +400,9 @@ def test_fetch_metadata_from_yahoo_builds_normalized_payload(monkeypatch) -> Non
 
 
 @pytest.mark.parametrize("fast_info_kind", ["object", "dict"])
-def test_fetch_metadata_from_yahoo_falls_back_to_info_and_fast_info(monkeypatch, fast_info_kind: str) -> None:
+def test_fetch_metadata_from_yahoo_falls_back_to_info_and_fast_info(
+    monkeypatch, fast_info_kind: str
+) -> None:
     def build_fast_info():
         if fast_info_kind == "object":
             return SimpleNamespace(currency="usd")
@@ -468,11 +474,55 @@ def test_auto_create_instrument_meta_merges_payload(monkeypatch, tmp_path) -> No
     assert saved == [("ZZZ", "L", expected)]
 
 
+def test_resolve_instrument_ticker_tries_london_then_us(monkeypatch) -> None:
+    monkeypatch.setattr(instruments, "get_instrument_meta", lambda _ticker: {})
+    attempted: list[str] = []
+
+    def fake_create(ticker: str):
+        attempted.append(ticker)
+        if ticker == "MSFT.N":
+            return {"ticker": ticker, "exchange": "N", "currency": "USD"}
+        return None
+
+    monkeypatch.setattr(instruments, "_auto_create_instrument_meta", fake_create)
+
+    assert instruments.resolve_instrument_ticker("msft", ("L", "N")) == "MSFT.N"
+    assert attempted == ["MSFT.L", "MSFT.N"]
+
+
+def test_resolve_instrument_ticker_reuses_metadata_without_fetch(monkeypatch) -> None:
+    monkeypatch.setattr(
+        instruments,
+        "get_instrument_meta",
+        lambda ticker: {"ticker": ticker, "currency": "USD"} if ticker == "PFE.N" else {},
+    )
+    monkeypatch.setattr(
+        instruments,
+        "_auto_create_instrument_meta",
+        lambda _ticker: (_ for _ in ()).throw(AssertionError("must not fetch")),
+    )
+
+    assert instruments.resolve_instrument_ticker("PFE", ("L", "N")) == "PFE.N"
+
+
+def test_sedol_is_not_resolved_as_equity(monkeypatch) -> None:
+    monkeypatch.setattr(
+        instruments,
+        "_auto_create_instrument_meta",
+        lambda _ticker: (_ for _ in ()).throw(AssertionError("must not fetch")),
+    )
+
+    assert instruments.is_sedol("BMNR1F3") is True
+    assert instruments.resolve_instrument_ticker("BMNR1F3") is None
+
+
 def test_auto_create_respects_offline_and_failure_cache(monkeypatch) -> None:
     monkeypatch.delenv("TESTING", raising=False)
     monkeypatch.setattr(instruments, "_AUTO_CREATE_FAILURES", set())
     monkeypatch.setattr(instruments.config, "offline_mode", True)
-    monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", instruments._ORIGINAL_FETCH_METADATA)
+    monkeypatch.setattr(
+        instruments, "_fetch_metadata_from_yahoo", instruments._ORIGINAL_FETCH_METADATA
+    )
 
     assert instruments._auto_create_instrument_meta("YYY.L") is None
 

--- a/tests/backend/common/test_instruments.py
+++ b/tests/backend/common/test_instruments.py
@@ -39,9 +39,7 @@ def test_instrument_path_generates_expected_locations(monkeypatch, tmp_path) -> 
 
 
 @pytest.mark.parametrize("ticker", ["BP.", "AV.", "SN.", "bp."])
-def test_instrument_path_treats_trailing_dot_as_no_exchange(
-    monkeypatch, tmp_path, ticker: str
-) -> None:
+def test_instrument_path_treats_trailing_dot_as_no_exchange(monkeypatch, tmp_path, ticker: str) -> None:
     """Real LSE tickers like "BP." split into an empty (not None) exchange
     part; that must resolve the same as the bare symbol, not raise (#6266).
     """
@@ -124,9 +122,7 @@ def test_get_instrument_meta_falls_back_to_local_on_s3_error(monkeypatch, tmp_pa
     assert "falling back to local file" in caplog.text
 
 
-def test_save_instrument_meta_writes_uploads_and_clears_cache(
-    monkeypatch, tmp_path, caplog
-) -> None:
+def test_save_instrument_meta_writes_uploads_and_clears_cache(monkeypatch, tmp_path, caplog) -> None:
     monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", tmp_path)
     monkeypatch.setenv(instruments.METADATA_BUCKET_ENV, "bucket")
     monkeypatch.setenv(instruments.METADATA_PREFIX_ENV, "prefix")
@@ -400,9 +396,7 @@ def test_fetch_metadata_from_yahoo_builds_normalized_payload(monkeypatch) -> Non
 
 
 @pytest.mark.parametrize("fast_info_kind", ["object", "dict"])
-def test_fetch_metadata_from_yahoo_falls_back_to_info_and_fast_info(
-    monkeypatch, fast_info_kind: str
-) -> None:
+def test_fetch_metadata_from_yahoo_falls_back_to_info_and_fast_info(monkeypatch, fast_info_kind: str) -> None:
     def build_fast_info():
         if fast_info_kind == "object":
             return SimpleNamespace(currency="usd")
@@ -475,6 +469,7 @@ def test_auto_create_instrument_meta_merges_payload(monkeypatch, tmp_path) -> No
 
 
 def test_resolve_instrument_ticker_tries_london_then_us(monkeypatch) -> None:
+    monkeypatch.setattr(instruments, "_catalogued_instrument_tickers", lambda: frozenset())
     monkeypatch.setattr(instruments, "get_instrument_meta", lambda _ticker: {})
     attempted: list[str] = []
 
@@ -491,6 +486,7 @@ def test_resolve_instrument_ticker_tries_london_then_us(monkeypatch) -> None:
 
 
 def test_resolve_instrument_ticker_reuses_metadata_without_fetch(monkeypatch) -> None:
+    monkeypatch.setattr(instruments, "_catalogued_instrument_tickers", lambda: frozenset({"PFE.N"}))
     monkeypatch.setattr(
         instruments,
         "get_instrument_meta",
@@ -503,6 +499,41 @@ def test_resolve_instrument_ticker_reuses_metadata_without_fetch(monkeypatch) ->
     )
 
     assert instruments.resolve_instrument_ticker("PFE", ("L", "N")) == "PFE.N"
+
+
+def test_find_known_instrument_indexes_s3_once_for_catalogue_misses(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", tmp_path)
+    monkeypatch.setenv(instruments.METADATA_BUCKET_ENV, "bucket")
+    monkeypatch.setenv(instruments.METADATA_PREFIX_ENV, "instruments")
+    calls: list[dict] = []
+
+    class FakeClient:
+        def list_objects_v2(self, **request):
+            calls.append(request)
+            return {
+                "Contents": [{"Key": "instruments/N/PFE.json"}],
+                "IsTruncated": False,
+            }
+
+        def get_object(self, **_request):
+            return {"Body": io.BytesIO(json.dumps({"ticker": "PFE.N", "currency": "USD"}).encode())}
+
+    monkeypatch.setattr(instruments, "_s3_client", lambda: FakeClient())
+    instruments._catalogued_instrument_tickers.cache_clear()
+    instruments.get_instrument_meta.cache_clear()
+    try:
+        assert instruments.find_known_instrument_ticker("UNKNOWN") is None
+        assert instruments.find_known_instrument_ticker("ALSO_UNKNOWN") is None
+        assert instruments.find_known_instrument_ticker("PFE") == "PFE.N"
+        assert calls == [{"Bucket": "bucket", "Prefix": "instruments/"}]
+    finally:
+        instruments._catalogued_instrument_tickers.cache_clear()
+        instruments.get_instrument_meta.cache_clear()
+
+
+def test_resolution_exchanges_include_paris() -> None:
+    assert "PARIS" in instruments.RESOLUTION_EXCHANGES
+    assert instruments._build_yahoo_symbol("AI", "PARIS") == "AI.PA"
 
 
 def test_sedol_is_not_resolved_as_equity(monkeypatch) -> None:
@@ -520,9 +551,7 @@ def test_auto_create_respects_offline_and_failure_cache(monkeypatch) -> None:
     monkeypatch.delenv("TESTING", raising=False)
     monkeypatch.setattr(instruments, "_AUTO_CREATE_FAILURES", set())
     monkeypatch.setattr(instruments.config, "offline_mode", True)
-    monkeypatch.setattr(
-        instruments, "_fetch_metadata_from_yahoo", instruments._ORIGINAL_FETCH_METADATA
-    )
+    monkeypatch.setattr(instruments, "_fetch_metadata_from_yahoo", instruments._ORIGINAL_FETCH_METADATA)
 
     assert instruments._auto_create_instrument_meta("YYY.L") is None
 

--- a/tests/backend/routes/test_instrument_admin.py
+++ b/tests/backend/routes/test_instrument_admin.py
@@ -86,7 +86,9 @@ async def test_list_group_labels_merges_trimmed_metadata(monkeypatch: pytest.Mon
     assert labels == sorted(["Alpha", "Beta", "Gamma"], key=str.casefold)
 
 
-async def test_create_group_handles_duplicates_and_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_create_group_handles_duplicates_and_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     store = _GroupStore(["Alpha"])
     monkeypatch.setattr(instrument_admin.instrument_groups, "load_groups", store.load_groups)
     monkeypatch.setattr(instrument_admin.instrument_groups, "add_group", store.add_group)
@@ -142,7 +144,12 @@ async def test_update_instrument_errors_and_merges(
     path_states[("AAA", "NYSE")] = True
 
     def load_meta(exchange: str, ticker: str) -> dict[str, Any]:
-        return {"ticker": f"{ticker}.{exchange}", "exchange": exchange, "name": "Existing", "meta": "keep"}
+        return {
+            "ticker": f"{ticker}.{exchange}",
+            "exchange": exchange,
+            "name": "Existing",
+            "meta": "keep",
+        }
 
     monkeypatch.setattr(instrument_admin, "_load_meta_for_update", load_meta)
 
@@ -180,11 +187,15 @@ async def test_refresh_instrument_offline_guard(
     def original_fetch(_: str) -> dict[str, Any]:  # pragma: no cover - guard prevents execution
         raise AssertionError("should not fetch when offline")
 
-    def fail_load(*_: Any, **__: Any) -> dict[str, Any]:  # pragma: no cover - guard prevents execution
+    def fail_load(
+        *_: Any, **__: Any
+    ) -> dict[str, Any]:  # pragma: no cover - guard prevents execution
         raise AssertionError("should not load metadata when offline")
 
     monkeypatch.setattr(instrument_admin, "_ORIGINAL_FETCH_METADATA", original_fetch, raising=False)
-    monkeypatch.setattr(instrument_admin, "_fetch_metadata_from_yahoo", original_fetch, raising=False)
+    monkeypatch.setattr(
+        instrument_admin, "_fetch_metadata_from_yahoo", original_fetch, raising=False
+    )
     monkeypatch.setattr(instrument_admin, "_load_meta_for_update", fail_load)
     monkeypatch.setattr(instrument_admin.config, "offline_mode", True)
 
@@ -339,3 +350,20 @@ async def test_clear_group_persists_then_skips_when_absent(
     result_second = await instrument_admin.clear_group("NYSE", "EEE")
     assert result_second == {"status": "cleared"}
     assert len(save_calls["saved"]) == first_save_count
+
+
+async def test_resolve_instrument_returns_persisted_ticker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(instrument_admin, "resolve_instrument_ticker", lambda ticker: f"{ticker}.N")
+
+    assert await instrument_admin.resolve_instrument("msft") == {
+        "status": "resolved",
+        "ticker": "MSFT.N",
+    }
+
+
+async def test_resolve_instrument_flags_sedol_for_manual_mapping() -> None:
+    assert await instrument_admin.resolve_instrument("BMNR1F3") == {
+        "status": "manual_mapping_required",
+        "ticker": "BMNR1F3",
+        "reason": "sedol",
+    }

--- a/tests/test_holdings_import.py
+++ b/tests/test_holdings_import.py
@@ -9,7 +9,9 @@ from backend.config import config
 from backend.importers import hargreaves
 from backend.utils import update_holdings_from_csv
 
-SAMPLE_CSV = "Code,Stock,Units held,Price (pence),Cost (£)\n" "AAA,Alpha,10,150,15\n" "BBB,Beta,5,200,10\n"
+SAMPLE_CSV = (
+    "Code,Stock,Units held,Price (pence),Cost (£)\n" "AAA,Alpha,10,150,15\n" "BBB,Beta,5,200,10\n"
+)
 
 
 def test_hargreaves_parse():
@@ -53,10 +55,28 @@ def test_update_holdings_from_csv(tmp_path: Path, monkeypatch):
     assert Path(result["path"]).resolve() == acct_file.resolve()
 
 
+def test_hargreaves_import_reuses_resolved_foreign_ticker(monkeypatch):
+    monkeypatch.setattr(
+        update_holdings_from_csv,
+        "find_known_instrument_ticker",
+        lambda ticker: "MSFT.N" if ticker == "MSFT" else None,
+    )
+
+    assert update_holdings_from_csv._normalise_ticker("msft", "hargreaves") == "MSFT.N"
+
+
+def test_hargreaves_import_does_not_force_sedol_onto_lse():
+    assert update_holdings_from_csv._normalise_ticker("BMNR1F3", "hargreaves") == "BMNR1F3"
+
+
 def test_update_holdings_from_csv_aggregates_duplicate_ticker_rows(tmp_path: Path, monkeypatch):
     """Two CSV rows for the same ticker must collapse into one holding (#6264)."""
     monkeypatch.setattr(config, "accounts_root", tmp_path)
-    csv_data = "Code,Stock,Units held,Price (pence),Cost (£)\n" "AAA,Alpha,10,150,15\n" "AAA,Alpha,5,150,7.5\n"
+    csv_data = (
+        "Code,Stock,Units held,Price (pence),Cost (£)\n"
+        "AAA,Alpha,10,150,15\n"
+        "AAA,Alpha,5,150,7.5\n"
+    )
     update_holdings_from_csv.update_from_csv(
         owner="alice", account="isa", provider="hargreaves", data=csv_data.encode()
     )
@@ -175,7 +195,9 @@ def test_holdings_reconcile_hargreaves_is_read_only(client: TestClient, tmp_path
     body = response.json()
     assert body["added"] == [{"ticker": "NEW.L", "units": 5.0, "value_gbp": 10.0}]
     assert body["removed"] == [{"ticker": "OLD.L", "units": 2.0, "value_gbp": 6.0}]
-    assert body["quantity_changed"] == [{"ticker": "AAA.L", "stored_units": 8.0, "imported_units": 10.0, "delta": 2.0}]
+    assert body["quantity_changed"] == [
+        {"ticker": "AAA.L", "stored_units": 8.0, "imported_units": 10.0, "delta": 2.0}
+    ]
     assert body["value_changed"] == [
         {"ticker": "AAA.L", "stored_value_gbp": 11.2, "imported_value_gbp": 15.0, "delta_gbp": 3.8}
     ]

--- a/tests/test_reconcile_holding_tickers.py
+++ b/tests/test_reconcile_holding_tickers.py
@@ -1,0 +1,32 @@
+import json
+
+from scripts.python import reconcile_holding_tickers
+
+
+def test_reconcile_file_rewrites_foreign_ticker_and_flags_sedol(tmp_path, monkeypatch):
+    account = tmp_path / "sipp.json"
+    account.write_text(
+        json.dumps(
+            {
+                "holdings": [
+                    {"ticker": "MSFT.L", "units": 2},
+                    {"ticker": "GSK.L", "units": 1},
+                    {"ticker": "BMNR1F3.L", "units": 0.001},
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(
+        reconcile_holding_tickers,
+        "resolve_instrument_ticker",
+        lambda symbol: "MSFT.N" if symbol == "MSFT" else f"{symbol}.L",
+    )
+
+    result = reconcile_holding_tickers.reconcile_file(account)
+
+    assert result == {
+        "changed": ["MSFT.L -> MSFT.N", "BMNR1F3.L -> BMNR1F3"],
+        "manual_mapping_required": ["BMNR1F3"],
+    }
+    holdings = json.loads(account.read_text())["holdings"]
+    assert [holding["ticker"] for holding in holdings] == ["MSFT.N", "GSK.L", "BMNR1F3"]


### PR DESCRIPTION
### Motivation

- Hargreaves Lansdown CSV parsing was blindly appending `.L` to bare `Code` values, which mis-tagged CDI (foreign) holdings and caused £0 valuations in the portfolio.  
- The CSV text has no reliable per-row signal to distinguish CDI from LSE equities, so resolution must reuse existing metadata/catalogue and the guarded Yahoo auto-create path rather than blind string mangling.  
- SEDOL-like values (fund identifiers) must not be forced through the equity resolution path and should be flagged for manual mapping.

### Description

- Added in-memory/helpers to prefer already-catalogued exchanges and to explicitly resolve bare symbols: `RESOLUTION_EXCHANGES`, `find_known_instrument_ticker`, `resolve_instrument_ticker`, and `_has_informative_metadata` in `backend/common/instruments.py`.  
- Implemented SEDOL detection via `is_sedol` and avoided treating SEDOLs as equities, preserving them for manual mapping.  
- Updated `backend/utils/update_holdings_from_csv.py::_normalise_ticker` to reuse `find_known_instrument_ticker` for Hargreaves imports and to warn/leave SEDOLs unsuffixed instead of forcing `.L`.  
- Exposed an explicit admin endpoint `POST /instrument/admin/resolve/{ticker}` that runs the deliberate resolution/persistence flow and returns `manual_mapping_required` for SEDOLs in `backend/routes/instrument_admin.py`.  
- Added a one-shot backfill utility `scripts/python/reconcile_holding_tickers.py` to audit and rewrite account JSON files (fixing `.L`-mislabelled holdings and flagging manual mappings).  
- Added regression tests covering exchange-resolution behaviour, SEDOL handling, CSV normalization reuse, admin route, and the reconcile script in `tests/`.

Closes #6296

### Testing

- Ran targeted unit tests: `PYENV_VERSION=3.11.15 python -m pytest --no-cov tests/backend/common/test_instruments.py tests/test_holdings_import.py tests/backend/routes/test_instrument_admin.py tests/test_reconcile_holding_tickers.py -q`, result: `79 passed, 1 xfailed`.  
- Ran formatting/lint checks: `black` and `ruff` invocations used during the rollout completed and were used to auto-fix import ordering/style issues.  
- Observed repo-wide coverage gating when running the full test suite; a full `pytest` run triggers the repository coverage threshold (fail-under=90%), so the broader suite still reports coverage < required, but the focused tests for the change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a40ef214483278085a537707db29e)