### PR TITLE
HoldingsTable: add rollupMode to suppress lot-only filters and days-held sort

### DIFF
--- a/frontend/src/components/HoldingsFilterControls.tsx
+++ b/frontend/src/components/HoldingsFilterControls.tsx
@@ -16,7 +16,7 @@ type Props = {
   onViewPresetChange: (preset: string) => void;
   minimumGain: string;
   onMinimumGainChange: (value: string) => void;
-  onSellEligible: () => void;
+  onSellEligible?: () => void;
 };
 
 export function HoldingsFilterControls({
@@ -63,13 +63,15 @@ export function HoldingsFilterControls({
       </span>
       <span className="flex items-center gap-1">
         {t('holdingsTable.quickFilters')}
-        <button
-          type="button"
-          className="ml-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
-          onClick={onSellEligible}
-        >
-          {t('holdingsTable.quickFiltersSellEligible')}
-        </button>
+        {onSellEligible && (
+          <button
+            type="button"
+            className="ml-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+            onClick={onSellEligible}
+          >
+            {t('holdingsTable.quickFiltersSellEligible')}
+          </button>
+        )}
         <input
           type="number"
           placeholder={t('holdingsTable.minimumGainPrompt')}

--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -47,6 +47,8 @@ type HoldingsTableRow = Holding & {
 
 type Props = {
   holdings: HoldingsTableRow[] | RollupRow[];
+  // Rollup rows have no per-lot fields, so lot-only filters and sorts are suppressed (§3 rule 2).
+  rollupMode?: boolean;
   showAccount?: boolean;
   onSelectInstrument?: (ticker: string, name: string) => void;
   selectedTicker?: string;
@@ -60,6 +62,7 @@ type Props = {
 
 export function HoldingsTable({
   holdings,
+  rollupMode = false,
   showAccount = false,
   onSelectInstrument,
   selectedTicker,
@@ -205,7 +208,7 @@ export function HoldingsTable({
       const minGain = parseFloat(filters.gain_pct);
       if (!Number.isNaN(minGain) && (h.gain_pct ?? 0) < minGain) return false;
     }
-    if (filters.sell_eligible) {
+    if (!rollupMode && filters.sell_eligible) {
       const expect = filters.sell_eligible === "true";
       if (!!h.sell_eligible !== expect) return false;
     }
@@ -465,7 +468,11 @@ export function HoldingsTable({
             onViewPresetChange={setViewPreset}
             minimumGain={filters.gain_pct}
             onMinimumGainChange={(value) => handleFilterChange("gain_pct", value)}
-            onSellEligible={() => handleFilterChange("sell_eligible", "true")}
+            onSellEligible={
+              rollupMode
+                ? undefined
+                : () => handleFilterChange("sell_eligible", "true")
+            }
           />
           <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1">
             {t("holdingsTable.columnsLabel")}
@@ -562,15 +569,17 @@ export function HoldingsTable({
             <th className={`${tableStyles.cell} ${tableStyles.right}`}></th>
             <th className={tableStyles.cell}></th>
             <th className={`${tableStyles.cell} ${tableStyles.center}`}>
-              <select
-                aria-label={t("holdingsTable.filters.sellEligible")}
-                value={filters.sell_eligible}
-                onChange={(e) => handleFilterChange("sell_eligible", e.target.value)}
-              >
-                <option value="">{t("holdingsTable.filters.all")}</option>
-                <option value="true">{t("holdingsTable.filters.yes")}</option>
-                <option value="false">{t("holdingsTable.filters.no")}</option>
-              </select>
+              {!rollupMode && (
+                <select
+                  aria-label={t("holdingsTable.filters.sellEligible")}
+                  value={filters.sell_eligible}
+                  onChange={(e) => handleFilterChange("sell_eligible", e.target.value)}
+                >
+                  <option value="">{t("holdingsTable.filters.all")}</option>
+                  <option value="true">{t("holdingsTable.filters.yes")}</option>
+                  <option value="false">{t("holdingsTable.filters.no")}</option>
+                </select>
+              )}
             </th>
           </tr>
           <tr>
@@ -649,10 +658,11 @@ export function HoldingsTable({
             <th className={tableStyles.cell}>{t("instrumentTable.columns.type")}</th>
             <th className={tableStyles.cell}>{t("holdingsTable.columns.acquired")}</th>
             <th
-              className={`${tableStyles.cell} ${tableStyles.right} ${tableStyles.clickable}`}
-              onClick={() => handleSort("days_held")}
+              className={`${tableStyles.cell} ${tableStyles.right}${rollupMode ? "" : ` ${tableStyles.clickable}`}`}
+              onClick={rollupMode ? undefined : () => handleSort("days_held")}
             >
-              {t("holdingsTable.columns.daysHeld")}{sortKey === "days_held" ? (asc ? " ▲" : " ▼") : ""}
+              {t("holdingsTable.columns.daysHeld")}
+              {!rollupMode && sortKey === "days_held" ? (asc ? " ▲" : " ▼") : ""}
             </th>
             <th className={`${tableStyles.cell} ${tableStyles.center}`}>{t("holdingsTable.columns.stage")}</th>
             <th className={`${tableStyles.cell} ${tableStyles.center}`}>{t("holdingsTable.columns.eligible")}</th>

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -131,6 +131,53 @@ describe("HoldingsTable", () => {
         },
     ];
 
+    const rollupRows: RollupRow[] = [
+        {
+            ticker: "ROLL-A",
+            name: "Rollup Alpha",
+            units: 10,
+            cost_basis_gbp: 500,
+            market_value_gbp: 600,
+            gain_gbp: 100,
+            gain_pct: 20,
+            weight_pct: 60,
+            lot_count: 3,
+            owners: ["Alice"],
+            accounts: ["isa"],
+            grouping: "Growth",
+            exchange: "L",
+            change_7d_pct: 2,
+            change_30d_pct: 5,
+            acquired_date: null,
+            days_held: null,
+            sell_eligible: null,
+            days_until_eligible: null,
+            next_eligible_sell_date: null,
+        },
+        {
+            ticker: "ROLL-Z",
+            name: "Rollup Zeta",
+            units: 5,
+            cost_basis_gbp: 400,
+            market_value_gbp: 400,
+            gain_gbp: 0,
+            gain_pct: 0,
+            weight_pct: 40,
+            lot_count: 2,
+            owners: ["Bob"],
+            accounts: ["sipp"],
+            grouping: "Income",
+            exchange: "L",
+            change_7d_pct: 1,
+            change_30d_pct: 3,
+            acquired_date: null,
+            days_held: null,
+            sell_eligible: null,
+            days_until_eligible: null,
+            next_eligible_sell_date: null,
+        },
+    ];
+
     const TestProvider = ({ children }: { children: React.ReactNode }) => {
         const [relativeViewEnabled, setRelativeViewEnabled] = useState(false);
         return (
@@ -537,6 +584,49 @@ describe("HoldingsTable", () => {
         await userEvent.selectOptions(select, "true");
         expect(screen.getByText("AAA")).toBeInTheDocument();
         expect(screen.queryByText("Test Holding")).toBeNull();
+    });
+
+    it("suppresses lot-only eligibility controls without changing the column count in rollup mode", async () => {
+        const { unmount } = renderWithConfig(<HoldingsTable holdings={holdings} />);
+        const flatHeaderRows = await screen.findAllByRole("row");
+        const flatColumnCount = within(flatHeaderRows[0]).getAllByRole("columnheader").length;
+        unmount();
+
+        renderWithConfig(<HoldingsTable holdings={rollupRows} rollupMode />);
+        const rollupHeaderRows = await screen.findAllByRole("row");
+
+        expect(within(rollupHeaderRows[0]).getAllByRole("columnheader")).toHaveLength(flatColumnCount);
+        expect(screen.queryByLabelText("Sell eligible")).toBeNull();
+        expect(screen.queryByRole("button", { name: "Sell-eligible" })).toBeNull();
+    });
+
+    it("ignores a leftover eligibility filter after switching to rollup mode", async () => {
+        const { rerender } = renderWithConfig(<HoldingsTable holdings={holdings} />);
+        await userEvent.selectOptions(await screen.findByLabelText("Sell eligible"), "true");
+        expect(screen.queryByText("Test Holding")).toBeNull();
+
+        rerender(
+            <TestProvider>
+                <HoldingsTable holdings={rollupRows} rollupMode />
+            </TestProvider>,
+        );
+
+        expect(await screen.findByText("ROLL-A")).toBeInTheDocument();
+        expect(screen.getByText("ROLL-Z")).toBeInTheDocument();
+    });
+
+    it("does not sort by days held in rollup mode", async () => {
+        renderWithConfig(<HoldingsTable holdings={rollupRows} rollupMode />);
+        await screen.findByText("ROLL-A");
+        const daysHeldHeader = screen.getByRole("columnheader", { name: "Days Held" });
+        const tickersBefore = screen.getAllByText(/^ROLL-/).map((cell) => cell.textContent);
+
+        expect(daysHeldHeader.className).not.toContain("clickable");
+        expect(daysHeldHeader).not.toHaveTextContent("▲");
+        expect(daysHeldHeader).not.toHaveTextContent("▼");
+        await userEvent.click(daysHeldHeader);
+
+        expect(screen.getAllByText(/^ROLL-/).map((cell) => cell.textContent)).toEqual(tickersBefore);
     });
 
     it("shows last price date badge when available", async () => {


### PR DESCRIPTION
### Motivation
- Rollup rows lack per-lot fields (acquired_date, days_held, sell_eligible, etc.), so existing sell-eligible filter and days-held sort produce incorrect behavior when applied to rollups (null → false collapse and meaningless ties).
- Add a non-breaking opt-in flag to suppress lot-only controls for views that render rollup rows so flat-mode behavior is unchanged.

### Description
- Add an optional `rollupMode?: boolean` prop to `HoldingsTable`, defaulting to `false`, and document its purpose. (changes in `frontend/src/components/HoldingsTable.tsx`).
- Prevent the persisted `filters.sell_eligible` predicate from being applied in rollup mode, so an existing filter does not hide rollup rows. (filter predicate guarded by `!rollupMode`).
- Suppress the sell-eligible header `<select>` and make the `HoldingsFilterControls` quick-filter callback optional; render an empty `<th>` in rollup mode to preserve column alignment. (changes in `HoldingsTable.tsx` and `HoldingsFilterControls.tsx`).
- Disable the days-held header's click handler, clickable styling, and sort indicator when `rollupMode` is true so rollup rows are not sorted by a meaningless field. (changes in `HoldingsTable.tsx`).
- Add unit tests exercising rollup behavior: header column-count parity, hidden eligibility controls, leftover filter state being ignored in rollup mode, and disabled days-held sorting. (tests added to `frontend/tests/unit/components/HoldingsTable.test.tsx`).
- No behavioral changes for existing callers because `rollupMode` defaults to `false`.

Closes #6433

### Testing
- Ran the focused component tests with `npm --prefix frontend run test -- --run tests/unit/components/HoldingsTable.test.tsx`, and the modified/spec tests passed (34 tests passing).
- Ran the frontend linter with `npm --prefix frontend run lint` and it succeeded with no introduced ESLint errors.
- Attempted a full frontend test run (`npm --prefix frontend run test -- --run`) in this environment but the full-suite run did not complete within the session constraints; the focused component suite used to validate the change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b160a143c8327b7fc26829e22c5f8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added roll-up mode for holdings tables, presenting grouped holdings without lot-specific eligibility controls or days-held sorting.
  - Sell-eligibility quick filters are now shown only where supported.
  - Standard holdings-table behaviour remains unchanged.

- **Bug Fixes**
  - Prevented previously selected sell-eligibility filters and days-held sorting from affecting roll-up views.

- **Tests**
  - Added coverage for grouped holdings, hidden controls, filter handling, and preserved row ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->