### PR TITLE
Remove redundant Portfolio nav entry (keep owner routing) — Closes #6716

### DIFF
--- a/frontend/src/routes/registry.ts
+++ b/frontend/src/routes/registry.ts
@@ -25,6 +25,9 @@ export interface RouteRegistryEntry {
   section: RouteSection;
   menuCategory?: MenuCategory;
   priority?: number;
+  /** Keep the mode routable (deep links, redirects, buildPathForMode) but
+   *  exclude it from the nav menu built by getMenuEntries. */
+  hideFromMenu?: boolean;
   defaultPath: (context: RoutePathContext) => string;
   routePath?: string;
   lazyComponent?: LazyExoticComponent<ComponentType>;
@@ -111,6 +114,10 @@ export const ROUTE_REGISTRY: RouteRegistryEntry[] = [
     routeSegment: 'portfolio',
     section: 'user',
     menuCategory: 'dashboard',
+    // The merged dashboard (mode 'group') already exposes the owner-scoped
+    // view with import/reconcile/export via its owner tabs (#6716); the
+    // duplicate 'Portfolio' entry stays routable but is hidden from the nav.
+    hideFromMenu: true,
     priority: 30,
     defaultPath: (context) => {
       const { owner } = routeContext(context);
@@ -449,7 +456,10 @@ export function getMenuEntries(
   section: MenuSection
 ): Array<RouteRegistryEntry & { menuCategory: MenuCategory }> {
   return ROUTE_REGISTRY.filter(
-    (entry) => entry.section === section && Boolean(entry.menuCategory)
+    (entry) =>
+      entry.section === section &&
+      Boolean(entry.menuCategory) &&
+      !entry.hideFromMenu
   ).sort(
     (left, right) => (left.priority ?? 0) - (right.priority ?? 0)
   ) as Array<RouteRegistryEntry & { menuCategory: MenuCategory }>;

--- a/frontend/tests/unit/App.test.tsx
+++ b/frontend/tests/unit/App.test.tsx
@@ -1986,7 +1986,9 @@ describe("App", () => {
 
     const nav = screen.getByRole("navigation");
     expect(within(nav).getByText("Market Overview")).toBeInTheDocument();
-    expect(within(nav).getByText("Portfolio")).toBeInTheDocument();
+    // The owner-scoped portfolio is reachable via the dashboard's owner tabs
+    // (it renders the same merged view), so the duplicate nav entry is gone.
+    expect(within(nav).queryByText("Portfolio")).not.toBeInTheDocument();
     expect(within(nav).getByText("Support")).toBeInTheDocument();
   });
 

--- a/frontend/tests/unit/components/Menu.test.tsx
+++ b/frontend/tests/unit/components/Menu.test.tsx
@@ -239,7 +239,9 @@ describe('Menu', () => {
     fireEvent.click(dashboardToggle);
 
     const firstMenuItem = await screen.findByRole('menuitem', {
-      name: i18n.t('app.modes.owner'),
+      // The owner-scoped portfolio entry was removed from the nav (#6716);
+      // the dashboard category now leads with the group (Dashboard) item.
+      name: i18n.t('app.modes.group'),
     });
     const list = firstMenuItem.closest('ul');
 

--- a/frontend/tests/unit/pageManifest.test.ts
+++ b/frontend/tests/unit/pageManifest.test.ts
@@ -6,6 +6,7 @@ import {
   deriveModeFromPathname,
   deriveModeFromLocation,
   deriveRouteFromPathname,
+  getMenuEntries,
   menuCategories,
   pageManifest,
   pageManifestByMode,
@@ -148,5 +149,20 @@ describe('page manifest', () => {
       owner: 'steve',
       account: 'isa',
     });
+  });
+
+  it('hides the owner mode from the nav menu while keeping it routable (#6716)', () => {
+    // The merged dashboard already exposes the owner-scoped view (with
+    // import/reconcile/export) via its owner tabs, so 'Portfolio' must not
+    // appear as a duplicate menu entry...
+    expect(getMenuEntries('user').some((entry) => entry.mode === 'owner')).toBe(
+      false
+    );
+    // ...but the registry entry stays so deep links and redirects keep
+    // working: /portfolio/:owner -> /?owner=X and buildPathForMode('owner').
+    expect(pageManifestByMode.owner.routeSegment).toBe('portfolio');
+    expect(buildPathForMode('owner', { owner: 'Steve Smith' })).toBe(
+      '/?owner=Steve%20Smith'
+    );
   });
 });


### PR DESCRIPTION
## What changed

Removed the redundant **"Portfolio"** nav menu item. The merged dashboard (`/`) already renders the owner-scoped view — with CSV import (+ reconcile preview), export, add-position and add-account — via its owner tabs, so the separate nav entry was a duplicate of the group page (reported in #6716, verified live: clicking "Portfolio" and clicking an owner tab on the dashboard produce the identical `/?owner=X` view).

- `frontend/src/routes/registry.ts`: added `hideFromMenu` to `RouteRegistryEntry`, set it on the `owner` entry, and excluded hidden entries in `getMenuEntries`. The `owner` registry entry **stays** so `/portfolio`, `/portfolio/:owner` redirects and `buildPathForMode('owner')` keep working.
- Tests: `pageManifest.test.ts` (menu excludes owner while routing is preserved), `App.test.tsx` (nav no longer renders "Portfolio"), `Menu.test.tsx` (dashboard dropdown now leads with the Group item).

## Why

The `owner`-mode page and the `group` dashboard render the exact same `GroupPortfolioView` component; the only difference was a pre-selected `?owner=` param. Two nav items pointing at the same page was confusing, and the import/reconcile tooling looked "gone" because it was only reachable via that second entry.

## What I validated

- Unit: full frontend suite `755 passed` (97 files), `tsc --noEmit` clean.
- Browser (worktree dev server): Dashboard dropdown now shows Group / Market Overview / Movers / Performance / Allocation and **no Portfolio**; `/portfolio/steve` still redirects to `/?owner=steve`; owner-scoped dashboard still shows Export CSV/PDF, + Import CSV (with Reconcile preview), + Add position, + Add account.

## Notes / follow-up

- Account import/creation (`AddAccountForm`, `POST /accounts`) is unaffected — it lives in the owner-actions row on the dashboard.
- `tabs.owner` in config is now unused by the menu; left as-is (harmless).

Closes #6716


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Removed the duplicate owner-scoped Portfolio entry from menus.
  * Portfolio remains accessible through dashboard owner tabs and direct links.
  * Added support for keeping routable pages hidden from navigation menus.

* **Tests**
  * Updated navigation and menu coverage to reflect the streamlined Portfolio experience.
  * Added verification that hidden pages remain routable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->