### PR TITLE
Resolve foreign holding tickers and add reconciliation script

### DIFF
--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -521,6 +521,10 @@ def resolve_instrument_ticker(
 ) -> Optional[str]:
     """Resolve a bare symbol to a persisted, informative instrument ticker.
 
+    ``ticker`` is expected to be a bare symbol without an exchange suffix
+    (e.g. ``"MSFT"``); any ``.SUFFIX`` present is stripped and ignored, it is
+    not treated as a preferred candidate.
+
     Existing metadata is checked before any live lookup, making this safe for
     the CSV import path. Persisted exchange aliases not in ``exchanges`` are
     also considered, so already-backfilled metadata under a non-canonical

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -277,6 +277,7 @@ def save_instrument_meta(
             )
 
     get_instrument_meta.cache_clear()
+    _persisted_metadata_exchanges.cache_clear()
     return path
 
 
@@ -499,6 +500,7 @@ def _has_informative_metadata(metadata: Dict[str, Any]) -> bool:
     return not informative_keys <= {"ticker", "exchange", "name"}
 
 
+@lru_cache(maxsize=2048)
 def _persisted_metadata_exchanges(symbol: str) -> tuple[str, ...]:
     """Return exchange codes with a persisted local metadata file for ``symbol``.
 
@@ -506,6 +508,10 @@ def _persisted_metadata_exchanges(symbol: str) -> tuple[str, ...]:
     alias (e.g. Pfizer persisted as ``PFE.N`` rather than ``PFE.US``) is still
     found. Only scans the local instruments directory; S3-only deployments
     still fall back to the canonical exchange list checked directly.
+
+    Cached like :func:`get_instrument_meta` (and invalidated alongside it) so
+    a CSV import with many bare tickers does not re-scan the instruments
+    directory once per row.
     """
     try:
         return tuple(sorted(p.parent.name for p in _active_instruments_dir().glob(f"*/{symbol}.json")))
@@ -569,6 +575,7 @@ def delete_instrument_meta(ticker: str, exchange: str) -> None:
         logger.warning("Permission denied deleting %s", path)
         return
     get_instrument_meta.cache_clear()
+    _persisted_metadata_exchanges.cache_clear()
 
 
 # def save_instrument_meta(ticker: str, meta: Dict[str, Any]) -> None:

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -499,6 +499,20 @@ def _has_informative_metadata(metadata: Dict[str, Any]) -> bool:
     return not informative_keys <= {"ticker", "exchange", "name"}
 
 
+def _persisted_metadata_exchanges(symbol: str) -> tuple[str, ...]:
+    """Return exchange codes with a persisted local metadata file for ``symbol``.
+
+    Widens resolution beyond :data:`TICKER_RESOLUTION_EXCHANGES` so an existing
+    alias (e.g. Pfizer persisted as ``PFE.N`` rather than ``PFE.US``) is still
+    found. Only scans the local instruments directory; S3-only deployments
+    still fall back to the canonical exchange list checked directly.
+    """
+    try:
+        return tuple(sorted(p.parent.name for p in _active_instruments_dir().glob(f"*/{symbol}.json")))
+    except OSError:
+        return ()
+
+
 def resolve_instrument_ticker(
     ticker: str,
     *,
@@ -508,23 +522,31 @@ def resolve_instrument_ticker(
     """Resolve a bare symbol to a persisted, informative instrument ticker.
 
     Existing metadata is checked before any live lookup, making this safe for
