### PR TITLE
Instrument detail drawer: fix stacking, extract viewport hook, and add interaction tests

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -249,6 +249,7 @@ export function InstrumentDetail({
             padding: "1rem",
             overflowY: "auto" as const,
             boxShadow: "-4px 0 8px rgba(0,0,0,0.5)",
+            zIndex: 1000,
           }
         : {
             position: "relative" as const,

--- a/frontend/src/components/useInstrumentDetailDrawer.ts
+++ b/frontend/src/components/useInstrumentDetailDrawer.ts
@@ -6,6 +6,7 @@ import {
   DRAWER_WIDTH_KEY,
   expandedDrawerWidth,
 } from "./instrumentDetailDrawer";
+import { useViewportWidth } from "@/hooks/useViewportWidth";
 
 const reportStorageError = (action: "read" | "write", error: unknown) => {
   console.warn(`Unable to ${action} the instrument detail drawer width`, error);
@@ -36,20 +37,13 @@ const persistDrawerWidth = (width: number) => {
 
 export const useInstrumentDetailDrawer = (enabled: boolean) => {
   const [width, setWidth] = useState(readDrawerWidth);
-  const [viewportWidth, setViewportWidth] = useState(() =>
-    typeof window === "undefined" ? DEFAULT_DRAWER_WIDTH : window.innerWidth,
-  );
+  const viewportWidth = useViewportWidth(enabled);
   const dragStart = useRef<{ pointerX: number; width: number } | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
-    const handleViewportResize = () => {
-      setViewportWidth(window.innerWidth);
-      setWidth((currentWidth) => clampDrawerWidth(currentWidth, window.innerWidth));
-    };
-    window.addEventListener("resize", handleViewportResize);
-    return () => window.removeEventListener("resize", handleViewportResize);
-  }, [enabled]);
+    setWidth((currentWidth) => clampDrawerWidth(currentWidth, viewportWidth));
+  }, [enabled, viewportWidth]);
 
   const resizeToPointer = useCallback((clientX: number) => {
     if (!dragStart.current) return null;

--- a/frontend/src/hooks/useViewportWidth.ts
+++ b/frontend/src/hooks/useViewportWidth.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+import { DEFAULT_DRAWER_WIDTH } from "@/components/instrumentDetailDrawer";
+
+export const useViewportWidth = (enabled = true): number => {
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    typeof window === "undefined" ? DEFAULT_DRAWER_WIDTH : window.innerWidth,
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleResize = () => setViewportWidth(window.innerWidth);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [enabled]);
+
+  return viewportWidth;
+};

--- a/frontend/tests/unit/components/InstrumentDetail.test.tsx
+++ b/frontend/tests/unit/components/InstrumentDetail.test.tsx
@@ -83,6 +83,22 @@ describe("InstrumentDetail", () => {
     mockGetInstrumentIntraday.mockReset();
   });
 
+  it("renders the drawer above page content", async () => {
+    mockGetInstrumentDetail.mockResolvedValue({ prices: [], positions: [], currency: null });
+    mockGetInstrumentIntraday.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <InstrumentDetail ticker="ABC.L" name="ABC" onClose={() => {}} />
+      </MemoryRouter>,
+    );
+
+    const separator = await screen.findByRole("separator", {
+      name: "Resize instrument details",
+    });
+    expect(separator.parentElement).toHaveStyle({ zIndex: "1000", background: "#111" });
+  });
+
   it("shows accessible loading skeletons before the instrument detail resolves", async () => {
     let resolveDetail: (value: { prices: unknown[]; positions: unknown[]; currency: null }) => void;
     mockGetInstrumentDetail.mockReturnValue(

--- a/frontend/tests/unit/components/useInstrumentDetailDrawer.test.tsx
+++ b/frontend/tests/unit/components/useInstrumentDetailDrawer.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_DRAWER_WIDTH,
+  expandedDrawerWidth,
+} from "@/components/instrumentDetailDrawer";
+import { useInstrumentDetailDrawer } from "@/components/useInstrumentDetailDrawer";
+
+const DrawerHarness = () => {
+  const drawer = useInstrumentDetailDrawer(true);
+  return (
+    <>
+      <output aria-label="Drawer width">{Math.round(drawer.width)}</output>
+      <div
+        aria-label="Resize drawer"
+        role="separator"
+        tabIndex={0}
+        onPointerDown={drawer.handlePointerDown}
+        onPointerMove={drawer.handlePointerMove}
+        onPointerUp={drawer.handlePointerUp}
+        onKeyDown={drawer.handleKeyDown}
+      />
+      <button type="button" onClick={drawer.toggleExpanded}>Toggle</button>
+    </>
+  );
+};
+
+const setViewportWidth = (width: number) => {
+  vi.spyOn(window, "innerWidth", "get").mockReturnValue(width);
+};
+
+const renderDrawer = (storedWidth = DEFAULT_DRAWER_WIDTH) => {
+  window.localStorage.setItem("allotmint.instrumentDetail.drawerWidth", String(storedWidth));
+  render(<DrawerHarness />);
+  const separator = screen.getByRole("separator");
+  Object.assign(separator, {
+    setPointerCapture: vi.fn(),
+    hasPointerCapture: vi.fn(() => true),
+    releasePointerCapture: vi.fn(),
+  });
+  return separator;
+};
+
+describe("useInstrumentDetailDrawer", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    setViewportWidth(1_000);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("resizes and persists the width after a pointer drag", () => {
+    const separator = renderDrawer();
+
+    fireEvent.pointerDown(separator, { clientX: 600, pointerId: 1 });
+    fireEvent.pointerMove(separator, { clientX: 500, pointerId: 1 });
+    expect(screen.getByLabelText("Drawer width")).toHaveTextContent("520");
+    fireEvent.pointerUp(separator, { clientX: 480, pointerId: 1 });
+
+    expect(screen.getByLabelText("Drawer width")).toHaveTextContent("540");
+    expect(window.localStorage.getItem("allotmint.instrumentDetail.drawerWidth")).toBe("540");
+  });
+
+  it("resizes by keyboard arrow increments", () => {
+    const separator = renderDrawer();
+    fireEvent.keyDown(separator, { key: "ArrowLeft" });
+    expect(screen.getByLabelText("Drawer width")).toHaveTextContent("440");
+    fireEvent.keyDown(separator, { key: "ArrowRight" });
+    expect(screen.getByLabelText("Drawer width")).toHaveTextContent("420");
+  });
+
+  it("toggles between restored and expanded widths", () => {
+    renderDrawer();
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+    expect(screen.getByLabelText("Drawer width")).toHaveTextContent("600");
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+    expect(screen.getByLabelText("Drawer width")).toHaveTextContent("420");
+  });
+
+  it("clamps the drawer when the viewport shrinks", () => {
+    renderDrawer(700);
+    setViewportWidth(500);
+    fireEvent(window, new Event("resize"));
+    expect(screen.getByLabelText("Drawer width")).toHaveTextContent("484");
+  });
+
+  it("collapses at the exact expanded width and expands below the comparison boundary", () => {
+    const threshold = expandedDrawerWidth(window.innerWidth);
+    window.localStorage.setItem("allotmint.instrumentDetail.drawerWidth", String(threshold));
+    const { unmount } = render(<DrawerHarness />);
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+    expect(screen.getByLabelText("Drawer width")).toHaveTextContent("420");
+    unmount();
+
+    window.localStorage.setItem("allotmint.instrumentDetail.drawerWidth", String(threshold - 2));
+    render(<DrawerHarness />);
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+    expect(screen.getByLabelText("Drawer width")).toHaveTextContent("600");
+  });
+});

--- a/frontend/tests/unit/hooks/useViewportWidth.test.tsx
+++ b/frontend/tests/unit/hooks/useViewportWidth.test.tsx
@@ -1,0 +1,22 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useViewportWidth } from "@/hooks/useViewportWidth";
+
+describe("useViewportWidth", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("tracks viewport resizes and removes its listener on unmount", () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(1_200);
+    const removeEventListener = vi.spyOn(window, "removeEventListener");
+    const { result, unmount } = renderHook(() => useViewportWidth());
+
+    expect(result.current).toBe(1_200);
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(900);
+    act(() => window.dispatchEvent(new Event("resize")));
+    expect(result.current).toBe(900);
+
+    unmount();
+    expect(removeEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+  });
+});


