### PR TITLE
Fix DeepSeek PR review race that can drop reviews silently

### DIFF
--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -12,8 +12,22 @@ on:
 # still executing when a newer event arrives, so branch protection and the
 # checks UI settle on a single up-to-date result per SHA instead of
 # accumulating stale ones from earlier label toggles or pushes.
+#
+# The group key is only shared across events that can actually produce a
+# review (opened/reopened/synchronize, plus labeled/unlabeled on "Deep
+# Review Required"). A labeled/unlabeled event on any *other* label (e.g. a
+# PR created with "codex" already attached, which fires "opened" and
+# "labeled" back-to-back) is a no-op per the job's `if` below and gets its
+# own unique group via github.run_id, so it can never cancel a real,
+# in-progress review run (#6313). Without this, that no-op run could win
+# the race against the substantive run and leave the PR with no review
+# posted at all.
 concurrency:
-  group: deepseek-pr-review-${{ github.event.pull_request.number }}
+  group: >-
+    ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+    github.event.label.name != 'Deep Review Required' &&
+    format('deepseek-pr-review-noop-{0}', github.run_id) ||
+    format('deepseek-pr-review-{0}', github.event.pull_request.number) }}
   # cancel-in-progress is safe here because this workflow has only one job (ai-review).
   # No other jobs have side effects (deployments, state mutations, cleanup) that would
   # be dangerous to interrupt. If additional jobs are added, reassess this setting.


### PR DESCRIPTION
Closes #6313

## Summary
- A PR opened with a non-"Deep Review Required" label already attached (e.g. `codex`) fires both `opened` and `labeled` events at nearly the same instant. Both runs shared one PR-scoped concurrency group with `cancel-in-progress: true`, so the no-op `labeled` run (job skips per its own `if`) could win the race and cancel the substantive `opened`-event run before it finished — leaving no DeepSeek review posted at all. This is what happened on [#6312](https://github.com/leonarduk/allotmint/pull/6312).
- Scope the concurrency `group` key so it's shared only across events that can actually produce a review (`opened`/`reopened`/`synchronize`, plus `labeled`/`unlabeled` on `Deep Review Required`). A `labeled`/`unlabeled` event on any other label gets its own unique group keyed on `github.run_id`, so it can never cancel a real in-progress run.
- The existing "Deep Review Required" label upgrade-cancel behavior (documented in the surrounding comment) is preserved unchanged.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deepseek-pr-review.yml'))"` — YAML parses.
- [x] `actionlint .github/workflows/deepseek-pr-review.yml` — no lint errors.
- [ ] Confirm on a follow-up PR opened with a non-"Deep Review Required" label already attached that the DeepSeek review actually posts.