### PR TITLE
Keep holdings top scrollbar accessible

### DIFF
--- a/frontend/src/components/HoldingsTable.tsx
+++ b/frontend/src/components/HoldingsTable.tsx
@@ -1,4 +1,12 @@
-import { Fragment, useState, useEffect, useRef, useMemo, type MouseEvent } from "react";
+import {
+  Fragment,
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useMemo,
+  type MouseEvent,
+} from "react";
 import { useTranslation } from "react-i18next";
 import type { Holding } from "../types";
 import { money, percent } from "../lib/money";
@@ -304,7 +312,7 @@ export function HoldingsTable({
     }
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const container = tableContainerRef.current;
     const topScrollbar = topScrollbarRef.current;
     const table = tableRef.current;
@@ -494,8 +502,10 @@ export function HoldingsTable({
           <div
             ref={topScrollbarRef}
             className={`${tableStyles.topScrollbar} ${hasHorizontalOverflow ? "" : tableStyles.topScrollbarHidden}`}
+            role="region"
             aria-label={t("holdingsTable.horizontalScroll")}
-            tabIndex={0}
+            aria-hidden={!hasHorizontalOverflow}
+            tabIndex={hasHorizontalOverflow ? 0 : -1}
           >
             <div className={tableStyles.topScrollbarContent} style={{ width: tableWidth }} />
           </div>

--- a/frontend/tests/unit/components/HoldingsTable.test.tsx
+++ b/frontend/tests/unit/components/HoldingsTable.test.tsx
@@ -822,10 +822,21 @@ describe("HoldingsTable", () => {
           }
       });
 
-      it("keeps the top and table horizontal scrollbars in sync", () => {
+      it("shows an accessible top scrollbar for overflowing holdings columns", () => {
+          const clientWidth = vi.spyOn(HTMLElement.prototype, "clientWidth", "get");
+          const scrollWidth = vi.spyOn(HTMLElement.prototype, "scrollWidth", "get");
+          clientWidth.mockReturnValue(600);
+          scrollWidth.mockReturnValue(1200);
+
           render(<HoldingsTable holdings={holdings} />);
           const tableContainer = screen.getByRole('table').parentElement as HTMLElement;
-          const topScrollbar = screen.getByLabelText('Scroll holdings columns horizontally');
+          const topScrollbar = screen.getByRole('region', {
+              name: 'Scroll holdings columns horizontally',
+          });
+
+          expect(topScrollbar).toHaveAttribute("tabindex", "0");
+          expect(topScrollbar).toHaveAttribute("aria-hidden", "false");
+          expect(topScrollbar.firstElementChild).toHaveStyle({ width: "1200px" });
 
           topScrollbar.scrollLeft = 240;
           fireEvent.scroll(topScrollbar);
@@ -834,5 +845,8 @@ describe("HoldingsTable", () => {
           tableContainer.scrollLeft = 80;
           fireEvent.scroll(tableContainer);
           expect(topScrollbar.scrollLeft).toBe(80);
+
+          clientWidth.mockRestore();
+          scrollWidth.mockRestore();
       });
   });


### PR DESCRIPTION
### Motivation
- Long holdings tables required users to reach the bottom scrollbar to scroll horizontally, which is poor for discoverability and keyboard accessibility.
- The goal is to expose a synchronized, top-anchored horizontal scrollbar that is available immediately and only focusable when needed.

### Description
- Measure horizontal overflow earlier (use `useLayoutEffect`) and expose a top scrollbar region so the synchronized top scrollbar is available before paint. 
- Make the top scrollbar an accessible labelled region (`role="region"`, `aria-label`) that is only keyboard-focusable when overflow exists by toggling `aria-hidden` and `tabIndex` based on overflow state. 
- Keep bidirectional synchronization between the top scrollbar and the table container (scroll events and resize observer) and update sizing using the table `scrollWidth` value. 
- Files changed: `frontend/src/components/HoldingsTable.tsx` and `frontend/tests/unit/components/HoldingsTable.test.tsx` (includes new regression coverage). Closes #6495.

### Testing
- Ran the unit tests for the component with `npm --prefix frontend run test -- --run tests/unit/components/HoldingsTable.test.tsx` and all tests passed (34 tests passed). 
- Ran lint and type-check with `npm --prefix frontend run lint -- --quiet` and `npm --prefix frontend run type-check`, both succeeded. 
- Attempted a Playwright screenshot but the Chromium browser binary was not available in the environment so visual capture could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b69ea8cfc8327b430730e57478e2f)