### PR TITLE
Remove exposed Telegram token sentinel from tests and move revoked token to ignored .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ SNS_TOPIC_ARN=arn:aws:sns:us-east-1:123456789012:allotmint
 # Telegram bot credentials for alerting (required for production)
 # Generate bot token via Telegram BotFather (@BotFather)
 # NEVER commit actual token values to source control
-TELEGRAM_BOT_TOKEN=123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ
+TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=123456789
 
 # Token used to secure sensitive routes via the X-API-Token header

--- a/docs/USER_README.md
+++ b/docs/USER_README.md
@@ -26,8 +26,8 @@ Additional runtime settings are supplied via environment variables. Copy
 - `ALPHA_VANTAGE_KEY`: API key for Alpha Vantage data (example: `demo`).
 - `SNS_TOPIC_ARN`: publish alerts to an AWS SNS topic (e.g.
   `arn:aws:sns:us-east-1:123456789012:allotmint`).
-- `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`: forward alerts to Telegram
-  (e.g. `123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ` and `123456789`).
+- `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`: forward alerts to Telegram;
+  set these only in an untracked `.env` file or the deployment secret store; never commit their values.
 - `DATA_BUCKET`: S3 bucket containing account data when running in AWS.
 - `METADATA_BUCKET` and `METADATA_PREFIX`: S3 bucket and key prefix for instrument metadata.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -230,22 +230,6 @@ def test_telegram_credentials_absent_when_env_unset(monkeypatch):
     assert not cfg.telegram_chat_id
 
 
-# Regression guard: the compromised token from commit 30b8f36 must never appear as a
-# default value loaded from config.yaml, regardless of env-var state.
-# This token was publicly exposed on 2025-07-23 and must be treated as revoked.
-# It is stored here solely as a regression sentinel — not as a usable credential.
-_COMPROMISED_TOKEN = "8491288399:AAGRRuCJtctSQ2igqnW56BxQ3L_c0Jsi_nA"  # noqa: S105
-
-
-def test_compromised_token_not_loaded_as_default(monkeypatch):
-    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
-    cfg = reload_config()
-    assert cfg.telegram_bot_token != _COMPROMISED_TOKEN, (
-        "Compromised Telegram token is still present as a default in config.yaml — "
-        "remove it and ensure the field defaults to an empty string."
-    )
-
-
 def test_allowed_emails_env_override(monkeypatch):
     monkeypatch.setenv("ALLOWED_EMAILS", "TEST@Example.com,Other@Example.com ,")
     cfg = reload_config()


### PR DESCRIPTION
### Motivation
- Secret scanning found a revoked Telegram bot token embedded as a regression sentinel in tracked tests, so the token must be removed from source and retained only in an untracked local environment file for remediation.

### Description
- Remove the `_COMPROMISED_TOKEN` constant and the `test_compromised_token_not_loaded_as_default` test from `tests/test_config.py`, and place the revoked token into the repository root `.env` as `COMPROMISED_TELEGRAM_BOT_TOKEN` while keeping `.env` ignored.

### Testing
- Ran `git diff --check` and `git grep` for the compromised token to confirm there are no tracked matches (passed), and verified `.env` is ignored with `git status --short --ignored` (passed); attempting `pytest tests/test_config.py` failed because the environment lacks the `yaml` dependency (`PyYAML`), so full test execution could not be completed (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b05c960e88327afe05afc63df6011)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an obsolete regression test and its associated security sentinel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->