### PR TITLE
Skip empty instrument history requests

### DIFF
--- a/frontend/src/hooks/useInstrumentHistory.ts
+++ b/frontend/src/hooks/useInstrumentHistory.ts
@@ -83,6 +83,13 @@ export function useInstrumentHistory(ticker: string, days: number) {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
+    if (!ticker || days <= 0) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
     let active = true;
     const cached = cache.get(ticker)?.get(days) ?? null;
     if (cached) {

--- a/frontend/tests/unit/hooks/useInstrumentHistory.test.ts
+++ b/frontend/tests/unit/hooks/useInstrumentHistory.test.ts
@@ -27,6 +27,17 @@ describe('useInstrumentHistory', () => {
     vi.useRealTimers();
   });
 
+  it.each([
+    { ticker: '', days: 7 },
+    { ticker: 'ABC', days: 0 },
+    { ticker: 'ABC', days: -1 },
+  ])('does not fetch without a valid ticker and day range', ({ ticker, days }) => {
+    const { result } = renderHook(() => useInstrumentHistory(ticker, days));
+
+    expect(mockGetInstrumentDetail).not.toHaveBeenCalled();
+    expect(result.current).toEqual({ data: null, loading: false, error: null });
+  });
+
   it('retries on HTTP 429 responses and succeeds', async () => {
     vi.useFakeTimers();
     mockGetInstrumentDetail


### PR DESCRIPTION
### Motivation
- The Research page currently fires pointless `GET /instrument/?ticker=&days=0` requests when no ticker is selected, generating 400 responses and console/network noise.
- Avoid wasted network calls by keeping the `useInstrumentHistory` hook idle for invalid inputs (empty ticker or non-positive day ranges).

### Description
- Add a guard in `useInstrumentHistory` to return early when `!ticker || days <= 0`, resetting the hook to an idle state (`data: null`, `loading: false`, `error: null`).
- Add regression tests in `frontend/tests/unit/hooks/useInstrumentHistory.test.ts` to assert the hook does not call the API for empty tickers or zero/negative days.
- No behavior changes for valid tickers with positive day ranges; existing retry/backoff and caching behavior are unchanged.
- Closes #6501.

### Testing
- Ran the focused unit tests with Vitest: `npm --prefix frontend run test -- --run tests/unit/hooks/useInstrumentHistory.test.ts`, and the test file passed (6 tests passed).
- Ran TypeScript type-check: `npm --prefix frontend run type-check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b6e5fe8b48327a9f004d28dee7eba)