### PR TITLE
[Issue #6641] Leaked i18n key 'holdingsTable.sparklineAria' rendered as sparkline aria-label in holdings table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ coverage.xml
 /frontend/test-results/
 /scripts/developer_tools/scripts/developer_tools/.coverage
 /scripts/developer_tools/test-results/junit.xml
+/.issue-worm/worktrees/

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -220,6 +220,7 @@
     "source": "Quelle:",
     "totalRowLabel": "Gesamt",
     "trendHeader": "Trend ({{range}}T)",
+    "sparklineAria": "30-Tage-Trend für {{ticker}}",
     "view": "Ansicht:",
     "viewPresets": {
       "all": "Alle"
@@ -295,6 +296,7 @@
       "name": "Name",
       "ticker": "Ticker",
       "trend": "Trend",
+      "sparklineAria": "Kurstrend für {{ticker}}",
       "type": "Typ",
       "units": "Einheiten"
     },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -260,6 +260,7 @@
     "source": "Source:",
     "totalRowLabel": "Total",
     "trendHeader": "Trend ({{range}}d)",
+    "sparklineAria": "30-day trend for {{ticker}}",
     "view": "View:",
     "viewPresets": {
       "all": "All"
@@ -356,6 +357,7 @@
       "name": "Name",
       "ticker": "Ticker",
       "trend": "Trend",
+      "sparklineAria": "Price trend for {{ticker}}",
       "type": "Type",
       "units": "Units"
     },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -220,6 +220,7 @@
     "source": "Fuente:",
     "totalRowLabel": "Total",
     "trendHeader": "Tendencia ({{range}}d)",
+    "sparklineAria": "Tendencia de 30 días para {{ticker}}",
     "view": "Vista:",
     "viewPresets": {
       "all": "Todos"
@@ -295,6 +296,7 @@
       "name": "Nombre",
       "ticker": "Ticker",
       "trend": "Tendencia",
+      "sparklineAria": "Tendencia de precio para {{ticker}}",
       "type": "Tipo",
       "units": "Unidades"
     },

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -220,6 +220,7 @@
     "source": "Source :",
     "totalRowLabel": "Total",
     "trendHeader": "Tendance ({{range}}j)",
+    "sparklineAria": "Tendance sur 30 jours pour {{ticker}}",
     "view": "Vue :",
     "viewPresets": {
       "all": "Tous"
@@ -295,6 +296,7 @@
       "name": "Nom",
       "ticker": "Ticker",
       "trend": "Tendance",
+      "sparklineAria": "Tendance du cours pour {{ticker}}",
       "type": "Type",
       "units": "Unités"
     },

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -220,6 +220,7 @@
     "source": "Fonte:",
     "totalRowLabel": "Totale",
     "trendHeader": "Tendenza ({{range}}d)",
+    "sparklineAria": "Andamento a 30 giorni per {{ticker}}",
     "view": "Visualizzazione:",
     "viewPresets": {
       "all": "Tutto"
@@ -295,6 +296,7 @@
       "name": "Nome",
       "ticker": "Ticker",
       "trend": "Trend",
+      "sparklineAria": "Andamento del prezzo per {{ticker}}",
       "type": "Tipo",
       "units": "Unità"
     },

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -220,6 +220,7 @@
     "source": "Fonte:",
     "totalRowLabel": "Total",
     "trendHeader": "Tendência ({{range}}d)",
+    "sparklineAria": "Tendência de 30 dias para {{ticker}}",
     "view": "Visão:",
     "viewPresets": {
       "all": "Todos"
@@ -295,6 +296,7 @@
       "name": "Nome",
       "ticker": "Ticker",
       "trend": "Tendência",
+      "sparklineAria": "Tendência de preço para {{ticker}}",
       "type": "Tipo",
       "units": "Unidades"
     },


### PR DESCRIPTION
## What
Added translated values for `holdingsTable.sparklineAria` and `instrumentTable.columns.sparklineAria` in all six locale files.

## Why
This change resolves an accessibility issue by ensuring that screen readers announce meaningful text instead of raw i18n keys, improving user experience for visually impaired users.

## Testing
- Loaded `/` and inspected the `aria-label` on sparkline SVGs in the holdings table DOM.
- Verified that the labels now display translated text, such as "30-day trend for ADBE.L".

## Checklist
- [ ] Tests added/updated (none required)
- [ ] Docs updated if needed (no changes to documentation)
- [ ] No breaking changes

Closes #6641