### PR TITLE
Fix query-scoped portfolio routing and account URL canonicalization

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -246,6 +246,16 @@ export default function App({ onLogout }: AppProps) {
     setPortfolioAsOf(isoDate);
   }, []);
 
+  const handleAccountTypeChange = useCallback(
+    (accountType: string | null) => {
+      if (!selectedOwner) return;
+      const params = new URLSearchParams({ owner: selectedOwner });
+      if (accountType) params.set('account', accountType);
+      navigate(`/?${params.toString()}`, { replace: true });
+    },
+    [navigate, selectedOwner]
+  );
+
   const handleLogout = useCallback(() => {
     portfolioCache.current.clear();
     setPortfolio(null);
@@ -606,6 +616,8 @@ export default function App({ onLogout }: AppProps) {
               loading={loading}
               error={err}
               onDateChange={handlePortfolioDateChange}
+              accountType={scopeQuery.account}
+              onAccountTypeChange={handleAccountTypeChange}
             />
           </>
         )}

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -13,7 +13,7 @@ import type { TabPluginId } from '../tabPlugins';
 import { SUPPORT_TABS } from '../tabPlugins';
 import {
   buildPathForMode,
-  deriveModeFromPathname,
+  deriveModeFromLocation,
   getMenuEntries,
   MENU_CATEGORY_ORDER,
 } from '../pageManifest';
@@ -49,7 +49,7 @@ export default function Menu({
   // caller doesn't thread one through explicitly, so the control stays
   // reachable regardless of where Menu is mounted (#4751).
   const effectiveLogout = onLogout ?? contextLogout ?? undefined;
-  const mode = deriveModeFromPathname(location.pathname) as TabPluginId;
+  const mode = deriveModeFromLocation(location.pathname, location.search) as TabPluginId;
   const isSupportMode = (SUPPORT_TABS as readonly string[]).includes(mode);
   const inSupport = mode === 'support';
   // Support link is shown whenever the support tab is enabled. It stays gated on

--- a/frontend/src/components/PortfolioView.tsx
+++ b/frontend/src/components/PortfolioView.tsx
@@ -217,6 +217,8 @@ type Props = {
   onDateChange?: (isoDate: string | null) => void;
   onAccountAdded?: () => void;
   onPositionAdded?: () => void;
+  accountType?: string | null;
+  onAccountTypeChange?: (accountType: string | null) => void;
 };
 
 /**
@@ -226,7 +228,7 @@ type Props = {
  * relies on its parent for data fetching. Conditional branches early-return to
  * keep the JSX at the bottom easy to follow.
  */
-export function PortfolioView({ data, loading, error, onDateChange, onAccountAdded, onPositionAdded }: Props) {
+export function PortfolioView({ data, loading, error, onDateChange, onAccountAdded, onPositionAdded, accountType, onAccountTypeChange }: Props) {
   const { t } = useTranslation();
   const [activeAccount, setActiveAccount] = useState("all");
   const [selectedInstrument, setSelectedInstrument] = useState<{
@@ -260,6 +262,21 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
       setActiveAccount("all");
     }
   }, [activeAccount, data]);
+
+  useEffect(() => {
+    if (!data || !accountType) return;
+    const accountIndex = data.accounts.findIndex(
+      (account) => account.account_type.toLowerCase() === accountType.toLowerCase(),
+    );
+    if (accountIndex < 0) {
+      setActiveAccount("all");
+      onAccountTypeChange?.(null);
+      return;
+    }
+    const account = data.accounts[accountIndex];
+    setActiveAccount(accountKey(account, accountIndex));
+    if (account.account_type !== accountType) onAccountTypeChange?.(account.account_type);
+  }, [accountType, data, onAccountTypeChange]);
 
   useEffect(() => {
     setPendingDate(data?.as_of ?? "");
@@ -597,7 +614,10 @@ export function PortfolioView({ data, loading, error, onDateChange, onAccountAdd
                     type="button"
                     role="tab"
                     aria-selected={activeAccount === tab.key}
-                    onClick={() => setActiveAccount(tab.key)}
+                    onClick={() => {
+                      setActiveAccount(tab.key);
+                      onAccountTypeChange?.(tab.key === "all" ? null : tab.label);
+                    }}
                     className={`shrink-0 border-b-2 px-3 py-2 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400 ${
                       activeAccount === tab.key
                         ? "border-blue-400 font-semibold text-white"

--- a/frontend/src/hooks/useRouteMode.ts
+++ b/frontend/src/hooks/useRouteMode.ts
@@ -5,7 +5,7 @@ import type { Mode } from '../modes';
 import useFetch from './useFetch';
 import { getGroups } from '../api';
 import { normaliseGroupSlug } from '../utils/groups';
-import { buildPathForMode, deriveRouteFromPathname } from '../pageManifest';
+import { buildPathForMode, deriveModeFromLocation, deriveRouteFromPathname, readRouteScopeQuery } from '../pageManifest';
 
 interface RouteState {
   mode: Mode;
@@ -17,13 +17,14 @@ interface RouteState {
 }
 
 function deriveInitialState() {
-  const params = new URLSearchParams(window.location.search);
+  const scope = readRouteScopeQuery(window.location.search);
   const route = deriveRouteFromPathname(window.location.pathname);
-  const owner = route.mode === 'owner' || route.mode === 'performance' ? route.slug : '';
-  const group = route.mode === 'instrument' ? route.slug : normaliseGroupSlug(params.get('group'));
+  const mode = deriveModeFromLocation(window.location.pathname, window.location.search);
+  const owner = mode === 'owner' ? route.slug || scope.owner || '' : route.mode === 'performance' ? route.slug : '';
+  const group = route.mode === 'instrument' ? route.slug : normaliseGroupSlug(scope.group);
 
   return {
-    mode: route.mode,
+    mode,
     owner,
     group,
   };
@@ -41,9 +42,9 @@ export function useRouteMode(): RouteState {
   const [selectedGroup, setSelectedGroup] = useState(initial.group);
 
   useEffect(() => {
-    const params = new URLSearchParams(location.search);
+    const scope = readRouteScopeQuery(location.search);
     const route = deriveRouteFromPathname(location.pathname);
-    const nextMode = route.mode;
+    const nextMode = deriveModeFromLocation(location.pathname, location.search);
     const isDisabled = tabs[nextMode] === false || disabledTabs?.includes(nextMode);
 
     if (isDisabled) {
@@ -64,7 +65,7 @@ export function useRouteMode(): RouteState {
     setMode(nextMode);
 
     if (nextMode === 'owner' || nextMode === 'performance') {
-      setSelectedOwner(route.slug);
+      setSelectedOwner(route.slug || scope.owner || '');
       return;
     }
 
@@ -89,7 +90,8 @@ export function useRouteMode(): RouteState {
     }
 
     if (nextMode === 'group') {
-      setSelectedGroup(normaliseGroupSlug(params.get('group')));
+      setSelectedOwner('');
+      setSelectedGroup(normaliseGroupSlug(scope.group));
     }
   }, [disabledTabs, groups, location.pathname, location.search, navigate, selectedGroup, selectedOwner, tabs]);
 

--- a/frontend/tests/unit/hooks/useRouteMode.test.tsx
+++ b/frontend/tests/unit/hooks/useRouteMode.test.tsx
@@ -70,6 +70,15 @@ describe("useRouteMode", () => {
     await waitFor(() => expect(result.current.route.mode).toBe("group"));
     expect(result.current.route.selectedGroup).toBe("kids");
   });
+  it("uses owner scope from the root query string", async () => {
+    window.history.pushState({}, "", "/?owner=steve&account=isa");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={["/?owner=steve&account=isa"]}>{children}</MemoryRouter>
+    );
+    const { result } = renderHook(() => useRouteMode(), { wrapper });
+    await waitFor(() => expect(result.current.mode).toBe("owner"));
+    expect(result.current.selectedOwner).toBe("steve");
+  });
   it("navigates to first enabled tab when movers is disabled", async () => {
     window.history.pushState({}, "", "/movers");
 


### PR DESCRIPTION
### Motivation
- Ensure bookmarkable root URLs like `/?owner=steve` and `/?owner=steve&account=isa` are honored across shared routing consumers and portfolio UI so the requested owner/account scope is displayed consistently. 
- Address review/CodeQL feedback that parsed the query params but did not fully propagate `owner`/`account` into shared route state and account tabs.

### Description
- Make route derivation query-aware by adding and using `readRouteScopeQuery` / `deriveModeFromLocation` in the shared routing hook and consumers, so `/?owner=...` activates owner mode for `useRouteMode` and the `Menu`. 
- Wire the `account` query param through `App` into `PortfolioView` by adding `accountType` and `onAccountTypeChange` props, reconcile invalid account values against loaded portfolio data, and canonicalize the URL to the portfolio-returned account name when necessary. 
- Add `handleAccountTypeChange` in `App` to update the canonical `/?owner=...&account=...` (or remove `account` for “All accounts”), and update account-tab clicks to call the callback. 
- Update unit tests to cover query-derived owner scope and adjust existing tests to expect canonical `/?owner=...` behavior.

### Testing
- Ran unit tests: `npm --prefix frontend run test -- --run tests/unit/hooks/useRouteMode.test.tsx tests/unit/pageManifest.test.ts tests/unit/App.test.tsx tests/unit/pages/Portfolio.test.tsx`, and the suite passed (47 tests passed). 
- Ran TypeScript checks: `npm --prefix frontend run type-check`, which completed with no errors. 
- Ran linter: `npm --prefix frontend run lint`, which completed with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7afab2c8108327b1a08725b55fb6c4)