-    the CSV import path.  A deliberate reconciliation/backfill operation can
-    set ``create_missing`` to try Yahoo in exchange-priority order; successful
-    metadata is persisted by :func:`_auto_create_instrument_meta`.
+    the CSV import path. Persisted exchange aliases not in ``exchanges`` are
+    also considered, so already-backfilled metadata under a non-canonical
+    exchange code is still honoured. A deliberate reconciliation/backfill
+    operation can set ``create_missing`` to try Yahoo in exchange-priority
+    order; successful metadata is persisted by :func:`_auto_create_instrument_meta`.
     """
     symbol = (ticker or "").strip().upper().split(".", 1)[0]
     if not symbol or symbol == "CASH":
         return None
 
-    candidates = tuple(f"{symbol}.{exchange.upper()}" for exchange in exchanges)
-    for candidate in candidates:
+    known_exchanges = list(dict.fromkeys(exchanges))
+    for exchange in _persisted_metadata_exchanges(symbol):
+        if exchange not in known_exchanges:
+            known_exchanges.append(exchange)
+
+    for exchange in known_exchanges:
+        candidate = f"{symbol}.{exchange.upper()}"
         if _has_informative_metadata(get_instrument_meta(candidate)):
             return candidate
 
     if not create_missing:
         return None
 
-    for candidate in candidates:
+    for exchange in exchanges:
+        candidate = f"{symbol}.{exchange.upper()}"
         metadata = _auto_create_instrument_meta(candidate)
         if metadata and _has_informative_metadata(metadata):
             return candidate

--- a/backend/common/instruments.py
+++ b/backend/common/instruments.py
@@ -59,6 +59,11 @@ METADATA_PREFIX_ENV = "METADATA_PREFIX"
 
 _AUTO_CREATE_FAILURES: set[str] = set()
 
+# Ordered from the market most commonly used by Hargreaves Lansdown exports to
+# progressively less common foreign markets.  ``US`` deliberately represents
+# Yahoo's suffix-less NASDAQ/NYSE symbols.
+TICKER_RESOLUTION_EXCHANGES = ("L", "US", "DE", "TO", "PARIS", "ASX", "F")
+
 
 @lru_cache(maxsize=1)
 def list_group_definitions() -> Dict[str, Dict[str, Any]]:
@@ -486,6 +491,44 @@ def _auto_create_instrument_meta(ticker: str) -> Optional[Dict[str, Any]]:
         logger.info("Auto-created instrument metadata for %s from Yahoo Finance", sanitise_log_value(full))
 
     return payload
+
+
+def _has_informative_metadata(metadata: Dict[str, Any]) -> bool:
+    """Return whether metadata contains more than identity placeholders."""
+    informative_keys = {key for key, value in metadata.items() if value not in (None, "")}
+    return not informative_keys <= {"ticker", "exchange", "name"}
+
+
+def resolve_instrument_ticker(
+    ticker: str,
+    *,
+    exchanges: tuple[str, ...] = TICKER_RESOLUTION_EXCHANGES,
+    create_missing: bool = False,
+) -> Optional[str]:
+    """Resolve a bare symbol to a persisted, informative instrument ticker.
+
+    Existing metadata is checked before any live lookup, making this safe for
+    the CSV import path.  A deliberate reconciliation/backfill operation can
+    set ``create_missing`` to try Yahoo in exchange-priority order; successful
+    metadata is persisted by :func:`_auto_create_instrument_meta`.
+    """
+    symbol = (ticker or "").strip().upper().split(".", 1)[0]
+    if not symbol or symbol == "CASH":
+        return None
+
+    candidates = tuple(f"{symbol}.{exchange.upper()}" for exchange in exchanges)
+    for candidate in candidates:
+        if _has_informative_metadata(get_instrument_meta(candidate)):
+            return candidate
+
+    if not create_missing:
+        return None
+
+    for candidate in candidates:
+        metadata = _auto_create_instrument_meta(candidate)
+        if metadata and _has_informative_metadata(metadata):
+            return candidate
+    return None
 
 
 def delete_instrument_meta(ticker: str, exchange: str) -> None:

--- a/backend/utils/update_holdings_from_csv.py
+++ b/backend/utils/update_holdings_from_csv.py
@@ -38,7 +38,15 @@ def _normalise_ticker(ticker: object, provider: str) -> str:
         # Resolution is metadata-only here: importing a CSV must never block on
         # one network call per holding.  The explicit ticker reconciliation
         # command persists discoveries, so subsequent imports use them freely.
-        return resolve_instrument_ticker(value) or f"{value}.L"
+        resolved = resolve_instrument_ticker(value)
+        if resolved is None:
+            logger.warning(
+                "No persisted metadata for bare Hargreaves ticker %s; defaulting to .L. "
+                "Run scripts/reconcile_holding_tickers.py --write if this is a foreign holding.",
+                sanitise_log_value(value),
+            )
+            return f"{value}.L"
+        return resolved
     return value
 
 

--- a/backend/utils/update_holdings_from_csv.py
+++ b/backend/utils/update_holdings_from_csv.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, List, Mapping
 
 from backend import importers
+from backend.common.instruments import resolve_instrument_ticker
 from backend.common.path_utils import safe_join
 from backend.config import config
 from backend.logging_setup import sanitise_log_value
@@ -34,7 +35,10 @@ def _normalise_ticker(ticker: object, provider: str) -> str:
     if value in {"CASH", "GBP", "CASH GBP", "CASH.GBP"}:
         return "CASH.GBP"
     if provider.lower() == "hargreaves" and value and "." not in value:
-        return f"{value}.L"
+        # Resolution is metadata-only here: importing a CSV must never block on
+        # one network call per holding.  The explicit ticker reconciliation
+        # command persists discoveries, so subsequent imports use them freely.
+        return resolve_instrument_ticker(value) or f"{value}.L"
     return value
 
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -259,3 +259,15 @@ python scripts/reconcile_drawdown.py --group family --ticker VUSA.L --ticker MSF
 
 Price series for each holding is written to `TICKER.EXCHANGE.csv` and `.json`
 in the current directory for manual inspection.
+
+## reconcile_holding_tickers.py
+
+Resolve bare Hargreaves Lansdown holdings against persisted instrument metadata
+and, when permitted by the runtime configuration, Yahoo Finance. The command is
+a dry run unless `--write` is supplied. Unresolvable identifiers (including UK
+fund SEDOLs) are printed as needing a manual mapping instead of being rewritten.
+
+```bash
+python -m scripts.reconcile_holding_tickers data/accounts/alice/isa.json
+python -m scripts.reconcile_holding_tickers --write data/accounts/alice/isa.json
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -264,8 +264,11 @@ in the current directory for manual inspection.
 
 Resolve bare Hargreaves Lansdown holdings against persisted instrument metadata
 and, when permitted by the runtime configuration, Yahoo Finance. The command is
-a dry run unless `--write` is supplied. Unresolvable identifiers (including UK
-fund SEDOLs) are printed as needing a manual mapping instead of being rewritten.
+a dry run unless `--write` is supplied — a dry run only reads existing
+metadata and never fetches from Yahoo or writes files. Unresolvable
+identifiers (including UK fund SEDOLs) are printed as needing a manual
+mapping instead of being rewritten. When `--write` changes an account file, a
+sibling `.bak` copy of the original is written alongside it first.
 
 ```bash
 python -m scripts.reconcile_holding_tickers data/accounts/alice/isa.json

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -268,9 +268,14 @@ a dry run unless `--write` is supplied — a dry run only reads existing
 metadata and never fetches from Yahoo or writes files. Unresolvable
 identifiers (including UK fund SEDOLs) are printed as needing a manual
 mapping instead of being rewritten. When `--write` changes an account file, a
-sibling `.bak` copy of the original is written alongside it first.
+sibling `.bak` copy of the original is written alongside it first — the
+`.bak` is never overwritten by a later run, so it always holds the earliest
+pre-reconciliation state. Without explicit paths, the command defaults to
+every account file under the accounts root; combining that default with
+`--write` also requires `--all` to confirm the bulk write is intentional.
 
 ```bash
 python -m scripts.reconcile_holding_tickers data/accounts/alice/isa.json
 python -m scripts.reconcile_holding_tickers --write data/accounts/alice/isa.json
+python -m scripts.reconcile_holding_tickers --write --all
 ```

--- a/scripts/reconcile_holding_tickers.py
+++ b/scripts/reconcile_holding_tickers.py
@@ -32,6 +32,8 @@ def reconcile_account_file(path: Path, *, write: bool = False) -> dict[str, list
             changed.append(f"{ticker} -> {resolved}")
 
     if write and changed:
+        backup_path = path.with_suffix(path.suffix + ".bak")
+        backup_path.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
         path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
     return {"changed": changed, "unresolved": unresolved}
 

--- a/scripts/reconcile_holding_tickers.py
+++ b/scripts/reconcile_holding_tickers.py
@@ -34,7 +34,10 @@ def reconcile_account_file(path: Path, *, write: bool = False) -> dict[str, list
 
     if write and changed:
         backup_path = path.with_suffix(path.suffix + ".bak")
-        _atomic_write_text(backup_path, path.read_text(encoding="utf-8"))
+        if not backup_path.exists():
+            # Preserve the earliest known-good copy: a second run must not let
+            # a fresh backup overwrite the original pre-reconciliation state.
+            _atomic_write_text(backup_path, path.read_text(encoding="utf-8"))
         _atomic_write_text(path, json.dumps(document, indent=2) + "\n")
     return {"changed": changed, "unresolved": unresolved}
 

--- a/scripts/reconcile_holding_tickers.py
+++ b/scripts/reconcile_holding_tickers.py
@@ -22,7 +22,9 @@ def reconcile_account_file(path: Path, *, write: bool = False) -> dict[str, list
         if not ticker.endswith(".L"):
             continue
         symbol = ticker.removesuffix(".L")
-        resolved = resolve_instrument_ticker(symbol, create_missing=True)
+        # Only try (and persist) live Yahoo lookups when actually writing;
+        # a dry run must not mutate instrument metadata as a side effect.
+        resolved = resolve_instrument_ticker(symbol, create_missing=write)
         if resolved is None:
             unresolved.append(ticker)
         elif resolved != ticker:

--- a/scripts/reconcile_holding_tickers.py
+++ b/scripts/reconcile_holding_tickers.py
@@ -44,9 +44,14 @@ def reconcile_account_file(path: Path, *, write: bool = False) -> dict[str, list
 
 def _atomic_write_text(path: Path, text: str) -> None:
     """Write ``text`` to ``path`` via a temp file + rename so a failed write
