### PR TITLE
Docs: clarify graphify hotspot and require S3 write failures be surfaced in ISSUE_6297 plan

### DIFF
--- a/docs/ISSUE_6297_INSTRUMENT_UNIVERSE_PLAN.md
+++ b/docs/ISSUE_6297_INSTRUMENT_UNIVERSE_PLAN.md
@@ -31,9 +31,12 @@ and persistence boundary.
 - `uk_sector_endpoint` and `default_sector_region` configure market-sector
   performance, not constituent discovery. They provide no reusable licensing or
   ingestion convention.
-- The graphify snapshot does not identify `backend/common/instruments.py` as a
-  high-fan-in hotspot. It is still manually refreshed and must not replace source
-  inspection when issue 6296 lands.
+- The graphify snapshot identifies `get_instrument_meta()` as a high-fan-in
+  function (degree 52), even though the finding is function-level rather than a
+  verdict on the whole `backend/common/instruments.py` module. Changes around
+  this read/enrichment boundary therefore warrant focused regression testing.
+  The snapshot is manually refreshed and must not replace source inspection when
+  issue 6296 lands.
 
 ## Data-source decision gate
 
@@ -91,6 +94,14 @@ ticker, resolves metadata, validates required fields, and persists through
 `save_instrument_meta()`. Return a structured result such as `created`, `updated`,
 `unchanged`, `skipped`, or `failed` with a reason. Required success fields for
 this issue are non-empty `name`, `currency`, `ticker`, and `exchange`.
+
+Before that service reports `created` or `updated`, strengthen the persistence
+boundary so it exposes the outcome for every configured target. In particular,
+when `METADATA_BUCKET` is configured, an S3 `put_object` failure must be returned
+as an explicit failure or raised to the caller; a successful local write must not
+mask it. The batch must classify that ticker as failed, remain eligible for retry,
+and include the failed target in its report. Tests should cover local-only,
+S3-only/read-only-local, dual-write success, and local-success/S3-failure cases.
 
 Keep membership snapshot storage and metadata enrichment as separate stages. This
 makes source parsing deterministic and testable without Yahoo, and lets a failed


### PR DESCRIPTION
### Motivation

- The original plan understated the graphify finding; the doc should reflect that `get_instrument_meta()` is a function-level high-fan-in hotspot to better guide risk/regression testing. 
- The design must not allow a successful local write to mask an S3 persistence failure, so the plan should require the persistence boundary to surface S3 outcomes before enrichment reports success.

### Description

- Updated `docs/ISSUE_6297_INSTRUMENT_UNIVERSE_PLAN.md` to correct the graphify conclusion, explicitly calling out `get_instrument_meta()` as a degree-52 high-fan-in function and recommending focused regression testing around the read/enrichment boundary. 
- Added persistence-boundary guidance that requires S3 `put_object` failures to be returned or raised (not masked by a local write) and enumerated persistence scenarios to be covered by tests (local-only, S3-only/read-only-local, dual-write success, and local-success/S3-failure).
- Kept the change documentation-only and confined to the plan text and test guidance; no runtime code changes were introduced.

### Testing

- Ran `git diff --cached --check` on the staged changes and it passed without indexable issues. 
- Verified the graphify entry using `jq -e '.gods[] | select(.id == "backend_common_instruments_get_instrument_meta" and .degree == 52)'` which succeeded. 
- Inspected repository references to S3 and `put_object` with `rg -n "put_object|except Exception.*best effort|return path" backend/common/instruments.py` to confirm the doc guidance aligns with existing persistence behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ac9d7d0fc8327bc932b9eae971c89)