### PR TITLE
Drive GroupPortfolioView owner/account scope from URL

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -60,6 +60,8 @@ import type { PieLabelRenderProps } from "recharts";
 import { BadgeCheck, LineChart, Shield } from "lucide-react";
 import { toRollupRows, toScopedHoldingRows } from "../lib/rollupAdapter";
 import { OwnerPortfolioActions } from "./OwnerPortfolioActions";
+import { useLocation, useNavigate } from "react-router-dom";
+import { readRouteScopeQuery } from "../routes/registry";
 
 const PIE_COLORS = [
   "#8884d8",
@@ -249,6 +251,9 @@ type Props = {
  * Component
  * ────────────────────────────────────────────────────────── */
 export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const routeScope = readRouteScopeQuery(location.search);
   const { t } = useTranslation();
   const {
     relativeViewEnabled,
@@ -293,8 +298,8 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   const [maxDrawdown, setMaxDrawdown] = useState<number | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [contribTab, setContribTab] = useState<"sector" | "region">("sector");
-  const [activeOwner, setActiveOwner] = useState<string | null>(null);
-  const [activeAccountType, setActiveAccountType] = useState<string | null>(null);
+  const activeOwner: string | null = routeScope.owner || null;
+  const activeAccountType: string | null = routeScope.account || null;
   const [instrumentRows, setInstrumentRows] = useState<InstrumentSummary[] | null>(null);
   const [instrumentLoading, setInstrumentLoading] = useState(false);
   const [instrumentError, setInstrumentError] = useState<Error | null>(null);
@@ -325,9 +330,32 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   );
 
   useEffect(() => {
-    setActiveOwner(null);
     setAsOfOverride(null);
   }, [slug]);
+
+  const handleOwnerChange = useCallback(
+    (owner: string | null, options?: { replace?: boolean }) => {
+      if (!owner) {
+        navigate({ pathname: "/", search: "" }, options);
+        return;
+      }
+      navigate(
+        { pathname: "/", search: new URLSearchParams({ owner }).toString() },
+        options,
+      );
+    },
+    [navigate],
+  );
+
+  const handleAccountTypeChange = useCallback(
+    (accountType: string | null, options?: { replace?: boolean }) => {
+      if (!activeOwner) return;
+      const params = new URLSearchParams({ owner: activeOwner });
+      if (accountType) params.set("account", accountType);
+      navigate({ pathname: "/", search: params.toString() }, options);
+    },
+    [activeOwner, navigate],
+  );
 
   const ownerTabs = useMemo<
     { value: string; label: string; accountTypes: string[] }[]
@@ -364,23 +392,26 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   );
 
   useEffect(() => {
+    if (!portfolio || ownerTabs.length === 0) return;
     if (activeOwner && !ownerTabs.some((tab) => tab.value === activeOwner)) {
-      setActiveOwner(null);
+      handleOwnerChange(null, { replace: true });
     }
-  }, [activeOwner, ownerTabs]);
+  }, [activeOwner, handleOwnerChange, ownerTabs, portfolio]);
 
   useEffect(() => {
-    setActiveAccountType(null);
-  }, [activeOwner]);
+    if (!activeOwner && activeAccountType) {
+      handleOwnerChange(null, { replace: true });
+    }
+  }, [activeAccountType, activeOwner, handleOwnerChange]);
 
   useEffect(() => {
     if (!activeOwner) return;
     const owner = ownerTabs.find((tab) => tab.value === activeOwner);
     if (!owner) return;
     if (activeAccountType && !owner.accountTypes.includes(activeAccountType)) {
-      setActiveAccountType(null);
+      handleAccountTypeChange(null, { replace: true });
     }
-  }, [activeOwner, activeAccountType, ownerTabs]);
+  }, [activeOwner, activeAccountType, handleAccountTypeChange, ownerTabs]);
 
   const ownerFilter = activeOwner ?? undefined;
   const accountFilter =
@@ -1224,7 +1255,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
           type="button"
           role="tab"
           aria-selected={activeOwner === null}
