### PR TITLE
Fix owner-scoped portfolio slug falling back to owner name

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -466,7 +466,7 @@ export default function App({ onLogout }: AppProps) {
 
   const portfolioGroupSlug =
     selectedOwnerGroup?.slug ??
-    (selectedOwner ? selectedOwner : mode === 'group' ? selectedGroup : '');
+    (selectedGroup || (selectedOwner ? selectedOwner : ''));
   const portfolioComplianceOwners = selectedOwnerGroup
     ? selectedOwnerGroup.members
     : selectedOwner

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -465,8 +465,7 @@ export default function App({ onLogout }: AppProps) {
   const exportGroupLabel = selectedGroup || 'all';
 
   const portfolioGroupSlug =
-    selectedOwnerGroup?.slug ??
-    (selectedGroup || (selectedOwner ? selectedOwner : ''));
+    selectedOwnerGroup?.slug ?? (selectedGroup || '');
   const portfolioComplianceOwners = selectedOwnerGroup
     ? selectedOwnerGroup.members
     : selectedOwner

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -404,13 +404,13 @@ test.describe('bootstrap to portfolio happy path', () => {
       });
     });
 
-    await page.route('**/portfolio-group/demo-owner', async (route) => {
+    await page.route('**/portfolio-group/all', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          name: 'Demo Owner',
-          slug: 'demo-owner',
+          name: 'All portfolios',
+          slug: 'all',
           as_of: '2026-03-22',
           trades_this_month: 0,
           trades_remaining: 10,

--- a/frontend/tests/unit/App.test.tsx
+++ b/frontend/tests/unit/App.test.tsx
@@ -61,14 +61,14 @@ describe("App", () => {
 
   it.each([
     ["/", "all", ["alice", "bob"], "/", 0],
-    ["/?owner=alice", "alice", ["alice"], "/?owner=alice", 0],
-    ["/?owner=alice&account=isa", "alice", ["alice"], "/?owner=alice&account=isa", 0],
+    ["/?owner=alice", "all", ["alice"], "/?owner=alice", 0],
+    ["/?owner=alice&account=isa", "all", ["alice"], "/?owner=alice&account=isa", 0],
     ["/?account=isa", "all", ["alice", "bob"], "/", 1],
     ["/?owner=family", "family", ["alice", "bob"], "/?owner=family", 0],
-    ["/portfolio/alice", "alice", ["alice"], "/?owner=alice", 1],
+    ["/portfolio/alice", "all", ["alice"], "/?owner=alice", 1],
     [
       "/portfolio/alice/?group=kids&owner=bob&account=isa",
-      "alice",
+      "all",
       ["alice"],
       "/?owner=alice&account=isa",
       1,


### PR DESCRIPTION
## Summary
- `portfolioGroupSlug` in `App.tsx` fell back to using the selected owner's name as a group slug whenever that owner wasn't itself a group, causing `GroupPortfolioView` to request `/portfolio-group/<owner-name>`, which 404s.
- Now prefers `selectedGroup` (already defaults to `"all"`), letting `GroupPortfolioView`'s existing URL-derived `activeOwner` scoping do the filtering, as it already does for in-page owner-tab clicks.

Closes #6492

## Test plan
- [x] Verified in browser: `/?owner=steve` and clicking an owner tab from "All positions" both loaded the scoped portfolio correctly (previously showed "We couldn't load your portfolio").
- [x] Verified "All positions" (`/`) and group navigation still work.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated merged-portfolio routing so owner URLs correctly resolve to the “all” group.
  * Preserved the selected owner in compliance-owner lists and canonical query strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->