### PR TITLE
Fix backend lint CI failure, add auto-format workflow

### DIFF
--- a/.claude/skills/ship-fix/SKILL.md
+++ b/.claude/skills/ship-fix/SKILL.md
@@ -36,7 +36,7 @@ git worktree add ../<repo>-fix-<issue-number> -b fix/issue-<N>-<short-slug> orig
 ```
 
 Branch naming: `fix/issue-NNNN-short-description`, `feat/issue-NNNN-...`,
-`docs/...`, or `chore/...` per `docs/CONTRIBUTING.md`.
+or `docs/...` per `docs/CONTRIBUTING.md`.
 
 If you stashed in step 1, apply *only the relevant files* into the new worktree:
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
-      - "chore"
 
   # Root npm workspace: package.json and package-lock.json in the repo root.
   - package-ecosystem: "npm"
@@ -24,7 +23,6 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
-      - "chore"
 
   # Frontend npm workspace: React/Vite app dependencies in frontend/.
   # Patch-level bumps of direct dev dependencies from this entry are
@@ -38,7 +36,6 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
-      - "chore"
 
   # Root Python dependencies: requirements.txt plus requirements-dev.txt.
   - package-ecosystem: "pip"
@@ -48,7 +45,6 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
-      - "chore"
 
   # CDK Python dependencies: infrastructure requirements in cdk/.
   - package-ecosystem: "pip"
@@ -58,7 +54,6 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
-      - "chore"
 
   # Backend Python dependencies: runtime deps in backend/requirements*.txt.
   - package-ecosystem: "pip"
@@ -68,4 +63,3 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
-      - "chore"

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,67 @@
+name: Auto-format backend Python
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - 'tests/**'
+      - 'backend/pyproject.toml'
+      - 'requirements*.txt'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-format-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    # Same-repo PR branches only: GITHUB_TOKEN cannot push to fork head branches.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - name: Install backend and development dependencies
+        # Same install as the CI lint job: runtime deps (requirements.txt) are
+        # needed too, because pytest collection loads tests/conftest.py which
+        # imports fastapi.
+        run: pip install --retries 10 -r requirements.txt -r requirements-dev.txt
+      - name: Apply black, isort, and safe ruff fixes
+        # Same rules as `make format` plus ruff's safe autofixes. The CI lint
+        # job installs the same requirements-dev.txt at the same commit, so the
+        # formatter versions can never drift from what lint checks against.
+        run: |
+          isort --sp backend/pyproject.toml backend tests
+          black --config backend/pyproject.toml backend tests
+          ruff check --fix --config backend/pyproject.toml backend tests
+      - name: Verify lint is clean before committing
+        # Never push a tree the CI lint job would reject: fail loudly here so
+        # the author fixes remaining (non-autofixable) violations instead of
+        # the bot committing a red tree. The log-sanitization ratchet is
+        # included because reformatting shifts the file:line keys it is keyed
+        # on (see tests/data/log_sanitization_baseline.txt).
+        run: |
+          ruff check --config backend/pyproject.toml backend tests
+          black --check --config backend/pyproject.toml backend tests
+          python -m pytest tests/test_log_sanitization_audit.py -q --no-cov
+      - name: Commit formatting changes to the PR branch
+        # Fixes the PR's own branch (not main), so branch protection and the
+        # required "Backend lint (ruff, black)" check still gate the merge.
+        # The no-diff guard stops this workflow from looping: the re-triggered
+        # run after the push finds nothing to change and exits here.
+        run: |
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "Apply black, isort, and ruff formatting"
+            git push
+          fi

--- a/.github/workflows/siteplan.yml
+++ b/.github/workflows/siteplan.yml
@@ -38,6 +38,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: update site snapshots"
+            git commit -m "docs: update site snapshots"
             git push origin main
           fi

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -13,4 +13,3 @@ from . import config as config_module
 config = config_module
 
 __all__ = ["config", "config_module"]
-

--- a/backend/agent/models.py
+++ b/backend/agent/models.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 """Pydantic models used by the trading agent."""
 
-from pydantic import BaseModel, ConfigDict
 from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict
 
 
 class TradingSignal(BaseModel):

--- a/backend/agent/trading_agent.py
+++ b/backend/agent/trading_agent.py
@@ -85,18 +85,15 @@ def send_trade_alert(message: str, publish: bool = True) -> None:
             logger.info("SNS topic ARN not configured; skipping publish")
         alert_utils.send_push_notification(message)
 
-    if (
-        config.telegram_bot_token
-        and config.telegram_chat_id
-        and config.app_env != "aws"
-    ):
+    if config.telegram_bot_token and config.telegram_chat_id and config.app_env != "aws":
         try:
             send_message(message)
         except Exception as exc:  # pragma: no cover - network errors are rare
             logger.warning("Telegram send failed: %s", sanitise_log_value(redact_token(str(exc))))
 
+
 PRICE_DROP_THRESHOLD = -5.0  # percent
-PRICE_GAIN_THRESHOLD = 5.0   # percent
+PRICE_GAIN_THRESHOLD = 5.0  # percent
 DRAWDOWN_ALERT_THRESHOLD = 0.2  # 20% decline; set to 0 to disable
 
 
@@ -146,14 +143,8 @@ def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
         # risk filters
         sharpe = info.get("sharpe")
         volatility = info.get("volatility")
-        if (
-            cfg.min_sharpe is not None
-            and sharpe is not None
-            and sharpe < cfg.min_sharpe
-        ) or (
-            cfg.max_volatility is not None
-            and volatility is not None
-            and volatility > cfg.max_volatility
+        if (cfg.min_sharpe is not None and sharpe is not None and sharpe < cfg.min_sharpe) or (
+            cfg.max_volatility is not None and volatility is not None and volatility > cfg.max_volatility
         ):
             continue
 
@@ -218,10 +209,7 @@ def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
                     "BUY",
                     indicator_name,
                     "RSI suggests the instrument is oversold.",
-                    (
-                        f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, below"
-                        f" the buy threshold of {cfg.rsi_buy:.0f}."
-                    ),
+                    (f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, below" f" the buy threshold of {cfg.rsi_buy:.0f}."),
                     confidence,
                 )
             elif cfg.rsi_sell is not None and rsi >= cfg.rsi_sell:
@@ -231,10 +219,7 @@ def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
                     "SELL",
                     indicator_name,
                     "RSI points to overbought conditions.",
-                    (
-                        f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, above"
-                        f" the sell threshold of {cfg.rsi_sell:.0f}."
-                    ),
+                    (f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, above" f" the sell threshold of {cfg.rsi_sell:.0f}."),
                     confidence,
                 )
             elif rsi < 30:
@@ -243,10 +228,7 @@ def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
                     "BUY",
                     indicator_name,
                     "RSI indicates the price may be oversold.",
-                    (
-                        f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, below"
-                        " the commonly used oversold level of 30."
-                    ),
+                    (f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, below" " the commonly used oversold level of 30."),
                     confidence,
                 )
             elif rsi > 70:
@@ -255,17 +237,12 @@ def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
                     "SELL",
                     indicator_name,
                     "RSI indicates the price may be overbought.",
-                    (
-                        f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, above"
-                        " the typical overbought level of 70."
-                    ),
+                    (f"The {cfg.rsi_window}-day RSI is {rsi:.2f}, above" " the typical overbought level of 70."),
                     confidence,
                 )
 
         if ma_short is not None and ma_long is not None:
-            indicator_name = (
-                f"{cfg.ma_short_window}- vs {cfg.ma_long_window}-day MA crossover"
-            )
+            indicator_name = f"{cfg.ma_short_window}- vs {cfg.ma_long_window}-day MA crossover"
             if ma_short > ma_long:
                 add_reason(
                     "BUY",
@@ -343,15 +320,9 @@ def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
         indicator_phrase = _join_with_and(indicator_names)
         count = len(best_reasons)
         if count == 1:
-            reason_text = (
-                f"{indicator_phrase or 'Indicator'} supports a"
-                f" {best_action.lower()} opportunity."
-            )
+            reason_text = f"{indicator_phrase or 'Indicator'} supports a" f" {best_action.lower()} opportunity."
         else:
-            reason_text = (
-                f"{count} indicators ({indicator_phrase}) support a"
-                f" {best_action.lower()} opportunity."
-            )
+            reason_text = f"{count} indicators ({indicator_phrase}) support a" f" {best_action.lower()} opportunity."
         factor_details = [reason["detail"] for reason in best_reasons if reason.get("detail")]
         rationale_text = " ".join(factor_details).strip()
 
@@ -370,7 +341,6 @@ def generate_signals(snapshot: Dict[str, Dict]) -> List[Dict]:
     return signals
 
 
-  
 def _log_trade(ticker: str, action: str, price: float, ts: Optional[datetime] = None) -> None:
     """Append a trade record to the trade log.
 
@@ -381,9 +351,7 @@ def _log_trade(ticker: str, action: str, price: float, ts: Optional[datetime] = 
     header = not TRADE_LOG_PATH.exists()
     TRADE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     with TRADE_LOG_PATH.open("a", newline="") as f:
-        writer = csv.DictWriter(
-            f, fieldnames=["timestamp", "ticker", "action", "price"]
-        )
+        writer = csv.DictWriter(f, fieldnames=["timestamp", "ticker", "action", "price"])
         if header:
             writer.writeheader()
         writer.writerow(
@@ -394,6 +362,7 @@ def _log_trade(ticker: str, action: str, price: float, ts: Optional[datetime] = 
                 "price": price,
             }
         )
+
 
 def _alert_on_drawdown(threshold: float = DRAWDOWN_ALERT_THRESHOLD) -> None:
     """Emit an alert if any portfolio drawdown exceeds ``threshold``."""
@@ -410,9 +379,7 @@ def _alert_on_drawdown(threshold: float = DRAWDOWN_ALERT_THRESHOLD) -> None:
         if max_dd is None or not (-1.0 <= max_dd <= 0.0):
             continue
         if abs(max_dd) >= threshold:
-            send_trade_alert(
-                f"{owner} portfolio drawdown {max_dd*100:.2f}% exceeds {threshold*100:.2f}%"
-            )
+            send_trade_alert(f"{owner} portfolio drawdown {max_dd*100:.2f}% exceeds {threshold*100:.2f}%")
 
 
 def run(tickers: Optional[Iterable[str]] = None, *, notify: bool = True) -> List[Dict]:
@@ -508,9 +475,7 @@ def run(tickers: Optional[Iterable[str]] = None, *, notify: bool = True) -> List
         if buy_tickers:
             fundamentals = screen(buy_tickers, **fundamental_params)
             allowed = {f.ticker for f in fundamentals}
-        signals = [
-            s for s in signals if s["action"] != "BUY" or s["ticker"] in allowed
-        ]
+        signals = [s for s in signals if s["action"] != "BUY" or s["ticker"] in allowed]
     allowed_signals: List[Dict] = []
     for sig in signals:
         blocked = False
@@ -523,9 +488,7 @@ def run(tickers: Optional[Iterable[str]] = None, *, notify: bool = True) -> List
             }
             result = compliance.check_trade(trade)
             if result.get("warnings"):
-                logger.warning(
-                    "Compliance warnings for %s: %s", owner, result["warnings"]
-                )
+                logger.warning("Compliance warnings for %s: %s", owner, result["warnings"])
                 blocked = True
                 break
         if blocked:

--- a/backend/bootstrap/config.py
+++ b/backend/bootstrap/config.py
@@ -22,9 +22,7 @@ def load_runtime_config() -> Config:
 
     prev_cfg = config_module.config
     overrides = {
-        attr: getattr(prev_cfg, attr, None)
-        for attr in _OVERRIDE_ATTRS
-        if getattr(prev_cfg, attr, None) is not None
+        attr: getattr(prev_cfg, attr, None) for attr in _OVERRIDE_ATTRS if getattr(prev_cfg, attr, None) is not None
     }
 
     cfg = reload_config()

--- a/backend/bootstrap/isolation.py
+++ b/backend/bootstrap/isolation.py
@@ -74,9 +74,7 @@ def _configured_root_uses_global_fallback(configured_root: object) -> bool:
         return True
 
 
-def _isolate_accounts_root(
-    paths: ResolvedPaths, accounts_root: Path
-) -> tuple[Path | None, Path | None]:
+def _isolate_accounts_root(paths: ResolvedPaths, accounts_root: Path) -> tuple[Path | None, Path | None]:
     try:
         accounts_root.relative_to(paths.repo_root)
     except ValueError:

--- a/backend/bootstrap/middleware.py
+++ b/backend/bootstrap/middleware.py
@@ -61,9 +61,7 @@ def register_middleware(app: FastAPI, cfg: Config) -> None:
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
     default_cors = ["http://localhost:3000", "http://localhost:5173"]
-    cors_origins = _validate_cors_origins(
-        list(dict.fromkeys((cfg.cors_origins or []) + default_cors))
-    )
+    cors_origins = _validate_cors_origins(list(dict.fromkeys((cfg.cors_origins or []) + default_cors)))
     app.add_middleware(
         CORSMiddleware,
         allow_origins=cors_origins,
@@ -87,9 +85,7 @@ def register_middleware(app: FastAPI, cfg: Config) -> None:
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(_: Request, exc: RequestValidationError):
         status = 422 if exc.body is not None else 400
-        return JSONResponse(
-            status_code=status, content={"detail": _sanitize_error_details(exc.errors())}
-        )
+        return JSONResponse(status_code=status, content={"detail": _sanitize_error_details(exc.errors())})
 
 
 def _validate_cors_origins(origins: list[str]) -> list[str]:

--- a/backend/common/alerts.py
+++ b/backend/common/alerts.py
@@ -20,6 +20,7 @@ def _alert_signature(alert: Dict) -> str:
     message = alert.get("message", "")
     return sha256(f"{ticker}|{message}".encode()).hexdigest()
 
+
 # Track last published state and time per instrument to throttle alerts and only
 # emit notifications when the state changes (e.g. threshold crossed vs. not).
 _LAST_ALERT_STATE: Dict[str, bool] = {}
@@ -37,14 +38,13 @@ def publish_sns_alert(alert: Dict) -> None:
     alerts are throttled to one per instrument per hour and are only published
     when the state changes.
     """
-    
+
     signature = _alert_signature(alert)
     if signature in _RECENT_ALERT_SIGNATURES:
         logger.info("Duplicate alert skipped: %s", alert)
         return
 
     _RECENT_ALERT_SIGNATURES.add(signature)
-
 
     instrument = alert.get("instrument")
     state = alert.get("state")

--- a/backend/common/allowances.py
+++ b/backend/common/allowances.py
@@ -28,7 +28,6 @@ from backend.config import config
 logger = logging.getLogger(__name__)
 
 
-
 # Default annual limits (GBP) for supported account types
 ALLOWANCE_LIMITS: Dict[str, float] = {
     "ISA": 20_000.0,

--- a/backend/common/analytics_store.py
+++ b/backend/common/analytics_store.py
@@ -9,9 +9,9 @@ path resolution, locking or serialisation concerns.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
-from datetime import datetime, timezone
 import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
 from typing import Any, Dict, Iterator, List, Optional
@@ -114,4 +114,3 @@ def clear_events() -> None:
     if path.exists():
         with _LOCK:
             path.unlink()
-

--- a/backend/common/approvals.py
+++ b/backend/common/approvals.py
@@ -77,15 +77,11 @@ def is_approval_valid(approved_on: date | None, as_of: date, days: int | None = 
     return as_of <= expiry
 
 
-def save_approvals(
-    owner: str, approvals: Dict[str, date], accounts_root: Path | None = None
-) -> None:
+def save_approvals(owner: str, approvals: Dict[str, date], accounts_root: Path | None = None) -> None:
     """Persist ``approvals`` for ``owner`` to ``approvals.json``."""
 
     path = approvals_path(owner, accounts_root)
-    entries = [
-        {"ticker": t.upper(), "approved_on": d.isoformat()} for t, d in approvals.items()
-    ]
+    entries = [{"ticker": t.upper(), "approved_on": d.isoformat()} for t, d in approvals.items()]
     try:
         path.write_text(json.dumps({"approvals": entries}, indent=2, sort_keys=True))
     except OSError as exc:
@@ -116,9 +112,7 @@ def upsert_approval(
     return approvals
 
 
-def delete_approval(
-    owner: str, ticker: str, accounts_root: Path | None = None
-) -> Dict[str, date]:
+def delete_approval(owner: str, ticker: str, accounts_root: Path | None = None) -> Dict[str, date]:
     """Remove ``ticker`` from approvals and return the updated mapping."""
 
     approvals = load_approvals(owner, accounts_root)
@@ -133,4 +127,3 @@ def delete_approval(
         )
         raise
     return approvals
-

--- a/backend/common/authz.py
+++ b/backend/common/authz.py
@@ -44,11 +44,7 @@ def _allowed_identities(owner: str, meta: Mapping[str, Any]) -> Set[str]:
 
     viewers = meta.get("viewers") if isinstance(meta, Mapping) else None
     if isinstance(viewers, list):
-        allowed.update(
-            viewer.strip().lower()
-            for viewer in viewers
-            if isinstance(viewer, str) and viewer.strip()
-        )
+        allowed.update(viewer.strip().lower() for viewer in viewers if isinstance(viewer, str) and viewer.strip())
     return allowed
 
 

--- a/backend/common/compliance.py
+++ b/backend/common/compliance.py
@@ -230,9 +230,7 @@ def _check_transactions(owner: str, txs: List[Dict[str, Any]], accounts_root: Op
             acq = last_buy.get(ticker)
             if acq and (d - acq).days < (ucfg.hold_days_min or 0):
                 days = (d - acq).days
-                warnings.append(
-                    f"Sold {ticker} after {days} days (min {ucfg.hold_days_min})"
-                )
+                warnings.append(f"Sold {ticker} after {days} days (min {ucfg.hold_days_min})")
                 logger.info(
                     "%s HOLD_DAYS_MIN %s %s",
                     datetime.now(UTC).isoformat(),
@@ -241,23 +239,15 @@ def _check_transactions(owner: str, txs: List[Dict[str, Any]], accounts_root: Op
                 )
 
             meta = get_instrument_meta(ticker)
-            instr_type = (
-                meta.get("instrumentType") or meta.get("instrument_type") or ""
-            ).upper()
-            asset_class = (
-                meta.get("assetClass") or meta.get("asset_class") or ""
-            ).upper()
+            instr_type = (meta.get("instrumentType") or meta.get("instrument_type") or "").upper()
+            asset_class = (meta.get("assetClass") or meta.get("asset_class") or "").upper()
             sector = (meta.get("sector") or "").upper()
             is_commodity = asset_class == "COMMODITY" or sector == "COMMODITY"
             is_etf = instr_type == "ETF"
             exempt_type = instr_type in exempt_types
             if is_etf and is_commodity:
                 exempt_type = False
-            needs_approval = not (
-                ticker in exempt_tickers
-                or ticker.split(".")[0] in exempt_tickers
-                or exempt_type
-            )
+            needs_approval = not (ticker in exempt_tickers or ticker.split(".")[0] in exempt_tickers or exempt_type)
             if needs_approval:
                 appr = approvals.get(ticker) or approvals.get(ticker.split(".")[0])
                 if not (appr and is_approval_valid(appr, d)):
@@ -302,9 +292,7 @@ def check_owner(
     scaffold_missing: bool = False,
 ) -> Dict[str, Any]:
     """Return compliance warnings for an owner."""
-    txs = load_transactions(
-        owner, accounts_root, scaffold_missing=scaffold_missing
-    )
+    txs = load_transactions(owner, accounts_root, scaffold_missing=scaffold_missing)
     return _check_transactions(owner, txs, accounts_root)
 
 
@@ -322,9 +310,7 @@ def check_trade(
     owner = trade.get("owner")
     if not owner:
         raise ValueError("owner is required")
-    txs = load_transactions(
-        owner, accounts_root, scaffold_missing=scaffold_missing
-    )
+    txs = load_transactions(owner, accounts_root, scaffold_missing=scaffold_missing)
     txs.append(trade)
     return _check_transactions(owner, txs, accounts_root)
 

--- a/backend/common/data_providers.py
+++ b/backend/common/data_providers.py
@@ -130,7 +130,9 @@ class S3DataProvider:
     def load_account(self, owner: str, account: str) -> AccountObject:
         key = f"{PLOTS_PREFIX}{owner}/{account}.json"
         obj = self._get_object(key)
-        return AccountObject(owner=owner, account=account, data=_parse_json_body(obj.get("Body"), f"s3://{self.bucket}/{key}"))
+        return AccountObject(
+            owner=owner, account=account, data=_parse_json_body(obj.get("Body"), f"s3://{self.bucket}/{key}")
+        )
 
     def load_person_meta(self, owner: str) -> OwnerMetadata:
         key = f"{PLOTS_PREFIX}{owner}/person.json"

--- a/backend/common/goals.py
+++ b/backend/common/goals.py
@@ -2,18 +2,16 @@ from __future__ import annotations
 
 """Goal tracking helpers."""
 
+import os
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from typing import Dict, List
-import os
 
-from backend.common.storage import get_storage, JSONStorage
+from backend.common.storage import JSONStorage, get_storage
 from backend.config import config
 
-_DEFAULT_GOALS_URI = (
-    f"file://{(config.repo_root or Path(__file__).resolve().parents[1]) / 'data' / 'goals.json'}"
-)
+_DEFAULT_GOALS_URI = f"file://{(config.repo_root or Path(__file__).resolve().parents[1]) / 'data' / 'goals.json'}"
 
 try:
     _STORAGE: JSONStorage = get_storage(os.getenv("GOALS_STORAGE_URI", _DEFAULT_GOALS_URI))
@@ -51,6 +49,7 @@ class Goal:
 
 
 # persistence helpers ---------------------------------------------------------
+
 
 def _load_raw() -> Dict[str, List[Dict[str, object]]]:
     data = _STORAGE.load()

--- a/backend/common/holding_utils.py
+++ b/backend/common/holding_utils.py
@@ -118,11 +118,7 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
 
             name_map = _lower_name_map(df)
             close_gbp_col = name_map.get("close_gbp")
-            close_native_col = (
-                name_map.get("close")
-                or name_map.get("adj close")
-                or name_map.get("adj_close")
-            )
+            close_native_col = name_map.get("close") or name_map.get("adj close") or name_map.get("adj_close")
 
             if not close_gbp_col and not close_native_col:
                 continue
@@ -139,10 +135,7 @@ def load_latest_prices(full_tickers: list[str]) -> dict[str, float]:
             if close_gbp_col is None:
                 full_ticker = f"{ticker}.{exchange}"
                 meta = (
-                    get_instrument_meta(full_ticker)
-                    or get_instrument_meta(full)
-                    or get_instrument_meta(ticker)
-                    or {}
+                    get_instrument_meta(full_ticker) or get_instrument_meta(full) or get_instrument_meta(ticker) or {}
                 )
 
                 raw_currency = str(meta.get("currency") or "").strip()
@@ -436,9 +429,7 @@ def enrich_holding(
         units = float(out.get(UNITS, 0) or 0.0)
         out["name"] = out.get("name") or _cash_name(full, account_ccy)
         out["currency"] = meta.get("currency") or account_ccy
-        out["instrument_type"] = (
-            meta.get("instrumentType") or meta.get("instrument_type") or "Cash"
-        )
+        out["instrument_type"] = meta.get("instrumentType") or meta.get("instrument_type") or "Cash"
         out["sector"] = out.get("sector") or meta.get("sector")
         out["region"] = out.get("region") or meta.get("region")
 
@@ -479,11 +470,7 @@ def enrich_holding(
     out["name"] = out.get("name") or meta.get("name") or full
     out["sector"] = out.get("sector") or meta.get("sector")
     out["region"] = out.get("region") or meta.get("region")
-    out["asset_class"] = (
-        out.get("asset_class")
-        or meta.get("assetClass")
-        or meta.get("asset_class")
-    )
+    out["asset_class"] = out.get("asset_class") or meta.get("assetClass") or meta.get("asset_class")
 
     units = float(out.get(UNITS, 0) or 0.0)
     if units <= 0:
@@ -540,11 +527,7 @@ def enrich_holding(
     exempt_type = instr_type in exempt_types
     if is_etf and is_commodity:
         exempt_type = False
-    needs_approval = not (
-        ticker.upper() in exempt_tickers
-        or full.upper() in exempt_tickers
-        or exempt_type
-    )
+    needs_approval = not (ticker.upper() in exempt_tickers or full.upper() in exempt_tickers or exempt_type)
 
     approved = False
     if approvals and needs_approval:
@@ -573,14 +556,10 @@ def enrich_holding(
             prev_date = calc.previous_pricing_date
         else:
             asof_date = calc.reporting_date
-            px, px_source = _get_price_for_date_scaled(
-                ticker, exchange, asof_date, field="Close_gbp"
-            )
+            px, px_source = _get_price_for_date_scaled(ticker, exchange, asof_date, field="Close_gbp")
             prev_date = calc.previous_pricing_date
 
-        prev_px, _ = _get_price_for_date_scaled(
-            ticker, exchange, prev_date, field="Close_gbp"
-        )
+        prev_px, _ = _get_price_for_date_scaled(ticker, exchange, prev_date, field="Close_gbp")
 
         if px is None and prev_px is not None:
             # Today's close is missing/unavailable (e.g. a gap in the price
@@ -596,9 +575,7 @@ def enrich_holding(
                 future_candidate = pricing_date + timedelta(days=7)
                 future_date = calc.resolve_weekday(future_candidate, forward=True)
                 if future_date > pricing_date:
-                    future_px, _ = _get_price_for_date_scaled(
-                        ticker, exchange, future_date, field="Close_gbp"
-                    )
+                    future_px, _ = _get_price_for_date_scaled(ticker, exchange, future_date, field="Close_gbp")
                     if future_px is not None:
                         change = (future_px / px) - 1
                         out["forward_7d_change_pct"] = round(change * 100, 4)
@@ -606,9 +583,7 @@ def enrich_holding(
                 future_candidate = pricing_date + timedelta(days=30)
                 future_date = calc.resolve_weekday(future_candidate, forward=True)
                 if future_date > pricing_date:
-                    future_px, _ = _get_price_for_date_scaled(
-                        ticker, exchange, future_date, field="Close_gbp"
-                    )
+                    future_px, _ = _get_price_for_date_scaled(ticker, exchange, future_date, field="Close_gbp")
                     if future_px is not None:
                         change = (future_px / px) - 1
                         out["forward_30d_change_pct"] = round(change * 100, 4)
@@ -631,9 +606,7 @@ def enrich_holding(
         if "price_hint" in params:
             pass_price_hint = True
         else:
-            pass_price_hint = any(
-                param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
-            )
+            pass_price_hint = any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values())
 
     if pass_price_hint:
         ecb = helper(out, price_cache, price_hint=px)

--- a/backend/common/instrument_api.py
+++ b/backend/common/instrument_api.py
@@ -1,4 +1,3 @@
-
 # backend/common/instrument_api.py
 """
 Instrument-level helpers for AllotMint
@@ -211,8 +210,7 @@ def update_latest_prices_from_snapshot(snapshot: Dict[str, Dict[str, Any]]) -> N
     _LATEST_PRICES = {
         t: float(info.get("last_price"))
         for t, info in snapshot.items()
-        if isinstance(info, dict)
-        and info.get("last_price") is not None
+        if isinstance(info, dict) and info.get("last_price") is not None
     }
 
 
@@ -326,10 +324,7 @@ def intraday_timeseries_for_ticker(ticker: str) -> Dict[str, Any]:
     inst_type = meta.get("instrument_type") or meta.get("instrumentType")
     if inst_type and inst_type.lower() in {"pension"}:
         daily = timeseries_for_ticker(ticker, days=2)["prices"]
-        prices = [
-            {"timestamp": f"{p['date']}T00:00:00", "price": float(p["close"])}
-            for p in daily
-        ]
+        prices = [{"timestamp": f"{p['date']}T00:00:00", "price": float(p["close"])} for p in daily]
         last_time = prices[-1]["timestamp"] if prices else None
         return {"prices": prices, "last_price_time": last_time}
 
@@ -341,19 +336,14 @@ def intraday_timeseries_for_ticker(ticker: str) -> Dict[str, Any]:
     df = None
     for interval in ("5m", "15m"):
         try:
-            df = fetch_yahoo_timeseries_period(
-                sym, ex, period="5d", interval=interval, normalize=False
-            )
+            df = fetch_yahoo_timeseries_period(sym, ex, period="5d", interval=interval, normalize=False)
             if not df.empty:
                 break
         except Exception:
             df = None
     if df is None or df.empty or "Date" not in df.columns:
         daily = timeseries_for_ticker(ticker, days=2)["prices"]
-        prices = [
-            {"timestamp": f"{p['date']}T00:00:00", "price": float(p["close"])}
-            for p in daily
-        ]
+        prices = [{"timestamp": f"{p['date']}T00:00:00", "price": float(p["close"])} for p in daily]
         last_time = prices[-1]["timestamp"] if prices else None
         return {"prices": prices, "last_price_time": last_time}
 
@@ -365,10 +355,7 @@ def intraday_timeseries_for_ticker(ticker: str) -> Dict[str, Any]:
     df = df[df["Date"] >= cutoff]
     col = "Close_gbp" if "Close_gbp" in df.columns else "Close"
 
-    prices = [
-        {"timestamp": r["Date"].to_pydatetime().isoformat(), "price": float(r[col])}
-        for _, r in df.iterrows()
-    ]
+    prices = [{"timestamp": r["Date"].to_pydatetime().isoformat(), "price": float(r[col])} for _, r in df.iterrows()]
     last_time = prices[-1]["timestamp"] if prices else None
     return {"prices": prices, "last_price_time": last_time}
 

--- a/backend/common/instrument_groups.py
+++ b/backend/common/instrument_groups.py
@@ -92,4 +92,3 @@ def add_group(name: str) -> List[str]:
         save_groups(groups)
         groups = load_groups()
     return groups
-

--- a/backend/common/metrics.py
+++ b/backend/common/metrics.py
@@ -10,7 +10,9 @@ from backend.common import portfolio as portfolio_mod
 from backend.common.compliance import load_transactions
 from backend.config import config
 
-METRICS_DIR = (config.data_root / "metrics") if config.data_root else Path(__file__).resolve().parents[2] / "data" / "metrics"
+METRICS_DIR = (
+    (config.data_root / "metrics") if config.data_root else Path(__file__).resolve().parents[2] / "data" / "metrics"
+)
 
 
 @dataclass

--- a/backend/common/moneyhub_tokens.py
+++ b/backend/common/moneyhub_tokens.py
@@ -75,8 +75,7 @@ def load_token_set(owner: str) -> Optional[TokenSet]:
     except KeyError as exc:
         required_field = exc.args[0]
         raise MoneyhubAuthError(
-            f"Stored Moneyhub token set for owner '{owner}' is missing "
-            f"required field '{required_field}'"
+            f"Stored Moneyhub token set for owner '{owner}' is missing " f"required field '{required_field}'"
         ) from exc
 
 
@@ -103,9 +102,7 @@ def get_valid_access_token(owner: str, client: MoneyhubClient) -> str:
     try:
         refreshed = client.refresh_access_token(token_set.refresh_token)
     except MoneyhubAPIError as exc:
-        raise MoneyhubAuthError(
-            f"Moneyhub token refresh failed for owner '{owner}': {exc}"
-        ) from exc
+        raise MoneyhubAuthError(f"Moneyhub token refresh failed for owner '{owner}': {exc}") from exc
 
     new_token_set = TokenSet(
         access_token=refreshed["access_token"],

--- a/backend/common/portfolio.py
+++ b/backend/common/portfolio.py
@@ -75,7 +75,9 @@ def _load_trades_aws(owner: str) -> List[Dict[str, Any]]:
     except (ClientError, BotoCoreError) as exc:
         logger.warning(
             "Failed to fetch trades %s from bucket %s: %s",
-            sanitise_log_value(key), sanitise_log_value(bucket), sanitise_log_value(exc),
+            sanitise_log_value(key),
+            sanitise_log_value(bucket),
+            sanitise_log_value(exc),
         )
     except ImportError as exc:
         logger.warning("boto3 not available for S3 trades fetch: %s", sanitise_log_value(exc))

--- a/backend/common/portfolio_utils.py
+++ b/backend/common/portfolio_utils.py
@@ -161,8 +161,7 @@ def _normalize_currency_code(currency: str | None) -> str:
     raw = (currency or "").strip()
     if not raw:
         logger.warning(
-            "_normalize_currency_code received empty/missing currency; defaulting to GBP. "
-            "Check instrument metadata."
+            "_normalize_currency_code received empty/missing currency; defaulting to GBP. " "Check instrument metadata."
         )
         return "GBP"
     if raw == "GBp":
@@ -238,9 +237,7 @@ def _load_snapshot() -> tuple[Dict[str, Dict], datetime | None]:
                 )
                 s3_failed = True
             except ClientError as exc:
-                error_code = (
-                    getattr(exc, "response", {}).get("Error", {}).get("Code", "")
-                )
+                error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
                 if error_code == "NoSuchKey":
                     # Key absent — normal on a fresh deployment before the first
                     # scheduled price-refresh run. Log at WARNING, not ERROR.
@@ -276,9 +273,7 @@ def _load_snapshot() -> tuple[Dict[str, Dict], datetime | None]:
 
     if config.prices_json is None:
         if s3_not_found:
-            logger.warning(
-                "Price snapshot not yet seeded; portfolio prices unavailable until first refresh"
-            )
+            logger.warning("Price snapshot not yet seeded; portfolio prices unavailable until first refresh")
         elif s3_failed:
             logger.error(
                 "No price data available: S3 snapshot unavailable and no local fallback configured. "
@@ -543,9 +538,7 @@ def list_all_unique_tickers() -> List[str]:
 # ──────────────────────────────────────────────────────────────
 # Core aggregation
 # ──────────────────────────────────────────────────────────────
-def aggregate_by_ticker(
-    portfolio: dict | VirtualPortfolio, base_currency: str = "GBP"
-) -> List[dict]:
+def aggregate_by_ticker(portfolio: dict | VirtualPortfolio, base_currency: str = "GBP") -> List[dict]:
     """Collapse a nested portfolio tree into one row per ticker,
     enriched with latest-price snapshot.
 
@@ -657,13 +650,11 @@ def aggregate_by_ticker(
                     "is_stale": None,
                     "change_7d_pct": None,
                     "change_30d_pct": None,
-                    "instrument_type": instrument_meta.get("instrumentType")
-                    or instrument_meta.get("instrument_type"),
+                    "instrument_type": instrument_meta.get("instrumentType") or instrument_meta.get("instrument_type"),
                     "cost_currency": base_currency,
                     "market_value_currency": base_currency,
                     "gain_currency": base_currency,
-                    "_grouping_from_fallback": bool(initial_grouping)
-                    and grouping_source in _GROUPING_FALLBACK_SOURCES,
+                    "_grouping_from_fallback": bool(initial_grouping) and grouping_source in _GROUPING_FALLBACK_SOURCES,
                 },
             )
             row["exchange"] = exch
@@ -682,11 +673,7 @@ def aggregate_by_ticker(
             _update_row_field(row, "region", instrument_meta.get("region"), "instrument_meta")
 
             security_meta: Dict[str, Any] | None = None
-            if (
-                row.get("currency") is None
-                or row.get("sector") is None
-                or row.get("region") is None
-            ):
+            if row.get("currency") is None or row.get("sector") is None or row.get("region") is None:
                 security_meta = get_security_meta(full_tkr) or {}
                 _update_row_field(row, "currency", security_meta.get("currency"), "security_meta")
                 _update_row_field(row, "sector", security_meta.get("sector"), "security_meta")
@@ -713,9 +700,7 @@ def aggregate_by_ticker(
                             ("instrument_meta_currency", instrument_meta.get("currency")),
                         ]
                     )
-                    grouping_value, grouping_label = _first_nonempty_str_with_source(
-                        *grouping_pairs
-                    )
+                    grouping_value, grouping_label = _first_nonempty_str_with_source(*grouping_pairs)
                     if grouping_value:
                         row["grouping"] = grouping_value
                         row["_grouping_from_fallback"] = grouping_label in _GROUPING_FALLBACK_SOURCES
@@ -783,9 +768,7 @@ def aggregate_by_ticker(
                         row["is_stale"] = snap.get("is_stale")
                         row["market_value_gbp"] = round(row["units"] * gbp_price, 2)
                         row["gain_gbp"] = (
-                            round(row["market_value_gbp"] - row["cost_gbp"], 2)
-                            if row["cost_gbp"]
-                            else row["gain_gbp"]
+                            round(row["market_value_gbp"] - row["cost_gbp"], 2) if row["cost_gbp"] else row["gain_gbp"]
                         )
                         row["_snapshot_native_price"] = native_price
                         row["_snapshot_native_currency"] = native_currency
@@ -911,9 +894,7 @@ def aggregate_by_ticker(
     return list(rows.values())
 
 
-def _aggregate_by_field(
-    portfolio: dict | VirtualPortfolio, field: str, base_currency: str = "GBP"
-) -> List[dict]:
+def _aggregate_by_field(portfolio: dict | VirtualPortfolio, field: str, base_currency: str = "GBP") -> List[dict]:
     """Helper to aggregate ticker rows by ``field`` (e.g. sector/region)."""
     rows = aggregate_by_ticker(portfolio, base_currency)
     groups: Dict[str, dict] = {}
@@ -949,16 +930,12 @@ def _aggregate_by_field(
     return list(groups.values())
 
 
-def aggregate_by_sector(
-    portfolio: dict | VirtualPortfolio, base_currency: str = "GBP"
-) -> List[dict]:
+def aggregate_by_sector(portfolio: dict | VirtualPortfolio, base_currency: str = "GBP") -> List[dict]:
     """Return aggregated holdings grouped by sector with return contribution."""
     return _aggregate_by_field(portfolio, "sector", base_currency)
 
 
-def aggregate_by_region(
-    portfolio: dict | VirtualPortfolio, base_currency: str = "GBP"
-) -> List[dict]:
+def aggregate_by_region(portfolio: dict | VirtualPortfolio, base_currency: str = "GBP") -> List[dict]:
     """Return aggregated holdings grouped by region with return contribution."""
     return _aggregate_by_field(portfolio, "region", base_currency)
 
@@ -1132,12 +1109,8 @@ def compute_owner_performance(
                 "date": raw_date.isoformat(),
                 "value": round(float(row.value), 2),
                 "daily_return": (float(row.daily_return) if pd.notna(row.daily_return) else None),
-                "weekly_return": (
-                    float(row.weekly_return) if pd.notna(row.weekly_return) else None
-                ),
-                "cumulative_return": (
-                    float(row.cumulative_return) if pd.notna(row.cumulative_return) else None
-                ),
+                "weekly_return": (float(row.weekly_return) if pd.notna(row.weekly_return) else None),
+                "cumulative_return": (float(row.cumulative_return) if pd.notna(row.cumulative_return) else None),
                 "running_max": round(float(row.running_max), 2),
                 "drawdown": (float(row.drawdown) if pd.notna(row.drawdown) else None),
             }
@@ -1243,11 +1216,7 @@ def _detect_single_day_flash_crash(
     repaired = values.astype(float).copy()
     issues: List[Dict[str, Any]] = []
     repaired_indices: set[Any] = set()
-    jump_threshold = (
-        rebound_drop_pct_threshold
-        if rebound_jump_pct_threshold is None
-        else rebound_jump_pct_threshold
-    )
+    jump_threshold = rebound_drop_pct_threshold if rebound_jump_pct_threshold is None else rebound_jump_pct_threshold
 
     epsilon = 1e-9
     for start_idx in range(0, len(values) - 1):
@@ -1280,9 +1249,7 @@ def _detect_single_day_flash_crash(
             window_min = float(finite_window.min())
             window_max = float(finite_window.max())
             max_neighbor = max(prev, nxt)
-            resembles_zero_glitch = (
-                window_min <= absolute_threshold or window_min <= min_neighbor * relative_threshold
-            )
+            resembles_zero_glitch = window_min <= absolute_threshold or window_min <= min_neighbor * relative_threshold
             drop_pct = 1 - (window_min / min_neighbor)
             jump_pct = (window_max / max_neighbor) - 1 if max_neighbor > epsilon else 0.0
             large_short_lived_drop = drop_pct >= rebound_drop_pct_threshold
@@ -1486,9 +1453,7 @@ def _alpha_vs_benchmark(
                 "date": idx.isoformat() if hasattr(idx, "isoformat") else str(idx),
                 "portfolio_cumulative_return": float(port_cum_series.loc[idx]),
                 "benchmark_cumulative_return": float(bench_cum_series.loc[idx]),
-                "excess_cumulative_return": float(
-                    port_cum_series.loc[idx] - bench_cum_series.loc[idx]
-                ),
+                "excess_cumulative_return": float(port_cum_series.loc[idx] - bench_cum_series.loc[idx]),
             }
         )
 
@@ -1600,11 +1565,7 @@ def _max_drawdown(
         if trough_date is not None:
             trough_val = float(total.loc[trough_date])
             trough_info = {
-                "date": (
-                    trough_date.isoformat()
-                    if hasattr(trough_date, "isoformat")
-                    else str(trough_date)
-                ),
+                "date": (trough_date.isoformat() if hasattr(trough_date, "isoformat") else str(trough_date)),
                 "value": trough_val,
                 "drawdown": float(drawdown.loc[trough_date]),
             }
@@ -1615,11 +1576,7 @@ def _max_drawdown(
                 if not peak_date_candidates.empty:
                     peak_date = peak_date_candidates.index[0]
                     peak_info = {
-                        "date": (
-                            peak_date.isoformat()
-                            if hasattr(peak_date, "isoformat")
-                            else str(peak_date)
-                        ),
+                        "date": (peak_date.isoformat() if hasattr(peak_date, "isoformat") else str(peak_date)),
                         "value": peak_value,
                     }
 
@@ -1654,9 +1611,7 @@ def compute_group_alpha_vs_benchmark(
     *,
     include_breakdown: bool = False,
 ) -> float | None | tuple[float | None, dict[str, Any]]:
-    value, breakdown = _alpha_vs_benchmark(
-        slug, benchmark, days, group=True, include_breakdown=include_breakdown
-    )
+    value, breakdown = _alpha_vs_benchmark(slug, benchmark, days, group=True, include_breakdown=include_breakdown)
     if include_breakdown:
         return value, breakdown
     return value
@@ -1689,9 +1644,7 @@ def compute_group_tracking_error(
     *,
     include_breakdown: bool = False,
 ) -> float | None | tuple[float | None, dict[str, Any]]:
-    value, breakdown = _tracking_error(
-        slug, benchmark, days, group=True, include_breakdown=include_breakdown
-    )
+    value, breakdown = _tracking_error(slug, benchmark, days, group=True, include_breakdown=include_breakdown)
     if include_breakdown:
         return value, breakdown
     return value
@@ -1704,9 +1657,7 @@ def compute_max_drawdown(
     include_breakdown: bool = False,
     pricing_date: date | None = None,
 ) -> float | None | tuple[float | None, dict[str, Any]]:
-    value, breakdown = _max_drawdown(
-        owner, days, include_breakdown=include_breakdown, pricing_date=pricing_date
-    )
+    value, breakdown = _max_drawdown(owner, days, include_breakdown=include_breakdown, pricing_date=pricing_date)
     if include_breakdown:
         return value, breakdown
     return value
@@ -1718,9 +1669,7 @@ def compute_group_max_drawdown(
     *,
     include_breakdown: bool = False,
 ) -> float | None | tuple[float | None, dict[str, Any]]:
-    value, breakdown = _max_drawdown(
-        slug, days, group=True, include_breakdown=include_breakdown
-    )
+    value, breakdown = _max_drawdown(slug, days, group=True, include_breakdown=include_breakdown)
     if include_breakdown:
         return value, breakdown
     return value
@@ -1840,9 +1789,7 @@ def compute_xirr(owner: str, days: int = 365, *, pricing_date: date | None = Non
         try:
             df = float(
                 sum(
-                    -((d - start).days / 365.0)
-                    * amt
-                    / (1.0 + rate) ** ((d - start).days / 365.0 + 1)
+                    -((d - start).days / 365.0) * amt / (1.0 + rate) ** ((d - start).days / 365.0 + 1)
                     for d, amt in flows
                 )
             )
@@ -2010,8 +1957,7 @@ def refresh_snapshot_in_memory_from_timeseries(days: int = 365) -> None:
             logger.info("Wrote %d prices to %s", len(merged), _PRICES_PATH)
         elif not _PRICES_PATH:
             logger.info(
-                "Price snapshot path not configured; skipping write"
-                " (expected when config.prices_json is unset)"
+                "Price snapshot path not configured; skipping write" " (expected when config.prices_json is unset)"
             )
         else:
             logger.info("Skipping price snapshot write — no timeseries data found")

--- a/backend/common/prices.py
+++ b/backend/common/prices.py
@@ -76,10 +76,7 @@ def _close_on(sym: str, exch: str, d: date) -> Optional[float]:
 
     name_map = {c.lower(): c for c in df.columns}
     close_col = (
-        name_map.get("close_gbp")
-        or name_map.get("close")
-        or name_map.get("adj close")
-        or name_map.get("adj_close")
+        name_map.get("close_gbp") or name_map.get("close") or name_map.get("adj close") or name_map.get("adj_close")
     )
     if not close_col:
         return None
@@ -271,8 +268,7 @@ def refresh_prices() -> Dict:
     else:
         merged = existing
         logger.info(
-            "Skipping local snapshot write — no valid prices fetched"
-            " (offline mode or data-source unavailable)"
+            "Skipping local snapshot write — no valid prices fetched" " (offline mode or data-source unavailable)"
         )
 
     # ---- persist to S3 (primary store read by all Lambda instances) ---------
@@ -294,9 +290,7 @@ def refresh_prices() -> Dict:
                     Body=json.dumps(merged, indent=2).encode("utf-8"),
                     ContentType="application/json",
                 )
-                logger.info(
-                    "Uploaded price snapshot to s3://%s/%s", _s3_bucket, PRICES_S3_KEY
-                )
+                logger.info("Uploaded price snapshot to s3://%s/%s", _s3_bucket, PRICES_S3_KEY)
             except Exception as exc:
                 logger.warning("Failed to upload price snapshot to S3: %s", sanitise_log_value(exc))
         else:

--- a/backend/common/signup_requests.py
+++ b/backend/common/signup_requests.py
@@ -20,7 +20,6 @@ import logging
 import re
 import secrets
 import threading
-
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -172,9 +171,7 @@ def create_signup_request(
     return record, token
 
 
-def _enforce_cap_unlocked(
-    directory: Path, max_pending: int, *, now: datetime | None = None
-) -> None:
+def _enforce_cap_unlocked(directory: Path, max_pending: int, *, now: datetime | None = None) -> None:
     """Remove oldest pending requests until the count is within ``max_pending``.
 
     Must be called with ``_PERSIST_LOCK`` already held.  Only removes pending
@@ -212,9 +209,7 @@ def _enforce_cap_unlocked(
                 pass
 
 
-def _enforce_cap(
-    store_dir: Path, max_pending: int, *, now: datetime | None = None
-) -> None:
+def _enforce_cap(store_dir: Path, max_pending: int, *, now: datetime | None = None) -> None:
     """Acquire ``_PERSIST_LOCK`` and enforce the pending-request cap."""
 
     directory = Path(store_dir)

--- a/backend/common/trade_metrics.py
+++ b/backend/common/trade_metrics.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 import csv
 from pathlib import Path
 from typing import Dict, Iterable, List
+
 from backend.config import config
 
-TRADE_LOG_PATH = (config.data_root / "trade_log.csv") if config.data_root else Path(__file__).resolve().parents[2] / "data" / "trade_log.csv"
+TRADE_LOG_PATH = (
+    (config.data_root / "trade_log.csv")
+    if config.data_root
+    else Path(__file__).resolve().parents[2] / "data" / "trade_log.csv"
+)
 
 
 def load_trades(path: Path = TRADE_LOG_PATH) -> List[Dict[str, str]]:

--- a/backend/common/url_validator.py
+++ b/backend/common/url_validator.py
@@ -74,14 +74,10 @@ def validate_external_url(url: str, *, allow_http: bool = False) -> None:
     config load time, so that values modified after startup are also caught.
     """
     parsed = urlparse(url)
-    allowed_schemes: frozenset[str] = (
-        frozenset({"https", "http"}) if allow_http else frozenset({"https"})
-    )
+    allowed_schemes: frozenset[str] = frozenset({"https", "http"}) if allow_http else frozenset({"https"})
     if parsed.scheme not in allowed_schemes:
         allowed_desc = "https or http" if allow_http else "https"
-        raise InvalidExternalURLError(
-            f"Disallowed URL scheme {parsed.scheme!r}; only {allowed_desc} is permitted"
-        )
+        raise InvalidExternalURLError(f"Disallowed URL scheme {parsed.scheme!r}; only {allowed_desc} is permitted")
 
     hostname = parsed.hostname
     if not hostname:
@@ -90,11 +86,7 @@ def validate_external_url(url: str, *, allow_http: bool = False) -> None:
     # Strip a trailing dot (valid DNS absolute-name syntax) before the
     # blocked-hostname check, so "localhost." cannot bypass the list.
     if hostname.lower().rstrip(".") in _BLOCKED_HOSTNAMES:
-        raise InvalidExternalURLError(
-            f"Hostname {hostname!r} is not permitted for external requests"
-        )
+        raise InvalidExternalURLError(f"Hostname {hostname!r} is not permitted for external requests")
 
     if _is_private_address(hostname):
-        raise InvalidExternalURLError(
-            f"IP address {hostname!r} is in a private or reserved range"
-        )
+        raise InvalidExternalURLError(f"IP address {hostname!r} is in a private or reserved range")

--- a/backend/common/virtual_portfolio.py
+++ b/backend/common/virtual_portfolio.py
@@ -5,10 +5,15 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
+
 from backend.config import config
 
 # Directory for storing virtual portfolio JSON files
-VIRTUAL_PORTFOLIO_DIR = (config.data_root / "virtual_portfolios") if config.data_root else Path(__file__).resolve().parents[2] / "data" / "virtual_portfolios"
+VIRTUAL_PORTFOLIO_DIR = (
+    (config.data_root / "virtual_portfolios")
+    if config.data_root
+    else Path(__file__).resolve().parents[2] / "data" / "virtual_portfolios"
+)
 
 
 class VirtualHolding(BaseModel):

--- a/backend/local_api/main.py
+++ b/backend/local_api/main.py
@@ -11,10 +11,4 @@ app = create_app()
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(
-        "main:app",
-        host="127.0.0.1",
-        port=8000,
-        reload=True,
-        log_level="debug"
-    )
+    uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=True, log_level="debug")

--- a/backend/quests/__init__.py
+++ b/backend/quests/__init__.py
@@ -26,9 +26,7 @@ QUEST_DEFINITIONS = [
 QUEST_IDS = {q["id"] for q in QUEST_DEFINITIONS}
 
 # Storage setup ---------------------------------------------------------------
-_DEFAULT_QUESTS_URI = (
-    f"file://{(config.repo_root or Path(__file__).resolve().parents[1]) / 'data' / 'quests.json'}"
-)
+_DEFAULT_QUESTS_URI = f"file://{(config.repo_root or Path(__file__).resolve().parents[1]) / 'data' / 'quests.json'}"
 _QUESTS_STORAGE = get_storage(os.getenv("QUESTS_URI", _DEFAULT_QUESTS_URI))
 
 # In-memory cache of quest progress keyed by user
@@ -61,17 +59,14 @@ def _save() -> None:
 
 # Public API -----------------------------------------------------------------
 
+
 def get_quests(user: str) -> Dict:
     """Return today's quests and progress for ``user``."""
     _load()
     today = date.today().isoformat()
-    user_data = _DATA.setdefault(
-        user, {"xp": 0, "streak": 0, "last_completed_day": "", "completed": {}}
-    )
+    user_data = _DATA.setdefault(user, {"xp": 0, "streak": 0, "last_completed_day": "", "completed": {}})
     completed_today = set(user_data["completed"].get(today, []))
-    quests = [
-        {**q, "completed": q["id"] in completed_today} for q in QUEST_DEFINITIONS
-    ]
+    quests = [{**q, "completed": q["id"] in completed_today} for q in QUEST_DEFINITIONS]
     return {"quests": quests, "xp": user_data["xp"], "streak": user_data["streak"]}
 
 
@@ -86,9 +81,7 @@ def mark_complete(user: str, quest_id: str) -> Dict:
     _load()
     today = date.today()
     today_str = today.isoformat()
-    user_data = _DATA.setdefault(
-        user, {"xp": 0, "streak": 0, "last_completed_day": "", "completed": {}}
-    )
+    user_data = _DATA.setdefault(user, {"xp": 0, "streak": 0, "last_completed_day": "", "completed": {}})
     completed = set(user_data["completed"].get(today_str, []))
     if quest_id in completed:
         return get_quests(user)

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -538,7 +538,8 @@ class DynamoTemplateStore(TemplateStore):
         except ValueError as exc:
             logger.warning(
                 "invalid template definition for %s: %s",
-                sanitise_log_value(template_id), sanitise_log_value(exc),
+                sanitise_log_value(template_id),
+                sanitise_log_value(exc),
             )
             return None
 
@@ -594,9 +595,7 @@ def _validate_template_id(template_id: str) -> str:
     if not candidate:
         raise ValueError("template_id is required")
     if not _TEMPLATE_ID_RE.fullmatch(candidate):
-        raise ValueError(
-            "template_id must contain only letters, numbers, dashes or underscores (max 64 chars)"
-        )
+        raise ValueError("template_id must contain only letters, numbers, dashes or underscores (max 64 chars)")
     return candidate
 
 
@@ -607,9 +606,7 @@ def _validate_section_id(section_id: str) -> str:
     if not candidate:
         raise ValueError("section id is required")
     if not _SECTION_ID_RE.fullmatch(candidate):
-        raise ValueError(
-            "section id must contain only letters, numbers, dashes or underscores (max 64 chars)"
-        )
+        raise ValueError("section id must contain only letters, numbers, dashes or underscores (max 64 chars)")
     return candidate
 
 
@@ -666,7 +663,8 @@ class ReportContext:
         except (FileNotFoundError, ValueError) as exc:
             logger.warning(
                 "failed to build owner portfolio for %s: %s",
-                sanitise_log_value(self.owner), sanitise_log_value(exc),
+                sanitise_log_value(self.owner),
+                sanitise_log_value(exc),
             )
             fallback_portfolio = self._portfolio
             if (
@@ -723,9 +721,7 @@ def _round_if_number(value: Any, digits: int) -> Optional[float]:
     return round(number, digits)
 
 
-def _normalise_transaction(
-    item: Dict[str, Any], start: Optional[date], end: Optional[date]
-) -> Dict[str, Any] | None:
+def _normalise_transaction(item: Dict[str, Any], start: Optional[date], end: Optional[date]) -> Dict[str, Any] | None:
     date_str = item.get("date")
     tx_date: Optional[date]
     tx_date = None
@@ -753,9 +749,7 @@ def _normalise_transaction(
             break
     tx_type = (item.get("type") or "").upper()
     return {
-        "date": (
-            tx_date.isoformat() if tx_date else (date_str if isinstance(date_str, str) else None)
-        ),
+        "date": (tx_date.isoformat() if tx_date else (date_str if isinstance(date_str, str) else None)),
         "type": tx_type,
         "description": description,
         "amount_gbp": round(amount, 2),
@@ -819,9 +813,7 @@ def _parse_key_findings_text(content: str, *, source_name: str = "key findings")
     return findings
 
 
-def _build_key_findings_section(
-    context: ReportContext, section: ReportSectionSchema
-) -> Sequence[Dict[str, Any]]:
+def _build_key_findings_section(context: ReportContext, section: ReportSectionSchema) -> Sequence[Dict[str, Any]]:
     owner_root = config.data_root / "accounts" / context.owner
     candidates = (
         owner_root / "key_findings.md",
@@ -837,9 +829,7 @@ def _build_key_findings_section(
 SectionBuilder = Callable[[ReportContext, ReportSectionSchema], Sequence[Dict[str, Any]]]
 
 
-def _build_metrics_section(
-    context: ReportContext, section: ReportSectionSchema
-) -> Sequence[Dict[str, Any]]:
+def _build_metrics_section(context: ReportContext, section: ReportSectionSchema) -> Sequence[Dict[str, Any]]:
     summary = context.summary()
     rows = [
         {"metric": "Owner", "value": summary.owner, "units": ""},
@@ -882,9 +872,7 @@ def _build_metrics_section(
     return rows
 
 
-def _build_history_section(
-    context: ReportContext, section: ReportSectionSchema
-) -> Sequence[Dict[str, Any]]:
+def _build_history_section(context: ReportContext, section: ReportSectionSchema) -> Sequence[Dict[str, Any]]:
     history_rows: List[Dict[str, Any]] = []
     for row in context.summary().history:
         history_rows.append(
@@ -900,15 +888,11 @@ def _build_history_section(
     return history_rows
 
 
-def _build_transactions_section(
-    context: ReportContext, section: ReportSectionSchema
-) -> Sequence[Dict[str, Any]]:
+def _build_transactions_section(context: ReportContext, section: ReportSectionSchema) -> Sequence[Dict[str, Any]]:
     return context.transactions()
 
 
-def _build_allocation_section(
-    context: ReportContext, section: ReportSectionSchema
-) -> Sequence[Dict[str, Any]]:
+def _build_allocation_section(context: ReportContext, section: ReportSectionSchema) -> Sequence[Dict[str, Any]]:
     return context.allocation()
 
 
@@ -1015,9 +999,7 @@ def _extract_var_value(payload: Any) -> float | None:
     return _safe_float(payload)
 
 
-def _build_portfolio_overview_section(
-    context: ReportContext, section: ReportSectionSchema
-) -> Sequence[Dict[str, Any]]:
+def _build_portfolio_overview_section(context: ReportContext, section: ReportSectionSchema) -> Sequence[Dict[str, Any]]:
     if _is_audit_overview_section(section):
         portfolio = context.portfolio()
         return [
@@ -1102,9 +1084,7 @@ def _build_portfolio_overview_section(
     return rows
 
 
-def _build_portfolio_sectors_section(
-    context: ReportContext, section: ReportSectionSchema
-) -> Sequence[Dict[str, Any]]:
+def _build_portfolio_sectors_section(context: ReportContext, section: ReportSectionSchema) -> Sequence[Dict[str, Any]]:
     if _is_audit_value_weight_section(section):
         portfolio = context.portfolio()
         rows = portfolio_utils.aggregate_by_sector(portfolio) or []
@@ -1137,9 +1117,7 @@ def _build_portfolio_sectors_section(
     return out
 
 
-def _build_portfolio_regions_section(
-    context: ReportContext, section: ReportSectionSchema
-) -> Sequence[Dict[str, Any]]:
+def _build_portfolio_regions_section(context: ReportContext, section: ReportSectionSchema) -> Sequence[Dict[str, Any]]:
     if _is_audit_value_weight_section(section):
         portfolio = context.portfolio()
         rows = portfolio_utils.aggregate_by_region(portfolio) or []
@@ -1241,9 +1219,7 @@ def _build_portfolio_concentration_section(
     return holding_rows + [summary_row]
 
 
-def _build_portfolio_var_section(
-    context: ReportContext, section: ReportSectionSchema
-) -> Sequence[Dict[str, Any]]:
+def _build_portfolio_var_section(context: ReportContext, section: ReportSectionSchema) -> Sequence[Dict[str, Any]]:
     """Unified VaR section builder — single code path for all templates.
 
     Guards on owner_portfolio() being available so VaR is only attempted when
@@ -1262,9 +1238,7 @@ def _build_portfolio_var_section(
     rows: List[Dict[str, Any]] = []
     for confidence, metric in ((0.95, "VaR (95%)"), (0.99, "VaR (99%)")):
         try:
-            payload = risk.compute_portfolio_var(
-                context.owner, confidence=confidence, include_cash=False
-            )
+            payload = risk.compute_portfolio_var(context.owner, confidence=confidence, include_cash=False)
         except (FileNotFoundError, ValueError):
             continue
         rows.append(
@@ -1424,9 +1398,7 @@ def _materialise_template(definition: Dict[str, Any], *, builtin: bool) -> Repor
 
 
 def list_templates(store: TemplateStore | None = None) -> List[ReportTemplate]:
-    templates: Dict[str, ReportTemplate] = {
-        template.template_id: template for template in iter_builtin_templates()
-    }
+    templates: Dict[str, ReportTemplate] = {template.template_id: template for template in iter_builtin_templates()}
     store = store or get_template_store()
     try:
         for definition in store.list_templates():
@@ -1458,9 +1430,7 @@ def get_template(template_id: str, store: TemplateStore | None = None) -> Report
     return _materialise_template(definition, builtin=False)
 
 
-def create_user_template(
-    definition: Dict[str, Any], store: TemplateStore | None = None
-) -> ReportTemplate:
+def create_user_template(definition: Dict[str, Any], store: TemplateStore | None = None) -> ReportTemplate:
     payload = _validate_template_payload(definition)
     if get_builtin_template(payload["template_id"]):
         raise ValueError("Cannot overwrite built-in template")
@@ -1686,9 +1656,7 @@ def _compile_summary(
     return data, perf
 
 
-def compile_report(
-    owner: str, start: Optional[date] = None, end: Optional[date] = None
-) -> ReportData:
+def compile_report(owner: str, start: Optional[date] = None, end: Optional[date] = None) -> ReportData:
     data, _perf = _compile_summary(owner, start=start, end=end)
     return data
 
@@ -1831,11 +1799,7 @@ def report_to_pdf(document: ReportDocument) -> bytes:
         c.drawString(40, height - 220, "CONFIDENTIAL")
         # Render user-visible parameters, excluding internal PDF rendering keys
         # such as "watermark" which would otherwise leak into the visible report.
-        visible_params = {
-            k: v
-            for k, v in document.parameters.items()
-            if k not in _PDF_INTERNAL_PARAM_KEYS
-        }
+        visible_params = {k: v for k, v in document.parameters.items() if k not in _PDF_INTERNAL_PARAM_KEYS}
         if visible_params:
             y = height - 245
             c.setFont("Helvetica", 10)
@@ -1875,10 +1839,7 @@ def report_to_pdf(document: ReportDocument) -> bytes:
         line_word_count = 1
         for word in words[1:]:
             candidate = f"{line} {word}"
-            if (
-                c.stringWidth(candidate, "Helvetica", 11) <= max_width
-                or line_word_count < min_words_before_wrap
-            ):
+            if c.stringWidth(candidate, "Helvetica", 11) <= max_width or line_word_count < min_words_before_wrap:
                 line = candidate
                 line_word_count += 1
             else:
@@ -1907,11 +1868,7 @@ def report_to_pdf(document: ReportDocument) -> bytes:
         return y
 
     def _draw_key_findings_section(section: ReportSectionData, y: float) -> float:
-        findings = [
-            str(row.get("finding", "")).strip()
-            for row in section.rows
-            if str(row.get("finding", "")).strip()
-        ]
+        findings = [str(row.get("finding", "")).strip() for row in section.rows if str(row.get("finding", "")).strip()]
 
         def _restart_key_findings_page() -> float:
             next_y = _start_content_page()
@@ -1960,20 +1917,14 @@ def report_to_pdf(document: ReportDocument) -> bytes:
         if Table is None:
             c.setFont("Helvetica", 9)
             for row in section.rows:
-                line = " | ".join(
-                    _format_cell_value(column, row.get(column.key))
-                    for column in section.schema.columns
-                )
+                line = " | ".join(_format_cell_value(column, row.get(column.key)) for column in section.schema.columns)
                 c.drawString(40, y, line)
                 y -= 12
             return y - 10
 
         headers = [column.label for column in section.schema.columns]
         body_rows = [
-            [
-                _format_cell_value(column, row.get(column.key))
-                for column in section.schema.columns
-            ]
+            [_format_cell_value(column, row.get(column.key)) for column in section.schema.columns]
             for row in section.rows
         ]
         if body_rows:
@@ -1994,9 +1945,7 @@ def report_to_pdf(document: ReportDocument) -> bytes:
         )
         for row_idx in range(1, len(table_data)):
             if row_idx % 2 == 0:
-                table_style.add(
-                    "BACKGROUND", (0, row_idx), (-1, row_idx), colors.HexColor("#F7F9FC")
-                )
+                table_style.add("BACKGROUND", (0, row_idx), (-1, row_idx), colors.HexColor("#F7F9FC"))
         for idx, column in enumerate(section.schema.columns):
             if column.type == "number" or column.key.lower() in {"value", "amount_gbp", "price"}:
                 table_style.add("ALIGN", (idx, 1), (idx, -1), "RIGHT")

--- a/backend/routes/alert_settings.py
+++ b/backend/routes/alert_settings.py
@@ -21,14 +21,10 @@ class ThresholdPayload(BaseModel):
 def _validate_owner(user: str, current_user: str) -> None:
     """Ensure requests only act on the authenticated user's settings."""
     if user != current_user:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Owner mismatch"
-        )
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Owner mismatch")
 
 
-async def _resolve_identity(
-    request: Request, current_user: str | None
-) -> str:
+async def _resolve_identity(request: Request, current_user: str | None) -> str:
     """Return the identity for the current request.
 
     The alert routes primarily rely on :func:`backend.auth.get_active_user` so
@@ -81,4 +77,3 @@ async def set_threshold(
     _validate_owner(user, identity)
     alert_utils.set_user_threshold(identity, payload.threshold)
     return {"threshold": payload.threshold}
-

--- a/backend/routes/analytics.py
+++ b/backend/routes/analytics.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from collections import Counter
 from datetime import datetime, timezone
-import json
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -134,11 +134,7 @@ async def get_funnel(source: str) -> FunnelSummary:
     first = min(evt.occurred_at for evt in events)
     last = max(evt.occurred_at for evt in events)
     funnel_steps = [FunnelStep(event=step, count=counts.get(step, 0)) for step in _FUNNEL_STEPS[source]]
-    other_events = {
-        name: count
-        for name, count in counts.items()
-        if name not in _FUNNEL_STEPS[source]
-    }
+    other_events = {name: count for name, count in counts.items() if name not in _FUNNEL_STEPS[source]}
 
     return FunnelSummary(
         source=source,
@@ -149,4 +145,3 @@ async def get_funnel(source: str) -> FunnelSummary:
         steps=funnel_steps,
         other_events=other_events or None,
     )
-

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -76,15 +76,12 @@ def serialise_config(cfg: config_module.Config) -> ConfigContract:
     tabs = data.get("tabs")
     if isinstance(tabs, dict):
         serialised_tabs = {
-            ("trade-compliance" if key == "trade_compliance" else key): value
-            for key, value in tabs.items()
+            ("trade-compliance" if key == "trade_compliance" else key): value for key, value in tabs.items()
         }
         data["tabs"] = serialised_tabs
     disabled = data.get("disabled_tabs")
     if isinstance(disabled, list):
-        data["disabled_tabs"] = [
-            "trade-compliance" if item == "trade_compliance" else item for item in disabled
-        ]
+        data["disabled_tabs"] = ["trade-compliance" if item == "trade_compliance" else item for item in disabled]
     raw = data.pop("aws_ui_auth", None)
     if isinstance(raw, dict) and raw.get("enabled"):
         data["awsUiAuth"] = {
@@ -226,9 +223,7 @@ async def update_config(payload: Dict[str, Any]) -> Dict[str, Any]:
     has_changes = data != existing_data
 
     persisted_data = deepcopy(data)
-    persisted_auth_section = (
-        persisted_data.get("auth", {}) if isinstance(persisted_data, dict) else {}
-    )
+    persisted_auth_section = persisted_data.get("auth", {}) if isinstance(persisted_data, dict) else {}
     if not isinstance(persisted_auth_section, dict):
         persisted_auth_section = {}
         persisted_data["auth"] = persisted_auth_section

--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -2,12 +2,18 @@
 
 import json
 from pathlib import Path
+
 from fastapi import APIRouter
+
 from backend.config import config
 
 router = APIRouter(tags=["events"])
 
-_events_path = globals().get("_events_path") or ((config.data_root / "events.json") if config.data_root else Path(__file__).resolve().parents[2] / "data" / "events.json")
+_events_path = globals().get("_events_path") or (
+    (config.data_root / "events.json")
+    if config.data_root
+    else Path(__file__).resolve().parents[2] / "data" / "events.json"
+)
 
 try:
     with _events_path.open() as fh:
@@ -20,4 +26,3 @@ except FileNotFoundError:
 def list_events():
     """Return configured scenario events."""
     return _EVENTS
-

--- a/backend/routes/goals.py
+++ b/backend/routes/goals.py
@@ -4,13 +4,14 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from backend.auth import get_current_user
 from backend.common.goals import Goal, add_goal, delete_goal, load_goals, save_goals
 from backend.common.rebalance import suggest_trades
-from backend.auth import get_current_user
 from backend.config import config, demo_identity
 
 router = APIRouter(prefix="/goals", tags=["goals"])
 DEMO_OWNER = demo_identity()
+
 
 class GoalPayload(BaseModel):
     name: str

--- a/backend/routes/instrument_admin.py
+++ b/backend/routes/instrument_admin.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from backend.config import config
+
 from backend.common import instrument_groups
 from backend.common.instruments import (
     _ORIGINAL_FETCH_METADATA,
@@ -15,9 +15,10 @@ from backend.common.instruments import (
     get_instrument_meta,
     instrument_meta_path,
     list_group_definitions,
-    save_instrument_meta,
     list_instruments,
+    save_instrument_meta,
 )
+from backend.config import config
 
 router = APIRouter(
     prefix="/instrument",
@@ -66,6 +67,7 @@ async def create_group(body: dict[str, Any]) -> dict[str, Any]:
     existed = any(g.casefold() == key for g in existing)
     status = "exists" if existed else "created"
     return {"status": status, "group": canonical, "groups": groups}
+
 
 @router.get("/admin/groupings")
 async def list_instrument_groupings() -> list[dict[str, Any]]:
@@ -142,9 +144,7 @@ async def update_instrument(exchange: str, ticker: str, body: dict[str, Any]) ->
 
 
 @router.post("/admin/{exchange}/{ticker}/refresh")
-async def refresh_instrument(
-    exchange: str, ticker: str, body: dict[str, Any] | None = None
-) -> dict[str, Any]:
+async def refresh_instrument(exchange: str, ticker: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
     """Fetch fresh metadata for an instrument and optionally persist it."""
 
     try:
@@ -160,10 +160,7 @@ async def refresh_instrument(
     if not exists:
         raise HTTPException(status_code=404, detail="Instrument not found")
 
-    if (
-        config.offline_mode
-        and _fetch_metadata_from_yahoo is _ORIGINAL_FETCH_METADATA
-    ):
+    if config.offline_mode and _fetch_metadata_from_yahoo is _ORIGINAL_FETCH_METADATA:
         raise HTTPException(status_code=503, detail="Metadata refresh disabled in offline mode")
 
     preview = True
@@ -283,4 +280,3 @@ async def clear_group(exchange: str, ticker: str) -> dict[str, Any]:
     if changed:
         save_instrument_meta(ticker, exchange, meta)
     return {"status": "cleared"}
-

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -2,7 +2,6 @@
 
 from fastapi import APIRouter
 
-
 # Static list of supported model identifiers. In a real deployment this could
 # be sourced from configuration or an external registry.
 MODEL_NAMES = ["gpt-4o-mini"]
@@ -14,7 +13,4 @@ router = APIRouter(prefix="/v1")
 @router.get("/models")
 def list_models() -> dict:
     """Return the available model identifiers."""
-    return {
-        "data": [{"id": name, "object": "model"} for name in MODEL_NAMES]
-    }
-
+    return {"data": [{"id": name, "object": "model"} for name in MODEL_NAMES]}

--- a/backend/routes/opportunities.py
+++ b/backend/routes/opportunities.py
@@ -13,9 +13,7 @@ from backend.agent.models import TradingSignal
 from backend.auth import decode_token
 from backend.common import instrument_api
 from backend.config import config
-from backend.routes.portfolio import (
-    _ALLOWED_DAYS as _PORTFOLIO_ALLOWED_DAYS,
-)
+from backend.routes.portfolio import _ALLOWED_DAYS as _PORTFOLIO_ALLOWED_DAYS
 from backend.routes.portfolio import (
     _calculate_weights_and_market_values,
     _enrich_movers_with_market_values,

--- a/backend/routes/query.py
+++ b/backend/routes/query.py
@@ -25,9 +25,7 @@ from backend.timeseries.cache import load_meta_timeseries_range
 router = APIRouter(prefix="/custom-query", tags=["query"])
 
 QUERIES_DIR = config.data_root / "queries"
-REPO_QUERIES_DIR = (
-    (config.repo_root or Path(__file__).resolve().parents[2]) / "data" / "queries"
-)
+REPO_QUERIES_DIR = (config.repo_root or Path(__file__).resolve().parents[2]) / "data" / "queries"
 DATA_BUCKET_ENV = "DATA_BUCKET"
 QUERIES_PREFIX = "queries/"
 
@@ -166,9 +164,7 @@ def _load_query_s3(slug: str) -> dict:
     try:
         import boto3  # type: ignore
 
-        obj = boto3.client("s3").get_object(
-            Bucket=bucket, Key=f"{QUERIES_PREFIX}{slug}.json"
-        )
+        obj = boto3.client("s3").get_object(Bucket=bucket, Key=f"{QUERIES_PREFIX}{slug}.json")
         body = obj.get("Body")
         txt = body.read().decode(encoding="utf-8", errors="replace") if body else ""
     except Exception as exc:  # pragma: no cover - defensive

--- a/backend/routes/quest_routes.py
+++ b/backend/routes/quest_routes.py
@@ -2,20 +2,17 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
+from backend import quests
 from backend.auth import (
     get_active_user,
-    get_current_user,
     resolve_current_user_override,
 )
 from backend.config import config, demo_identity
-from backend import quests
 
 router = APIRouter(prefix="/quests", tags=["quests"])
 
 
-async def require_active_user(
-    request: Request, current_user: str | None = Depends(get_active_user)
-) -> str:
+async def require_active_user(request: Request, current_user: str | None = Depends(get_active_user)) -> str:
     """Resolve the authenticated user or raise ``401`` when missing."""
 
     if current_user:
@@ -28,9 +25,7 @@ async def require_active_user(
     if config.disable_auth:
         return demo_identity()
 
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
-    )
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
 
 
 @router.get("/today")

--- a/backend/routes/scenario.py
+++ b/backend/routes/scenario.py
@@ -8,9 +8,9 @@ from backend.common.data_loader import ProviderUnavailable, list_plots
 from backend.common.portfolio import build_owner_portfolio
 from backend.utils.scenario_tester import (
     _HORIZONS,
-    apply_historical_event_portfolio as apply_historical_event,
     apply_price_shock,
 )
+from backend.utils.scenario_tester import apply_historical_event_portfolio as apply_historical_event
 
 router = APIRouter(tags=["scenario"])
 
@@ -57,9 +57,7 @@ def run_scenario(
 def run_historical_scenario(
     event_id: str | None = Query(None, description="Historical event identifier"),
     date: str | None = Query(None, description="Event date (YYYY-MM-DD)"),
-    horizons: List[str] = Query(
-        ..., description="Event horizons as day counts or tokens like '1w'"
-    ),
+    horizons: List[str] = Query(..., description="Event horizons as day counts or tokens like '1w'"),
 ):
     """Calculate shocked portfolio values for a historical event.
 
@@ -109,17 +107,10 @@ def run_historical_scenario(
             baseline = sum(a.get("value_estimate_gbp") or 0.0 for a in pf.get("accounts", []))
             pf["total_value_estimate_gbp"] = baseline
 
-        shocked = apply_historical_event(
-            pf, event_id=event_id, date=date, horizons=parsed
-        )
+        shocked = apply_historical_event(pf, event_id=event_id, date=date, horizons=parsed)
         horizon_map = {}
         for label, days in label_pairs:
-            shocked_pf = (
-                shocked.get(days)
-                or shocked.get(label)
-                or shocked.get(str(days))
-                or {}
-            )
+            shocked_pf = shocked.get(days) or shocked.get(label) or shocked.get(str(days)) or {}
             val = shocked_pf.get("total_value_estimate_gbp")
             if val is None:
                 val = shocked_pf.get("total_value_gbp")

--- a/backend/routes/screener.py
+++ b/backend/routes/screener.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 """API route for basic stock screening based on valuation metrics."""
 
+import hashlib
 from typing import List
 
-import hashlib
-
-from fastapi import APIRouter, HTTPException, Query, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 
 from backend.screener import Fundamentals, screen
 from backend.utils import page_cache
+
 
 class RankedFundamentals(Fundamentals):
     rank: int
@@ -121,10 +121,7 @@ def _hash_params(
 def _apply_rank(rows: List[dict]) -> None:
     rows.sort(
         key=lambda x: (
-            float("inf")
-            if x.get("peg_ratio") in (None,)
-            or x.get("roe") in (None, 0)
-            else x["peg_ratio"] / x["roe"]
+            float("inf") if x.get("peg_ratio") in (None,) or x.get("roe") in (None, 0) else x["peg_ratio"] / x["roe"]
         )
     )
     for i, row in enumerate(rows, 1):

--- a/backend/routes/support.py
+++ b/backend/routes/support.py
@@ -64,10 +64,12 @@ async def _compute_portfolio_health(threshold: float) -> _PortfolioHealthSnapsho
         # Deferred: scripts/ is outside the backend package and not present in the
         # Lambda Docker image, so a module-level import would block Lambda startup.
         from scripts.check_portfolio_health import run_check  # noqa: PLC0415
+
         findings = await asyncio.to_thread(run_check, threshold)
     except Exception:  # pragma: no cover - defensive logging
         logger.exception(
-            "Portfolio health check failed for threshold %.4f", threshold,
+            "Portfolio health check failed for threshold %.4f",
+            threshold,
         )
         raise
     return _PortfolioHealthSnapshot(
@@ -127,19 +129,13 @@ def _format_portfolio_health_response(
 async def post_portfolio_health(req: PortfolioHealthRequest | None = None) -> dict[str, Any]:
     """Run portfolio health check and return structured findings."""
 
-    threshold = (
-        req.threshold
-        if req and req.threshold is not None
-        else float(os.getenv("DRAWDOWN_THRESHOLD", "0.2"))
-    )
+    threshold = req.threshold if req and req.threshold is not None else float(os.getenv("DRAWDOWN_THRESHOLD", "0.2"))
 
     global _portfolio_health_cache
     cache = _portfolio_health_cache
     stale = False
     error: Exception | None = None
-    snapshot: _PortfolioHealthSnapshot | None = (
-        cache if cache and cache.threshold == threshold else None
-    )
+    snapshot: _PortfolioHealthSnapshot | None = cache if cache and cache.threshold == threshold else None
 
     if cache and _cache_is_fresh(cache, threshold):
         snapshot = cache

--- a/backend/routes/tax.py
+++ b/backend/routes/tax.py
@@ -6,12 +6,12 @@ from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel
 
 from backend.auth import get_active_user
-from backend.common.tax import harvest_losses
+from backend.common import data_loader
 from backend.common.allowances import (
     current_tax_year,
     remaining_allowances,
 )
-from backend.common import data_loader
+from backend.common.tax import harvest_losses
 from backend.config import demo_identity
 
 router = APIRouter(prefix="/tax", tags=["tax"])

--- a/backend/routes/timeseries_admin.py
+++ b/backend/routes/timeseries_admin.py
@@ -17,9 +17,7 @@ from backend.timeseries.cache import (
     meta_timeseries_cache_path,
 )
 
-router = APIRouter(
-    prefix="/timeseries", tags=["timeseries"], dependencies=[Depends(get_current_user)]
-)
+router = APIRouter(prefix="/timeseries", tags=["timeseries"], dependencies=[Depends(get_current_user)])
 logger = logging.getLogger(__name__)
 
 
@@ -32,9 +30,7 @@ def _summarize(df: pd.DataFrame, ticker: str, exchange: str) -> dict[str, Any]:
     completeness = len(df) / bdays * 100
     latest_source = df.iloc[-1]["Source"] if "Source" in df.columns else None
     main_source = (
-        df["Source"].value_counts().idxmax()
-        if "Source" in df.columns and not df["Source"].dropna().empty
-        else None
+        df["Source"].value_counts().idxmax() if "Source" in df.columns and not df["Source"].dropna().empty else None
     )
     meta = get_instrument_meta(f"{ticker}.{exchange}")
     return {

--- a/backend/routes/timeseries_meta.py
+++ b/backend/routes/timeseries_meta.py
@@ -91,18 +91,12 @@ async def get_meta_timeseries(
     days: int = Query(365, ge=0, le=36500),
     format: str = Query("html", pattern="^(html|json|csv)$"),
     scaling: float = Query(1.0, ge=0.00001, le=1_000_000),
-    start_date: date | None = Query(
-        None, description="Start date (YYYY-MM-DD). Overrides days when provided."
-    ),
-    end_date: date | None = Query(
-        None, description="End date (YYYY-MM-DD). Defaults to yesterday when omitted."
-    ),
+    start_date: date | None = Query(None, description="Start date (YYYY-MM-DD). Overrides days when provided."),
+    end_date: date | None = Query(None, description="End date (YYYY-MM-DD). Defaults to yesterday when omitted."),
 ):
     ticker, exchange = _resolve_ticker_exchange(ticker, exchange)
 
-    start_date, end_date = resolve_date_range(
-        days, start_date=start_date, end_date=end_date
-    )
+    start_date, end_date = resolve_date_range(days, start_date=start_date, end_date=end_date)
 
     # 422 matches FastAPI's convention for parameter validation errors (issue #2747 AC).
     if start_date > end_date:
@@ -112,17 +106,15 @@ async def get_meta_timeseries(
         )
 
     try:
-        df = load_meta_timeseries_range(
-            ticker, exchange, start_date=start_date, end_date=end_date
-        )
+        df = load_meta_timeseries_range(ticker, exchange, start_date=start_date, end_date=end_date)
     except Exception as exc:
         logger.debug(
             "Failed to load meta timeseries for %s.%s: %s",
-            sanitise_log_value(ticker), sanitise_log_value(exchange), sanitise_log_value(exc),
+            sanitise_log_value(ticker),
+            sanitise_log_value(exchange),
+            sanitise_log_value(exc),
         )
-        raise HTTPException(
-            status_code=404, detail="timeseries meta not found"
-        ) from exc
+        raise HTTPException(status_code=404, detail="timeseries meta not found") from exc
 
     if df is None or df.empty:
         raise HTTPException(status_code=404, detail="timeseries meta not found")
@@ -139,9 +131,7 @@ async def get_meta_timeseries(
 
     # ── JSON output ───────────────────────────────────────────
     if format == "json":
-        datetime_columns = [
-            col for col in df.columns if pd_types.is_datetime64_any_dtype(df[col])
-        ]
+        datetime_columns = [col for col in df.columns if pd_types.is_datetime64_any_dtype(df[col])]
         for col in datetime_columns:
             df[col] = df[col].map(lambda x: x.isoformat() if pd.notnull(x) else None)
         return JSONResponse(

--- a/backend/timeseries/fetch_ft_timeseries.py
+++ b/backend/timeseries/fetch_ft_timeseries.py
@@ -63,9 +63,7 @@ def fetch_ft_timeseries_range(
     user_agent: Optional[str] = None,
 ) -> pd.DataFrame:
     template = (
-        url_template
-        or config.ft_url_template
-        or "https://markets.ft.com/data/funds/tearsheet/historical?s={ticker}"
+        url_template or config.ft_url_template or "https://markets.ft.com/data/funds/tearsheet/historical?s={ticker}"
     )
     url = template.format(ticker=ticker)
     logger.info("Navigating to %s", sanitise_log_value(url))

--- a/backend/timeseries/fetch_meta_timeseries.py
+++ b/backend/timeseries/fetch_meta_timeseries.py
@@ -8,6 +8,7 @@ and merges the first successful result. Helpers return snapshots
     supplement from Stooq, Alpha Vantage, then FT.
   - Added ticker sanity-check and quieter logging for expected fall-backs.
 """
+
 from __future__ import annotations
 
 import logging
@@ -86,9 +87,7 @@ def _sanitize_metadata_symbol(value: str) -> str:
             # Warn rather than debug: no valid ticker or exchange MIC exceeds
             # _METADATA_SYMBOL_MAX_LEN chars, so an oversized value is likely
             # unexpected data in production rather than normal operation.
-            logger.warning(
-                "Rejected oversized metadata identifier (len=%d)", len(cleaned)
-            )
+            logger.warning("Rejected oversized metadata identifier (len=%d)", len(cleaned))
         return ""
     if not _METADATA_SAFE_RE.match(cleaned):
         logger.debug("Rejected unsafe metadata identifier: %r", sanitise_log_value(cleaned))
@@ -169,9 +168,7 @@ def _resolve_exchange_from_metadata(symbol: str) -> str:
 
 
 @lru_cache(maxsize=2048)
-def _resolve_exchange_from_metadata_cached(
-    symbol: str, directories: tuple[str, ...]
-) -> tuple[str, str]:
+def _resolve_exchange_from_metadata_cached(symbol: str, directories: tuple[str, ...]) -> tuple[str, str]:
     """Cached helper that scopes lookups to the active instrument directories.
 
     Callers are responsible for sanitizing ``symbol`` before calling this
@@ -200,9 +197,10 @@ def _resolve_exchange_from_metadata_cached(
             continue
     return "", ""
 
+
 def _metadata_entry_exists_in_directory(symbol: str, directory: Path) -> bool:
     """Return ``True`` if *symbol* metadata exists in the provided directory.
-    
+
     Unlike ``_resolve_exchange_from_metadata_cached`` (which is ``@lru_cache``
     decorated and therefore requires the caller to pre-sanitize so that the
     cache key is the clean value), this function is not cached and may be
@@ -230,9 +228,7 @@ def _metadata_entry_exists_in_directory(symbol: str, directory: Path) -> bool:
         return False
 
 
-def _metadata_entry_exists(
-    symbol: str, exchange: str, directories: tuple[str, ...]
-) -> bool:
+def _metadata_entry_exists(symbol: str, exchange: str, directories: tuple[str, ...]) -> bool:
     """Return ``True`` when metadata for *symbol* exists under *exchange*."""
 
     symbol = _sanitize_metadata_symbol(symbol)
@@ -264,9 +260,7 @@ def _metadata_entry_exists(
     return False
 
 
-def _resolve_symbol_exchange_details(
-    ticker: str, exchange: str | None
-) -> Tuple[str, str, str]:
+def _resolve_symbol_exchange_details(ticker: str, exchange: str | None) -> Tuple[str, str, str]:
     """Return symbol, resolved exchange and metadata exchange."""
 
     sym, suffix = (re.split(r"[._]", ticker, 1) + [""])[:2]
@@ -275,7 +269,9 @@ def _resolve_symbol_exchange_details(
     if suffix and provided and suffix != provided:
         logger.debug(
             "Exchange mismatch for %s: suffix %s vs argument %s",
-            sanitise_log_value(ticker), sanitise_log_value(suffix), sanitise_log_value(provided),
+            sanitise_log_value(ticker),
+            sanitise_log_value(suffix),
+            sanitise_log_value(provided),
         )
     resolved = suffix or provided
 
@@ -304,9 +300,7 @@ def _resolve_ticker_exchange(ticker: str, exchange: str | None) -> Tuple[str, st
     return sym, ex
 
 
-def _resolve_loader_exchange(
-    ticker: str, exchange_arg: str | None, symbol: str, resolved_exchange: str
-) -> str:
+def _resolve_loader_exchange(ticker: str, exchange_arg: str | None, symbol: str, resolved_exchange: str) -> str:
     """Return the exchange to use when fetching cached data."""
 
     parts = re.split(r"[._]", ticker, 1)
@@ -335,9 +329,7 @@ def _resolve_cache_exchange(
 ) -> str:
     """Return the exchange code to use when reading from the cache."""
 
-    loader_exchange = _resolve_loader_exchange(
-        ticker, exchange_arg, symbol, resolved_exchange
-    )
+    loader_exchange = _resolve_loader_exchange(ticker, exchange_arg, symbol, resolved_exchange)
     explicit_exchange = _explicit_exchange_from_ticker(ticker)
     provided_exchange = (exchange_arg or "").strip().upper()
 
@@ -350,11 +342,7 @@ def _resolve_cache_exchange(
                 sanitise_log_value(metadata_exchange or "<empty>"),
             )
 
-        if (
-            provided_exchange
-            and not explicit_exchange
-            and provided_exchange != metadata_exchange
-        ):
+        if provided_exchange and not explicit_exchange and provided_exchange != metadata_exchange:
             logger.debug(
                 "Cache exchange override for %s: metadata %s vs argument %s",
                 sanitise_log_value(symbol),
@@ -389,12 +377,12 @@ def _merge(sources: List[pd.DataFrame]) -> pd.DataFrame:
     return df.sort_values("Date").reset_index(drop=True)
 
 
-def _coverage_ratio(df: pd.DataFrame,
-                    expected: set[date]) -> float:
+def _coverage_ratio(df: pd.DataFrame, expected: set[date]) -> float:
     if df.empty or not expected:
         return 0.0
     present = set(pd.to_datetime(df["Date"]).dt.date)
     return len(present & expected) / len(expected)
+
 
 # ──────────────────────────────────────────────────────────────
 # Core fetch
@@ -405,7 +393,7 @@ def fetch_meta_timeseries(
     start_date: Optional[date] = None,
     end_date: Optional[date] = None,
     *,
-    min_coverage: float = 0.95,          # 95 % of trading days
+    min_coverage: float = 0.95,  # 95 % of trading days
 ) -> pd.DataFrame:
     """
     Fetch price history from Yahoo, Stooq, FT - only as much as needed.
@@ -425,7 +413,9 @@ def fetch_meta_timeseries(
     ticker, exchange = _resolve_ticker_exchange(ticker, exchange)
     logger.debug(
         "Resolved %s to %s.%s",
-        sanitise_log_value(raw_ticker), sanitise_log_value(ticker), sanitise_log_value(exchange),
+        sanitise_log_value(raw_ticker),
+        sanitise_log_value(ticker),
+        sanitise_log_value(exchange),
     )
 
     if end_date is None:
@@ -434,7 +424,7 @@ def fetch_meta_timeseries(
         start_date = end_date - timedelta(days=365)
 
     start_date = _nearest_weekday(start_date, forward=False)
-    end_date   = _nearest_weekday(end_date,   forward=True)
+    end_date = _nearest_weekday(end_date, forward=True)
 
     if ticker.upper() == "CASH" or exchange.upper() == "CASH":
         dates = pd.bdate_range(start_date, end_date)
@@ -471,8 +461,7 @@ def fetch_meta_timeseries(
 
     # ── 1 · Yahoo ─────────────────────────────────────────────
     try:
-        yahoo = fetch_yahoo_timeseries_range(ticker, exchange,
-                                             start_date, end_date)
+        yahoo = fetch_yahoo_timeseries_range(ticker, exchange, start_date, end_date)
         if not yahoo.empty:
             data.append(yahoo)
             if _coverage_ratio(yahoo, expected_dates) >= min_coverage:
@@ -480,13 +469,14 @@ def fetch_meta_timeseries(
     except Exception as exc:
         logger.debug(
             "Yahoo miss for %s.%s: %s",
-            sanitise_log_value(ticker), sanitise_log_value(exchange), sanitise_log_value(exc),
+            sanitise_log_value(ticker),
+            sanitise_log_value(exchange),
+            sanitise_log_value(exc),
         )
 
     # ── 2 · Stooq (fill gaps only if needed) ──────────────────
     try:
-        stooq = fetch_stooq_timeseries_range(ticker, exchange,
-                                             start_date, end_date)
+        stooq = fetch_stooq_timeseries_range(ticker, exchange, start_date, end_date)
         if not stooq.empty:
             combined = _merge([*data, stooq])
             if _coverage_ratio(combined, expected_dates) >= min_coverage:
@@ -495,20 +485,22 @@ def fetch_meta_timeseries(
     except StooqRateLimitError as exc:
         logger.debug(
             "Stooq rate limit for %s.%s: %s",
-            sanitise_log_value(ticker), sanitise_log_value(exchange), sanitise_log_value(exc),
+            sanitise_log_value(ticker),
+            sanitise_log_value(exchange),
+            sanitise_log_value(exc),
         )
     except Exception as exc:
         logger.debug(
             "Stooq miss for %s.%s: %s",
-            sanitise_log_value(ticker), sanitise_log_value(exchange), sanitise_log_value(exc),
+            sanitise_log_value(ticker),
+            sanitise_log_value(exchange),
+            sanitise_log_value(exc),
         )
 
     # ── 3 · Alpha Vantage (fill gaps if still needed) ─────────
     if config.alpha_vantage_enabled:
         try:
-            av = fetch_alphavantage_timeseries_range(
-                ticker, exchange, start_date, end_date
-            )
+            av = fetch_alphavantage_timeseries_range(ticker, exchange, start_date, end_date)
             if not av.empty:
                 combined = _merge([*data, av])
                 if _coverage_ratio(combined, expected_dates) >= min_coverage:
@@ -517,19 +509,24 @@ def fetch_meta_timeseries(
         except AlphaVantageRateLimitError as exc:
             logger.debug(
                 "Alpha Vantage rate limit for %s.%s: %s",
-                sanitise_log_value(ticker), sanitise_log_value(exchange), sanitise_log_value(exc),
+                sanitise_log_value(ticker),
+                sanitise_log_value(exchange),
+                sanitise_log_value(exc),
             )
             if exc.retry_after:
                 time.sleep(exc.retry_after)
         except Exception as exc:
             logger.debug(
                 "Alpha Vantage miss for %s.%s: %s",
-                sanitise_log_value(ticker), sanitise_log_value(exchange), sanitise_log_value(exc),
+                sanitise_log_value(ticker),
+                sanitise_log_value(exchange),
+                sanitise_log_value(exc),
             )
     else:
         logger.debug(
             "Alpha Vantage disabled; skipping for %s.%s",
-            sanitise_log_value(ticker), sanitise_log_value(exchange),
+            sanitise_log_value(ticker),
+            sanitise_log_value(exchange),
         )
 
     # ── 4 · FT fallback – last resort ─────────────────────────
@@ -539,8 +536,7 @@ def fetch_meta_timeseries(
         data.append(ft_df)
 
     if not data:
-        logger.info("No data sources succeeded for %s.%s",
-                    sanitise_log_value(ticker), sanitise_log_value(exchange))
+        logger.info("No data sources succeeded for %s.%s", sanitise_log_value(ticker), sanitise_log_value(exchange))
         return pd.DataFrame(columns=STANDARD_COLUMNS)
 
     df = _merge(data)
@@ -562,11 +558,10 @@ def fetch_ft_df(ticker, end_date, start_date):
         logger.debug("FT miss for %s: %s", sanitise_log_value(ticker), sanitise_log_value(exc))
         return pd.DataFrame(columns=STANDARD_COLUMNS)
 
+
 # ──────────────────────────────────────────────────────────────
 # Cache-aware batch helpers (local import) ─────────────────────
-def run_all_tickers(
-    tickers: List[str], exchange: str = "", days: int = 365
-) -> List[str]:
+def run_all_tickers(tickers: List[str], exchange: str = "", days: int = 365) -> List[str]:
     """Warm-up helper - returns tickers that produced data.
 
     ``tickers`` may contain base symbols ("VOD") or full tickers ("VOD.L").
@@ -594,7 +589,9 @@ def run_all_tickers(
         sym, ex, meta_exchange = _resolve_symbol_exchange_details(t, exchange)
         logger.debug(
             "run_all_tickers resolved %s -> %s.%s",
-            sanitise_log_value(t), sanitise_log_value(sym), sanitise_log_value(ex),
+            sanitise_log_value(t),
+            sanitise_log_value(sym),
+            sanitise_log_value(ex),
         )
         cache_exchange = _resolve_cache_exchange(t, exchange, sym, ex, meta_exchange)
         try:
@@ -602,23 +599,22 @@ def run_all_tickers(
                 ok.append(t)
         except Exception as exc:
             logger.warning("[WARN] %s: %s", sanitise_log_value(t), sanitise_log_value(exc))
-    logger.info(
-        "Bulk warm-up complete: %d updated, %d skipped", len(ok), len(tickers) - len(ok)
-    )
+    logger.info("Bulk warm-up complete: %d updated, %d skipped", len(ok), len(tickers) - len(ok))
     return ok
 
 
-def load_timeseries_data(
-    tickers: List[str], exchange: str = "", days: int = 365
-) -> Dict[str, pd.DataFrame]:
+def load_timeseries_data(tickers: List[str], exchange: str = "", days: int = 365) -> Dict[str, pd.DataFrame]:
     """Return {ticker: dataframe} using the parquet cache."""
     from backend.timeseries.cache import load_meta_timeseries
+
     out: dict[str, pd.DataFrame] = {}
     for t in tickers:
         sym, ex, meta_exchange = _resolve_symbol_exchange_details(t, exchange)
         logger.debug(
             "load_timeseries_data resolved %s -> %s.%s",
-            sanitise_log_value(t), sanitise_log_value(sym), sanitise_log_value(ex),
+            sanitise_log_value(t),
+            sanitise_log_value(sym),
+            sanitise_log_value(ex),
         )
         cache_exchange = _resolve_cache_exchange(t, exchange, sym, ex, meta_exchange)
         try:
@@ -627,9 +623,7 @@ def load_timeseries_data(
                 out[t] = df
         except Exception as exc:
             logger.warning("Load fail %s: %s", sanitise_log_value(t), sanitise_log_value(exc))
-    logger.info(
-        "Bulk load complete: %d updated, %d skipped", len(out), len(tickers) - len(out)
-    )
+    logger.info("Bulk load complete: %d updated, %d skipped", len(out), len(tickers) - len(out))
     return out
 
 

--- a/backend/timeseries/fetch_stooq_timeseries.py
+++ b/backend/timeseries/fetch_stooq_timeseries.py
@@ -25,12 +25,20 @@ STOOQ_DISABLED_UNTIL: date = date.min
 
 def get_stooq_suffix(exchange: str) -> str:
     exchange_map = {
-        "L": ".UK", "LSE": ".UK", "UK": ".UK", "LON": ".UK", "XLON": ".UK",
-        "NASDAQ": ".US", "NYSE": ".US", "US": ".US", "AMEX": ".US",
-        "XETRA": ".DE", "DE": ".DE",
+        "L": ".UK",
+        "LSE": ".UK",
+        "UK": ".UK",
+        "LON": ".UK",
+        "XLON": ".UK",
+        "NASDAQ": ".US",
+        "NYSE": ".US",
+        "US": ".US",
+        "AMEX": ".US",
+        "XETRA": ".DE",
+        "DE": ".DE",
         "F": ".F",
-        "TO" : ".TO", "TSX": ".TO"
-
+        "TO": ".TO",
+        "TSX": ".TO",
     }
     suffix = exchange_map.get(exchange.upper())
     if suffix is None:
@@ -42,12 +50,7 @@ def format_date(d: date) -> str:
     return d.strftime("%Y%m%d")
 
 
-def fetch_stooq_timeseries_range(
-    ticker: str,
-    exchange: str,
-    start_date: date,
-    end_date: date
-) -> pd.DataFrame:
+def fetch_stooq_timeseries_range(ticker: str, exchange: str, start_date: date, end_date: date) -> pd.DataFrame:
     """
     Fetch historical Stooq data using date range.
     """
@@ -67,17 +70,14 @@ def fetch_stooq_timeseries_range(
 
     logger.debug(
         "Preparing request for ticker=%s, exchange=%s, full_ticker=%s, start_date=%s, end_date=%s",
-        sanitise_log_value(ticker), sanitise_log_value(exchange),
-        sanitise_log_value(full_ticker), start_date, end_date,
+        sanitise_log_value(ticker),
+        sanitise_log_value(exchange),
+        sanitise_log_value(full_ticker),
+        start_date,
+        end_date,
     )
 
-    params = {
-        "s": full_ticker,
-        "d1": format_date(start_date),
-        "d2": format_date(end_date),
-        "i": "d",
-        "d": "d"
-    }
+    params = {"s": full_ticker, "d1": format_date(start_date), "d2": format_date(end_date), "i": "d", "d": "d"}
 
     logger.debug("Fetching Stooq data with URL: %s and params: %s", BASE_URL, sanitise_log_value(params))
     try:
@@ -98,13 +98,13 @@ def fetch_stooq_timeseries_range(
         if df.empty:
             raise RuntimeError("No data returned from Stooq")
 
-        if 'Date' not in df.columns or 'Close' not in df.columns:
+        if "Date" not in df.columns or "Close" not in df.columns:
             raise ValueError(f"Unexpected format for {full_ticker}: columns = {df.columns.tolist()}")
 
         df["Date"] = pd.to_datetime(df["Date"]).dt.date
-        df.sort_values('Date', inplace=True)
-        df['Volume'] = df.get('Volume', None)
-        df['Ticker'] = ticker
+        df.sort_values("Date", inplace=True)
+        df["Volume"] = df.get("Volume", None)
+        df["Ticker"] = ticker
 
         logger.info("Fetched %d rows for %s", len(df), sanitise_log_value(full_ticker))
 
@@ -128,11 +128,16 @@ def fetch_stooq_timeseries(ticker: str, exchange: str, days: int = 365) -> pd.Da
     start = today - timedelta(days=days)
     logger.debug(
         "Fetching trailing %d days of data for %s on %s",
-        days, sanitise_log_value(ticker), sanitise_log_value(exchange),
+        days,
+        sanitise_log_value(ticker),
+        sanitise_log_value(exchange),
     )
     logger.debug(
         "Preparing request for ticker=%s, exchange=%s, start_date=%s, end_date=%s",
-        sanitise_log_value(ticker), sanitise_log_value(exchange), start, today,
+        sanitise_log_value(ticker),
+        sanitise_log_value(exchange),
+        start,
+        today,
     )
     return fetch_stooq_timeseries_range(ticker, exchange, start, today)
 

--- a/backend/timeseries/fetch_yahoo_timeseries.py
+++ b/backend/timeseries/fetch_yahoo_timeseries.py
@@ -95,7 +95,8 @@ def fetch_yahoo_timeseries_range(ticker: str, exchange: str, start_date: date, e
     if not is_valid_ticker(ticker, exchange):
         logger.info(
             "Skipping Yahoo fetch for unrecognized ticker %s.%s",
-            sanitise_log_value(ticker), sanitise_log_value(exchange),
+            sanitise_log_value(ticker),
+            sanitise_log_value(exchange),
         )
         record_skipped_ticker(ticker, exchange, reason="unknown")
         return pd.DataFrame(columns=STANDARD_COLUMNS)
@@ -141,7 +142,9 @@ def fetch_yahoo_timeseries_period(
     safe_interval = sanitise_log_value(interval)
     logger.debug(
         "Fetching Yahoo data for %s with period=%r, interval=%r",
-        sanitise_log_value(full_ticker), safe_period, safe_interval,
+        sanitise_log_value(full_ticker),
+        safe_period,
+        safe_interval,
     )
 
     try:

--- a/backend/timeseries/ticker_validator.py
+++ b/backend/timeseries/ticker_validator.py
@@ -28,11 +28,7 @@ def is_valid_ticker(ticker: str, exchange: str) -> bool:
     meta = get_instrument_meta(full)
     if not meta:
         return False
-    informative_keys = {
-        key
-        for key, value in meta.items()
-        if value not in (None, "")
-    }
+    informative_keys = {key for key, value in meta.items() if value not in (None, "")}
     if informative_keys <= {"ticker", "exchange", "name"}:
         return False
     return True
@@ -49,5 +45,7 @@ def record_skipped_ticker(ticker: str, exchange: str, *, reason: str = "") -> No
     except Exception as exc:
         logger.warning(
             "Failed to record skipped ticker %s.%s: %s",
-            sanitise_log_value(ticker), sanitise_log_value(exchange), sanitise_log_value(exc),
+            sanitise_log_value(ticker),
+            sanitise_log_value(exchange),
+            sanitise_log_value(exc),
         )

--- a/backend/timeseries/timeseries_api.py
+++ b/backend/timeseries/timeseries_api.py
@@ -35,7 +35,9 @@ def _fetch_yahoo(ticker: str, period: str, interval: str) -> pd.DataFrame:
     """Fetch OHLCV data from Yahoo Finance and return a DataFrame."""
     logging.info(
         "Yahoo download | ticker=%s period=%s interval=%s",
-        sanitise_log_value(ticker), sanitise_log_value(period), sanitise_log_value(interval),
+        sanitise_log_value(ticker),
+        sanitise_log_value(period),
+        sanitise_log_value(interval),
     )
     df = yf.Ticker(ticker).history(period=period, interval=interval)
     if df.empty:
@@ -69,9 +71,7 @@ def get_timeseries(
     ticker: str,
     period: str = Query("1y", description="1d, 5d, 1mo, 3mo, 1y, ytd, max ..."),
     interval: str = Query("1d", description="1m, 5m, 15m, 1h, 1d, 1wk, 1mo ..."),
-    fmt: str = Query(
-        "csv", pattern="^(csv|json|html)$", description="csv, json or html table"
-    ),
+    fmt: str = Query("csv", pattern="^(csv|json|html)$", description="csv, json or html table"),
 ):
     """
     Return a CSV (streamed), JSON, or HTML time-series for *ticker*.

--- a/backend/utils/convert_portfolio_xml_to_input_files.py
+++ b/backend/utils/convert_portfolio_xml_to_input_files.py
@@ -3,10 +3,11 @@ import os
 from datetime import date, datetime
 from pathlib import Path
 
+from positions import extract_holdings_from_transactions
+
 from backend.common.approvals import is_approval_valid, load_approvals
 from backend.common.instruments import get_instrument_meta
 from backend.config import config
-from positions import extract_holdings_from_transactions
 
 
 def normalize_account(account: str) -> tuple[str, str]:
@@ -50,9 +51,7 @@ def generate_json_holdings(xml_path: str, output_base_dir: str | Path = config.a
             meta_tkr = str(row.get("ticker", "")).strip().upper()
             meta = get_instrument_meta(meta_tkr)
             instr_type = (meta.get("instrumentType") or meta.get("instrument_type") or "").upper()
-            asset_class = (
-                meta.get("assetClass") or meta.get("asset_class") or ""
-            ).upper()
+            asset_class = (meta.get("assetClass") or meta.get("asset_class") or "").upper()
             sector = (meta.get("sector") or "").upper()
             is_commodity = asset_class == "COMMODITY" or sector == "COMMODITY"
             is_etf = instr_type == "ETF"

--- a/backend/utils/fx_rates.py
+++ b/backend/utils/fx_rates.py
@@ -53,9 +53,7 @@ def fetch_fx_rate_range(base: str, quote: str, start_date: date, end_date: date)
 
     try:
         ticker = yf.Ticker(pair)
-        df = ticker.history(
-            start=start_date, end=end_date + timedelta(days=1), interval="1d"
-        )
+        df = ticker.history(start=start_date, end=end_date + timedelta(days=1), interval="1d")
         if not df.empty:
             df.reset_index(inplace=True)
             df["Date"] = pd.to_datetime(df["Date"]).dt.date

--- a/backend/utils/growth_stage.py
+++ b/backend/utils/growth_stage.py
@@ -1,8 +1,11 @@
 """Determine growth stage for holdings."""
+
 from __future__ import annotations
-from typing import Optional, Dict
+
+from typing import Dict, Optional
 
 StageInfo = Dict[str, str]
+
 
 def get_growth_stage(
     days_held: Optional[int] = None,
@@ -10,11 +13,7 @@ def get_growth_stage(
     target_price: Optional[float] = None,
 ) -> StageInfo:
     """Return a dictionary describing the growth stage of a holding."""
-    if (
-        target_price is not None
-        and current_price is not None
-        and current_price >= target_price
-    ):
+    if target_price is not None and current_price is not None and current_price >= target_price:
         return {
             "stage": "harvest",
             "icon": "🍾",

--- a/backend/utils/html_render.py
+++ b/backend/utils/html_render.py
@@ -17,8 +17,7 @@ def render_timeseries_html(df: DataFrame, title: str, subtitle: str = "") -> HTM
     escaped_title = html.escape(title)
     escaped_subtitle = html.escape(subtitle)
 
-    return HTMLResponse(
-        content=f"""
+    return HTMLResponse(content=f"""
     <html>
     <head>
         <title>{escaped_title}</title>
@@ -35,5 +34,4 @@ def render_timeseries_html(df: DataFrame, title: str, subtitle: str = "") -> HTM
         {html_table}
     </body>
     </html>
-    """
-    )
+    """)

--- a/backend/utils/page_cache.py
+++ b/backend/utils/page_cache.py
@@ -123,9 +123,7 @@ def schedule_refresh(
                 try:
                     data = await _call_builder()
                 except Exception as exc:
-                    if isinstance(
-                        exc, asyncio.CancelledError
-                    ):  # pragma: no cover - defensive
+                    if isinstance(exc, asyncio.CancelledError):  # pragma: no cover - defensive
                         raise
                     logger.exception("Cache refresh failed for %s", sanitise_log_value(page_name))
                     # Immediately retry on failure so the cache can still be

--- a/backend/utils/pricing_dates.py
+++ b/backend/utils/pricing_dates.py
@@ -27,9 +27,7 @@ class PricingDateCalculator:
     ) -> None:
         self._weekday_func = weekday_func or _nearest_weekday
         self._explicit_reporting_date = (
-            self.resolve_weekday(reporting_date, forward=False)
-            if reporting_date is not None
-            else None
+            self.resolve_weekday(reporting_date, forward=False) if reporting_date is not None else None
         )
         if today is None and self._explicit_reporting_date is not None:
             today = self._explicit_reporting_date + dt.timedelta(days=1)

--- a/backend/utils/scenario_tester.py
+++ b/backend/utils/scenario_tester.py
@@ -66,6 +66,7 @@ def apply_price_shock(portfolio: Dict[str, Any], ticker: str, pct_change: float)
     )
     return shocked
 
+
 def _scale_portfolio(portfolio: Dict[str, Any], horizons: Iterable[int] | None = None) -> Dict[int, Dict[str, Any]]:
     """Scale ``portfolio`` by a simple factor for each horizon."""
 
@@ -193,10 +194,7 @@ def apply_historical_event_portfolio(
 
     baseline = float(portfolio.get("total_value_estimate_gbp") or 0.0)
     if baseline == 0.0:
-        baseline = sum(
-            float(a.get("value_estimate_gbp") or 0.0)
-            for a in portfolio.get("accounts", [])
-        )
+        baseline = sum(float(a.get("value_estimate_gbp") or 0.0) for a in portfolio.get("accounts", []))
 
     proxy_val = getattr(event, "proxy", None)
     if proxy_val is None and isinstance(event, dict):

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -155,7 +155,7 @@ at the end. If the current checkout is dirty or already contains unrelated
 work, create a clean worktree from `main` and do the task there.
 
 Always:
-1. Create a branch (`fix/issue-NNNN-short-description`, `feat/issue-NNNN-short-description`, `docs/short-description`, or `chore/short-description`)
+1. Create a branch (`fix/issue-NNNN-short-description`, `feat/issue-NNNN-short-description`, or `docs/short-description`)
 2. Push changes to the branch
 3. Open a PR targeting `main`
 4. Wait for review/merge

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ pytest-cov~=7.1.0
 pytest~=9.0.3
 reportlab~=5.0.0
 black>=26.5.1
+isort~=8.0.1
 ruff~=0.16.0
 pytest-asyncio~=1.4.0
 jsonschema~=4.23.0

--- a/tests/backend/common/test_account_models.py
+++ b/tests/backend/common/test_account_models.py
@@ -37,9 +37,7 @@ class TestOwnerSummaryRecord:
             OwnerSummaryRecord.model_validate({"owner": "alice", "accounts": "isa"})
 
     def test_duplicate_accounts_are_deduped_case_insensitively(self) -> None:
-        record = OwnerSummaryRecord.model_validate(
-            {"owner": "alice", "accounts": ["isa", "ISA", "Isa", "sipp"]}
-        )
+        record = OwnerSummaryRecord.model_validate({"owner": "alice", "accounts": ["isa", "ISA", "Isa", "sipp"]})
 
         assert record.accounts == ["isa", "sipp"]
 

--- a/tests/backend/common/test_accounts_store.py
+++ b/tests/backend/common/test_accounts_store.py
@@ -265,9 +265,7 @@ def test_s3_store_rebuild_portfolio(s3_store) -> None:
     assert tickers == {"ABC", "CASH.GBP"}
 
 
-def test_s3_store_rebuild_portfolio_missing_transactions(
-    s3_store, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_s3_store_rebuild_portfolio_missing_transactions(s3_store, caplog: pytest.LogCaptureFixture) -> None:
     """S3 rebuild warns and returns early when no transaction document exists."""
     store, _ = s3_store
     caplog.set_level(logging.WARNING, logger="accounts_store")
@@ -287,6 +285,8 @@ def test_local_store_rebuild_portfolio_none_root(
     store.rebuild_portfolio("alex", "isa")
 
     assert "no local root" in caplog.text
+
+
 # S3AccountsStore — full write-then-read integration (issue #4316)
 # ---------------------------------------------------------------------------
 
@@ -324,9 +324,7 @@ class TestS3Integration:
 
         # 2. Write a manual holding document (mirrors ``_locked_account_holdings_data``).
         holding = {"ticker": "AAPL", "units": 10, "price": 150.0}
-        with store.edit_document(
-            owner, f"{account_slug}.json", default={}, trailing_newline=True
-        ) as data:
+        with store.edit_document(owner, f"{account_slug}.json", default={}, trailing_newline=True) as data:
             data["owner"] = owner
             data["account_type"] = account_slug
             data["currency"] = "GBP"
@@ -385,9 +383,7 @@ class TestS3Integration:
         store.ensure_owner(owner)
 
         # Initial write.
-        with store.edit_document(
-            owner, f"{account_slug}.json", default={}, trailing_newline=True
-        ) as data:
+        with store.edit_document(owner, f"{account_slug}.json", default={}, trailing_newline=True) as data:
             data["holdings"] = [{"ticker": "MSFT", "units": 20, "price": 300.0}]
 
         doc = store.read_document(owner, f"{account_slug}.json")
@@ -396,9 +392,7 @@ class TestS3Integration:
         assert doc["holdings"][0]["ticker"] == "MSFT"
 
         # Update: replace MSFT holding.
-        with store.edit_document(
-            owner, f"{account_slug}.json", default={}, trailing_newline=True
-        ) as data:
+        with store.edit_document(owner, f"{account_slug}.json", default={}, trailing_newline=True) as data:
             holdings = data.setdefault("holdings", [])
             ticker = "MSFT"
             new_holding = {"ticker": ticker, "units": 25, "price": 310.0}

--- a/tests/backend/common/test_analytics_store.py
+++ b/tests/backend/common/test_analytics_store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -59,7 +59,7 @@ def test_load_events_skips_invalid_rows_and_normalises(monkeypatch: pytest.Monke
 
     lines = [
         "",  # blank line should be ignored
-        "{\"source\": \"broken\"",  # invalid JSON skipped
+        '{"source": "broken"',  # invalid JSON skipped
         json.dumps(
             {
                 "source": "valid",

--- a/tests/backend/common/test_approvals.py
+++ b/tests/backend/common/test_approvals.py
@@ -34,9 +34,7 @@ def test_load_approvals_handles_variants_and_invalid_rows(tmp_path):
 
     dict_owner = "dict-owner"
     dict_dir = _owner_dir(tmp_path, dict_owner)
-    (dict_dir / "approvals.json").write_text(
-        json.dumps({"approvals": [{"ticker": "msft", "date": "2024-04-02"}]})
-    )
+    (dict_dir / "approvals.json").write_text(json.dumps({"approvals": [{"ticker": "msft", "date": "2024-04-02"}]}))
 
     malformed_owner = "broken-owner"
     malformed_dir = _owner_dir(tmp_path, malformed_owner)
@@ -53,13 +51,9 @@ def test_load_approvals_handles_variants_and_invalid_rows(tmp_path):
         "MSFT": date(2024, 4, 2)
     }, "dict payloads should be supported and tickers uppercased"
 
-    assert (
-        load_approvals(malformed_owner, tmp_path) == {}
-    ), "malformed JSON should yield an empty approvals map"
+    assert load_approvals(malformed_owner, tmp_path) == {}, "malformed JSON should yield an empty approvals map"
 
-    assert (
-        load_approvals(empty_owner, tmp_path) == {}
-    ), "missing approvals file should return empty map"
+    assert load_approvals(empty_owner, tmp_path) == {}, "missing approvals file should return empty map"
 
 
 def test_trading_days_and_validity_calculations(monkeypatch):

--- a/tests/backend/common/test_compliance.py
+++ b/tests/backend/common/test_compliance.py
@@ -1,5 +1,6 @@
 import json
-from datetime import date as real_date, datetime as real_datetime
+from datetime import date as real_date
+from datetime import datetime as real_datetime
 
 import pytest
 
@@ -64,9 +65,7 @@ def test_load_transactions_missing_owner_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         compliance.load_transactions(owner, accounts_root=accounts_root)
 
-    records = compliance.load_transactions(
-        owner, accounts_root=accounts_root, scaffold_missing=True
-    )
+    compliance.load_transactions(owner, accounts_root=accounts_root, scaffold_missing=True)
 
     assert not (accounts_root / owner).exists()
 
@@ -148,9 +147,7 @@ def test_check_transactions_logs_sanitised_invalid_share_count(monkeypatch, stub
     assert "ABCinjected" in message
 
 
-def test_check_transactions_sanitises_ticker_when_shares_valid(
-    monkeypatch, stubbed_env, caplog
-):
+def test_check_transactions_sanitises_ticker_when_shares_valid(monkeypatch, stubbed_env, caplog):
     """CRLF in ``ticker`` is sanitised even when ``shares`` is valid.
 
     Complements test_check_transactions_logs_sanitised_invalid_share_count,
@@ -178,14 +175,10 @@ def test_check_transactions_sanitises_ticker_when_shares_valid(
     with caplog.at_level("INFO"):
         result = compliance._check_transactions("alice", txs)
 
-    assert not any(
-        "invalid share count" in r.getMessage() for r in caplog.records
-    )
+    assert not any("invalid share count" in r.getMessage() for r in caplog.records)
 
     ticker_records = [
-        r
-        for r in caplog.records
-        if "HOLD_DAYS_MIN" in r.getMessage() or "APPROVAL_REQUIRED" in r.getMessage()
+        r for r in caplog.records if "HOLD_DAYS_MIN" in r.getMessage() or "APPROVAL_REQUIRED" in r.getMessage()
     ]
     assert ticker_records
     for record in ticker_records:

--- a/tests/backend/common/test_data_loader.py
+++ b/tests/backend/common/test_data_loader.py
@@ -62,6 +62,7 @@ def _clear_owner_index_cache() -> None:
     yield
     clear_local_owner_index_cache()
 
+
 class TestExtractAccountNames:
     def test_dedupes_and_filters_metadata(self, tmp_path: Path) -> None:
         owner_dir = tmp_path / "alice"
@@ -215,9 +216,7 @@ class TestLoadPersonMeta:
     def test_load_person_metadata_rejects_malformed_viewers(self, tmp_path: Path) -> None:
         owner_dir = tmp_path / "alice"
         owner_dir.mkdir()
-        (owner_dir / "person.json").write_text(
-            json.dumps({"dob": "1980-01-01", "viewers": " bob@example.com "})
-        )
+        (owner_dir / "person.json").write_text(json.dumps({"dob": "1980-01-01", "viewers": " bob@example.com "}))
 
         with pytest.raises(Exception, match="viewers must be a list"):
             load_person_metadata("alice", data_root=tmp_path)
@@ -507,9 +506,7 @@ class TestListLocalPlots:
             {"owner": "carol", "full_name": "Carol Example", "accounts": ["gamma"]},
         ]
 
-    def test_skips_metadata_and_transaction_exports(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_skips_metadata_and_transaction_exports(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_root = tmp_path / "accounts"
         self._configure(monkeypatch, tmp_path, data_root, disable_auth=True)
 
@@ -569,11 +566,7 @@ class TestListLocalPlots:
 
         assert result == []
 
-
-
-    def test_falls_back_to_repository_when_primary_empty(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_falls_back_to_repository_when_primary_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         repo_root = tmp_path / "repo"
         primary_accounts = repo_root / "accounts"
         fallback_accounts = tmp_path / "fallback" / "accounts"
@@ -599,9 +592,7 @@ class TestListLocalPlots:
             {"owner": "eve", "accounts": ["gia"]},
         ]
 
-    def test_explicit_root_does_not_merge_fallback(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_explicit_root_does_not_merge_fallback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         repo_root = tmp_path / "repo"
         primary_accounts = repo_root / "accounts"
         fallback_accounts = tmp_path / "fallback" / "accounts"
@@ -648,9 +639,7 @@ class TestListLocalPlots:
         assert all(entry.full_name is None for entry in result)
         assert all(entry.owner not in {"demo", ".idea"} for entry in result)
 
-    def test_allows_access_when_user_matches_owner_email(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_allows_access_when_user_matches_owner_email(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_root = tmp_path / "accounts"
         self._configure(monkeypatch, tmp_path, data_root, disable_auth=False)
 
@@ -712,14 +701,16 @@ class TestLocalOwnerIndexCache:
         first = _list_local_plots(data_root=data_root, current_user=None)
         second = _list_local_plots(data_root=data_root, current_user=None)
 
-        assert first == second == [
-            {"owner": "alice", "accounts": ["isa"], "full_name": "Alice Example"},
-        ]
+        assert (
+            first
+            == second
+            == [
+                {"owner": "alice", "accounts": ["isa"], "full_name": "Alice Example"},
+            ]
+        )
         assert build_calls["count"] == 1
 
-    def test_invalidates_cached_owner_index_when_metadata_changes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_invalidates_cached_owner_index_when_metadata_changes(self, tmp_path: Path) -> None:
         data_root = tmp_path / "accounts"
         data_root.mkdir()
         _write_owner(data_root, "alice", ["isa"], viewers=[], full_name="Alice One")
@@ -736,9 +727,7 @@ class TestLocalOwnerIndexCache:
         assert second[0]["full_name"] == "Alice Updated"
         assert meta["full_name"] == "Alice Updated"
 
-    def test_invalidates_cached_owner_index_when_accounts_change(
-        self, tmp_path: Path
-    ) -> None:
+    def test_invalidates_cached_owner_index_when_accounts_change(self, tmp_path: Path) -> None:
         data_root = tmp_path / "accounts"
         data_root.mkdir()
         _write_owner(data_root, "alice", ["isa"], viewers=[])
@@ -752,9 +741,7 @@ class TestLocalOwnerIndexCache:
 
         assert second == [{"owner": "alice", "accounts": ["gia", "isa"]}]
 
-    def test_invalidates_cached_owner_index_when_owner_added(
-        self, tmp_path: Path
-    ) -> None:
+    def test_invalidates_cached_owner_index_when_owner_added(self, tmp_path: Path) -> None:
         data_root = tmp_path / "accounts"
         data_root.mkdir()
         _write_owner(data_root, "alice", ["isa"], viewers=[])
@@ -774,9 +761,7 @@ class TestLocalOwnerIndexCache:
             "content-only changes cannot be detected without re-reading"
         ),
     )
-    def test_invalidates_cached_owner_index_when_content_changes_without_stat_change(
-        self, tmp_path: Path
-    ) -> None:
+    def test_invalidates_cached_owner_index_when_content_changes_without_stat_change(self, tmp_path: Path) -> None:
         data_root = tmp_path / "accounts"
         data_root.mkdir()
         _write_owner(data_root, "alice", ["isa"], viewers=[], full_name="Alice One")
@@ -812,9 +797,7 @@ class TestLocalOwnerIndexCache:
 
 
 class TestLoadDemoOwner:
-    def test_returns_demo_summary_when_available(
-        self, tmp_path: Path
-    ) -> None:
+    def test_returns_demo_summary_when_available(self, tmp_path: Path) -> None:
         demo_root = tmp_path / "data"
         demo_dir = demo_root / "demo"
         demo_dir.mkdir(parents=True)
@@ -836,9 +819,7 @@ class TestLoadDemoOwner:
         assert result is None
 
 
-def test_list_aws_plots_enforces_email_and_viewer_permissions(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_list_aws_plots_enforces_email_and_viewer_permissions(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cfg = Config()
     cfg.app_env = "aws"
     cfg.disable_auth = False
@@ -959,9 +940,7 @@ def test_list_plots_skips_invalid_entries_without_failing_whole_batch(
 # ---------------------------------------------------------------------------
 
 
-def test_load_account_dotdot_owner_raises_missing_data(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_load_account_dotdot_owner_raises_missing_data(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """load_account must raise MissingData for traversal in owner.
 
     safe_join catches the traversal and re-raises as MissingData so callers
@@ -981,9 +960,7 @@ def test_load_account_dotdot_owner_raises_missing_data(
         load_account("../evil", "isa", data_root=tmp_path)
 
 
-def test_load_account_dotdot_account_raises_missing_data(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_load_account_dotdot_account_raises_missing_data(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """load_account must raise MissingData for traversal in account."""
     from backend.common.data_loader import load_account
     from backend.common.data_providers import MissingData

--- a/tests/backend/common/test_data_provider_parity.py
+++ b/tests/backend/common/test_data_provider_parity.py
@@ -76,9 +76,7 @@ def shared_provider_dataset(tmp_path: Path) -> dict[str, object]:
     for owner, payload in owners.items():
         aws_objects[f"accounts/{owner}/person.json"] = json.dumps(payload["person"]).encode("utf-8")
         for account, account_payload in payload["accounts"].items():
-            aws_objects[f"accounts/{owner}/{account}.json"] = json.dumps(account_payload).encode(
-                "utf-8"
-            )
+            aws_objects[f"accounts/{owner}/{account}.json"] = json.dumps(account_payload).encode("utf-8")
 
     return {
         "accounts_root": accounts_root,

--- a/tests/backend/common/test_data_providers.py
+++ b/tests/backend/common/test_data_providers.py
@@ -1,4 +1,5 @@
 """Tests confirming LocalDataProvider rejects path traversal in owner/account inputs."""
+
 from __future__ import annotations
 
 import json
@@ -9,7 +10,6 @@ from unittest.mock import patch
 import pytest
 
 from backend.common.data_providers import (
-    InvalidPayload,
     LocalDataProvider,
     MissingData,
     S3DataProvider,

--- a/tests/backend/common/test_metrics.py
+++ b/tests/backend/common/test_metrics.py
@@ -101,9 +101,7 @@ def test_compute_and_store_metrics_writes_file(monkeypatch, tmp_path):
     ]
 
     as_of = dt.date(2024, 1, 31)
-    metrics_data = metrics.compute_and_store_metrics(
-        "owner", txs, as_of=as_of, portfolio_value=100
-    )
+    metrics_data = metrics.compute_and_store_metrics("owner", txs, as_of=as_of, portfolio_value=100)
 
     metrics_path = tmp_path / "owner_metrics.json"
     assert metrics_path.exists()
@@ -112,9 +110,5 @@ def test_compute_and_store_metrics_writes_file(monkeypatch, tmp_path):
     assert stored == metrics_data
     assert metrics_data["owner"] == "owner"
     assert metrics_data["as_of"] == as_of.isoformat()
-    assert metrics_data["turnover"] == metrics.calculate_portfolio_turnover(
-        "owner", txs, portfolio_value=100
-    )
-    assert metrics_data["average_holding_period"] == metrics.calculate_average_holding_period(
-        "owner", txs, as_of=as_of
-    )
+    assert metrics_data["turnover"] == metrics.calculate_portfolio_turnover("owner", txs, portfolio_value=100)
+    assert metrics_data["average_holding_period"] == metrics.calculate_average_holding_period("owner", txs, as_of=as_of)

--- a/tests/backend/common/test_portfolio_builder.py
+++ b/tests/backend/common/test_portfolio_builder.py
@@ -55,9 +55,7 @@ def fixture_portfolio_stubs(monkeypatch, today):
             holdings=list(base_holdings),
         )
 
-    def fake_enrich_holding(
-        holding, as_of, price_cache, approvals, ucfg, *, calc=None
-    ):  # noqa: ARG001
+    def fake_enrich_holding(holding, as_of, price_cache, approvals, ucfg, *, calc=None):  # noqa: ARG001
         return {
             **holding,
             "market_value_gbp": holding["base_value"],
@@ -113,9 +111,7 @@ def test_build_owner_portfolio_requires_plot(monkeypatch, today):
     "discovered_plots",
     [[], [OwnerSummaryRecord(owner="other", accounts=["account-one"])]],
 )
-def test_build_owner_portfolio_logs_total_plot_count_on_miss(
-    monkeypatch, today, caplog, discovered_plots
-):
+def test_build_owner_portfolio_logs_total_plot_count_on_miss(monkeypatch, today, caplog, discovered_plots):
     """Regression test for #5286.
 
     When an owner has no matching plot, log how many plots were discovered in
@@ -131,7 +127,6 @@ def test_build_owner_portfolio_logs_total_plot_count_on_miss(
             build_owner_portfolio("nope")
 
     expected_message = (
-        "build_owner_portfolio: no plot found for owner=nope "
-        f"(total plots discovered={len(discovered_plots)})"
+        "build_owner_portfolio: no plot found for owner=nope " f"(total plots discovered={len(discovered_plots)})"
     )
     assert expected_message in caplog.messages

--- a/tests/backend/common/test_portfolio_utils.py
+++ b/tests/backend/common/test_portfolio_utils.py
@@ -227,10 +227,7 @@ def test_load_snapshot_local_missing_file(monkeypatch, tmp_path):
 
 
 def test_first_nonempty_str_returns_trimmed_value():
-    assert (
-        portfolio_utils._first_nonempty_str(None, "   ", "  result  ", "other")
-        == "result"
-    )
+    assert portfolio_utils._first_nonempty_str(None, "   ", "  result  ", "other") == "result"
 
 
 def test_first_nonempty_str_returns_none_when_missing():
@@ -289,9 +286,7 @@ def test_aggregate_by_ticker_uses_shared_grouping(monkeypatch):
 
     definitions = {"shared": {"id": "shared", "name": "Shared Group"}}
     monkeypatch.setattr(ia, "list_group_definitions", lambda: definitions)
-    monkeypatch.setattr(
-        ia, "_resolve_full_ticker", lambda ticker, latest: (ticker.split(".")[0], "L")
-    )
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda ticker, latest: (ticker.split(".")[0], "L"))
     monkeypatch.setattr(ia, "price_change_pct", lambda *args, **kwargs: None)
 
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {})
@@ -316,9 +311,7 @@ def test_aggregate_by_ticker_uses_shared_grouping(monkeypatch):
 
     from backend.common import instrument_api
 
-    monkeypatch.setattr(
-        instrument_api, "_resolve_full_ticker", lambda ticker, latest: (ticker, "L")
-    )
+    monkeypatch.setattr(instrument_api, "_resolve_full_ticker", lambda ticker, latest: (ticker, "L"))
     monkeypatch.setattr(instrument_api, "price_change_pct", lambda *args, **kwargs: None)
 
     rows = portfolio_utils.aggregate_by_ticker(portfolio, base_currency="GBP")
@@ -350,9 +343,7 @@ def test_aggregate_by_ticker_prefers_cost_basis(monkeypatch):
         ]
     }
 
-    monkeypatch.setattr(
-        ia, "_resolve_full_ticker", lambda ticker, latest: (ticker.split(".")[0], "L")
-    )
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda ticker, latest: (ticker.split(".")[0], "L"))
     monkeypatch.setattr(ia, "price_change_pct", lambda *args, **kwargs: None)
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {}, raising=False)
     monkeypatch.setattr(portfolio_utils, "get_instrument_meta", lambda ticker: {})
@@ -384,9 +375,7 @@ def test_aggregate_by_ticker_uses_zero_snapshot_price(monkeypatch):
         ]
     }
 
-    monkeypatch.setattr(
-        ia, "_resolve_full_ticker", lambda ticker, latest: (ticker.split(".")[0], "L")
-    )
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda ticker, latest: (ticker.split(".")[0], "L"))
     monkeypatch.setattr(ia, "price_change_pct", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         portfolio_utils,
@@ -624,9 +613,7 @@ def test_aggregate_by_ticker_security_meta_and_default_fallback(monkeypatch):
         ]
     }
 
-    monkeypatch.setattr(
-        ia, "_resolve_full_ticker", lambda ticker, latest: (ticker.split(".")[0], "L")
-    )
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda ticker, latest: (ticker.split(".")[0], "L"))
     monkeypatch.setattr(ia, "price_change_pct", lambda *args, **kwargs: None)
 
     def fake_resolve_grouping_details(*sources, current=None):
@@ -657,9 +644,7 @@ def test_aggregate_by_ticker_security_meta_and_default_fallback(monkeypatch):
         "AAA.L": {},
     }
 
-    monkeypatch.setattr(
-        portfolio_utils, "get_security_meta", lambda ticker: security_meta.get(ticker, {})
-    )
+    monkeypatch.setattr(portfolio_utils, "get_security_meta", lambda ticker: security_meta.get(ticker, {}))
 
     rows = portfolio_utils.aggregate_by_ticker(portfolio, base_currency="GBP")
     rows_by_ticker = {row["ticker"]: row for row in rows}

--- a/tests/backend/common/test_prices.py
+++ b/tests/backend/common/test_prices.py
@@ -80,9 +80,7 @@ def test_close_on_converts_native_currency_to_gbp(monkeypatch: pytest.MonkeyPatc
     from backend.common import portfolio_utils
 
     monkeypatch.setattr(portfolio_utils, "_fx_to_base", lambda *_: 0.8)
-    monkeypatch.setattr(
-        "backend.common.instruments.get_instrument_meta", lambda *_: {"currency": "USD"}
-    )
+    monkeypatch.setattr("backend.common.instruments.get_instrument_meta", lambda *_: {"currency": "USD"})
 
     assert prices._close_on("USDX", "US", sample_date) == pytest.approx(80.0)
 
@@ -95,9 +93,7 @@ def test_close_on_converts_gbx_pence_to_gbp(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(prices, "_nearest_weekday", lambda d, forward=False: sample_date)
     monkeypatch.setattr(prices, "load_meta_timeseries_range", lambda *args, **kwargs: frame)
-    monkeypatch.setattr(
-        "backend.common.instruments.get_instrument_meta", lambda *_: {"currency": "GBX"}
-    )
+    monkeypatch.setattr("backend.common.instruments.get_instrument_meta", lambda *_: {"currency": "GBX"})
 
     # GBX conversion is arithmetic (/100); FX resolver must not be called.
     monkeypatch.setattr(
@@ -128,9 +124,7 @@ def test_get_price_snapshot_handles_stale_and_missing_data(monkeypatch: pytest.M
     )
 
     mapping = {"ABC.L": ("ABC", "L"), "DEF.N": ("DEF", "N"), "GHI.L": ("GHI", "L")}
-    monkeypatch.setattr(
-        prices.instrument_api, "_resolve_full_ticker", lambda full, latest: mapping.get(full)
-    )
+    monkeypatch.setattr(prices.instrument_api, "_resolve_full_ticker", lambda full, latest: mapping.get(full))
 
     last_trading_day = prices._nearest_weekday(date.today() - timedelta(days=1), forward=False)
     seven_day = last_trading_day - timedelta(days=7)
@@ -228,9 +222,7 @@ def _stub_refresh_prices(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(prices, "check_price_alerts", lambda: None)
 
 
-def test_refresh_prices_uploads_to_s3_in_aws_env(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
-):
+def test_refresh_prices_uploads_to_s3_in_aws_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog):
     """refresh_prices() must call s3.put_object with PRICES_S3_KEY when app_env==aws."""
     _stub_refresh_prices(tmp_path, monkeypatch)
     monkeypatch.setattr(prices.config, "app_env", "aws", raising=False)
@@ -278,15 +270,13 @@ def test_refresh_prices_s3_upload_failure_logs_warning_not_error(
 
     assert "Failed to upload price snapshot to S3" in caplog.text
     error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
-    assert error_records == [], (
-        f"S3 upload failure must log WARNING, not ERROR; got: {[r.message for r in error_records]}"
-    )
+    assert (
+        error_records == []
+    ), f"S3 upload failure must log WARNING, not ERROR; got: {[r.message for r in error_records]}"
     assert result is not None, "refresh_prices() must still return normally after S3 upload failure"
 
 
-def test_refresh_prices_skips_s3_when_data_bucket_not_set(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
-):
+def test_refresh_prices_skips_s3_when_data_bucket_not_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog):
     """refresh_prices() must log a WARNING and skip S3 when DATA_BUCKET env var is absent."""
     _stub_refresh_prices(tmp_path, monkeypatch)
     monkeypatch.setattr(prices.config, "app_env", "aws", raising=False)
@@ -300,9 +290,7 @@ def test_refresh_prices_skips_s3_when_data_bucket_not_set(
     assert "DATA_BUCKET not set" in caplog.text
 
 
-def test_refresh_prices_does_not_upload_to_s3_in_local_env(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_refresh_prices_does_not_upload_to_s3_in_local_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """refresh_prices() must not call s3.put_object when app_env != 'aws'."""
     _stub_refresh_prices(tmp_path, monkeypatch)
     monkeypatch.setattr(prices.config, "app_env", "local", raising=False)
@@ -373,24 +361,16 @@ def test_last_close_fallback_snapshot_does_not_double_convert_fx(
     monkeypatch.setattr(prices, "_load_latest_prices", lambda _: {ticker: 80.0})
     monkeypatch.setattr(prices, "load_live_prices", lambda _: {})
     monkeypatch.setattr(prices, "_close_on", lambda *_: 80.0)
-    monkeypatch.setattr(
-        prices.instrument_api, "_resolve_full_ticker", lambda full, latest: ("USDX", "US")
-    )
+    monkeypatch.setattr(prices.instrument_api, "_resolve_full_ticker", lambda full, latest: ("USDX", "US"))
 
     snapshot = prices.get_price_snapshot([ticker])
     assert snapshot[ticker]["price_currency"] == "GBP"
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", snapshot, raising=False)
-    monkeypatch.setattr(
-        "backend.common.instrument_api._resolve_full_ticker", lambda t, _: ("USDX", "US")
-    )
-    monkeypatch.setattr(
-        portfolio_utils, "get_instrument_meta", lambda _: {"currency": "USD", "name": "USD X"}
-    )
+    monkeypatch.setattr("backend.common.instrument_api._resolve_full_ticker", lambda t, _: ("USDX", "US"))
+    monkeypatch.setattr(portfolio_utils, "get_instrument_meta", lambda _: {"currency": "USD", "name": "USD X"})
     monkeypatch.setattr(portfolio_utils, "get_security_meta", lambda _: {})
     monkeypatch.setattr("backend.common.instrument_api.price_change_pct", lambda *_: None)
-    monkeypatch.setattr(
-        portfolio_utils, "_fx_to_base", lambda c, b, cache: 0.8 if c == "USD" else 1.0
-    )
+    monkeypatch.setattr(portfolio_utils, "_fx_to_base", lambda c, b, cache: 0.8 if c == "USD" else 1.0)
 
     portfolio = {
         "accounts": [
@@ -422,17 +402,13 @@ def test_last_close_fallback_snapshot_marks_gbx_prices_as_gbp(
     monkeypatch.setattr(prices, "_load_latest_prices", lambda _: {ticker: 1.103})
     monkeypatch.setattr(prices, "load_live_prices", lambda _: {})
     monkeypatch.setattr(prices, "_close_on", lambda *_: 1.103)
-    monkeypatch.setattr(
-        prices.instrument_api, "_resolve_full_ticker", lambda full, latest: ("VOD", "L")
-    )
+    monkeypatch.setattr(prices.instrument_api, "_resolve_full_ticker", lambda full, latest: ("VOD", "L"))
 
     snapshot = prices.get_price_snapshot([ticker])
     assert snapshot[ticker]["price_currency"] == "GBP"
 
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", snapshot, raising=False)
-    monkeypatch.setattr(
-        "backend.common.instrument_api._resolve_full_ticker", lambda t, _: ("VOD", "L")
-    )
+    monkeypatch.setattr("backend.common.instrument_api._resolve_full_ticker", lambda t, _: ("VOD", "L"))
     monkeypatch.setattr(
         portfolio_utils,
         "get_instrument_meta",
@@ -475,8 +451,6 @@ def test_close_on_returns_none_when_fx_lookup_is_invalid(monkeypatch: pytest.Mon
     from backend.common import portfolio_utils
 
     monkeypatch.setattr(portfolio_utils, "_fx_to_base", lambda *_: None)
-    monkeypatch.setattr(
-        "backend.common.instruments.get_instrument_meta", lambda *_: {"currency": "USD"}
-    )
+    monkeypatch.setattr("backend.common.instruments.get_instrument_meta", lambda *_: {"currency": "USD"})
 
     assert prices._close_on("USDX", "US", sample_date) is None

--- a/tests/backend/common/test_storage.py
+++ b/tests/backend/common/test_storage.py
@@ -43,9 +43,7 @@ def test_file_storage_save_and_load(tmp_path: Path) -> None:
     assert storage.load() == payload
 
 
-def test_file_storage_invalid_json_logs_warning(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_file_storage_invalid_json_logs_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     path = tmp_path / "invalid.json"
     path.write_text("{not-valid-json}")
     storage = FileJSONStorage(path=path)

--- a/tests/backend/common/test_transaction_reconciliation.py
+++ b/tests/backend/common/test_transaction_reconciliation.py
@@ -146,5 +146,3 @@ def test_reconcile_transactions_with_holdings_adds_synthetic_entries(tmp_path: P
         "units": 2.0,
         "synthetic": True,
     }
-
-

--- a/tests/backend/routes/conftest.py
+++ b/tests/backend/routes/conftest.py
@@ -1,4 +1,5 @@
 """Shared fixtures for tests under tests/backend/routes/."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/backend/routes/test_accounts_helpers.py
+++ b/tests/backend/routes/test_accounts_helpers.py
@@ -41,7 +41,9 @@ def restore_config() -> None:
         config.accounts_root = original_accounts_root
 
 
-def test_resolve_accounts_root_cached_directory_and_config_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_accounts_root_cached_directory_and_config_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The cached state is preferred when valid, otherwise configuration paths are used."""
 
     request = make_request()

--- a/tests/backend/routes/test_alert_settings.py
+++ b/tests/backend/routes/test_alert_settings.py
@@ -58,42 +58,32 @@ async def test_resolve_identity_defaults_to_demo(app: FastAPI) -> None:
 
 
 @pytest.mark.anyio("asyncio")
-async def test_get_threshold_uses_resolved_identity(
-    app: FastAPI, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_get_threshold_uses_resolved_identity(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
     def fake_get_user_threshold(user: str) -> float:
         calls.append(user)
         return 3.14
 
-    monkeypatch.setattr(
-        alert_settings.alert_utils, "get_user_threshold", fake_get_user_threshold
-    )
+    monkeypatch.setattr(alert_settings.alert_utils, "get_user_threshold", fake_get_user_threshold)
 
     app.dependency_overrides[get_current_user] = lambda: "resolved-user"
     request = _make_request(app)
 
-    response = await alert_settings.get_threshold(
-        user="resolved-user", request=request, current_user=None
-    )
+    response = await alert_settings.get_threshold(user="resolved-user", request=request, current_user=None)
 
     assert calls == ["resolved-user"]
     assert response == {"threshold": 3.14}
 
 
 @pytest.mark.anyio("asyncio")
-async def test_set_threshold_uses_resolved_identity(
-    app: FastAPI, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_set_threshold_uses_resolved_identity(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[str, float]] = []
 
     def fake_set_user_threshold(user: str, threshold: float) -> None:
         calls.append((user, threshold))
 
-    monkeypatch.setattr(
-        alert_settings.alert_utils, "set_user_threshold", fake_set_user_threshold
-    )
+    monkeypatch.setattr(alert_settings.alert_utils, "set_user_threshold", fake_set_user_threshold)
 
     app.dependency_overrides[get_current_user] = lambda: "resolved-user"
     request = _make_request(app)
@@ -112,9 +102,7 @@ async def test_get_threshold_owner_mismatch(app: FastAPI) -> None:
     request = _make_request(app)
 
     with pytest.raises(alert_settings.HTTPException) as excinfo:
-        await alert_settings.get_threshold(
-            user="alice", request=request, current_user="bob"
-        )
+        await alert_settings.get_threshold(user="alice", request=request, current_user="bob")
 
     assert excinfo.value.status_code == alert_settings.status.HTTP_403_FORBIDDEN
 
@@ -125,8 +113,6 @@ async def test_set_threshold_owner_mismatch(app: FastAPI) -> None:
     payload = alert_settings.ThresholdPayload(threshold=5.0)
 
     with pytest.raises(alert_settings.HTTPException) as excinfo:
-        await alert_settings.set_threshold(
-            user="alice", payload=payload, request=request, current_user="bob"
-        )
+        await alert_settings.set_threshold(user="alice", payload=payload, request=request, current_user="bob")
 
     assert excinfo.value.status_code == alert_settings.status.HTTP_403_FORBIDDEN

--- a/tests/backend/routes/test_analytics.py
+++ b/tests/backend/routes/test_analytics.py
@@ -113,9 +113,7 @@ async def test_log_event_appends_expected_event(monkeypatch: pytest.MonkeyPatch)
         ({"source": "trail", "event": "does-not-exist"}, "Unsupported event for source"),
     ],
 )
-async def test_log_event_validation_errors(
-    payload_kwargs: dict[str, Any], expected_detail: str
-) -> None:
+async def test_log_event_validation_errors(payload_kwargs: dict[str, Any], expected_detail: str) -> None:
     """Validation failures raise ``HTTPException`` with a 400 status code."""
 
     payload = analytics.AnalyticsEventIn(**payload_kwargs)
@@ -195,4 +193,3 @@ async def test_get_funnel_with_events(monkeypatch: pytest.MonkeyPatch) -> None:
     assert [step.event for step in summary.steps] == ["view", "task_started", "task_completed"]
     assert [step.count for step in summary.steps] == [2, 2, 1]
     assert summary.other_events == {"unexpected": 1}
-

--- a/tests/backend/routes/test_compliance.py
+++ b/tests/backend/routes/test_compliance.py
@@ -3,7 +3,6 @@ import types
 import pytest
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
-from fastapi.testclient import TestClient
 
 from backend.common.account_models import OwnerSummaryRecord
 from backend.common.errors import AppError, OwnerNotFoundError
@@ -88,9 +87,7 @@ def test_known_owners_falls_back_to_directory_iteration(tmp_path, monkeypatch):
     monkeypatch.setattr(
         compliance_module.data_loader,
         "resolve_paths",
-        lambda *_, **__: types.SimpleNamespace(
-            accounts_root=tmp_path / "no_demo"
-        ),
+        lambda *_, **__: types.SimpleNamespace(accounts_root=tmp_path / "no_demo"),
     )
 
     owners = compliance_module._known_owners(accounts_root)
@@ -201,9 +198,7 @@ async def test_compliance_for_owner_missing_directory(tmp_path, monkeypatch, fas
 
 
 @pytest.mark.anyio
-async def test_compliance_for_remote_owner_without_local_directory(
-    tmp_path, monkeypatch, fastapi_request
-):
+async def test_compliance_for_remote_owner_without_local_directory(tmp_path, monkeypatch, fastapi_request):
     app, request = fastapi_request
     accounts_root = tmp_path / "accounts"
 
@@ -524,9 +519,7 @@ async def test_validate_trade_scaffolds_missing_directory(tmp_path, monkeypatch,
 
 
 @pytest.mark.anyio
-async def test_validate_trade_scaffolds_when_owner_discovery_fails(
-    tmp_path, monkeypatch
-):
+async def test_validate_trade_scaffolds_when_owner_discovery_fails(tmp_path, monkeypatch):
     request = PayloadRequest(
         {
             "owner": " demo ",

--- a/tests/backend/routes/test_config.py
+++ b/tests/backend/routes/test_config.py
@@ -222,9 +222,7 @@ async def test_update_config_rejects_blank_client_id(monkeypatch: pytest.MonkeyP
     assert calls == [(True, None)]
 
 
-async def test_update_config_validates_with_env_client_id(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_update_config_validates_with_env_client_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     _write_config(config_path, {"auth": {"google_auth_enabled": True}})
     monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
@@ -283,9 +281,7 @@ async def test_update_config_env_provides_client_id(monkeypatch: pytest.MonkeyPa
     assert written["auth"]["allowed_emails"] == ["user@example.com"]
 
 
-async def test_update_config_noop_payload_preserves_config(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_update_config_noop_payload_preserves_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     base_config = {
         "auth": {
@@ -301,16 +297,14 @@ async def test_update_config_noop_payload_preserves_config(
     }
     _write_config(config_path, base_config)
     monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
-    loader = _patch_loader(
-        monkeypatch, _DummyConfig(google_auth_enabled=False, google_client_id=None)
-    )
+    loader = _patch_loader(monkeypatch, _DummyConfig(google_auth_enabled=False, google_client_id=None))
     dummy_config = _DummyConfig(google_auth_enabled=False, google_client_id=None)
     monkeypatch.setattr(routes_config.config_module, "config", dummy_config)
     calls = _spy_validate(monkeypatch)
 
     original_contents = config_path.read_text()
 
-    result = await routes_config.update_config({})
+    await routes_config.update_config({})
 
     assert calls == []
     assert loader.cleared is True
@@ -341,9 +335,7 @@ async def test_update_config_normalises_string_google_auth_flag(
     assert result["google_client_id"] is None
 
 
-async def test_update_config_accepts_string_false_flag(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_update_config_accepts_string_false_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     _write_config(config_path, {"auth": {"google_auth_enabled": "false"}})
     monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
@@ -381,9 +373,7 @@ async def test_update_config_empty_payload_env_toggle_requires_client_id(
     }
     _write_config(config_path, base_config)
     monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
-    loader = _patch_loader(
-        monkeypatch, _DummyConfig(google_auth_enabled=False, google_client_id=None)
-    )
+    loader = _patch_loader(monkeypatch, _DummyConfig(google_auth_enabled=False, google_client_id=None))
     dummy_config = _DummyConfig(google_auth_enabled=False, google_client_id=None)
     monkeypatch.setattr(routes_config.config_module, "config", dummy_config)
     calls = _spy_validate(monkeypatch)
@@ -416,9 +406,7 @@ async def test_update_config_treats_blank_google_auth_env_as_absent(
     }
     _write_config(config_path, base_config)
     monkeypatch.setattr(routes_config, "_project_config_path", lambda: config_path)
-    loader = _patch_loader(
-        monkeypatch, _DummyConfig(google_auth_enabled=False, google_client_id=None)
-    )
+    loader = _patch_loader(monkeypatch, _DummyConfig(google_auth_enabled=False, google_client_id=None))
     dummy_config = _DummyConfig(google_auth_enabled=False, google_client_id=None)
     monkeypatch.setattr(routes_config.config_module, "config", dummy_config)
     calls = _spy_validate(monkeypatch)

--- a/tests/backend/routes/test_metrics.py
+++ b/tests/backend/routes/test_metrics.py
@@ -1,5 +1,4 @@
 import pytest
-from fastapi import HTTPException
 
 from backend.common.errors import OwnerNotFoundError
 from backend.routes import metrics

--- a/tests/backend/routes/test_portfolio_helpers.py
+++ b/tests/backend/routes/test_portfolio_helpers.py
@@ -35,8 +35,7 @@ def test_collect_account_stems_filters_metadata_and_transactions(tmp_path: Path)
     assert normalised == {"brokerage", "isa"}
     assert all(not stem.casefold().endswith("_transactions") for stem in stems)
     assert all(
-        stem.casefold()
-        not in {"person", "config", "notes", "settings", "approvals", "approval_requests"}
+        stem.casefold() not in {"person", "config", "notes", "settings", "approvals", "approval_requests"}
         for stem in stems
     )
 

--- a/tests/backend/routes/test_query.py
+++ b/tests/backend/routes/test_query.py
@@ -7,9 +7,7 @@ from backend.routes import query
 
 
 @pytest.mark.anyio
-async def test_list_saved_queries_returns_rich_entries(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_list_saved_queries_returns_rich_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     saved_dir = tmp_path / "queries"
     saved_dir.mkdir()
 

--- a/tests/backend/routes/test_signup.py
+++ b/tests/backend/routes/test_signup.py
@@ -179,9 +179,7 @@ def test_email_send_ses_failure_returns_502_and_logs(client, monkeypatch, caplog
     monkeypatch.setattr(signup_module, "send_signup_admin_email", boom)
 
     with caplog.at_level("ERROR"):
-        resp = test_client.post(
-            "/signup/request", json={"name": "Jane", "email": "jane@example.com"}
-        )
+        resp = test_client.post("/signup/request", json={"name": "Jane", "email": "jane@example.com"})
 
     assert resp.status_code == 502
     assert resp.json()["detail"] == "failed to notify administrator"

--- a/tests/backend/routes/test_transactions.py
+++ b/tests/backend/routes/test_transactions.py
@@ -42,9 +42,7 @@ def reset_transactions_state():
     transactions_module._PORTFOLIO_IMPACT.clear()
 
 
-def _seed_transactions_file(
-    accounts_root: Path, owner: str, account: str, transactions: list[dict]
-) -> Path:
+def _seed_transactions_file(accounts_root: Path, owner: str, account: str, transactions: list[dict]) -> Path:
     owner_dir = accounts_root / owner
     owner_dir.mkdir(parents=True, exist_ok=True)
     file_path = owner_dir / f"{account}_transactions.json"
@@ -75,13 +73,9 @@ def test_require_writable_store_rejects_global_cache(monkeypatch, tmp_path):
     accounts_dir = tmp_path / "accounts"
     accounts_dir.mkdir()
 
-    request = _make_request(
-        {"accounts_root": accounts_dir, "accounts_root_is_global": True}
-    )
+    request = _make_request({"accounts_root": accounts_dir, "accounts_root_is_global": True})
 
-    monkeypatch.setattr(
-        transactions_module.config, "accounts_root", accounts_dir.as_posix()
-    )
+    monkeypatch.setattr(transactions_module.config, "accounts_root", accounts_dir.as_posix())
 
     fallback_dir = tmp_path / "fallback"
     fallback_dir.mkdir()
@@ -92,9 +86,7 @@ def test_require_writable_store_rejects_global_cache(monkeypatch, tmp_path):
         lambda *_args, **_kwargs: dummy_paths,
     )
 
-    monkeypatch.setattr(
-        transactions_module, "resolve_accounts_root", lambda _req: accounts_dir
-    )
+    monkeypatch.setattr(transactions_module, "resolve_accounts_root", lambda _req: accounts_dir)
 
     with pytest.raises(HTTPException) as excinfo:
         transactions_module._require_writable_store(request)
@@ -108,9 +100,7 @@ def test_require_writable_store_missing_resolved_path(monkeypatch, tmp_path):
 
     request = _make_request({})
 
-    monkeypatch.setattr(
-        transactions_module.config, "accounts_root", configured_dir.as_posix()
-    )
+    monkeypatch.setattr(transactions_module.config, "accounts_root", configured_dir.as_posix())
 
     global_dir = tmp_path / "global"
     global_dir.mkdir()
@@ -121,9 +111,7 @@ def test_require_writable_store_missing_resolved_path(monkeypatch, tmp_path):
     )
 
     missing_dir = tmp_path / "missing"
-    monkeypatch.setattr(
-        transactions_module, "resolve_accounts_root", lambda _req: missing_dir
-    )
+    monkeypatch.setattr(transactions_module, "resolve_accounts_root", lambda _req: missing_dir)
 
     with pytest.raises(HTTPException) as excinfo:
         transactions_module._require_writable_store(request)
@@ -139,9 +127,7 @@ def test_require_writable_store_rejects_matching_global_root(monkeypatch, tmp_pa
 
     request = _make_request({})
 
-    monkeypatch.setattr(
-        transactions_module.config, "accounts_root", configured_dir.as_posix()
-    )
+    monkeypatch.setattr(transactions_module.config, "accounts_root", configured_dir.as_posix())
 
     monkeypatch.setattr(
         transactions_module.data_loader,
@@ -257,9 +243,7 @@ def test_instrument_name_from_entry(monkeypatch):
         assert ticker == "ABC"
         return {"display_name": "  Looked Up Name  "}
 
-    monkeypatch.setattr(
-        transactions_module, "get_instrument_meta", fake_get_meta
-    )
+    monkeypatch.setattr(transactions_module, "get_instrument_meta", fake_get_meta)
 
     fallback_resolved = transactions_module._instrument_name_from_entry(lookup_entry)
 
@@ -270,15 +254,11 @@ def test_instrument_name_from_entry(monkeypatch):
     def raise_value_error(_ticker: str):
         raise ValueError("bad ticker")
 
-    monkeypatch.setattr(
-        transactions_module, "get_instrument_meta", raise_value_error
-    )
+    monkeypatch.setattr(transactions_module, "get_instrument_meta", raise_value_error)
 
     assert transactions_module._instrument_name_from_entry(failing_entry) is None
 
-    monkeypatch.setattr(
-        transactions_module, "get_instrument_meta", lambda _ticker: {}
-    )
+    monkeypatch.setattr(transactions_module, "get_instrument_meta", lambda _ticker: {})
 
     assert transactions_module._instrument_name_from_entry(failing_entry) is None
 
@@ -292,9 +272,7 @@ def test_format_transaction_response_injects_instrument_name(monkeypatch):
         lambda payload: "Resolved Instrument",
     )
 
-    payload = transactions_module._format_transaction_response(
-        "alice", "primary", tx_data, "tx-1"
-    )
+    payload = transactions_module._format_transaction_response("alice", "primary", tx_data, "tx-1")
 
     assert payload == {
         "owner": "alice",
@@ -315,9 +293,7 @@ def test_format_transaction_response_omits_missing_instrument_name(monkeypatch):
         lambda payload: None,
     )
 
-    payload = transactions_module._format_transaction_response(
-        "alice", "primary", tx_data
-    )
+    payload = transactions_module._format_transaction_response("alice", "primary", tx_data)
 
     assert payload == {
         "owner": "alice",
@@ -457,9 +433,7 @@ async def test_update_and_delete_transactions_flow(monkeypatch, tmp_path):
     accounts_root.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(transactions_module.config, "accounts_root", accounts_root)
-    monkeypatch.setattr(
-        transactions_module, "_rebuild_portfolio", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(transactions_module, "_rebuild_portfolio", lambda *args, **kwargs: None)
 
     initial_entry = {
         "date": "2024-01-01",
@@ -468,9 +442,7 @@ async def test_update_and_delete_transactions_flow(monkeypatch, tmp_path):
         "units": 2.0,
         "ticker": "AAA",
     }
-    original_file = _seed_transactions_file(
-        accounts_root, "alice", "primary", [initial_entry]
-    )
+    original_file = _seed_transactions_file(accounts_root, "alice", "primary", [initial_entry])
 
     with TestClient(create_app()) as client:
         move_payload = {
@@ -493,9 +465,7 @@ async def test_update_and_delete_transactions_flow(monkeypatch, tmp_path):
         assert original_after_move["transactions"] == []
 
         destination_file = accounts_root / "bob" / "savings_transactions.json"
-        destination_after_move = json.loads(
-            destination_file.read_text(encoding="utf-8")
-        )
+        destination_after_move = json.loads(destination_file.read_text(encoding="utf-8"))
         assert len(destination_after_move["transactions"]) == 1
         moved_entry = destination_after_move["transactions"][0]
         assert moved_entry["reason"] == "Move to new account"
@@ -514,14 +484,10 @@ async def test_update_and_delete_transactions_flow(monkeypatch, tmp_path):
             "units": 5.0,
             "reason": "Adjust units",
         }
-        in_place_response = client.put(
-            f"/transactions/{moved_payload['id']}", json=in_place_payload
-        )
+        in_place_response = client.put(f"/transactions/{moved_payload['id']}", json=in_place_payload)
         assert in_place_response.status_code == 200
 
-        updated_destination = json.loads(
-            destination_file.read_text(encoding="utf-8")
-        )
+        updated_destination = json.loads(destination_file.read_text(encoding="utf-8"))
         assert len(updated_destination["transactions"]) == 1
         updated_entry = updated_destination["transactions"][0]
         assert updated_entry["price_gbp"] == pytest.approx(9.0)
@@ -538,9 +504,7 @@ async def test_update_and_delete_transactions_flow(monkeypatch, tmp_path):
         final_original = json.loads(original_file.read_text(encoding="utf-8"))
         assert final_original["transactions"] == []
 
-        final_destination = json.loads(
-            destination_file.read_text(encoding="utf-8")
-        )
+        final_destination = json.loads(destination_file.read_text(encoding="utf-8"))
         assert final_destination["transactions"] == []
 
         assert transactions_module._PORTFOLIO_IMPACT["bob"] == pytest.approx(0.0)
@@ -553,9 +517,7 @@ async def test_update_transaction_out_of_range_index(monkeypatch, tmp_path):
     accounts_root.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(transactions_module.config, "accounts_root", accounts_root)
-    monkeypatch.setattr(
-        transactions_module, "_rebuild_portfolio", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(transactions_module, "_rebuild_portfolio", lambda *args, **kwargs: None)
 
     entry = {
         "date": "2024-01-01",
@@ -564,9 +526,7 @@ async def test_update_transaction_out_of_range_index(monkeypatch, tmp_path):
         "units": 2.0,
         "ticker": "AAA",
     }
-    original_file = _seed_transactions_file(
-        accounts_root, "alice", "primary", [entry]
-    )
+    original_file = _seed_transactions_file(accounts_root, "alice", "primary", [entry])
 
     with TestClient(create_app()) as client:
         response = client.put(
@@ -596,9 +556,7 @@ async def test_update_transaction_pending_entry_guard(monkeypatch, tmp_path):
     accounts_root.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(transactions_module.config, "accounts_root", accounts_root)
-    monkeypatch.setattr(
-        transactions_module, "_rebuild_portfolio", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(transactions_module, "_rebuild_portfolio", lambda *args, **kwargs: None)
 
     entry = {
         "date": "2024-01-01",
@@ -649,4 +607,3 @@ async def test_update_transaction_pending_entry_guard(monkeypatch, tmp_path):
     assert response.status_code == 500
     assert response.json()["detail"] == "Failed to update transaction"
     assert not transactions_module._PORTFOLIO_IMPACT
-

--- a/tests/backend/routes/test_transactions_accounts_root.py
+++ b/tests/backend/routes/test_transactions_accounts_root.py
@@ -47,19 +47,13 @@ def test_require_writable_store_rejects_matching_global_root(monkeypatch, tmp_pa
 
     request = _build_request()
 
-    monkeypatch.setattr(
-        transactions_module.config, "accounts_root", configured_dir.as_posix()
-    )
+    monkeypatch.setattr(transactions_module.config, "accounts_root", configured_dir.as_posix())
     monkeypatch.setattr(
         transactions_module.data_loader,
         "resolve_paths",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            accounts_root=configured_dir.resolve()
-        ),
+        lambda *_args, **_kwargs: SimpleNamespace(accounts_root=configured_dir.resolve()),
     )
-    monkeypatch.setattr(
-        transactions_module, "resolve_accounts_root", lambda _req: configured_dir
-    )
+    monkeypatch.setattr(transactions_module, "resolve_accounts_root", lambda _req: configured_dir)
 
     with pytest.raises(HTTPException) as excinfo:
         transactions_module._require_writable_store(request)
@@ -101,9 +95,7 @@ def test_require_writable_store_rejects_nonexistent_configured_root(monkeypatch,
 
 
 @pytest.mark.parametrize("state_global_flag", [False, True])
-def test_require_writable_store_rejects_invalid_resolution(
-    monkeypatch, tmp_path, state_global_flag
-):
+def test_require_writable_store_rejects_invalid_resolution(monkeypatch, tmp_path, state_global_flag):
     configured_dir = tmp_path / "configured"
     configured_dir.mkdir()
 
@@ -116,9 +108,7 @@ def test_require_writable_store_rejects_invalid_resolution(
 
     request = _build_request(state)
 
-    monkeypatch.setattr(
-        transactions_module.config, "accounts_root", configured_dir.as_posix()
-    )
+    monkeypatch.setattr(transactions_module.config, "accounts_root", configured_dir.as_posix())
     monkeypatch.setattr(
         transactions_module.data_loader,
         "resolve_paths",
@@ -128,14 +118,10 @@ def test_require_writable_store_rejects_invalid_resolution(
     if state_global_flag:
         valid_dir = tmp_path / "valid"
         valid_dir.mkdir()
-        monkeypatch.setattr(
-            transactions_module, "resolve_accounts_root", lambda _req: valid_dir
-        )
+        monkeypatch.setattr(transactions_module, "resolve_accounts_root", lambda _req: valid_dir)
     else:
         missing_dir = tmp_path / "missing"
-        monkeypatch.setattr(
-            transactions_module, "resolve_accounts_root", lambda _req: missing_dir
-        )
+        monkeypatch.setattr(transactions_module, "resolve_accounts_root", lambda _req: missing_dir)
 
     with pytest.raises(HTTPException) as excinfo:
         transactions_module._require_writable_store(request)

--- a/tests/backend/routes/test_transactions_writable_store.py
+++ b/tests/backend/routes/test_transactions_writable_store.py
@@ -48,9 +48,7 @@ class _FakeS3:
         self.objects[Key] = Body
 
     def list_objects_v2(self, Bucket: str, Prefix: str, **_kwargs):  # noqa: N803
-        contents = [
-            {"Key": key} for key in sorted(self.objects) if key.startswith(Prefix)
-        ]
+        contents = [{"Key": key} for key in sorted(self.objects) if key.startswith(Prefix)]
         return {"Contents": contents, "IsTruncated": False}
 
 
@@ -65,9 +63,7 @@ def test_resolve_writable_store_uses_s3_in_aws(monkeypatch):
     assert store.bucket == "data-bucket"
 
 
-def test_resolve_writable_store_falls_back_local_without_bucket(
-    monkeypatch, tmp_path, caplog, reset_warning_flag
-):
+def test_resolve_writable_store_falls_back_local_without_bucket(monkeypatch, tmp_path, caplog, reset_warning_flag):
     monkeypatch.setattr(transactions_module.config, "app_env", "aws")
     monkeypatch.delenv(data_loader.DATA_BUCKET_ENV, raising=False)
     reset_warning_flag(transactions_module, "_warned_missing_data_bucket")
@@ -78,9 +74,7 @@ def test_resolve_writable_store_falls_back_local_without_bucket(
 
     assert not isinstance(store, S3AccountsStore)
     assert store.local_root == tmp_path.resolve()
-    assert any(
-        data_loader.DATA_BUCKET_ENV in record.message for record in caplog.records
-    )
+    assert any(data_loader.DATA_BUCKET_ENV in record.message for record in caplog.records)
 
 
 def test_resolve_writable_store_no_warning_outside_aws(monkeypatch, tmp_path, caplog):
@@ -91,29 +85,19 @@ def test_resolve_writable_store_no_warning_outside_aws(monkeypatch, tmp_path, ca
     with caplog.at_level("WARNING", logger="transactions"):
         transactions_module.resolve_writable_store(request)
 
-    assert not any(
-        data_loader.DATA_BUCKET_ENV in record.message for record in caplog.records
-    )
+    assert not any(data_loader.DATA_BUCKET_ENV in record.message for record in caplog.records)
 
 
-def test_resolve_writable_store_warns_only_once_per_process(
-    monkeypatch, tmp_path, caplog, reset_warning_flag
-):
+def test_resolve_writable_store_warns_only_once_per_process(monkeypatch, tmp_path, caplog, reset_warning_flag):
     monkeypatch.setattr(transactions_module.config, "app_env", "aws")
     monkeypatch.delenv(data_loader.DATA_BUCKET_ENV, raising=False)
     reset_warning_flag(transactions_module, "_warned_missing_data_bucket")
 
     with caplog.at_level("WARNING", logger="transactions"):
         for _ in range(3):
-            transactions_module.resolve_writable_store(
-                _make_request({"accounts_root": tmp_path})
-            )
+            transactions_module.resolve_writable_store(_make_request({"accounts_root": tmp_path}))
 
-    warnings = [
-        record
-        for record in caplog.records
-        if data_loader.DATA_BUCKET_ENV in record.message
-    ]
+    warnings = [record for record in caplog.records if data_loader.DATA_BUCKET_ENV in record.message]
     assert len(warnings) == 1
 
 
@@ -129,9 +113,7 @@ async def test_create_manual_holding_persists_to_s3(monkeypatch):
         lambda _req: (S3AccountsStore(bucket="data-bucket", client=fake), transactions_module._RootResolution.WRITABLE),
     )
 
-    payload = transactions_module.ManualHoldingCreate(
-        owner="alice", account="ISA", ticker="aaa", value_gbp=1000
-    )
+    payload = transactions_module.ManualHoldingCreate(owner="alice", account="ISA", ticker="aaa", value_gbp=1000)
     result = await transactions_module.create_manual_holding(_make_request(), payload)
 
     assert result["status"] == "saved"
@@ -155,9 +137,7 @@ async def test_create_transaction_persists_to_s3(monkeypatch):
         "resolve_writable_store",
         lambda _req: (S3AccountsStore(bucket="data-bucket", client=fake), transactions_module._RootResolution.WRITABLE),
     )
-    monkeypatch.setattr(
-        transactions_module, "_rebuild_portfolio", lambda *a, **k: None
-    )
+    monkeypatch.setattr(transactions_module, "_rebuild_portfolio", lambda *a, **k: None)
 
     from datetime import date
 

--- a/tests/backend/test_alert_settings.py
+++ b/tests/backend/test_alert_settings.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from backend.auth import get_active_user, get_current_user
-from backend.config import load_config, config
+from backend.config import config, load_config
 from backend.routes import alert_settings
 
 
@@ -43,9 +43,7 @@ def test_set_alert_threshold(monkeypatch):
 
 
 def test_set_alert_threshold_invalid_payload(monkeypatch):
-    monkeypatch.setattr(
-        "backend.alerts.set_user_threshold", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr("backend.alerts.set_user_threshold", lambda *args, **kwargs: None)
     client = _app_for("alice")
     resp = client.post("/alert-thresholds/alice", json={})
     assert resp.status_code == 422
@@ -67,18 +65,20 @@ def test_alert_thresholds_auth_disabled(monkeypatch):
 
     app = FastAPI()
     app.include_router(alert_settings.router)
-    
+
     # Override get_active_user to return None (simulating disabled auth)
     async def override_active_user():
         return None
+
     app.dependency_overrides[get_active_user] = override_active_user
-    
-    # Also override get_current_user to return "demo" 
+
+    # Also override get_current_user to return "demo"
     # This allows the _resolve_identity fallback to work
     async def override_current_user():
         return "demo"
+
     app.dependency_overrides[get_current_user] = override_current_user
-    
+
     client = TestClient(app)
 
     resp = client.get("/alert-thresholds/demo")

--- a/tests/backend/test_analytics.py
+++ b/tests/backend/test_analytics.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from backend import config as config_module
 from backend.common import analytics_store
 from backend.routes.analytics import router as analytics_router
-
 
 
 @pytest.fixture

--- a/tests/backend/test_async_endpoints.py
+++ b/tests/backend/test_async_endpoints.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
 
 from backend.app import create_app
 from backend.common.account_models import OwnerSummaryRecord
@@ -8,9 +8,7 @@ from backend.common.account_models import OwnerSummaryRecord
 @pytest.mark.asyncio
 async def test_auth_alerts_portfolio(monkeypatch):
     app = create_app()
-    monkeypatch.setattr(
-        "backend.common.alerts.get_recent_alerts", lambda: [{"message": "hi"}]
-    )
+    monkeypatch.setattr("backend.common.alerts.get_recent_alerts", lambda: [{"message": "hi"}])
     monkeypatch.setattr(
         "backend.common.data_loader.list_plots",
         lambda root, current_user=None: [
@@ -20,9 +18,7 @@ async def test_auth_alerts_portfolio(monkeypatch):
     )
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        token_resp = await client.post(
-            "/token", data={"username": "testuser", "password": "password"}
-        )
+        token_resp = await client.post("/token", data={"username": "testuser", "password": "password"})
         token = token_resp.json()["access_token"]
         headers = {"Authorization": f"Bearer {token}"}
         alerts_resp = await client.get("/alerts/", headers=headers)

--- a/tests/backend/test_drawdown_reconciliation.py
+++ b/tests/backend/test_drawdown_reconciliation.py
@@ -1,11 +1,10 @@
 import logging
-from datetime import date
 
 import pandas as pd
 import pytest
 
-from backend.common import portfolio_utils
 from backend.common import portfolio as portfolio_mod
+from backend.common import portfolio_utils
 
 
 @pytest.fixture

--- a/tests/backend/test_goals_route.py
+++ b/tests/backend/test_goals_route.py
@@ -1,15 +1,15 @@
-from datetime import date
 import importlib
+from datetime import date
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import backend.routes as routes_pkg
+from backend.auth import get_current_user
 from backend.common import goals as goals_mod
 from backend.common.storage import get_storage
 from backend.routes import goals as goals_route
-from backend.auth import get_current_user
 
 
 def _app(tmp_path, monkeypatch, *, active_user: str | None = "alice", disable_auth: bool = False):
@@ -24,6 +24,7 @@ def _app(tmp_path, monkeypatch, *, active_user: str | None = "alice", disable_au
         # Override before including router
         async def override_user():
             return active_user
+
         app.dependency_overrides[get_current_user] = override_user
     app.include_router(module.router)
     return TestClient(app)

--- a/tests/backend/test_holding_utils.py
+++ b/tests/backend/test_holding_utils.py
@@ -3,8 +3,8 @@ import datetime as dt
 import pandas as pd
 import pytest
 
-from backend.common.constants import ACQUIRED_DATE, COST_BASIS_GBP, TICKER, UNITS
 from backend.common import holding_utils as hu
+from backend.common.constants import ACQUIRED_DATE, COST_BASIS_GBP, TICKER, UNITS
 from backend.common.holding_utils import EFFECTIVE_COST_BASIS_GBP
 
 
@@ -72,9 +72,7 @@ def test_gbx_scaling_defaults_apply_without_override(monkeypatch):
         lambda sym, *_args: (sym.split(".", 1)[0], exchange),
     )
     monkeypatch.setattr(instrument_api, "price_change_pct", lambda *_a, **_k: None)
-    monkeypatch.setattr(
-        instrument_api, "_resolve_grouping_details", lambda *_a, **_k: (None, None)
-    )
+    monkeypatch.setattr(instrument_api, "_resolve_grouping_details", lambda *_a, **_k: (None, None))
 
     frame = pd.DataFrame(
         {
@@ -156,9 +154,9 @@ def test_enrich_holding_market_value_set_from_price_snapshot(monkeypatch):
     today = dt.date(2026, 5, 16)
     result = hu.enrich_holding(holding, today, price_cache={})
 
-    assert result["market_value_gbp"] == pytest.approx(975.0), (
-        "market_value_gbp must not be None when price snapshot has data"
-    )
+    assert result["market_value_gbp"] == pytest.approx(
+        975.0
+    ), "market_value_gbp must not be None when price snapshot has data"
     assert result["gain_gbp"] is not None
     assert result["current_price_gbp"] == pytest.approx(97.5)
 

--- a/tests/backend/test_instrument_admin.py
+++ b/tests/backend/test_instrument_admin.py
@@ -40,9 +40,7 @@ def test_update_instrument_preserves_existing_fields(monkeypatch):
         saved["args"] = (ticker, exchange)
         saved["payload"] = payload
 
-    monkeypatch.setattr(
-        instrument_admin, "instrument_meta_path", fake_instrument_meta_path
-    )
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_instrument_meta_path)
     monkeypatch.setattr(instrument_admin, "get_instrument_meta", fake_get_instrument_meta)
     monkeypatch.setattr(instrument_admin, "save_instrument_meta", fake_save_instrument_meta)
 
@@ -89,12 +87,12 @@ def test_refresh_instrument_preview(monkeypatch):
         assert exchange == "NYSE"
         return {"name": "Alpha Corp", "currency": "GBP", "instrument_type": "EQUITY"}
 
-    monkeypatch.setattr(
-        instrument_admin, "instrument_meta_path", fake_instrument_meta_path
-    )
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_instrument_meta_path)
     monkeypatch.setattr(instrument_admin, "get_instrument_meta", fake_get_instrument_meta)
     monkeypatch.setattr(
-        instrument_admin, "_fetch_metadata_from_yahoo", fake_fetch,
+        instrument_admin,
+        "_fetch_metadata_from_yahoo",
+        fake_fetch,
     )
     monkeypatch.setattr(
         instrument_admin,
@@ -140,9 +138,7 @@ def test_refresh_instrument_confirm(monkeypatch):
         stored["args"] = (ticker, exchange)
         stored["payload"] = payload
 
-    monkeypatch.setattr(
-        instrument_admin, "instrument_meta_path", fake_instrument_meta_path
-    )
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_instrument_meta_path)
     monkeypatch.setattr(instrument_admin, "get_instrument_meta", fake_get_instrument_meta)
     monkeypatch.setattr(instrument_admin, "_fetch_metadata_from_yahoo", fake_fetch)
     monkeypatch.setattr(instrument_admin, "save_instrument_meta", fake_save)

--- a/tests/backend/test_intraday_route.py
+++ b/tests/backend/test_intraday_route.py
@@ -1,5 +1,6 @@
+from datetime import datetime
+
 import pandas as pd
-from datetime import datetime, timedelta
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -16,9 +17,11 @@ def test_intraday_route(monkeypatch):
             return pd.DataFrame({"Close": [1.0, 2.0, 3.0]}, index=idx)
 
     captured = {}
+
     def fake_ticker(t):
         captured["ticker"] = t
         return FakeTicker()
+
     monkeypatch.setattr(instrument, "yf", type("YF", (), {"Ticker": fake_ticker}))
 
     app = FastAPI()

--- a/tests/backend/test_lazy_import.py
+++ b/tests/backend/test_lazy_import.py
@@ -25,6 +25,7 @@ def test_attribute_access_triggers_import(monkeypatch):
     # First access triggers the load
     result = proxy.ModuleType
     import types
+
     assert result is types.ModuleType
 
 
@@ -90,6 +91,7 @@ def test_string_path_monkeypatch(monkeypatch):
     sentinel = lazy_import_module.lazy_import("json")
     # Attach proxy as a module attribute for the dotted-path resolution test
     import backend.utils.lazy_import as lim
+
     lim._test_proxy = sentinel
 
     try:

--- a/tests/backend/test_logs.py
+++ b/tests/backend/test_logs.py
@@ -37,10 +37,13 @@ def test_logs_endpoint_missing_file(tmp_path, monkeypatch):
 def test_logs_endpoint_respects_lines_parameter(tmp_path, monkeypatch):
     log_file = tmp_path / "logs" / "backend.log"
     log_file.parent.mkdir(parents=True, exist_ok=True)
-    log_file.write_text("""line1
+    log_file.write_text(
+        """line1
 line2
 line3
-""", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
     monkeypatch.setattr(config, "repo_root", tmp_path)
     app = create_app()
     with TestClient(app) as client:

--- a/tests/backend/test_market_route.py
+++ b/tests/backend/test_market_route.py
@@ -1,14 +1,12 @@
 import backend.routes.market as market
 
+
 def test_fetch_indexes_includes_ftse(monkeypatch):
     prices = {sym: i * 100.0 for i, sym in enumerate(market.INDEX_SYMBOLS.values(), start=1)}
 
     def fake_Tickers(symbols):
         assert "^FTSE" in symbols and "^FTMC" in symbols
-        tickers = {
-            sym: type("T", (), {"info": {"regularMarketPrice": price}})()
-            for sym, price in prices.items()
-        }
+        tickers = {sym: type("T", (), {"info": {"regularMarketPrice": price}})() for sym, price in prices.items()}
         return type("TT", (), {"tickers": tickers})()
 
     monkeypatch.setattr(market.yf, "Tickers", fake_Tickers)

--- a/tests/backend/test_models_route.py
+++ b/tests/backend/test_models_route.py
@@ -12,8 +12,5 @@ def test_models_route_returns_available_models():
         resp = client.get("/v1/models")
 
     assert resp.status_code == 200
-    expected = {
-        "data": [{"id": name, "object": "model"} for name in models.MODEL_NAMES]
-    }
+    expected = {"data": [{"id": name, "object": "model"} for name in models.MODEL_NAMES]}
     assert resp.json() == expected
-

--- a/tests/backend/test_news_route.py
+++ b/tests/backend/test_news_route.py
@@ -1,7 +1,8 @@
+from typing import Dict, List, Tuple
+
 import requests
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from typing import Dict, List, Tuple
 
 from backend.routes import news
 from backend.utils import page_cache
@@ -98,10 +99,7 @@ def test_get_news_trims_payload_and_caches(monkeypatch):
 
 
 def test_parse_alpha_time_legacy_format():
-    assert (
-        news._parse_alpha_time("20230825T160000")
-        == "2023-08-25T16:00:00Z"
-    )
+    assert news._parse_alpha_time("20230825T160000") == "2023-08-25T16:00:00Z"
 
 
 def test_fallback_helpers_filter_finance_headlines(monkeypatch):
@@ -128,9 +126,7 @@ def test_fallback_helpers_filter_finance_headlines(monkeypatch):
 
     monkeypatch.setattr(news.requests, "get", fake_yahoo)
     yahoo_items = news.fetch_news_yahoo("PFE")
-    assert yahoo_items == [
-        {"headline": "PFE stock jumps on earnings", "url": "https://example.com/finance"}
-    ]
+    assert yahoo_items == [{"headline": "PFE stock jumps on earnings", "url": "https://example.com/finance"}]
 
     def fake_google(url, params=None, timeout=10, **kwargs):
         class Response:
@@ -156,6 +152,4 @@ def test_fallback_helpers_filter_finance_headlines(monkeypatch):
 
     monkeypatch.setattr(news.requests, "get", fake_google)
     google_items = news.fetch_news_google("MSFT")
-    assert google_items == [
-        {"headline": "MSFT shares slump after outlook", "url": "https://example.com/outlook"}
-    ]
+    assert google_items == [{"headline": "MSFT shares slump after outlook", "url": "https://example.com/outlook"}]

--- a/tests/backend/test_path_utils.py
+++ b/tests/backend/test_path_utils.py
@@ -1,4 +1,5 @@
 """Tests for path_utils: safe_join path-traversal guard and sanitize_for_log."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/backend/test_pension_route.py
+++ b/tests/backend/test_pension_route.py
@@ -1,7 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch
 
-import pytest
 from pytest import MonkeyPatch
 
 from backend.common.account_models import PersonMetadata
@@ -34,6 +32,7 @@ def test_pension_forecast_counts_prefixed_sipp_accounts(monkeypatch: MonkeyPatch
     monkeypatch.setattr("backend.routes.pension.resolve_accounts_root", lambda req: Path("."))
 
     from unittest.mock import MagicMock
+
     from starlette.requests import Request
 
     app = MagicMock()

--- a/tests/backend/test_portfolio_group_instruments_filters.py
+++ b/tests/backend/test_portfolio_group_instruments_filters.py
@@ -241,6 +241,7 @@ def test_group_endpoints_accept_as_of(monkeypatch):
     assert len(captured) == 5
     assert all(date == dt.date(2024, 1, 15) for date in captured)
 
+
 def test_calculate_weights_and_market_values_dedupes_case_and_sums_duplicates():
     summaries = [
         {"ticker": "aaa", "market_value_gbp": 100.0},

--- a/tests/backend/test_portfolio_group_movers.py
+++ b/tests/backend/test_portfolio_group_movers.py
@@ -6,9 +6,7 @@ import backend.routes.portfolio as portfolio
 from backend.local_api.main import app
 
 client = TestClient(app)
-token = client.post(
-    "/token", data={"username": "testuser", "password": "password"}
-).json()["access_token"]
+token = client.post("/token", data={"username": "testuser", "password": "password"}).json()["access_token"]
 client.headers.update({"Authorization": f"Bearer {token}"})
 
 
@@ -46,7 +44,7 @@ def test_group_movers_weighted(monkeypatch):
     data = resp.json()
     assert [g["ticker"] for g in data["gainers"]] == ["AAA"]
     assert data["gainers"][0]["market_value_gbp"] == 100.0
-    assert [l["ticker"] for l in data["losers"]] == ["BBB"]
+    assert [loser["ticker"] for loser in data["losers"]] == ["BBB"]
     assert data["losers"][0]["market_value_gbp"] == 50.0
 
 

--- a/tests/backend/test_portfolio_routes.py
+++ b/tests/backend/test_portfolio_routes.py
@@ -92,9 +92,7 @@ def test_portfolio_var_owner_missing(monkeypatch, tmp_path):
     client = _client(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "backend.routes.portfolio.risk.compute_portfolio_var",
-        lambda owner, days=365, confidence=0.95, include_cash=True: (_ for _ in ()).throw(
-            FileNotFoundError()
-        ),
+        lambda owner, days=365, confidence=0.95, include_cash=True: (_ for _ in ()).throw(FileNotFoundError()),
     )
     resp = client.get("/var/alice")
     assert resp.status_code == 404

--- a/tests/backend/test_portfolio_utils.py
+++ b/tests/backend/test_portfolio_utils.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 import backend.common.portfolio_utils as pu
 
+
 def test_fx_to_base_logs_warning_on_failure(monkeypatch, caplog):
     def fake_fetch(currency, quote, start, end):
         raise RuntimeError("boom")

--- a/tests/backend/test_routers.py
+++ b/tests/backend/test_routers.py
@@ -6,14 +6,14 @@ from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
 import backend.routes as routes_pkg
-from backend.routes import compliance, trading_agent, rebalance
+from backend.routes import compliance, rebalance, trading_agent
 
 
 def test_all_routes_registered():
     missing = []
     for _, name, _ in pkgutil.iter_modules(routes_pkg.__path__):
         # Skip private/helper modules that start with underscore
-        if name.startswith('_'):
+        if name.startswith("_"):
             continue
         module = importlib.import_module(f"backend.routes.{name}")
         router = getattr(module, "router", None)
@@ -32,9 +32,10 @@ def test_compliance_routes(monkeypatch):
         "backend.routes.compliance.resolve_owner_directory",
         lambda root, owner: Path(f"/fake/{owner}") if owner == "alice" else None,
     )
-    
+
     # Mock _known_owners to return alice as a known owner
     from backend.routes.compliance import KnownOwnerSet
+
     monkeypatch.setattr(
         "backend.routes.compliance._known_owners",
         lambda root: KnownOwnerSet(["alice"], active_root_has_entries=True),
@@ -123,9 +124,7 @@ def test_rebalance_route(monkeypatch):
 
 def test_agent_stats_route(monkeypatch):
     fake_metrics = {"win_rate": 0.5, "average_profit": 1.23}
-    monkeypatch.setattr(
-        "backend.common.trade_metrics.load_and_compute_metrics", lambda: fake_metrics
-    )
+    monkeypatch.setattr("backend.common.trade_metrics.load_and_compute_metrics", lambda: fake_metrics)
     agent = importlib.import_module("backend.routes.agent")
     importlib.reload(agent)
     app = FastAPI()

--- a/tests/backend/test_scenario_routes.py
+++ b/tests/backend/test_scenario_routes.py
@@ -1,6 +1,6 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-import pytest
 
 from backend.common.account_models import OwnerSummaryRecord
 from backend.routes import scenario
@@ -18,19 +18,18 @@ def _client(monkeypatch, list_plots_return, build_map=None):
             action = build_map.get(owner)
         if action == "error":
             raise FileNotFoundError
-        return build_map.get(owner, {
-            "total_value_estimate_gbp": 100.0,
-            "accounts": []
-        }) if build_map and owner in build_map else {
-            "total_value_estimate_gbp": 100.0,
-            "accounts": []
-        }
+        return (
+            build_map.get(owner, {"total_value_estimate_gbp": 100.0, "accounts": []})
+            if build_map and owner in build_map
+            else {"total_value_estimate_gbp": 100.0, "accounts": []}
+        )
 
     monkeypatch.setattr("backend.routes.scenario.build_owner_portfolio", build)
     monkeypatch.setattr(
         "backend.routes.scenario.apply_price_shock",
         lambda pf, ticker, pct: {"total_value_estimate_gbp": pf["total_value_estimate_gbp"] * (1 + pct)},
     )
+
     def fake_historical(pf, event_id=None, date=None, horizons=None):
         results = {}
         for h in horizons or []:
@@ -75,9 +74,7 @@ def test_run_scenario_derives_baseline(monkeypatch):
 @pytest.mark.xfail(reason="Scenario data structure changed")
 def test_historical_scenario_parses_tokens(monkeypatch):
     client = _client(monkeypatch, [{"owner": "alice", "accounts": ["acc1"]}])
-    resp = client.get(
-        "/scenario/historical", params={"event_id": "evt", "horizons": "1d,1w"}
-    )
+    resp = client.get("/scenario/historical", params={"event_id": "evt", "horizons": "1d,1w"})
     assert resp.status_code == 200
     data = resp.json()
     assert data[0]["horizons"]["1d"]["shocked_total_value_gbp"] == pytest.approx(100.1)

--- a/tests/backend/test_signup_approved_email.py
+++ b/tests/backend/test_signup_approved_email.py
@@ -83,8 +83,6 @@ def test_send_signup_approved_email_propagates_ses_failures(make_error):
         client_factory.return_value = ses_client
 
         with pytest.raises(type(make_error())):
-            send_signup_approved_email(
-                "jane@example.com", "Jane Doe", "https://allotmint.example/login"
-            )
+            send_signup_approved_email("jane@example.com", "Jane Doe", "https://allotmint.example/login")
 
     ses_client.send_email.assert_called_once()

--- a/tests/backend/test_signup_request_email.py
+++ b/tests/backend/test_signup_request_email.py
@@ -34,9 +34,7 @@ def test_render_includes_request_details_and_links():
 
 
 def test_render_escapes_hostile_input():
-    html = render_signup_admin_email(
-        _notification(name="<script>alert(1)</script>", note="<img src=x onerror=y>")
-    )
+    html = render_signup_admin_email(_notification(name="<script>alert(1)</script>", note="<img src=x onerror=y>"))
     assert "<script>" not in html
     assert "<img" not in html
     assert "&lt;script&gt;" in html

--- a/tests/backend/test_smoke_endpoint_list.py
+++ b/tests/backend/test_smoke_endpoint_list.py
@@ -3,19 +3,19 @@ import re
 from pathlib import Path
 
 import pytest
-
-from backend.app import create_app
 from fastapi.routing import APIRoute
 
-SMOKE_FILE = Path(__file__).resolve().parents[2] / 'scripts' / 'frontend-backend-smoke.ts'
+from backend.app import create_app
+
+SMOKE_FILE = Path(__file__).resolve().parents[2] / "scripts" / "frontend-backend-smoke.ts"
 
 
 def load_smoke_endpoints():
     text = SMOKE_FILE.read_text()
     match = re.search(r"smokeEndpoints: SmokeEndpoint\[] = (\[.*?\]) as const;", text, re.DOTALL)
-    assert match, 'smokeEndpoints array not found'
+    assert match, "smokeEndpoints array not found"
     data = json.loads(match.group(1))
-    return {(item['method'], item['path']) for item in data}
+    return {(item["method"], item["path"]) for item in data}
 
 
 def list_backend_routes():
@@ -32,4 +32,4 @@ def list_backend_routes():
 def test_smoke_endpoint_list_up_to_date():
     smoke = load_smoke_endpoints()
     backend = list_backend_routes()
-    assert smoke == backend, 'Update scripts/frontend-backend-smoke.ts for new routes'
+    assert smoke == backend, "Update scripts/frontend-backend-smoke.ts for new routes"

--- a/tests/backend/test_startup_timed_phase.py
+++ b/tests/backend/test_startup_timed_phase.py
@@ -14,6 +14,7 @@ in (see ``AppLifecycleService._warm_snapshot``). It must:
 * tolerate a ``None`` or non-string phase name via ``sanitise_log_value``
   rather than raising while trying to log.
 """
+
 from __future__ import annotations
 
 import json
@@ -37,12 +38,9 @@ def test_timed_phase_logs_duration_and_reraises_on_exception(
             with _timed_phase("exploding_phase"):
                 raise ValueError("boom")
 
-    phase_records = [
-        record for record in caplog.records if getattr(record, "phase", None) == "exploding_phase"
-    ]
-    assert len(phase_records) == 1, (
-        "Expected exactly one 'cold_start_phase' log for the failing phase, got: "
-        + str([r.message for r in caplog.records])
+    phase_records = [record for record in caplog.records if getattr(record, "phase", None) == "exploding_phase"]
+    assert len(phase_records) == 1, "Expected exactly one 'cold_start_phase' log for the failing phase, got: " + str(
+        [r.message for r in caplog.records]
     )
     record = phase_records[0]
     assert record.levelno == logging.INFO

--- a/tests/backend/test_tabs_config.py
+++ b/tests/backend/test_tabs_config.py
@@ -4,14 +4,16 @@ from backend.config import ConfigValidationError, TabsConfig, validate_tabs
 
 
 def test_validate_tabs_accepts_new_keys():
-    tabs = validate_tabs({
-        "market": False,
-        "allocation": True,
-        "rebalance": False,
-        "pension": True,
-        "alertsettings": True,
-        "research": True,
-    })
+    tabs = validate_tabs(
+        {
+            "market": False,
+            "allocation": True,
+            "rebalance": False,
+            "pension": True,
+            "alertsettings": True,
+            "research": True,
+        }
+    )
     assert isinstance(tabs, TabsConfig)
     assert tabs.market is False
     assert tabs.allocation is True

--- a/tests/backend/test_virtual_portfolio_routes.py
+++ b/tests/backend/test_virtual_portfolio_routes.py
@@ -1,11 +1,11 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from backend.routes.virtual_portfolio import router
 from backend.common.virtual_portfolio import (
     VirtualPortfolio,
     VirtualPortfolioSummary,
 )
+from backend.routes.virtual_portfolio import router
 
 
 def create_app():

--- a/tests/backend/test_weekly_report_email.py
+++ b/tests/backend/test_weekly_report_email.py
@@ -86,11 +86,7 @@ def test_render_weekly_report_strips_nested_disallowed_tags():
     report = WeeklyReport(
         week_number=5,
         portfolio_stats={},
-        holdings_table=(
-            "<table><tr><td>"
-            "<div><span onclick=\"evil()\">inner text</span></div>"
-            "</td></tr></table>"
-        ),
+        holdings_table=("<table><tr><td>" '<div><span onclick="evil()">inner text</span></div>' "</td></tr></table>"),
         transactions_table="<table></table>",
     )
     html = render_weekly_report(report)
@@ -109,12 +105,7 @@ def test_render_weekly_report_strips_script_inside_allowed_tag():
     report = WeeklyReport(
         week_number=5,
         portfolio_stats={},
-        holdings_table=(
-            "<table><tr><td>"
-            "<script>evil()</script>"
-            "safe text"
-            "</td></tr></table>"
-        ),
+        holdings_table=("<table><tr><td>" "<script>evil()</script>" "safe text" "</td></tr></table>"),
         transactions_table="<table></table>",
     )
     html = render_weekly_report(report)

--- a/tests/common/test_allowances.py
+++ b/tests/common/test_allowances.py
@@ -1,5 +1,5 @@
-import json
 import datetime as dt
+import json
 
 from backend.common.allowances import (
     current_tax_year,
@@ -37,16 +37,12 @@ def test_load_yearly_contributions_non_numeric(tmp_path):
 def test_remaining_allowances_clamps_and_custom_limits(tmp_path):
     allowances_dir = tmp_path / "allowances"
     allowances_dir.mkdir()
-    (allowances_dir / "carol.json").write_text(
-        json.dumps({"2024-2025": {"ISA": 25_000}})
-    )
+    (allowances_dir / "carol.json").write_text(json.dumps({"2024-2025": {"ISA": 25_000}}))
 
     # Exceeds default ISA limit -> remaining is clamped to zero
     default_res = remaining_allowances("carol", "2024-2025", root=tmp_path)
     assert default_res["ISA"] == {"used": 25_000.0, "limit": 20_000.0, "remaining": 0.0}
 
     # Custom limit is honoured
-    custom_res = remaining_allowances(
-        "carol", "2024-2025", limits={"ISA": 30_000}, root=tmp_path
-    )
+    custom_res = remaining_allowances("carol", "2024-2025", limits={"ISA": 30_000}, root=tmp_path)
     assert custom_res["ISA"] == {"used": 25_000.0, "limit": 30_000.0, "remaining": 5_000.0}

--- a/tests/common/test_compute_var.py
+++ b/tests/common/test_compute_var.py
@@ -1,5 +1,5 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
 
 from backend.common import portfolio_utils as pu
@@ -20,4 +20,3 @@ def test_compute_var_insufficient_data_returns_none():
 def test_compute_var_empty_dataframe_returns_none():
     df = pd.DataFrame()
     assert pu.compute_var(df) is None
-

--- a/tests/common/test_fx_to_base.py
+++ b/tests/common/test_fx_to_base.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+
 from backend.common import portfolio_utils as pu
 
 

--- a/tests/common/test_fx_to_gbp.py
+++ b/tests/common/test_fx_to_gbp.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pytest
 
 from backend.common import portfolio_utils as pu
 

--- a/tests/common/test_goals.py
+++ b/tests/common/test_goals.py
@@ -4,8 +4,8 @@ from datetime import date
 
 import pytest
 
-from backend.common.storage import get_storage
 from backend.common import goals as goals_mod
+from backend.common.storage import get_storage
 
 
 @pytest.fixture

--- a/tests/common/test_group_portfolio.py
+++ b/tests/common/test_group_portfolio.py
@@ -29,10 +29,7 @@ def test_list_groups_returns_expected_defaults():
 
 def test_list_groups_does_not_load_portfolio_contents():
     """Group discovery must not issue one data load per owner or account."""
-    owner_rows = [
-        OwnerSummaryRecord(owner=f"owner-{index}", accounts=[f"account-{index}"])
-        for index in range(1_000)
-    ]
+    owner_rows = [OwnerSummaryRecord(owner=f"owner-{index}", accounts=[f"account-{index}"]) for index in range(1_000)]
 
     started_at = time.perf_counter()
     with (
@@ -57,7 +54,7 @@ def test_build_group_portfolio_merges_accounts_and_totals():
                     HOLDINGS: [
                         {"ticker": "AAA", "market_value_gbp": 100.0},
                         {"ticker": "BBB", "market_value_gbp": 50.0},
-                    ]
+                    ],
                 }
             ],
         },
@@ -68,7 +65,7 @@ def test_build_group_portfolio_merges_accounts_and_totals():
                     "currency": None,
                     HOLDINGS: [
                         {"ticker": "CCC", "market_value_gbp": 200.0},
-                    ]
+                    ],
                 }
             ],
         },

--- a/tests/common/test_holding_utils.py
+++ b/tests/common/test_holding_utils.py
@@ -16,6 +16,7 @@ def test_is_pence_currency_wrapper(raw_currency):
 def test_is_pence_currency_wrapper_false_for_gbp():
     assert not holding_utils._is_pence_currency("GBP")
 
+
 def test_close_column_selection():
     df = pd.DataFrame({"CLOSE_GBP": [1], "Close": [2], "Adj Close": [3]})
     assert holding_utils._close_column(df) == "CLOSE_GBP"
@@ -129,9 +130,7 @@ def test_load_latest_prices_does_not_double_convert_close_gbp(monkeypatch):
     monkeypatch.setattr(
         holding_utils,
         "load_meta_timeseries_range",
-        lambda *args, **kwargs: pd.DataFrame(
-            {"Date": [dt.date(2024, 1, 1)], "Close": [100.0], "Close_gbp": [79.0]}
-        ),
+        lambda *args, **kwargs: pd.DataFrame({"Date": [dt.date(2024, 1, 1)], "Close": [100.0], "Close_gbp": [79.0]}),
     )
     monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 1.0)
     monkeypatch.setattr(holding_utils, "get_instrument_meta", lambda *_: {"currency": "USD"})
@@ -153,9 +152,7 @@ def test_load_latest_prices_close_gbp_not_rescaled(monkeypatch):
     monkeypatch.setattr(
         holding_utils,
         "load_meta_timeseries_range",
-        lambda *args, **kwargs: pd.DataFrame(
-            {"Date": [dt.date(2024, 1, 1)], "Close": [283.4], "Close_gbp": [2.834]}
-        ),
+        lambda *args, **kwargs: pd.DataFrame({"Date": [dt.date(2024, 1, 1)], "Close": [283.4], "Close_gbp": [2.834]}),
     )
     monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 0.01)
     monkeypatch.setattr(holding_utils, "get_instrument_meta", lambda *_: {"currency": "GBX"})
@@ -178,20 +175,14 @@ def test_load_latest_prices_gbx_pence_no_scaling_override(monkeypatch, raw_curre
     monkeypatch.setattr(
         holding_utils,
         "load_meta_timeseries_range",
-        lambda *args, **kwargs: pd.DataFrame(
-            {"Date": [dt.date(2024, 1, 1)], "Close": [10_000.0]}
-        ),
+        lambda *args, **kwargs: pd.DataFrame({"Date": [dt.date(2024, 1, 1)], "Close": [10_000.0]}),
     )
     # scale=1.0: no scaling override present, so our code must divide by 100
     monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 1.0)
-    monkeypatch.setattr(
-        holding_utils, "get_instrument_meta", lambda *_: {"currency": raw_currency}
-    )
+    monkeypatch.setattr(holding_utils, "get_instrument_meta", lambda *_: {"currency": raw_currency})
 
     def _boom_fx(*args, **kwargs):
-        raise AssertionError(
-            f"_fx_to_base must not be called for pence currency {raw_currency!r}"
-        )
+        raise AssertionError(f"_fx_to_base must not be called for pence currency {raw_currency!r}")
 
     monkeypatch.setattr(holding_utils, "_fx_to_base", _boom_fx)
 
@@ -213,15 +204,11 @@ def test_load_latest_prices_gbx_pence_with_scaling_override(monkeypatch):
     monkeypatch.setattr(
         holding_utils,
         "load_meta_timeseries_range",
-        lambda *args, **kwargs: pd.DataFrame(
-            {"Date": [dt.date(2024, 1, 1)], "Close": [10_000.0]}
-        ),
+        lambda *args, **kwargs: pd.DataFrame({"Date": [dt.date(2024, 1, 1)], "Close": [10_000.0]}),
     )
     # scale=0.01: standard GBX override — apply_scaling handles pence->pounds
     monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 0.01)
-    monkeypatch.setattr(
-        holding_utils, "get_instrument_meta", lambda *_: {"currency": "GBX"}
-    )
+    monkeypatch.setattr(holding_utils, "get_instrument_meta", lambda *_: {"currency": "GBX"})
 
     def _boom_fx(*args, **kwargs):
         raise AssertionError("_fx_to_base must not be called for GBX")
@@ -251,15 +238,11 @@ def test_load_latest_prices_gbx_non_pence_factor_scale_still_converts(monkeypatc
     monkeypatch.setattr(
         holding_utils,
         "load_meta_timeseries_range",
-        lambda *args, **kwargs: pd.DataFrame(
-            {"Date": [dt.date(2024, 1, 1)], "Close": [200.0]}
-        ),
+        lambda *args, **kwargs: pd.DataFrame({"Date": [dt.date(2024, 1, 1)], "Close": [200.0]}),
     )
     # scale=0.5: non-unity but NOT the pence factor; pence->GBP must still run
     monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 0.5)
-    monkeypatch.setattr(
-        holding_utils, "get_instrument_meta", lambda *_: {"currency": "GBX"}
-    )
+    monkeypatch.setattr(holding_utils, "get_instrument_meta", lambda *_: {"currency": "GBX"})
 
     def _boom_fx(*args, **kwargs):
         raise AssertionError("_fx_to_base must not be called for GBX")
@@ -284,9 +267,7 @@ def test_load_live_prices_gbx_non_pence_factor_scale_still_converts(monkeypatch)
         def json(self):
             return {
                 "quoteResponse": {
-                    "result": [
-                        {"symbol": "HFEL.L", "regularMarketPrice": 200.0, "regularMarketTime": ts}
-                    ]
+                    "result": [{"symbol": "HFEL.L", "regularMarketPrice": 200.0, "regularMarketTime": ts}]
                 }
             }
 
@@ -319,9 +300,7 @@ def test_load_latest_prices_non_pence_scale_point_zero_one_still_fx_converts(mon
     monkeypatch.setattr(
         holding_utils,
         "load_meta_timeseries_range",
-        lambda *args, **kwargs: pd.DataFrame(
-            {"Date": [dt.date(2024, 1, 1)], "Close": [100.0]}
-        ),
+        lambda *args, **kwargs: pd.DataFrame({"Date": [dt.date(2024, 1, 1)], "Close": [100.0]}),
     )
     # 100.0 * 0.01 = 1.0 USD after apply_scaling, then FX 0.8 => 0.8 GBP.
     monkeypatch.setattr(holding_utils, "get_scaling_override", lambda *a, **k: 0.01)
@@ -456,9 +435,7 @@ def test_load_live_prices_gbx_with_scaling_override_not_double_converted(monkeyp
         def json(self):
             return {
                 "quoteResponse": {
-                    "result": [
-                        {"symbol": "HFEL.L", "regularMarketPrice": 10_000.0, "regularMarketTime": ts}
-                    ]
+                    "result": [{"symbol": "HFEL.L", "regularMarketPrice": 10_000.0, "regularMarketTime": ts}]
                 }
             }
 

--- a/tests/common/test_instrument_api_core.py
+++ b/tests/common/test_instrument_api_core.py
@@ -42,7 +42,7 @@ def test_prime_latest_prices_populates(monkeypatch):
 
 
 def test_price_and_changes_unresolved(monkeypatch):
-    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, l: None)
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, loc: None)
     ia._price_and_changes.cache_clear()
     res = ia._price_and_changes("FOO")
     assert res["last_price_gbp"] is None
@@ -50,9 +50,10 @@ def test_price_and_changes_unresolved(monkeypatch):
 
 
 def test_price_and_changes_snapshot(monkeypatch):
-    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, l: ("ABC", "L"))
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, loc: ("ABC", "L"))
     monkeypatch.setattr(ia, "price_change_pct", lambda t, d: 1.0)
     from backend.common import portfolio_utils as pu
+
     monkeypatch.setattr(
         pu,
         "_PRICE_SNAPSHOT",
@@ -66,9 +67,10 @@ def test_price_and_changes_snapshot(monkeypatch):
 
 
 def test_price_and_changes_fallback(monkeypatch):
-    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, l: ("ABC", "L"))
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, loc: ("ABC", "L"))
     monkeypatch.setattr(ia, "price_change_pct", lambda t, d: 2.0)
     from backend.common import portfolio_utils as pu
+
     monkeypatch.setattr(pu, "_PRICE_SNAPSHOT", {})
     monkeypatch.setattr(ia, "_close_on", lambda s, e, d: 50.0)
     ia._price_and_changes.cache_clear()

--- a/tests/common/test_load_snapshot.py
+++ b/tests/common/test_load_snapshot.py
@@ -114,9 +114,7 @@ def _make_fake_s3_modules(fail: bool):
     return fake_boto3, fake_exc
 
 
-def test_load_snapshot_aws_s3_and_local_both_missing_logs_error(
-    tmp_path, monkeypatch, caplog
-):
+def test_load_snapshot_aws_s3_and_local_both_missing_logs_error(tmp_path, monkeypatch, caplog):
     """ERROR (not WARNING) when S3 fails and local fallback file is also absent."""
     missing = tmp_path / "missing.json"
     fake_boto3, fake_exc = _make_fake_s3_modules(fail=True)
@@ -140,9 +138,7 @@ def test_load_snapshot_aws_s3_and_local_both_missing_logs_error(
     assert "Price snapshot not found" not in caplog.text
 
 
-def test_load_snapshot_aws_s3_fails_no_local_path_configured_logs_error(
-    monkeypatch, caplog
-):
+def test_load_snapshot_aws_s3_fails_no_local_path_configured_logs_error(monkeypatch, caplog):
     """ERROR when S3 fails and prices_json is not configured at all."""
     fake_boto3, fake_exc = _make_fake_s3_modules(fail=True)
 
@@ -248,14 +244,10 @@ def test_load_snapshot_nosuchkey_logs_warning_not_error(tmp_path, monkeypatch, c
     assert "Failed to fetch price snapshot" not in caplog.text
     assert "No price data available" not in caplog.text
     records = [r for r in caplog.records if r.levelno >= logging.ERROR]
-    assert records == [], (
-        f"Expected no ERROR logs for NoSuchKey; got: {[r.message for r in records]}"
-    )
+    assert records == [], f"Expected no ERROR logs for NoSuchKey; got: {[r.message for r in records]}"
 
 
-def test_load_snapshot_nosuchkey_no_local_path_logs_single_warning(
-    monkeypatch, caplog
-):
+def test_load_snapshot_nosuchkey_no_local_path_logs_single_warning(monkeypatch, caplog):
     """NoSuchKey + no local path configured: single WARNING, no ERROR."""
     fake_boto3, fake_exc = _make_no_such_key_s3_modules()
 
@@ -276,9 +268,7 @@ def test_load_snapshot_nosuchkey_no_local_path_logs_single_warning(
     warning_texts = [r.message for r in caplog.records if r.levelno == logging.WARNING]
     error_texts = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
     assert error_texts == [], f"Expected no ERROR logs for NoSuchKey; got: {error_texts}"
-    assert any("not yet" in m for m in warning_texts), (
-        f"Expected a 'not yet seeded' warning; got: {warning_texts}"
-    )
+    assert any("not yet" in m for m in warning_texts), f"Expected a 'not yet seeded' warning; got: {warning_texts}"
 
 
 def test_load_snapshot_botocore_error_logs_error(tmp_path, monkeypatch, caplog):
@@ -316,9 +306,7 @@ def test_load_snapshot_botocore_error_logs_error(tmp_path, monkeypatch, caplog):
     assert "not yet present" not in caplog.text
 
 
-def test_load_snapshot_non_aws_missing_local_logs_only_warning(
-    tmp_path, monkeypatch, caplog
-):
+def test_load_snapshot_non_aws_missing_local_logs_only_warning(tmp_path, monkeypatch, caplog):
     """Non-AWS env: missing local file logs WARNING, not ERROR."""
     missing = tmp_path / "missing.json"
 
@@ -357,7 +345,7 @@ def test_seed_prices_file_loads_demo_holdings(tmp_path, monkeypatch):
     for ticker in ("VWRL.L", "ERNS.L", "PFE.N"):
         assert ticker in data, f"Seed prices must include demo holding {ticker}"
         entry = data[ticker]
-        assert entry.get("last_price") is not None and entry["last_price"] > 0, (
-            f"{ticker} must have a positive last_price"
-        )
+        assert (
+            entry.get("last_price") is not None and entry["last_price"] > 0
+        ), f"{ticker} must have a positive last_price"
         assert entry.get("price_currency") == "GBP", f"{ticker} price must be in GBP"

--- a/tests/common/test_portfolio_loader.py
+++ b/tests/common/test_portfolio_loader.py
@@ -220,9 +220,7 @@ def test_load_accounts_for_owner_missing_file(
     assert "Account file missing: alex/isa.json" in caplog.text
 
 
-def test_load_accounts_for_owner_json_error(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_load_accounts_for_owner_json_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.WARNING, logger="portfolio_loader")
 
     def _raise_decode_error(owner: str, account: str) -> dict:
@@ -285,9 +283,7 @@ def test_list_portfolios_aggregates_owners(patched_portfolio_loader: list[OwnerS
     assert result == expected
 
 
-def test_load_portfolio_case_insensitive(
-    patched_portfolio_loader: list[OwnerSummaryRecord]
-) -> None:
+def test_load_portfolio_case_insensitive(patched_portfolio_loader: list[OwnerSummaryRecord]) -> None:
     all_portfolios = portfolio_loader.list_portfolios()
 
     beth_portfolio = portfolio_loader.load_portfolio("BeTh")

--- a/tests/common/test_portfolio_utils_cash_meta.py
+++ b/tests/common/test_portfolio_utils_cash_meta.py
@@ -1,5 +1,3 @@
-import pytest
-
 from backend.common import portfolio_utils as pu
 
 

--- a/tests/common/test_portfolio_utils_core.py
+++ b/tests/common/test_portfolio_utils_core.py
@@ -1,8 +1,8 @@
 import json
 from datetime import datetime
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
 
 from backend.common import portfolio_utils as pu
@@ -74,4 +74,3 @@ def test_load_snapshot_missing_file(tmp_path, monkeypatch, caplog):
     assert data == {}
     assert ts is None
     assert str(path) in caplog.text
-

--- a/tests/common/test_portfolio_utils_returns.py
+++ b/tests/common/test_portfolio_utils_returns.py
@@ -8,9 +8,7 @@ def test_compute_alpha_and_tracking_error(monkeypatch: pytest.MonkeyPatch) -> No
     dates = pd.date_range("2024-01-01", periods=3, freq="D")
     portfolio_series = pd.Series([100.0, 110.0, 115.0], index=dates.date)
 
-    def fake_portfolio_value_series(
-        name: str, days: int, *, group: bool = False, pricing_date=None, **_
-    ) -> pd.Series:
+    def fake_portfolio_value_series(name: str, days: int, *, group: bool = False, pricing_date=None, **_) -> pd.Series:
         assert name == "alice"
         assert days == 365
         assert group is False
@@ -37,9 +35,7 @@ def test_compute_metrics_none_when_series_misaligned(monkeypatch: pytest.MonkeyP
     dates = pd.date_range("2024-01-01", periods=3, freq="D")
     portfolio_series = pd.Series([100.0, 110.0, 115.0], index=dates.date)
 
-    def fake_portfolio_value_series(
-        name: str, days: int, *, group: bool = False, pricing_date=None, **_
-    ) -> pd.Series:
+    def fake_portfolio_value_series(name: str, days: int, *, group: bool = False, pricing_date=None, **_) -> pd.Series:
         return portfolio_series
 
     monkeypatch.setattr(portfolio_utils, "_portfolio_value_series", fake_portfolio_value_series)
@@ -72,9 +68,7 @@ def test_compute_metrics_none_when_benchmark_data_entirely_missing(
     dates = pd.date_range("2024-01-01", periods=3, freq="D")
     portfolio_series = pd.Series([100.0, 110.0, 115.0], index=dates.date)
 
-    def fake_portfolio_value_series(
-        name: str, days: int, *, group: bool = False, pricing_date=None, **_
-    ) -> pd.Series:
+    def fake_portfolio_value_series(name: str, days: int, *, group: bool = False, pricing_date=None, **_) -> pd.Series:
         return portfolio_series
 
     monkeypatch.setattr(portfolio_utils, "_portfolio_value_series", fake_portfolio_value_series)
@@ -101,9 +95,7 @@ def test_group_metrics_and_max_drawdown(monkeypatch: pytest.MonkeyPatch) -> None
 
     monkeypatch.setattr(portfolio_utils.group_portfolio, "build_group_portfolio", fake_group_portfolio)
 
-    def fake_portfolio_value_series(
-        name: str, days: int, *, group: bool = False, pricing_date=None, **_
-    ) -> pd.Series:
+    def fake_portfolio_value_series(name: str, days: int, *, group: bool = False, pricing_date=None, **_) -> pd.Series:
         if group:
             # Mirror the real helper by touching the group portfolio builder.
             portfolio_utils.group_portfolio.build_group_portfolio(name)
@@ -128,9 +120,7 @@ def test_group_metrics_and_max_drawdown(monkeypatch: pytest.MonkeyPatch) -> None
     drawdown_dates = pd.date_range("2024-02-01", periods=4, freq="D")
     drawdown_series = pd.Series([100.0, 120.0, 90.0, 110.0], index=drawdown_dates.date)
 
-    def fake_drawdown_series(
-        name: str, days: int, *, group: bool = False, pricing_date=None, **_
-    ) -> pd.Series:
+    def fake_drawdown_series(name: str, days: int, *, group: bool = False, pricing_date=None, **_) -> pd.Series:
         if group:
             portfolio_utils.group_portfolio.build_group_portfolio(name)
             return drawdown_series

--- a/tests/common/test_portfolio_utils_series.py
+++ b/tests/common/test_portfolio_utils_series.py
@@ -113,9 +113,7 @@ def test_portfolio_value_series_uses_group_builder(monkeypatch):
     monkeypatch.setattr(
         pu,
         "load_meta_timeseries",
-        lambda ticker, exchange, days: _make_df(
-            [("2024-02-01", 50.0), ("2024-02-02", 55.0)]
-        ),
+        lambda ticker, exchange, days: _make_df([("2024-02-01", 50.0), ("2024-02-02", 55.0)]),
     )
 
     result = pu._portfolio_value_series("group-1", days=10, group=True)

--- a/tests/common/test_prices.py
+++ b/tests/common/test_prices.py
@@ -7,11 +7,10 @@ import sys
 from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
 from typing import Dict, List
+from unittest.mock import Mock
 
 import pandas as pd
 import pytest
-
-from unittest.mock import Mock
 
 from backend.common import prices
 
@@ -370,17 +369,13 @@ def test_refresh_prices_writes_json_and_updates_cache(tmp_path, monkeypatch: pyt
     alerts_mock.assert_called_once_with()
 
 
-def test_refresh_prices_skips_write_when_all_prices_null(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_refresh_prices_skips_write_when_all_prices_null(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Offline/no-data refresh must not overwrite a valid seed file with all-null prices."""
     seed = {"VWRL.L": {"last_price": 97.5, "price_currency": "GBP"}}
     output_path = tmp_path / "prices.json"
     output_path.write_text(json.dumps(seed))
 
-    null_snapshot = {
-        "VWRL.L": {"last_price": None, "price_currency": None, "is_stale": True}
-    }
+    null_snapshot = {"VWRL.L": {"last_price": None, "price_currency": None, "is_stale": True}}
     monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: ["VWRL.L"])
     monkeypatch.setattr(prices, "get_price_snapshot", lambda _: null_snapshot)
     monkeypatch.setattr(prices, "refresh_snapshot_in_memory", Mock())
@@ -390,9 +385,9 @@ def test_refresh_prices_skips_write_when_all_prices_null(
 
     prices.refresh_prices()
 
-    assert json.loads(output_path.read_text()) == seed, (
-        "Seed file must not be overwritten when every fetched price is None"
-    )
+    assert (
+        json.loads(output_path.read_text()) == seed
+    ), "Seed file must not be overwritten when every fetched price is None"
 
 
 def test_refresh_prices_uploads_existing_snapshot_to_s3_when_all_prices_null(
@@ -409,9 +404,7 @@ def test_refresh_prices_uploads_existing_snapshot_to_s3_when_all_prices_null(
     output_path = tmp_path / "prices.json"
     output_path.write_text(json.dumps(seed))
 
-    null_snapshot = {
-        "VWRL.L": {"last_price": None, "price_currency": None, "is_stale": True}
-    }
+    null_snapshot = {"VWRL.L": {"last_price": None, "price_currency": None, "is_stale": True}}
     monkeypatch.setattr(prices, "list_all_unique_tickers", lambda: ["VWRL.L"])
     monkeypatch.setattr(prices, "get_price_snapshot", lambda _: null_snapshot)
     monkeypatch.setattr(prices, "refresh_snapshot_in_memory", Mock())
@@ -438,9 +431,7 @@ def test_refresh_prices_uploads_existing_snapshot_to_s3_when_all_prices_null(
     assert put_calls[0]["ContentType"] == "application/json"
 
 
-def test_refresh_prices_partial_null_preserves_existing_prices(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_refresh_prices_partial_null_preserves_existing_prices(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Partial-outage refresh updates valid prices and preserves existing ones for null tickers."""
     seed = {
         "AAA.L": {"last_price": 10.0, "price_currency": "GBP"},
@@ -470,29 +461,23 @@ def test_refresh_prices_partial_null_preserves_existing_prices(
     prices.refresh_prices()
 
     result = json.loads(output_path.read_text())
-    assert result["AAA.L"]["last_price"] == pytest.approx(11.5), (
-        "Successfully-fetched price must be updated"
-    )
-    assert result["BBB.L"]["last_price"] == pytest.approx(20.0), (
-        "Seed price for null-returning ticker must be preserved"
-    )
+    assert result["AAA.L"]["last_price"] == pytest.approx(11.5), "Successfully-fetched price must be updated"
+    assert result["BBB.L"]["last_price"] == pytest.approx(
+        20.0
+    ), "Seed price for null-returning ticker must be preserved"
 
     assert len(in_memory_calls) == 1, "refresh_snapshot_in_memory must be called once"
     in_mem = in_memory_calls[0]
-    assert in_mem["AAA.L"]["last_price"] == pytest.approx(11.5), (
-        "In-memory snapshot must contain updated price"
-    )
-    assert in_mem["BBB.L"]["last_price"] == pytest.approx(20.0), (
-        "In-memory snapshot must contain preserved seed price, not None"
-    )
-    assert price_cache.get("BBB.L") == pytest.approx(20.0), (
-        "_price_cache must contain preserved seed price for null-returning ticker"
-    )
+    assert in_mem["AAA.L"]["last_price"] == pytest.approx(11.5), "In-memory snapshot must contain updated price"
+    assert in_mem["BBB.L"]["last_price"] == pytest.approx(
+        20.0
+    ), "In-memory snapshot must contain preserved seed price, not None"
+    assert price_cache.get("BBB.L") == pytest.approx(
+        20.0
+    ), "_price_cache must contain preserved seed price for null-returning ticker"
 
 
-def test_refresh_prices_filters_nan_zero_and_negative_prices(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_refresh_prices_filters_nan_zero_and_negative_prices(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """End-to-end NaN/zero/negative guard: mock the underlying price fetches
     (``_load_latest_prices`` / ``load_live_prices``) so ``get_price_snapshot``
     runs for real, then verify ``refresh_prices``'s write-boundary filter

--- a/tests/common/test_refresh_snapshot_in_memory.py
+++ b/tests/common/test_refresh_snapshot_in_memory.py
@@ -59,9 +59,7 @@ def test_refresh_snapshot_in_memory_stores_exactly_what_it_is_given(monkeypatch)
     assert pu._PRICE_SNAPSHOT_TS == ts
 
 
-def test_refresh_prices_write_boundary_guard_prevents_nan_reaching_in_memory_snapshot(
-    tmp_path, monkeypatch
-) -> None:
+def test_refresh_prices_write_boundary_guard_prevents_nan_reaching_in_memory_snapshot(tmp_path, monkeypatch) -> None:
     """Defense-in-depth: ``refresh_prices`` must never hand a NaN/zero/negative
     price to ``refresh_snapshot_in_memory``. The ``to_persist`` filter at the
     write boundary (backend/common/prices.py) is what protects the in-memory
@@ -87,9 +85,7 @@ def test_refresh_prices_write_boundary_guard_prevents_nan_reaching_in_memory_sna
     monkeypatch.setattr(prices, "_price_cache", {})
 
     captured: list = []
-    monkeypatch.setattr(
-        prices, "refresh_snapshot_in_memory", lambda merged: captured.append(merged)
-    )
+    monkeypatch.setattr(prices, "refresh_snapshot_in_memory", lambda merged: captured.append(merged))
 
     prices.refresh_prices()
 
@@ -102,4 +98,3 @@ def test_refresh_prices_write_boundary_guard_prevents_nan_reaching_in_memory_sna
     assert "ZERO.L" not in merged
     assert "NEG.L" not in merged
     assert merged["OK.L"]["last_price"] == 12.0
-

--- a/tests/common/test_tax.py
+++ b/tests/common/test_tax.py
@@ -4,11 +4,10 @@ from backend.common.tax import harvest_losses
 def test_harvest_losses_filters_and_rounds():
     positions = [
         {"ticker": "GOOD", "basis": 100.0, "price": 89.123},  # valid loss
-        {"ticker": "LOW", "basis": 100.0, "price": 95.0},    # below threshold
+        {"ticker": "LOW", "basis": 100.0, "price": 95.0},  # below threshold
         {"ticker": "BADBASIS", "basis": "oops", "price": 50.0},  # malformed basis
         {"ticker": "BADPRICE", "basis": 100.0, "price": "oops"},  # malformed price
     ]
     result = harvest_losses(positions, threshold=0.1)
     assert result == [{"ticker": "GOOD", "loss": 10.88}]
     assert result[0]["loss"] == 10.88
-

--- a/tests/common/test_url_validator.py
+++ b/tests/common/test_url_validator.py
@@ -6,6 +6,7 @@ from backend.common.url_validator import InvalidExternalURLError, validate_exter
 
 # ── scheme enforcement ────────────────────────────────────────────────────────
 
+
 def test_https_url_passes():
     validate_external_url("https://api.example.com/query?key=abc")
 
@@ -30,6 +31,7 @@ def test_no_scheme_rejected():
 
 
 # ── blocked hostnames ─────────────────────────────────────────────────────────
+
 
 def test_localhost_rejected():
     with pytest.raises(InvalidExternalURLError, match="not permitted"):
@@ -61,6 +63,7 @@ def test_ip6_loopback_rejected():
 
 
 # ── private IP ranges ─────────────────────────────────────────────────────────
+
 
 @pytest.mark.parametrize(
     "url",
@@ -103,6 +106,7 @@ def test_abbreviated_ipv4_rejected(url: str) -> None:
 
 # ── valid public endpoints ────────────────────────────────────────────────────
 
+
 @pytest.mark.parametrize(
     "url",
     [
@@ -119,6 +123,7 @@ def test_public_url_passes(url: str) -> None:
 
 # ── allow_http does not bypass IP-range check ─────────────────────────────────
 
+
 def test_allow_http_does_not_bypass_ip_check():
     # allow_http=True relaxes the scheme requirement only; private IPs must
     # still be rejected so that an attacker cannot reach internal services
@@ -133,6 +138,7 @@ def test_allow_http_does_not_bypass_localhost_check():
 
 
 # ── missing hostname ──────────────────────────────────────────────────────────
+
 
 def test_no_hostname_rejected():
     with pytest.raises(InvalidExternalURLError, match="no hostname"):

--- a/tests/common/test_virtual_portfolio.py
+++ b/tests/common/test_virtual_portfolio.py
@@ -1,5 +1,3 @@
-import pytest
-
 from backend.common import virtual_portfolio
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,9 @@ import pytest
 os.environ.setdefault("TESTING", "1")
 os.environ.setdefault("DATA_ROOT", str(Path(__file__).resolve().parent.parent / "data"))
 
-from backend.config import config
-from backend import auth as auth_module
 from backend import app as app_module
+from backend import auth as auth_module
+from backend.config import config
 
 _real_verify_google_token = auth_module.verify_google_token
 
@@ -34,9 +34,7 @@ def pytest_pyfunc_call(pyfuncitem):
         return None
 
     call_kwargs = {
-        name: value
-        for name, value in pyfuncitem.funcargs.items()
-        if name in pyfuncitem._fixtureinfo.argnames
+        name: value for name, value in pyfuncitem.funcargs.items() if name in pyfuncitem._fixtureinfo.argnames
     }
 
     loop = asyncio.new_event_loop()

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -1,49 +1,36 @@
-backend/agent/trading_agent.py:526
-backend/agent/trading_agent.py:543
-backend/agent/trading_agent.py:549
+backend/agent/trading_agent.py:491
+backend/agent/trading_agent.py:506
+backend/agent/trading_agent.py:512
 backend/agent/trading_agent.py:56
 backend/alerts.py:104
 backend/alerts.py:152
 backend/alerts.py:194
 backend/alerts.py:93
-# accounts-root path comes from server config, not attacker-controlled input.
-backend/auth.py:172
-# provider is always a hardcoded literal ("Google"/"Cognito") passed by the
-# caller, never attacker-controlled; email/token on the same call are already
-# wrapped in sanitise_log_value.
-backend/auth.py:590
 backend/auth.py:178
-backend/auth.py:537
 # provider is always a hardcoded literal ("Google"/"Cognito") passed by the
 # caller, never attacker-controlled; email/token on the same call are already
 # wrapped in sanitise_log_value.
 backend/auth.py:612
-backend/bootstrap/isolation.py:89
-backend/bootstrap/startup.py:92
-backend/common/accounts_store.py:244
 backend/common/accounts_store.py:283
 backend/common/accounts_store.py:291
 backend/common/accounts_store.py:410
-backend/common/alerts.py:43
+backend/common/alerts.py:44
 backend/common/approvals.py:40
-backend/common/approvals.py:92
-# issue #5215 diagnostic: identity is not None (always bool) and len(...)
-# (always int) cannot carry attacker-controlled input.
-backend/common/authz.py:82
+backend/common/approvals.py:88
 # (always int) can't carry attacker-controlled input.
-backend/common/authz.py:86
+backend/common/authz.py:82
 backend/common/compliance.py:198
-backend/common/compliance.py:236
-backend/common/compliance.py:265
+backend/common/compliance.py:234
+backend/common/compliance.py:255
 backend/common/dividends.py:74
 # Issue #5879: do not double-sanitise values prepared by the diagnostic helper.
 backend/common/errors.py:102
+backend/common/holding_utils.py:356
+backend/common/holding_utils.py:169
+backend/common/holding_utils.py:466
 backend/common/holding_utils.py:104
-backend/common/holding_utils.py:176
-backend/common/holding_utils.py:363
-backend/common/holding_utils.py:475
-backend/common/instrument_api.py:411
-backend/common/instrument_api.py:415
+backend/common/instrument_api.py:398
+backend/common/instrument_api.py:402
 backend/common/instrument_groups.py:53
 backend/common/instrument_groups.py:56
 backend/common/instruments.py:36
@@ -52,12 +39,7 @@ backend/common/instruments.py:87
 backend/common/instruments.py:91
 backend/common/instruments.py:575
 backend/common/instruments.py:606
-backend/common/portfolio.py:81
-backend/common/instruments.py:82
-backend/common/instruments.py:86
-backend/common/instruments.py:500
-backend/common/instruments.py:530
-backend/common/portfolio.py:115
+backend/common/portfolio.py:117
 # raw/d_raw/amount_minor are logged with %r (repr), which already escapes
 # real newlines as the literal two-character sequence \n -- wrapping in
 # sanitise_log_value would call str() first and lose the type info (int vs
@@ -65,36 +47,36 @@ backend/common/portfolio.py:115
 backend/common/portfolio_loader.py:240
 backend/common/portfolio_loader.py:253
 backend/common/portfolio_loader.py:260
-backend/common/portfolio_utils.py:1386
-backend/common/portfolio_utils.py:1414
-backend/common/portfolio_utils.py:2010
-backend/common/portfolio_utils.py:2021
-backend/common/portfolio_utils.py:217
-backend/common/portfolio_utils.py:234
-backend/common/portfolio_utils.py:247
-backend/common/portfolio_utils.py:255
-backend/common/portfolio_utils.py:263
-backend/common/portfolio_utils.py:293
-backend/common/portfolio_utils.py:299
-backend/common/portfolio_utils.py:305
-backend/common/portfolio_utils.py:312
-backend/common/portfolio_utils.py:334
-backend/common/portfolio_utils.py:509
-backend/common/portfolio_utils.py:525
-backend/common/portfolio_utils.py:532
-backend/common/prices.py:179
-backend/common/prices.py:203
-backend/common/prices.py:242
-backend/common/prices.py:297
-backend/common/prices.py:353
-backend/common/prices.py:381
+backend/common/portfolio_utils.py:1353
+backend/common/portfolio_utils.py:1381
+backend/common/portfolio_utils.py:1957
+backend/common/portfolio_utils.py:1967
+backend/common/portfolio_utils.py:216
+backend/common/portfolio_utils.py:233
+backend/common/portfolio_utils.py:244
+backend/common/portfolio_utils.py:260
+backend/common/portfolio_utils.py:252
+backend/common/portfolio_utils.py:288
+backend/common/portfolio_utils.py:294
+backend/common/portfolio_utils.py:300
+backend/common/portfolio_utils.py:307
+backend/common/portfolio_utils.py:329
+backend/common/portfolio_utils.py:504
+backend/common/portfolio_utils.py:520
+backend/common/portfolio_utils.py:527
+backend/common/prices.py:347
+backend/common/prices.py:200
+backend/common/prices.py:239
+backend/common/prices.py:293
+backend/common/prices.py:176
+backend/common/prices.py:375
 backend/common/signup_provision.py:71
 backend/common/signup_provision.py:74
 backend/common/signup_provision.py:77
-backend/common/signup_requests.py:206
-backend/common/signup_requests.py:254
-backend/common/signup_requests.py:274
-backend/common/signup_requests.py:378
+backend/common/signup_requests.py:203
+backend/common/signup_requests.py:249
+backend/common/signup_requests.py:269
+backend/common/signup_requests.py:373
 # len(adjustments) is always an int (a count of synthetic transactions just
 # built in this function) and can't carry attacker-controlled string content.
 backend/common/transaction_reconciliation.py:180
@@ -104,20 +86,20 @@ backend/config.py:279
 # parser in this function) and can't carry attacker-controlled string content.
 backend/importers/hargreaves.py:125
 backend/importers/hargreaves.py:148
-backend/reports.py:446
-backend/reports.py:452
 backend/reports.py:462
 backend/reports.py:468
-backend/reports.py:809
+backend/reports.py:446
+backend/reports.py:452
+backend/reports.py:803
 backend/common/storage.py:114
 backend/common/storage.py:54
 backend/common/storage.py:80
 backend/lambda_api/price_refresh.py:62
 backend/nudges.py:161
-backend/reports.py:1518
-backend/reports.py:1604
-backend/reports.py:1615
-backend/reports.py:1630
+backend/reports.py:1488
+backend/reports.py:1574
+backend/reports.py:1585
+backend/reports.py:1600
 backend/routes/market.py:164
 backend/routes/market.py:170
 backend/routes/market.py:179
@@ -126,13 +108,13 @@ backend/routes/market.py:72
 backend/routes/market.py:80
 backend/routes/signup.py:139
 backend/routes/signup.py:252
-backend/routes/support.py:108
-backend/routes/support.py:158
-backend/routes/support.py:172
-backend/routes/support.py:184
-backend/routes/support.py:69
-backend/routes/timeseries_admin.py:111
-backend/routes/timeseries_admin.py:89
+backend/routes/support.py:110
+backend/routes/support.py:154
+backend/routes/support.py:168
+backend/routes/support.py:180
+backend/routes/support.py:70
+backend/routes/timeseries_admin.py:107
+backend/routes/timeseries_admin.py:85
 backend/timeseries/cache.py:115
 backend/timeseries/cache.py:177
 backend/timeseries/cache.py:180
@@ -142,10 +124,10 @@ backend/timeseries/cache.py:243
 backend/timeseries/cache.py:259
 backend/timeseries/cache.py:271
 backend/timeseries/cache.py:408
-backend/timeseries/cache.py:436
-backend/timeseries/cache.py:442
 backend/timeseries/cache.py:450
 backend/timeseries/cache.py:456
+backend/timeseries/cache.py:436
+backend/timeseries/cache.py:442
 backend/timeseries/cache.py:498
 backend/timeseries/cache.py:586
 backend/timeseries/cache.py:638
@@ -156,16 +138,16 @@ backend/timeseries/cache.py:812
 backend/timeseries/cache.py:824
 backend/timeseries/fetch_alphavantage_timeseries.py:100
 backend/timeseries/fetch_alphavantage_timeseries.py:119
-backend/timeseries/fetch_meta_timeseries.py:224
-backend/timeseries/fetch_meta_timeseries.py:605
-backend/timeseries/fetch_meta_timeseries.py:630
-backend/timeseries/fetch_meta_timeseries.py:89
+backend/timeseries/fetch_meta_timeseries.py:222
+backend/timeseries/fetch_meta_timeseries.py:602
+backend/timeseries/fetch_meta_timeseries.py:626
+backend/timeseries/fetch_meta_timeseries.py:90
 backend/timeseries/fetch_stooq_timeseries.py:109
 backend/timeseries/fetch_stooq_timeseries.py:129
-backend/timeseries/fetch_stooq_timeseries.py:133
-backend/timeseries/fetch_stooq_timeseries.py:68
+backend/timeseries/fetch_stooq_timeseries.py:135
+backend/timeseries/fetch_stooq_timeseries.py:71
 backend/timeseries/fetch_stooq_timeseries.py:82
-backend/timeseries/fetch_yahoo_timeseries.py:103
-backend/timeseries/fetch_yahoo_timeseries.py:111
-backend/timeseries/fetch_yahoo_timeseries.py:142
+backend/timeseries/fetch_yahoo_timeseries.py:104
+backend/timeseries/fetch_yahoo_timeseries.py:112
+backend/timeseries/fetch_yahoo_timeseries.py:143
 backend/utils/telegram_utils.py:78

--- a/tests/quests/test_trail.py
+++ b/tests/quests/test_trail.py
@@ -202,9 +202,7 @@ def test_threshold_once_task_ignores_seeded_default(memory_storage, monkeypatch)
     monkeypatch.setattr(alerts, "_USER_THRESHOLDS", {"demo": 5})
 
     response = trail.get_tasks("demo")
-    threshold_task = next(
-        task for task in response["tasks"] if task["id"] == "set_alert_threshold"
-    )
+    threshold_task = next(task for task in response["tasks"] if task["id"] == "set_alert_threshold")
 
     assert threshold_task["completed"] is False
 
@@ -213,9 +211,7 @@ def test_threshold_once_task_marks_custom_value(memory_storage, monkeypatch):
     monkeypatch.setattr(alerts, "_USER_THRESHOLDS", {"demo": 10})
 
     response = trail.get_tasks("demo")
-    threshold_task = next(
-        task for task in response["tasks"] if task["id"] == "set_alert_threshold"
-    )
+    threshold_task = next(task for task in response["tasks"] if task["id"] == "set_alert_threshold")
 
     assert threshold_task["completed"] is True
 
@@ -224,8 +220,6 @@ def test_threshold_once_task_handles_percent_strings(memory_storage, monkeypatch
     monkeypatch.setattr(alerts, "_USER_THRESHOLDS", {"demo": "5%"})
 
     response = trail.get_tasks("demo")
-    threshold_task = next(
-        task for task in response["tasks"] if task["id"] == "set_alert_threshold"
-    )
+    threshold_task = next(task for task in response["tasks"] if task["id"] == "set_alert_threshold")
 
     assert threshold_task["completed"] is False

--- a/tests/routes/test_accounts_root.py
+++ b/tests/routes/test_accounts_root.py
@@ -36,9 +36,7 @@ def test_resolve_accounts_root_uses_cached_state(tmp_path: Path) -> None:
     assert request.app.state.accounts_root == tmp_path
 
 
-def test_resolve_accounts_root_falls_back_to_global_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_resolve_accounts_root_falls_back_to_global_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When configured paths are missing the helper should use the global fallback."""
 
     from backend.common import data_loader
@@ -122,9 +120,7 @@ def test_resolve_accounts_root_handles_deleted_cached_directory(
             return SimpleNamespace(accounts_root=tmp_path / "missing-from-config")
         if repo_root is None and accounts_root is None:
             return SimpleNamespace(accounts_root=fallback_root)
-        raise AssertionError(
-            f"Unexpected resolve_paths call: {repo_root!r}, {accounts_root!r}"
-        )
+        raise AssertionError(f"Unexpected resolve_paths call: {repo_root!r}, {accounts_root!r}")
 
     monkeypatch.setattr(data_loader, "resolve_paths", fake_resolve_paths)
 

--- a/tests/routes/test_approvals.py
+++ b/tests/routes/test_approvals.py
@@ -7,17 +7,16 @@ import os
 from pathlib import Path
 from typing import Any
 
+import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
-import pytest
 
-import backend.routes.approvals as approvals
 import backend.routes._accounts as account_utils
+import backend.routes.approvals as approvals
 from backend.common.data_loader import ResolvedPaths
 from backend.common.errors import AppError
 from backend.config import config
-
 
 _DEFAULT = object()
 
@@ -78,9 +77,7 @@ def test_get_approvals_success(tmp_path: Path) -> None:
     client = make_client(tmp_path)
     resp = client.get("/accounts/bob/approvals")
     assert resp.status_code == 200
-    assert resp.json() == {
-        "approvals": [{"ticker": "ADM.L", "approved_on": "2024-06-04"}]
-    }
+    assert resp.json() == {"approvals": [{"ticker": "ADM.L", "approved_on": "2024-06-04"}]}
 
 
 def test_post_approval_request_success(tmp_path: Path) -> None:
@@ -133,12 +130,8 @@ def test_post_approval_request_owner_dir_case_insensitive(tmp_path: Path) -> Non
     assert resp.status_code == 200
 
 
-def test_post_approval_request_accounts_root_fallback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    state_root, default_missing, owner_dir, calls = configure_accounts_root_fallback(
-        tmp_path, monkeypatch
-    )
+def test_post_approval_request_accounts_root_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_root, default_missing, owner_dir, calls = configure_accounts_root_fallback(tmp_path, monkeypatch)
 
     client = make_client(tmp_path, accounts_root=state_root)
     resp = client.post("/accounts/bob/approval-requests", json={"ticker": "adm.l"})
@@ -158,9 +151,7 @@ def test_post_approval_request_accounts_root_fallback(
         ({"approved_on": "not-a-date"}, "invalid approved_on"),
     ],
 )
-def test_post_approval_invalid_or_missing_approved_on(
-    tmp_path: Path, payload: dict[str, str], detail: str
-) -> None:
+def test_post_approval_invalid_or_missing_approved_on(tmp_path: Path, payload: dict[str, str], detail: str) -> None:
     (tmp_path / "bob").mkdir()
     client = make_client(tmp_path)
     data = {"ticker": "ADM.L", **payload}
@@ -172,26 +163,16 @@ def test_post_approval_invalid_or_missing_approved_on(
 def test_post_approval_success(tmp_path: Path) -> None:
     (tmp_path / "bob").mkdir()
     client = make_client(tmp_path)
-    resp = client.post(
-        "/accounts/bob/approvals", json={"ticker": "adm.l", "approved_on": "2024-06-04"}
-    )
+    resp = client.post("/accounts/bob/approvals", json={"ticker": "adm.l", "approved_on": "2024-06-04"})
     assert resp.status_code == 200
-    assert resp.json()["approvals"] == [
-        {"ticker": "ADM.L", "approved_on": "2024-06-04"}
-    ]
+    assert resp.json()["approvals"] == [{"ticker": "ADM.L", "approved_on": "2024-06-04"}]
 
 
-def test_post_approval_accounts_root_fallback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    state_root, default_missing, owner_dir, calls = configure_accounts_root_fallback(
-        tmp_path, monkeypatch
-    )
+def test_post_approval_accounts_root_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_root, default_missing, owner_dir, calls = configure_accounts_root_fallback(tmp_path, monkeypatch)
 
     client = make_client(tmp_path, accounts_root=state_root)
-    resp = client.post(
-        "/accounts/bob/approvals", json={"ticker": "adm.l", "approved_on": "2024-06-04"}
-    )
+    resp = client.post("/accounts/bob/approvals", json={"ticker": "adm.l", "approved_on": "2024-06-04"})
 
     assert resp.status_code == 200
     saved_path = owner_dir / "approvals.json"
@@ -204,9 +185,7 @@ def test_post_approval_accounts_root_fallback(
 
 def test_post_approval_missing_owner(tmp_path: Path) -> None:
     client = make_client(tmp_path)
-    resp = client.post(
-        "/accounts/missing/approvals", json={"ticker": "ADM.L", "approved_on": "2024-06-04"}
-    )
+    resp = client.post("/accounts/missing/approvals", json={"ticker": "ADM.L", "approved_on": "2024-06-04"})
     assert resp.status_code == 404
     assert resp.json() == {"detail": "Owner not found"}
 
@@ -219,9 +198,7 @@ def test_post_approval_write_failure(tmp_path: Path, monkeypatch: pytest.MonkeyP
         raise OSError("db down")
 
     monkeypatch.setattr(approvals, "upsert_approval", boom)
-    resp = client.post(
-        "/accounts/bob/approvals", json={"ticker": "ADM.L", "approved_on": "2024-06-04"}
-    )
+    resp = client.post("/accounts/bob/approvals", json={"ticker": "ADM.L", "approved_on": "2024-06-04"})
     assert resp.status_code == 500
     assert "Internal Server Error" in resp.text
 
@@ -229,9 +206,7 @@ def test_post_approval_write_failure(tmp_path: Path, monkeypatch: pytest.MonkeyP
 def test_delete_approval_route_success(tmp_path: Path) -> None:
     (tmp_path / "bob").mkdir()
     client = make_client(tmp_path)
-    client.post(
-        "/accounts/bob/approvals", json={"ticker": "ADM.L", "approved_on": "2024-06-04"}
-    )
+    client.post("/accounts/bob/approvals", json={"ticker": "ADM.L", "approved_on": "2024-06-04"})
     resp = client.request("DELETE", "/accounts/bob/approvals", json={"ticker": "ADM.L"})
     assert resp.status_code == 200
     assert resp.json()["approvals"] == []
@@ -240,22 +215,14 @@ def test_delete_approval_route_success(tmp_path: Path) -> None:
 def test_delete_approval_route_nonexistent_ticker(tmp_path: Path) -> None:
     (tmp_path / "bob").mkdir()
     client = make_client(tmp_path)
-    client.post(
-        "/accounts/bob/approvals", json={"ticker": "ADM.L", "approved_on": "2024-06-04"}
-    )
+    client.post("/accounts/bob/approvals", json={"ticker": "ADM.L", "approved_on": "2024-06-04"})
     resp = client.request("DELETE", "/accounts/bob/approvals", json={"ticker": "XYZ"})
     assert resp.status_code == 200
-    assert resp.json()["approvals"] == [
-        {"ticker": "ADM.L", "approved_on": "2024-06-04"}
-    ]
+    assert resp.json()["approvals"] == [{"ticker": "ADM.L", "approved_on": "2024-06-04"}]
 
 
-def test_delete_approval_accounts_root_fallback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    state_root, default_missing, owner_dir, calls = configure_accounts_root_fallback(
-        tmp_path, monkeypatch
-    )
+def test_delete_approval_accounts_root_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_root, default_missing, owner_dir, calls = configure_accounts_root_fallback(tmp_path, monkeypatch)
     saved_path = owner_dir / "approvals.json"
     saved_path.write_text(
         json.dumps(

--- a/tests/routes/test_config.py
+++ b/tests/routes/test_config.py
@@ -18,13 +18,11 @@ def _setup_config(monkeypatch, tmp_path, content: str = "auth:\n  google_auth_en
     return config_path
 
 
-
 def test_deep_merge_nested_dicts():
     dst = {"a": {"b": 1, "c": {"d": 2}}}
     src = {"a": {"b": 3, "c": {"e": 4}}, "f": 5}
     routes_config.deep_merge(dst, src)
     assert dst == {"a": {"b": 3, "c": {"d": 2, "e": 4}}, "f": 5}
-
 
 
 def test_update_config_writes_and_merges(monkeypatch, tmp_path):
@@ -41,7 +39,6 @@ def test_update_config_writes_and_merges(monkeypatch, tmp_path):
 
     monkeypatch.undo()
     reload_config()
-
 
 
 def test_update_config_accepts_research_tab(monkeypatch, tmp_path):
@@ -70,7 +67,6 @@ def test_update_config_env_invalid_google_auth(monkeypatch, tmp_path):
 
     monkeypatch.undo()
     reload_config()
-
 
 
 def test_update_config_env_requires_client_id(monkeypatch, tmp_path):

--- a/tests/routes/test_events.py
+++ b/tests/routes/test_events.py
@@ -21,9 +21,7 @@ def create_client() -> TestClient:
 
 def test_list_events_filters_extra_fields(monkeypatch, tmp_path):
     fixture = tmp_path / "custom.json"
-    fixture.write_text(
-        json.dumps([{"id": "custom", "name": "Custom", "ignored": "value"}])
-    )
+    fixture.write_text(json.dumps([{"id": "custom", "name": "Custom", "ignored": "value"}]))
 
     with monkeypatch.context() as patcher:
         patcher.setattr(events_module, "_events_path", fixture, raising=False)

--- a/tests/routes/test_instrument_admin.py
+++ b/tests/routes/test_instrument_admin.py
@@ -1,8 +1,7 @@
-import pytest
+from typing import Any
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-from typing import Any
 
 import backend.routes.instrument_admin as instrument_admin
 
@@ -67,6 +66,7 @@ def test_create_group_rejects_invalid(monkeypatch):
     resp = client.post("/instrument/admin/groups", json={"name": "   "})
     assert resp.status_code == 400
 
+
 def test_list_instrument_groupings(monkeypatch):
     monkeypatch.setattr(
         instrument_admin,
@@ -84,9 +84,7 @@ def test_get_instrument_ok(monkeypatch, tmp_path):
         return tmp_path / f"{e}" / f"{t}.json"
 
     monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
-    monkeypatch.setattr(
-        instrument_admin, "get_instrument_meta", lambda t: {"ticker": t}
-    )
+    monkeypatch.setattr(instrument_admin, "get_instrument_meta", lambda t: {"ticker": t})
     client = make_client()
     resp = client.get("/instrument/admin/L/ABC")
     assert resp.status_code == 200
@@ -130,9 +128,7 @@ def test_post_instrument_create(monkeypatch, tmp_path):
     monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
     monkeypatch.setattr(instrument_admin, "save_instrument_meta", fake_save)
     client = make_client()
-    resp = client.post(
-        "/instrument/admin/L/ABC", json={"ticker": "ABC.L", "grouping": "Income"}
-    )
+    resp = client.post("/instrument/admin/L/ABC", json={"ticker": "ABC.L", "grouping": "Income"})
     assert resp.status_code == 200
     assert resp.json() == {"status": "created"}
     assert saved["ticker"] == "ABC.L"
@@ -228,9 +224,7 @@ def test_put_instrument_update(monkeypatch, tmp_path):
     monkeypatch.setattr(instrument_admin, "instrument_meta_path", fake_path)
     monkeypatch.setattr(instrument_admin, "save_instrument_meta", fake_save)
     client = make_client()
-    resp = client.put(
-        "/instrument/admin/L/ABC", json={"ticker": "ABC.L", "grouping": "Income"}
-    )
+    resp = client.put("/instrument/admin/L/ABC", json={"ticker": "ABC.L", "grouping": "Income"})
     assert resp.status_code == 200
     assert resp.json() == {"status": "updated"}
     assert saved["ticker"] == "ABC.L"
@@ -297,9 +291,7 @@ def test_put_instrument_not_found(monkeypatch, tmp_path):
 
 
 def test_put_instrument_invalid(monkeypatch):
-    monkeypatch.setattr(
-        instrument_admin, "instrument_meta_path", lambda *a: (_ for _ in ()).throw(ValueError("bad"))
-    )
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", lambda *a: (_ for _ in ()).throw(ValueError("bad")))
     client = make_client()
     resp = client.put("/instrument/admin/L/ABC", json={"ticker": "ABC.L"})
     assert resp.status_code == 400
@@ -354,9 +346,7 @@ def test_delete_instrument_not_found(monkeypatch, tmp_path):
 
 
 def test_delete_instrument_invalid(monkeypatch):
-    monkeypatch.setattr(
-        instrument_admin, "instrument_meta_path", lambda *a: (_ for _ in ()).throw(ValueError("bad"))
-    )
+    monkeypatch.setattr(instrument_admin, "instrument_meta_path", lambda *a: (_ for _ in ()).throw(ValueError("bad")))
     client = make_client()
     resp = client.delete("/instrument/admin/L/ABC")
     assert resp.status_code == 400

--- a/tests/routes/test_logs_route.py
+++ b/tests/routes/test_logs_route.py
@@ -1,6 +1,6 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-import pytest
 
 from backend.config import config
 from backend.routes.logs import router

--- a/tests/routes/test_market.py
+++ b/tests/routes/test_market.py
@@ -176,9 +176,7 @@ def test_fetch_sectors_does_not_fall_back_when_lse_valid(monkeypatch):
 
 
 def test_fetch_us_sector_etf_changes_from_download(monkeypatch):
-    columns = pd.MultiIndex.from_product(
-        [["Close"], ["XLB", "XLE", "XLF"]], names=["Price", "Ticker"]
-    )
+    columns = pd.MultiIndex.from_product([["Close"], ["XLB", "XLE", "XLF"]], names=["Price", "Ticker"])
     frame = pd.DataFrame(
         [[100.0, 50.0, 10.0], [110.0, 55.0, 11.0]],
         columns=columns,
@@ -202,9 +200,7 @@ def test_fetch_us_sector_etf_changes_from_download(monkeypatch):
 
 
 def test_fetch_us_sector_etf_changes_partial_missing(monkeypatch):
-    columns = pd.MultiIndex.from_product(
-        [["Close"], ["XLB", "XLE", "XLF"]], names=["Price", "Ticker"]
-    )
+    columns = pd.MultiIndex.from_product([["Close"], ["XLB", "XLE", "XLF"]], names=["Price", "Ticker"])
     frame = pd.DataFrame(
         [[100.0, None, 10.0], [110.0, None, None]],
         columns=columns,
@@ -302,9 +298,7 @@ def test_fetch_headlines_propagates_stale_flag_from_get_cached_news(monkeypatch)
 def test_market_overview_default_region_handles_fetch_failures(monkeypatch):
     client = _client()
     monkeypatch.setattr(market.cfg, "default_sector_region", "US", raising=False)
-    monkeypatch.setattr(
-        market, "_fetch_uk_sectors", lambda: pytest.fail("UK sectors fetch should not be used")
-    )
+    monkeypatch.setattr(market, "_fetch_uk_sectors", lambda: pytest.fail("UK sectors fetch should not be used"))
     calls = []
 
     def boom_indexes():
@@ -340,9 +334,7 @@ def test_market_overview_uk_region_handles_fetch_errors(monkeypatch):
         "_fetch_indexes",
         lambda: {"Dow Jones": {"value": 100.0, "change": 1.5}},
     )
-    monkeypatch.setattr(
-        market, "_fetch_sectors", lambda: pytest.fail("US sector fetch should not be used")
-    )
+    monkeypatch.setattr(market, "_fetch_sectors", lambda: pytest.fail("US sector fetch should not be used"))
     calls = []
 
     def boom_uk():

--- a/tests/routes/test_news_helpers.py
+++ b/tests/routes/test_news_helpers.py
@@ -337,4 +337,3 @@ def test_get_cached_news_reuses_fresh_cache(monkeypatch):
     ]
     assert len(scheduled) == 1
     _assert_refresh_call(scheduled[0], page="news_CACHED", delay=42.0)
-

--- a/tests/routes/test_nudges_route.py
+++ b/tests/routes/test_nudges_route.py
@@ -1,6 +1,6 @@
+import pytest
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
-import pytest
 
 import backend.routes.nudges as nudges
 from backend.common.account_models import OwnerSummaryRecord
@@ -73,9 +73,7 @@ def test_snooze_calls_snooze_user(tmp_path, monkeypatch):
 
 def test_list_nudges_gets_recent_nudges(tmp_path, monkeypatch):
     nudges_list = [{"id": 1}]
-    monkeypatch.setattr(
-        nudges.nudge_utils, "get_recent_nudges", lambda limit=50: nudges_list
-    )
+    monkeypatch.setattr(nudges.nudge_utils, "get_recent_nudges", lambda limit=50: nudges_list)
     client = make_client(tmp_path, monkeypatch)
     resp = client.get("/nudges/")
     assert resp.status_code == 200

--- a/tests/routes/test_pension_routes.py
+++ b/tests/routes/test_pension_routes.py
@@ -1,10 +1,8 @@
-from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
-from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 from backend.common.account_models import PersonMetadata

--- a/tests/routes/test_portfolio_group.py
+++ b/tests/routes/test_portfolio_group.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi.testclient import TestClient
 
 from backend.local_api.main import app
@@ -71,14 +70,10 @@ def test_group_instruments_filters_accounts(monkeypatch):
         captured_portfolio.update(portfolio)
         return {"aggregated": True}
 
-    monkeypatch.setattr(
-        portfolio_module.group_portfolio, "build_group_portfolio", fake_group
-    )
+    monkeypatch.setattr(portfolio_module.group_portfolio, "build_group_portfolio", fake_group)
     monkeypatch.setattr(portfolio_module, "_normalise_filter_values", spy_normalise)
     monkeypatch.setattr(portfolio_module, "_account_matches_filters", spy_match)
-    monkeypatch.setattr(
-        portfolio_module.portfolio_utils, "aggregate_by_ticker", fake_aggregate
-    )
+    monkeypatch.setattr(portfolio_module.portfolio_utils, "aggregate_by_ticker", fake_aggregate)
 
     client = _auth_client()
     response = client.get(

--- a/tests/routes/test_portfolio_helpers.py
+++ b/tests/routes/test_portfolio_helpers.py
@@ -6,7 +6,6 @@ from starlette.requests import Request
 
 from backend.common.account_models import PersonMetadata
 from backend.routes import portfolio as portfolio_routes
-from backend.common import data_loader
 
 
 def _make_request_with_root(tmp_path: Path) -> Request:

--- a/tests/routes/test_portfolio_models.py
+++ b/tests/routes/test_portfolio_models.py
@@ -57,9 +57,7 @@ def test_movers_response_lists_are_isolated() -> None:
     """MoversResponse gainers/losers lists should not share mutable defaults."""
 
     response = portfolio.MoversResponse()
-    response.gainers.append(
-        portfolio.Mover(ticker="AAPL.US", name="Apple", change_pct=2.0)
-    )
+    response.gainers.append(portfolio.Mover(ticker="AAPL.US", name="Apple", change_pct=2.0))
 
     another = portfolio.MoversResponse()
 

--- a/tests/routes/test_query.py
+++ b/tests/routes/test_query.py
@@ -62,9 +62,7 @@ def test_slugify_handles_special_characters():
 
 def test_save_query_local(monkeypatch, tmp_path):
     monkeypatch.setattr(query, "QUERIES_DIR", tmp_path)
-    q = query.CustomQuery(
-        start=date(2020, 1, 1), end=date(2020, 1, 2), tickers=["ABC.L"]
-    )
+    q = query.CustomQuery(start=date(2020, 1, 1), end=date(2020, 1, 2), tickers=["ABC.L"])
     query._save_query_local("sample", q)
     saved = json.loads((tmp_path / "sample.json").read_text())
     assert saved["tickers"] == ["ABC.L"]
@@ -83,9 +81,7 @@ def mock_s3(monkeypatch):
 
         def list_objects_v2(self, Bucket, Prefix, ContinuationToken=None):
             contents = [
-                {"Key": key}
-                for (bucket, key), _ in self.storage.items()
-                if bucket == Bucket and key.startswith(Prefix)
+                {"Key": key} for (bucket, key), _ in self.storage.items() if bucket == Bucket and key.startswith(Prefix)
             ]
             return {"Contents": contents}
 
@@ -100,9 +96,7 @@ def mock_s3(monkeypatch):
 
 def test_s3_helpers(monkeypatch, mock_s3):
     monkeypatch.setenv(query.DATA_BUCKET_ENV, "bucket")
-    q = query.CustomQuery(
-        start=date(2020, 1, 1), end=date(2020, 1, 2), tickers=["ABC.L"]
-    )
+    q = query.CustomQuery(start=date(2020, 1, 1), end=date(2020, 1, 2), tickers=["ABC.L"])
     query._save_query_s3("s3-query", q)
     assert ("bucket", f"{query.QUERIES_PREFIX}s3-query.json") in mock_s3
     assert query._list_queries_s3() == ["s3-query"]
@@ -265,10 +259,7 @@ def test_run_query_xlsx(monkeypatch):
     }
     resp = client.post("/custom-query/run", json=body)
     assert resp.status_code == 200
-    assert (
-        resp.headers["content-type"]
-        == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    )
+    assert resp.headers["content-type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     assert resp.content.startswith(b"PK")
     zf = zipfile.ZipFile(io.BytesIO(resp.content))
     sheet = zf.read("xl/worksheets/sheet1.xml")
@@ -290,9 +281,7 @@ def test_saved_and_load_local(monkeypatch, tmp_path):
     assert resp.status_code == 200
     saved_entries = resp.json()
     assert any(
-        entry.get("id") == "sample"
-        and entry.get("name") == "sample"
-        and entry.get("params") == data
+        entry.get("id") == "sample" and entry.get("name") == "sample" and entry.get("params") == data
         for entry in saved_entries
     )
     resp = client.get("/custom-query/saved", params={"detailed": "0"})
@@ -306,9 +295,7 @@ def test_saved_and_load_local(monkeypatch, tmp_path):
 def test_saved_and_load_aws(monkeypatch, mock_s3):
     monkeypatch.setattr(query.config, "app_env", "aws")
     monkeypatch.setenv(query.DATA_BUCKET_ENV, "bucket")
-    q = query.CustomQuery(
-        start=date(2020, 1, 1), end=date(2020, 1, 2), tickers=["ABC.L"]
-    )
+    q = query.CustomQuery(start=date(2020, 1, 1), end=date(2020, 1, 2), tickers=["ABC.L"])
     query._save_query_s3("remote", q)
     client = make_client()
     resp = client.get("/custom-query/saved")
@@ -317,9 +304,7 @@ def test_saved_and_load_aws(monkeypatch, mock_s3):
     expected_params = q.model_dump(mode="json")
     expected_params.pop("name", None)
     assert any(
-        entry.get("id") == "remote"
-        and entry.get("name") == "remote"
-        and entry.get("params") == expected_params
+        entry.get("id") == "remote" and entry.get("name") == "remote" and entry.get("params") == expected_params
         for entry in saved_entries
     )
     resp = client.get("/custom-query/saved", params={"detailed": "0"})

--- a/tests/routes/test_quotes_failures.py
+++ b/tests/routes/test_quotes_failures.py
@@ -1,12 +1,11 @@
 from types import SimpleNamespace
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from backend.routes import quotes as quotes_module
 from backend.bootstrap.middleware import register_middleware
 from backend.config import config
+from backend.routes import quotes as quotes_module
 
 
 def _make_client():

--- a/tests/routes/test_screener.py
+++ b/tests/routes/test_screener.py
@@ -1,6 +1,5 @@
 import asyncio
 
-import pytest
 from fastapi import BackgroundTasks, FastAPI
 from fastapi.testclient import TestClient
 

--- a/tests/routes/test_support.py
+++ b/tests/routes/test_support.py
@@ -82,9 +82,7 @@ def test_portfolio_health_handles_run_check_errors(monkeypatch):
 
     # Mark the cache as stale so the next request triggers a refresh attempt.
     assert support._portfolio_health_cache is not None
-    support._portfolio_health_cache.generated_at = (
-        support._now() - support._portfolio_health_ttl - timedelta(seconds=1)
-    )
+    support._portfolio_health_cache.generated_at = support._now() - support._portfolio_health_ttl - timedelta(seconds=1)
     stale_generated_at = support._portfolio_health_cache.generated_at.isoformat()
 
     # First retry kicks off the failing background task.

--- a/tests/routes/test_timeseries_admin.py
+++ b/tests/routes/test_timeseries_admin.py
@@ -1,13 +1,11 @@
 import asyncio
-import builtins
 import io
 import sys
 
 import pandas as pd
 
-from backend.routes import timeseries_admin
 from backend.config import config
-
+from backend.routes import timeseries_admin
 
 
 def test_summarize_fields(monkeypatch):
@@ -19,11 +17,13 @@ def test_summarize_fields(monkeypatch):
 
     df = pd.DataFrame(
         {
-            "Date": pd.to_datetime([
-                "2024-01-01",
-                "2024-01-02",
-                "2024-01-03",
-            ]),
+            "Date": pd.to_datetime(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                ]
+            ),
             "Source": ["A", "B", "A"],
         }
     )
@@ -45,10 +45,12 @@ def test_summarize_missing_source(monkeypatch):
 
     no_source_df = pd.DataFrame(
         {
-            "Date": pd.to_datetime([
-                "2024-01-05",
-                "2024-01-08",
-            ]),
+            "Date": pd.to_datetime(
+                [
+                    "2024-01-05",
+                    "2024-01-08",
+                ]
+            ),
             "Price": [1.0, 2.0],
         }
     )
@@ -60,10 +62,12 @@ def test_summarize_missing_source(monkeypatch):
 
     nan_source_df = pd.DataFrame(
         {
-            "Date": pd.to_datetime([
-                "2024-02-01",
-                "2024-02-02",
-            ]),
+            "Date": pd.to_datetime(
+                [
+                    "2024-02-01",
+                    "2024-02-02",
+                ]
+            ),
             "Source": [None, None],
         }
     )
@@ -74,15 +78,16 @@ def test_summarize_missing_source(monkeypatch):
     assert summary_nan_source["main_source"] is None
 
 
-
 def test_timeseries_admin_local(monkeypatch, tmp_path):
     df = pd.DataFrame(
         {
-            "Date": pd.to_datetime([
-                "2024-01-01",
-                "2024-01-02",
-                "2024-01-03",
-            ]),
+            "Date": pd.to_datetime(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                ]
+            ),
             "Source": ["A", "B", "A"],
         }
     )
@@ -93,9 +98,7 @@ def test_timeseries_admin_local(monkeypatch, tmp_path):
     # file without underscore should be skipped
     df.to_parquet(meta_dir / "INVALID.parquet")
     # empty dataframe should be skipped
-    pd.DataFrame({"Date": pd.Series([], dtype="datetime64[ns]")}).to_parquet(
-        meta_dir / "EMPTY_L.parquet"
-    )
+    pd.DataFrame({"Date": pd.Series([], dtype="datetime64[ns]")}).to_parquet(meta_dir / "EMPTY_L.parquet")
 
     monkeypatch.setattr(timeseries_admin, "get_instrument_meta", lambda *_: {"name": "Test"})
     monkeypatch.setattr(config, "app_env", "local")
@@ -117,7 +120,6 @@ def test_timeseries_admin_local(monkeypatch, tmp_path):
         ]
 
     asyncio.run(run())
-
 
 
 def test_timeseries_admin_no_meta(monkeypatch, tmp_path):

--- a/tests/routes/test_timeseries_meta.py
+++ b/tests/routes/test_timeseries_meta.py
@@ -16,9 +16,7 @@ def _client_with_df(monkeypatch, df):
 
     import backend.routes.timeseries_meta as ts_meta
 
-    monkeypatch.setattr(
-        ts_meta, "load_meta_timeseries_range", lambda *a, **k: df.copy()
-    )
+    monkeypatch.setattr(ts_meta, "load_meta_timeseries_range", lambda *a, **k: df.copy())
     monkeypatch.setattr(ts_meta.pd, "to_datetime", lambda x: x)
 
     from backend.app import create_app
@@ -60,9 +58,7 @@ def test_resolve_missing_ticker_error():
 def test_resolve_cannot_infer_exchange(monkeypatch):
     import backend.routes.timeseries_meta as ts_meta
 
-    monkeypatch.setattr(
-        ts_meta.instrument_api, "_resolve_full_ticker", lambda t, latest: None
-    )
+    monkeypatch.setattr(ts_meta.instrument_api, "_resolve_full_ticker", lambda t, latest: None)
     with pytest.raises(HTTPException):
         ts_meta._resolve_ticker_exchange("xyz", None)
 
@@ -96,12 +92,15 @@ def test_resolve_dotted_ticker_no_exchange():
     assert ex == "L"
 
 
-@pytest.mark.parametrize("ticker_input,exchange_input", [
-    ("<script>alert(1)</script>", "L"),
-    ("ABC", "<img src=x onerror=alert(1)>"),
-    ("ABC&foo=bar", "L"),
-    ("ABC\"onload=x", "L"),
-])
+@pytest.mark.parametrize(
+    "ticker_input,exchange_input",
+    [
+        ("<script>alert(1)</script>", "L"),
+        ("ABC", "<img src=x onerror=alert(1)>"),
+        ("ABC&foo=bar", "L"),
+        ('ABC"onload=x', "L"),
+    ],
+)
 def test_resolve_rejects_unsafe_ticker_exchange(ticker_input, exchange_input):
     """User-supplied exchange path rejects payloads that fail the regex allowlist."""
     import backend.routes.timeseries_meta as ts_meta
@@ -111,11 +110,14 @@ def test_resolve_rejects_unsafe_ticker_exchange(ticker_input, exchange_input):
     assert exc_info.value.status_code == 400
 
 
-@pytest.mark.parametrize("bad_dotted_ticker", [
-    "<script>.L",      # XSS payload in the sym segment
-    "ABC.<img>",       # XSS payload in the exchange segment
-    "ABC&foo=bar.L",   # injection attempt in the sym segment
-])
+@pytest.mark.parametrize(
+    "bad_dotted_ticker",
+    [
+        "<script>.L",  # XSS payload in the sym segment
+        "ABC.<img>",  # XSS payload in the exchange segment
+        "ABC&foo=bar.L",  # injection attempt in the sym segment
+    ],
+)
 def test_resolve_rejects_unsafe_dotted_ticker_no_exchange(bad_dotted_ticker):
     """The 'if . in t' branch validates sym/ex derived from the dotted ticker.
 
@@ -133,16 +135,17 @@ def test_resolve_rejects_unsafe_dotted_ticker_no_exchange(bad_dotted_ticker):
 def test_timeseries_meta_json_rejects_xss_ticker(monkeypatch):
     df = _sample_df()
     client = _client_with_df(monkeypatch, df)
-    resp = client.get(
-        "/timeseries/meta?ticker=%3Cscript%3Ealert(1)%3C%2Fscript%3E&exchange=L&format=json"
-    )
+    resp = client.get("/timeseries/meta?ticker=%3Cscript%3Ealert(1)%3C%2Fscript%3E&exchange=L&format=json")
     assert resp.status_code == 400
 
 
-@pytest.mark.parametrize("ticker,exchange", [
-    ("BRK_B", "NYSE"),   # underscore in ticker symbol — allowed by widened regex
-    ("FUND_ETF", "L"),   # underscore in fund identifier — allowed
-])
+@pytest.mark.parametrize(
+    "ticker,exchange",
+    [
+        ("BRK_B", "NYSE"),  # underscore in ticker symbol — allowed by widened regex
+        ("FUND_ETF", "L"),  # underscore in fund identifier — allowed
+    ],
+)
 def test_resolve_accepts_underscore_ticker(ticker, exchange):
     """Underscores are explicitly permitted (some providers use them as separators)."""
     import backend.routes.timeseries_meta as ts_meta
@@ -152,10 +155,13 @@ def test_resolve_accepts_underscore_ticker(ticker, exchange):
     assert ex == exchange.upper()
 
 
-@pytest.mark.parametrize("ticker,exchange", [
-    ("A" * 51, "L"),   # ticker segment exceeds 50-char limit
-    ("AAPL", "X" * 51),   # exchange code exceeds 50-char limit
-])
+@pytest.mark.parametrize(
+    "ticker,exchange",
+    [
+        ("A" * 51, "L"),  # ticker segment exceeds 50-char limit
+        ("AAPL", "X" * 51),  # exchange code exceeds 50-char limit
+    ],
+)
 def test_resolve_rejects_oversized_segments(ticker, exchange):
     """Segments longer than 50 characters are rejected."""
     import backend.routes.timeseries_meta as ts_meta
@@ -165,20 +171,23 @@ def test_resolve_rejects_oversized_segments(ticker, exchange):
     assert exc_info.value.status_code == 400
 
 
-@pytest.mark.parametrize("char,should_match", [
-    ("A", True),
-    ("Z", True),
-    ("0", True),
-    ("9", True),
-    ("_", True),
-    ("-", True),
-    (".", False),
-    (" ", False),
-    ("@", False),
-    ("!", False),
-    ("/", False),
-    ("$", False),
-])
+@pytest.mark.parametrize(
+    "char,should_match",
+    [
+        ("A", True),
+        ("Z", True),
+        ("0", True),
+        ("9", True),
+        ("_", True),
+        ("-", True),
+        (".", False),
+        (" ", False),
+        ("@", False),
+        ("!", False),
+        ("/", False),
+        ("$", False),
+    ],
+)
 def test_ticker_symbol_regex_pins_character_class(char, should_match):
     """Pin the [A-Z0-9_-] allowlist of _TICKER_SYMBOL_RE.
 
@@ -217,9 +226,7 @@ def test_timeseries_meta_formats_with_scaling(fmt, monkeypatch):
     df = _sample_df()
     client = _client_with_df(monkeypatch, df)
 
-    resp = client.get(
-        f"/timeseries/meta?ticker=ABC&exchange=L&format={fmt}&scaling=2"
-    )
+    resp = client.get(f"/timeseries/meta?ticker=ABC&exchange=L&format={fmt}&scaling=2")
     assert resp.status_code == 200
 
     if fmt == "json":
@@ -304,10 +311,7 @@ def _multi_day_df():
 def test_explicit_start_and_end_date(monkeypatch):
     """Both dates supplied: response reflects the provided bounds."""
     client = _client_with_df(monkeypatch, _multi_day_df())
-    resp = client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json"
-        "&start_date=2024-01-01&end_date=2024-01-03"
-    )
+    resp = client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json" "&start_date=2024-01-01&end_date=2024-01-03")
     assert resp.status_code == 200
     data = resp.json()
     assert data["from"] == "2024-01-01"
@@ -317,9 +321,7 @@ def test_explicit_start_and_end_date(monkeypatch):
 def test_open_start_only_end_date(monkeypatch):
     """Only end_date supplied: response uses end_date and days-derived start."""
     client = _client_with_df(monkeypatch, _multi_day_df())
-    resp = client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json&end_date=2024-01-03"
-    )
+    resp = client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json&end_date=2024-01-03")
     assert resp.status_code == 200
     assert resp.json()["to"] == "2024-01-03"
 
@@ -327,9 +329,7 @@ def test_open_start_only_end_date(monkeypatch):
 def test_open_end_only_start_date(monkeypatch):
     """Only start_date supplied: response uses start_date and yesterday as end."""
     client = _client_with_df(monkeypatch, _multi_day_df())
-    resp = client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json&start_date=2024-01-01"
-    )
+    resp = client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json&start_date=2024-01-01")
     assert resp.status_code == 200
     assert resp.json()["from"] == "2024-01-01"
 
@@ -346,20 +346,14 @@ def test_neither_date_param_uses_days(monkeypatch):
 def test_invalid_range_returns_422(monkeypatch):
     """start_date after end_date must return HTTP 422 (FastAPI validation convention)."""
     client = _client_with_df(monkeypatch, _multi_day_df())
-    resp = client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json"
-        "&start_date=2024-01-10&end_date=2024-01-01"
-    )
+    resp = client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json" "&start_date=2024-01-10&end_date=2024-01-01")
     assert resp.status_code == 422
 
 
 def test_single_day_range(monkeypatch):
     """start_date == end_date is a valid single-day window; must not raise."""
     client = _client_with_df(monkeypatch, _multi_day_df())
-    resp = client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json"
-        "&start_date=2024-01-02&end_date=2024-01-02"
-    )
+    resp = client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json" "&start_date=2024-01-02&end_date=2024-01-02")
     assert resp.status_code == 200
     data = resp.json()
     assert data["from"] == "2024-01-02"
@@ -373,19 +367,14 @@ def test_malformed_date_returns_4xx(monkeypatch):
     to 400 rather than the default 422, so either status is accepted here.
     """
     client = _client_with_df(monkeypatch, _multi_day_df())
-    resp = client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json&start_date=not-a-date"
-    )
+    resp = client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json&start_date=not-a-date")
     assert resp.status_code in (400, 422)
 
 
 def test_html_shows_date_range(monkeypatch):
     """HTML output subtitle must contain the resolved date range."""
     client = _client_with_df(monkeypatch, _multi_day_df())
-    resp = client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=html"
-        "&start_date=2024-01-01&end_date=2024-01-03"
-    )
+    resp = client.get("/timeseries/meta?ticker=ABC&exchange=L&format=html" "&start_date=2024-01-01&end_date=2024-01-03")
     assert resp.status_code == 200
     assert "2024-01-01" in resp.text
     assert "2024-01-03" in resp.text
@@ -399,10 +388,7 @@ def test_csv_with_date_range(monkeypatch):
     path returns early, so the CSV `if` must still be reached independently.
     """
     client = _client_with_df(monkeypatch, _multi_day_df())
-    resp = client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=csv"
-        "&start_date=2024-01-01&end_date=2024-01-03"
-    )
+    resp = client.get("/timeseries/meta?ticker=ABC&exchange=L&format=csv" "&start_date=2024-01-01&end_date=2024-01-03")
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/csv")
     assert "Date,Open,High,Low,Close,Volume" in resp.text
@@ -437,10 +423,7 @@ def test_explicit_start_date_ignores_days(monkeypatch):
     from backend.app import create_app
 
     client = TestClient(create_app())
-    resp = client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json"
-        "&start_date=2024-01-02&days=0"
-    )
+    resp = client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json" "&start_date=2024-01-02&days=0")
     assert resp.status_code == 200
     # days=0 must NOT override the explicit start_date with the 1900 sentinel
     assert captured["start_date"] == date(2024, 1, 2)
@@ -478,10 +461,7 @@ def test_load_called_with_resolved_dates(monkeypatch):
         return _multi_day_df().copy()
 
     client = _client_with_spy(monkeypatch, _spy)
-    client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json"
-        "&start_date=2024-01-01&end_date=2024-01-03"
-    )
+    client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json" "&start_date=2024-01-01&end_date=2024-01-03")
     assert captured["start_date"] == date(2024, 1, 1)
     assert captured["end_date"] == date(2024, 1, 3)
 
@@ -498,10 +478,7 @@ def test_end_date_with_days_derives_start(monkeypatch):
         return _multi_day_df().copy()
 
     client = _client_with_spy(monkeypatch, _spy)
-    client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json"
-        "&end_date=2024-01-03&days=2"
-    )
+    client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json" "&end_date=2024-01-03&days=2")
     assert captured["end_date"] == date(2024, 1, 3)
     assert captured["start_date"] == date(2024, 1, 3) - timedelta(days=2)
 
@@ -518,10 +495,7 @@ def test_days_zero_with_end_date_means_all_history(monkeypatch):
         return _multi_day_df().copy()
 
     client = _client_with_spy(monkeypatch, _spy)
-    client.get(
-        "/timeseries/meta?ticker=ABC&exchange=L&format=json"
-        "&end_date=2024-01-03&days=0"
-    )
+    client.get("/timeseries/meta?ticker=ABC&exchange=L&format=json" "&end_date=2024-01-03&days=0")
     assert captured["end_date"] == date(2024, 1, 3)
     assert captured["start_date"] == date(1900, 1, 1)  # "all history" sentinel
 
@@ -545,13 +519,14 @@ def test_days_zero_with_end_date_means_all_history(monkeypatch):
 # test_timeseries_meta_formats_with_scaling[html] above.
 
 
-@pytest.mark.parametrize("ticker,exchange", [
-    ("<script>alert(1)</script>", "L"),
-    ("ABC", '"><img src=x onerror=alert(1)>'),
-])
-def test_timeseries_meta_html_user_input_xss_rejected_by_validation(
-    ticker, exchange, monkeypatch
-):
+@pytest.mark.parametrize(
+    "ticker,exchange",
+    [
+        ("<script>alert(1)</script>", "L"),
+        ("ABC", '"><img src=x onerror=alert(1)>'),
+    ],
+)
+def test_timeseries_meta_html_user_input_xss_rejected_by_validation(ticker, exchange, monkeypatch):
     """Input validation rejects XSS payloads before they reach the HTML renderer.
 
     _TICKER_SYMBOL_RE / _EXCHANGE_CODE_RE return 400 for these inputs.
@@ -568,10 +543,13 @@ def test_timeseries_meta_html_user_input_xss_rejected_by_validation(
     assert "application/json" in resp.headers.get("content-type", "")
 
 
-@pytest.mark.parametrize("xss_ticker,escaped_fragment", [
-    ("<script>alert(1)</script>", "&lt;script&gt;"),
-    ('"><img src=x onerror=alert(1)>', "&lt;img"),
-])
+@pytest.mark.parametrize(
+    "xss_ticker,escaped_fragment",
+    [
+        ("<script>alert(1)</script>", "&lt;script&gt;"),
+        ('"><img src=x onerror=alert(1)>', "&lt;img"),
+    ],
+)
 def test_timeseries_html_xss_not_reflected(xss_ticker, escaped_fragment, monkeypatch):
     """/timeseries/html has no input validation; output escaping must prevent injection.
 
@@ -654,11 +632,20 @@ def test_timeseries_html_xss_ticker_column_in_dataframe_is_escaped(monkeypatch):
     the table cell — deliberately isolated to test that specific layer.
     """
     xss = "<script>alert(1)</script>"
-    df = pd.DataFrame([{
-        "Date": "2024-01-01",
-        "Open": 1.0, "High": 2.0, "Low": 0.5, "Close": 1.5,
-        "Volume": 100, "Ticker": xss, "Source": "Yahoo",
-    }])
+    df = pd.DataFrame(
+        [
+            {
+                "Date": "2024-01-01",
+                "Open": 1.0,
+                "High": 2.0,
+                "Low": 0.5,
+                "Close": 1.5,
+                "Volume": 100,
+                "Ticker": xss,
+                "Source": "Yahoo",
+            }
+        ]
+    )
     client = _html_client(monkeypatch, df)
     # ticker param is benign; injection surface is the DataFrame Ticker column only
     resp = client.get(
@@ -704,7 +691,7 @@ def test_timeseries_meta_csv_output_not_html_escaped(monkeypatch):
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/csv")
     assert "Date,Open,High,Low,Close,Volume" in resp.text  # headers intact, no entity encoding
-    assert "&lt;" not in resp.text   # no HTML-escaped angle brackets
+    assert "&lt;" not in resp.text  # no HTML-escaped angle brackets
     assert "&amp;" not in resp.text  # no HTML-escaped ampersands
 
 

--- a/tests/routes/test_trail_routes.py
+++ b/tests/routes/test_trail_routes.py
@@ -14,6 +14,7 @@ def test_trail_routes(tmp_path, monkeypatch, disable_auth):
     import backend.app as app_mod
     import backend.quests.trail as trail_module
     import backend.routes.trail as trail_route_module
+
     importlib.reload(trail_module)
     importlib.reload(trail_route_module)
     importlib.reload(app_mod)
@@ -54,7 +55,4 @@ def test_trail_routes(tmp_path, monkeypatch, disable_auth):
         persisted_payload = resp.json()
         assert persisted_payload["xp"] == final_payload["xp"]
         assert persisted_payload["streak"] == final_payload["streak"]
-        assert (
-            persisted_payload["daily_totals"][today]["completed"]
-            == len(daily_task_ids)
-        )
+        assert persisted_payload["daily_totals"][today]["completed"] == len(daily_task_ids)

--- a/tests/screener/test_screener.py
+++ b/tests/screener/test_screener.py
@@ -1,13 +1,14 @@
-import pytest
 from datetime import UTC, datetime, timedelta
+
+import pytest
 
 from backend import config
 from backend.screener import (
+    Fundamentals,
     _parse_float,
     _parse_int,
     fetch_fundamentals,
     screen,
-    Fundamentals,
 )
 
 

--- a/tests/scripts/test_check_branch_protection_required_checks.py
+++ b/tests/scripts/test_check_branch_protection_required_checks.py
@@ -127,9 +127,7 @@ def _write_ruleset(path: Path, contexts: list[str]) -> None:
                 "rules": [
                     {
                         "type": "required_status_checks",
-                        "parameters": {
-                            "required_status_checks": [{"context": c} for c in contexts]
-                        },
+                        "parameters": {"required_status_checks": [{"context": c} for c in contexts]},
                     }
                 ],
             }
@@ -160,8 +158,6 @@ def test_context_from_disabled_workflow_fails(
     contexts = [*_mod.EXPECTED_REQUIRED_CHECKS, "dependency-review"]
     _write_ruleset(ruleset, contexts)
     monkeypatch.setattr(_mod, "RULESET_PATH", ruleset)
-    monkeypatch.setattr(
-        _mod, "EXPECTED_REQUIRED_CHECKS", _mod.EXPECTED_REQUIRED_CHECKS | {"dependency-review"}
-    )
+    monkeypatch.setattr(_mod, "EXPECTED_REQUIRED_CHECKS", _mod.EXPECTED_REQUIRED_CHECKS | {"dependency-review"})
     assert _mod.main() == 1
     assert "disabled workflows" in capsys.readouterr().err

--- a/tests/scripts/test_check_contract_version_sync.py
+++ b/tests/scripts/test_check_contract_version_sync.py
@@ -1,4 +1,5 @@
 """Unit tests for scripts/check_contract_version_sync.py."""
+
 from __future__ import annotations
 
 import importlib.util
@@ -22,6 +23,7 @@ main = _mod.main
 # ---------------------------------------------------------------------------
 # extract_contract_version
 # ---------------------------------------------------------------------------
+
 
 class TestExtractContractVersion:
     def test_python_style_single_quotes(self, tmp_path: Path) -> None:
@@ -50,10 +52,7 @@ class TestExtractContractVersion:
     def test_duplicate_definition_raises(self, tmp_path: Path) -> None:
         """Two real (non-comment) definitions on separate lines must raise."""
         f = tmp_path / "dup.py"
-        f.write_text(
-            "SPA_RESPONSE_CONTRACT_VERSION = '0.9'\n"
-            "SPA_RESPONSE_CONTRACT_VERSION = '1.0'\n"
-        )
+        f.write_text("SPA_RESPONSE_CONTRACT_VERSION = '0.9'\n" "SPA_RESPONSE_CONTRACT_VERSION = '1.0'\n")
         with pytest.raises(ValueError, match="2 occurrences"):
             extract_contract_version(f)
 
@@ -61,8 +60,7 @@ class TestExtractContractVersion:
         """A full-line Python comment referencing the old version is ignored."""
         f = tmp_path / "contracts.py"
         f.write_text(
-            "# SPA_RESPONSE_CONTRACT_VERSION = '0.9'  # previous version\n"
-            "SPA_RESPONSE_CONTRACT_VERSION = '1.0'\n"
+            "# SPA_RESPONSE_CONTRACT_VERSION = '0.9'  # previous version\n" "SPA_RESPONSE_CONTRACT_VERSION = '1.0'\n"
         )
         assert extract_contract_version(f) == "1.0"
 
@@ -80,18 +78,14 @@ class TestExtractContractVersion:
         trigger the duplicate guard.
         """
         f = tmp_path / "contracts.py"
-        f.write_text(
-            "SPA_RESPONSE_CONTRACT_VERSION = '1.0'  "
-            "# bumped from SPA_RESPONSE_CONTRACT_VERSION = '0.9'\n"
-        )
+        f.write_text("SPA_RESPONSE_CONTRACT_VERSION = '1.0'  " "# bumped from SPA_RESPONSE_CONTRACT_VERSION = '0.9'\n")
         assert extract_contract_version(f) == "1.0"
 
     def test_typescript_inline_comment_with_old_version_is_stripped(self, tmp_path: Path) -> None:
         """Same check for TypeScript inline // comment."""
         f = tmp_path / "spa.ts"
         f.write_text(
-            'export const SPA_RESPONSE_CONTRACT_VERSION = "1.0";  '
-            '// was SPA_RESPONSE_CONTRACT_VERSION = "0.9"\n'
+            'export const SPA_RESPONSE_CONTRACT_VERSION = "1.0";  ' '// was SPA_RESPONSE_CONTRACT_VERSION = "0.9"\n'
         )
         assert extract_contract_version(f) == "1.0"
 
@@ -104,12 +98,15 @@ class TestExtractContractVersion:
 # main() end-to-end
 # ---------------------------------------------------------------------------
 
+
 class TestMain:
     def _patch_paths(self, monkeypatch: pytest.MonkeyPatch, py_file: Path, ts_file: Path) -> None:
         monkeypatch.setattr(_mod, "PYTHON_CONTRACT", py_file)
         monkeypatch.setattr(_mod, "TYPESCRIPT_CONTRACT", ts_file)
 
-    def test_versions_match_returns_0(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_versions_match_returns_0(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         py = tmp_path / "contracts.py"
         ts = tmp_path / "spa.ts"
         py.write_text("SPA_RESPONSE_CONTRACT_VERSION = '1.0'\n")
@@ -118,7 +115,9 @@ class TestMain:
         assert main() == 0
         assert "in sync" in capsys.readouterr().out
 
-    def test_versions_mismatch_returns_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_versions_mismatch_returns_1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         py = tmp_path / "contracts.py"
         ts = tmp_path / "spa.ts"
         py.write_text("SPA_RESPONSE_CONTRACT_VERSION = '1.0'\n")
@@ -127,14 +126,18 @@ class TestMain:
         assert main() == 1
         assert "mismatch" in capsys.readouterr().err
 
-    def test_missing_file_returns_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_missing_file_returns_1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         py = tmp_path / "contracts.py"
         py.write_text("SPA_RESPONSE_CONTRACT_VERSION = '1.0'\n")
         self._patch_paths(monkeypatch, py, tmp_path / "nonexistent.ts")
         assert main() == 1
         assert "ERROR" in capsys.readouterr().err
 
-    def test_version_not_found_returns_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_version_not_found_returns_1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         py = tmp_path / "contracts.py"
         ts = tmp_path / "spa.ts"
         py.write_text("SPA_RESPONSE_CONTRACT_VERSION = '1.0'\n")

--- a/tests/scripts/test_check_live_branch_protection.py
+++ b/tests/scripts/test_check_live_branch_protection.py
@@ -47,14 +47,10 @@ def _fetch_factory(
 ):
     """Build a `fetch` stub covering every endpoint the script calls."""
     live = _live_from_checked_in() if ruleset is None else ruleset
-    listing = (
-        [{"id": RULESET_ID, "name": live.get("name")}] if rulesets_list is None else rulesets_list
-    )
+    listing = [{"id": RULESET_ID, "name": live.get("name")}] if rulesets_list is None else rulesets_list
     default_names = sorted(_mod.DISABLED_WORKFLOW_FILES)
     names = default_names if disabled_workflows is None else disabled_workflows
-    workflows = [
-        {"path": f".github/workflows/{name}", "state": "disabled_manually"} for name in names
-    ]
+    workflows = [{"path": f".github/workflows/{name}", "state": "disabled_manually"} for name in names]
 
     def fetch(path: str) -> Any:
         if path == f"repos/{REPO}/rulesets":
@@ -239,9 +235,7 @@ def test_required_context_from_newly_disabled_workflow_is_drift() -> None:
     disabled = sorted(_mod.DISABLED_WORKFLOW_FILES | {"conflict-check.yml"})
     errors = _errors(disabled_workflows=disabled)
     assert any("not listed in DISABLED_WORKFLOW_FILES" in e for e in errors)
-    assert any(
-        "can never report" in e and "Check for merge conflicts with main" in e for e in errors
-    )
+    assert any("can never report" in e and "Check for merge conflicts with main" in e for e in errors)
 
 
 def test_context_matching_no_workflow_is_drift(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/scripts/test_check_portfolio_health.py
+++ b/tests/scripts/test_check_portfolio_health.py
@@ -1,7 +1,6 @@
 import logging
 from pathlib import Path
 
-import pytest
 import scripts.check_portfolio_health as cph
 
 

--- a/tests/scripts/test_deepseek_pr_review_workflow.py
+++ b/tests/scripts/test_deepseek_pr_review_workflow.py
@@ -17,9 +17,7 @@ from pathlib import Path
 
 import yaml
 
-WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deepseek-pr-review.yml"
-)
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deepseek-pr-review.yml"
 
 REQUIRED_LABEL = "Deep Review Required"
 
@@ -75,9 +73,7 @@ def test_no_labels_select_empty_overrides_so_script_defaults_apply() -> None:
     assert tokens == ""
 
 
-def _job_runs(
-    actor: str, action: str, enable_var: str | None = None, label_name: str | None = None
-) -> bool:
+def _job_runs(actor: str, action: str, enable_var: str | None = None, label_name: str | None = None) -> bool:
     """Evaluate the ai-review job's `if:` condition for a simulated event."""
     condition = _ai_review_job()["if"]
 
@@ -86,9 +82,7 @@ def _job_runs(
     blocked_actor = actor_match.group(1)
 
     disabled_match = re.search(r"vars\.ENABLE_DEEPSEEK_REVIEW != '([^']+)'", condition)
-    assert (
-        disabled_match
-    ), f"Could not find ENABLE_DEEPSEEK_REVIEW gate in job condition: {condition!r}"
+    assert disabled_match, f"Could not find ENABLE_DEEPSEEK_REVIEW gate in job condition: {condition!r}"
     disabled_value = disabled_match.group(1)
 
     required_label_match = re.search(r"github\.event\.label\.name == '([^']+)'", condition)

--- a/tests/scripts/test_deploy_lambda_workflow.py
+++ b/tests/scripts/test_deploy_lambda_workflow.py
@@ -46,9 +46,7 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
     deploy_job = workflow["jobs"]["deploy"]
     steps = deploy_job["steps"]
 
-    verify_step = next(
-        step for step in steps if step.get("name") == "Verify price snapshot seeded in S3"
-    )
+    verify_step = next(step for step in steps if step.get("name") == "Verify price snapshot seeded in S3")
 
     run_script = verify_step["run"]
 
@@ -91,7 +89,7 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
     assert "head_exit=" in head_exit_statement, (
         "head_exit must be captured in the same statement as the "
         "head_output subshell (e.g. `&& head_exit=0 || head_exit=$?` "
-        "immediately after the closing `)\"`), not via a later, separate "
+        'immediately after the closing `)"`), not via a later, separate '
         "statement that could capture a different command's exit code"
     )
     # Explicitly verify the ordering, not just co-occurrence: head_output's
@@ -102,9 +100,9 @@ def test_deploy_workflow_verify_price_snapshot_fails_hard_on_non_404() -> None:
     head_output_pos = capture_block.index("head_output=")
     head_exit_pos = capture_block.index("head_exit=")
     assert head_output_pos < capture_end <= head_exit_pos, (
-        "head_output must be fully assigned (subshell closed) before "
-        "head_exit is captured"
+        "head_output must be fully assigned (subshell closed) before " "head_exit is captured"
     )
+
 
 def test_deploy_workflow_verify_price_snapshot_retries_transient_s3_errors() -> None:
     workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
@@ -112,9 +110,7 @@ def test_deploy_workflow_verify_price_snapshot_retries_transient_s3_errors() -> 
     deploy_job = workflow["jobs"]["deploy"]
     steps = deploy_job["steps"]
 
-    verify_step = next(
-        step for step in steps if step.get("name") == "Verify price snapshot seeded in S3"
-    )
+    verify_step = next(step for step in steps if step.get("name") == "Verify price snapshot seeded in S3")
     run_script = verify_step["run"]
 
     # Transient S3 errors (throttling, 5xx, timeouts) must be retried with
@@ -176,9 +172,7 @@ def test_deploy_workflow_cognito_retry_documents_why_it_remains() -> None:
     deploy_job = workflow["jobs"]["deploy"]
     steps = deploy_job["steps"]
 
-    reconcile_step = next(
-        step for step in steps if step.get("name") == "Reconcile UiAuthClient OAuth configuration"
-    )
+    reconcile_step = next(step for step in steps if step.get("name") == "Reconcile UiAuthClient OAuth configuration")
     run_script = reconcile_step["run"]
 
     assert "cognito_retry() {" in run_script

--- a/tests/scripts/test_fetch_cloudwatch_logs.py
+++ b/tests/scripts/test_fetch_cloudwatch_logs.py
@@ -25,9 +25,7 @@ def _make_stub_aws(tmp_path: Path, stdout: str, exit_code: int) -> Path:
     stub_dir.mkdir()
     stub = stub_dir / "aws"
     stub.write_text(
-        "#!/usr/bin/env bash\n"
-        f"printf '%s' {os.fsdecode(_shell_quote(stdout))}\n"
-        f"exit {exit_code}\n",
+        "#!/usr/bin/env bash\n" f"printf '%s' {os.fsdecode(_shell_quote(stdout))}\n" f"exit {exit_code}\n",
         encoding="utf-8",
     )
     stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
@@ -91,9 +89,7 @@ def test_no_log_events_prints_placeholder(tmp_path: Path) -> None:
 def test_aws_cli_failure_still_exits_zero_under_set_dash_e(tmp_path: Path) -> None:
     # A failing `aws` call must not abort the script via `set -e` before the
     # exit_code handling below it runs; this diagnostic step always exits 0.
-    stub_dir = _make_stub_aws(
-        tmp_path, stdout="AccessDeniedException: not authorized", exit_code=254
-    )
+    stub_dir = _make_stub_aws(tmp_path, stdout="AccessDeniedException: not authorized", exit_code=254)
 
     result = _run_script("my-log-group", "600", stub_dir=stub_dir)
 

--- a/tests/scripts/test_frontend_smoke_workflow.py
+++ b/tests/scripts/test_frontend_smoke_workflow.py
@@ -6,11 +6,8 @@ from pathlib import Path
 
 import yaml
 
-
 CI_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
-DEPLOY_WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy-lambda.yml"
-)
+DEPLOY_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy-lambda.yml"
 
 
 def _step_name(step: dict) -> str:
@@ -84,9 +81,7 @@ def test_verify_smoke_tests_needs_existing_job() -> None:
     verify_job = workflow["jobs"]["verify-smoke-tests"]
     needed = verify_job.get("needs")
 
-    assert needed is not None, (
-        "verify-smoke-tests job must declare a needs: dependency on smoke-test"
-    )
+    assert needed is not None, "verify-smoke-tests job must declare a needs: dependency on smoke-test"
 
     # needs: can be a string or a list — normalise to a list for comparison.
     needed_jobs = [needed] if isinstance(needed, str) else list(needed)
@@ -102,9 +97,7 @@ def test_verify_smoke_tests_needs_existing_job() -> None:
     # Explicitly verify that smoke-test (the job that runs the actual smoke
     # checks) is among the needed jobs — this is the critical dependency
     # that validates pass/fail propagation.
-    assert "smoke-test" in needed_jobs, (
-        f"verify-smoke-tests must need smoke-test, but needs: is {needed_jobs}"
-    )
+    assert "smoke-test" in needed_jobs, f"verify-smoke-tests must need smoke-test, but needs: is {needed_jobs}"
 
 
 def test_frontend_smoke_builds_preview_before_running_playwright() -> None:
@@ -116,12 +109,8 @@ def test_frontend_smoke_builds_preview_before_running_playwright() -> None:
     build_idx = _first_step_index(steps, lambda step: "build:preview" in _step_run(step))
     playwright_idx = _first_step_index(steps, lambda step: "playwright test" in _step_run(step))
 
-    assert build_idx is not None, (
-        "frontend-smoke job has no step running 'npm run build:preview'"
-    )
-    assert playwright_idx is not None, (
-        "frontend-smoke job has no step running a Playwright test command"
-    )
+    assert build_idx is not None, "frontend-smoke job has no step running 'npm run build:preview'"
+    assert playwright_idx is not None, "frontend-smoke job has no step running a Playwright test command"
     assert build_idx < playwright_idx, (
         "frontend-smoke must run 'npm run build:preview' before the Playwright "
         "test step, otherwise smoke tests would run against a stale/missing build"

--- a/tests/scripts/test_n_review_issue.py
+++ b/tests/scripts/test_n_review_issue.py
@@ -16,9 +16,7 @@ def test_limited_disposition_prompt_aborts_after_maximum_feedback(monkeypatch) -
 
     assert limited_prompt() == ("abort", None)
     assert prompt.call_count == n_review_issue.MAX_FEEDBACK_RETRIES + 1
-    log_error.assert_called_once_with(
-        "Maximum feedback retries reached; aborting without applying the review."
-    )
+    log_error.assert_called_once_with("Maximum feedback retries reached; aborting without applying the review.")
 
 
 def test_limited_disposition_prompt_preserves_apply_and_abort() -> None:

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.config import config
+import backend.app as app_mod
 import backend.common.prices as prices
 from backend.common import portfolio_utils
-import backend.app as app_mod
+from backend.config import config
 
 
 @pytest.fixture(scope="session")
@@ -26,10 +26,7 @@ def client():
 
 
 def sample_accounts():
-    root = Path(
-        config.accounts_root
-        or (Path(__file__).resolve().parents[1] / "data" / "accounts")
-    )
+    root = Path(config.accounts_root or (Path(__file__).resolve().parents[1] / "data" / "accounts"))
     if not root.exists():
         pytest.skip("accounts sample data unavailable", allow_module_level=True)
     metadata_stems = {
@@ -62,19 +59,12 @@ def test_owners_endpoint_matches_sample_data(client):
     resp = client.get("/owners")
     assert resp.status_code == 200
     payload = resp.json()
-    owners_by_lower = {
-        entry["owner"].casefold(): (entry["owner"], set(entry.get("accounts", [])))
-        for entry in payload
-    }
+    owners_by_lower = {entry["owner"].casefold(): (entry["owner"], set(entry.get("accounts", []))) for entry in payload}
 
     sample = list(sample_accounts())
     demo_lower = config.demo_identity.casefold()
 
-    non_demo = [
-        (owner, accounts)
-        for owner, accounts in sample
-        if owner.casefold() != demo_lower
-    ]
+    non_demo = [(owner, accounts) for owner, accounts in sample if owner.casefold() != demo_lower]
 
     if non_demo:
         assert demo_lower not in owners_by_lower
@@ -112,15 +102,11 @@ def test_account_route_adds_missing_account_type(tmp_path):
     acct = "missing"
     acct_dir = tmp_path / owner
     acct_dir.mkdir()
-    (acct_dir / f"{acct}.json").write_text(
-        json.dumps({"currency": "GBP", "holdings": []})
-    )
+    (acct_dir / f"{acct}.json").write_text(json.dumps({"currency": "GBP", "holdings": []}))
 
     demo_dir = tmp_path / "demo"
     demo_dir.mkdir()
-    (demo_dir / "demo.json").write_text(
-        json.dumps({"currency": "GBP", "holdings": []})
-    )
+    (demo_dir / "demo.json").write_text(json.dumps({"currency": "GBP", "holdings": []}))
 
     old_root = config.accounts_root
     config.accounts_root = tmp_path

--- a/tests/test_ai_review_scripts.py
+++ b/tests/test_ai_review_scripts.py
@@ -9,12 +9,10 @@ import sys
 import urllib.error
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import patch
-
-import pytest
 
 import cicaid_devtools.lib.review_common as review_common
-from cicaid_devtools.lib.review_common import ProviderAuthError, ProviderOutageError
+import pytest
+from cicaid_devtools.lib.review_common import ProviderOutageError
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".github" / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
@@ -23,7 +21,8 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 def load_script_module(module_name: str, file_name: str) -> ModuleType:
     spec = importlib.util.spec_from_file_location(
-        module_name, SCRIPTS_DIR / file_name,
+        module_name,
+        SCRIPTS_DIR / file_name,
     )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
@@ -77,7 +76,8 @@ def test_deepseek_review_disables_thinking_mode_for_default_model(
 ) -> None:
     """Regression test for #5697: flash-tier reviews must disable thinking."""
     module = load_script_module(
-        "deepseek_review_thinking_flash", "deepseek_review.py",
+        "deepseek_review_thinking_flash",
+        "deepseek_review.py",
     )
     monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
     monkeypatch.setenv("PR_TITLE", "Add thing")
@@ -89,12 +89,16 @@ def test_deepseek_review_disables_thinking_mode_for_default_model(
 
     def fake_urlopen(request, *args, **kwargs):
         captured_payloads.append(json.loads(request.data.decode()))
-        return FakeResponse({
-            "choices": [{"message": {"content": "Looks good\n**APPROVE**"}}],
-        })
+        return FakeResponse(
+            {
+                "choices": [{"message": {"content": "Looks good\n**APPROVE**"}}],
+            }
+        )
 
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen", fake_urlopen,
+        review_common.urllib.request,
+        "urlopen",
+        fake_urlopen,
     )
     assert module.main() == 0
     assert captured_payloads[0]["thinking"] == {"type": "disabled"}
@@ -104,7 +108,8 @@ def test_deepseek_review_leaves_thinking_mode_enabled_for_reasoner_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = load_script_module(
-        "deepseek_review_thinking_reasoner", "deepseek_review.py",
+        "deepseek_review_thinking_reasoner",
+        "deepseek_review.py",
     )
     monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
     monkeypatch.setenv("PR_TITLE", "Add thing")
@@ -116,12 +121,16 @@ def test_deepseek_review_leaves_thinking_mode_enabled_for_reasoner_model(
 
     def fake_urlopen(request, *args, **kwargs):
         captured_payloads.append(json.loads(request.data.decode()))
-        return FakeResponse({
-            "choices": [{"message": {"content": "Looks good\n**APPROVE**"}}],
-        })
+        return FakeResponse(
+            {
+                "choices": [{"message": {"content": "Looks good\n**APPROVE**"}}],
+            }
+        )
 
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen", fake_urlopen,
+        review_common.urllib.request,
+        "urlopen",
+        fake_urlopen,
     )
     assert module.main() == 0
     assert "thinking" not in captured_payloads[0]
@@ -132,20 +141,24 @@ def test_deepseek_review_warns_when_only_reasoning_content_returned(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     module = load_script_module(
-        "deepseek_review_reasoning_only", "deepseek_review.py",
+        "deepseek_review_reasoning_only",
+        "deepseek_review.py",
     )
     monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
     monkeypatch.setenv("PR_TITLE", "Add thing")
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     payload = {
-        "choices": [{
-            "message": {"content": "", "reasoning_content": "thinking…"},
-            "finish_reason": "length",
-        }],
+        "choices": [
+            {
+                "message": {"content": "", "reasoning_content": "thinking…"},
+                "finish_reason": "length",
+            }
+        ],
     }
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen",
+        review_common.urllib.request,
+        "urlopen",
         lambda *a, **kw: FakeResponse(payload),
     )
     # The package's finalize_review soft-skips an empty review (returns 0).
@@ -213,15 +226,21 @@ def test_review_script_exits_cleanly_on_empty_diff(
     ("module_name", "file_name", "api_env", "payload"),
     [
         (
-            "gpt_review_success", "gpt_review.py", "OPENAI_API_KEY",
+            "gpt_review_success",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
             {"choices": [{"message": {"content": "Looks good\n**APPROVE**"}}]},
         ),
         (
-            "claude_review_success", "claude_review.py", "ANTHROPIC_API_KEY",
+            "claude_review_success",
+            "claude_review.py",
+            "ANTHROPIC_API_KEY",
             {"content": [{"type": "text", "text": "Looks good\n**APPROVE**"}]},
         ),
         (
-            "deepseek_review_success", "deepseek_review.py", "DEEPSEEK_API_KEY",
+            "deepseek_review_success",
+            "deepseek_review.py",
+            "DEEPSEEK_API_KEY",
             {"choices": [{"message": {"content": "Looks good\n**APPROVE**"}}]},
         ),
     ],
@@ -240,7 +259,8 @@ def test_review_script_prints_review_on_mocked_api_success(
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen",
+        review_common.urllib.request,
+        "urlopen",
         lambda *a, **kw: FakeResponse(payload),
     )
     assert module.main() == 0
@@ -254,15 +274,21 @@ def test_review_script_prints_review_on_mocked_api_success(
     ("module_name", "file_name", "api_env", "payload"),
     [
         (
-            "gpt_review_discussion", "gpt_review.py", "OPENAI_API_KEY",
+            "gpt_review_discussion",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
             {"choices": [{"message": {"content": "Looks good\n**APPROVE**"}}]},
         ),
         (
-            "claude_review_discussion", "claude_review.py", "ANTHROPIC_API_KEY",
+            "claude_review_discussion",
+            "claude_review.py",
+            "ANTHROPIC_API_KEY",
             {"content": [{"type": "text", "text": "Looks good\n**APPROVE**"}]},
         ),
         (
-            "deepseek_review_discussion", "deepseek_review.py", "DEEPSEEK_API_KEY",
+            "deepseek_review_discussion",
+            "deepseek_review.py",
+            "DEEPSEEK_API_KEY",
             {"choices": [{"message": {"content": "Looks good\n**APPROVE**"}}]},
         ),
     ],
@@ -304,23 +330,33 @@ def test_review_script_includes_discussion_in_prompt(
     ("module_name", "file_name", "api_env", "payload"),
     [
         (
-            "gpt_review_empty_choices", "gpt_review.py", "OPENAI_API_KEY",
+            "gpt_review_empty_choices",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
             {"choices": []},
         ),
         (
-            "gpt_review_empty_content", "gpt_review.py", "OPENAI_API_KEY",
+            "gpt_review_empty_content",
+            "gpt_review.py",
+            "OPENAI_API_KEY",
             {"choices": [{"message": {"content": ""}}]},
         ),
         (
-            "claude_review_empty_content", "claude_review.py", "ANTHROPIC_API_KEY",
+            "claude_review_empty_content",
+            "claude_review.py",
+            "ANTHROPIC_API_KEY",
             {"content": []},
         ),
         (
-            "deepseek_review_empty_choices", "deepseek_review.py", "DEEPSEEK_API_KEY",
+            "deepseek_review_empty_choices",
+            "deepseek_review.py",
+            "DEEPSEEK_API_KEY",
             {"choices": []},
         ),
         (
-            "deepseek_review_empty_content", "deepseek_review.py", "DEEPSEEK_API_KEY",
+            "deepseek_review_empty_content",
+            "deepseek_review.py",
+            "DEEPSEEK_API_KEY",
             {"choices": [{"message": {"content": ""}}]},
         ),
     ],
@@ -339,7 +375,8 @@ def test_review_script_soft_skips_on_empty_api_response(
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen",
+        review_common.urllib.request,
+        "urlopen",
         lambda *a, **kw: FakeResponse(payload),
     )
     assert module.main() == 0
@@ -351,8 +388,11 @@ def test_review_script_soft_skips_on_empty_api_response(
 
 def _raise_fake_500(*args, **kwargs):
     raise urllib.error.HTTPError(
-        url="https://example.test", code=500, msg="server error",
-        hdrs=None, fp=io.BytesIO(b"upstream broke"),
+        url="https://example.test",
+        code=500,
+        msg="server error",
+        hdrs=None,
+        fp=io.BytesIO(b"upstream broke"),
     )
 
 
@@ -369,10 +409,13 @@ def _disabled_test_claude_and_gpt_raise_provider_outage_on_500(
         monkeypatch.setenv("PR_TITLE", "Add thing")
         monkeypatch.setenv("ISSUE_BODY", "Do thing")
         monkeypatch.setenv(
-            "DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n",
+            "DIFF",
+            "diff --git a/a.py b/a.py\n+print('hi')\n",
         )
         monkeypatch.setattr(
-            review_common.urllib.request, "urlopen", _raise_fake_500,
+            review_common.urllib.request,
+            "urlopen",
+            _raise_fake_500,
         )
         with pytest.raises(ProviderOutageError):
             module.main()
@@ -384,14 +427,17 @@ def test_deepseek_handles_500_as_soft_skip(
 ) -> None:
     """DeepSeek catches ProviderOutageError and emits soft-fail notice."""
     module = load_script_module(
-        "deepseek_review_500", "deepseek_review.py",
+        "deepseek_review_500",
+        "deepseek_review.py",
     )
     monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
     monkeypatch.setenv("PR_TITLE", "Add thing")
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen", _raise_fake_500,
+        review_common.urllib.request,
+        "urlopen",
+        _raise_fake_500,
     )
     assert module.main() == 0
     assert "PROVIDER OUTAGE" in capsys.readouterr().out
@@ -416,10 +462,13 @@ def _disabled_test_claude_and_gpt_raise_provider_outage_on_url_error(
         monkeypatch.setenv("PR_TITLE", "Add thing")
         monkeypatch.setenv("ISSUE_BODY", "Do thing")
         monkeypatch.setenv(
-            "DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n",
+            "DIFF",
+            "diff --git a/a.py b/a.py\n+print('hi')\n",
         )
         monkeypatch.setattr(
-            review_common.urllib.request, "urlopen", _raise_url_error,
+            review_common.urllib.request,
+            "urlopen",
+            _raise_url_error,
         )
         with pytest.raises(ProviderOutageError):
             module.main()
@@ -430,14 +479,17 @@ def test_deepseek_handles_url_error_as_soft_skip(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     module = load_script_module(
-        "deepseek_review_url_error", "deepseek_review.py",
+        "deepseek_review_url_error",
+        "deepseek_review.py",
     )
     monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
     monkeypatch.setenv("PR_TITLE", "Add thing")
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen", _raise_url_error,
+        review_common.urllib.request,
+        "urlopen",
+        _raise_url_error,
     )
     assert module.main() == 0
     assert "PROVIDER OUTAGE" in capsys.readouterr().out
@@ -466,7 +518,8 @@ def test_review_script_reports_mocked_non_json_response(
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen",
+        review_common.urllib.request,
+        "urlopen",
         lambda *a, **kw: FakeResponse(b"<html>not json</html>", raw=True),
     )
     with pytest.raises(SystemExit):
@@ -481,18 +534,11 @@ class TestFilterBinaryFiles:
         assert review_common.filter_binary_files("") == ""
 
     def test_text_only_diff_is_unchanged(self) -> None:
-        diff = (
-            "diff --git a/file.py b/file.py\n"
-            "--- a/file.py\n+++ b/file.py\n"
-            "@@ -1 +1 @@\n-old\n+new\n"
-        )
+        diff = "diff --git a/file.py b/file.py\n" "--- a/file.py\n+++ b/file.py\n" "@@ -1 +1 @@\n-old\n+new\n"
         assert review_common.filter_binary_files(diff) == diff
 
     def test_binary_only_diff_becomes_empty(self) -> None:
-        diff = (
-            "diff --git a/logo.png b/logo.png\n"
-            "Binary files a/logo.png and b/logo.png differ\n"
-        )
+        diff = "diff --git a/logo.png b/logo.png\n" "Binary files a/logo.png and b/logo.png differ\n"
         assert review_common.filter_binary_files(diff) == ""
 
     def test_mixed_diff_keeps_only_text_files(self) -> None:
@@ -509,10 +555,7 @@ class TestFilterBinaryFiles:
         assert "+new" in filtered
 
     def test_git_binary_patch_form_is_also_filtered(self) -> None:
-        diff = (
-            "diff --git a/data.bin b/data.bin\n"
-            "GIT binary patch\nliteral 10\n...\n"
-        )
+        diff = "diff --git a/data.bin b/data.bin\n" "GIT binary patch\nliteral 10\n...\n"
         assert review_common.filter_binary_files(diff) == ""
 
     def test_renamed_binary_file_is_filtered(self) -> None:
@@ -524,6 +567,7 @@ class TestFilterBinaryFiles:
             "Binary files a/old.png and b/new.png differ\n"
         )
         assert review_common.filter_binary_files(diff) == ""
+
 
 # --- Replacement tests for disabled loop-based tests above ---
 
@@ -538,7 +582,9 @@ def test_claude_raises_provider_outage_on_500(
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen", _raise_fake_500,
+        review_common.urllib.request,
+        "urlopen",
+        _raise_fake_500,
     )
     with pytest.raises(ProviderOutageError):
         module.main()
@@ -555,7 +601,9 @@ def test_gpt_handles_500_as_soft_skip(
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen", _raise_fake_500,
+        review_common.urllib.request,
+        "urlopen",
+        _raise_fake_500,
     )
     assert module.main() == 0
     assert "PROVIDER OUTAGE" in capsys.readouterr().out
@@ -570,7 +618,9 @@ def test_claude_raises_provider_outage_on_url_error(
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen", _raise_url_error,
+        review_common.urllib.request,
+        "urlopen",
+        _raise_url_error,
     )
     with pytest.raises(ProviderOutageError):
         module.main()
@@ -586,7 +636,9 @@ def test_gpt_handles_url_error_as_soft_skip(
     monkeypatch.setenv("ISSUE_BODY", "Do thing")
     monkeypatch.setenv("DIFF", "diff --git a/a.py b/a.py\n+print('hi')\n")
     monkeypatch.setattr(
-        review_common.urllib.request, "urlopen", _raise_url_error,
+        review_common.urllib.request,
+        "urlopen",
+        _raise_url_error,
     )
     assert module.main() == 0
     assert "PROVIDER OUTAGE" in capsys.readouterr().out

--- a/tests/test_alert_thresholds_route.py
+++ b/tests/test_alert_thresholds_route.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -106,8 +106,10 @@ def test_publish_failure_does_not_throttle(monkeypatch):
 
     def failing_client(name):
         assert name == "sns"
+
         def publish(**kwargs):
             raise Exception("boom")
+
         return SimpleNamespace(publish=publish)
 
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=failing_client))
@@ -120,7 +122,9 @@ def test_publish_failure_does_not_throttle(monkeypatch):
 
     def success_client(name):
         assert name == "sns"
-        return SimpleNamespace(publish=lambda TopicArn, Message: sent.update({"TopicArn": TopicArn, "Message": Message}))
+        return SimpleNamespace(
+            publish=lambda TopicArn, Message: sent.update({"TopicArn": TopicArn, "Message": Message})
+        )
 
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=success_client))
 

--- a/tests/test_alerts_notifications.py
+++ b/tests/test_alerts_notifications.py
@@ -1,6 +1,8 @@
 import sys
 import types
+
 import pytest
+
 import backend.alerts as alerts
 
 

--- a/tests/test_alphavantage_disabled.py
+++ b/tests/test_alphavantage_disabled.py
@@ -1,10 +1,11 @@
 from datetime import date
+
 import pytest
+import requests
 
 from backend import config as cfg
-from backend.timeseries.fetch_alphavantage_timeseries import fetch_alphavantage_timeseries_range
 from backend.tasks.quotes import fetch_quote
-import requests
+from backend.timeseries.fetch_alphavantage_timeseries import fetch_alphavantage_timeseries_range
 
 
 def test_alphavantage_timeseries_disabled(monkeypatch):

--- a/tests/test_alphavantage_errors.py
+++ b/tests/test_alphavantage_errors.py
@@ -2,8 +2,8 @@ from datetime import date
 
 import pytest
 
-from backend import config as cfg
 import backend.timeseries.fetch_alphavantage_timeseries as av
+from backend import config as cfg
 from backend.timeseries.fetch_alphavantage_timeseries import (
     fetch_alphavantage_timeseries_range,
 )
@@ -48,8 +48,6 @@ def test_information_field_propagated_when_disabled(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
 
     with pytest.raises(ValueError) as exc:
-        fetch_alphavantage_timeseries_range(
-            "IBM", "US", date(2024, 1, 1), date(2024, 1, 10), api_key="demo"
-        )
+        fetch_alphavantage_timeseries_range("IBM", "US", date(2024, 1, 1), date(2024, 1, 10), api_key="demo")
 
     assert str(exc.value) == "disabled"

--- a/tests/test_alphavantage_rate_limit.py
+++ b/tests/test_alphavantage_rate_limit.py
@@ -1,13 +1,14 @@
-import pandas as pd
-import pytest
 from datetime import date
 
+import pandas as pd
+import pytest
+
 import backend.timeseries.fetch_alphavantage_timeseries as av
-from backend.timeseries.fetch_alphavantage_timeseries import (
-    fetch_alphavantage_timeseries_range,
-    AlphaVantageRateLimitError,
-)
 import backend.timeseries.fetch_meta_timeseries as fm
+from backend.timeseries.fetch_alphavantage_timeseries import (
+    AlphaVantageRateLimitError,
+    fetch_alphavantage_timeseries_range,
+)
 
 
 class _Resp429:
@@ -38,9 +39,7 @@ def test_http_429_raises_rate_limit_error(monkeypatch):
     monkeypatch.setattr(av.requests, "get", lambda *a, **k: _Resp429())
 
     with pytest.raises(AlphaVantageRateLimitError) as exc:
-        fetch_alphavantage_timeseries_range(
-            "AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo"
-        )
+        fetch_alphavantage_timeseries_range("AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo")
     assert exc.value.retry_after == 12
 
 
@@ -50,9 +49,7 @@ def test_note_field_triggers_rate_limit(monkeypatch):
     monkeypatch.setattr(av.requests, "get", lambda *a, **k: _RespNote())
 
     with pytest.raises(AlphaVantageRateLimitError) as exc:
-        fetch_alphavantage_timeseries_range(
-            "AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo"
-        )
+        fetch_alphavantage_timeseries_range("AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo")
     assert exc.value.retry_after == 60
 
 
@@ -85,8 +82,6 @@ def test_meta_timeseries_handles_av_rate_limit(monkeypatch):
 
     monkeypatch.setattr(fm, "fetch_ft_timeseries", fake_ft)
 
-    df = fm.fetch_meta_timeseries(
-        "AAA", "L", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2)
-    )
+    df = fm.fetch_meta_timeseries("AAA", "L", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2))
     assert not df.empty
     assert df["Source"].iloc[0] == "FT"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -154,21 +154,24 @@ def test_api_console_admin_allowlist_enforced_when_auth_disabled(monkeypatch):
     assert resp_invalid.status_code in (401, 403)
 
 
-@pytest.mark.parametrize("admin_emails,disable_auth,email,expected_status", [
-    # allowlist configured: enforced regardless of disable_auth
-    ("admin@example.com", False, "admin@example.com", 200),
-    ("admin@example.com", False, "other@example.com", 403),
-    # DISABLE_AUTH=true is set on the production Lambda (API GW handles Cognito auth)
-    # and must NOT bypass the admin allowlist when ADMIN_EMAILS is configured.
-    ("admin@example.com", True, "admin@example.com", 200),
-    ("admin@example.com", True, "other@example.com", 403),
-    # case-insensitivity: both sides are lowercased before comparison
-    ("Admin@Example.COM", False, "admin@example.com", 200),
-    # no allowlist in prod-like env: deny all (misconfiguration guard)
-    ("", False, "anyone@example.com", 403),
-    # no allowlist + disable_auth=True → local dev bypass, allow through
-    ("", True, "anyone@example.com", 200),
-])
+@pytest.mark.parametrize(
+    "admin_emails,disable_auth,email,expected_status",
+    [
+        # allowlist configured: enforced regardless of disable_auth
+        ("admin@example.com", False, "admin@example.com", 200),
+        ("admin@example.com", False, "other@example.com", 403),
+        # DISABLE_AUTH=true is set on the production Lambda (API GW handles Cognito auth)
+        # and must NOT bypass the admin allowlist when ADMIN_EMAILS is configured.
+        ("admin@example.com", True, "admin@example.com", 200),
+        ("admin@example.com", True, "other@example.com", 403),
+        # case-insensitivity: both sides are lowercased before comparison
+        ("Admin@Example.COM", False, "admin@example.com", 200),
+        # no allowlist in prod-like env: deny all (misconfiguration guard)
+        ("", False, "anyone@example.com", 403),
+        # no allowlist + disable_auth=True → local dev bypass, allow through
+        ("", True, "anyone@example.com", 200),
+    ],
+)
 def test_api_console_admin_check(monkeypatch, admin_emails, disable_auth, email, expected_status):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     monkeypatch.setattr(config, "snapshot_warm_days", 30)

--- a/tests/test_auth_overrides.py
+++ b/tests/test_auth_overrides.py
@@ -80,7 +80,9 @@ def test_iter_override_mappings_accepts_gettable_objects():
             dependency_overrides=Gettable({}),
             dependency_overrides_provider=SimpleNamespace(
                 dependency_overrides=Gettable({}),
-                dependency_overrides_provider=(SimpleNamespace(dependency_overrides=Gettable({}), dependency_overrides_provider=None),),
+                dependency_overrides_provider=(
+                    SimpleNamespace(dependency_overrides=Gettable({}), dependency_overrides_provider=None),
+                ),
             ),
         )
     )
@@ -145,12 +147,14 @@ async def test_invoke_override_handles_request_annotations(monkeypatch):
     captured: dict[str, object] = {}
 
     def override(pos_only="default", /, request=None, *, token, annotated: AnnotatedRequest):
-        captured.update({
-            "pos_only": pos_only,
-            "request": request,
-            "token": token,
-            "annotated": annotated,
-        })
+        captured.update(
+            {
+                "pos_only": pos_only,
+                "request": request,
+                "token": token,
+                "annotated": annotated,
+            }
+        )
         return "done"
 
     request = AnnotatedRequest()
@@ -298,9 +302,7 @@ async def test_resolve_current_user_override_invokes_override(monkeypatch):
 
     monkeypatch.setattr(auth, "_find_override", lambda request, dependency: override)
 
-    has_override, result = await auth.resolve_current_user_override(
-        SimpleNamespace(), token="token"
-    )
+    has_override, result = await auth.resolve_current_user_override(SimpleNamespace(), token="token")
 
     assert has_override is True
     assert result == "override:token"

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -69,9 +69,7 @@ def mock_group_portfolio(monkeypatch):
             "total_value_estimate_gbp": 100.0,
         }
 
-    monkeypatch.setattr(
-        "backend.common.group_portfolio.build_group_portfolio", _build
-    )
+    monkeypatch.setattr("backend.common.group_portfolio.build_group_portfolio", _build)
 
 
 @pytest.fixture
@@ -98,9 +96,7 @@ def mock_timeseries_for_ticker(monkeypatch):
         mini = {"7": prices[-7:], "30": prices[-30:], "180": prices[-180:]}
         return {"prices": prices, "mini": mini}
 
-    monkeypatch.setattr(
-        "backend.common.instrument_api.timeseries_for_ticker", _fake_timeseries
-    )
+    monkeypatch.setattr("backend.common.instrument_api.timeseries_for_ticker", _fake_timeseries)
 
 
 @pytest.fixture
@@ -110,9 +106,7 @@ def mock_positions_for_ticker(monkeypatch):
     def _fake_positions(group_slug: str, ticker: str):
         return [{"gain_pct": 0.0}]
 
-    monkeypatch.setattr(
-        "backend.common.instrument_api.positions_for_ticker", _fake_positions
-    )
+    monkeypatch.setattr("backend.common.instrument_api.positions_for_ticker", _fake_positions)
 
 
 def validate_timeseries(prices):
@@ -342,9 +336,7 @@ def test_prices_live_missing_timestamp(client, monkeypatch):
 
 
 def test_prices_live_defaults_to_portfolio_universe(client, monkeypatch):
-    monkeypatch.setattr(
-        "backend.common.portfolio_utils.list_all_unique_tickers", lambda: ["STUB.L"]
-    )
+    monkeypatch.setattr("backend.common.portfolio_utils.list_all_unique_tickers", lambda: ["STUB.L"])
     monkeypatch.setattr("backend.common.holding_utils.load_live_prices", lambda t: {})
     monkeypatch.setattr("backend.common.holding_utils.load_latest_prices", lambda t: {})
 
@@ -396,6 +388,7 @@ def _post_sample_tx(client, owner: str, account: str, **overrides):
     payload.update(overrides)
     return client.post("/transactions", json=payload)
 
+
 @pytest.mark.xfail(reason="To fix")
 def test_post_transaction_persists_and_updates_portfolio(client):
     owners = _get_owners(client)
@@ -423,6 +416,7 @@ def test_post_transaction_persists_and_updates_portfolio(client):
 
     after = client.get(f"/portfolio/{owner}").json()["total_value_estimate_gbp"]
     assert after == pytest.approx(before + 10.0)
+
 
 @pytest.mark.parametrize(
     "field,value",
@@ -555,26 +549,62 @@ def test_hash_params_helper(monkeypatch):
     monkeypatch.setattr("backend.screener.fetch_fundamentals", mock_fetch)
 
     symbols = ["AAA", "BBB"]
-    page1, call1 = _hash_params(symbols, peg_max=1, pe_max=None, de_max=None, lt_de_max=None,
-                                interest_coverage_min=None, current_ratio_min=None,
-                                quick_ratio_min=None, fcf_min=None, eps_min=None,
-                                gross_margin_min=None, operating_margin_min=None,
-                                net_margin_min=None, ebitda_margin_min=None, roa_min=None,
-                                roe_min=0.15, roi_min=None, dividend_yield_min=None,
-                                dividend_payout_ratio_max=None, beta_max=None,
-                                shares_outstanding_min=None, float_shares_min=None,
-                                market_cap_min=None, high_52w_max=None, low_52w_min=None,
-                                avg_volume_min=None)
-    page2, _ = _hash_params(symbols, peg_max=1, pe_max=None, de_max=None, lt_de_max=None,
-                             interest_coverage_min=None, current_ratio_min=None,
-                             quick_ratio_min=None, fcf_min=None, eps_min=None,
-                             gross_margin_min=None, operating_margin_min=None,
-                             net_margin_min=None, ebitda_margin_min=None, roa_min=None,
-                             roe_min=0.15, roi_min=None, dividend_yield_min=None,
-                             dividend_payout_ratio_max=None, beta_max=None,
-                             shares_outstanding_min=None, float_shares_min=None,
-                             market_cap_min=None, high_52w_max=None, low_52w_min=None,
-                             avg_volume_min=None)
+    page1, call1 = _hash_params(
+        symbols,
+        peg_max=1,
+        pe_max=None,
+        de_max=None,
+        lt_de_max=None,
+        interest_coverage_min=None,
+        current_ratio_min=None,
+        quick_ratio_min=None,
+        fcf_min=None,
+        eps_min=None,
+        gross_margin_min=None,
+        operating_margin_min=None,
+        net_margin_min=None,
+        ebitda_margin_min=None,
+        roa_min=None,
+        roe_min=0.15,
+        roi_min=None,
+        dividend_yield_min=None,
+        dividend_payout_ratio_max=None,
+        beta_max=None,
+        shares_outstanding_min=None,
+        float_shares_min=None,
+        market_cap_min=None,
+        high_52w_max=None,
+        low_52w_min=None,
+        avg_volume_min=None,
+    )
+    page2, _ = _hash_params(
+        symbols,
+        peg_max=1,
+        pe_max=None,
+        de_max=None,
+        lt_de_max=None,
+        interest_coverage_min=None,
+        current_ratio_min=None,
+        quick_ratio_min=None,
+        fcf_min=None,
+        eps_min=None,
+        gross_margin_min=None,
+        operating_margin_min=None,
+        net_margin_min=None,
+        ebitda_margin_min=None,
+        roa_min=None,
+        roe_min=0.15,
+        roi_min=None,
+        dividend_yield_min=None,
+        dividend_payout_ratio_max=None,
+        beta_max=None,
+        shares_outstanding_min=None,
+        float_shares_min=None,
+        market_cap_min=None,
+        high_52w_max=None,
+        low_52w_min=None,
+        avg_volume_min=None,
+    )
     assert page1 == page2
     payload = call1()
     assert [d["ticker"] for d in payload] == ["AAA"]

--- a/tests/test_broker_api.py
+++ b/tests/test_broker_api.py
@@ -37,13 +37,8 @@ def test_recent_trades_parsing_and_headers(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
     trades = api.recent_trades(since)
 
-    assert trades == [
-        {"date": "2024-03-05", "ticker": "ABC", "units": "2", "price": "42.5"}
-    ]
-    assert (
-        called["url"]
-        == "https://paper-api.alpaca.markets/v2/account/activities/trades"
-    )
+    assert trades == [{"date": "2024-03-05", "ticker": "ABC", "units": "2", "price": "42.5"}]
+    assert called["url"] == "https://paper-api.alpaca.markets/v2/account/activities/trades"
     assert called["params"] == {"after": since.isoformat()}
     assert called["headers"] == {
         "APCA-API-KEY-ID": "key",

--- a/tests/test_claude_guidance.py
+++ b/tests/test_claude_guidance.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 CLAUDE_PATH = Path(__file__).parent.parent / "CLAUDE.md"
 
 
@@ -16,10 +15,7 @@ def test_claude_has_cdk_infrastructure_section() -> None:
 def test_claude_has_read_before_writing_rules() -> None:
     text = _claude_text()
     assert "read the full current content of every file you plan to change" in text
-    assert (
-        "read the current file content in full from disk before writing; do not rely on diff snippets"
-        in text
-    )
+    assert "read the current file content in full from disk before writing; do not rely on diff snippets" in text
 
 
 def test_claude_requires_handler_trace_evidence_for_iam_changes() -> None:

--- a/tests/test_clean_accounts.py
+++ b/tests/test_clean_accounts.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 from backend.common import clean_accounts
-from backend.common.clean_accounts import simplify_account_file, KEEP_FIELDS
+from backend.common.clean_accounts import KEEP_FIELDS, simplify_account_file
 
 
 def test_simplify_account_file(tmp_path: Path):

--- a/tests/test_compliance_route.py
+++ b/tests/test_compliance_route.py
@@ -49,9 +49,7 @@ def test_compliance_owner_route(tmp_path, monkeypatch):
 
 def test_validate_trade(tmp_path, monkeypatch):
     app = _setup_app(tmp_path)
-    monkeypatch.setattr(
-        "backend.common.compliance.get_instrument_meta", lambda t: {"instrumentType": "ETF"}
-    )
+    monkeypatch.setattr("backend.common.compliance.get_instrument_meta", lambda t: {"instrumentType": "ETF"})
     monkeypatch.setattr(compliance.config, "approval_exempt_types", ["ETF"])
     with TestClient(app) as client:
         resp = client.post(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -264,8 +264,20 @@ def test_reload_preserves_monkeypatched_allowed_emails(monkeypatch):
 @pytest.mark.parametrize(
     "config_text",
     [
-        "demo_identity: legacy-demo\nsmoke_identity: legacy-smoke\nauth:\n  demo_identity: section-demo\n  smoke_identity: section-smoke\n",
-        "auth:\n  demo_identity: section-demo\n  smoke_identity: section-smoke\ndemo_identity: legacy-demo\nsmoke_identity: legacy-smoke\n",
+        (
+            "demo_identity: legacy-demo\n"
+            "smoke_identity: legacy-smoke\n"
+            "auth:\n"
+            "  demo_identity: section-demo\n"
+            "  smoke_identity: section-smoke\n"
+        ),
+        (
+            "auth:\n"
+            "  demo_identity: section-demo\n"
+            "  smoke_identity: section-smoke\n"
+            "demo_identity: legacy-demo\n"
+            "smoke_identity: legacy-smoke\n"
+        ),
     ],
 )
 def test_reload_prefers_canonical_auth_section_over_legacy_top_level(monkeypatch, tmp_path, config_text):
@@ -359,13 +371,13 @@ def test_update_config_merges_ui_section(monkeypatch, tmp_path):
 
 def test_aws_ui_auth_disabled_when_only_domain_set(monkeypatch):
     """
-     #4630
+    #4630
 
-     Set UI_AUTH_DOMAIN to a valid domain, leave UI_AUTH_CLIENT_ID unset/empty.
+    Set UI_AUTH_DOMAIN to a valid domain, leave UI_AUTH_CLIENT_ID unset/empty.
 
-     Assert that enabled is False and that the serialized /config response
-     omits awsUiAuth (or includes it with enabled: false depending
-     on the serialization logic — verify against routes/config.py line 71).
+    Assert that enabled is False and that the serialized /config response
+    omits awsUiAuth (or includes it with enabled: false depending
+    on the serialization logic — verify against routes/config.py line 71).
     """
     monkeypatch.setenv("UI_AUTH_DOMAIN", "https://allotmint-123.auth.eu-west-1.amazoncognito.com")
     monkeypatch.setenv("UI_AUTH_CLIENT_ID", "")

--- a/tests/test_custom_query.py
+++ b/tests/test_custom_query.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.config import config
 import backend.timeseries.cache as ts_cache
+from backend.config import config
 from backend.routes.query import Metric
 
 
@@ -25,6 +25,7 @@ def client():
     finally:
         config.data_root = orig_root
         ts_cache._CACHE_BASE = orig_cache_base
+
 
 BASE_QUERY = {
     "start": "2025-01-01",

--- a/tests/test_custom_query_aws.py
+++ b/tests/test_custom_query_aws.py
@@ -4,9 +4,8 @@ from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
-from backend.app import create_app
 import backend.routes.query as qr
-
+from backend.app import create_app
 
 BASE_QUERY = {
     "start": "2025-01-01",
@@ -40,9 +39,7 @@ def test_s3_save_load_and_list(monkeypatch):
             assert kwargs["Prefix"] == qr.QUERIES_PREFIX
             return {"Contents": [{"Key": k} for k in storage.keys()]}
 
-        return SimpleNamespace(
-            put_object=put_object, get_object=get_object, list_objects_v2=list_objects_v2
-        )
+        return SimpleNamespace(put_object=put_object, get_object=get_object, list_objects_v2=list_objects_v2)
 
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
 
@@ -71,4 +68,3 @@ def test_s3_save_load_and_list(monkeypatch):
     resp = client.get("/custom-query/saved", params={"detailed": "0"})
     assert resp.status_code == 200
     assert resp.json() == [slug]
-

--- a/tests/test_data_loader_aws.py
+++ b/tests/test_data_loader_aws.py
@@ -5,10 +5,11 @@ import os
 import sys
 from types import SimpleNamespace
 
+import pytest
+from botocore.exceptions import ClientError
+
 import backend.common.data_loader as dl
 from backend.logging_setup import sanitise_log_value
-from botocore.exceptions import ClientError
-import pytest
 
 
 @pytest.fixture
@@ -257,7 +258,7 @@ def test_load_account_from_s3(monkeypatch):
         def get_object(Bucket, Key):
             assert Bucket == "bucket"
             assert Key == "accounts/Alice/ISA.json"
-            return {"Body": io.BytesIO(b"{\"balance\": 10}")}
+            return {"Body": io.BytesIO(b'{"balance": 10}')}
 
         return SimpleNamespace(get_object=get_object)
 
@@ -272,7 +273,7 @@ def test_load_account_falls_back_to_local(tmp_path, monkeypatch, caplog, cleanup
 
     owner_dir = tmp_path / "owner"
     owner_dir.mkdir()
-    (owner_dir / "account.json").write_text("{\"value\": 7}")
+    (owner_dir / "account.json").write_text('{"value": 7}')
 
     def fake_client(name):
         assert name == "s3"
@@ -295,9 +296,7 @@ def test_load_account_falls_back_to_local(tmp_path, monkeypatch, caplog, cleanup
     )
 
 
-def test_load_account_falls_back_sanitises_log_fields(
-    tmp_path, monkeypatch, caplog, cleanup_boto3_module
-):
+def test_load_account_falls_back_sanitises_log_fields(tmp_path, monkeypatch, caplog, cleanup_boto3_module):
     """Owner/account values are sanitised before being logged on fallback.
 
     Regression test for #4009: a malicious owner/account containing CRLF
@@ -328,9 +327,7 @@ def test_load_account_falls_back_sanitises_log_fields(
         with pytest.raises(FileNotFoundError):
             dl.load_account(owner, account, data_root=tmp_path)
 
-    warning_records = [
-        r for r in caplog.records if "falling back to local file" in r.getMessage()
-    ]
+    warning_records = [r for r in caplog.records if "falling back to local file" in r.getMessage()]
     assert len(warning_records) == 1
     record = warning_records[0]
 
@@ -380,10 +377,7 @@ def test_load_account_missing_bucket(monkeypatch):
     with pytest.raises(FileNotFoundError) as exc:
         dl.load_account("owner", "acct")
 
-    assert (
-        str(exc.value)
-        == f"Missing {dl.DATA_BUCKET_ENV} env var for AWS account loading"
-    )
+    assert str(exc.value) == f"Missing {dl.DATA_BUCKET_ENV} env var for AWS account loading"
 
 
 def test_load_account_empty_payload(monkeypatch, cleanup_boto3_module):
@@ -437,11 +431,13 @@ def test_load_account_s3_unavailable_no_fallback(monkeypatch, cleanup_boto3_modu
 
         def get_object(Bucket, Key):
             from botocore.exceptions import BotoCoreError
+
             raise BotoCoreError()
 
         return SimpleNamespace(get_object=get_object)
 
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=fake_client))
+
     # Force local_root to None so the exception is not swallowed by a local fallback.
     def _raise(*a, **kw):
         raise RuntimeError("no path")
@@ -501,7 +497,7 @@ def test_load_person_meta_from_s3(monkeypatch):
 
         def get_object(Bucket, Key):
             if Key == "accounts/Alice/person.json":
-                return {"Body": io.BytesIO(b"{\"dob\": \"1980\"}")}
+                return {"Body": io.BytesIO(b'{"dob": "1980"}')}
             raise ClientError({"Error": {"Code": "NoSuchKey"}}, "get_object")
 
         return SimpleNamespace(get_object=get_object)
@@ -543,9 +539,7 @@ def test_load_person_meta_boto_failure(monkeypatch, cleanup_boto3_module):
     assert dl.load_person_meta("Alice") == {}
 
 
-def test_load_person_meta_s3_unavailable_falls_back_to_local(
-    tmp_path, monkeypatch, caplog, cleanup_boto3_module
-):
+def test_load_person_meta_s3_unavailable_falls_back_to_local(tmp_path, monkeypatch, caplog, cleanup_boto3_module):
     """When S3 is unavailable but an explicit local fallback exists, local metadata is returned."""
     monkeypatch.setattr(dl.config, "app_env", "aws", raising=False)
     monkeypatch.setenv(dl.DATA_BUCKET_ENV, "bucket")
@@ -574,6 +568,7 @@ def test_load_person_meta_s3_unavailable_falls_back_to_local(
 def test_extract_person_meta_non_list_viewers_drops_key_preserves_rest(monkeypatch):
     """_extract_person_meta drops viewers when not a list but keeps other valid keys."""
     from backend.common.data_providers import _extract_person_meta
+
     # Non-list viewers: key is dropped, other valid fields are preserved.
     assert _extract_person_meta({"viewers": "bad", "dob": "1980"}) == {"dob": "1980"}
     assert _extract_person_meta({"viewers": "bad"}) == {}

--- a/tests/test_extract_pr_comments.py
+++ b/tests/test_extract_pr_comments.py
@@ -218,9 +218,7 @@ def test_fetch_paginated_strict_success_returns_items_untruncated(mod):
         json.dumps([]),
     ]
     with patch.object(mod, "run_gh_command", side_effect=[(p, 0) for p in pages]):
-        items, truncated = mod.fetch_paginated(
-            "owner", "repo", "/some/endpoint", strict=True
-        )
+        items, truncated = mod.fetch_paginated("owner", "repo", "/some/endpoint", strict=True)
 
     assert items == [{"id": 1}, {"id": 2}]
     assert truncated is False

--- a/tests/test_fx_conversion.py
+++ b/tests/test_fx_conversion.py
@@ -206,6 +206,7 @@ def test_memoized_range_offline_no_cache_returns_empty(monkeypatch):
     assert df.empty
     assert calls["n"] == 1
 
+
 def test_offline_mode_uses_fx_cache(tmp_path, monkeypatch):
     start = dt.date(2024, 1, 1)
     end = dt.date(2024, 1, 2)
@@ -255,6 +256,7 @@ def test_offline_falls_back_to_live_loader(tmp_path, monkeypatch):
 
     df = cache.load_meta_timeseries_range("T", "L", start, end)
     assert list(df["Close"].astype(float)) == [1.0, 2.0]
+
 
 def test_offline_mode_fetch_fallback(monkeypatch, tmp_path):
     start = dt.date(2024, 1, 1)

--- a/tests/test_group_instruments_changes.py
+++ b/tests/test_group_instruments_changes.py
@@ -19,15 +19,11 @@ def test_group_instruments_populates_change_fields(monkeypatch, client):
         "accounts": [
             {
                 "account_type": "TEST",
-                "holdings": [
-                    {"ticker": "AAA.L", "units": 1.0, "cost_gbp": 90.0}
-                ],
+                "holdings": [{"ticker": "AAA.L", "units": 1.0, "cost_gbp": 90.0}],
             }
         ]
     }
-    monkeypatch.setattr(
-        group_portfolio, "build_group_portfolio", lambda slug, **_: portfolio
-    )
+    monkeypatch.setattr(group_portfolio, "build_group_portfolio", lambda slug, **_: portfolio)
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", {"AAA.L": {"last_price": 100.0}})
     monkeypatch.setattr(
         instrument_api,

--- a/tests/test_group_movers_route.py
+++ b/tests/test_group_movers_route.py
@@ -1,9 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
 
-import pytest
-from fastapi.testclient import TestClient
-
 import backend.common.instrument_api as ia
 from backend.local_api.main import app
 

--- a/tests/test_instrument_admin_route.py
+++ b/tests/test_instrument_admin_route.py
@@ -1,7 +1,8 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import MagicMock, patch
-from pathlib import Path
 
 from backend.app import create_app
 from backend.config import config
@@ -22,18 +23,16 @@ def test_get_instrument_admin_route(client):
     """GET returns 200 when metadata exists and 404 when missing."""
     meta_path = Path("/tmp/meta.json")
     # Existing metadata
-    with patch(
-        "backend.routes.instrument_admin.instrument_meta_path", return_value=meta_path
-    ), patch(
-        "backend.routes.instrument_admin.get_instrument_meta", return_value={"ticker": "ABC.L"}
+    with (
+        patch("backend.routes.instrument_admin.instrument_meta_path", return_value=meta_path),
+        patch("backend.routes.instrument_admin.get_instrument_meta", return_value={"ticker": "ABC.L"}),
     ):
         resp = client.get("/instrument/admin/L/ABC")
         assert resp.status_code == 200
     # Missing metadata
-    with patch(
-        "backend.routes.instrument_admin.instrument_meta_path", return_value=meta_path
-    ), patch(
-        "backend.routes.instrument_admin.get_instrument_meta", return_value={}
+    with (
+        patch("backend.routes.instrument_admin.instrument_meta_path", return_value=meta_path),
+        patch("backend.routes.instrument_admin.get_instrument_meta", return_value={}),
     ):
         resp = client.get("/instrument/admin/L/ABC")
         assert resp.status_code == 404
@@ -44,9 +43,10 @@ def test_post_instrument_admin_route(client, exists, status):
     """POST returns 200 when creating and 409 if already exists."""
     fake_path = MagicMock()
     fake_path.exists.return_value = exists
-    with patch(
-        "backend.routes.instrument_admin.instrument_meta_path", return_value=fake_path
-    ), patch("backend.routes.instrument_admin.save_instrument_meta"):
+    with (
+        patch("backend.routes.instrument_admin.instrument_meta_path", return_value=fake_path),
+        patch("backend.routes.instrument_admin.save_instrument_meta"),
+    ):
         resp = client.post("/instrument/admin/L/ABC", json={"ticker": "ABC.L"})
     assert resp.status_code == status
 
@@ -56,9 +56,10 @@ def test_put_instrument_admin_route(client, exists, status):
     """PUT returns 200 when updating and 404 if missing."""
     fake_path = MagicMock()
     fake_path.exists.return_value = exists
-    with patch(
-        "backend.routes.instrument_admin.instrument_meta_path", return_value=fake_path
-    ), patch("backend.routes.instrument_admin.save_instrument_meta"):
+    with (
+        patch("backend.routes.instrument_admin.instrument_meta_path", return_value=fake_path),
+        patch("backend.routes.instrument_admin.save_instrument_meta"),
+    ):
         resp = client.put("/instrument/admin/L/ABC", json={"ticker": "ABC.L"})
     assert resp.status_code == status
 
@@ -68,8 +69,9 @@ def test_delete_instrument_admin_route(client, exists, status):
     """DELETE returns 200 when deleting and 404 if missing."""
     fake_path = MagicMock()
     fake_path.exists.return_value = exists
-    with patch(
-        "backend.routes.instrument_admin.instrument_meta_path", return_value=fake_path
-    ), patch("backend.routes.instrument_admin.delete_instrument_meta"):
+    with (
+        patch("backend.routes.instrument_admin.instrument_meta_path", return_value=fake_path),
+        patch("backend.routes.instrument_admin.delete_instrument_meta"),
+    ):
         resp = client.delete("/instrument/admin/L/ABC")
     assert resp.status_code == status

--- a/tests/test_instrument_api.py
+++ b/tests/test_instrument_api.py
@@ -125,10 +125,12 @@ def test_intraday_timeseries_success(monkeypatch):
 
     df = pd.DataFrame(
         {
-            "Date": pd.to_datetime([
-                "2024-01-02 10:00:00",
-                "2024-01-02 11:45:00",
-            ]),
+            "Date": pd.to_datetime(
+                [
+                    "2024-01-02 10:00:00",
+                    "2024-01-02 11:45:00",
+                ]
+            ),
             "Close": [10.0, 11.0],
         }
     )

--- a/tests/test_instrument_api_functions.py
+++ b/tests/test_instrument_api_functions.py
@@ -78,7 +78,7 @@ def test_timeseries_for_ticker_renames_columns(monkeypatch):
     df = pd.DataFrame({"Date": pd.to_datetime(["2023-01-08"]), "Close_gbp": [2.0]})
 
     monkeypatch.setattr(ia.dt, "date", FixedDate)
-    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, l: ("XYZ", "L"))
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, loc: ("XYZ", "L"))
     monkeypatch.setattr(ia, "has_cached_meta_timeseries", lambda s, e: True)
     monkeypatch.setattr(ia, "load_meta_timeseries_range", lambda s, e, start_date, end_date: df)
 
@@ -97,7 +97,7 @@ def test_timeseries_for_ticker_mini_slices(monkeypatch):
     df = pd.DataFrame({"date": dates, "close": range(200)})
 
     monkeypatch.setattr(ia.dt, "date", FixedDate)
-    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, l: ("XYZ", "L"))
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, loc: ("XYZ", "L"))
     monkeypatch.setattr(ia, "has_cached_meta_timeseries", lambda s, e: True)
     monkeypatch.setattr(ia, "load_meta_timeseries_range", lambda s, e, start_date, end_date: df)
 
@@ -112,7 +112,7 @@ def test_timeseries_for_ticker_inverted_range_returns_empty(monkeypatch):
     """Inverted start/end (start > end) returns the empty payload without hitting the cache."""
     calls: list[str] = []
 
-    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, l: ("XYZ", "L"))
+    monkeypatch.setattr(ia, "_resolve_full_ticker", lambda t, loc: ("XYZ", "L"))
     monkeypatch.setattr(ia, "has_cached_meta_timeseries", lambda s, e: True)
     monkeypatch.setattr(
         ia,
@@ -123,9 +123,8 @@ def test_timeseries_for_ticker_inverted_range_returns_empty(monkeypatch):
     res = ia.timeseries_for_ticker(
         "XYZ",
         start_date=dt.date(2024, 6, 1),
-        end_date=dt.date(2024, 1, 1),   # end before start
+        end_date=dt.date(2024, 1, 1),  # end before start
     )
 
     assert res == {"prices": [], "mini": {"7": [], "30": [], "180": []}}
     assert calls == [], "load_meta_timeseries_range must not be called for an inverted range"
-

--- a/tests/test_instrument_grouping.py
+++ b/tests/test_instrument_grouping.py
@@ -22,6 +22,7 @@ def _prepare_group_portfolio(monkeypatch, portfolio, meta_map):
         "build_group_portfolio",
         lambda slug, *, pricing_date=None: portfolio,
     )
+
     def _fake_build_group_portfolio(slug: str, *, pricing_date=None):
         return portfolio
 

--- a/tests/test_instrument_route.py
+++ b/tests/test_instrument_route.py
@@ -1,12 +1,12 @@
-import pandas as pd
+from datetime import date
+from unittest.mock import patch
+
 import pandas as pd
 import pytest
-from unittest.mock import patch
-from datetime import date
+from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.config import config
-from fastapi.testclient import TestClient
 
 
 def _auth_client(app):
@@ -83,12 +83,8 @@ def test_instrument_search_filters_by_sector_and_region(monkeypatch):
 
     with patch("backend.routes.instrument.list_instruments", return_value=_SEARCH_FIXTURES):
         client = _auth_client(app)
-        resp_sector = client.get(
-            "/instrument/search", params={"q": "alpha", "sector": "Technology"}
-        )
-        resp_region = client.get(
-            "/instrument/search", params={"q": "alpha", "region": "US"}
-        )
+        resp_sector = client.get("/instrument/search", params={"q": "alpha", "sector": "Technology"})
+        resp_region = client.get("/instrument/search", params={"q": "alpha", "region": "US"})
 
     assert resp_sector.status_code == 200
     sector_rows = resp_sector.json()
@@ -136,23 +132,23 @@ def test_full_history_json(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ) as mock_load, patch(
-        "backend.routes.instrument.list_portfolios",
-        return_value=[
-            {
-                "owner": "alex",
-                "accounts": [
-                    {
-                        "account_type": "isa",
-                        "holdings": [{"ticker": "ABC.L", "units": 2}],
-                    }
-                ],
-            }
-        ],
-    ), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df) as mock_load,
+        patch(
+            "backend.routes.instrument.list_portfolios",
+            return_value=[
+                {
+                    "owner": "alex",
+                    "accounts": [
+                        {
+                            "account_type": "isa",
+                            "holdings": [{"ticker": "ABC.L", "units": 2}],
+                        }
+                    ],
+                }
+            ],
+        ),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
     ):
         client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=0&format=json")
@@ -169,10 +165,10 @@ def test_html_response(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch("backend.routes.instrument.list_portfolios", return_value=[]),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
     ):
         client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=html")
@@ -186,25 +182,24 @@ def test_positions_scaled(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch(
-        "backend.routes.instrument.list_portfolios",
-        return_value=[
-            {
-                "owner": "alex",
-                "accounts": [
-                    {
-                        "account_type": "isa",
-                        "holdings": [
-                            {"ticker": "ABC.L", "units": 2, "gain_gbp": 4}
-                        ],
-                    }
-                ],
-            }
-        ],
-    ), patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}), patch(
-        "backend.routes.instrument.get_scaling_override", return_value=0.5
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch(
+            "backend.routes.instrument.list_portfolios",
+            return_value=[
+                {
+                    "owner": "alex",
+                    "accounts": [
+                        {
+                            "account_type": "isa",
+                            "holdings": [{"ticker": "ABC.L", "units": 2, "gain_gbp": 4}],
+                        }
+                    ],
+                }
+            ],
+        ),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
+        patch("backend.routes.instrument.get_scaling_override", return_value=0.5),
     ):
         client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
@@ -221,28 +216,30 @@ def test_positions_gain_from_cost(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     df = _make_df()
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch(
-        "backend.routes.instrument.list_portfolios",
-        return_value=[
-            {
-                "owner": "alex",
-                "accounts": [
-                    {
-                        "account_type": "isa",
-                        "holdings": [
-                            {
-                                "ticker": "ABC.L",
-                                "units": 2,
-                                "cost_basis_gbp": 20.0,
-                            }
-                        ],
-                    }
-                ],
-            }
-        ],
-    ), patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}):
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch(
+            "backend.routes.instrument.list_portfolios",
+            return_value=[
+                {
+                    "owner": "alex",
+                    "accounts": [
+                        {
+                            "account_type": "isa",
+                            "holdings": [
+                                {
+                                    "ticker": "ABC.L",
+                                    "units": 2,
+                                    "cost_basis_gbp": 20.0,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        ),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
+    ):
         client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
     assert resp.status_code == 200
@@ -262,12 +259,10 @@ def test_non_gbp_instrument_has_distinct_close(monkeypatch):
             "Close_gbp": [8.0, 8.8],
         }
     )
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch(
-        "backend.routes.instrument.list_portfolios", return_value=[]
-    ), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "USD"}
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch("backend.routes.instrument.list_portfolios", return_value=[]),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "USD"}),
     ):
         client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.N&days=1&format=json")
@@ -279,12 +274,15 @@ def test_non_gbp_instrument_has_distinct_close(monkeypatch):
 def test_intraday_route(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
+
     class FakeTicker:
         def history(self, period: str, interval: str):
-            return pd.DataFrame({
-                "Datetime": [pd.Timestamp("2024-01-02T10:00:00")],
-                "Close": [10.0],
-            })
+            return pd.DataFrame(
+                {
+                    "Datetime": [pd.Timestamp("2024-01-02T10:00:00")],
+                    "Close": [10.0],
+                }
+            )
 
     with patch("backend.routes.instrument.yf.Ticker", return_value=FakeTicker()):
         client = _auth_client(app)
@@ -336,17 +334,14 @@ def test_base_currency_param_gbp_to_usd(monkeypatch):
             "Rate": [0.8, 0.8],
         }
     )
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
-    ), patch(
-        "backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch("backend.routes.instrument.list_portfolios", return_value=[]),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
+        patch("backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df),
     ):
         client = _auth_client(app)
-        resp = client.get(
-            "/instrument?ticker=ABC.L&days=1&format=json&base_currency=USD"
-        )
+        resp = client.get("/instrument?ticker=ABC.L&days=1&format=json&base_currency=USD")
     assert resp.status_code == 200
     data = resp.json()
     prices = data["prices"]
@@ -370,17 +365,14 @@ def test_base_currency_param_usd_to_eur(monkeypatch):
             "Rate": [0.9, 0.9],
         }
     )
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "USD"}
-    ), patch(
-        "backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch("backend.routes.instrument.list_portfolios", return_value=[]),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "USD"}),
+        patch("backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df),
     ):
         client = _auth_client(app)
-        resp = client.get(
-            "/instrument?ticker=ABC.N&days=1&format=json&base_currency=EUR"
-        )
+        resp = client.get("/instrument?ticker=ABC.N&days=1&format=json&base_currency=EUR")
     assert resp.status_code == 200
     data = resp.json()
     prices = data["prices"]
@@ -400,12 +392,11 @@ def test_base_currency_from_config(monkeypatch):
             "Rate": [0.8, 0.8],
         }
     )
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=df
-    ), patch("backend.routes.instrument.list_portfolios", return_value=[]), patch(
-        "backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}
-    ), patch(
-        "backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=df),
+        patch("backend.routes.instrument.list_portfolios", return_value=[]),
+        patch("backend.routes.instrument.get_security_meta", return_value={"currency": "GBP"}),
+        patch("backend.routes.instrument.fetch_fx_rate_range", return_value=fx_df),
     ):
         client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
@@ -420,10 +411,10 @@ def test_missing_history_returns_404(monkeypatch):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     app = create_app()
     empty = pd.DataFrame()
-    with patch(
-        "backend.routes.instrument.load_meta_timeseries_range", return_value=empty
-    ), patch("backend.routes.instrument.get_security_meta", return_value={}), patch(
-        "backend.routes.instrument.list_portfolios", return_value=[]
+    with (
+        patch("backend.routes.instrument.load_meta_timeseries_range", return_value=empty),
+        patch("backend.routes.instrument.get_security_meta", return_value={}),
+        patch("backend.routes.instrument.list_portfolios", return_value=[]),
     ):
         client = _auth_client(app)
         resp = client.get("/instrument?ticker=ABC.L&days=1&format=json")
@@ -440,12 +431,8 @@ def test_gbx_prices_scaled_and_cost_basis_fallback(monkeypatch):
         }
     )
 
-    monkeypatch.setattr(
-        "backend.routes.instrument.load_meta_timeseries_range", lambda *args, **kwargs: df
-    )
-    monkeypatch.setattr(
-        "backend.routes.instrument.get_security_meta", lambda ticker: {"currency": "GBX"}
-    )
+    monkeypatch.setattr("backend.routes.instrument.load_meta_timeseries_range", lambda *args, **kwargs: df)
+    monkeypatch.setattr("backend.routes.instrument.get_security_meta", lambda ticker: {"currency": "GBX"})
     monkeypatch.setattr(
         "backend.routes.instrument.list_portfolios",
         lambda: [
@@ -492,12 +479,8 @@ def test_gbx_close_gbp_not_double_scaled_by_pence_override(monkeypatch):
         }
     )
 
-    monkeypatch.setattr(
-        "backend.routes.instrument.load_meta_timeseries_range", lambda *args, **kwargs: df
-    )
-    monkeypatch.setattr(
-        "backend.routes.instrument.get_security_meta", lambda ticker: {"currency": "GBX"}
-    )
+    monkeypatch.setattr("backend.routes.instrument.load_meta_timeseries_range", lambda *args, **kwargs: df)
+    monkeypatch.setattr("backend.routes.instrument.get_security_meta", lambda ticker: {"currency": "GBX"})
     monkeypatch.setattr("backend.routes.instrument.list_portfolios", lambda: [])
     monkeypatch.setattr("backend.routes.instrument.get_scaling_override", lambda *_: 0.01)
 
@@ -527,12 +510,8 @@ def test_gbx_close_gbp_tracks_scaled_close_for_non_pence_override(monkeypatch):
         }
     )
 
-    monkeypatch.setattr(
-        "backend.routes.instrument.load_meta_timeseries_range", lambda *args, **kwargs: df
-    )
-    monkeypatch.setattr(
-        "backend.routes.instrument.get_security_meta", lambda ticker: {"currency": "GBX"}
-    )
+    monkeypatch.setattr("backend.routes.instrument.load_meta_timeseries_range", lambda *args, **kwargs: df)
+    monkeypatch.setattr("backend.routes.instrument.get_security_meta", lambda ticker: {"currency": "GBX"})
     monkeypatch.setattr("backend.routes.instrument.list_portfolios", lambda: [])
     monkeypatch.setattr("backend.routes.instrument.get_scaling_override", lambda *_: 0.001)
 
@@ -557,12 +536,8 @@ def test_base_currency_fetch_failure_is_resilient(monkeypatch):
     app = create_app()
     df = _make_df()
 
-    monkeypatch.setattr(
-        "backend.routes.instrument.load_meta_timeseries_range", lambda *args, **kwargs: df
-    )
-    monkeypatch.setattr(
-        "backend.routes.instrument.get_security_meta", lambda ticker: {"currency": "GBP"}
-    )
+    monkeypatch.setattr("backend.routes.instrument.load_meta_timeseries_range", lambda *args, **kwargs: df)
+    monkeypatch.setattr("backend.routes.instrument.get_security_meta", lambda ticker: {"currency": "GBP"})
     monkeypatch.setattr("backend.routes.instrument.list_portfolios", lambda: [])
 
     def _boom(*_args, **_kwargs):

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -1,4 +1,3 @@
-from backend.common import instruments
 import io
 import json
 import sys
@@ -6,6 +5,8 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+
+from backend.common import instruments
 
 
 def test_missing_file_returns_empty(monkeypatch, tmp_path):
@@ -48,6 +49,7 @@ def test_save_and_delete_instrument_meta(monkeypatch, tmp_path):
     instruments.delete_instrument_meta("ABC", "L")
     assert not path.exists()
     assert instruments.get_instrument_meta("ABC.L") == {}
+
 
 def test_get_instrument_meta_from_s3(monkeypatch):
     monkeypatch.setenv(instruments.METADATA_BUCKET_ENV, "bucket")
@@ -100,6 +102,7 @@ def test_save_instrument_meta_uploads_s3(monkeypatch, tmp_path):
     assert uploaded["Bucket"] == "bucket"
     assert uploaded["Key"] == "meta/L/ABC.json"
     assert json.loads(uploaded["Body"].decode()) == {"bar": 2}
+
 
 def test_get_instrument_meta_known_records(caplog):
     tickers = {

--- a/tests/test_lambda_dockerfile.py
+++ b/tests/test_lambda_dockerfile.py
@@ -1,7 +1,7 @@
 """Regression tests for Lambda Dockerfile and requirements dependency hygiene (issue #2810)."""
 
-from pathlib import Path
 import unittest
+from pathlib import Path
 
 DOCKERFILE = Path(__file__).resolve().parents[1] / "backend" / "Dockerfile.lambda"
 REQUIREMENTS = Path(__file__).resolve().parents[1] / "backend" / "requirements.txt"

--- a/tests/test_lambda_import_safety.py
+++ b/tests/test_lambda_import_safety.py
@@ -6,6 +6,7 @@ This would have caught the cold-start 503 in #2975, where _load_snapshot() was
 called at module scope in portfolio_utils.py and made a blocking S3 GetObject
 during Lambda init, exceeding the 10 s init limit.
 """
+
 import ast
 from pathlib import Path
 
@@ -37,9 +38,12 @@ def _module_level_calls(rel_path: str) -> list[tuple[str, int]]:
 _AWS_FUNCTIONS = {"_load_snapshot"}
 
 
-@pytest.mark.parametrize("rel_path", [
-    "common/portfolio_utils.py",
-])
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        "common/portfolio_utils.py",
+    ],
+)
 def test_no_aws_call_at_module_scope(rel_path):
     """No AWS-touching function may be called at module scope."""
     hits = _module_level_calls(rel_path)

--- a/tests/test_load_latest_prices.py
+++ b/tests/test_load_latest_prices.py
@@ -1,6 +1,7 @@
+import datetime as dt
+
 import pandas as pd
 import pytest
-import datetime as dt
 
 from backend.common import holding_utils
 

--- a/tests/test_load_live_prices.py
+++ b/tests/test_load_live_prices.py
@@ -1,4 +1,5 @@
 import datetime as dt
+
 import pytest
 
 from backend.common import holding_utils

--- a/tests/test_logging_json_end_to_end.py
+++ b/tests/test_logging_json_end_to_end.py
@@ -11,8 +11,6 @@ import json
 import logging
 from pathlib import Path
 
-import pytest
-
 import backend.logging_setup as logging_setup
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -36,9 +36,7 @@ def test_setup_logging_relative_path(monkeypatch):
 
     try:
         logging_setup.setup_logging()
-        file_config_mock.assert_called_once_with(
-            Path("/repo/logging.ini"), disable_existing_loggers=False
-        )
+        file_config_mock.assert_called_once_with(Path("/repo/logging.ini"), disable_existing_loggers=False)
     finally:
         root_logger.handlers = original_handlers
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,9 +7,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from backend import config as backend_config
 from backend.app import create_app
 from backend.common import data_loader
-from backend import config as backend_config
 from backend.local_api.main import app
 
 
@@ -28,6 +28,7 @@ def client():
         yield client
     finally:
         backend_config.offline_mode = previous
+
 
 # Shared mock data
 mock_owners = [
@@ -106,15 +107,13 @@ def test_owners(client, mock_list_plots):
             continue
 
         if accounts_root is None:
-            pytest.fail(
-                f"Unexpected synthetic accounts {sorted(extras)} for owner '{owner}'"
-            )
+            pytest.fail(f"Unexpected synthetic accounts {sorted(extras)} for owner '{owner}'")
 
         owner_dir = accounts_root / owner
         for account in extras:
-            assert (owner_dir / f"{account}.json").exists(), (
-                f"Unexpected synthetic account '{account}' for owner '{owner}'"
-            )
+            assert (
+                owner_dir / f"{account}.json"
+            ).exists(), f"Unexpected synthetic account '{account}' for owner '{owner}'"
 
 
 def test_groups(client, mock_list_groups):
@@ -259,9 +258,10 @@ def test_openapi_no_duplicate_operation_ids():
     refresh_path = schema.get("paths", {}).get("/prices/refresh", {})
     assert refresh_path, "Expected /prices/refresh path in OpenAPI schema"
     refresh_ops = {m: refresh_path[m].get("operationId") for m in ("get", "post") if m in refresh_path}
-    assert refresh_ops == {"get": "refresh_prices_get", "post": "refresh_prices_post"}, (
-        f"Unexpected refresh_prices operationIds: {refresh_ops}"
-    )
+    assert refresh_ops == {
+        "get": "refresh_prices_get",
+        "post": "refresh_prices_post",
+    }, f"Unexpected refresh_prices operationIds: {refresh_ops}"
     assert len(operation_ids) == len(set(operation_ids)), "Found duplicate operationIds in OpenAPI schema"
 
 

--- a/tests/test_meta_timeseries_exchange_resolution.py
+++ b/tests/test_meta_timeseries_exchange_resolution.py
@@ -1,5 +1,6 @@
-import pandas as pd
 from datetime import date
+
+import pandas as pd
 
 from backend.timeseries import fetch_meta_timeseries
 

--- a/tests/test_movers_route.py
+++ b/tests/test_movers_route.py
@@ -1,6 +1,7 @@
-import backend.common.instrument_api as ia
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+import backend.common.instrument_api as ia
 
 
 def _client():
@@ -31,7 +32,7 @@ def test_movers_success(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert [g["ticker"] for g in data["gainers"]] == ["AAA"]
-    assert [l["ticker"] for l in data["losers"]] == ["BBB"]
+    assert [loser["ticker"] for loser in data["losers"]] == ["BBB"]
 
 
 def test_movers_invalid_days():

--- a/tests/test_news_route.py
+++ b/tests/test_news_route.py
@@ -1,8 +1,8 @@
 from fastapi.testclient import TestClient
 
+import backend.routes.news as news
 from backend.app import create_app
 from backend.utils import page_cache
-import backend.routes.news as news
 
 
 def test_news_quota_enforced(monkeypatch, tmp_path):

--- a/tests/test_nudges_frequency.py
+++ b/tests/test_nudges_frequency.py
@@ -57,4 +57,3 @@ def test_iter_due_users_respects_snooze(tmp_path, monkeypatch):
     later = now + nudge_utils.timedelta(days=2)
     due_users_later = set(nudge_utils.iter_due_users(later))
     assert due_users_later == {"new", "due", "snoozed"}
-

--- a/tests/test_nudges_persistence.py
+++ b/tests/test_nudges_persistence.py
@@ -1,5 +1,3 @@
-import pytest
-
 from backend import nudges as nudge_utils
 from backend.common.storage import get_storage
 

--- a/tests/test_pension_forecast.py
+++ b/tests/test_pension_forecast.py
@@ -1,7 +1,5 @@
 import datetime as dt
 
-import datetime as dt
-
 from backend.common.pension import forecast_pension
 
 

--- a/tests/test_pension_route.py
+++ b/tests/test_pension_route.py
@@ -1,9 +1,9 @@
 import sys
 from types import SimpleNamespace
 
-import backend.common.data_loader as dl
 from fastapi.testclient import TestClient
 
+import backend.common.data_loader as dl
 from backend.app import create_app
 from backend.common.account_models import PersonMetadata
 from backend.common.pension import state_pension_age_uk
@@ -23,9 +23,7 @@ def test_pension_route_uses_owner_metadata(monkeypatch):
         called.update(kwargs)
         return {"forecast": [], "projected_pot_gbp": 0.0}
 
-    def fake_portfolio(
-        owner: str, *, pricing_date=None, root=None
-    ):  # pragma: no cover - signature match
+    def fake_portfolio(owner: str, *, pricing_date=None, root=None):  # pragma: no cover - signature match
         return {
             "accounts": [
                 {"account_type": "sipp", "value_estimate_gbp": 100},
@@ -36,14 +34,10 @@ def test_pension_route_uses_owner_metadata(monkeypatch):
 
     monkeypatch.setattr("backend.routes.pension.load_person_metadata", fake_meta)
     monkeypatch.setattr("backend.routes.pension.forecast_pension", fake_forecast)
-    monkeypatch.setattr(
-        "backend.routes.pension.build_owner_portfolio", fake_portfolio
-    )
+    monkeypatch.setattr("backend.routes.pension.build_owner_portfolio", fake_portfolio)
     app = create_app()
     with TestClient(app) as client:
-        resp = client.get(
-            "/pension/forecast", params={"owner": "alice", "death_age": 90}
-        )
+        resp = client.get("/pension/forecast", params={"owner": "alice", "death_age": 90})
     assert resp.status_code == 200
     assert captured_owner == ["alice"]
     expected_age = state_pension_age_uk("1980-01-01")
@@ -57,9 +51,7 @@ def test_pension_route_uses_owner_metadata(monkeypatch):
 
 
 def test_pension_route_missing_dob(monkeypatch):
-    monkeypatch.setattr(
-        "backend.routes.pension.load_person_metadata", lambda owner, root=None: PersonMetadata()
-    )
+    monkeypatch.setattr("backend.routes.pension.load_person_metadata", lambda owner, root=None: PersonMetadata())
     app = create_app()
     with TestClient(app) as client:
         resp = client.get("/pension/forecast", params={"owner": "bob", "death_age": 90})
@@ -110,44 +102,32 @@ def test_pension_route_prefers_monthly_over_annual(monkeypatch):
 
 
 def test_pension_route_rejects_death_age_not_exceeding_retirement(monkeypatch):
-    monkeypatch.setattr(
-        "backend.routes.pension.state_pension_age_uk", lambda dob: 67
-    )
+    monkeypatch.setattr("backend.routes.pension.state_pension_age_uk", lambda dob: 67)
     monkeypatch.setattr(
         "backend.routes.pension.load_person_metadata",
         lambda owner, root=None: PersonMetadata(dob="1980-01-01"),
     )
     app = create_app()
     with TestClient(app) as client:
-        resp = client.get(
-            "/pension/forecast", params={"owner": "carol", "death_age": 67}
-        )
+        resp = client.get("/pension/forecast", params={"owner": "carol", "death_age": 67})
     assert resp.status_code == 400
     assert resp.json() == {"detail": "death_age must exceed retirement_age"}
 
 
 def test_pension_route_propagates_missing_portfolio(monkeypatch):
-    monkeypatch.setattr(
-        "backend.routes.pension.state_pension_age_uk", lambda dob: 67
-    )
+    monkeypatch.setattr("backend.routes.pension.state_pension_age_uk", lambda dob: 67)
     monkeypatch.setattr(
         "backend.routes.pension.load_person_metadata",
         lambda owner, root=None: PersonMetadata(dob="1980-01-01"),
     )
 
-    def fake_portfolio(
-        owner: str, *, pricing_date=None, root=None
-    ):  # pragma: no cover - signature match
+    def fake_portfolio(owner: str, *, pricing_date=None, root=None):  # pragma: no cover - signature match
         raise FileNotFoundError("no portfolio for owner")
 
-    monkeypatch.setattr(
-        "backend.routes.pension.build_owner_portfolio", fake_portfolio
-    )
+    monkeypatch.setattr("backend.routes.pension.build_owner_portfolio", fake_portfolio)
     app = create_app()
     with TestClient(app) as client:
-        resp = client.get(
-            "/pension/forecast", params={"owner": "dave", "death_age": 90}
-        )
+        resp = client.get("/pension/forecast", params={"owner": "dave", "death_age": 90})
     assert resp.status_code == 404
     assert resp.json() == {"detail": "no portfolio for owner"}
 
@@ -170,9 +150,7 @@ def test_pension_route_falls_back_to_local_metadata(tmp_path, monkeypatch):
 
     monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace(client=raising_client))
 
-    def fake_portfolio(
-        owner: str, *, pricing_date=None, root=None
-    ):  # pragma: no cover - signature match
+    def fake_portfolio(owner: str, *, pricing_date=None, root=None):  # pragma: no cover - signature match
         return {"accounts": [{"account_type": "sipp", "value_estimate_gbp": 100.0}]}
 
     captured: dict[str, object] = {}
@@ -188,9 +166,7 @@ def test_pension_route_falls_back_to_local_metadata(tmp_path, monkeypatch):
     app.state.accounts_root = tmp_path
 
     with TestClient(app) as client:
-        resp = client.get(
-            "/pension/forecast", params={"owner": owner, "death_age": 90}
-        )
+        resp = client.get("/pension/forecast", params={"owner": owner, "death_age": 90})
 
     assert resp.status_code == 200
     body = resp.json()
@@ -210,18 +186,14 @@ def test_pension_route_passes_accounts_root_keyword(monkeypatch):
         captured_meta.append((owner, root))
         return PersonMetadata(dob="1980-01-01")
 
-    def fake_portfolio(
-        owner: str, *, accounts_root=None
-    ):  # pragma: no cover - signature match
+    def fake_portfolio(owner: str, *, accounts_root=None):  # pragma: no cover - signature match
         captured_portfolio["owner"] = owner
         captured_portfolio["accounts_root"] = accounts_root
         return {"accounts": []}
 
     monkeypatch.setattr("backend.routes.pension.resolve_accounts_root", fake_resolve)
     monkeypatch.setattr("backend.routes.pension.load_person_metadata", fake_meta)
-    monkeypatch.setattr(
-        "backend.routes.pension.build_owner_portfolio", fake_portfolio
-    )
+    monkeypatch.setattr("backend.routes.pension.build_owner_portfolio", fake_portfolio)
     monkeypatch.setattr(
         "backend.routes.pension.forecast_pension",
         lambda **kwargs: {"forecast": [], "initial_pot": kwargs["initial_pot"]},
@@ -254,9 +226,7 @@ def test_pension_route_passes_accounts_root_positional(monkeypatch):
 
     monkeypatch.setattr("backend.routes.pension.resolve_accounts_root", fake_resolve)
     monkeypatch.setattr("backend.routes.pension.load_person_metadata", fake_meta)
-    monkeypatch.setattr(
-        "backend.routes.pension.build_owner_portfolio", fake_portfolio
-    )
+    monkeypatch.setattr("backend.routes.pension.build_owner_portfolio", fake_portfolio)
     monkeypatch.setattr(
         "backend.routes.pension.forecast_pension",
         lambda **kwargs: {"forecast": [], "initial_pot": kwargs["initial_pot"]},
@@ -337,9 +307,7 @@ def test_pension_route_includes_db_inputs(monkeypatch):
         )
 
     assert resp.status_code == 200
-    assert captured["db_pensions"] == [
-        {"annual_income_gbp": 1200.0, "normal_retirement_age": 60}
-    ]
+    assert captured["db_pensions"] == [{"annual_income_gbp": 1200.0, "normal_retirement_age": 60}]
     body = resp.json()
     assert body["pension_pot_gbp"] == 1000.0
     assert captured["initial_pot"] == 1000.0

--- a/tests/test_performance_route.py
+++ b/tests/test_performance_route.py
@@ -215,9 +215,7 @@ def test_owner_metrics_with_as_of(monkeypatch):
         captured["pricing_date"] = pricing_date
         return 0.42, {"series": []}
 
-    monkeypatch.setattr(
-        portfolio_utils, "compute_alpha_vs_benchmark", fake
-    )
+    monkeypatch.setattr(portfolio_utils, "compute_alpha_vs_benchmark", fake)
     client = _auth_client()
     resp = client.get(
         "/performance/alice/alpha",

--- a/tests/test_performance_routes.py
+++ b/tests/test_performance_routes.py
@@ -157,9 +157,7 @@ def test_performance_summary_success(client, monkeypatch):
         assert owner == "alice"
         return result
 
-    monkeypatch.setattr(
-        portfolio_utils, "compute_owner_performance", fake
-    )
+    monkeypatch.setattr(portfolio_utils, "compute_owner_performance", fake)
     resp = client.get("/performance/alice")
     assert resp.status_code == 200
     assert resp.json() == {"owner": "alice", **result}
@@ -169,9 +167,7 @@ def test_performance_summary_not_found(client, monkeypatch):
     def fake(*args, **kwargs):
         raise FileNotFoundError
 
-    monkeypatch.setattr(
-        portfolio_utils, "compute_owner_performance", fake
-    )
+    monkeypatch.setattr(portfolio_utils, "compute_owner_performance", fake)
     resp = client.get("/performance/missing")
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Owner not found"
@@ -224,9 +220,7 @@ def test_group_alpha_handles_near_zero_benchmark(client, monkeypatch):
             }
         )
 
-    monkeypatch.setattr(
-        portfolio_utils, "_portfolio_value_series", fake_portfolio_value_series
-    )
+    monkeypatch.setattr(portfolio_utils, "_portfolio_value_series", fake_portfolio_value_series)
     monkeypatch.setattr(portfolio_utils, "load_meta_timeseries", fake_load_meta_timeseries)
 
     resp = client.get("/performance-group/test-group/alpha")

--- a/tests/test_portfolio_helpers.py
+++ b/tests/test_portfolio_helpers.py
@@ -74,6 +74,5 @@ def test_concentration_insight_weights_reflect_aggregated_duplicates():
 
     # Explicitly verify the raw aggregated value
     assert market_values["AAA"] == pytest.approx(150.0), (
-        "market_values['AAA'] should be 100+50=150; "
-        f"got {market_values['AAA']} — last-write-wins regression"
+        "market_values['AAA'] should be 100+50=150; " f"got {market_values['AAA']} — last-write-wins regression"
     )

--- a/tests/test_portfolio_list_owners.py
+++ b/tests/test_portfolio_list_owners.py
@@ -18,9 +18,7 @@ def test_list_owners_skips_bad_json(tmp_path, caplog):
 def test_list_owners_filters_by_viewer(tmp_path):
     alice = tmp_path / "alice"
     alice.mkdir()
-    (alice / "person.json").write_text(
-        json.dumps({"owner": "alice", "viewers": ["bob"]})
-    )
+    (alice / "person.json").write_text(json.dumps({"owner": "alice", "viewers": ["bob"]}))
     bob = tmp_path / "bob"
     bob.mkdir()
     (bob / "person.json").write_text(json.dumps({"owner": "bob"}))
@@ -33,9 +31,7 @@ def test_list_owners_matches_email_case_insensitively(tmp_path):
     """Aligns with /owners: identities matching an owner's email are authorized."""
     alice = tmp_path / "alice"
     alice.mkdir()
-    (alice / "person.json").write_text(
-        json.dumps({"owner": "alice", "email": "Alice@Example.com"})
-    )
+    (alice / "person.json").write_text(json.dumps({"owner": "alice", "email": "Alice@Example.com"}))
     bob = tmp_path / "bob"
     bob.mkdir()
     (bob / "person.json").write_text(json.dumps({"owner": "bob"}))

--- a/tests/test_portfolio_trades.py
+++ b/tests/test_portfolio_trades.py
@@ -1,8 +1,9 @@
 import sys
 from types import SimpleNamespace
 
-import backend.common.portfolio as portfolio
 from botocore.exceptions import ClientError
+
+import backend.common.portfolio as portfolio
 
 
 def test_load_trades_aws_success(monkeypatch):

--- a/tests/test_portfolio_utils_aggregate_by_field.py
+++ b/tests/test_portfolio_utils_aggregate_by_field.py
@@ -1,6 +1,7 @@
+import pytest
+
 import backend.common.portfolio_utils as portfolio_utils
 from backend.common import instrument_api
-import pytest
 
 
 def _sample_portfolio():

--- a/tests/test_portfolio_utils_contribution.py
+++ b/tests/test_portfolio_utils_contribution.py
@@ -1,5 +1,6 @@
-import backend.common.portfolio_utils as portfolio_utils
 import pytest
+
+import backend.common.portfolio_utils as portfolio_utils
 
 
 def test_aggregate_by_sector_and_region():

--- a/tests/test_portfolio_utils_currency.py
+++ b/tests/test_portfolio_utils_currency.py
@@ -1,4 +1,5 @@
 import pytest
+
 import backend.common.portfolio_utils as portfolio_utils
 from backend.common import instrument_api as ia
 
@@ -216,7 +217,4 @@ def test_normalize_currency_code_logs_when_missing(caplog):
         normalized = portfolio_utils._normalize_currency_code(None)
 
     assert normalized == "GBP"
-    assert (
-        "_normalize_currency_code received empty/missing currency; defaulting to GBP."
-        in caplog.text
-    )
+    assert "_normalize_currency_code received empty/missing currency; defaulting to GBP." in caplog.text

--- a/tests/test_portfolio_utils_returns.py
+++ b/tests/test_portfolio_utils_returns.py
@@ -1,7 +1,8 @@
+import datetime as dt
+from datetime import date, timedelta
+
 import pandas as pd
 import pytest
-from datetime import date, timedelta
-import datetime as dt
 
 from backend.common import instrument_api
 from backend.common import portfolio_utils as pu
@@ -48,9 +49,7 @@ def test_compute_time_weighted_return_requires_two_points(monkeypatch):
         "_portfolio_value_series",
         lambda owner, days=365, *, pricing_date=None, **_: series,
     )
-    monkeypatch.setattr(
-        pu, "load_transactions", lambda owner, *, scaffold_missing=False: []
-    )
+    monkeypatch.setattr(pu, "load_transactions", lambda owner, *, scaffold_missing=False: [])
 
     assert pu.compute_time_weighted_return("owner") is None
 
@@ -74,9 +73,7 @@ def test_compute_xirr_simple_contribution(monkeypatch, one_year_series):
         {"date": "2023-12-01", "type": "deposit", "amount_minor": 1000},
         {"date": "2025-02-01", "kind": "WITHDRAWAL", "amount_minor": 1000},
     ]
-    monkeypatch.setattr(
-        pu, "load_transactions", lambda owner, *, scaffold_missing=False: transactions
-    )
+    monkeypatch.setattr(pu, "load_transactions", lambda owner, *, scaffold_missing=False: transactions)
 
     result = pu.compute_xirr("owner")
 
@@ -89,9 +86,7 @@ def test_compute_xirr_requires_cashflows(monkeypatch, one_year_series):
         "_portfolio_value_series",
         lambda owner, days=365, *, pricing_date=None, **_: one_year_series,
     )
-    monkeypatch.setattr(
-        pu, "load_transactions", lambda owner, *, scaffold_missing=False: []
-    )
+    monkeypatch.setattr(pu, "load_transactions", lambda owner, *, scaffold_missing=False: [])
 
     assert pu.compute_xirr("owner") is None
 
@@ -135,6 +130,7 @@ def test_compute_cash_apy_empty(monkeypatch):
     monkeypatch.setattr(pu, "_cash_value_series", lambda owner, days=365: empty_series)
 
     assert pu.compute_cash_apy("owner") is None
+
 
 @pytest.fixture
 def sample_portfolio():
@@ -278,12 +274,8 @@ def test_compute_owner_performance_respects_flagged_and_cash(monkeypatch):
     monkeypatch.setattr(pu, "load_meta_timeseries", fake_load_meta_timeseries)
 
     excluded = pu.compute_owner_performance("owner", days=10, include_flagged=False, include_cash=False)
-    included_flagged = pu.compute_owner_performance(
-        "owner", days=10, include_flagged=True, include_cash=False
-    )
-    included_cash = pu.compute_owner_performance(
-        "owner", days=10, include_flagged=False, include_cash=True
-    )
+    included_flagged = pu.compute_owner_performance("owner", days=10, include_flagged=True, include_cash=False)
+    included_cash = pu.compute_owner_performance("owner", days=10, include_flagged=False, include_cash=True)
 
     assert [row["value"] for row in excluded["history"]] == [10.0, 11.0]
     assert [row["value"] for row in included_flagged["history"]] == [15.0, 17.0]
@@ -350,9 +342,7 @@ def test_compute_owner_performance_filters_single_day_zero(monkeypatch):
 
 
 def test_compute_owner_performance_drops_partial_close_nans(monkeypatch):
-    portfolio = {
-        "accounts": [{"holdings": [{"ticker": "NAN.L", "units": 2}, {"ticker": "CASH.GBP", "units": 1}]}]
-    }
+    portfolio = {"accounts": [{"holdings": [{"ticker": "NAN.L", "units": 2}, {"ticker": "CASH.GBP", "units": 1}]}]}
     monkeypatch.setattr(
         pu.portfolio_mod,
         "build_owner_portfolio",
@@ -413,9 +403,7 @@ def test_detect_single_day_flash_crash_keeps_real_downtrend():
 
 
 def test_detect_single_day_flash_crash_removes_two_day_rebound_drop():
-    idx = pd.Index(
-        [date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4)]
-    )
+    idx = pd.Index([date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4)])
     values = pd.Series([20000.0, 6000.0, 5500.0, 19950.0], index=idx)
 
     cleaned, issues = pu._detect_single_day_flash_crash(values)
@@ -491,9 +479,7 @@ def test_detect_single_day_flash_crash_short_series_noop():
 
 
 def test_detect_single_day_flash_crash_ignores_nan_in_window():
-    idx = pd.Index(
-        [date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4)]
-    )
+    idx = pd.Index([date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4)])
     values = pd.Series([1000.0, float("nan"), 50.0, 1001.0], index=idx)
 
     cleaned, issues = pu._detect_single_day_flash_crash(values)

--- a/tests/test_push_subscription_route.py
+++ b/tests/test_push_subscription_route.py
@@ -1,14 +1,13 @@
-import os
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
-from backend import config as backend_config
-from backend.local_api.main import app
 from backend import alerts as alert_utils
+from backend import config as backend_config
 from backend.common import data_loader
 from backend.common.storage import get_storage
+from backend.local_api.main import app
 
 
 @pytest.fixture

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -40,6 +40,7 @@ def test_mark_complete_updates_xp_and_streak(quests, monkeypatch):
             @classmethod
             def today(cls):
                 return day
+
         monkeypatch.setattr(quests, "date", DummyDate)
 
     # Day one: complete both quests

--- a/tests/test_quests_route.py
+++ b/tests/test_quests_route.py
@@ -7,8 +7,8 @@ from fastapi.testclient import TestClient
 from backend.auth import get_current_user
 from backend.config import config
 
-
 # Helper ----------------------------------------------------------------------
+
 
 def _build_app(tmp_path, monkeypatch) -> FastAPI:
     """Return a FastAPI app with quests storage isolated to ``tmp_path``."""
@@ -32,6 +32,7 @@ def _client_for(user: str, tmp_path, monkeypatch) -> TestClient:
 
 
 # Tests -----------------------------------------------------------------------
+
 
 def test_complete_quest_success(tmp_path, monkeypatch):
     """Completing a valid quest returns updated progress."""

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -156,22 +156,16 @@ def test_build_report_document_uses_context(monkeypatch):
     )
     performance = {"history": history, "reporting_date": "2024-01-01", "max_drawdown": -0.1}
 
-    monkeypatch.setattr(
-        reports, "_compile_summary", lambda owner, start, end: (summary, performance)
-    )
+    monkeypatch.setattr(reports, "_compile_summary", lambda owner, start, end: (summary, performance))
     monkeypatch.setattr(
         reports,
         "_load_transactions",
-        lambda owner: [
-            {"date": "2024-01-01", "type": "SELL", "amount_minor": 1000, "currency": "GBP"}
-        ],
+        lambda owner: [{"date": "2024-01-01", "type": "SELL", "amount_minor": 1000, "currency": "GBP"}],
     )
     monkeypatch.setattr(
         reports.portfolio_utils,
         "portfolio_value_breakdown",
-        lambda owner, date: [
-            {"ticker": "ABC", "exchange": "L", "units": 2, "price": 10.5, "value": 21.0}
-        ],
+        lambda owner, date: [{"ticker": "ABC", "exchange": "L", "units": 2, "price": 10.5, "value": 21.0}],
     )
 
     document = reports.build_report_document("performance-summary", "alice")
@@ -186,6 +180,7 @@ def test_build_report_document_uses_context(monkeypatch):
 # ---------------------------------------------------------------------------
 # Helpers shared across portfolio section tests
 # ---------------------------------------------------------------------------
+
 
 def _portfolio_template():
     return reports.ReportTemplate(
@@ -213,6 +208,7 @@ def _preloaded_context(portfolio: dict) -> reports.ReportContext:
 # ---------------------------------------------------------------------------
 # Happy-path integration test
 # ---------------------------------------------------------------------------
+
 
 def test_portfolio_section_builders(monkeypatch):
     portfolio_payload = {
@@ -302,16 +298,13 @@ def test_portfolio_section_builders(monkeypatch):
     monkeypatch.setattr(reports.risk, "compute_sharpe_ratio", lambda owner: 1.23456)
     monkeypatch.setattr(reports, "get_template", lambda template_id, store=None: _portfolio_template())
 
-    document = reports.build_report_document(
-        "portfolio-insights", "alice", end=date(2024, 1, 31)
-    )
+    document = reports.build_report_document("portfolio-insights", "alice", end=date(2024, 1, 31))
     sources = {section.schema.source: section.rows for section in document.sections}
 
     overview_rows = sources["portfolio.overview"]
     assert any(row["label"] == "Total portfolio value" and row["value"] == 1000.0 for row in overview_rows)
     assert any(
-        row["category"] == "asset_class" and row["label"] == "Equity" and row["value"] == 700.0
-        for row in overview_rows
+        row["category"] == "asset_class" and row["label"] == "Equity" and row["value"] == 700.0 for row in overview_rows
     )
 
     sectors_rows = sources["portfolio.sectors"]
@@ -346,6 +339,7 @@ def test_portfolio_section_builders(monkeypatch):
 # Overview builder edge cases
 # ---------------------------------------------------------------------------
 
+
 def test_overview_empty_accounts(monkeypatch):
     """Overview with no accounts produces only summary rows (no account/asset_class rows)."""
     ctx = _preloaded_context({"total_value_estimate_gbp": 500.0, "accounts": []})
@@ -360,16 +354,20 @@ def test_overview_empty_accounts(monkeypatch):
 
 def test_overview_non_dict_account_entries_are_skipped(monkeypatch):
     """Non-dict entries in the accounts list must be skipped in both passes without raising."""
-    ctx = _preloaded_context({
-        "total_value_estimate_gbp": 200.0,
-        "accounts": [
-            "not-a-dict",
-            None,
-            {"account_type": "ISA", "value_estimate_gbp": 200.0, "holdings": [
-                {"asset_class": "Equity", "market_value_gbp": 200.0}
-            ]},
-        ],
-    })
+    ctx = _preloaded_context(
+        {
+            "total_value_estimate_gbp": 200.0,
+            "accounts": [
+                "not-a-dict",
+                None,
+                {
+                    "account_type": "ISA",
+                    "value_estimate_gbp": 200.0,
+                    "holdings": [{"asset_class": "Equity", "market_value_gbp": 200.0}],
+                },
+            ],
+        }
+    )
     result = reports._build_portfolio_overview_section(ctx, reports.PORTFOLIO_OVERVIEW_SECTION)
     account_rows = [r for r in result if r["category"] == "account"]
     # Only the dict account should produce a row
@@ -384,6 +382,7 @@ def test_overview_non_dict_account_entries_are_skipped(monkeypatch):
 # ---------------------------------------------------------------------------
 # Sectors / regions edge cases
 # ---------------------------------------------------------------------------
+
 
 def test_sectors_weight_pct_sums_to_100(monkeypatch):
     """weight_pct values across all sector rows should sum to 100%."""
@@ -436,14 +435,12 @@ def test_sectors_zero_total_value_yields_none_weight(monkeypatch):
 # Concentration edge cases
 # ---------------------------------------------------------------------------
 
+
 def test_concentration_n_holdings_is_total_not_top_n(monkeypatch):
     """n_holdings in the summary row must reflect total portfolio holding count,
     not the capped top-10 slice."""
     # 12 holdings: top-10 slice != total
-    tickers = [
-        {"ticker": f"T{i:02d}.L", "market_value_gbp": float(100 - i * 5)}
-        for i in range(12)
-    ]
+    tickers = [{"ticker": f"T{i:02d}.L", "market_value_gbp": float(100 - i * 5)} for i in range(12)]
     monkeypatch.setattr(
         reports.portfolio_utils,
         "aggregate_by_ticker",
@@ -464,9 +461,7 @@ def test_concentration_n_holdings_is_total_not_top_n(monkeypatch):
     expected_hhi = sum((t["market_value_gbp"] / total_value) ** 2 for t in tickers)
     assert summary["hhi"] == pytest.approx(expected_hhi, abs=1e-6)
     # top_n_weight_pct covers only the top-10 by value
-    top10_weight = sum(sorted(
-        [t["market_value_gbp"] for t in tickers], reverse=True
-    )[:10]) / total_value * 100.0
+    top10_weight = sum(sorted([t["market_value_gbp"] for t in tickers], reverse=True)[:10]) / total_value * 100.0
     assert summary["top_n_weight_pct"] == pytest.approx(top10_weight, abs=1e-4)
 
 
@@ -474,10 +469,12 @@ def test_concentration_n_holdings_is_total_not_top_n(monkeypatch):
 # VaR edge cases
 # ---------------------------------------------------------------------------
 
+
 def test_portfolio_var_partial_failure_one_confidence_level(monkeypatch):
     """If 0.95 raises but 0.99 succeeds, the section returns only the 0.99 rows."""
-    monkeypatch.setattr(reports.portfolio_mod, "build_owner_portfolio",
-                        lambda owner, pricing_date=None: {"accounts": []})
+    monkeypatch.setattr(
+        reports.portfolio_mod, "build_owner_portfolio", lambda owner, pricing_date=None: {"accounts": []}
+    )
 
     call_count = {"n": 0}
 
@@ -504,13 +501,18 @@ def test_portfolio_var_partial_failure_one_confidence_level(monkeypatch):
 
 def test_portfolio_var_omits_sharpe_row_when_sharpe_fails(monkeypatch):
     """When VaR succeeds but compute_sharpe_ratio raises, no Sharpe row is appended."""
-    monkeypatch.setattr(reports.portfolio_mod, "build_owner_portfolio",
-                        lambda owner, pricing_date=None: {"accounts": []})
+    monkeypatch.setattr(
+        reports.portfolio_mod, "build_owner_portfolio", lambda owner, pricing_date=None: {"accounts": []}
+    )
     monkeypatch.setattr(
         reports,
         "risk",
         SimpleNamespace(
-            compute_portfolio_var=lambda owner, confidence, include_cash=True: {"confidence": confidence, "1d": 10.0, "10d": 20.0},
+            compute_portfolio_var=lambda owner, confidence, include_cash=True: {
+                "confidence": confidence,
+                "1d": 10.0,
+                "10d": 20.0,
+            },
             compute_sharpe_ratio=Mock(side_effect=ValueError("no returns")),
         ),
     )
@@ -522,8 +524,9 @@ def test_portfolio_var_omits_sharpe_row_when_sharpe_fails(monkeypatch):
 
 def test_portfolio_var_returns_empty_when_var_rows_unavailable(monkeypatch):
     """VaR builder returns [] when both confidence-level calls raise."""
-    monkeypatch.setattr(reports.portfolio_mod, "build_owner_portfolio",
-                        lambda owner, pricing_date=None: {"accounts": []})
+    monkeypatch.setattr(
+        reports.portfolio_mod, "build_owner_portfolio", lambda owner, pricing_date=None: {"accounts": []}
+    )
     monkeypatch.setattr(
         reports,
         "risk",
@@ -540,6 +543,7 @@ def test_portfolio_var_returns_empty_when_var_rows_unavailable(monkeypatch):
 # ---------------------------------------------------------------------------
 # Caching / module-missing paths
 # ---------------------------------------------------------------------------
+
 
 def test_owner_portfolio_failure_is_cached_once_per_report_build(monkeypatch):
     call_count = {"count": 0}
@@ -603,6 +607,7 @@ def test_portfolio_sections_return_empty_when_optional_modules_missing(monkeypat
 # ---------------------------------------------------------------------------
 # Template store / existing tests
 # ---------------------------------------------------------------------------
+
 
 def test_list_template_metadata_merges_user_templates(tmp_path):
     reports.get_template_store.cache_clear()
@@ -922,12 +927,8 @@ def test_audit_report_portfolio_sections_use_requested_end_snapshot(monkeypatch)
     assert list(rows_by_source["portfolio.overview"]) == [
         {"total_value_gbp": 500.0, "holdings_count": 1, "accounts_count": 1}
     ]
-    assert list(rows_by_source["portfolio.sectors"]) == [
-        {"sector": "dated", "value": 500.0, "weight": 1.0}
-    ]
-    assert list(rows_by_source["portfolio.regions"]) == [
-        {"region": "dated", "value": 500.0, "weight": 1.0}
-    ]
+    assert list(rows_by_source["portfolio.sectors"]) == [{"sector": "dated", "value": 500.0, "weight": 1.0}]
+    assert list(rows_by_source["portfolio.regions"]) == [{"region": "dated", "value": 500.0, "weight": 1.0}]
     assert rows_by_source["portfolio.concentration"][0]["ticker"] == "dated"
     assert observed_pricing_dates == [requested_end]
 
@@ -1143,8 +1144,7 @@ def test_build_key_findings_section_skips_standalone_separator_line(tmp_path, mo
     owner_dir = tmp_path / "accounts" / "demo-owner"
     owner_dir.mkdir(parents=True)
     (owner_dir / "key_findings.md").write_text(
-        "---\n"
-        "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
+        "---\n" "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
         encoding="utf-8",
     )
 
@@ -1166,9 +1166,7 @@ def test_build_key_findings_section_skips_setext_heading_preamble(tmp_path, monk
     owner_dir = tmp_path / "accounts" / "demo-owner"
     owner_dir.mkdir(parents=True)
     (owner_dir / "key_findings.md").write_text(
-        "Summary\n"
-        "-------\n"
-        "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
+        "Summary\n" "-------\n" "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
         encoding="utf-8",
     )
 
@@ -1190,8 +1188,7 @@ def test_build_key_findings_section_keeps_numbered_finding_before_separator(tmp_
     owner_dir = tmp_path / "accounts" / "demo-owner"
     owner_dir.mkdir(parents=True)
     (owner_dir / "key_findings.md").write_text(
-        "1. Cash drag is elevated versus target corridor.\n"
-        "----------------\n",
+        "1. Cash drag is elevated versus target corridor.\n" "----------------\n",
         encoding="utf-8",
     )
 
@@ -1213,9 +1210,7 @@ def test_build_key_findings_section_skips_setext_heading_with_equals(tmp_path, m
     owner_dir = tmp_path / "accounts" / "demo-owner"
     owner_dir.mkdir(parents=True)
     (owner_dir / "key_findings.md").write_text(
-        "Summary\n"
-        "=======\n"
-        "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
+        "Summary\n" "=======\n" "- Portfolio is well-diversified across 4 regions and 8 sectors.\n",
         encoding="utf-8",
     )
 
@@ -1237,9 +1232,7 @@ def test_build_key_findings_section_allows_findings_after_interleaved_heading(tm
     owner_dir = tmp_path / "accounts" / "demo-owner"
     owner_dir.mkdir(parents=True)
     (owner_dir / "key_findings.md").write_text(
-        "- Finding one.\n"
-        "## Sub-section\n"
-        "- Finding two.\n",
+        "- Finding one.\n" "## Sub-section\n" "- Finding two.\n",
         encoding="utf-8",
     )
 
@@ -1329,10 +1322,7 @@ def test_build_key_findings_section_skips_empty_entries_after_trimming(tmp_path,
     owner_dir = tmp_path / "accounts" / "demo-owner"
     owner_dir.mkdir(parents=True)
     (owner_dir / "key_findings.md").write_text(
-        "- \n"
-        "* \n"
-        "2.   \n"
-        "- ok\n",
+        "- \n" "* \n" "2.   \n" "- ok\n",
         encoding="utf-8",
     )
 
@@ -1368,9 +1358,7 @@ def test_build_key_findings_section_reads_txt_fallback(tmp_path, monkeypatch):
 
     rows = reports._build_key_findings_section(context, schema)
 
-    assert rows == [
-        {"finding": "Cash drag is 6.4% above the 2.0% target corridor"}
-    ]
+    assert rows == [{"finding": "Cash drag is 6.4% above the 2.0% target corridor"}]
 
 
 def test_key_findings_source_is_registered_for_template_validation():
@@ -1472,11 +1460,7 @@ def test_audit_template_is_registered_with_expected_sections():
 
 def test_audit_template_sources_are_all_registered():
     template = reports.BUILTIN_TEMPLATES["audit-report"]
-    missing = [
-        section.source
-        for section in template.sections
-        if section.source not in reports.SECTION_BUILDERS
-    ]
+    missing = [section.source for section in template.sections if section.source not in reports.SECTION_BUILDERS]
     assert missing == []
 
 
@@ -1590,9 +1574,7 @@ def test_audit_risk_section_includes_var_and_sharpe(monkeypatch):
     monkeypatch.setattr(
         reports,
         "portfolio_mod",
-        SimpleNamespace(
-            build_owner_portfolio=lambda owner, pricing_date=None: {"accounts": []}
-        ),
+        SimpleNamespace(build_owner_portfolio=lambda owner, pricing_date=None: {"accounts": []}),
     )
 
     rows = reports._build_portfolio_var_section(
@@ -1635,15 +1617,9 @@ def test_build_report_document_omits_empty_var_section_for_audit_report(monkeypa
         "build_owner_portfolio",
         lambda owner, pricing_date=None: {"total_value_estimate_gbp": 0.0, "accounts": []},
     )
-    monkeypatch.setattr(
-        reports.portfolio_utils, "aggregate_by_sector", lambda portfolio: []
-    )
-    monkeypatch.setattr(
-        reports.portfolio_utils, "aggregate_by_region", lambda portfolio: []
-    )
-    monkeypatch.setattr(
-        reports.portfolio_utils, "aggregate_by_ticker", lambda portfolio: []
-    )
+    monkeypatch.setattr(reports.portfolio_utils, "aggregate_by_sector", lambda portfolio: [])
+    monkeypatch.setattr(reports.portfolio_utils, "aggregate_by_region", lambda portfolio: [])
+    monkeypatch.setattr(reports.portfolio_utils, "aggregate_by_ticker", lambda portfolio: [])
     monkeypatch.setattr(reports.config, "data_root", tmp_path, raising=False)
 
     document = reports.build_report_document("audit-report", "alice")

--- a/tests/test_reports_additional.py
+++ b/tests/test_reports_additional.py
@@ -2,6 +2,7 @@ import json
 import sys
 from datetime import UTC, date, datetime
 from types import SimpleNamespace
+
 import pytest
 
 import backend.reports as reports
@@ -112,14 +113,23 @@ def test_dynamo_template_store_list_and_get(monkeypatch, caplog):
             if not params:
                 return {
                     "Items": [
-                        {"definition": json.dumps({"template_id": "custom", "name": "Custom", "description": "", "sections": [
-                            {
-                                "id": "metrics",
-                                "title": "Metrics",
-                                "source": "performance.metrics",
-                                "columns": [{"key": "metric", "label": "Metric"}],
-                            }
-                        ]})},
+                        {
+                            "definition": json.dumps(
+                                {
+                                    "template_id": "custom",
+                                    "name": "Custom",
+                                    "description": "",
+                                    "sections": [
+                                        {
+                                            "id": "metrics",
+                                            "title": "Metrics",
+                                            "source": "performance.metrics",
+                                            "columns": [{"key": "metric", "label": "Metric"}],
+                                        }
+                                    ],
+                                }
+                            )
+                        },
                         {"definition": "not json"},
                         {"definition": json.dumps({"template_id": "invalid", "name": "", "sections": []})},
                     ],
@@ -127,14 +137,23 @@ def test_dynamo_template_store_list_and_get(monkeypatch, caplog):
                 }
             return {
                 "Items": [
-                    {"definition": json.dumps({"template_id": "other", "name": "Other", "description": "", "sections": [
-                        {
-                            "id": "metrics",
-                            "title": "Metrics",
-                            "source": "performance.metrics",
-                            "columns": [{"key": "metric", "label": "Metric"}],
-                        }
-                    ]})}
+                    {
+                        "definition": json.dumps(
+                            {
+                                "template_id": "other",
+                                "name": "Other",
+                                "description": "",
+                                "sections": [
+                                    {
+                                        "id": "metrics",
+                                        "title": "Metrics",
+                                        "source": "performance.metrics",
+                                        "columns": [{"key": "metric", "label": "Metric"}],
+                                    }
+                                ],
+                            }
+                        )
+                    }
                 ]
             }
 
@@ -147,19 +166,21 @@ def test_dynamo_template_store_list_and_get(monkeypatch, caplog):
                 return {"Item": {"definition": json.dumps({"template_id": "baddef", "name": "", "sections": []})}}
             return {
                 "Item": {
-                    "definition": json.dumps({
-                        "template_id": Key["template_id"],
-                        "name": "Loaded",
-                        "description": "",
-                        "sections": [
-                            {
-                                "id": "metrics",
-                                "title": "Metrics",
-                                "source": "performance.metrics",
-                                "columns": [{"key": "metric", "label": "Metric"}],
-                            }
-                        ],
-                    })
+                    "definition": json.dumps(
+                        {
+                            "template_id": Key["template_id"],
+                            "name": "Loaded",
+                            "description": "",
+                            "sections": [
+                                {
+                                    "id": "metrics",
+                                    "title": "Metrics",
+                                    "source": "performance.metrics",
+                                    "columns": [{"key": "metric", "label": "Metric"}],
+                                }
+                            ],
+                        }
+                    )
                 }
             }
 
@@ -249,26 +270,70 @@ def test_user_template_management_errors(monkeypatch):
     monkeypatch.setattr(reports, "get_template_store", lambda: store)
 
     with pytest.raises(ValueError):
-        reports.create_user_template({"template_id": reports.DEFAULT_TEMPLATE_ID, "name": "Built-in", "sections": [
-            {"id": "metrics", "title": "Metrics", "source": "performance.metrics", "columns": [{"key": "metric"}]}
-        ]})
+        reports.create_user_template(
+            {
+                "template_id": reports.DEFAULT_TEMPLATE_ID,
+                "name": "Built-in",
+                "sections": [
+                    {
+                        "id": "metrics",
+                        "title": "Metrics",
+                        "source": "performance.metrics",
+                        "columns": [{"key": "metric"}],
+                    }
+                ],
+            }
+        )
 
     store.get_template = lambda template_id: {"template_id": template_id}
     with pytest.raises(ValueError):
-        reports.create_user_template({"template_id": "custom", "name": "Custom", "sections": [
-            {"id": "metrics", "title": "Metrics", "source": "performance.metrics", "columns": [{"key": "metric"}]}
-        ]})
+        reports.create_user_template(
+            {
+                "template_id": "custom",
+                "name": "Custom",
+                "sections": [
+                    {
+                        "id": "metrics",
+                        "title": "Metrics",
+                        "source": "performance.metrics",
+                        "columns": [{"key": "metric"}],
+                    }
+                ],
+            }
+        )
 
     store.get_template = lambda template_id: None
     with pytest.raises(ValueError):
-        reports.update_user_template(reports.DEFAULT_TEMPLATE_ID, {"name": "Built-in", "sections": [
-            {"id": "metrics", "title": "Metrics", "source": "performance.metrics", "columns": [{"key": "metric"}]}
-        ]})
+        reports.update_user_template(
+            reports.DEFAULT_TEMPLATE_ID,
+            {
+                "name": "Built-in",
+                "sections": [
+                    {
+                        "id": "metrics",
+                        "title": "Metrics",
+                        "source": "performance.metrics",
+                        "columns": [{"key": "metric"}],
+                    }
+                ],
+            },
+        )
 
     with pytest.raises(FileNotFoundError):
-        reports.update_user_template("missing", {"name": "Custom", "sections": [
-            {"id": "metrics", "title": "Metrics", "source": "performance.metrics", "columns": [{"key": "metric"}]}
-        ]})
+        reports.update_user_template(
+            "missing",
+            {
+                "name": "Custom",
+                "sections": [
+                    {
+                        "id": "metrics",
+                        "title": "Metrics",
+                        "source": "performance.metrics",
+                        "columns": [{"key": "metric"}],
+                    }
+                ],
+            },
+        )
 
     store.get_template = lambda template_id: None
     with pytest.raises(ValueError):
@@ -350,10 +415,14 @@ def test_get_template_store_returns_dynamo(monkeypatch):
 
 
 def test_compile_summary_filters_history(monkeypatch):
-    monkeypatch.setattr(reports, "_load_transactions", lambda owner: [
-        {"date": "2024-01-01", "type": "SELL", "amount_minor": 1000},
-        {"date": "invalid", "type": "DIVIDEND", "amount_minor": 200},
-    ])
+    monkeypatch.setattr(
+        reports,
+        "_load_transactions",
+        lambda owner: [
+            {"date": "2024-01-01", "type": "SELL", "amount_minor": 1000},
+            {"date": "invalid", "type": "DIVIDEND", "amount_minor": 200},
+        ],
+    )
 
     performance = {
         "history": [
@@ -615,10 +684,7 @@ def test_report_to_pdf_formats_values_and_optional_watermark(monkeypatch):
     assert any("45.32%" in value for value in drawn_values)
     assert not any("0.4532" in value for value in drawn_values)
     assert not any("4,532.00%" in value for value in drawn_values)
-    assert any(
-        name == "drawCentredString" and args[-1] == "SAMPLE"
-        for name, args, _ in calls
-    )
+    assert any(name == "drawCentredString" and args[-1] == "SAMPLE" for name, args, _ in calls)
 
 
 def test_report_to_pdf_key_findings_wrap_across_pages(monkeypatch):
@@ -829,29 +895,17 @@ def test_portfolio_section_builders_use_monkeypatched_dependencies(monkeypatch):
     monkeypatch.setattr(
         reports.risk,
         "compute_portfolio_var",
-        lambda owner, confidence=0.95, include_cash=True: {"1d": 0.12}
-        if confidence == 0.95
-        else {"1d": 0.2},
+        lambda owner, confidence=0.95, include_cash=True: {"1d": 0.12} if confidence == 0.95 else {"1d": 0.2},
     )
     monkeypatch.setattr(reports.risk, "compute_sharpe_ratio", lambda owner: 1.75)
 
     context = reports.ReportContext(owner="alice", start=None, end=None)
 
-    overview = reports._build_portfolio_overview_section(
-        context, reports.AUDIT_REPORT_TEMPLATE.sections[0]
-    )
-    sectors = reports._build_portfolio_sectors_section(
-        context, reports.AUDIT_REPORT_TEMPLATE.sections[1]
-    )
-    regions = reports._build_portfolio_regions_section(
-        context, reports.AUDIT_REPORT_TEMPLATE.sections[2]
-    )
-    concentration = reports._build_portfolio_concentration_section(
-        context, reports.AUDIT_REPORT_TEMPLATE.sections[3]
-    )
-    var_rows = reports._build_portfolio_var_section(
-        context, reports.AUDIT_REPORT_TEMPLATE.sections[4]
-    )
+    overview = reports._build_portfolio_overview_section(context, reports.AUDIT_REPORT_TEMPLATE.sections[0])
+    sectors = reports._build_portfolio_sectors_section(context, reports.AUDIT_REPORT_TEMPLATE.sections[1])
+    regions = reports._build_portfolio_regions_section(context, reports.AUDIT_REPORT_TEMPLATE.sections[2])
+    concentration = reports._build_portfolio_concentration_section(context, reports.AUDIT_REPORT_TEMPLATE.sections[3])
+    var_rows = reports._build_portfolio_var_section(context, reports.AUDIT_REPORT_TEMPLATE.sections[4])
 
     assert overview == [{"total_value_gbp": 1234.56, "holdings_count": 2, "accounts_count": 1}]
     assert sectors == [{"sector": "Technology", "value": 700.0, "weight": 1.0}]
@@ -931,9 +985,7 @@ def test_portfolio_section_builders_return_declared_schema_keys(monkeypatch):
 
     sectors = reports._build_portfolio_sectors_section(context, reports.AUDIT_REPORT_TEMPLATE.sections[1])
     regions = reports._build_portfolio_regions_section(context, reports.AUDIT_REPORT_TEMPLATE.sections[2])
-    concentration = reports._build_portfolio_concentration_section(
-        context, reports.AUDIT_REPORT_TEMPLATE.sections[3]
-    )
+    concentration = reports._build_portfolio_concentration_section(context, reports.AUDIT_REPORT_TEMPLATE.sections[3])
 
     assert set(sectors[0]) == {"sector", "value", "weight"}
     assert set(regions[0]) == {"region", "value", "weight"}
@@ -941,27 +993,19 @@ def test_portfolio_section_builders_return_declared_schema_keys(monkeypatch):
 
 
 def test_audit_concentration_hhi_uses_full_holding_set(monkeypatch):
-    tickers = [
-        {"ticker": f"T{i:02d}", "market_value_gbp": float(120 - i)}
-        for i in range(12)
-    ]
+    tickers = [{"ticker": f"T{i:02d}", "market_value_gbp": float(120 - i)} for i in range(12)]
     monkeypatch.setattr(
         reports,
         "_portfolio_snapshot",
-        lambda owner, pricing_date=None: {
-            "accounts": [{"holdings": [{"ticker": row["ticker"]} for row in tickers]}]
-        },
+        lambda owner, pricing_date=None: {"accounts": [{"holdings": [{"ticker": row["ticker"]} for row in tickers]}]},
     )
     monkeypatch.setattr(reports.portfolio_utils, "aggregate_by_ticker", lambda pf: tickers)
     context = reports.ReportContext(owner="alice", start=None, end=None)
 
-    concentration = reports._build_portfolio_concentration_section(
-        context, reports.AUDIT_REPORT_TEMPLATE.sections[3]
-    )
+    concentration = reports._build_portfolio_concentration_section(context, reports.AUDIT_REPORT_TEMPLATE.sections[3])
 
     expected_hhi = sum(
-        (row["market_value_gbp"] / sum(item["market_value_gbp"] for item in tickers)) ** 2
-        for row in tickers
+        (row["market_value_gbp"] / sum(item["market_value_gbp"] for item in tickers)) ** 2 for row in tickers
     )
     assert len(concentration) == 10
     assert all(row["hhi"] == pytest.approx(expected_hhi) for row in concentration)
@@ -1040,9 +1084,7 @@ def test_audit_portfolio_var_builder_returns_empty_when_risk_data_missing(monkey
     monkeypatch.setattr(
         reports.risk,
         "compute_portfolio_var",
-        lambda owner, confidence=0.95, include_cash=True: (_ for _ in ()).throw(
-            FileNotFoundError("missing risk data")
-        ),
+        lambda owner, confidence=0.95, include_cash=True: (_ for _ in ()).throw(FileNotFoundError("missing risk data")),
     )
     monkeypatch.setattr(
         reports.risk,
@@ -1146,27 +1188,18 @@ def test_build_report_document_audit_template_dispatches_real_builders(monkeypat
     monkeypatch.setattr(
         reports.risk,
         "compute_portfolio_var",
-        lambda owner, confidence=0.95, include_cash=True: {
-            "1d": 10.0 if confidence == 0.95 else 20.0
-        },
+        lambda owner, confidence=0.95, include_cash=True: {"1d": 10.0 if confidence == 0.95 else 20.0},
     )
     monkeypatch.setattr(reports.risk, "compute_sharpe_ratio", lambda owner: 1.11)
 
     document = reports.build_report_document("audit-report", "alice")
 
-    rows_by_source = {
-        section.schema.source: list(section.rows)
-        for section in document.sections
-    }
+    rows_by_source = {section.schema.source: list(section.rows) for section in document.sections}
     assert rows_by_source["portfolio.overview"] == [
         {"total_value_gbp": 200.0, "holdings_count": 2, "accounts_count": 1}
     ]
-    assert rows_by_source["portfolio.sectors"] == [
-        {"sector": "Technology", "value": 120.0, "weight": 1.0}
-    ]
-    assert rows_by_source["portfolio.regions"] == [
-        {"region": "North America", "value": 120.0, "weight": 1.0}
-    ]
+    assert rows_by_source["portfolio.sectors"] == [{"sector": "Technology", "value": 120.0, "weight": 1.0}]
+    assert rows_by_source["portfolio.regions"] == [{"region": "North America", "value": 120.0, "weight": 1.0}]
     assert rows_by_source["portfolio.concentration"][0]["ticker"] == "AAA"
     assert rows_by_source["portfolio.var"] == [
         {"metric": "VaR (95%)", "value": 10.0, "units": "GBP"},

--- a/tests/test_reports_audit.py
+++ b/tests/test_reports_audit.py
@@ -23,9 +23,7 @@ def _patched_audit_report_dependencies(monkeypatch) -> dict:
     monkeypatch.setattr(
         reports.risk,
         "compute_portfolio_var",
-        lambda owner, confidence=0.95, include_cash=True: {
-            "1d": 25.0 if confidence == 0.95 else 40.0
-        },
+        lambda owner, confidence=0.95, include_cash=True: {"1d": 25.0 if confidence == 0.95 else 40.0},
     )
     monkeypatch.setattr(reports.risk, "compute_sharpe_ratio", lambda owner: 1.2)
 

--- a/tests/test_reports_pdf.py
+++ b/tests/test_reports_pdf.py
@@ -1,5 +1,3 @@
-import pytest
-
 from datetime import datetime
 
 import pytest
@@ -233,9 +231,7 @@ def test_audit_report_json_section_order_and_presence(monkeypatch):
     assert len(overview_section.rows) >= 1
 
     # Concentration rows are ordered by value descending (highest weight first)
-    concentration_section = next(
-        s for s in document.sections if s.schema.source == "portfolio.concentration"
-    )
+    concentration_section = next(s for s in document.sections if s.schema.source == "portfolio.concentration")
     assert len(concentration_section.rows) >= 1
 
     # VaR section present and non-empty when risk module available
@@ -283,7 +279,6 @@ def test_audit_report_var_section_omitted_when_risk_unavailable(monkeypatch, tmp
 
 def test_existing_templates_unaffected_by_audit_report_changes(monkeypatch):
     """performance-summary, transactions, allocation-breakdown must still build correctly."""
-    from types import SimpleNamespace
 
     summary = reports.ReportData(
         owner="alice",
@@ -295,9 +290,7 @@ def test_existing_templates_unaffected_by_audit_report_changes(monkeypatch):
         max_drawdown=-0.02,
         history=[],
     )
-    monkeypatch.setattr(
-        reports, "_compile_summary", lambda owner, start, end: (summary, {"history": []})
-    )
+    monkeypatch.setattr(reports, "_compile_summary", lambda owner, start, end: (summary, {"history": []}))
     monkeypatch.setattr(reports, "_load_transactions", lambda owner: [])
     monkeypatch.setattr(
         reports.portfolio_utils,

--- a/tests/test_reports_route.py
+++ b/tests/test_reports_route.py
@@ -117,8 +117,7 @@ def test_reports_pdf(client, monkeypatch):
 
 def test_audit_report_json_smoke_includes_all_sections(client, monkeypatch):
     section_data = tuple(
-        reports.ReportSectionData(schema=schema, rows=())
-        for schema in reports.AUDIT_REPORT_TEMPLATE.sections
+        reports.ReportSectionData(schema=schema, rows=()) for schema in reports.AUDIT_REPORT_TEMPLATE.sections
     )
     document = reports.ReportDocument(
         template=reports.AUDIT_REPORT_TEMPLATE,
@@ -148,8 +147,7 @@ def test_audit_report_json_smoke_includes_all_sections(client, monkeypatch):
 
 def test_audit_report_pdf_smoke_returns_pdf_prefix(client, monkeypatch):
     section_data = tuple(
-        reports.ReportSectionData(schema=schema, rows=())
-        for schema in reports.AUDIT_REPORT_TEMPLATE.sections
+        reports.ReportSectionData(schema=schema, rows=()) for schema in reports.AUDIT_REPORT_TEMPLATE.sections
     )
     document = reports.ReportDocument(
         template=reports.AUDIT_REPORT_TEMPLATE,
@@ -310,9 +308,7 @@ def test_create_template_endpoint(client, monkeypatch):
                 "id": "metrics",
                 "title": "Metrics",
                 "source": "performance.metrics",
-                "columns": [
-                    {"key": "metric", "label": "Metric", "type": "string"}
-                ],
+                "columns": [{"key": "metric", "label": "Metric", "type": "string"}],
             }
         ],
     }
@@ -357,9 +353,7 @@ def test_update_template_endpoint(client, monkeypatch):
                 "id": "metrics",
                 "title": "Metrics",
                 "source": "performance.metrics",
-                "columns": [
-                    {"key": "metric", "label": "Metric", "type": "string"}
-                ],
+                "columns": [{"key": "metric", "label": "Metric", "type": "string"}],
             }
         ],
     }
@@ -381,9 +375,7 @@ def test_update_template_endpoint_not_found(client, monkeypatch):
                 "id": "metrics",
                 "title": "Metrics",
                 "source": "performance.metrics",
-                "columns": [
-                    {"key": "metric", "label": "Metric", "type": "string"}
-                ],
+                "columns": [{"key": "metric", "label": "Metric", "type": "string"}],
             }
         ],
     }
@@ -407,9 +399,7 @@ def test_update_template_endpoint_validation_error(client, monkeypatch):
                 "id": "metrics",
                 "title": "Metrics",
                 "source": "performance.metrics",
-                "columns": [
-                    {"key": "metric", "label": "Metric", "type": "string"}
-                ],
+                "columns": [{"key": "metric", "label": "Metric", "type": "string"}],
             }
         ],
     }

--- a/tests/test_resolve_paths_windows.py
+++ b/tests/test_resolve_paths_windows.py
@@ -1,5 +1,6 @@
-import backend.common.data_loader as dl
 from pathlib import Path
+
+import backend.common.data_loader as dl
 
 
 def test_resolve_paths_accepts_windows_accounts_root(monkeypatch):

--- a/tests/test_review_common.py
+++ b/tests/test_review_common.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from cicaid_devtools.lib import review_common
 from cicaid_devtools.lib.verdict import is_soft_skip
 
@@ -12,9 +11,7 @@ def test_emit_empty_diff_notice_returns_success(provider) -> None:
 
 
 @pytest.mark.parametrize("provider", ["Claude", "GPT", "DeepSeek"])
-def test_emit_empty_diff_notice_parses_as_soft_skip(
-    capsys, provider
-) -> None:
+def test_emit_empty_diff_notice_parses_as_soft_skip(capsys, provider) -> None:
     """The empty-diff advisory notice must contain a soft-skip marker so
     extract_verdict.py treats it as "no review performed" rather than
     "no valid verdict found" (which the workflow's check_approval step
@@ -28,9 +25,7 @@ def test_emit_empty_diff_notice_parses_as_soft_skip(
 
 
 @pytest.mark.parametrize("provider", ["Claude", "GPT", "DeepSeek"])
-def test_genuine_request_changes_verdict_fails_workflow(
-    capsys, tmp_path, provider
-) -> None:
+def test_genuine_request_changes_verdict_fails_workflow(capsys, tmp_path, provider) -> None:
     """A real, non-empty REQUEST CHANGES review must still fail the workflow
     via the verdict module.
 
@@ -63,9 +58,7 @@ def test_genuine_request_changes_verdict_fails_workflow(
 
 
 @pytest.mark.parametrize("provider", ["Claude", "GPT", "DeepSeek"])
-def test_finalize_review_soft_skips_on_empty_review(
-    capsys, provider
-) -> None:
+def test_finalize_review_soft_skips_on_empty_review(capsys, provider) -> None:
     """Empty provider responses now soft-skip rather than hard-failing."""
     assert review_common.finalize_review("", provider) == 0
     output = capsys.readouterr().out

--- a/tests/test_run_all_tickers.py
+++ b/tests/test_run_all_tickers.py
@@ -1,5 +1,6 @@
-import pandas as pd
 from unittest.mock import patch
+
+import pandas as pd
 
 from backend.timeseries.fetch_meta_timeseries import run_all_tickers
 
@@ -40,12 +41,9 @@ def test_run_all_tickers_resolves_exchange_from_metadata():
         calls.append((sym, ex, days))
         return pd.DataFrame({"Date": [1], "Close": [2]})
 
-    with patch(
-        "backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load
-    ) as mock_load:
+    with patch("backend.timeseries.cache.load_meta_timeseries", side_effect=fake_load) as mock_load:
         out = run_all_tickers(["GSK"], days=3)
 
     assert out == ["GSK"]
     assert calls == [("GSK", "L", 3)]
     mock_load.assert_called_once()
-

--- a/tests/test_scenario_route.py
+++ b/tests/test_scenario_route.py
@@ -1,6 +1,7 @@
-from fastapi.testclient import TestClient
-from pathlib import Path
 import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.common.account_models import OwnerSummaryRecord
@@ -56,9 +57,7 @@ def test_historical_scenario_route(monkeypatch):
         total = portfolio.get("total_value_estimate_gbp") or 0.0
         return {h: {"total_value_estimate_gbp": total} for h in horizons}
 
-    monkeypatch.setattr(
-        scenario_route, "apply_historical_event", fake_apply_historical_event
-    )
+    monkeypatch.setattr(scenario_route, "apply_historical_event", fake_apply_historical_event)
     monkeypatch.setattr(
         scenario_route,
         "list_plots",
@@ -113,4 +112,3 @@ def test_events_route():
     with events_path.open() as fh:
         expected = [{"id": e["id"], "name": e["name"]} for e in json.load(fh)]
     assert data == expected
-

--- a/tests/test_scenario_tester.py
+++ b/tests/test_scenario_tester.py
@@ -1,13 +1,13 @@
 import datetime as dt
+from datetime import date
 
 import pandas as pd
 import pytest
-import backend.utils.scenario_tester as sc_tester
-from backend.utils.scenario_tester import apply_price_shock, apply_historical_returns
-from backend.utils import scenario_tester as sc
-import backend.common.prices as prices
-from datetime import date
 
+import backend.common.prices as prices
+import backend.utils.scenario_tester as sc_tester
+from backend.utils import scenario_tester as sc
+from backend.utils.scenario_tester import apply_historical_returns, apply_price_shock
 
 
 def test_price_shock_uses_cached_price_for_missing_current_price(monkeypatch):
@@ -77,7 +77,7 @@ def test_apply_historical_event_uses_proxy_for_missing(monkeypatch):
             df = idx
         else:
             return pd.DataFrame()
-        return df.loc[:pd.to_datetime(end_date)]
+        return df.loc[: pd.to_datetime(end_date)]
 
     monkeypatch.setattr(sc_tester, "load_meta_timeseries_range", fake_load)
     monkeypatch.setattr(sc_tester, "get_scaling_override", lambda *a, **k: 1.0)
@@ -90,6 +90,7 @@ def test_apply_historical_event_uses_proxy_for_missing(monkeypatch):
     assert result["ABC.L"][365] == pytest.approx(2.0)
     assert result["MISSING.L"][365] == pytest.approx(2.0)
 
+
 def test_apply_historical_event_scales_portfolio(monkeypatch):
     portfolio = {"accounts": [{"holdings": [{"ticker": "AAA.L"}]}]}
     df = pd.DataFrame(
@@ -98,7 +99,7 @@ def test_apply_historical_event_scales_portfolio(monkeypatch):
     )
 
     def fake_load(ticker, exchange, start_date, end_date):
-        return df.loc[:pd.to_datetime(end_date)]
+        return df.loc[: pd.to_datetime(end_date)]
 
     monkeypatch.setattr(sc, "load_meta_timeseries_range", fake_load)
 
@@ -111,6 +112,7 @@ def test_apply_historical_event_scales_portfolio(monkeypatch):
 
     assert returns["AAA.L"][1] == pytest.approx(-0.1)
     assert returns["AAA.L"][5] == pytest.approx(-0.2)
+
 
 def test_historical_event_falls_back_to_proxy(monkeypatch):
     portfolio = {"accounts": [{"holdings": [{"ticker": "AAA.L"}]}]}

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,9 +1,9 @@
-from datetime import UTC, datetime, timedelta, date
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 
 import backend.screener as screener_module
-from backend.screener import fetch_fundamentals, screen, Fundamentals
+from backend.screener import Fundamentals, fetch_fundamentals, screen
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_setup_env.py
+++ b/tests/test_setup_env.py
@@ -1,6 +1,7 @@
 import py_compile
 from pathlib import Path
 
+
 def test_setup_env_compiles():
     script = Path(__file__).resolve().parents[1] / "scripts" / "setup_env.py"
     py_compile.compile(str(script), doraise=True)

--- a/tests/test_stooq_rate_limit.py
+++ b/tests/test_stooq_rate_limit.py
@@ -1,11 +1,12 @@
-import pandas as pd
-import pytest
-import requests
 from datetime import date
 from types import SimpleNamespace
 
-from backend.timeseries import fetch_stooq_timeseries as fst
+import pandas as pd
+import pytest
+import requests
+
 from backend.timeseries import fetch_meta_timeseries
+from backend.timeseries import fetch_stooq_timeseries as fst
 
 
 def _csv_response():
@@ -90,20 +91,22 @@ def test_meta_timeseries_handles_stooq_rate_limit(monkeypatch):
     monkeypatch.setattr(fetch_meta_timeseries, "fetch_stooq_timeseries_range", raise_limit)
 
     def fake_ft(ticker, days):
-        return pd.DataFrame({
-            "Date": [date(2024, 1, 1)],
-            "Open": [1.0],
-            "High": [1.0],
-            "Low": [1.0],
-            "Close": [1.0],
-            "Volume": [0],
-            "Ticker": [ticker],
-            "Source": ["FT"],
-        })
+        return pd.DataFrame(
+            {
+                "Date": [date(2024, 1, 1)],
+                "Open": [1.0],
+                "High": [1.0],
+                "Low": [1.0],
+                "Close": [1.0],
+                "Volume": [0],
+                "Ticker": [ticker],
+                "Source": ["FT"],
+            }
+        )
 
     monkeypatch.setattr(fetch_meta_timeseries, "fetch_ft_timeseries", fake_ft)
 
-    df = fetch_meta_timeseries.fetch_meta_timeseries("AAA", "L", start_date=date(2024,1,1), end_date=date(2024,1,2))
+    df = fetch_meta_timeseries.fetch_meta_timeseries("AAA", "L", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2))
     assert not df.empty
     assert df["Source"].iloc[0] == "FT"
 
@@ -118,8 +121,6 @@ def test_stooq_timeout_returns_empty(monkeypatch, caplog):
 
     monkeypatch.setattr(fst.requests, "get", timeout_get)
     with caplog.at_level("WARNING"):
-        df = fst.fetch_stooq_timeseries_range(
-            "AAA", "L", date(2024, 1, 1), date(2024, 1, 2)
-        )
+        df = fst.fetch_stooq_timeseries_range("AAA", "L", date(2024, 1, 1), date(2024, 1, 2))
     assert df.empty
     assert "timed out" in caplog.text.lower()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -47,9 +47,7 @@ def test_get_storage_unknown_scheme():
 
 
 def _client_error(operation):
-    return ClientError(
-        {"Error": {"Code": "TestException", "Message": "boom"}}, operation
-    )
+    return ClientError({"Error": {"Code": "TestException", "Message": "boom"}}, operation)
 
 
 def test_s3_load_client_error(monkeypatch):

--- a/tests/test_support_route.py
+++ b/tests/test_support_route.py
@@ -60,9 +60,7 @@ def test_portfolio_health_empty_cache(monkeypatch):
     assert resp.status_code == 200
     payload = resp.json()
     assert payload["status"] == "ok"
-    assert payload["findings"] == [
-        {"type": "owner", "message": "Owner foo max drawdown unavailable"}
-    ]
+    assert payload["findings"] == [{"type": "owner", "message": "Owner foo max drawdown unavailable"}]
     generated = datetime.fromisoformat(payload["generated_at"])
     assert isinstance(generated, datetime)
     assert "stale" not in payload

--- a/tests/test_tax_route.py
+++ b/tests/test_tax_route.py
@@ -12,6 +12,7 @@ def test_tax_harvest_route(monkeypatch):
         lambda positions, threshold: dummy_trades,
     )
     from backend.app import create_app
+
     app = create_app()
     with TestClient(app) as client:
         resp = client.post(
@@ -30,10 +31,9 @@ def test_tax_allowances_route(monkeypatch):
     monkeypatch.setattr(config, "disable_auth", True)
     monkeypatch.setattr("backend.routes.tax.current_tax_year", lambda: 2024)
     allowances = {"isa": {"limit": 20000, "used": 5000, "remaining": 15000}}
-    monkeypatch.setattr(
-        "backend.routes.tax.remaining_allowances", lambda owner, ty: allowances
-    )
+    monkeypatch.setattr("backend.routes.tax.remaining_allowances", lambda owner, ty: allowances)
     from backend.app import create_app
+
     app = create_app()
     with TestClient(app) as client:
         resp = client.get("/tax/allowances")
@@ -65,6 +65,7 @@ def test_tax_allowances_route_with_auth(monkeypatch):
     )
 
     from backend.app import create_app
+
     app = create_app()
     # Override get_current_user so the auth path returns "alice" without a real token
     app.dependency_overrides[auth_module.get_current_user] = lambda: "alice"

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -295,9 +295,7 @@ def test_invalid_retry_after(monkeypatch):
 
     responses = iter(
         [
-            SimpleNamespace(
-                status_code=429, headers={"Retry-After": "bad"}, raise_for_status=lambda: None
-            ),
+            SimpleNamespace(status_code=429, headers={"Retry-After": "bad"}, raise_for_status=lambda: None),
             SimpleNamespace(status_code=200, headers={}, raise_for_status=lambda: None),
         ]
     )

--- a/tests/test_timeseries_admin_auth.py
+++ b/tests/test_timeseries_admin_auth.py
@@ -1,9 +1,8 @@
 from pathlib import Path
-from importlib import reload
 
 import pytest
-from pytest import MonkeyPatch
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 
 import backend.config as config
 from backend.app import create_app

--- a/tests/test_timeseries_api.py
+++ b/tests/test_timeseries_api.py
@@ -1,9 +1,9 @@
-import pandas as pd
-import pytest
-from fastapi.testclient import TestClient
 from types import SimpleNamespace
 
+import pandas as pd
 import yfinance as yf
+from fastapi.testclient import TestClient
+
 from backend.app import create_app
 from backend.config import config
 
@@ -28,6 +28,7 @@ def _client(monkeypatch, history_result):
     app = create_app()
     # Ensure timeseries API router is available
     from backend.timeseries.timeseries_api import router as ts_router
+
     app.include_router(ts_router)
     return TestClient(app)
 

--- a/tests/test_timeseries_cache_base.py
+++ b/tests/test_timeseries_cache_base.py
@@ -252,9 +252,7 @@ def test_s3_head_object_registers_miss_on_404(monkeypatch):
 
     class FakeS3:
         def head_object(self, *, Bucket, Key):
-            raise cache.ClientError(
-                {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
-            )
+            raise cache.ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
 
     patch_s3_client(monkeypatch, cache, FakeS3())
 
@@ -270,9 +268,7 @@ def test_s3_head_object_non_404_client_error_does_not_register_miss(monkeypatch,
 
     class FakeS3:
         def head_object(self, *, Bucket, Key):
-            raise cache.ClientError(
-                {"Error": {"Code": "AccessDenied", "Message": "Denied"}}, "HeadObject"
-            )
+            raise cache.ClientError({"Error": {"Code": "AccessDenied", "Message": "Denied"}}, "HeadObject")
 
     patch_s3_client(monkeypatch, cache, FakeS3())
 
@@ -292,9 +288,7 @@ def test_s3_head_object_respects_log_as_error_override(monkeypatch, caplog):
 
     class FakeS3:
         def head_object(self, *, Bucket, Key):
-            raise cache.ClientError(
-                {"Error": {"Code": "AccessDenied", "Message": "Denied"}}, "HeadObject"
-            )
+            raise cache.ClientError({"Error": {"Code": "AccessDenied", "Message": "Denied"}}, "HeadObject")
 
     patch_s3_client(monkeypatch, cache, FakeS3())
 

--- a/tests/test_timeseries_cache_merge.py
+++ b/tests/test_timeseries_cache_merge.py
@@ -15,9 +15,7 @@ def import_cache():
     return importlib.import_module("backend.timeseries.cache")
 
 
-def _seed_existing_parquet(
-    cache, cache_path: str, days: int, *, include_window_end: bool = False
-) -> pd.DataFrame:
+def _seed_existing_parquet(cache, cache_path: str, days: int, *, include_window_end: bool = False) -> pd.DataFrame:
     """Populate ``cache_path`` with deterministic sample data and return expected slice."""
 
     base_today = datetime.today().date()
@@ -86,7 +84,6 @@ def test_merge_skips_empty_frames(monkeypatch, tmp_path):
     assert result["Volume"].iloc[0] == 100
 
 
-
 def test_ensure_schema_missing_date(caplog):
     """Missing Date column should return empty frame with schema and log warning."""
     cache = import_cache()
@@ -139,9 +136,9 @@ def test_ensure_schema_normalises_date_to_ms(date_input, input_id):
         }
     )
     result = cache._ensure_schema(df)
-    assert result["Date"].dtype == "datetime64[ms]", (
-        f"input_id={input_id}: expected datetime64[ms], got {result['Date'].dtype}"
-    )
+    assert (
+        result["Date"].dtype == "datetime64[ms]"
+    ), f"input_id={input_id}: expected datetime64[ms], got {result['Date'].dtype}"
 
 
 def test_rolling_cache_serves_cached_slice_on_fetch_failure(monkeypatch, tmp_path):

--- a/tests/test_timeseries_edit_route.py
+++ b/tests/test_timeseries_edit_route.py
@@ -43,7 +43,6 @@ def test_timeseries_edit_roundtrip(tmp_path, monkeypatch):
     assert returned[0]["Source"] == "Manual"
 
 
-
 def test_timeseries_edit_invalid_json_logs_validation_failure(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(config, "skip_snapshot_warm", True)
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))

--- a/tests/test_timeseries_helpers.py
+++ b/tests/test_timeseries_helpers.py
@@ -41,10 +41,7 @@ def test_apply_scaling_noop(scale):
 
 
 def test_get_scaling_override_prefers_requested(tmp_path, monkeypatch):
-    assert (
-        th.get_scaling_override("ABC.L", "L", requested_scaling=3.0)
-        == 3.0
-    )
+    assert th.get_scaling_override("ABC.L", "L", requested_scaling=3.0) == 3.0
 
 
 def test_get_scaling_override_reads_override_file(tmp_path, monkeypatch):
@@ -63,8 +60,7 @@ def test_get_scaling_override_reads_override_file(tmp_path, monkeypatch):
 def test_get_scaling_override_currency_detection(monkeypatch):
     monkeypatch.setattr(th.config, "repo_root", Path("/nonexistent"))
 
-    from backend.common import instruments
-    from backend.common import portfolio_utils
+    from backend.common import instruments, portfolio_utils
 
     monkeypatch.setattr(instruments, "get_instrument_meta", lambda ticker: {"currency": "GBp"})
     monkeypatch.setattr(
@@ -81,8 +77,7 @@ def test_get_scaling_override_currency_detection(monkeypatch):
 def test_get_scaling_override_falls_back_to_security_meta(monkeypatch):
     monkeypatch.setattr(th.config, "repo_root", Path("/nonexistent"))
 
-    from backend.common import instruments
-    from backend.common import portfolio_utils
+    from backend.common import instruments, portfolio_utils
 
     monkeypatch.setattr(instruments, "get_instrument_meta", lambda ticker: {})
     monkeypatch.setattr(
@@ -99,16 +94,14 @@ def test_get_scaling_override_falls_back_to_security_meta(monkeypatch):
 def test_handle_timeseries_response_empty_df():
     df = pd.DataFrame()
 
-    response = th.handle_timeseries_response(
-        df, format="html", title="Title", subtitle="Sub"
-    )
+    response = th.handle_timeseries_response(df, format="html", title="Title", subtitle="Sub")
 
     assert response.status_code == 404
     assert response.body == b"<h1>No data found</h1>"
 
 
 def test_handle_timeseries_response_json_includes_metadata():
-    df = pd.DataFrame([{ "Close": 10 }])
+    df = pd.DataFrame([{"Close": 10}])
 
     response = th.handle_timeseries_response(
         df,
@@ -124,14 +117,14 @@ def test_handle_timeseries_response_json_includes_metadata():
 
 
 def test_handle_timeseries_response_csv(tmp_path):
-    df = pd.DataFrame([
-        {"Date": "2024-01-01", "Close": 10},
-        {"Date": "2024-01-02", "Close": 11},
-    ])
-
-    response = th.handle_timeseries_response(
-        df, format="csv", title="Title", subtitle="Sub"
+    df = pd.DataFrame(
+        [
+            {"Date": "2024-01-01", "Close": 10},
+            {"Date": "2024-01-02", "Close": 11},
+        ]
     )
+
+    response = th.handle_timeseries_response(df, format="csv", title="Title", subtitle="Sub")
 
     assert response.media_type == "text/csv"
     assert "Date,Close" in response.body.decode()
@@ -144,11 +137,9 @@ def test_handle_timeseries_response_html(monkeypatch):
         "render_timeseries_html",
         lambda df, title, subtitle: marker,
     )
-    df = pd.DataFrame([{ "Close": 10 }])
+    df = pd.DataFrame([{"Close": 10}])
 
-    response = th.handle_timeseries_response(
-        df, format="htmlish", title="Title", subtitle="Sub"
-    )
+    response = th.handle_timeseries_response(df, format="htmlish", title="Title", subtitle="Sub")
 
     assert response is marker
 
@@ -156,9 +147,9 @@ def test_handle_timeseries_response_html(monkeypatch):
 @pytest.mark.parametrize(
     "input_date, forward, expected",
     [
-        (date(2024, 1, 6), True, date(2024, 1, 8)),   # Saturday -> Monday
+        (date(2024, 1, 6), True, date(2024, 1, 8)),  # Saturday -> Monday
         (date(2024, 1, 7), False, date(2024, 1, 5)),  # Sunday -> Friday
-        (date(2024, 1, 8), True, date(2024, 1, 8)),   # Weekday unchanged
+        (date(2024, 1, 8), True, date(2024, 1, 8)),  # Weekday unchanged
     ],
 )
 def test_nearest_weekday(input_date, forward, expected):

--- a/tests/test_timeseries_meta_route.py
+++ b/tests/test_timeseries_meta_route.py
@@ -13,6 +13,7 @@ def _make_client(monkeypatch, tmp_path, df):
     monkeypatch.setenv("TIMESERIES_CACHE_BASE", str(tmp_path))
     monkeypatch.setattr("backend.timeseries.cache.load_meta_timeseries_range", fake_load)
     import backend.routes.timeseries_meta as ts_meta
+
     monkeypatch.setattr(ts_meta, "load_meta_timeseries_range", fake_load)
     from backend.app import create_app
 
@@ -88,9 +89,7 @@ def test_timeseries_meta_bad_request(monkeypatch, tmp_path):
 )
 def test_timeseries_meta_xss_payload_rejected(params, monkeypatch, tmp_path):
     """XSS payloads in ticker/exchange are rejected; never reflected verbatim (CodeQL #276)."""
-    df = pd.DataFrame(
-        [{"Date": "2024-01-01", "Open": 1.0, "High": 2.0, "Low": 0.5, "Close": 1.5, "Volume": 100}]
-    )
+    df = pd.DataFrame([{"Date": "2024-01-01", "Open": 1.0, "High": 2.0, "Low": 0.5, "Close": 1.5, "Volume": 100}])
     client = _make_client(monkeypatch, tmp_path, df)
     resp = client.get("/timeseries/meta", params=params)
     assert resp.status_code == 400
@@ -108,9 +107,7 @@ def test_timeseries_meta_xss_payload_rejected(params, monkeypatch, tmp_path):
 )
 def test_timeseries_meta_valid_exchange_codes(ticker, exchange, monkeypatch, tmp_path):
     """Valid exchange codes including those with dots are accepted (dot-in-exchange regression)."""
-    df = pd.DataFrame(
-        [{"Date": "2024-01-01", "Open": 1.0, "High": 2.0, "Low": 0.5, "Close": 1.5, "Volume": 100}]
-    )
+    df = pd.DataFrame([{"Date": "2024-01-01", "Open": 1.0, "High": 2.0, "Low": 0.5, "Close": 1.5, "Volume": 100}])
     client = _make_client(monkeypatch, tmp_path, df)
     resp = client.get(
         "/timeseries/meta",

--- a/tests/test_trade_approvals.py
+++ b/tests/test_trade_approvals.py
@@ -5,7 +5,6 @@ from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.common.approvals import load_approvals, save_approvals
-
 from backend.common.compliance import check_owner
 from backend.common.holding_utils import enrich_holding
 from backend.config import config
@@ -51,9 +50,7 @@ def test_enrich_holding_weekend_anniversary(monkeypatch):
         lambda *a, **k: (1.0, None),
     )
     calc = PricingDateCalculator(today=today)
-    expected_next_date = calc.resolve_weekday(
-        acq_date + timedelta(days=config.hold_days_min), forward=True
-    )
+    expected_next_date = calc.resolve_weekday(acq_date + timedelta(days=config.hold_days_min), forward=True)
 
     out = enrich_holding(holding, today, {}, {})
     assert out["sell_eligible"] is False
@@ -134,9 +131,7 @@ def test_approvals_endpoints(tmp_path):
         data = resp.json()
         assert data["approvals"][0]["ticker"] == "ADM.L"
 
-        resp = client.request(
-            "DELETE", "/accounts/bob/approvals", json={"ticker": "ADM.L"}
-        )
+        resp = client.request("DELETE", "/accounts/bob/approvals", json={"ticker": "ADM.L"})
         assert resp.status_code == 200
         assert resp.json() == {"approvals": []}
     finally:

--- a/tests/test_trades_task.py
+++ b/tests/test_trades_task.py
@@ -38,9 +38,7 @@ def test_lambda_handler_saves_and_alerts(monkeypatch, tmp_path):
 
     result = trades.lambda_handler({"owner": "bob"}, None)
     assert result == {"count": 2}
-    assert alerts == [
-        {"ticker": "IMPORT", "change_pct": 0.0, "message": "Imported 2 trades for bob"}
-    ]
+    assert alerts == [{"ticker": "IMPORT", "change_pct": 0.0, "message": "Imported 2 trades for bob"}]
 
     csv_path = tmp_path / "bob" / "trades.csv"
     with csv_path.open() as f:

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -1,9 +1,10 @@
 import json
-import pytest
 import shutil
-from backend.common import portfolio_utils
-from backend.agent.trading_agent import send_trade_alert, run, generate_signals as ta_generate_signals
+
 from backend.agent import trading_agent
+from backend.agent.trading_agent import generate_signals as ta_generate_signals
+from backend.agent.trading_agent import run, send_trade_alert
+from backend.common import portfolio_utils
 
 # Alias to match the terminology of "generate_signals"
 generate_signals = portfolio_utils.check_price_alerts
@@ -37,11 +38,7 @@ def test_generate_signals_buy_sell_actions(monkeypatch):
 
 def test_generate_signals_emits_alerts(monkeypatch):
     snapshot = {"AAA.L": {"last_price": 110.0}}
-    portfolio = {
-        "accounts": [
-            {"holdings": [{"ticker": "AAA", "units": 1, "cost_gbp": 100}]}
-        ]
-    }
+    portfolio = {"accounts": [{"holdings": [{"ticker": "AAA", "units": 1, "cost_gbp": 100}]}]}
     monkeypatch.setattr(portfolio_utils, "_PRICE_SNAPSHOT", snapshot)
     monkeypatch.setattr(portfolio_utils, "list_portfolios", lambda: [portfolio])
 
@@ -112,12 +109,8 @@ def test_send_trade_alert_with_telegram(monkeypatch):
     published = {}
     telegram_msgs = []
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", lambda alert: published.update(alert)
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg)
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", lambda alert: published.update(alert))
+    monkeypatch.setattr("backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg))
     monkeypatch.setattr(trading_agent.config, "telegram_bot_token", "T")
     monkeypatch.setattr(trading_agent.config, "telegram_chat_id", "C")
 
@@ -134,12 +127,8 @@ def test_send_trade_alert_no_publish_with_telegram(monkeypatch):
     def fake_publish(alert):
         published["called"] = True
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", fake_publish
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg)
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", fake_publish)
+    monkeypatch.setattr("backend.agent.trading_agent.send_message", lambda msg: telegram_msgs.append(msg))
     monkeypatch.setattr(trading_agent.config, "telegram_bot_token", "T")
     monkeypatch.setattr(trading_agent.config, "telegram_chat_id", "C")
 
@@ -172,12 +161,8 @@ def test_run_defaults_to_all_known_tickers(monkeypatch):
         "backend.agent.trading_agent.prices.load_prices_for_tickers",
         fake_load_prices,
     )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", lambda alert: None
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.list_portfolios", lambda: [{"owner": "alice"}]
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", lambda alert: None)
+    monkeypatch.setattr("backend.agent.trading_agent.list_portfolios", lambda: [{"owner": "alice"}])
     monkeypatch.setattr(
         "backend.agent.trading_agent.compliance.check_trade",
         lambda trade: {"owner": trade.get("owner"), "warnings": []},
@@ -190,9 +175,7 @@ def test_run_defaults_to_all_known_tickers(monkeypatch):
 
 def test_run_sends_telegram_when_not_aws(monkeypatch):
     # Trigger a BUY signal for ticker AAA
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.list_all_unique_tickers", lambda: ["AAA"]
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.list_all_unique_tickers", lambda: ["AAA"])
 
     def fake_load_prices(tickers, days=60):
         import pandas as pd
@@ -200,24 +183,16 @@ def test_run_sends_telegram_when_not_aws(monkeypatch):
         data = {"Ticker": ["AAA"] * 7, "close": [1, 1, 1, 1, 1, 1, 2]}
         return pd.DataFrame(data)
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.prices.load_prices_for_tickers", fake_load_prices
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", lambda alert: None
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.list_portfolios", lambda: [{"owner": "alice"}]
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.prices.load_prices_for_tickers", fake_load_prices)
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", lambda alert: None)
+    monkeypatch.setattr("backend.agent.trading_agent.list_portfolios", lambda: [{"owner": "alice"}])
     monkeypatch.setattr(
         "backend.agent.trading_agent.compliance.check_trade",
         lambda trade: {"owner": trade.get("owner"), "warnings": []},
     )
 
     sent: list[str] = []
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.send_message", lambda msg: sent.append(msg)
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.send_message", lambda msg: sent.append(msg))
     monkeypatch.setattr(trading_agent.config, "telegram_bot_token", "T")
     monkeypatch.setattr(trading_agent.config, "telegram_chat_id", "C")
     monkeypatch.setattr(trading_agent.config, "app_env", "local")
@@ -228,9 +203,7 @@ def test_run_sends_telegram_when_not_aws(monkeypatch):
 
 
 def test_run_compliance_gates_actions(monkeypatch):
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.list_all_unique_tickers", lambda: ["AAA"]
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.list_all_unique_tickers", lambda: ["AAA"])
 
     def fake_load_prices(tickers, days=60):
         import pandas as pd
@@ -238,24 +211,16 @@ def test_run_compliance_gates_actions(monkeypatch):
         data = {"Ticker": ["AAA"] * 7, "close": [1, 1, 1, 1, 1, 1, 2]}
         return pd.DataFrame(data)
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.prices.load_prices_for_tickers", fake_load_prices
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.list_portfolios", lambda: [{"owner": "alice"}]
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.prices.load_prices_for_tickers", fake_load_prices)
+    monkeypatch.setattr("backend.agent.trading_agent.list_portfolios", lambda: [{"owner": "alice"}])
 
     def fake_check(trade):
         return {"owner": trade["owner"], "warnings": ["blocked"]}
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.compliance.check_trade", fake_check
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.compliance.check_trade", fake_check)
 
     published: list = []
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", lambda alert: published.append(alert)
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", lambda alert: published.append(alert))
 
     signals = run()
 
@@ -264,9 +229,7 @@ def test_run_compliance_gates_actions(monkeypatch):
 
 
 def test_run_skips_signal_when_compliance_blocks(monkeypatch):
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.list_all_unique_tickers", lambda: ["AAA", "BBB"]
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.list_all_unique_tickers", lambda: ["AAA", "BBB"])
 
     def fake_load_prices(tickers, days=60):
         import pandas as pd
@@ -277,12 +240,8 @@ def test_run_skips_signal_when_compliance_blocks(monkeypatch):
         }
         return pd.DataFrame(data)
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.prices.load_prices_for_tickers", fake_load_prices
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.list_portfolios", lambda: [{"owner": "alice"}]
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.prices.load_prices_for_tickers", fake_load_prices)
+    monkeypatch.setattr("backend.agent.trading_agent.list_portfolios", lambda: [{"owner": "alice"}])
 
     calls: list[str] = []
 
@@ -293,20 +252,12 @@ def test_run_skips_signal_when_compliance_blocks(monkeypatch):
             return {"owner": owner, "warnings": []}
         return {"owner": owner, "warnings": ["limit"]}
 
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.compliance.check_trade", fake_check
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.compliance.check_trade", fake_check)
 
     published: list = []
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.publish_alert", lambda alert: published.append(alert)
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.send_message", lambda msg: None
-    )
-    monkeypatch.setattr(
-        "backend.agent.trading_agent._log_trade", lambda *a, **k: None
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.publish_alert", lambda alert: published.append(alert))
+    monkeypatch.setattr("backend.agent.trading_agent.send_message", lambda msg: None)
+    monkeypatch.setattr("backend.agent.trading_agent._log_trade", lambda *a, **k: None)
 
     signals = run()
 
@@ -339,8 +290,7 @@ def test_run_uses_rsi_and_fundamentals(monkeypatch):
 
         data = {
             "Ticker": ["AAA"] * 15 + ["BBB"] * 5,
-            "close": [15, 14, 13, 12, 11, 10, 9, 8, 5, 5, 5, 5, 5, 5, 5]
-            + [10, 11, 12, 13, 14],
+            "close": [15, 14, 13, 12, 11, 10, 9, 8, 5, 5, 5, 5, 5, 5, 5] + [10, 11, 12, 13, 14],
         }
         return pd.DataFrame(data)
 
@@ -476,5 +426,3 @@ def test_alert_on_drawdown_handles_value_error(monkeypatch):
     trading_agent._alert_on_drawdown()
 
     assert alerts == []
-
-

--- a/tests/test_trading_agent_errors.py
+++ b/tests/test_trading_agent_errors.py
@@ -1,7 +1,4 @@
 import pandas as pd
-import pytest
-
-import pandas as pd
 
 from backend.agent import trading_agent
 

--- a/tests/test_trading_agent_route.py
+++ b/tests/test_trading_agent_route.py
@@ -1,10 +1,10 @@
-from fastapi.testclient import TestClient
-
-from backend.app import create_app
-import backend.routes.trading_agent as ta
 import asyncio
 import logging
-import pytest
+
+from fastapi.testclient import TestClient
+
+import backend.routes.trading_agent as ta
+from backend.app import create_app
 
 
 def test_trading_agent_signals_route(monkeypatch):
@@ -18,9 +18,7 @@ def test_trading_agent_signals_route(monkeypatch):
             "ignored": True,
         }
     ]
-    monkeypatch.setattr(
-        "backend.agent.trading_agent.run", lambda **_: fake_signals
-    )
+    monkeypatch.setattr("backend.agent.trading_agent.run", lambda **_: fake_signals)
     app = create_app()
     with TestClient(app) as client:
         token = client.post("/token", json={"id_token": "good"}).json()["access_token"]

--- a/tests/test_trail_route.py
+++ b/tests/test_trail_route.py
@@ -1,7 +1,5 @@
-import importlib
 import asyncio
-
-import pytest
+import importlib
 
 from backend.routes import trail as trail_module
 
@@ -47,6 +45,7 @@ def test_complete_task_authenticated_preserves_full_response(monkeypatch):
     result = asyncio.run(trail_module.complete_task("t4", current_user="alice"))
     assert result is payload
 
+
 def test_complete_task_demo_passthrough(monkeypatch):
     monkeypatch.setattr(trail_module.config, "disable_auth", True)
     importlib.reload(trail_module)
@@ -64,7 +63,6 @@ def test_complete_task_authenticated_passthrough(monkeypatch):
 
     payload = {"tasks": ["exists"], "streak": 5}
     monkeypatch.setattr(trail_module.trail, "mark_complete", lambda user, tid: payload)
-
 
     result = asyncio.run(trail_module.complete_task("t4", current_user="alice"))
     assert result is payload

--- a/tests/test_transaction_post_updates_portfolio.py
+++ b/tests/test_transaction_post_updates_portfolio.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/test_transactions_round_trip.py
+++ b/tests/test_transactions_round_trip.py
@@ -1,6 +1,7 @@
 import json
-from fastapi.testclient import TestClient
+
 import pytest
+from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.config import config

--- a/tests/test_transactions_route.py
+++ b/tests/test_transactions_route.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
-from backend.common.accounts_store import LocalAccountsStore, WRITABLE_ACCOUNTS_PREFIX
+from backend.common.accounts_store import WRITABLE_ACCOUNTS_PREFIX, LocalAccountsStore
 from backend.config import config
 from backend.routes import transactions
 
@@ -667,9 +667,7 @@ def test_create_manual_holding_updates_existing_ticker_in_account(tmp_path, monk
     assert saved["holdings"] == [{"ticker": "VUSA.L", "units": 3.0, "price": 100.0}]
 
 
-def test_create_manual_holding_with_value_takes_precedence_over_units_and_price(
-    tmp_path, monkeypatch
-):
+def test_create_manual_holding_with_value_takes_precedence_over_units_and_price(tmp_path, monkeypatch):
     client = _make_client(tmp_path, monkeypatch)
     payload = {
         "owner": "alice",
@@ -946,9 +944,7 @@ class _FakeS3Client:
             raise FileNotFoundError(Key)
         return {"Body": _FakeStreamingBody(self._objects[key])}
 
-    def list_objects_v2(
-        self, Bucket: str, Prefix: str, ContinuationToken: str | None = None, **kwargs: object
-    ) -> dict:
+    def list_objects_v2(self, Bucket: str, Prefix: str, ContinuationToken: str | None = None, **kwargs: object) -> dict:
         contents: list[dict[str, str]] = []
         for (b, k), _ in self._objects.items():
             if b == Bucket and k.startswith(Prefix):
@@ -1007,19 +1003,11 @@ def test_post_manual_holding_s3_aws_returns_2xx_and_writes_to_writable_prefix(
 
     # ── assert: object written under writable prefix ─────────────
     writable_key = f"{WRITABLE_ACCOUNTS_PREFIX}/alice/isa.json"
-    assert fake_s3._has_key("fake-bucket", writable_key), (
-        f"Expected s3://fake-bucket/{writable_key} to exist"
-    )
+    assert fake_s3._has_key("fake-bucket", writable_key), f"Expected s3://fake-bucket/{writable_key} to exist"
 
     # ── assert: global accounts/ prefix is untouched ─────────────
-    global_keys = sum(
-        1
-        for (b, k) in fake_s3._objects
-        if b == "fake-bucket" and k.startswith("accounts/")
-    )
-    assert global_keys == 0, (
-        f"Global accounts/ prefix must be untouched, found {global_keys} keys"
-    )
+    global_keys = sum(1 for (b, k) in fake_s3._objects if b == "fake-bucket" and k.startswith("accounts/"))
+    assert global_keys == 0, f"Global accounts/ prefix must be untouched, found {global_keys} keys"
 
 
 def test_get_manual_holdings_s3_aws_returns_created_holding(

--- a/tests/test_var_route.py
+++ b/tests/test_var_route.py
@@ -2,9 +2,9 @@ import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.app import create_app
 from backend.common import portfolio as portfolio_mod
 from backend.common import portfolio_utils
-from backend.app import create_app
 
 
 def _auth_client():

--- a/tests/test_weekly_report_email.py
+++ b/tests/test_weekly_report_email.py
@@ -1,5 +1,3 @@
-import pytest
-
 from backend.emails import weekly_report
 
 

--- a/tests/timeseries/test_fetch_alphavantage_timeseries.py
+++ b/tests/timeseries/test_fetch_alphavantage_timeseries.py
@@ -73,9 +73,7 @@ def test_fetch_range_http_rate_limit(monkeypatch):
 
     monkeypatch.setattr(av.requests, "get", fake_get)
     with pytest.raises(AlphaVantageRateLimitError) as exc:
-        fetch_alphavantage_timeseries_range(
-            "AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo"
-        )
+        fetch_alphavantage_timeseries_range("AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo")
     assert exc.value.retry_after == 11
 
 
@@ -87,9 +85,7 @@ def test_fetch_range_missing_timeseries(monkeypatch):
 
     monkeypatch.setattr(av.requests, "get", fake_get)
     with pytest.raises(ValueError) as exc:
-        fetch_alphavantage_timeseries_range(
-            "AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo"
-        )
+        fetch_alphavantage_timeseries_range("AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo")
     assert "Unexpected response" in str(exc.value)
 
 
@@ -101,9 +97,7 @@ def test_fetch_range_note_rate_limit(monkeypatch):
 
     monkeypatch.setattr(av.requests, "get", fake_get)
     with pytest.raises(AlphaVantageRateLimitError) as exc:
-        fetch_alphavantage_timeseries_range(
-            "AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo"
-        )
+        fetch_alphavantage_timeseries_range("AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo")
     assert exc.value.retry_after == 60
 
 
@@ -131,9 +125,7 @@ def test_fetch_range_success(monkeypatch):
 
     monkeypatch.setattr(av.requests, "get", lambda *a, **k: FakeResp(payload=payload))
 
-    df = fetch_alphavantage_timeseries_range(
-        "AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo"
-    )
+    df = fetch_alphavantage_timeseries_range("AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo")
     assert not df.empty
     assert list(df.columns) == [
         "Date",
@@ -152,9 +144,7 @@ def test_fetch_range_invalid_ticker(monkeypatch):
     monkeypatch.setattr(av, "is_valid_ticker", lambda *a, **k: False)
     monkeypatch.setattr(av, "record_skipped_ticker", lambda *a, **k: None)
 
-    df = fetch_alphavantage_timeseries_range(
-        "BAD", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo"
-    )
+    df = fetch_alphavantage_timeseries_range("BAD", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo")
     assert df.empty
 
 
@@ -162,9 +152,7 @@ def test_fetch_range_disabled(monkeypatch):
     _patch_validation(monkeypatch)
     monkeypatch.setattr(av.config, "alpha_vantage_enabled", False)
 
-    df = fetch_alphavantage_timeseries_range(
-        "AAA", "US", date(2024, 1, 1), date(2024, 1, 2)
-    )
+    df = fetch_alphavantage_timeseries_range("AAA", "US", date(2024, 1, 1), date(2024, 1, 2))
     assert df.empty
 
 
@@ -186,6 +174,4 @@ def test_fetch_range_rejects_private_base_url(monkeypatch, bad_url: str) -> None
     _patch_validation(monkeypatch)
     monkeypatch.setattr(av, "BASE_URL", bad_url)
     with pytest.raises(InvalidExternalURLError):
-        fetch_alphavantage_timeseries_range(
-            "AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo"
-        )
+        fetch_alphavantage_timeseries_range("AAA", "US", date(2024, 1, 1), date(2024, 1, 2), api_key="demo")

--- a/tests/timeseries/test_fetch_ft_timeseries.py
+++ b/tests/timeseries/test_fetch_ft_timeseries.py
@@ -72,13 +72,9 @@ def test_fetch_ft_timeseries_range_cookie_banner(monkeypatch):
         def until(self, condition):
             return True
 
-    monkeypatch.setattr(
-        "backend.timeseries.fetch_ft_timeseries.webdriver.Chrome", lambda *a, **k: driver
-    )
+    monkeypatch.setattr("backend.timeseries.fetch_ft_timeseries.webdriver.Chrome", lambda *a, **k: driver)
     monkeypatch.setattr("backend.timeseries.fetch_ft_timeseries.WebDriverWait", FakeWait)
-    monkeypatch.setattr(
-        "backend.timeseries.fetch_ft_timeseries.time.sleep", lambda *a, **k: None
-    )
+    monkeypatch.setattr("backend.timeseries.fetch_ft_timeseries.time.sleep", lambda *a, **k: None)
 
     df = fetch_ft_timeseries_range("TEST:GBP", date(2024, 1, 1), date(2024, 1, 2))
 
@@ -112,9 +108,7 @@ def test_fetch_ft_timeseries_range_find_element_failure(monkeypatch):
         def until(self, condition):
             return True
 
-    monkeypatch.setattr(
-        "backend.timeseries.fetch_ft_timeseries.webdriver.Chrome", lambda *a, **k: driver
-    )
+    monkeypatch.setattr("backend.timeseries.fetch_ft_timeseries.webdriver.Chrome", lambda *a, **k: driver)
     monkeypatch.setattr("backend.timeseries.fetch_ft_timeseries.WebDriverWait", FakeWait)
 
     df = fetch_ft_timeseries_range("TEST:GBP", date(2024, 1, 1), date(2024, 1, 2))
@@ -127,4 +121,3 @@ def test_fetch_ft_timeseries_range_find_element_failure(monkeypatch):
 def test_fetch_ft_timeseries_non_isin_returns_empty_df():
     df = fetch_ft_timeseries("PFE")
     assert df.empty
-

--- a/tests/timeseries/test_fetch_meta_timeseries.py
+++ b/tests/timeseries/test_fetch_meta_timeseries.py
@@ -14,8 +14,6 @@ from backend.timeseries.fetch_meta_timeseries import (
     _metadata_entry_exists_in_directory,
     _resolve_cache_exchange,
     _resolve_loader_exchange,
-    _resolve_ticker_exchange,
-    _metadata_entry_exists,
     _sanitize_metadata_symbol,
     fetch_meta_timeseries,
 )
@@ -158,9 +156,7 @@ def test_resolve_symbol_exchange_details(
     monkeypatch.setattr(meta, "_resolve_exchange_from_metadata", _fake_resolve)
 
     with caplog.at_level("DEBUG"):
-        symbol, resolved_exchange, metadata_exchange = meta._resolve_symbol_exchange_details(
-            ticker, exchange_arg
-        )
+        symbol, resolved_exchange, metadata_exchange = meta._resolve_symbol_exchange_details(ticker, exchange_arg)
 
     base_symbol = re.split(r"[._]", ticker, 1)[0]
     assert captured_symbols == [base_symbol]
@@ -194,10 +190,7 @@ def test_resolve_ticker_exchange_precedence():
     ],
 )
 def test_resolve_loader_exchange(ticker, exchange_arg, resolved_exchange, expected):
-    assert (
-        _resolve_loader_exchange(ticker, exchange_arg, ticker.split(".")[0], resolved_exchange)
-        == expected
-    )
+    assert _resolve_loader_exchange(ticker, exchange_arg, ticker.split(".")[0], resolved_exchange) == expected
 
 
 def test_metadata_entry_exists_requires_symbol_and_exchange(tmp_path):
@@ -246,9 +239,7 @@ def test_metadata_entry_exists_skips_problem_directories(tmp_path, monkeypatch):
         pytest.param("ABC", "", "Q", "", "", id="resolved_without_sources"),
     ],
 )
-def test_resolve_cache_exchange(
-    ticker, exchange_arg, resolved_exchange, metadata_exchange, expected, caplog
-):
+def test_resolve_cache_exchange(ticker, exchange_arg, resolved_exchange, metadata_exchange, expected, caplog):
     with caplog.at_level("DEBUG"):
         result = _resolve_cache_exchange(
             ticker,
@@ -322,9 +313,11 @@ def test_coverage_ratio_partial_and_empty():
 def test_fetch_meta_timeseries_invalid_ticker():
     import backend.timeseries.fetch_meta_timeseries as meta
 
-    with patch.object(meta, "is_valid_ticker", return_value=False) as valid_mock, \
-        patch.object(meta, "record_skipped_ticker") as record_mock, \
-        patch.object(meta, "fetch_yahoo_timeseries_range") as yahoo_mock:
+    with (
+        patch.object(meta, "is_valid_ticker", return_value=False) as valid_mock,
+        patch.object(meta, "record_skipped_ticker") as record_mock,
+        patch.object(meta, "fetch_yahoo_timeseries_range") as yahoo_mock,
+    ):
         df = meta.fetch_meta_timeseries("ABC", "L")
 
     assert df.empty
@@ -371,11 +364,13 @@ def test_fetch_meta_timeseries_yahoo_only():
 
     import backend.timeseries.fetch_meta_timeseries as meta
 
-    with patch.object(meta, "fetch_yahoo_timeseries_range", return_value=yahoo_df) as yahoo_mock, \
-        patch.object(meta, "fetch_stooq_timeseries_range") as stooq_mock, \
-        patch.object(meta, "fetch_ft_df") as ft_mock, \
-        patch.object(meta, "is_valid_ticker", return_value=True), \
-        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=False)):
+    with (
+        patch.object(meta, "fetch_yahoo_timeseries_range", return_value=yahoo_df) as yahoo_mock,
+        patch.object(meta, "fetch_stooq_timeseries_range") as stooq_mock,
+        patch.object(meta, "fetch_ft_df") as ft_mock,
+        patch.object(meta, "is_valid_ticker", return_value=True),
+        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=False)),
+    ):
         df = meta.fetch_meta_timeseries("ABC", "L", start_date=start, end_date=end)
 
     assert df.equals(yahoo_df)
@@ -392,11 +387,13 @@ def test_fetch_meta_timeseries_yahoo_stooq_merge():
 
     import backend.timeseries.fetch_meta_timeseries as meta
 
-    with patch.object(meta, "fetch_yahoo_timeseries_range", return_value=yahoo_df) as yahoo_mock, \
-        patch.object(meta, "fetch_stooq_timeseries_range", return_value=stooq_df) as stooq_mock, \
-        patch.object(meta, "fetch_ft_df") as ft_mock, \
-        patch.object(meta, "is_valid_ticker", return_value=True), \
-        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=False)):
+    with (
+        patch.object(meta, "fetch_yahoo_timeseries_range", return_value=yahoo_df) as yahoo_mock,
+        patch.object(meta, "fetch_stooq_timeseries_range", return_value=stooq_df) as stooq_mock,
+        patch.object(meta, "fetch_ft_df") as ft_mock,
+        patch.object(meta, "is_valid_ticker", return_value=True),
+        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=False)),
+    ):
         df = meta.fetch_meta_timeseries("ABC", "L", start_date=start, end_date=end)
 
     assert df["Source"].tolist() == ["Yahoo", "Yahoo", "Stooq"]
@@ -413,11 +410,13 @@ def test_fetch_meta_timeseries_coverage_shortfall():
 
     import backend.timeseries.fetch_meta_timeseries as meta
 
-    with patch.object(meta, "fetch_yahoo_timeseries_range", return_value=yahoo_df) as yahoo_mock, \
-        patch.object(meta, "fetch_stooq_timeseries_range", return_value=stooq_df) as stooq_mock, \
-        patch.object(meta, "fetch_ft_df", return_value=pd.DataFrame(columns=STANDARD_COLUMNS)) as ft_mock, \
-        patch.object(meta, "is_valid_ticker", return_value=True), \
-        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=False)):
+    with (
+        patch.object(meta, "fetch_yahoo_timeseries_range", return_value=yahoo_df) as yahoo_mock,
+        patch.object(meta, "fetch_stooq_timeseries_range", return_value=stooq_df) as stooq_mock,
+        patch.object(meta, "fetch_ft_df", return_value=pd.DataFrame(columns=STANDARD_COLUMNS)) as ft_mock,
+        patch.object(meta, "is_valid_ticker", return_value=True),
+        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=False)),
+    ):
         df = meta.fetch_meta_timeseries("ABC", "L", start_date=start, end_date=end)
 
     expected = set(pd.bdate_range(start, end).date)
@@ -434,14 +433,14 @@ def test_fetch_meta_timeseries_min_coverage_threshold():
 
     import backend.timeseries.fetch_meta_timeseries as meta
 
-    with patch.object(meta, "fetch_yahoo_timeseries_range", return_value=yahoo_df) as yahoo_mock, \
-        patch.object(meta, "fetch_stooq_timeseries_range") as stooq_mock, \
-        patch.object(meta, "fetch_ft_df") as ft_mock, \
-        patch.object(meta, "is_valid_ticker", return_value=True), \
-        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=False)):
-        df = meta.fetch_meta_timeseries(
-            "ABC", "L", start_date=start, end_date=end, min_coverage=0.5
-        )
+    with (
+        patch.object(meta, "fetch_yahoo_timeseries_range", return_value=yahoo_df) as yahoo_mock,
+        patch.object(meta, "fetch_stooq_timeseries_range") as stooq_mock,
+        patch.object(meta, "fetch_ft_df") as ft_mock,
+        patch.object(meta, "is_valid_ticker", return_value=True),
+        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=False)),
+    ):
+        df = meta.fetch_meta_timeseries("ABC", "L", start_date=start, end_date=end, min_coverage=0.5)
 
     assert df.equals(yahoo_df)
     yahoo_mock.assert_called_once()
@@ -467,15 +466,15 @@ def test_fetch_meta_timeseries_isin_returns_ft_without_other_sources():
 
     import backend.timeseries.fetch_meta_timeseries as meta
 
-    with patch.object(meta, "is_valid_ticker", return_value=True), \
-        patch.object(meta, "_is_isin", return_value=True) as isin_mock, \
-        patch.object(meta, "fetch_ft_df", return_value=ft_df) as ft_mock, \
-        patch.object(meta, "fetch_yahoo_timeseries_range") as yahoo_mock, \
-        patch.object(meta, "fetch_stooq_timeseries_range") as stooq_mock, \
-        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=True)):
-        df = meta.fetch_meta_timeseries(
-            "US1234567890", start_date=start, end_date=end
-        )
+    with (
+        patch.object(meta, "is_valid_ticker", return_value=True),
+        patch.object(meta, "_is_isin", return_value=True) as isin_mock,
+        patch.object(meta, "fetch_ft_df", return_value=ft_df) as ft_mock,
+        patch.object(meta, "fetch_yahoo_timeseries_range") as yahoo_mock,
+        patch.object(meta, "fetch_stooq_timeseries_range") as stooq_mock,
+        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=True)),
+    ):
+        df = meta.fetch_meta_timeseries("US1234567890", start_date=start, end_date=end)
 
     assert df.equals(ft_df)
     isin_mock.assert_called_once()
@@ -487,12 +486,15 @@ def test_fetch_meta_timeseries_isin_returns_ft_without_other_sources():
 def test_fetch_meta_timeseries_alpha_vantage_rate_limit(monkeypatch):
     start = date(2024, 1, 1)
     end = date(2024, 1, 4)
-    fallback_df = _make_df([
-        "2024-01-01",
-        "2024-01-02",
-        "2024-01-03",
-        "2024-01-04",
-    ], "FT")
+    fallback_df = _make_df(
+        [
+            "2024-01-01",
+            "2024-01-02",
+            "2024-01-03",
+            "2024-01-04",
+        ],
+        "FT",
+    )
 
     import backend.timeseries.fetch_meta_timeseries as meta
 
@@ -503,24 +505,26 @@ def test_fetch_meta_timeseries_alpha_vantage_rate_limit(monkeypatch):
 
     monkeypatch.setattr(meta.time, "sleep", fake_sleep)
 
-    with patch.object(meta, "is_valid_ticker", return_value=True), \
+    with (
+        patch.object(meta, "is_valid_ticker", return_value=True),
         patch.object(
             meta,
             "fetch_yahoo_timeseries_range",
             return_value=pd.DataFrame(columns=STANDARD_COLUMNS),
-        ) as yahoo_mock, \
+        ) as yahoo_mock,
         patch.object(
             meta,
             "fetch_stooq_timeseries_range",
             return_value=pd.DataFrame(columns=STANDARD_COLUMNS),
-        ) as stooq_mock, \
+        ) as stooq_mock,
         patch.object(
             meta,
             "fetch_alphavantage_timeseries_range",
             side_effect=meta.AlphaVantageRateLimitError("limit", retry_after=5),
-        ) as av_mock, \
-        patch.object(meta, "fetch_ft_df", return_value=fallback_df) as ft_mock, \
-        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=True)):
+        ) as av_mock,
+        patch.object(meta, "fetch_ft_df", return_value=fallback_df) as ft_mock,
+        patch.object(meta, "config", SimpleNamespace(alpha_vantage_enabled=True)),
+    ):
         df = meta.fetch_meta_timeseries("ABC", "L", start_date=start, end_date=end)
 
     assert df.equals(fallback_df)
@@ -529,26 +533,6 @@ def test_fetch_meta_timeseries_alpha_vantage_rate_limit(monkeypatch):
     stooq_mock.assert_called_once()
     av_mock.assert_called_once()
     ft_mock.assert_called_once()
-
-
-@pytest.mark.parametrize(
-    "symbol, expected",
-    [
-        ("AAPL", "AAPL"),
-        ("aapl", "AAPL"),
-        ("  aapl  ", "AAPL"),
-        ("BRK.B", "BRK.B"),
-        ("BTC-USD", "BTC-USD"),
-        ("VOD_L", "VOD_L"),
-        ("", ""),
-        ("../../../etc/passwd", ""),
-        ("AAPL\x00.json", ""),
-        ("ABC/DEF", ""),
-        ("ABC DEF", ""),
-    ],
-)
-def test_sanitize_metadata_symbol(symbol, expected):
-    assert _sanitize_metadata_symbol(symbol) == expected
 
 
 def test_metadata_entry_exists_rejects_path_traversal_in_exchange(tmp_path):
@@ -560,7 +544,10 @@ def test_metadata_entry_exists_rejects_path_traversal_in_exchange(tmp_path):
 
     assert _metadata_entry_exists("ABC", "../instruments/L", directories) is False
     assert _metadata_entry_exists("ABC", "L", directories) is True
+
+
 # ── _sanitize_metadata_symbol ────────────────────────────────────────────────
+
 
 @pytest.mark.parametrize(
     "value, expected",
@@ -577,6 +564,7 @@ def test_metadata_entry_exists_rejects_path_traversal_in_exchange(tmp_path):
         pytest.param("ABC\x00DEF", "", id="null_byte_rejected"),
         pytest.param("ABC/DEF", "", id="forward_slash_rejected"),
         pytest.param("ABC\\DEF", "", id="backslash_rejected"),
+        pytest.param("ABC DEF", "", id="embedded_space_rejected"),
         pytest.param("", "", id="empty_rejected"),
         pytest.param("   ", "", id="whitespace_only_rejected"),
         pytest.param("1234", "1234", id="numeric_only_valid"),
@@ -638,4 +626,3 @@ def test_resolve_exchange_rejects_traversal_symbol():
     # before _instrument_dirs() or any Path operations are reached.
     assert meta._resolve_exchange_from_metadata("../L/ABC") == ""
     meta._resolve_exchange_from_metadata_cached.cache_clear()
-

--- a/tests/timeseries/test_fetch_stooq_timeseries.py
+++ b/tests/timeseries/test_fetch_stooq_timeseries.py
@@ -1,8 +1,9 @@
+from datetime import date
+from types import SimpleNamespace
+
 import pandas as pd
 import pytest
 import requests
-from datetime import date
-from types import SimpleNamespace
 
 from backend.timeseries import fetch_stooq_timeseries as fst
 from backend.utils.timeseries_helpers import STANDARD_COLUMNS

--- a/tests/timeseries/test_fetch_yahoo_timeseries.py
+++ b/tests/timeseries/test_fetch_yahoo_timeseries.py
@@ -66,9 +66,7 @@ def test_fetch_yahoo_timeseries_range_normalizes(mock_ticker_cls):
         "backend.timeseries.fetch_yahoo_timeseries.is_valid_ticker",
         return_value=True,
     ):
-        df = fetch_yahoo_timeseries_range(
-            "abc", "l", start_date=date(2024, 1, 1), end_date=date(2024, 1, 1)
-        )
+        df = fetch_yahoo_timeseries_range("abc", "l", start_date=date(2024, 1, 1), end_date=date(2024, 1, 1))
     assert list(df.columns) == STANDARD_COLUMNS
     assert df.loc[0, "Date"] == date(2024, 1, 1)
     assert df.loc[0, "Open"] == 1.12
@@ -87,9 +85,7 @@ def test_fetch_yahoo_timeseries_range_empty(mock_ticker_cls):
         return_value=True,
     ):
         with pytest.raises(ValueError):
-            fetch_yahoo_timeseries_range(
-                "abc", "l", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2)
-            )
+            fetch_yahoo_timeseries_range("abc", "l", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2))
 
 
 @patch("backend.timeseries.fetch_yahoo_timeseries.yf.Ticker")
@@ -102,9 +98,7 @@ def test_fetch_yahoo_timeseries_range_exception(mock_ticker_cls):
         return_value=True,
     ):
         with pytest.raises(Exception):
-            fetch_yahoo_timeseries_range(
-                "abc", "l", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2)
-            )
+            fetch_yahoo_timeseries_range("abc", "l", start_date=date(2024, 1, 1), end_date=date(2024, 1, 2))
 
 
 @patch("backend.timeseries.fetch_yahoo_timeseries.yf.Ticker")
@@ -145,9 +139,7 @@ def test_fetch_yahoo_timeseries_period_no_normalize_preserves_datetime(mock_tick
     raw.index.name = "Datetime"
     mock_stock.history.return_value = raw
     mock_ticker_cls.return_value = mock_stock
-    df = fetch_yahoo_timeseries_period(
-        "abc", "l", period="5d", interval="5m", normalize=False
-    )
+    df = fetch_yahoo_timeseries_period("abc", "l", period="5d", interval="5m", normalize=False)
     assert df.loc[0, "Date"] == pd.Timestamp("2024-01-01 10:30:00")
 
 
@@ -167,4 +159,3 @@ def test_fetch_yahoo_timeseries_period_exception(mock_ticker_cls):
     mock_ticker_cls.return_value = mock_stock
     with pytest.raises(Exception):
         fetch_yahoo_timeseries_period("abc", "l", period="1mo", interval="1d")
-

--- a/tests/timeseries/test_run_all_and_load_timeseries.py
+++ b/tests/timeseries/test_run_all_and_load_timeseries.py
@@ -1,6 +1,8 @@
-import pandas as pd
-import backend.timeseries.fetch_meta_timeseries as fmt
 from unittest.mock import patch
+
+import pandas as pd
+
+import backend.timeseries.fetch_meta_timeseries as fmt
 
 
 def _df():

--- a/tests/utils/test_build_instruments_from_accounts.py
+++ b/tests/utils/test_build_instruments_from_accounts.py
@@ -1,10 +1,11 @@
 import json
+
 import pytest
 
 from backend.utils.build_instruments_from_accounts import (
-    split_ticker,
     best_name,
     infer_currency,
+    split_ticker,
 )
 
 

--- a/tests/utils/test_convert_portfolio_xml_to_account_transactions.py
+++ b/tests/utils/test_convert_portfolio_xml_to_account_transactions.py
@@ -134,8 +134,8 @@ def test_billion_laughs_xml_rejected(tmp_path):
         '<?xml version="1.0"?>'
         "<!DOCTYPE lolz ["
         '  <!ENTITY lol "lol">'
-        "  <!ENTITY lol2 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">"
-        "  <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">"
+        '  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">'
+        '  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">'
         "]>"
         "<lolz>&lol3;</lolz>"
     )

--- a/tests/utils/test_fx_rates.py
+++ b/tests/utils/test_fx_rates.py
@@ -12,9 +12,7 @@ def _fake_df(start, end):
     return pd.DataFrame({"Date": dates, "Close": [1.0 + i * 0.1 for i in range(len(dates))]})
 
 
-@pytest.mark.parametrize(
-    "base,quote", [("USD", "GBP"), ("CHF", "GBP"), ("JPY", "GBP"), ("CAD", "GBP")]
-)
+@pytest.mark.parametrize("base,quote", [("USD", "GBP"), ("CHF", "GBP"), ("JPY", "GBP"), ("CAD", "GBP")])
 def test_fetch_fx_rate_range_success(monkeypatch, base, quote):
     start = dt.date(2024, 1, 1)
     end = dt.date(2024, 1, 3)
@@ -82,6 +80,3 @@ def test_fetch_fx_rate_same_currency():
     fetch_fx_rate_range.cache_clear()
     df = fetch_fx_rate_range("USD", "USD", start, end)
     assert list(df["Rate"]) == [1.0, 1.0, 1.0]
-
-
-

--- a/tests/utils/test_growth_stage.py
+++ b/tests/utils/test_growth_stage.py
@@ -17,4 +17,3 @@ def test_get_growth_stage(days_held, current_price, target_price, expected_stage
     assert info["stage"] == expected_stage
     if expected_message is not None:
         assert info["message"] == expected_message
-

--- a/tests/utils/test_html_render.py
+++ b/tests/utils/test_html_render.py
@@ -1,10 +1,10 @@
 from pathlib import Path
+
 import numpy as np
 import pandas as pd
 from lxml import html
 
 from backend.utils.html_render import render_timeseries_html
-
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 

--- a/tests/utils/test_period_utils.py
+++ b/tests/utils/test_period_utils.py
@@ -1,7 +1,5 @@
 import pytest
 
-import pytest
-
 from backend.utils.period_utils import parse_period_to_days
 
 

--- a/tests/utils/test_positions.py
+++ b/tests/utils/test_positions.py
@@ -185,10 +185,18 @@ def test_extract_holdings_ignores_invalid(tmp_path):
     <security><name>NoID</name></security>
   </securities>
   <account>
-    <portfolio-transaction type="BUY"><date>2020-01-01</date><shares/><security reference="s1"/></portfolio-transaction>
-    <portfolio-transaction type="BUY"><date>2020-01-01</date><shares>100000000</shares></portfolio-transaction>
-    <portfolio-transaction type="BUY"><date>2020-01-01</date><shares>100000000</shares><security></security></portfolio-transaction>
-    <portfolio-transaction type="BUY"><date>2020-01-01</date><shares>0</shares><security reference="s1"/></portfolio-transaction>
+    <portfolio-transaction type="BUY">
+      <date>2020-01-01</date><shares/><security reference="s1"/>
+    </portfolio-transaction>
+    <portfolio-transaction type="BUY">
+      <date>2020-01-01</date><shares>100000000</shares>
+    </portfolio-transaction>
+    <portfolio-transaction type="BUY">
+      <date>2020-01-01</date><shares>100000000</shares><security></security>
+    </portfolio-transaction>
+    <portfolio-transaction type="BUY">
+      <date>2020-01-01</date><shares>0</shares><security reference="s1"/>
+    </portfolio-transaction>
   </account>
 </root>"""
     path = tmp_path / "invalid.xml"
@@ -205,11 +213,19 @@ def test_extract_dividends_ignores_invalid(tmp_path):
     <security><name>NoID</name></security>
   </securities>
   <account>
-    <portfolio-transaction type="DIVIDEND"><date>2020-02-01</date><amount>5</amount><security reference="s1"/></portfolio-transaction>
+    <portfolio-transaction type="DIVIDEND">
+      <date>2020-02-01</date><amount>5</amount><security reference="s1"/>
+    </portfolio-transaction>
     <portfolio-transaction type="DIVIDEND"><date>2020-01-01</date></portfolio-transaction>
-    <portfolio-transaction type="DIVIDEND"><date>2020-01-01</date><amount>abc</amount><security reference="s1"/></portfolio-transaction>
-    <portfolio-transaction type="DIVIDEND"><date>2020-01-01</date><amount>5</amount></portfolio-transaction>
-    <portfolio-transaction type="DIVIDEND"><date>2020-01-01</date><amount>5</amount><security></security></portfolio-transaction>
+    <portfolio-transaction type="DIVIDEND">
+      <date>2020-01-01</date><amount>abc</amount><security reference="s1"/>
+    </portfolio-transaction>
+    <portfolio-transaction type="DIVIDEND">
+      <date>2020-01-01</date><amount>5</amount>
+    </portfolio-transaction>
+    <portfolio-transaction type="DIVIDEND">
+      <date>2020-01-01</date><amount>5</amount><security></security>
+    </portfolio-transaction>
   </account>
 </root>"""
     path = tmp_path / "divs.xml"

--- a/tests/utils/test_scenario_tester.py
+++ b/tests/utils/test_scenario_tester.py
@@ -6,7 +6,6 @@ import pytest
 import backend.utils.scenario_tester as sc_tester
 
 
-
 def test_apply_price_shock_falls_back_to_get_price(monkeypatch):
     portfolio = {
         "accounts": [
@@ -161,10 +160,7 @@ def test_forward_returns_empty(monkeypatch):
 
 def test_forward_returns_with_data(monkeypatch):
     event_date = dt.date(2024, 1, 1)
-    dates = [
-        event_date + dt.timedelta(days=d)
-        for d in [0, 1, 7, 30, 90, 365]
-    ]
+    dates = [event_date + dt.timedelta(days=d) for d in [0, 1, 7, 30, 90, 365]]
     prices = [100, 110, 120, 130, 140, 200]
     df = pd.DataFrame({"Date": dates, "Close_gbp": prices}).set_index("Date")
 
@@ -183,10 +179,7 @@ def test_forward_returns_with_data(monkeypatch):
 
 def test_forward_returns_nonfinite_prices(monkeypatch):
     event_date = dt.date(2024, 1, 1)
-    dates = [
-        event_date + dt.timedelta(days=d)
-        for d in [0, 1, 7, 30, 90, 365]
-    ]
+    dates = [event_date + dt.timedelta(days=d) for d in [0, 1, 7, 30, 90, 365]]
     prices = [100, float("nan"), 120, float("inf"), 140, 200]
     df = pd.DataFrame({"Date": dates, "Close_gbp": prices}).set_index("Date")
 

--- a/tests/utils/test_timeseries_helpers.py
+++ b/tests/utils/test_timeseries_helpers.py
@@ -118,6 +118,7 @@ def test_is_isin():
 
 # ── resolve_date_range ──────────────────────────────────────────────────────
 
+
 class TestResolveDateRange:
     """Tests for the resolve_date_range service helper."""
 


### PR DESCRIPTION
## What

Unblocks the release pipeline by making the `Backend lint (ruff, black)` CI job pass, and adds automation so the tree stays clean going forward:

1. **Formatting/lint cleanup** (`f9c6a493`): applied `isort`/`black` and `ruff check --fix` across `backend/` and `tests/`, then manually fixed the remaining ruff findings (F841 unused vars, E741 ambiguous names, E501 long lines, F811 duplicate test). Refreshed `tests/data/log_sanitization_baseline.txt` — the log-sanitization ratchet is keyed by `file:line`, so the reformat shifted line numbers; entries were remapped by call-site content and stale entries (calls already sanitized in earlier commits) were dropped.
2. **Auto-format workflow** (`edccec0f`): new `.github/workflows/auto-format.yml` runs on PRs touching backend/test paths, applies black/isort/ruff `--fix`, verifies the tree is lint-clean, and commits the result **to the PR's own branch** (never to `main`, respecting branch protection and the repo's PR-first policy). The no-diff guard prevents loops.
3. **Chore convention removal** (`8cb2d196`): dropped `chore/` from the branch-naming policy in `docs/CONTRIBUTING.md` and `.claude/skills/ship-fix/SKILL.md`, removed the `chore` label from all dependabot entries, and changed the siteplan bot commit message to `docs:`.

## Why

PR #6261 added the backend lint job to CI, but the job lints the whole tree on push events and the tree was never clean under those rules (186 ruff errors, 220 files black would reformat). Since Aug 13 every push to `main` has been red, and tag-triggered deploys fail at the "Verify CI passed on tagged commit" gate (e.g. run 31781637036 for `v0.35.0`) — so no release can deploy.

## Validation

- `ruff check --config backend/pyproject.toml` and `black --check --config backend/pyproject.toml` pass on the full tree (exact CI commands, verified with the same pinned tool versions CI installs: ruff 0.16.3, black 26.5.1).
- Full backend pytest suite: **3423 passed, 1 failed** — the single failure was `test_no_new_unwrapped_logger_calls`, caused by the line-shift in the baseline; fixed by regenerating the baseline (all 3 audit tests now pass, every baseline entry verified to match a current scan call).
- All 140 tests in the 9 files with semantic edits pass.
- `docs/CONTRIBUTING.md` formatting-only/functional commit split respected.

## Known follow-up / risk

- The existing `v0.35.0` tag still points at a red commit; once this lands on `main`, the tag must be moved or superseded (e.g. `v0.35.1`) for the deploy gate to pass — the gate checks the exact tagged SHA's ci.yml run.
- The auto-format workflow only fixes what's auto-fixable (formatting, import order, unused imports); the remaining manual-only rules were cleaned up once here.
- `tests/data/log_sanitization_baseline.txt` is inherently line-number-sensitive; future formatting changes will need the same refresh (the workflow does not regenerate it).

Closes #6691
