### PR TITLE
Fix mobile holdings table dead-scroll zone

### DIFF
--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -158,8 +158,10 @@
   }
 
   .table {
-    display: block;
-    max-width: 100%;
+    /* Keep native table layout so virtual spacer rows contribute only their
+       requested height. The scroll container already clips wide columns. */
+    min-width: 100%;
+    width: max-content;
   }
 
   .table thead,

--- a/frontend/tests/responsive-layout.spec.ts
+++ b/frontend/tests/responsive-layout.spec.ts
@@ -269,3 +269,57 @@ for (const viewport of VIEWPORTS) {
     });
   });
 }
+
+test('mobile holdings keep native table layout while virtual rows scroll', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await preparePage(page);
+
+  const holdings = Array.from({ length: 160 }, (_, index) => ({
+    ticker: `MOB${index.toString().padStart(3, '0')}`,
+    name: `Mobile holding ${index}`,
+    units: index + 1,
+    market_value_gbp: 100 + index,
+    cost_basis_gbp: 80 + index,
+    current_price_gbp: 10,
+    currency: 'GBP',
+    instrument_type: 'Equity',
+    acquired_date: '2025-01-01',
+  }));
+  await page.route('**/portfolio-group/all*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ...groupPortfolio,
+        accounts: [{ ...groupPortfolio.accounts[0], holdings }],
+      }),
+    })
+  );
+
+  await page.goto(new URL('/', baseUrl).toString());
+  const table = page.getByRole('table');
+  await expect(table).toBeVisible();
+  await expect(table).toHaveCSS('display', 'table');
+
+  const scrollContainer = table.locator('..');
+  await scrollContainer.evaluate((element) => {
+    element.scrollTop = element.scrollHeight / 2;
+    element.dispatchEvent(new Event('scroll'));
+  });
+
+  await expect
+    .poll(() =>
+      scrollContainer.evaluate((element) => {
+        const bounds = element.getBoundingClientRect();
+        return Array.from(
+          element.querySelectorAll('tbody tr[data-index]')
+        ).some((row) => {
+          const rowBounds = row.getBoundingClientRect();
+          return rowBounds.bottom > bounds.top && rowBounds.top < bounds.bottom;
+        });
+      })
+    )
+    .toBe(true);
+});


### PR DESCRIPTION
### Motivation
- Mobile view showed a multi-screen blank "dead-scroll" region inside the holdings table because the mobile CSS forced the table to `display: block`, which made the virtual spacer rows size incorrectly.
- The change restores correct scrolling behavior for the core portfolio holdings page on small viewports and adds a regression to prevent regression.

### Description
- Change `frontend/src/styles/table.module.css` to preserve native table layout on mobile by replacing the `display: block` override with `min-width: 100%` and `width: max-content` so wide columns remain horizontally scrollable while virtual spacer rows keep their intended heights.
- Add a Playwright regression in `frontend/tests/responsive-layout.spec.ts` that runs at a 375×812 viewport with 160 virtualized holdings and asserts the table uses a native `display: table` and that virtual rows are visible after scrolling mid-way.
- Keep horizontal overflow handled by the existing scroll container and do not change the table's scroll UX beyond fixing the dead-scroll gap.
- Closes #6526.

### Testing
- Ran `npm --prefix frontend run test -- --run tests/unit/components/HoldingsTable.test.tsx`, which passed (`34 tests passed`).
- Ran typecheck/build with `npx tsc -b` which completed successfully.
- Ran `npx playwright test tests/responsive-layout.spec.ts --list` which discovered the new regression (13 tests total), and added the Playwright test; however, attempting to execute Playwright browsers failed because `playwright install chromium` could not download browsers from the CDN (HTTP 403), so full browser execution was not available in this environment.
- Ran Prettier/ESLint formatting checks and linting on the changed files, which passed after formatting adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b704d87388327a37a5bbd7f39ce27)