### PR TITLE
Add repo-local skills for QA sweeps, issue filing, and shipping fixes

### DIFF
--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: file-issue
+description: File a well-formed GitHub issue for this repo — searches for an existing duplicate first, then uses the exact section headers from .github/ISSUE_TEMPLATE (bug_report.md or feature_request.md), the repo's Value rubric, and cites real file:line evidence rather than guesses. Use whenever logging a bug, regression, or product/enhancement finding for allotmint — including when asked to "log this", "file an issue", "create an issue for X", or as the filing step inside a larger QA pass.
+---
+
+# File a well-formed issue
+
+This repo enforces a specific issue shape (see `CLAUDE.md`: "Always use the
+template format... and include every required section"). Free-form issues get
+rejected or ignored in triage. This skill is the mechanical part of that —
+composition and evidence-gathering are still on you.
+
+## 1. Search first
+
+Before creating anything, check whether this is already tracked:
+
+```
+gh issue list --repo leonarduk/allotmint --search "<key terms>" --state all
+```
+
+or `mcp__github__search_issues`. If you find the same root cause reached via a
+different repro path, add a comment (`mcp__github__add_issue_comment`) to the
+existing issue instead of opening a new one — quote the new repro, note what's
+different, and link back if relevant (e.g. "also reproduces via bare `/portfolio`,
+see #6492").
+
+## 2. Pick the template
+
+- `.github/ISSUE_TEMPLATE/bug_report.md` — something is broken or behaves
+  incorrectly. Label `bug`.
+- `.github/ISSUE_TEMPLATE/feature_request.md` — something should be built,
+  changed, or is a product/architecture judgment call (consolidation candidates,
+  incomplete features, disabled-route UX, etc.). Label `enhancement`.
+- Add `performance` alongside `bug` when latency/redundant-requests are the
+  finding.
+
+Both templates share the same section skeleton — use these exact headers,
+in order, every time:
+
+```
+## What
+## Why
+## How
+## Files Affected
+## Constraints
+## LLM tier
+## Value
+## Success looks like
+## Failure looks like
+```
+
+## 3. Fill each section with evidence, not vibes
+
+- **What**: exact repro — URL/route, steps, and what you actually observed
+  (quote console errors, network status codes, or screenshot findings inline).
+  Don't paraphrase an error message you saw; paste it.
+- **Why**: user/dev impact. "This looks wrong" is not a reason; "this blocks
+  every owner-scoped page" is.
+- **How**: cite `file:line` you actually opened and read. If multiple files are
+  plausibly involved, list them and say which one needs confirmation — don't
+  assert a fix location you haven't verified. For product/architecture findings,
+  say explicitly "no mechanical fix proposed — needs a product decision" rather
+  than implying a clean patch exists.
+- **Files Affected**: repo-relative paths only, one per line.
+- **Constraints**: anything the fix must not break (e.g. "must not regress the
+  existing group-view", "don't remove the config flag without confirming nothing
+  else depends on it").
+- **LLM tier**: haiku (mechanical/additive) / sonnet (judgment required) / opus
+  (complex, cross-cutting, or needs a product decision first).
+- **Value**: use the repo's own rubric, don't invent one —
+  - High: real bugs, security/auth gaps, financial-data correctness, substantive
+    product features.
+  - Medium: reliability/observability with real but non-urgent blast radius, or
+    consolidated hardening/test-coverage backlogs.
+  - Low: single-file mechanical fixes, renames, doc/formatting, or discussion-
+    starter product observations with no functional risk.
+- **Success/Failure looks like**: concrete, checkable — "X request fires once"
+  not "the bug is fixed."
+
+## 4. File it
+
+`mcp__github__create_issue` with `owner: "leonarduk"`, `repo: "allotmint"`,
+the title, `labels`, and the body assembled above. If the user gave a milestone
+for a batch of issues, apply it afterward with `mcp__github__update_issue` —
+batch these in parallel across all the issues in the set rather than one at a
+time.
+
+## 5. Cross-link
+
+If this finding blocks or relates to other open issues (e.g. "can't test X until
+issue #N is fixed"), say so explicitly in the body or a follow-up comment — this
+kind of dependency note has real value for whoever triages next (see #6492's
+comment thread for the pattern: noting it blocked verification of a second issue).

--- a/.claude/skills/qa-sweep/SKILL.md
+++ b/.claude/skills/qa-sweep/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: qa-sweep
+description: Explore-and-log QA pass over the AllotMint frontend. Drives the app in the Browser pane across every nav route (and mobile/tablet/theme variants), classifies what it finds (broken / incomplete / duplicate-or-overlapping / consolidation candidate), and files GitHub issues using the repo's bug_report/feature_request templates. Does NOT fix code. Use when asked to "QA the app", "log issues", "audit the UI", "find regressions", or "redo the QA sweep".
+---
+
+# QA sweep (log-only, no fixes)
+
+Goal: find real problems by actually driving the running app, and leave a clean paper
+trail of GitHub issues — not a pile of unreviewed local edits. This skill is
+**log-only by default**: identify and file, don't patch, unless the user explicitly
+asks for a fix in the same turn.
+
+Treat this as an iterative loop across a session, not a single pass: the user will
+likely say "keep going" repeatedly. Each iteration should open genuinely new ground
+(new page, new viewport, new interaction) rather than re-describing what's already
+been reported.
+
+## 0. Ground rules
+
+- **Never commit to `main` or edit files as a side effect of QA.** If you spot an
+  obvious one-line fix, resist the urge — file it instead. If the user explicitly
+  asks you to fix something mid-sweep, follow the branch/worktree/PR policy in
+  `docs/CONTRIBUTING.md` (never commit to `main`, create a branch first, open a PR)
+  — see the "If asked to fix" section below.
+- **Read `CLAUDE.md` and `docs/CONTRIBUTING.md`** (specifically the branch/PR policy
+  and issue-template requirements) before filing anything if you haven't already
+  this session.
+- **Search before filing.** For every finding, check whether an open issue already
+  covers it (`mcp__github__search_issues` or `gh issue list --search`) before
+  creating a new one. If it's the same root cause via a different repro path, add a
+  comment to the existing issue instead of opening a duplicate.
+- **Don't guess at severity.** Use the repo's own `## Value` rubric (High/Medium/Low,
+  defined in the issue templates) rather than inventing your own scale.
+- **Distinguish confirmed bugs from hypotheses.** If you can't pin the exact root
+  cause, say so in the issue body ("needs investigation") rather than asserting a
+  fix location you haven't verified by reading the code.
+
+## 1. Set up
+
+1. Confirm a dev server is already running (check `.claude/launch.json` for the
+   `frontend` config) — prefer attaching to whatever's already up over starting a
+   fresh one (`mcp__Claude_Browser__preview_start` with `{url: "http://localhost:5173"}`
+   if something's already bound to that port).
+2. Skim `frontend/src/routes/registry.ts` and the nav menu components
+   (`frontend/src/components/Menu.tsx` / `AppHeader.tsx`) to build a checklist of
+   every route reachable from the nav, plus any deep-link-only routes.
+3. Check `config.yaml`'s `ui.tabs` block and `enable_*` flags — routes disabled here
+   will redirect/gate rather than render; know this going in so you don't file a
+   "broken route" issue for something that's deliberately off (but *do* flag if the
+   disabled-route UX itself is bad — see #6521 for precedent).
+
+## 2. Sweep loop
+
+For each route/surface not yet covered this session:
+
+1. Navigate, wait for load, `get_page_text` — does real content render, or is it
+   stuck loading / blank / an error banner?
+2. `read_console_messages({onlyErrors: true})` and `read_network_requests` — look
+   for non-2xx responses, React warnings (duplicate keys, act() warnings), and
+   requests that seem redundant (same URL fired 3+ times on one load — this found
+   a real bug last time, see #6573).
+3. If the page has forms or interactive controls, exercise them: submit empty
+   (validation should reject, not silently no-op or 500), submit valid input,
+   check the happy path actually completes. Use `javascript_tool` to click by text
+   content when refs are unreliable (virtualized tables often don't expose full
+   `read_page` trees).
+4. Note anything that reads as: incomplete/stub (nav item leads to near-empty
+   content), duplicate/overlapping (two pages answer the same question), or a
+   combine/drop/expand candidate — these are as valuable as hard bugs, just file
+   them under `enhancement` with "no mechanical fix proposed, needs a product
+   decision" framing rather than pretending there's a clean fix.
+
+Once the nav sweep is done, repeat the same loop for:
+- **Mobile** (`resize_window({preset:"mobile"})`, 375×812) — reload, screenshot if
+  the Browser pane is displaying, and specifically watch for: overlapping chart
+  labels, horizontal-scroll dead zones, clipped text at viewport edges.
+- **Tablet** (`resize_window({preset:"tablet"})`).
+- **Light theme** (`resize_window({colorScheme:"light"})` + reload) — confirm the
+  "system" theme config actually follows OS preference; this repo has shipped that
+  bug before (#6530).
+- **Any owner/config-gated states**: with `disable_auth: true` locally, you can
+  usually reach every state directly, but note if a whole feature category (e.g.
+  every owner-scoped page) is unreachable due to a bug upstream — that's worth its
+  own high-priority issue, not just noting each blocked page individually.
+
+If a screenshot tool call fails with "Browser pane is not displayed," fall back to
+`get_page_text` + `read_page`/`read_console_messages`/`read_network_requests` for the
+rest of the session rather than blocking on it.
+
+## 3. Filing issues
+
+Use `mcp__github__create_issue` with the exact section headers from
+`.github/ISSUE_TEMPLATE/bug_report.md` (bugs) or `feature_request.md`
+(incomplete/duplicate/combine/drop/expand findings): `## What`, `## Why`, `## How`,
+`## Files Affected`, `## Constraints`, `## LLM tier`, `## Value`,
+`## Success looks like`, `## Failure looks like`. Label `bug` or `enhancement`
+accordingly; add `performance` too when relevant.
+
+- `## What`: exact repro (URL/route, steps, what you observed) — screenshots or
+  network/console evidence quoted inline where you have them.
+- `## Why`: user/dev impact, not just "this looks wrong."
+- `## How`: cite specific `file:line` you actually read, not a guess. If several
+  files are plausibly involved, list them and say which needs confirmation.
+- For consolidation/product findings: explicitly note in `## How` that this needs a
+  product decision, not a mechanical patch — don't imply there's an obvious fix that
+  isn't there.
+- If the user gave a milestone, apply it to every issue via `mcp__github__update_issue`
+  (`milestone: <number>`) — batch these calls in parallel.
+- If a finding is the *same bug* reached via a second repro path, add a comment to
+  the existing issue (`mcp__github__add_issue_comment`) instead of a new issue —
+  this repo's issue count is already large; don't inflate it.
+
+## 4. If asked to fix (not the default — only when explicitly requested)
+
+1. `git status` — if dirty, `git stash` the relevant files.
+2. `git worktree add ../<repo>-fix-<issue-number> -b fix/issue-<N>-<slug> origin/main`.
+3. Apply the fix there, re-read the full file first (per `CLAUDE.md`), keep the diff
+   scoped to one logical change — don't bundle an unrelated finding into the same PR
+   just because you found it in the same session.
+4. Verify live in the browser before committing.
+5. Commit (stage explicit files, never `-a`), push, `gh pr create` with `Closes #N`
+   in the body.
+6. If you have several fixes ready but they're independent, prefer separate
+   branches/PRs over one big one — this repo's own history shows large multi-file
+   UX PRs are exactly what caused the regressions this skill exists to catch.
+
+## 5. Resuming a sweep after fixes land
+
+When the user says fixes have merged and asks you to continue:
+
+1. `git log --oneline -20 main` to see what actually landed — don't assume from
+   memory which issues are closed.
+2. Check the state of every issue you filed this session in one batch (a loop of
+   `gh issue view $n --json state` is fine) rather than re-testing everything blind.
+3. Re-verify closed items live (quick smoke check, not a full re-audit) and spend
+   the rest of the budget on genuinely new ground — previously-blocked flows
+   (anything gated behind a now-fixed crash), interaction paths not yet tried,
+   viewport/theme combinations not yet tried.
+
+## Reference: prior run
+
+The first full run of this skill against this repo (2026-08-11) found 20 issues in
+one session, 13 of which were fixed within the same day by parallel work — see
+issues #6492–#6534, #6573 and PR #6496 for calibration on the level of detail and
+evidence expected per finding.

--- a/.claude/skills/ship-fix/SKILL.md
+++ b/.claude/skills/ship-fix/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: ship-fix
+description: Take a scoped code fix from a dirty/main checkout to a proper branch, commit, and PR following this repo's branch policy (docs/CONTRIBUTING.md) — never commits to main, uses a clean worktree when the checkout is dirty, keeps unrelated findings out of the diff, and links the PR to its issue with "Closes #N". Use whenever about to commit or push a fix for allotmint, or when told to "ship this", "open a PR for X", or "move this to a branch".
+---
+
+# Ship a fix properly
+
+This repo's #1 rule (`docs/CONTRIBUTING.md`): never commit directly to `main`.
+This skill is the checklist for going from "I have a fix" (possibly sitting
+uncommitted on a dirty `main` checkout) to a mergeable PR without violating that,
+and without smuggling unrelated changes along for the ride.
+
+## 1. Assess the starting state
+
+```
+git status --short
+git log --oneline -5 main
+```
+
+- If `main` is clean and you haven't written the fix yet: create the branch
+  *first* (see step 2), then write the fix. Don't edit-then-branch.
+- If `main` already has uncommitted changes (yours or pre-existing) when you
+  reach this point: **don't just branch in place** — a branch created from a
+  dirty checkout carries whatever else was sitting there, silently. Stash first:
+
+  ```
+  git stash push -u -m "<description>" -- <specific files, not -A>
+  git status --short   # confirm main is clean
+  ```
+
+## 2. Create a clean worktree + branch off the remote
+
+```
+git fetch origin main -q
+git worktree add ../<repo>-fix-<issue-number> -b fix/issue-<N>-<short-slug> origin/main
+```
+
+Branch naming: `fix/issue-NNNN-short-description`, `feat/issue-NNNN-...`,
+`docs/...`, or `chore/...` per `docs/CONTRIBUTING.md`.
+
+If you stashed in step 1, apply *only the relevant files* into the new worktree:
+
+```
+git -C ../<repo>-fix-<issue-number> stash apply stash@{0}
+git -C ../<repo>-fix-<issue-number> checkout -- <files that belong to a different, unrelated finding>
+```
+
+Don't ship two unrelated fixes in one PR just because they were sitting in the
+same stash — split them into separate branches/PRs (see #6494 vs #6493 in this
+repo's history for why: they looked related but needed independent design
+decisions, and bundling them would have blocked the easy one on the hard one).
+
+## 3. Before committing
+
+- Re-read the **full current content** of every file you're changing from disk —
+  not a diff, not memory of an earlier read (`CLAUDE.md` rule #1).
+- Verify the fix live: reload the app in the Browser pane, exercise the exact
+  repro from the issue, confirm it's actually fixed (not just "looks right").
+- Run the narrowest relevant test/lint command, not the full suite, unless the
+  change is broad.
+- If the diff drifted to include formatting-only changes to unrelated lines
+  (e.g. from an editor auto-format), split those into a separate commit —
+  don't bury the real diff in cosmetic noise (`docs/CONTRIBUTING.md`).
+
+## 4. Commit, push, PR
+
+- Stage explicit files — never `git add -A` / `git commit -am` (risk of sweeping
+  in lockfile drift or unrelated changes).
+- Commit message: what changed and why, not a restatement of the diff.
+- `git push -u origin <branch>`.
+- `gh pr create` with a body containing `Closes #<issue-number>` so the issue
+  auto-closes on merge, plus a `## Test plan` section listing what you actually
+  verified (live browser check, not just "should work").
+
+## 5. If you have multiple ready fixes
+
+Prefer one branch/PR per logical change over one big branch. If several fixes
+share a root cause (e.g. they'd all be touched by the same refactor), that's a
+signal to slow down and call it out to the user rather than bundling — this
+repo's own regression history (the Portfolio UX merge, #6470) is what happens
+when several logically-separate changes land in one PR.


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/qa-sweep/SKILL.md` — drives the app across every nav route plus mobile/tablet/light-theme variants, classifies findings (broken / incomplete / duplicate-overlapping / consolidation candidate), files issues. Log-only by default, doesn't patch code.
- Adds `.claude/skills/file-issue/SKILL.md` — search-before-file, then use this repo's exact `.github/ISSUE_TEMPLATE` section headers and `Value` rubric with real `file:line` evidence.
- Adds `.claude/skills/ship-fix/SKILL.md` — scoped fix → clean worktree/branch → verified commit → PR with `Closes #N`, per `docs/CONTRIBUTING.md`'s branch policy.

No application code changes — purely additive process/tooling files.

Closes #6574

## Test plan
- [x] Files are additive only; `git status` on the branch shows only the three new `SKILL.md` files.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)