### PR TITLE
Direct owner navigation to query-scoped portfolio (/?owner=...)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -237,7 +237,7 @@ export default function App({ onLogout }: AppProps) {
     (owner: string) => {
       const trimmedOwner = owner.trim();
       setSelectedOwner(trimmedOwner);
-      navigate(`/portfolio/${encodePathSegment(trimmedOwner)}`);
+      navigate(`/?owner=${encodeURIComponent(trimmedOwner)}`);
     },
     [navigate]
   );

--- a/frontend/src/routes/registry.ts
+++ b/frontend/src/routes/registry.ts
@@ -114,7 +114,7 @@ export const ROUTE_REGISTRY: RouteRegistryEntry[] = [
     priority: 30,
     defaultPath: (context) => {
       const { owner } = routeContext(context);
-      return owner ? `/portfolio/${owner}` : '/portfolio';
+      return owner ? `/?owner=${encodeURIComponent(owner)}` : '/portfolio';
     },
   },
   {

--- a/frontend/tests/unit/App.test.tsx
+++ b/frontend/tests/unit/App.test.tsx
@@ -1125,7 +1125,7 @@ describe("App", () => {
     });
 
     // Use the real useNavigate so handleOwnerSelectPortfolio can navigate to
-    // /portfolio/bob when the user changes the owner selector.
+    // /?owner=bob when the user changes the owner selector.
     vi.doMock("react-router-dom", async () =>
       vi.importActual<typeof import("react-router-dom")>("react-router-dom"),
     );
@@ -1152,10 +1152,10 @@ describe("App", () => {
     await waitFor(() =>
       expect(screen.getByTestId("active-route-marker")).toHaveAttribute(
         "data-pathname",
-        "/portfolio/bob",
+        "/",
       ),
     );
-    expect(router.state.location.search).toBe("");
+    expect(router.state.location.search).toBe("?owner=bob");
     await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
     expect(
       screen.getByTestId("active-route-marker").getAttribute("data-pathname")?.startsWith("/performance"),

--- a/frontend/tests/unit/pageManifest.test.ts
+++ b/frontend/tests/unit/pageManifest.test.ts
@@ -64,7 +64,10 @@ describe('page manifest', () => {
     // redirect, which treats '/' with no query as "go to the entry page" (#5075).
     expect(buildPathForMode('group', { group: 'all' })).toBe('/?group=all');
     expect(buildPathForMode('group', { group: 'kids' })).toBe('/?group=kids');
-    expect(buildPathForMode('owner', { owner: 'alex' })).toBe('/portfolio/alex');
+    expect(buildPathForMode('owner', { owner: 'alex' })).toBe('/?owner=alex');
+    expect(buildPathForMode('owner', { owner: 'Alex Smith' })).toBe(
+      '/?owner=Alex%20Smith'
+    );
     expect(buildPathForMode('transactions')).toBe('/input');
     expect(buildPathForMode('pension')).toBe('/pension/forecast');
   });
@@ -85,7 +88,11 @@ describe('page manifest', () => {
       });
       expect(defaultPath.startsWith('/')).toBe(true);
 
-      if (page.routeSegment !== null && page.mode !== 'group') {
+      if (
+        page.routeSegment !== null &&
+        page.mode !== 'group' &&
+        page.mode !== 'owner'
+      ) {
         // 'transactions' mode has routeSegment 'transactions' but its canonical
         // URL is '/input' (the entry screen). The segment and defaultPath are
         // intentionally mismatched — exclude it from the containment check.


### PR DESCRIPTION
### Motivation
- Avoid a needless double-hop where in-app owner selections navigate to `/portfolio/:owner` and then redirect to `/?owner=…`, improving UX and navigation performance.
- Preserve the existing `/portfolio/:owner` pathname so external bookmarks and direct links continue resolving, while making fresh in-app navigation go straight to the merged, query-scoped page.

### Description
- Change `handleOwnerSelectPortfolio` in `frontend/src/App.tsx` to navigate to `/?owner=<encoded-owner>` instead of `/portfolio/<owner>`.
- Update the owner route registry in `frontend/src/routes/registry.ts` so the owner `defaultPath` generates `/?owner=…` (with proper URL encoding) while keeping the `/portfolio` pathname available.
- Adjust unit tests in `frontend/tests/unit/App.test.tsx` and `frontend/tests/unit/pageManifest.test.ts` to assert the new canonical query-string owner paths and encoding behavior.
- Closes #6461.

### Testing
- Ran the affected unit test suites with `npm --prefix frontend run test -- --run tests/unit/pageManifest.test.ts tests/unit/App.test.tsx`, and the tests passed (35 tests passing).
- Ran the frontend linter with `npm --prefix frontend run lint`, which completed without blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b3e215f408327b5212accf329d729)