### PR TITLE
Document InstrumentTable catalogue role and record #6382 cleanup outcome

### DIFF
--- a/docs/decisions/6365-portfolio-consolidation.md
+++ b/docs/decisions/6365-portfolio-consolidation.md
@@ -281,6 +281,26 @@ assignment is the `InstrumentDetail` drawer, where exactly one ticker is in
 focus and the write is unambiguous. File that as a separate issue after #6365
 lands; do not fold it into a consolidation child task.
 
+### Cleanup outcome (#6382)
+
+After the portfolio-page merge shipped, the remaining call sites were reviewed.
+`InstrumentTable` remains deliberately scoped to the instrument catalogue route
+rather than being migrated to `HoldingsTable`:
+
+- `InstrumentTable` consumes `InstrumentSummary[]`, provides exchange filtering,
+  and owns the `assignInstrumentGroup`, `createInstrumentGroup`, and
+  `clearInstrumentGroup` write workflow.
+- `HoldingsTable` consumes holding/rollup rows and is the sole table used for
+  portfolio presentation. It does not own catalogue mutation.
+
+Moving `/instrument/:group` to `HoldingsTable` would therefore remove the
+group-assignment feature or mix an administrative write path into the portfolio
+table. The two components no longer represent competing portfolio-table
+implementations: one is a catalogue editor and the other is a portfolio viewer.
+Keep the catalogue editor until group assignment has a confirmed replacement
+(such as the `InstrumentDetail` drawer), at which point its route and component
+can be retired together.
+
 ---
 
 ## 5. `familyMvpEnabled` — gates the controls, never the scope selector

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -39,6 +39,14 @@ type Props = {
   showSparklines?: boolean;
 };
 
+/**
+ * Instrument catalogue editor for `/instrument/:group`.
+ *
+ * This is intentionally separate from HoldingsTable: it consumes catalogue
+ * summaries and owns the instrument-group mutation workflow. Portfolio pages
+ * use HoldingsTable for read-only holding and rollup presentation. See the
+ * cleanup outcome in docs/decisions/6365-portfolio-consolidation.md#cleanup-outcome-6382.
+ */
 export function InstrumentTable({ rows, showGroupTotals = true, showSparklines = true }: Props) {
   const { t } = useTranslation();
   const { relativeViewEnabled, baseCurrency } = useConfig();
@@ -761,4 +769,3 @@ async function handleGroupSelection(
     setPending(null);
   }
 }
-


### PR DESCRIPTION
Closes #6382 

### Motivation

- Clarify and record why `InstrumentTable` must remain as the instrument-catalogue editor after the portfolio-page consolidation, and capture the cleanup outcome for issue #6382.

### Description

- Add a JSDoc comment to `frontend/src/components/InstrumentTable.tsx` documenting that `InstrumentTable` is the catalogue editor for `/instrument/:group` and that it owns the `assignInstrumentGroup`/`createInstrumentGroup`/`clearInstrumentGroup` mutation workflow, distinct from `HoldingsTable` which is the portfolio viewer.
- Append a "Cleanup outcome (#6382)" section to `docs/decisions/6365-portfolio-consolidation.md` explaining the retained boundary between catalogue mutation and portfolio presentation and the retirement criteria (move group-assignment to a confirmed replacement such as the `InstrumentDetail` drawer before retiring the component). This PR closes the action recorded in this issue: `Closes #6382`.

### Testing

- Ran the relevant frontend unit tests with `npm --prefix frontend run test -- --run tests/unit/components/InstrumentTable.test.tsx`, which executed the suite and passed (13 tests).
- Ran the frontend linter with `npm --prefix frontend run lint` and checked for diff errors with `git diff --check`; no lint or diff-check issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b5f77bc9083279d3666a67cb09243)