### PR TITLE
Resizable InstrumentDetail drawer with persistent width and expand/restore

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { getInstrumentDetail, getInstrumentIntraday } from "../api";
@@ -15,11 +15,11 @@ import ChartSkeleton from "./skeletons/ChartSkeleton";
 import TableRowsSkeleton from "./skeletons/TableRowsSkeleton";
 import TextSkeleton from "./skeletons/TextSkeleton";
 import {
-  clampDrawerWidth,
-  DEFAULT_DRAWER_WIDTH,
-  DRAWER_WIDTH_KEY,
+  canExpandDrawer,
+  expandedDrawerWidth,
   MIN_DRAWER_WIDTH,
 } from "./instrumentDetailDrawer";
+import { useInstrumentDetailDrawer } from "./useInstrumentDetailDrawer";
 import {
   ResponsiveContainer,
   LineChart,
@@ -69,14 +69,6 @@ type PositionsTableProps = {
 // ───────────────── helpers ─────────────────
 const toNum = (v: unknown): number =>
   typeof v === "number" && Number.isFinite(v) ? v : NaN;
-
-const readDrawerWidth = (): number => {
-  if (typeof window === "undefined") return DEFAULT_DRAWER_WIDTH;
-  const storedWidth = Number(window.localStorage.getItem(DRAWER_WIDTH_KEY));
-  return Number.isFinite(storedWidth) && storedWidth > 0
-    ? clampDrawerWidth(storedWidth, window.innerWidth)
-    : clampDrawerWidth(DEFAULT_DRAWER_WIDTH, window.innerWidth);
-};
 
 const fixed = (v: unknown, dp = 2): string => {
   const n = toNum(v);
@@ -221,8 +213,15 @@ export function InstrumentDetail({
 }: Props) {
   const { t } = useTranslation();
   const { baseCurrency } = useConfig();
-  const [drawerWidth, setDrawerWidth] = useState(readDrawerWidth);
-  const dragStart = useRef<{ pointerX: number; width: number } | null>(null);
+  const {
+    width: drawerWidth,
+    viewportWidth,
+    handlePointerDown: handleResizePointerDown,
+    handlePointerMove: handleResizePointerMove,
+    handlePointerUp: handleResizePointerUp,
+    handleKeyDown: handleResizeKeyDown,
+    toggleExpanded,
+  } = useInstrumentDetailDrawer(variant === "drawer");
   const palette = useMemo(
     () => ({
       background: variant === "drawer" ? "#111" : "transparent",
@@ -261,64 +260,6 @@ export function InstrumentDetail({
           },
     [drawerWidth, palette.background, palette.text, variant],
   );
-  useEffect(() => {
-    if (variant !== "drawer") return;
-    const handleViewportResize = () => {
-      setDrawerWidth((width) => clampDrawerWidth(width, window.innerWidth));
-    };
-    window.addEventListener("resize", handleViewportResize);
-    return () => window.removeEventListener("resize", handleViewportResize);
-  }, [variant]);
-
-  const persistDrawerWidth = useCallback((width: number) => {
-    window.localStorage.setItem(DRAWER_WIDTH_KEY, String(Math.round(width)));
-  }, []);
-
-  const handleResizePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    dragStart.current = { pointerX: event.clientX, width: drawerWidth };
-    event.currentTarget.setPointerCapture(event.pointerId);
-  };
-
-  const handleResizePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (!dragStart.current) return;
-    const nextWidth = clampDrawerWidth(
-      dragStart.current.width + dragStart.current.pointerX - event.clientX,
-      window.innerWidth,
-    );
-    setDrawerWidth(nextWidth);
-  };
-
-  const handleResizePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (!dragStart.current) return;
-    const nextWidth = clampDrawerWidth(
-      dragStart.current.width + dragStart.current.pointerX - event.clientX,
-      window.innerWidth,
-    );
-    dragStart.current = null;
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-    setDrawerWidth(nextWidth);
-    persistDrawerWidth(nextWidth);
-  };
-
-  const handleResizeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
-    event.preventDefault();
-    const direction = event.key === "ArrowLeft" ? 1 : -1;
-    const nextWidth = clampDrawerWidth(drawerWidth + direction * 20, window.innerWidth);
-    setDrawerWidth(nextWidth);
-    persistDrawerWidth(nextWidth);
-  };
-
-  const toggleExpanded = () => {
-    const expandedWidth = clampDrawerWidth(window.innerWidth * 0.6, window.innerWidth);
-    const nextWidth = drawerWidth >= expandedWidth - 1
-      ? clampDrawerWidth(DEFAULT_DRAWER_WIDTH, window.innerWidth)
-      : expandedWidth;
-    setDrawerWidth(nextWidth);
-    persistDrawerWidth(nextWidth);
-  };
   const [data, setData] = useState<{
     prices: Price[];
     positions: Position[];
@@ -556,7 +497,7 @@ export function InstrumentDetail({
           aria-label="Resize instrument details"
           aria-orientation="vertical"
           aria-valuemin={MIN_DRAWER_WIDTH}
-          aria-valuemax={typeof window === "undefined" ? DEFAULT_DRAWER_WIDTH : window.innerWidth}
+          aria-valuemax={viewportWidth}
           aria-valuenow={Math.round(drawerWidth)}
           tabIndex={0}
           onPointerDown={handleResizePointerDown}
@@ -565,11 +506,12 @@ export function InstrumentDetail({
           onPointerCancel={handleResizePointerUp}
           onKeyDown={handleResizeKeyDown}
           style={{
-            position: "absolute",
+            position: "fixed",
             top: 0,
             bottom: 0,
-            left: 0,
+            left: `calc(100vw - ${drawerWidth}px)`,
             width: "10px",
+            zIndex: 1,
             cursor: "ew-resize",
             touchAction: "none",
           }}
@@ -580,14 +522,14 @@ export function InstrumentDetail({
           ✕
         </button>
       )}
-      {variant === "drawer" && (
+      {variant === "drawer" && canExpandDrawer(viewportWidth) && (
         <button
           type="button"
           aria-label="Expand or restore instrument details"
           onClick={toggleExpanded}
           style={{ float: "right", marginRight: "0.5rem" }}
         >
-          {drawerWidth >= (typeof window === "undefined" ? 0 : window.innerWidth * 0.6) - 1
+          {drawerWidth >= expandedDrawerWidth(viewportWidth) - 1
             ? "↘"
             : "↗"}
         </button>

--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { getInstrumentDetail, getInstrumentIntraday } from "../api";
@@ -14,6 +14,12 @@ import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 import ChartSkeleton from "./skeletons/ChartSkeleton";
 import TableRowsSkeleton from "./skeletons/TableRowsSkeleton";
 import TextSkeleton from "./skeletons/TextSkeleton";
+import {
+  clampDrawerWidth,
+  DEFAULT_DRAWER_WIDTH,
+  DRAWER_WIDTH_KEY,
+  MIN_DRAWER_WIDTH,
+} from "./instrumentDetailDrawer";
 import {
   ResponsiveContainer,
   LineChart,
@@ -63,6 +69,14 @@ type PositionsTableProps = {
 // ───────────────── helpers ─────────────────
 const toNum = (v: unknown): number =>
   typeof v === "number" && Number.isFinite(v) ? v : NaN;
+
+const readDrawerWidth = (): number => {
+  if (typeof window === "undefined") return DEFAULT_DRAWER_WIDTH;
+  const storedWidth = Number(window.localStorage.getItem(DRAWER_WIDTH_KEY));
+  return Number.isFinite(storedWidth) && storedWidth > 0
+    ? clampDrawerWidth(storedWidth, window.innerWidth)
+    : clampDrawerWidth(DEFAULT_DRAWER_WIDTH, window.innerWidth);
+};
 
 const fixed = (v: unknown, dp = 2): string => {
   const n = toNum(v);
@@ -207,6 +221,8 @@ export function InstrumentDetail({
 }: Props) {
   const { t } = useTranslation();
   const { baseCurrency } = useConfig();
+  const [drawerWidth, setDrawerWidth] = useState(readDrawerWidth);
+  const dragStart = useRef<{ pointerX: number; width: number } | null>(null);
   const palette = useMemo(
     () => ({
       background: variant === "drawer" ? "#111" : "transparent",
@@ -227,7 +243,8 @@ export function InstrumentDetail({
             top: 0,
             right: 0,
             bottom: 0,
-            width: "420px",
+            width: `${drawerWidth}px`,
+            maxWidth: "100vw",
             background: palette.background,
             color: palette.text,
             padding: "1rem",
@@ -242,8 +259,66 @@ export function InstrumentDetail({
             color: palette.text === "inherit" ? undefined : palette.text,
             padding: 0,
           },
-    [palette.background, palette.text, variant],
+    [drawerWidth, palette.background, palette.text, variant],
   );
+  useEffect(() => {
+    if (variant !== "drawer") return;
+    const handleViewportResize = () => {
+      setDrawerWidth((width) => clampDrawerWidth(width, window.innerWidth));
+    };
+    window.addEventListener("resize", handleViewportResize);
+    return () => window.removeEventListener("resize", handleViewportResize);
+  }, [variant]);
+
+  const persistDrawerWidth = useCallback((width: number) => {
+    window.localStorage.setItem(DRAWER_WIDTH_KEY, String(Math.round(width)));
+  }, []);
+
+  const handleResizePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    dragStart.current = { pointerX: event.clientX, width: drawerWidth };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handleResizePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragStart.current) return;
+    const nextWidth = clampDrawerWidth(
+      dragStart.current.width + dragStart.current.pointerX - event.clientX,
+      window.innerWidth,
+    );
+    setDrawerWidth(nextWidth);
+  };
+
+  const handleResizePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragStart.current) return;
+    const nextWidth = clampDrawerWidth(
+      dragStart.current.width + dragStart.current.pointerX - event.clientX,
+      window.innerWidth,
+    );
+    dragStart.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setDrawerWidth(nextWidth);
+    persistDrawerWidth(nextWidth);
+  };
+
+  const handleResizeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const direction = event.key === "ArrowLeft" ? 1 : -1;
+    const nextWidth = clampDrawerWidth(drawerWidth + direction * 20, window.innerWidth);
+    setDrawerWidth(nextWidth);
+    persistDrawerWidth(nextWidth);
+  };
+
+  const toggleExpanded = () => {
+    const expandedWidth = clampDrawerWidth(window.innerWidth * 0.6, window.innerWidth);
+    const nextWidth = drawerWidth >= expandedWidth - 1
+      ? clampDrawerWidth(DEFAULT_DRAWER_WIDTH, window.innerWidth)
+      : expandedWidth;
+    setDrawerWidth(nextWidth);
+    persistDrawerWidth(nextWidth);
+  };
   const [data, setData] = useState<{
     prices: Price[];
     positions: Position[];
@@ -475,9 +550,46 @@ export function InstrumentDetail({
 
   return (
     <div style={containerStyle}>
+      {variant === "drawer" && (
+        <div
+          role="separator"
+          aria-label="Resize instrument details"
+          aria-orientation="vertical"
+          aria-valuemin={MIN_DRAWER_WIDTH}
+          aria-valuemax={typeof window === "undefined" ? DEFAULT_DRAWER_WIDTH : window.innerWidth}
+          aria-valuenow={Math.round(drawerWidth)}
+          tabIndex={0}
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={handleResizePointerMove}
+          onPointerUp={handleResizePointerUp}
+          onPointerCancel={handleResizePointerUp}
+          onKeyDown={handleResizeKeyDown}
+          style={{
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            left: 0,
+            width: "10px",
+            cursor: "ew-resize",
+            touchAction: "none",
+          }}
+        />
+      )}
       {onClose && variant === "drawer" && (
-        <button onClick={onClose} style={{ float: "right" }}>
+        <button aria-label="Close instrument details" onClick={onClose} style={{ float: "right" }}>
           ✕
+        </button>
+      )}
+      {variant === "drawer" && (
+        <button
+          type="button"
+          aria-label="Expand or restore instrument details"
+          onClick={toggleExpanded}
+          style={{ float: "right", marginRight: "0.5rem" }}
+        >
+          {drawerWidth >= (typeof window === "undefined" ? 0 : window.innerWidth * 0.6) - 1
+            ? "↘"
+            : "↗"}
         </button>
       )}
       {signal && (

--- a/frontend/src/components/instrumentDetailDrawer.ts
+++ b/frontend/src/components/instrumentDetailDrawer.ts
@@ -9,3 +9,10 @@ export const clampDrawerWidth = (width: number, viewportWidth: number): number =
     Math.min(MIN_DRAWER_WIDTH, viewportWidth),
     Math.min(width, viewportWidth - DRAWER_VIEWPORT_MARGIN),
   );
+
+export const expandedDrawerWidth = (viewportWidth: number): number =>
+  clampDrawerWidth(viewportWidth * 0.6, viewportWidth);
+
+export const canExpandDrawer = (viewportWidth: number): boolean =>
+  expandedDrawerWidth(viewportWidth) >
+  clampDrawerWidth(DEFAULT_DRAWER_WIDTH, viewportWidth);

--- a/frontend/src/components/instrumentDetailDrawer.ts
+++ b/frontend/src/components/instrumentDetailDrawer.ts
@@ -1,0 +1,11 @@
+export const DRAWER_WIDTH_KEY = "allotmint.instrumentDetail.drawerWidth";
+export const DEFAULT_DRAWER_WIDTH = 420;
+export const MIN_DRAWER_WIDTH = 320;
+
+const DRAWER_VIEWPORT_MARGIN = 16;
+
+export const clampDrawerWidth = (width: number, viewportWidth: number): number =>
+  Math.max(
+    Math.min(MIN_DRAWER_WIDTH, viewportWidth),
+    Math.min(width, viewportWidth - DRAWER_VIEWPORT_MARGIN),
+  );

--- a/frontend/src/components/useInstrumentDetailDrawer.ts
+++ b/frontend/src/components/useInstrumentDetailDrawer.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  clampDrawerWidth,
+  DEFAULT_DRAWER_WIDTH,
+  DRAWER_WIDTH_KEY,
+  expandedDrawerWidth,
+} from "./instrumentDetailDrawer";
+
+const reportStorageError = (action: "read" | "write", error: unknown) => {
+  console.warn(`Unable to ${action} the instrument detail drawer width`, error);
+};
+
+export const readDrawerWidth = (): number => {
+  if (typeof window === "undefined") return DEFAULT_DRAWER_WIDTH;
+
+  try {
+    const storedWidth = Number(window.localStorage.getItem(DRAWER_WIDTH_KEY));
+    const width = Number.isFinite(storedWidth) && storedWidth > 0
+      ? storedWidth
+      : DEFAULT_DRAWER_WIDTH;
+    return clampDrawerWidth(width, window.innerWidth);
+  } catch (error) {
+    reportStorageError("read", error);
+    return clampDrawerWidth(DEFAULT_DRAWER_WIDTH, window.innerWidth);
+  }
+};
+
+const persistDrawerWidth = (width: number) => {
+  try {
+    window.localStorage.setItem(DRAWER_WIDTH_KEY, String(Math.round(width)));
+  } catch (error) {
+    reportStorageError("write", error);
+  }
+};
+
+export const useInstrumentDetailDrawer = (enabled: boolean) => {
+  const [width, setWidth] = useState(readDrawerWidth);
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    typeof window === "undefined" ? DEFAULT_DRAWER_WIDTH : window.innerWidth,
+  );
+  const dragStart = useRef<{ pointerX: number; width: number } | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handleViewportResize = () => {
+      setViewportWidth(window.innerWidth);
+      setWidth((currentWidth) => clampDrawerWidth(currentWidth, window.innerWidth));
+    };
+    window.addEventListener("resize", handleViewportResize);
+    return () => window.removeEventListener("resize", handleViewportResize);
+  }, [enabled]);
+
+  const resizeToPointer = useCallback((clientX: number) => {
+    if (!dragStart.current) return null;
+    return clampDrawerWidth(
+      dragStart.current.width + dragStart.current.pointerX - clientX,
+      window.innerWidth,
+    );
+  }, []);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    dragStart.current = { pointerX: event.clientX, width };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const nextWidth = resizeToPointer(event.clientX);
+    if (nextWidth != null) setWidth(nextWidth);
+  };
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    const nextWidth = resizeToPointer(event.clientX);
+    dragStart.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    if (nextWidth != null) {
+      setWidth(nextWidth);
+      persistDrawerWidth(nextWidth);
+    }
+  };
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const direction = event.key === "ArrowLeft" ? 1 : -1;
+    const nextWidth = clampDrawerWidth(width + direction * 20, window.innerWidth);
+    setWidth(nextWidth);
+    persistDrawerWidth(nextWidth);
+  };
+  const toggleExpanded = () => {
+    const expandedWidth = expandedDrawerWidth(viewportWidth);
+    const nextWidth = width >= expandedWidth - 1
+      ? clampDrawerWidth(DEFAULT_DRAWER_WIDTH, viewportWidth)
+      : expandedWidth;
+    setWidth(nextWidth);
+    persistDrawerWidth(nextWidth);
+  };
+
+  return {
+    width,
+    viewportWidth,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handleKeyDown,
+    toggleExpanded,
+  };
+};

--- a/frontend/tests/unit/components/InstrumentDetail.test.ts
+++ b/frontend/tests/unit/components/InstrumentDetail.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { clampDrawerWidth } from '@/components/instrumentDetailDrawer';
+
+describe('clampDrawerWidth', () => {
+  it('keeps a requested drawer width within desktop viewport bounds', () => {
+    expect(clampDrawerWidth(700, 1200)).toBe(700);
+    expect(clampDrawerWidth(200, 1200)).toBe(320);
+    expect(clampDrawerWidth(1400, 1200)).toBe(1184);
+  });
+
+  it('allows the drawer to fit a viewport narrower than its desktop minimum', () => {
+    expect(clampDrawerWidth(420, 300)).toBe(300);
+  });
+});

--- a/frontend/tests/unit/components/InstrumentDetail.test.ts
+++ b/frontend/tests/unit/components/InstrumentDetail.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { clampDrawerWidth } from '@/components/instrumentDetailDrawer';
+import {
+  canExpandDrawer,
+  clampDrawerWidth,
+  expandedDrawerWidth,
+} from '@/components/instrumentDetailDrawer';
+import { readDrawerWidth } from '@/components/useInstrumentDetailDrawer';
 
 describe('clampDrawerWidth', () => {
   it('keeps a requested drawer width within desktop viewport bounds', () => {
@@ -11,5 +16,27 @@ describe('clampDrawerWidth', () => {
 
   it('allows the drawer to fit a viewport narrower than its desktop minimum', () => {
     expect(clampDrawerWidth(420, 300)).toBe(300);
+  });
+});
+
+describe('drawer expansion', () => {
+  it('only offers expansion when it can make the default drawer wider', () => {
+    expect(canExpandDrawer(600)).toBe(false);
+    expect(canExpandDrawer(1200)).toBe(true);
+    expect(expandedDrawerWidth(1200)).toBe(720);
+  });
+});
+
+describe('readDrawerWidth', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('falls back to the default width when local storage is unavailable', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage is disabled');
+    });
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(readDrawerWidth()).toBe(420);
+    expect(console.warn).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
Closes #6294 

### Motivation

- The `InstrumentDetail` drawer used a fixed narrow width which cramped charts and tables inside the panel, so users need a resizable/expandable panel to improve legibility and usability.

### Description

- Make the drawer resizable by adding a draggable left-edge separator with pointer handlers and keyboard support (arrow keys) in `frontend/src/components/InstrumentDetail.tsx` and an expand/restore toggle that switches between the default width and ~60% viewport width. 
- Persist the chosen width to `localStorage` (`allotmint.instrumentDetail.drawerWidth`) and clamp the width to viewport bounds so it degrades sensibly on narrow/mobile screens. 
- Factor constants and `clampDrawerWidth` into a small module `frontend/src/components/instrumentDetailDrawer.ts` and add ARIA attributes to the separator for accessibility. 
- Add a unit test `frontend/tests/unit/components/InstrumentDetail.test.ts` covering `clampDrawerWidth` behaviour for normal, min, max, and narrow viewports.

### Testing

- Ran the component unit test with `npm --prefix frontend run test -- --run tests/unit/components/InstrumentDetail.test.ts` and it passed. 
- Ran TypeScript checks with `npm --prefix frontend run type-check` and the type-check passed. 
- Ran frontend lint with `npm --prefix frontend run lint` and the linter passed. 
- Ran `git diff --check` to verify no whitespace/patch problems and it passed. 
- Attempted a Playwright screenshot smoke (headed browser) to visually verify but it failed because the Playwright Chromium binary was not installed in the environment (no browser download), so visual smoke could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a4010b5cc832786ec55d19b9c6e7c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a resizable instrument detail drawer with pointer and keyboard controls.
  - Drawer width is restored between sessions and adapts to viewport size.
  - Added expand/restore controls and an accessible resize separator.
  - Improved accessibility with a labelled close button.

- **Bug Fixes**
  - Drawer width is now constrained to suitable minimum and maximum limits across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->