### PR TITLE
Harden S3 safety for timeseries exchange moves

### DIFF
--- a/backend/routes/timeseries_edit.py
+++ b/backend/routes/timeseries_edit.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import io
 import logging
+import os
 from pathlib import Path
 
 import pandas as pd
+from botocore.exceptions import BotoCoreError, ClientError
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
@@ -17,6 +19,7 @@ from backend.timeseries.cache import (
     _s3_client,
     _split_s3_cache_uri,
     has_cached_meta_timeseries,
+    invalidate_s3_cache_metadata,
     meta_timeseries_cache_path,
 )
 
@@ -54,7 +57,7 @@ def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> tuple[str, st
 
 def _load_timeseries(ticker: str, exchange: str) -> pd.DataFrame:
     cache = meta_timeseries_cache_path(ticker, exchange)
-    exists = cache.startswith("s3://") or Path(cache).exists()
+    exists = _s3_object_exists_strict(cache) if cache.startswith("s3://") else Path(cache).exists()
     if exists:
         try:
             return _ensure_schema(pd.read_parquet(cache))
@@ -66,15 +69,67 @@ def _load_timeseries(ticker: str, exchange: str) -> pd.DataFrame:
     return pd.DataFrame(columns=EXPECTED_COLS)
 
 
+def _s3_object_exists_strict(cache: str) -> bool:
+    """Check S3 without confusing a missing key with an operational failure."""
+    parsed = _split_s3_cache_uri(cache)
+    if parsed is None:
+        raise InternalServiceError("Invalid S3 cache path")
+    bucket, key = parsed
+    try:
+        _s3_client().head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code")
+        if code in {"404", "NoSuchKey", "NotFound"}:
+            return False
+        raise InternalServiceError("Failed to check S3 timeseries cache") from exc
+    except BotoCoreError as exc:
+        raise InternalServiceError("Failed to check S3 timeseries cache") from exc
+    return True
+
+
+def _create_s3_destination(destination: str, df: pd.DataFrame) -> None:
+    parsed = _split_s3_cache_uri(destination)
+    if parsed is None:
+        raise InternalServiceError("Invalid destination cache path")
+    payload = io.BytesIO()
+    df.to_parquet(payload, index=False)
+    bucket, key = parsed
+    try:
+        _s3_client().put_object(Bucket=bucket, Key=key, Body=payload.getvalue(), IfNoneMatch="*")
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code")
+        status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        if code in {"PreconditionFailed", "ConditionalRequestConflict"} or status in {409, 412}:
+            raise HTTPException(status_code=409, detail="Destination time series already exists") from exc
+        raise InternalServiceError("Failed to create destination time series") from exc
+    except BotoCoreError as exc:
+        raise InternalServiceError("Failed to create destination time series") from exc
+    invalidate_s3_cache_metadata(destination)
+
+
+def _delete_s3_object(cache: str) -> None:
+    parsed = _split_s3_cache_uri(cache)
+    if parsed is None:
+        raise InternalServiceError("Invalid S3 cache path")
+    bucket, key = parsed
+    _s3_client().delete_object(Bucket=bucket, Key=key)
+    invalidate_s3_cache_metadata(cache)
+
+
 def _move_timeseries(ticker: str, source_exchange: str, destination_exchange: str) -> int:
     source = meta_timeseries_cache_path(ticker, source_exchange)
     destination = meta_timeseries_cache_path(ticker, destination_exchange)
     if source == destination:
         raise HTTPException(status_code=400, detail="Source and destination must differ")
 
-    if not has_cached_meta_timeseries(ticker, source_exchange):
+    source_exists = (
+        _s3_object_exists_strict(source)
+        if source.startswith("s3://")
+        else has_cached_meta_timeseries(ticker, source_exchange)
+    )
+    if not source_exists:
         raise HTTPException(status_code=404, detail="Source time series does not exist")
-    if has_cached_meta_timeseries(ticker, destination_exchange):
+    if not destination.startswith("s3://") and has_cached_meta_timeseries(ticker, destination_exchange):
         raise HTTPException(status_code=409, detail="Destination time series already exists")
 
     df = _load_timeseries(ticker, source_exchange)
@@ -82,27 +137,33 @@ def _move_timeseries(ticker: str, source_exchange: str, destination_exchange: st
         raise HTTPException(status_code=404, detail="Source time series does not exist")
 
     if destination.startswith("s3://"):
-        # pandas/fsspec performs the destination write before the source is
-        # removed, so a failed write cannot destroy the original series.
-        df.to_parquet(destination, index=False)
-        parsed = _split_s3_cache_uri(source)
-        if parsed is None:  # pragma: no cover - guarded by cache path builder
-            raise InternalServiceError("Invalid source cache path")
-        bucket, key = parsed
+        _create_s3_destination(destination, df)
         try:
-            _s3_client().delete_object(Bucket=bucket, Key=key)
+            _delete_s3_object(source)
         except Exception as exc:
-            # The destination copy already succeeded; surface this loudly
-            # rather than reporting "ok" while the source still exists.
+            try:
+                _delete_s3_object(destination)
+            except Exception as rollback_exc:
+                raise InternalServiceError(
+                    "Failed to remove the source and could not roll back the destination",
+                    extra={"ticker": ticker, "source_exchange": source_exchange},
+                ) from rollback_exc
             raise InternalServiceError(
-                f"Moved {ticker} to {destination_exchange} but failed to remove "
-                f"the source series at {source_exchange}; both now exist",
+                "Failed to remove the source series; destination was rolled back",
                 extra={"ticker": ticker, "source_exchange": source_exchange},
             ) from exc
     else:
         destination_path = Path(destination)
         destination_path.parent.mkdir(parents=True, exist_ok=True)
-        Path(source).replace(destination_path)
+        try:
+            os.link(source, destination)
+        except FileExistsError as exc:
+            raise HTTPException(status_code=409, detail="Destination time series already exists") from exc
+        try:
+            os.unlink(source)
+        except OSError:
+            os.unlink(destination)
+            raise
     return len(df)
 
 
@@ -151,6 +212,8 @@ async def post_timeseries_edit(
     if not cache.startswith("s3://"):
         Path(cache).parent.mkdir(parents=True, exist_ok=True)
     df.to_parquet(cache, index=False)
+    if cache.startswith("s3://"):
+        invalidate_s3_cache_metadata(cache)
     return JSONResponse({"status": "ok", "rows": len(df)})
 
 

--- a/backend/timeseries/cache.py
+++ b/backend/timeseries/cache.py
@@ -374,6 +374,14 @@ def _s3_object_recently_confirmed_missing(cache: str) -> bool:
     return missed_at is not None and time.monotonic() - missed_at < _S3_HEAD_MISS_TTL_SECONDS
 
 
+def invalidate_s3_cache_metadata(cache: str) -> None:
+    """Forget cached S3 presence metadata after this process changes an object."""
+    with _S3_HEAD_MISS_CACHE_LOCK:
+        _S3_HEAD_MISS_CACHE.pop(cache, None)
+    with _S3_MTIME_CACHE_LOCK:
+        _S3_MTIME_CACHE.pop(cache, None)
+
+
 # boto3's defaults (connect_timeout=60s, no read_timeout, 3 retries) let a
 # single stalled HeadObject call block a cold Lambda invocation for minutes.
 # These metadata checks are advisory (every caller already has a local/

--- a/tests/routes/test_timeseries_edit.py
+++ b/tests/routes/test_timeseries_edit.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
-from fastapi import FastAPI
+from botocore.exceptions import ClientError
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from backend.common.errors import ValidationFailure
@@ -147,13 +148,30 @@ def test_move_timeseries_missing_source_returns_404(tmp_path, monkeypatch):
 
 
 class _FakeS3Client:
-    def __init__(self, *, fail_delete=False):
-        self.fail_delete = fail_delete
+    def __init__(self, *, fail_delete_key=None, existing=None):
+        self.fail_delete_key = fail_delete_key
+        self.existing = set(existing or [])
         self.deleted = []
+        self.puts = []
+
+    def head_object(self, Bucket, Key):  # noqa: N803 - matches boto3 signature
+        if Key not in self.existing:
+            raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+        return {}
+
+    def put_object(self, Bucket, Key, Body, IfNoneMatch):  # noqa: N803 - matches boto3 signature
+        if Key in self.existing:
+            raise ClientError(
+                {"Error": {"Code": "PreconditionFailed"}, "ResponseMetadata": {"HTTPStatusCode": 412}},
+                "PutObject",
+            )
+        self.existing.add(Key)
+        self.puts.append((Bucket, Key, Body, IfNoneMatch))
 
     def delete_object(self, Bucket, Key):  # noqa: N803 - matches boto3 signature
-        if self.fail_delete:
+        if Key == self.fail_delete_key:
             raise RuntimeError("simulated S3 delete failure")
+        self.existing.discard(Key)
         self.deleted.append((Bucket, Key))
 
 
@@ -165,22 +183,18 @@ class _FakeDataFrame:
 
     def to_parquet(self, destination, index=False):
         self.to_parquet_calls.append(destination)
+        destination.write(b"parquet")
 
     def __len__(self):
         return len(self._rows)
 
 
-def _setup_s3_move(monkeypatch, *, fake_client, source_exists=True, destination_exists=False):
+def _setup_s3_move(monkeypatch, *, fake_client):
     fake_df = _FakeDataFrame([{"Close": 1.5}])
     monkeypatch.setattr(
         timeseries_edit,
         "meta_timeseries_cache_path",
         lambda ticker, exchange: f"s3://bucket/{ticker}-{exchange}.parquet",
-    )
-    monkeypatch.setattr(
-        timeseries_edit,
-        "has_cached_meta_timeseries",
-        lambda ticker, exchange: destination_exists if exchange == "N" else source_exists,
     )
     monkeypatch.setattr(timeseries_edit, "_load_timeseries", lambda ticker, exchange: fake_df)
     monkeypatch.setattr(timeseries_edit, "_s3_client", lambda: fake_client)
@@ -188,27 +202,55 @@ def _setup_s3_move(monkeypatch, *, fake_client, source_exists=True, destination_
 
 
 def test_move_timeseries_s3_success_writes_then_deletes(monkeypatch):
-    fake_client = _FakeS3Client()
+    fake_client = _FakeS3Client(existing={"IONQ-L.parquet"})
     fake_df = _setup_s3_move(monkeypatch, fake_client=fake_client)
+    destination = "s3://bucket/IONQ-N.parquet"
+    with cache._S3_HEAD_MISS_CACHE_LOCK:
+        cache._S3_HEAD_MISS_CACHE[destination] = cache.time.monotonic()
 
     rows = timeseries_edit._move_timeseries("IONQ", "L", "N")
 
     assert rows == 1
-    assert fake_df.to_parquet_calls == ["s3://bucket/IONQ-N.parquet"]
+    assert len(fake_df.to_parquet_calls) == 1
+    assert fake_client.puts[0][1:] == ("IONQ-N.parquet", b"parquet", "*")
     assert fake_client.deleted == [("bucket", "IONQ-L.parquet")]
+    assert destination not in cache._S3_HEAD_MISS_CACHE
 
 
-def test_move_timeseries_s3_delete_failure_reports_error(monkeypatch):
+def test_move_timeseries_s3_delete_failure_rolls_back_destination(monkeypatch):
     from backend.common.errors import InternalServiceError
 
-    fake_client = _FakeS3Client(fail_delete=True)
-    fake_df = _setup_s3_move(monkeypatch, fake_client=fake_client)
+    fake_client = _FakeS3Client(fail_delete_key="IONQ-L.parquet", existing={"IONQ-L.parquet"})
+    _setup_s3_move(monkeypatch, fake_client=fake_client)
 
     with pytest.raises(InternalServiceError) as exc:
         timeseries_edit._move_timeseries("IONQ", "L", "N")
 
-    assert fake_df.to_parquet_calls == ["s3://bucket/IONQ-N.parquet"]
-    assert "both now exist" in str(exc.value)
+    assert "destination was rolled back" in str(exc.value)
+    assert fake_client.existing == {"IONQ-L.parquet"}
+
+
+def test_move_timeseries_s3_atomic_destination_conflict(monkeypatch):
+    fake_client = _FakeS3Client(existing={"IONQ-L.parquet", "IONQ-N.parquet"})
+    _setup_s3_move(monkeypatch, fake_client=fake_client)
+
+    with pytest.raises(HTTPException) as exc:
+        timeseries_edit._move_timeseries("IONQ", "L", "N")
+
+    assert exc.value.status_code == 409
+    assert fake_client.deleted == []
+
+
+def test_get_missing_s3_file_returns_empty(monkeypatch):
+    fake_client = _FakeS3Client()
+    monkeypatch.setattr(timeseries_edit, "_s3_client", lambda: fake_client)
+    monkeypatch.setattr(
+        timeseries_edit,
+        "meta_timeseries_cache_path",
+        lambda ticker, exchange: f"s3://bucket/{ticker}-{exchange}.parquet",
+    )
+
+    assert timeseries_edit._load_timeseries("NOPE", "L").empty
 
 
 def test_move_timeseries_case_insensitive_exchange_rejected(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation

- Fix production S3 path issues where a missing S3 key became a 500 instead of an empty/no-data response. 
- Prevent race conditions and silent overwrites when moving timeseries into S3-backed cache paths. 
- Ensure S3 negative-cache/mtime caches are invalidated after writes/deletes so warm Lambdas see new objects immediately. 
- Provide rollback behaviour so a failed source deletion does not leave a duplicate destination.

### Description

- Add strict S3 existence checking and distinguish genuine 404 (missing key) from operational S3 failures by introducing `_s3_object_exists_strict` and using it in `_load_timeseries`. 
- Implement conditional S3 destination creation with `_create_s3_destination` using a conditional `PutObject` (no-clobber) and translate conflicts into HTTP 409. 
- Add `_delete_s3_object` and rollback logic to remove a newly-created destination when source deletion fails, and change the local-file move to a no-clobber hard-link + unlink pattern with rollback on failure. 
- Add `invalidate_s3_cache_metadata` to clear the negative/mtime caches in `backend/timeseries/cache.py` and call it after S3 writes/deletes and after `post_timeseries_edit` writes. 
- Update `tests/routes/test_timeseries_edit.py` to cover S3-path behaviours: success write+delete, delete-failure rollback, atomic destination-conflict, and missing-S3-key returning empty; and add a negative-cache invalidation assertion. 

### Testing

- Ran the updated backend route tests with `PYENV_VERSION=3.11.15 python -m pytest tests/routes/test_timeseries_edit.py tests/test_timeseries_cache_base.py -q --no-cov` and all tests passed (`42 passed`).
- Ran static checks with `PYENV_VERSION=3.11.15 python -m ruff check --config backend/pyproject.toml backend/routes/timeseries_edit.py backend/timeseries/cache.py tests/routes/test_timeseries_edit.py` and the linter passed. 
- Verified repository diff/whitespace checks and test suite status before committing; automated checks completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aec37ec5c8327a5dfead7d9b1b3fd)