### PR TITLE
Holdings table uses full width when instrument drawer is closed (fix #6347)

### DIFF
--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -395,7 +395,7 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
 
   return (
     <div className="space-y-6">
-      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+      <div className="grid grid-cols-1 gap-6">
         <section className="rounded-lg border border-gray-800 bg-gray-900/70 p-4 md:p-6">
           {!familyMvpEnabled && (
             <form

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -85,6 +85,16 @@ describe("PortfolioView", () => {
         expect(within(row).getByText("66.7%")).toBeInTheDocument();
     });
 
+    it("allows the holdings section to use the full portfolio width", () => {
+        render(<PortfolioView data={mockOwner} />);
+
+        const holdings = screen.getByRole("region", { name: "Portfolio holdings" });
+        const layout = holdings.parentElement?.parentElement;
+
+        expect(layout).toHaveClass("grid-cols-1");
+        expect(layout?.className).not.toContain("xl:grid-cols-");
+    });
+
     it("updates holdings and total when the active account tab changes", () => {
         render(<PortfolioView data={mockOwner}/>);
 

--- a/frontend/tests/unit/components/PortfolioView.test.tsx
+++ b/frontend/tests/unit/components/PortfolioView.test.tsx
@@ -102,6 +102,8 @@ describe("PortfolioView", () => {
 
         expect(layout).toHaveClass("grid-cols-1");
         expect(layout?.className).not.toContain("xl:grid-cols-");
+    });
+
     it("highlights the detail row until the instrument drawer is closed", () => {
         render(<PortfolioView data={mockOwner}/>);
 


### PR DESCRIPTION
### Motivation

- The holdings table was permanently capped at ~60% width by an `xl` two-column grid that reserved space for an instrument detail pane which is actually rendered as a fixed overlay, wasting horizontal space on wide viewports and causing truncated/ellipsized columns.

### Description

- Remove the unconditional `xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]` grid from `frontend/src/components/PortfolioView.tsx` so the holdings section can expand to the full available width (`grid grid-cols-1 gap-6` is used instead).
- Add a regression unit test in `frontend/tests/unit/components/PortfolioView.test.tsx` that asserts the holdings region is rendered inside a `grid-cols-1` layout and no `xl:grid-cols-` cap is present.
- Files changed: `frontend/src/components/PortfolioView.tsx`, `frontend/tests/unit/components/PortfolioView.test.tsx`.
- Closes #6347

### Testing

- Ran the targeted frontend unit tests: `npm --prefix frontend run test -- --run tests/unit/components/PortfolioView.test.tsx` and all tests passed (`19 tests passed`).
- Ran lint: `npm --prefix frontend run lint -- --quiet` and it completed with no errors.
- Ran type-check: `npm --prefix frontend run type-check` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae343017c8327a94461cb3da6619a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the portfolio view to use a single-column layout across all screen sizes.
  * Portfolio holdings now use the full available width for improved consistency and readability.

* **Tests**
  * Added coverage confirming the holdings section remains single-column without a wide-screen split layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->