### PR TITLE
Highlight selected holding row while details are open

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -30,6 +30,7 @@ type Props = {
   holdings: HoldingsTableRow[];
   showAccount?: boolean;
   onSelectInstrument?: (ticker: string, name: string) => void;
+  selectedTicker?: string;
   showForward7d?: boolean;
   showForward30d?: boolean;
   onAddPosition?: () => void;
@@ -40,6 +41,7 @@ export function HoldingsTable({
   holdings,
   showAccount = false,
   onSelectInstrument,
+  selectedTicker,
   showForward7d = false,
   showForward30d = false,
   onAddPosition,
@@ -527,6 +529,7 @@ export function HoldingsTable({
           )}
           {items.map((virtualRow) => {
             const h = sortedRows[virtualRow.index];
+            const isSelected = h.ticker === selectedTicker;
             const handleSelect = () => {
               onSelectInstrument?.(h.ticker, h.name ?? h.ticker);
             };
@@ -541,7 +544,13 @@ export function HoldingsTable({
                 data-index={virtualRow.index}
                 key={h.row_key ?? h.ticker + h.acquired_date}
                 onClick={onSelectInstrument ? handleSelect : undefined}
-                className={onSelectInstrument ? tableStyles.clickable : undefined}
+                aria-selected={isSelected || undefined}
+                className={[
+                  onSelectInstrument ? tableStyles.clickable : undefined,
+                  isSelected ? tableStyles.selected : undefined,
+                ]
+                  .filter(Boolean)
+                  .join(" ") || undefined}
               >
                 {showAccount && (
                   <td className={tableStyles.cell}>{h.source_account}</td>

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -614,6 +614,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
                 onSelectInstrument={(ticker, name) =>
                   setSelectedInstrument({ ticker, name })
                 }
+                selectedTicker={selectedInstrument?.ticker}
                 showForward7d={showForward7d}
                 showForward30d={showForward30d}
                 onAddPosition={() =>

--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -77,6 +77,11 @@
   cursor: pointer;
 }
 
+.selected {
+  background-color: rgba(59, 130, 246, 0.16);
+  box-shadow: inset 3px 0 0 #3b82f6;
+}
+
 .badge {
   margin-left: 0.25rem;
   background-color: #444;

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -218,6 +218,16 @@ describe("HoldingsTable", () => {
         expect(screen.getAllByTestId(/^sparkline/)).toHaveLength(holdings.length);
     });
 
+    it("marks only the row matching the selected ticker as selected", async () => {
+        renderWithConfig(<HoldingsTable holdings={holdings} selectedTicker="XYZ" />);
+
+        const selectedRow = (await screen.findByText("Test Holding")).closest("tr");
+        const otherRow = screen.getByText("Alpha").closest("tr");
+
+        expect(selectedRow).toHaveAttribute("aria-selected", "true");
+        expect(otherRow).not.toHaveAttribute("aria-selected");
+    });
+
     it("shows days to go if not eligible", async () => {
         render(<HoldingsTable holdings={holdings}/>);
         const row = (await screen.findByText("Test Holding")).closest("tr");

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -21,6 +21,15 @@ vi.mock("@/components/PerformanceDashboard", () => ({
   default: () => <div data-testid="performance-dashboard" />,
 }));
 
+vi.mock("@/components/InstrumentDetail", () => ({
+  InstrumentDetail: ({ ticker, onClose }: { ticker: string; onClose: () => void }) => (
+    <aside>
+      <span>Details for {ticker}</span>
+      <button type="button" onClick={onClose}>Close instrument details</button>
+    </aside>
+  ),
+}));
+
 describe("PortfolioView", () => {
     const mockOwner: Portfolio = {
         owner: "steve",
@@ -83,6 +92,21 @@ describe("PortfolioView", () => {
         expect(within(row).getByText("£30.00")).toBeInTheDocument();
         expect(within(row).getByText("£12.00")).toBeInTheDocument();
         expect(within(row).getByText("66.7%")).toBeInTheDocument();
+    });
+
+    it("highlights the detail row until the instrument drawer is closed", () => {
+        render(<PortfolioView data={mockOwner}/>);
+
+        const row = screen.getByText("SHARED").closest("tr")!;
+        fireEvent.click(row);
+
+        expect(screen.getByText("Details for SHARED")).toBeInTheDocument();
+        expect(row).toHaveAttribute("aria-selected", "true");
+
+        fireEvent.click(screen.getByRole("button", { name: "Close instrument details" }));
+
+        expect(screen.queryByText("Details for SHARED")).not.toBeInTheDocument();
+        expect(row).not.toHaveAttribute("aria-selected");
     });
 
     it("updates holdings and total when the active account tab changes", () => {


### PR DESCRIPTION
### Motivation

- Improve UX by visually linking the holdings table row to the instrument detail drawer so users can see which row the drawer corresponds to.
- Use existing `selectedInstrument` state from `PortfolioView` to avoid introducing new cross-component state.

### Description

- Add an optional `selectedTicker?: string` prop to `HoldingsTable` and compute a per-row `isSelected` flag when rendering rows.
- Apply `aria-selected` and a `selected` CSS class to the matching row and keep existing `clickable` behavior; add `.selected` styles to `frontend/src/styles/table.module.css` to provide a blue-tinted background and inset accent bar.
- Pass `selectedInstrument?.ticker` from `PortfolioView` into `HoldingsTable` so opening/closing the instrument drawer controls the highlight.
- Add/adjust unit tests to cover the behavior in `HoldingsTable.test.tsx` and `PortfolioView.test.tsx` to assert selection is applied and cleared on drawer open/close, and keep the change backwards-compatible because `selectedTicker` is optional.
- Closes #6348

### Testing

- Ran the targeted frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/components/HoldingsTable.test.tsx tests/unit/components/PortfolioView.test.tsx`, and all tests passed (42 tests across the two files).
- Ran lint via `npm --prefix frontend run lint` which completed successfully.
- Ran TypeScript checks via `npm --prefix frontend run type-check` which completed successfully.
- Attempted to install Playwright browsers (`npm --prefix frontend exec playwright install chromium`) for screenshot/smoke capture but the download failed in this environment (HTTP 403), so browser-based smoke assertions/screenshots were not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae18f89f883279b1050957a180777)