-          onClick={() => setActiveOwner(null)}
+          onClick={() => handleOwnerChange(null)}
           style={{
             padding: "0.5rem 0.75rem",
             borderRadius: "4px",
@@ -1242,7 +1273,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
             type="button"
             role="tab"
             aria-selected={activeOwner === tab.value}
-            onClick={() => setActiveOwner(tab.value)}
+            onClick={() => handleOwnerChange(tab.value)}
             style={{
               padding: "0.5rem 0.75rem",
               borderRadius: "4px",
@@ -1273,7 +1304,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
             type="button"
             role="tab"
             aria-selected={activeAccountType === null}
-            onClick={() => setActiveAccountType(null)}
+            onClick={() => handleAccountTypeChange(null)}
             style={{
               padding: "0.5rem 0.75rem",
               borderRadius: "4px",
@@ -1294,7 +1325,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
                 type="button"
                 role="tab"
                 aria-selected={activeAccountType === type}
-                onClick={() => setActiveAccountType(type)}
+                onClick={() => handleAccountTypeChange(type)}
                 style={{
                   padding: "0.5rem 0.75rem",
                   borderRadius: "4px",

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -398,10 +398,11 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   }, [activeOwner, handleOwnerChange, loading, ownerTabs, portfolio]);
 
   useEffect(() => {
+    if (loading || !portfolio) return;
     if (!activeOwner && activeAccountType) {
       handleOwnerChange(null, { replace: true });
     }
-  }, [activeAccountType, activeOwner, handleOwnerChange]);
+  }, [activeAccountType, activeOwner, handleOwnerChange, loading, portfolio]);
 
   useEffect(() => {
     if (!activeOwner) return;

--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -60,7 +60,7 @@ import type { PieLabelRenderProps } from "recharts";
 import { BadgeCheck, LineChart, Shield } from "lucide-react";
 import { toRollupRows, toScopedHoldingRows } from "../lib/rollupAdapter";
 import { OwnerPortfolioActions } from "./OwnerPortfolioActions";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useSearchParams } from "react-router-dom";
 import { readRouteScopeQuery } from "../routes/registry";
 
 const PIE_COLORS = [
@@ -251,8 +251,8 @@ type Props = {
  * Component
  * ────────────────────────────────────────────────────────── */
 export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
-  const navigate = useNavigate();
   const location = useLocation();
+  const [, setSearchParams] = useSearchParams();
   const routeScope = readRouteScopeQuery(location.search);
   const { t } = useTranslation();
   const {
@@ -335,26 +335,25 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
 
   const handleOwnerChange = useCallback(
     (owner: string | null, options?: { replace?: boolean }) => {
-      if (!owner) {
-        navigate({ pathname: "/", search: "" }, options);
-        return;
-      }
-      navigate(
-        { pathname: "/", search: new URLSearchParams({ owner }).toString() },
-        options,
-      );
+      const params = new URLSearchParams(location.search);
+      if (owner) params.set("owner", owner);
+      else params.delete("owner");
+      params.delete("account");
+      setSearchParams(params, options);
     },
-    [navigate],
+    [location.search, setSearchParams],
   );
 
   const handleAccountTypeChange = useCallback(
     (accountType: string | null, options?: { replace?: boolean }) => {
       if (!activeOwner) return;
-      const params = new URLSearchParams({ owner: activeOwner });
+      const params = new URLSearchParams(location.search);
+      params.set("owner", activeOwner);
       if (accountType) params.set("account", accountType);
-      navigate({ pathname: "/", search: params.toString() }, options);
+      else params.delete("account");
+      setSearchParams(params, options);
     },
-    [activeOwner, navigate],
+    [activeOwner, location.search, setSearchParams],
   );
 
   const ownerTabs = useMemo<
@@ -392,11 +391,11 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   );
 
   useEffect(() => {
-    if (!portfolio || ownerTabs.length === 0) return;
+    if (loading || !portfolio || ownerTabs.length === 0) return;
     if (activeOwner && !ownerTabs.some((tab) => tab.value === activeOwner)) {
       handleOwnerChange(null, { replace: true });
     }
-  }, [activeOwner, handleOwnerChange, ownerTabs, portfolio]);
+  }, [activeOwner, handleOwnerChange, loading, ownerTabs, portfolio]);
 
   useEffect(() => {
     if (!activeOwner && activeAccountType) {

--- a/frontend/tests/unit/components/GroupPortfolioView.test.tsx
+++ b/frontend/tests/unit/components/GroupPortfolioView.test.tsx
@@ -1331,4 +1331,69 @@ describe("GroupPortfolioView", () => {
     expect(screen.queryByText("Alpha vs Benchmark")).not.toBeInTheDocument();
     expect(screen.queryByText("Tracking Error")).not.toBeInTheDocument();
   });
+
+  it("keeps the current path and unrelated query parameters when changing scope", async () => {
+    const user = userEvent.setup();
+    mockAllFetches({
+      name: "At a glance",
+      accounts: [
+        { owner: "alice", account_type: "isa", value_estimate_gbp: 100, holdings: [] },
+      ],
+    });
+
+    const RouteDisplay = () => {
+      const location = useLocation();
+      return <output data-testid="scope-route">{`${location.pathname}${location.search}`}</output>;
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/portfolio/all?period=1y"]}>
+        <TestProvider>
+          <GroupPortfolioView slug="all" owners={ownerFixtures} />
+        </TestProvider>
+        <RouteDisplay />
+      </MemoryRouter>,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Alice Example" }));
+    expect(screen.getByTestId("scope-route")).toHaveTextContent(
+      "/portfolio/all?period=1y&owner=alice",
+    );
+
+    await user.click(screen.getByRole("tab", { name: "isa" }));
+    expect(screen.getByTestId("scope-route")).toHaveTextContent(
+      "/portfolio/all?period=1y&owner=alice&account=isa",
+    );
+  });
+
+  it("removes an invalid account without dropping other URL state", async () => {
+    mockAllFetches({
+      name: "At a glance",
+      accounts: [
+        { owner: "alice", account_type: "isa", value_estimate_gbp: 100, holdings: [] },
+      ],
+    });
+
+    const RouteDisplay = () => {
+      const location = useLocation();
+      return <output data-testid="scope-route">{`${location.pathname}${location.search}`}</output>;
+    };
+
+    render(
+      <MemoryRouter
+        initialEntries={["/portfolio/all?period=1y&owner=alice&account=invalid"]}
+      >
+        <TestProvider>
+          <GroupPortfolioView slug="all" owners={ownerFixtures} />
+        </TestProvider>
+        <RouteDisplay />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("scope-route")).toHaveTextContent(
+        "/portfolio/all?period=1y&owner=alice",
+      ),
+    );
+  });
 });


### PR DESCRIPTION
Closes #6460 
### Motivation

- Make `GroupPortfolioView` owner/account scope bookmarkable and navigable via browser back/forward instead of held as ephemeral component state. 
- Preserve the existing `string | null` shape so downstream consumers (`ownerFilter`/`accountTypeFilter`/`isAllPositions`) continue to behave unchanged.

### Description

- Replace local `activeOwner`/`activeAccountType` state with values derived from the URL query using `readRouteScopeQuery` and the router location. 
- Add `handleOwnerChange` and `handleAccountTypeChange` navigation helpers that write `owner`/`account` query params and use `navigate(..., { replace: true })` for reconciliation updates. 
- Update reconciliation effects to validate owner/account against available `ownerTabs` and rewrite the URL to the next-widest valid scope when an invalid value is present. 
- Wire the owner and account tab strips to call the new navigation handlers so clicking tabs updates the URL rather than internal state, while leaving visual structure unchanged.

### Testing

- Ran lint with `npm --prefix frontend run lint -- --no-warn-ignored` which passed. 
- Ran targeted unit tests `npm --prefix frontend run test -- --run tests/unit/components/GroupPortfolioView.test.tsx` and observed `47` tests executed with `39` passing and `8` failing; failing cases are focused in `GroupPortfolioView` tests and include scope/tab interaction and chart/alerts expectations (for example: "switches instrument rows across owner and account tabs", "does not show concentration warning when filtered to a single owner", "shows owner actions only after selecting an owner", "renders family-level charts and metrics only at All family scope, not at owner scope"). 
- Ran `git diff --check` which reported no problems, but pushing/creating a remote PR could not be completed in this environment due to missing remote/authentication.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b3e18649083279f3435707bb6b133)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Owner and account filters are now reflected in the page URL.
  * Filter selections preserve the current page and existing query parameters.
  * Invalid account filter values are automatically removed while retaining other URL state.

* **Bug Fixes**
  * Improved handling of invalid owner and account filter combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->