### PR TITLE
Link Data Admin login error to Support local-login override

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -642,6 +642,9 @@
     "tickers": "Tickers",
     "watchlist": "Watchlist:"
   },
+  "dataadmin": {
+    "configureLocalLogin": "Configure local login override"
+  },
   "support": {
     "config": {
       "otherParams": "Other parameters",

--- a/frontend/src/pages/DataAdmin.tsx
+++ b/frontend/src/pages/DataAdmin.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
   listTimeseries,
   refetchTimeseries,
@@ -45,7 +45,23 @@ export default function DataAdmin() {
   }, []);
 
   if (error) {
-    return <p style={{ color: "red" }}>{error}</p>;
+    const needsLocalLogin = error.includes(
+      "No local login override is configured",
+    );
+
+    return (
+      <div className="container mx-auto max-w-5xl p-4" role="alert">
+        <p className="text-red-600">{error}</p>
+        {needsLocalLogin && (
+          <Link
+            className="mt-2 inline-block text-blue-600 hover:underline"
+            to="/support#local-login-override"
+          >
+            {t("dataadmin.configureLocalLogin")}
+          </Link>
+        )}
+      </div>
+    );
   }
 
   const handleRefetch = (ticker: string, exchange: string) => {

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -366,7 +366,8 @@ export default function Support() {
         </p>
       </header>
 
-      <SectionCard title={t("support.localLogin.title", "Local login override")}>
+      <div id="local-login-override">
+        <SectionCard title={t("support.localLogin.title", "Local login override")}>
         <p className="mb-2 text-sm text-gray-600">
           {t(
             "support.localLogin.description",
@@ -420,7 +421,8 @@ export default function Support() {
               : t("support.status.error")}
           </p>
         )}
-      </SectionCard>
+        </SectionCard>
+      </div>
 
       <SectionCard title={t("support.dataExplorer.title", "Data Explorer")}>
         <p className="mb-2 text-sm text-gray-600">

--- a/frontend/tests/unit/pages/DataAdmin.test.tsx
+++ b/frontend/tests/unit/pages/DataAdmin.test.tsx
@@ -2,8 +2,15 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 
+const mockListTimeseries = vi.hoisted(() => vi.fn());
+
 vi.mock("@/api", () => ({
-  listTimeseries: vi.fn().mockResolvedValue([
+  listTimeseries: mockListTimeseries,
+  refetchTimeseries: vi.fn().mockResolvedValue({ status: "ok", rows: 1 }),
+  rebuildTimeseriesCache: vi.fn().mockResolvedValue({ status: "ok", rows: 1 }),
+}));
+
+const timeseriesRows = [
     {
       ticker: "ABC",
       exchange: "L",
@@ -14,15 +21,13 @@ vi.mock("@/api", () => ({
       latest_source: "Feed",
       main_source: "Feed",
     },
-  ]),
-  refetchTimeseries: vi.fn().mockResolvedValue({ status: "ok", rows: 1 }),
-  rebuildTimeseriesCache: vi.fn().mockResolvedValue({ status: "ok", rows: 1 }),
-}));
+  ];
 
 import DataAdmin from "@/pages/DataAdmin";
 
 describe("DataAdmin page", () => {
   it("renders table, actions, and ticker link", async () => {
+    mockListTimeseries.mockResolvedValue(timeseriesRows);
     render(
       <MemoryRouter>
         <DataAdmin />
@@ -37,5 +42,26 @@ describe("DataAdmin page", () => {
     expect(await screen.findByRole("button", { name: "Refetch" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Rebuild cache" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open instrument" })).toBeInTheDocument();
+  });
+
+  it("links a missing local login error to the relevant support control", async () => {
+    mockListTimeseries.mockRejectedValue(
+      new Error(
+        "No local login override is configured. Go to Support -> Local login override and select a user to continue in local/demo mode.",
+      ),
+    );
+
+    render(
+      <MemoryRouter>
+        <DataAdmin />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "No local login override is configured",
+    );
+    expect(
+      screen.getByRole("link", { name: "Configure local login override" }),
+    ).toHaveAttribute("href", "/support#local-login-override");
   });
 });


### PR DESCRIPTION
### Motivation

- The Data Admin page displayed a dead-end error when no local login override was configured, instructing the user to go to Support but providing no in-page action.  
- Provide a direct, discoverable action that takes the user to the exact control on the Support page to resolve the issue.

### Description

- `frontend/src/pages/DataAdmin.tsx`: detect the specific "No local login override is configured" error and render an accessible alert with a link to `/support#local-login-override` using the i18n key `dataadmin.configureLocalLogin`.  
- `frontend/src/pages/Support.tsx`: add an anchor wrapper (`id="local-login-override"`) around the local-login SectionCard so the Data Admin link targets the correct control.  
- `frontend/src/locales/en/translation.json`: add English label `dataadmin.configureLocalLogin` with the text "Configure local login override".  
- `frontend/tests/unit/pages/DataAdmin.test.tsx`: add a regression test that simulates the missing-local-login error and asserts the alert and link target are rendered.  
- Files changed: `frontend/src/pages/DataAdmin.tsx`, `frontend/src/pages/Support.tsx`, `frontend/src/locales/en/translation.json`, `frontend/tests/unit/pages/DataAdmin.test.tsx`.  
- Closes #6506

### Testing

- Ran `npm --prefix frontend run test -- --run tests/unit/pages/DataAdmin.test.tsx tests/unit/pages/Support.test.tsx` and all tests passed (2 files, 20 tests passed).  
- Ran `npm --prefix frontend run type-check` and `npm --prefix frontend run lint -- --quiet` with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b6ddee4d48327a3ea0a47e1a0ed95)