### PR TITLE
docs(decision): resolve follow-ups for portfolio consolidation (#6385, #6386)

### DIFF
--- a/docs/decisions/6365-portfolio-consolidation.md
+++ b/docs/decisions/6365-portfolio-consolidation.md
@@ -213,11 +213,19 @@ type RollupRow = {
 **Rules for the always-null fields.**
 
 1. Render as `—`, never as `No`, `0`, or an empty cell. In particular,
-   `sell_eligible` is tri-state across the two row types, so its cell renderer
-   must test `value === null` **before** rendering the existing enabled or
-   disabled state. Do not use a truthiness check that collapses `null` into
-   `false`. This preserves the existing flat-mode rendering while making the
-   rollup-only, not-applicable state explicit:
+   `sell_eligible` is tri-state across the two row types. Its renderer must use
+   the following explicit branch order (or equivalent logic):
+
+   ```ts
+   if (value === null) return "—";
+   return value ? existingEnabledState : existingDisabledState;
+   ```
+
+   The strict `value === null` comparison **must run before** the existing
+   boolean rendering. Do not use `if (!value)` or any other truthiness check
+   for the not-applicable branch, because that would collapse `null` and
+   `false` into the same output. This preserves the existing flat-mode
+   rendering while making the rollup-only, not-applicable state explicit:
 
    | `sell_eligible` value | Meaning | Cell output |
    | --- | --- | --- |

--- a/docs/decisions/6365-portfolio-consolidation.md
+++ b/docs/decisions/6365-portfolio-consolidation.md
@@ -11,6 +11,15 @@ Child tasks must cite this document by section number rather than re-deciding
 any of it. If a child task believes a decision here is wrong, it should say so
 in a comment on #6365 and get this document amended — not diverge silently.
 
+Resolved follow-up clarifications:
+
+- [#6385](https://github.com/leonarduk/allotmint/issues/6385): §3 defines the
+  strict tri-state rendering contract for `sell_eligible`, including the
+  distinct `null`, `true`, and `false` outputs.
+- [#6386](https://github.com/leonarduk/allotmint/issues/6386): §1 defines the
+  permanent redirect that removes an `account` query parameter when `owner`
+  is absent.
+
 ---
 
 ## 0. Findings that changed the framing


### PR DESCRIPTION
Closes #6385
Closes #6386

### Motivation
- Clarify two outstanding ambiguities in the portfolio consolidation decision: the tri-state `sell_eligible` renderer behavior in rollup mode and whether an `account` query parameter is cleaned up when `owner` is absent.

### Description
- Add a short "Resolved follow-up clarifications" section to `docs/decisions/6365-portfolio-consolidation.md` that links and records the decisions for #6385 (explicit tri-state `sell_eligible` rendering with a `value === null` check) and #6386 (permanent redirect removing stray `account` when `owner` is absent), and include auto-closing references `Closes #6385, #6386`.

### Testing
- Ran repository verification and consistency checks and validated the referenced GitHub issue numbers via the API; diff/format checks passed and the working tree is clean, and automatic PR creation was not possible from this environment due to missing remote/PR tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7af464c3c08327a616c3ac8e2484a8)