### PR TITLE
Show sector contributions for selected owners

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -263,6 +263,8 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   } = useConfig();
   const [asOfOverride, setAsOfOverride] = useState<string | null>(null);
   const [instrumentRefreshVersion, setInstrumentRefreshVersion] = useState(0);
+  const activeOwner: string | null = routeScope.owner || null;
+  const activeAccountType: string | null = routeScope.account || null;
 
   const fetchPortfolio = useCallback(
     () => getGroupPortfolio(slug, { asOf: asOfOverride ?? undefined }),
@@ -276,8 +278,13 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   } = useFetch<GroupPortfolio>(fetchPortfolio, [slug, asOfOverride], !!slug);
 
   const fetchSector = useCallback(
-    () => getGroupSectorContributions(slug, { asOf: asOfOverride ?? undefined }),
-    [slug, asOfOverride],
+    () =>
+      activeOwner
+        ? api.getOwnerSectorContributions(activeOwner, {
+            asOf: asOfOverride ?? undefined,
+          })
+        : getGroupSectorContributions(slug, { asOf: asOfOverride ?? undefined }),
+    [activeOwner, slug, asOfOverride],
   );
   const fetchRegion = useCallback(
     () => getGroupRegionContributions(slug, { asOf: asOfOverride ?? undefined }),
@@ -285,21 +292,19 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   );
   const { data: sectorContrib } = useFetch<SectorContribution[]>(
     fetchSector,
-    [slug, asOfOverride, enableAdvancedAnalytics],
+    [activeOwner, slug, asOfOverride, enableAdvancedAnalytics],
     !!slug && enableAdvancedAnalytics,
   );
   const { data: regionContrib } = useFetch<RegionContribution[]>(
     fetchRegion,
     [slug, asOfOverride, enableAdvancedAnalytics],
-    !!slug && enableAdvancedAnalytics,
+    !!slug && !activeOwner && enableAdvancedAnalytics,
   );
   const [alpha, setAlpha] = useState<number | null>(null);
   const [trackingError, setTrackingError] = useState<number | null>(null);
   const [maxDrawdown, setMaxDrawdown] = useState<number | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [contribTab, setContribTab] = useState<"sector" | "region">("sector");
-  const activeOwner: string | null = routeScope.owner || null;
-  const activeAccountType: string | null = routeScope.account || null;
   const [instrumentRows, setInstrumentRows] = useState<InstrumentSummary[] | null>(null);
   const [instrumentLoading, setInstrumentLoading] = useState(false);
   const [instrumentError, setInstrumentError] = useState<Error | null>(null);
@@ -759,6 +764,7 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
   }, []);
 
   const isAllPositions = activeOwner === null;
+  const activeContribTab = isAllPositions ? contribTab : "sector";
   const hasFilteredAccounts = filteredAccounts.length > 0;
   const portfolioInsight = useMemo<PortfolioInsight>(() => {
     // Filtered owner/account slices can look spuriously concentrated, so only surface the
@@ -1025,22 +1031,25 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
         </div>
       )}
 
