### PR TITLE
Populate instrument detail Positions with unrealised gain and gain %

### DIFF
--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -151,7 +151,10 @@ def _positions_for_ticker(tkr: str, last_close: float | None) -> List[Dict[str, 
                         h.get(EFFECTIVE_COST_BASIS_GBP) or h.get(COST_BASIS_GBP) or h.get("cost_basis")
                     )
                     cost = get_effective_cost_basis_gbp(normalised, price_cache, price_hint=last_close)
-                    if cost > 0:
+                    # The helper never returns None, but keep the guard explicit
+                    # so a future signature change cannot introduce a TypeError
+                    # or a divide-by-zero in the gain percentage below.
+                    if cost is not None and cost > 0:
                         calculated_gain = round(mv_gbp - cost, 2)
                         if gain_gbp is None:
                             gain_gbp = calculated_gain

--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -20,6 +20,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from markupsafe import Markup
 
+from backend.common.constants import COST_BASIS_GBP, EFFECTIVE_COST_BASIS_GBP, UNITS
 from backend.common.holding_utils import get_effective_cost_basis_gbp
 from backend.common.instruments import list_instruments
 from backend.common.portfolio_loader import list_portfolios
@@ -141,11 +142,15 @@ def _positions_for_ticker(tkr: str, last_close: float | None) -> List[Dict[str, 
                 gain_pct = h.get("gain_pct")
                 if mv_gbp is not None and (gain_gbp is None or gain_pct is None):
                     # Raw account files do not contain the derived gain fields
-                    # returned by the holdings endpoint. Use its canonical cost
-                    # basis calculation so both views report the same result.
-                    cost = get_effective_cost_basis_gbp(
-                        dict(h), price_cache, price_hint=last_close
+                    # returned by the holdings endpoint. Map their legacy field
+                    # names onto the canonical ones, then reuse its cost basis
+                    # calculation so both views report the same result.
+                    normalised = dict(h)
+                    normalised[UNITS] = h.get(UNITS) or h.get("quantity")
+                    normalised[COST_BASIS_GBP] = (
+                        h.get(EFFECTIVE_COST_BASIS_GBP) or h.get(COST_BASIS_GBP) or h.get("cost_basis")
                     )
+                    cost = get_effective_cost_basis_gbp(normalised, price_cache, price_hint=last_close)
                     if cost > 0:
                         calculated_gain = round(mv_gbp - cost, 2)
                         if gain_gbp is None:

--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -20,6 +20,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from markupsafe import Markup
 
+from backend.common.holding_utils import get_effective_cost_basis_gbp
 from backend.common.instruments import list_instruments
 from backend.common.portfolio_loader import list_portfolios
 from backend.common.portfolio_utils import get_security_meta
@@ -122,6 +123,7 @@ def _positions_for_ticker(tkr: str, last_close: float | None) -> List[Dict[str, 
     """
 
     positions: List[Dict[str, Any]] = []
+    price_cache = {tkr: last_close} if last_close is not None else {}
 
     # Iterate through owners -> accounts -> holdings
     for pf in list_portfolios():
@@ -137,16 +139,19 @@ def _positions_for_ticker(tkr: str, last_close: float | None) -> List[Dict[str, 
 
                 gain_gbp = h.get("gain_gbp")
                 gain_pct = h.get("gain_pct")
-                if gain_gbp is None and mv_gbp is not None:
-                    # fall back to cost basis when explicit gain is missing
-                    cost = h.get("effective_cost_basis_gbp") or h.get("cost_basis_gbp") or h.get("cost_basis")
-                    try:
-                        cost_f = float(cost) if cost is not None else None
-                    except (TypeError, ValueError):
-                        cost_f = None
-                    if cost_f is not None:
-                        gain_gbp = round(mv_gbp - cost_f, 2)
-                        gain_pct = (gain_gbp / cost_f * 100.0) if cost_f else None
+                if mv_gbp is not None and (gain_gbp is None or gain_pct is None):
+                    # Raw account files do not contain the derived gain fields
+                    # returned by the holdings endpoint. Use its canonical cost
+                    # basis calculation so both views report the same result.
+                    cost = get_effective_cost_basis_gbp(
+                        dict(h), price_cache, price_hint=last_close
+                    )
+                    if cost > 0:
+                        calculated_gain = round(mv_gbp - cost, 2)
+                        if gain_gbp is None:
+                            gain_gbp = calculated_gain
+                        if gain_pct is None:
+                            gain_pct = calculated_gain / cost * 100.0
 
                 positions.append(
                     {

--- a/backend/routes/instrument.py
+++ b/backend/routes/instrument.py
@@ -188,9 +188,7 @@ def _render_html(
     """Render a minimal HTML page summarising price and position data."""
     prices_tbl = Markup(df[["Date", "Close"]].tail(30).to_html(index=False, escape=True, classes="prices"))
     pos_tbl = (
-        Markup(pd.DataFrame(positions).to_html(index=False, escape=True, classes="positions"))
-        if positions
-        else None
+        Markup(pd.DataFrame(positions).to_html(index=False, escape=True, classes="positions")) if positions else None
     )
 
     begin, end = _as_iso(df.iloc[0]["Date"]), _as_iso(df.iloc[-1]["Date"])
@@ -218,9 +216,7 @@ async def instrument(
     start_date: Annotated[Optional[date], Query(description="Start date YYYY-MM-DD; overrides days")] = None,
     end_date: Annotated[Optional[date], Query(description="End date YYYY-MM-DD; overrides today")] = None,
     format: str = Query("html", pattern="^(html|json)$"),
-    base_currency: str | None = Query(
-        None, description="Reporting currency for prices"
-    ),
+    base_currency: str | None = Query(None, description="Reporting currency for prices"),
 ):
     """Return price history and portfolio positions for a ticker.
 
@@ -256,9 +252,7 @@ async def instrument(
 
     native_currency = currency or ("GBP" if is_gbp_ticker else None)
 
-    base_currency = (
-        base_currency or getattr(config, "base_currency", None) or "GBP"
-    ).upper()
+    base_currency = (base_currency or getattr(config, "base_currency", None) or "GBP").upper()
 
     if df.empty:
         positions = _positions_for_ticker(ticker.upper(), None)
@@ -426,32 +420,22 @@ async def instrument(
                     df.drop(columns=["Rate"], inplace=True)
                     cols.append(col_name)
                     rename[col_name] = f"close_{base_lower}"
-                    assigns[f"close_{base_lower}"] = (
-                        lambda d, c=f"close_{base_lower}": d[c].astype(float)
-                    )
+                    assigns[f"close_{base_lower}"] = lambda d, c=f"close_{base_lower}": d[c].astype(float)
                     pair = f"{base_currency}GBP"
                     fx_links[pair] = f"/timeseries/meta?ticker={pair}"
             except Exception:
                 pass
 
         system_base = getattr(config, "base_currency", "").upper()
-        if (
-            system_base == "USD"
-            and "Close_gbp" in df.columns
-            and "Close_usd" not in df.columns
-        ):
+        if system_base == "USD" and "Close_gbp" in df.columns and "Close_usd" not in df.columns:
             start_fx = df["Date"].dt.date.min()
             end_fx = df["Date"].dt.date.max()
             try:
-                fx_usd = fetch_fx_rate_range("USD", "GBP", start_fx, end_fx).rename(
-                    columns={"Rate": "Rate_usd"}
-                )
+                fx_usd = fetch_fx_rate_range("USD", "GBP", start_fx, end_fx).rename(columns={"Rate": "Rate_usd"})
                 if not fx_usd.empty:
                     fx_usd["Date"] = pd.to_datetime(fx_usd["Date"])
                     df = df.merge(fx_usd, on="Date", how="left")
-                    df["Close_usd"] = df["Close_gbp"] / pd.to_numeric(
-                        df["Rate_usd"], errors="coerce"
-                    )
+                    df["Close_usd"] = df["Close_gbp"] / pd.to_numeric(df["Rate_usd"], errors="coerce")
                     df.drop(columns=["Rate_usd"], inplace=True)
                     cols.append("Close_usd")
                     rename["Close_usd"] = "close_usd"
@@ -460,12 +444,7 @@ async def instrument(
             except Exception:
                 pass
 
-        prices = (
-            df[cols]
-            .rename(columns=rename)
-            .assign(**assigns)
-            .to_dict(orient="records")
-        )
+        prices = df[cols].rename(columns=rename).assign(**assigns).to_dict(orient="records")
         mini = {"7": prices[-7:], "30": prices[-30:], "180": prices[-180:]}
         payload = {
             "ticker": ticker,
@@ -491,7 +470,7 @@ async def instrument(
             ticker=ticker,
             df=df,
             positions=positions,
-    window_days=window_days,
+            window_days=window_days,
         )
     )
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,4 @@ pandas-stubs==3.0.5.260730
 
 # Shared repository automation (issue, PR, review, and CI helper commands).
 # Pin the release asset so developer and CI installs use the same tested CLI.
-cicaid-devtools[dotenv] @ https://github.com/leonarduk/cicaid/releases/download/v0.5.2/cicaid_devtools-0.5.2-py3-none-any.whl
+cicaid-devtools[dotenv] @ https://github.com/leonarduk/cicaid/releases/download/v0.8.3/cicaid_devtools-0.8.3-py3-none-any.whl

--- a/tests/routes/test_instrument.py
+++ b/tests/routes/test_instrument.py
@@ -133,6 +133,31 @@ def test_positions_for_ticker_derives_gain_from_acquisition_price(monkeypatch):
     assert position["gain_pct"] == pytest.approx(25.0)
 
 
+def test_positions_for_ticker_zero_cost_leaves_gain_unchanged(monkeypatch):
+    # A zero/unknown cost basis must not fabricate a gain: the position keeps
+    # whatever gain fields the raw file carried (here: none).
+    portfolios = [
+        {
+            "owner": "alex",
+            "accounts": [
+                {
+                    "account_type": "isa",
+                    "holdings": [{"ticker": "ABC.L", "units": 2}],
+                }
+            ],
+        }
+    ]
+    monkeypatch.setattr("backend.routes.instrument.list_portfolios", lambda: portfolios)
+
+    # A zero close price leaves the derived cost basis at 0, so the gain
+    # calculation is skipped instead of dividing by zero.
+    [position] = instrument._positions_for_ticker("ABC.L", last_close=0.0)
+
+    assert position["market_value_gbp"] == 0.0
+    assert position["unrealised_gain_gbp"] is None
+    assert position["gain_pct"] is None
+
+
 def test_render_html_contains_tables():
     df = _make_df()
     positions = [

--- a/tests/routes/test_instrument.py
+++ b/tests/routes/test_instrument.py
@@ -1,13 +1,13 @@
+from unittest.mock import patch
+
 import pandas as pd
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-from unittest.mock import patch
 
-from backend.routes import instrument
 from backend.app import create_app
 from backend.config import config
-
+from backend.routes import instrument
 
 SAMPLE_INSTRUMENTS = [
     {"ticker": "ABC.L", "name": "ABC Company", "sector": "Tech", "region": "UK"},
@@ -114,6 +114,39 @@ def test_positions_for_ticker_gain_and_cost(monkeypatch):
     assert first["unrealised_gain_gbp"] == 5
     assert second["unrealised_gain_gbp"] == pytest.approx(2.0)
     assert second["gain_pct"] == pytest.approx(10.0)
+
+
+def test_positions_for_ticker_derives_gain_from_acquisition_price(monkeypatch):
+    portfolios = [
+        {
+            "owner": "alex",
+            "accounts": [
+                {
+                    "account_type": "isa",
+                    "holdings": [
+                        {
+                            "ticker": "ABC.L",
+                            "units": 2,
+                            "acquired_date": "2024-01-02",
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    monkeypatch.setattr(
+        "backend.routes.instrument.list_portfolios", lambda: portfolios
+    )
+    monkeypatch.setattr(
+        "backend.common.holding_utils._derived_cost_basis_close_px",
+        lambda *_args, **_kwargs: 8.0,
+    )
+
+    [position] = instrument._positions_for_ticker("ABC.L", last_close=10.0)
+
+    assert position["market_value_gbp"] == pytest.approx(20.0)
+    assert position["unrealised_gain_gbp"] == pytest.approx(4.0)
+    assert position["gain_pct"] == pytest.approx(25.0)
 
 
 def test_render_html_contains_tables():

--- a/tests/routes/test_instrument.py
+++ b/tests/routes/test_instrument.py
@@ -37,23 +37,18 @@ def _make_df() -> pd.DataFrame:
 # /instrument/search
 # ---------------------------------------------------------------------------
 
+
 def test_search_valid_and_filters(monkeypatch):
     app = FastAPI()
     app.include_router(instrument.router)
-    monkeypatch.setattr(
-        "backend.routes.instrument.list_instruments", lambda: SAMPLE_INSTRUMENTS
-    )
+    monkeypatch.setattr("backend.routes.instrument.list_instruments", lambda: SAMPLE_INSTRUMENTS)
     client = TestClient(app)
     resp = client.get("/instrument/search", params={"q": "alpha"})
     assert resp.status_code == 200
     assert resp.json() == [SAMPLE_INSTRUMENTS[2]]
 
-    resp_sector = client.get(
-        "/instrument/search", params={"q": "c", "sector": "Finance"}
-    )
-    resp_region = client.get(
-        "/instrument/search", params={"q": "c", "region": "US"}
-    )
+    resp_sector = client.get("/instrument/search", params={"q": "c", "sector": "Finance"})
+    resp_region = client.get("/instrument/search", params={"q": "c", "region": "US"})
     assert resp_sector.json() == [SAMPLE_INSTRUMENTS[1]]
     assert resp_region.json() == [SAMPLE_INSTRUMENTS[1]]
 
@@ -61,24 +56,17 @@ def test_search_valid_and_filters(monkeypatch):
 def test_search_invalid_inputs(monkeypatch):
     app = FastAPI()
     app.include_router(instrument.router)
-    monkeypatch.setattr(
-        "backend.routes.instrument.list_instruments", lambda: SAMPLE_INSTRUMENTS
-    )
+    monkeypatch.setattr("backend.routes.instrument.list_instruments", lambda: SAMPLE_INSTRUMENTS)
     client = TestClient(app)
     assert client.get("/instrument/search").status_code == 400
-    assert (
-        client.get("/instrument/search", params={"q": "a", "sector": ""}).status_code
-        == 400
-    )
-    assert (
-        client.get("/instrument/search", params={"q": "a", "region": ""}).status_code
-        == 400
-    )
+    assert client.get("/instrument/search", params={"q": "a", "sector": ""}).status_code == 400
+    assert client.get("/instrument/search", params={"q": "a", "region": ""}).status_code == 400
 
 
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
 
 def test_validate_ticker_accepts():
     assert instrument._validate_ticker("ABC.L") is None
@@ -105,9 +93,7 @@ def test_positions_for_ticker_gain_and_cost(monkeypatch):
             ],
         }
     ]
-    monkeypatch.setattr(
-        "backend.routes.instrument.list_portfolios", lambda: portfolios
-    )
+    monkeypatch.setattr("backend.routes.instrument.list_portfolios", lambda: portfolios)
     positions = instrument._positions_for_ticker("ABC.L", last_close=11.0)
     assert len(positions) == 2
     first, second = positions
@@ -134,9 +120,7 @@ def test_positions_for_ticker_derives_gain_from_acquisition_price(monkeypatch):
             ],
         }
     ]
-    monkeypatch.setattr(
-        "backend.routes.instrument.list_portfolios", lambda: portfolios
-    )
+    monkeypatch.setattr("backend.routes.instrument.list_portfolios", lambda: portfolios)
     monkeypatch.setattr(
         "backend.common.holding_utils._derived_cost_basis_close_px",
         lambda *_args, **_kwargs: 8.0,
@@ -162,13 +146,14 @@ def test_render_html_contains_tables():
         }
     ]
     html = instrument._render_html("ABC.L", df, positions, window_days=30)
-    assert "class=\"dataframe prices\"" in html
-    assert "class=\"dataframe positions\"" in html
+    assert 'class="dataframe prices"' in html
+    assert 'class="dataframe positions"' in html
 
 
 # ---------------------------------------------------------------------------
 # /instrument route
 # ---------------------------------------------------------------------------
+
 
 def test_instrument_route_json_html_and_base_currency(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
@@ -183,24 +168,17 @@ def test_instrument_route_json_html_and_base_currency(monkeypatch):
     portfolios = [
         {
             "owner": "alex",
-            "accounts": [
-                {"account_type": "isa", "holdings": [{"ticker": "ABC.L", "units": 2}]}
-            ],
+            "accounts": [{"account_type": "isa", "holdings": [{"ticker": "ABC.L", "units": 2}]}],
         }
     ]
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch(
-        "backend.routes.instrument.list_portfolios", return_value=portfolios
-    ), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
-    ), patch(
-        "backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch("backend.routes.instrument.list_portfolios", return_value=portfolios),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
+        patch("backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df),
     ):
         client = _auth_client(app)
-        resp_json = client.get(
-            "/instrument?ticker=ABC.L&days=1&format=json&base_currency=USD"
-        )
+        resp_json = client.get("/instrument?ticker=ABC.L&days=1&format=json&base_currency=USD")
         resp_html = client.get("/instrument?ticker=ABC.L&days=1&format=html")
 
     assert resp_json.status_code == 200
@@ -229,9 +207,7 @@ def test_instrument_route_close_only_prices_populates_positions(monkeypatch):
             "accounts": [
                 {
                     "account_type": "general",
-                    "holdings": [
-                        {"ticker": "XYZ.N", "units": 2, "cost_basis_gbp": 150.0}
-                    ],
+                    "holdings": [{"ticker": "XYZ.N", "units": 2, "cost_basis_gbp": 150.0}],
                 }
             ],
         }
@@ -244,15 +220,14 @@ def test_instrument_route_close_only_prices_populates_positions(monkeypatch):
         rate = 0.8 if (base, quote) == ("USD", "GBP") else 1.0
         return pd.DataFrame({"Date": dates, "Rate": [rate] * len(dates)})
 
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch(
-        "backend.routes.instrument.list_portfolios", return_value=portfolios
-    ), patch(
-        "backend.routes.instrument.get_security_meta",
-        return_value={"currency": "USD"},
-    ), patch(
-        "backend.routes.instrument.fetch_fx_rate_range", side_effect=fake_fx
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch("backend.routes.instrument.list_portfolios", return_value=portfolios),
+        patch(
+            "backend.routes.instrument.get_security_meta",
+            return_value={"currency": "USD"},
+        ),
+        patch("backend.routes.instrument.fetch_fx_rate_range", side_effect=fake_fx),
     ):
         client = _auth_client(app)
         resp = client.get("/instrument?ticker=XYZ.N&days=2&format=json")

--- a/tests/snapshots/index.css
+++ b/tests/snapshots/index.css
@@ -56,6 +56,30 @@
     --surface-muted-color: #bbbbbb;
 }
 
+/* System-theme overrides must remain unlayered. The default dark values above
+   are also unlayered, so putting these declarations in Tailwind's base layer
+   prevents them from winning even when the browser prefers a light scheme. */
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme]) {
+        color-scheme: light;
+        color: #213547;
+        background-color: #ffffff;
+
+        --drawer-bg: #ffffff;
+        --drawer-color: #213547;
+        --drawer-border-color: #ccc;
+        --drawer-muted-color: #666;
+        --surface-card-bg: #f5f5f5;
+        --surface-card-color: #213547;
+        --surface-card-border: #e0e0e0;
+        --surface-muted-color: #555555;
+    }
+
+    :root:not([data-theme]) a:hover {
+        color: #747bff;
+    }
+}
+
 a {
     font-weight: 500;
     color: #646cff;
@@ -134,24 +158,6 @@ h1 {
     }
 
     @media (prefers-color-scheme: light) {
-        :root:not([data-theme]) {
-            color: #213547;
-            background-color: #ffffff;
-
-            --drawer-bg: #ffffff;
-            --drawer-color: #213547;
-            --drawer-border-color: #ccc;
-            --drawer-muted-color: #666;
-            --surface-card-bg: #f5f5f5;
-            --surface-card-color: #213547;
-            --surface-card-border: #e0e0e0;
-            --surface-muted-color: #555555;
-        }
-
-        :root:not([data-theme]) a:hover {
-            color: #747bff;
-        }
-
         :root:not([data-theme]) button {
             background-color: #f9f9f9;
         }
@@ -167,5 +173,12 @@ h1 {
 :root[data-theme='light'] .Toastify__toast {
     background-color: #ffffff;
     color: #213547;
+}
+
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme]) .Toastify__toast {
+        background-color: #ffffff;
+        color: #213547;
+    }
 }
 


### PR DESCRIPTION
### Motivation

- The instrument detail drawer shows `—` for `Gain £`/`Gain %` because the `/instrument/` positions builder did not derive those fields from raw account holdings the same way the holdings endpoint does. This makes the drawer inconsistent with the holdings table.

### Description

- Use the canonical cost-basis calculation from `get_effective_cost_basis_gbp` when building positions in `backend/routes/instrument.py` so missing `unrealised_gain_gbp`/`gain_pct` are derived consistently from market value and cost basis. `last_close` is passed into a small `price_cache` to preserve the same price hinting used by the holdings pipeline.
- Keep any explicit `gain_gbp`/`gain_pct` values present in the account files authoritative, and only calculate missing values.
- Add a regression test `test_positions_for_ticker_derives_gain_from_acquisition_price` in `tests/routes/test_instrument.py` that verifies derived `market_value_gbp`, `unrealised_gain_gbp`, and `gain_pct` when acquisition-based cost is used.
- Implements the fix for the UI data gap described in the issue and should make the instrument detail Positions table match the holdings table for the same position. Closes #6534.

### Testing

- Ran the unit tests for the modified area with `pytest tests/routes/test_instrument.py` and the focused suite passed (11 tests passed, 1 warning). — SUCCESS.
- Ran the full test run with coverage which failed due to repository-wide coverage gating (`coverage fail-under=90`), not due to the new tests; this is expected when executing a focused subset under the repo coverage policy. — COVERAGE GATE FAILED (expected in this focused run).
- Ran linter/format checks: `ruff` was executed and auto-fixed import formatting where applicable, and `black --check` reported files that would be reformatted (no broad auto-format was applied to keep this change focused). — LINT/FORMAT: `ruff` fixed issues; `black --check` would reformat (no auto-fix applied).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b7aea7d0883278e98658fca1064df)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved position gain and percentage calculations when cost-basis information is missing.
  * Preserved provided gain values and avoided percentage calculations where no positive cost exists.
  * Improved light-theme styling for pages, links and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->