### PR TITLE
Update vulnerable transitive npm deps (brace-expansion, tar) to address Dependabot advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -846,16 +846,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-crc32": {
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
### Motivation
- Fix transitive npm vulnerabilities reported by Dependabot by updating affected packages in the root lockfile.

### Description
- Bumped `brace-expansion` from 5.0.7 to 5.0.9 and `tar` from 7.5.20 to 7.5.22 in `package-lock.json` to pull in patched versions that mitigate the reported DoS/stack-overflow advisories.

### Testing
- Ran `python scripts/check_lockfile_platform_coverage.py`, `npm ci`, `npm audit --audit-level=high`, and `npm --prefix frontend audit`, which completed and show no high/critical vulnerabilities remaining (the frontend audit is clean and three unrelated moderate findings remain in the `@capacitor/cli` → `xcode` → `uuid` chain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b059a1050832796fec784ed2c66a0)

Closes #6431