### PR DESCRIPTION
### Motivation

- Fix a UX bug where the instrument detail drawer bled through page content and its thin pointer resize handle could be obscured and not receive pointer events. 
- Improve maintainability by extracting viewport-width tracking so multiple components can share deterministic resize behavior. 
- Add interaction tests to cover pointer drag, keyboard resizing, expansion toggles, viewport clamping, and the expansion-threshold boundary to prevent regressions.

### Description

- Add an explicit `zIndex: 1000` to the drawer container so the fixed overlay renders above other page content (updated `frontend/src/components/InstrumentDetail.tsx`).
- Extract viewport tracking into a reusable hook `useViewportWidth` in `frontend/src/hooks/useViewportWidth.ts` and wire it into the drawer logic (updated `frontend/src/components/useInstrumentDetailDrawer.ts`).
- Update `useInstrumentDetailDrawer` to clamp width on viewport changes and to consume `useViewportWidth` instead of managing `window.innerWidth` directly (updated `frontend/src/components/useInstrumentDetailDrawer.ts`).
- Add unit tests for interaction paths: `frontend/tests/unit/components/useInstrumentDetailDrawer.test.tsx` (pointer drag, keyboard, toggle expand/restore, clamping, threshold behavior), `frontend/tests/unit/hooks/useViewportWidth.test.tsx` (resize tracking and cleanup), and a regression assertion in `frontend/tests/unit/components/InstrumentDetail.test.tsx` asserting the drawer stacks above content.
- This PR addresses and closes issues: Closes #6346, Closes #6322, Closes #6323, Closes #6325.

### Testing

- Ran frontend linting with `npm --prefix frontend run lint` which completed without errors.
- Performed type checking with `npm --prefix frontend run type-check` which completed successfully.
- Ran unit tests with `npm --prefix frontend run test -- --run` on the modified test files and observed all tests pass: 3 test files and 19 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae279c36483279618491f6eb54122)