### PR TITLE
Add grouped/expandable rollup mode to HoldingsTable

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, type MouseEvent } from "react";
+import { Fragment, useState, useEffect, useRef, useMemo, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import type { Holding } from "../types";
 import { money, percent } from "../lib/money";
@@ -20,6 +20,18 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import Sparkline from "./Sparkline";
 import { getGrowthStage } from "../utils/growthStage";
 import { preloadInstrumentHistory } from "../hooks/useInstrumentHistory";
+import type { RollupRow } from "../lib/rollupAdapter";
+import {
+  buildCategoryLookup,
+  calculateGroupTotals,
+  createGroups,
+  sanitizeGroupKey,
+} from "./instrumentTable/utils";
+import type {
+  GroupedRows,
+  GroupingMode,
+  RowWithCost,
+} from "./instrumentTable/types";
 
 const VIEW_PRESET_STORAGE_KEY = "holdingsTableViewPreset";
 const ESTIMATED_ROW_HEIGHT = 32;
@@ -27,16 +39,20 @@ const ESTIMATED_ROW_HEIGHT = 32;
 type HoldingsTableRow = Holding & {
   source_account?: string;
   row_key?: string;
+  grouping?: string | null;
+  change_7d_pct?: number | null;
+  change_30d_pct?: number | null;
 };
 
 type Props = {
-  holdings: HoldingsTableRow[];
+  holdings: HoldingsTableRow[] | RollupRow[];
   showAccount?: boolean;
   onSelectInstrument?: (ticker: string, name: string) => void;
   selectedTicker?: string;
   showForward7d?: boolean;
   showForward30d?: boolean;
   onAddPosition?: () => void;
+  groupingMode?: GroupingMode;
 };
 
 
@@ -48,7 +64,11 @@ export function HoldingsTable({
   showForward7d = false,
   showForward30d = false,
   onAddPosition,
+  groupingMode = "flat",
 }: Props) {
+  // RollupRow is the adapter's deliberately presentation-neutral shape. Its
+  // nullable lot-only fields are rendered the same way as absent Holding fields.
+  const holdingRows = holdings as HoldingsTableRow[];
   const { t } = useTranslation();
   const { relativeViewEnabled, baseCurrency, familyMvpEnabled } = useConfig();
   let navigate: (path: string) => void = () => {};
@@ -62,7 +82,7 @@ export function HoldingsTable({
 
   const viewPresets = useMemo(() => {
     const instrumentTypes = new Map<string, string>();
-    holdings.forEach(({ instrument_type: instrumentType }) => {
+    holdingRows.forEach(({ instrument_type: instrumentType }) => {
       const trimmedType = instrumentType?.trim();
       if (trimmedType) {
         instrumentTypes.set(trimmedType.toLocaleLowerCase(), trimmedType);
@@ -76,7 +96,7 @@ export function HoldingsTable({
         value: instrumentType,
       })),
     ];
-  }, [holdings, t]);
+  }, [holdingRows, t]);
 
   const [filters, dispatchFilters] = useFilterReducer();
 
@@ -103,11 +123,11 @@ export function HoldingsTable({
   }, [viewPreset, viewPresets]);
 
   useEffect(() => {
-    const tickers = Array.from(new Set(holdings.map((h) => h.ticker)));
+    const tickers = Array.from(new Set(holdingRows.map((h) => h.ticker)));
     if (tickers.length) {
       preloadInstrumentHistory(tickers, sparkRange).catch(() => {});
     }
-  }, [holdings, sparkRange]);
+  }, [holdingRows, sparkRange]);
 
   const toggleColumn = (key: keyof typeof visibleColumns) => {
     setVisibleColumns((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -140,7 +160,7 @@ export function HoldingsTable({
   }, [viewPreset, dispatchFilters]);
 
   // derive cost/market/gain/gain_pct
-  const computed = holdings.map((h) => {
+  const computed = holdingRows.map((h) => {
     const cost =
       (h.cost_basis_gbp ?? 0) > 0
         ? h.cost_basis_gbp ?? 0
@@ -207,6 +227,44 @@ export function HoldingsTable({
   );
   const totalGainPct = totals.cost ? (totals.gain / totals.cost) * 100 : 0;
 
+  const groups = useMemo(() => {
+    const groupingRows = sortedRows.map((row, index) => ({
+      ...row,
+      __holdingsIndex: index,
+      cost: row.cost,
+      market_value_gbp: row.market,
+      gain_gbp: row.gain,
+      change_7d_pct: row.change_7d_pct ?? row.forward_7d_change_pct ?? null,
+      change_30d_pct: row.change_30d_pct ?? row.forward_30d_change_pct ?? null,
+    })) as RowWithCost[];
+
+    // HoldingsTable does not own group definitions. In category mode, callers
+    // without category metadata therefore get the shared "uncategorised" rollup.
+    return createGroups(
+      groupingRows,
+      sortKey as keyof RowWithCost,
+      asc,
+      groupingMode,
+      {
+        ungroupedLabel: t("instrumentTable.ungrouped", { defaultValue: "Ungrouped" }),
+        uncategorisedLabel: t("instrumentTable.uncategorised", {
+          defaultValue: "Uncategorised",
+        }),
+      },
+      buildCategoryLookup([]),
+    );
+  }, [asc, groupingMode, sortKey, sortedRows, t]);
+  const overallGroupTotals = useMemo(
+    () =>
+      calculateGroupTotals(
+        groups.flatMap((group) => group.rows),
+        t("holdingsTable.totalRowLabel"),
+      ),
+    [groups, t],
+  );
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set());
+  const showGroupHeaders = groupingMode !== "flat";
+
   const columnLabels: [keyof typeof visibleColumns, string][] = [
     ["units", t("holdingsTable.columns.units")],
     ["cost", t("holdingsTable.columns.cost")],
@@ -271,13 +329,13 @@ export function HoldingsTable({
   }, [sortedRows.length, relativeViewEnabled, visibleColumns, showForward7d, showForward30d]);
 
   const rowVirtualizer = useVirtualizer({
-    count: sortedRows.length,
+    count: showGroupHeaders ? 0 : sortedRows.length,
     getScrollElement: () => tableContainerRef.current,
     estimateSize: () => ESTIMATED_ROW_HEIGHT,
     overscan: 5,
     scrollMargin: headerHeight,
   });
-  const virtualRows = rowVirtualizer.getVirtualItems();
+  const virtualRows = showGroupHeaders ? [] : rowVirtualizer.getVirtualItems();
   const paddingTop = virtualRows.length ? virtualRows[0].start : 0;
   const paddingBottom = virtualRows.length
     ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
@@ -289,6 +347,91 @@ export function HoldingsTable({
         start: index * ESTIMATED_ROW_HEIGHT,
         end: (index + 1) * ESTIMATED_ROW_HEIGHT,
       }));
+
+  const renderGroupHeader = (group: GroupedRows, expanded: boolean) => {
+    const groupDomId = `holdings-group-${sanitizeGroupKey(group.key)}`;
+    const groupWeight = overallGroupTotals.marketValue
+      ? (group.totals.marketValue / overallGroupTotals.marketValue) * 100
+      : 0;
+
+    return (
+      <tr key={`group-${group.key}`} className={tableStyles.groupRow}>
+        {showAccount && <td className={`${tableStyles.cell} ${tableStyles.groupCell}`}>—</td>}
+        <th
+          scope="row"
+          className={`${tableStyles.cell} ${tableStyles.groupCell}`}
+          colSpan={2}
+        >
+          <button
+            type="button"
+            className={tableStyles.groupToggle}
+            onClick={() =>
+              setExpandedGroups((previous) => {
+                const next = new Set(previous);
+                if (next.has(group.key)) next.delete(group.key);
+                else next.add(group.key);
+                return next;
+              })
+            }
+            aria-expanded={expanded}
+            aria-controls={groupDomId}
+            aria-label={t("instrumentTable.groupToggle", {
+              group: group.label,
+              defaultValue: `Toggle ${group.label}`,
+            })}
+          >
+            <span aria-hidden="true" className={tableStyles.groupToggleIcon}>
+              {expanded ? "−" : "+"}
+            </span>
+            <span>{group.label}</span>
+            <span className={tableStyles.groupCount}>({group.rows.length})</span>
+          </button>
+        </th>
+        {!relativeViewEnabled && visibleColumns.units && (
+          <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>
+            {new Intl.NumberFormat(i18n.language).format(group.totals.units)}
+          </td>
+        )}
+        {!relativeViewEnabled && visibleColumns.market && (
+          <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>
+            {money(group.totals.marketValue, baseCurrency)}
+          </td>
+        )}
+        {!relativeViewEnabled && visibleColumns.gain && (
+          <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>
+            {money(group.totals.gain, baseCurrency)}
+          </td>
+        )}
+        {visibleColumns.gain_pct && (
+          <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>
+            {percent(group.totals.gainPct, 1)}
+          </td>
+        )}
+        <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>—</td>
+        {!relativeViewEnabled && visibleColumns.cost && (
+          <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>
+            {money(group.totals.cost, baseCurrency)}
+          </td>
+        )}
+        {showForward7d && (
+          <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>
+            {percent(group.totals.change7dPct, 1)}
+          </td>
+        )}
+        {showForward30d && (
+          <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>
+            {percent(group.totals.change30dPct, 1)}
+          </td>
+        )}
+        <td className={`${tableStyles.cell} ${tableStyles.groupCell} ${tableStyles.right}`}>
+          {percent(groupWeight, 1)}
+        </td>
+        {Array.from({ length: 7 }, (_, index) => (
+          <td key={index} className={`${tableStyles.cell} ${tableStyles.groupCell}`}>—</td>
+        ))}
+      </tr>
+    );
+  };
 
   return (
     <>
@@ -509,6 +652,20 @@ export function HoldingsTable({
           )}
           {items.map((virtualRow) => {
             const h = sortedRows[virtualRow.index];
+            const group = showGroupHeaders
+              ? groups.find((candidate) =>
+                  candidate.rows.some(
+                    (row) =>
+                      (row as RowWithCost & { __holdingsIndex: number }).__holdingsIndex ===
+                      virtualRow.index,
+                  ),
+                )
+              : undefined;
+            const isFirstGroupRow =
+              (group?.rows[0] as (RowWithCost & { __holdingsIndex: number }) | undefined)
+                ?.__holdingsIndex === virtualRow.index;
+            const expanded = group ? expandedGroups.has(group.key) : true;
+            if (group && !expanded && !isFirstGroupRow) return null;
             const isSelected = h.ticker === selectedTicker;
             const handleSelect = () => {
               onSelectInstrument?.(h.ticker, h.name ?? h.ticker);
@@ -518,10 +675,11 @@ export function HoldingsTable({
               event.stopPropagation();
               handleSelect();
             };
-            return (
+            const holdingRow = (
               <tr
                 ref={rowVirtualizer.measureElement}
                 data-index={virtualRow.index}
+                id={group && isFirstGroupRow ? `holdings-group-${sanitizeGroupKey(group.key)}` : undefined}
                 key={h.row_key ?? h.ticker + h.acquired_date}
                 onClick={onSelectInstrument ? handleSelect : undefined}
                 aria-selected={isSelected || undefined}
@@ -673,6 +831,13 @@ export function HoldingsTable({
                     : `✗ ${h.days_until_eligible ?? ""}`}
                 </td>
               </tr>
+            );
+            if (!group) return holdingRow;
+            return (
+              <Fragment key={`section-${group.key}`}>
+                {isFirstGroupRow && renderGroupHeader(group, expanded)}
+                {expanded && holdingRow}
+              </Fragment>
             );
           })}
           {paddingBottom > 0 && (

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -20,6 +20,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import Sparkline from "./Sparkline";
 import { getGrowthStage } from "../utils/growthStage";
 import { preloadInstrumentHistory } from "../hooks/useInstrumentHistory";
+import type { InstrumentGroupDefinition } from "../types";
 import type { RollupRow } from "../lib/rollupAdapter";
 import {
   buildCategoryLookup,
@@ -53,6 +54,7 @@ type Props = {
   showForward30d?: boolean;
   onAddPosition?: () => void;
   groupingMode?: GroupingMode;
+  categoryDefinitions?: InstrumentGroupDefinition[];
 };
 
 
@@ -65,6 +67,7 @@ export function HoldingsTable({
   showForward30d = false,
   onAddPosition,
   groupingMode = "flat",
+  categoryDefinitions = [],
 }: Props) {
   // RollupRow is the adapter's deliberately presentation-neutral shape. Its
   // nullable lot-only fields are rendered the same way as absent Holding fields.
@@ -227,6 +230,18 @@ export function HoldingsTable({
   );
   const totalGainPct = totals.cost ? (totals.gain / totals.cost) * 100 : 0;
 
+  const categoryLookup = useMemo(
+    () => buildCategoryLookup(categoryDefinitions),
+    [categoryDefinitions],
+  );
+  const hasCategories = categoryLookup.categories.size > 0;
+
+  // Category mode requires categoryDefinitions; fall back to 'group' when the
+  // caller requests 'category' without providing definitions (matching
+  // InstrumentTable's useInstrumentTableState behaviour).
+  const effectiveGroupingMode: GroupingMode =
+    groupingMode === "category" && !hasCategories ? "group" : groupingMode;
+
   const groups = useMemo(() => {
     const groupingRows = sortedRows.map((row, index) => ({
       ...row,
@@ -238,22 +253,20 @@ export function HoldingsTable({
       change_30d_pct: row.change_30d_pct ?? row.forward_30d_change_pct ?? null,
     })) as RowWithCost[];
 
-    // HoldingsTable does not own group definitions. In category mode, callers
-    // without category metadata therefore get the shared "uncategorised" rollup.
     return createGroups(
       groupingRows,
       sortKey as keyof RowWithCost,
       asc,
-      groupingMode,
+      effectiveGroupingMode,
       {
         ungroupedLabel: t("instrumentTable.ungrouped", { defaultValue: "Ungrouped" }),
         uncategorisedLabel: t("instrumentTable.uncategorised", {
           defaultValue: "Uncategorised",
         }),
       },
-      buildCategoryLookup([]),
+      categoryLookup,
     );
-  }, [asc, groupingMode, sortKey, sortedRows, t]);
+  }, [asc, categoryLookup, effectiveGroupingMode, sortKey, sortedRows, t]);
   const overallGroupTotals = useMemo(
     () =>
       calculateGroupTotals(
@@ -263,7 +276,7 @@ export function HoldingsTable({
     [groups, t],
   );
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set());
-  const showGroupHeaders = groupingMode !== "flat";
+  const showGroupHeaders = effectiveGroupingMode !== "flat";
 
   const columnLabels: [keyof typeof visibleColumns, string][] = [
     ["units", t("holdingsTable.columns.units")],
@@ -328,6 +341,11 @@ export function HoldingsTable({
     };
   }, [sortedRows.length, relativeViewEnabled, visibleColumns, showForward7d, showForward30d]);
 
+  // Grouped mode disables the virtualizer (count=0) so that all group headers
+  // and their rows remain addressable in the DOM regardless of expand/collapse
+  // state. This renders every row at once — acceptable for the typical grouped
+  // view size (tens of groups) but should be revisited before wiring this mode
+  // to pages that display hundreds of holdings.
   const rowVirtualizer = useVirtualizer({
     count: showGroupHeaders ? 0 : sortedRows.length,
     getScrollElement: () => tableContainerRef.current,
@@ -813,28 +831,38 @@ export function HoldingsTable({
                   {h.days_held ?? "—"}
                 </td>
                 <td className={`${tableStyles.cell} ${tableStyles.center}`}>
-                  {(() => {
-                    const stage = getGrowthStage({ daysHeld: h.days_held });
-                    return <span title={stage.message}>{stage.icon}</span>;
-                  })()}
+                  {h.days_held != null
+                    ? (() => {
+                        const stage = getGrowthStage({ daysHeld: h.days_held });
+                        return <span title={stage.message}>{stage.icon}</span>;
+                      })()
+                    : "—"}
                 </td>
                 <td
-                  className={`${tableStyles.cell} ${tableStyles.center} ${h.sell_eligible ? 'text-positive' : 'text-warning'}`}
+                  className={`${tableStyles.cell} ${tableStyles.center} ${
+                    h.sell_eligible == null
+                      ? ""
+                      : h.sell_eligible
+                        ? "text-positive"
+                        : "text-warning"
+                  }`}
                   title={
                     h.next_eligible_sell_date
                       ? formatDateISO(new Date(h.next_eligible_sell_date))
                       : undefined
                   }
                 >
-                  {h.sell_eligible
-                    ? `✓ ${t("holdingsTable.eligible")}`
-                    : `✗ ${h.days_until_eligible ?? ""}`}
+                  {h.sell_eligible == null
+                    ? "—"
+                    : h.sell_eligible
+                      ? `✓ ${t("holdingsTable.eligible")}`
+                      : `✗ ${h.days_until_eligible ?? ""}`}
                 </td>
               </tr>
             );
             if (!group) return holdingRow;
             return (
-              <Fragment key={`section-${group.key}`}>
+              <Fragment key={`section-${group.key}-${h.row_key ?? virtualRow.index}`}>
                 {isFirstGroupRow && renderGroupHeader(group, expanded)}
                 {expanded && holdingRow}
               </Fragment>

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -178,6 +178,38 @@ describe("HoldingsTable", () => {
         expect(screen.getByRole("columnheader", { name: "Trend (30d)" })).toBeInTheDocument();
     });
 
+    it("renders shared group totals and expands grouped holdings", async () => {
+        const groupedHoldings = holdings.map((holding) => ({
+            ...holding,
+            grouping: holding.ticker === "XYZ" ? "Technology" : "Income",
+        }));
+
+        renderWithConfig(
+            <HoldingsTable holdings={groupedHoldings} groupingMode="group" />,
+        );
+
+        const incomeToggle = screen.getByRole("button", { name: "Toggle Income" });
+        expect(incomeToggle).toHaveAttribute("aria-expanded", "false");
+        const incomeRow = incomeToggle.closest("tr");
+        expect(incomeRow).not.toBeNull();
+        expect(within(incomeRow!).getByText("£180.00")).toBeInTheDocument();
+        expect(within(incomeRow!).getByText("£50.00")).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "AAA" })).toBeNull();
+
+        await userEvent.click(incomeToggle);
+
+        expect(incomeToggle).toHaveAttribute("aria-expanded", "true");
+        expect(screen.getByRole("button", { name: "AAA" })).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "XYZ" })).toBeNull();
+    });
+
+    it("keeps the existing flat rendering when groupingMode is omitted", async () => {
+        renderWithConfig(<HoldingsTable holdings={holdings} />);
+
+        expect(await screen.findByRole("button", { name: "AAA" })).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: /Toggle / })).toBeNull();
+    });
+
     it("keeps footer columns aligned with the header in relative view", async () => {
         const TestProviderRelative = ({ children }: { children: React.ReactNode }) => (
             <configContext.Provider

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -23,9 +23,12 @@ vi.mock("@/components/TopMoversSummary", () => ({
     TopMoversSummary: () => <div data-testid="top-movers-summary" />,
 }));
 import { HoldingsTable } from "@/components/HoldingsTable";
+import { InstrumentTable } from "@/components/InstrumentTable";
 import { GroupPortfolioView } from "@/components/GroupPortfolioView";
 import { configContext, type AppConfig } from "@/ConfigContext";
 import { getGroupPortfolio } from "@/api";
+import type { InstrumentSummary } from "@/types";
+import type { RollupRow } from "@/lib/rollupAdapter";
 
 const defaultConfig: AppConfig = {
     relativeViewEnabled: false,
@@ -208,6 +211,193 @@ describe("HoldingsTable", () => {
 
         expect(await screen.findByRole("button", { name: "AAA" })).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: /Toggle / })).toBeNull();
+    });
+
+    it("falls back to group mode when category mode is requested without definitions", async () => {
+        const groupedHoldings = holdings.map((holding) => ({
+            ...holding,
+            grouping: holding.ticker === "XYZ" ? "Technology" : "Income",
+        }));
+
+        renderWithConfig(
+            <HoldingsTable holdings={groupedHoldings} groupingMode="category" />,
+        );
+
+        // Falls back to 'group' mode → meaningful headers, not "Uncategorised"
+        expect(
+            await screen.findByRole("button", { name: "Toggle Income" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Toggle Technology" }),
+        ).toBeInTheDocument();
+    });
+
+    it("uses category definitions when provided in category mode", async () => {
+        const groupedHoldings = holdings.map((holding) => ({
+            ...holding,
+            grouping: holding.ticker === "XYZ" ? "tech" : "dividend",
+        }));
+
+        renderWithConfig(
+            <HoldingsTable
+                holdings={groupedHoldings}
+                groupingMode="category"
+                categoryDefinitions={[
+                    {
+                        id: "tech-group",
+                        name: "tech",
+                        category: "growth",
+                        category_name: "Growth Assets",
+                    },
+                    {
+                        id: "div-group",
+                        name: "dividend",
+                        category: "income",
+                        category_name: "Income Assets",
+                    },
+                ]}
+            />,
+        );
+
+        // Category resolution: "tech" → "Growth Assets", "dividend" → "Income Assets"
+        expect(
+            await screen.findByRole("button", { name: /Toggle Growth Assets/ }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: /Toggle Income Assets/ }),
+        ).toBeInTheDocument();
+    });
+
+    it("produces group totals matching InstrumentTable for equivalent data", async () => {
+        const parityInstruments: InstrumentSummary[] = [
+            {
+                ticker: "P1",
+                name: "Parity One",
+                grouping: "Alpha",
+                currency: "GBP",
+                instrument_type: "Equity",
+                units: 10,
+                market_value_gbp: 500,
+                gain_gbp: 100,
+            },
+            {
+                ticker: "P2",
+                name: "Parity Two",
+                grouping: "Alpha",
+                currency: "GBP",
+                instrument_type: "Equity",
+                units: 5,
+                market_value_gbp: 500,
+                gain_gbp: -50,
+            },
+            {
+                ticker: "P3",
+                name: "Parity Three",
+                grouping: "Beta",
+                currency: "GBP",
+                instrument_type: "Equity",
+                units: 3,
+                market_value_gbp: 300,
+                gain_gbp: 30,
+            },
+        ];
+
+        const parityHoldings = parityInstruments.map((inst) => ({
+            ticker: inst.ticker,
+            name: inst.name,
+            grouping: inst.grouping,
+            currency: inst.currency ?? "GBP",
+            instrument_type: inst.instrument_type ?? "Equity",
+            units: inst.units,
+            price: 0,
+            cost_basis_gbp: inst.market_value_gbp - inst.gain_gbp,
+            market_value_gbp: inst.market_value_gbp,
+            gain_gbp: inst.gain_gbp,
+            current_price_gbp: 100,
+            latest_source: "Feed",
+            acquired_date: "2024-01-01",
+            last_price_date: "2024-01-01",
+            days_held: 100,
+            sell_eligible: true,
+            days_until_eligible: 0,
+        }));
+
+        const { unmount } = renderWithConfig(
+            <MemoryRouter>
+                <InstrumentTable rows={parityInstruments} />
+            </MemoryRouter>,
+        );
+
+        // Capture InstrumentTable group header totals
+        await screen.findByRole("button", { name: /Toggle Alpha/i });
+        const itAlphaRow = screen.getByRole("button", { name: /Toggle Alpha/i }).closest("tr")!;
+        const itAlphaMarket = within(itAlphaRow).getByText("£1,000.00").textContent;
+        const itAlphaGainCell = within(itAlphaRow).getByText(/£50\.00/);
+        const itAlphaGain = itAlphaGainCell.textContent;
+        const itBetaRow = screen.getByRole("button", { name: /Toggle Beta/i }).closest("tr")!;
+        const itBetaMarket = within(itBetaRow).getByText("£300.00").textContent;
+
+        unmount();
+
+        renderWithConfig(
+            <HoldingsTable holdings={parityHoldings} groupingMode="group" />,
+        );
+
+        await screen.findByRole("button", { name: "Toggle Alpha" });
+        const htAlphaRow = screen.getByRole("button", { name: "Toggle Alpha" }).closest("tr")!;
+        const htAlphaMarket = within(htAlphaRow).getByText("£1,000.00").textContent;
+        const htAlphaGainCell = within(htAlphaRow).getByText(/£50\.00/);
+        const htAlphaGain = htAlphaGainCell.textContent;
+        // InstrumentTable annotates gain with ▲/▼ prefix (formatSignedMoney);
+        // HoldingsTable does not. Strip prefix for fair comparison.
+        const stripPrefix = (text: string | null) => (text ?? "").replace(/^[▲▼]/, "");
+        const htBetaRow = screen.getByRole("button", { name: "Toggle Beta" }).closest("tr")!;
+        const htBetaMarket = within(htBetaRow).getByText("£300.00").textContent;
+
+        expect(htAlphaMarket).toBe(itAlphaMarket);
+        expect(stripPrefix(htAlphaGain)).toBe(stripPrefix(itAlphaGain));
+        expect(htBetaMarket).toBe(itBetaMarket);
+    });
+
+    it("renders — for growth stage and eligibility when data is null (rollup rows)", async () => {
+        const rollupRows: RollupRow[] = [
+            {
+                ticker: "ROLL",
+                name: "Rollup Co",
+                units: 10,
+                cost_basis_gbp: 500,
+                market_value_gbp: 600,
+                gain_gbp: 100,
+                gain_pct: 20,
+                weight_pct: 10,
+                lot_count: 3,
+                owners: ["Alice"],
+                accounts: ["isa"],
+                grouping: "Growth",
+                exchange: "L",
+                change_7d_pct: 2,
+                change_30d_pct: 5,
+                acquired_date: null,
+                days_held: null,
+                sell_eligible: null,
+                days_until_eligible: null,
+                next_eligible_sell_date: null,
+            },
+        ];
+
+        renderWithConfig(
+            <HoldingsTable holdings={rollupRows} groupingMode="group" />,
+        );
+
+        await screen.findByRole("button", { name: "Toggle Growth" });
+        // Expand the group to see the row
+        await userEvent.click(screen.getByRole("button", { name: "Toggle Growth" }));
+
+        const row = screen.getByText("Rollup Co").closest("tr")!;
+        // Stage and eligibility cells should show "—" for null rollup fields
+        const cells = within(row).getAllByText("—");
+        // days_held cell, stage cell, eligibility cell, and acquired_date cell
+        expect(cells.length).toBeGreaterThanOrEqual(3);
     });
 
     it("keeps footer columns aligned with the header in relative view", async () => {


### PR DESCRIPTION
### Motivation

- Provide HoldingsTable with the same grouped/expandable rollup view that InstrumentTable offers so it can render family-level aggregated rollups without duplicating grouping logic.

### Description

- Added an optional `groupingMode?: 'group' | 'flat' | 'category'` prop to `HoldingsTable` and accepted adapter-shaped `RollupRow` input so the component can be driven by the rollup adapter or existing holdings data.
- Reused `createGroups` and `calculateGroupTotals` from `frontend/src/components/instrumentTable/utils` to compute groups and totals, and ported the group-header/expand-collapse rendering into `frontend/src/components/HoldingsTable.tsx` without changing `InstrumentTable.tsx`.
- Rendered group header rows with aggregate values and an expand/collapse toggle, and disabled the virtualizer for grouped mode so collapsed groups remain addressable while preserving virtualized performance in flat mode.
- Added unit tests to `frontend/tests/unit/components/HoldingsTable.test.tsx` covering grouped totals, expand/collapse behavior, and that the default flat rendering is unchanged, and updated code to accept the rollup adapter shape.

### Testing

- Ran the holdings table unit tests with `npm --prefix frontend run test -- --run tests/unit/components/HoldingsTable.test.tsx` and observed all tests pass (27 tests passed). 
- Ran lint with `npm --prefix frontend run lint` and a production build with `npm --prefix frontend run build`, both of which completed successfully. 
- Verified via the build and diffs that `InstrumentTable.tsx` was not modified and existing flat `HoldingsTable` behavior remains unchanged when `groupingMode` is omitted.

Closes #6379

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7afafaf5d08327bc0200f40ec3135a)