### PR TITLE
Add rollup adapter and unit tests for holdings aggregation

### DIFF
--- a/frontend/src/lib/rollupAdapter.ts
+++ b/frontend/src/lib/rollupAdapter.ts
@@ -1,0 +1,138 @@
+import type { Account, Holding, InstrumentSummary } from "../types";
+
+export type ScopedHoldingRow = Holding & {
+  owner: string;
+  source_account: string;
+  row_key: string;
+};
+
+export type RollupRow = {
+  ticker: string;
+  name: string;
+  units: number;
+  cost_basis_gbp: number;
+  market_value_gbp: number;
+  gain_gbp: number;
+  gain_pct: number;
+  weight_pct: number;
+  lot_count: number;
+  owners: string[];
+  accounts: string[];
+  grouping: string | null;
+  exchange: string | null;
+  change_7d_pct: number | null;
+  change_30d_pct: number | null;
+  acquired_date: null;
+  days_held: null;
+  sell_eligible: null;
+  days_until_eligible: null;
+  next_eligible_sell_date: null;
+};
+
+export function toScopedHoldingRows(accounts: Account[]): ScopedHoldingRow[] {
+  let rowIndex = 0;
+
+  return accounts.flatMap((account) => {
+    const owner = account.owner ?? "";
+
+    return account.holdings.map((holding) => {
+      const row = {
+        ...holding,
+        owner,
+        source_account: account.account_type,
+        row_key: `${owner}:${account.account_type}:${holding.ticker}:${rowIndex}`,
+      };
+      rowIndex += 1;
+      return row;
+    });
+  });
+}
+
+type MutableRollup = Omit<
+  RollupRow,
+  | "weight_pct"
+  | "grouping"
+  | "exchange"
+  | "change_7d_pct"
+  | "change_30d_pct"
+> & {
+  ownerSet: Set<string>;
+  accountSet: Set<string>;
+};
+
+function addHolding(
+  grouped: Map<string, MutableRollup>,
+  holding: ScopedHoldingRow,
+): void {
+  const existing = grouped.get(holding.ticker);
+  if (existing) {
+    existing.units += holding.units;
+    existing.cost_basis_gbp += holding.cost_basis_gbp ?? 0;
+    existing.market_value_gbp += holding.market_value_gbp ?? 0;
+    existing.gain_gbp += holding.gain_gbp ?? 0;
+    existing.lot_count += 1;
+    existing.ownerSet.add(holding.owner);
+    existing.accountSet.add(holding.source_account);
+    return;
+  }
+
+  grouped.set(holding.ticker, {
+    ticker: holding.ticker,
+    name: holding.name,
+    units: holding.units,
+    cost_basis_gbp: holding.cost_basis_gbp ?? 0,
+    market_value_gbp: holding.market_value_gbp ?? 0,
+    gain_gbp: holding.gain_gbp ?? 0,
+    gain_pct: 0,
+    lot_count: 1,
+    owners: [],
+    accounts: [],
+    acquired_date: null,
+    days_held: null,
+    sell_eligible: null,
+    days_until_eligible: null,
+    next_eligible_sell_date: null,
+    ownerSet: new Set([holding.owner]),
+    accountSet: new Set([holding.source_account]),
+  });
+}
+
+export function toRollupRows(
+  holdings: ScopedHoldingRow[],
+  instruments: InstrumentSummary[] = [],
+): RollupRow[] {
+  const grouped = new Map<string, MutableRollup>();
+
+  for (const holding of holdings) {
+    addHolding(grouped, holding);
+  }
+
+  const scopedTotal = Array.from(grouped.values()).reduce(
+    (total, row) => total + row.market_value_gbp,
+    0,
+  );
+  const instrumentByTicker = new Map(
+    instruments.map((instrument) => [instrument.ticker, instrument]),
+  );
+
+  return Array.from(grouped.values(), (row) => {
+    const instrument = instrumentByTicker.get(row.ticker);
+    const { ownerSet, accountSet, ...rollup } = row;
+
+    return {
+      ...rollup,
+      gain_pct: row.cost_basis_gbp
+        ? (row.gain_gbp / row.cost_basis_gbp) * 100
+        : 0,
+      weight_pct: scopedTotal
+        ? (row.market_value_gbp / scopedTotal) * 100
+        : 0,
+      owners: Array.from(ownerSet),
+      accounts: Array.from(accountSet),
+      grouping: instrument?.grouping ?? null,
+      exchange: instrument?.exchange ?? null,
+      change_7d_pct: instrument?.change_7d_pct ?? null,
+      change_30d_pct: instrument?.change_30d_pct ?? null,
+    };
+  });
+}

