### PR TITLE
Validate timeseries cache identifiers

### DIFF
--- a/backend/routes/timeseries_edit.py
+++ b/backend/routes/timeseries_edit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import logging
 import os
+import re
 import shutil
 from pathlib import Path
 
@@ -28,6 +29,17 @@ from backend.timeseries.cache import (
 router = APIRouter(prefix="/timeseries", tags=["timeseries"])
 logger = logging.getLogger(__name__)
 
+_TICKER_RE = re.compile(r"^[A-Z0-9][A-Z0-9_-]{0,49}$")
+_EXCHANGE_RE = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,49}$")
+
+
+def _validate_cache_identifier(value: str, *, kind: str) -> str:
+    """Validate an identifier before incorporating it into a cache path."""
+    pattern = _TICKER_RE if kind == "ticker" else _EXCHANGE_RE
+    if not pattern.fullmatch(value):
+        raise ValidationFailure(f"Invalid {kind} format", extra={"field": kind})
+    return value
+
 
 def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> tuple[str, str]:
     t = (ticker or "").upper()
@@ -35,13 +47,15 @@ def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> tuple[str, st
         raise ValidationFailure("Ticker is required", extra={"field": "ticker"})
 
     if exchange:
-        sym = t.split(".", 1)[0]
-        ex = exchange.upper()
+        sym = _validate_cache_identifier(t.split(".", 1)[0], kind="ticker")
+        ex = _validate_cache_identifier(exchange.upper(), kind="exchange")
         logger.debug("Resolved %s.%s (provided exchange)", sanitise_log_value(sym), sanitise_log_value(ex))
         return sym, ex
 
     if "." in t:
         sym, ex = t.split(".", 1)
+        sym = _validate_cache_identifier(sym, kind="ticker")
+        ex = _validate_cache_identifier(ex, kind="exchange")
         logger.debug("Resolved %s.%s (provided exchange)", sanitise_log_value(sym), sanitise_log_value(ex))
         return sym, ex
 
@@ -53,6 +67,8 @@ def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> tuple[str, st
             extra={"field": "exchange", "ticker": ticker},
         )
     sym, ex = resolved
+    sym = _validate_cache_identifier(sym.upper(), kind="ticker")
+    ex = _validate_cache_identifier(ex.upper(), kind="exchange")
     logger.debug("Resolved %s.%s (inferred exchange)", sanitise_log_value(sym), sanitise_log_value(ex))
     return sym, ex
 

--- a/tests/routes/test_timeseries_edit.py
+++ b/tests/routes/test_timeseries_edit.py
@@ -41,6 +41,33 @@ def test_resolve_ticker_exchange_error(monkeypatch):
     assert "could not be inferred" in exc.value.detail
 
 
+@pytest.mark.parametrize(
+    "ticker,exchange",
+    [
+        ("../outside", "L"),
+        ("ABC", "../outside"),
+        ("ABC", ".hidden"),
+        ("ABC/DEF", "L"),
+    ],
+)
+def test_resolve_ticker_exchange_rejects_unsafe_cache_identifiers(ticker, exchange):
+    with pytest.raises(ValidationFailure) as exc:
+        timeseries_edit._resolve_ticker_exchange(ticker, exchange)
+
+    assert exc.value.status_code == 400
+    assert "Invalid" in exc.value.detail
+
+
+def test_unsafe_cache_identifier_never_reaches_path_builder(monkeypatch):
+    def fail_if_called(*_args):
+        raise AssertionError("unsafe identifier reached cache path builder")
+
+    monkeypatch.setattr(timeseries_edit, "meta_timeseries_cache_path", fail_if_called)
+
+    with pytest.raises(ValidationFailure):
+        timeseries_edit._resolve_ticker_exchange("../../etc/passwd", "L")
+
+
 def _make_client(tmp_path, monkeypatch):
     monkeypatch.setattr(cache, "_CACHE_BASE", str(tmp_path))
     app = FastAPI()


### PR DESCRIPTION
### Motivation

- Address a repository code-scanning finding (security alert #297) where user-controlled timeseries identifiers could be incorporated into filesystem or S3 cache paths, creating path-traversal / namespace-escape risk. 
- Apply a conservative, bounded allowlist for ticker and exchange segments so paths are constrained before any on-disk or S3 operations.

### Description

- Add bounded allowlist regexes `_TICKER_RE` and `_EXCHANGE_RE` and a helper `_validate_cache_identifier` that raises `ValidationFailure` for invalid identifiers. 
- Apply validation to explicitly supplied, dot-qualified, and instrument-api-inferred ticker/exchange values inside `_resolve_ticker_exchange` so unsafe inputs are rejected early. 
- Add regression tests (`tests/routes/test_timeseries_edit.py`) that assert rejection of traversal sequences, path separators, hidden (leading-dot) exchange values, and that unsafe input never reaches `meta_timeseries_cache_path`.

### Testing

- Ran module tests with `PYENV_VERSION=3.11.15 python -m pytest tests/routes/test_timeseries_edit.py -q --no-cov` and `PYENV_VERSION=3.11.15 python -m pytest tests/routes/test_timeseries_edit.py -q`; both runs: 23 tests passed. 
- Static checks: `ruff` check passed for the changed files (`python -m ruff check --config backend/pyproject.toml backend/routes/timeseries_edit.py tests/routes/test_timeseries_edit.py`). 
- Formatting: applied `black` to the modified files during iteration. 
- Note: running the single test module with coverage triggered the repo-wide coverage gate and failed because overall repository coverage is below the configured `fail-under=90%`, but this is unrelated to the change itself and all local tests for the touched module passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b057c40f08327880db8fa86ca8a98)

Closes #6432