### PR TITLE
Derive portfolio type filters and extract holdings filter controls

### DIFF
--- a/frontend/src/components/HoldingsFilterControls.tsx
+++ b/frontend/src/components/HoldingsFilterControls.tsx
@@ -1,0 +1,83 @@
+import { useTranslation } from 'react-i18next';
+import { RelativeViewToggle } from './RelativeViewToggle';
+
+export type SparkRange = 7 | 30 | 180;
+
+type ViewPreset = {
+  label: string;
+  value: string;
+};
+
+type Props = {
+  sparkRange: SparkRange;
+  onSparkRangeChange: (range: SparkRange) => void;
+  viewPresets: ViewPreset[];
+  viewPreset: string;
+  onViewPresetChange: (preset: string) => void;
+  minimumGain: string;
+  onMinimumGainChange: (value: string) => void;
+  onSellEligible: () => void;
+};
+
+export function HoldingsFilterControls({
+  sparkRange,
+  onSparkRangeChange,
+  viewPresets,
+  viewPreset,
+  onViewPresetChange,
+  minimumGain,
+  onMinimumGainChange,
+  onSellEligible,
+}: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mb-2 flex flex-wrap items-center gap-x-4 gap-y-1">
+      <RelativeViewToggle />
+      <span className="flex items-center gap-1">
+        {t('holdingsTable.range')}
+        {([7, 30, 180] as const).map((days) => (
+          <label key={days} className="ml-1">
+            <input
+              type="radio"
+              name="sparkRange"
+              checked={sparkRange === days}
+              onChange={() => onSparkRangeChange(days)}
+            />
+            {t('holdingsTable.rangeOption', { count: days })}
+          </label>
+        ))}
+      </span>
+      <span className="flex items-center gap-1">
+        {t('holdingsTable.view')}
+        {viewPresets.map((preset) => (
+          <button
+            key={preset.value}
+            type="button"
+            onClick={() => onViewPresetChange(preset.value)}
+            className={`ml-1 ${viewPreset === preset.value ? 'font-bold' : ''} focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500`}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </span>
+      <span className="flex items-center gap-1">
+        {t('holdingsTable.quickFilters')}
+        <button
+          type="button"
+          className="ml-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+          onClick={onSellEligible}
+        >
+          {t('holdingsTable.quickFiltersSellEligible')}
+        </button>
+        <input
+          type="number"
+          placeholder={t('holdingsTable.minimumGainPrompt')}
+          value={minimumGain}
+          onChange={(event) => onMinimumGainChange(event.target.value)}
+          className="ml-1 w-24"
+        />
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -9,7 +9,10 @@ import i18n from "../i18n";
 import { useConfig } from "../ConfigContext";
 import { isSupportedFx } from "../lib/fx";
 import { formatDateISO } from "../lib/date";
-import { RelativeViewToggle } from "./RelativeViewToggle";
+import {
+  HoldingsFilterControls,
+  type SparkRange,
+} from "./HoldingsFilterControls";
 import FilterBar, { useFilterReducer, type FilterState } from "./FilterBar";
 import EmptyState from "./EmptyState";
 import { useNavigate } from "react-router-dom";
@@ -55,15 +58,23 @@ export function HoldingsTable({
     // useNavigate() is only used for the EmptyState screener shortcut.
   }
 
-  const viewPresets = useMemo(
-    () => [
+  const viewPresets = useMemo(() => {
+    const instrumentTypes = new Map<string, string>();
+    holdings.forEach(({ instrument_type: instrumentType }) => {
+      const trimmedType = instrumentType?.trim();
+      if (trimmedType) {
+        instrumentTypes.set(trimmedType.toLocaleLowerCase(), trimmedType);
+      }
+    });
+
+    return [
       { label: t("holdingsTable.viewPresets.all"), value: "" },
-      { label: t("instrumentType.etf"), value: "ETF" },
-      { label: t("instrumentType.equity"), value: "Equity" },
-      { label: t("instrumentType.bond"), value: "Bond" },
-    ],
-    [t],
-  );
+      ...Array.from(instrumentTypes.values()).map((instrumentType) => ({
+        label: translateInstrumentType(t, instrumentType),
+        value: instrumentType,
+      })),
+    ];
+  }, [holdings, t]);
 
   const [filters, dispatchFilters] = useFilterReducer();
 
@@ -81,7 +92,13 @@ export function HoldingsTable({
     gain_pct: true,
   });
 
-  const [sparkRange, setSparkRange] = useState<7 | 30 | 180>(30);
+  const [sparkRange, setSparkRange] = useState<SparkRange>(30);
+
+  useEffect(() => {
+    if (viewPreset && !viewPresets.some(({ value }) => value === viewPreset)) {
+      setViewPreset("");
+    }
+  }, [viewPreset, viewPresets]);
 
   useEffect(() => {
     const tickers = Array.from(new Set(holdings.map((h) => h.ticker)));
@@ -277,53 +294,16 @@ export function HoldingsTable({
       {!familyMvpEnabled && (
         <>
           <FilterBar state={filters} dispatch={dispatchFilters} />
-          <div className="mb-2 flex flex-wrap items-center gap-x-4 gap-y-1">
-            <RelativeViewToggle />
-            <span className="flex items-center gap-1">
-              {t("holdingsTable.range")}
-              {[7, 30, 180].map((d) => (
-                <label key={d} className="ml-1">
-                  <input
-                    type="radio"
-                    name="sparkRange"
-                    checked={sparkRange === d}
-                    onChange={() => setSparkRange(d as 7 | 30 | 180)}
-                  />
-                  {t("holdingsTable.rangeOption", { count: d })}
-                </label>
-              ))}
-            </span>
-            <span className="flex items-center gap-1">
-              {t("holdingsTable.view")}
-              {viewPresets.map((p) => (
-                <button
-                  key={p.label}
-                  type="button"
-                  onClick={() => setViewPreset(p.value)}
-                  className={`ml-1 ${viewPreset === p.value ? 'font-bold' : ''} focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500`}
-                >
-                  {p.label}
-                </button>
-              ))}
-            </span>
-            <span className="flex items-center gap-1">
-              {t("holdingsTable.quickFilters")}
-              <button
-                type="button"
-                className="ml-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
-                onClick={() => handleFilterChange("sell_eligible", "true")}
-              >
-                {t("holdingsTable.quickFiltersSellEligible")}
-              </button>
-              <input
-                type="number"
-                placeholder={t("holdingsTable.minimumGainPrompt")}
-                value={filters.gain_pct}
-                onChange={(e) => handleFilterChange("gain_pct", e.target.value)}
-                className="ml-1 w-24"
-              />
-            </span>
-          </div>
+          <HoldingsFilterControls
+            sparkRange={sparkRange}
+            onSparkRangeChange={setSparkRange}
+            viewPresets={viewPresets}
+            viewPreset={viewPreset}
+            onViewPresetChange={setViewPreset}
+            minimumGain={filters.gain_pct}
+            onMinimumGainChange={(value) => handleFilterChange("gain_pct", value)}
+            onSellEligible={() => handleFilterChange("sell_eligible", "true")}
+          />
           <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1">
             {t("holdingsTable.columnsLabel")}
             {columnLabels.map(([key, label]) => (

--- a/frontend/src/lib/instrumentType.ts
+++ b/frontend/src/lib/instrumentType.ts
@@ -8,6 +8,7 @@ const TYPE_KEYS: Record<string, string> = {
   fund: "instrumentType.fund",
   "investment trust": "instrumentType.investmentTrust",
   "real estate": "instrumentType.realEstate",
+  other: "instrumentType.other",
 };
 
 export function translateInstrumentType(t: TFunction, type?: string | null) {
@@ -15,5 +16,5 @@ export function translateInstrumentType(t: TFunction, type?: string | null) {
     return t("instrumentType.other", { defaultValue: t("common.other") });
   }
   const key = TYPE_KEYS[type.toLowerCase()];
-  return t(key || "instrumentType.other", { defaultValue: type });
+  return key ? t(key, { defaultValue: type }) : type;
 }

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -381,10 +381,37 @@ describe("HoldingsTable", () => {
           expect(screen.queryByText('AAA')).toBeNull();
       });
 
-      it("shows controls and fallback when no rows match", async () => {
+      it("derives translated view presets from the holdings", async () => {
+          const mixedHoldings: Holding[] = [
+              holdings[0],
+              { ...holdings[0], ticker: "OTHER", instrument_type: "Other" },
+              { ...holdings[0], ticker: "TRUST", instrument_type: "Investment Trust" },
+              { ...holdings[0], ticker: "UNKNOWN", instrument_type: "Commodity" },
+          ];
+
+          render(<HoldingsTable holdings={mixedHoldings} />);
+
+          expect(await screen.findByRole("button", { name: "Equity" })).toBeInTheDocument();
+          expect(screen.getByRole("button", { name: "Other" })).toBeInTheDocument();
+          expect(screen.getByRole("button", { name: "Investment Trust" })).toBeInTheDocument();
+          expect(screen.getByRole("button", { name: "Commodity" })).toBeInTheDocument();
+          expect(screen.queryByRole("button", { name: "Bond" })).toBeNull();
+      });
+
+      it("clears a persisted view preset that is absent from the holdings", async () => {
           localStorage.setItem("holdingsTableViewPreset", "Bond");
           render(<HoldingsTable holdings={holdings} />);
+
+          expect(await screen.findByText("AAA")).toBeInTheDocument();
+          await waitFor(() => expect(screen.getByPlaceholderText("Type")).toHaveValue(""));
+          expect(localStorage.getItem("holdingsTableViewPreset")).toBe("");
+      });
+
+      it("shows controls and fallback when no rows match", async () => {
+          localStorage.setItem("holdingsTableViewPreset", "Equity");
+          render(<HoldingsTable holdings={holdings} />);
           expect(await screen.findByText('View:')).toBeInTheDocument();
+          await userEvent.type(screen.getByPlaceholderText("Ticker"), "missing");
           expect(screen.getByText('No holdings match the current filters.')).toBeInTheDocument();
           expect(screen.getByRole('button', { name: 'Clear filters' })).toBeInTheDocument();
           expect(screen.getByRole('button', { name: 'Open Screener' })).toBeInTheDocument();


### PR DESCRIPTION
### Motivation
- The holdings table used a fixed, hardcoded set of Type filter buttons that did not reflect the actual instrument types present in the current holdings view, causing confusing or useless options.
- The filter/control markup in `HoldingsTable.tsx` had grown dense and decreased maintainability, so the controls deserved extraction into a dedicated component.
- Translations for known instrument types and graceful fallback for unknown types needed to be preserved.

### Description
- Replace the static `viewPresets` array with a data-driven `useMemo` that derives distinct `instrument_type` values from the scoped `holdings` and maps them to translated labels using `translateInstrumentType` (file: `frontend/src/components/HoldingsTable.tsx`).
- Clear a persisted `viewPreset` when it becomes stale (i.e. no longer present in the currently scoped holdings) via an effect that resets `localStorage`-backed selection.
- Extract the Relative view toggle, sparkline `range` radio group, view presets, quick filters, and minimum-gain input into a new `HoldingsFilterControls` component to reduce `HoldingsTable.tsx` complexity while preserving layout and handlers (new file: `frontend/src/components/HoldingsFilterControls.tsx`).
- Update `translateInstrumentType` to prefer known translation keys and fall back to the raw type string for unknown types (file: `frontend/src/lib/instrumentType.ts`).
- Add unit test coverage for the derived presets, unknown-type fallback, stale persisted-preset clearing, and the existing behaviors (file updated: `frontend/tests/unit/components/HoldingsTable.test.tsx`).
- Closes #6350 and Closes #6303.

### Testing
- Ran the targeted unit tests with `npm --prefix frontend run test -- --run tests/unit/components/HoldingsTable.test.tsx` and observed `24 tests passed` (all tests in that file passed).
- Ran `npm --prefix frontend run lint` and `npm --prefix frontend run type-check` which completed without errors in this environment.
- Attempted a Playwright-based screenshot; browser download failed in the environment (Playwright CDN returned HTTP 403), so visual smoke capture was unavailable but the dev server started successfully during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae2b08ef883279bbe1d9ad5c5f140)