-      {isAllPositions && enableAdvancedAnalytics && (sectorContrib?.length || regionContrib?.length) && (
+      {enableAdvancedAnalytics &&
+        (sectorContrib?.length || (isAllPositions && regionContrib?.length)) && (
         <div style={{ width: "100%", height: 300, margin: "1rem 0" }}>
           <div style={{ marginBottom: "0.5rem" }}>
             <button
               onClick={() => setContribTab("sector")}
-              disabled={contribTab === "sector"}
+              disabled={activeContribTab === "sector"}
               style={{ marginRight: "0.5rem" }}
             >
               Sector
             </button>
-            <button
-              onClick={() => setContribTab("region")}
-              disabled={contribTab === "region"}
-            >
-              Region
-            </button>
+            {isAllPositions && (
+              <button
+                onClick={() => setContribTab("region")}
+                disabled={activeContribTab === "region"}
+              >
+                Region
+              </button>
+            )}
           </div>
           <ResponsiveContainer
             width="100%"
@@ -1051,16 +1060,16 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
           >
             <BarChart
               data={
-                (contribTab === "sector"
+                (activeContribTab === "sector"
                   ? sectorContrib || []
                   : regionContrib || []) as (SectorContribution | RegionContribution)[]
               }
             >
-              <XAxis dataKey={contribTab === "sector" ? "sector" : "region"} />
+              <XAxis dataKey={activeContribTab === "sector" ? "sector" : "region"} />
               <YAxis />
               <Tooltip formatter={(v) => money(v as number | undefined, baseCurrency)} />
               <Bar dataKey="gain_gbp">
-                {(contribTab === "sector" ? sectorContrib : regionContrib)?.map(
+                {(activeContribTab === "sector" ? sectorContrib : regionContrib)?.map(
                   (row, idx) => (
                     <Cell
                       key={`cell-bar-${idx}`}

--- a/frontend/tests/unit/components/GroupPortfolioView.test.tsx
+++ b/frontend/tests/unit/components/GroupPortfolioView.test.tsx
@@ -139,9 +139,18 @@ const mockAllFetches = (
     instruments?: Record<string, any[]>;
     complianceWarnings?: any[];
     complianceFails?: boolean;
+    sectorContributions?: any[];
+    regionContributions?: any[];
   } = {},
 ) => {
-  const { metrics, instruments = {}, complianceWarnings = [], complianceFails = false } = options;
+  const {
+    metrics,
+    instruments = {},
+    complianceWarnings = [],
+    complianceFails = false,
+    sectorContributions = [],
+    regionContributions = [],
+  } = options;
   const { alpha = 0, trackingError = 0, maxDrawdown = 0 } = metrics ?? {};
   const defaultInstrumentRows =
     instruments[instrumentKey(undefined, undefined)] ?? [];
@@ -203,13 +212,19 @@ const mockAllFetches = (
     if (url.includes("/instrument/admin/groups")) {
       return Promise.resolve({
         ok: true,
-        json: async () => [],
+        json: async () => sectorContributions,
+      } as Response);
+    }
+    if (url.includes("/portfolio/") && url.includes("/sectors")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => sectorContributions,
       } as Response);
     }
     if (url.includes("/instrument/admin/groupings")) {
       return Promise.resolve({
         ok: true,
-        json: async () => [],
+        json: async () => regionContributions,
       } as Response);
     }
     if (url.includes("/portfolio-group/") && url.includes("/movers")) {
@@ -1344,6 +1359,46 @@ describe("GroupPortfolioView", () => {
     expect(screen.queryByTestId("top-movers-summary")).not.toBeInTheDocument();
     expect(screen.queryByText("Alpha vs Benchmark")).not.toBeInTheDocument();
     expect(screen.queryByText("Tracking Error")).not.toBeInTheDocument();
+  });
+
+  it("renders owner sector contributions from the owner-scoped endpoint", async () => {
+    const getOwnerSectorContributions = vi
+      .spyOn(api, "getOwnerSectorContributions")
+      .mockResolvedValue([{ sector: "Technology", gain_gbp: 12 }]);
+    const fetchMock = mockAllFetches(
+      {
+        name: "At a glance",
+        accounts: [
+          { owner: "alice", account_type: "isa", value_estimate_gbp: 100, holdings: [] },
+        ],
+      },
+      {
+        sectorContributions: [{ sector: "Technology", gain_gbp: 12 }],
+        regionContributions: [{ region: "Europe", gain_gbp: 8 }],
+      },
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/?owner=alice"]}>
+        <TestProvider>
+          <GroupPortfolioView slug="all" owners={ownerFixtures} />
+        </TestProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Technology")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sector" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Region" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Europe")).not.toBeInTheDocument();
+    expect(getOwnerSectorContributions).toHaveBeenCalledWith(
+      "alice",
+      { asOf: undefined },
+    );
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        toUrlString(input).includes("region-contributions"),
+      ),
+    ).toBe(false);
   });
 
   it("keeps the current path and unrelated query parameters when changing scope", async () => {


### PR DESCRIPTION
### Motivation

- The GroupPortfolio view hidden per-owner sector breakdowns after owner selection because the contribution chart only used the group-wide endpoint and was gated to the "All positions" scope.  This change restores owner-scoped analytics so users can see sector contributions when an owner is selected.

### Description

- Use the owner-scoped sector API when an owner is selected by calling `getOwnerSectorContributions(owner, { asOf })` instead of the group endpoint, while preserving the group-wide endpoints for the All-positions view in `frontend/src/components/GroupPortfolioView.tsx`.
- Keep region contributions tied to the group endpoint and hide the Region tab for owner scope because there is no owner-scoped region endpoint, forcing owner-scoped views to show Sector only and disabling Region controls accordingly.
- Make the contribution chart visible for owner scope (Sector-only) while leaving the All-positions behavior unchanged and preserve gating behind `enableAdvancedAnalytics`.
- Add a unit test covering the owner-scoped flow to assert the owner sector data is rendered, `getOwnerSectorContributions` is called, the Region tab is hidden, and no group-region request is made (`frontend/tests/unit/components/GroupPortfolioView.test.tsx`).

### Testing

- Ran `npm --prefix frontend run test -- --run tests/unit/components/GroupPortfolioView.test.tsx` and the suite passed (`51 tests passed`).
- Ran lint and type-check with `npm --prefix frontend run lint` and `npm --prefix frontend run type-check`, and both completed without errors.
- Ran repository checks (`git diff --check`) and local smoke/test commands used during validation; no issues were reported.

Closes #6493

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b6af9ee6c8327a6287ffa57c6718a)