### PR TITLE
Remove legacy owner portfolio fetch/cache from App and update tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,24 +2,21 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
   Suspense,
   type CSSProperties,
 } from 'react';
 import { Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { getGroupInstruments, getGroups, getOwners, getPortfolio } from './api';
+import { getGroupInstruments, getGroups, getOwners } from './api';
 
 import type {
   GroupSummary,
   InstrumentSummary,
   OwnerSummary,
-  Portfolio,
 } from './types';
 
 import { OwnerSelector } from './components/OwnerSelector';
-import { PortfolioView as _PortfolioView } from './components/PortfolioView';
 import { GroupPortfolioView } from './components/GroupPortfolioView';
 import { InstrumentTable } from './components/InstrumentTable';
 import { TransactionsPage } from './components/TransactionsPage';
@@ -198,25 +195,11 @@ export default function App({ onLogout }: AppProps) {
 
   const [owners, setOwners] = useState<OwnerSummary[]>([]);
   const [groups, setGroups] = useState<GroupSummary[]>([]);
-  // Retain the legacy portfolio fetch/cache until its dedicated cleanup child.
-  const [_portfolio, setPortfolio] = useState<Portfolio | null>(null);
-  const [portfolioAsOf, setPortfolioAsOf] = useState<string | null>(null);
   // Full catalogue stored in state — never truncated here.
   const [instruments, setInstruments] = useState<InstrumentSummary[]>([]);
 
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
-
-  const portfolioCache = useRef(
-    new Map<
-      string,
-      {
-        data: Portfolio;
-        fetchedAt: number;
-        lastRefresh: string | null;
-      }
-    >()
-  );
 
   const [backendUnavailable, setBackendUnavailable] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
@@ -244,16 +227,11 @@ export default function App({ onLogout }: AppProps) {
   );
 
   const handleLogout = useCallback(() => {
-    portfolioCache.current.clear();
-    setPortfolio(null);
     onLogout?.();
   }, [onLogout]);
 
   const ownersReq = useFetchWithRetry(getOwners, 500, 5, retryNonce);
   const groupsReq = useFetchWithRetry(getGroups, 500, 5, retryNonce);
-  // The portfolio fetch below only needs `selectedOwnerIsGroup`, which is
-  // derived from groupsReq.data alone — it must not wait on ownersReq (#5094).
-  const groupsCatalogReady = groupsReq.data !== null;
   const selectedOwnerGroup = useMemo(
     () =>
       selectedOwner && groupsReq.data
@@ -268,8 +246,6 @@ export default function App({ onLogout }: AppProps) {
         : null,
     [groupsReq.data, selectedGroup]
   );
-  const selectedOwnerIsGroup = selectedOwnerGroup !== null;
-
   // Redirect the bare root to the Family MVP entry path (the only Family MVP
   // redirect that remains — see getFamilyMvpRedirectPath, #4641). Fires on every
   // location change and whenever the config (and therefore familyMvpEnabled /
@@ -468,44 +444,6 @@ export default function App({ onLogout }: AppProps) {
   ]);
 
   // data fetching based on route
-  useEffect(() => {
-    if (mode === 'owner' && selectedOwner && groupsCatalogReady && !selectedOwnerIsGroup) {
-      const cacheKey = `${selectedOwner}::${portfolioAsOf ?? ''}::${lastRefresh ?? ''}`;
-      const cached = portfolioCache.current.get(cacheKey);
-
-      if (cached) {
-        setPortfolio(cached.data);
-        setErr(null);
-        setLoading(false);
-        return;
-      }
-
-      setLoading(true);
-      setErr(null);
-      const request = portfolioAsOf
-        ? getPortfolio(selectedOwner, { asOf: portfolioAsOf })
-        : getPortfolio(selectedOwner);
-
-      request
-        .then((data) => {
-          portfolioCache.current.set(cacheKey, {
-            data,
-            fetchedAt: Date.now(),
-            lastRefresh,
-          });
-          setPortfolio(data);
-        })
-        .catch((e) => setErr(String(e)))
-        .finally(() => setLoading(false));
-    }
-  }, [mode, selectedOwner, portfolioAsOf, lastRefresh, selectedOwnerIsGroup, groupsCatalogReady]);
-
-  useEffect(() => {
-    if (mode === 'owner' && selectedOwner && groupsCatalogReady) {
-      setPortfolioAsOf(null);
-    }
-  }, [mode, selectedOwner, groupsCatalogReady]);
-
   useEffect(() => {
     if (mode === 'instrument' && selectedGroup) {
       setLoading(true);

--- a/frontend/tests/unit/App.test.tsx
+++ b/frontend/tests/unit/App.test.tsx
@@ -83,6 +83,7 @@ describe("App", () => {
   ])(
     "renders %s through the merged portfolio with the canonical URL",
     async (entry, expectedSlug, expectedComplianceOwners, expectedUrl, expectedNavigationCount) => {
+      const mockGetPortfolio = vi.fn();
       vi.doMock("@/components/GroupPortfolioView", () => ({
         GroupPortfolioView: ({ slug }: { slug: string }) => {
           const location = useLocation();
@@ -105,7 +106,7 @@ describe("App", () => {
             { slug: "all", name: "All", members: ["alice", "bob"] },
             { slug: "family", name: "Family", members: ["alice", "bob"] },
           ]),
-          getPortfolio: vi.fn(),
+          getPortfolio: mockGetPortfolio,
           getGroupInstruments: vi.fn().mockResolvedValue([]),
         };
       });
@@ -141,6 +142,7 @@ describe("App", () => {
         ]),
       );
       expect(navigationCount).toBe(expectedNavigationCount);
+      expect(mockGetPortfolio).not.toHaveBeenCalled();
       unsubscribe();
       unmount();
       vi.doUnmock("@/components/GroupPortfolioView");
@@ -494,7 +496,7 @@ describe("App", () => {
     expect(mockComplianceWarnings.mock.calls).toContainEqual([["alex"]]);
   });
 
-  it("fetches the owner portfolio as soon as groups resolve, without waiting for owners (#5094)", async () => {
+  it("does not fetch the legacy owner portfolio while owners resolve", async () => {
     window.history.pushState({}, "", "/portfolio/alice");
 
     let resolveOwners:
@@ -557,14 +559,13 @@ describe("App", () => {
       </MemoryRouter>,
     );
 
-    // getGroups already resolved (empty array) but getOwners is still pending —
-    // the portfolio fetch must not wait on it.
-    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+    // The merged view owns portfolio loading; App must not start the legacy request.
+    expect(mockGetPortfolio).not.toHaveBeenCalled();
 
     resolveOwners?.([]);
   });
 
-  it("keeps the legacy owner fetch working while owners resolve", async () => {
+  it("keeps owner navigation working without the legacy fetch", async () => {
     window.history.pushState({}, "", "/portfolio/alice");
 
     let resolveOwners:
@@ -641,12 +642,9 @@ describe("App", () => {
 
     render(<RouterProvider router={router} />);
 
-    // Initial fetch for alice fires with no "as of" filter.
-    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+    expect(mockGetPortfolio).not.toHaveBeenCalled();
 
-    // Switch owners via direct navigation while getOwners is still pending.
-    // The fetch is retained for the later cleanup child and must continue to
-    // follow pathname-based owner navigation while the owners request is pending.
+    // Owner navigation remains independent of the pending owners request.
     await act(async () => {
       await router.navigate("/portfolio/bob");
     });
@@ -960,8 +958,7 @@ describe("App", () => {
     );
 
     expect(locationUpdates).not.toContain("/portfolio/alice");
-    expect(mockGetPortfolio).toHaveBeenCalledOnce();
-    expect(mockGetPortfolio).toHaveBeenCalledWith("steve");
+    expect(mockGetPortfolio).not.toHaveBeenCalled();
   });
 
   it("stays on the portfolio route when switching owners from the portfolio page", async () => {
@@ -1075,7 +1072,7 @@ describe("App", () => {
     });
     await user.selectOptions(portfolioSelector as HTMLSelectElement, "bob");
 
-    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
+    expect(mockGetPortfolio).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(locationUpdates.at(-1)?.startsWith("/portfolio")).toBe(true),
     );
@@ -1274,7 +1271,7 @@ describe("App", () => {
     render(<RouterProvider router={router} />);
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/portfolio/alice"));
-    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+    expect(mockGetPortfolio).not.toHaveBeenCalled();
   });
 
   it("redirects /portfolio to the owner matching the logged-in user's email, not the first owner", async () => {
@@ -1340,7 +1337,7 @@ describe("App", () => {
     render(<RouterProvider router={router} />);
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/portfolio/bob"));
-    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
+    expect(mockGetPortfolio).not.toHaveBeenCalled();
   });
 
   it("redirects /performance to the first owner when multiple owners are available", async () => {
@@ -1582,7 +1579,7 @@ describe("App", () => {
 
     await waitFor(() => expect(locationUpdates).toContain("/portfolio/alice"));
     expect(locationUpdates.filter((path) => path === "/portfolio/alice")).toHaveLength(1);
-    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alice"));
+    expect(mockGetPortfolio).not.toHaveBeenCalled();
   });
 
   it("redirects once owners load asynchronously on /performance root", async () => {
@@ -1713,7 +1710,7 @@ describe("App", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("bob"));
+    expect(mockGetPortfolio).not.toHaveBeenCalled();
     expect(locationUpdates).toContain("/portfolio/bob");
     expect(locationUpdates).not.toContain("/portfolio/alice");
   });
@@ -1774,97 +1771,6 @@ describe("App", () => {
     );
     expect(locationUpdates).toContain("/performance/bob");
     expect(locationUpdates).not.toContain("/performance/alice");
-  });
-
-  it("reuses cached portfolio data when returning from research", async () => {
-    window.history.pushState({}, "", "/portfolio/alice");
-    globalThis.AbortSignal = window.AbortSignal;
-
-    const renderStates: Array<{ loading: boolean; owner: string | null }> = [];
-
-    vi.doMock("@/components/PortfolioView", () => ({
-      PortfolioView: ({
-        data,
-        loading,
-      }: {
-        data: Portfolio | null;
-        loading?: boolean;
-      }) => {
-        renderStates.push({ loading: Boolean(loading), owner: data?.owner ?? null });
-        return (
-          <div data-testid="portfolio-view">
-            {loading ? "loading" : data?.owner ?? "none"}
-          </div>
-        );
-      },
-    }));
-
-    const mockGetOwners = vi
-      .fn()
-      .mockResolvedValue([{ owner: "alice", accounts: [] }]);
-    const mockGetGroups = vi.fn().mockResolvedValue([]);
-    const mockGetPortfolio = vi.fn().mockResolvedValue({
-      owner: "alice",
-      as_of: "2024-01-01T00:00:00.000Z",
-      trades_this_month: 0,
-      trades_remaining: 0,
-      total_value_estimate_gbp: 0,
-      accounts: [],
-    });
-
-    vi.doMock("@/api", async () => {
-      const actual = await vi.importActual<typeof import("@/api")>("@/api");
-      return {
-        ...actual,
-        getOwners: mockGetOwners,
-        getGroups: mockGetGroups,
-        getPortfolio: mockGetPortfolio,
-        getGroupInstruments: vi.fn().mockResolvedValue([]),
-        getGroupPortfolio: vi.fn(),
-        getGroupAlphaVsBenchmark: vi.fn(),
-        getGroupTrackingError: vi.fn(),
-        getGroupMaxDrawdown: vi.fn(),
-        getGroupSectorContributions: vi.fn(),
-        getGroupRegionContributions: vi.fn(),
-        getGroupMovers: vi.fn(),
-        getCachedGroupInstruments: vi.fn(),
-        listInstrumentMetadata: vi.fn().mockResolvedValue([]),
-        listInstrumentGroups: vi.fn().mockResolvedValue([]),
-        listInstrumentGroupingDefinitions: vi.fn().mockResolvedValue([]),
-        refreshPrices: vi.fn(),
-        getAlerts: vi.fn().mockResolvedValue([]),
-        getNudges: vi.fn().mockResolvedValue([]),
-        getAlertSettings: vi.fn().mockResolvedValue({ threshold: 0 }),
-        getCompliance: vi
-          .fn()
-          .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
-        complianceForOwner: vi
-          .fn()
-          .mockResolvedValue({ owner: "", warnings: [], trade_counts: {} }),
-        getTimeseries: vi.fn().mockResolvedValue([]),
-        saveTimeseries: vi.fn(),
-        refetchTimeseries: vi.fn(),
-        rebuildTimeseriesCache: vi.fn(),
-        getTradingSignals: vi.fn().mockResolvedValue([]),
-        getTopMovers: vi.fn().mockResolvedValue({ gainers: [], losers: [] }),
-        getValueAtRisk: vi.fn().mockResolvedValue({ var: {} }),
-        recomputeValueAtRisk: vi.fn(),
-        getVarBreakdown: vi.fn().mockResolvedValue([]),
-      };
-    });
-
-    const { default: App } = await import("@/App");
-
-    render(
-      <MemoryRouter initialEntries={["/portfolio/alice"]}>
-        <App />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledTimes(1));
-
-    expect(mockGetPortfolio).toHaveBeenCalledTimes(1);
-    expect(renderStates).toHaveLength(0);
   });
 
   it("allows navigation to enabled tabs", async () => {


### PR DESCRIPTION
Closes #6437 

### Motivation

- Consolidate portfolio loading into the merged `GroupPortfolioView` to eliminate a duplicate `getPortfolio` network path and its unused cache/state in `App.tsx`.
- Keep runtime behaviour stable and revertible while following the parity gate that prevents deleting `PortfolioView.tsx` until its consumers are migrated.

### Description

- Removed the `getPortfolio` import, the legacy owner-portfolio state (`_portfolio`, `portfolioAsOf`), the `portfolioCache` and the App-level effect that repeatedly fetched owner portfolios from `frontend/src/App.tsx`.
- Simplified `handleLogout` by removing cache/portfolio clears and left owner selection, routing, and `ComplianceWarnings`/`GroupPortfolioView` rendering intact.
- Updated `frontend/tests/unit/App.test.tsx` to assert that `getPortfolio` is not invoked by `App` (including renaming a couple tests to match the new contract) and removed the redundant cached-portfolio test behavior.
- Did not delete `PortfolioView.tsx` because it is still referenced by other consumers (`MainApp.tsx` and `pages/Portfolio.tsx`), so the component remains until those consumers are migrated.

### Testing

- Ran `npm --prefix frontend run lint` and the lint step completed normally.
- Ran the focused unit test file with `npm --prefix frontend run test -- --run tests/unit/App.test.tsx` and the suite passed (37 tests passed).
- Attempted a full frontend test run, but the run did not complete within the session and was interrupted, so validation is limited to lint and the focused unit suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b5beb8a988327b162a901ad83b2a5)