### PR TITLE
Fix system theme cascade so `system` follows OS light preference and add Playwright regression test

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -56,6 +56,30 @@
     --surface-muted-color: #bbbbbb;
 }
 
+/* System-theme overrides must remain unlayered. The default dark values above
+   are also unlayered, so putting these declarations in Tailwind's base layer
+   prevents them from winning even when the browser prefers a light scheme. */
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme]) {
+        color-scheme: light;
+        color: #213547;
+        background-color: #ffffff;
+
+        --drawer-bg: #ffffff;
+        --drawer-color: #213547;
+        --drawer-border-color: #ccc;
+        --drawer-muted-color: #666;
+        --surface-card-bg: #f5f5f5;
+        --surface-card-color: #213547;
+        --surface-card-border: #e0e0e0;
+        --surface-muted-color: #555555;
+    }
+
+    :root:not([data-theme]) a:hover {
+        color: #747bff;
+    }
+}
+
 a {
     font-weight: 500;
     color: #646cff;
@@ -134,24 +158,6 @@ h1 {
     }
 
     @media (prefers-color-scheme: light) {
-        :root:not([data-theme]) {
-            color: #213547;
-            background-color: #ffffff;
-
-            --drawer-bg: #ffffff;
-            --drawer-color: #213547;
-            --drawer-border-color: #ccc;
-            --drawer-muted-color: #666;
-            --surface-card-bg: #f5f5f5;
-            --surface-card-color: #213547;
-            --surface-card-border: #e0e0e0;
-            --surface-muted-color: #555555;
-        }
-
-        :root:not([data-theme]) a:hover {
-            color: #747bff;
-        }
-
         :root:not([data-theme]) button {
             background-color: #f9f9f9;
         }
@@ -167,5 +173,12 @@ h1 {
 :root[data-theme='light'] .Toastify__toast {
     background-color: #ffffff;
     color: #213547;
+}
+
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme]) .Toastify__toast {
+        background-color: #ffffff;
+        color: #213547;
+    }
 }
 

--- a/frontend/tests/systemTheme.spec.ts
+++ b/frontend/tests/systemTheme.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test, type Page } from '@playwright/test';
+import {
+  DEFAULT_CONFIG_BODY,
+  DEFAULT_GROUPS_BODY,
+  DEFAULT_OWNERS_BODY,
+} from './support/smokeFixtures';
+
+const baseUrl = process.env.SMOKE_URL ?? 'http://localhost:5173';
+
+const mockAppShell = async (page: Page, theme: 'dark' | 'light' | 'system') => {
+  for (const [path, body] of [
+    ['config', { ...DEFAULT_CONFIG_BODY, theme }],
+    ['owners', DEFAULT_OWNERS_BODY],
+    ['groups', DEFAULT_GROUPS_BODY],
+  ] as const) {
+    await page.route(`**/${path}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      })
+    );
+  }
+};
+
+const readRootTheme = (page: Page) =>
+  page.evaluate(() => {
+    const styles = getComputedStyle(document.documentElement);
+    return {
+      attribute: document.documentElement.getAttribute('data-theme'),
+      backgroundColor: styles.backgroundColor,
+      colorScheme: styles.colorScheme,
+      drawerBackground: styles.getPropertyValue('--drawer-bg').trim(),
+    };
+  });
+
+test.describe('application theme', () => {
+  test('system follows a light browser preference', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    await mockAppShell(page, 'system');
+    await page.goto(baseUrl);
+
+    await expect
+      .poll(() => readRootTheme(page))
+      .toEqual({
+        attribute: null,
+        backgroundColor: 'rgb(255, 255, 255)',
+        colorScheme: 'light',
+        drawerBackground: '#ffffff',
+      });
+  });
+
+  for (const override of ['dark', 'light'] as const) {
+    test(`${override} overrides the browser preference`, async ({ page }) => {
+      await page.emulateMedia({
+        colorScheme: override === 'dark' ? 'light' : 'dark',
+      });
+      await mockAppShell(page, override);
+      await page.goto(baseUrl);
+
+      const expected =
+        override === 'dark' ? 'rgb(36, 36, 36)' : 'rgb(255, 255, 255)';
+      await expect
+        .poll(() => readRootTheme(page))
+        .toMatchObject({
+          attribute: override,
+          backgroundColor: expected,
+          colorScheme: override,
+        });
+    });
+  }
+});


### PR DESCRIPTION
### Motivation

- The app's `theme: "system"` case did not apply the light-theme variable overrides when the browser preferred light because those rules were placed inside Tailwind's `@layer base`, which lost to utility classes; this change restores the intended behavior described in the issue. 

### Description

- Move the `prefers-color-scheme: light` `:root:not([data-theme])` declarations out of Tailwind's `@layer base` and into unlayered CSS so the browser `prefers-color-scheme`-driven variables win when `theme === "system"` (`frontend/src/index.css`).
- Add the same unlayered system-theme override for toast notifications so `.Toastify__toast` is correct under `system` + light preference (`frontend/src/index.css`).
- Add a Playwright regression test `frontend/tests/systemTheme.spec.ts` that asserts `system` follows a light browser preference and that explicit `dark`/`light` overrides still take precedence.
- Include an auto-closing reference to the related issue by implementing the behavior requested (Closes #6530).

### Testing

- Ran formatting and lint checks with `npx prettier --check` and `npm run lint` and they passed for the modified files.
- Verified production build with `npm --prefix frontend run build` which completed successfully.
- Attempted to run the new Playwright test with `npm exec playwright test -- --config playwright.config.ts tests/systemTheme.spec.ts`, but Playwright browser installation failed due to a CDN download permission error in this environment, so the browser-driven tests could not execute here (test harness present and assertions are in place).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b7070a70c83278a61e87f450a02fe)