--- a/frontend/tests/unit/lib/rollupAdapter.test.ts
+++ b/frontend/tests/unit/lib/rollupAdapter.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  toRollupRows,
+  toScopedHoldingRows,
+} from "@/lib/rollupAdapter";
+import type { Account, InstrumentSummary } from "@/types";
+
+const accounts: Account[] = [
+  {
+    owner: "alice",
+    account_type: "ISA",
+    currency: "GBP",
+    value_estimate_gbp: 180,
+    holdings: [
+      {
+        ticker: "AAA",
+        name: "Alpha",
+        units: 2,
+        cost_basis_gbp: 100,
+        market_value_gbp: 120,
+        gain_gbp: 20,
+        acquired_date: "2025-01-01",
+        days_held: 100,
+        sell_eligible: true,
+        days_until_eligible: 0,
+        next_eligible_sell_date: "2025-01-01",
+      },
+      {
+        ticker: "BBB",
+        name: "Beta",
+        units: 3,
+        cost_basis_gbp: 50,
+        market_value_gbp: 60,
+        gain_gbp: 10,
+      },
+    ],
+  },
+  {
+    owner: "bob",
+    account_type: "SIPP",
+    currency: "GBP",
+    value_estimate_gbp: 180,
+    holdings: [
+      {
+        ticker: "AAA",
+        name: "Alpha",
+        units: 1,
+        cost_basis_gbp: 50,
+        market_value_gbp: 180,
+        gain_gbp: 130,
+        sell_eligible: false,
+      },
+    ],
+  },
+];
+
+describe("toScopedHoldingRows", () => {
+  it("flattens account holdings and annotates their provenance", () => {
+    const rows = toScopedHoldingRows(accounts);
+
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      ticker: "AAA",
+      owner: "alice",
+      source_account: "ISA",
+      row_key: "alice:ISA:AAA:0",
+    });
+    expect(rows[2]).toMatchObject({
+      ticker: "AAA",
+      owner: "bob",
+      source_account: "SIPP",
+      row_key: "bob:SIPP:AAA:2",
+    });
+    expect(new Set(rows.map(({ row_key }) => row_key)).size).toBe(rows.length);
+  });
+});
+
+describe("toRollupRows", () => {
+  it("aggregates lots, recomputes percentages, and retains provenance", () => {
+    const rows = toRollupRows(toScopedHoldingRows(accounts));
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      ticker: "AAA",
+      name: "Alpha",
+      units: 3,
+      cost_basis_gbp: 150,
+      market_value_gbp: 300,
+      gain_gbp: 150,
+      gain_pct: 100,
+      weight_pct: 300 / 360 * 100,
+      lot_count: 2,
+      owners: ["alice", "bob"],
+      accounts: ["ISA", "SIPP"],
+    });
+  });
+
+  it("sets every per-lot eligibility field to null", () => {
+    const [row] = toRollupRows(toScopedHoldingRows(accounts));
+
+    expect(row).toMatchObject({
+      acquired_date: null,
+      days_held: null,
+      sell_eligible: null,
+      days_until_eligible: null,
+      next_eligible_sell_date: null,
+    });
+  });
+
+  it("joins instrument fields by ticker and uses null for an unmatched row", () => {
+    const instruments: InstrumentSummary[] = [
+      {
+        ticker: "AAA",
+        name: "Alpha instrument",
+        units: 3,
+        market_value_gbp: 300,
+        gain_gbp: 150,
+        grouping: "Equity",
+        exchange: "LSE",
+        change_7d_pct: 2.5,
+        change_30d_pct: null,
+      },
+    ];
+
+    const [matched, unmatched] = toRollupRows(
+      toScopedHoldingRows(accounts),
+      instruments,
+    );
+
+    expect(matched).toMatchObject({
+      grouping: "Equity",
+      exchange: "LSE",
+      change_7d_pct: 2.5,
+      change_30d_pct: null,
+    });
+    expect(unmatched).toMatchObject({
+      grouping: null,
+      exchange: null,
+      change_7d_pct: null,
+      change_30d_pct: null,
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Implement the adapter that maps `Holding[]` → rollup and scoped rows so the consolidated GroupPortfolio UI can render both flat (per-lot) and rollup (per-ticker) views as specified by the decision doc and issue #6378.
- Ensure rollup rows never fabricate per-lot eligibility fields and that monetary aggregates and percentages are recomputed from lots in scope.

### Description
- Add a pure-function module `frontend/src/lib/rollupAdapter.ts` exposing `toScopedHoldingRows(accounts: Account[])` and `toRollupRows(holdings: ScopedHoldingRow[], instruments?: InstrumentSummary[])` plus `ScopedHoldingRow` and `RollupRow` types to represent flat and rollup row shapes. 
- `toScopedHoldingRows` flattens `Account[].holdings[]` and annotates each lot with `owner`, `source_account`, and a unique `row_key`.
- `toRollupRows` groups lots by `ticker`, sums monetary fields, recomputes `gain_pct` and scoped `weight_pct`, deduplicates `owners` and `accounts`, enforces `null` for the five per-lot eligibility fields, and optionally joins `InstrumentSummary` enrichment fields (`grouping`, `exchange`, `change_7d_pct`, `change_30d_pct`).
- Add unit tests at `frontend/tests/unit/lib/rollupAdapter.test.ts` covering flat annotation, aggregation sums, recomputed percentages, null-field enforcement, provenance arrays, and instrument join behavior; include strong typing via the project `tsconfig` contracts.
- Closes #6378.

### Testing
- Ran the unit tests for the new adapter with `npm --prefix frontend run test -- --run tests/unit/lib/rollupAdapter.test.ts` and all tests passed (4 tests, 1 file).
- Ran type checking with `npm --prefix frontend run type-check` and lint with `npm --prefix frontend run lint -- --quiet`, both of which completed successfully.
- Ran repository checks (`git diff --check` / staged checks) and they reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7af7b97ce4832788465807f92b5752)