### PR TITLE
Hide inline pie labels below 640px to avoid overlap on mobile

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -62,6 +62,7 @@ import { toRollupRows, toScopedHoldingRows } from "../lib/rollupAdapter";
 import { OwnerPortfolioActions } from "./OwnerPortfolioActions";
 import { useLocation, useSearchParams } from "react-router-dom";
 import { readRouteScopeQuery } from "../routes/registry";
+import { useViewportWidth } from "../hooks/useViewportWidth";
 
 const PIE_COLORS = [
   "#8884d8",
@@ -73,6 +74,8 @@ const PIE_COLORS = [
   "#d0ed57",
   "#ffc0cb",
 ];
+
+const INLINE_PIE_LABEL_MIN_WIDTH = 640;
 
 const DAY_CHANGE_BASELINE_EPSILON = 1e-2;
 // Warn when a single holding represents more than this share of the full portfolio.
@@ -251,6 +254,7 @@ type Props = {
  * Component
  * ────────────────────────────────────────────────────────── */
 export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
+  const showInlinePieLabels = useViewportWidth() >= INLINE_PIE_LABEL_MIN_WIDTH;
   const location = useLocation();
   const [, setSearchParams] = useSearchParams();
   const routeScope = readRouteScopeQuery(location.search);
@@ -1000,11 +1004,11 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
               <Pie
                 dataKey="value"
                 data={typeRows}
-                label={(props) => {
+                label={showInlinePieLabels && ((props) => {
                   const { name, percent: slicePercent } = props as PieLabelRenderProps;
                   const labelName = typeof name === "string" ? name : name != null ? String(name) : "";
                   return `${labelName} ${percent((slicePercent ?? 0) * 100)}`;
-                }}
+                })}
               >
                 {typeRows.map((_, idx) => (
                   <Cell

--- a/frontend/src/pages/AllocationCharts.tsx
+++ b/frontend/src/pages/AllocationCharts.tsx
@@ -7,6 +7,7 @@ import { money } from "../lib/money";
 import { useConfig } from "../ConfigContext";
 import { RelativeViewToggle } from "../components/RelativeViewToggle";
 import ChartSkeleton from "../components/skeletons/ChartSkeleton";
+import { useViewportWidth } from "../hooks/useViewportWidth";
 import {
   PieChart,
   Pie,
@@ -27,6 +28,8 @@ const COLORS = [
   "#d0ed57",
   "#ffc0cb",
 ];
+
+const INLINE_PIE_LABEL_MIN_WIDTH = 640;
 
 const toFiniteNumber = (value: unknown): number => {
   const numeric = typeof value === "number" ? value : Number(value);
@@ -65,6 +68,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const allToggleRef = useRef<HTMLInputElement>(null);
+  const showInlinePieLabels = useViewportWidth() >= INLINE_PIE_LABEL_MIN_WIDTH;
   const supportsResizeObserver =
     typeof window !== "undefined" && typeof window.ResizeObserver === "function";
 
@@ -259,7 +263,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
                 cy="50%"
                 outerRadius="80%"
                 // "percent" may be undefined for empty datasets; default it to 0
-                label={(props) => {
+                label={showInlinePieLabels && ((props) => {
                   const { name, value, percent: slicePercent } = props as PieLabelRenderProps;
                   const labelName = typeof name === "string" ? name : name != null ? String(name) : "";
                   const percentValue = (slicePercent ?? 0) * 100;
@@ -273,7 +277,7 @@ export function AllocationCharts({ slug = "all" }: AllocationChartsProps) {
                   return relativeViewEnabled
                     ? `${labelName}: ${percentValue.toFixed(2)}%`
                     : `${labelName}: ${money(numericValue, baseCurrency)} (${percentValue.toFixed(2)}%)`;
-                }}
+                })}
               >
                 {chartData.map((_, index) => (
                   <Cell

--- a/frontend/tests/unit/pages/AllocationCharts.test.tsx
+++ b/frontend/tests/unit/pages/AllocationCharts.test.tsx
@@ -13,8 +13,8 @@ vi.mock("recharts", () => ({
   PieChart: ({ children }: { children: ReactNode }) => (
     <div data-testid="pie-chart">{children}</div>
   ),
-  Pie: ({ data, children }: { data: Array<{ name: string; value: number }>; children: ReactNode }) => (
-    <div data-testid="pie-slices">
+  Pie: ({ data, children, label }: { data: Array<{ name: string; value: number }>; children: ReactNode; label?: unknown }) => (
+    <div data-testid="pie-slices" data-inline-labels={Boolean(label)}>
       {data.length === 0 ? (
         <span data-testid="no-slices">no-slices</span>
       ) : (
@@ -93,6 +93,30 @@ describe("AllocationCharts page", () => {
     resolveFn!(samplePortfolio);
     expect(await screen.findByText(/Instrument Types/)).toBeInTheDocument();
     expect(screen.queryByRole("status", { name: /Loading/ })).not.toBeInTheDocument();
+  });
+
+  it("uses the legend instead of inline labels on mobile viewports", async () => {
+    mockGetGroupPortfolio.mockResolvedValueOnce(samplePortfolio);
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 375 });
+
+    render(<AllocationCharts />);
+
+    expect(await screen.findByTestId("pie-slices")).toHaveAttribute(
+      "data-inline-labels",
+      "false",
+    );
+  });
+
+  it("restores inline labels when the viewport grows", async () => {
+    mockGetGroupPortfolio.mockResolvedValueOnce(samplePortfolio);
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 375 });
+    render(<AllocationCharts />);
+    const pie = await screen.findByTestId("pie-slices");
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 });
+    fireEvent(window, new Event("resize"));
+
+    expect(pie).toHaveAttribute("data-inline-labels", "true");
   });
 
   it("displays an error message when API call fails", async () => {


### PR DESCRIPTION
### Motivation

- The allocation and instrument-type pie charts render inline slice labels that overlap and clip on narrow mobile viewports (e.g. 375px), making the chart unreadable.
- The change switches small viewports to a legend/tooltip-first presentation so all categories remain legible while preserving desktop behavior.

### Description

- Add a viewport-aware toggle by importing and using `useViewportWidth` and defining `INLINE_PIE_LABEL_MIN_WIDTH = 640` to determine whether inline pie labels are shown.  
- Apply the conditional inline-label behavior to `frontend/src/pages/AllocationCharts.tsx` so the allocation pie uses the legend/tooltip at narrow widths and restores inline labels when resized larger.  
- Apply the same behavior to `frontend/src/components/GroupPortfolioView.tsx` for the instrument-type pie so both charts are consistent.  
- Update the Recharts test mock and `frontend/tests/unit/pages/AllocationCharts.test.tsx` to assert that inline labels are disabled on a mobile-width viewport and re-enabled after resizing, preventing regressions.  
- Closes #6525.

### Testing

- Ran linter: `npm run lint` — succeeded.  
- Ran type-check: `npm run type-check` — succeeded.  
- Ran unit tests for the affected specs: `npm run test -- --run tests/unit/pages/AllocationCharts.test.tsx tests/unit/components/GroupPortfolioView.test.tsx` — all tests passed (2 test files; 65 tests total passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b7063b06c8327813d7e344dacb9c4)