### PR TITLE
[Issue #6655] Instrument Admin table logs 12 duplicate-key React errors (CASH x8, PFE x4)

### DIFF
--- a/frontend/src/pages/InstrumentAdmin.tsx
+++ b/frontend/src/pages/InstrumentAdmin.tsx
@@ -199,7 +199,13 @@ export default function InstrumentAdmin() {
         </thead>
         <tbody>
           {filteredRows.map((r, idx) => (
-            <tr key={r._originalTicker ?? idx}>
+            <tr
+              key={
+                r._originalTicker && r._originalExchange
+                  ? `${r._originalTicker}.${r._originalExchange}`
+                  : idx
+              }
+            >
               <td>
                 <input
                   value={r.ticker}

--- a/frontend/tests/unit/pages/InstrumentAdmin.test.tsx
+++ b/frontend/tests/unit/pages/InstrumentAdmin.test.tsx
@@ -26,7 +26,11 @@ vi.mock("@/api", () => ({
 }));
 
 import InstrumentAdmin from "@/pages/InstrumentAdmin";
-import { createInstrumentMetadata, updateInstrumentMetadata } from "@/api";
+import {
+  createInstrumentMetadata,
+  listInstrumentMetadata,
+  updateInstrumentMetadata,
+} from "@/api";
 
 describe("InstrumentAdmin page", () => {
   afterEach(() => {
@@ -134,5 +138,41 @@ describe("InstrumentAdmin page", () => {
     );
 
     expect(updateInstrumentMetadata).not.toHaveBeenCalled();
+  });
+
+  it("renders duplicate symbols without duplicate-key errors and keeps rows independent", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(listInstrumentMetadata).mockResolvedValueOnce([
+      { ticker: "CASH.GBP", name: "Cash GBP", region: "UK", sector: "Cash", grouping: "ISA" },
+      { ticker: "CASH.EUR", name: "Cash EUR", region: "EU", sector: "Cash", grouping: "GIA" },
+      { ticker: "CASH.USD", name: "Cash USD", region: "US", sector: "Cash", grouping: "ISA" },
+      { ticker: "PFE.L", name: "Pfizer L", region: "UK", sector: "Pharma", grouping: "ISA" },
+      { ticker: "PFE.N", name: "Pfizer N", region: "US", sector: "Pharma", grouping: "GIA" },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <InstrumentAdmin />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findAllByDisplayValue("CASH")).toHaveLength(3);
+    expect(screen.getAllByDisplayValue("PFE")).toHaveLength(2);
+
+    const duplicateKeyErrors = consoleError.mock.calls.filter((call) =>
+      String(call[0]).includes("Encountered two children with the same key"),
+    );
+    expect(duplicateKeyErrors).toHaveLength(0);
+
+    fireEvent.change(screen.getByDisplayValue("Cash GBP"), {
+      target: { value: "Cash GBP edited" },
+    });
+
+    expect(screen.getByDisplayValue("Cash GBP edited")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Cash EUR")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Cash USD")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Pfizer L")).toBeInTheDocument();
+
+    consoleError.mockRestore();
   });
 });


### PR DESCRIPTION
## What

Updated the key for rows in the `/instrumentadmin` table to use a unique combination of `_originalTicker` and `_originalExchange`, falling back to `idx` when either is missing. Added unit tests to cover duplicate-symbol scenarios.

## Why

Duplicate keys in React can lead to wrong-row edits, corrupting data and flooding the console with errors. This change ensures that each row has a unique key, maintaining correct state updates and improving user experience.

## Testing

Added unit tests in `frontend/tests/unit/pages/InstrumentAdmin.test.tsx` to verify that duplicate symbols are handled correctly and that individual row edits do not affect other rows.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #6655