### PR TITLE
[Issue #6654] Rebalance page default prefill totals 100.02% and blocks the happy path

### DIFF
--- a/frontend/src/pages/Rebalance.tsx
+++ b/frontend/src/pages/Rebalance.tsx
@@ -38,11 +38,30 @@ function rowsFromPortfolio(portfolio: Portfolio): Row[] {
   if (!entries.length) return [BLANK_ROW];
 
   const totalValue = entries.reduce((sum, [, value]) => sum + value, 0);
-  return entries.map(([ticker, current]) => ({
+  const rows: Row[] = entries.map(([ticker, current]) => ({
     ticker,
     current: current.toFixed(2),
     target: totalValue > 0 ? ((current / totalValue) * 100).toFixed(2) : "0",
   }));
+
+  // Rounding each weight to 2dp independently drifts the sum off 100
+  // (100.02 for alex's portfolio), which fails the page's own validation.
+  // Absorb the residual in one prefilled row so targets always sum to exactly
+  // 100.00. Prefer the smallest holding (entries are sorted descending) to
+  // minimize relative distortion; skip it only if the adjustment would go
+  // negative (degenerate tiny holding).
+  if (totalValue > 0 && rows.length > 1) {
+    const residual = 100 - rows.reduce((sum, row) => sum + parseFloat(row.target), 0);
+    for (let i = rows.length - 1; i >= 0; i--) {
+      const adjusted = parseFloat(rows[i].target) + residual;
+      if (adjusted >= 0) {
+        rows[i] = { ...rows[i], target: adjusted.toFixed(2) };
+        break;
+      }
+    }
+  }
+
+  return rows;
 }
 
 export default function Rebalance() {

--- a/frontend/tests/unit/pages/Rebalance.test.tsx
+++ b/frontend/tests/unit/pages/Rebalance.test.tsx
@@ -71,6 +71,46 @@ describe("Rebalance page", () => {
     expect(screen.getByText(/treated as no-change/i)).toBeInTheDocument();
   });
 
+  it("prefills targets that sum to exactly 100% so the untouched prefill can be submitted", async () => {
+    // Weights 16.666.../16.666.../16.666.../50 round independently to
+    // 16.67+16.67+16.67+50.00 = 100.01, the same drift-above-100 failure as
+    // the issue's alex repro. The residual must be absorbed by the smallest
+    // holding (CCC) instead of failing the page's own validation.
+    mockGetPortfolio.mockResolvedValue({
+      accounts: [
+        {
+          holdings: [
+            { ticker: "AAA", market_value_gbp: 1 },
+            { ticker: "BBB", market_value_gbp: 1 },
+            { ticker: "CCC", market_value_gbp: 1 },
+            { ticker: "DDD", market_value_gbp: 3 },
+          ],
+        },
+      ],
+    });
+    mockGetRebalance.mockResolvedValue([]);
+    const { default: Rebalance } = await import("@/pages/Rebalance");
+    render(<Rebalance />);
+
+    await waitFor(() => expect(mockGetPortfolio).toHaveBeenCalledWith("alex"));
+    await waitFor(() =>
+      expect(screen.getByLabelText("Target weight (%) for DDD")).toHaveValue(50),
+    );
+    expect(screen.getByLabelText("Target weight (%) for AAA")).toHaveValue(16.67);
+    expect(screen.getByLabelText("Target weight (%) for BBB")).toHaveValue(16.67);
+    expect(screen.getByLabelText("Target weight (%) for CCC")).toHaveValue(16.66);
+    expect(
+      screen.getByText(/Total target weight: 100.00% \(ready to rebalance\)/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /rebalance/i }));
+
+    await waitFor(() => expect(mockGetRebalance).toHaveBeenCalledTimes(1));
+    expect(
+      screen.queryByText(/Target weights must total 100%/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("explains when target weights do not add up to 100%", async () => {
     mockGetRebalance.mockResolvedValue([]);
     const { default: Rebalance } = await import("@/pages/Rebalance");


### PR DESCRIPTION
## What
Fixed a rounding issue in the default prefill of the `/rebalance` page, ensuring that the total always sums to exactly 100% while maintaining strict validation for user-entered values.

## Why
The current implementation resulted in a default prefill where the total weight deviated slightly from 100%, blocking the happy path for users. This change normalizes the auto-prefill path without altering user-input validation, ensuring that genuine deviations are still rejected.

## Testing
A new unit test was added to verify that the drift fixture (equal-weight holdings or the alex numbers) prefills to exactly 100.00% and submits successfully. Existing tests covering user-edited non-100 totals were also reviewed and updated as necessary.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #6654