### PR TITLE
Add full-page research link to instrument drawer

### DIFF
--- a/frontend/src/components/InstrumentDetail.tsx
+++ b/frontend/src/components/InstrumentDetail.tsx
@@ -535,6 +535,14 @@ export function InstrumentDetail({
             : "↗"}
         </button>
       )}
+      {variant === "drawer" && (
+        <Link
+          to={`/research/${ticker}`}
+          style={{ color: palette.link, float: "right", marginRight: "0.5rem" }}
+        >
+          View full page
+        </Link>
+      )}
       {signal && (
         <div style={{ marginBottom: "0.5rem" }}>
           <strong>{signal.action.toUpperCase()}</strong> – {signal.reason}

--- a/frontend/tests/unit/components/InstrumentDetail.test.tsx
+++ b/frontend/tests/unit/components/InstrumentDetail.test.tsx
@@ -99,6 +99,30 @@ describe("InstrumentDetail", () => {
     expect(separator.parentElement).toHaveStyle({ zIndex: "1000", background: "#111" });
   });
 
+  it("links from the drawer to the full research page", async () => {
+    mockGetInstrumentDetail.mockResolvedValue({ prices: [], positions: [], currency: null });
+    mockGetInstrumentIntraday.mockResolvedValue([]);
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <InstrumentDetail ticker="ABC.L" name="ABC" onClose={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "View full page" })).toHaveAttribute(
+      "href",
+      "/research/ABC.L",
+    );
+
+    rerender(
+      <MemoryRouter>
+        <InstrumentDetail ticker="ABC.L" name="ABC" variant="standalone" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("link", { name: "View full page" })).not.toBeInTheDocument();
+  });
+
   it("shows accessible loading skeletons before the instrument detail resolves", async () => {
     let resolveDetail: (value: { prices: unknown[]; positions: unknown[]; currency: null }) => void;
     mockGetInstrumentDetail.mockReturnValue(


### PR DESCRIPTION
Closes #6380 

### Motivation

- Ensure the drawer variant of `InstrumentDetail` provides an explicit path to the specialist research page `/research/:ticker` so users can reach the deep-dive tabs when the UI consolidates instrument interactions.
- Keep the change additive and scoped so the standalone variant and existing navigation behavior remain unchanged.

### Description

- Add a drawer-only `Link` to `/research/${ticker}` in `frontend/src/components/InstrumentDetail.tsx`, styled to float right and reuse the existing `Link`/palette styling.
- Add a unit test in `frontend/tests/unit/components/InstrumentDetail.test.tsx` asserting the drawer renders a `View full page` link to `/research/:ticker` and that the link is absent in the `standalone` variant.
- Change set is limited to the two frontend files above and is additive with no behavior changes elsewhere; `Closes #6380`.

### Testing

- Ran the component unit tests with `npm --prefix frontend run test -- --run tests/unit/components/InstrumentDetail.test.tsx` and the test run passed (14 tests passed).
- Ran frontend lint with `npm --prefix frontend run lint -- --max-warnings=0` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7af7cecb308327aa32c2fb40ca053c)