### PR TITLE
[Issue #6725] Standalone-routed pages (data-quality, data-explorer, etc.) render with no nav — dead end, no way back to app

### DIFF
--- a/backend/bootstrap/routers.py
+++ b/backend/bootstrap/routers.py
@@ -15,6 +15,7 @@ from backend.routes.compliance import router as compliance_router
 from backend.routes.config import router as config_router
 from backend.routes.data_explorer import router as data_explorer_router
 from backend.routes.data_quality import router as data_quality_router
+from backend.routes.data_quality_admin import router as data_quality_admin_router
 from backend.routes.events import router as events_router
 from backend.routes.goals import router as goals_router
 from backend.routes.instrument import router as instrument_router
@@ -64,6 +65,7 @@ def register_routers(app: FastAPI, cfg: Config) -> None:
     app.include_router(instrument_admin_router, dependencies=protected)
     app.include_router(timeseries_router)
     app.include_router(data_quality_router)
+    app.include_router(data_quality_admin_router, dependencies=protected)
     app.include_router(timeseries_edit_router)
     app.include_router(timeseries_admin_router, dependencies=protected)
     app.include_router(data_explorer_router, dependencies=protected)

--- a/backend/config.py
+++ b/backend/config.py
@@ -141,6 +141,9 @@ class Config:
     enable_compliance_workflows: bool = False
     enable_advanced_analytics: bool = False
     enable_reporting_extended: bool = False
+    # Read-write Data Quality Admin surface (issue list + preview/fix/audit).
+    # Defaults to enabled; set False to keep the read-only series view only.
+    enable_data_quality_admin: bool = True
     theme: Optional[str] = None
     timeseries_cache_base: Optional[str] = None
     fx_proxy_url: Optional[str] = None
@@ -166,6 +169,7 @@ class Config:
     data_root: Optional[Path] = None
     accounts_root: Optional[Path] = None
     prices_json: Optional[Path] = None
+    audit_dir: Optional[Path] = None
     risk_free_rate: Optional[float] = None
     base_currency: Optional[str] = "GBP"
 
@@ -323,6 +327,11 @@ def load_config() -> Config:
 
     prices_json_raw = data.get("prices_json")
     prices_json = (data_root / prices_json_raw).resolve() if prices_json_raw else None
+
+    # Where the data-quality admin audit trail is written (append-only JSONL).
+    # Defaults to ``{data_root}/audit`` when not set explicitly.
+    audit_dir_raw = data.get("audit_dir")
+    audit_dir = (data_root / "audit").resolve() if audit_dir_raw is None else (data_root / audit_dir_raw).resolve()
 
     ts_cache_raw = data.get("timeseries_cache_base")
     env_ts_cache = os.getenv("TIMESERIES_CACHE_BASE")
@@ -483,6 +492,11 @@ def load_config() -> Config:
             key="enable_reporting_extended",
             default=False,
         ),
+        enable_data_quality_admin=_coerce_bool_with_default(
+            data.get("enable_data_quality_admin"),
+            key="enable_data_quality_admin",
+            default=True,
+        ),
         theme=data.get("theme"),
         timeseries_cache_base=timeseries_cache_base,
         fx_proxy_url=data.get("fx_proxy_url"),
@@ -498,6 +512,7 @@ def load_config() -> Config:
         data_root=data_root,
         accounts_root=accounts_root,
         prices_json=prices_json,
+        audit_dir=audit_dir,
         risk_free_rate=data.get("risk_free_rate"),
         approval_valid_days=data.get("approval_valid_days"),
         approval_exempt_types=approval_exempt_types,

