### PR TITLE
[Issue #6675] Mobile/tablet: wide tables without scroll wrappers force page-level horizontal scroll on /, /instrument, /trading

### DIFF
--- a/frontend/src/components/GroupPortfolioView.tsx
+++ b/frontend/src/components/GroupPortfolioView.tsx
@@ -1110,7 +1110,8 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
       {isAllPositions && enableAdvancedAnalytics && <TopMoversSummary slug={slug} />}
 
       {ownerRows.length > 0 && (
-        <table className={tableStyles.table} style={{ marginBottom: "1rem" }}>
+        <div className={tableStyles.scrollContainer} style={{ marginBottom: "1rem" }}>
+          <table className={tableStyles.table}>
           <thead>
             <tr>
               <th className={tableStyles.cell}>Owner</th>
@@ -1271,7 +1272,8 @@ export function GroupPortfolioView({ slug, owners, onTradeInfo }: Props) {
               );
             })}
           </tbody>
-        </table>
+          </table>
+        </div>
       )}
 
       <div

--- a/frontend/src/components/InstrumentTable.tsx
+++ b/frontend/src/components/InstrumentTable.tsx
@@ -231,6 +231,7 @@ export function InstrumentTable({ rows, showGroupTotals = true, showSparklines =
       {noFilteredRows ? (
         <p>{t('instrumentTable.noInstruments')}</p>
       ) : (
+        <div className={tableStyles.scrollContainer}>
         <table className={`${tableStyles.table} ${tableStyles.clickable}`} style={{ marginBottom: '0' }}>
         <thead>
           <tr>
@@ -694,6 +695,7 @@ export function InstrumentTable({ rows, showGroupTotals = true, showSparklines =
           </tr>
         </tfoot>
         </table>
+        </div>
       )}
 
     </>

--- a/frontend/src/pages/Trading.module.css
+++ b/frontend/src/pages/Trading.module.css
@@ -1,6 +1,7 @@
 .page {
   display: grid;
   gap: 1.5rem;
+  grid-template-columns: minmax(0, 1fr);
   padding: 1rem;
 }
 .header {

--- a/frontend/src/pages/Trading.tsx
+++ b/frontend/src/pages/Trading.tsx
@@ -172,7 +172,8 @@ export default function Trading() {
             </p>
           </div>
         ) : (
-          <table className={tableStyles.table}>
+          <div className={tableStyles.scrollContainer}>
+            <table className={tableStyles.table}>
             <caption>
               {t('trading.signalsTableCaption', 'Trading signals')}
             </caption>
@@ -209,6 +210,7 @@ export default function Trading() {
               ))}
             </tbody>
           </table>
+          </div>
         )}
         {signals.length > MAX_TRADING_SIGNAL_ROWS && (
           <p>

--- a/frontend/src/styles/table.module.css
+++ b/frontend/src/styles/table.module.css
@@ -5,6 +5,7 @@
 
 .scrollContainer {
   max-height: min(70vh, 48rem);
+  max-width: 100%;
   overflow: auto;
   scrollbar-color: rgba(71, 85, 105, 0.8) rgba(148, 163, 184, 0.2);
   scrollbar-gutter: stable;
@@ -14,6 +15,7 @@
   position: sticky;
   top: 0;
   z-index: 2;
+  max-width: 100%;
   overflow-x: auto;
   overflow-y: hidden;
   height: 16px;

--- a/frontend/tests/responsive-layout.spec.ts
+++ b/frontend/tests/responsive-layout.spec.ts
@@ -299,7 +299,12 @@ test('mobile holdings keep native table layout while virtual rows scroll', async
   );
 
   await page.goto(new URL('/', baseUrl).toString());
-  const table = page.getByRole('table');
+  // The dashboard now renders the owner summary table (wrapped in its own
+  // scroll container) before the holdings table; target the holdings table
+  // specifically via its virtualised rows.
+  const table = page
+    .getByRole('table')
+    .filter({ has: page.locator('tbody tr[data-index]') });
   await expect(table).toBeVisible();
   await expect(table).toHaveCSS('display', 'table');
 
@@ -322,4 +327,123 @@ test('mobile holdings keep native table layout while virtual rows scroll', async
       })
     )
     .toBe(true);
+});
+
+test('issue 6675: dashboard, instrument and trading wide tables stay inside their scroll wrappers', async ({
+  page,
+}) => {
+  // Deliberately unbreakable long strings force every table to exceed the
+  // container at mobile/tablet widths (see forceOverflow), reproducing the
+  // page-level horizontal scroll reported in #6675.
+  const longName = forceOverflow(
+    'Extremely-Long-Unbreakable-Instrument-Name-For-Overflow-Check'
+  );
+  const holdings = Array.from({ length: 20 }, (_, index) => ({
+    ticker: `WIDE${index.toString().padStart(3, '0')}`,
+    name: `${longName}${index}`,
+    units: index + 1,
+    market_value_gbp: 100 + index,
+    cost_basis_gbp: 80 + index,
+    current_price_gbp: 10,
+    currency: 'GBP',
+    instrument_type: 'Equity',
+    acquired_date: '2025-01-01',
+  }));
+  const instruments = holdings.map((h) => ({
+    ticker: h.ticker,
+    name: h.name,
+    exchange: 'LSE',
+    currency: 'GBP',
+    units: h.units,
+    market_value_gbp: h.market_value_gbp,
+    gain_gbp: 5,
+    instrument_type: 'Equity',
+    gain_pct: 2.5,
+  }));
+  const signals = Array.from({ length: 10 }, (_, index) => ({
+    ticker: `SIG${index}`,
+    action: 'buy' as const,
+    reason: `${longName}${index}`,
+    confidence: 80,
+    factors: [longName, forceOverflow('Secondary-Factor-Also-Very-Long')],
+  }));
+  const settings = {
+    rsi_buy: 30,
+    rsi_sell: 70,
+    rsi_window: 14,
+    ma_short_window: 20,
+    ma_long_window: 50,
+    pe_max: null,
+    de_max: null,
+    min_sharpe: null,
+    max_volatility: null,
+  };
+
+  await applyAuth(page, authToken);
+  await setupCoreMocks(page);
+  // Generic group-portfolio mock with holdings so both the owner summary
+  // table and the (wrapped) holdings table render on `/`.
+  await page.route('**/portfolio-group/all*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ...groupPortfolio,
+        accounts: [{ ...groupPortfolio.accounts[0], holdings }],
+      }),
+    })
+  );
+  // More specific mock for the /instrument catalogue; registered after the
+  // generic pattern above so it takes precedence.
+  await page.route('**/portfolio-group/all/instruments', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(instruments),
+    })
+  );
+  await page.route('**/trading-agent/signals', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(signals),
+    })
+  );
+  await page.route('**/trading-agent/settings', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(settings),
+    })
+  );
+  await page.route('**/quotes*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+
+  const viewports = [
+    { name: 'mobile', width: 375, height: 812 },
+    { name: 'tablet', width: 768, height: 1024 },
+    { name: 'desktop', width: 1280, height: 800 },
+  ] as const;
+
+  for (const viewport of viewports) {
+    for (const path of ['/', '/instrument', '/trading']) {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto(new URL(path, baseUrl).toString());
+
+      // Wait until the route's real table(s) render (and the loading
+      // skeleton, whose parent is not a scroll wrapper, is gone).
+      const expectedTables = path === '/' ? 2 : 1;
+      await expect(page.getByRole('table')).toHaveCount(expectedTables);
+
+      await assertNoPageOverflow(page);
+
+      const tables = await page.getByRole('table').all();
+      expect(tables.length).toBeGreaterThan(0);
+      for (const table of tables) {
+        // Every wide table must live inside a clipping wrapper.
+        await expect(table.locator('..')).toHaveCSS('overflow-x', 'auto');
+      }
+    }
+  }
 });


### PR DESCRIPTION
## What
Fixed wide tables on mobile/tablet pages by adding scroll wrappers to ensure tables are clipped and do not force document-level horizontal scrolling.

## Why
This change resolves the issue where wide tables cause horizontal scrolling on key pages, making content inaccessible and user experience poor on smaller devices. This is a regression from previous responsive work that assumed all wide tables would be wrapped in scroll containers.

## Testing
Verified fixes using Playwright to check `document.documentElement.scrollWidth` against viewport width for `/`, `/instrument`, and `/trading`. Also inspected table behavior at 375x812 and 768x1024 viewports.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] No breaking changes

Closes #6675