### PR TITLE
Aggregate 'All accounts' holdings by ticker and tighten virtualized table rows

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -19,6 +19,7 @@ import { getGrowthStage } from "../utils/growthStage";
 import { preloadInstrumentHistory } from "../hooks/useInstrumentHistory";
 
 const VIEW_PRESET_STORAGE_KEY = "holdingsTableViewPreset";
+const ESTIMATED_ROW_HEIGHT = 32;
 
 type HoldingsTableRow = Holding & {
   source_account?: string;
@@ -233,7 +234,7 @@ export function HoldingsTable({
   const rowVirtualizer = useVirtualizer({
     count: sortedRows.length,
     getScrollElement: () => tableContainerRef.current,
-    estimateSize: () => 40,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
     overscan: 5,
     scrollMargin: headerHeight,
   });
@@ -244,7 +245,11 @@ export function HoldingsTable({
     : 0;
   const items = virtualRows.length
     ? virtualRows
-    : sortedRows.map((_, index) => ({ index, start: index * 40, end: (index + 1) * 40 }));
+    : sortedRows.map((_, index) => ({
+        index,
+        start: index * ESTIMATED_ROW_HEIGHT,
+        end: (index + 1) * ESTIMATED_ROW_HEIGHT,
+      }));
 
   return (
     <>
@@ -503,6 +508,8 @@ export function HoldingsTable({
             };
             return (
               <tr
+                ref={rowVirtualizer.measureElement}
+                data-index={virtualRow.index}
                 key={h.row_key ?? h.ticker + h.acquired_date}
                 onClick={onSelectInstrument ? handleSelect : undefined}
                 className={onSelectInstrument ? tableStyles.clickable : undefined}

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -18,6 +18,7 @@ import lazyWithDelay from "../utils/lazyWithDelay";
 import PortfolioDashboardSkeleton from "./skeletons/PortfolioDashboardSkeleton";
 import TextSkeleton from "./skeletons/TextSkeleton";
 import { useFetch } from "../hooks/useFetch";
+import { aggregateHoldingsByTicker } from "../utils/aggregateHoldings";
 import {
   ResponsiveContainer,
   BarChart,
@@ -332,7 +333,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
     (sum, account) => sum + account.value_estimate_gbp,
     0,
   );
-  const scopedHoldings = scopedAccounts.flatMap((account) => {
+  const accountHoldings = scopedAccounts.flatMap((account) => {
     const originalIndex = data.accounts.indexOf(account);
     const sourceKey = accountKey(account, originalIndex);
     return account.holdings.map((holding, holdingIndex) => ({
@@ -341,6 +342,10 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
       row_key: `${sourceKey}-${holdingIndex}`,
     }));
   });
+  const scopedHoldings =
+    activeAccount === "all"
+      ? aggregateHoldingsByTicker(accountHoldings, data.as_of)
+      : accountHoldings;
 
   const asOfDate = data.as_of ? new Date(data.as_of) : null;
   const todayIso = formatDateISO(new Date());
@@ -605,7 +610,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
               </div>
               <HoldingsTable
                 holdings={scopedHoldings}
-                showAccount={activeAccount === "all"}
+                showAccount={false}
                 onSelectInstrument={(ticker, name) =>
                   setSelectedInstrument({ ticker, name })
                 }

--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -4,7 +4,8 @@
 }
 
 .scrollContainer {
-  overflow-x: auto;
+  max-height: min(70vh, 48rem);
+  overflow: auto;
   scrollbar-color: rgba(71, 85, 105, 0.8) rgba(148, 163, 184, 0.2);
   scrollbar-gutter: stable;
 }
@@ -22,6 +23,12 @@
 
 .cell {
   padding: 4px 6px;
+  line-height: 1.25;
+  vertical-align: middle;
+}
+
+.cell svg {
+  display: block;
 }
 
 .name {

--- a/frontend/src/utils/aggregateHoldings.ts
+++ b/frontend/src/utils/aggregateHoldings.ts
@@ -1,0 +1,77 @@
+import type { Holding } from "../types";
+
+export type ScopedHolding = Holding & {
+  source_account?: string;
+  row_key: string;
+};
+
+const sum = (values: Array<number | null | undefined>): number =>
+  values.reduce<number>((total, value) => total + (value ?? 0), 0);
+
+/**
+ * Combine account lots into one portfolio-level position per ticker.
+ *
+ * Dates and eligibility describe the oldest lot: its acquisition date is the
+ * earliest date, days held is recalculated at the portfolio snapshot, and its
+ * eligibility metadata is retained. Instrument metadata and prices come from
+ * the first lot because they describe the ticker rather than an account lot.
+ */
+export const aggregateHoldingsByTicker = (
+  holdings: ScopedHolding[],
+  asOf: string,
+): ScopedHolding[] => {
+  const grouped = new Map<string, ScopedHolding[]>();
+  holdings.forEach((holding) => {
+    const lots = grouped.get(holding.ticker) ?? [];
+    lots.push(holding);
+    grouped.set(holding.ticker, lots);
+  });
+
+  return Array.from(grouped, ([ticker, lots]) => {
+    const first = lots[0];
+    const datedLots = lots
+      .filter(
+        (lot) =>
+          lot.acquired_date && !Number.isNaN(Date.parse(lot.acquired_date)),
+      )
+      .sort(
+        (left, right) =>
+          Date.parse(left.acquired_date!) - Date.parse(right.acquired_date!),
+      );
+    const oldest = datedLots[0] ?? first;
+    const acquiredDate = oldest.acquired_date ?? null;
+    const snapshotTime = Date.parse(asOf);
+    const acquiredTime = acquiredDate ? Date.parse(acquiredDate) : Number.NaN;
+    const daysHeld =
+      Number.isNaN(snapshotTime) || Number.isNaN(acquiredTime)
+        ? oldest.days_held
+        : Math.max(0, Math.floor((snapshotTime - acquiredTime) / 86_400_000));
+    const costBasis = sum(
+      lots.map((lot) =>
+        (lot.cost_basis_gbp ?? 0) > 0
+          ? lot.cost_basis_gbp
+          : lot.effective_cost_basis_gbp,
+      ),
+    );
+    const gain = sum(lots.map((lot) => lot.gain_gbp));
+
+    return {
+      ...first,
+      ticker,
+      units: sum(lots.map((lot) => lot.units)),
+      market_value_gbp: sum(lots.map((lot) => lot.market_value_gbp)),
+      cost_basis_gbp: costBasis,
+      effective_cost_basis_gbp: costBasis,
+      gain_gbp: gain,
+      gain_pct: costBasis ? (gain / costBasis) * 100 : 0,
+      day_change_gbp: sum(lots.map((lot) => lot.day_change_gbp)),
+      acquired_date: acquiredDate,
+      days_held: daysHeld,
+      sell_eligible: oldest.sell_eligible,
+      days_until_eligible: oldest.days_until_eligible,
+      next_eligible_sell_date: oldest.next_eligible_sell_date,
+      source_account: undefined,
+      row_key: `all-${ticker}`,
+    };
+  });
+};

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { PortfolioView } from "@/components/PortfolioView";
+import { aggregateHoldingsByTicker } from "@/utils/aggregateHoldings";
 import type { Portfolio } from "@/types";
 import { configContext } from "@/ConfigContext";
 
@@ -34,7 +35,7 @@ describe("PortfolioView", () => {
                 value_estimate_gbp: 0,
                 last_updated: "2025-07-24",
                 holdings: [
-                    { ticker: "SHARED", name: "ISA holding", units: 1, market_value_gbp: 10 },
+                    { ticker: "SHARED", name: "Shared holding", units: 1, market_value_gbp: 10, cost_basis_gbp: 8, gain_gbp: 2, gain_pct: 25, day_change_gbp: 1 },
                 ],
             },
             {
@@ -43,13 +44,31 @@ describe("PortfolioView", () => {
                 value_estimate_gbp: 14925,
                 last_updated: "2025-07-15",
                 holdings: [
-                    { ticker: "SHARED", name: "SIPP holding", units: 2, market_value_gbp: 20 },
+                    { ticker: "SHARED", name: "Shared holding", units: 2, market_value_gbp: 20, effective_cost_basis_gbp: 10, gain_gbp: 10, gain_pct: 100, day_change_gbp: 3 },
                 ],
             },
         ],
     };
 
-    it("renders one tabbed holdings view and identifies source accounts", () => {
+    it("sums day change and uses effective cost when aggregating account lots", () => {
+        const [combined] = aggregateHoldingsByTicker(
+            [
+                { ticker: "SHARED", name: "Shared", units: 1, market_value_gbp: 10, cost_basis_gbp: 8, gain_gbp: 2, gain_pct: 25, day_change_gbp: 1, row_key: "isa-0" },
+                { ticker: "SHARED", name: "Shared", units: 2, market_value_gbp: 20, effective_cost_basis_gbp: 10, gain_gbp: 10, gain_pct: 100, day_change_gbp: 3, row_key: "sipp-0" },
+            ],
+            "2025-07-29",
+        );
+
+        expect(combined).toMatchObject({
+            market_value_gbp: 30,
+            cost_basis_gbp: 18,
+            gain_gbp: 12,
+            gain_pct: 12 / 18 * 100,
+            day_change_gbp: 4,
+        });
+    });
+
+    it("combines matching tickers and recomputes totals in the all-accounts tab", () => {
         render(<PortfolioView data={mockOwner}/>);
 
         expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
@@ -57,10 +76,13 @@ describe("PortfolioView", () => {
             "ISA",
             "SIPP",
         ]);
-        expect(screen.getByRole("columnheader", { name: "Account" })).toBeInTheDocument();
-        expect(screen.getAllByText("SHARED")).toHaveLength(2);
-        expect(screen.getByText("ISA holding")).toBeInTheDocument();
-        expect(screen.getByText("SIPP holding")).toBeInTheDocument();
+        expect(screen.queryByRole("columnheader", { name: "Account" })).not.toBeInTheDocument();
+        expect(screen.getAllByText("SHARED")).toHaveLength(1);
+        const row = screen.getByText("SHARED").closest("tr")!;
+        expect(within(row).getByText("3")).toBeInTheDocument();
+        expect(within(row).getByText("£30.00")).toBeInTheDocument();
+        expect(within(row).getByText("£12.00")).toBeInTheDocument();
+        expect(within(row).getByText("66.7%")).toBeInTheDocument();
     });
 
     it("updates holdings and total when the active account tab changes", () => {
@@ -72,13 +94,14 @@ describe("PortfolioView", () => {
         fireEvent.click(screen.getByRole("tab", { name: "ISA" }));
 
         expect(total).toHaveTextContent("£0.00");
-        expect(screen.getByText("ISA holding")).toBeInTheDocument();
-        expect(screen.queryByText("SIPP holding")).not.toBeInTheDocument();
+        expect(screen.getByText("Shared holding")).toBeInTheDocument();
+        expect(screen.getAllByText("SHARED")).toHaveLength(1);
         expect(screen.queryByRole("columnheader", { name: "Account" })).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("tab", { name: "SIPP" }));
         expect(total).toHaveTextContent("£14,925.00");
-        expect(screen.getByText("SIPP holding")).toBeInTheDocument();
+        expect(screen.getByText("Shared holding")).toBeInTheDocument();
+        expect(screen.getAllByText("SHARED")).toHaveLength(1);
     });
 
     it("resets the active account tab to 'all' when the owner changes even if the new owner has a colliding account key", () => {


### PR DESCRIPTION
Closes #6291 
Closes #6292 

### Motivation

- The "All accounts" holdings view currently shows one row per (ticker, account) pair instead of a single combined row per ticker, making the table unnecessarily long and hiding total positions. 
- The TanStack virtualizer was using an incorrect static row height (40px) while real rows measured larger, causing visual spacing and scroll-jump issues. 

### Description

- Add a new aggregation utility `frontend/src/utils/aggregateHoldings.ts` that groups lots by `ticker`, sums `units`, `market_value_gbp`, `cost_basis_gbp`/`effective_cost_basis_gbp`, `gain_gbp`, and `day_change_gbp`, recomputes `gain_pct` from summed gain/cost, and uses the oldest lot for date/eligibility conventions. 
- Apply aggregation in `PortfolioView.tsx` only when `activeAccount === "all"`, keep per-account tabs unchanged, and hide the redundant `Account` column in the combined view. 
- Reduce the virtualizer estimate to 32px, wire `rowVirtualizer.measureElement` on each `<tr>`, bound the vertical scroll area and tighten table cell CSS (`frontend/src/styles/table.module.css`) to remove excess vertical whitespace while preserving the sticky header and sparklines. 
- Update unit tests in `frontend/tests/unit/components/PortfolioView.test.tsx` to cover aggregation math and tab behavior and adjust expectations; small changes were made to `HoldingsTable.tsx` to support measurement. 
- Closes `#6291` and `#6292`. 

### Testing

- Ran type-check with `npm --prefix frontend run type-check` and it passed. 
- Ran linter with `npm --prefix frontend run lint` and it passed. 
- Ran unit tests with `npm --prefix frontend run test -- --run tests/unit/components/PortfolioView.test.tsx tests/unit/components/HoldingsTable.test.tsx` and the suite for the affected tests passed (39 tests passed). 
- Built a preview with `npm --prefix frontend run build:preview` which succeeded. 
- Attempted to capture a Playwright screenshot (`npx --prefix frontend playwright test ...`) but browser download failed due to the Playwright CDN returning HTTP 403 so no screenshot could be attached.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a3ff8069c832798b10ab24aad9219)