### PR TITLE
Clarify Virtual Portfolio is a browser-local draft

### DIFF
--- a/frontend/src/pages/VirtualPortfolio.tsx
+++ b/frontend/src/pages/VirtualPortfolio.tsx
@@ -312,12 +312,33 @@ export function VirtualPortfolio() {
   return (
     <div className="container mx-auto max-w-5xl space-y-6 p-4">
       <header>
-        <h1 className="text-2xl font-semibold md:text-4xl">Family Manual Portfolio Setup</h1>
+        <p className="mb-2 inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900">
+          Local draft
+        </p>
+        <h1 className="text-2xl font-semibold md:text-4xl">Family Manual Portfolio Draft</h1>
         <p className="mt-2 text-sm text-slate-600">
-          Add accounts and holdings manually. Entries are saved in this browser and survive page
-          refresh.
+          Explore a possible family portfolio without changing your saved portfolio. This draft is
+          stored only in this browser and is not saved to your AllotMint account.
         </p>
       </header>
+
+      <aside
+        className="rounded border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950"
+        aria-labelledby="local-draft-notice"
+      >
+        <h2 id="local-draft-notice" className="font-semibold">This draft stays separate</h2>
+        <p className="mt-1">
+          Draft accounts and holdings cannot currently be transferred automatically. To keep them
+          in your account, open your saved portfolio and use Add account, Add position, or Import
+          CSV.
+        </p>
+        <a
+          href="/portfolio"
+          className="mt-3 inline-flex rounded bg-slate-900 px-4 py-2 font-medium text-white hover:bg-slate-700"
+        >
+          Open saved portfolio
+        </a>
+      </aside>
 
       {statusMessage && (
         <p className="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -143,7 +143,7 @@ const ROUTES: RouteConfig[] = [
   { path: '/research/AAA', assertion: { kind: 'mode', mode: 'research' } },
   {
     path: '/virtual',
-    assertion: { kind: 'heading', name: 'Family Manual Portfolio Setup' },
+    assertion: { kind: 'heading', name: 'Family Manual Portfolio Draft' },
     setup: async (page) => {
       let handled = false;
       await page.route('**/virtual-portfolios', async (route) => {

--- a/frontend/tests/unit/pages/VirtualPortfolio.test.tsx
+++ b/frontend/tests/unit/pages/VirtualPortfolio.test.tsx
@@ -27,6 +27,18 @@ describe("VirtualPortfolio page", () => {
     );
   });
 
+  it("clearly identifies browser-only drafts and links to the saved portfolio", () => {
+    render(<VirtualPortfolio />);
+
+    expect(screen.getByText("Local draft")).toBeInTheDocument();
+    expect(screen.getByText(/not saved to your AllotMint account/i)).toBeInTheDocument();
+    expect(screen.getByText(/cannot currently be transferred automatically/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open saved portfolio" })).toHaveAttribute(
+      "href",
+      "/portfolio",
+    );
+  });
+
   it("adds multiple accounts and holdings", () => {
     render(<VirtualPortfolio />);
 


### PR DESCRIPTION
### Motivation
- The Virtual Portfolio page duplicates the saved-portfolio "add" flows but stores data only in `localStorage`, which is confusing to users who may expect drafts to persist to their account.
- The intent is to make the local-only nature and limitations of the Virtual Portfolio explicit in the UI so users know these drafts do not affect their saved portfolio.

### Description
- Update `frontend/src/pages/VirtualPortfolio.tsx` to label the page as a "Local draft" and change the heading to "Family Manual Portfolio Draft" with copy that explains the draft is stored only in the browser.
- Add an informational aside that explains draft accounts/holdings cannot currently be transferred automatically and include a link to the saved portfolio (`/portfolio`) with guidance to use Add account / Add position / Import CSV to persist data.
- Add a unit test in `frontend/tests/unit/pages/VirtualPortfolio.test.tsx` that asserts the local-draft disclosure, transfer limitation text, and the saved-portfolio link are present.
- Update the frontend smoke expectation in `frontend/tests/smoke.spec.ts` to reflect the new heading name and include the UI change in test coverage. Closes #6520.

### Testing
- Ran the component unit tests with Vitest for `tests/unit/pages/VirtualPortfolio.test.tsx`, and all tests passed (`10 tests passed`).
- Ran ESLint across the frontend and the touched files, and linting completed without errors for the modified files.
- Updated the smoke test assertion to expect the new heading; a full Playwright browser smoke run could not be completed because the Playwright Chromium executable was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b70a48f108327ac37ce76a27e7750)