### PR TITLE
Show explanatory UI for config-disabled routes instead of silent redirect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import Support from './pages/Support';
 import ScenarioTester from './pages/ScenarioTester';
 import UserConfigPage from './pages/UserConfig';
 import BackendUnavailableCard from './components/BackendUnavailableCard';
+import DisabledFeature from './components/DisabledFeature';
 import Reports from './pages/Reports';
 import ReportTemplateCreator from './pages/ReportTemplateCreator';
 import AllocationCharts from './pages/AllocationCharts';
@@ -135,7 +136,7 @@ export function getFamilyMvpRedirectPath(
   //   keep sends the bare root ('/' with no query) to the configured entry flow.
   // - Every other route is left untouched: enabled tabs (search, settings, …)
   //   must be fully navigable. Truly disabled tabs are handled separately by the
-  //   tab gating in the route-sync effect, which redirects them to '/'.
+  //   tab gating in the route-sync effect, which shows an explanatory state.
   // - If every Family MVP tab is disabled, leave route selection to the caller.
   //
   // This is intentionally separate from getOwnerRootRedirectPath, which only
@@ -263,7 +264,7 @@ export default function App({ onLogout }: AppProps) {
   }, [familyMvpEnabled, familyMvpEntryPath, location.pathname, location.search, navigate]);
 
   // Sync route state (mode, selectedOwner, selectedGroup) with the current