-    (e.g. disk full) cannot leave ``path`` partially overwritten."""
+    (e.g. disk full) cannot leave ``path`` partially overwritten. The temp
+    file is fsync'd before the rename so the new content survives a crash
+    immediately after this call returns."""
     tmp_path = path.with_suffix(path.suffix + ".tmp")
-    tmp_path.write_text(text, encoding="utf-8")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        fh.write(text)
+        fh.flush()
+        os.fsync(fh.fileno())
     os.replace(tmp_path, path)
 
 
@@ -60,8 +65,19 @@ def main() -> int:
     parser.add_argument(
         "--write", action="store_true", help="Write resolved tickers back to account files"
     )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Required alongside --write with no explicit paths, to confirm "
+        "writing every account file under the accounts root is intentional",
+    )
     args = parser.parse_args()
     paths = args.paths or sorted(config.accounts_root.glob("*/*.json"))
+
+    if args.write and not args.paths and not args.all:
+        parser.error(
+            "--write with no explicit paths also requires --all (writes every account file)"
+        )
 
     for path in paths:
         result = reconcile_account_file(path, write=args.write)

--- a/scripts/reconcile_holding_tickers.py
+++ b/scripts/reconcile_holding_tickers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -33,9 +34,17 @@ def reconcile_account_file(path: Path, *, write: bool = False) -> dict[str, list
 
     if write and changed:
         backup_path = path.with_suffix(path.suffix + ".bak")
-        backup_path.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
-        path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+        _atomic_write_text(backup_path, path.read_text(encoding="utf-8"))
+        _atomic_write_text(path, json.dumps(document, indent=2) + "\n")
     return {"changed": changed, "unresolved": unresolved}
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` via a temp file + rename so a failed write
+    (e.g. disk full) cannot leave ``path`` partially overwritten."""
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(text, encoding="utf-8")
+    os.replace(tmp_path, path)
 
 
 def main() -> int:

--- a/scripts/reconcile_holding_tickers.py
+++ b/scripts/reconcile_holding_tickers.py
@@ -1,0 +1,62 @@
+"""Resolve incorrectly suffixed holdings using persisted/Yahoo metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from backend.common.instruments import resolve_instrument_ticker
+from backend.config import config
+
+
+def reconcile_account_file(path: Path, *, write: bool = False) -> dict[str, list[str]]:
+    """Resolve ``.L`` holdings in one account file and optionally save changes."""
+    document: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    changed: list[str] = []
+    unresolved: list[str] = []
+
+    for holding in document.get("holdings", []):
+        ticker = str(holding.get("ticker", "")).strip().upper()
+        if not ticker.endswith(".L"):
+            continue
+        symbol = ticker.removesuffix(".L")
+        resolved = resolve_instrument_ticker(symbol, create_missing=True)
+        if resolved is None:
+            unresolved.append(ticker)
+        elif resolved != ticker:
+            holding["ticker"] = resolved
+            changed.append(f"{ticker} -> {resolved}")
+
+    if write and changed:
+        path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    return {"changed": changed, "unresolved": unresolved}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve account holdings against instrument metadata (dry-run by default)."
+    )
+    parser.add_argument(
+        "paths", nargs="*", type=Path, help="Account JSON files (defaults to every account file)"
+    )
+    parser.add_argument(
+        "--write", action="store_true", help="Write resolved tickers back to account files"
+    )
+    args = parser.parse_args()
+    paths = args.paths or sorted(config.accounts_root.glob("*/*.json"))
+
+    for path in paths:
+        result = reconcile_account_file(path, write=args.write)
+        if result["changed"] or result["unresolved"]:
+            print(f"{path}:")
+            for change in result["changed"]:
+                print(f"  resolved: {change}")
+            for ticker in result["unresolved"]:
+                print(f"  needs manual mapping: {ticker}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/common/test_instrument_ticker_resolution.py
+++ b/tests/common/test_instrument_ticker_resolution.py
@@ -1,0 +1,44 @@
+from backend.common import instruments
+
+
+def test_resolver_prefers_existing_metadata_without_creating(monkeypatch):
+    monkeypatch.setattr(
+        instruments,
+        "get_instrument_meta",
+        lambda ticker: (
+            {"ticker": ticker, "exchange": "US", "currency": "USD"} if ticker == "MSFT.US" else {}
+        ),
+    )
+    create = monkeypatch.setattr(instruments, "_auto_create_instrument_meta", lambda ticker: None)
+
+    assert instruments.resolve_instrument_ticker("MSFT") == "MSFT.US"
+    assert create is None
+
+
+def test_resolver_explicitly_creates_and_persists_first_valid_candidate(monkeypatch):
+    monkeypatch.setattr(instruments, "get_instrument_meta", lambda ticker: {})
+    attempted: list[str] = []
+
+    def create(ticker: str):
+        attempted.append(ticker)
+        if ticker == "ADBE.US":
+            return {"ticker": ticker, "exchange": "US", "currency": "USD"}
+        return None
+
+    monkeypatch.setattr(instruments, "_auto_create_instrument_meta", create)
+
+    assert (
+        instruments.resolve_instrument_ticker("ADBE.L", exchanges=("L", "US"), create_missing=True)
+        == "ADBE.US"
+    )
+    assert attempted == ["ADBE.L", "ADBE.US"]
+
+
+def test_resolver_rejects_placeholder_metadata(monkeypatch):
+    monkeypatch.setattr(
+        instruments,
+        "get_instrument_meta",
+        lambda ticker: {"ticker": ticker, "exchange": "L", "name": ticker},
+    )
+
+    assert instruments.resolve_instrument_ticker("BMNR1F3", exchanges=("L", "US")) is None

--- a/tests/common/test_instrument_ticker_resolution.py
+++ b/tests/common/test_instrument_ticker_resolution.py
@@ -5,9 +5,7 @@ def test_resolver_prefers_existing_metadata_without_creating(monkeypatch):
     monkeypatch.setattr(
         instruments,
         "get_instrument_meta",
-        lambda ticker: (
-            {"ticker": ticker, "exchange": "US", "currency": "USD"} if ticker == "MSFT.US" else {}
-        ),
+        lambda ticker: ({"ticker": ticker, "exchange": "US", "currency": "USD"} if ticker == "MSFT.US" else {}),
     )
     create = monkeypatch.setattr(instruments, "_auto_create_instrument_meta", lambda ticker: None)
 
@@ -27,10 +25,7 @@ def test_resolver_explicitly_creates_and_persists_first_valid_candidate(monkeypa
 
     monkeypatch.setattr(instruments, "_auto_create_instrument_meta", create)
 
-    assert (
-        instruments.resolve_instrument_ticker("ADBE.L", exchanges=("L", "US"), create_missing=True)
-        == "ADBE.US"
-    )
+    assert instruments.resolve_instrument_ticker("ADBE.L", exchanges=("L", "US"), create_missing=True) == "ADBE.US"
     assert attempted == ["ADBE.L", "ADBE.US"]
 
 
@@ -52,9 +47,7 @@ def test_resolver_honours_persisted_exchange_alias_not_in_canonical_list(monkeyp
     monkeypatch.setattr(
         instruments,
         "get_instrument_meta",
-        lambda ticker: (
-            {"ticker": ticker, "exchange": "N", "currency": "USD"} if ticker == "PFE.N" else {}
-        ),
+        lambda ticker: ({"ticker": ticker, "exchange": "N", "currency": "USD"} if ticker == "PFE.N" else {}),
     )
 
     assert instruments.resolve_instrument_ticker("PFE", exchanges=("L", "US")) == "PFE.N"

--- a/tests/common/test_instrument_ticker_resolution.py
+++ b/tests/common/test_instrument_ticker_resolution.py
@@ -74,3 +74,25 @@ def test_resolver_finds_genuine_lse_ticker_from_real_persisted_metadata(monkeypa
     )
 
     assert instruments.resolve_instrument_ticker("3IN") == "3IN.L"
+
+
+def test_persisted_metadata_exchanges_degrades_gracefully_on_oserror(monkeypatch):
+    """A filesystem error scanning the instruments directory (e.g. a transient
+    permission or mount issue) must not raise out of the resolver — it should
+    behave as if no aliases were found (#6310)."""
+
+    class _RaisingDir:
+        def glob(self, pattern):
+            raise OSError("simulated filesystem error")
+
+    monkeypatch.setattr(instruments, "_active_instruments_dir", lambda: _RaisingDir())
+    instruments._persisted_metadata_exchanges.cache_clear()
+    try:
+        assert instruments._persisted_metadata_exchanges("MSFT") == ()
+
+        monkeypatch.setattr(instruments, "get_instrument_meta", lambda ticker: {})
+        assert instruments.resolve_instrument_ticker("MSFT", exchanges=("L", "US")) is None
+    finally:
+        # This test poisons the module-level lru_cache with a fake result for
+        # "MSFT" under a fake directory; clear it so later tests see real state.
+        instruments._persisted_metadata_exchanges.cache_clear()

--- a/tests/common/test_instrument_ticker_resolution.py
+++ b/tests/common/test_instrument_ticker_resolution.py
@@ -58,3 +58,19 @@ def test_resolver_honours_persisted_exchange_alias_not_in_canonical_list(monkeyp
     )
 
     assert instruments.resolve_instrument_ticker("PFE", exchanges=("L", "US")) == "PFE.N"
+
+
+def test_resolver_finds_genuine_lse_ticker_from_real_persisted_metadata(monkeypatch, tmp_path):
+    """Unmocked end-to-end check: a real LSE holding with informative metadata
+    already on disk (e.g. ``3IN.L``) must resolve to itself, not be treated
+    as needing reconciliation (#6310)."""
+    monkeypatch.setattr(instruments, "_INSTRUMENTS_DIR", tmp_path)
+    instruments.get_instrument_meta.cache_clear()
+    instruments._persisted_metadata_exchanges.cache_clear()
+    instruments.save_instrument_meta(
+        "3IN",
+        "L",
+        {"ticker": "3IN.L", "exchange": "L", "name": "3i Infrastructure", "currency": "GBP"},
+    )
+
+    assert instruments.resolve_instrument_ticker("3IN") == "3IN.L"

--- a/tests/common/test_instrument_ticker_resolution.py
+++ b/tests/common/test_instrument_ticker_resolution.py
@@ -42,3 +42,19 @@ def test_resolver_rejects_placeholder_metadata(monkeypatch):
     )
 
     assert instruments.resolve_instrument_ticker("BMNR1F3", exchanges=("L", "US")) is None
+
+
+def test_resolver_honours_persisted_exchange_alias_not_in_canonical_list(monkeypatch):
+    """Metadata persisted under a non-canonical exchange (e.g. ``N`` for NYSE)
+    must still be found instead of falling through to an incorrect ``.L``
+    ticker (#6310)."""
+    monkeypatch.setattr(instruments, "_persisted_metadata_exchanges", lambda symbol: ("N",))
+    monkeypatch.setattr(
+        instruments,
+        "get_instrument_meta",
+        lambda ticker: (
+            {"ticker": ticker, "exchange": "N", "currency": "USD"} if ticker == "PFE.N" else {}
+        ),
+    )
+
+    assert instruments.resolve_instrument_ticker("PFE", exchanges=("L", "US")) == "PFE.N"

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -56,10 +56,10 @@ backend/common/instrument_groups.py:52
 backend/common/instrument_groups.py:55
 backend/common/instruments.py:36
 backend/common/instruments.py:39
-backend/common/instruments.py:82
-backend/common/instruments.py:86
-backend/common/instruments.py:500
-backend/common/instruments.py:530
+backend/common/instruments.py:87
+backend/common/instruments.py:91
+backend/common/instruments.py:575
+backend/common/instruments.py:606
 backend/common/portfolio.py:81
 backend/common/portfolio.py:115
 # raw/d_raw/amount_minor are logged with %r (repr), which already escapes

--- a/tests/scripts/test_reconcile_holding_tickers.py
+++ b/tests/scripts/test_reconcile_holding_tickers.py
@@ -48,3 +48,33 @@ def test_reconcile_account_file_dry_run_does_not_create_missing_metadata(tmp_pat
 
     assert seen_create_missing == [False]
     assert result == {"changed": [], "unresolved": ["MSFT.L"]}
+
+
+def test_reconcile_account_file_missing_holdings_key_is_a_noop(tmp_path, monkeypatch):
+    path = tmp_path / "person.json"
+    path.write_text(json.dumps({"owner": "alice"}))
+    monkeypatch.setattr(
+        reconcile_holding_tickers, "resolve_instrument_ticker", lambda *args, **kwargs: None
+    )
+
+    result = reconcile_holding_tickers.reconcile_account_file(path, write=True)
+
+    assert result == {"changed": [], "unresolved": []}
+    assert not path.with_suffix(path.suffix + ".bak").exists()
+
+
+def test_reconcile_account_file_already_correct_ticker_is_not_reported(tmp_path, monkeypatch):
+    """A ticker that resolves back to itself is already correct and should be
+    left untouched rather than reported as changed or unresolved."""
+    path = tmp_path / "isa.json"
+    path.write_text(json.dumps({"holdings": [{"ticker": "3IN.L", "units": 1}]}))
+    monkeypatch.setattr(
+        reconcile_holding_tickers,
+        "resolve_instrument_ticker",
+        lambda ticker, create_missing: "3IN.L",
+    )
+
+    result = reconcile_holding_tickers.reconcile_account_file(path, write=True)
+
+    assert result == {"changed": [], "unresolved": []}
+    assert not path.with_suffix(path.suffix + ".bak").exists()

--- a/tests/scripts/test_reconcile_holding_tickers.py
+++ b/tests/scripts/test_reconcile_holding_tickers.py
@@ -56,9 +56,7 @@ def test_reconcile_account_file_dry_run_does_not_create_missing_metadata(tmp_pat
 def test_reconcile_account_file_missing_holdings_key_is_a_noop(tmp_path, monkeypatch):
     path = tmp_path / "person.json"
     path.write_text(json.dumps({"owner": "alice"}))
-    monkeypatch.setattr(
-        reconcile_holding_tickers, "resolve_instrument_ticker", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(reconcile_holding_tickers, "resolve_instrument_ticker", lambda *args, **kwargs: None)
 
     result = reconcile_holding_tickers.reconcile_account_file(path, write=True)
 
@@ -123,11 +121,7 @@ def test_reconcile_account_file_second_run_does_not_overwrite_backup(tmp_path, m
     backup_path = path.with_suffix(path.suffix + ".bak")
     assert backup_path.read_text() == original_text
 
-    path.write_text(
-        json.dumps(
-            {"holdings": [{"ticker": "MSFT.US", "units": 2}, {"ticker": "ADBE.L", "units": 1}]}
-        )
-    )
+    path.write_text(json.dumps({"holdings": [{"ticker": "MSFT.US", "units": 2}, {"ticker": "ADBE.L", "units": 1}]}))
     monkeypatch.setattr(
         reconcile_holding_tickers,
         "resolve_instrument_ticker",
@@ -154,9 +148,7 @@ def test_main_rejects_write_with_no_paths_and_no_all_flag(monkeypatch, capsys):
 def test_main_allows_write_with_no_paths_when_all_flag_set(tmp_path, monkeypatch):
     account_dir = tmp_path / "alice"
     account_dir.mkdir()
-    (account_dir / "isa.json").write_text(
-        json.dumps({"holdings": [{"ticker": "MSFT.L", "units": 1}]})
-    )
+    (account_dir / "isa.json").write_text(json.dumps({"holdings": [{"ticker": "MSFT.L", "units": 1}]}))
     monkeypatch.setattr(reconcile_holding_tickers.config, "accounts_root", tmp_path)
     monkeypatch.setattr(
         reconcile_holding_tickers,

--- a/tests/scripts/test_reconcile_holding_tickers.py
+++ b/tests/scripts/test_reconcile_holding_tickers.py
@@ -21,11 +21,15 @@ def test_reconcile_account_file_updates_equity_and_flags_fund(tmp_path, monkeypa
         lambda ticker, create_missing: "MSFT.US" if ticker == "MSFT" and create_missing else None,
     )
 
+    original_text = path.read_text()
     result = reconcile_holding_tickers.reconcile_account_file(path, write=True)
 
     assert result == {"changed": ["MSFT.L -> MSFT.US"], "unresolved": ["BMNR1F3.L"]}
     holdings = json.loads(path.read_text())["holdings"]
     assert [holding["ticker"] for holding in holdings] == ["MSFT.US", "BMNR1F3.L"]
+
+    backup_path = path.with_suffix(path.suffix + ".bak")
+    assert backup_path.read_text() == original_text
 
 
 def test_reconcile_account_file_dry_run_does_not_create_missing_metadata(tmp_path, monkeypatch):

--- a/tests/scripts/test_reconcile_holding_tickers.py
+++ b/tests/scripts/test_reconcile_holding_tickers.py
@@ -1,0 +1,28 @@
+import json
+
+from scripts import reconcile_holding_tickers
+
+
+def test_reconcile_account_file_updates_equity_and_flags_fund(tmp_path, monkeypatch):
+    path = tmp_path / "sipp.json"
+    path.write_text(
+        json.dumps(
+            {
+                "holdings": [
+                    {"ticker": "MSFT.L", "units": 2},
+                    {"ticker": "BMNR1F3.L", "units": 0.001},
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(
+        reconcile_holding_tickers,
+        "resolve_instrument_ticker",
+        lambda ticker, create_missing: "MSFT.US" if ticker == "MSFT" else None,
+    )
+
+    result = reconcile_holding_tickers.reconcile_account_file(path, write=True)
+
+    assert result == {"changed": ["MSFT.L -> MSFT.US"], "unresolved": ["BMNR1F3.L"]}
+    holdings = json.loads(path.read_text())["holdings"]
+    assert [holding["ticker"] for holding in holdings] == ["MSFT.US", "BMNR1F3.L"]

--- a/tests/scripts/test_reconcile_holding_tickers.py
+++ b/tests/scripts/test_reconcile_holding_tickers.py
@@ -1,4 +1,7 @@
 import json
+import sys
+
+import pytest
 
 from scripts import reconcile_holding_tickers
 
@@ -133,3 +136,35 @@ def test_reconcile_account_file_second_run_does_not_overwrite_backup(tmp_path, m
     reconcile_holding_tickers.reconcile_account_file(path, write=True)
 
     assert backup_path.read_text() == original_text
+
+
+def test_main_rejects_write_with_no_paths_and_no_all_flag(monkeypatch, capsys):
+    """--write with no explicit paths would rewrite every account file; that
+    must require an explicit --all to guard against an accidental bulk
+    write (#6310)."""
+    monkeypatch.setattr(sys, "argv", ["reconcile_holding_tickers", "--write"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        reconcile_holding_tickers.main()
+
+    assert exc_info.value.code == 2
+    assert "--all" in capsys.readouterr().err
+
+
+def test_main_allows_write_with_no_paths_when_all_flag_set(tmp_path, monkeypatch):
+    account_dir = tmp_path / "alice"
+    account_dir.mkdir()
+    (account_dir / "isa.json").write_text(
+        json.dumps({"holdings": [{"ticker": "MSFT.L", "units": 1}]})
+    )
+    monkeypatch.setattr(reconcile_holding_tickers.config, "accounts_root", tmp_path)
+    monkeypatch.setattr(
+        reconcile_holding_tickers,
+        "resolve_instrument_ticker",
+        lambda ticker, create_missing: "MSFT.US",
+    )
+    monkeypatch.setattr(sys, "argv", ["reconcile_holding_tickers", "--write", "--all"])
+
+    assert reconcile_holding_tickers.main() == 0
+    holdings = json.loads((account_dir / "isa.json").read_text())["holdings"]
+    assert holdings[0]["ticker"] == "MSFT.US"

--- a/tests/scripts/test_reconcile_holding_tickers.py
+++ b/tests/scripts/test_reconcile_holding_tickers.py
@@ -78,3 +78,58 @@ def test_reconcile_account_file_already_correct_ticker_is_not_reported(tmp_path,
 
     assert result == {"changed": [], "unresolved": []}
     assert not path.with_suffix(path.suffix + ".bak").exists()
+
+
+def test_reconcile_account_file_preserves_non_holdings_fields(tmp_path, monkeypatch):
+    path = tmp_path / "sipp.json"
+    path.write_text(
+        json.dumps(
+            {
+                "owner": "alice",
+                "account_type": "SIPP",
+                "holdings": [{"ticker": "MSFT.L", "units": 2}],
+            }
+        )
+    )
+    monkeypatch.setattr(
+        reconcile_holding_tickers,
+        "resolve_instrument_ticker",
+        lambda ticker, create_missing: "MSFT.US",
+    )
+
+    reconcile_holding_tickers.reconcile_account_file(path, write=True)
+
+    document = json.loads(path.read_text())
+    assert document["owner"] == "alice"
+    assert document["account_type"] == "SIPP"
+
+
+def test_reconcile_account_file_second_run_does_not_overwrite_backup(tmp_path, monkeypatch):
+    """A second reconciliation run must not clobber the backup of the
+    original pre-reconciliation state with an already-corrected copy."""
+    path = tmp_path / "sipp.json"
+    original_text = json.dumps({"holdings": [{"ticker": "MSFT.L", "units": 2}]})
+    path.write_text(original_text)
+    monkeypatch.setattr(
+        reconcile_holding_tickers,
+        "resolve_instrument_ticker",
+        lambda ticker, create_missing: "MSFT.US",
+    )
+
+    reconcile_holding_tickers.reconcile_account_file(path, write=True)
+    backup_path = path.with_suffix(path.suffix + ".bak")
+    assert backup_path.read_text() == original_text
+
+    path.write_text(
+        json.dumps(
+            {"holdings": [{"ticker": "MSFT.US", "units": 2}, {"ticker": "ADBE.L", "units": 1}]}
+        )
+    )
+    monkeypatch.setattr(
+        reconcile_holding_tickers,
+        "resolve_instrument_ticker",
+        lambda ticker, create_missing: "ADBE.US",
+    )
+    reconcile_holding_tickers.reconcile_account_file(path, write=True)
+
+    assert backup_path.read_text() == original_text

--- a/tests/scripts/test_reconcile_holding_tickers.py
+++ b/tests/scripts/test_reconcile_holding_tickers.py
@@ -18,7 +18,7 @@ def test_reconcile_account_file_updates_equity_and_flags_fund(tmp_path, monkeypa
     monkeypatch.setattr(
         reconcile_holding_tickers,
         "resolve_instrument_ticker",
-        lambda ticker, create_missing: "MSFT.US" if ticker == "MSFT" else None,
+        lambda ticker, create_missing: "MSFT.US" if ticker == "MSFT" and create_missing else None,
     )
 
     result = reconcile_holding_tickers.reconcile_account_file(path, write=True)
@@ -26,3 +26,21 @@ def test_reconcile_account_file_updates_equity_and_flags_fund(tmp_path, monkeypa
     assert result == {"changed": ["MSFT.L -> MSFT.US"], "unresolved": ["BMNR1F3.L"]}
     holdings = json.loads(path.read_text())["holdings"]
     assert [holding["ticker"] for holding in holdings] == ["MSFT.US", "BMNR1F3.L"]
+
+
+def test_reconcile_account_file_dry_run_does_not_create_missing_metadata(tmp_path, monkeypatch):
+    """A dry run (no --write) must not trigger live Yahoo lookups/persistence (#6310)."""
+    path = tmp_path / "sipp.json"
+    path.write_text(json.dumps({"holdings": [{"ticker": "MSFT.L", "units": 2}]}))
+    seen_create_missing: list[bool] = []
+
+    def fake_resolve(ticker, create_missing):
+        seen_create_missing.append(create_missing)
+        return None
+
+    monkeypatch.setattr(reconcile_holding_tickers, "resolve_instrument_ticker", fake_resolve)
+
+    result = reconcile_holding_tickers.reconcile_account_file(path, write=False)
+
+    assert seen_create_missing == [False]
+    assert result == {"changed": [], "unresolved": ["MSFT.L"]}

--- a/tests/test_holdings_import.py
+++ b/tests/test_holdings_import.py
@@ -64,6 +64,18 @@ def test_hargreaves_import_uses_persisted_foreign_ticker(monkeypatch):
     assert update_holdings_from_csv._normalise_ticker("3IN", "hargreaves") == "3IN.L"
 
 
+def test_hargreaves_import_warns_when_falling_back_to_l_suffix(monkeypatch, caplog):
+    """An unresolvable bare ticker must still fall back to .L (CSV import can't
+    block on a live lookup) but should log so it can be reconciled later (#6310)."""
+    monkeypatch.setattr(update_holdings_from_csv, "resolve_instrument_ticker", lambda ticker: None)
+
+    with caplog.at_level("WARNING", logger=update_holdings_from_csv.logger.name):
+        result = update_holdings_from_csv._normalise_ticker("3IN", "hargreaves")
+
+    assert result == "3IN.L"
+    assert any("3IN" in record.getMessage() for record in caplog.records)
+
+
 def test_update_holdings_from_csv_aggregates_duplicate_ticker_rows(tmp_path: Path, monkeypatch):
     """Two CSV rows for the same ticker must collapse into one holding (#6264)."""
     monkeypatch.setattr(config, "accounts_root", tmp_path)

--- a/tests/test_holdings_import.py
+++ b/tests/test_holdings_import.py
@@ -53,6 +53,17 @@ def test_update_holdings_from_csv(tmp_path: Path, monkeypatch):
     assert Path(result["path"]).resolve() == acct_file.resolve()
 
 
+def test_hargreaves_import_uses_persisted_foreign_ticker(monkeypatch):
+    monkeypatch.setattr(
+        update_holdings_from_csv,
+        "resolve_instrument_ticker",
+        lambda ticker: "MSFT.US" if ticker == "MSFT" else None,
+    )
+
+    assert update_holdings_from_csv._normalise_ticker("MSFT", "hargreaves") == "MSFT.US"
+    assert update_holdings_from_csv._normalise_ticker("3IN", "hargreaves") == "3IN.L"
+
+
 def test_update_holdings_from_csv_aggregates_duplicate_ticker_rows(tmp_path: Path, monkeypatch):
     """Two CSV rows for the same ticker must collapse into one holding (#6264)."""
     monkeypatch.setattr(config, "accounts_root", tmp_path)


### PR DESCRIPTION
### Motivation

- Hargreaves Lansdown CSV imports were blindly appending `.L` to bare codes which incorrectly converted CDI (foreign) holdings to LSE tickers and produced £0 valuations. 
- The intent is to resolve ambiguous bare symbols against persisted instrument metadata (and only fall back to live Yahoo lookups during an explicit reconciliation/backfill). 
- Provide a safe, dry-run reconciliation path to backfill and correct already-stored holdings while avoiding synchronous network calls on every CSV import. 

### Description

- Add `resolve_instrument_ticker` and `_has_informative_metadata` to `backend/common/instruments.py` with an exchange-priority list `TICKER_RESOLUTION_EXCHANGES` so existing informative metadata is preferred and Yahoo is used only when explicitly requested via `create_missing` (file: `backend/common/instruments.py`).
- Teach Hargreaves CSV normalization to consult the resolver (`resolve_instrument_ticker`) and otherwise fall back to the fast `.L` suffix, avoiding per-row blocking network calls during import (file: `backend/utils/update_holdings_from_csv.py`).
- Add a dry-run-first script `scripts/reconcile_holding_tickers.py` to scan account JSONs, resolve `.L` holdings (optionally persist with `--write`), and report unresolved identifiers that need manual mapping (file: `scripts/reconcile_holding_tickers.py`).
- Add regression tests for resolver behavior, importer integration, and the reconciliation script, and document the new script usage in `scripts/README.md` (files: `tests/common/test_instrument_ticker_resolution.py`, `tests/scripts/test_reconcile_holding_tickers.py`, updated `tests/test_holdings_import.py`).
- Closes #6296.

### Testing

- Ran targeted tests with `python -m pytest --no-cov tests/test_holdings_import.py tests/common/test_instrument_ticker_resolution.py tests/scripts/test_reconcile_holding_tickers.py` and all selected tests passed (13 passed, 1 warning). 
- Ran targeted lint/format checks (`ruff` and `black`) against the modified and added files and fixed formatting issues in the new script and tests. 
- Verified the reconciliation script help and dry-run behavior with `python -m scripts.reconcile_holding_tickers --help` and exercised the script in dry-run and write modes during local checks. 

Note: a repository-wide `make lint`/coverage gate exposes many pre-existing issues unrelated to this change; targeted checks for the modified files and new tests passed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a402eccf88327a99a9aad8312d771)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved ticker resolution using saved instrument information and exchange aliases.
  - Added a reconciliation utility for updating `.L` holding tickers, with dry-run support, backups and write safeguards.
  - Improved CSV holding imports for resolvable foreign tickers.

- **Bug Fixes**
  - Reduced incorrect `.L` fallbacks when a more accurate ticker is available.
  - Unresolved tickers now fall back safely with a warning.

- **Documentation**
  - Added usage guidance and examples for ticker reconciliation.

- **Tests**
  - Added coverage for resolution, imports, reconciliation, backups and command safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->