--- a/backend/data_quality/audit.py
+++ b/backend/data_quality/audit.py
@@ -1,0 +1,115 @@
+"""Append-only audit trail for data-quality fix actions.
+
+Records every applied fix (before/after snapshots, actor, timestamp) as one
+JSON object per line in a JSONL file, so the history is durable and replayable.
+Writes are atomic (temp file + rename) and the file is created if missing.
+
+The audit file lives under ``config.audit_dir`` when configured, otherwise
+``{config.data_root}/audit`` — the same data root that holds accounts/cache.
+Tests override ``config.audit_dir`` (or monkeypatch :func:`audit_path`) to keep
+writes out of the repo.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from backend.config import config
+
+_AUDIT_FILENAME = "data_quality_audit.jsonl"
+_lock = threading.Lock()
+
+
+def audit_path() -> Path:
+    """Return the audit JSONL path for the current config."""
+    configured = getattr(config, "audit_dir", None)
+    if configured:
+        return Path(configured) / _AUDIT_FILENAME
+    data_root = getattr(config, "data_root", None)
+    base = Path(data_root) if data_root else Path(__file__).resolve().parents[2] / "data"
+    return base / "audit" / _AUDIT_FILENAME
+
+
+def _atomic_append_text(path: Path, line: str) -> None:
+    """Append ``line`` to ``path`` via a temp file + rename.
+
+    Reads the existing file (if any), writes the combined content to a
+    ``.tmp`` sibling, fsyncs it, then renames over the original — so a failed
+    write or crash cannot leave the trail partially written or corrupted.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        fh.write(existing)
+        fh.write(line)
+        if existing and not existing.endswith("\n"):
+            fh.write("\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, path)
+
+
+def append_audit(
+    *,
+    action: str,
+    issue_id: str,
+    entity: dict[str, Any],
+    before: dict[str, Any],
+    after: dict[str, Any],
+    actor: Optional[str] = None,
+    extra: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Record one audit entry and return it. Reversible actions pass the
+    ``before`` snapshot so ``undo`` can restore it."""
+    entry: dict[str, Any] = {
+        "id": str(uuid.uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "action": action,
+        "issue_id": issue_id,
+        "entity": entity,
+        "before": before,
+        "after": after,
+        "actor": actor,
+    }
+    if extra:
+        entry["extra"] = extra
+    with _lock:
+        _atomic_append_text(audit_path(), json.dumps(entry) + "\n")
+    return entry
+
+
+def read_audit(limit: Optional[int] = None) -> list[dict[str, Any]]:
+    """Return audit entries, newest first. Missing/corrupt file -> []."""
+    path = audit_path()
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    except OSError:
+        return []
+    entries.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
+    if limit is not None:
+        return entries[:limit]
+    return entries
+
+
+def find_audit_entry(entry_id: str) -> Optional[dict[str, Any]]:
+    for entry in read_audit():
+        if entry.get("id") == entry_id:
+            return entry
+    return None

--- a/backend/data_quality/issues.py
+++ b/backend/data_quality/issues.py
@@ -1,0 +1,498 @@
+"""Unified data-quality issue aggregation (read-only).
+
+Aggregates holdings, cached timeseries, and instrument metadata into a single
+list of typed issues so an admin (or an MCP/AI consumer) can see every problem
+and its suggested fix without a CLI or file inspection.
+
+Read path contract (mirrors backend/routes/data_quality.py):
+  * No live fetches.  ``resolve_instrument_ticker`` is only ever called with
+    ``create_missing=False`` so it consults persisted metadata only.
+  * No mutation.  Nothing here writes holdings, metadata, or the cache.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Sequence
+
+from backend.common.instruments import get_instrument_meta, resolve_instrument_ticker
+from backend.config import config
+from backend.timeseries.cache import (
+    has_cached_meta_timeseries,
+    list_cached_meta_tickers,
+    load_cached_meta_timeseries_full,
+)
+from backend.timeseries.quality import (
+    DEFAULT_GAP_THRESHOLD_DAYS,
+    DEFAULT_OUTLIER_SIGMA,
+    DEFAULT_ROLLING_WINDOW,
+    compute_quality,
+)
+
+# A cached series is STALE when its last date is older than this many days.
+DEFAULT_STALE_SERIES_MAX_AGE_DAYS = 10
+
+_NON_HOLDINGS_FILES = frozenset({"person.json", "settings.json", "approvals.json"})
+
+
+class IssueType:
+    WRONG_EXCHANGE = "WRONG_EXCHANGE"
+    UNRESOLVED_TICKER = "UNRESOLVED_TICKER"
+    MISSING_SERIES = "MISSING_SERIES"
+    STALE_SERIES = "STALE_SERIES"
+    GAPS = "GAPS"
+    DUPLICATES = "DUPLICATES"
+    OUTLIERS = "OUTLIERS"
+    MISSING_METADATA = "MISSING_METADATA"
+    TICKER_MISMATCH = "TICKER_MISMATCH"
+
+
+SEVERITY = {
+    IssueType.WRONG_EXCHANGE: "high",
+    IssueType.UNRESOLVED_TICKER: "high",
+    IssueType.MISSING_SERIES: "medium",
+    IssueType.STALE_SERIES: "medium",
+    IssueType.GAPS: "medium",
+    IssueType.DUPLICATES: "low",
+    IssueType.OUTLIERS: "low",
+    IssueType.MISSING_METADATA: "low",
+    IssueType.TICKER_MISMATCH: "low",
+}
+
+# Issue types whose fix is a fetch/refetch of the cached series.
+_FETCH_FIX_TYPES = frozenset(
+    {
+        IssueType.UNRESOLVED_TICKER,
+        IssueType.MISSING_SERIES,
+        IssueType.STALE_SERIES,
+        IssueType.GAPS,
+        IssueType.MISSING_METADATA,
+    }
+)
+
+# Issue types that have an automated, reversible fix in data_quality_admin.
+FIXABLE_TYPES = frozenset(
+    {
+        IssueType.WRONG_EXCHANGE,
+        IssueType.UNRESOLVED_TICKER,
+        IssueType.MISSING_SERIES,
+        IssueType.STALE_SERIES,
+        IssueType.GAPS,
+        IssueType.DUPLICATES,
+        IssueType.MISSING_METADATA,
+        IssueType.TICKER_MISMATCH,
+    }
+)
+
+_TICKER_RE = re.compile(r"^[A-Z0-9_-]{1,50}$")
+_EXCHANGE_RE = re.compile(r"^[A-Z0-9._-]{1,50}$")
+
+
+@dataclass
+class DataQualityIssue:
+    """One detected problem with a stable id and a suggested fix."""
+
+    id: str
+    type: str
+    severity: str
+    entity: dict[str, Any]
+    description: str
+    suggested_fix: str
+    preview: dict[str, Any]
+    fixable: bool = True
+    # Extra structured payload (holding ticker, cache rows, ...) used by the
+    # admin route to execute the fix.  Not part of the read contract output.
+    fix_payload: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "severity": self.severity,
+            "entity": self.entity,
+            "description": self.description,
+            "suggested_fix": self.suggested_fix,
+            "preview": self.preview,
+            "fixable": self.fixable,
+        }
+
+
+def _validate_symbol(value: str, *, kind: str) -> str:
+    upper = value.upper()
+    pattern = _TICKER_RE if kind == "ticker" else _EXCHANGE_RE
+    if not pattern.match(upper):
+        raise ValueError(f"Invalid {kind} format: {value!r}")
+    return upper
+
+
+def _parse_holding_ticker(ticker: str) -> tuple[str, str] | None:
+    """Split ``SYM.EX`` into (symbol, exchange); None for CASH or malformed."""
+    symbol, sep, exchange = ticker.upper().partition(".")
+    if not sep or not symbol or not exchange:
+        return None
+    if symbol == "CASH":
+        return None
+    try:
+        return _validate_symbol(symbol, kind="ticker"), _validate_symbol(exchange, kind="exchange")
+    except ValueError:
+        return None
+
+
+def iter_holdings(accounts_root: Path | None = None) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    """Yield ``(owner, account, holding)`` for every holdings document.
+
+    Scans ``{accounts_root}/*/*.json`` skipping metadata/scaffold files
+    (person.json, settings.json, approvals.json, *_transactions.json).
+    Pure read: never creates owners or writes anything.
+    """
+    root = accounts_root or getattr(config, "accounts_root", None)
+    if root is None or not Path(root).exists():
+        return
+    for path in sorted(Path(root).glob("*/*.json")):
+        if path.name in _NON_HOLDINGS_FILES or path.name.endswith("_transactions.json"):
+            continue
+        try:
+            import json
+
+            document = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(document, dict):
+            continue
+        owner = str(document.get("owner") or path.parent.name)
+        account = str(document.get("account_type") or path.stem)
+        holdings = document.get("holdings")
+        if not isinstance(holdings, list):
+            continue
+        for holding in holdings:
+            if isinstance(holding, dict):
+                yield owner, account, holding
+
+
+def _holding_entity(owner: str, account: str, holding: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "owner": owner,
+        "account": account,
+        "holding": str(holding.get("ticker") or ""),
+    }
+
+
+def _issue_id(issue_type: str, *parts: str) -> str:
+    return ":".join([issue_type, *(p or "" for p in parts)])
+
+
+def _dedupe_issues(issues: Iterable[DataQualityIssue]) -> list[DataQualityIssue]:
+    """Keep the highest-severity issue per id, stable first-seen order."""
+    seen: dict[str, DataQualityIssue] = {}
+    for issue in issues:
+        existing = seen.get(issue.id)
+        if existing is None:
+            seen[issue.id] = issue
+        elif SEVERITY[issue.type] == "high" and SEVERITY[existing.type] != "high":
+            seen[issue.id] = issue
+    return list(seen.values())
+
+
+def aggregate_holding_issues(
+    accounts_root: Path | None = None,
+    *,
+    instruments_root: Path | None = None,
+) -> list[DataQualityIssue]:
+    """Detect holdings-side issues: wrong exchange, unresolved ticker, missing series."""
+    issues: list[DataQualityIssue] = []
+    for owner, account, holding in iter_holdings(accounts_root):
+        ticker = str(holding.get("ticker") or "").strip().upper()
+        parsed = _parse_holding_ticker(ticker)
+        if parsed is None:
+            continue
+        symbol, exchange = parsed
+        meta = get_instrument_meta(f"{symbol}.{exchange}")
+        has_meta = bool(meta and meta.get("name"))
+        resolved = resolve_instrument_ticker(symbol, create_missing=False)
+
+        entity = _holding_entity(owner, account, holding)
+
+        if not has_meta:
+            if resolved is not None and resolved.upper() != ticker:
+                issues.append(
+                    DataQualityIssue(
+                        id=_issue_id(IssueType.WRONG_EXCHANGE, owner, account, ticker),
+                        type=IssueType.WRONG_EXCHANGE,
+                        severity=SEVERITY[IssueType.WRONG_EXCHANGE],
+                        entity=entity,
+                        description=(
+                            f"Holding {ticker} has no metadata on {exchange}; " f"instrument resolves to {resolved}."
+                        ),
+                        suggested_fix=f"Correct holding exchange to {resolved}.",
+                        preview={
+                            "before": {"ticker": ticker},
+                            "after": {"ticker": resolved.upper()},
+                        },
+                        fix_payload={
+                            "kind": "wrong_exchange",
+                            "owner": owner,
+                            "account": account,
+                            "holding_ticker": ticker,
+                            "resolved_ticker": resolved.upper(),
+                        },
+                    )
+                )
+            else:
+                issues.append(
+                    DataQualityIssue(
+                        id=_issue_id(IssueType.UNRESOLVED_TICKER, owner, account, ticker),
+                        type=IssueType.UNRESOLVED_TICKER,
+                        severity=SEVERITY[IssueType.UNRESOLVED_TICKER],
+                        entity=entity,
+                        description=(
+                            f"Holding {ticker} has no instrument metadata and the "
+                            f"symbol could not be resolved from persisted metadata."
+                        ),
+                        suggested_fix="Create metadata and fetch the series.",
+                        preview={
+                            "before": {"metadata": "missing"},
+                            "after": {"metadata": "created", "series": "fetched"},
+                        },
+                        fix_payload={
+                            "kind": "unresolved_ticker",
+                            "owner": owner,
+                            "account": account,
+                            "symbol": symbol,
+                            "exchange": exchange,
+                        },
+                    )
+                )
+            continue
+
+        # Metadata exists; the fix is a missing series on the canonical pair.
+        if resolved is not None:
+            canonical_ticker = resolved.upper()
+            canonical_symbol, canonical_exchange = _parse_holding_ticker(canonical_ticker) or (symbol, exchange)
+        else:
+            canonical_symbol, canonical_exchange = symbol, exchange
+        if not has_cached_meta_timeseries(canonical_symbol, canonical_exchange):
+            issues.append(
+                DataQualityIssue(
+                    id=_issue_id(IssueType.MISSING_SERIES, owner, account, canonical_ticker),
+                    type=IssueType.MISSING_SERIES,
+                    severity=SEVERITY[IssueType.MISSING_SERIES],
+                    entity=entity,
+                    description=(
+                        f"Holding {canonical_ticker} has metadata but no cached "
+                        f"timeseries for {canonical_symbol}.{canonical_exchange}."
+                    ),
+                    suggested_fix="Fetch the series.",
+                    preview={
+                        "before": {"series": "missing"},
+                        "after": {"series": "fetched"},
+                    },
+                    fix_payload={
+                        "kind": "missing_series",
+                        "ticker": canonical_symbol,
+                        "exchange": canonical_exchange,
+                    },
+                )
+            )
+    return _dedupe_issues(issues)
+
+
+def aggregate_series_issues(
+    *,
+    stale_max_age_days: int = DEFAULT_STALE_SERIES_MAX_AGE_DAYS,
+    gap_threshold_days: int = DEFAULT_GAP_THRESHOLD_DAYS,
+    outlier_sigma: float = DEFAULT_OUTLIER_SIGMA,
+    rolling_window: int = DEFAULT_ROLLING_WINDOW,
+) -> list[DataQualityIssue]:
+    """Detect timeseries-side issues: stale, gaps, duplicates, outliers,
+    missing metadata, and ticker/cache-key mismatches."""
+    issues: list[DataQualityIssue] = []
+    today = date.today()
+    for ticker, exchange in list_cached_meta_tickers():
+        try:
+            df = load_cached_meta_timeseries_full(ticker, exchange)
+        except Exception:
+            continue
+        if df is None or df.empty:
+            continue
+
+        quality = compute_quality(
+            df,
+            ticker,
+            exchange,
+            gap_threshold_days=gap_threshold_days,
+            outlier_sigma=outlier_sigma,
+            rolling_window=rolling_window,
+        )
+        meta = get_instrument_meta(f"{ticker}.{exchange}")
+        has_meta = bool(meta and meta.get("name"))
+        entity: dict[str, Any] = {"ticker": ticker, "exchange": exchange}
+
+        if not has_meta:
+            issues.append(
+                DataQualityIssue(
+                    id=_issue_id(IssueType.MISSING_METADATA, ticker, exchange),
+                    type=IssueType.MISSING_METADATA,
+                    severity=SEVERITY[IssueType.MISSING_METADATA],
+                    entity=entity,
+                    description=(f"Cached series {ticker}.{exchange} has no instrument metadata."),
+                    suggested_fix="Auto-create metadata via refresh.",
+                    preview={
+                        "before": {"metadata": "missing"},
+                        "after": {"metadata": "created"},
+                    },
+                    fix_payload={
+                        "kind": "missing_metadata",
+                        "ticker": ticker,
+                        "exchange": exchange,
+                    },
+                )
+            )
+
+        if quality.get("gap_count", 0) > 0:
+            issues.append(
+                DataQualityIssue(
+                    id=_issue_id(IssueType.GAPS, ticker, exchange),
+                    type=IssueType.GAPS,
+                    severity=SEVERITY[IssueType.GAPS],
+                    entity=entity,
+                    description=(
+                        f"{quality['gap_count']} gap(s) in {ticker}.{exchange} "
+                        f"covering {len(quality.get('gaps', []))} period(s)."
+                    ),
+                    suggested_fix="Refetch / fill the missing range.",
+                    preview={
+                        "before": {"gap_count": quality["gap_count"]},
+                        "after": {"gap_count": 0},
+                    },
+                    fix_payload={
+                        "kind": "refetch",
+                        "ticker": ticker,
+                        "exchange": exchange,
+                    },
+                )
+            )
+
+        duplicate_dates = quality.get("duplicate_dates", [])
+        if duplicate_dates:
+            issues.append(
+                DataQualityIssue(
+                    id=_issue_id(IssueType.DUPLICATES, ticker, exchange),
+                    type=IssueType.DUPLICATES,
+                    severity=SEVERITY[IssueType.DUPLICATES],
+                    entity=entity,
+                    description=(f"{len(duplicate_dates)} duplicate date(s) in " f"{ticker}.{exchange} cache."),
+                    suggested_fix="Dedupe cache (keep latest row per date).",
+                    preview={
+                        "before": {"duplicate_dates": duplicate_dates},
+                        "after": {"duplicate_dates": []},
+                    },
+                    fix_payload={
+                        "kind": "dedupe",
+                        "ticker": ticker,
+                        "exchange": exchange,
+                    },
+                )
+            )
+
+        outliers = quality.get("outliers", [])
+        if outliers:
+            issues.append(
+                DataQualityIssue(
+                    id=_issue_id(IssueType.OUTLIERS, ticker, exchange),
+                    type=IssueType.OUTLIERS,
+                    severity=SEVERITY[IssueType.OUTLIERS],
+                    entity=entity,
+                    description=(f"{len(outliers)} outlier point(s) in {ticker}.{exchange}."),
+                    suggested_fix="Review/edit points in the Time Series editor.",
+                    preview={
+                        "before": {"outliers": outliers},
+                        "after": {"reviewed": True},
+                    },
+                    fixable=False,
+                )
+            )
+
+        last_date = quality.get("last_date")
+        if last_date is not None:
+            last = last_date if isinstance(last_date, date) else date.fromisoformat(str(last_date))
+            age_days = (today - last).days
+            if age_days > stale_max_age_days:
+                issues.append(
+                    DataQualityIssue(
+                        id=_issue_id(IssueType.STALE_SERIES, ticker, exchange),
+                        type=IssueType.STALE_SERIES,
+                        severity=SEVERITY[IssueType.STALE_SERIES],
+                        entity=entity,
+                        description=(f"Series {ticker}.{exchange} last updated {last} " f"({age_days} days ago)."),
+                        suggested_fix="Refetch the series.",
+                        preview={
+                            "before": {"last_date": last.isoformat()},
+                            "after": {"last_date": "refetched"},
+                        },
+                        fix_payload={
+                            "kind": "refetch",
+                            "ticker": ticker,
+                            "exchange": exchange,
+                        },
+                    )
+                )
+
+        # Ticker column in the cache rows must match the cache key.
+        if "Ticker" in df.columns:
+            row_tickers = {str(v).strip().upper() for v in df["Ticker"].dropna().unique() if str(v).strip()}
+            if row_tickers and row_tickers != {ticker}:
+                issues.append(
+                    DataQualityIssue(
+                        id=_issue_id(IssueType.TICKER_MISMATCH, ticker, exchange),
+                        type=IssueType.TICKER_MISMATCH,
+                        severity=SEVERITY[IssueType.TICKER_MISMATCH],
+                        entity=entity,
+                        description=(
+                            f"Cache rows for {ticker}.{exchange} carry ticker "
+                            f"value(s) {sorted(row_tickers)} instead of {ticker}."
+                        ),
+                        suggested_fix="Normalize rows to the cache key.",
+                        preview={
+                            "before": {"tickers": sorted(row_tickers)},
+                            "after": {"tickers": [ticker]},
+                        },
+                        fix_payload={
+                            "kind": "ticker_mismatch",
+                            "ticker": ticker,
+                            "exchange": exchange,
+                        },
+                    )
+                )
+    return issues
+
+
+def aggregate_issues(
+    accounts_root: Path | None = None,
+    *,
+    include_series: bool = True,
+    **series_kwargs: Any,
+) -> list[DataQualityIssue]:
+    """Aggregate holdings + series issues into one deduplicated list."""
+    issues: list[DataQualityIssue] = aggregate_holding_issues(accounts_root)
+    if include_series:
+        issues.extend(aggregate_series_issues(**series_kwargs))
+    return _dedupe_issues(issues)
+
+
+def find_issue(issues: Sequence[DataQualityIssue], issue_id: str) -> DataQualityIssue | None:
+    """Return the issue with ``issue_id`` or None."""
+    for issue in issues:
+        if issue.id == issue_id:
+            return issue
+    return None
+
+
+def writable_accounts_root() -> Path | None:
+    """Return the local writable accounts root (None in S3 deployments)."""
+    if getattr(config, "app_env", None) == "aws":
+        return None
+    root = getattr(config, "accounts_root", None)
+    return Path(root) if root else None

--- a/backend/routes/data_quality_admin.py
+++ b/backend/routes/data_quality_admin.py
@@ -1,0 +1,483 @@
+"""Read-write Data Quality Admin endpoints.
+
+Extends the read-only ``/data-quality`` surface with an aggregated issue list
+plus preview/fix/batch/dedupe/audit/undo write actions.  Every fix:
+
+  * backs up the affected file (``.bak``, never overwriting an existing one),
+  * records an append-only audit entry atomic with the change,
+  * goes through the same accounts-store write path as transactions.py for
+    holding changes (never direct JSON file mutation).
+
+Read endpoints (``GET /issues``, ``GET /issues/{id}/preview``, ``GET /audit``)
+never fetch live data and never mutate state.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from backend.common.accounts_store import LocalAccountsStore
+from backend.common.instruments import resolve_instrument_ticker
+from backend.data_quality.audit import append_audit, find_audit_entry, read_audit
+from backend.data_quality.issues import (
+    FIXABLE_TYPES,
+    aggregate_issues,
+    find_issue,
+)
+from backend.routes import get_active_user
+from backend.routes.transactions import (
+    _normalise_account_file_name,
+    resolve_writable_store,
+)
+from backend.timeseries.cache import (
+    load_cached_meta_timeseries_full,
+    load_meta_timeseries,
+    meta_timeseries_cache_path,
+)
+
+router = APIRouter(prefix="/data-quality", tags=["data-quality-admin"])
+
+_FETCH_DAYS = 3650
+
+
+class BatchFixRequest(BaseModel):
+    issue_ids: list[str] = Field(min_length=1)
+
+
+def _issue_list(**filters: Any) -> list[dict[str, Any]]:
+    """Return the aggregated issue list as plain dicts."""
+    issues = aggregate_issues()
+    result = []
+    for issue in issues:
+        item = issue.to_dict()
+        if _matches_filters(item, filters):
+            result.append(item)
+    return result
+
+
+def _matches_filters(item: dict[str, Any], filters: dict[str, Any]) -> bool:
+    issue_type = filters.get("type")
+    severity = filters.get("severity")
+    owner = filters.get("owner")
+    account = filters.get("account")
+    ticker = filters.get("ticker")
+    entity = item.get("entity") or {}
+    if issue_type and item.get("type") != issue_type:
+        return False
+    if severity and item.get("severity") != severity:
+        return False
+    if owner and str(entity.get("owner") or "") != owner:
+        return False
+    if account and str(entity.get("account") or "") != account:
+        return False
+    if ticker and ticker.upper() not in (
+        str(entity.get("ticker") or "").upper(),
+        str(entity.get("holding") or "").upper(),
+    ):
+        return False
+    return True
+
+
+def _backup_path_for(path: Path) -> Path:
+    return path.with_suffix(path.suffix + ".bak")
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` via temp file + rename (fsync'd)."""
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        fh.write(text)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, path)
+
+
+def _backup_file_if_needed(path: Path) -> Path:
+    """Create ``{path}.bak`` from the current content when missing.
+
+    Never overwrites an existing backup so the earliest known-good state is
+    preserved (convention from ``scripts/reconcile_holding_tickers.py``).
+    Backs up binary files (e.g. parquet) byte-for-byte.
+    """
+    backup = _backup_path_for(path)
+    if not backup.exists() and path.exists():
+        data = path.read_bytes()
+        backup.parent.mkdir(parents=True, exist_ok=True)
+        with backup.open("wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+    return backup
+
+
+def _resolve_writable_accounts_store(request: Request) -> LocalAccountsStore:
+    """Return the writable accounts store, refusing demo/global roots."""
+    store, _kind = resolve_writable_store(request)
+    if getattr(store, "is_global", False):
+        raise HTTPException(
+            status_code=400,
+            detail="Accounts root is the read-only demo dataset; create a writable account first.",
+        )
+    return store
+
+
+def _fix_wrong_exchange(request: Request, payload: dict[str, Any], actor: str | None) -> dict[str, Any]:
+    """Correct a holding's ticker through the accounts-store write path."""
+    owner = str(payload["owner"])
+    account = _normalise_account_file_name(str(payload["account"]))
+    holding_ticker = str(payload["holding_ticker"]).upper()
+    resolved_ticker = str(payload["resolved_ticker"]).upper()
+
+    store = _resolve_writable_accounts_store(request)
+    file_path = Path(store.local_root) / owner / f"{account}.json" if store.local_root else None
+
+    # Backup before any holding write; never overwrite an existing .bak
+    # (convention from scripts/reconcile_holding_tickers.py).
+    if file_path is not None and file_path.exists():
+        _backup_file_if_needed(file_path)
+
+    before_holdings: list[dict[str, Any]] = []
+    with store.edit_document(owner, f"{account}.json", default={}, trailing_newline=True) as data:
+        holdings = data.setdefault("holdings", [])
+        if not isinstance(holdings, list):
+            holdings = data["holdings"] = []
+        found = False
+        for holding in holdings:
+            if not isinstance(holding, dict):
+                continue
+            if str(holding.get("ticker") or "").upper() == holding_ticker:
+                before_holdings.append(dict(holding))
+                holding["ticker"] = resolved_ticker
+                found = True
+        if not found:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Holding {holding_ticker} no longer exists in {owner}/{account}.",
+            )
+
+    entry = append_audit(
+        action="wrong_exchange",
+        issue_id=str(payload.get("issue_id") or ""),
+        entity={"owner": owner, "account": account, "holding": holding_ticker},
+        before={"holdings": before_holdings},
+        after={"holdings": [{"ticker": resolved_ticker}]},
+        actor=actor,
+        extra={"kind": "wrong_exchange", "owner": owner, "account": account},
+    )
+    return {"status": "fixed", "ticker": resolved_ticker, "audit_id": entry["id"]}
+
+
+def _fix_refetch(payload: dict[str, Any], actor: str | None) -> dict[str, Any]:
+    """Fetch/refetch a cached meta timeseries (missing/stale/gaps)."""
+    ticker = str(payload["ticker"]).upper()
+    exchange = str(payload["exchange"]).upper()
+    df = load_meta_timeseries(ticker, exchange, days=_FETCH_DAYS)
+    entry = append_audit(
+        action="refetch",
+        issue_id=str(payload.get("issue_id") or ""),
+        entity={"ticker": ticker, "exchange": exchange},
+        before={"rows": None},
+        after={"rows": len(df) if df is not None else 0},
+        actor=actor,
+        extra={"kind": "refetch", "ticker": ticker, "exchange": exchange},
+    )
+    return {"status": "fixed", "rows": len(df) if df is not None else 0, "audit_id": entry["id"]}
+
+
+def _fix_unresolved_ticker(payload: dict[str, Any], actor: str | None) -> dict[str, Any]:
+    """Create metadata for a bare symbol (live lookup) then fetch the series."""
+    symbol = str(payload["symbol"]).upper()
+    exchange = str(payload["exchange"]).upper()
+    resolved = resolve_instrument_ticker(symbol, create_missing=True)
+    if resolved is None:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unable to resolve metadata for {symbol} from any source.",
+        )
+    resolved_symbol, _, resolved_exchange = resolved.partition(".")
+    df = load_meta_timeseries(resolved_symbol, resolved_exchange or exchange, days=_FETCH_DAYS)
+    entry = append_audit(
+        action="unresolved_ticker",
+        issue_id=str(payload.get("issue_id") or ""),
+        entity={"symbol": symbol, "exchange": exchange},
+        before={"metadata": "missing", "series": "missing"},
+        after={"metadata": resolved, "series_rows": len(df) if df is not None else 0},
+        actor=actor,
+        extra={"kind": "unresolved_ticker", "symbol": symbol, "exchange": exchange},
+    )
+    return {"status": "fixed", "ticker": resolved, "rows": len(df) if df is not None else 0, "audit_id": entry["id"]}
+
+
+def _fix_dedupe(payload: dict[str, Any], actor: str | None) -> dict[str, Any]:
+    """Dedupe a cached series keeping the latest row per date."""
+    ticker = str(payload["ticker"]).upper()
+    exchange = str(payload["exchange"]).upper()
+    cache = meta_timeseries_cache_path(ticker, exchange)
+    if cache.startswith("s3://"):
+        raise HTTPException(
+            status_code=400,
+            detail="Dedupe currently supports the local cache only.",
+        )
+    path = Path(cache)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Cached series not found.")
+    df = load_cached_meta_timeseries_full(ticker, exchange)
+    before_rows = len(df)
+    if "Date" not in df.columns:
+        raise HTTPException(status_code=400, detail="Cached series has no Date column.")
+    deduped = df.drop_duplicates(subset=["Date"], keep="last").sort_values("Date").reset_index(drop=True)
+    _backup_file_if_needed(path)
+    deduped.to_parquet(path, index=False)
+    entry = append_audit(
+        action="dedupe",
+        issue_id=str(payload.get("issue_id") or ""),
+        entity={"ticker": ticker, "exchange": exchange},
+        before={"rows": before_rows},
+        after={"rows": len(deduped)},
+        actor=actor,
+        extra={"kind": "dedupe", "ticker": ticker, "exchange": exchange},
+    )
+    return {
+        "status": "fixed",
+        "removed": before_rows - len(deduped),
+        "rows": len(deduped),
+        "audit_id": entry["id"],
+    }
+
+
+def _fix_missing_metadata(payload: dict[str, Any], actor: str | None) -> dict[str, Any]:
+    """Auto-create instrument metadata for a cached pair (live refresh)."""
+    ticker = str(payload["ticker"]).upper()
+    exchange = str(payload["exchange"]).upper()
+    resolved = resolve_instrument_ticker(ticker, exchanges=(exchange,), create_missing=True)
+    if resolved is None:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unable to create metadata for {ticker}.{exchange}.",
+        )
+    entry = append_audit(
+        action="missing_metadata",
+        issue_id=str(payload.get("issue_id") or ""),
+        entity={"ticker": ticker, "exchange": exchange},
+        before={"metadata": "missing"},
+        after={"metadata": resolved},
+        actor=actor,
+        extra={"kind": "missing_metadata", "ticker": ticker, "exchange": exchange},
+    )
+    return {"status": "fixed", "ticker": resolved, "audit_id": entry["id"]}
+
+
+def _fix_ticker_mismatch(payload: dict[str, Any], actor: str | None) -> dict[str, Any]:
+    """Normalize the cache rows' Ticker column to the cache key."""
+    ticker = str(payload["ticker"]).upper()
+    exchange = str(payload["exchange"]).upper()
+    cache = meta_timeseries_cache_path(ticker, exchange)
+    if cache.startswith("s3://"):
+        raise HTTPException(
+            status_code=400,
+            detail="Ticker normalization currently supports the local cache only.",
+        )
+    path = Path(cache)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Cached series not found.")
+    df = load_cached_meta_timeseries_full(ticker, exchange)
+    before_tickers: list[str] = []
+    if "Ticker" in df.columns:
+        before_tickers = sorted({str(v).strip().upper() for v in df["Ticker"].dropna().unique()})
+        df["Ticker"] = ticker
+    _backup_file_if_needed(path)
+    df.to_parquet(path, index=False)
+    entry = append_audit(
+        action="ticker_mismatch",
+        issue_id=str(payload.get("issue_id") or ""),
+        entity={"ticker": ticker, "exchange": exchange},
+        before={"tickers": before_tickers},
+        after={"tickers": [ticker]},
+        actor=actor,
+        extra={"kind": "ticker_mismatch", "ticker": ticker, "exchange": exchange},
+    )
+    return {"status": "fixed", "tickers": [ticker], "audit_id": entry["id"]}
+
+
+def _apply_fix(issue_id: str, request: Request, actor: str | None) -> dict[str, Any]:
+    issues = aggregate_issues()
+    issue = find_issue(issues, issue_id)
+    if issue is None:
+        raise HTTPException(status_code=404, detail=f"Unknown issue id: {issue_id}")
+    if not issue.fixable or issue.type not in FIXABLE_TYPES:
+        raise HTTPException(status_code=409, detail=f"Issue type {issue.type} has no automated fix.")
+    payload = dict(issue.fix_payload)
+    payload["issue_id"] = issue_id
+
+    kind = payload.get("kind")
+    if kind == "wrong_exchange":
+        return _fix_wrong_exchange(request, payload, actor)
+    if kind == "refetch":
+        return _fix_refetch(payload, actor)
+    if kind == "unresolved_ticker":
+        return _fix_unresolved_ticker(payload, actor)
+    if kind == "dedupe":
+        return _fix_dedupe(payload, actor)
+    if kind == "missing_metadata":
+        return _fix_missing_metadata(payload, actor)
+    if kind == "ticker_mismatch":
+        return _fix_ticker_mismatch(payload, actor)
+    raise HTTPException(status_code=409, detail=f"Unsupported fix kind: {kind}")
+
+
+@router.get("/issues")
+async def list_issues(
+    type: str | None = Query(None, description="Filter by issue type (WRONG_EXCHANGE, GAPS, ...)"),
+    severity: str | None = Query(None, description="Filter by severity: high | medium | low"),
+    owner: str | None = Query(None, description="Filter by holding owner"),
+    account: str | None = Query(None, description="Filter by holding account"),
+    ticker: str | None = Query(None, description="Filter by ticker (series) or holding ticker"),
+) -> dict[str, Any]:
+    issues = _issue_list(type=type, severity=severity, owner=owner, account=account, ticker=ticker)
+    return {"count": len(issues), "issues": issues}
+
+
+@router.get("/issues/{issue_id}/preview")
+async def preview_issue(issue_id: str) -> dict[str, Any]:
+    issues = aggregate_issues()
+    issue = find_issue(issues, issue_id)
+    if issue is None:
+        raise HTTPException(status_code=404, detail=f"Unknown issue id: {issue_id}")
+    return {
+        "id": issue.id,
+        "type": issue.type,
+        "severity": issue.severity,
+        "entity": issue.entity,
+        "description": issue.description,
+        "suggested_fix": issue.suggested_fix,
+        "preview": issue.preview,
+        "fixable": issue.fixable,
+    }
+
+
+@router.post("/issues/{issue_id}/fix")
+async def fix_issue(
+    issue_id: str,
+    request: Request,
+    user: str | None = Depends(get_active_user),
+) -> dict[str, Any]:
+    return _apply_fix(issue_id, request, user)
+
+
+@router.post("/fixes")
+async def batch_fix(
+    body: BatchFixRequest,
+    request: Request,
+    user: str | None = Depends(get_active_user),
+) -> dict[str, Any]:
+    """Apply the same-type fix for every listed issue, reporting per-issue results."""
+    results: list[dict[str, Any]] = []
+    for issue_id in body.issue_ids:
+        try:
+            result = _apply_fix(issue_id, request, user)
+            results.append({"issue_id": issue_id, **result, "status": "ok"})
+        except HTTPException as exc:
+            results.append({"issue_id": issue_id, "status": "error", "detail": exc.detail})
+    ok = sum(1 for r in results if r["status"] == "ok")
+    return {"applied": ok, "failed": len(results) - ok, "results": results}
+
+
+@router.post("/series/{ticker}/{exchange}/dedupe")
+async def dedupe_series(
+    ticker: str,
+    exchange: str,
+    user: str | None = Depends(get_active_user),
+) -> dict[str, Any]:
+    """Dedupe a cached series directly (keeps the latest row per date)."""
+    payload = {
+        "kind": "dedupe",
+        "ticker": ticker.upper(),
+        "exchange": exchange.upper(),
+        "issue_id": f"manual:{ticker.upper()}.{exchange.upper()}",
+    }
+    return _fix_dedupe(payload, user)
+
+
+@router.get("/audit")
+async def list_audit(limit: int | None = Query(None, ge=1, le=1000)) -> dict[str, Any]:
+    entries = read_audit(limit=limit)
+    return {"count": len(entries), "entries": entries}
+
+
+@router.post("/audit/{entry_id}/undo")
+async def undo_audit(
+    entry_id: str,
+    request: Request,
+    user: str | None = Depends(get_active_user),
+) -> dict[str, Any]:
+    """Undo a reversible action recorded in the audit trail."""
+    entry = find_audit_entry(entry_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail=f"Unknown audit entry: {entry_id}")
+    kind = (entry.get("extra") or {}).get("kind")
+
+    if kind == "wrong_exchange":
+        store = _resolve_writable_accounts_store(request)
+        owner = str((entry.get("entity") or {}).get("owner") or "")
+        account = _normalise_account_file_name(str((entry.get("entity") or {}).get("account") or ""))
+        before = entry.get("before") or {}
+        after = entry.get("after") or {}
+        before_holdings = before.get("holdings") or []
+        after_holdings = after.get("holdings") or []
+        # Map the post-fix ticker(s) back to their original pre-fix values.
+        restore_map = {
+            str(a.get("ticker") or "").upper(): str(b.get("ticker") or "")
+            for b, a in zip(before_holdings, after_holdings)
+            if b.get("ticker") and a.get("ticker")
+        }
+        with store.edit_document(owner, f"{account}.json", default={}, trailing_newline=True) as data:
+            data.setdefault("holdings", [])
+            for holding in data["holdings"]:
+                if not isinstance(holding, dict):
+                    continue
+                current = str(holding.get("ticker") or "").upper()
+                if current in restore_map:
+                    holding["ticker"] = restore_map[current]
+        append_audit(
+            action="undo",
+            issue_id=str(entry.get("issue_id") or ""),
+            entity=entry.get("entity") or {},
+            before={"action": entry.get("action"), "undo_of": entry_id},
+            after={"restored": True},
+            actor=user,
+            extra={"kind": "undo", "undo_of": entry_id},
+        )
+        return {"status": "undone", "entry_id": entry_id}
+
+    if kind in {"dedupe", "ticker_mismatch"}:
+        ticker = str((entry.get("extra") or {}).get("ticker") or "")
+        exchange = str((entry.get("extra") or {}).get("exchange") or "")
+        cache = meta_timeseries_cache_path(ticker, exchange)
+        if cache.startswith("s3://"):
+            raise HTTPException(status_code=400, detail="Undo supports the local cache only.")
+        path = Path(cache)
+        backup = _backup_path_for(path)
+        if not backup.exists():
+            raise HTTPException(status_code=409, detail="No backup available to restore from.")
+        shutil.copy2(backup, path)
+        append_audit(
+            action="undo",
+            issue_id=str(entry.get("issue_id") or ""),
+            entity={"ticker": ticker, "exchange": exchange},
+            before={"action": entry.get("action"), "undo_of": entry_id},
+            after={"restored": True},
+            actor=user,
+            extra={"kind": "undo", "undo_of": entry_id},
+        )
+        return {"status": "undone", "entry_id": entry_id}
+
+    raise HTTPException(
+        status_code=409,
+        detail=f"Action {entry.get('action')!r} is not reversible.",
+    )

