### PR TITLE
Add accessible top scrollbar to HoldingsTable

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -196,9 +196,13 @@ export function HoldingsTable({
   ];
 
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const topScrollbarRef = useRef<HTMLDivElement>(null);
+  const tableRef = useRef<HTMLTableElement>(null);
   const tableHeaderRef = useRef<HTMLTableSectionElement>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [hasMoreColumns, setHasMoreColumns] = useState(false);
+  const [hasHorizontalOverflow, setHasHorizontalOverflow] = useState(false);
+  const [tableWidth, setTableWidth] = useState(0);
 
   useEffect(() => {
     if (tableHeaderRef.current) {
@@ -208,24 +212,40 @@ export function HoldingsTable({
 
   useEffect(() => {
     const container = tableContainerRef.current;
-    if (!container) return;
+    const topScrollbar = topScrollbarRef.current;
+    const table = tableRef.current;
+    if (!container || !topScrollbar || !table) return;
 
     const updateOverflowCue = () => {
       const remainingScroll =
         container.scrollWidth - container.clientWidth - container.scrollLeft;
       setHasMoreColumns(remainingScroll > 1);
+      setHasHorizontalOverflow(container.scrollWidth - container.clientWidth > 1);
+      setTableWidth(table.scrollWidth);
+    };
+
+    const syncFromTable = () => {
+      topScrollbar.scrollLeft = container.scrollLeft;
+      updateOverflowCue();
+    };
+    const syncFromTopScrollbar = () => {
+      container.scrollLeft = topScrollbar.scrollLeft;
+      updateOverflowCue();
     };
 
     updateOverflowCue();
-    container.addEventListener("scroll", updateOverflowCue, { passive: true });
+    container.addEventListener("scroll", syncFromTable, { passive: true });
+    topScrollbar.addEventListener("scroll", syncFromTopScrollbar, { passive: true });
     const resizeObserver =
       typeof ResizeObserver === "undefined"
         ? null
         : new ResizeObserver(updateOverflowCue);
     resizeObserver?.observe(container);
+    resizeObserver?.observe(table);
 
     return () => {
-      container.removeEventListener("scroll", updateOverflowCue);
+      container.removeEventListener("scroll", syncFromTable);
+      topScrollbar.removeEventListener("scroll", syncFromTopScrollbar);
       resizeObserver?.disconnect();
     };
   }, [sortedRows.length, relativeViewEnabled, visibleColumns, showForward7d, showForward30d]);
@@ -315,11 +335,20 @@ export function HoldingsTable({
         </>
       )}
       {sortedRows.length ? (
-        <div
-          ref={tableContainerRef}
-          className={`${tableStyles.scrollContainer} ${hasMoreColumns ? tableStyles.hasMoreColumns : ""}`}
-        >
-          <table className={`${tableStyles.table} mb-4 w-full`}>
+        <>
+          <div
+            ref={topScrollbarRef}
+            className={`${tableStyles.topScrollbar} ${hasHorizontalOverflow ? "" : tableStyles.topScrollbarHidden}`}
+            aria-label={t("holdingsTable.horizontalScroll")}
+            tabIndex={0}
+          >
+            <div className={tableStyles.topScrollbarContent} style={{ width: tableWidth }} />
+          </div>
+          <div
+            ref={tableContainerRef}
+            className={`${tableStyles.scrollContainer} ${hasMoreColumns ? tableStyles.hasMoreColumns : ""}`}
+          >
+            <table ref={tableRef} className={`${tableStyles.table} mb-4 w-full`}>
         <thead ref={tableHeaderRef}>
           <tr>
             {showAccount && <th className={tableStyles.cell}></th>}
@@ -706,8 +735,9 @@ export function HoldingsTable({
             ))}
           </tr>
         </tfoot>
-        </table>
-        </div>
+            </table>
+          </div>
+        </>
       ) : (
         <EmptyState
           message={t("holdingsTable.noHoldings")}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -174,6 +174,7 @@
   "holdingsTable": {
     "actualPurchaseCost": "Tatsächliche Anschaffungskosten",
     "clearFilters": "Filter löschen",
+    "horizontalScroll": "Bestandsspalten horizontal scrollen",
     "columns": {
       "acquired": "Erworben",
       "ccy": "Währung",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -204,6 +204,7 @@
   "holdingsTable": {
     "actualPurchaseCost": "Actual purchase cost",
     "clearFilters": "Clear filters",
+    "horizontalScroll": "Scroll holdings columns horizontally",
     "columns": {
       "acquired": "Acquired",
       "ccy": "CCY",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -174,6 +174,7 @@
   "holdingsTable": {
     "actualPurchaseCost": "Costo de compra real",
     "clearFilters": "Limpiar filtros",
+    "horizontalScroll": "Desplazar horizontalmente las columnas de posiciones",
     "columns": {
       "acquired": "Adquirido",
       "ccy": "Moneda",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -174,6 +174,7 @@
   "holdingsTable": {
     "actualPurchaseCost": "Coût d'achat réel",
     "clearFilters": "Effacer les filtres",
+    "horizontalScroll": "Faire défiler horizontalement les colonnes des positions",
     "columns": {
       "acquired": "Acquis",
       "ccy": "Devise",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -174,6 +174,7 @@
   "holdingsTable": {
     "actualPurchaseCost": "Costo di acquisto effettivo",
     "clearFilters": "Cancella filtri",
+    "horizontalScroll": "Scorri orizzontalmente le colonne delle posizioni",
     "columns": {
       "acquired": "Acquisito",
       "ccy": "CCY",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -174,6 +174,7 @@
   "holdingsTable": {
     "actualPurchaseCost": "Custo de compra real",
     "clearFilters": "Limpar filtros",
+    "horizontalScroll": "Deslocar horizontalmente as colunas das posições",
     "columns": {
       "acquired": "Adquirido",
       "ccy": "Moeda",

--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -9,6 +9,27 @@
   scrollbar-gutter: stable;
 }
 
+.topScrollbar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  overflow-x: auto;
+  overflow-y: hidden;
+  height: 16px;
+  background: inherit;
+  scrollbar-color: rgba(71, 85, 105, 0.8) rgba(148, 163, 184, 0.2);
+  scrollbar-gutter: stable;
+}
+
+.topScrollbarContent {
+  height: 1px;
+}
+
+.topScrollbarHidden {
+  height: 0;
+  scrollbar-gutter: auto;
+}
+
 .hasMoreColumns {
   box-shadow: inset -14px 0 12px -14px rgba(15, 23, 42, 0.85);
 }

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within, act, waitFor } from "@testing-library/react";
+import { render, screen, within, act, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import i18n from "@/i18n";
@@ -471,5 +471,19 @@ describe("HoldingsTable", () => {
           } finally {
               vi.useRealTimers();
           }
+      });
+
+      it("keeps the top and table horizontal scrollbars in sync", () => {
+          render(<HoldingsTable holdings={holdings} />);
+          const tableContainer = screen.getByRole('table').parentElement as HTMLElement;
+          const topScrollbar = screen.getByLabelText('Scroll holdings columns horizontally');
+
+          topScrollbar.scrollLeft = 240;
+          fireEvent.scroll(topScrollbar);
+          expect(tableContainer.scrollLeft).toBe(240);
+
+          tableContainer.scrollLeft = 80;
+          fireEvent.scroll(tableContainer);
+          expect(topScrollbar.scrollLeft).toBe(80);
       });
   });


### PR DESCRIPTION
### Motivation
- Users cannot reach the table's native horizontal scrollbar when the holdings table is long and virtualized, making right-hand columns effectively undiscoverable without scrolling through all rows.

### Description
- Add a sticky, keyboard-focusable top scrollbar above the holdings table and mirror its content width via `topScrollbarRef` and `topScrollbarContent` to provide an always-reachable horizontal scroll control (`frontend/src/components/HoldingsTable.tsx`, `frontend/src/styles/table.module.css`).
- Synchronize scrolling in both directions between the top scrollbar and the table container, update overflow cues responsively, and hide the top control when no horizontal overflow exists.
- Preserve the existing right-edge fade cue (`hasMoreColumns`) and keep the native bottom scrollbar available while adding localized accessible label strings in the `frontend/src/locales/*/translation.json` files.
- Add a unit test verifying bidirectional synchronization of the two scrollbars and update related unit tests (`frontend/tests/unit/components/HoldingsTable.test.tsx`).
- Closes #6295.

### Testing
- Ran the component unit tests with `npm --prefix frontend run test -- --run tests/unit/components/HoldingsTable.test.tsx tests/unit/components/responsiveRender.test.tsx`, and all tests passed (25 tests passed).
- Ran lint with `npm --prefix frontend run lint`, and it completed successfully.
- Built the frontend with `npm --prefix frontend run build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a407f9a7c832793b7ed8512bca75e)