-  // location. Waits for config to load so that disabled-tab redirects use
+  // location. Waits for config to load so that disabled-tab gating uses
   // the correct tab config. Also skips the sync when a Family MVP redirect
   // is about to fire, to avoid transient mode flips.
   useEffect(() => {
@@ -289,8 +290,7 @@ export default function App({ onLogout }: AppProps) {
     const isDisabled =
       tabs[newMode] === false || disabledTabs?.includes(newMode);
     if (isDisabled) {
-      setMode('group');
-      navigate('/', { replace: true });
+      setMode(newMode);
       return;
     }
     if (newMode === 'movers' && location.pathname !== '/movers') {
@@ -482,6 +482,13 @@ export default function App({ onLogout }: AppProps) {
   }, [instruments, exportGroupLabel]);
 
   const renderMainContent = () => {
+    const isDisabled =
+      configLoaded &&
+      (tabs[mode] === false || disabledTabs?.includes(mode));
+    if (isDisabled) {
+      return <DisabledFeature />;
+    }
+
     if (backendUnavailable) {
       return <BackendUnavailableCard onRetry={handleRetry} />;
     }

--- a/frontend/src/components/DisabledFeature.tsx
+++ b/frontend/src/components/DisabledFeature.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import EmptyState from './EmptyState';
+
+export default function DisabledFeature() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  return (
+    <EmptyState
+      role="status"
+      aria-live="polite"
+      message={t(
+        'app.featureDisabled',
+        "This feature isn't enabled for this application."
+      )}
+      actions={[
+        {
+          label: t('app.returnHome', 'Return home'),
+          onClick: () => navigate('/'),
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,7 +14,6 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import {
   BrowserRouter,
-  Navigate,
   Route,
   Routes,
   useLocation,
@@ -38,6 +37,7 @@ import { logConfigFetchFailure } from './configFetchLogging';
 import LoginPage from './LoginPage';
 import { UserProvider, useUser } from './UserContext';
 import ErrorBoundary from './ErrorBoundary';
+import DisabledFeature from './components/DisabledFeature';
 import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage';
 import { RouteProvider } from './RouteContext';
 import { clearCognitoSession, cognitoLogout, ensureAwsUiAuth, extractTokenExchangeErrorReason, getCognitoSessionExpiresAt, getStoredCognitoIdToken, refreshCognitoSession, UserCancelledError, type AwsUiAuthConfig } from './awsUiAuth';
@@ -479,7 +479,7 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
                   <Route
                     key={`disabled-${path}`}
                     path={path}
-                    element={<Navigate to="/" replace />}
+                    element={<DisabledFeature />}
                   />,
                 ]
           )}

--- a/frontend/tests/unit/App.familyMvpRedirect.test.tsx
+++ b/frontend/tests/unit/App.familyMvpRedirect.test.tsx
@@ -314,9 +314,7 @@ describe("App family MVP redirects", () => {
     expect(router.state.location.pathname).toBe("/settings");
   });
 
-  it("still redirects a disabled tab away in Family MVP mode", async () => {
-    // Tab gating remains the source of truth: a disabled tab is unreachable and
-    // is redirected off its route (to '/', then onward to the entry path).
+  it("explains a disabled tab in Family MVP mode", async () => {
     mockConfig({
       configLoaded: true,
       familyMvpEnabled: true,
@@ -334,14 +332,12 @@ describe("App family MVP redirects", () => {
 
     await mockCommonAppDependencies();
 
-    await renderAppAt("/movers");
+    const router = await renderAppAt("/movers");
 
-    // The disabled-tab guard flips the mode off 'movers' (to the default 'group'
-    // view) and the movers content never renders.
-    await waitFor(() => {
-      const marker = screen.getByTestId("active-route-marker");
-      expect(marker).not.toHaveAttribute("data-mode", "movers");
-    });
+    expect(
+      await screen.findByText("This feature isn't enabled for this application."),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe("/movers");
     expect(screen.queryByRole("heading", { name: /movers/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/App.test.tsx
+++ b/frontend/tests/unit/App.test.tsx
@@ -827,7 +827,7 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
-  it("hides disabled tabs and prevents navigation", async () => {
+  it("hides disabled tabs and explains disabled deep links", async () => {
     window.history.pushState({}, "", "/movers");
 
     vi.doMock("@/api", async () => {
@@ -869,6 +869,10 @@ describe("App", () => {
     );
 
     expect(screen.queryByRole("link", { name: /movers/i })).toBeNull();
+    expect(
+      await screen.findByText("This feature isn't enabled for this application."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Return home" })).toBeInTheDocument();
   });
 
   it("keeps unknown research owner slugs without redirecting", async () => {

--- a/frontend/tests/unit/main.familyMvpRoutes.test.tsx
+++ b/frontend/tests/unit/main.familyMvpRoutes.test.tsx
@@ -31,7 +31,7 @@ describe('Root Family MVP route gating', () => {
     localStorage.clear();
   });
 
-  it('redirects disabled input route to a safe fallback', async () => {
+  it('explains a disabled reports route without discarding the URL', async () => {
     vi.doMock('react-dom/client', () => ({
       createRoot: () => ({ render: vi.fn() }),
     }));
@@ -53,7 +53,10 @@ describe('Root Family MVP route gating', () => {
       default: AppShellPath,
     }));
 
-    await renderRootAt('/input');
-    expect(await screen.findByTestId('app-shell-path')).toHaveTextContent('/');
+    await renderRootAt('/reports');
+    expect(
+      await screen.findByText("This feature isn't enabled for this application.")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('app-shell-path')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #6521 

### Motivation

- Config-controlled tabs that were disabled by `config.yaml` silently redirected deep links to `/`, making bookmarks and deliberate deep links indistinguishable from broken routes; the change makes disabled routes surface a clear explanatory state while preserving the original URL.

### Description

- Added a reusable `DisabledFeature` component at `frontend/src/components/DisabledFeature.tsx` that renders an accessible `EmptyState` with a localized message and a `Return home` action.
- Updated `frontend/src/App.tsx` so the route-sync logic no longer navigates away when a mode is config-disabled and instead sets the `mode` and renders `DisabledFeature` at render time for disabled modes.
- Updated `frontend/src/main.tsx` to mount `DisabledFeature` for the explicit family‑MVP gated routes instead of redirecting them to `/`.
- Adjusted unit tests in `frontend/tests/unit/App.test.tsx`, `frontend/tests/unit/App.familyMvpRedirect.test.tsx`, and `frontend/tests/unit/main.familyMvpRoutes.test.tsx` to expect the explanatory UI and to assert that the original disabled URL is preserved.

### Testing

- Ran the focused unit tests with `npm --prefix frontend run test -- --run tests/unit/App.test.tsx tests/unit/App.familyMvpRedirect.test.tsx tests/unit/main.familyMvpRoutes.test.tsx` and the suite passed (47 tests across those files passed).
- Ran lint and typescript checks with `npm --prefix frontend run lint` and `npm --prefix frontend run type-check`, both completing successfully.
- Attempted a Playwright smoke check to capture a screenshot, but `npx playwright install chromium` failed due to the browser download returning HTTP 403, so the end-to-end browser snapshot step was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b6fa9ce508327a14692325886e544)