--- a/config.lambda.yaml
+++ b/config.lambda.yaml
@@ -88,6 +88,7 @@ ui:
   enable_compliance_workflows: false
   enable_advanced_analytics: false
   enable_reporting_extended: false
+  enable_data_quality_admin: true
   relative_view_enabled: false
   theme: system
   tabs:

--- a/config.yaml
+++ b/config.yaml
@@ -73,6 +73,7 @@ ui:
   enable_compliance_workflows: false
   enable_advanced_analytics: false
   enable_reporting_extended: false
+  enable_data_quality_admin: true
   relative_view_enabled: false
   theme: system
   tabs:

--- a/docs/TECHNICAL_SUPPORT.md
+++ b/docs/TECHNICAL_SUPPORT.md
@@ -6,6 +6,23 @@
 - **Configuration**: Copy `config.example.yaml` to `config.yaml` and `.env.example`
   to `.env` for local or AWS environments. Provide secrets via environment variables.
 
+## Data Quality Admin
+- **Screen**: `/data-quality` shows a tabbed admin surface (Issues / Series /
+  Holdings / Metadata / Audit) when the `enable_data_quality_admin` config flag
+  is enabled (default: on). When disabled, the page falls back to the original
+  read-only series table.
+- **Issues tab**: lists unified issues across holdings (wrong exchange,
+  unresolved ticker, missing series), cached series (stale, gaps, duplicates,
+  outliers, ticker mismatch) and instrument metadata. Filter by type, severity
+  or ticker; every fix has a Preview (before → after) and, when applied,
+  creates a `.bak` backup and an append-only audit record.
+- **Audit tab**: shows the JSONL audit trail (`{data_root}/audit/`); reversible
+  actions (wrong-exchange corrections, dedupe, ticker normalization) can be
+  undone from there.
+- **Holding writes** go through the same accounts-store write path as manual
+  holdings; the shared demo dataset under `data/accounts/` is read-only and
+  must be copied to a writable root before fixes can be applied.
+
 ## Common Troubleshooting Steps
 - Verify that Python (3.11+) and Node.js versions meet project requirements
   (CI/CD uses Python 3.12).

--- a/frontend/src/ConfigContext.tsx
+++ b/frontend/src/ConfigContext.tsx
@@ -27,6 +27,7 @@ export interface TabsConfig {
   instrumentadmin: boolean;
   dataadmin: boolean;
   dataexplorer: boolean;
+  dataquality: boolean;
   virtual: boolean;
   research: boolean;
   support: boolean;
@@ -40,7 +41,6 @@ export interface TabsConfig {
   'trade-compliance': boolean;
   reports: boolean;
   scenario: boolean;
-  dataquality: boolean;
 }
 
 export interface AppConfig {
@@ -57,6 +57,12 @@ export interface AppConfig {
   theme: "dark" | "light" | "system";
   baseCurrency: string;
   enableAdvancedAnalytics?: boolean;
+  /**
+   * Read-write Data Quality Admin surface (issue list + preview/fix/audit).
+   * Fails open: the read-only series table stays available even when this is
+   * false, only the write tabs (Issues/Holdings/Audit) are hidden.
+   */
+  dataQualityAdmin?: boolean;
 }
 
 export interface RawConfig {
@@ -67,6 +73,7 @@ export interface RawConfig {
   enable_compliance_workflows?: boolean;
   enable_advanced_analytics?: boolean;
   enable_reporting_extended?: boolean;
+  enable_data_quality_admin?: boolean;
   theme?: string | null;
   allowed_emails?: string[] | null;
 }
@@ -123,6 +130,7 @@ export const configContext = createContext<ConfigContextValue>({
   theme: "system",
   baseCurrency: "GBP",
   enableAdvancedAnalytics: true,
+  dataQualityAdmin: true,
   refreshConfig: async () => {},
   setRelativeViewEnabled: () => {},
   setBaseCurrency: () => {},
@@ -149,6 +157,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       theme: "system",
       baseCurrency: storedCurrency || "GBP",
       enableAdvancedAnalytics: true,
+      dataQualityAdmin: true,
     };
   });
   const setRelativeViewEnabled = useCallback((enabled: boolean) => {
@@ -214,6 +223,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
         theme,
         baseCurrency: previousConfig.baseCurrency,
         enableAdvancedAnalytics: cfg.enable_advanced_analytics !== false,
+        dataQualityAdmin: cfg.enable_data_quality_admin !== false,
       }));
       applyTheme(theme);
     } catch {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -63,6 +63,8 @@ import {
   portfolioContractSchema,
   transactionsContractSchema,
   dataQualityTimeseriesContractSchema,
+  dataQualityIssuesContractSchema,
+  dataQualityAuditContractSchema,
 } from "./contracts/apiContracts";
 
 const cleanOptionalString = (value: unknown): string | null => {
@@ -1612,6 +1614,132 @@ export const getDataQualityTimeseries = async (
     await fetchJson<DataQualityTimeseriesResponse>(
       `${API_BASE}/data-quality/timeseries${qs ? `?${qs}` : ""}`,
     ),
+  );
+};
+
+// ───────────── Data Quality Admin API (read-write) ─────────────
+
+export interface DataQualityIssue {
+  id: string;
+  type: string;
+  severity: "high" | "medium" | "low";
+  entity: Record<string, unknown>;
+  description: string;
+  suggested_fix: string;
+  preview: Record<string, unknown>;
+  fixable: boolean;
+}
+
+export interface DataQualityIssuesResponse {
+  count: number;
+  issues: DataQualityIssue[];
+}
+
+export interface DataQualityAuditEntry {
+  id: string;
+  timestamp: string;
+  action: string;
+  issue_id: string;
+  entity: Record<string, unknown>;
+  before: Record<string, unknown>;
+  after: Record<string, unknown>;
+  actor: string | null;
+}
+
+export interface DataQualityAuditResponse {
+  count: number;
+  entries: DataQualityAuditEntry[];
+}
+
+export interface DataQualityFixResult {
+  status: string;
+  ticker?: string;
+  rows?: number;
+  removed?: number;
+  audit_id?: string;
+}
+
+export interface DataQualityBatchFixResponse {
+  applied: number;
+  failed: number;
+  results: Array<{ issue_id: string; status: string; detail?: string } & DataQualityFixResult>;
+}
+
+export const getDataQualityIssues = async (filters: {
+  type?: string;
+  severity?: string;
+  owner?: string;
+  account?: string;
+  ticker?: string;
+} = {}): Promise<DataQualityIssuesResponse> => {
+  const params = new URLSearchParams();
+  if (filters.type) params.set("type", filters.type);
+  if (filters.severity) params.set("severity", filters.severity);
+  if (filters.owner) params.set("owner", filters.owner);
+  if (filters.account) params.set("account", filters.account);
+  if (filters.ticker) params.set("ticker", filters.ticker);
+  const qs = params.toString();
+  return dataQualityIssuesContractSchema.parse(
+    await fetchJson<DataQualityIssuesResponse>(
+      `${API_BASE}/data-quality/issues${qs ? `?${qs}` : ""}`,
+    ),
+  );
+};
+
+export const getDataQualityIssuePreview = async (
+  issueId: string,
+): Promise<DataQualityIssue> => {
+  return fetchJson<DataQualityIssue>(
+    `${API_BASE}/data-quality/issues/${encodeURIComponent(issueId)}/preview`,
+  );
+};
+
+export const fixDataQualityIssue = async (
+  issueId: string,
+): Promise<DataQualityFixResult> => {
+  return fetchJson<DataQualityFixResult>(
+    `${API_BASE}/data-quality/issues/${encodeURIComponent(issueId)}/fix`,
+    { method: "POST" },
+  );
+};
+
+export const fixDataQualityBatch = async (
+  issueIds: string[],
+): Promise<DataQualityBatchFixResponse> => {
+  return fetchJson<DataQualityBatchFixResponse>(`${API_BASE}/data-quality/fixes`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ issue_ids: issueIds }),
+  });
+};
+
+export const dedupeDataQualitySeries = async (
+  ticker: string,
+  exchange: string,
+): Promise<DataQualityFixResult> => {
+  return fetchJson<DataQualityFixResult>(
+    `${API_BASE}/data-quality/series/${encodeURIComponent(ticker)}/${encodeURIComponent(exchange)}/dedupe`,
+    { method: "POST" },
+  );
+};
+
+export const getDataQualityAudit = async (
+  limit?: number,
+): Promise<DataQualityAuditResponse> => {
+  const qs = limit != null ? `?limit=${limit}` : "";
+  return dataQualityAuditContractSchema.parse(
+    await fetchJson<DataQualityAuditResponse>(
+      `${API_BASE}/data-quality/audit${qs}`,
+    ),
+  );
+};
+
+export const undoDataQualityAudit = async (
+  entryId: string,
+): Promise<{ status: string; entry_id: string }> => {
+  return fetchJson<{ status: string; entry_id: string }>(
+    `${API_BASE}/data-quality/audit/${encodeURIComponent(entryId)}/undo`,
+    { method: "POST" },
   );
 };
 

--- a/frontend/src/contracts/apiContracts.ts
+++ b/frontend/src/contracts/apiContracts.ts
@@ -200,6 +200,40 @@ export const dataQualityTimeseriesContractSchema = z.object({
   positions: z.array(timeseriesQualityPositionSchema),
 });
 
+// ───────────── Data Quality Admin (read-write) ─────────────
+
+const dataQualityIssueSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  severity: z.enum(["high", "medium", "low"]),
+  entity: z.record(z.string(), z.unknown()),
+  description: z.string(),
+  suggested_fix: z.string(),
+  preview: z.record(z.string(), z.unknown()),
+  fixable: z.boolean(),
+});
+
+export const dataQualityIssuesContractSchema = z.object({
+  count: z.number(),
+  issues: z.array(dataQualityIssueSchema),
+});
+
+export const dataQualityAuditContractSchema = z.object({
+  count: z.number(),
+  entries: z.array(
+    z.object({
+      id: z.string(),
+      timestamp: z.string(),
+      action: z.string(),
+      issue_id: z.string(),
+      entity: z.record(z.string(), z.unknown()),
+      before: z.record(z.string(), z.unknown()),
+      after: z.record(z.string(), z.unknown()),
+      actor: nullableString,
+    }),
+  ),
+});
+
 export const apiContractSchemas = {
   config: configContractSchema,
   owners: ownersContractSchema,
@@ -208,6 +242,8 @@ export const apiContractSchemas = {
   portfolio: portfolioContractSchema,
   transactions: transactionsContractSchema,
   dataQualityTimeseries: dataQualityTimeseriesContractSchema,
+  dataQualityIssues: dataQualityIssuesContractSchema,
+  dataQualityAudit: dataQualityAuditContractSchema,
 } as const;
 
 // satisfies Record<keyof typeof apiContractSchemas, object> enforces that every
@@ -224,4 +260,6 @@ export const apiContractJsonSchemas = {
   portfolio: toJSONSchema(portfolioContractSchema),
   transactions: toJSONSchema(transactionsContractSchema),
   dataQualityTimeseries: toJSONSchema(dataQualityTimeseriesContractSchema),
+  dataQualityIssues: toJSONSchema(dataQualityIssuesContractSchema),
+  dataQualityAudit: toJSONSchema(dataQualityAuditContractSchema),
 } satisfies Record<keyof typeof apiContractSchemas, object>;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -149,6 +149,99 @@
       "missingDays_other": "{{count}} missing business days",
       "noIssues": "No data quality issues found for this position.",
       "close": "Close"
+    },
+    "admin": {
+      "tabs": {
+        "issues": "Issues",
+        "series": "Series",
+        "holdings": "Holdings",
+        "metadata": "Metadata",
+        "audit": "Audit"
+      },
+      "issues": {
+        "title": "Data Quality Issues",
+        "subtitle": "Unified issues across holdings, cached series and instrument metadata.",
+        "noIssues": "No issues found for the current filters.",
+        "filters": {
+          "type": "Type",
+          "severity": "Severity",
+          "ticker": "Ticker",
+          "allTypes": "All types",
+          "allSeverities": "All severities"
+        },
+        "columns": {
+          "type": "Type",
+          "severity": "Severity",
+          "entity": "Entity",
+          "description": "Description",
+          "suggestedFix": "Suggested fix",
+          "actions": "Actions"
+        },
+        "severity": {
+          "high": "High",
+          "medium": "Medium",
+          "low": "Low"
+        },
+        "actions": {
+          "preview": "Preview",
+          "fix": "Apply fix",
+          "fixing": "Applying...",
+          "fixAll": "Apply fix to all shown",
+          "fixAllShort": "Fix all",
+          "backupNote": "Every fix creates a .bak backup and an audit record.",
+          "notFixable": "Manual review",
+          "applied": "Fix applied",
+          "failed": "Fix failed",
+          "batchApplied": "Applied {{applied}} of {{total}} issues.",
+          "batchFailed": "{{failed}} issue(s) could not be applied.",
+          "close": "Close",
+          "confirmTitle": "Apply this fix?",
+          "confirmBody": "The change is backed up and recorded in the audit trail.",
+          "cancel": "Cancel",
+          "apply": "Apply"
+        },
+        "previewTitle": "Fix preview: {{type}}",
+        "before": "Before",
+        "after": "After"
+      },
+      "series": {
+        "title": "Series",
+        "refetch": "Refetch",
+        "dedupe": "Dedupe",
+        "edit": "Edit",
+        "rebuild": "Rebuild",
+        "deduped": "Deduped {{removed}} duplicate row(s).",
+        "refetched": "Refetched {{rows}} row(s)."
+      },
+      "holdings": {
+        "title": "Holdings",
+        "correctExchange": "Correct exchange",
+        "createMetadata": "Create metadata & fetch",
+        "corrected": "Corrected holding to {{ticker}}."
+      },
+      "metadata": {
+        "title": "Metadata",
+        "note": "Instrument metadata management lives in the Instrument Admin screen.",
+        "openInstrumentAdmin": "Open Instrument Admin"
+      },
+      "audit": {
+        "title": "Audit Trail",
+        "empty": "No audit records yet.",
+        "columns": {
+          "timestamp": "Timestamp",
+          "action": "Action",
+          "entity": "Entity",
+          "before": "Before",
+          "after": "After",
+          "actor": "Actor"
+        },
+        "actions": {
+          "undo": "Undo",
+          "undone": "Undone",
+          "undoFailed": "Undo failed: {{detail}}",
+          "notReversible": "Not reversible"
+        }
+      }
     }
   },
   "dashboard": {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -38,6 +38,7 @@ import LoginPage from './LoginPage';
 import { UserProvider, useUser } from './UserContext';
 import ErrorBoundary from './ErrorBoundary';
 import DisabledFeature from './components/DisabledFeature';
+import AppHeader from './components/AppHeader';
 import { loadStoredAuthUser, loadStoredUserProfile } from './authStorage';
 import { RouteProvider } from './RouteContext';
 import { clearCognitoSession, cognitoLogout, ensureAwsUiAuth, extractTokenExchangeErrorReason, getCognitoSessionExpiresAt, getStoredCognitoIdToken, refreshCognitoSession, UserCancelledError, type AwsUiAuthConfig } from './awsUiAuth';
@@ -464,11 +465,30 @@ export function Root({ awsUiAuth = runtimeAwsUiAuth }: { awsUiAuth?: AwsUiAuthCo
             }
 
             const Component = route.lazyComponent;
+            // Standalone pages mount outside App.tsx's mode dispatch, so they
+            // render with zero nav chrome unless the wrapper is added here
+            // (or the page self-renders AppHeader like AlertSettings does).
+            // Wrap every standalone route in AppHeader except: /alert-settings
+            // (already renders AppHeader itself with lastRefresh), and the two
+            // public pre-login routes that must stay chrome-free (#6725).
+            const needsChrome =
+              route.routePath !== '/alert-settings' &&
+              route.routePath !== '/support' &&
+              route.routePath !== '/create-account';
             return [
               <Route
                 key={route.routePath}
                 path={route.routePath}
-                element={<Component />}
+                element={
+                  needsChrome ? (
+                    <>
+                      <AppHeader />
+                      <Component />
+                    </>
+                  ) : (
+                    <Component />
+                  )
+                }
               />,
             ];
           })}

--- a/frontend/src/pages/DataQuality.tsx
+++ b/frontend/src/pages/DataQuality.tsx
@@ -1,6 +1,16 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getDataQualityTimeseries } from "../api";
+import {
+  dedupeDataQualitySeries,
+  fixDataQualityBatch,
+  fixDataQualityIssue,
+  getDataQualityAudit,
+  getDataQualityIssues,
+  getDataQualityTimeseries,
+  undoDataQualityAudit,
+  type DataQualityAuditEntry,
+  type DataQualityIssue,
+} from "../api";
 import type { TimeseriesQualityPosition } from "../types";
 import { useSortableTable } from "../hooks/useSortableTable";
 import tableStyles from "../styles/table.module.css";
@@ -8,6 +18,7 @@ import { QualityStatusBadge } from "../components/QualityStatusBadge";
 import { getQualityStatus, type QualityStatus } from "../lib/dataQualityStatus";
 import { DataQualityDrilldownModal } from "../components/DataQualityDrilldownModal";
 import EmptyState from "../components/EmptyState";
+import { useConfig } from "../ConfigContext";
 
 type Row = TimeseriesQualityPosition & {
   duplicate_count: number;
@@ -15,34 +26,395 @@ type Row = TimeseriesQualityPosition & {
   status: QualityStatus;
 };
 
-export default function DataQuality() {
+type TabId = "issues" | "series" | "holdings" | "metadata" | "audit";
+
+const ISSUE_TYPES = [
+  "WRONG_EXCHANGE",
+  "UNRESOLVED_TICKER",
+  "MISSING_SERIES",
+  "STALE_SERIES",
+  "GAPS",
+  "DUPLICATES",
+  "OUTLIERS",
+  "MISSING_METADATA",
+  "TICKER_MISMATCH",
+] as const;
+
+/** Holdings-related issue types surfaced by the Holdings tab (#6724). */
+const HOLDING_ISSUE_TYPES = ["WRONG_EXCHANGE", "UNRESOLVED_TICKER", "MISSING_SERIES"] as const;
+
+interface IssueFilters {
+  type: string;
+  severity: string;
+  ticker: string;
+}
+
+function entityLabel(entity: Record<string, unknown>): string {
+  const holding = entity.holding as string | undefined;
+  const ticker = entity.ticker as string | undefined;
+  const exchange = entity.exchange as string | undefined;
+  const owner = entity.owner as string | undefined;
+  const account = entity.account as string | undefined;
+  const parts: string[] = [];
+  if (owner) parts.push(String(owner));
+  if (account) parts.push(String(account));
+  if (holding) parts.push(holding);
+  else if (ticker) parts.push(exchange ? `${ticker}.${exchange}` : ticker);
+  return parts.join(" / ") || "—";
+}
+
+function IssueTable({
+  issues,
+  loading,
+  error,
+  onPreview,
+  onFix,
+  fixingId,
+  fixAllVisible,
+  fixingAll,
+}: {
+  issues: DataQualityIssue[];
+  loading: boolean;
+  error: string | null;
+  onPreview: (issue: DataQualityIssue) => void;
+  onFix: (issue: DataQualityIssue) => void;
+  fixingId: string | null;
+  fixAllVisible: (() => void) | null;
+  fixingAll: boolean;
+}) {
+  const { t } = useTranslation();
+  if (loading) return <div>{t("common.loading")}</div>;
+  if (error) return <p style={{ color: "red" }}>{error}</p>;
+  if (issues.length === 0) {
+    return <EmptyState message={t("dataQuality.admin.issues.noIssues")} actions={[]} />;
+  }
+  return (
+    <>
+      {fixAllVisible && issues.some((i) => i.fixable) && (
+        <div className="mb-4">
+          <button
+            type="button"
+            onClick={fixAllVisible}
+            disabled={fixingAll}
+            aria-label={t("dataQuality.admin.issues.actions.fixAll")}
+          >
+            {fixingAll
+              ? t("dataQuality.admin.issues.actions.fixing")
+              : t("dataQuality.admin.issues.actions.fixAllShort")}
+          </button>
+          <span className="ml-2 text-xs opacity-70">
+            {t("dataQuality.admin.issues.actions.backupNote")}
+          </span>
+        </div>
+      )}
+      <table className={`${tableStyles.table} mb-4 w-full`}>
+        <thead>
+          <tr>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.issues.columns.type")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.issues.columns.severity")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.issues.columns.entity")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.issues.columns.description")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.issues.columns.suggestedFix")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.issues.columns.actions")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {issues.map((issue) => (
+            <tr key={issue.id}>
+              <td className={tableStyles.cell}>
+                <code>{issue.type}</code>
+              </td>
+              <td className={tableStyles.cell}>
+                {t(`dataQuality.admin.issues.severity.${issue.severity}`)}
+              </td>
+              <td className={tableStyles.cell}>{entityLabel(issue.entity)}</td>
+              <td className={tableStyles.cell}>{issue.description}</td>
+              <td className={tableStyles.cell}>{issue.suggested_fix}</td>
+              <td className={tableStyles.cell}>
+                <button
+                  type="button"
+                  onClick={() => onPreview(issue)}
+                  aria-label={t("dataQuality.admin.issues.actions.preview")}
+                >
+                  {t("dataQuality.admin.issues.actions.preview")}
+                </button>{" "}
+                {issue.fixable ? (
+                  <button
+                    type="button"
+                    onClick={() => onFix(issue)}
+                    disabled={fixingId === issue.id}
+                    aria-label={t("dataQuality.admin.issues.actions.fix")}
+                  >
+                    {fixingId === issue.id
+                      ? t("dataQuality.admin.issues.actions.fixing")
+                      : t("dataQuality.admin.issues.actions.fix")}
+                  </button>
+                ) : (
+                  <span className="text-xs opacity-60">
+                    {t("dataQuality.admin.issues.actions.notFixable")}
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+}
+
+function IssueFiltersBar({
+  filters,
+  onChange,
+}: {
+  filters: IssueFilters;
+  onChange: (filters: IssueFilters) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-2">
+      <label className="text-sm">
+        {t("dataQuality.admin.issues.filters.type")}
+        <select
+          value={filters.type}
+          onChange={(e) => onChange({ ...filters, type: e.target.value })}
+          className="ml-2"
+        >
+          <option value="">{t("dataQuality.admin.issues.filters.allTypes")}</option>
+          {ISSUE_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="text-sm">
+        {t("dataQuality.admin.issues.filters.severity")}
+        <select
+          value={filters.severity}
+          onChange={(e) => onChange({ ...filters, severity: e.target.value })}
+          className="ml-2"
+        >
+          <option value="">{t("dataQuality.admin.issues.filters.allSeverities")}</option>
+          <option value="high">{t("dataQuality.admin.issues.severity.high")}</option>
+          <option value="medium">{t("dataQuality.admin.issues.severity.medium")}</option>
+          <option value="low">{t("dataQuality.admin.issues.severity.low")}</option>
+        </select>
+      </label>
+      <label className="text-sm">
+        {t("dataQuality.admin.issues.filters.ticker")}
+        <input
+          type="text"
+          value={filters.ticker}
+          onChange={(e) => onChange({ ...filters, ticker: e.target.value })}
+          className="ml-2"
+          placeholder="ABC.L"
+        />
+      </label>
+    </div>
+  );
+}
+
+function IssuesTab({ presetTypes }: { presetTypes?: readonly string[] }) {
+  const { t } = useTranslation();
+  const [issues, setIssues] = useState<DataQualityIssue[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<IssueFilters>({
+    type: presetTypes?.length === 1 ? presetTypes[0] : "",
+    severity: "",
+    ticker: "",
+  });
+  const [preview, setPreview] = useState<DataQualityIssue | null>(null);
+  const [confirming, setConfirming] = useState<DataQualityIssue | null>(null);
+  const [fixingId, setFixingId] = useState<string | null>(null);
+  const [fixingAll, setFixingAll] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [messageError, setMessageError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getDataQualityIssues();
+      setIssues(res.issues);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const visible = useMemo(() => {
+    return issues.filter((issue) => {
+      if (presetTypes && presetTypes.length > 1 && !presetTypes.includes(issue.type)) {
+        return false;
+      }
+      if (filters.type && issue.type !== filters.type) return false;
+      if (filters.severity && issue.severity !== filters.severity) return false;
+      if (filters.ticker) {
+        const needle = filters.ticker.trim().toUpperCase();
+        const haystack = `${String(issue.entity.ticker ?? "")}.${String(issue.entity.exchange ?? "")} ${String(issue.entity.holding ?? "")}`.toUpperCase();
+        if (!haystack.includes(needle)) return false;
+      }
+      return true;
+    });
+  }, [issues, filters, presetTypes]);
+
+  const applyFix = useCallback(
+    async (issue: DataQualityIssue) => {
+      setFixingId(issue.id);
+      setMessageError(null);
+      setMessage(null);
+      try {
+        await fixDataQualityIssue(issue.id);
+        setMessage(t("dataQuality.admin.issues.actions.applied"));
+        await load();
+      } catch (e) {
+        setMessageError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setFixingId(null);
+        setConfirming(null);
+      }
+    },
+    [load, t],
+  );
+
+  const applyBatch = useCallback(async () => {
+    const ids = visible.filter((i) => i.fixable).map((i) => i.id);
+    if (ids.length === 0) return;
+    setFixingAll(true);
+    setMessageError(null);
+    setMessage(null);
+    try {
+      const res = await fixDataQualityBatch(ids);
+      setMessage(t("dataQuality.admin.issues.actions.batchApplied", { applied: res.applied, total: ids.length }));
+      if (res.failed > 0) {
+        setMessageError(t("dataQuality.admin.issues.actions.batchFailed", { failed: res.failed }));
+      }
+      await load();
+    } catch (e) {
+      setMessageError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setFixingAll(false);
+    }
+  }, [visible, load, t]);
+
+  return (
+    <div>
+      <h2 className="mb-2 text-xl">{t("dataQuality.admin.issues.title")}</h2>
+      <p className="mb-4 text-sm opacity-70">{t("dataQuality.admin.issues.subtitle")}</p>
+      <IssueFiltersBar filters={filters} onChange={setFilters} />
+      {message && <p role="status" className="mb-2 text-green-700">{message}</p>}
+      {messageError && <p role="alert" className="mb-2 text-red-700">{messageError}</p>}
+      <IssueTable
+        issues={visible}
+        loading={loading}
+        error={error}
+        onPreview={setPreview}
+        onFix={(issue) => setConfirming(issue)}
+        fixingId={fixingId}
+        fixAllVisible={visible.some((i) => i.fixable) ? applyBatch : null}
+        fixingAll={fixingAll}
+      />
+
+      {preview && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => setPreview(null)}
+        >
+          <div className="max-h-[80vh] w-full max-w-2xl overflow-auto rounded-lg bg-white p-6 text-slate-900"
+            onClick={(e) => e.stopPropagation()}>
+            <h3 className="mb-2 text-lg font-semibold">
+              {t("dataQuality.admin.issues.previewTitle", { type: preview.type })}
+            </h3>
+            <p className="mb-4 text-sm">{preview.description}</p>
+            <div className="mb-4 grid grid-cols-2 gap-4">
+              <div>
+                <h4 className="mb-1 text-sm font-semibold">{t("dataQuality.admin.issues.before")}</h4>
+                <pre className="overflow-auto rounded bg-gray-100 p-2 text-xs">{JSON.stringify(preview.preview.before ?? {}, null, 2)}</pre>
+              </div>
+              <div>
+                <h4 className="mb-1 text-sm font-semibold">{t("dataQuality.admin.issues.after")}</h4>
+                <pre className="overflow-auto rounded bg-gray-100 p-2 text-xs">{JSON.stringify(preview.preview.after ?? {}, null, 2)}</pre>
+              </div>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button type="button" onClick={() => setPreview(null)}>
+                {t("dataQuality.admin.issues.actions.close")}
+              </button>
+              {preview.fixable && (
+                <button type="button" onClick={() => { setConfirming(preview); setPreview(null); }}>
+                  {t("dataQuality.admin.issues.actions.apply")}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {confirming && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => setConfirming(null)}
+        >
+          <div className="w-full max-w-md rounded-lg bg-white p-6 text-slate-900"
+            onClick={(e) => e.stopPropagation()}>
+            <h3 className="mb-2 text-lg font-semibold">
+              {t("dataQuality.admin.issues.actions.confirmTitle")}
+            </h3>
+            <p className="mb-2 text-sm">{confirming.suggested_fix}</p>
+            <p className="mb-4 text-xs opacity-70">{t("dataQuality.admin.issues.actions.confirmBody")}</p>
+            <div className="flex justify-end gap-2">
+              <button type="button" onClick={() => setConfirming(null)}>
+                {t("dataQuality.admin.issues.actions.cancel")}
+              </button>
+              <button type="button" onClick={() => applyFix(confirming)} disabled={fixingId === confirming.id}>
+                {fixingId === confirming.id
+                  ? t("dataQuality.admin.issues.actions.fixing")
+                  : t("dataQuality.admin.issues.actions.apply")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SeriesTab() {
   const { t } = useTranslation();
   const [positions, setPositions] = useState<TimeseriesQualityPosition[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<TimeseriesQualityPosition | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getDataQualityTimeseries();
+      setPositions(res.positions);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    getDataQualityTimeseries()
-      .then((res) => {
-        if (cancelled) return;
-        setPositions(res.positions);
-        setError(null);
-      })
-      .catch((e) => {
-        if (cancelled) return;
-        setError(e instanceof Error ? e.message : String(e));
-        setPositions([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    load();
+  }, [load]);
 
   const rows: Row[] = useMemo(
     () =>
@@ -57,17 +429,29 @@ export default function DataQuality() {
 
   const { sorted, sortKey, asc, handleSort } = useSortableTable(rows, "ticker");
 
-  return (
-    <div style={{ maxWidth: 1000, margin: "0 auto", padding: "1rem" }}>
-      <h1>{t("dataQuality.title")}</h1>
+  const handleDedupe = async (row: Row) => {
+    setBusyKey(`dedupe:${row.ticker}.${row.exchange}`);
+    setMessage(null);
+    try {
+      const res = await dedupeDataQualitySeries(row.ticker, row.exchange);
+      setMessage(t("dataQuality.admin.series.deduped", { removed: res.removed ?? 0 }));
+      await load();
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusyKey(null);
+    }
+  };
 
+  return (
+    <div>
+      <h2 className="mb-2 text-xl">{t("dataQuality.admin.series.title")}</h2>
+      {message && <p role="status" className="mb-2 text-green-700">{message}</p>}
       {loading && <div>{t("common.loading")}</div>}
       {error && <p style={{ color: "red" }}>{error}</p>}
-
       {!loading && !error && sorted.length === 0 && (
         <EmptyState message={t("dataQuality.noData")} actions={[]} />
       )}
-
       {!loading && !error && sorted.length > 0 && (
         <table className={`${tableStyles.table} mb-4 w-full`}>
           <thead>
@@ -135,6 +519,16 @@ export default function DataQuality() {
                 <td className={tableStyles.cell}>
                   <button
                     type="button"
+                    onClick={() => handleDedupe(row)}
+                    disabled={busyKey === `dedupe:${row.ticker}.${row.exchange}`}
+                    aria-label={t("dataQuality.admin.series.dedupe")}
+                  >
+                    {busyKey === `dedupe:${row.ticker}.${row.exchange}`
+                      ? "…"
+                      : t("dataQuality.admin.series.dedupe")}
+                  </button>{" "}
+                  <button
+                    type="button"
                     onClick={() => setSelected(row)}
                     aria-label={t("dataQuality.viewDetailsFor", {
                       ticker: row.ticker,
@@ -153,6 +547,170 @@ export default function DataQuality() {
       {selected && (
         <DataQualityDrilldownModal position={selected} onClose={() => setSelected(null)} />
       )}
+    </div>
+  );
+}
+
+function AuditTab() {
+  const { t } = useTranslation();
+  const [entries, setEntries] = useState<DataQualityAuditEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [undoingId, setUndoingId] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [messageError, setMessageError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getDataQualityAudit();
+      setEntries(res.entries);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleUndo = async (entryId: string) => {
+    setUndoingId(entryId);
+    setMessage(null);
+    setMessageError(null);
+    try {
+      await undoDataQualityAudit(entryId);
+      setMessage(t("dataQuality.admin.audit.actions.undone"));
+      await load();
+    } catch (e) {
+      setMessageError(
+        t("dataQuality.admin.audit.actions.undoFailed", {
+          detail: e instanceof Error ? e.message : String(e),
+        }),
+      );
+    } finally {
+      setUndoingId(null);
+    }
+  };
+
+  if (loading) return <div>{t("common.loading")}</div>;
+  if (error) return <p style={{ color: "red" }}>{error}</p>;
+  if (entries.length === 0) {
+    return <EmptyState message={t("dataQuality.admin.audit.empty")} actions={[]} />;
+  }
+
+  return (
+    <div>
+      <h2 className="mb-2 text-xl">{t("dataQuality.admin.audit.title")}</h2>
+      {message && <p role="status" className="mb-2 text-green-700">{message}</p>}
+      {messageError && <p role="alert" className="mb-2 text-red-700">{messageError}</p>}
+      <table className={`${tableStyles.table} mb-4 w-full`}>
+        <thead>
+          <tr>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.audit.columns.timestamp")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.audit.columns.action")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.audit.columns.entity")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.audit.columns.before")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.audit.columns.after")}</th>
+            <th className={tableStyles.cell}>{t("dataQuality.admin.audit.columns.actor")}</th>
+            <th className={tableStyles.cell}></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => (
+            <tr key={entry.id}>
+              <td className={tableStyles.cell}>
+                {new Date(entry.timestamp).toLocaleString()}
+              </td>
+              <td className={tableStyles.cell}>{entry.action}</td>
+              <td className={tableStyles.cell}>{entityLabel(entry.entity)}</td>
+              <td className={tableStyles.cell}>
+                <pre className="text-xs">{JSON.stringify(entry.before)}</pre>
+              </td>
+              <td className={tableStyles.cell}>
+                <pre className="text-xs">{JSON.stringify(entry.after)}</pre>
+              </td>
+              <td className={tableStyles.cell}>{entry.actor ?? "—"}</td>
+              <td className={tableStyles.cell}>
+                <button
+                  type="button"
+                  onClick={() => handleUndo(entry.id)}
+                  disabled={undoingId === entry.id}
+                  aria-label={t("dataQuality.admin.audit.actions.undo")}
+                >
+                  {undoingId === entry.id ? "…" : t("dataQuality.admin.audit.actions.undo")}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MetadataTab() {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <h2 className="mb-2 text-xl">{t("dataQuality.admin.metadata.title")}</h2>
+      <p className="mb-4 text-sm opacity-70">{t("dataQuality.admin.metadata.note")}</p>
+      <a href="/instrumentadmin" className="underline">
+        {t("dataQuality.admin.metadata.openInstrumentAdmin")}
+      </a>
+    </div>
+  );
+}
+
+export default function DataQuality() {
+  const { t } = useTranslation();
+  const { dataQualityAdmin } = useConfig();
+  const [tab, setTab] = useState<TabId>(dataQualityAdmin === false ? "series" : "issues");
+
+  if (dataQualityAdmin === false) {
+    // Read-only fallback: keep the original series table available when the
+    // admin surface is disabled by configuration (#6724).
+    return (
+      <div style={{ maxWidth: 1000, margin: "0 auto", padding: "1rem" }}>
+        <h1>{t("dataQuality.title")}</h1>
+        <SeriesTab />
+      </div>
+    );
+  }
+
+  const tabs: Array<{ id: TabId; label: string }> = [
+    { id: "issues", label: t("dataQuality.admin.tabs.issues") },
+    { id: "series", label: t("dataQuality.admin.tabs.series") },
+    { id: "holdings", label: t("dataQuality.admin.tabs.holdings") },
+    { id: "metadata", label: t("dataQuality.admin.tabs.metadata") },
+    { id: "audit", label: t("dataQuality.admin.tabs.audit") },
+  ];
+
+  return (
+    <div style={{ maxWidth: 1000, margin: "0 auto", padding: "1rem" }}>
+      <h1>{t("dataQuality.title")}</h1>
+      <nav role="tablist" aria-label="Data quality admin" className="mb-4 flex flex-wrap gap-2">
+        {tabs.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={tab === item.id}
+            onClick={() => setTab(item.id)}
+            className={tab === item.id ? "rounded bg-blue-700 px-3 py-1 text-white" : "rounded bg-gray-200 px-3 py-1"}
+          >
+            {item.label}
+          </button>
+        ))}
+      </nav>
+      {tab === "issues" && <IssuesTab />}
+      {tab === "series" && <SeriesTab />}
+      {tab === "holdings" && <IssuesTab presetTypes={HOLDING_ISSUE_TYPES} />}
+      {tab === "metadata" && <MetadataTab />}
+      {tab === "audit" && <AuditTab />}
     </div>
   );
 }

--- a/frontend/tests/unit/pages/DataQuality.test.tsx
+++ b/frontend/tests/unit/pages/DataQuality.test.tsx
@@ -5,15 +5,76 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import en from "@/locales/en/translation.json";
 import DataQuality from "@/pages/DataQuality";
+import { configContext, type ConfigContextValue } from "@/ConfigContext";
 
 const mockGetDataQualityTimeseries = vi.hoisted(() => vi.fn());
+const mockGetDataQualityIssues = vi.hoisted(() => vi.fn());
+const mockFixDataQualityIssue = vi.hoisted(() => vi.fn());
+const mockFixDataQualityBatch = vi.hoisted(() => vi.fn());
+const mockDedupeDataQualitySeries = vi.hoisted(() => vi.fn());
+const mockGetDataQualityAudit = vi.hoisted(() => vi.fn());
+const mockUndoDataQualityAudit = vi.hoisted(() => vi.fn());
 
 vi.mock("@/api", async () => {
   const actual = await vi.importActual<typeof import("@/api")>("@/api");
   return {
     ...actual,
     getDataQualityTimeseries: mockGetDataQualityTimeseries,
+    getDataQualityIssues: mockGetDataQualityIssues,
+    fixDataQualityIssue: mockFixDataQualityIssue,
+    fixDataQualityBatch: mockFixDataQualityBatch,
+    dedupeDataQualitySeries: mockDedupeDataQualitySeries,
+    getDataQualityAudit: mockGetDataQualityAudit,
+    undoDataQualityAudit: mockUndoDataQualityAudit,
   };
+});
+
+const baseConfig: ConfigContextValue = {
+  configLoaded: true,
+  relativeViewEnabled: false,
+  familyMvpEnabled: false,
+  disabledTabs: [],
+  tabs: {} as ConfigContextValue["tabs"],
+  theme: "system",
+  baseCurrency: "GBP",
+  enableAdvancedAnalytics: true,
+  dataQualityAdmin: true,
+  refreshConfig: async () => {},
+  setRelativeViewEnabled: () => {},
+  setBaseCurrency: () => {},
+};
+
+function renderWithConfig(dataQualityAdmin: boolean) {
+  return render(
+    <configContext.Provider value={{ ...baseConfig, dataQualityAdmin }}>
+      <DataQuality />
+    </configContext.Provider>,
+  );
+}
+
+const position = (ticker: string, exchange: string, overrides: Record<string, unknown> = {}) => ({
+  ticker,
+  exchange,
+  total_points: 100,
+  first_date: "2026-01-01",
+  last_date: "2026-06-01",
+  gap_count: 0,
+  gaps: [],
+  duplicate_dates: [],
+  outliers: [],
+  ...overrides,
+});
+
+const issue = (overrides: Record<string, unknown>) => ({
+  id: "WRONG_EXCHANGE:demo:isa:MICC.L",
+  type: "WRONG_EXCHANGE",
+  severity: "high",
+  entity: { owner: "demo", account: "isa", holding: "MICC.L" },
+  description: "Holding MICC.L has no metadata on L.",
+  suggested_fix: "Correct holding exchange to MICC.N.",
+  preview: { before: { ticker: "MICC.L" }, after: { ticker: "MICC.N" } },
+  fixable: true,
+  ...overrides,
 });
 
 beforeEach(() => {
@@ -21,71 +82,30 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("DataQuality page", () => {
+describe("DataQuality page (read-only fallback)", () => {
   it("renders a row per position with counts and RAG status", async () => {
     mockGetDataQualityTimeseries.mockResolvedValue({
       count: 3,
       positions: [
-        {
-          ticker: "CLEAN",
-          exchange: "L",
-          total_points: 100,
-          first_date: "2026-01-01",
-          last_date: "2026-06-01",
-          gap_count: 0,
-          gaps: [],
-          duplicate_dates: [],
-          outliers: [],
-        },
-        {
-          ticker: "GAPPY",
-          exchange: "L",
-          total_points: 50,
-          first_date: "2026-01-01",
-          last_date: "2026-06-01",
-          gap_count: 1,
-          gaps: [{ start: "2026-02-01", end: "2026-02-05", missing_business_days: 4 }],
-          duplicate_dates: [],
-          outliers: [],
-        },
-        {
-          ticker: "DUPED",
-          exchange: "N",
-          total_points: 30,
-          first_date: "2026-01-01",
-          last_date: "2026-06-01",
-          gap_count: 0,
-          gaps: [],
-          duplicate_dates: ["2026-03-01"],
-          outliers: [{ date: "2026-04-01", value: 999, z_score: 5.2 }],
-        },
+        position("CLEAN", "L"),
+        position("GAPPY", "L", { gap_count: 1, gaps: [{ start: "2026-02-01", end: "2026-02-05", missing_business_days: 4 }] }),
+        position("DUPED", "N", { duplicate_dates: ["2026-03-01"], outliers: [{ date: "2026-04-01", value: 999, z_score: 5.2 }] }),
       ],
     });
 
-    render(<DataQuality />);
+    renderWithConfig(false);
 
-    expect(await screen.findByRole("heading", { name: en.dataQuality.title })).toBeInTheDocument();
     expect(await screen.findByText("CLEAN")).toBeInTheDocument();
     expect(screen.getByText("GAPPY")).toBeInTheDocument();
     expect(screen.getByText("DUPED")).toBeInTheDocument();
-
-    expect(screen.getByText(en.dataQuality.status.green)).toBeInTheDocument();
-    expect(screen.getByText(en.dataQuality.status.amber)).toBeInTheDocument();
-    expect(screen.getByText(en.dataQuality.status.red)).toBeInTheDocument();
-  });
-
-  it("shows loading state while fetching", async () => {
-    mockGetDataQualityTimeseries.mockReturnValue(new Promise(() => {}));
-
-    render(<DataQuality />);
-
-    expect(await screen.findByText(en.common.loading)).toBeInTheDocument();
+    // Admin tabs are hidden in the read-only fallback.
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
   });
 
   it("shows an empty state when no positions are cached", async () => {
     mockGetDataQualityTimeseries.mockResolvedValue({ count: 0, positions: [] });
 
-    render(<DataQuality />);
+    renderWithConfig(false);
 
     expect(await screen.findByText(en.dataQuality.noData)).toBeInTheDocument();
   });
@@ -93,7 +113,7 @@ describe("DataQuality page", () => {
   it("shows an error message when the request fails", async () => {
     mockGetDataQualityTimeseries.mockRejectedValueOnce(new Error("boom"));
 
-    render(<DataQuality />);
+    renderWithConfig(false);
 
     expect(await screen.findByText("boom")).toBeInTheDocument();
   });
@@ -102,21 +122,16 @@ describe("DataQuality page", () => {
     mockGetDataQualityTimeseries.mockResolvedValue({
       count: 1,
       positions: [
-        {
-          ticker: "DUPED",
-          exchange: "N",
-          total_points: 30,
-          first_date: "2026-01-01",
-          last_date: "2026-06-01",
+        position("DUPED", "N", {
           gap_count: 1,
           gaps: [{ start: "2026-02-01", end: "2026-02-05", missing_business_days: 4 }],
           duplicate_dates: ["2026-03-01"],
           outliers: [{ date: "2026-04-01", value: 999, z_score: 5.2 }],
-        },
+        }),
       ],
     });
 
-    render(<DataQuality />);
+    renderWithConfig(false);
 
     const viewDetailsButton = await screen.findByRole("button", {
       name: en.dataQuality.viewDetailsFor
@@ -137,5 +152,193 @@ describe("DataQuality page", () => {
       await userEvent.click(closeButton);
     });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("DataQuality admin UI", () => {
+  it("shows the Issues tab by default with issue rows", async () => {
+    mockGetDataQualityIssues.mockResolvedValue({
+      count: 1,
+      issues: [issue({})],
+    });
+
+    renderWithConfig(true);
+
+    expect(await screen.findAllByText(/MICC\.L/)).not.toHaveLength(0);
+    expect(screen.getAllByText("WRONG_EXCHANGE").length).toBeGreaterThan(0);
+    expect(screen.getByText("Correct holding exchange to MICC.N.")).toBeInTheDocument();
+    // Tab labels visible.
+    expect(screen.getByRole("tab", { name: en.dataQuality.admin.tabs.issues })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: en.dataQuality.admin.tabs.audit })).toBeInTheDocument();
+  });
+
+  it("filters issues by type and ticker", async () => {
+    mockGetDataQualityIssues.mockResolvedValue({
+      count: 2,
+      issues: [
+        issue({ id: "WRONG_EXCHANGE:demo:isa:MICC.L", type: "WRONG_EXCHANGE", entity: { holding: "MICC.L" } }),
+        issue({
+          id: "GAPS:ABC:L",
+          type: "GAPS",
+          severity: "medium",
+          entity: { ticker: "ABC", exchange: "L" },
+          description: "1 gap(s) in ABC.L.",
+          suggested_fix: "Refetch / fill the missing range.",
+          preview: { before: { gap_count: 1 }, after: { gap_count: 0 } },
+        }),
+      ],
+    });
+
+    renderWithConfig(true);
+
+    expect(await screen.findAllByText(/MICC\.L/)).not.toHaveLength(0);
+    expect(screen.getByText(/^ABC\.L$/)).toBeInTheDocument();
+
+    // Filter by type.
+    await act(async () => {
+      await userEvent.selectOptions(screen.getByLabelText(en.dataQuality.admin.issues.filters.type), "GAPS");
+    });
+    expect(screen.queryByText(/MICC\.L/)).not.toBeInTheDocument();
+    expect(screen.getByText(/^ABC\.L$/)).toBeInTheDocument();
+
+    // Reset and filter by ticker.
+    await act(async () => {
+      await userEvent.selectOptions(screen.getByLabelText(en.dataQuality.admin.issues.filters.type), "");
+      await userEvent.type(screen.getByLabelText(en.dataQuality.admin.issues.filters.ticker), "ABC");
+    });
+    expect(screen.queryByText(/MICC\.L/)).not.toBeInTheDocument();
+    expect(screen.getByText(/^ABC\.L$/)).toBeInTheDocument();
+  });
+
+  it("shows preview before/after and applies a fix", async () => {
+    mockGetDataQualityIssues.mockResolvedValue({
+      count: 1,
+      issues: [issue({})],
+    });
+    mockFixDataQualityIssue.mockResolvedValue({ status: "fixed", ticker: "MICC.N", audit_id: "a1" });
+
+    renderWithConfig(true);
+
+    const previewButton = await screen.findByRole("button", {
+      name: en.dataQuality.admin.issues.actions.preview,
+    });
+    await act(async () => {
+      await userEvent.click(previewButton);
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("MICC.L");
+    expect(dialog).toHaveTextContent("MICC.N");
+
+    // Apply from the preview dialog.
+    await act(async () => {
+      await userEvent.click(screen.getByRole("button", { name: en.dataQuality.admin.issues.actions.apply }));
+    });
+
+    // Confirmation dialog then applies.
+    await act(async () => {
+      await userEvent.click(screen.getByRole("button", { name: en.dataQuality.admin.issues.actions.apply }));
+    });
+
+    expect(mockFixDataQualityIssue).toHaveBeenCalledWith("WRONG_EXCHANGE:demo:isa:MICC.L");
+    expect(await screen.findByText(en.dataQuality.admin.issues.actions.applied)).toBeInTheDocument();
+  });
+
+  it("applies fixes to all visible issues via batch", async () => {
+    mockGetDataQualityIssues.mockResolvedValue({
+      count: 2,
+      issues: [
+        issue({ id: "WRONG_EXCHANGE:demo:isa:MICC.L" }),
+        issue({
+          id: "WRONG_EXCHANGE:demo:isa:PFE.N",
+          entity: { holding: "PFE.N" },
+          preview: { before: { ticker: "PFE.N" }, after: { ticker: "PFE.N" } },
+          suggested_fix: "Correct holding exchange to PFE.N.",
+        }),
+      ],
+    });
+    mockFixDataQualityBatch.mockResolvedValue({
+      applied: 2,
+      failed: 0,
+      results: [
+        { issue_id: "WRONG_EXCHANGE:demo:isa:MICC.L", status: "ok" },
+        { issue_id: "WRONG_EXCHANGE:demo:isa:PFE.N", status: "ok" },
+      ],
+    });
+
+    renderWithConfig(true);
+
+    const fixAll = await screen.findByRole("button", {
+      name: en.dataQuality.admin.issues.actions.fixAll,
+    });
+    await act(async () => {
+      await userEvent.click(fixAll);
+    });
+
+    expect(mockFixDataQualityBatch).toHaveBeenCalledWith([
+      "WRONG_EXCHANGE:demo:isa:MICC.L",
+      "WRONG_EXCHANGE:demo:isa:PFE.N",
+    ]);
+    expect(
+      await screen.findByText(
+        en.dataQuality.admin.issues.actions.batchApplied.replace("{{applied}}", "2").replace("{{total}}", "2"),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the Audit tab with undo", async () => {
+    mockGetDataQualityIssues.mockResolvedValue({ count: 0, issues: [] });
+    mockGetDataQualityAudit.mockResolvedValue({
+      count: 1,
+      entries: [
+        {
+          id: "e1",
+          timestamp: "2026-08-01T10:00:00Z",
+          action: "wrong_exchange",
+          issue_id: "WRONG_EXCHANGE:demo:isa:MICC.L",
+          entity: { owner: "demo", account: "isa", holding: "MICC.L" },
+          before: { holdings: [{ ticker: "MICC.L" }] },
+          after: { holdings: [{ ticker: "MICC.N" }] },
+          actor: "user@example.com",
+        },
+      ],
+    });
+    mockUndoDataQualityAudit.mockResolvedValue({ status: "undone", entry_id: "e1" });
+
+    renderWithConfig(true);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole("tab", { name: en.dataQuality.admin.tabs.audit }));
+    });
+
+    expect(await screen.findByText("wrong_exchange")).toBeInTheDocument();
+    const undoButton = screen.getByRole("button", { name: en.dataQuality.admin.audit.actions.undo });
+    await act(async () => {
+      await userEvent.click(undoButton);
+    });
+    expect(mockUndoDataQualityAudit).toHaveBeenCalledWith("e1");
+    expect(await screen.findByText(en.dataQuality.admin.audit.actions.undone)).toBeInTheDocument();
+  });
+
+  it("shows the Series tab with dedupe inside the admin UI", async () => {
+    mockGetDataQualityIssues.mockResolvedValue({ count: 0, issues: [] });
+    mockGetDataQualityTimeseries.mockResolvedValue({
+      count: 1,
+      positions: [position("DUPED", "N", { duplicate_dates: ["2026-03-01"] })],
+    });
+    mockDedupeDataQualitySeries.mockResolvedValue({ status: "fixed", removed: 1, rows: 2 });
+
+    renderWithConfig(true);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole("tab", { name: en.dataQuality.admin.tabs.series }));
+    });
+
+    expect(await screen.findByText("DUPED")).toBeInTheDocument();
+    const dedupeButton = screen.getByRole("button", { name: en.dataQuality.admin.series.dedupe });
+    await act(async () => {
+      await userEvent.click(dedupeButton);
+    });
+    expect(mockDedupeDataQualitySeries).toHaveBeenCalledWith("DUPED", "N");
   });
 });

--- a/tests/data/log_sanitization_baseline.txt
+++ b/tests/data/log_sanitization_baseline.txt
@@ -80,8 +80,8 @@ backend/common/signup_requests.py:373
 # len(adjustments) is always an int (a count of synthetic transactions just
 # built in this function) and can't carry attacker-controlled string content.
 backend/common/transaction_reconciliation.py:180
-backend/config.py:276
-backend/config.py:279
+backend/config.py:280
+backend/config.py:283
 # len(lines)/len(data) are always ints (row counts produced by the CSV
 # parser in this function) and can't carry attacker-controlled string content.
 backend/importers/hargreaves.py:125

--- a/tests/data_quality/test_audit.py
+++ b/tests/data_quality/test_audit.py
@@ -1,0 +1,82 @@
+"""Unit tests for backend/data_quality/audit.py (append-only JSONL, atomic)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.data_quality import audit as audit_module
+from backend.data_quality.audit import append_audit, find_audit_entry, read_audit
+
+
+@pytest.fixture
+def audit_dir(tmp_path, monkeypatch):
+    target = tmp_path / "audit"
+    monkeypatch.setattr(audit_module.config, "audit_dir", target)
+    return target
+
+
+def test_append_and_read_roundtrip(audit_dir):
+    entry = append_audit(
+        action="wrong_exchange",
+        issue_id="WRONG_EXCHANGE:demo:isa:MICC.L",
+        entity={"owner": "demo", "account": "isa"},
+        before={"ticker": "MICC.L"},
+        after={"ticker": "MICC.N"},
+        actor="user@example.com",
+    )
+    assert entry["id"]
+    assert entry["action"] == "wrong_exchange"
+
+    entries = read_audit()
+    assert len(entries) == 1
+    assert entries[0]["id"] == entry["id"]
+    assert entries[0]["before"] == {"ticker": "MICC.L"}
+    assert entries[0]["actor"] == "user@example.com"
+
+
+def test_append_is_jsonl_and_atomic(audit_dir):
+    append_audit(
+        action="refetch",
+        issue_id="GAPS:ABC:L",
+        entity={"ticker": "ABC", "exchange": "L"},
+        before={},
+        after={"rows": 10},
+    )
+    lines = (audit_dir / "data_quality_audit.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    json.loads(lines[0])  # each line is valid JSON
+    assert not (audit_dir / "data_quality_audit.jsonl.tmp").exists()
+
+
+def test_append_preserves_earlier_entries(audit_dir):
+    append_audit(action="refetch", issue_id="a", entity={}, before={}, after={})
+    append_audit(action="dedupe", issue_id="b", entity={}, before={}, after={})
+    entries = read_audit()
+    assert len(entries) == 2
+    # Newest first.
+    assert entries[0]["issue_id"] == "b"
+
+
+def test_find_audit_entry(audit_dir):
+    entry = append_audit(
+        action="dedupe", issue_id="DUPLICATES:ABC:L", entity={}, before={}, after={}
+    )
+    assert find_audit_entry(entry["id"]) is not None
+    assert find_audit_entry("missing-id") is None
+
+
+def test_read_missing_file_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(audit_module.config, "audit_dir", tmp_path / "no-audit")
+    assert read_audit() == []
+
+
+def test_corrupt_line_is_skipped(audit_dir):
+    path = audit_dir / "data_quality_audit.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json}\n", encoding="utf-8")
+    append_audit(action="refetch", issue_id="c", entity={}, before={}, after={})
+    entries = read_audit()
+    assert len(entries) == 1
+    assert entries[0]["issue_id"] == "c"

--- a/tests/data_quality/test_audit.py
+++ b/tests/data_quality/test_audit.py
@@ -60,9 +60,7 @@ def test_append_preserves_earlier_entries(audit_dir):
 
 
 def test_find_audit_entry(audit_dir):
-    entry = append_audit(
-        action="dedupe", issue_id="DUPLICATES:ABC:L", entity={}, before={}, after={}
-    )
+    entry = append_audit(action="dedupe", issue_id="DUPLICATES:ABC:L", entity={}, before={}, after={})
     assert find_audit_entry(entry["id"]) is not None
     assert find_audit_entry("missing-id") is None
 

--- a/tests/data_quality/test_issues.py
+++ b/tests/data_quality/test_issues.py
@@ -72,9 +72,7 @@ def test_aggregate_holding_issues_wrong_exchange(monkeypatch, tmp_path, accounts
 def test_aggregate_holding_issues_unresolved(monkeypatch, tmp_path, accounts_root):
     """A holding with no metadata and no resolution is UNRESOLVED_TICKER."""
     monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {})
-    monkeypatch.setattr(
-        issues_module, "resolve_instrument_ticker", lambda symbol, create_missing=False: None
-    )
+    monkeypatch.setattr(issues_module, "resolve_instrument_ticker", lambda symbol, create_missing=False: None)
 
     issues = aggregate_holding_issues(accounts_root)
     unresolved = [i for i in issues if i.type == IssueType.UNRESOLVED_TICKER]
@@ -99,9 +97,7 @@ def test_aggregate_holding_issues_missing_series(monkeypatch, tmp_path, accounts
 
 def test_cash_holdings_skipped(monkeypatch, tmp_path, accounts_root):
     monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {})
-    monkeypatch.setattr(
-        issues_module, "resolve_instrument_ticker", lambda symbol, create_missing=False: None
-    )
+    monkeypatch.setattr(issues_module, "resolve_instrument_ticker", lambda symbol, create_missing=False: None)
 
     issues = aggregate_holding_issues(accounts_root)
     assert all("CASH" not in i.entity.get("holding", "") for i in issues)
@@ -191,9 +187,7 @@ def test_aggregate_series_issues_stale(monkeypatch):
 def test_aggregate_issues_dedupes_across_sources(monkeypatch, tmp_path, accounts_root):
     """aggregate_issues returns one issue per (type, entity) pair."""
     monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {})
-    monkeypatch.setattr(
-        issues_module, "resolve_instrument_ticker", lambda symbol, create_missing=False: None
-    )
+    monkeypatch.setattr(issues_module, "resolve_instrument_ticker", lambda symbol, create_missing=False: None)
     monkeypatch.setattr(issues_module, "list_cached_meta_tickers", lambda: [])
     monkeypatch.setattr(issues_module, "load_cached_meta_timeseries_full", lambda t, e: None)
 

--- a/tests/data_quality/test_issues.py
+++ b/tests/data_quality/test_issues.py
@@ -1,0 +1,202 @@
+"""Unit tests for backend/data_quality/issues.py aggregation (no live fetches)."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from backend.data_quality import issues as issues_module
+from backend.data_quality.issues import (
+    IssueType,
+    aggregate_holding_issues,
+    aggregate_issues,
+    aggregate_series_issues,
+)
+
+
+@pytest.fixture
+def accounts_root(tmp_path):
+    owner = tmp_path / "demo"
+    owner.mkdir()
+    (owner / "person.json").write_text(
+        json.dumps({"owner": "demo", "holdings": []}),
+        encoding="utf-8",
+    )
+    isa = {
+        "owner": "demo",
+        "account_type": "isa",
+        "currency": "GBP",
+        "holdings": [
+            {"ticker": "VWRL.L"},
+            {"ticker": "MICC.L"},  # wrong exchange: resolves to MICC.N
+            {"ticker": "PFE.N"},
+            {"ticker": "CASH.GBP"},
+        ],
+    }
+    (owner / "isa.json").write_text(json.dumps(isa), encoding="utf-8")
+    return tmp_path
+
+
+def _write_instrument_meta(tmp_path, symbol, exchange, name="Test Instrument"):
+    path = tmp_path / "instruments" / exchange / f"{symbol}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"ticker": f"{symbol}.{exchange}", "exchange": exchange, "name": name}),
+        encoding="utf-8",
+    )
+
+
+def test_aggregate_holding_issues_wrong_exchange(monkeypatch, tmp_path, accounts_root):
+    """A holding whose exchange has no metadata but resolves elsewhere is WRONG_EXCHANGE."""
+    _write_instrument_meta(tmp_path, "MICC", "N", name="MercadoLibre")
+
+    def fake_meta(ticker: str) -> dict:
+        return {"name": "MercadoLibre", "ticker": ticker} if ticker == "MICC.N" else {}
+
+    def fake_resolve(symbol, create_missing=False):
+        return "MICC.N" if symbol == "MICC" else None
+
+    monkeypatch.setattr(issues_module, "get_instrument_meta", fake_meta)
+    monkeypatch.setattr(issues_module, "resolve_instrument_ticker", fake_resolve)
+    monkeypatch.setattr(issues_module, "has_cached_meta_timeseries", lambda t, e: True)
+
+    issues = aggregate_holding_issues(accounts_root)
+    wrong = [i for i in issues if i.type == IssueType.WRONG_EXCHANGE]
+    assert len(wrong) == 1
+    assert wrong[0].entity["holding"] == "MICC.L"
+    assert wrong[0].suggested_fix == "Correct holding exchange to MICC.N."
+
+
+def test_aggregate_holding_issues_unresolved(monkeypatch, tmp_path, accounts_root):
+    """A holding with no metadata and no resolution is UNRESOLVED_TICKER."""
+    monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {})
+    monkeypatch.setattr(
+        issues_module, "resolve_instrument_ticker", lambda symbol, create_missing=False: None
+    )
+
+    issues = aggregate_holding_issues(accounts_root)
+    unresolved = [i for i in issues if i.type == IssueType.UNRESOLVED_TICKER]
+    # MICC.L and VWRL.L and PFE.N all have no metadata and don't resolve.
+    assert len(unresolved) == 3
+
+
+def test_aggregate_holding_issues_missing_series(monkeypatch, tmp_path, accounts_root):
+    """A holding with metadata but no cached series is MISSING_SERIES."""
+    monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {"name": "x"})
+    monkeypatch.setattr(
+        issues_module,
+        "resolve_instrument_ticker",
+        lambda symbol, create_missing=False: f"{symbol}.L",
+    )
+    monkeypatch.setattr(issues_module, "has_cached_meta_timeseries", lambda t, e: False)
+
+    issues = aggregate_holding_issues(accounts_root)
+    missing = [i for i in issues if i.type == IssueType.MISSING_SERIES]
+    assert len(missing) == 3  # VWRL.L, MICC.L -> MICC.L, PFE.N -> PFE.L
+
+
+def test_cash_holdings_skipped(monkeypatch, tmp_path, accounts_root):
+    monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {})
+    monkeypatch.setattr(
+        issues_module, "resolve_instrument_ticker", lambda symbol, create_missing=False: None
+    )
+
+    issues = aggregate_holding_issues(accounts_root)
+    assert all("CASH" not in i.entity.get("holding", "") for i in issues)
+
+
+def test_aggregate_series_issues_detects_gaps_duplicates_outliers(monkeypatch):
+    dates = [f"2026-01-{d:02d}" for d in range(3, 25)]
+    closes = [100.0 + i for i in range(len(dates))]
+    closes[10] = 500.0  # clear outlier spike
+    df = pd.DataFrame(
+        {
+            "Date": dates,
+            "Close": closes,
+            "Ticker": ["ABC"] * len(dates),
+            "Source": ["Test"] * len(dates),
+        }
+    )
+    monkeypatch.setattr(issues_module, "list_cached_meta_tickers", lambda: [("ABC", "L")])
+    monkeypatch.setattr(issues_module, "load_cached_meta_timeseries_full", lambda t, e: df.copy())
+    monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {"name": "x"})
+
+    issues = aggregate_series_issues(rolling_window=20, outlier_sigma=3.0)
+    types = {i.type for i in issues}
+    assert IssueType.OUTLIERS in types
+
+
+def test_aggregate_series_issues_detects_duplicates(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "Date": ["2026-01-01", "2026-01-01", "2026-01-02"],
+            "Close": [100.0, 101.0, 102.0],
+        },
+    )
+    monkeypatch.setattr(issues_module, "list_cached_meta_tickers", lambda: [("ABC", "L")])
+    monkeypatch.setattr(issues_module, "load_cached_meta_timeseries_full", lambda t, e: df.copy())
+    monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {"name": "x"})
+
+    issues = aggregate_series_issues()
+    dup = [i for i in issues if i.type == IssueType.DUPLICATES]
+    assert len(dup) == 1
+    assert dup[0].preview["before"]["duplicate_dates"] == ["2026-01-01"]
+
+
+def test_aggregate_series_issues_missing_metadata(monkeypatch):
+    df = pd.DataFrame(
+        {"Date": ["2026-01-01", "2026-01-02"], "Close": [100.0, 101.0]},
+    )
+    monkeypatch.setattr(issues_module, "list_cached_meta_tickers", lambda: [("ABC", "L")])
+    monkeypatch.setattr(issues_module, "load_cached_meta_timeseries_full", lambda t, e: df.copy())
+    monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {})
+
+    issues = aggregate_series_issues()
+    assert any(i.type == IssueType.MISSING_METADATA for i in issues)
+
+
+def test_aggregate_series_issues_ticker_mismatch(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "Date": ["2026-01-01", "2026-01-02"],
+            "Close": [100.0, 101.0],
+            "Ticker": ["WRONG", "WRONG"],
+        },
+    )
+    monkeypatch.setattr(issues_module, "list_cached_meta_tickers", lambda: [("ABC", "L")])
+    monkeypatch.setattr(issues_module, "load_cached_meta_timeseries_full", lambda t, e: df.copy())
+    monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {"name": "x"})
+
+    issues = aggregate_series_issues()
+    mismatch = [i for i in issues if i.type == IssueType.TICKER_MISMATCH]
+    assert len(mismatch) == 1
+    assert mismatch[0].entity == {"ticker": "ABC", "exchange": "L"}
+
+
+def test_aggregate_series_issues_stale(monkeypatch):
+    """A series whose last date is older than the threshold is STALE_SERIES."""
+    df = pd.DataFrame(
+        {"Date": ["2000-01-03", "2000-01-04"], "Close": [100.0, 101.0]},
+    )
+    monkeypatch.setattr(issues_module, "list_cached_meta_tickers", lambda: [("ABC", "L")])
+    monkeypatch.setattr(issues_module, "load_cached_meta_timeseries_full", lambda t, e: df.copy())
+    monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {"name": "x"})
+
+    issues = aggregate_series_issues(stale_max_age_days=5)
+    assert any(i.type == IssueType.STALE_SERIES for i in issues)
+
+
+def test_aggregate_issues_dedupes_across_sources(monkeypatch, tmp_path, accounts_root):
+    """aggregate_issues returns one issue per (type, entity) pair."""
+    monkeypatch.setattr(issues_module, "get_instrument_meta", lambda t: {})
+    monkeypatch.setattr(
+        issues_module, "resolve_instrument_ticker", lambda symbol, create_missing=False: None
+    )
+    monkeypatch.setattr(issues_module, "list_cached_meta_tickers", lambda: [])
+    monkeypatch.setattr(issues_module, "load_cached_meta_timeseries_full", lambda t, e: None)
+
+    issues = aggregate_issues(accounts_root)
+    ids = [i.id for i in issues]
+    assert len(ids) == len(set(ids))

--- a/tests/routes/test_data_quality_admin.py
+++ b/tests/routes/test_data_quality_admin.py
@@ -1,0 +1,229 @@
+"""Route tests for the read-write Data Quality Admin endpoints."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.config import config
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """TestClient with auth disabled, isolated audit dir, and a writable accounts root."""
+    return _build_client(monkeypatch, tmp_path, series=[])
+
+
+def _build_client(monkeypatch, tmp_path, *, series: list[tuple[str, str, pd.DataFrame]]):
+    """Build a TestClient; ``series`` seeds the cached-timeseries aggregation."""
+    monkeypatch.setattr(config, "skip_snapshot_warm", True)
+    monkeypatch.setattr(config, "disable_auth", True)
+    monkeypatch.setattr(config, "audit_dir", tmp_path / "audit")
+
+    accounts = tmp_path / "accounts"
+    (accounts / "demo").mkdir(parents=True)
+    (accounts / "demo" / "isa.json").write_text(
+        json.dumps(
+            {
+                "owner": "demo",
+                "account_type": "isa",
+                "currency": "GBP",
+                "holdings": [{"ticker": "MICC.L"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    # A writable root distinct from the global demo dataset.
+    monkeypatch.setattr(config, "accounts_root", accounts)
+
+    import backend.data_quality.issues as issues_module
+
+    monkeypatch.setattr(
+        issues_module,
+        "get_instrument_meta",
+        lambda ticker: {"name": "MercadoLibre"} if ticker == "MICC.N" else {},
+    )
+    monkeypatch.setattr(
+        issues_module,
+        "resolve_instrument_ticker",
+        lambda symbol, create_missing=False: "MICC.N" if symbol == "MICC" else None,
+    )
+    monkeypatch.setattr(issues_module, "has_cached_meta_timeseries", lambda t, e: False)
+    monkeypatch.setattr(
+        issues_module, "list_cached_meta_tickers", lambda: [(t, e) for t, e, _ in series]
+    )
+    monkeypatch.setattr(
+        issues_module,
+        "load_cached_meta_timeseries_full",
+        lambda t, e: next((df.copy() for st, se, df in series if st == t and se == e), None),
+    )
+
+    # Point the app's accounts store at the writable root so holding writes are allowed.
+    from backend.app import create_app
+
+    app = create_app()
+    app.state.accounts_root = str(accounts)
+    app.state.accounts_root_is_global = False
+    return TestClient(app)
+
+
+
+def test_get_issues_lists_wrong_exchange(client):
+    resp = client.get("/data-quality/issues")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] >= 1
+    wrong = [i for i in data["issues"] if i["type"] == "WRONG_EXCHANGE"]
+    assert wrong
+    assert wrong[0]["entity"]["holding"] == "MICC.L"
+    assert wrong[0]["preview"]["after"] == {"ticker": "MICC.N"}
+
+
+def test_get_issues_filters_by_type(client):
+    resp = client.get("/data-quality/issues?type=WRONG_EXCHANGE")
+    assert resp.status_code == 200
+    assert all(i["type"] == "WRONG_EXCHANGE" for i in resp.json()["issues"])
+
+
+def test_preview_issue(client):
+    issues = client.get("/data-quality/issues").json()["issues"]
+    wrong = next(i for i in issues if i["type"] == "WRONG_EXCHANGE")
+    resp = client.get(f"/data-quality/issues/{wrong['id']}/preview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == wrong["id"]
+    assert data["fixable"] is True
+
+
+def test_preview_unknown_issue_404(client):
+    resp = client.get("/data-quality/issues/nope/preview")
+    assert resp.status_code == 404
+
+
+def test_fix_wrong_exchange_writes_holding_and_audit(client, tmp_path):
+    issues = client.get("/data-quality/issues").json()["issues"]
+    wrong = next(i for i in issues if i["type"] == "WRONG_EXCHANGE")
+
+    resp = client.post(f"/data-quality/issues/{wrong['id']}/fix")
+    assert resp.status_code == 200
+    assert resp.json()["ticker"] == "MICC.N"
+
+    account_path = tmp_path / "accounts" / "demo" / "isa.json"
+    doc = json.loads(account_path.read_text(encoding="utf-8"))
+    assert doc["holdings"] == [{"ticker": "MICC.N"}]
+    # .bak backup preserved the pre-fix state.
+    assert (tmp_path / "accounts" / "demo" / "isa.json.bak").exists()
+
+    audit = client.get("/data-quality/audit").json()["entries"]
+    assert audit
+    assert audit[0]["action"] == "wrong_exchange"
+    assert audit[0]["before"] == {"holdings": [{"ticker": "MICC.L"}]}
+
+
+def test_fix_unknown_issue_404(client):
+    resp = client.post("/data-quality/issues/nope/fix")
+    assert resp.status_code == 404
+
+
+def test_batch_fix_reports_per_issue(client):
+    issues = client.get("/data-quality/issues").json()["issues"]
+    wrong = [i for i in issues if i["type"] == "WRONG_EXCHANGE"]
+    ids = [i["id"] for i in wrong]
+    resp = client.post("/data-quality/fixes", json={"issue_ids": ids})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["applied"] == len(ids)
+    assert data["failed"] == 0
+    assert all(r["status"] == "ok" for r in data["results"])
+
+
+def test_batch_fix_reports_failures(client):
+    resp = client.post(
+        "/data-quality/fixes",
+        json={"issue_ids": ["WRONG_EXCHANGE:demo:isa:MICC.L", "not-a-real-id"]},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["applied"] == 1
+    assert data["failed"] == 1
+    failed = next(r for r in data["results"] if r["issue_id"] == "not-a-real-id")
+    assert failed["status"] == "error"
+
+
+def test_dedupe_series_direct_endpoint(monkeypatch, client, tmp_path):
+    df = pd.DataFrame(
+        {"Date": ["2026-01-01", "2026-01-01", "2026-01-02"], "Close": [1.0, 2.0, 3.0]}
+    )
+    cache_path = tmp_path / "ABC_L.parquet"
+    df.to_parquet(cache_path, index=False)
+
+    import backend.routes.data_quality_admin as admin_module
+
+    monkeypatch.setattr(admin_module, "meta_timeseries_cache_path", lambda t, e: str(cache_path))
+    monkeypatch.setattr(admin_module, "load_cached_meta_timeseries_full", lambda t, e: df.copy())
+
+    resp = client.post("/data-quality/series/ABC/L/dedupe")
+    assert resp.status_code == 200
+    assert resp.json()["removed"] == 1
+    assert cache_path.with_suffix(".parquet.bak").exists()
+
+    audit = client.get("/data-quality/audit").json()["entries"]
+    assert audit[0]["action"] == "dedupe"
+    assert audit[0]["before"] == {"rows": 3}
+    assert audit[0]["after"] == {"rows": 2}
+
+
+def test_audit_undo_wrong_exchange(client, tmp_path):
+    issues = client.get("/data-quality/issues").json()["issues"]
+    wrong = next(i for i in issues if i["type"] == "WRONG_EXCHANGE")
+    client.post(f"/data-quality/issues/{wrong['id']}/fix")
+
+    audit = client.get("/data-quality/audit").json()["entries"]
+    entry_id = audit[0]["id"]
+
+    resp = client.post(f"/data-quality/audit/{entry_id}/undo")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "undone"
+
+    doc = json.loads((tmp_path / "accounts" / "demo" / "isa.json").read_text(encoding="utf-8"))
+    assert doc["holdings"] == [{"ticker": "MICC.L"}]
+
+
+def test_audit_undo_non_reversible_409(client):
+    # A refetch action is not reversible; manufacture one via the audit file.
+    import backend.data_quality.audit as audit_module
+
+    entry = audit_module.append_audit(
+        action="refetch",
+        issue_id="GAPS:ABC:L",
+        entity={"ticker": "ABC", "exchange": "L"},
+        before={},
+        after={"rows": 5},
+    )
+    resp = client.post(f"/data-quality/audit/{entry['id']}/undo")
+    assert resp.status_code == 409
+
+
+def test_audit_undo_unknown_404(client):
+    resp = client.post("/data-quality/audit/missing/undo")
+    assert resp.status_code == 404
+
+
+def test_outliers_not_fixable(monkeypatch, tmp_path):
+    """OUTLIERS issues report fixable=False and the fix endpoint rejects them."""
+    dates = [f"2026-01-{d:02d}" for d in range(3, 25)]
+    closes = [100.0 + i for i in range(len(dates))]
+    closes[10] = 500.0
+    df = pd.DataFrame({"Date": dates, "Close": closes, "Ticker": ["ABC"] * len(dates)})
+
+    outlier_client = _build_client(monkeypatch, tmp_path, series=[("ABC", "L", df)])
+    issues = outlier_client.get("/data-quality/issues").json()["issues"]
+    outliers = [i for i in issues if i["type"] == "OUTLIERS"]
+    assert outliers
+    assert outliers[0]["fixable"] is False
+    resp = outlier_client.post(f"/data-quality/issues/{outliers[0]['id']}/fix")
+    assert resp.status_code == 409
+

--- a/tests/routes/test_data_quality_admin.py
+++ b/tests/routes/test_data_quality_admin.py
@@ -52,9 +52,7 @@ def _build_client(monkeypatch, tmp_path, *, series: list[tuple[str, str, pd.Data
         lambda symbol, create_missing=False: "MICC.N" if symbol == "MICC" else None,
     )
     monkeypatch.setattr(issues_module, "has_cached_meta_timeseries", lambda t, e: False)
-    monkeypatch.setattr(
-        issues_module, "list_cached_meta_tickers", lambda: [(t, e) for t, e, _ in series]
-    )
+    monkeypatch.setattr(issues_module, "list_cached_meta_tickers", lambda: [(t, e) for t, e, _ in series])
     monkeypatch.setattr(
         issues_module,
         "load_cached_meta_timeseries_full",
@@ -68,7 +66,6 @@ def _build_client(monkeypatch, tmp_path, *, series: list[tuple[str, str, pd.Data
     app.state.accounts_root = str(accounts)
     app.state.accounts_root_is_global = False
     return TestClient(app)
-
 
 
 def test_get_issues_lists_wrong_exchange(client):
@@ -154,9 +151,7 @@ def test_batch_fix_reports_failures(client):
 
 
 def test_dedupe_series_direct_endpoint(monkeypatch, client, tmp_path):
-    df = pd.DataFrame(
-        {"Date": ["2026-01-01", "2026-01-01", "2026-01-02"], "Close": [1.0, 2.0, 3.0]}
-    )
+    df = pd.DataFrame({"Date": ["2026-01-01", "2026-01-01", "2026-01-02"], "Close": [1.0, 2.0, 3.0]})
     cache_path = tmp_path / "ABC_L.parquet"
     df.to_parquet(cache_path, index=False)
 
@@ -226,4 +221,3 @@ def test_outliers_not_fixable(monkeypatch, tmp_path):
     assert outliers[0]["fixable"] is False
     resp = outlier_client.post(f"/data-quality/issues/{outliers[0]['id']}/fix")
     assert resp.status_code == 409
-


### PR DESCRIPTION
## What
Added `AppHeader` to `DataQuality.tsx` and `DataExplorer.tsx` to provide navigation chrome for standalone pages.

## Why
These pages render without the full header, creating a usability issue. Adding `AppHeader` ensures these pages have proper navigation chrome.

## Testing
- Confirmed `/data-quality` and `/data-explorer` now show the "Operations ▾ / Settings ▾ / 🔔" header.
- Verified no regression on public support routes (`/support`, `/create-account`) and existing standalone page with header (`/alert-settings`).

## Checklist
- [x] Tests added/updated
- [ ] Docs updated if needed
- [x] No breaking changes

Closes #6725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Data Quality Admin interface for identifying, filtering and previewing data issues.
  - Added individual and batch fixes, series deduplication, metadata corrections and ticker normalisation.
  - Added an audit trail with before-and-after details and undo support.
  - Added issue severity indicators and configurable read-only or admin access.

- **Documentation**
  - Added guidance covering the Data Quality interface, workflows, audit history and data requirements.

- **Tests**
  - Added comprehensive coverage for issue detection, fixes, auditing and interface behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->